### PR TITLE
WIP: Use an internal 'Metric' data type for telegraf metrics

### DIFF
--- a/accumulator.go
+++ b/accumulator.go
@@ -8,8 +8,7 @@ import (
 	"time"
 
 	imodels "github.com/influxdata/telegraf/internal/models"
-
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 )
 
 type Accumulator interface {
@@ -30,7 +29,7 @@ type Accumulator interface {
 
 func NewAccumulator(
 	inputConfig *imodels.InputConfig,
-	points chan *client.Point,
+	points chan models.Metric,
 ) Accumulator {
 	acc := accumulator{}
 	acc.points = points
@@ -41,7 +40,7 @@ func NewAccumulator(
 type accumulator struct {
 	sync.Mutex
 
-	points chan *client.Point
+	points chan models.Metric
 
 	defaultTags map[string]string
 
@@ -152,15 +151,15 @@ func (ac *accumulator) AddFields(
 		measurement = ac.prefix + measurement
 	}
 
-	pt, err := client.NewPoint(measurement, tags, result, timestamp)
+	metric, err := models.NewMetric(measurement, tags, result, timestamp)
 	if err != nil {
 		log.Printf("Error adding point [%s]: %s\n", measurement, err.Error())
 		return
 	}
 	if ac.debug {
-		fmt.Println("> " + pt.String())
+		fmt.Println("> " + metric.String())
 	}
-	ac.points <- pt
+	ac.points <- metric
 }
 
 func (ac *accumulator) SetDefaultTags(tags map[string]string) {

--- a/accumulator.go
+++ b/accumulator.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/influxdata/telegraf/internal/models"
+	imodels "github.com/influxdata/telegraf/internal/models"
 
 	"github.com/influxdata/influxdb/client/v2"
 )
@@ -29,7 +29,7 @@ type Accumulator interface {
 }
 
 func NewAccumulator(
-	inputConfig *models.InputConfig,
+	inputConfig *imodels.InputConfig,
 	points chan *client.Point,
 ) Accumulator {
 	acc := accumulator{}
@@ -47,7 +47,7 @@ type accumulator struct {
 
 	debug bool
 
-	inputConfig *models.InputConfig
+	inputConfig *imodels.InputConfig
 
 	prefix string
 }

--- a/agent.go
+++ b/agent.go
@@ -12,10 +12,8 @@ import (
 
 	"github.com/influxdata/telegraf/internal/config"
 	imodels "github.com/influxdata/telegraf/internal/models"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/outputs"
-
-	"github.com/influxdata/influxdb/client/v2"
 )
 
 // Agent runs telegraf and collects data based on the given config
@@ -47,7 +45,7 @@ func NewAgent(config *config.Config) (*Agent, error) {
 func (a *Agent) Connect() error {
 	for _, o := range a.Config.Outputs {
 		switch ot := o.Output.(type) {
-		case outputs.ServiceOutput:
+		case models.ServiceOutput:
 			if err := ot.Start(); err != nil {
 				log.Printf("Service for output %s failed to start, exiting\n%s\n",
 					o.Name, err.Error())
@@ -80,7 +78,7 @@ func (a *Agent) Close() error {
 	for _, o := range a.Config.Outputs {
 		err = o.Output.Close()
 		switch ot := o.Output.(type) {
-		case outputs.ServiceOutput:
+		case models.ServiceOutput:
 			ot.Stop()
 		}
 	}
@@ -89,7 +87,7 @@ func (a *Agent) Close() error {
 
 // gatherParallel runs the inputs that are using the same reporting interval
 // as the telegraf agent.
-func (a *Agent) gatherParallel(pointChan chan *client.Point) error {
+func (a *Agent) gatherParallel(pointChan chan models.Metric) error {
 	var wg sync.WaitGroup
 
 	start := time.Now()
@@ -146,7 +144,7 @@ func (a *Agent) gatherParallel(pointChan chan *client.Point) error {
 func (a *Agent) gatherSeparate(
 	shutdown chan struct{},
 	input *imodels.RunningInput,
-	pointChan chan *client.Point,
+	pointChan chan models.Metric,
 ) error {
 	ticker := time.NewTicker(input.Config.Interval)
 
@@ -186,7 +184,7 @@ func (a *Agent) gatherSeparate(
 func (a *Agent) Test() error {
 	shutdown := make(chan struct{})
 	defer close(shutdown)
-	pointChan := make(chan *client.Point)
+	pointChan := make(chan models.Metric)
 
 	// dummy receiver for the point channel
 	go func() {
@@ -248,7 +246,7 @@ func (a *Agent) flush() {
 }
 
 // flusher monitors the points input channel and flushes on the minimum interval
-func (a *Agent) flusher(shutdown chan struct{}, pointChan chan *client.Point) error {
+func (a *Agent) flusher(shutdown chan struct{}, pointChan chan models.Metric) error {
 	// Inelegant, but this sleep is to allow the Gather threads to run, so that
 	// the flusher will flush after metrics are collected.
 	time.Sleep(time.Millisecond * 200)
@@ -306,7 +304,7 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 		a.Config.Agent.Hostname, a.Config.Agent.FlushInterval.Duration)
 
 	// channel shared between all input threads for accumulating points
-	pointChan := make(chan *client.Point, 1000)
+	pointChan := make(chan models.Metric, 1000)
 
 	// Round collection to nearest interval by sleeping
 	if a.Config.Agent.RoundInterval {

--- a/agent.go
+++ b/agent.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf/internal/config"
-	"github.com/influxdata/telegraf/internal/models"
+	imodels "github.com/influxdata/telegraf/internal/models"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/outputs"
 
@@ -102,7 +102,7 @@ func (a *Agent) gatherParallel(pointChan chan *client.Point) error {
 
 		wg.Add(1)
 		counter++
-		go func(input *models.RunningInput) {
+		go func(input *imodels.RunningInput) {
 			defer wg.Done()
 
 			acc := NewAccumulator(input.Config, pointChan)
@@ -145,7 +145,7 @@ func (a *Agent) gatherParallel(pointChan chan *client.Point) error {
 // reporting interval.
 func (a *Agent) gatherSeparate(
 	shutdown chan struct{},
-	input *models.RunningInput,
+	input *imodels.RunningInput,
 	pointChan chan *client.Point,
 ) error {
 	ticker := time.NewTicker(input.Config.Interval)
@@ -234,7 +234,7 @@ func (a *Agent) flush() {
 
 	wg.Add(len(a.Config.Outputs))
 	for _, o := range a.Config.Outputs {
-		go func(output *models.RunningOutput) {
+		go func(output *imodels.RunningOutput) {
 			defer wg.Done()
 			err := output.Write()
 			if err != nil {
@@ -341,7 +341,7 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 		// configured. Default intervals are handled below with gatherParallel
 		if input.Config.Interval != 0 {
 			wg.Add(1)
-			go func(input *models.RunningInput) {
+			go func(input *imodels.RunningInput) {
 				defer wg.Done()
 				if err := a.gatherSeparate(shutdown, input, pointChan); err != nil {
 					log.Printf(err.Error())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf/internal"
-	"github.com/influxdata/telegraf/internal/models"
+	imodels "github.com/influxdata/telegraf/internal/models"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/outputs"
 
@@ -28,8 +28,8 @@ type Config struct {
 	OutputFilters []string
 
 	Agent   *AgentConfig
-	Inputs  []*models.RunningInput
-	Outputs []*models.RunningOutput
+	Inputs  []*imodels.RunningInput
+	Outputs []*imodels.RunningOutput
 }
 
 func NewConfig() *Config {
@@ -43,8 +43,8 @@ func NewConfig() *Config {
 		},
 
 		Tags:          make(map[string]string),
-		Inputs:        make([]*models.RunningInput, 0),
-		Outputs:       make([]*models.RunningOutput, 0),
+		Inputs:        make([]*imodels.RunningInput, 0),
+		Outputs:       make([]*imodels.RunningOutput, 0),
 		InputFilters:  make([]string, 0),
 		OutputFilters: make([]string, 0),
 	}
@@ -402,7 +402,7 @@ func (c *Config) addOutput(name string, table *ast.Table) error {
 		return err
 	}
 
-	ro := models.NewRunningOutput(name, output, outputConfig)
+	ro := imodels.NewRunningOutput(name, output, outputConfig)
 	if c.Agent.MetricBufferLimit > 0 {
 		ro.PointBufferLimit = c.Agent.MetricBufferLimit
 	}
@@ -435,7 +435,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 		return err
 	}
 
-	rp := &models.RunningInput{
+	rp := &imodels.RunningInput{
 		Name:   name,
 		Input:  input,
 		Config: pluginConfig,
@@ -445,10 +445,10 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 }
 
 // buildFilter builds a Filter (tagpass/tagdrop/pass/drop) to
-// be inserted into the models.OutputConfig/models.InputConfig to be used for prefix
+// be inserted into the imodels.OutputConfig/imodels.InputConfig to be used for prefix
 // filtering on tags and measurements
-func buildFilter(tbl *ast.Table) models.Filter {
-	f := models.Filter{}
+func buildFilter(tbl *ast.Table) imodels.Filter {
+	f := imodels.Filter{}
 
 	if node, ok := tbl.Fields["pass"]; ok {
 		if kv, ok := node.(*ast.KeyValue); ok {
@@ -480,7 +480,7 @@ func buildFilter(tbl *ast.Table) models.Filter {
 		if subtbl, ok := node.(*ast.Table); ok {
 			for name, val := range subtbl.Fields {
 				if kv, ok := val.(*ast.KeyValue); ok {
-					tagfilter := &models.TagFilter{Name: name}
+					tagfilter := &imodels.TagFilter{Name: name}
 					if ary, ok := kv.Value.(*ast.Array); ok {
 						for _, elem := range ary.Value {
 							if str, ok := elem.(*ast.String); ok {
@@ -499,7 +499,7 @@ func buildFilter(tbl *ast.Table) models.Filter {
 		if subtbl, ok := node.(*ast.Table); ok {
 			for name, val := range subtbl.Fields {
 				if kv, ok := val.(*ast.KeyValue); ok {
-					tagfilter := &models.TagFilter{Name: name}
+					tagfilter := &imodels.TagFilter{Name: name}
 					if ary, ok := kv.Value.(*ast.Array); ok {
 						for _, elem := range ary.Value {
 							if str, ok := elem.(*ast.String); ok {
@@ -523,9 +523,9 @@ func buildFilter(tbl *ast.Table) models.Filter {
 
 // buildInput parses input specific items from the ast.Table,
 // builds the filter and returns a
-// models.InputConfig to be inserted into models.RunningInput
-func buildInput(name string, tbl *ast.Table) (*models.InputConfig, error) {
-	cp := &models.InputConfig{Name: name}
+// imodels.InputConfig to be inserted into imodels.RunningInput
+func buildInput(name string, tbl *ast.Table) (*imodels.InputConfig, error) {
+	cp := &imodels.InputConfig{Name: name}
 	if node, ok := tbl.Fields["interval"]; ok {
 		if kv, ok := node.(*ast.KeyValue); ok {
 			if str, ok := kv.Value.(*ast.String); ok {
@@ -582,10 +582,10 @@ func buildInput(name string, tbl *ast.Table) (*models.InputConfig, error) {
 }
 
 // buildOutput parses output specific items from the ast.Table, builds the filter and returns an
-// models.OutputConfig to be inserted into models.RunningInput
+// imodels.OutputConfig to be inserted into imodels.RunningInput
 // Note: error exists in the return for future calls that might require error
-func buildOutput(name string, tbl *ast.Table) (*models.OutputConfig, error) {
-	oc := &models.OutputConfig{
+func buildOutput(name string, tbl *ast.Table) (*imodels.OutputConfig, error) {
+	oc := &imodels.OutputConfig{
 		Name:   name,
 		Filter: buildFilter(tbl),
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf/internal/models"
+	imodels "github.com/influxdata/telegraf/internal/models"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/inputs/exec"
 	"github.com/influxdata/telegraf/plugins/inputs/memcached"
@@ -19,19 +19,19 @@ func TestConfig_LoadSingleInput(t *testing.T) {
 	memcached := inputs.Inputs["memcached"]().(*memcached.Memcached)
 	memcached.Servers = []string{"localhost"}
 
-	mConfig := &models.InputConfig{
+	mConfig := &imodels.InputConfig{
 		Name: "memcached",
-		Filter: models.Filter{
+		Filter: imodels.Filter{
 			Drop: []string{"other", "stuff"},
 			Pass: []string{"some", "strings"},
-			TagDrop: []models.TagFilter{
-				models.TagFilter{
+			TagDrop: []imodels.TagFilter{
+				imodels.TagFilter{
 					Name:   "badtag",
 					Filter: []string{"othertag"},
 				},
 			},
-			TagPass: []models.TagFilter{
-				models.TagFilter{
+			TagPass: []imodels.TagFilter{
+				imodels.TagFilter{
 					Name:   "goodtag",
 					Filter: []string{"mytag"},
 				},
@@ -62,19 +62,19 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	memcached := inputs.Inputs["memcached"]().(*memcached.Memcached)
 	memcached.Servers = []string{"localhost"}
 
-	mConfig := &models.InputConfig{
+	mConfig := &imodels.InputConfig{
 		Name: "memcached",
-		Filter: models.Filter{
+		Filter: imodels.Filter{
 			Drop: []string{"other", "stuff"},
 			Pass: []string{"some", "strings"},
-			TagDrop: []models.TagFilter{
-				models.TagFilter{
+			TagDrop: []imodels.TagFilter{
+				imodels.TagFilter{
 					Name:   "badtag",
 					Filter: []string{"othertag"},
 				},
 			},
-			TagPass: []models.TagFilter{
-				models.TagFilter{
+			TagPass: []imodels.TagFilter{
+				imodels.TagFilter{
 					Name:   "goodtag",
 					Filter: []string{"mytag"},
 				},
@@ -92,7 +92,7 @@ func TestConfig_LoadDirectory(t *testing.T) {
 
 	ex := inputs.Inputs["exec"]().(*exec.Exec)
 	ex.Command = "/usr/bin/myothercollector --foo=bar"
-	eConfig := &models.InputConfig{
+	eConfig := &imodels.InputConfig{
 		Name:              "exec",
 		MeasurementSuffix: "_myothercollector",
 	}
@@ -111,7 +111,7 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	pstat := inputs.Inputs["procstat"]().(*procstat.Procstat)
 	pstat.PidFile = "/var/run/grafana-server.pid"
 
-	pConfig := &models.InputConfig{Name: "procstat"}
+	pConfig := &imodels.InputConfig{Name: "procstat"}
 	pConfig.Tags = make(map[string]string)
 
 	assert.Equal(t, pstat, c.Inputs[3].Input,

--- a/internal/models/filter.go
+++ b/internal/models/filter.go
@@ -3,8 +3,8 @@ package models
 import (
 	"strings"
 
-	"github.com/influxdata/influxdb/client/v2"
 	"github.com/influxdata/telegraf/internal"
+	emodels "github.com/influxdata/telegraf/models"
 )
 
 // TagFilter is the name of a tag, and the values on which to filter
@@ -24,8 +24,8 @@ type Filter struct {
 	IsActive bool
 }
 
-func (f Filter) ShouldPointPass(point *client.Point) bool {
-	if f.ShouldPass(point.Name()) && f.ShouldTagsPass(point.Tags()) {
+func (f Filter) ShouldPointPass(metric emodels.Metric) bool {
+	if f.ShouldPass(metric.Name()) && f.ShouldTagsPass(metric.Tags()) {
 		return true
 	}
 	return false

--- a/models/accumulator.go
+++ b/models/accumulator.go
@@ -1,0 +1,18 @@
+package models
+
+import "time"
+
+type Accumulator interface {
+	// Create a point with a value, decorating it with tags
+	// NOTE: tags is expected to be owned by the caller, don't mutate
+	// it after passing to Add.
+	Add(measurement string,
+		value interface{},
+		tags map[string]string,
+		t ...time.Time)
+
+	AddFields(measurement string,
+		fields map[string]interface{},
+		tags map[string]string,
+		t ...time.Time)
+}

--- a/models/input.go
+++ b/models/input.go
@@ -1,0 +1,31 @@
+package models
+
+type Input interface {
+	// SampleConfig returns the default configuration of the Input
+	SampleConfig() string
+
+	// Description returns a one-sentence description on the Input
+	Description() string
+
+	// Gather takes in an accumulator and adds the metrics that the Input
+	// gathers. This is called every "interval"
+	Gather(Accumulator) error
+}
+
+type ServiceInput interface {
+	// SampleConfig returns the default configuration of the Input
+	SampleConfig() string
+
+	// Description returns a one-sentence description on the Input
+	Description() string
+
+	// Gather takes in an accumulator and adds the metrics that the Input
+	// gathers. This is called every "interval"
+	Gather(Accumulator) error
+
+	// Start starts the ServiceInput's service, whatever that may be
+	Start() error
+
+	// Stop stops the services and closes any necessary channels and connections
+	Stop()
+}

--- a/models/metric.go
+++ b/models/metric.go
@@ -28,6 +28,9 @@ type Metric interface {
 
 	// PrecisionString returns a line-protocol string of the metric, at precision
 	PrecisionString(precison string) string
+
+	// Point returns a influxdb client.Point object
+	Point() *client.Point
 }
 
 // metric is a wrapper of the influxdb client.Point struct
@@ -102,4 +105,8 @@ func (m *metric) String() string {
 
 func (m *metric) PrecisionString(precison string) string {
 	return m.pt.PrecisionString(precison)
+}
+
+func (m *metric) Point() *client.Point {
+	return m.pt
 }

--- a/models/metric.go
+++ b/models/metric.go
@@ -1,0 +1,105 @@
+package models
+
+import (
+	"time"
+
+	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/influxdb/models"
+)
+
+type Metric interface {
+	// Name returns the measurement name of the metric
+	Name() string
+
+	// Name returns the tags associated with the metric
+	Tags() map[string]string
+
+	// Time return the timestamp for the metric
+	Time() time.Time
+
+	// UnixNano returns the unix nano time of the metric
+	UnixNano() int64
+
+	// Fields returns the fields for the metric
+	Fields() map[string]interface{}
+
+	// String returns a line-protocol string of the metric
+	String() string
+
+	// PrecisionString returns a line-protocol string of the metric, at precision
+	PrecisionString(precison string) string
+}
+
+// metric is a wrapper of the influxdb client.Point struct
+type metric struct {
+	pt *client.Point
+}
+
+// NewMetric returns a metric with the given timestamp. If a timestamp is not
+// given, then data is sent to the database without a timestamp, in which case
+// the server will assign local time upon reception. NOTE: it is recommended to
+// send data with a timestamp.
+func NewMetric(
+	name string,
+	tags map[string]string,
+	fields map[string]interface{},
+	t ...time.Time,
+) (Metric, error) {
+	var T time.Time
+	if len(t) > 0 {
+		T = t[0]
+	}
+
+	pt, err := client.NewPoint(name, tags, fields, T)
+	if err != nil {
+		return nil, err
+	}
+	return &metric{
+		pt: pt,
+	}, nil
+}
+
+// ParseMetrics returns a slice of Metrics from a text representation of a
+// metric (in line-protocol format)
+// with each metric separated by newlines. If any metrics fail to parse,
+// a non-nil error will be returned in addition to the metrics that parsed
+// successfully.
+func ParseMetrics(buf []byte) ([]Metric, error) {
+	points, err := models.ParsePoints(buf)
+	metrics := make([]Metric, len(points))
+	for i, point := range points {
+		// Ignore error here because it's impossible that a model.Point
+		// wouldn't parse into client.Point properly
+		metrics[i], _ = NewMetric(point.Name(), point.Tags(),
+			point.Fields(), point.Time())
+	}
+	return metrics, err
+}
+
+func (m *metric) Name() string {
+	return m.pt.Name()
+}
+
+func (m *metric) Tags() map[string]string {
+	return m.pt.Tags()
+}
+
+func (m *metric) Time() time.Time {
+	return m.pt.Time()
+}
+
+func (m *metric) UnixNano() int64 {
+	return m.pt.UnixNano()
+}
+
+func (m *metric) Fields() map[string]interface{} {
+	return m.pt.Fields()
+}
+
+func (m *metric) String() string {
+	return m.pt.String()
+}
+
+func (m *metric) PrecisionString(precison string) string {
+	return m.pt.PrecisionString(precison)
+}

--- a/models/output.go
+++ b/models/output.go
@@ -1,0 +1,31 @@
+package models
+
+type Output interface {
+	// Connect to the Output
+	Connect() error
+	// Close any connections to the Output
+	Close() error
+	// Description returns a one-sentence description on the Output
+	Description() string
+	// SampleConfig returns the default configuration of the Output
+	SampleConfig() string
+	// Write takes in group of points to be written to the Output
+	Write(metrics []*Metric) error
+}
+
+type ServiceOutput interface {
+	// Connect to the Output
+	Connect() error
+	// Close any connections to the Output
+	Close() error
+	// Description returns a one-sentence description on the Output
+	Description() string
+	// SampleConfig returns the default configuration of the Output
+	SampleConfig() string
+	// Write takes in group of points to be written to the Output
+	Write(metrics []*Metric) error
+	// Start the "service" that will provide an Output
+	Start() error
+	// Stop the "service" that will provide an Output
+	Stop()
+}

--- a/models/output.go
+++ b/models/output.go
@@ -10,7 +10,7 @@ type Output interface {
 	// SampleConfig returns the default configuration of the Output
 	SampleConfig() string
 	// Write takes in group of points to be written to the Output
-	Write(metrics []*Metric) error
+	Write(metrics []Metric) error
 }
 
 type ServiceOutput interface {
@@ -23,7 +23,7 @@ type ServiceOutput interface {
 	// SampleConfig returns the default configuration of the Output
 	SampleConfig() string
 	// Write takes in group of points to be written to the Output
-	Write(metrics []*Metric) error
+	Write(metrics []Metric) error
 	// Start the "service" that will provide an Output
 	Start() error
 	// Stop the "service" that will provide an Output

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/influxdata/telegraf/testutil"
 
-	//	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSNMPErrorGet1(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	get1 := Data{
 		Name: "oid1",
 		Unit: "octets",
@@ -30,6 +32,9 @@ func TestSNMPErrorGet1(t *testing.T) {
 }
 
 func TestSNMPErrorGet2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	get1 := Data{
 		Name: "oid1",
 		Unit: "octets",
@@ -49,6 +54,9 @@ func TestSNMPErrorGet2(t *testing.T) {
 }
 
 func TestSNMPErrorBulk(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	bulk1 := Data{
 		Name: "oid1",
 		Unit: "octets",
@@ -69,13 +77,16 @@ func TestSNMPErrorBulk(t *testing.T) {
 }
 
 func TestSNMPGet1(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	get1 := Data{
 		Name: "oid1",
 		Unit: "octets",
 		Oid:  ".1.3.6.1.2.1.2.2.1.16.1",
 	}
 	h := Host{
-		Address:   "127.0.0.1:31161",
+		Address:   testutil.GetLocalHost() + ":31161",
 		Community: "telegraf",
 		Version:   2,
 		Timeout:   2.0,
@@ -104,12 +115,15 @@ func TestSNMPGet1(t *testing.T) {
 }
 
 func TestSNMPGet2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	get1 := Data{
 		Name: "oid1",
 		Oid:  "ifNumber",
 	}
 	h := Host{
-		Address:   "127.0.0.1:31161",
+		Address:   testutil.GetLocalHost() + ":31161",
 		Community: "telegraf",
 		Version:   2,
 		Timeout:   2.0,
@@ -139,6 +153,9 @@ func TestSNMPGet2(t *testing.T) {
 }
 
 func TestSNMPGet3(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	get1 := Data{
 		Name:     "oid1",
 		Unit:     "octets",
@@ -146,7 +163,7 @@ func TestSNMPGet3(t *testing.T) {
 		Instance: "1",
 	}
 	h := Host{
-		Address:   "127.0.0.1:31161",
+		Address:   testutil.GetLocalHost() + ":31161",
 		Community: "telegraf",
 		Version:   2,
 		Timeout:   2.0,
@@ -177,6 +194,9 @@ func TestSNMPGet3(t *testing.T) {
 }
 
 func TestSNMPEasyGet4(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	get1 := Data{
 		Name:     "oid1",
 		Unit:     "octets",
@@ -184,7 +204,7 @@ func TestSNMPEasyGet4(t *testing.T) {
 		Instance: "1",
 	}
 	h := Host{
-		Address:   "127.0.0.1:31161",
+		Address:   testutil.GetLocalHost() + ":31161",
 		Community: "telegraf",
 		Version:   2,
 		Timeout:   2.0,
@@ -227,6 +247,9 @@ func TestSNMPEasyGet4(t *testing.T) {
 }
 
 func TestSNMPEasyGet5(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	get1 := Data{
 		Name:     "oid1",
 		Unit:     "octets",
@@ -234,7 +257,7 @@ func TestSNMPEasyGet5(t *testing.T) {
 		Instance: "1",
 	}
 	h := Host{
-		Address:   "127.0.0.1:31161",
+		Address:   testutil.GetLocalHost() + ":31161",
 		Community: "telegraf",
 		Version:   2,
 		Timeout:   2.0,
@@ -277,8 +300,11 @@ func TestSNMPEasyGet5(t *testing.T) {
 }
 
 func TestSNMPEasyGet6(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	h := Host{
-		Address:   "127.0.0.1:31161",
+		Address:   testutil.GetLocalHost() + ":31161",
 		Community: "telegraf",
 		Version:   2,
 		Timeout:   2.0,
@@ -307,6 +333,9 @@ func TestSNMPEasyGet6(t *testing.T) {
 }
 
 func TestSNMPBulk1(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	bulk1 := Data{
 		Name:          "oid1",
 		Unit:          "octets",
@@ -314,7 +343,7 @@ func TestSNMPBulk1(t *testing.T) {
 		MaxRepetition: 2,
 	}
 	h := Host{
-		Address:   "127.0.0.1:31161",
+		Address:   testutil.GetLocalHost() + ":31161",
 		Community: "telegraf",
 		Version:   2,
 		Timeout:   2.0,
@@ -385,6 +414,9 @@ func TestSNMPBulk1(t *testing.T) {
 // bash scripts/circle-test.sh died unexpectedly
 // Maybe the test is too long ??
 func dTestSNMPBulk2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	bulk1 := Data{
 		Name:          "oid1",
 		Unit:          "octets",
@@ -392,7 +424,7 @@ func dTestSNMPBulk2(t *testing.T) {
 		MaxRepetition: 2,
 	}
 	h := Host{
-		Address:   "127.0.0.1:31161",
+		Address:   testutil.GetLocalHost() + ":31161",
 		Community: "telegraf",
 		Version:   2,
 		Timeout:   2.0,

--- a/plugins/outputs/amon/amon_test.go
+++ b/plugins/outputs/amon/amon_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/influxdata/telegraf/testutil"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 )
 
 func TestBuildPoint(t *testing.T) {
 	var tagtests = []struct {
-		ptIn  *client.Point
+		ptIn  models.Metric
 		outPt Point
 		err   error
 	}{

--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/streadway/amqp"
 )
@@ -149,7 +149,7 @@ func (q *AMQP) Description() string {
 	return "Configuration for the AMQP server to send metrics to"
 }
 
-func (q *AMQP) Write(points []*client.Point) error {
+func (q *AMQP) Write(points []models.Metric) error {
 	q.Lock()
 	defer q.Unlock()
 	if len(points) == 0 {
@@ -190,7 +190,7 @@ func (q *AMQP) Write(points []*client.Point) error {
 }
 
 func init() {
-	outputs.Add("amqp", func() outputs.Output {
+	outputs.Add("amqp", func() models.Output {
 		return &AMQP{
 			Database:        DefaultDatabase,
 			Precision:       DefaultPrecision,

--- a/plugins/outputs/amqp/amqp_test.go
+++ b/plugins/outputs/amqp/amqp_test.go
@@ -23,6 +23,6 @@ func TestConnectAndWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that we can successfully write data to the amqp broker
-	err = q.Write(testutil.MockBatchPoints().Points())
+	err = q.Write(testutil.MockBatchPoints())
 	require.NoError(t, err)
 }

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -72,7 +72,7 @@ func (c *CloudWatch) Close() error {
 	return nil
 }
 
-func (c *CloudWatch) Write(points []*client.Point) error {
+func (c *CloudWatch) Write(points []models.Metric) error {
 	for _, pt := range points {
 		err := c.WriteSinglePoint(pt)
 		if err != nil {
@@ -86,7 +86,7 @@ func (c *CloudWatch) Write(points []*client.Point) error {
 // Write data for a single point. A point can have many fields and one field
 // is equal to one MetricDatum. There is a limit on how many MetricDatums a
 // request can have so we process one Point at a time.
-func (c *CloudWatch) WriteSinglePoint(point *client.Point) error {
+func (c *CloudWatch) WriteSinglePoint(point models.Metric) error {
 	datums := BuildMetricDatum(point)
 
 	const maxDatumsPerCall = 20 // PutMetricData only supports up to 20 data points per call
@@ -143,7 +143,7 @@ func PartitionDatums(size int, datums []*cloudwatch.MetricDatum) [][]*cloudwatch
 
 // Make a MetricDatum for each field in a Point. Only fields with values that can be
 // converted to float64 are supported. Non-supported fields are skipped.
-func BuildMetricDatum(point *client.Point) []*cloudwatch.MetricDatum {
+func BuildMetricDatum(point models.Metric) []*cloudwatch.MetricDatum {
 	datums := make([]*cloudwatch.MetricDatum, len(point.Fields()))
 	i := 0
 
@@ -230,7 +230,7 @@ func BuildDimensions(ptTags map[string]string) []*cloudwatch.Dimension {
 }
 
 func init() {
-	outputs.Add("cloudwatch", func() outputs.Output {
+	outputs.Add("cloudwatch", func() models.Output {
 		return &CloudWatch{}
 	})
 }

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/testutil"
 
 	"github.com/stretchr/testify/assert"
@@ -51,7 +51,7 @@ func TestBuildDimensions(t *testing.T) {
 func TestBuildMetricDatums(t *testing.T) {
 	assert := assert.New(t)
 
-	validPoints := []*client.Point{
+	validPoints := []models.Metric{
 		testutil.TestPoint(1),
 		testutil.TestPoint(int32(1)),
 		testutil.TestPoint(int64(1)),

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/influxdata/telegraf/testutil"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +38,7 @@ func TestUriOverride(t *testing.T) {
 	d.Apikey = "123456"
 	err := d.Connect()
 	require.NoError(t, err)
-	err = d.Write(testutil.MockBatchPoints().Points())
+	err = d.Write(testutil.MockBatchPoints())
 	require.NoError(t, err)
 }
 
@@ -57,7 +57,7 @@ func TestBadStatusCode(t *testing.T) {
 	d.Apikey = "123456"
 	err := d.Connect()
 	require.NoError(t, err)
-	err = d.Write(testutil.MockBatchPoints().Points())
+	err = d.Write(testutil.MockBatchPoints())
 	if err == nil {
 		t.Errorf("error expected but none returned")
 	} else {
@@ -100,7 +100,7 @@ func TestBuildTags(t *testing.T) {
 
 func TestBuildPoint(t *testing.T) {
 	var tagtests = []struct {
-		ptIn  *client.Point
+		ptIn  models.Metric
 		outPt Point
 		err   error
 	}{

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -3,7 +3,7 @@ package graphite
 import (
 	"errors"
 	"fmt"
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"log"
 	"math/rand"
@@ -67,7 +67,7 @@ func (g *Graphite) Description() string {
 
 // Choose a random server in the cluster to write to until a successful write
 // occurs, logging each unsuccessful. If all servers fail, return error.
-func (g *Graphite) Write(points []*client.Point) error {
+func (g *Graphite) Write(points []models.Metric) error {
 	// Prepare data
 	var bp []string
 	for _, point := range points {
@@ -128,7 +128,7 @@ func (g *Graphite) Write(points []*client.Point) error {
 }
 
 func init() {
-	outputs.Add("graphite", func() outputs.Output {
+	outputs.Add("graphite", func() models.Output {
 		return &Graphite{}
 	})
 }

--- a/plugins/outputs/graphite/graphite_test.go
+++ b/plugins/outputs/graphite/graphite_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,14 +21,14 @@ func TestGraphiteError(t *testing.T) {
 		Prefix:  "my.prefix",
 	}
 	// Init points
-	pt1, _ := client.NewPoint(
+	pt1, _ := models.NewMetric(
 		"mymeasurement",
 		map[string]string{"host": "192.168.0.1"},
 		map[string]interface{}{"mymeasurement": float64(3.14)},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 	// Prepare point list
-	var points []*client.Point
+	var points []models.Metric
 	points = append(points, pt1)
 	// Error
 	err1 := g.Connect()
@@ -45,26 +45,26 @@ func TestGraphiteOK(t *testing.T) {
 		Prefix: "my.prefix",
 	}
 	// Init points
-	pt1, _ := client.NewPoint(
+	pt1, _ := models.NewMetric(
 		"mymeasurement",
 		map[string]string{"host": "192.168.0.1"},
 		map[string]interface{}{"mymeasurement": float64(3.14)},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-	pt2, _ := client.NewPoint(
+	pt2, _ := models.NewMetric(
 		"mymeasurement",
 		map[string]string{"host": "192.168.0.1"},
 		map[string]interface{}{"value": float64(3.14)},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-	pt3, _ := client.NewPoint(
+	pt3, _ := models.NewMetric(
 		"my_measurement",
 		map[string]string{"host": "192.168.0.1"},
 		map[string]interface{}{"value": float64(3.14)},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 	// Prepare point list
-	var points []*client.Point
+	var points []models.Metric
 	points = append(points, pt1)
 	points = append(points, pt2)
 	points = append(points, pt3)

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/influxdb/client/v2"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
+
+	"github.com/influxdata/influxdb/client/v2"
 )
 
 type InfluxDB struct {
@@ -130,14 +132,14 @@ func (i *InfluxDB) Description() string {
 
 // Choose a random server in the cluster to write to until a successful write
 // occurs, logging each unsuccessful. If all servers fail, return error.
-func (i *InfluxDB) Write(points []*client.Point) error {
+func (i *InfluxDB) Write(metrics []models.Metric) error {
 	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
 		Database:  i.Database,
 		Precision: i.Precision,
 	})
 
-	for _, point := range points {
-		bp.AddPoint(point)
+	for _, metric := range metrics {
+		bp.AddPoint(metric.Point())
 	}
 
 	// This will get set to nil if a successful write occurs
@@ -156,7 +158,7 @@ func (i *InfluxDB) Write(points []*client.Point) error {
 }
 
 func init() {
-	outputs.Add("influxdb", func() outputs.Output {
+	outputs.Add("influxdb", func() models.Output {
 		return &InfluxDB{}
 	})
 }

--- a/plugins/outputs/influxdb/influxdb_test.go
+++ b/plugins/outputs/influxdb/influxdb_test.go
@@ -18,7 +18,7 @@ func TestUDPInflux(t *testing.T) {
 
 	err := i.Connect()
 	require.NoError(t, err)
-	err = i.Write(testutil.MockBatchPoints().Points())
+	err = i.Write(testutil.MockBatchPoints())
 	require.NoError(t, err)
 }
 
@@ -36,6 +36,6 @@ func TestHTTPInflux(t *testing.T) {
 
 	err := i.Connect()
 	require.NoError(t, err)
-	err = i.Write(testutil.MockBatchPoints().Points())
+	err = i.Write(testutil.MockBatchPoints())
 	require.NoError(t, err)
 }

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Shopify/sarama"
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"io/ioutil"
 )
@@ -112,7 +112,7 @@ func (k *Kafka) Description() string {
 	return "Configuration for the Kafka server to send metrics to"
 }
 
-func (k *Kafka) Write(points []*client.Point) error {
+func (k *Kafka) Write(points []models.Metric) error {
 	if len(points) == 0 {
 		return nil
 	}
@@ -140,7 +140,7 @@ func (k *Kafka) Write(points []*client.Point) error {
 }
 
 func init() {
-	outputs.Add("kafka", func() outputs.Output {
+	outputs.Add("kafka", func() models.Output {
 		return &Kafka{}
 	})
 }

--- a/plugins/outputs/kafka/kafka_test.go
+++ b/plugins/outputs/kafka/kafka_test.go
@@ -23,6 +23,6 @@ func TestConnectAndWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that we can successfully write data to the kafka broker
-	err = k.Write(testutil.MockBatchPoints().Points())
+	err = k.Write(testutil.MockBatchPoints())
 	require.NoError(t, err)
 }

--- a/plugins/outputs/kinesis/kinesis.go
+++ b/plugins/outputs/kinesis/kinesis.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -103,7 +103,7 @@ func (k *KinesisOutput) Close() error {
 	return nil
 }
 
-func FormatMetric(k *KinesisOutput, point *client.Point) (string, error) {
+func FormatMetric(k *KinesisOutput, point models.Metric) (string, error) {
 	if k.Format == "string" {
 		return point.String(), nil
 	} else {
@@ -138,7 +138,7 @@ func writekinesis(k *KinesisOutput, r []*kinesis.PutRecordsRequestEntry) time.Du
 	return time.Since(start)
 }
 
-func (k *KinesisOutput) Write(points []*client.Point) error {
+func (k *KinesisOutput) Write(points []models.Metric) error {
 	var sz uint32 = 0
 
 	if len(points) == 0 {
@@ -172,7 +172,7 @@ func (k *KinesisOutput) Write(points []*client.Point) error {
 }
 
 func init() {
-	outputs.Add("kinesis", func() outputs.Output {
+	outputs.Add("kinesis", func() models.Output {
 		return &KinesisOutput{}
 	})
 }

--- a/plugins/outputs/kinesis/kinesis_test.go
+++ b/plugins/outputs/kinesis/kinesis_test.go
@@ -15,7 +15,7 @@ func TestFormatMetric(t *testing.T) {
 		Format: "string",
 	}
 
-	p := testutil.MockBatchPoints().Points()[0]
+	p := testutil.MockBatchPoints()[0]
 
 	valid_string := "test1,tag1=value1 value=1 1257894000000000000"
 	func_string, err := FormatMetric(k, p)

--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/influxdata/influxdb/client/v2"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -69,7 +69,7 @@ func (l *Librato) Connect() error {
 	return nil
 }
 
-func (l *Librato) Write(points []*client.Point) error {
+func (l *Librato) Write(points []models.Metric) error {
 	if len(points) == 0 {
 		return nil
 	}
@@ -122,7 +122,7 @@ func (l *Librato) Description() string {
 	return "Configuration for Librato API to send metrics to."
 }
 
-func (l *Librato) buildGauges(pt *client.Point) ([]*Gauge, error) {
+func (l *Librato) buildGauges(pt models.Metric) ([]*Gauge, error) {
 	gauges := []*Gauge{}
 	for fieldName, value := range pt.Fields() {
 		gauge := &Gauge{
@@ -169,7 +169,7 @@ func (l *Librato) Close() error {
 }
 
 func init() {
-	outputs.Add("librato", func() outputs.Output {
+	outputs.Add("librato", func() models.Output {
 		return NewLibrato(librato_api)
 	})
 }

--- a/plugins/outputs/librato/librato_test.go
+++ b/plugins/outputs/librato/librato_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/influxdata/telegraf/testutil"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +39,7 @@ func TestUriOverride(t *testing.T) {
 	l.ApiToken = "123456"
 	err := l.Connect()
 	require.NoError(t, err)
-	err = l.Write(testutil.MockBatchPoints().Points())
+	err = l.Write(testutil.MockBatchPoints())
 	require.NoError(t, err)
 }
 
@@ -61,7 +61,7 @@ func TestBadStatusCode(t *testing.T) {
 	l.ApiToken = "123456"
 	err := l.Connect()
 	require.NoError(t, err)
-	err = l.Write(testutil.MockBatchPoints().Points())
+	err = l.Write(testutil.MockBatchPoints())
 	if err == nil {
 		t.Errorf("error expected but none returned")
 	} else {
@@ -71,7 +71,7 @@ func TestBadStatusCode(t *testing.T) {
 
 func TestBuildGauge(t *testing.T) {
 	var gaugeTests = []struct {
-		ptIn     *client.Point
+		ptIn     models.Metric
 		outGauge *Gauge
 		err      error
 	}{
@@ -161,20 +161,20 @@ func TestBuildGauge(t *testing.T) {
 }
 
 func TestBuildGaugeWithSource(t *testing.T) {
-	pt1, _ := client.NewPoint(
+	pt1, _ := models.NewMetric(
 		"test1",
 		map[string]string{"hostname": "192.168.0.1"},
 		map[string]interface{}{"value": 0.0},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-	pt2, _ := client.NewPoint(
+	pt2, _ := models.NewMetric(
 		"test2",
 		map[string]string{"hostnam": "192.168.0.1"},
 		map[string]interface{}{"value": 1.0},
 		time.Date(2010, time.December, 10, 23, 0, 0, 0, time.UTC),
 	)
 	var gaugeTests = []struct {
-		ptIn     *client.Point
+		ptIn     models.Metric
 		outGauge *Gauge
 		err      error
 	}{

--- a/plugins/outputs/mqtt/mqtt.go
+++ b/plugins/outputs/mqtt/mqtt.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 
 	paho "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
-	"github.com/influxdata/influxdb/client/v2"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -78,7 +78,7 @@ func (m *MQTT) Description() string {
 	return "Configuration for MQTT server to send metrics to"
 }
 
-func (m *MQTT) Write(points []*client.Point) error {
+func (m *MQTT) Write(points []models.Metric) error {
 	m.Lock()
 	defer m.Unlock()
 	if len(points) == 0 {
@@ -184,7 +184,7 @@ func getCertPool(pemPath string) (*x509.CertPool, error) {
 }
 
 func init() {
-	outputs.Add("mqtt", func() outputs.Output {
+	outputs.Add("mqtt", func() models.Output {
 		return &MQTT{}
 	})
 }

--- a/plugins/outputs/mqtt/mqtt_test.go
+++ b/plugins/outputs/mqtt/mqtt_test.go
@@ -22,6 +22,6 @@ func TestConnectAndWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that we can successfully write data to the mqtt broker
-	err = m.Write(testutil.MockBatchPoints().Points())
+	err = m.Write(testutil.MockBatchPoints())
 	require.NoError(t, err)
 }

--- a/plugins/outputs/nsq/nsq.go
+++ b/plugins/outputs/nsq/nsq.go
@@ -2,7 +2,7 @@ package nsq
 
 import (
 	"fmt"
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/nsqio/go-nsq"
 )
@@ -45,7 +45,7 @@ func (n *NSQ) Description() string {
 	return "Send telegraf measurements to NSQD"
 }
 
-func (n *NSQ) Write(points []*client.Point) error {
+func (n *NSQ) Write(points []models.Metric) error {
 	if len(points) == 0 {
 		return nil
 	}
@@ -65,7 +65,7 @@ func (n *NSQ) Write(points []*client.Point) error {
 }
 
 func init() {
-	outputs.Add("nsq", func() outputs.Output {
+	outputs.Add("nsq", func() models.Output {
 		return &NSQ{}
 	})
 }

--- a/plugins/outputs/nsq/nsq_test.go
+++ b/plugins/outputs/nsq/nsq_test.go
@@ -23,6 +23,6 @@ func TestConnectAndWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that we can successfully write data to the NSQ daemon
-	err = n.Write(testutil.MockBatchPoints().Points())
+	err = n.Write(testutil.MockBatchPoints())
 	require.NoError(t, err)
 }

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -58,7 +58,7 @@ func (o *OpenTSDB) Connect() error {
 	return nil
 }
 
-func (o *OpenTSDB) Write(points []*client.Point) error {
+func (o *OpenTSDB) Write(points []models.Metric) error {
 	if len(points) == 0 {
 		return nil
 	}
@@ -101,7 +101,7 @@ func buildTags(ptTags map[string]string) []string {
 	return tags
 }
 
-func buildMetrics(pt *client.Point, now time.Time, prefix string) []*MetricLine {
+func buildMetrics(pt models.Metric, now time.Time, prefix string) []*MetricLine {
 	ret := []*MetricLine{}
 	for fieldName, value := range pt.Fields() {
 		metric := &MetricLine{
@@ -162,7 +162,7 @@ func (o *OpenTSDB) Close() error {
 }
 
 func init() {
-	outputs.Add("opentsdb", func() outputs.Output {
+	outputs.Add("opentsdb", func() models.Output {
 		return &OpenTSDB{}
 	})
 }

--- a/plugins/outputs/opentsdb/opentsdb_test.go
+++ b/plugins/outputs/opentsdb/opentsdb_test.go
@@ -54,18 +54,18 @@ func TestWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that we can successfully write data to OpenTSDB
-	err = o.Write(testutil.MockBatchPoints().Points())
+	err = o.Write(testutil.MockBatchPoints())
 	require.NoError(t, err)
 
 	// Verify postive and negative test cases of writing data
 	bp := testutil.MockBatchPoints()
-	bp.AddPoint(testutil.TestPoint(float64(1.0), "justametric.float"))
-	bp.AddPoint(testutil.TestPoint(int64(123456789), "justametric.int"))
-	bp.AddPoint(testutil.TestPoint(uint64(123456789012345), "justametric.uint"))
-	bp.AddPoint(testutil.TestPoint("Lorem Ipsum", "justametric.string"))
-	bp.AddPoint(testutil.TestPoint(float64(42.0), "justametric.anotherfloat"))
+	bp = append(bp, testutil.TestPoint(float64(1.0), "justametric.float"))
+	bp = append(bp, testutil.TestPoint(int64(123456789), "justametric.int"))
+	bp = append(bp, testutil.TestPoint(uint64(123456789012345), "justametric.uint"))
+	bp = append(bp, testutil.TestPoint("Lorem Ipsum", "justametric.string"))
+	bp = append(bp, testutil.TestPoint(float64(42.0), "justametric.anotherfloat"))
 
-	err = o.Write(bp.Points())
+	err = o.Write(bp)
 	require.NoError(t, err)
 
 }

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -58,7 +58,7 @@ func (p *PrometheusClient) Description() string {
 	return "Configuration for the Prometheus client to spawn"
 }
 
-func (p *PrometheusClient) Write(points []*client.Point) error {
+func (p *PrometheusClient) Write(points []models.Metric) error {
 	if len(points) == 0 {
 		return nil
 	}
@@ -119,7 +119,7 @@ func (p *PrometheusClient) Write(points []*client.Point) error {
 }
 
 func init() {
-	outputs.Add("prometheus_client", func() outputs.Output {
+	outputs.Add("prometheus_client", func() models.Output {
 		return &PrometheusClient{}
 	})
 }

--- a/plugins/outputs/prometheus_client/prometheus_client_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/inputs/prometheus"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -21,15 +21,15 @@ func TestPrometheusWritePointEmptyTag(t *testing.T) {
 		Urls: []string{"http://localhost:9126/metrics"},
 	}
 	tags := make(map[string]string)
-	pt1, _ := client.NewPoint(
+	pt1, _ := models.NewMetric(
 		"test_point_1",
 		tags,
 		map[string]interface{}{"value": 0.0})
-	pt2, _ := client.NewPoint(
+	pt2, _ := models.NewMetric(
 		"test_point_2",
 		tags,
 		map[string]interface{}{"value": 1.0})
-	var points = []*client.Point{
+	var points = []models.Metric{
 		pt1,
 		pt2,
 	}
@@ -63,15 +63,15 @@ func TestPrometheusWritePointTag(t *testing.T) {
 	}
 	tags := make(map[string]string)
 	tags["testtag"] = "testvalue"
-	pt1, _ := client.NewPoint(
+	pt1, _ := models.NewMetric(
 		"test_point_3",
 		tags,
 		map[string]interface{}{"value": 0.0})
-	pt2, _ := client.NewPoint(
+	pt2, _ := models.NewMetric(
 		"test_point_4",
 		tags,
 		map[string]interface{}{"value": 1.0})
-	var points = []*client.Point{
+	var points = []models.Metric{
 		pt1,
 		pt2,
 	}

--- a/plugins/outputs/registry.go
+++ b/plugins/outputs/registry.go
@@ -1,40 +1,10 @@
 package outputs
 
 import (
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 )
 
-type Output interface {
-	// Connect to the Output
-	Connect() error
-	// Close any connections to the Output
-	Close() error
-	// Description returns a one-sentence description on the Output
-	Description() string
-	// SampleConfig returns the default configuration of the Output
-	SampleConfig() string
-	// Write takes in group of points to be written to the Output
-	Write(points []*client.Point) error
-}
-
-type ServiceOutput interface {
-	// Connect to the Output
-	Connect() error
-	// Close any connections to the Output
-	Close() error
-	// Description returns a one-sentence description on the Output
-	Description() string
-	// SampleConfig returns the default configuration of the Output
-	SampleConfig() string
-	// Write takes in group of points to be written to the Output
-	Write(points []*client.Point) error
-	// Start the "service" that will provide an Output
-	Start() error
-	// Stop the "service" that will provide an Output
-	Stop()
-}
-
-type Creator func() Output
+type Creator func() models.Output
 
 var Outputs = map[string]Creator{}
 

--- a/plugins/outputs/riemann/riemann.go
+++ b/plugins/outputs/riemann/riemann.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/amir/raidman"
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -48,7 +48,7 @@ func (r *Riemann) Description() string {
 	return "Configuration for the Riemann server to send metrics to"
 }
 
-func (r *Riemann) Write(points []*client.Point) error {
+func (r *Riemann) Write(points []models.Metric) error {
 	if len(points) == 0 {
 		return nil
 	}
@@ -70,7 +70,7 @@ func (r *Riemann) Write(points []*client.Point) error {
 	return nil
 }
 
-func buildEvents(p *client.Point) []*raidman.Event {
+func buildEvents(p models.Metric) []*raidman.Event {
 	events := []*raidman.Event{}
 	for fieldName, value := range p.Fields() {
 		host, ok := p.Tags()["host"]
@@ -95,7 +95,7 @@ func buildEvents(p *client.Point) []*raidman.Event {
 }
 
 func init() {
-	outputs.Add("riemann", func() outputs.Output {
+	outputs.Add("riemann", func() models.Output {
 		return &Riemann{}
 	})
 }

--- a/plugins/outputs/riemann/riemann_test.go
+++ b/plugins/outputs/riemann/riemann_test.go
@@ -22,6 +22,6 @@ func TestConnectAndWrite(t *testing.T) {
 	err := r.Connect()
 	require.NoError(t, err)
 
-	err = r.Write(testutil.MockBatchPoints().Points())
+	err = r.Write(testutil.MockBatchPoints())
 	require.NoError(t, err)
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/telegraf/models"
 )
 
 var localhost = "localhost"
@@ -33,11 +33,11 @@ func GetLocalHost() string {
 
 // MockBatchPoints returns a mock BatchPoints object for using in unit tests
 // of telegraf output sinks.
-func MockBatchPoints() client.BatchPoints {
+func MockBatchPoints() []models.Metric {
 	// Create a new point batch
-	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{})
-	bp.AddPoint(TestPoint(1.0))
-	return bp
+	ret := []models.Metric{}
+	ret = append(ret, TestPoint(1.0))
+	return ret
 }
 
 // TestPoint Returns a simple test point:
@@ -45,7 +45,7 @@ func MockBatchPoints() client.BatchPoints {
 //     tags -> "tag1":"value1"
 //     value -> value
 //     time -> time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-func TestPoint(value interface{}, name ...string) *client.Point {
+func TestPoint(value interface{}, name ...string) models.Metric {
 	if value == nil {
 		panic("Cannot use a nil value")
 	}
@@ -54,7 +54,7 @@ func TestPoint(value interface{}, name ...string) *client.Point {
 		measurement = name[0]
 	}
 	tags := map[string]string{"tag1": "value1"}
-	pt, _ := client.NewPoint(
+	pt, _ := models.NewMetric(
 		measurement,
 		tags,
 		map[string]interface{}{"value": value},


### PR DESCRIPTION
As of now, this is pretty much just a wrapper around client.Point, but
this gives latitude to expand functionality more easily.

closes #564