### PR TITLE
Start telegraf after installation on Debian/Ubuntu

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -31,6 +31,8 @@ DEFAULT_CONFIG = "etc/telegraf.conf"
 DEFAULT_WINDOWS_CONFIG = "etc/telegraf_windows.conf"
 POSTINST_SCRIPT = "scripts/post-install.sh"
 PREINST_SCRIPT = "scripts/pre-install.sh"
+POSTREMOVE_SCRIPT = "scripts/post-remove.sh"
+PREREMOVE_SCRIPT = "scripts/pre-remove.sh"
 
 # Default AWS S3 bucket for uploads
 DEFAULT_BUCKET = "get.influxdb.org/telegraf"
@@ -61,6 +63,8 @@ fpm_common_args = "-f -s dir --log error \
  --config-files {} \
  --after-install {} \
  --before-install {} \
+ --after-remove {} \
+ --before-remove {} \
  --description \"{}\"".format(
     VENDOR,
     PACKAGE_URL,
@@ -70,6 +74,8 @@ fpm_common_args = "-f -s dir --log error \
     LOGROTATE_DIR + '/telegraf',
     POSTINST_SCRIPT,
     PREINST_SCRIPT,
+    POSTREMOVE_SCRIPT,
+    PREREMOVE_SCRIPT,
     DESCRIPTION)
 
 targets = {

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -13,6 +13,7 @@ function install_init {
 function install_systemd {
     cp -f $SCRIPT_DIR/telegraf.service /lib/systemd/system/telegraf.service
     systemctl enable telegraf
+    systemctl daemon-reload || true
 }
 
 function install_update_rcd {
@@ -63,10 +64,12 @@ elif [[ -f /etc/debian_version ]]; then
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then
 	install_systemd
+	deb-systemd-invoke restart telegraf.service
     else
 	# Assuming sysv
 	install_init
 	install_update_rcd
+	invoke-rc.d telegraf restart
     fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release

--- a/scripts/post-remove.sh
+++ b/scripts/post-remove.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function disable_systemd {
+    systemctl disable telegraf
+    rm -f /lib/systemd/system/telegraf.service
+}
+
+function disable_update_rcd {
+    update-rc.d -f telegraf remove
+    rm -f /etc/init.d/telegraf
+}
+
+function disable_chkconfig {
+    chkconfig --del telegraf
+    rm -f /etc/init.d/telegraf
+}
+
+if [[ -f /etc/redhat-release ]]; then
+    # RHEL-variant logic
+    if [[ "$1" = "0" ]]; then
+	# InfluxDB is no longer installed, remove from init system
+	rm -f /etc/default/telegraf
+	
+	which systemctl &>/dev/null
+	if [[ $? -eq 0 ]]; then
+	    disable_systemd
+	else
+	    # Assuming sysv
+	    disable_chkconfig
+	fi
+    fi
+elif [[ -f /etc/debian_version ]]; then
+    # Debian/Ubuntu logic
+    if [[ "$1" != "upgrade" ]]; then
+	# Remove/purge
+	rm -f /etc/default/telegraf
+	
+	which systemctl &>/dev/null
+	if [[ $? -eq 0 ]]; then
+	    disable_systemd
+	else
+	    # Assuming sysv
+	    disable_update_rcd
+	fi
+    fi
+fi

--- a/scripts/pre-remove.sh
+++ b/scripts/pre-remove.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+BIN_DIR=/usr/bin
+
+# Distribution-specific logic
+if [[ -f /etc/debian_version ]]; then
+    # Debian/Ubuntu logic
+    which systemctl &>/dev/null
+    if [[ $? -eq 0 ]]; then
+	deb-systemd-invoke stop telegraf.service
+    else
+	# Assuming sysv
+	invoke-rc.d telegraf stop
+    fi
+fi


### PR DESCRIPTION
On Debian/Ubuntu, installing package also start the service associated. This PR add call to init system to start/stop telegraf when installing/removing package.

In addition, copied from InfluxDB packaging, when removed/purged it disable service.

Note:
* I only start/stop service on Debian/Ubuntu. AFAIK other distribution do not automatically start service.
* I use invoke-rc.d / deb-systemd-invoke (both probably Debian-specific) : this avoid starting service when it shouldn't be, for example on Docker container.

After building package with ```./scripts/build.py --package --platform=linux```, I tried to install, reinstall and remove the package. It worked on Trusty (upstart/sysv), Wily (Systemd) and Xenial (Systemd).