### PR TITLE
update gitattributes for easier fork mngmnt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 CHANGELOG.md merge=union
-
+README.md merge=union
+plugins/inputs/all/all.go merge=union
+plugins/outputs/all/all.go merge=union


### PR DESCRIPTION
cc @daviesalex @wrigtim

this is the gitattributes change I had mentioned a couple weeks back. Should make keeping your fork up to date a bit easier. With this, git should always take care of merging the all.go files automatically.

