### PR TITLE
Removed leaked "database" tag on redis metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ time before a new metric is included by the plugin.
 - [#1268](https://github.com/influxdata/telegraf/pull/1268): Fix potential influxdb input type assertion panic.
 - [#1283](https://github.com/influxdata/telegraf/pull/1283): Still send processes metrics if a process exited during metric collection.
 - [#1297](https://github.com/influxdata/telegraf/issues/1297): disk plugin panic when usage grab fails.
+- [#1315](https://github.com/influxdata/telegraf/pull/1315): removed leaked "database" tag on redis metrics. Thanks @PierreF!
 
 ## v0.13.1 [2016-05-24]
 

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -229,6 +229,9 @@ func gatherInfoOutput(
 		keyspace_hitrate = float64(keyspace_hits) / float64(keyspace_hits+keyspace_misses)
 	}
 	fields["keyspace_hitrate"] = keyspace_hitrate
+
+	// gatherKeyspaceLine may have added "database" to tags.
+	delete(tags, "database")
 	acc.AddFields("redis", fields, tags)
 	return nil
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

I've found that Redis input plugin may add "database" tag on global redis stats. This is due to tags map being passed by-reference to gatherKeyspaceLine which modify it.

The result is that if you have at least one database in redis (e.g. at least one key), metric result is:

```
$ ./build/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d -input-filter redis -test
* Plugin: redis, Collection 1
> redis_keyspace,database=db0,host=xps-pierref,port=6379,role=master,server=172.17.0.5 avg_ttl=0i,expires=0i,keys=50000i 1464869517956355485
> redis_keyspace,database=db1,host=xps-pierref,port=6379,role=master,server=172.17.0.5 avg_ttl=0i,expires=0i,keys=1i 1464869517956396646
> redis,database=db1,host=xps-pierref,port=6379,role=master,server=172.17.0.5 clients=7i,connected_slaves=0i,ev[...] 1464869517956443591
```

The last line should NOT contains "database=db1" since those metrics are global.
This PR make sure that database tag is not present in redis global metrics.
