### PR TITLE
Specify host mount prefix with envvar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ based on _prefix_ in addition to globs. This means that a filter like
   - disque: `host -> disque_host`
   - rethinkdb: `host -> rethinkdb_host`
 
+- The `disk` input plugin can now be configured with the `HOST_MOUNT_PREFIX` environment variable.
+This value is prepended to any mountpaths discovered before retrieving stats.
+It is not included on the report path. This is necessary for reporting host disk stats when running from within a container.
+
 ### Features
 
 - [#1031](https://github.com/influxdata/telegraf/pull/1031): Jolokia plugin proxy mode. Thanks @saiello!

--- a/plugins/inputs/system/DISK_README.md
+++ b/plugins/inputs/system/DISK_README.md
@@ -16,6 +16,14 @@ https://en.wikipedia.org/wiki/Df_(Unix) for more details.
   # mount_points = ["/"]
 ```
 
+Additionally, the behavior of resolving the `mount_points` can be configured by using the `HOST_MOUNT_PREFIX` environment variable.
+When present, this variable is prepended to the mountpoints discovered by the plugin before retrieving stats.
+The prefix is stripped from the reported `path` in the measurement.
+This settings is useful when running `telegraf` inside a docker container to report host machine metrics.
+In this case, the host's root volume should be mounted into the container and the `HOST_MOUNT_PREFIX` and `HOST_ETC` environment variables set.
+
+`docker run -v /:/hostfs:ro -e HOST_MOUNT_PREFIX=/hostfs -e HOST_ETC=/hostfs/etc telegraf-docker`
+
 ### Measurements & Fields:
 
 - disk

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -81,8 +81,10 @@ func (s *systemPS) DiskUsage(
 				continue
 			}
 		}
-		if _, err := os.Stat(p.Mountpoint); err == nil {
-			du, err := disk.DiskUsage(p.Mountpoint)
+		mountpoint := os.Getenv("HOST_MOUNT_PREFIX") + p.Mountpoint
+		if _, err := os.Stat(mountpoint); err == nil {
+			du, err := disk.DiskUsage(mountpoint)
+			du.Path = p.Mountpoint
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Allows for configuring a prefix for the location of mount points.
This allows `telegraf` to report host disk metrics from within a Docker container.

The configuration looks like this:

```
docker run -v /:/rootfs:ro -e HOST_MOUNT_PREFIX=/rootfs -e HOST_ETC=/rootfs/etc -e HOST_PROC=/rootfs/proc HOST_SYS=/rootfs/sys telegraf-docker
```

- `HOST_MOUNT_PREFIX` is applied to any entry that is found in the `${HOST_ETC}/fstab` file before making the system call to get the disk usage stats.

- `HOST_MOUNT_PREFIX` is stripped from the mount path so that the metric reported uses the path as specified on the host system.