### PR TITLE
Support default config paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,7 @@ based on _prefix_ in addition to globs. This means that a filter like
 - [#1096](https://github.com/influxdata/telegraf/pull/1096): Performance refactor of running output buffers.
 - [#967](https://github.com/influxdata/telegraf/issues/967): Buffer logging improvements.
 - [#1107](https://github.com/influxdata/telegraf/issues/1107): Support lustre2 job stats. Thanks @hanleyja!
-- [#1110](https://github.com/influxdata/telegraf/pull/1110): Sanitize * to - in graphite serializer. Thanks @goodeggs!
-- [#1118] (https://github.com/influxdata/telegraf/pull/1118): Sanitize Counter names for `win_perf_counters` input.
+- [#1122](https://github.com/influxdata/telegraf/pull/1122): Support setting config path through env variable and default paths.
 
 ### Bugfixes
 
@@ -84,6 +83,8 @@ based on _prefix_ in addition to globs. This means that a filter like
 - [#1089](https://github.com/influxdata/telegraf/issues/1089): Fix leaky TCP connections in phpfpm plugin.
 - [#914](https://github.com/influxdata/telegraf/issues/914): Telegraf can drop metrics on full buffers.
 - [#1098](https://github.com/influxdata/telegraf/issues/1098): Sanitize invalid OpenTSDB characters.
+- [#1110](https://github.com/influxdata/telegraf/pull/1110): Sanitize * to - in graphite serializer. Thanks @goodeggs!
+- [#1118](https://github.com/influxdata/telegraf/pull/1118): Sanitize Counter names for `win_perf_counters` input.
 
 ## v0.12.1 [2016-04-14]
 

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -71,6 +71,13 @@ The flags are:
   -quiet             run in quiet mode
   -version           print the version to stdout
 
+In addition to the -config flag, telegraf will also load the config file from
+an environment variable or default location. Precedence is:
+  1. -config flag
+  2. $TELEGRAF_CONFIG_PATH environment variable
+  3. $HOME/.telegraf/telegraf.conf
+  4. /etc/telegraf/telegraf.conf
+
 Examples:
 
   # generate a telegraf config file:
@@ -98,12 +105,10 @@ func main() {
 		flag.Parse()
 		args := flag.Args()
 
-		if flag.NFlag() == 0 && len(args) == 0 {
-			usageExit(0)
-		}
-
 		var inputFilters []string
 		if *fInputFiltersLegacy != "" {
+			fmt.Printf("WARNING '--filter' flag is deprecated, please use" +
+				" '--input-filter'")
 			inputFilter := strings.TrimSpace(*fInputFiltersLegacy)
 			inputFilters = strings.Split(":"+inputFilter+":", ":")
 		}
@@ -114,6 +119,8 @@ func main() {
 
 		var outputFilters []string
 		if *fOutputFiltersLegacy != "" {
+			fmt.Printf("WARNING '--outputfilter' flag is deprecated, please use" +
+				" '--output-filter'")
 			outputFilter := strings.TrimSpace(*fOutputFiltersLegacy)
 			outputFilters = strings.Split(":"+outputFilter+":", ":")
 		}
@@ -170,25 +177,19 @@ func main() {
 			return
 		}
 
-		var (
-			c   *config.Config
-			err error
-		)
-
-		if *fConfig != "" {
-			c = config.NewConfig()
-			c.OutputFilters = outputFilters
-			c.InputFilters = inputFilters
-			err = c.LoadConfig(*fConfig)
-			if err != nil {
-				log.Fatal(err)
-			}
-		} else {
-			fmt.Println("You must specify a config file. See telegraf --help")
+		// If no other options are specified, load the config file and run.
+		c := config.NewConfig()
+		c.OutputFilters = outputFilters
+		c.InputFilters = inputFilters
+		err := c.LoadConfig(*fConfig)
+		if err != nil {
+			fmt.Println(err)
 			os.Exit(1)
 		}
 
 		if *fConfigDirectoryLegacy != "" {
+			fmt.Printf("WARNING '--configdirectory' flag is deprecated, please use" +
+				" '--config-directory'")
 			err = c.LoadDirectory(*fConfigDirectoryLegacy)
 			if err != nil {
 				log.Fatal(err)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -15,8 +15,8 @@ To generate a file with specific inputs and outputs, you can use the
 telegraf -sample-config -input-filter cpu:mem:net:swap -output-filter influxdb:kafka
 ```
 
-You can see the latest config file with all available plugins
-[here](https://github.com/influxdata/telegraf/blob/master/etc/telegraf.conf)
+You can see the latest config file with all available plugins here:
+[telegraf.conf](https://github.com/influxdata/telegraf/blob/master/etc/telegraf.conf)
 
 ## Environment Variables
 
@@ -79,7 +79,7 @@ match against the tag name, and if it matches the measurement is emitted.
 * **tagdrop**: The inverse of tagpass. If a tag matches, the measurement is not
 emitted. This is tested on measurements that have passed the tagpass test.
 * **tagexclude**: tagexclude can be used to exclude a tag from measurement(s).
-As opposed to tagdrop, which will drop an entire measurement based on it's 
+As opposed to tagdrop, which will drop an entire measurement based on it's
 tags, tagexclude simply strips the given tag keys from the measurement. This
 can be used on inputs & outputs, but it is _recommended_ to be used on inputs,
 as it is more efficient to filter out tags at the ingestion point.


### PR DESCRIPTION
precedence will be:

 1. --config command-line option
 2. $TELEGRAF_CONFIG_PATH
 3. $HOME/.telegraf/telegraf.conf
 4. /etc/telegraf/telegraf.conf