### PR TITLE
Made the apache input’s urls parameter optional by using a reasonable default user input

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -454,6 +454,7 @@
 # # Read Apache status information (mod_status)
 # [[inputs.apache]]
 #   ## An array of Apache status URI to gather stats.
+#   ## Default is "http://localhost/server-status?auto".
 #   urls = ["http://localhost/server-status?auto"]
 
 

--- a/plugins/inputs/apache/README.md
+++ b/plugins/inputs/apache/README.md
@@ -1,7 +1,7 @@
 # Telegraf plugin: Apache
 
 #### Plugin arguments:
-- **urls** []string: List of apache-status URLs to collect from.
+- **urls** []string: List of apache-status URLs to collect from. Default is "http://localhost/server-status?auto".
 
 #### Description
 

--- a/plugins/inputs/apache/apache.go
+++ b/plugins/inputs/apache/apache.go
@@ -21,6 +21,7 @@ type Apache struct {
 
 var sampleConfig = `
   ## An array of Apache status URI to gather stats.
+  ## Default is "http://localhost/server-status?auto".
   urls = ["http://localhost/server-status?auto"]
 `
 
@@ -33,6 +34,10 @@ func (n *Apache) Description() string {
 }
 
 func (n *Apache) Gather(acc telegraf.Accumulator) error {
+	if len(n.Urls) == 0 {
+		n.Urls = []string{"http://localhost/server-status?auto"}
+	}
+
 	var wg sync.WaitGroup
 	var outerr error
 


### PR DESCRIPTION
- [x ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Why? Since most users will run this plugin on the destination host, the default http://localhost/server-status?auto is just fine and will be the default if urls is not defined simplifying the telegraf configuration for those users. They just need to add [[inputs.apache]] to be done.