### PR TITLE
Change [tags] to [global_tags] to deal with toml bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bugfixes
 - [#443](https://github.com/influxdata/telegraf/issues/443): Fix Ping command timeout parameter on Linux.
+- [#662](https://github.com/influxdata/telegraf/pull/667): Change `[tags]` to `[global_tags]` to fix multiple-plugin tags bug.
 
 ## v0.10.2 [2016-02-04]
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -9,9 +9,9 @@ To generate a file with specific inputs and outputs, you can use the
 -input-filter and -output-filter flags:
 `telegraf -sample-config -input-filter cpu:mem:net:swap -output-filter influxdb:kafka`
 
-## `[tags]` Configuration
+## `[global_tags]` Configuration
 
-Global tags can be specific in the `[tags]` section of the config file in
+Global tags can be specific in the `[global_tags]` section of the config file in
 key="value" format. All metrics being gathered on this host will be tagged
 with the tags specified here.
 
@@ -76,7 +76,7 @@ measurements at a 10s interval and will collect per-cpu data, dropping any
 fields which begin with `time_`.
 
 ```toml
-[tags]
+[global_tags]
   dc = "denver-1"
 
 [agent]

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -10,7 +10,7 @@
 # file would generate.
 
 # Global tags can be specified here in key="value" format.
-[tags]
+[global_tags]
   # dc = "us-east-1" # will tag all metrics with dc=us-east-1
   # rack = "1a"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,7 +138,7 @@ var header = `# Telegraf configuration
 # file would generate.
 
 # Global tags can be specified here in key="value" format.
-[tags]
+[global_tags]
   # dc = "us-east-1" # will tag all metrics with dc=us-east-1
   # rack = "1a"
 
@@ -333,9 +333,9 @@ func (c *Config) LoadConfig(path string) error {
 				log.Printf("Could not parse [agent] config\n")
 				return err
 			}
-		case "tags":
+		case "global_tags", "tags":
 			if err = config.UnmarshalTable(subTable, c.Tags); err != nil {
-				log.Printf("Could not parse [tags] config\n")
+				log.Printf("Could not parse [global_tags] config\n")
 				return err
 			}
 		case "outputs":

--- a/internal/config/testdata/telegraf-agent.toml
+++ b/internal/config/testdata/telegraf-agent.toml
@@ -20,7 +20,7 @@
 # with 'required'. Be sure to edit those to make this configuration work.
 
 # Tags can also be specified via a normal map, but only one form at a time:
-[tags]
+[global_tags]
   dc = "us-east-1"
 
 # Configuration for telegraf agent


### PR DESCRIPTION
closes #662 

This is to workaround the following issue with the naoina toml parser: https://github.com/naoina/toml/issues/18