### PR TITLE
Fix crash in Docker input plugin - Fixes #1195

### DIFF
--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -221,7 +221,7 @@ func (d *Docker) gatherContainer(
 	defer cancel()
 	r, err := d.client.ContainerStats(ctx, container.ID, false)
 	if err != nil {
-		log.Printf("Error getting docker stats: %s\n", err.Error())
+		return fmt.Errorf("Error getting docker stats: %s", err.Error())
 	}
 	defer r.Close()
 	dec := json.NewDecoder(r)


### PR DESCRIPTION
Commit fixes crash in Docker input plugin caused by the fact that return value
might be nil when error occurs.