### PR TITLE
don't include NodeType as a value, it's already a Tag

### DIFF
--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -139,6 +139,9 @@ func (d *Datadog) authenticatedUrl() string {
 func buildMetrics(m telegraf.Metric) (map[string]Point, error) {
 	ms := make(map[string]Point)
 	for k, v := range m.Fields() {
+		if !verifyValue(v) {
+			continue
+		}
 		var p Point
 		if err := p.setValue(v); err != nil {
 			return ms, fmt.Errorf("unable to extract value from Fields, %s", err.Error())
@@ -158,6 +161,14 @@ func buildTags(mTags map[string]string) []string {
 	}
 	sort.Strings(tags)
 	return tags
+}
+
+func verifyValue(v interface{}) bool {
+	switch v.(type) {
+	case string:
+		return false
+	}
+	return true
 }
 
 func (p *Point) setValue(v interface{}) error {

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -152,14 +152,6 @@ func TestBuildPoint(t *testing.T) {
 			},
 			nil,
 		},
-		{
-			testutil.TestMetric("11234.5", "test7"),
-			Point{
-				float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
-				11234.5,
-			},
-			fmt.Errorf("unable to extract value from Fields, undeterminable type"),
-		},
 	}
 	for _, tt := range tagtests {
 		pt, err := buildMetrics(tt.ptIn)
@@ -172,6 +164,28 @@ func TestBuildPoint(t *testing.T) {
 		if !reflect.DeepEqual(pt["value"], tt.outPt) && tt.err == nil {
 			t.Errorf("%s: \nexpected %+v\ngot %+v\n",
 				tt.ptIn.Name(), tt.outPt, pt["value"])
+		}
+	}
+}
+
+func TestVerifyValue(t *testing.T) {
+	var tagtests = []struct {
+		ptIn        telegraf.Metric
+		validMetric bool
+	}{
+		{
+			testutil.TestMetric(float32(11234.5), "test1"),
+			true,
+		},
+		{
+			testutil.TestMetric("11234.5", "test2"),
+			false,
+		},
+	}
+	for _, tt := range tagtests {
+		ok := verifyValue(tt.ptIn.Fields()["value"])
+		if tt.validMetric != ok {
+			t.Errorf("%s: verification failed\n", tt.ptIn.Name())
 		}
 	}
 }

--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -165,6 +165,9 @@ func (l *Librato) buildGauges(m telegraf.Metric) ([]*Gauge, error) {
 			Name:        l.buildGaugeName(m, fieldName),
 			MeasureTime: m.Time().Unix(),
 		}
+		if !gauge.verifyValue(value) {
+			continue
+		}
 		if err := gauge.setValue(value); err != nil {
 			return gauges, fmt.Errorf("unable to extract value from Fields, %s\n",
 				err.Error())
@@ -184,6 +187,14 @@ func (l *Librato) buildGauges(m telegraf.Metric) ([]*Gauge, error) {
 		fmt.Printf("[DEBUG] Built gauges: %v\n", gauges)
 	}
 	return gauges, nil
+}
+
+func (g *Gauge) verifyValue(v interface{}) bool {
+	switch v.(type) {
+	case string:
+		return false
+	}
+	return true
 }
 
 func (g *Gauge) setValue(v interface{}) error {

--- a/plugins/outputs/librato/librato_test.go
+++ b/plugins/outputs/librato/librato_test.go
@@ -139,12 +139,8 @@ func TestBuildGauge(t *testing.T) {
 		},
 		{
 			testutil.TestMetric("11234.5", "test7"),
-			&Gauge{
-				Name:        "value1.test7.value",
-				MeasureTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix(),
-				Value:       11234.5,
-			},
-			fmt.Errorf("unable to extract value from Fields, undeterminable type"),
+			nil,
+			nil,
 		},
 	}
 
@@ -157,6 +153,9 @@ func TestBuildGauge(t *testing.T) {
 		if gt.err != nil && err == nil {
 			t.Errorf("%s: expected an error (%s) but none returned",
 				gt.ptIn.Name(), gt.err.Error())
+		}
+		if len(gauges) != 0 && gt.outGauge == nil {
+			t.Errorf("%s: unexpected gauge, %+v\n", gt.ptIn.Name(), gt.outGauge)
 		}
 		if len(gauges) == 0 {
 			continue


### PR DESCRIPTION
@sparrc as part of investigating https://github.com/influxdata/telegraf/issues/760, I found that having the `NodeType` (i.e. 'PRI', 'SEC', etc.) as a value causes some outputs to fail due to it being a `string`. It's already being included as a tag [here](https://github.com/influxdata/telegraf/blob/9c0d14bb60d7abf36a530bce400ff460d0a18c38/plugins/inputs/mongodb/mongodb_data.go#L18-L20) so will still be available as part of the metric.