### PR TITLE
Refactor running_output buffering

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -38,8 +38,12 @@ config.
 * **interval**: Default data collection interval for all inputs
 * **round_interval**: Rounds collection interval to 'interval'
 ie, if interval="10s" then always collect on :00, :10, :20, etc.
+* **metric_batch_size**: Telegraf will send metrics to output in batch of at
+most metric_batch_size metrics.
 * **metric_buffer_limit**: Telegraf will cache metric_buffer_limit metrics
 for each output, and will flush this buffer on a successful write.
+This should be a multiple of metric_batch_size and could not be less
+than 2 times metric_batch_size.
 * **collection_jitter**: Collection jitter is used to jitter
 the collection by a random amount.
 Each plugin will sleep for a random time within jitter before collecting.

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -30,9 +30,13 @@
   ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
   round_interval = true
 
+  ## Telegraf will send metrics to output in batch of at
+  ## most metric_batch_size metrics.
+  metric_batch_size = 1000
   ## Telegraf will cache metric_buffer_limit metrics for each output, and will
-  ## flush this buffer on a successful write.
-  metric_buffer_limit = 1000
+  ## flush this buffer on a successful write. This should be a multiple of
+  ## metric_batch_size and could not be less than 2 times metric_batch_size
+  metric_buffer_limit = 10000
   ## Flush the buffer whenever full, regardless of flush_interval.
   flush_buffer_when_full = true
 

--- a/internal/models/running_output_test.go
+++ b/internal/models/running_output_test.go
@@ -193,7 +193,7 @@ func TestRunningOutputDefault(t *testing.T) {
 	assert.Len(t, m.Metrics(), 10)
 }
 
-// Test that the first metric gets overwritten if there is a buffer overflow.
+// Test that the first metrics batch gets overwritten if there is a buffer overflow.
 func TestRunningOutputOverwrite(t *testing.T) {
 	conf := &OutputConfig{
 		Filter: Filter{
@@ -203,6 +203,7 @@ func TestRunningOutputOverwrite(t *testing.T) {
 
 	m := &mockOutput{}
 	ro := NewRunningOutput("test", m, conf)
+	ro.MetricBatchSize = 1
 	ro.MetricBufferLimit = 4
 
 	for _, metric := range first5 {
@@ -236,6 +237,7 @@ func TestRunningOutputMultiOverwrite(t *testing.T) {
 
 	m := &mockOutput{}
 	ro := NewRunningOutput("test", m, conf)
+	ro.MetricBatchSize = 1
 	ro.MetricBufferLimit = 3
 
 	for _, metric := range first5 {
@@ -274,7 +276,8 @@ func TestRunningOutputFlushWhenFull(t *testing.T) {
 	m := &mockOutput{}
 	ro := NewRunningOutput("test", m, conf)
 	ro.FlushBufferWhenFull = true
-	ro.MetricBufferLimit = 5
+	ro.MetricBatchSize = 5
+	ro.MetricBufferLimit = 10
 
 	// Fill buffer to limit
 	for _, metric := range first5 {
@@ -286,7 +289,7 @@ func TestRunningOutputFlushWhenFull(t *testing.T) {
 	// add one more metric
 	ro.AddMetric(next5[0])
 	// now it flushed
-	assert.Len(t, m.Metrics(), 6)
+	assert.Len(t, m.Metrics(), 5)
 
 	// add one more metric and write it manually
 	ro.AddMetric(next5[1])
@@ -307,7 +310,8 @@ func TestRunningOutputMultiFlushWhenFull(t *testing.T) {
 	m := &mockOutput{}
 	ro := NewRunningOutput("test", m, conf)
 	ro.FlushBufferWhenFull = true
-	ro.MetricBufferLimit = 4
+	ro.MetricBatchSize = 4
+	ro.MetricBufferLimit = 12
 
 	// Fill buffer past limit twive
 	for _, metric := range first5 {
@@ -317,7 +321,7 @@ func TestRunningOutputMultiFlushWhenFull(t *testing.T) {
 		ro.AddMetric(metric)
 	}
 	// flushed twice
-	assert.Len(t, m.Metrics(), 10)
+	assert.Len(t, m.Metrics(), 8)
 }
 
 func TestRunningOutputWriteFail(t *testing.T) {
@@ -331,7 +335,8 @@ func TestRunningOutputWriteFail(t *testing.T) {
 	m.failWrite = true
 	ro := NewRunningOutput("test", m, conf)
 	ro.FlushBufferWhenFull = true
-	ro.MetricBufferLimit = 4
+	ro.MetricBatchSize = 4
+	ro.MetricBufferLimit = 12
 
 	// Fill buffer past limit twice
 	for _, metric := range first5 {


### PR DESCRIPTION
This PR refactor running_output buffering and try to make it more user-friendly

It change running_output to :
* send buffered metrics in order
* Has a buffer size of metric_buffer_limit (and not 100 times metric_buffer_limit - where 100 is hardcoded value)
* Has consistent behavious regarding size of buffer whether flush_buffer_when_full is true or not.

It also fix bug, where:

* only the very oldest batch get overwritten
* unlimited metrics could be buffered

# Only oldest batch overwritten

With default configuration of flush_buffer_when_full at true, when output is down, metrics get buffered in ro.tmpmetrics [see here](https://github.com/influxdata/telegraf/blob/d3a25e4dc1865f1e229d1629c68fcd5dc24d52a5/internal/models/running_output.go#L93).

When ro.tmpmetrics is full, it starts overwritting value... but it only overwrite first slot: [code](https://github.com/influxdata/telegraf/blob/d3a25e4dc1865f1e229d1629c68fcd5dc24d52a5/internal/models/running_output.go#L88)

# Order of metrics sent

If we hit the previous bug, running_output will ends with the following state:

ro.metrics : contains batch N of metrics
ro.tmpmetrics contains: N-1, 1, 2, 3, ..., 99

When output became available, [ro.Write](https://github.com/influxdata/telegraf/blob/d3a25e4dc1865f1e229d1629c68fcd5dc24d52a5/internal/models/running_output.go#L113) will take batch in this order:

ro.metrics, then ro.tmpmetrics, which result in : 
N, N-1, 1, 2, ...

User may except that metrics are read in the following order : 1, 2, 3, ...,  99, N-1, N

Note that code in this PR may still be unordered in the following case:

* output is not available, some metrics are waiting in ro.tmpmetrics
* output is now available, flusher didn't yet called ro.Write
* new metrics are added which cause ro.metrics to become full. Due to flush_buffer_when_full, ro.metrics are written (so latest metrics are sent)
* flusher now call ro.Write, which unqueue metrics from ro.tmpmetrics (so older metrics are sent)

This should be pretty rare (output need to because available just before new added metrics cause ro.metrics to become full) and allowed simpler code in AddMetric.

# buffer size

When flush_buffer_when_full was false, running_output actually keep up to metric_buffer_limit metrics.

But with flush_buffer_when_full to true (default config), it was ro.metrics which was limited to metric_buffer_limit [code](https://github.com/influxdata/telegraf/blob/d3a25e4dc1865f1e229d1629c68fcd5dc24d52a5/internal/models/running_output.go#L75)
When it was full, it get moved to rm.tmpmetrics which could hold up to 100 buffers.

So at the end, running_output could keep up to 100 * metric_buffer_limit metrics.

# unlimited buffer

If the output get offline for some time, and let's say that 50 buffers are waiting in ro.tmpmetrics.
E.g. running_output has the following state:

ro.metrics : [metrics]
ro.tmpmetrics {0: [metrics], 1: [metrics], ..., 49: [metrics]]
ro.mapI = 50

Now output is back online and flusher write all value. running_output has the following state:

ro.metrics : empty or few metrics
ro.tmpmetrics : empty
ro.mapI = 50

If the output is once more offline for long enough, ro.AddMetric will continue to add in ro.tmpmetrics on
slot 50, 51, 52, etc (mapI continue to increase).
running_output will ends with the following state

ro.tmpmetrics = {50: [metrics], 51: [metrics], ..., 149:[metrics]}
len(ro.tmpmetrics) = 100
ro.mapI = 150

At this point, [when overwritting value](https://github.com/influxdata/telegraf/blob/d3a25e4dc1865f1e229d1629c68fcd5dc24d52a5/internal/models/running_output.go#L87) it will "overwrite" slot 0 which is unused. So instead of overwriting, it will add one next value to ro.tmpmetrics which now has a len() of 101.
If output keeps offline, ro.tmpmetrics will only ever grow.