### PR TITLE
Add graylog input pluging  entry to change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ in conjunction with wildcard dimension values as it will control the amount of
 time before a new metric is included by the plugin.
 
 ### Features
+- [#1262](https://github.com/influxdata/telegraf/pull/1261): Add graylog input pluging. 
 - [#1294](https://github.com/influxdata/telegraf/pull/1294): consul input plugin. Thanks @harnash
 - [#1164](https://github.com/influxdata/telegraf/pull/1164): conntrack input plugin. Thanks @robinpercy!
 - [#1165](https://github.com/influxdata/telegraf/pull/1165): vmstat input plugin. Thanks @jshim-xm!


### PR DESCRIPTION
@sparrc  I forget to add an entry to  ChangeLOG for Graylog input plugin, sorry I miss that in the original pull request
 
