### PR TITLE
Fix issue 657 - support for super hero protocol(estatsd) (WIP)

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -525,7 +525,7 @@ func (s *Statsd) aggregate(m metric) {
 		} else {
 			s.gauges[m.hash].fields[m.field] = m.floatvalue
 		}
-	case "s":
+	case "s", "m", "mr":
 		// check if the measurement exists
 		_, ok := s.sets[m.hash]
 		if !ok {

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -324,7 +324,7 @@ func (s *Statsd) parseStatsdLine(line string) error {
 
 		// Validate metric type
 		switch pipesplit[1] {
-		case "g", "c", "s", "ms", "h":
+		case "g", "c", "s", "ms", "mr", "m", "h":
 			m.mtype = pipesplit[1]
 		default:
 			log.Printf("Error: Statsd Metric type %s unsupported", pipesplit[1])
@@ -348,7 +348,7 @@ func (s *Statsd) parseStatsdLine(line string) error {
 				return errors.New("Error Parsing statsd line")
 			}
 			m.floatvalue = v
-		case "c", "s":
+		case "c", "s", "m", "mr":
 			var v int64
 			v, err := strconv.ParseInt(pipesplit[0], 10, 64)
 			if err != nil {
@@ -382,6 +382,10 @@ func (s *Statsd) parseStatsdLine(line string) error {
 			m.tags["metric_type"] = "set"
 		case "ms":
 			m.tags["metric_type"] = "timing"
+		case "mr":
+			m.tags["metric_type"] = "micrometer"
+		case "m":
+			m.tags["metric_type"] = "meter"
 		case "h":
 			m.tags["metric_type"] = "histogram"
 		}

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -487,7 +487,7 @@ func (s *Statsd) aggregate(m metric) {
 			cached.stats.AddValue(m.floatvalue)
 			s.timings[m.hash] = cached
 		}
-	case "c":
+	case "c", "m":
 		// check if the measurement exists
 		_, ok := s.counters[m.hash]
 		if !ok {
@@ -525,7 +525,7 @@ func (s *Statsd) aggregate(m metric) {
 		} else {
 			s.gauges[m.hash].fields[m.field] = m.floatvalue
 		}
-	case "s", "m", "mr":
+	case "s", "mr":
 		// check if the measurement exists
 		_, ok := s.sets[m.hash]
 		if !ok {

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -18,6 +18,8 @@ func TestParse_InvalidLines(t *testing.T) {
 		"invalid.plus.minus.non.gauge:+10|c",
 		"invalid.plus.minus.non.gauge:+10|s",
 		"invalid.plus.minus.non.gauge:+10|ms",
+		"invalid.plus.minus.non.gauge:+10|mr",
+		"invalid.plus.minus.non.gauge:+10|m",
 		"invalid.plus.minus.non.gauge:+10|h",
 		"invalid.plus.minus.non.gauge:-10|c",
 		"invalid.value:foobar|c",
@@ -627,6 +629,8 @@ func TestParse_ValidLines(t *testing.T) {
 	valid_lines := []string{
 		"valid:45|c",
 		"valid:45|s",
+		"valid:45|m",
+		"valid:45|mr",
 		"valid:45|g",
 		"valid.timer:45|ms",
 		"valid.timer:45|h",


### PR DESCRIPTION
Support for [super hero metrics](https://github.com/chef/stats_hero#metrics-reported-to-estatsd) ([estatsd](https://github.com/b/statsd_spec))

Extanding unit types based on https://github.com/chef/estatsd/blob/master/src/estatsd_shp.erl#L79-L86

WIP - metrics are collected correctly but there is "unknown" for me line eg.: `1|167`(https://github.com/chef/stats_hero#metrics-reported-to-estatsd)