### PR TITLE
Fix parse fcgi URI path in php-fpm input module

### DIFF
--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -122,6 +122,11 @@ func (g *phpfpm) gatherServer(addr string, acc telegraf.Accumulator) error {
 		fcgiIp := socketAddr[0]
 		fcgiPort, _ := strconv.Atoi(socketAddr[1])
 		fcgi, err = newFcgiClient(fcgiIp, fcgiPort)
+		if len(u.Path) > 1 {
+			statusPath = strings.Trim(u.Path, "/")
+		} else {
+			statusPath = "status"
+		}
 	} else {
 		socketAddr := strings.Split(addr, ":")
 		if len(socketAddr) >= 2 {


### PR DESCRIPTION
We actively use php-fpm with connection via tcp. Unfortunately the current implementation of php-fpm plugin does not handle php-fpm status page. Our correction is in this pull request.