### PR TITLE
Haproxy socket support

### DIFF
--- a/plugins/inputs/haproxy/haproxy.go
+++ b/plugins/inputs/haproxy/haproxy.go
@@ -93,8 +93,8 @@ var sampleConfig = `
 
   ## If no servers are specified, then default to 127.0.0.1:1936
   servers = ["http://myhaproxy.com:1936", "http://anotherhaproxy.com:1936"]
-  ## Or you can also use local socket(not work yet)
-  ## servers = ["socket://run/haproxy/admin.sock"]
+  ## Or you can also use local socket
+  ## servers = ["socket:/run/haproxy/admin.sock"]
 `
 
 func (r *haproxy) SampleConfig() string {

--- a/plugins/inputs/haproxy/haproxy.go
+++ b/plugins/inputs/haproxy/haproxy.go
@@ -6,9 +6,11 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -47,7 +49,7 @@ const (
 	HF_THROTTLE       = 29 //29. throttle [...S]: current throttle percentage for the server, when slowstart is active, or no value if not in slowstart.
 	HF_LBTOT          = 30 //30. lbtot [..BS]: total number of times a server was selected, either for new sessions, or when re-dispatching. The server counter is the number of times that server was selected.
 	HF_TRACKED        = 31 //31. tracked [...S]: id of proxy/server if tracking is enabled.
-	HF_TYPE           = 32 //32. type [LFBS]: (0                                                                                                                                                                                                  = frontend, 1 = backend, 2 = server, 3 = socket/listener)
+	HF_TYPE           = 32 //32. type [LFBS]: (0 = frontend, 1 = backend, 2 = server, 3 = socket/listener)
 	HF_RATE           = 33 //33. rate [.FBS]: number of sessions per second over last elapsed second
 	HF_RATE_LIM       = 34 //34. rate_lim [.F..]: configured limit on new sessions per second
 	HF_RATE_MAX       = 35 //35. rate_max [.FBS]: max number of new sessions per second
@@ -127,7 +129,36 @@ func (g *haproxy) Gather(acc telegraf.Accumulator) error {
 	return outerr
 }
 
+func (g *haproxy) gatherServerSocket(addr string, acc telegraf.Accumulator) error {
+	var socketPath string
+	socketAddr := strings.Split(addr, ":")
+
+	if len(socketAddr) >= 2 {
+		socketPath = socketAddr[1]
+	} else {
+		socketPath = socketAddr[0]
+	}
+
+	c, err := net.Dial("unix", socketPath)
+
+	if err != nil {
+		return fmt.Errorf("Could not connect to socket '%s': %s", addr, err)
+	}
+
+	_, errw := c.Write([]byte("show stat\n"))
+
+	if errw != nil {
+		return fmt.Errorf("Could not write to socket '%s': %s", addr, errw)
+	}
+
+	return importCsvResult(c, acc, socketPath)
+}
+
 func (g *haproxy) gatherServer(addr string, acc telegraf.Accumulator) error {
+	if !strings.HasPrefix(addr, "http") {
+		return g.gatherServerSocket(addr, acc)
+	}
+
 	if g.client == nil {
 		tr := &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
 		client := &http.Client{

--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -1,14 +1,14 @@
 package haproxy
 
 import (
-	"fmt"
-	"strings"
-	"testing"
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"

--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -4,13 +4,38 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"crypto/rand"
+	"encoding/binary"
+	"net"
+	"net/http"
+	"net/http/httptest"
 
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"net/http/httptest"
 )
+
+type statServer struct{}
+
+func (s statServer) serverSocket(l net.Listener) {
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+
+		go func(c net.Conn) {
+			buf := make([]byte, 1024)
+			n, _ := c.Read(buf)
+
+			data := buf[:n]
+			if string(data) == "show stat\n" {
+				c.Write([]byte(csvOutputSample))
+				c.Close()
+			}
+		}(conn)
+	}
+}
 
 func TestHaproxyGeneratesMetricsWithAuthentication(t *testing.T) {
 	//We create a fake server to return test data
@@ -108,6 +133,69 @@ func TestHaproxyGeneratesMetricsWithoutAuthentication(t *testing.T) {
 	tags := map[string]string{
 		"proxy":  "be_app",
 		"server": ts.Listener.Addr().String(),
+		"sv":     "host0",
+	}
+
+	fields := map[string]interface{}{
+		"active_servers":    uint64(1),
+		"backup_servers":    uint64(0),
+		"bin":               uint64(510913516),
+		"bout":              uint64(2193856571),
+		"check_duration":    uint64(10),
+		"cli_abort":         uint64(73),
+		"ctime":             uint64(2),
+		"downtime":          uint64(0),
+		"dresp":             uint64(0),
+		"econ":              uint64(0),
+		"eresp":             uint64(1),
+		"http_response.1xx": uint64(0),
+		"http_response.2xx": uint64(119534),
+		"http_response.3xx": uint64(48051),
+		"http_response.4xx": uint64(2345),
+		"http_response.5xx": uint64(1056),
+		"lbtot":             uint64(171013),
+		"qcur":              uint64(0),
+		"qmax":              uint64(0),
+		"qtime":             uint64(0),
+		"rate":              uint64(3),
+		"rate_max":          uint64(12),
+		"rtime":             uint64(312),
+		"scur":              uint64(1),
+		"smax":              uint64(32),
+		"srv_abort":         uint64(1),
+		"stot":              uint64(171014),
+		"ttime":             uint64(2341),
+		"wredis":            uint64(0),
+		"wretr":             uint64(1),
+	}
+	acc.AssertContainsTaggedFields(t, "haproxy", fields, tags)
+}
+
+func TestHaproxyGeneratesMetricsUsingSocket(t *testing.T) {
+	var randomNumber int64
+	binary.Read(rand.Reader, binary.LittleEndian, &randomNumber)
+	sock, err := net.Listen("unix", fmt.Sprintf("/tmp/test-haproxy%d.sock", randomNumber))
+	if err != nil {
+		t.Fatal("Cannot initialize socket ")
+	}
+
+	defer sock.Close()
+
+	s := statServer{}
+	go s.serverSocket(sock)
+
+	r := &haproxy{
+		Servers: []string{sock.Addr().String()},
+	}
+
+	var acc testutil.Accumulator
+
+	err = r.Gather(&acc)
+	require.NoError(t, err)
+
+	tags := map[string]string{
+		"proxy":  "be_app",
+		"server": sock.Addr().String(),
 		"sv":     "host0",
 	}
 


### PR DESCRIPTION
This adds HAproxy stats socket support which can be used to poll for stats instead of using web interface. Has added benefit of not requiring separate management interface/port defined as stats socket should be enabled by default.