### PR TITLE
Create a FreeBSD build

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -72,12 +72,14 @@ targets = {
 supported_builds = {
     'darwin': [ "amd64", "i386" ],
     'windows': [ "amd64", "i386" ],
-    'linux': [ "amd64", "i386", "arm" ]
+    'linux': [ "amd64", "i386", "arm" ],
+    'freebsd': [ "amd64" ]
 }
 supported_packages = {
     "darwin": [ "tar", "zip" ],
     "linux": [ "deb", "rpm", "tar", "zip" ],
     "windows": [ "zip" ],
+    'freebsd': [ "tar" ]
 }
 supported_tags = {
     # "linux": {

--- a/scripts/circle-test.sh
+++ b/scripts/circle-test.sh
@@ -77,5 +77,6 @@ if [ $? -eq 0 ]; then
     echo $tag
     exit_if_fail ./scripts/build.py --package --version=$tag --platform=linux --arch=all --upload
     exit_if_fail ./scripts/build.py --package --version=$tag --platform=windows --arch=all --upload
+    exit_if_fail ./scripts/build.py --package --version=$tag --platform=freebsd --arch=all --upload
     mv build $CIRCLE_ARTIFACTS
 fi


### PR DESCRIPTION
As the FreeBSD build works from version 0.2.1 on (https://github.com/influxdata/telegraf/blob/master/CHANGELOG.md#v021-2015-11-16) it should be possible to build it automatically during the build process. It can be improved even more once jordansissel/fpm#870 is done. Given changes build a proper FreeBSD binary in my local environment.