### PR TITLE
Fixing a bug in sampleConfig

### DIFF
--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -31,9 +31,9 @@ var sampleConfig string = `
     ObjectName = "Processor"
     Instances = ["*"]
     Counters = [
-      "% Idle Time", "% Interrupt Time",
-      "% Privileged Time", "% User Time",
-      "% Processor Time"
+      "%% Idle Time", "%% Interrupt Time",
+      "%% Privileged Time", "%% User Time",
+      "%% Processor Time"
     ]
     Measurement = "win_cpu"
     # Set to true to include _Total instance when querying for all (*).
@@ -46,8 +46,8 @@ var sampleConfig string = `
     ObjectName = "LogicalDisk"
     Instances = ["*"]
     Counters = [
-      "% Idle Time", "% Disk Time","% Disk Read Time",
-      "% Disk Write Time", "% User Time", "Current Disk Queue Length"
+      "%% Idle Time", "%% Disk Time","%% Disk Read Time",
+      "%% Disk Write Time", "%% User Time", "Current Disk Queue Length"
     ]
     Measurement = "win_disk"
 


### PR DESCRIPTION
@TheFlyingCorpse @sparrc: please review this bug fix. 
Replace all single percentage characters with double percentage charcters in sampleConfig string so that fmt.Printf will interpret them as literal percentage characters when running 'telegraf.exe -sample-config'