### PR TITLE
Don't allow inputs to overwrite host tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ for more details.
 only. Previously there was an undocumented behavior where filters would match
 based on _prefix_ in addition to globs. This means that a filter like
 `fielddrop = ["time_"]` will need to be changed to `fielddrop = ["time_*"]`
+- The following plugins have changed their tags to _not_ overwrite the host tag:
+  - cassandra: `host -> cassandra_host`
+  - disque: `host -> disque_host`
+  - rethinkdb: `host -> rethinkdb_host`
 
 ### Features
 
@@ -31,6 +35,7 @@ based on _prefix_ in addition to globs. This means that a filter like
 - [#1015](https://github.com/influxdata/telegraf/pull/1015): Docker plugin schema refactor.
 - [#889](https://github.com/influxdata/telegraf/pull/889): Improved MySQL plugin. Thanks @maksadbek!
 - [#1060](https://github.com/influxdata/telegraf/pull/1060): TTL metrics added to MongoDB input plugin
+- [#1056](https://github.com/influxdata/telegraf/pull/1056): Don't allow inputs to overwrite host tags.
 
 ### Bugfixes
 

--- a/agent/accumulator.go
+++ b/agent/accumulator.go
@@ -84,17 +84,13 @@ func (ac *accumulator) AddFields(
 	if tags == nil {
 		tags = make(map[string]string)
 	}
-	// Apply plugin-wide tags if set
-	for k, v := range ac.inputConfig.Tags {
-		if _, ok := tags[k]; !ok {
-			tags[k] = v
-		}
-	}
 	// Apply daemon-wide tags if set
 	for k, v := range ac.defaultTags {
-		if _, ok := tags[k]; !ok {
-			tags[k] = v
-		}
+		tags[k] = v
+	}
+	// Apply plugin-wide tags if set
+	for k, v := range ac.inputConfig.Tags {
+		tags[k] = v
 	}
 	ac.inputConfig.Filter.FilterTags(tags)
 

--- a/plugins/inputs/cassandra/cassandra_test.go
+++ b/plugins/inputs/cassandra/cassandra_test.go
@@ -58,7 +58,7 @@ const validCassandraNestedMultiValueJSON = `
     "status": 200,
     "timestamp": 1458089184,
     "value": {
-		"org.apache.cassandra.metrics:keyspace=test_keyspace1,name=ReadLatency,scope=test_table1,type=Table": 
+		"org.apache.cassandra.metrics:keyspace=test_keyspace1,name=ReadLatency,scope=test_table1,type=Table":
 		{  	"999thPercentile": 1.0,
 			"Count": 100,
 			"DurationUnit": "microseconds",
@@ -66,7 +66,7 @@ const validCassandraNestedMultiValueJSON = `
 			"RateUnit": "events/second",
 			"StdDev": null
 		},
-		"org.apache.cassandra.metrics:keyspace=test_keyspace2,name=ReadLatency,scope=test_table2,type=Table": 
+		"org.apache.cassandra.metrics:keyspace=test_keyspace2,name=ReadLatency,scope=test_table2,type=Table":
 		{  	"999thPercentile": 2.0,
 			"Count": 200,
 			"DurationUnit": "microseconds",
@@ -163,13 +163,13 @@ func TestHttpJsonJavaMultiValue(t *testing.T) {
 		"HeapMemoryUsage_used":      203288528.0,
 	}
 	tags1 := map[string]string{
-		"host":  "10.10.10.10",
-		"mname": "HeapMemoryUsage",
+		"cassandra_host": "10.10.10.10",
+		"mname":          "HeapMemoryUsage",
 	}
 
 	tags2 := map[string]string{
-		"host":  "10.10.10.11",
-		"mname": "HeapMemoryUsage",
+		"cassandra_host": "10.10.10.11",
+		"mname":          "HeapMemoryUsage",
 	}
 	acc.AssertContainsTaggedFields(t, "javaMemory", fields, tags1)
 	acc.AssertContainsTaggedFields(t, "javaMemory", fields, tags2)
@@ -190,8 +190,8 @@ func TestHttpJsonJavaMultiType(t *testing.T) {
 	}
 
 	tags := map[string]string{
-		"host":  "10.10.10.10",
-		"mname": "ConcurrentMarkSweep",
+		"cassandra_host": "10.10.10.10",
+		"mname":          "ConcurrentMarkSweep",
 	}
 	acc.AssertContainsTaggedFields(t, "javaGarbageCollector", fields, tags)
 }
@@ -231,10 +231,10 @@ func TestHttpJsonCassandraMultiValue(t *testing.T) {
 	}
 
 	tags := map[string]string{
-		"host":     "10.10.10.10",
-		"mname":    "ReadLatency",
-		"keyspace": "test_keyspace1",
-		"scope":    "test_table",
+		"cassandra_host": "10.10.10.10",
+		"mname":          "ReadLatency",
+		"keyspace":       "test_keyspace1",
+		"scope":          "test_table",
 	}
 	acc.AssertContainsTaggedFields(t, "cassandraTable", fields, tags)
 }
@@ -268,17 +268,17 @@ func TestHttpJsonCassandraNestedMultiValue(t *testing.T) {
 	}
 
 	tags1 := map[string]string{
-		"host":     "10.10.10.10",
-		"mname":    "ReadLatency",
-		"keyspace": "test_keyspace1",
-		"scope":    "test_table1",
+		"cassandra_host": "10.10.10.10",
+		"mname":          "ReadLatency",
+		"keyspace":       "test_keyspace1",
+		"scope":          "test_table1",
 	}
 
 	tags2 := map[string]string{
-		"host":     "10.10.10.10",
-		"mname":    "ReadLatency",
-		"keyspace": "test_keyspace2",
-		"scope":    "test_table2",
+		"cassandra_host": "10.10.10.10",
+		"mname":          "ReadLatency",
+		"keyspace":       "test_keyspace2",
+		"scope":          "test_table2",
 	}
 
 	acc.AssertContainsTaggedFields(t, "cassandraTable", fields1, tags1)

--- a/plugins/inputs/disque/disque.go
+++ b/plugins/inputs/disque/disque.go
@@ -162,7 +162,7 @@ func (g *Disque) gatherServer(addr *url.URL, acc telegraf.Accumulator) error {
 	var read int
 
 	fields := make(map[string]interface{})
-	tags := map[string]string{"host": addr.String()}
+	tags := map[string]string{"disque_host": addr.String()}
 	for read < sz {
 		line, err := r.ReadString('\n')
 		if err != nil {

--- a/plugins/inputs/rethinkdb/rethinkdb_server.go
+++ b/plugins/inputs/rethinkdb/rethinkdb_server.go
@@ -97,8 +97,8 @@ func (s *Server) getServerStatus() error {
 
 func (s *Server) getDefaultTags() map[string]string {
 	tags := make(map[string]string)
-	tags["host"] = s.Url.Host
-	tags["hostname"] = s.serverStatus.Network.Hostname
+	tags["rethinkdb_host"] = s.Url.Host
+	tags["rethinkdb_hostname"] = s.serverStatus.Network.Hostname
 	return tags
 }
 

--- a/plugins/inputs/rethinkdb/rethinkdb_server_test.go
+++ b/plugins/inputs/rethinkdb/rethinkdb_server_test.go
@@ -20,8 +20,8 @@ func TestGetDefaultTags(t *testing.T) {
 		in  string
 		out string
 	}{
-		{"host", server.Url.Host},
-		{"hostname", server.serverStatus.Network.Hostname},
+		{"rethinkdb_host", server.Url.Host},
+		{"rethinkdb_hostname", server.serverStatus.Network.Hostname},
 	}
 	defaultTags := server.getDefaultTags()
 	for _, tt := range tagTests {


### PR DESCRIPTION
closes #1054

This affects tags in the following plugins:

- cassandra
- disque
- rethinkdb