### PR TITLE
Add processes status stats in system input plugin

### DIFF
--- a/plugins/inputs/system/processes.go
+++ b/plugins/inputs/system/processes.go
@@ -1,0 +1,61 @@
+package system
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/shirou/gopsutil/process"
+)
+
+type Processes struct {
+}
+
+func (_ *Processes) Description() string {
+	return "Get the number of processes and group them by status (Linux only)"
+}
+
+func (_ *Processes) SampleConfig() string { return "" }
+
+func (s *Processes) Gather(acc telegraf.Accumulator) error {
+	pids, err := process.Pids()
+	if err != nil {
+		return fmt.Errorf("error getting pids list: %s", err)
+	}
+	// TODO handle other OS (Windows/BSD/Solaris/OSX)
+	fields := map[string]interface{}{
+		"paging":   uint64(0),
+		"blocked":  uint64(0),
+		"zombie":   uint64(0),
+		"stopped":  uint64(0),
+		"running":  uint64(0),
+		"sleeping": uint64(0),
+	}
+	for _, pid := range pids {
+		process, err := process.NewProcess(pid)
+		if err != nil {
+			log.Printf("Can not get process %d status: %s", pid, err)
+			continue
+		}
+		status, err := process.Status()
+		if err != nil {
+			log.Printf("Can not get process %d status: %s\n", pid, err)
+			continue
+		}
+		_, exists := fields[status]
+		if !exists {
+			log.Printf("Status '%s' for process with pid: %d\n", status, pid)
+			continue
+		}
+		fields[status] = fields[status].(uint64) + uint64(1)
+	}
+
+	acc.AddFields("processes", fields, nil)
+	return nil
+}
+func init() {
+	inputs.Add("processes", func() telegraf.Input {
+		return &Processes{}
+	})
+}

--- a/plugins/inputs/system/processes_test.go
+++ b/plugins/inputs/system/processes_test.go
@@ -1,0 +1,21 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcesses(t *testing.T) {
+	processes := &Processes{}
+	var acc testutil.Accumulator
+
+	err := processes.Gather(&acc)
+	require.NoError(t, err)
+
+	assert.True(t, acc.HasUIntField("processes", "running"))
+	assert.True(t, acc.HasUIntField("processes", "sleeping"))
+	assert.True(t, acc.HasUIntField("processes", "stopped"))
+}


### PR DESCRIPTION
It returns the number of processus grouped by their status (running/sleeping/zombie/...)