### PR TITLE
added json serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 - [#863](https://github.com/influxdata/telegraf/pull/863): AMQP output: allow external auth. Thanks @ekini!
 - [#707](https://github.com/influxdata/telegraf/pull/707): Improved prometheus plugin. Thanks @titilambert!
+- [#878](https://github.com/influxdata/telegraf/pull/878): Added json serializer. Thanks @ch3lo!
 
 ### Bugfixes
 

--- a/docs/DATA_FORMATS_OUTPUT.md
+++ b/docs/DATA_FORMATS_OUTPUT.md
@@ -53,7 +53,7 @@ metrics are serialized directly into InfluxDB line-protocol.
   ## Files to write to, "stdout" is a specially handled file.
   files = ["stdout", "/tmp/metrics.out"]
 
-  ## Data format to output. This can be "influx" or "graphite"
+  ## Data format to output. This can be "influx", "json" or "graphite"
   ## Each data format has it's own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
@@ -87,11 +87,45 @@ tars.cpu-total.us-east-1.cpu.usage_idle 98.09 1455320690
   ## Files to write to, "stdout" is a specially handled file.
   files = ["stdout", "/tmp/metrics.out"]
 
-  ## Data format to output. This can be "influx" or "graphite"
+  ## Data format to output. This can be "influx", "json" or "graphite"
   ## Each data format has it's own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "influx"
 
   prefix = "telegraf"
+```
+
+## Json:
+
+The Json data format serialized Telegraf metrics in json format. The format is:
+
+```json
+{
+   "fields":{
+      "field_1":30,
+      "field_2":4,
+      "field_N":59,
+      "n_images":660
+   },
+   "name":"docker",
+   "tags":{
+      "host":"raynor"
+   },
+   "timestamp":1458229140
+}
+```
+
+#### Json Configuration:
+
+```toml
+[[outputs.file]]
+  ## Files to write to, "stdout" is a specially handled file.
+  files = ["stdout", "/tmp/metrics.out"]
+
+  ## Data format to output. This can be "influx", "json" or "graphite"
+  ## Each data format has it's own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "json"
 ```

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -1,0 +1,27 @@
+package json
+
+import (
+	ejson "encoding/json"
+
+	"github.com/influxdata/telegraf"
+)
+
+type JsonSerializer struct {
+}
+
+func (s *JsonSerializer) Serialize(metric telegraf.Metric) ([]string, error) {
+	out := []string{}
+
+	m := make(map[string]interface{})
+	m["tags"] = metric.Tags()
+	m["fields"] = metric.Fields()
+	m["name"] = metric.Name()
+	m["timestamp"] = metric.UnixNano() / 1000000000
+	serialized, err := ejson.Marshal(m)
+	if err != nil {
+		return []string{}, err
+	}
+	out = append(out, string(serialized))
+
+	return out, nil
+}

--- a/plugins/serializers/json/json_test.go
+++ b/plugins/serializers/json/json_test.go
@@ -1,0 +1,87 @@
+package json
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/influxdata/telegraf"
+)
+
+func TestSerializeMetricFloat(t *testing.T) {
+	now := time.Now()
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": float64(91.5),
+	}
+	m, err := telegraf.NewMetric("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s := JsonSerializer{}
+	mS, err := s.Serialize(m)
+	assert.NoError(t, err)
+	expS := []string{fmt.Sprintf("{\"fields\":{\"usage_idle\":91.5},\"name\":\"cpu\",\"tags\":{\"cpu\":\"cpu0\"},\"timestamp\":%d}", now.Unix())}
+	assert.Equal(t, expS, mS)
+}
+
+func TestSerializeMetricInt(t *testing.T) {
+	now := time.Now()
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": int64(90),
+	}
+	m, err := telegraf.NewMetric("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s := JsonSerializer{}
+	mS, err := s.Serialize(m)
+	assert.NoError(t, err)
+
+	expS := []string{fmt.Sprintf("{\"fields\":{\"usage_idle\":90},\"name\":\"cpu\",\"tags\":{\"cpu\":\"cpu0\"},\"timestamp\":%d}", now.Unix())}
+	assert.Equal(t, expS, mS)
+}
+
+func TestSerializeMetricString(t *testing.T) {
+	now := time.Now()
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": "foobar",
+	}
+	m, err := telegraf.NewMetric("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s := JsonSerializer{}
+	mS, err := s.Serialize(m)
+	assert.NoError(t, err)
+
+	expS := []string{fmt.Sprintf("{\"fields\":{\"usage_idle\":\"foobar\"},\"name\":\"cpu\",\"tags\":{\"cpu\":\"cpu0\"},\"timestamp\":%d}", now.Unix())}
+	assert.Equal(t, expS, mS)
+}
+
+func TestSerializeMultiFields(t *testing.T) {
+	now := time.Now()
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle":  int64(90),
+		"usage_total": 8559615,
+	}
+	m, err := telegraf.NewMetric("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s := JsonSerializer{}
+	mS, err := s.Serialize(m)
+	assert.NoError(t, err)
+
+	expS := []string{fmt.Sprintf("{\"fields\":{\"usage_idle\":90,\"usage_total\":8559615},\"name\":\"cpu\",\"tags\":{\"cpu\":\"cpu0\"},\"timestamp\":%d}", now.Unix())}
+	assert.Equal(t, expS, mS)
+}

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
+	"github.com/influxdata/telegraf/plugins/serializers/json"
 )
 
 // SerializerOutput is an interface for output plugins that are able to
@@ -40,8 +41,14 @@ func NewSerializer(config *Config) (Serializer, error) {
 		serializer, err = NewInfluxSerializer()
 	case "graphite":
 		serializer, err = NewGraphiteSerializer(config.Prefix)
+	case "json":
+		serializer, err = NewJsonSerializer()
 	}
 	return serializer, err
+}
+
+func NewJsonSerializer() (Serializer, error) {
+	return &json.JsonSerializer{}, nil
 }
 
 func NewInfluxSerializer() (Serializer, error) {


### PR DESCRIPTION
In my company we have an use case using telegraf with file output, this file is read with a Splunk Forwarder and then data are send to an indexer.

With this PR the data can be serialized in a standard json and then they could be processed with other components.