### PR TITLE
.gitignore too restrictive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 tivan
 .vagrant
-telegraf
+/telegraf
 .idea


### PR DESCRIPTION
I noticed that in `.gitignore` the line with `telegraf` prevents more than just the executable created:
```
$ find . -name telegraf | xargs file
./cmd/telegraf:             directory
./etc/logrotate.d/telegraf: ASCII text
./telegraf:                 Mach-O 64-bit executable x86_64
```

With this PR I suggest to change that line to the more specific ignore rule: `/telegraf` to target just the `telegraf` executable created calling `make`.