### PR TITLE
replace @ character with - for librato

### DIFF
--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -159,7 +159,10 @@ func (l *Librato) buildGaugeName(m telegraf.Metric, fieldName string) string {
 	serializedMetric := graphiteSerializer.SerializeBucketName(m, fieldName)
 
 	// Deal with slash characters:
-	return strings.Replace(serializedMetric, "/", "-", -1)
+	replacedString := strings.Replace(serializedMetric, "/", "-", -1)
+	// Deal with @ characters:
+	replacedString = strings.Replace(replacedString, "@", "-", -1)
+	return replacedString
 }
 
 func (l *Librato) buildGauges(m telegraf.Metric) ([]*Gauge, error) {


### PR DESCRIPTION
When attempting to send metrics from `rabbitmq` input, the `@` character which is part of the `node_name` tag causes an issue. This seemed like the _simplest_ fix but am open to other ways.