### PR TITLE
Disable MQTT Consumer KeepAlive timer

### DIFF
--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -217,7 +217,7 @@ func (m *MQTTConsumer) createOpts() (*mqtt.ClientOptions, error) {
 		opts.AddBroker(server)
 	}
 	opts.SetAutoReconnect(true)
-	opts.SetKeepAlive(time.Second * 60)
+	opts.SetKeepAlive(time.Duration(0))
 	opts.SetCleanSession(!m.PersistentSession)
 	return opts, nil
 }


### PR DESCRIPTION
This has not been consistently reliable. This is likely a bug with the
paho MQTT client library. It was supposed to be fixed, but will need to
be revisited in the future.

fixes #921 

cc @jvermillard, When I was first working on this plugin I had problems with this KeepAlive setting and the paho MQTT client. By setting KeepAlive to 0 we can just disable it for the time being.