### PR TITLE
allow measurement to be defined for logparser_grok plugin

### DIFF
--- a/plugins/inputs/logparser/grok/grok.go
+++ b/plugins/inputs/logparser/grok/grok.go
@@ -56,6 +56,7 @@ type Parser struct {
 	Patterns           []string
 	CustomPatterns     string
 	CustomPatternFiles []string
+	Measurement string
 
 	// typeMap is a map of patterns -> capture name -> modifier,
 	//   ie, {
@@ -112,6 +113,10 @@ func (p *Parser) Compile() error {
 
 		scanner := bufio.NewScanner(bufio.NewReader(file))
 		p.addCustomPatterns(scanner)
+	}
+
+	if p.Measurement == "" {
+		p.Measurement = "logparser_grok"
 	}
 
 	return p.compileCustomPatterns()
@@ -215,7 +220,7 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 		}
 	}
 
-	return telegraf.NewMetric("logparser_grok", tags, fields, p.tsModder.tsMod(timestamp))
+	return telegraf.NewMetric(p.Measurement, tags, fields, p.tsModder.tsMod(timestamp))
 }
 
 func (p *Parser) addCustomPatterns(scanner *bufio.Scanner) {


### PR DESCRIPTION
Allows the logparser plugin to define the measurement for the data. I know that normally this is not configurable but it seems to make sense for the logparser plugin as what is being parsed can vary significantly. Also this is the only way to separate data from multiple instances of the plugin.

New example config:
```
[[inputs.logparser]]
   files = ["/var/lib/pmacct/in_port.txt"]
   from_beginning = true
   [inputs.logparser.grok]
     measurement = "net_in_port"
     patterns = ["%{NONNEGINT:port:tag},%{NONNEGINT:packets:int},%{NONNEGINT:bytes:int}"]

[[inputs.logparser]]
   files = ["/var/lib/pmacct/out_port.txt"]
   from_beginning = true
   [inputs.logparser.grok]
     measurement = "net_out_port"
     patterns = ["%{NONNEGINT:port:tag},%{NONNEGINT:packets:int},%{NONNEGINT:bytes:int}"]
```

- [ ] CHANGELOG.md updated
- [ ] README.md updated (if adding a new plugin)



