### PR TITLE
Webhooks plugin: add mandrill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ should now look like:
 
 - [#1289](https://github.com/influxdata/telegraf/pull/1289): webhooks input plugin. Thanks @francois2metz and @cduez!
 - [#1247](https://github.com/influxdata/telegraf/pull/1247): rollbar webhook plugin.
+- [#1408](https://github.com/influxdata/telegraf/pull/1408): mandrill webhook plugin.
 - [#1402](https://github.com/influxdata/telegraf/pull/1402): docker-machine/boot2docker no longer required for unit tests.
 - [#1350](https://github.com/influxdata/telegraf/pull/1350): cgroup input plugin.
 - [#1369](https://github.com/influxdata/telegraf/pull/1369): Add input plugin for consuming metrics from NSQD.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Telegraf can also collect metrics via the following service plugins:
 * [nats_consumer](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nats_consumer)
 * [webhooks](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks)
   * [github](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/github)
+  * [mandrill](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/mandrill)
   * [rollbar](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/webhooks/rollbar)
 * [nsq_consumer](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/nsq_consumer)
 

--- a/plugins/inputs/webhooks/README.md
+++ b/plugins/inputs/webhooks/README.md
@@ -16,6 +16,7 @@ $ sudo service telegraf start
 ## Available webhooks
 
 - [Github](github/)
+- [Mandrill](mandrill/)
 - [Rollbar](rollbar/)
 
 ## Adding new webhooks plugin

--- a/plugins/inputs/webhooks/mandrill/README.md
+++ b/plugins/inputs/webhooks/mandrill/README.md
@@ -1,0 +1,15 @@
+# mandrill webhook
+
+You should configure your Mandrill's Webhooks to point at the `webhooks` service. To do this go to `mandrillapp.com/` and click `Settings > Webhooks`. In the resulting page, click on `Add a Webhook`, select all events, and set the `URL` to `http://<my_ip>:1619/mandrill`, and click on `Create Webhook`.
+
+## Events
+
+See the [webhook doc](https://mandrill.zendesk.com/hc/en-us/articles/205583307-Message-Event-Webhook-format).
+
+All events for logs the original timestamp, the event name and the unique identifier of the message that generated the event.
+
+**Tags:**
+* 'event' = `event.event` string
+
+**Fields:**
+* 'id' = `event._id` string

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks.go
@@ -18,9 +18,15 @@ type MandrillWebhook struct {
 }
 
 func (md *MandrillWebhook) Register(router *mux.Router, acc telegraf.Accumulator) {
+	router.HandleFunc(md.Path, md.returnOK).Methods("HEAD")
 	router.HandleFunc(md.Path, md.eventHandler).Methods("POST")
+
 	log.Printf("Started the webhooks_mandrill on %s\n", md.Path)
 	md.acc = acc
+}
+
+func (md *MandrillWebhook) returnOK(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
 }
 
 func (md *MandrillWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks.go
@@ -1,0 +1,45 @@
+package mandrill
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/influxdata/telegraf"
+)
+
+type MandrillWebhook struct {
+	Path string
+	acc  telegraf.Accumulator
+}
+
+func (md *MandrillWebhook) Register(router *mux.Router, acc telegraf.Accumulator) {
+	router.HandleFunc(md.Path, md.eventHandler).Methods("POST")
+	log.Printf("Started the webhooks_mandrill on %s\n", md.Path)
+	md.acc = acc
+}
+
+func (md *MandrillWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	var events []MandrillEvent
+	err = json.Unmarshal(data, &events)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	for _, event := range events {
+		md.acc.AddFields("mandrill_webhooks", event.Fields(), event.Tags(), time.Unix(event.TimeStamp, 0))
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events.go
@@ -1,0 +1,23 @@
+package mandrill
+
+type Event interface {
+	Tags() map[string]string
+	Fields() map[string]interface{}
+}
+
+type MandrillEvent struct {
+	EventName string `json:"event"`
+	TimeStamp int64  `json:"ts"`
+}
+
+func (me *MandrillEvent) Tags() map[string]string {
+	return map[string]string{
+		"event": me.EventName,
+	}
+}
+
+func (me *MandrillEvent) Fields() map[string]interface{} {
+	return map[string]interface{}{
+		"id": "1",
+	}
+}

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events.go
@@ -8,6 +8,7 @@ type Event interface {
 type MandrillEvent struct {
 	EventName string `json:"event"`
 	TimeStamp int64  `json:"ts"`
+	Id        string `json:"_id"`
 }
 
 func (me *MandrillEvent) Tags() map[string]string {
@@ -18,6 +19,6 @@ func (me *MandrillEvent) Tags() map[string]string {
 
 func (me *MandrillEvent) Fields() map[string]interface{} {
 	return map[string]interface{}{
-		"id": "1",
+		"id": me.Id,
 	}
 }

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events_json_test.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events_json_test.go
@@ -25,7 +25,7 @@ func SendEventJSON() string {
 	      "_id": "exampleaaaaaaaaaaaaaaaaaaaaaaaaa",
 	      "_version": "exampleaaaaaaaaaaaaaaa"
 	    },
-	    "_id": "exampleaaaaaaaaaaaaaaaaaaaaaaaaa",
+	    "_id": "id1",
 	    "ts": 1384954004
 	}`
 }
@@ -52,7 +52,7 @@ func HardBounceEventJSON() string {
 	      "bgtools_code": 10,
 	      "diag": "smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces."
 	    },
-	    "_id": "exampleaaaaaaaaaaaaaaaaaaaaaaaaa2",
+	    "_id": "id2",
 	    "ts": 1384954004
 	}`
 }

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events_json_test.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events_json_test.go
@@ -1,0 +1,58 @@
+package mandrill
+
+func SendEventJSON() string {
+	return `
+	{
+	    "event": "send",
+	    "msg": {
+	      "ts": 1365109999,
+	      "subject": "This an example webhook message",
+	      "email": "example.webhook@mandrillapp.com",
+	      "sender": "example.sender@mandrillapp.com",
+	      "tags": [
+	        "webhook-example"
+	      ],
+	      "opens": [
+
+	      ],
+	      "clicks": [
+
+	      ],
+	      "state": "sent",
+	      "metadata": {
+	        "user_id": 111
+	      },
+	      "_id": "exampleaaaaaaaaaaaaaaaaaaaaaaaaa",
+	      "_version": "exampleaaaaaaaaaaaaaaa"
+	    },
+	    "_id": "exampleaaaaaaaaaaaaaaaaaaaaaaaaa",
+	    "ts": 1384954004
+	}`
+}
+
+func HardBounceEventJSON() string {
+	return `
+	{
+	    "event": "hard_bounce",
+	    "msg": {
+	      "ts": 1365109999,
+	      "subject": "This an example webhook message",
+	      "email": "example.webhook@mandrillapp.com",
+	      "sender": "example.sender@mandrillapp.com",
+	      "tags": [
+	        "webhook-example"
+	      ],
+	      "state": "bounced",
+	      "metadata": {
+	        "user_id": 111
+	      },
+	      "_id": "exampleaaaaaaaaaaaaaaaaaaaaaaaaa2",
+	      "_version": "exampleaaaaaaaaaaaaaaa",
+	      "bounce_description": "bad_mailbox",
+	      "bgtools_code": 10,
+	      "diag": "smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces."
+	    },
+	    "_id": "exampleaaaaaaaaaaaaaaaaaaaaaaaaa2",
+	    "ts": 1384954004
+	}`
+}

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
@@ -1,16 +1,18 @@
 package mandrill
 
 import (
+	"net/url"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func postWebhooks(md *MandrillWebhook, eventBody string) *httptest.ResponseRecorder {
-	req, _ := http.NewRequest("POST", "/mandrill", strings.NewReader(eventBody))
+	body := url.Values{}
+	body.Set("mandrill_events", eventBody)
+	req, _ := http.NewRequest("POST", "/mandrill", strings.NewReader(body.Encode()))
 	w := httptest.NewRecorder()
 	w.Code = 500
 
@@ -24,7 +26,7 @@ func TestSendEvent(t *testing.T) {
 	md := &MandrillWebhook{Path: "/mandrill", acc: &acc}
 	resp := postWebhooks(md, "["+ SendEventJSON() +"]")
 	if resp.Code != http.StatusOK {
-		t.Errorf("POST new_item returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
+		t.Errorf("POST send returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}
 
 	fields := map[string]interface{}{
@@ -44,7 +46,7 @@ func TestMultipleEvents(t *testing.T) {
 	md := &MandrillWebhook{Path: "/mandrill", acc: &acc}
 	resp := postWebhooks(md, "["+ SendEventJSON() +","+ HardBounceEventJSON() +"]")
 	if resp.Code != http.StatusOK {
-		t.Errorf("POST new_item returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
+		t.Errorf("POST send returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}
 
 	fields := map[string]interface{}{

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
@@ -1,12 +1,12 @@
 package mandrill
 
 import (
-	"net/url"
+	"github.com/influxdata/telegraf/testutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
-	"github.com/influxdata/telegraf/testutil"
 )
 
 func postWebhooks(md *MandrillWebhook, eventBody string) *httptest.ResponseRecorder {
@@ -40,13 +40,13 @@ func TestHead(t *testing.T) {
 func TestSendEvent(t *testing.T) {
 	var acc testutil.Accumulator
 	md := &MandrillWebhook{Path: "/mandrill", acc: &acc}
-	resp := postWebhooks(md, "["+ SendEventJSON() +"]")
+	resp := postWebhooks(md, "["+SendEventJSON()+"]")
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST send returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}
 
 	fields := map[string]interface{}{
-		"id":"id1",
+		"id": "id1",
 	}
 
 	tags := map[string]string{
@@ -56,17 +56,16 @@ func TestSendEvent(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "mandrill_webhooks", fields, tags)
 }
 
-
 func TestMultipleEvents(t *testing.T) {
 	var acc testutil.Accumulator
 	md := &MandrillWebhook{Path: "/mandrill", acc: &acc}
-	resp := postWebhooks(md, "["+ SendEventJSON() +","+ HardBounceEventJSON() +"]")
+	resp := postWebhooks(md, "["+SendEventJSON()+","+HardBounceEventJSON()+"]")
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST send returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}
 
 	fields := map[string]interface{}{
-		"id":"id1",
+		"id": "id1",
 	}
 
 	tags := map[string]string{
@@ -76,7 +75,7 @@ func TestMultipleEvents(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "mandrill_webhooks", fields, tags)
 
 	fields = map[string]interface{}{
-		"id":"id2",
+		"id": "id2",
 	}
 
 	tags = map[string]string{

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
@@ -1,0 +1,68 @@
+package mandrill
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+)
+
+func postWebhooks(md *MandrillWebhook, eventBody string) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest("POST", "/mandrill", strings.NewReader(eventBody))
+	w := httptest.NewRecorder()
+	w.Code = 500
+
+	md.eventHandler(w, req)
+
+	return w
+}
+
+func TestSendEvent(t *testing.T) {
+	var acc testutil.Accumulator
+	md := &MandrillWebhook{Path: "/mandrill", acc: &acc}
+	resp := postWebhooks(md, "["+ SendEventJSON() +"]")
+	if resp.Code != http.StatusOK {
+		t.Errorf("POST new_item returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
+	}
+
+	fields := map[string]interface{}{
+		"id":"1",
+	}
+
+	tags := map[string]string{
+		"event": "send",
+	}
+
+	acc.AssertContainsTaggedFields(t, "mandrill_webhooks", fields, tags)
+}
+
+
+func TestMultipleEvents(t *testing.T) {
+	var acc testutil.Accumulator
+	md := &MandrillWebhook{Path: "/mandrill", acc: &acc}
+	resp := postWebhooks(md, "["+ SendEventJSON() +","+ HardBounceEventJSON() +"]")
+	if resp.Code != http.StatusOK {
+		t.Errorf("POST new_item returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
+	}
+
+	fields := map[string]interface{}{
+		"id":"1",
+	}
+
+	tags := map[string]string{
+		"event": "send",
+	}
+
+	acc.AssertContainsTaggedFields(t, "mandrill_webhooks", fields, tags)
+
+	fields = map[string]interface{}{
+		"id":"1",
+	}
+
+	tags = map[string]string{
+		"event": "hard_bounce",
+	}
+	acc.AssertContainsTaggedFields(t, "mandrill_webhooks", fields, tags)
+}

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
@@ -14,11 +14,27 @@ func postWebhooks(md *MandrillWebhook, eventBody string) *httptest.ResponseRecor
 	body.Set("mandrill_events", eventBody)
 	req, _ := http.NewRequest("POST", "/mandrill", strings.NewReader(body.Encode()))
 	w := httptest.NewRecorder()
-	w.Code = 500
 
 	md.eventHandler(w, req)
 
 	return w
+}
+
+func headRequest(md *MandrillWebhook) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest("HEAD", "/mandrill", strings.NewReader(""))
+	w := httptest.NewRecorder()
+
+	md.returnOK(w, req)
+
+	return w
+}
+
+func TestHead(t *testing.T) {
+	md := &MandrillWebhook{Path: "/mandrill"}
+	resp := headRequest(md)
+	if resp.Code != http.StatusOK {
+		t.Errorf("HEAD returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
+	}
 }
 
 func TestSendEvent(t *testing.T) {

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
@@ -28,7 +28,7 @@ func TestSendEvent(t *testing.T) {
 	}
 
 	fields := map[string]interface{}{
-		"id":"1",
+		"id":"id1",
 	}
 
 	tags := map[string]string{
@@ -48,7 +48,7 @@ func TestMultipleEvents(t *testing.T) {
 	}
 
 	fields := map[string]interface{}{
-		"id":"1",
+		"id":"id1",
 	}
 
 	tags := map[string]string{
@@ -58,7 +58,7 @@ func TestMultipleEvents(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "mandrill_webhooks", fields, tags)
 
 	fields = map[string]interface{}{
-		"id":"1",
+		"id":"id2",
 	}
 
 	tags = map[string]string{

--- a/plugins/inputs/webhooks/webhooks.go
+++ b/plugins/inputs/webhooks/webhooks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/github"
+	"github.com/influxdata/telegraf/plugins/inputs/webhooks/mandrill"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/rollbar"
 )
 
@@ -26,6 +27,7 @@ type Webhooks struct {
 	ServiceAddress string
 
 	Github  *github.GithubWebhook
+	Mandrill *mandrill.MandrillWebhook
 	Rollbar *rollbar.RollbarWebhook
 }
 
@@ -40,6 +42,9 @@ func (wb *Webhooks) SampleConfig() string {
 
   [inputs.webhooks.github]
     path = "/github"
+
+  [inputs.webhooks.mandrill]
+    path = "/mandrill"
 
   [inputs.webhooks.rollbar]
     path = "/rollbar"

--- a/plugins/inputs/webhooks/webhooks.go
+++ b/plugins/inputs/webhooks/webhooks.go
@@ -26,9 +26,9 @@ func init() {
 type Webhooks struct {
 	ServiceAddress string
 
-	Github  *github.GithubWebhook
+	Github   *github.GithubWebhook
 	Mandrill *mandrill.MandrillWebhook
-	Rollbar *rollbar.RollbarWebhook
+	Rollbar  *rollbar.RollbarWebhook
 }
 
 func NewWebhooks() *Webhooks {


### PR DESCRIPTION
This add a new mandrill webhooks to store send, bounce, click, open events.

### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)
