### PR TITLE
sanitize * to - in graphite serializer

### DIFF
--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -17,7 +17,7 @@ type GraphiteSerializer struct {
 	Template string
 }
 
-var sanitizedChars = strings.NewReplacer("/", "-", "@", "-", " ", "_", "..", ".")
+var sanitizedChars = strings.NewReplacer("/", "-", "@", "-", "*", "-", " ", "_", "..", ".")
 
 func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]string, error) {
 	out := []string{}


### PR DESCRIPTION
same issue as #891 but now it's `*`.  (need to sanitize a character Librato doesn't like, also coming from my rabbitmq input, FWIW)
