### PR TITLE
First sketch for a bind plugin

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/aerospike"
 	_ "github.com/influxdata/telegraf/plugins/inputs/apache"
 	_ "github.com/influxdata/telegraf/plugins/inputs/bcache"
+	_ "github.com/influxdata/telegraf/plugins/inputs/bind"
 	_ "github.com/influxdata/telegraf/plugins/inputs/cassandra"
 	_ "github.com/influxdata/telegraf/plugins/inputs/ceph"
 	_ "github.com/influxdata/telegraf/plugins/inputs/cgroup"

--- a/plugins/inputs/bind/bind.go
+++ b/plugins/inputs/bind/bind.go
@@ -1,0 +1,96 @@
+package bind
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+type Bind struct {
+	Url string
+}
+
+func (_ *Bind) Description() string {
+	return "Grab statistics from BIND servers"
+}
+
+var bindSampleConfig = `
+  ## url of the statistics server
+  url = "http://localhost:8053/json"
+`
+
+func (_ *Bind) SampleConfig() string {
+	return bindSampleConfig
+}
+
+func (b *Bind) Gather(acc telegraf.Accumulator) error {
+	response, err := http.Get(b.Url)
+
+	if err != nil {
+		return fmt.Errorf("error getting json statistics from bind: %s", err)
+	}
+
+	buffer := bytes.NewBuffer([]byte{})
+
+	if _, err = io.Copy(buffer, response.Body); err != nil {
+		return fmt.Errorf("error reading json statistics from bind: %s", err)
+	}
+
+	stats := statistics{}
+
+	if err = json.Unmarshal(buffer.Bytes(), &stats); err != nil {
+		return fmt.Errorf("error getting json statistics from bind: %s", err)
+	}
+
+	memory := map[string]int64{
+		"MemoryTotalUse":    stats.Memory.TotalUse,
+		"MemoryInUse":       stats.Memory.InUse,
+		"MemoryBlockSize":   stats.Memory.BlockSize,
+		"MemoryContextSize": stats.Memory.ContextSize,
+		"MemoryLost":        stats.Memory.Lost,
+	}
+
+	tags := map[string]string{}
+	accumulateFromMap(acc, "memory", memory, tags)
+	accumulateFromMap(acc, "opcodes", stats.Opcodes, tags)
+	accumulateFromMap(acc, "qtypes", stats.Qtypes, tags)
+	accumulateFromMap(acc, "nsstats", stats.Nsstats, tags)
+	accumulateFromMap(acc, "sockstats", stats.Sockstats, tags)
+
+	for viewName, view := range stats.Views {
+		tags["view"] = viewName
+
+		accumulateFromMap(acc, "stats", view.Resolver.Stats, tags)
+		accumulateFromMap(acc, "qtypes", view.Resolver.Qtypes, tags)
+		accumulateFromMap(acc, "cache", view.Resolver.Cache, tags)
+		accumulateFromMap(acc, "cachestats", view.Resolver.Cachestats, tags)
+		accumulateFromMap(acc, "adb", view.Resolver.Adb, tags)
+	}
+
+	return nil
+}
+
+func accumulateFromMap(acc telegraf.Accumulator, context string, m map[string]int64, tags map[string]string) {
+	tags["context"] = context
+
+	fields := map[string]interface{}{}
+
+	for key, value := range m {
+		fields[key] = value
+	}
+
+	acc.AddFields("bind", fields, tags)
+}
+
+func init() {
+	inputs.Add("bind", func() telegraf.Input {
+		return &Bind{
+			Url: "http://localhost:8053/json",
+		}
+	})
+}

--- a/plugins/inputs/bind/statistics.go
+++ b/plugins/inputs/bind/statistics.go
@@ -1,0 +1,72 @@
+package bind
+
+import "time"
+
+type statistics struct {
+	JSONStatsVersion string           `json:"json-stats-version"`
+	BootTime         time.Time        `json:"boot-time"`
+	ConfigTime       time.Time        `json:"config-time"`
+	CurrentTime      time.Time        `json:"current-time"`
+	Opcodes          map[string]int64 `json:"opcodes"`
+	Qtypes           map[string]int64 `json:"qtypes"`
+	Nsstats          map[string]int64 `json:"nsstats"`
+	Views            map[string]struct {
+		Zones []struct {
+			Name   string `json:"name"`
+			Class  string `json:"class"`
+			Serial int    `json:"serial"`
+		} `json:"zones"`
+		Resolver struct {
+			Stats      map[string]int64 `json:"stats"`
+			Qtypes     map[string]int64 `json:"qtypes"`
+			Cache      map[string]int64 `json:"cache"`
+			Cachestats map[string]int64 `json:"cachestats"`
+			Adb        map[string]int64 `json:"adb"`
+		} `json:"resolver"`
+	} `json:"views"`
+	Sockstats map[string]int64 `json:"sockstats"`
+	Socketmgr struct {
+		Sockets []struct {
+			ID           string   `json:"id"`
+			References   int      `json:"references"`
+			Type         string   `json:"type"`
+			LocalAddress string   `json:"local-address,omitempty"`
+			States       []string `json:"states"`
+			PeerAddress  string   `json:"peer-address,omitempty"`
+		} `json:"sockets"`
+	} `json:"socketmgr"`
+	Taskmgr struct {
+		ThreadModel    string `json:"thread-model"`
+		WorkerThreads  int    `json:"worker-threads"`
+		DefaultQuantum int    `json:"default-quantum"`
+		TasksRunning   int    `json:"tasks-running"`
+		TasksReady     int    `json:"tasks-ready"`
+		Tasks          []struct {
+			ID         string `json:"id"`
+			Name       string `json:"name,omitempty"`
+			References int    `json:"references"`
+			State      string `json:"state"`
+			Quantum    int    `json:"quantum"`
+			Events     int    `json:"events"`
+		} `json:"tasks"`
+	} `json:"taskmgr"`
+	Memory struct {
+		TotalUse    int64 `json:"TotalUse"`
+		InUse       int64 `json:"InUse"`
+		BlockSize   int64 `json:"BlockSize"`
+		ContextSize int64 `json:"ContextSize"`
+		Lost        int64 `json:"Lost"`
+		Contexts    []struct {
+			ID         string `json:"id"`
+			Name       string `json:"name"`
+			References int    `json:"references"`
+			Total      int    `json:"total"`
+			Inuse      int    `json:"inuse"`
+			Maxinuse   int    `json:"maxinuse"`
+			Blocksize  int    `json:"blocksize,omitempty"`
+			Pools      int    `json:"pools"`
+			Hiwater    int    `json:"hiwater"`
+			Lowater    int    `json:"lowater"`
+		} `json:"contexts"`
+	} `json:"memory"`
+}


### PR DESCRIPTION
First try on the development of a plugin for gathering data from BIND servers as requested in #299.

I kind of dislike this implementation, actually... BIND emits a lot of structured data that is a bit hard to transform to the standard used by influxDB. The previous implementation used different measurements for each of the contexts (memory, opcodes, nsstats, etc, but as the convention is to avoid things like "underscored measurements" and use tags instead, I dropped it. The consequence is that the values list in Chronograf is a bit polluted.

I'd be glad to discuss alternative ways of transforming the data.

Regards,