### PR TITLE
User name matching for procstat input

### DIFF
--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -7,7 +7,8 @@ individual process using their /proc data.
 
 The plugin will tag processes by their PID and their process name.
 
-Processes can be specified either by pid file or by executable name. Procstat
+Processes can be specified either by pid file, by executable name, by command
+line pattern matching, or by username (in this order or priority. Procstat
 plugin will use `pgrep` when executable name is provided to obtain the pid.
 Proctstas plugin will transmit IO, memory, cpu, file descriptor related
 measurements for every process specified. A prefix can be set to isolate

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -56,7 +56,7 @@ func (_ *Procstat) Description() string {
 func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 	err := p.createProcesses()
 	if err != nil {
-	log.Printf("Error: procstat getting process, exe: [%s]	pidfile: [%s] pattern: [%s] user: [%s] %s",
+		log.Printf("Error: procstat getting process, exe: [%s]	pidfile: [%s] pattern: [%s] user: [%s] %s",
 			p.Exe, p.PidFile, p.Pattern, p.User, err.Error())
 	} else {
 		for _, proc := range p.pidmap {


### PR DESCRIPTION
Hello.

A small patch on procstat input to be able to search process by username (useful for me to monitor the user usage of a system on a mutualized environment).

Using the -u for pgrep, i.e. the effective uid of user.

Thanks.