### PR TITLE
kernel: use strconv.ParseInt instead of strconv.Atoi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ time before a new metric is included by the plugin.
 
 - [#1252](https://github.com/influxdata/telegraf/pull/1252): Fix systemd service. Thanks @zbindenren!
 - [#1221](https://github.com/influxdata/telegraf/pull/1221): Fix influxdb n_shards counter.
+- [#1258](https://github.com/influxdata/telegraf/pull/1258): Fix potential kernel plugin integer parse error.
 
 ## v0.13.1 [2016-05-24]
 

--- a/plugins/inputs/system/kernel.go
+++ b/plugins/inputs/system/kernel.go
@@ -44,35 +44,35 @@ func (k *Kernel) Gather(acc telegraf.Accumulator) error {
 	for i, field := range dataFields {
 		switch {
 		case bytes.Equal(field, interrupts):
-			m, err := strconv.Atoi(string(dataFields[i+1]))
+			m, err := strconv.ParseInt(string(dataFields[i+1]), 10, 64)
 			if err != nil {
 				return err
 			}
 			fields["interrupts"] = int64(m)
 		case bytes.Equal(field, context_switches):
-			m, err := strconv.Atoi(string(dataFields[i+1]))
+			m, err := strconv.ParseInt(string(dataFields[i+1]), 10, 64)
 			if err != nil {
 				return err
 			}
 			fields["context_switches"] = int64(m)
 		case bytes.Equal(field, processes_forked):
-			m, err := strconv.Atoi(string(dataFields[i+1]))
+			m, err := strconv.ParseInt(string(dataFields[i+1]), 10, 64)
 			if err != nil {
 				return err
 			}
 			fields["processes_forked"] = int64(m)
 		case bytes.Equal(field, boot_time):
-			m, err := strconv.Atoi(string(dataFields[i+1]))
+			m, err := strconv.ParseInt(string(dataFields[i+1]), 10, 64)
 			if err != nil {
 				return err
 			}
 			fields["boot_time"] = int64(m)
 		case bytes.Equal(field, disk_pages):
-			in, err := strconv.Atoi(string(dataFields[i+1]))
+			in, err := strconv.ParseInt(string(dataFields[i+1]), 10, 64)
 			if err != nil {
 				return err
 			}
-			out, err := strconv.Atoi(string(dataFields[i+2]))
+			out, err := strconv.ParseInt(string(dataFields[i+2]), 10, 64)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated

closes #1258