### PR TITLE
InfluxDB output should not default to 'no timeout' for http writes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,14 +92,17 @@ docker-kill:
 	-docker rm nsq aerospike redis opentsdb rabbitmq postgres memcached mysql kafka mqtt riemann snmp
 
 # Run full unit tests using docker containers (includes setup and teardown)
-test: docker-kill docker-run
+test: vet docker-kill docker-run
 	# Sleeping for kafka leadership election, TSDB setup, etc.
 	sleep 60
 	# SUCCESS, running tests
 	go test -race ./...
 
 # Run "short" unit tests
-test-short:
+test-short: vet
 	go test -short ./...
+
+vet:
+	go vet ./...
 
 .PHONY: test

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -67,9 +67,9 @@
   # note: using second precision greatly helps InfluxDB compression
   precision = "s"
 
-  # Connection timeout (for the connection with InfluxDB), formatted as a string.
-  # If not provided, will default to 0 (no timeout)
-  # timeout = "5s"
+  ## Write timeout (for the InfluxDB client), formatted as a string.
+  ## If not provided, will default to 5s. 0s means no timeout (not recommended).
+  timeout = "5s"
   # username = "telegraf"
   # password = "metricsmetricsmetricsmetrics"
   # Set the user agent for HTTP POSTs (can be useful for log differentiation)

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -52,9 +52,9 @@ var sampleConfig = `
   ## note: using "s" precision greatly improves InfluxDB compression
   precision = "s"
 
-  ## Connection timeout (for the connection with InfluxDB), formatted as a string.
-  ## If not provided, will default to 0 (no timeout)
-  # timeout = "5s"
+  ## Write timeout (for the InfluxDB client), formatted as a string.
+  ## If not provided, will default to 5s. 0s means no timeout (not recommended).
+  timeout = "5s"
   # username = "telegraf"
   # password = "metricsmetricsmetricsmetrics"
   ## Set the user agent for HTTP POSTs (can be useful for log differentiation)
@@ -185,6 +185,8 @@ func (i *InfluxDB) Write(metrics []telegraf.Metric) error {
 
 func init() {
 	outputs.Add("influxdb", func() telegraf.Output {
-		return &InfluxDB{}
+		return &InfluxDB{
+			Timeout: internal.Duration{Duration: time.Second * 5},
+		}
 	})
 }


### PR DESCRIPTION
default to 5s instead, since even if it times out we will cache the
points and move on

closes #685