### PR TITLE
Add new input plugin type: Webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Release Notes
 
+- **Breaking changes**: New input plugins type: WebhookInput. You have to update
+the configuration for *github_webhooks* and *rollbar_webhooks* plugins. All
+webhook inputs now register to an internal webserver listener which dispatch
+requests.
+
 - All AWS plugins now utilize a standard mechanism for evaluating credentials.
 This allows all AWS plugins to support environment variables, shared credential
 files & profiles, and role assumptions. See the specific plugin README for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ creating the `Parser` object.
 You should also add the following to your SampleConfig() return:
 
 ```toml
-  ## Data format to consume. 
+  ## Data format to consume.
   ## Each data format has it's own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
@@ -159,6 +159,17 @@ and `Stop()` methods.
 
 * Same as the `Plugin` guidelines, except that they must conform to the
 `inputs.ServiceInput` interface.
+
+## Webhook Input Plugins
+
+A webhook plugins `Register()` itself to the internal webserver under a specific path.
+It will then be called in background upon according http requests. The `github_webhooks` plugins
+illustrate this behaviour.
+
+### Webhook Plugin Guidelines
+
+* Same as the `Plugin` guidelines, except that they must conform to the
+`inputs.WebhookInput` interface.
 
 ## Output Plugins
 
@@ -244,7 +255,7 @@ instantiating and creating the `Serializer` object.
 You should also add the following to your SampleConfig() return:
 
 ```toml
-  ## Data format to output. 
+  ## Data format to output.
   ## Each data format has it's own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md

--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ Telegraf can also collect metrics via the following service plugins:
 * [mqtt_consumer](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/mqtt_consumer)
 * [kafka_consumer](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/kafka_consumer)
 * [nats_consumer](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nats_consumer)
+
+and via webhook plugins:
+
 * [github_webhooks](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/github_webhooks)
 * [rollbar_webhooks](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/rollbar_webhooks)
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -342,7 +342,7 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 			defer p.Stop()
 		case telegraf.WebhookInput:
 			acc := createAccumulatorForInput(a, input, metricC)
-			if err := p.Register(webserver.Router(), acc); err != nil {
+			if err := p.Register(webserver.Router, acc); err != nil {
 				log.Printf("Webhook for input %s failed to start, exiting\n%s\n",
 					input.Name, err.Error())
 				return err

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -328,7 +328,7 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 	// channel shared between all input threads for accumulating metrics
 	metricC := make(chan telegraf.Metric, 10000)
 	webserver := webserver.NewWebserver()
-	webserver.ServiceAddress = ":1619"
+	webserver.ServiceAddress = a.Config.Agent.WebhookServiceAddress
 
 	for _, input := range a.Config.Inputs {
 		// Start service of any ServicePlugins

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -329,8 +329,9 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 	metricC := make(chan telegraf.Metric, 10000)
 	webserver := webserver.NewWebserver(a.Config.Agent.WebhookServiceAddress)
 
+	// Handle special input plugin: Start any ServiceInput and
+	// Register any WebhookInput
 	for _, input := range a.Config.Inputs {
-		// Start service of any ServicePlugins
 		switch p := input.Input.(type) {
 		case telegraf.ServiceInput:
 			acc := createAccumulatorForInput(a, input, metricC)
@@ -347,9 +348,9 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 					input.Name, err.Error())
 				return err
 			}
+			webserver.StartOnce()
 		}
 	}
-	webserver.Start()
 
 	// Round collection to nearest interval by sleeping
 	if a.Config.Agent.RoundInterval {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/config"
 	"github.com/influxdata/telegraf/internal/models"
+	"github.com/influxdata/telegraf/internal/webserver"
 )
 
 // Agent runs telegraf and collects data based on the given config
@@ -304,6 +305,13 @@ func jitterInterval(ininterval, injitter time.Duration) time.Duration {
 	return outinterval
 }
 
+func createAccumulatorForInput(a *Agent, input *internal_models.RunningInput, metricC chan telegraf.Metric) *accumulator {
+	acc := NewAccumulator(input.Config, metricC)
+	acc.SetDebug(a.Config.Agent.Debug)
+	acc.setDefaultTags(a.Config.Tags)
+	return acc
+}
+
 // Run runs the agent daemon, gathering every Interval
 func (a *Agent) Run(shutdown chan struct{}) error {
 	var wg sync.WaitGroup
@@ -319,22 +327,30 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 
 	// channel shared between all input threads for accumulating metrics
 	metricC := make(chan telegraf.Metric, 10000)
+	webserver := webserver.NewWebserver()
+	webserver.ServiceAddress = ":1619"
 
 	for _, input := range a.Config.Inputs {
 		// Start service of any ServicePlugins
 		switch p := input.Input.(type) {
 		case telegraf.ServiceInput:
-			acc := NewAccumulator(input.Config, metricC)
-			acc.SetDebug(a.Config.Agent.Debug)
-			acc.setDefaultTags(a.Config.Tags)
+			acc := createAccumulatorForInput(a, input, metricC)
 			if err := p.Start(acc); err != nil {
 				log.Printf("Service for input %s failed to start, exiting\n%s\n",
 					input.Name, err.Error())
 				return err
 			}
 			defer p.Stop()
+		case telegraf.WebhookInput:
+			acc := createAccumulatorForInput(a, input, metricC)
+			if err := p.Register(webserver.Router(), acc); err != nil {
+				log.Printf("Webhook for input %s failed to start, exiting\n%s\n",
+					input.Name, err.Error())
+				return err
+			}
 		}
 	}
+	webserver.Start()
 
 	// Round collection to nearest interval by sleeping
 	if a.Config.Agent.RoundInterval {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -327,8 +327,7 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 
 	// channel shared between all input threads for accumulating metrics
 	metricC := make(chan telegraf.Metric, 10000)
-	webserver := webserver.NewWebserver()
-	webserver.ServiceAddress = a.Config.Agent.WebhookServiceAddress
+	webserver := webserver.NewWebserver(a.Config.Agent.WebhookServiceAddress)
 
 	for _, input := range a.Config.Inputs {
 		// Start service of any ServicePlugins

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1397,9 +1397,8 @@
 
 # # A Github Webhook Event collector
 # [[inputs.github_webhooks]]
-#   ## Address and port to host Webhook listener on
-#   service_address = ":1618"
-
+#   ## Path of the global server
+#   path = "/github"
 
 # # Read metrics from Kafka topic(s)
 # [[inputs.kafka_consumer]]
@@ -1479,8 +1478,8 @@
 
 # # A Rollbar Webhook Event collector
 # [[inputs.rollbar_webhooks]]
-#   ## Address and port to host Webhook listener on
-#   service_address = ":1619"
+#   ## Path of the global server
+#   path = "/rollbar"
 
 
 # # Statsd Server

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -61,6 +61,9 @@
   ## If set to true, do no set the "host" tag in the telegraf agent.
   omit_hostname = false
 
+  ## Address to listen for webhook
+  webhook_service_address = ":1925"
+
 
 ###############################################################################
 #                            OUTPUT PLUGINS                                   #

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -49,6 +49,9 @@
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""
 
+  ## Address to listen for webhook
+  webhook_service_address = ":1925"
+
 
 ###############################################################################
 #                                  OUTPUTS                                    #

--- a/input.go
+++ b/input.go
@@ -1,5 +1,9 @@
 package telegraf
 
+import (
+	"github.com/gorilla/mux"
+)
+
 type Input interface {
 	// SampleConfig returns the default configuration of the Input
 	SampleConfig() string
@@ -28,4 +32,19 @@ type ServiceInput interface {
 
 	// Stop stops the services and closes any necessary channels and connections
 	Stop()
+}
+
+type WebhookInput interface {
+	// SampleConfig returns the default configuration of the Input
+	SampleConfig() string
+
+	// Description returns a one-sentence description on the Input
+	Description() string
+
+	// Gather takes in an accumulator and adds the metrics that the Input
+	// gathers. This is called every "interval"
+	Gather(Accumulator) error
+
+	// Register
+	Register(*mux.Router, Accumulator) error
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,6 +246,13 @@ var serviceInputHeader = `
 ###############################################################################
 `
 
+var webhookInputHeader = `
+
+###############################################################################
+#                            WEBHOOK INPUT PLUGINS                            #
+###############################################################################
+`
+
 // PrintSampleConfig prints the sample config
 func PrintSampleConfig(inputFilters []string, outputFilters []string) {
 	fmt.Printf(header)
@@ -292,10 +299,15 @@ func printFilteredInputs(inputFilters []string, commented bool) {
 	}
 	sort.Strings(pnames)
 
-	// cache service inputs to print them at the end
-	servInputs := make(map[string]telegraf.ServiceInput)
+	// cache service inputs to print them after inputs
+	servInputs := make(map[string]telegraf.Input)
 	// for alphabetical looping:
 	servInputNames := []string{}
+
+	// cache service inputs to print them after at the end
+	webhookInputs := make(map[string]telegraf.Input)
+	// for alphabetical looping:
+	webhookInputNames := []string{}
 
 	// Print Inputs
 	for _, pname := range pnames {
@@ -307,19 +319,31 @@ func printFilteredInputs(inputFilters []string, commented bool) {
 			servInputs[pname] = p
 			servInputNames = append(servInputNames, pname)
 			continue
+		case telegraf.WebhookInput:
+			webhookInputs[pname] = p
+			webhookInputNames = append(webhookInputNames, pname)
+			continue
 		}
 
 		printConfig(pname, input, "inputs", commented)
 	}
 
-	// Print Service Inputs
-	if len(servInputs) == 0 {
+	// Print service input
+	printOtherInputs(serviceInputHeader, servInputs, servInputNames, commented)
+
+	// Print webhook input
+	printOtherInputs(webhookInputHeader, webhookInputs, webhookInputNames, commented)
+}
+
+func printOtherInputs(header string, inputs map[string]telegraf.Input, names []string, commented bool) {
+	if len(names) == 0 {
 		return
 	}
-	sort.Strings(servInputNames)
-	fmt.Printf(serviceInputHeader)
-	for _, name := range servInputNames {
-		printConfig(name, servInputs[name], "inputs", commented)
+
+	sort.Strings(names)
+	fmt.Printf(header)
+	for _, name := range names {
+		printConfig(name, inputs[name], "inputs", commented)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,10 +55,10 @@ func NewConfig() *Config {
 	c := &Config{
 		// Agent defaults:
 		Agent: &AgentConfig{
-			Interval:      internal.Duration{Duration: 10 * time.Second},
-			RoundInterval: true,
-			FlushInterval: internal.Duration{Duration: 10 * time.Second},
-			FlushJitter:   internal.Duration{Duration: 5 * time.Second},
+			Interval:              internal.Duration{Duration: 10 * time.Second},
+			RoundInterval:         true,
+			FlushInterval:         internal.Duration{Duration: 10 * time.Second},
+			FlushJitter:           internal.Duration{Duration: 5 * time.Second},
 			WebhookServiceAddress: ":1925",
 		},
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,9 @@ type AgentConfig struct {
 	Quiet        bool
 	Hostname     string
 	OmitHostname bool
+
+	//
+	WebhookServiceAddress  string
 }
 
 // Inputs returns a list of strings of the configured inputs.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,7 +124,7 @@ type AgentConfig struct {
 	OmitHostname bool
 
 	//
-	WebhookServiceAddress  string
+	WebhookServiceAddress string
 }
 
 // Inputs returns a list of strings of the configured inputs.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,7 @@ func NewConfig() *Config {
 			RoundInterval: true,
 			FlushInterval: internal.Duration{Duration: 10 * time.Second},
 			FlushJitter:   internal.Duration{Duration: 5 * time.Second},
+			WebhookServiceAddress: ":1925",
 		},
 
 		Tags:          make(map[string]string),
@@ -123,7 +124,7 @@ type AgentConfig struct {
 	Hostname     string
 	OmitHostname bool
 
-	//
+	// Address for listening webhooks
 	WebhookServiceAddress string
 }
 
@@ -221,6 +222,9 @@ var header = `# Telegraf Configuration
   hostname = ""
   ## If set to true, do no set the "host" tag in the telegraf agent.
   omit_hostname = false
+
+  ## Address to listen for webhook
+  webhook_service_address = ":1925"
 
 
 ###############################################################################

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -13,8 +13,8 @@ type Webserver struct {
 	router         *mux.Router
 }
 
-func NewWebserver() *Webserver {
-	return &Webserver{router: mux.NewRouter()}
+func NewWebserver(serviceAddress string) *Webserver {
+	return &Webserver{Router: mux.NewRouter(), ServiceAddress: serviceAddress}
 }
 
 func (wb *Webserver) Router() *mux.Router {

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -1,0 +1,35 @@
+package webserver
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type Webserver struct {
+	ServiceAddress string
+	router *mux.Router
+}
+
+func NewWebserver() *Webserver {
+	return &Webserver{router:mux.NewRouter()}
+}
+
+func (wb *Webserver) Router() *mux.Router {
+	return wb.router
+}
+
+func (wb *Webserver) Listen() {
+	err := http.ListenAndServe(fmt.Sprintf("%s", wb.ServiceAddress), wb.router)
+	if err != nil {
+		log.Printf("Error starting server: %v", err)
+	}
+}
+
+func (wb *Webserver) Start() error {
+	go wb.Listen()
+	log.Printf("Started the webhook server on %s\n", wb.ServiceAddress)
+	return nil
+}

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -10,19 +10,15 @@ import (
 
 type Webserver struct {
 	ServiceAddress string
-	router         *mux.Router
+	Router         *mux.Router
 }
 
 func NewWebserver(serviceAddress string) *Webserver {
 	return &Webserver{Router: mux.NewRouter(), ServiceAddress: serviceAddress}
 }
 
-func (wb *Webserver) Router() *mux.Router {
-	return wb.router
-}
-
 func (wb *Webserver) Listen() {
-	err := http.ListenAndServe(fmt.Sprintf("%s", wb.ServiceAddress), wb.router)
+	err := http.ListenAndServe(fmt.Sprintf("%s", wb.ServiceAddress), wb.Router)
 	if err != nil {
 		log.Printf("Error starting server: %v", err)
 	}

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -10,11 +10,11 @@ import (
 
 type Webserver struct {
 	ServiceAddress string
-	router *mux.Router
+	router         *mux.Router
 }
 
 func NewWebserver() *Webserver {
-	return &Webserver{router:mux.NewRouter()}
+	return &Webserver{router: mux.NewRouter()}
 }
 
 func (wb *Webserver) Router() *mux.Router {

--- a/plugins/inputs/github_webhooks/github_webhooks.go
+++ b/plugins/inputs/github_webhooks/github_webhooks.go
@@ -30,7 +30,7 @@ func NewGithubWebhooks() *GithubWebhooks {
 
 func (gh *GithubWebhooks) SampleConfig() string {
 	return `
-  ## Address and port to host Webhook listener on
+  ## Path of the global server
   path = "/github"
 `
 }

--- a/plugins/inputs/rollbar_webhooks/rollbar_webhooks.go
+++ b/plugins/inputs/rollbar_webhooks/rollbar_webhooks.go
@@ -53,7 +53,7 @@ func (rb *RollbarWebhooks) Gather(acc telegraf.Accumulator) error {
 
 func (rb *RollbarWebhooks) Register(r *mux.Router, _ telegraf.Accumulator) error {
 	r.HandleFunc(rb.Path, rb.eventHandler).Methods("POST")
-	log.Printf("Register the rollbar_webhooks router on %s\n", rb.Path)
+	log.Printf("Registering rollbar_webhooks on %s\n", rb.Path)
 	return nil
 }
 

--- a/plugins/inputs/rollbar_webhooks/rollbar_webhooks.go
+++ b/plugins/inputs/rollbar_webhooks/rollbar_webhooks.go
@@ -3,7 +3,6 @@ package rollbar_webhooks
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -20,7 +19,7 @@ func init() {
 }
 
 type RollbarWebhooks struct {
-	ServiceAddress string
+	Path string
 	// Lock for the struct
 	sync.Mutex
 	// Events buffer to store events between Gather calls
@@ -33,8 +32,8 @@ func NewRollbarWebhooks() *RollbarWebhooks {
 
 func (rb *RollbarWebhooks) SampleConfig() string {
 	return `
-  ## Address and port to host Webhook listener on
-  service_address = ":1619"
+  ## Path of the global server
+  path = "/rollbar"
 `
 }
 
@@ -52,23 +51,10 @@ func (rb *RollbarWebhooks) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (rb *RollbarWebhooks) Listen() {
-	r := mux.NewRouter()
-	r.HandleFunc("/", rb.eventHandler).Methods("POST")
-	err := http.ListenAndServe(fmt.Sprintf("%s", rb.ServiceAddress), r)
-	if err != nil {
-		log.Printf("Error starting server: %v", err)
-	}
-}
-
-func (rb *RollbarWebhooks) Start(_ telegraf.Accumulator) error {
-	go rb.Listen()
-	log.Printf("Started the rollbar_webhooks service on %s\n", rb.ServiceAddress)
+func (rb *RollbarWebhooks) Register(r *mux.Router, _ telegraf.Accumulator) error {
+	r.HandleFunc(rb.Path, rb.eventHandler).Methods("POST")
+	log.Printf("Register the rollbar_webhooks router on %s\n", rb.Path)
 	return nil
-}
-
-func (rb *RollbarWebhooks) Stop() {
-	log.Println("Stopping the rbWebhooks service")
 }
 
 func (rb *RollbarWebhooks) eventHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)

---

As proposed in https://github.com/influxdata/telegraf/issues/1248, we moved service plugins which listen independently for webhooks into a new plugin type Webhook. This allow us to register each of these plugin under the same http listener.


What do you think?  