### PR TITLE
Fixes #1277 Use the DefaultURL parameter if no url is explicitly set by the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ time before a new metric is included by the plugin.
 - [#1264](https://github.com/influxdata/telegraf/pull/1264): Add SSL config options to http_response plugin.
 - [#1272](https://github.com/influxdata/telegraf/pull/1272): graphite parser: add ability to specify multiple tag keys, for consistency with influxdb parser.
 - [#1265](https://github.com/influxdata/telegraf/pull/1265): Make dns lookups for chrony configurable. Thanks @zbindenren!
+- [#1278](https://github.com/influxdata/telegraf/pull/1278): RabbitMQ input: made url parameter optional by using DefaultURL (http://localhost:15672) if not specified
 
 ### Bugfixes
 

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1176,7 +1176,7 @@
 
 # # Read metrics from one or many RabbitMQ servers via the management API
 # [[inputs.rabbitmq]]
-#   url = "http://localhost:15672" # required
+#   # url = "http://localhost:15672"
 #   # name = "rmq-server-1" # optional tag
 #   # username = "guest"
 #   # password = "guest"

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -149,9 +149,9 @@ func (r *RabbitMQ) requestJSON(u string, target interface{}) error {
 	if r.URL == "" {
 		r.URL = DefaultURL
 	}
-	u = fmt.Sprintf("%s%s", url, u)
+	u = fmt.Sprintf("%s%s", r.URL, u)
 
-	req, err := http.NewRequest("GET", r.URL, nil)
+	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -146,13 +146,12 @@ func (r *RabbitMQ) Gather(acc telegraf.Accumulator) error {
 }
 
 func (r *RabbitMQ) requestJSON(u string, target interface{}) error {
-	url := r.URL
-	if url == "" {
-		url = DefaultURL
+	if r.URL == "" {
+		r.URL = DefaultURL
 	}
 	u = fmt.Sprintf("%s%s", url, u)
 
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequest("GET", r.URL, nil)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -146,7 +146,11 @@ func (r *RabbitMQ) Gather(acc telegraf.Accumulator) error {
 }
 
 func (r *RabbitMQ) requestJSON(u string, target interface{}) error {
-	u = fmt.Sprintf("%s%s", r.URL, u)
+	url := r.URL
+	if url == "" {
+		url = DefaultURL
+	}
+	u = fmt.Sprintf("%s%s", url, u)
 
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -102,7 +102,7 @@ type gatherFunc func(r *RabbitMQ, acc telegraf.Accumulator, errChan chan error)
 var gatherFunctions = []gatherFunc{gatherOverview, gatherNodes, gatherQueues}
 
 var sampleConfig = `
-  url = "http://localhost:15672" # required
+  # url = "http://localhost:15672"
   # name = "rmq-server-1" # optional tag
   # username = "guest"
   # password = "guest"


### PR DESCRIPTION
This fixes #1277 hopefully by checking if a url is set by the user and if not the DefaultURL is used which is fine for lots of RMQ installations