### PR TITLE
sanitize known issue characters from graphite tag name

### DIFF
--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
@@ -156,13 +155,7 @@ func (l *Librato) Description() string {
 func (l *Librato) buildGaugeName(m telegraf.Metric, fieldName string) string {
 	// Use the GraphiteSerializer
 	graphiteSerializer := graphite.GraphiteSerializer{}
-	serializedMetric := graphiteSerializer.SerializeBucketName(m, fieldName)
-
-	// Deal with slash characters:
-	replacedString := strings.Replace(serializedMetric, "/", "-", -1)
-	// Deal with @ characters:
-	replacedString = strings.Replace(replacedString, "@", "-", -1)
-	return replacedString
+	return graphiteSerializer.SerializeBucketName(m, fieldName)
 }
 
 func (l *Librato) buildGauges(m telegraf.Metric) ([]*Gauge, error) {

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -12,6 +12,8 @@ type GraphiteSerializer struct {
 	Prefix string
 }
 
+var sanitizedChars = strings.NewReplacer("/", "-", "@", "-", " ", "_")
+
 func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]string, error) {
 	out := []string{}
 
@@ -85,5 +87,5 @@ func buildTags(metric telegraf.Metric) string {
 			tag_str += "." + tag_value
 		}
 	}
-	return tag_str
+	return sanitizedChars.Replace(tag_str)
 }


### PR DESCRIPTION
Because graphite has certain restrictions on what characters can be in the metric name (i.e. `/`, `@`, ` `), the graphite serializer should be responsible for substituting those characters with good alternatives.