### PR TITLE
Telegraf stop sending metrics when some input plugin hang

### DIFF
--- a/plugins/inputs/apache/apache.go
+++ b/plugins/inputs/apache/apache.go
@@ -58,7 +58,10 @@ var tr = &http.Transport{
 	ResponseHeaderTimeout: time.Duration(3 * time.Second),
 }
 
-var client = &http.Client{Transport: tr}
+var client = &http.Client{
+	Transport: tr,
+	Timeout:   time.Duration(4 * time.Second),
+}
 
 func (n *Apache) gatherUrl(addr *url.URL, acc telegraf.Accumulator) error {
 	resp, err := client.Get(addr.String())

--- a/plugins/inputs/couchdb/couchdb.go
+++ b/plugins/inputs/couchdb/couchdb.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Schema:
@@ -112,9 +113,18 @@ func (c *CouchDB) Gather(accumulator telegraf.Accumulator) error {
 
 }
 
+var tr = &http.Transport{
+	ResponseHeaderTimeout: time.Duration(3 * time.Second),
+}
+
+var client = &http.Client{
+	Transport: tr,
+	Timeout:   time.Duration(4 * time.Second),
+}
+
 func (c *CouchDB) fetchAndInsertData(accumulator telegraf.Accumulator, host string) error {
 
-	response, error := http.Get(host)
+	response, error := client.Get(host)
 	if error != nil {
 		return error
 	}

--- a/plugins/inputs/dovecot/dovecot.go
+++ b/plugins/inputs/dovecot/dovecot.go
@@ -34,6 +34,8 @@ var sampleConfig = `
   domains = []
 `
 
+var defaultTimeout = time.Second * time.Duration(5)
+
 func (d *Dovecot) SampleConfig() string { return sampleConfig }
 
 const defaultPort = "24242"
@@ -74,11 +76,14 @@ func (d *Dovecot) gatherServer(addr string, acc telegraf.Accumulator, doms map[s
 		return fmt.Errorf("Error: %s on url %s\n", err, addr)
 	}
 
-	c, err := net.Dial("tcp", addr)
+	c, err := net.DialTimeout("tcp", addr, defaultTimeout)
 	if err != nil {
 		return fmt.Errorf("Unable to connect to dovecot server '%s': %s", addr, err)
 	}
 	defer c.Close()
+
+	// Extend connection
+	c.SetDeadline(time.Now().Add(defaultTimeout))
 
 	c.Write([]byte("EXPORT\tdomain\n\n"))
 	var buf bytes.Buffer

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -81,7 +81,12 @@ type Elasticsearch struct {
 
 // NewElasticsearch return a new instance of Elasticsearch
 func NewElasticsearch() *Elasticsearch {
-	return &Elasticsearch{client: http.DefaultClient}
+	tr := &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   time.Duration(4 * time.Second),
+	}
+	return &Elasticsearch{client: client}
 }
 
 // SampleConfig returns sample configuration for this plugin.

--- a/plugins/inputs/elasticsearch/elasticsearch_test.go
+++ b/plugins/inputs/elasticsearch/elasticsearch_test.go
@@ -34,6 +34,9 @@ func (t *transportMock) RoundTrip(r *http.Request) (*http.Response, error) {
 	return res, nil
 }
 
+func (t *transportMock) CancelRequest(_ *http.Request) {
+}
+
 func TestElasticsearch(t *testing.T) {
 	es := NewElasticsearch()
 	es.Servers = []string{"http://example.com:9200"}

--- a/plugins/inputs/haproxy/haproxy.go
+++ b/plugins/inputs/haproxy/haproxy.go
@@ -129,8 +129,11 @@ func (g *haproxy) Gather(acc telegraf.Accumulator) error {
 
 func (g *haproxy) gatherServer(addr string, acc telegraf.Accumulator) error {
 	if g.client == nil {
-
-		client := &http.Client{}
+		tr := &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
+		client := &http.Client{
+			Transport: tr,
+			Timeout:   time.Duration(4 * time.Second),
+		}
 		g.client = client
 	}
 

--- a/plugins/inputs/httpjson/httpjson.go
+++ b/plugins/inputs/httpjson/httpjson.go
@@ -244,6 +244,11 @@ func (h *HttpJson) sendRequest(serverURL string) (string, float64, error) {
 
 func init() {
 	inputs.Add("httpjson", func() telegraf.Input {
-		return &HttpJson{client: RealHTTPClient{client: &http.Client{}}}
+		tr := &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
+		client := &http.Client{
+			Transport: tr,
+			Timeout:   time.Duration(4 * time.Second),
+		}
+		return &HttpJson{client: RealHTTPClient{client: client}}
 	})
 }

--- a/plugins/inputs/influxdb/influxdb.go
+++ b/plugins/inputs/influxdb/influxdb.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -70,6 +71,15 @@ type point struct {
 	Values map[string]interface{} `json:"values"`
 }
 
+var tr = &http.Transport{
+	ResponseHeaderTimeout: time.Duration(3 * time.Second),
+}
+
+var client = &http.Client{
+	Transport: tr,
+	Timeout:   time.Duration(4 * time.Second),
+}
+
 // Gathers data from a particular URL
 // Parameters:
 //     acc    : The telegraf Accumulator to use
@@ -81,7 +91,7 @@ func (i *InfluxDB) gatherURL(
 	acc telegraf.Accumulator,
 	url string,
 ) error {
-	resp, err := http.Get(url)
+	resp, err := client.Get(url)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/jolokia/jolokia.go
+++ b/plugins/inputs/jolokia/jolokia.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -160,6 +161,11 @@ func (j *Jolokia) Gather(acc telegraf.Accumulator) error {
 
 func init() {
 	inputs.Add("jolokia", func() telegraf.Input {
-		return &Jolokia{jClient: &JolokiaClientImpl{client: &http.Client{}}}
+		tr := &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
+		client := &http.Client{
+			Transport: tr,
+			Timeout:   time.Duration(4 * time.Second),
+		}
+		return &Jolokia{jClient: &JolokiaClientImpl{client: client}}
 	})
 }

--- a/plugins/inputs/mailchimp/chimp_api.go
+++ b/plugins/inputs/mailchimp/chimp_api.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 	"sync"
+	"time"
 )
 
 const (
@@ -120,7 +121,10 @@ func (a *ChimpAPI) GetReport(campaignID string) (Report, error) {
 }
 
 func runChimp(api *ChimpAPI, params ReportsParams) ([]byte, error) {
-	client := &http.Client{Transport: api.Transport}
+	client := &http.Client{
+		Transport: api.Transport,
+		Timeout:   time.Duration(4 * time.Second),
+	}
 
 	var b bytes.Buffer
 	req, err := http.NewRequest("GET", api.url.String(), &b)

--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -261,6 +262,15 @@ func (m *Mesos) removeGroup(j *map[string]interface{}) {
 	}
 }
 
+var tr = &http.Transport{
+	ResponseHeaderTimeout: time.Duration(3 * time.Second),
+}
+
+var client = &http.Client{
+	Transport: tr,
+	Timeout:   time.Duration(4 * time.Second),
+}
+
 // This should not belong to the object
 func (m *Mesos) gatherMetrics(a string, acc telegraf.Accumulator) error {
 	var jsonOut map[string]interface{}
@@ -282,7 +292,7 @@ func (m *Mesos) gatherMetrics(a string, acc telegraf.Accumulator) error {
 
 	ts := strconv.Itoa(m.Timeout) + "ms"
 
-	resp, err := http.Get("http://" + a + "/metrics/snapshot?timeout=" + ts)
+	resp, err := client.Get("http://" + a + "/metrics/snapshot?timeout=" + ts)
 
 	if err != nil {
 		return err

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -216,6 +216,12 @@ func (m *Mysql) gatherServer(serv string, acc telegraf.Accumulator) error {
 }
 
 func dsnAddTimeout(dsn string) (string, error) {
+
+	// DSN "?timeout=5s" is not valid, but "/?timeout=5s" is valid ("" and "/"
+	// are the same DSN)
+	if dsn == "" {
+		dsn = "/"
+	}
 	u, err := url.Parse(dsn)
 	if err != nil {
 		return "", err

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -92,11 +92,7 @@ func TestMysqlDNSAddTimeout(t *testing.T) {
 	}{
 		{
 			"",
-			"?timeout=5s",
-		},
-		{
-			"127.0.0.1",
-			"127.0.0.1?timeout=5s",
+			"/?timeout=5",
 		},
 		{
 			"tcp(192.168.1.1:3306)/",

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -84,3 +84,38 @@ func TestMysqlParseDSN(t *testing.T) {
 		}
 	}
 }
+
+func TestMysqlDNSAddTimeout(t *testing.T) {
+	tests := []struct {
+		input  string
+		output string
+	}{
+		{
+			"",
+			"?timeout=5s",
+		},
+		{
+			"127.0.0.1",
+			"127.0.0.1?timeout=5s",
+		},
+		{
+			"tcp(192.168.1.1:3306)/",
+			"tcp(192.168.1.1:3306)/?timeout=5s",
+		},
+		{
+			"root:passwd@tcp(192.168.1.1:3306)/?tls=false",
+			"root:passwd@tcp(192.168.1.1:3306)/?timeout=5s&tls=false",
+		},
+		{
+			"root:passwd@tcp(192.168.1.1:3306)/?tls=false&timeout=10s",
+			"root:passwd@tcp(192.168.1.1:3306)/?tls=false&timeout=10s",
+		},
+	}
+
+	for _, test := range tests {
+		output, _ := parseDSN(test.input)
+		if output != test.output {
+			t.Errorf("Expected %s, got %s\n", test.output, output)
+		}
+	}
+}

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -92,7 +92,7 @@ func TestMysqlDNSAddTimeout(t *testing.T) {
 	}{
 		{
 			"",
-			"/?timeout=5",
+			"/?timeout=5s",
 		},
 		{
 			"tcp(192.168.1.1:3306)/",

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -113,7 +113,7 @@ func TestMysqlDNSAddTimeout(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output, _ := parseDSN(test.input)
+		output, _ := dsnAddTimeout(test.input)
 		if output != test.output {
 			t.Errorf("Expected %s, got %s\n", test.output, output)
 		}

--- a/plugins/inputs/nginx/nginx.go
+++ b/plugins/inputs/nginx/nginx.go
@@ -58,7 +58,10 @@ var tr = &http.Transport{
 	ResponseHeaderTimeout: time.Duration(3 * time.Second),
 }
 
-var client = &http.Client{Transport: tr}
+var client = &http.Client{
+	Transport: tr,
+	Timeout:   time.Duration(4 * time.Second),
+}
 
 func (n *Nginx) gatherUrl(addr *url.URL, acc telegraf.Accumulator) error {
 	resp, err := client.Get(addr.String())

--- a/plugins/inputs/nsq/nsq.go
+++ b/plugins/inputs/nsq/nsq.go
@@ -84,7 +84,10 @@ var tr = &http.Transport{
 	ResponseHeaderTimeout: time.Duration(3 * time.Second),
 }
 
-var client = &http.Client{Transport: tr}
+var client = &http.Client{
+	Transport: tr,
+	Timeout:   time.Duration(4 * time.Second),
+}
 
 func (n *NSQ) gatherEndpoint(e string, acc telegraf.Accumulator) error {
 	u, err := buildURL(e)

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"time"
 )
 
 type Prometheus struct {
@@ -51,8 +52,17 @@ func (g *Prometheus) Gather(acc telegraf.Accumulator) error {
 	return outerr
 }
 
+var tr = &http.Transport{
+	ResponseHeaderTimeout: time.Duration(3 * time.Second),
+}
+
+var client = &http.Client{
+	Transport: tr,
+	Timeout:   time.Duration(4 * time.Second),
+}
+
 func (g *Prometheus) gatherURL(url string, acc telegraf.Accumulator) error {
-	resp, err := http.Get(url)
+	resp, err := client.Get(url)
 	if err != nil {
 		return fmt.Errorf("error making HTTP request to %s: %s", url, err)
 	}

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -122,7 +122,11 @@ func (r *RabbitMQ) Description() string {
 
 func (r *RabbitMQ) Gather(acc telegraf.Accumulator) error {
 	if r.Client == nil {
-		r.Client = &http.Client{}
+		tr := &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
+		r.Client = &http.Client{
+			Transport: tr,
+			Timeout:   time.Duration(4 * time.Second),
+		}
 	}
 
 	var errChan = make(chan error, len(gatherFunctions))

--- a/plugins/inputs/raindrops/raindrops.go
+++ b/plugins/inputs/raindrops/raindrops.go
@@ -177,8 +177,11 @@ func (r *Raindrops) getTags(addr *url.URL) map[string]string {
 
 func init() {
 	inputs.Add("raindrops", func() telegraf.Input {
-		return &Raindrops{http_client: &http.Client{Transport: &http.Transport{
-			ResponseHeaderTimeout: time.Duration(3 * time.Second),
-		}}}
+		return &Raindrops{http_client: &http.Client{
+			Transport: &http.Transport{
+				ResponseHeaderTimeout: time.Duration(3 * time.Second),
+			},
+			Timeout: time.Duration(4 * time.Second),
+		}}
 	})
 }

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -29,6 +30,8 @@ var sampleConfig = `
   ## If no port is specified, 6379 is used
   servers = ["tcp://localhost:6379"]
 `
+
+var defaultTimeout = 5 * time.Second
 
 func (r *Redis) SampleConfig() string {
 	return sampleConfig
@@ -120,11 +123,14 @@ func (r *Redis) gatherServer(addr *url.URL, acc telegraf.Accumulator) error {
 		addr.Host = addr.Host + ":" + defaultPort
 	}
 
-	c, err := net.Dial("tcp", addr.Host)
+	c, err := net.DialTimeout("tcp", addr.Host, defaultTimeout)
 	if err != nil {
 		return fmt.Errorf("Unable to connect to redis server '%s': %s", addr.Host, err)
 	}
 	defer c.Close()
+
+	// Extend connection
+	c.SetDeadline(time.Now().Add(defaultTimeout))
 
 	if addr.User != nil {
 		pwd, set := addr.User.Password()

--- a/plugins/inputs/riak/riak.go
+++ b/plugins/inputs/riak/riak.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -20,7 +21,12 @@ type Riak struct {
 
 // NewRiak return a new instance of Riak with a default http client
 func NewRiak() *Riak {
-	return &Riak{client: http.DefaultClient}
+	tr := &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   time.Duration(4 * time.Second),
+	}
+	return &Riak{client: client}
 }
 
 // Type riakStats represents the data that is received from Riak

--- a/plugins/inputs/zookeeper/zookeeper.go
+++ b/plugins/inputs/zookeeper/zookeeper.go
@@ -67,6 +67,9 @@ func (z *Zookeeper) gatherServer(address string, acc telegraf.Accumulator) error
 	}
 	defer c.Close()
 
+	// Extend connection
+	c.SetDeadline(time.Now().Add(defaultTimeout))
+
 	fmt.Fprintf(c, "%s\n", "mntr")
 	rdr := bufio.NewReader(c)
 	scanner := bufio.NewScanner(rdr)


### PR DESCRIPTION
This PR improve timeout of input plugins to avoid blocking all inputs.

For example, with Nginx, if the server does not respond at all (either firewall that DROP or host just shutdown), zero metrics are wrote for about 2 minutes, then one batch is wrote, 2 minutes with nothing ...

To reproduce:
```
$ telegraf -sample-config -input-filter nginx:cpu -output-filter influxdb > test.conf
$ sed -i 's@http://localhost/status@http://1.2.3.4/status@' test.conf    # point to a non-responding IP address.
$ telegraf -config test.conf
2016/02/29 18:07:08 Starting Telegraf (version 0.10.4.1)
2016/02/29 18:07:08 Loaded outputs: influxdb
2016/02/29 18:07:08 Loaded inputs: cpu nginx
2016/02/29 18:07:08 Tags enabled: host=ubuntu
2016/02/29 18:07:08 Agent Config: Interval:10s, Debug:false, Quiet:false, Hostname:"ubuntu", Flush Interval:10s 
2016/02/29 18:07:20 Wrote 0 metrics to output influxdb in 761.636µs
2016/02/29 18:07:30 Wrote 0 metrics to output influxdb in 554.27µs
2016/02/29 18:07:40 Wrote 0 metrics to output influxdb in 438.092µs
2016/02/29 18:07:50 Wrote 0 metrics to output influxdb in 468.076µs
2016/02/29 18:08:00 Wrote 0 metrics to output influxdb in 469.61µs
2016/02/29 18:08:10 Wrote 0 metrics to output influxdb in 432.655µs
2016/02/29 18:08:20 Wrote 0 metrics to output influxdb in 406.972µs
2016/02/29 18:08:30 Wrote 0 metrics to output influxdb in 820.321µs
2016/02/29 18:08:40 Wrote 0 metrics to output influxdb in 461.684µs
2016/02/29 18:08:50 Wrote 0 metrics to output influxdb in 482.844µs
2016/02/29 18:09:00 Wrote 0 metrics to output influxdb in 472.513µs
2016/02/29 18:09:10 Wrote 0 metrics to output influxdb in 472.036µs
2016/02/29 18:09:17 Error in input [nginx]: error making HTTP request to http://1.2.3.4/status: Get http://1.2.3.4/status: dial tcp 1.2.3.4:80: getsockopt: connection timed out
2016/02/29 18:09:17 Gathered metrics, (10s interval), from 2 inputs in 2m7.259746986s
2016/02/29 18:09:20 Wrote 5 metrics to output influxdb in 4.064824ms
2016/02/29 18:09:30 Wrote 0 metrics to output influxdb in 649.197µs
[...]
```

With this PR applied:
```
$ ./build/linux/amd64/telegraf -config test.conf 
2016/02/29 18:10:07 Starting Telegraf (version 0.10.4.1-9-g322871d)
2016/02/29 18:10:07 Loaded outputs: influxdb
2016/02/29 18:10:07 Loaded inputs: cpu nginx
2016/02/29 18:10:07 Tags enabled: host=ubuntu
2016/02/29 18:10:07 Agent Config: Interval:10s, Debug:false, Quiet:false, Hostname:"ubuntu", Flush Interval:10s 
2016/02/29 18:10:14 Error in input [nginx]: error making HTTP request to http://1.2.3.4/status: Get http://1.2.3.4/status: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
2016/02/29 18:10:14 Gathered metrics, (10s interval), from 2 inputs in 4.006359088s
2016/02/29 18:10:20 Wrote 5 metrics to output influxdb in 4.016221ms
2016/02/29 18:10:24 Error in input [nginx]: error making HTTP request to http://1.2.3.4/status: Get http://1.2.3.4/status: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
2016/02/29 18:10:24 Gathered metrics, (10s interval), from 2 inputs in 4.000246823s
2016/02/29 18:10:30 Wrote 5 metrics to output influxdb in 3.470205ms
```

This could happen in real situation with Docker. Right after a docker stop of a monitored Nginx container, Telegraf will took ~2 minute to fail with connection timeout for each run of nginx input pluging.

I've tested that the following input work (both in normal case and after a docker stop): memcached mysql zookeeper redis nginx apache dovecot

I've change 3 kind of input:

* TCP using net.Dial : change to net.DialTimeout and then using conn.SetDeadline
* net/http : adding Timeout to http.Client (for connection timeout) and ensure that ResponseHeaderTimeout is set on http.Transport)
* mysql : Modify the DSN to add timeout parameter. I don't know if DSN should be modified by Telegraf or only strongly suggest user to use DSN with timeout.