### PR TITLE
Removed leaked "database" tag on redis metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ time before a new metric is included by the plugin.
 - [#1268](https://github.com/influxdata/telegraf/pull/1268): Fix potential influxdb input type assertion panic.
 - [#1283](https://github.com/influxdata/telegraf/pull/1283): Still send processes metrics if a process exited during metric collection.
 - [#1297](https://github.com/influxdata/telegraf/issues/1297): disk plugin panic when usage grab fails.
+- [#1316](https://github.com/influxdata/telegraf/pull/1316): Removed leaked "database" tag on redis metrics. Thanks @PierreF!
 
 ## v0.13.1 [2016-05-24]
 

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -241,10 +241,14 @@ func gatherKeyspaceLine(
 	name string,
 	line string,
 	acc telegraf.Accumulator,
-	tags map[string]string,
+	global_tags map[string]string,
 ) {
 	if strings.Contains(line, "keys=") {
 		fields := make(map[string]interface{})
+		tags := make(map[string]string)
+		for k, v := range global_tags {
+			tags[k] = v
+		}
 		tags["database"] = name
 		dbparts := strings.Split(line, ",")
 		for _, dbp := range dbparts {

--- a/plugins/inputs/redis/redis_test.go
+++ b/plugins/inputs/redis/redis_test.go
@@ -35,6 +35,7 @@ func TestRedis_ParseMetrics(t *testing.T) {
 	err := gatherInfoOutput(rdr, &acc, tags)
 	require.NoError(t, err)
 
+	tags = map[string]string{"host": "redis.net", "role": "master"}
 	fields := map[string]interface{}{
 		"uptime":                      uint64(238),
 		"clients":                     uint64(1),
@@ -70,13 +71,14 @@ func TestRedis_ParseMetrics(t *testing.T) {
 		"used_cpu_user_children":      float64(0.00),
 		"keyspace_hitrate":            float64(0.50),
 	}
+	keyspaceTags := map[string]string{"host": "redis.net", "role": "master", "database": "db0"}
 	keyspaceFields := map[string]interface{}{
 		"avg_ttl": uint64(0),
 		"expires": uint64(0),
 		"keys":    uint64(2),
 	}
 	acc.AssertContainsTaggedFields(t, "redis", fields, tags)
-	acc.AssertContainsTaggedFields(t, "redis_keyspace", keyspaceFields, tags)
+	acc.AssertContainsTaggedFields(t, "redis_keyspace", keyspaceFields, keyspaceTags)
 }
 
 const testOutput = `# Server


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

See PR #1315 

Redis add a "database" tag on global metrics due to tags maps being passed by-reference to gatherKeyspaceLine. This PR do a copy of that map in gatherKeyspaceLine before modifying it. 

