### PR TITLE
Objects missing caused an early return from configuration parsing

### DIFF
--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -136,7 +136,7 @@ func (m *Win_PerfCounters) InvalidObject(exists uint32, query string, PerfObject
 		if PerfObject.FailOnMissing {
 			err := errors.New("Performance object does not exist")
 			return err
-		} else if PerfObject.WarnOnMissing {
+		} else {
 			fmt.Printf("Performance Object '%s' does not exist in query: %s\n", PerfObject.ObjectName, query)
 		}
 	} else if exists == 3221228473 { //win.PDH_CSTATUS_NO_COUNTER
@@ -144,14 +144,14 @@ func (m *Win_PerfCounters) InvalidObject(exists uint32, query string, PerfObject
 		if PerfObject.FailOnMissing {
 			err := errors.New("Counter in Performance object does not exist")
 			return err
-		} else if PerfObject.WarnOnMissing {
+		} else {
 			fmt.Printf("Counter '%s' does not exist in query: %s\n", counter, query)
 		}
 	} else if exists == 2147485649 { //win.PDH_CSTATUS_NO_INSTANCE
 		if PerfObject.FailOnMissing {
 			err := errors.New("Instance in Performance object does not exist")
 			return err
-		} else if PerfObject.WarnOnMissing {
+		} else {
 			fmt.Printf("Instance '%s' does not exist in query: %s\n", instance, query)
 
 		}
@@ -199,8 +199,10 @@ func (m *Win_PerfCounters) ParseConfig(metrics *itemList) error {
 						m.AddItem(metrics, query, objectname, counter, instance,
 							PerfObject.Measurement, PerfObject.IncludeTotal)
 					} else {
-						err := m.InvalidObject(exists, query, PerfObject, instance, counter)
-						return err
+						if PerfObject.FailOnMissing || PerfObject.WarnOnMissing {
+							err := m.InvalidObject(exists, query, PerfObject, instance, counter)
+							return err
+						}
 					}
 				}
 			}

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -273,6 +273,56 @@ func TestWinPerfcountersConfigGet6(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestWinPerfcountersConfigGet7(t *testing.T) {
+	metrics := itemList{}
+
+	var instances = make([]string, 1)
+	var counters = make([]string, 3)
+	var perfobjects = make([]perfobject, 1)
+
+	objectname := "Processor Information"
+	instances[0] = "_Total"
+	counters[0] = "% Processor Time"
+	counters[1] = "% Processor TimeERROR"
+	counters[2] = "% Idle Time"
+
+	var measurement string = "test"
+	var warnonmissing bool = false
+	var failonmissing bool = false
+	var includetotal bool = false
+
+	PerfObject := perfobject{
+		ObjectName:    objectname,
+		Instances:     instances,
+		Counters:      counters,
+		Measurement:   measurement,
+		WarnOnMissing: warnonmissing,
+		FailOnMissing: failonmissing,
+		IncludeTotal:  includetotal,
+	}
+
+	perfobjects[0] = PerfObject
+
+	m := Win_PerfCounters{PrintValid: false, TestName: "ConfigGet7", Object: perfobjects}
+
+	err := m.ParseConfig(&metrics)
+	require.NoError(t, err)
+
+	if len(metrics.items) == 2 {
+		require.NoError(t, nil)
+	} else if len(metrics.items) < 2 {
+		var errorstring1 string = "Too few results returned from the query: " +
+			string(len(metrics.items))
+		err2 := errors.New(errorstring1)
+		require.NoError(t, err2)
+	} else if len(metrics.items) > 2 {
+		var errorstring1 string = "Too many results returned from the query: " +
+			string(len(metrics.items))
+		err2 := errors.New(errorstring1)
+		require.NoError(t, err2)
+	}
+}
+
 func TestWinPerfcountersConfigError1(t *testing.T) {
 	metrics := itemList{}
 


### PR DESCRIPTION
Corrected a issue that came from code cleanup earlier wherein missing performance counters caused it to return early from the loop, instead of ignoring missing in default configuration mode.