### PR TITLE
Use timeout smaller than 10 seconds

### DIFF
--- a/plugins/inputs/mongodb/mongodb.go
+++ b/plugins/inputs/mongodb/mongodb.go
@@ -103,7 +103,7 @@ func (m *MongoDB) gatherServer(server *Server, acc telegraf.Accumulator) error {
 				dialAddrs[0], err.Error())
 		}
 		dialInfo.Direct = true
-		dialInfo.Timeout = time.Duration(10) * time.Second
+		dialInfo.Timeout = time.Duration(8) * time.Second
 
 		if m.Ssl.Enabled {
 			tlsConfig := &tls.Config{}

--- a/plugins/inputs/mongodb/mongodb_test.go
+++ b/plugins/inputs/mongodb/mongodb_test.go
@@ -43,7 +43,7 @@ func testSetup(m *testing.M) {
 		log.Fatalf("Unable to parse URL (%s), %s\n", dialAddrs[0], err.Error())
 	}
 	dialInfo.Direct = true
-	dialInfo.Timeout = time.Duration(10) * time.Second
+	dialInfo.Timeout = time.Duration(8) * time.Second
 	sess, err := mgo.DialWithInfo(dialInfo)
 	if err != nil {
 		log.Fatalf("Unable to connect to MongoDB, %s\n", err.Error())

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -80,10 +80,10 @@ func (p *Prometheus) gatherURL(url string, acc telegraf.Accumulator) error {
 
 	var rt http.RoundTripper = &http.Transport{
 		Dial: (&net.Dialer{
-			Timeout:   10 * time.Second,
+			Timeout:   8 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).Dial,
-		TLSHandshakeTimeout: 10 * time.Second,
+		TLSHandshakeTimeout: 8 * time.Second,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: p.InsecureSkipVerify,
 		},


### PR DESCRIPTION
Mongo and Prometheus use timeout of 10 seconds. At least with Mongo, 10 seconds timeout raise strange behavior, probably because metrics collection took more time than the metric collection interval (10 second - default config):

Data wrote by telegraf are no longer "rounded" to 10 seconds and create hole if you round them using group by time(10s)
second:
```
> select usage_idle from cpu where cpu='cpu-total' and time >= '2016-04-04T09:56:37Z' and time <= '2016-04-04T09:57:23Z'
name: cpu
---------
time                    usage_idle
2016-04-04T09:56:37Z     88.7699366396944
2016-04-04T09:56:49Z     84.20123565754106
2016-04-04T09:57:00Z     86.28820960698596
2016-04-04T09:57:12Z     85.76434515993311
2016-04-04T09:57:23Z     82.51209854815667

> select mean(usage_idle) from cpu where cpu='cpu-total' and time >= '2016-04-04T09:56:37Z' and time <= '2016-04-04T09:57:23Z'  group by time(10s)
name: cpu
---------
time                    mean
2016-04-04T09:56:30Z     88.7699366396944
2016-04-04T09:56:40Z     84.20123565754106
2016-04-04T09:56:50Z
2016-04-04T09:57:00Z     86.28820960698596
2016-04-04T09:57:10Z     85.76434515993311
2016-04-04T09:57:20Z     82.51209854815667
```

Telegraf logs:
```
2016/04/04 11:55:31 Starting Telegraf (version 0.11.1-75-g357849c)
[...]
2016/04/04 11:56:40 Wrote 35 metrics to output influxdb in 5.402099ms
error dialing over ssl, no reachable servers
2016/04/04 11:56:49 Error in input [mongodb]: Unable to connect to MongoDB, no reachable servers
2016/04/04 11:56:49 Gathered metrics, (10s interval), from 11 inputs in 11.507262321s
2016/04/04 11:56:50 Wrote 35 metrics to output influxdb in 4.578914ms
error dialing over ssl, no reachable servers
2016/04/04 11:57:00 Error in input [mongodb]: Unable to connect to MongoDB, no reachable servers
2016/04/04 11:57:00 Gathered metrics, (10s interval), from 11 inputs in 11.513853869s
[NOTE: no data wrote at 11:57:00]
2016/04/04 11:57:10 Wrote 35 metrics to output influxdb in 4.51493ms
```

This PR use a slightly smaller timeout (8 seconds) which make Telegraf behave as usual: datapoint sent every 10 second and rounded to tenth of seconds (0, 10, 20, ...).
