### PR TITLE
Change configuration package to influxdata/config

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -22,6 +22,7 @@ github.com/hailocab/go-hostpool 50839ee41f32bfca8d03a183031aa634b2dc1c64
 github.com/hashicorp/go-msgpack fa3f63826f7c23912c15263591e65d54d080b458
 github.com/hashicorp/raft b95f335efee1992886864389183ebda0c0a5d0f6
 github.com/hashicorp/raft-boltdb d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee
+github.com/influxdata/config bae7cb98197d842374d3b8403905924094930f24
 github.com/influxdata/influxdb 0e0f85a0c1fd1788ae4f9145531b02c539cfa5b5
 github.com/influxdb/influxdb 0e0f85a0c1fd1788ae4f9145531b02c539cfa5b5
 github.com/jmespath/go-jmespath c01cf91b011868172fdcd9f41838e80c9d716264

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/outputs"
 
-	"github.com/naoina/toml"
+	"github.com/influxdata/config"
 	"github.com/naoina/toml/ast"
 )
 
@@ -314,12 +314,7 @@ func (c *Config) LoadDirectory(path string) error {
 
 // LoadConfig loads the given config file and applies it to c
 func (c *Config) LoadConfig(path string) error {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
-	tbl, err := toml.Parse(data)
+	tbl, err := config.ParseFile(path)
 	if err != nil {
 		return err
 	}
@@ -332,12 +327,12 @@ func (c *Config) LoadConfig(path string) error {
 
 		switch name {
 		case "agent":
-			if err = toml.UnmarshalTable(subTable, c.Agent); err != nil {
+			if err = config.UnmarshalTable(subTable, c.Agent); err != nil {
 				log.Printf("Could not parse [agent] config\n")
 				return err
 			}
 		case "tags":
-			if err = toml.UnmarshalTable(subTable, c.Tags); err != nil {
+			if err = config.UnmarshalTable(subTable, c.Tags); err != nil {
 				log.Printf("Could not parse [tags] config\n")
 				return err
 			}
@@ -403,7 +398,7 @@ func (c *Config) addOutput(name string, table *ast.Table) error {
 		return err
 	}
 
-	if err := toml.UnmarshalTable(table, output); err != nil {
+	if err := config.UnmarshalTable(table, output); err != nil {
 		return err
 	}
 
@@ -436,7 +431,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 		return err
 	}
 
-	if err := toml.UnmarshalTable(table, input); err != nil {
+	if err := config.UnmarshalTable(table, input); err != nil {
 		return err
 	}
 
@@ -571,7 +566,7 @@ func buildInput(name string, tbl *ast.Table) (*models.InputConfig, error) {
 	cp.Tags = make(map[string]string)
 	if node, ok := tbl.Fields["tags"]; ok {
 		if subtbl, ok := node.(*ast.Table); ok {
-			if err := toml.UnmarshalTable(subtbl, cp.Tags); err != nil {
+			if err := config.UnmarshalTable(subtbl, cp.Tags); err != nil {
 				log.Printf("Could not parse tags for input %s\n", name)
 			}
 		}


### PR DESCRIPTION
We are unifying the way that we handle configuration across the products
into the influxdata/config package. This provides the same API as
naoina/toml that was used previously, but provides some additional
features such as support for documenting generated TOML configs as well
as support for handling default options. This replaces all usage of
naoina/toml with influxdata/config.