### PR TITLE
fix interval rounding error

### DIFF
--- a/plugins/inputs/sysstat/sysstat.go
+++ b/plugins/inputs/sysstat/sysstat.go
@@ -140,7 +140,7 @@ func (s *Sysstat) Gather(acc telegraf.Accumulator) error {
 		if firstTimestamp.IsZero() {
 			firstTimestamp = time.Now()
 		} else {
-			s.interval = int(time.Since(firstTimestamp).Seconds())
+			s.interval = int(time.Since(firstTimestamp).Seconds() + 0.5)
 		}
 	}
 	ts := time.Now().Add(time.Duration(s.interval) * time.Second)


### PR DESCRIPTION
This pull request fixes a interval calculation error.

Before, the interval time was cast to an integer. This can lead to an interval of 29 seconds with an interval of 30 second, when the time between the first and second `Gather` is for example 29.91.

With this pull request the interval is rounded to the closest integer, to 30 in the above case.