### PR TITLE
Additional request header parameters for httpjson plugin

### DIFF
--- a/plugins/inputs/httpjson/README.md
+++ b/plugins/inputs/httpjson/README.md
@@ -45,6 +45,16 @@ You can also specify additional request parameters for the service:
 
 ```
 
+You can also specify additional request header parameters for the service:
+
+```
+[[httpjson.services]]
+  ...
+
+ [httpjson.services.headers]
+    X-Auth-Token = "my-xauth-token"
+    apiVersion = "v1"
+```
 
 # Example:
 

--- a/plugins/inputs/httpjson/httpjson.go
+++ b/plugins/inputs/httpjson/httpjson.go
@@ -21,6 +21,7 @@ type HttpJson struct {
 	Method     string
 	TagKeys    []string
 	Parameters map[string]string
+	Headers    map[string]string
 	client     HTTPClient
 }
 
@@ -70,6 +71,12 @@ var sampleConfig = `
   [inputs.httpjson.parameters]
     event_type = "cpu_spike"
     threshold = "0.75"
+
+  # HTTP Header parameters (all values must be strings)
+  # [inputs.httpjson.headers]
+  #   X-Auth-Token = "my-xauth-token"
+  #   apiVersion = "v1"
+
 `
 
 func (h *HttpJson) SampleConfig() string {
@@ -189,6 +196,11 @@ func (h *HttpJson) sendRequest(serverURL string) (string, float64, error) {
 	req, err := http.NewRequest(h.Method, requestURL.String(), nil)
 	if err != nil {
 		return "", -1, err
+	}
+
+	// Add header parameters
+	for k, v := range h.Headers {
+		req.Header.Add(k, v)
 	}
 
 	start := time.Now()

--- a/plugins/inputs/httpjson/httpjson_test.go
+++ b/plugins/inputs/httpjson/httpjson_test.go
@@ -97,6 +97,10 @@ func genMockHttpJson(response string, statusCode int) []*HttpJson {
 				"httpParam1": "12",
 				"httpParam2": "the second parameter",
 			},
+			Headers: map[string]string{
+				"X-Auth-Token": "the-first-parameter",
+				"apiVersion":   "v1",
+			},
 		},
 		&HttpJson{
 			client: mockHTTPClient{responseBody: response, statusCode: statusCode},
@@ -109,6 +113,10 @@ func genMockHttpJson(response string, statusCode int) []*HttpJson {
 			Parameters: map[string]string{
 				"httpParam1": "12",
 				"httpParam2": "the second parameter",
+			},
+			Headers: map[string]string{
+				"X-Auth-Token": "the-first-parameter",
+				"apiVersion":   "v1",
 			},
 			TagKeys: []string{
 				"role",


### PR DESCRIPTION
This will provide the ability to specify header parameters for httpjson plugin.

Example:
```
[plugins.httpjson.services.headers]
  X-Auth-Token = "my-xauth-token"
  apiVersion = "v1"
```