### PR TITLE
snmp: possible fix for oid key collision when there is an oid key partially matches with current oid_key

### DIFF
--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -732,7 +732,7 @@ func (h *Host) HandleResponse(oids map[string]Data, result *gosnmp.SnmpPacket, a
 					break nextresult
 				}
 			}
-			if strings.HasPrefix(variable.Name, oid_key) {
+			if variable.Name == oid_key {
 				switch variable.Type {
 				// handle Metrics
 				case gosnmp.Boolean, gosnmp.Integer, gosnmp.Counter32, gosnmp.Gauge32,

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -732,7 +732,11 @@ func (h *Host) HandleResponse(oids map[string]Data, result *gosnmp.SnmpPacket, a
 					break nextresult
 				}
 			}
-			if variable.Name == oid_key {
+			// If variable.Name is the same as oid_key
+			// OR
+			// the result is SNMP table which "." comes right after oid_key.
+			// ex: oid_key: .1.3.6.1.2.1.2.2.1.16, variable.Name: .1.3.6.1.2.1.2.2.1.16.1
+			if variable.Name == oid_key || strings.HasPrefix(variable.Name, oid_key+".") {
 				switch variable.Type {
 				// handle Metrics
 				case gosnmp.Boolean, gosnmp.Integer, gosnmp.Counter32, gosnmp.Gauge32,


### PR DESCRIPTION
![chronograf_-_chrome_2016-04-17_02-06-13](https://cloud.githubusercontent.com/assets/308623/14582503/8d7a7e24-0441-11e6-8297-db1a4ebc3a5b.png)

I found this strange when I first set up Chronograf and Telegraf, it doesn't make sense that the graph falls to negative value. From the graph, I suspected there is some kind of input collision so `DERIVATIVE()` returns negative value, since I found several same values from both eth0 (instance id: 1) and the other network interface with instance id 11. 

To see if my assumption is right, I put the following line to [this line](https://github.com/influxdata/telegraf/blob/e436b2d72004a940549c21751ba33acf13117004/plugins/inputs/snmp/snmp.go#L736):
```
log.Printf("[snmp input] oid_key: %s, variable.Name: %s", oid_key, variable.Name)
```

and the log shows:

```
2016/04/17 01:52:20 [snmp input] oid_key: .1.3.6.1.2.1.31.1.1.1.10.5, variable.Name: .1.3.6.1.2.1.31.1.1.1.10.57
```

I'm not an expert on SNMP nor Telegraf plugins, not sure if this change won't make any side effects.