### PR TITLE
add option to disable dns lookup for chronyc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#1247](https://github.com/influxdata/telegraf/pull/1247): rollbar input plugin. Thanks @francois2metz and @cduez!
+- [#1265](https://github.com/influxdata/telegraf/pull/1265): Make dns lookups for chrony configurable. Thanks @zbindenren!
 
 ### Bugfixes
 

--- a/plugins/inputs/chrony/README.md
+++ b/plugins/inputs/chrony/README.md
@@ -40,7 +40,7 @@ is computed for the new frequency, with weights depending on these accuracies. I
 measurements from the reference source follow a consistent trend, the residual will be
 driven to zero over time.
 - Skew - This is the estimated error bound on the frequency.
-- Root delay -This is the total of the network path delays to the stratum-1 computer
+- Root delay - This is the total of the network path delays to the stratum-1 computer
 from which the computer is ultimately synchronised. In certain extreme situations, this
 value can be negative. (This can arise in a symmetric peer arrangement where the computers’
 frequencies are not tracking each other and the network delay is very short relative to the
@@ -56,7 +56,8 @@ Delete second or Not synchronised.
 ```toml
 # Get standard chrony metrics, requires chronyc executable.
 [[inputs.chrony]]
-  # no configuration
+  ## If true, chronyc tries to perform a DNS lookup for the time server.
+  # dns_lookup = false
 ```
 
 ### Measurements & Fields:


### PR DESCRIPTION
Make reverse lookups of time server configurable.

### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)

