### PR TITLE
Fix a bug when setting host header in httpjson

### DIFF
--- a/plugins/inputs/httpjson/httpjson.go
+++ b/plugins/inputs/httpjson/httpjson.go
@@ -201,7 +201,11 @@ func (h *HttpJson) sendRequest(serverURL string) (string, float64, error) {
 
 	// Add header parameters
 	for k, v := range h.Headers {
-		req.Header.Add(k, v)
+		if strings.ToLower(k) == "host" {
+			req.Host = v
+		} else {
+			req.Header.Add(k, v)
+		}
 	}
 
 	start := time.Now()


### PR DESCRIPTION
When setting request Host Header with req.Header.Add(k, v) the host is ignored. The correct is to set req.Host = "value"