### PR TITLE
Fix build-for-docker Makefile target syntax.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ build-windows:
 		./cmd/telegraf/telegraf.go
 
 build-for-docker:
-	CGO_ENABLED=0 GOOS=linux go -o telegraf -ldflags \
-					"-X main.Version=$(VERSION)" \
+	CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -o telegraf -ldflags \
+					"-s -X main.Version=$(VERSION)" \
 					./cmd/telegraf/telegraf.go
 
 # Build with race detector


### PR DESCRIPTION
The Makefile target for build-for-docker did not have build nor the support for static.