### PR TITLE
RabbitMQ plugin - extra fields

### DIFF
--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -57,14 +57,14 @@ type ObjectTotals struct {
 }
 
 type QueueTotals struct {
-	Messages                    int64
-	MessagesReady               int64 `json:"messages_ready"`
-	MessagesUnacknowledged      int64 `json:"messages_unacknowledged"`
-	MessageBytes                int64 `json:"message_bytes"`
-	MessageBytesReady           int64 `json:"message_bytes_ready"`
-	MessageBytesUnacknowledged  int64 `json:"message_bytes_unacknowledged"`
-	MessageRam                  int64 `json:"message_bytes_ram"`
-	MessagePersistent           int64 `json:"message_bytes_persistent"`
+	Messages                   int64
+	MessagesReady              int64 `json:"messages_ready"`
+	MessagesUnacknowledged     int64 `json:"messages_unacknowledged"`
+	MessageBytes               int64 `json:"message_bytes"`
+	MessageBytesReady          int64 `json:"message_bytes_ready"`
+	MessageBytesUnacknowledged int64 `json:"message_bytes_unacknowledged"`
+	MessageRam                 int64 `json:"message_bytes_ram"`
+	MessagePersistent          int64 `json:"message_bytes_persistent"`
 }
 
 type Queue struct {

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -57,9 +57,14 @@ type ObjectTotals struct {
 }
 
 type QueueTotals struct {
-	Messages               int64
-	MessagesReady          int64 `json:"messages_ready"`
-	MessagesUnacknowledged int64 `json:"messages_unacknowledged"`
+	Messages                    int64
+	MessagesReady               int64 `json:"messages_ready"`
+	MessagesUnacknowledged      int64 `json:"messages_unacknowledged"`
+	MessageBytes                int64 `json:"message_bytes"`
+	MessageBytesReady           int64 `json:"message_bytes_ready"`
+	MessageBytesUnacknowledged  int64 `json:"message_bytes_unacknowledged"`
+	MessageRam                  int64 `json:"message_bytes_ram"`
+	MessagePersistent           int64 `json:"message_bytes_persistent"`
 }
 
 type Queue struct {
@@ -270,6 +275,11 @@ func gatherQueues(r *RabbitMQ, acc inputs.Accumulator, errChan chan error) {
 				"consumer_utilisation": queue.ConsumerUtilisation,
 				"memory":               queue.Memory,
 				// messages information
+				"message_bytes":             queue.MessageBytes,
+				"message_bytes_ready":       queue.MessageBytesReady,
+				"message_bytes_unacked":     queue.MessageBytesUnacknowledged,
+				"message_bytes_ram":         queue.MessageRam,
+				"message_bytes_persist":     queue.MessagePersistent,
 				"messages":                  queue.Messages,
 				"messages_ready":            queue.MessagesReady,
 				"messages_unack":            queue.MessagesUnacknowledged,

--- a/plugins/inputs/rabbitmq/rabbitmq_test.go
+++ b/plugins/inputs/rabbitmq/rabbitmq_test.go
@@ -407,12 +407,6 @@ func TestRabbitMQGeneratesMetrics(t *testing.T) {
 		"messages_ready",
 		"messages_unacked",
 
-		"message_bytes",
-		"message_bytes_ready",
-		"message_bytes_unacked",
-		"message_bytes_ram",
-		"message_bytes_persist",
-
 		"messages_acked",
 		"messages_delivered",
 		"messages_published",

--- a/plugins/inputs/rabbitmq/rabbitmq_test.go
+++ b/plugins/inputs/rabbitmq/rabbitmq_test.go
@@ -407,6 +407,12 @@ func TestRabbitMQGeneratesMetrics(t *testing.T) {
 		"messages_ready",
 		"messages_unacked",
 
+		"message_bytes",
+		"message_bytes_ready",
+		"message_bytes_unacked",
+		"message_bytes_ram",
+		"message_bytes_persist",
+
 		"messages_acked",
 		"messages_delivered",
 		"messages_published",


### PR DESCRIPTION
Extra fields describing size of all message bodies in the queue.
* message_bytes
* message_bytes_ready
* message_bytes_unacknowledged
* message_bytes_ram
* message_bytes_persistent

More information about each field:
https://www.rabbitmq.com/man/rabbitmqctl.1.man.html

Number of elements in the queue is not always a sufficient information about the queue.