### PR TITLE
add regex parser

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -895,8 +895,19 @@ func buildParser(name string, tbl *ast.Table) (parsers.Parser, error) {
 		}
 	}
 
-	c.MetricName = name
+	c.RegexExpr = make(map[string][]string)
+	if val, ok := tbl.Fields["regex_expr"]; ok {
+		subTable, ok := val.(*ast.Table)
+		if !ok {
+			log.Printf("Could not parse [regex_expr] config\n")
+		}
+		if err := config.UnmarshalTable(subTable, c.RegexExpr); err != nil {
+			log.Printf("Could not parse [regex_expr] config\n")
+		}
+	}
 
+	c.MetricName = name
+	delete(tbl.Fields, "regex_expr")
 	delete(tbl.Fields, "data_format")
 	delete(tbl.Fields, "separator")
 	delete(tbl.Fields, "templates")

--- a/plugins/parsers/regex/parser.go
+++ b/plugins/parsers/regex/parser.go
@@ -1,0 +1,93 @@
+package regex_parser
+
+import (
+	"fmt"
+	"github.com/influxdata/telegraf"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type REGEXParser struct {
+	MetricName    string
+	RegexEXPRList map[string][]string
+	DefaultTags   map[string]string
+}
+
+func (p *REGEXParser) Parse(buf []byte) ([]telegraf.Metric, error) {
+	metrics := make([]telegraf.Metric, 0)
+	for mName, list := range p.RegexEXPRList {
+		matches := make([]*regexp.Regexp, 0)
+		fields := make(map[string]interface{}, 0)
+		for _, value := range list {
+			item, err := regexp.Compile(value)
+			if err != nil {
+				return nil, err
+			}
+			matches = append(matches, item)
+		}
+
+		for _, s_for := range matches {
+			list := s_for.FindAllStringSubmatch(string(buf), -1)
+			if list != nil {
+				for _, item := range list {
+					if len(item) == 3 {
+						value, err := strconv.ParseFloat(item[2], 64)
+						fName := strings.TrimSpace(item[1])
+						if err != nil {
+							return nil, fmt.Errorf("Can't parse secound match of regex as Float, %s", err.Error())
+						}
+						if fields[fName] == nil {
+							fields[fName] = value
+							continue
+						}
+						if val, ok := fields[fName].(float64); ok {
+							val += value
+							fields[fName] = val
+						}
+					} else {
+						fName := strings.TrimSpace(item[0])
+						if fields[fName] == nil {
+							var v float64 = 1.0
+							fields[fName] = v
+							continue
+						}
+						if val, ok := fields[item[0]].(float64); ok {
+							val++
+							fields[fName] = val
+						}
+					}
+				}
+			}
+		}
+		if len(fields) == 0 {
+			return metrics, nil
+		}
+		metric, err := telegraf.NewMetric(mName, p.DefaultTags, fields, time.Now().UTC())
+
+		if err != nil {
+			return nil, err
+		}
+		metrics = append(metrics, metric)
+	}
+	return metrics, nil
+}
+
+func (p *REGEXParser) ParseLine(line string) (telegraf.Metric, error) {
+	metrics, err := p.Parse([]byte(line + "\n"))
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(metrics) < 1 {
+		return nil, nil
+	}
+
+	return metrics[0], nil
+}
+
+func (p *REGEXParser) SetDefaultTags(tags map[string]string) {
+	p.DefaultTags = tags
+}

--- a/plugins/parsers/regex/parser_test.go
+++ b/plugins/parsers/regex/parser_test.go
@@ -1,0 +1,94 @@
+package regex_parser
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const (
+	oneMatch                   = "Lookingfor  I don't care about other thing in the string"
+	twoMatch                   = "firstMatch I don't care about other thing\n secound match is really good for me"
+	noMatch                    = "Not matches "
+	extractValueTwo            = "a=1,don'tcare=2,somethingelse=4"
+	extractValuethreeTwoMetric = "inMetric1=1,don'tcare=2,somethingelse=4,a=3\n inMetric2=2"
+)
+
+func TestOneMatch(t *testing.T) {
+	parser := REGEXParser{
+		RegexEXPRList: map[string][]string{
+			"m1": []string{"Lookingfor"},
+		},
+	}
+	metrics, err := parser.Parse([]byte(oneMatch))
+	assert.NoError(t, err)
+	assert.Len(t, metrics, 1)
+	assert.Equal(t, "m1", metrics[0].Name())
+	assert.Equal(t, map[string]interface{}{
+		"Lookingfor": float64(1),
+	}, metrics[0].Fields())
+	assert.Equal(t, map[string]string{}, metrics[0].Tags())
+}
+func TestTwoMatch(t *testing.T) {
+	parser := REGEXParser{
+		RegexEXPRList: map[string][]string{
+			"m1": []string{"firstMatch", "secound match"},
+		},
+	}
+	metrics, err := parser.Parse([]byte(twoMatch))
+	assert.NoError(t, err)
+	assert.Len(t, metrics, 1)
+	assert.Equal(t, "m1", metrics[0].Name())
+	assert.Equal(t, map[string]interface{}{
+		"firstMatch":    float64(1),
+		"secound match": float64(1),
+	}, metrics[0].Fields())
+	assert.Equal(t, map[string]string{}, metrics[0].Tags())
+}
+func TestNoMatch(t *testing.T) {
+	parser := REGEXParser{
+		RegexEXPRList: map[string][]string{
+			"m1": []string{"something"},
+		},
+	}
+	metrics, err := parser.Parse([]byte(noMatch))
+	assert.NoError(t, err)
+	assert.Len(t, metrics, 0)
+}
+func TestExtractValueOne(t *testing.T) {
+	parser := REGEXParser{
+		RegexEXPRList: map[string][]string{
+			"m1": []string{"(a)=([0-9]+)", "(somethingelse)=([0-9]+)"},
+		},
+	}
+	metrics, err := parser.Parse([]byte(extractValueTwo))
+	assert.NoError(t, err)
+	assert.Len(t, metrics, 1)
+	assert.Equal(t, "m1", metrics[0].Name())
+	assert.Equal(t, map[string]string{}, metrics[0].Tags())
+	assert.Equal(t, map[string]interface{}{
+		"a":             float64(1),
+		"somethingelse": float64(4),
+	}, metrics[0].Fields())
+}
+func TestExtractValueInTwoMetric(t *testing.T) {
+	parser := REGEXParser{
+		RegexEXPRList: map[string][]string{
+			"m1": []string{"(inMetric1)=([0-9]+)"},
+			"m2": []string{"(inMetric2)=([0-9]+)"},
+		},
+	}
+	metrics, err := parser.Parse([]byte(extractValuethreeTwoMetric))
+	assert.NoError(t, err)
+	assert.Len(t, metrics, 2)
+	assert.Equal(t, "m1", metrics[0].Name())
+	assert.Equal(t, "m2", metrics[1].Name())
+	assert.Equal(t, map[string]string{}, metrics[0].Tags())
+	assert.Equal(t, map[string]string{}, metrics[1].Tags())
+	assert.Equal(t, map[string]interface{}{
+		"inMetric1": float64(1),
+	}, metrics[0].Fields())
+	assert.Equal(t, map[string]interface{}{
+		"inMetric2": float64(2),
+	}, metrics[1].Fields())
+
+}

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/plugins/parsers/json"
 	"github.com/influxdata/telegraf/plugins/parsers/nagios"
+	"github.com/influxdata/telegraf/plugins/parsers/regex"
 	"github.com/influxdata/telegraf/plugins/parsers/value"
 )
 
@@ -56,6 +57,9 @@ type Config struct {
 	// DataType only applies to value, this will be the type to parse value to
 	DataType string
 
+	//  RegexExpr only applies to regex matcher
+	RegexExpr map[string][]string
+
 	// DefaultTags are the default tags that will be added to all parsed metrics.
 	DefaultTags map[string]string
 }
@@ -65,6 +69,8 @@ func NewParser(config *Config) (Parser, error) {
 	var err error
 	var parser Parser
 	switch config.DataFormat {
+	case "regex":
+		parser, err = NewREGEXParser(config.RegexExpr, config.DefaultTags)
 	case "json":
 		parser, err = NewJSONParser(config.MetricName,
 			config.TagKeys, config.DefaultTags)
@@ -82,6 +88,16 @@ func NewParser(config *Config) (Parser, error) {
 		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
 	}
 	return parser, err
+}
+func NewREGEXParser(
+	regexExpr map[string][]string,
+	defaultTags map[string]string,
+) (Parser, error) {
+	parser := &regex_parser.REGEXParser{
+		RegexEXPRList: regexExpr,
+		DefaultTags:   defaultTags,
+	}
+	return parser, nil
 }
 
 func NewJSONParser(


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated
- [ x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

Add new input parser called REGEX, this will allow for creating metrics from non-formated input stream like raw log file. currently it support two model counting matches or extract value. Counting matches works by counting matches of REGEX and report it as a field, while Extract value use capture group to collect  field name and value.

 [inputs.tail.regex_expr]
    request_type = ["GET", "POST", "PUT"]
    request_duration  = ["(RequestDuration)=([0-9]+)"]

This will create two metrics, the first one is request_type contain a count for GET, POST and PUT occurrence in the file, the second is request_duration metric which will have one field called RequestDuration with extracted duration from REGEX file