### PR TITLE
Use optimeDate to get MongoTimestamp (mongo input plugin).

### DIFF
--- a/plugins/inputs/mongodb/mongodb_server.go
+++ b/plugins/inputs/mongodb/mongodb_server.go
@@ -33,7 +33,7 @@ func (s *Server) gatherData(acc telegraf.Accumulator) error {
 	result_repl := &ReplSetStatus{}
 	err = s.Session.DB("admin").Run(bson.D{{"replSetGetStatus", 1}}, result_repl)
 	if err != nil {
-		log.Println("Not gathering replica set status, member not in replica set")
+		log.Println("Not gathering replica set status, member not in replica set (" + err.Error() + ")")
 	}
 
 	jumbo_chunks, _ := s.Session.DB("config").C("chunks").Find(bson.M{"jumbo": true}).Count()

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -78,9 +78,9 @@ type ReplSetStatus struct {
 
 // ReplSetMember stores information related to a replica set member
 type ReplSetMember struct {
-	Name   string               `bson:"name"`
-	State  int64                `bson:"state"`
-	Optime *bson.MongoTimestamp `bson:"optime"`
+	Name       string               `bson:"name"`
+	State      int64                `bson:"state"`
+	OptimeDate *bson.MongoTimestamp `bson:"optimeDate"`
 }
 
 // WiredTiger stores information related to the WiredTiger storage engine.
@@ -663,9 +663,9 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 			}
 		}
 
-		if me.Optime != nil && master.Optime != nil && me.State == 2 {
+		if me.OptimeDate != nil && master.OptimeDate != nil && me.State == 2 {
 			// MongoTimestamp type is int64 where the first 32bits are the unix timestamp
-			lag := int64(*master.Optime>>32 - *me.Optime>>32)
+			lag := int64(*master.OptimeDate>>32 - *me.OptimeDate>>32)
 			if lag < 0 {
 				returnVal.ReplLag = 0
 			} else {


### PR DESCRIPTION
Although I am running mongo with replicas, telegrafs mongo input plugin reported:
`2016/05/26 02:32:28 Not gathering replica set status, member not in replica set`

Patching the error message showed:
`Unsupported document type for unmarshalling: bson.MongoTimestamp`

Changing optime to optimeDate fixes that.  Has been a mismatch or it was recently changed? I am using MongoDB 3.2.6.
