### PR TITLE
Changes to move telegraf out of /etc/opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Latest:
 
 ##### Package instructions:
 
-* Telegraf binary is installed in `/opt/telegraf/telegraf`
-* Telegraf daemon configuration file is in `/etc/opt/telegraf/telegraf.conf`
+* Telegraf binary is installed in `/usr/sbin/telegraf`
+* Telegraf daemon configuration file is in `/etc/telegraf/telegraf.conf`
 * On sysv systems, the telegraf daemon can be controlled via
 `service telegraf [action]`
 * On systemd systems (such as Ubuntu 15+), the telegraf daemon can be

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Latest:
 
 ##### Package instructions:
 
-* Telegraf binary is installed in `/usr/sbin/telegraf`
+* Telegraf binary is installed in `/usr/bin/telegraf`
 * Telegraf daemon configuration file is in `/etc/telegraf/telegraf.conf`
 * On sysv systems, the telegraf daemon can be controlled via
 `service telegraf [action]`

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -95,7 +95,7 @@ function log_success_msg() {
 name=telegraf
 
 # Daemon name, where is the actual executable
-daemon=/opt/telegraf/telegraf
+daemon=/bin/telegraf
 
 # pid file for the daemon
 pidfile=/var/run/telegraf/telegraf.pid
@@ -107,7 +107,7 @@ if [ ! -d "$piddir" ]; then
 fi
 
 # Configuration file
-config=/etc/opt/telegraf/telegraf.conf
+config=/etc/telegraf/telegraf.conf
 
 # If the daemon is not there, then exit.
 [ -x $daemon ] || exit 5

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -95,7 +95,7 @@ function log_success_msg() {
 name=telegraf
 
 # Daemon name, where is the actual executable
-daemon=/bin/telegraf
+daemon=/usr/bin/telegraf
 
 # pid file for the daemon
 pidfile=/var/run/telegraf/telegraf.pid

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -32,7 +32,7 @@
 AWS_FILE=~/aws.conf
 
 INSTALL_ROOT_DIR=/opt/telegraf
-INSTALL_BIN_DIR=/bin
+INSTALL_BIN_DIR=/usr/bin
 TELEGRAF_LOG_DIR=/var/log/telegraf
 CONFIG_ROOT_DIR=/etc/telegraf
 LOGROTATE_DIR=/etc/logrotate.d

--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/default/telegraf
 User=telegraf
-ExecStart=/opt/telegraf/telegraf -config /etc/opt/telegraf/telegraf.conf $TELEGRAF_OPTS
+ExecStart=/usr/bin/telegraf -config /etc/telegraf/telegraf.conf $TELEGRAF_OPTS
 Restart=on-failure
 KillMode=process
 


### PR DESCRIPTION
Issue #264: This attempts to fix the /etc/opt and put the binary
linked into /bin

Note: I can't seem to find the right combination of packages for
getting package.sh to run, so I haven't been able to test this.