### PR TITLE
Add configuration management service

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -4,11 +4,13 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 
+	cfg "github.com/influxdata/config"
 	"github.com/influxdata/telegraf/agent"
 	"github.com/influxdata/telegraf/internal/config"
 	_ "github.com/influxdata/telegraf/plugins/inputs/all"
@@ -144,6 +146,13 @@ func main() {
 			c.OutputFilters = outputFilters
 			c.InputFilters = inputFilters
 			err = c.LoadConfig(*fConfig)
+
+			if c.Agent.ConfigPort != "" {
+				cf, _ := cfg.NewConfig(*fConfig, struct{}{})
+				log.Printf("Starting configuration management service on port %s\n", c.Agent.ConfigPort)
+				go http.ListenAndServe(c.Agent.ConfigPort, cf.HTTP())
+			}
+
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,9 @@ type AgentConfig struct {
 	// Quiet is the option for running in quiet mode
 	Quiet    bool
 	Hostname string
+
+	// ConfigPort is the location of the HTTP handlers for remotely changing config
+	ConfigPort string
 }
 
 // Inputs returns a list of strings of the configured inputs.
@@ -174,6 +177,9 @@ var header = `# Telegraf configuration
   quiet = false
   # Override default hostname, if empty use os.Hostname()
   hostname = ""
+
+	# Set configuration management port
+	config-port = ""
 
 
 ###############################################################################

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,9 +178,8 @@ var header = `# Telegraf configuration
   # Override default hostname, if empty use os.Hostname()
   hostname = ""
 
-	# Set configuration management port
-	config-port = ""
-
+  # Set configuration management port
+  config_port = ""
 
 ###############################################################################
 #                                  OUTPUTS                                    #


### PR DESCRIPTION
This sets up a configuration managemet service on a configureable port
(which itself is configureable by the configuration management
service!). It sets up an HTTP handler on this port whereby GETs to /
will deliver the current TOML configuration that Telegraf booted from.
POSTs to / will update that configuration. Telegraf can then be
restarted from the configuration by sending SIGHUP through existing
mechanisms.

This configuration management service is not authenticated in any way!
It is assumed that this service will only be available behind the
firewall.