### PR TITLE
statsd input plugin: Use a single measurement with fields for timings

### DIFF
--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -725,13 +725,13 @@ func TestParse_Timings(t *testing.T) {
 
 	s.Gather(acc)
 
-	valid := map[string]interface{} {
+	valid := map[string]interface{}{
 		"90_percentile": float64(11),
-		"count": int64(5),
-		"lower": float64(1),
-		"mean": float64(3),
-		"stddev": float64(4),
-		"upper": float64(11),
+		"count":         int64(5),
+		"lower":         float64(1),
+		"mean":          float64(3),
+		"stddev":        float64(4),
+		"upper":         float64(11),
 	}
 
 	acc.AssertContainsFields(t, "test_timing", valid)

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -710,7 +710,7 @@ func TestParse_Timings(t *testing.T) {
 	// Test that counters work
 	valid_lines := []string{
 		"test.timing:1|ms",
-		"test.timing:1|ms",
+		"test.timing:11|ms",
 		"test.timing:1|ms",
 		"test.timing:1|ms",
 		"test.timing:1|ms",
@@ -725,40 +725,17 @@ func TestParse_Timings(t *testing.T) {
 
 	s.Gather(acc)
 
-	tests := []struct {
-		name  string
-		value interface{}
-	}{
-		{
-			"test_timing_mean",
-			float64(1),
-		},
-		{
-			"test_timing_stddev",
-			float64(0),
-		},
-		{
-			"test_timing_upper",
-			float64(1),
-		},
-		{
-			"test_timing_lower",
-			float64(1),
-		},
-		{
-			"test_timing_count",
-			int64(5),
-		},
-		{
-			"test_timing_percentile_90",
-			float64(1),
-		},
+	valid := map[string]interface{} {
+		"90_percentile": float64(11),
+		"count": int64(5),
+		"lower": float64(1),
+		"mean": float64(3),
+		"stddev": float64(4),
+		"upper": float64(11),
 	}
 
-	for _, test := range tests {
-		acc.AssertContainsFields(t, test.name,
-			map[string]interface{}{"value": test.value})
-	}
+	acc.AssertContainsFields(t, "test_timing", valid)
+
 }
 
 func TestParse_Timings_Delete(t *testing.T) {


### PR DESCRIPTION
Currently, taking a "mytiming" timing produces at least 5 measurements with the prefixes: _mean, _stddev, _upper, _lower, _count. Additionally, it creates more, depending on the percentile setup.

This PR changes the gathering of these metrics to store appropriate values in their respective fields. This makes sure we create only one measurement.
