### PR TITLE
Added sanization of fieldName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ based on _prefix_ in addition to globs. This means that a filter like
   - cassandra: `host -> cassandra_host`
   - disque: `host -> disque_host`
   - rethinkdb: `host -> rethinkdb_host`
+  
+- **Breaking Change**: The `win_perf_counters` input has been changed to sanitize field names, replacing `/Sec` and `/sec` with `_persec`, as well as spaces with underscores. This is needed because Graphite doesn't like slashes and spaces, and was failing to accept metrics that had them. The `/[sS]ec` -> `_persec` is just to make things clearer and uniform.
 
 ### Features
 
@@ -65,6 +67,7 @@ based on _prefix_ in addition to globs. This means that a filter like
 - [#967](https://github.com/influxdata/telegraf/issues/967): Buffer logging improvements.
 - [#1107](https://github.com/influxdata/telegraf/issues/1107): Support lustre2 job stats. Thanks @hanleyja!
 - [#1110](https://github.com/influxdata/telegraf/pull/1110): Sanitize * to - in graphite serializer. Thanks @goodeggs!
+- [#1118] (https://github.com/influxdata/telegraf/pull/1118): Sanitize Counter names for `win_perf_counters` input.
 
 ### Bugfixes
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -107,6 +107,8 @@ type item struct {
 	counterHandle win.PDH_HCOUNTER
 }
 
+var sanitizedChars = strings.NewReplacer("/sec", "_persec", "/Sec", "_persec", " ", "_")
+
 func (m *Win_PerfCounters) AddItem(metrics *itemList, query string, objectName string, counter string, instance string,
 	measurement string, include_total bool) {
 
@@ -297,7 +299,7 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 							tags["instance"] = s
 						}
 						tags["objectname"] = metric.objectName
-						fields[string(metric.counter)] = float32(c.FmtValue.DoubleValue)
+						fields[sanitizedChars.Replace(string(metric.counter))] = float32(c.FmtValue.DoubleValue)
 
 						var measurement string
 						if metric.measurement == "" {

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -32,7 +32,7 @@ func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]string, error)
 		valueS := fmt.Sprintf("%#v", value)
 		point := fmt.Sprintf("%s %s %d",
 			// insert "field" section of template
-			InsertField(bucket, sanitizedChars.Replace(fieldName)),
+			InsertField(bucket, fieldName),
 			valueS,
 			timestamp)
 		out = append(out, point)

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -32,7 +32,7 @@ func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]string, error)
 		valueS := fmt.Sprintf("%#v", value)
 		point := fmt.Sprintf("%s %s %d",
 			// insert "field" section of template
-			InsertField(bucket, fieldName),
+			InsertField(bucket, sanitizedChars.Replace(fieldName)),
 			valueS,
 			timestamp)
 		out = append(out, point)


### PR DESCRIPTION
When sending Telegraf data to Graphite, many of the metrics generated by the `win_perf_counters` input plugin aren't properly sanitized, and get ignored by Carbon.

For example, for the following config, only `Processes` and `Threads` succeed:
```
[[outputs.graphite]]
  template = "host.measurement.tags.field"

[[inputs.win_perf_counters]]
  [[inputs.win_perf_counters.object]]
    ObjectName = "System"
    Counters = ["Context Switches/sec", "System Calls/sec", "Threads", "System Up Time", "Processes", "Processor Queue Length"]
    Instances = ["------"]
    Measurement = "win_system"
```

If run in debug mode, telegraf produces this output:
```
> win_system,host=ServerA,objectname=System Context\ Switches/sec=9189.787 1461855980003819600
> win_system,host=ServerA,objectname=System System\ Calls/sec=41990.85 1461855980003819600
> win_system,host=ServerA,objectname=System Threads=2260 1461855980013820100
> win_system,host=ServerA,objectname=System System\ Up\ Time=1480454.9 1461855980013820100
> win_system,host=ServerA,objectname=System Processes=158 1461855980013820100
> win_system,host=ServerA,objectname=System Processor\ Queue\ Length=0 1461855980023820600
```

The metrics are received by carbon, but it throws these 4 errors:
```
28/04/2016 11:06:20 :: invalid line (ServerA.win_system.System.Context Switches/sec 9189.787 1461855980) received from client 127.0.0.1:57807, ignoring
28/04/2016 11:06:20 :: invalid line (ServerA.win_system.System.System Calls/sec 41990.85 1461855980) received from client 127.0.0.1:57807, ignoring
28/04/2016 11:06:20 :: invalid line (ServerA.win_system.System.System Up Time 1.4804549e+06 1461855980) received from client 127.0.0.1:57807, ignoring
28/04/2016 11:06:20 :: invalid line (ServerA.win_system.System.Processor Queue Length 0 1461855980) received from client 127.0.0.1:57807, ignoring
```

I see that the Graphite output serializer sanitizes the [bucket name](https://github.com/influxdata/telegraf/blob/master/plugins/serializers/graphite/graphite.go#L92), but it doesn't sanitize the [field itself](https://github.com/influxdata/telegraf/blob/master/plugins/serializers/graphite/graphite.go#L35), and  `win_perf_counters` [doesn't](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/win_perf_counters/win_perf_counters.go#L300) do any kind of sanitizing when gathering metrics.