### PR TITLE
fix mongodb input concurrent map read/write

### DIFF
--- a/plugins/inputs/mongodb/mongodb.go
+++ b/plugins/inputs/mongodb/mongodb.go
@@ -69,10 +69,10 @@ func (m *MongoDB) Gather(acc telegraf.Accumulator) error {
 			}
 		}
 		wg.Add(1)
-		go func() {
+		go func(srv *Server) {
 			defer wg.Done()
-			outerr = m.gatherServer(m.getMongoServer(u), acc)
-		}()
+			outerr = m.gatherServer(srv, acc)
+		}(m.getMongoServer(u))
 	}
 
 	wg.Wait()


### PR DESCRIPTION
fix a crash caused by concurrent map read/write

```
2016/05/17 17:22:59 Agent Config: Interval:10s, Debug:false, Quiet:false, Hostname:"redeye01", Flush Interval:10s 
fatal error: concurrent map read and map write
fatal error: concurrent map read and map write

goroutine 98 [running]:
runtime.throw(0x136a720, 0x21)
        /usr/local/go/src/runtime/panic.go:547 +0x90 fp=0xc8205d3ec8 sp=0xc8205d3eb0
runtime.mapaccess2_faststr(0xe74ec0, 0xc8201fe6c0, 0xc8200f83e1, 0x10, 0x0, 0x0)
        /usr/local/go/src/runtime/hashmap_fast.go:307 +0x5b fp=0xc8205d3f28 sp=0xc8205d3ec8
github.com/influxdata/telegraf/plugins/inputs/mongodb.(*MongoDB).Gather.func1(0xc8200e3620, 0xc8200e3630, 0xc82021ec80, 0xc820208880, 0x7fd0b2c55878, 0xc82021f2c0)
        /root/go/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongodb.go:74 +0x93 fp=0xc8205d3f90 sp=0xc8205d3f28
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1998 +0x1 fp=0xc8205d3f98 sp=0xc8205d3f90
created by github.com/influxdata/telegraf/plugins/inputs/mongodb.(*MongoDB).Gather
        /root/go/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongodb.go:75 +0x5c1
```