### PR TITLE
core: print error on output connect fail

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -58,7 +58,7 @@ func (a *Agent) Connect() error {
 		}
 		err := o.Output.Connect()
 		if err != nil {
-			log.Printf("Failed to connect to output %s, retrying in 15s\n", o.Name)
+			log.Printf("Failed to connect to output %s, retrying in 15s, error was '%s' \n", o.Name, err)
 			time.Sleep(15 * time.Second)
 			err = o.Output.Connect()
 			if err != nil {


### PR DESCRIPTION
When telegraf fails to connect to output at the start, it's unclear what was the problem.
So we have to wait 15 seconds for another try, which prints the error.

This code will print error on the first try.