### PR TITLE
Re-Subscribe onConnect (or re-connect)

### DIFF
--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -133,6 +133,7 @@ func (m *MQTTConsumer) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 func (m *MQTTConsumer) onConnect(c mqtt.Client) {
+	log.Printf("MQTT Client Connected")
 	if !m.PersistentSession || !m.started {
 		topics := make(map[string]byte)
 		for _, topic := range m.Topics {
@@ -150,7 +151,7 @@ func (m *MQTTConsumer) onConnect(c mqtt.Client) {
 }
 
 func (m *MQTTConsumer) onConnectionLost(c mqtt.Client, err error) {
-	log.Printf("MQTT Connection lost\nerror: %s\nClient should retry to reconnect", err.Error())
+	log.Printf("MQTT Connection lost\nerror: %s\nMQTT Client will try to reconnect", err.Error())
 	return
 }
 


### PR DESCRIPTION
Refer to (http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718028)

> If CleanSession is set to 0, the Server MUST resume communications with the Client based on state from the current Session (as identified by the Client identifier).
[...]
>If CleanSession is set to 1, the Client and Server MUST discard any previous Session and start a new one.
[..]
>The Session state in the Server consists of:
>·         The existence of a Session, even if the rest of the Session state is empty.
>·         The Client’s subscriptions.
>·         QoS 1 and QoS 2 messages which have been sent to the Client, but have not been completely acknowledged.
>·         QoS 1 and QoS 2 messages pending transmission to the Client.
>·         QoS 2 messages which have been received from the Client, but have not been completely acknowledged.
>·         Optionally, QoS 0 messages pending transmission to the Client. 


This means that if you set Clean Session (persistent  session to false)... on Re-Connect, agent must re-subscribe to receive the message again.

Left todo:

- Let say that persistent session is set to true and broker is restarted, how does it work? Broker persists session and recover?
