### PR TITLE
Connection Loss Improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ should now look like:
 - [#1374](https://github.com/influxdata/telegraf/pull/1374): Change "default" retention policy to "".
 - [#1377](https://github.com/influxdata/telegraf/issues/1377): Graphite output mangling '%' character.
 - [#1396](https://github.com/influxdata/telegraf/pull/1396): Prometheus input plugin now supports x509 certs authentication
+- [#1](https://github.com/Instrumental/telegraf/pull/1): Instrumental output has better reconnect behavior
 
 ## v1.0 beta 1 [2016-06-07]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ should now look like:
 - [#1405](https://github.com/influxdata/telegraf/issues/1405): Fix memory/connection leak in prometheus input plugin.
 - [#1378](https://github.com/influxdata/telegraf/issues/1378): Trim BOM from config file for Windows support.
 - [#1339](https://github.com/influxdata/telegraf/issues/1339): Prometheus client output panic on service reload.
+- [#1412](https://github.com/influxdata/telegraf/pull/1412): Instrumental output has better reconnect behavior
 
 ## v1.0 beta 2 [2016-06-21]
 
@@ -61,7 +62,6 @@ should now look like:
 - [#1374](https://github.com/influxdata/telegraf/pull/1374): Change "default" retention policy to "".
 - [#1377](https://github.com/influxdata/telegraf/issues/1377): Graphite output mangling '%' character.
 - [#1396](https://github.com/influxdata/telegraf/pull/1396): Prometheus input plugin now supports x509 certs authentication
-- [#1](https://github.com/Instrumental/telegraf/pull/1): Instrumental output has better reconnect behavior
 
 ## v1.0 beta 1 [2016-06-07]
 

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -28,9 +28,9 @@ type Instrumental struct {
 }
 
 const (
-	DefaultHost     = "collector.instrumentalapp.com"
-	HelloMessage    = "hello version go/telegraf/1.1\n"
-	AuthFormat      = "authenticate %s\n"
+	DefaultHost  = "collector.instrumentalapp.com"
+	HelloMessage = "hello version go/telegraf/1.1\n"
+	AuthFormat   = "authenticate %s\n"
 )
 
 var (

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -29,7 +29,7 @@ type Instrumental struct {
 
 const (
 	DefaultHost     = "collector.instrumentalapp.com"
-	HelloMessage    = "hello version go/telegraf/1.0\n"
+	HelloMessage    = "hello version go/telegraf/1.1\n"
 	AuthFormat      = "authenticate %s\n"
 )
 

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -24,7 +24,6 @@ func TestWrite(t *testing.T) {
 		ApiToken: "abc123token",
 		Prefix:   "my.prefix",
 	}
-	i.Connect()
 
 	// Default to gauge
 	m1, _ := telegraf.NewMetric(
@@ -40,10 +39,8 @@ func TestWrite(t *testing.T) {
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 
-	// Simulate a connection close and reconnect.
 	metrics := []telegraf.Metric{m1, m2}
 	i.Write(metrics)
-	i.Close()
 
 	// Counter and Histogram are increments
 	m3, _ := telegraf.NewMetric(
@@ -70,7 +67,6 @@ func TestWrite(t *testing.T) {
 	i.Write(metrics)
 
 	wg.Wait()
-	i.Close()
 }
 
 func TCPServer(t *testing.T, wg *sync.WaitGroup) {
@@ -82,11 +78,11 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 	tp := textproto.NewReader(reader)
 
 	hello, _ := tp.ReadLine()
-	assert.Equal(t, "hello version go/telegraf/1.0", hello)
+	assert.Equal(t, "hello version go/telegraf/1.1", hello)
+	conn.Write([]byte("ok\n"))
 	auth, _ := tp.ReadLine()
 	assert.Equal(t, "authenticate abc123token", auth)
-
-	conn.Write([]byte("ok\nok\n"))
+	conn.Write([]byte("ok\n"))
 
 	data1, _ := tp.ReadLine()
 	assert.Equal(t, "gauge my.prefix.192_168_0_1.mymeasurement.myfield 3.14 1289430000", data1)
@@ -99,11 +95,12 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 	tp = textproto.NewReader(reader)
 
 	hello, _ = tp.ReadLine()
-	assert.Equal(t, "hello version go/telegraf/1.0", hello)
+	assert.Equal(t, "hello version go/telegraf/1.1", hello)
+	conn.Write([]byte("ok\n"))
+
 	auth, _ = tp.ReadLine()
 	assert.Equal(t, "authenticate abc123token", auth)
-
-	conn.Write([]byte("ok\nok\n"))
+	conn.Write([]byte("ok\n"))
 
 	data3, _ := tp.ReadLine()
 	assert.Equal(t, "increment my.prefix.192_168_0_1.my_histogram 3.14 1289430000", data3)

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -79,10 +79,9 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 
 	hello, _ := tp.ReadLine()
 	assert.Equal(t, "hello version go/telegraf/1.1", hello)
-	conn.Write([]byte("ok\n"))
 	auth, _ := tp.ReadLine()
 	assert.Equal(t, "authenticate abc123token", auth)
-	conn.Write([]byte("ok\n"))
+	conn.Write([]byte("ok\nok\n"))
 
 	data1, _ := tp.ReadLine()
 	assert.Equal(t, "gauge my.prefix.192_168_0_1.mymeasurement.myfield 3.14 1289430000", data1)
@@ -96,11 +95,9 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 
 	hello, _ = tp.ReadLine()
 	assert.Equal(t, "hello version go/telegraf/1.1", hello)
-	conn.Write([]byte("ok\n"))
-
 	auth, _ = tp.ReadLine()
 	assert.Equal(t, "authenticate abc123token", auth)
-	conn.Write([]byte("ok\n"))
+	conn.Write([]byte("ok\nok\n"))
 
 	data3, _ := tp.ReadLine()
 	assert.Equal(t, "increment my.prefix.192_168_0_1.my_histogram 3.14 1289430000", data3)


### PR DESCRIPTION
## What & Why

- Separate hello and authenticate functions
- Force connection close at end of write cycle so we don't hold open idle connections, which has the benefit of mostly removing the chance of getting hopelessly connection lost when either end of the connection innermittently drops

## Required for all PRs:
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

@jasonroelofs pinging you since you wrote the first version
