### PR TITLE
Considere Zookeeper's state as a tags

### DIFF
--- a/plugins/inputs/zookeeper/README.md
+++ b/plugins/inputs/zookeeper/README.md
@@ -32,7 +32,7 @@ echo mntr | nc localhost 2181
 
 Meta:
 - units: int64
-- tags: `server=<hostname> port=<port>`
+- tags: `server=<hostname> port=<port> state=<leader|follower>`
 
 Measurement names:
 - zookeeper_avg_latency
@@ -55,8 +55,12 @@ Measurement names:
 
 Meta:
 - units: string
-- tags: `server=<hostname> port=<port>`
+- tags: `server=<hostname> port=<port> state=<leader|follower>`
 
 Measurement names:
 - zookeeper_version
-- zookeeper_server_state
+
+### Tags:
+
+- All measurements have the following tags:
+	- 


### PR DESCRIPTION
This change will send the state of Zookeeper (leader|follower) as a tag
and not a metrics
That way it will be easier to search for filter per state