### PR TITLE
Metric for MongoDB jumbo chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ based on _prefix_ in addition to globs. This means that a filter like
 - [#967](https://github.com/influxdata/telegraf/issues/967): Buffer logging improvements.
 - [#1107](https://github.com/influxdata/telegraf/issues/1107): Support lustre2 job stats. Thanks @hanleyja!
 - [#1122](https://github.com/influxdata/telegraf/pull/1122): Support setting config path through env variable and default paths.
+- [#1128](https://github.com/influxdata/telegraf/pull/1128): MongoDB jumbo chunks metric for MongoDB input plugin
 
 ### Bugfixes
 

--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -51,3 +51,4 @@ and create a single measurement containing values e.g.
  * ttl_deletes_per_sec
  * ttl_passes_per_sec
  * repl_lag
+ * jumbo_chunks (only if mongos or mongo config)

--- a/plugins/inputs/mongodb/mongodb_data.go
+++ b/plugins/inputs/mongodb/mongodb_data.go
@@ -57,6 +57,10 @@ var DefaultReplStats = map[string]string{
 	"repl_lag":              "ReplLag",
 }
 
+var DefaultClusterStats = map[string]string{
+	"jumbo_chunks": "JumboChunksCount",
+}
+
 var MmapStats = map[string]string{
 	"mapped_megabytes":     "Mapped",
 	"non-mapped_megabytes": "NonMapped",
@@ -74,6 +78,7 @@ func (d *MongodbData) AddDefaultStats() {
 	if d.StatLine.NodeType != "" {
 		d.addStat(statLine, DefaultReplStats)
 	}
+	d.addStat(statLine, DefaultClusterStats)
 	if d.StatLine.StorageEngine == "mmapv1" {
 		d.addStat(statLine, MmapStats)
 	} else if d.StatLine.StorageEngine == "wiredTiger" {

--- a/plugins/inputs/mongodb/mongodb_data_test.go
+++ b/plugins/inputs/mongodb/mongodb_data_test.go
@@ -133,6 +133,7 @@ func TestStateTag(t *testing.T) {
 		"vsize_megabytes":       int64(0),
 		"ttl_deletes_per_sec":   int64(0),
 		"ttl_passes_per_sec":    int64(0),
+		"jumbo_chunks":          int64(0),
 	}
 	acc.AssertContainsTaggedFields(t, "mongodb", fields, stateTags)
 }

--- a/plugins/inputs/mongodb/mongodb_server.go
+++ b/plugins/inputs/mongodb/mongodb_server.go
@@ -36,9 +36,16 @@ func (s *Server) gatherData(acc telegraf.Accumulator) error {
 		log.Println("Not gathering replica set status, member not in replica set")
 	}
 
+	jumbo_chunks, _ := s.Session.DB("config").C("chunks").Find(bson.M{"jumbo": true}).Count()
+
+	result_cluster := &ClusterStatus{
+		JumboChunksCount: int64(jumbo_chunks),
+	}
+
 	result := &MongoStatus{
 		ServerStatus:  result_server,
 		ReplSetStatus: result_repl,
+		ClusterStatus: result_cluster,
 	}
 
 	defer func() {

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -34,6 +34,7 @@ type MongoStatus struct {
 	SampleTime    time.Time
 	ServerStatus  *ServerStatus
 	ReplSetStatus *ReplSetStatus
+	ClusterStatus *ClusterStatus
 }
 
 type ServerStatus struct {
@@ -62,6 +63,11 @@ type ServerStatus struct {
 	StorageEngine      map[string]string      `bson:"storageEngine"`
 	WiredTiger         *WiredTiger            `bson:"wiredTiger"`
 	Metrics            *MetricsStats          `bson:"metrics"`
+}
+
+// ClusterStatus stores information related to the whole cluster
+type ClusterStatus struct {
+	JumboChunksCount int64
 }
 
 // ReplSetStatus stores information from replSetGetStatus
@@ -387,6 +393,9 @@ type StatLine struct {
 	NumConnections                                        int64
 	ReplSetName                                           string
 	NodeType                                              string
+
+	// Cluster fields
+	JumboChunksCount int64
 }
 
 func parseLocks(stat ServerStatus) map[string]LockUsage {
@@ -664,6 +673,9 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 			}
 		}
 	}
+
+	newClusterStat := *newMongo.ClusterStatus
+	returnVal.JumboChunksCount = newClusterStat.JumboChunksCount
 
 	return returnVal
 }


### PR DESCRIPTION
MongoDB jumbo chunks can be an important problem in your cluster, if they exist your shard will be unevenly balanced. This is normally caused by a bad sharding key, so proper monitoring of jumbo chunks is needed.

