### PR TITLE
processes: Don't return error if process exited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ time before a new metric is included by the plugin.
 - [#1221](https://github.com/influxdata/telegraf/pull/1221): Fix influxdb n_shards counter.
 - [#1258](https://github.com/influxdata/telegraf/pull/1258): Fix potential kernel plugin integer parse error.
 - [#1268](https://github.com/influxdata/telegraf/pull/1268): Fix potential influxdb input type assertion panic.
+- [#1283](https://github.com/influxdata/telegraf/pull/1283): Still send processes metrics if a process exited during metric collection.
 
 ## v0.13.1 [2016-05-24]
 

--- a/plugins/inputs/system/processes.go
+++ b/plugins/inputs/system/processes.go
@@ -141,6 +141,9 @@ func (p *Processes) gatherFromProc(fields map[string]interface{}) error {
 		statFile := path.Join("/proc", file.Name(), "stat")
 		data, err := p.readProcFile(statFile)
 		if err != nil {
+			if !file.IsDir() {
+				continue
+			}
 			return err
 		}
 		if data == nil {


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


I've sometime the following error:
```
$ grep telegraf /var/log/syslog |grep Error
May 26 06:28:20 hostname telegraf[15844]: 2016/05/26 06:28:20 Error in input [processes]: open /proc/16683/stat: no such file or directory
May 26 07:21:30 hostname telegraf[15844]: 2016/05/26 07:21:30 Error in input [processes]: read /proc/19975/stat: no such process
May 26 09:29:40 hostname telegraf[15844]: 2016/05/26 09:29:40 Error in input [processes]: read /proc/27969/stat: no such process
May 26 09:40:40 hostname telegraf[15844]: 2016/05/26 09:40:40 Error in input [processes]: read /proc/28637/stat: no such process
```

This cause the processes plugin to skip all metrics for the affected collection round.

This PR add a second file.IsDir() during error handling, if path is no longer a directory then the process must have terminated so it continues instead of returning an error 
