### PR TITLE
Adds ability to parse datadog-formatted tags in the statsd input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.11.2 [unreleased]
 
 ### Features
+- [#927](https://github.com/influxdata/telegraf/pull/927): Adds parsing of tags to the statsd input when using DataDog's dogstatsd extension
 - [#863](https://github.com/influxdata/telegraf/pull/863): AMQP output: allow external auth. Thanks @ekini!
 - [#707](https://github.com/influxdata/telegraf/pull/707): Improved prometheus plugin. Thanks @titilambert!
 - [#878](https://github.com/influxdata/telegraf/pull/878): Added json serializer. Thanks @ch3lo!

--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -21,6 +21,9 @@
   ## convert measurement names, "." to "_" and "-" to "__"
   convert_names = true
 
+  ## parses tags in the datadog statsd format
+  parse_data_dog_tags = false
+
   ## Statsd data translation templates, more info can be read here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md#graphite
   # templates = [

--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -21,7 +21,8 @@
   ## convert measurement names, "." to "_" and "-" to "__"
   convert_names = true
 
-  ## parses tags in the datadog statsd format
+  ## Parses tags in DataDog's dogstatsd format
+  ## http://docs.datadoghq.com/guides/dogstatsd/
   parse_data_dog_tags = false
 
   ## Statsd data translation templates, more info can be read here:
@@ -158,6 +159,7 @@ per-measurement in the calculation of percentiles. Raising this limit increases
 the accuracy of percentiles but also increases the memory usage and cpu time.
 - **templates** []string: Templates for transforming statsd buckets into influx
 measurements and tags.
+- **parse_data_dog_tags** boolean: Enable parsing of tags in DataDog's dogstatsd format (http://docs.datadoghq.com/guides/dogstatsd/)
 
 ### Statsd bucket -> InfluxDB line-protocol Templates
 

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -152,7 +152,8 @@ const sampleConfig = `
   ## convert measurement names, "." to "_" and "-" to "__"
   convert_names = true
 
-  ## parses tags in the datadog statsd format
+  ## Parses tags in the datadog statsd format
+  ## http://docs.datadoghq.com/guides/dogstatsd/
   parse_data_dog_tags = false
 
   ## Statsd data translation templates, more info can be read here:
@@ -336,7 +337,7 @@ func (s *Statsd) parseStatsdLine(line string) error {
 		pipesplit := strings.Split(line, "|")
 		for _, segment := range pipesplit {
 			if len(segment) > 0 && segment[0] == '#' {
-				// we have ourselves a tag; they are comma serated
+				// we have ourselves a tag; they are comma separated
 				tagstr := segment[1:]
 				tags := strings.Split(tagstr, ",")
 				for _, tag := range tags {


### PR DESCRIPTION
This change optionally allows DataDog-formatted statsd messages to have their tags parsed by `telegraf` (default is off).

More about the dogstatsd extensions [here](http://docs.datadoghq.com/guides/dogstatsd/).