### PR TITLE
Add calculated cpu and memory percentages to docker input (via config option)

### DIFF
--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -22,7 +22,15 @@ for the stat structure can be found
   endpoint = "unix:///var/run/docker.sock"
   # Only collect metrics for these containers, collect all if empty
   container_names = []
+  calculate_percentages = false
 ```
+
+### Calculate Percentages
+
+Optionally percentages can be calculated for cpu and memory usage.  This uses
+the same calculation as the 'docker stats' command line tool.  Set this option
+to 'true' to enable this feature.
+
 
 ### Measurements & Fields:
 

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -22,15 +22,7 @@ for the stat structure can be found
   endpoint = "unix:///var/run/docker.sock"
   # Only collect metrics for these containers, collect all if empty
   container_names = []
-  calculate_percentages = false
 ```
-
-### Calculate Percentages
-
-Optionally percentages can be calculated for cpu and memory usage.  This uses
-the same calculation as the 'docker stats' command line tool.  Set this option
-to 'true' to enable this feature.
-
 
 ### Measurements & Fields:
 

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -18,7 +18,7 @@ func TestDockerGatherContainerStats(t *testing.T) {
 		"cont_name":  "redis",
 		"cont_image": "redis/image",
 	}
-	gatherContainerStats(stats, &acc, tags)
+	gatherContainerStats(stats, &acc, tags, false)
 
 	// test docker_net measurement
 	netfields := map[string]interface{}{
@@ -45,55 +45,13 @@ func TestDockerGatherContainerStats(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "docker_blkio", blkiofields, blkiotags)
 
 	// test docker_mem measurement
-	memfields := map[string]interface{}{
-		"max_usage":                 uint64(1001),
-		"usage":                     uint64(1111),
-		"fail_count":                uint64(1),
-		"limit":                     uint64(20),
-		"total_pgmafault":           uint64(0),
-		"cache":                     uint64(0),
-		"mapped_file":               uint64(0),
-		"total_inactive_file":       uint64(0),
-		"pgpgout":                   uint64(0),
-		"rss":                       uint64(0),
-		"total_mapped_file":         uint64(0),
-		"writeback":                 uint64(0),
-		"unevictable":               uint64(0),
-		"pgpgin":                    uint64(0),
-		"total_unevictable":         uint64(0),
-		"pgmajfault":                uint64(0),
-		"total_rss":                 uint64(44),
-		"total_rss_huge":            uint64(444),
-		"total_writeback":           uint64(55),
-		"total_inactive_anon":       uint64(0),
-		"rss_huge":                  uint64(0),
-		"hierarchical_memory_limit": uint64(0),
-		"total_pgfault":             uint64(0),
-		"total_active_file":         uint64(0),
-		"active_anon":               uint64(0),
-		"total_active_anon":         uint64(0),
-		"total_pgpgout":             uint64(0),
-		"total_cache":               uint64(0),
-		"inactive_anon":             uint64(0),
-		"active_file":               uint64(1),
-		"pgfault":                   uint64(2),
-		"inactive_file":             uint64(3),
-		"total_pgpgin":              uint64(4),
-	}
+	memfields := sample_mem_fields()
 	acc.AssertContainsTaggedFields(t, "docker_mem", memfields, tags)
 
 	// test docker_cpu measurement
 	cputags := copyTags(tags)
 	cputags["cpu"] = "cpu-total"
-	cpufields := map[string]interface{}{
-		"usage_total":                  uint64(500),
-		"usage_in_usermode":            uint64(100),
-		"usage_in_kernelmode":          uint64(200),
-		"usage_system":                 uint64(100),
-		"throttling_periods":           uint64(1),
-		"throttling_throttled_periods": uint64(0),
-		"throttling_throttled_time":    uint64(0),
-	}
+	cpufields := sample_cpu_fields()
 	acc.AssertContainsTaggedFields(t, "docker_cpu", cpufields, cputags)
 
 	cputags["cpu"] = "cpu0"
@@ -109,6 +67,30 @@ func TestDockerGatherContainerStats(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "docker_cpu", cpu1fields, cputags)
 }
 
+func TestDockerGatherContainerPercentages(t *testing.T) {
+	var acc testutil.Accumulator
+	stats := testStats()
+
+	tags := map[string]string{
+		"cont_id":    "foobarbaz",
+		"cont_name":  "redis",
+		"cont_image": "redis/image",
+	}
+	gatherContainerStats(stats, &acc, tags, true)
+
+	// test docker_mem measurement
+	memfields := sample_mem_fields()
+	memfields["usage_percent"] = 55.55
+	acc.AssertContainsTaggedFields(t, "docker_mem", memfields, tags)
+
+	// test docker_cpu measurement
+	cputags := copyTags(tags)
+	cputags["cpu"] = "cpu-total"
+	cpufields := sample_cpu_fields()
+	cpufields["usage_percent"] = 400.0
+	acc.AssertContainsTaggedFields(t, "docker_cpu", cpufields, cputags)
+}
+
 func testStats() *docker.Stats {
 	stats := &docker.Stats{
 		Read:     time.Now(),
@@ -121,6 +103,9 @@ func testStats() *docker.Stats {
 	stats.CPUStats.CPUUsage.UsageInKernelmode = 200
 	stats.CPUStats.SystemCPUUsage = 100
 	stats.CPUStats.ThrottlingData.Periods = 1
+
+	stats.PreCPUStats.CPUUsage.TotalUsage = 400
+	stats.PreCPUStats.SystemCPUUsage = 50
 
 	stats.MemoryStats.Stats.TotalPgmafault = 0
 	stats.MemoryStats.Stats.Cache = 0
@@ -155,7 +140,7 @@ func testStats() *docker.Stats {
 	stats.MemoryStats.MaxUsage = 1001
 	stats.MemoryStats.Usage = 1111
 	stats.MemoryStats.Failcnt = 1
-	stats.MemoryStats.Limit = 20
+	stats.MemoryStats.Limit = 2000
 
 	stats.Networks["eth0"] = docker.NetworkStats{
 		RxDropped: 1,
@@ -187,4 +172,59 @@ func testStats() *docker.Stats {
 		stats.BlkioStats.IOServicedRecursive, sr)
 
 	return stats
+}
+
+func sample_mem_fields() map[string]interface{} {
+
+	memfields := map[string]interface{}{
+		"max_usage":                 uint64(1001),
+		"usage":                     uint64(1111),
+		"fail_count":                uint64(1),
+		"limit":                     uint64(2000),
+		"total_pgmafault":           uint64(0),
+		"cache":                     uint64(0),
+		"mapped_file":               uint64(0),
+		"total_inactive_file":       uint64(0),
+		"pgpgout":                   uint64(0),
+		"rss":                       uint64(0),
+		"total_mapped_file":         uint64(0),
+		"writeback":                 uint64(0),
+		"unevictable":               uint64(0),
+		"pgpgin":                    uint64(0),
+		"total_unevictable":         uint64(0),
+		"pgmajfault":                uint64(0),
+		"total_rss":                 uint64(44),
+		"total_rss_huge":            uint64(444),
+		"total_writeback":           uint64(55),
+		"total_inactive_anon":       uint64(0),
+		"rss_huge":                  uint64(0),
+		"hierarchical_memory_limit": uint64(0),
+		"total_pgfault":             uint64(0),
+		"total_active_file":         uint64(0),
+		"active_anon":               uint64(0),
+		"total_active_anon":         uint64(0),
+		"total_pgpgout":             uint64(0),
+		"total_cache":               uint64(0),
+		"inactive_anon":             uint64(0),
+		"active_file":               uint64(1),
+		"pgfault":                   uint64(2),
+		"inactive_file":             uint64(3),
+		"total_pgpgin":              uint64(4),
+	}
+
+	return memfields
+}
+
+func sample_cpu_fields() map[string]interface{} {
+
+	cpufields := map[string]interface{}{
+		"usage_total":                  uint64(500),
+		"usage_in_usermode":            uint64(100),
+		"usage_in_kernelmode":          uint64(200),
+		"usage_system":                 uint64(100),
+		"throttling_periods":           uint64(1),
+		"throttling_throttled_periods": uint64(0),
+		"throttling_throttled_time":    uint64(0),
+	}
+	return cpufields
 }


### PR DESCRIPTION
I made this optional by adding config option.  Updated test data to give sensible percentages.