### PR TITLE
add 'cpu_percent' to process cpu usage as percent of total system

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -552,7 +552,7 @@ func parseFile(fpath string) (*ast.Table, error) {
 	env_vars := envExecRe.FindAll(contents, -1)
 	for _, env_var := range env_vars {
 		str := strings.TrimPrefix(string(env_var), "$(")
-		str = strings.TrimSuffix(str, ")")
+		args := strings.Fields(strings.TrimSuffix(str, ")"))
 		v, err := exec.Command(args[0], args[1:]...).Output()
 		if err != nil {
 			return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -549,7 +549,7 @@ func parseFile(fpath string) (*ast.Table, error) {
 		}
 	}
 
-	env_vars := envExecRe.FindAll(contents, -1)
+	env_vars = envExecRe.FindAll(contents, -1)
 	for _, env_var := range env_vars {
 		str := strings.TrimPrefix(string(env_var), "$(")
 		args := strings.Fields(strings.TrimSuffix(str, ")"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -553,6 +553,9 @@ func parseFile(fpath string) (*ast.Table, error) {
 	for _, env_var := range env_vars {
 		str := strings.TrimPrefix(string(env_var), "$(")
 		args := strings.Fields(strings.TrimSuffix(str, ")"))
+		if len(args) == 0 {
+			return nil, fmt.Errorf("Empty command string")
+		}
 		v, err := exec.Command(args[0], args[1:]...).Output()
 		if err != nil {
 			return nil, err

--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -54,6 +54,7 @@ I/O related measurement names:
 
 CPU related measurement names:
 - procstat_[prefix_]cpu_user value=0
+- procstat_[prefix_]cpu_percent value=0.0
 - procstat_[prefix_]cpu_system value=0.01
 - procstat_[prefix_]cpu_idle value=0
 - procstat_[prefix_]cpu_nice value=0

--- a/plugins/inputs/procstat/spec_processor.go
+++ b/plugins/inputs/procstat/spec_processor.go
@@ -38,7 +38,7 @@ func NewSpecProcessor(
 var cores int32
 
 func init() {
-	if info, err := cpu.Info(); err == nil {
+	if info, err := cpu.CPUInfo(); err == nil {
 		for _, in := range info {
 			cores += in.Cores
 		}
@@ -76,7 +76,7 @@ func (p *SpecProcessor) pushMetrics() {
 		fields[prefix+"write_bytes"] = io.WriteCount
 	}
 
-	cpu_time, err := p.proc.Times()
+	cpu_time, err := p.proc.CPUTimes()
 	if err == nil {
 		fields[prefix+"cpu_time_user"] = cpu_time.User
 		fields[prefix+"cpu_time_system"] = cpu_time.System
@@ -91,7 +91,7 @@ func (p *SpecProcessor) pushMetrics() {
 		fields[prefix+"cpu_time_guest_nice"] = cpu_time.GuestNice
 	}
 
-	cpu_perc, err := p.proc.Percent(time.Duration(0))
+	cpu_perc, err := p.proc.CPUPercent(time.Duration(0))
 	if err == nil && cpu_perc != 0 {
 		fields[prefix+"cpu_usage"] = cpu_perc
 		if cores > 0 {


### PR DESCRIPTION
Seeing cpu_usage per process is nice and all, but it really is of interest to see what percentage of the total CPU it's using. This adds one more field that adjusts cpu_usage as a percentage of whole system.