### PR TITLE
Close the UDP connection in Stop() of statsd input plugin.

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -66,7 +66,7 @@ type Statsd struct {
 	// bucket -> influx templates
 	Templates []string
 
-        listener *net.UDPConn
+	listener *net.UDPConn
 }
 
 func NewStatsd() *Statsd {
@@ -248,7 +248,7 @@ func (s *Statsd) Start(_ telegraf.Accumulator) error {
 
 // udpListen starts listening for udp packets on the configured port.
 func (s *Statsd) udpListen() error {
-        var err error
+	var err error
 	address, _ := net.ResolveUDPAddr("udp", s.ServiceAddress)
 	s.listener, err = net.ListenUDP("udp", address)
 	if err != nil {
@@ -266,7 +266,7 @@ func (s *Statsd) udpListen() error {
 			n, _, err := s.listener.ReadFromUDP(buf)
 			if err != nil {
 				log.Printf("ERROR READ: %s\n", err.Error())
-                                continue
+				continue
 			}
 
 			select {
@@ -561,7 +561,7 @@ func (s *Statsd) Stop() {
 	s.Lock()
 	defer s.Unlock()
 	log.Println("Stopping the statsd service")
-        s.listener.Close()
+	s.listener.Close()
 	close(s.done)
 	close(s.in)
 }

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -65,6 +65,8 @@ type Statsd struct {
 
 	// bucket -> influx templates
 	Templates []string
+
+        listener *net.UDPConn
 }
 
 func NewStatsd() *Statsd {
@@ -246,13 +248,14 @@ func (s *Statsd) Start(_ telegraf.Accumulator) error {
 
 // udpListen starts listening for udp packets on the configured port.
 func (s *Statsd) udpListen() error {
+        var err error
 	address, _ := net.ResolveUDPAddr("udp", s.ServiceAddress)
-	listener, err := net.ListenUDP("udp", address)
+	s.listener, err = net.ListenUDP("udp", address)
 	if err != nil {
 		log.Fatalf("ERROR: ListenUDP - %s", err)
 	}
-	defer listener.Close()
-	log.Println("Statsd listener listening on: ", listener.LocalAddr().String())
+	defer s.listener.Close()
+	log.Println("Statsd listener listening on: ", s.listener.LocalAddr().String())
 
 	for {
 		select {
@@ -260,9 +263,10 @@ func (s *Statsd) udpListen() error {
 			return nil
 		default:
 			buf := make([]byte, s.UDPPacketSize)
-			n, _, err := listener.ReadFromUDP(buf)
+			n, _, err := s.listener.ReadFromUDP(buf)
 			if err != nil {
-				log.Printf("ERROR: %s\n", err.Error())
+				log.Printf("ERROR READ: %s\n", err.Error())
+                                continue
 			}
 
 			select {
@@ -557,6 +561,7 @@ func (s *Statsd) Stop() {
 	s.Lock()
 	defer s.Unlock()
 	log.Println("Stopping the statsd service")
+        s.listener.Close()
 	close(s.done)
 	close(s.in)
 }


### PR DESCRIPTION
If not, when doing reload, we may listen to the same port, we'll get
error about listen to already used address.