### PR TITLE
Ignore boring filesystems from disk plugin

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -97,6 +97,10 @@
   # Setting mountpoints will restrict the stats to the specified mountpoints.
   # mount_points=["/"]
 
+  # Ignore some mountpoints by filesystem type. For example (dev)tmpfs (usually
+  # present on /run, /var/run, /dev/shm or /dev).
+  ignore_fs = ["tmpfs", "devtmpfs"]
+
 # Read metrics about disk IO by device
 [[inputs.diskio]]
   # By default, telegraf will gather stats for all devices including

--- a/plugins/inputs/system/disk.go
+++ b/plugins/inputs/system/disk.go
@@ -14,6 +14,7 @@ type DiskStats struct {
 	Mountpoints []string
 
 	MountPoints []string
+	IgnoreFS    []string `toml:"ignore_fs"`
 }
 
 func (_ *DiskStats) Description() string {
@@ -24,6 +25,10 @@ var diskSampleConfig = `
   ## By default, telegraf gather stats for all mountpoints.
   ## Setting mountpoints will restrict the stats to the specified mountpoints.
   # mount_points = ["/"]
+
+  # Ignore some mountpoints by filesystem type. For example (dev)tmpfs (usually
+  # present on /run, /var/run, /dev/shm or /dev).
+  ignore_fs = ["tmpfs", "devtmpfs"]
 `
 
 func (_ *DiskStats) SampleConfig() string {
@@ -36,12 +41,16 @@ func (s *DiskStats) Gather(acc telegraf.Accumulator) error {
 		s.MountPoints = s.Mountpoints
 	}
 
-	disks, err := s.ps.DiskUsage(s.MountPoints)
+	disks, err := s.ps.DiskUsage(s.MountPoints, s.IgnoreFS)
 	if err != nil {
 		return fmt.Errorf("error getting disk usage info: %s", err)
 	}
 
 	for _, du := range disks {
+		if du.Total == 0 {
+			// Skip dummy filesystem (procfs, cgroupfs, ...)
+			continue
+		}
 		tags := map[string]string{
 			"path":   du.Path,
 			"fstype": du.Fstype,

--- a/plugins/inputs/system/disk_test.go
+++ b/plugins/inputs/system/disk_test.go
@@ -50,9 +50,9 @@ func TestDiskStats(t *testing.T) {
 		},
 	}
 
-	mps.On("DiskUsage", []string(nil)).Return(duAll, nil)
-	mps.On("DiskUsage", []string{"/", "/dev"}).Return(duFiltered, nil)
-	mps.On("DiskUsage", []string{"/", "/home"}).Return(duAll, nil)
+	mps.On("DiskUsage", []string(nil), []string(nil)).Return(duAll, nil)
+	mps.On("DiskUsage", []string{"/", "/dev"}, []string(nil)).Return(duFiltered, nil)
+	mps.On("DiskUsage", []string{"/", "/home"}, []string(nil)).Return(duAll, nil)
 
 	err = (&DiskStats{ps: &mps}).Gather(&acc)
 	require.NoError(t, err)

--- a/plugins/inputs/system/mock_PS.go
+++ b/plugins/inputs/system/mock_PS.go
@@ -33,8 +33,8 @@ func (m *MockPS) CPUTimes(perCPU, totalCPU bool) ([]cpu.CPUTimesStat, error) {
 	return r0, r1
 }
 
-func (m *MockPS) DiskUsage(mountPointFilter []string) ([]*disk.DiskUsageStat, error) {
-	ret := m.Called(mountPointFilter)
+func (m *MockPS) DiskUsage(mountPointFilter []string, fstypeExclude []string) ([]*disk.DiskUsageStat, error) {
+	ret := m.Called(mountPointFilter, fstypeExclude)
 
 	r0 := ret.Get(0).([]*disk.DiskUsageStat)
 	r1 := ret.Error(1)


### PR DESCRIPTION
Modern Linux has a lots of boring filesystem (tmpfs on /dev, devpts on /dev/pts, lots of cgroup on /sys/fs/cgroup/*, ...).

This pull request:
* Ignore filesystem with 0 bytes (this cover cgroup, devpts and other).
* Add IgnoreFS configuration option to ignore additional FS by their type. Add tmpfs and
  devtmpfs as default ignored type.


With telegraf 0.10.3, on my laptop I've 34 disk monitored !
```
$ telegraf -version
Telegraf - Version 0.10.3
$ telegraf -sample-config -input-filter disk -output-filter influxdb > test.conf
$ telegraf -config test.conf -test|wc -l
35
$ telegraf -config test.conf -test
* Plugin: disk, Collection 1
> disk,fstype=sysfs,path=/sys free=0i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=0i,used=0i,used_percent=0 1456162583021865183
> disk,fstype=proc,path=/proc free=0i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=0i,used=0i,used_percent=0 1456162583021903499
> disk,fstype=devtmpfs,path=/dev free=4117389312i,inodes_free=1004598i,inodes_total=1005222i,inodes_used=624i,total=4117389312i,used=0i,used_percent=0 1456162583021929217
[...]
> disk,fstype=ext4,path=/home free=15607943168i,inodes_free=7812422i,inodes_total=9601776i,inodes_used=1789354i,total=155572985856i,used=133537521664i,used_percent=89.5350869799621 1456162583022424585
> disk,fstype=tmpfs,path=/run/cgmanager/fs free=102400i,inodes_free=1009804i,inodes_total=1009817i,inodes_used=13i,total=102400i,used=0i,used_percent=0 1456162583022447295
> disk,fstype=binfmt_misc,path=/proc/sys/fs/binfmt_misc free=0i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=0i,used=0i,used_percent=0 1456162583022463800
> disk,fstype=tmpfs,path=/run/user/1000 free=827158528i,inodes_free=1009779i,inodes_total=1009817i,inodes_used=38i,total=827244544i,used=86016i,used_percent=0.0103978926937474 1456162644453701250
> disk,fstype=fuse.gvfsd-fuse,path=/run/user/1000/gvfs free=0i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=0i,used=0i,used_percent=0 1456162644453718581
```

After this patch, the list is reduced to more useful length:
```
$ ./bin/telegraf -version
Telegraf - Version 0.10.3-14-g86093ae
$ ./bin/telegraf -sample-config -input-filter disk -output-filter influxdb > test.conf
$ ./bin/telegraf -config test.conf -test
* Plugin: disk, Collection 1
> disk,fstype=ext4,path=/ free=11217313792i,inodes_free=1434426i,inodes_total=2239600i,inodes_used=805174i,total=36132761600i,used=23335747584i,used_percent=67.53597700089358 1456162785532394598
> disk,fstype=ext4,path=/boot free=106813440i,inodes_free=62201i,inodes_total=62496i,inodes_used=295i,total=243577856i,used=119778304i,used_percent=52.86084209670058 1456162785532438342
> disk,fstype=vfat,path=/boot/efi free=254140416i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=520093696i,used=265953280i,used_percent=51.135647681451616 1456162785532464010
> disk,fstype=ext4,path=/home free=15605620736i,inodes_free=7812367i,inodes_total=9601776i,inodes_used=1789409i,total=155572985856i,used=133539844096i,used_percent=89.53664413894286 1456162785532482106
```