### PR TITLE
fix sysstat timeout error

### DIFF
--- a/plugins/inputs/sysstat/sysstat.go
+++ b/plugins/inputs/sysstat/sysstat.go
@@ -199,9 +199,9 @@ func (s *Sysstat) collect() error {
 
 	options = append(options, strconv.Itoa(collectInterval), "2", s.tmpFile)
 	cmd := execCommand(s.Sadc, options...)
-	out, err := internal.CombinedOutputTimeout(cmd, time.Second*5)
+	out, err := internal.CombinedOutputTimeout(cmd, time.Second*time.Duration(collectInterval+parseInterval))
 	if err != nil {
-		return fmt.Errorf("failed to run command %s: %s", strings.Join(cmd.Args, " "), string(out))
+		return fmt.Errorf("failed to run command %s: %s - %s", strings.Join(cmd.Args, " "), err, string(out))
 	}
 	return nil
 }


### PR DESCRIPTION
With a default timeout of 5 seconds, the sysstat plugin does not work for collect intervals larger than 5 seconds. This pull request fixes that issue.

I also added the error in the return error string so it is possible to see in the logs when the command timeouts.

