### PR TITLE
pugins/outputs/influxdb: Prevent runtime panic.

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -63,7 +63,7 @@
   urls = ["http://localhost:8086"] # required
   # The target database for metrics (telegraf will create it if not exists)
   database = "telegraf" # required
-  # Precision of writes, valid values are n, u, ms, s, m, and h
+  # Precision of writes, valid values are "ns", "us" (or "µs"), "ms", "s", "m", "h".
   # note: using second precision greatly helps InfluxDB compression
   precision = "s"
 


### PR DESCRIPTION
- Check and return error from NewBatchPoints to prevent runtime panic if
   user provides an unparsable precision time unit in config.
- Provide correct sample config precision examples.