### PR TITLE
[WIP] Etcd integration for configuration

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,4 +1,5 @@
 git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git dbd8d5c40a582eb9adacde36b47932b3a3ad0034
+github.com/BurntSushi/toml 5c4df71dfe9ac89ef6287afc05e4c1b16ae65a1e
 github.com/Shopify/sarama d37c73f2b2bce85f7fa16b6a550d26c5372892ef
 github.com/Sirupsen/logrus f7f79f729e0fbe2fcc061db48a9ba0263f588252
 github.com/amir/raidman 6a8e089bbe32e6b907feae5ba688841974b3c339
@@ -8,6 +9,7 @@ github.com/beorn7/perks b965b613227fddccbfffe13eae360ed3fa822f8d
 github.com/boltdb/bolt ee4a0888a9abe7eefe5a0992ca4cb06864839873
 github.com/cenkalti/backoff 4dc77674aceaabba2c7e3da25d4c823edfb73f99
 github.com/dancannon/gorethink 6f088135ff288deb9d5546f4c71919207f891a70
+github.com/coreos/etcd bdee27b19e8601ffd7bd4f0481abe9bbae04bd09
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
 github.com/eapache/go-resiliency b86b1ec0dd4209a588dc1285cdd471e73525c0b3
 github.com/eapache/queue ded5959c0d4e360646dc9e9908cff48666781367

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ endif
 	docker run --name mqtt -p "1883:1883" -d ncarlier/mqtt
 	docker run --name riemann -p "5555:5555" -d blalor/riemann
 	docker run --name snmp -p "31161:31161/udp" -d titilambert/snmpsim
+	docker run --name etcd -p "2379:2379" -d quay.io/coreos/etcd -name etcd0 -advertise-client-urls http://localhost:2379 -listen-client-urls http://0.0.0.0:2379
 
 # Run docker containers necessary for CircleCI unit tests
 docker-run-circle:
@@ -97,11 +98,17 @@ docker-run-circle:
 	docker run --name mqtt -p "1883:1883" -d ncarlier/mqtt
 	docker run --name riemann -p "5555:5555" -d blalor/riemann
 	docker run --name snmp -p "31161:31161/udp" -d titilambert/snmpsim
+	docker run --name etcd -p "2379:2379" -d quay.io/coreos/etcd -name etcd0 -advertise-client-urls http://localhost:2379 -listen-client-urls http://0.0.0.0:2379
 
 # Kill all docker containers, ignore errors
 docker-kill:
-	-docker kill nsq aerospike redis opentsdb rabbitmq postgres memcached mysql kafka mqtt riemann snmp
-	-docker rm nsq aerospike redis opentsdb rabbitmq postgres memcached mysql kafka mqtt riemann snmp
+	-docker kill nsq aerospike redis opentsdb rabbitmq postgres memcached mysql kafka mqtt riemann snmp etcd
+	-docker rm nsq aerospike redis opentsdb rabbitmq postgres memcached mysql kafka mqtt riemann snmp etcd
+
+# Kill all docker containers, ignore errors
+docker-kill:
+	-docker kill nsq aerospike redis opentsdb rabbitmq postgres memcached mysql kafka mqtt riemann etcd
+	-docker rm nsq aerospike redis opentsdb rabbitmq postgres memcached mysql kafka mqtt riemann etcd
 
 # Run full unit tests using docker containers (includes setup and teardown)
 test: docker-kill docker-run

--- a/internal/etcd/etcd.go
+++ b/internal/etcd/etcd.go
@@ -1,0 +1,268 @@
+package etcd
+
+import (
+	"bytes"
+	"encoding/json"
+	"golang.org/x/net/context"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/coreos/etcd/client"
+
+	"github.com/influxdata/telegraf/internal/config"
+)
+
+type EtcdClient struct {
+	Kapi   client.KeysAPI
+	Folder string
+}
+
+func (e *EtcdClient) LaunchWatcher(shutdown chan struct{}, signals chan os.Signal) {
+	// TODO: All telegraf client will reload for each changes...
+	// Maybe we want to reload on those we need to ???
+	// So we need to create a watcher by labels ??
+
+	for {
+		watcherOpts := client.WatcherOptions{AfterIndex: 0, Recursive: true}
+		w := e.Kapi.Watcher(e.Folder, &watcherOpts)
+		r, err := w.Next(context.Background())
+		if err != nil {
+			// TODO What we have to do here ????
+			log.Fatal("Error occurred", err)
+		}
+		if r.Action == "set" || r.Action == "update" {
+			// do something with Response r here
+			log.Printf("Changes detected in etcd (%s action detected)\n", r.Action)
+			log.Print("Reloading Telegraf config\n")
+			signals <- syscall.SIGHUP
+			time.Sleep(time.Duration(1) * time.Second)
+		}
+	}
+}
+
+func NewEtcdClient(urls string, folder string) *EtcdClient {
+	// Create a new etcd client
+	cfg := client.Config{
+		Endpoints: []string{"http://127.0.0.1:2379"},
+		Transport: client.DefaultTransport,
+	}
+
+	e := &EtcdClient{}
+	c, err := client.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	kapi := client.NewKeysAPI(c)
+
+	e.Kapi = kapi
+	e.Folder = folder
+
+	return e
+}
+
+func (e *EtcdClient) Connect() error {
+	//c, err := eclient.New(cfg)
+	return nil
+}
+
+func (e *EtcdClient) WriteConfigDir(configdir string) error {
+	directoryEntries, err := ioutil.ReadDir(configdir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range directoryEntries {
+		name := entry.Name()
+		if entry.IsDir() {
+			if name == "labels" {
+				// Handle labels
+				directoryEntries, err := ioutil.ReadDir(path.Join(configdir, name))
+				if err != nil {
+					return err
+				}
+				for _, entry := range directoryEntries {
+					filename := entry.Name()
+					if len(filename) < 6 || filename[len(filename)-5:] != ".conf" {
+						continue
+					}
+					label := filename[:len(filename)-5]
+					err = e.WriteLabelConfig(label, path.Join(configdir, name, filename))
+					if err != nil {
+						return err
+					}
+				}
+			} else if name == "hosts" {
+				// Handle hosts specific config
+				directoryEntries, err := ioutil.ReadDir(path.Join(configdir, name))
+				if err != nil {
+					return err
+				}
+
+				for _, entry := range directoryEntries {
+					filename := entry.Name()
+					if len(filename) < 6 || filename[len(filename)-5:] != ".conf" {
+						continue
+					}
+					hostname := filename[:len(filename)-5]
+					err = e.WriteHostConfig(hostname, path.Join(configdir, name, filename))
+					if err != nil {
+						return err
+					}
+				}
+			}
+			continue
+		}
+		if name == "main.conf" {
+			// Handle main config
+			err := e.WriteMainConfig(path.Join(configdir, name))
+			if err != nil {
+				return err
+			}
+		} else {
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (e *EtcdClient) WriteMainConfig(path string) error {
+	// Write main config file in etcd
+	key := "main"
+	err := e.WriteConfig(key, path)
+	return err
+}
+
+func (e *EtcdClient) WriteLabelConfig(label string, path string) error {
+	// Write label config file in etcd
+	key := "labels/" + label
+	err := e.WriteConfig(key, path)
+	return err
+}
+
+func (e *EtcdClient) WriteHostConfig(host string, path string) error {
+	// Write host config file in etcd
+	key := "hosts/" + host
+	err := e.WriteConfig(key, path)
+	return err
+}
+
+func (e *EtcdClient) WriteConfig(relative_key string, path string) error {
+	// Read config file, get conf in tomlformat, convert to json
+	// Then write it to etcd
+	// TODO: Maybe we just want to store toml in etcd ? Is json really needed ????
+	// Read file
+	raw_data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	// Get toml
+	var data interface{}
+	_, err = toml.Decode(string(raw_data), &data)
+	if err != nil {
+		return err
+	}
+	// Get json
+	json_data, _ := json.Marshal(&data)
+	// Write it
+	key := e.Folder + "/" + relative_key
+	resp, _ := e.Kapi.Get(context.Background(), key, nil)
+	if resp == nil {
+		_, err = e.Kapi.Set(context.Background(), key, string(json_data), nil)
+	} else {
+		_, err = e.Kapi.Update(context.Background(), key, string(json_data))
+	}
+	if err != nil {
+		log.Fatal(err)
+		return err
+	} else {
+		log.Printf("Config written with key %s\n", key)
+	}
+	return nil
+}
+
+//func (e *EtcdClient) ReadConfig(labels []string) (*config.Config, error) {
+func (e *EtcdClient) ReadConfig(c *config.Config, labels string) (*config.Config, error) {
+	// Get default config in etcd
+	// key = /telegraf/default
+	key := e.Folder + "/main"
+	resp, err := e.Kapi.Get(context.Background(), key, nil)
+	if err != nil {
+		log.Printf("WARNING: [etcd] %s", err)
+	} else {
+		// Put it in toml
+		data, err := json2toml(resp)
+		if err != nil {
+			log.Printf("WARNING: [etcd] %s", err)
+		}
+		c.LoadConfigFromText(data)
+	}
+
+	// Get specific host config
+	// key = /telegraf/hosts/HOSTNAME
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Printf("WARNING: [etcd] %s", err)
+	} else if hostname != "" {
+		key = e.Folder + "/hosts/" + hostname
+		resp, err := e.Kapi.Get(context.Background(), key, nil)
+		if err != nil {
+			log.Printf("WARNING: [etcd] %s", err)
+		} else {
+			// Put it in toml
+			data, err := json2toml(resp)
+			if err != nil {
+				log.Print(err)
+			}
+			c.LoadConfigFromText(data)
+		}
+	}
+
+	// Concat labels from etcd and labels from command line
+	labels_list := c.Agent.Labels
+	if labels != "" {
+		labels_list = append(labels_list, strings.Split(labels, ",")...)
+	}
+
+	// Iterate on all labels
+	// TODO check label order of importance ?
+	for _, label := range labels_list {
+		// Read from etcd
+		// key = /telegraf/labels/LABEL
+		key := e.Folder + "/labels/" + label
+		resp, err := e.Kapi.Get(context.Background(), key, nil)
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+		// Put it in toml
+		data, err := json2toml(resp)
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+		// Load config
+		err = c.LoadConfigFromText(data)
+		if err != nil {
+			log.Print(err)
+		}
+	}
+
+	return c, nil
+}
+
+func json2toml(resp *client.Response) ([]byte, error) {
+	// Convert json to toml
+	var json_data interface{}
+	var data []byte
+	json.Unmarshal([]byte(resp.Node.Value), &json_data)
+	buf := new(bytes.Buffer)
+	err := toml.NewEncoder(buf).Encode(json_data)
+	data = buf.Bytes()
+	return data, err
+}

--- a/internal/etcd/etcd_test.go
+++ b/internal/etcd/etcd_test.go
@@ -1,0 +1,74 @@
+package etcd
+
+import (
+	"golang.org/x/net/context"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/internal/config"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/outputs"
+
+	"github.com/influxdata/telegraf/plugins/inputs/system"
+	"github.com/influxdata/telegraf/plugins/outputs/influxdb"
+)
+
+func TestWrite(t *testing.T) {
+	e := NewEtcdClient("http://localhost:2379", "/telegraf")
+
+	// Test write dir
+	err := e.WriteConfigDir("./testdata/")
+	require.NoError(t, err)
+	resp, _ := e.Kapi.Get(context.Background(), "/telegraf/main", nil)
+	assert.Equal(t,
+		`{"agent":{"debug":false,"flush_interval":"10s","flush_jitter":"0s","hostname":"","interval":"2s","round_interval":true},"tags":{"dc":"us-east-1"}}`,
+		resp.Node.Value)
+	resp, _ = e.Kapi.Get(context.Background(), "/telegraf/hosts/localhost", nil)
+	assert.Equal(t,
+		`{"agent":{"interval":"2s","labels":["influx"]},"inputs":{"cpu":[{"drop":["cpu_time*"],"percpu":true,"totalcpu":true}]}}`,
+		resp.Node.Value)
+
+	// Test write conf
+	err = e.WriteLabelConfig("mylabel", "./testdata/labels/network.conf")
+	require.NoError(t, err)
+	resp, _ = e.Kapi.Get(context.Background(), "/telegraf/labels/mylabel", nil)
+	assert.Equal(t, `{"inputs":{"net":[{}]}}`, resp.Node.Value)
+
+	// Test read
+	c := config.NewConfig()
+	var inputFilters []string
+	var outputFilters []string
+	c.OutputFilters = outputFilters
+	c.InputFilters = inputFilters
+
+	net := inputs.Inputs["net"]().(*system.NetIOStats)
+	influx := outputs.Outputs["influxdb"]().(*influxdb.InfluxDB)
+	influx.URLs = []string{"http://localhost:8086"}
+	influx.Database = "telegraf"
+	influx.Precision = "s"
+
+	c, err = e.ReadConfig(c, "mylabel,influx")
+	require.NoError(t, err)
+	assert.Equal(t, net, c.Inputs[0].Input,
+		"Testdata did not produce a correct net struct.")
+	assert.Equal(t, influx, c.Outputs[0].Output,
+		"Testdata did not produce a correct influxdb struct.")
+
+	// Test reload
+	shutdown := make(chan struct{})
+	signals := make(chan os.Signal)
+	go e.LaunchWatcher(shutdown, signals)
+	// Test write conf
+	err = e.WriteLabelConfig("mylabel", "./testdata/labels/network2.conf")
+	require.NoError(t, err)
+	resp, _ = e.Kapi.Get(context.Background(), "/telegraf/labels/mylabel", nil)
+	assert.Equal(t, `{"inputs":{"net":[{"interfaces":["eth0"]}]}}`, resp.Node.Value)
+	// TODO found a way to test reload ....
+	sig := <-signals
+	assert.Equal(t, syscall.SIGHUP, sig)
+
+}

--- a/internal/etcd/testdata/hosts/localhost.conf
+++ b/internal/etcd/testdata/hosts/localhost.conf
@@ -1,0 +1,9 @@
+
+[agent]
+  interval = "2s"
+  labels = ["influx"]
+
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = true
+  drop = ["cpu_time*"]

--- a/internal/etcd/testdata/labels/influx.conf
+++ b/internal/etcd/testdata/labels/influx.conf
@@ -1,0 +1,4 @@
+[[outputs.influxdb]]
+  urls = ["http://localhost:8086"]
+  database = "telegraf"
+  precision = "s"

--- a/internal/etcd/testdata/labels/network.conf
+++ b/internal/etcd/testdata/labels/network.conf
@@ -1,0 +1,2 @@
+[[inputs.net]]
+

--- a/internal/etcd/testdata/labels/network2.conf
+++ b/internal/etcd/testdata/labels/network2.conf
@@ -1,0 +1,4 @@
+[[inputs.net]]
+
+  interfaces = ["eth0"]
+

--- a/internal/etcd/testdata/main.conf
+++ b/internal/etcd/testdata/main.conf
@@ -1,0 +1,10 @@
+[tags]
+  dc = "us-east-1"
+
+[agent]
+  interval = "2s"
+  round_interval = true
+  flush_interval = "10s"
+  flush_jitter = "0s"
+  debug = false
+  hostname = ""

--- a/plugins/outputs/graphite/graphite_test.go
+++ b/plugins/outputs/graphite/graphite_test.go
@@ -83,6 +83,7 @@ func TestGraphiteOK(t *testing.T) {
 	wg.Add(1)
 	// Waiting TCPserver
 	wg.Wait()
+	require.NoError(t, err2)
 	g.Close()
 }
 


### PR DESCRIPTION
Hello !
I just started an example of what could be the etcd integration with telegraf

Here an example:
1 . Make a myconf.conf file, which will be stored in etcd, with the following content :
```
[tags]
  dc = "us-east-1"

[agent]
  interval = "10s"
  round_interval = true
  flush_interval = "10s"
  flush_jitter = "0s"
  debug = false
  hostname = ""


[[outputs.influxdb]]
  urls = ["http://localhost:8086"]
  database = "telegraf"
  precision = "s"


[[inputs.cpu]]
  percpu = true
  totalcpu = true
  drop = ["cpu_time*"]
```

2 . Send this file to etcd using the label **mylabel**
```
./telegraf  -etcd http://127.0.0.1:2379 -etcdwritelabel mylabel -etcdwriteconfig myconf.conf
```

3 . You can check if data is really written in etcd with
```
./etcdctl get /telegraf/labels/mylabel
```

3 . Now any telegraf agent can load this config use the label **mylabel**
```
./telegraf  -etcd http://127.0.0.1:2379 -etcdreadlabels mylabel
Config read with label mylabel
2015/12/27 20:58:34 Database creation failed: Get http://localhost:8086/query?db=&q=CREATE+DATABASE+IF+NOT+EXISTS+telegraf: dial tcp 127.0.0.1:8086: getsockopt: connection refused
2015/12/27 20:58:34 Starting Telegraf (version v0.2.4-16-ga0bb7db)
2015/12/27 20:58:34 Loaded outputs: influxdb
2015/12/27 20:58:34 Loaded plugins: cpu
2015/12/27 20:58:34 Tags enabled: dc=us-east-1 host=osselait
2015/12/27 20:58:34 Agent Config: Interval:{10s}, Debug:false, Hostname:"osselait", Flush Interval:{10s}

```

Notes:
* DO NOT forget to change your etcd server URL
* All data is, for now, stored in etcd in /telegraf/labels/... "folder"
* Tested with etcd 2.2.2