### PR TITLE
add support for diskio tags & naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2137](https://github.com/influxdata/telegraf/pull/2137): Added userstats to mysql input plugin.
 - [#2179](https://github.com/influxdata/telegraf/pull/2179): Added more InnoDB metric to MySQL plugin.
 - [#2251](https://github.com/influxdata/telegraf/pull/2251): InfluxDB output: use own client for improved through-put and less allocations.
+- [#1453](https://github.com/influxdata/telegraf/pull/1453): diskio: add support for name templates and udev tags.
 
 ### Bugfixes
 

--- a/plugins/inputs/system/disk.go
+++ b/plugins/inputs/system/disk.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/influxdata/telegraf"
@@ -82,7 +83,11 @@ type DiskIOStats struct {
 	ps PS
 
 	Devices          []string
+	DeviceTags       []string
+	NameTemplates    []string
 	SkipSerialNumber bool
+
+	infoCache map[string]diskInfoCache
 }
 
 func (_ *DiskIOStats) Description() string {
@@ -96,6 +101,23 @@ var diskIoSampleConfig = `
   # devices = ["sda", "sdb"]
   ## Uncomment the following line if you need disk serial numbers.
   # skip_serial_number = false
+  #
+  ## On systems which support it, device metadata can be added in the form of
+  ## tags.
+  ## Currently only Linux is supported via udev properties. You can view
+  ## available properties for a device by running:
+  ## 'udevadm info -q property -n /dev/sda'
+  # device_tags = ["ID_FS_TYPE", "ID_FS_USAGE"]
+  #
+  ## Using the same metadata source as device_tags, you can also customize the
+  ## name of the device via templates.
+  ## The 'name_templates' parameter is a list of templates to try and apply to
+  ## the device. The template may contain variables in the form of '$PROPERTY' or
+  ## '${PROPERTY}'. The first template which does not contain any variables not
+  ## present for the device is used as the device name tag.
+  ## The typical use case is for LVM volumes, to get the VG/LV name instead of
+  ## the near-meaningless DM-0 name.
+  # name_templates = ["$ID_FS_LABEL","$DM_VG_NAME/$DM_LV_NAME"]
 `
 
 func (_ *DiskIOStats) SampleConfig() string {
@@ -123,7 +145,10 @@ func (s *DiskIOStats) Gather(acc telegraf.Accumulator) error {
 			continue
 		}
 		tags := map[string]string{}
-		tags["name"] = io.Name
+		tags["name"] = s.diskName(io.Name)
+		for t, v := range s.diskTags(io.Name) {
+			tags[t] = v
+		}
 		if !s.SkipSerialNumber {
 			if len(io.SerialNumber) != 0 {
 				tags["serial"] = io.SerialNumber
@@ -146,6 +171,64 @@ func (s *DiskIOStats) Gather(acc telegraf.Accumulator) error {
 	}
 
 	return nil
+}
+
+var varRegex = regexp.MustCompile(`\$(?:\w+|\{\w+\})`)
+
+func (s *DiskIOStats) diskName(devName string) string {
+	di, err := s.diskInfo(devName)
+	if err != nil {
+		// discard error :-(
+		// We can't return error because it's non-fatal to the Gather().
+		// And we have no logger, so we can't log it.
+		return devName
+	}
+	if di == nil {
+		return devName
+	}
+
+	for _, nt := range s.NameTemplates {
+		miss := false
+		name := varRegex.ReplaceAllStringFunc(nt, func(sub string) string {
+			sub = sub[1:] // strip leading '$'
+			if sub[0] == '{' {
+				sub = sub[1 : len(sub)-1] // strip leading & trailing '{' '}'
+			}
+			if v, ok := di[sub]; ok {
+				return v
+			}
+			miss = true
+			return ""
+		})
+
+		if !miss {
+			return name
+		}
+	}
+
+	return devName
+}
+
+func (s *DiskIOStats) diskTags(devName string) map[string]string {
+	di, err := s.diskInfo(devName)
+	if err != nil {
+		// discard error :-(
+		// We can't return error because it's non-fatal to the Gather().
+		// And we have no logger, so we can't log it.
+		return nil
+	}
+	if di == nil {
+		return nil
+	}
+
+	tags := map[string]string{}
+	for _, dt := range s.DeviceTags {
+		if v, ok := di[dt]; ok {
+			tags[dt] = v
+		}
+	}
+
+	return tags
 }
 
 func init() {

--- a/plugins/inputs/system/disk_linux.go
+++ b/plugins/inputs/system/disk_linux.go
@@ -1,0 +1,66 @@
+package system
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
+
+type diskInfoCache struct {
+	stat   syscall.Stat_t
+	values map[string]string
+}
+
+var udevPath = "/run/udev/data"
+
+func (s *DiskIOStats) diskInfo(devName string) (map[string]string, error) {
+	fi, err := os.Stat("/dev/" + devName)
+	if err != nil {
+		return nil, err
+	}
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil, nil
+	}
+
+	if s.infoCache == nil {
+		s.infoCache = map[string]diskInfoCache{}
+	}
+	ic, ok := s.infoCache[devName]
+	if ok {
+		return ic.values, nil
+	} else {
+		ic = diskInfoCache{
+			stat:   *stat,
+			values: map[string]string{},
+		}
+		s.infoCache[devName] = ic
+	}
+	di := ic.values
+
+	major := stat.Rdev >> 8 & 0xff
+	minor := stat.Rdev & 0xff
+
+	f, err := os.Open(fmt.Sprintf("%s/b%d:%d", udevPath, major, minor))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	scnr := bufio.NewScanner(f)
+
+	for scnr.Scan() {
+		l := scnr.Text()
+		if len(l) < 4 || l[:2] != "E:" {
+			continue
+		}
+		kv := strings.SplitN(l[2:], "=", 2)
+		if len(kv) < 2 {
+			continue
+		}
+		di[kv[0]] = kv[1]
+	}
+
+	return di, nil
+}

--- a/plugins/inputs/system/disk_linux_test.go
+++ b/plugins/inputs/system/disk_linux_test.go
@@ -1,0 +1,101 @@
+// +build linux
+
+package system
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var nullDiskInfo = []byte(`
+E:MY_PARAM_1=myval1
+E:MY_PARAM_2=myval2
+`)
+
+// setupNullDisk sets up fake udev info as if /dev/null were a disk.
+func setupNullDisk(t *testing.T) func() error {
+	td, err := ioutil.TempDir("", ".telegraf.TestDiskInfo")
+	require.NoError(t, err)
+
+	origUdevPath := udevPath
+
+	cleanFunc := func() error {
+		udevPath = origUdevPath
+		return os.RemoveAll(td)
+	}
+
+	udevPath = td
+	err = ioutil.WriteFile(td+"/b1:3", nullDiskInfo, 0644) // 1:3 is the 'null' device
+	if err != nil {
+		cleanFunc()
+		t.Fatal(err)
+	}
+
+	return cleanFunc
+}
+
+func TestDiskInfo(t *testing.T) {
+	clean := setupNullDisk(t)
+	defer clean()
+
+	s := &DiskIOStats{}
+	di, err := s.diskInfo("null")
+	require.NoError(t, err)
+	assert.Equal(t, "myval1", di["MY_PARAM_1"])
+	assert.Equal(t, "myval2", di["MY_PARAM_2"])
+
+	// test that data is cached
+	err = clean()
+	require.NoError(t, err)
+
+	di, err = s.diskInfo("null")
+	require.NoError(t, err)
+	assert.Equal(t, "myval1", di["MY_PARAM_1"])
+	assert.Equal(t, "myval2", di["MY_PARAM_2"])
+
+	// unfortunately we can't adjust mtime on /dev/null to test cache invalidation
+}
+
+// DiskIOStats.diskName isn't a linux specific function, but dependent
+// functions are a no-op on non-Linux.
+func TestDiskIOStats_diskName(t *testing.T) {
+	defer setupNullDisk(t)()
+
+	tests := []struct {
+		templates []string
+		expected  string
+	}{
+		{[]string{"$MY_PARAM_1"}, "myval1"},
+		{[]string{"${MY_PARAM_1}"}, "myval1"},
+		{[]string{"x$MY_PARAM_1"}, "xmyval1"},
+		{[]string{"x${MY_PARAM_1}x"}, "xmyval1x"},
+		{[]string{"$MISSING", "$MY_PARAM_1"}, "myval1"},
+		{[]string{"$MY_PARAM_1", "$MY_PARAM_2"}, "myval1"},
+		{[]string{"$MISSING"}, "null"},
+		{[]string{"$MY_PARAM_1/$MY_PARAM_2"}, "myval1/myval2"},
+		{[]string{"$MY_PARAM_2/$MISSING"}, "null"},
+	}
+
+	for _, tc := range tests {
+		s := DiskIOStats{
+			NameTemplates: tc.templates,
+		}
+		assert.Equal(t, tc.expected, s.diskName("null"), "Templates: %#v", tc.templates)
+	}
+}
+
+// DiskIOStats.diskTags isn't a linux specific function, but dependent
+// functions are a no-op on non-Linux.
+func TestDiskIOStats_diskTags(t *testing.T) {
+	defer setupNullDisk(t)()
+
+	s := &DiskIOStats{
+		DeviceTags: []string{"MY_PARAM_2"},
+	}
+	dt := s.diskTags("null")
+	assert.Equal(t, map[string]string{"MY_PARAM_2": "myval2"}, dt)
+}

--- a/plugins/inputs/system/disk_other.go
+++ b/plugins/inputs/system/disk_other.go
@@ -1,0 +1,9 @@
+// +build !linux
+
+package system
+
+type diskInfoCache struct{}
+
+func (s *DiskIOStats) diskInfo(devName string) (map[string]string, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This adds support for adding tags and device naming via udev info.
This should address #1386, and #1428 

Lets start with the configuration

```
[[inputs.diskio]]
    NameTemplates = ["$ID_FS_LABEL","$DM_VG_NAME/$DM_LV_NAME"]
    DeviceTags = ["ID_FS_TYPE","ID_FS_USAGE"]
```

The `NameTemplates` parameter says to set the `name` parameter to the `ID_FS_LABEL` value if it exists, and if not then a concatenation of `DM_VG_NAME/DM_LV_NAME`, and if either of those tags don't exist, it falls back to the original device name.

The `DeviceTags` parameter is a list of udev variables to add as device tags to the measurement.

The result looks like this on my system:

```
* Plugin: diskio, Collection 1
> diskio,ID_FS_TYPE=xfs,ID_FS_USAGE=filesystem,host=whistler,name=mytestlabel io_time=1266i,read_bytes=2421760i,read_time=957i,reads=303i,write_bytes=10881024i,write_time=360i,writes=89i 1467672615000000000
> diskio,host=whistler,name=sda io_time=6598789i,read_bytes=5906184704i,read_time=1914387i,reads=182112i,write_bytes=26210285056i,write_time=52565790i,writes=1878296i 1467672615000000000
> diskio,ID_FS_TYPE=vfat,ID_FS_USAGE=filesystem,host=whistler,name=sda1 io_time=987i,read_bytes=1765376i,read_time=1078i,reads=215i,write_bytes=0i,write_time=0i,writes=0i 1467672615000000000
> diskio,ID_FS_TYPE=xfs,ID_FS_USAGE=filesystem,host=whistler,name=sys/crypt io_time=6851i,read_bytes=9407488i,read_time=8688i,reads=1019i,write_bytes=2098176i,write_time=2009i,writes=2051i 1467672615000000000
> diskio,ID_FS_TYPE=xfs,ID_FS_USAGE=filesystem,host=whistler,name=sys/usr-portage io_time=58660i,read_bytes=86578688i,read_time=51486i,reads=13245i,write_bytes=35152384i,write_time=1025767i,writes=3790i 1467672615000000000
> diskio,ID_FS_TYPE=xfs,ID_FS_USAGE=filesystem,host=whistler,name=sys/am io_time=639i,read_bytes=1867776i,read_time=939i,reads=236i,write_bytes=0i,write_time=0i,writes=0i 1467672615000000000
> diskio,ID_FS_TYPE=LVM2_member,ID_FS_USAGE=raid,host=whistler,name=sda2 io_time=3891613i,read_bytes=5903923712i,read_time=1912824i,reads=181837i,write_bytes=26210285056i,write_time=44116445i,writes=1398911i 1467672615000000000
> diskio,host=whistler,name=sys/root io_time=636082i,read_bytes=1317065728i,read_time=404206i,reads=36903i,write_bytes=801451520i,write_time=1559775i,writes=96473i 1467672615000000000
> diskio,ID_FS_TYPE=xfs,ID_FS_USAGE=filesystem,host=whistler,name=sys/root-old io_time=1682i,read_bytes=1867776i,read_time=2054i,reads=236i,write_bytes=0i,write_time=0i,writes=0i 1467672615000000000
> diskio,ID_FS_TYPE=btrfs,ID_FS_USAGE=filesystem,host=whistler,name=sys/docker io_time=66057i,read_bytes=287211520i,read_time=28592i,reads=3386i,write_bytes=2467983360i,write_time=6786216i,writes=37110i 1467672615000000000
> diskio,ID_FS_TYPE=xfs,ID_FS_USAGE=filesystem,host=whistler,name=dm-9 io_time=5607021i,read_bytes=4150764032i,read_time=1421167i,reads=124988i,write_bytes=22246219776i,write_time=84288330i,writes=1265505i 1467672615000000000
> diskio,ID_FS_TYPE=crypto_LUKS,ID_FS_USAGE=crypto,host=whistler,name=sys/home-phemmer-luks io_time=5526527i,read_bytes=4151519744i,read_time=1387029i,reads=125057i,write_bytes=22246219776i,write_time=52502736i,writes=1386108i 1467672615000000000
> diskio,ID_FS_TYPE=xfs,ID_FS_USAGE=filesystem,host=whistler,name=sys/stmp io_time=2674i,read_bytes=3829248i,read_time=2334i,reads=233i,write_bytes=2110464i,write_time=566i,writes=11i 1467672615000000000
> diskio,ID_FS_TYPE=xfs,ID_FS_USAGE=filesystem,host=whistler,name=sys/var-log io_time=522335i,read_bytes=41872896i,read_time=42444i,reads=2050i,write_bytes=644383232i,write_time=3587523i,writes=132792i 1467672615000000000
```

The first line is an example of `$ID_FS_LABEL` being used (`name=mytestlabel`).
On several of the entries we can see the `$DM_VG_NAME/$DM_LV_NAME` in action, such as in `sys/crypt`.
The 3rd line shows us an entry that fell all the way through to normal naming (`name=sda1`).

And then on many of the lines, we can see the `ID_FS_TYPE` and `ID_FS_USAGE` tags.

I designed the code so that on operating systems without udev, the plugin still works, and that the plugin can be easily adapted for any device information available in these other operating systems.

Still needs tests & documentation, but can add once some high level feedback is obtained.
### Required for all PRs:
- [x] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
