### PR TITLE
Procstat input plugin - functionality for overriding of process_name

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -15,11 +15,12 @@ import (
 )
 
 type Procstat struct {
-	PidFile string `toml:"pid_file"`
-	Exe     string
-	Pattern string
-	Prefix  string
-	User    string
+	PidFile     string `toml:"pid_file"`
+	Exe         string
+	Pattern     string
+	Prefix      string
+	ProcessName string
+	User        string
 
 	// pidmap maps a pid to a process object, so we don't recreate every gather
 	pidmap map[int32]*process.Process
@@ -45,6 +46,9 @@ var sampleConfig = `
   ## user as argument for pgrep (ie, pgrep -u <user>)
   # user = "nginx"
 
+  ## override for process_name
+  ## This is optional; default is sourced from /proc/<pid>/status
+  # process_name = "bar"
   ## Field name prefix
   prefix = ""
   ## comment this out if you want raw cpu_time stats
@@ -66,7 +70,7 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 			p.Exe, p.PidFile, p.Pattern, p.User, err.Error())
 	} else {
 		for pid, proc := range p.pidmap {
-			p := NewSpecProcessor(p.Prefix, acc, proc, p.tagmap[pid])
+			p := NewSpecProcessor(p.ProcessName, p.Prefix, acc, proc, p.tagmap[pid])
 			p.pushMetrics()
 		}
 	}

--- a/plugins/inputs/procstat/spec_processor.go
+++ b/plugins/inputs/procstat/spec_processor.go
@@ -17,13 +17,19 @@ type SpecProcessor struct {
 }
 
 func NewSpecProcessor(
+	processName string,
 	prefix string,
 	acc telegraf.Accumulator,
 	p *process.Process,
 	tags map[string]string,
 ) *SpecProcessor {
-	if name, err := p.Name(); err == nil {
-		tags["process_name"] = name
+	if processName != "" {
+		tags["process_name"] = processName
+	} else {
+		name, err := p.Name()
+		if err == nil {
+			tags["process_name"] = name
+		}
 	}
 	return &SpecProcessor{
 		Prefix: prefix,


### PR DESCRIPTION
Being able to override the process_name in the procstat module is useful for daemonized perl, ruby, erlang etc. processes. This allows for manually setting process_name rather than it being set to the interpreter/VM of the process.