### PR TITLE
Add flags -usage-list to print all plugins inputs for telegraf

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -62,7 +62,7 @@ The flags are:
   -sample-config     print out full sample configuration to stdout
   -config-directory  directory containing additional *.conf files
   -input-filter      filter the input plugins to enable, separator is :
-  -input-list	     print all the plugins inputs
+  -input-list        print all the plugins inputs
   -output-filter     filter the output plugins to enable, separator is :
   -output-list       print all the available outputs 
   -usage             print usage for a plugin, ie, 'telegraf -usage mysql'

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/influxdata/telegraf/agent"
 	"github.com/influxdata/telegraf/internal/config"
-
+	"github.com/influxdata/telegraf/plugins/inputs"
 	_ "github.com/influxdata/telegraf/plugins/inputs/all"
 	_ "github.com/influxdata/telegraf/plugins/outputs/all"
 )
@@ -34,6 +34,7 @@ var fOutputFilters = flag.String("output-filter", "",
 	"filter the outputs to enable, separator is :")
 var fUsage = flag.String("usage", "",
 	"print usage for a plugin, ie, 'telegraf -usage mysql'")
+var fUsageList = flag.Bool("usage-list", false, "print all the plugins inputs")
 
 var fInputFiltersLegacy = flag.String("filter", "",
 	"filter the inputs to enable, separator is :")
@@ -61,6 +62,7 @@ The flags are:
   -input-filter      filter the input plugins to enable, separator is :
   -output-filter     filter the output plugins to enable, separator is :
   -usage             print usage for a plugin, ie, 'telegraf -usage mysql'
+  -usage-list	     print all the plugins input
   -debug             print metrics as they're generated to stdout
   -quiet             run in quiet mode
   -version           print the version to stdout
@@ -133,6 +135,13 @@ func main() {
 				}
 			}
 			return
+		}
+
+		if *fUsageList {
+			fmt.Println("The plugin inputs avaiable:")
+			for k, _ := range inputs.Inputs {
+				fmt.Printf("  %s\n", k)
+			}
 		}
 
 		var (

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/telegraf/internal/config"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	_ "github.com/influxdata/telegraf/plugins/inputs/all"
+	"github.com/influxdata/telegraf/plugins/outputs"
 	_ "github.com/influxdata/telegraf/plugins/outputs/all"
 )
 
@@ -30,12 +31,13 @@ var fSampleConfig = flag.Bool("sample-config", false,
 var fPidfile = flag.String("pidfile", "", "file to write our pid to")
 var fInputFilters = flag.String("input-filter", "",
 	"filter the inputs to enable, separator is :")
+var fInpuList = flag.Bool("input-list", false, "print all the plugins inputs")
 var fOutputFilters = flag.String("output-filter", "",
 	"filter the outputs to enable, separator is :")
+var fOutputList = flag.Bool("output-list", false,
+	"print all the available outputs")
 var fUsage = flag.String("usage", "",
 	"print usage for a plugin, ie, 'telegraf -usage mysql'")
-var fUsageList = flag.Bool("usage-list", false, "print all the plugins inputs")
-
 var fInputFiltersLegacy = flag.String("filter", "",
 	"filter the inputs to enable, separator is :")
 var fOutputFiltersLegacy = flag.String("outputfilter", "",
@@ -60,9 +62,10 @@ The flags are:
   -sample-config     print out full sample configuration to stdout
   -config-directory  directory containing additional *.conf files
   -input-filter      filter the input plugins to enable, separator is :
+  -input-list	     print all the plugins inputs
   -output-filter     filter the output plugins to enable, separator is :
+  -output-list       print all the available outputs 
   -usage             print usage for a plugin, ie, 'telegraf -usage mysql'
-  -usage-list	     print all the plugins input
   -debug             print metrics as they're generated to stdout
   -quiet             run in quiet mode
   -version           print the version to stdout
@@ -117,6 +120,13 @@ func main() {
 			outputFilters = strings.Split(":"+outputFilter+":", ":")
 		}
 
+		if *fOutputList {
+			fmt.Println("The outputs available:")
+			for k, _ := range outputs.Outputs {
+				fmt.Printf("  %s\n", k)
+			}
+		}
+
 		if *fVersion {
 			v := fmt.Sprintf("Telegraf - Version %s", Version)
 			fmt.Println(v)
@@ -137,8 +147,8 @@ func main() {
 			return
 		}
 
-		if *fUsageList {
-			fmt.Println("The plugin inputs avaiable:")
+		if *fInpuList {
+			fmt.Println("The plugin inputs available:")
 			for k, _ := range inputs.Inputs {
 				fmt.Printf("  %s\n", k)
 			}


### PR DESCRIPTION
This pull request add a flag -usage-list for the telegraf,it will print all the plugins inputs when using telegraf -usage-list.
It will help the user to know what input is supported by the plugins.

Could you review this and merge this if it is OK?