### PR TITLE
"DELAYED" Inserts were deprecated in MySQL 5.6.6

### DIFF
--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -117,7 +117,6 @@ The unit of fields varies by the tags.
     * write_normal(float, number/milliseconds)
     * write_allow_write(float, number/milliseconds)
     * write_concurrent_insert(float, number/milliseconds)
-    * write_delayed(float, number/milliseconds)
     * write_low_priority(float, number/milliseconds)
     * read(float, number/milliseconds)
     * write(float, number/milliseconds)

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -454,7 +454,6 @@ const (
             COUNT_READ_EXTERNAL,
             COUNT_WRITE_ALLOW_WRITE,
             COUNT_WRITE_CONCURRENT_INSERT,
-            COUNT_WRITE_DELAYED,
             COUNT_WRITE_LOW_PRIORITY,
             COUNT_WRITE_NORMAL,
             COUNT_WRITE_EXTERNAL,
@@ -465,7 +464,6 @@ const (
             SUM_TIMER_READ_EXTERNAL,
             SUM_TIMER_WRITE_ALLOW_WRITE,
             SUM_TIMER_WRITE_CONCURRENT_INSERT,
-            SUM_TIMER_WRITE_DELAYED,
             SUM_TIMER_WRITE_LOW_PRIORITY,
             SUM_TIMER_WRITE_NORMAL,
             SUM_TIMER_WRITE_EXTERNAL
@@ -1126,7 +1124,6 @@ func (m *Mysql) gatherPerfTableLockWaits(db *sql.DB, serv string, acc telegraf.A
 		countReadExternal          float64
 		countWriteAllowWrite       float64
 		countWriteConcurrentInsert float64
-		countWriteDelayed          float64
 		countWriteLowPriority      float64
 		countWriteNormal           float64
 		countWriteExternal         float64
@@ -1137,7 +1134,6 @@ func (m *Mysql) gatherPerfTableLockWaits(db *sql.DB, serv string, acc telegraf.A
 		timeReadExternal           float64
 		timeWriteAllowWrite        float64
 		timeWriteConcurrentInsert  float64
-		timeWriteDelayed           float64
 		timeWriteLowPriority       float64
 		timeWriteNormal            float64
 		timeWriteExternal          float64
@@ -1154,7 +1150,6 @@ func (m *Mysql) gatherPerfTableLockWaits(db *sql.DB, serv string, acc telegraf.A
 			&countReadExternal,
 			&countWriteAllowWrite,
 			&countWriteConcurrentInsert,
-			&countWriteDelayed,
 			&countWriteLowPriority,
 			&countWriteNormal,
 			&countWriteExternal,
@@ -1165,7 +1160,6 @@ func (m *Mysql) gatherPerfTableLockWaits(db *sql.DB, serv string, acc telegraf.A
 			&timeReadExternal,
 			&timeWriteAllowWrite,
 			&timeWriteConcurrentInsert,
-			&timeWriteDelayed,
 			&timeWriteLowPriority,
 			&timeWriteNormal,
 			&timeWriteExternal,
@@ -1190,7 +1184,6 @@ func (m *Mysql) gatherPerfTableLockWaits(db *sql.DB, serv string, acc telegraf.A
 			"write_normal":            countWriteNormal,
 			"write_allow_write":       countWriteAllowWrite,
 			"write_concurrent_insert": countWriteConcurrentInsert,
-			"write_delayed":           countWriteDelayed,
 			"write_low_priority":      countWriteLowPriority,
 		}
 		acc.AddFields("mysql_perf_schema", sqlLWFields, sqlLWTags)
@@ -1213,7 +1206,6 @@ func (m *Mysql) gatherPerfTableLockWaits(db *sql.DB, serv string, acc telegraf.A
 			"write_normal":            timeWriteNormal / picoSeconds,
 			"write_allow_write":       timeWriteAllowWrite / picoSeconds,
 			"write_concurrent_insert": timeWriteConcurrentInsert / picoSeconds,
-			"write_delayed":           timeWriteDelayed / picoSeconds,
 			"write_low_priority":      timeWriteLowPriority / picoSeconds,
 		}
 		acc.AddFields("mysql_perf_schema", sqlLWSecTotalFields, sqlLWSecTotalTags)


### PR DESCRIPTION
This PR remove gathering of deprecated metrics, PR taken from https://github.com/prometheus/mysqld_exporter/pull/106

With MySQL 5.7.11, it cause MySQL plugins to gather only partial metrics by failing [here](https://github.com/influxdata/telegraf/blob/40dccf5b2974b59eaf30ce6f1354a0702040466f/plugins/inputs/mysql/mysql.go#L619) with:
```
Error in input [mysql]: Error 1054: Unknown column 'COUNT_WRITE_DELAYED' in 'field list'
```