### PR TITLE
Fixed incorrect prometheus metrics source selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ time before a new metric is included by the plugin.
 - [#1316](https://github.com/influxdata/telegraf/pull/1316): Removed leaked "database" tag on redis metrics. Thanks @PierreF!
 - [#1323](https://github.com/influxdata/telegraf/issues/1323): Processes plugin: fix potential error with /proc/net/stat directory.
 - [#1322](https://github.com/influxdata/telegraf/issues/1322): Fix rare RHEL 5.2 panic in gopsutil diskio gathering function.
+- [#1336](https://github.com/influxdata/telegraf/issues/1336): Fixed incorrect prometheus metrics source selection
 
 ## v0.13.1 [2016-05-24]
 

--- a/plugins/inputs/prometheus/parser.go
+++ b/plugins/inputs/prometheus/parser.go
@@ -74,13 +74,13 @@ func (p *PrometheusParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 				if mf.GetType() == dto.MetricType_SUMMARY {
 					// summary metric
 					fields = makeQuantiles(m)
-					fields["count"] = float64(m.GetHistogram().GetSampleCount())
+					fields["count"] = float64(m.GetSummary().GetSampleCount())
 					fields["sum"] = float64(m.GetSummary().GetSampleSum())
 				} else if mf.GetType() == dto.MetricType_HISTOGRAM {
 					// historgram metric
 					fields = makeBuckets(m)
 					fields["count"] = float64(m.GetHistogram().GetSampleCount())
-					fields["sum"] = float64(m.GetSummary().GetSampleSum())
+					fields["sum"] = float64(m.GetHistogram().GetSampleSum())
 
 				} else {
 					// standard metric

--- a/plugins/inputs/prometheus/parser_test.go
+++ b/plugins/inputs/prometheus/parser_test.go
@@ -138,7 +138,7 @@ func TestParseValidPrometheus(t *testing.T) {
 		"0.5":   552048.506,
 		"0.9":   5.876804288e+06,
 		"0.99":  5.876804288e+06,
-		"count": 0.0,
+		"count": 9.0,
 		"sum":   1.8909097205e+07,
 	}, metrics[0].Fields())
 	assert.Equal(t, map[string]string{"handler": "prometheus"}, metrics[0].Tags())
@@ -151,7 +151,7 @@ func TestParseValidPrometheus(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{
 		"500000": 2000.0,
 		"count":  2025.0,
-		"sum":    0.0,
+		"sum":    1.02726334e+08,
 		"250000": 1997.0,
 		"2e+06":  2012.0,
 		"4e+06":  2017.0,


### PR DESCRIPTION
This should solve issue #1336 by taking the correct prometheus metrics source:
Metrics type summary should retrieve values via GetSummary while histogram should retrieve values via GetHistogram for both count and sum.

### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)