### PR TITLE
Username not set for mqtt_consumer plugin

### DIFF
--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -181,7 +181,7 @@ func (m *MQTTConsumer) createOpts() (*mqtt.ClientOptions, error) {
 	}
 
 	user := m.Username
-	if user == "" {
+	if user != "" {
 		opts.SetUsername(user)
 	}
 	password := m.Password


### PR DESCRIPTION
Username parameter for the mqtt_consumer plugin was not pass to the client because an incorrect empty check. (user == "" versus user != "")