### PR TITLE
Reduce default metrics buffer size

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -24,7 +24,7 @@
 
   ## Telegraf will cache metric_buffer_limit metrics for each output, and will
   ## flush this buffer on a successful write.
-  metric_buffer_limit = 10000
+  metric_buffer_limit = 1000
   ## Flush the buffer whenever full, regardless of flush_interval.
   flush_buffer_when_full = true
 

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -24,7 +24,7 @@
 
   ## Telegraf will cache metric_buffer_limit metrics for each output, and will
   ## flush this buffer on a successful write.
-  metric_buffer_limit = 10000
+  metric_buffer_limit = 1000
   ## Flush the buffer whenever full, regardless of flush_interval.
   flush_buffer_when_full = true
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -159,7 +159,7 @@ var header = `# Telegraf Configuration
 
   ## Telegraf will cache metric_buffer_limit metrics for each output, and will
   ## flush this buffer on a successful write.
-  metric_buffer_limit = 10000
+  metric_buffer_limit = 1000
   ## Flush the buffer whenever full, regardless of flush_interval.
   flush_buffer_when_full = true
 

--- a/internal/models/running_output.go
+++ b/internal/models/running_output.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// Default number of metrics kept between flushes.
-	DEFAULT_METRIC_BUFFER_LIMIT = 10000
+	DEFAULT_METRIC_BUFFER_LIMIT = 1000
 
 	// Limit how many full metric buffers are kept due to failed writes.
 	FULL_METRIC_BUFFERS_LIMIT = 100


### PR DESCRIPTION
By default Telegraf use 100 buffers of 10000 metric values, this makes 1 million metric values.

The size of buffer seems a bit huge for default configuration. With the default, my laptop return ~20 metrics per iteration... 1 million means that it could buffer up to 5 days.

We had Telegraf instance that took about 900 Mb of memory (probably due to the buffers being full).

Step to reproduce : install Telegraf with default configuration (InfluxDB output enabled). Don't have InfluxDB installed (or started). Reboot your server (this will start Telegraf). Wait for few days, memory increase slowly.

I suggest to reduce buffer size by a factor 10, changing metric_buffer_limit to 1000.