### PR TITLE
fix telegraf service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## v1.0 [unreleased]
 
+### Release Notes
+
+### Features
+
+### Bugfixes
+
+- [#1252](https://github.com/influxdata/telegraf/pull/1252): Fix systemd service. Thanks @zbindenren!
+
 ## v0.13.1 [2016-05-24]
 
 ### Release Notes

--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -11,7 +11,7 @@ Environment='STDERR=/var/log/telegraf/telegraf.log'
 ExecStart=/bin/sh -c "/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d ${TELEGRAF_OPTS} >>${STDOUT} 2>>${STDERR}"
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
-KillMode=process
+KillMode=control-group
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There has been a change in systemd service to start telegraf which does not work anymore with the `KillMode=process` setting.

If you keep that KillMode, a stop just kills the bash, but keeps telegraf service. With that setting, it is possible to run serveral telegraf instances.

With the old setting:
```
$ systemctl start telegraf
```

you see following process:
```
/bin/sh -c /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d  >>/var/log/telegraf/telegraf.log 2>>/var/log/telegraf/telegraf.log
```
Then with:
```
$ systemctl stop telegraf
```

the service is still running.
```
/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
```
Only the parent bash got killed. If you start telegraf with sytemd again, the service runs twice.

This Pull Request fixes that issue.

### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)

