### PR TITLE
Consolidate AWS credentials, Cloudwatch dimension wilcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ new plugins.
 ### Linux deb and rpm Packages:
 
 Latest:
-* https://dl.influxdata.com/telegraf/releases/telegraf_0.13.0-1_amd64.deb
-* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0-1.x86_64.rpm
+* https://dl.influxdata.com/telegraf/releases/telegraf_0.13.0_amd64.deb
+* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0.x86_64.rpm
 
 Latest (arm):
-* https://dl.influxdata.com/telegraf/releases/telegraf_0.13.0-1_armhf.deb
-* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0-1.armhf.rpm
+* https://dl.influxdata.com/telegraf/releases/telegraf_0.13.0_armhf.deb
+* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0.armhf.rpm
 
 ##### Package Instructions:
 
@@ -46,28 +46,28 @@ to use this repo to install & update telegraf.
 ### Linux tarballs:
 
 Latest:
-* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0-1_linux_amd64.tar.gz
-* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0-1_linux_i386.tar.gz
-* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0-1_linux_armhf.tar.gz
+* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0_linux_amd64.tar.gz
+* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0_linux_i386.tar.gz
+* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0_linux_armhf.tar.gz
 
 ##### tarball Instructions:
 
 To install the full directory structure with config file, run:
 
 ```
-sudo tar -C / -zxvf ./telegraf-0.13.0-1_linux_amd64.tar.gz
+sudo tar -C / -zxvf ./telegraf-0.13.0_linux_amd64.tar.gz
 ```
 
 To extract only the binary, run:
 
 ```
-tar -zxvf telegraf-0.13.0-1_linux_amd64.tar.gz --strip-components=3 ./usr/bin/telegraf
+tar -zxvf telegraf-0.13.0_linux_amd64.tar.gz --strip-components=3 ./usr/bin/telegraf
 ```
 
 ### FreeBSD tarball:
 
 Latest:
-* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0-1_freebsd_amd64.tar.gz
+* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0_freebsd_amd64.tar.gz
 
 ##### tarball Instructions:
 
@@ -87,8 +87,8 @@ brew install telegraf
 ### Windows Binaries (EXPERIMENTAL)
 
 Latest:
-* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0-1_windows_amd64.zip
-* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0-1_windows_i386.zip
+* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0_windows_amd64.zip
+* https://dl.influxdata.com/telegraf/releases/telegraf-0.13.0_windows_i386.zip
 
 ### From Source:
 

--- a/internal/config/aws/credentials.go
+++ b/internal/config/aws/credentials.go
@@ -3,9 +3,9 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/awslabs/aws-sdk-go/aws/credentials"
-	"github.com/kelseyhightower/confd/vendor/github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	"github.com/kelseyhightower/confd/vendor/github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 type AwsCredentials struct {

--- a/internal/config/aws/credentials.go
+++ b/internal/config/aws/credentials.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/awslabs/aws-sdk-go/aws/credentials"
+	"github.com/kelseyhightower/confd/vendor/github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/kelseyhightower/confd/vendor/github.com/aws/aws-sdk-go/aws/session"
+)
+
+type AwsCredentials struct {
+	Region    string `toml:"region"`                 // AWS Region
+	AccessKey string `toml:"access_key"`             // Explicit AWS Access Key ID
+	SecretKey string `toml:"secret_key"`             // Explicit AWS Secret Access Key
+	RoleArn   string `toml:"role_arn"`               // Role ARN to assume
+	Profile   string `toml:"profile"`                // the shared profile to use
+	SharedCredentialFile  string `toml:"shared_credential_file"` // location of shared credential file
+	Token     string `toml:"token"`                  // STS session token
+}
+
+func (c *AwsCredentials) Credentials() client.ConfigProvider {
+	if c.RoleArn != "" {
+		return c.assumeCredentials()
+	} else {
+		return c.rootCredentials()
+	}
+}
+
+func (c *AwsCredentials) rootCredentials() client.ConfigProvider {
+	config := &aws.Config{
+		Region: aws.String(c.Region),
+	}
+	if c.AccessKey != "" || c.SecretKey != "" {
+		config.Credentials = credentials.NewStaticCredentials(c.AccessKey, c.SecretKey, c.Token)
+	} else if c.Profile != "" || c.SharedCredentialFile != "" {
+		config.Credentials = credentials.NewSharedCredentials(c.SharedCredentialFile, c.Profile)
+	}
+
+	return session.New(config)
+}
+
+func (c *AwsCredentials) assumeCredentials() client.ConfigProvider {
+	rootCredentials := c.rootCredentials()
+	config := &aws.Config{
+		Region: aws.String(c.Region),
+	}
+	config.Credentials = stscreds.NewCredentials(rootCredentials, c.RoleArn)
+	return session.New(config)
+}

--- a/internal/config/aws/credentials.go
+++ b/internal/config/aws/credentials.go
@@ -9,13 +9,13 @@ import (
 )
 
 type AwsCredentials struct {
-	Region    string `toml:"region"`                 // AWS Region
-	AccessKey string `toml:"access_key"`             // Explicit AWS Access Key ID
-	SecretKey string `toml:"secret_key"`             // Explicit AWS Secret Access Key
-	RoleArn   string `toml:"role_arn"`               // Role ARN to assume
-	Profile   string `toml:"profile"`                // the shared profile to use
-	SharedCredentialFile  string `toml:"shared_credential_file"` // location of shared credential file
-	Token     string `toml:"token"`                  // STS session token
+	Region               string `toml:"region"`                 // AWS Region
+	AccessKey            string `toml:"access_key"`             // Explicit AWS Access Key ID
+	SecretKey            string `toml:"secret_key"`             // Explicit AWS Secret Access Key
+	RoleArn              string `toml:"role_arn"`               // Role ARN to assume
+	Profile              string `toml:"profile"`                // the shared profile to use
+	SharedCredentialFile string `toml:"shared_credential_file"` // location of shared credential file
+	Token                string `toml:"token"`                  // STS session token
 }
 
 func (c *AwsCredentials) Credentials() client.ConfigProvider {

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -11,12 +11,19 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 
 	"github.com/influxdata/telegraf"
-	influxaws "github.com/influxdata/telegraf/internal/config/aws"
+	internalaws "github.com/influxdata/telegraf/internal/config/aws"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
 type CloudWatch struct {
-	influxaws.AwsCredentials
+	Region    string `toml:"region"`
+	AccessKey string `toml:"access_key"`
+	SecretKey string `toml:"secret_key"`
+	RoleARN   string `toml:"role_arn"`
+	Profile   string `toml:"profile"`
+	Filename  string `toml:"shared_credential_file"`
+	Token     string `toml:"token"`
+
 	Namespace string `toml:"namespace"` // CloudWatch Metrics Namespace
 	svc       *cloudwatch.CloudWatch
 }
@@ -35,6 +42,10 @@ var sampleConfig = `
   ## 6) EC2 Instance Profile
   #access_key = ""
   #secret_key = ""
+  #token = ""
+  #role_arn = ""
+  #profile = ""
+  #shared_credential_file = ""
 
   ## Namespace for the CloudWatch MetricDatums
   namespace = 'InfluxData/Telegraf'
@@ -49,7 +60,16 @@ func (c *CloudWatch) Description() string {
 }
 
 func (c *CloudWatch) Connect() error {
-	configProvider := c.Credentials()
+	credentialConfig := &internalaws.CredentialConfig{
+		Region:    c.Region,
+		AccessKey: c.AccessKey,
+		SecretKey: c.SecretKey,
+		RoleARN:   c.RoleARN,
+		Profile:   c.Profile,
+		Filename:  c.Filename,
+		Token:     c.Token,
+	}
+	configProvider := credentialConfig.Credentials()
 
 	svc := cloudwatch.New(configProvider)
 

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -8,19 +8,16 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 
 	"github.com/influxdata/telegraf"
+	influxaws "github.com/influxdata/telegraf/internal/config/aws"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
 type CloudWatch struct {
-	Region    string `toml:"region"`     // AWS Region
-	AccessKey string `toml:"access_key"` // Explicit AWS Access Key ID
-	SecretKey string `toml:"secret_key"` // Explicit AWS Secret Access Key
-	Namespace string `toml:"namespace"`  // CloudWatch Metrics Namespace
+	influxaws.AwsCredentials
+	Namespace string `toml:"namespace"` // CloudWatch Metrics Namespace
 	svc       *cloudwatch.CloudWatch
 }
 
@@ -30,10 +27,12 @@ var sampleConfig = `
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) explicit credentials from 'access_key' and 'secret_key'
-  ## 2) environment variables
-  ## 3) shared credentials file
-  ## 4) EC2 Instance Profile
+  ## 1) Assumed credentials via STS if role_arn is specified
+  ## 2) explicit credentials from 'access_key' and 'secret_key'
+  ## 3) shared profile from 'profile'
+  ## 4) environment variables
+  ## 5) shared credentials file
+  ## 6) EC2 Instance Profile
   #access_key = ""
   #secret_key = ""
 
@@ -50,14 +49,9 @@ func (c *CloudWatch) Description() string {
 }
 
 func (c *CloudWatch) Connect() error {
-	Config := &aws.Config{
-		Region: aws.String(c.Region),
-	}
-	if c.AccessKey != "" || c.SecretKey != "" {
-		Config.Credentials = credentials.NewStaticCredentials(c.AccessKey, c.SecretKey, "")
-	}
+	configProvider := c.Credentials()
 
-	svc := cloudwatch.New(session.New(Config))
+	svc := cloudwatch.New(configProvider)
 
 	params := &cloudwatch.ListMetricsInput{
 		Namespace: aws.String(c.Namespace),

--- a/plugins/outputs/kinesis/kinesis.go
+++ b/plugins/outputs/kinesis/kinesis.go
@@ -8,18 +8,15 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 
 	"github.com/influxdata/telegraf"
+	influxaws "github.com/influxdata/telegraf/internal/config/aws"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
 type KinesisOutput struct {
-	Region       string `toml:"region"`
-	AccessKey    string `toml:"access_key"`
-	SecretKey    string `toml:"secret_key"`
+	influxaws.AwsCredentials
 	StreamName   string `toml:"streamname"`
 	PartitionKey string `toml:"partitionkey"`
 	Format       string `toml:"format"`
@@ -33,10 +30,12 @@ var sampleConfig = `
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) explicit credentials from 'access_key' and 'secret_key'
-  ## 2) environment variables
-  ## 3) shared credentials file
-  ## 4) EC2 Instance Profile
+  ## 1) Assumed credentials via STS if role_arn is specified
+  ## 2) explicit credentials from 'access_key' and 'secret_key'
+  ## 3) shared profile from 'profile'
+  ## 4) environment variables
+  ## 5) shared credentials file
+  ## 6) EC2 Instance Profile
   #access_key = ""
   #secret_key = ""
 
@@ -75,13 +74,9 @@ func (k *KinesisOutput) Connect() error {
 	if k.Debug {
 		log.Printf("kinesis: Establishing a connection to Kinesis in %+v", k.Region)
 	}
-	Config := &aws.Config{
-		Region: aws.String(k.Region),
-	}
-	if k.AccessKey != "" || k.SecretKey != "" {
-		Config.Credentials = credentials.NewStaticCredentials(k.AccessKey, k.SecretKey, "")
-	}
-	svc := kinesis.New(session.New(Config))
+
+	configProvider := k.Credentials()
+	svc := kinesis.New(configProvider)
 
 	KinesisParams := &kinesis.ListStreamsInput{
 		Limit: aws.Int64(100),


### PR DESCRIPTION
Wasn't sure if you'd be ok with trying to squeeze this into 0.13 or not (I can retarget it to master if you'd like).

This PR does 3 things:
1) Consolidates how AWS credentials are configured across all inputs/outputs
2) Adds support for configuration AWS credentials via shared credential file and profile and via assuming a role through STS
3) Adds support to the cloudwatch input to specify a wildcard for the dimension value allowing for ingesting all metrics that have that dimension regardless of value.

Closes #1115, #1101 