### PR TITLE
Fix reloading Telegraf under systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ time before a new metric is included by the plugin.
 
 ### Bugfixes
 
-- [#1252](https://github.com/influxdata/telegraf/pull/1252): Fix systemd service. Thanks @zbindenren!
+- [#1252](https://github.com/influxdata/telegraf/pull/1252) & [#1279](https://github.com/influxdata/telegraf/pull/1279): Fix systemd service. Thanks @zbindenren & @PierreF!
 - [#1221](https://github.com/influxdata/telegraf/pull/1221): Fix influxdb n_shards counter.
 - [#1258](https://github.com/influxdata/telegraf/pull/1258): Fix potential kernel plugin integer parse error.
 - [#1268](https://github.com/influxdata/telegraf/pull/1268): Fix potential influxdb input type assertion panic.

--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -8,7 +8,7 @@ EnvironmentFile=-/etc/default/telegraf
 User=telegraf
 Environment='STDOUT=/var/log/telegraf/telegraf.log'
 Environment='STDERR=/var/log/telegraf/telegraf.log'
-ExecStart=/bin/sh -c "/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d ${TELEGRAF_OPTS} >>${STDOUT} 2>>${STDERR}"
+ExecStart=/bin/sh -c "exec /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d ${TELEGRAF_OPTS} >>${STDOUT} 2>>${STDERR}"
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 KillMode=control-group


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

PR #1252 works well for stopping Telegraf, but reloading cause Telegraf to exit:

```
$ dpkg -l telegraf 
ii  telegraf       0.13.1~a8334c3-0
$ ps waux|grep telegraf
telegraf 13662  0.0  0.0   4508   756 ?        Ss   11:31   0:00 /bin/sh -c /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d  >>/var/log/telegraf/telegraf.log 2>>/var/log/telegraf/telegraf.log
telegraf 13663  0.3  0.2 227988 23380 ?        Sl   11:31   0:00 /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
$ sudo systemctl reload telegraf
$ sudo systemctl status telegraf
[...]
   Active: inactive (dead) since jeu. 2016-05-26 11:33:08 CEST; 3s ago
[...]
 Main PID: 13662 (code=killed, signal=HUP)
$ ps waux|grep telegraf
nothing
```

This is caused since $MAINPID (used by ExecReload=/bin/kill -HUP $MAINPID) is the sh process. When sh process get a SIGHUP, it exits which cause child process (Telegraf) to be killed.

This PR add an "exec" which cause sh processed to be replaced by Telegraf, thus $MAINPID is now Telegraf itself.

```
$ dpkg -l telegraf 
ii  telegraf       0.13.1~46f0196-0
$ ps waux|grep telegraf
telegraf 15816  1.0  0.2 301976 23756 ?        Ssl  11:37   0:00 /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
$ sudo systemctl reload telegraf
$ sudo systemctl status telegraf
[...]
   Active: active (running) since jeu. 2016-05-26 11:37:04 CEST; 35s ago
[...]
 Main PID: 15816 (telegraf)
$ ps waux|grep telegraf
telegraf 15816  0.5  0.3 460808 30972 ?        Ssl  11:37   0:00 /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
```

Logs continue to be written to /var/log/telegraf/telegraf.log