### PR TITLE
[amqp output] Allow external auth (cert-based tls auth)

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -109,6 +109,7 @@ func GetTLSConfig(
 			RootCAs:            caCertPool,
 			InsecureSkipVerify: InsecureSkipVerify,
 		}
+		t.BuildNameToCertificate()
 	} else {
 		if InsecureSkipVerify {
 			t.InsecureSkipVerify = true


### PR DESCRIPTION
This pull request is a followup for #536 
It adds ssl auth mechanism as described here: https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl/blob/rabbitmq_v3_6_1/README.md

I've tested externalit on my own, and it works, but I'd love to get some help.