### PR TITLE
Moving the path to a field to reduce cardinality

### DIFF
--- a/plugins/inputs/cgroup/cgroup_linux.go
+++ b/plugins/inputs/cgroup/cgroup_linux.go
@@ -34,6 +34,7 @@ func (g *CGroup) Gather(acc telegraf.Accumulator) error {
 
 func (g *CGroup) gatherDir(dir string, acc telegraf.Accumulator) error {
 	fields := make(map[string]interface{})
+	tags := make(map[string]string)
 
 	list := make(chan pathInfo)
 	go g.generateFiles(dir, list)
@@ -56,8 +57,7 @@ func (g *CGroup) gatherDir(dir string, acc telegraf.Accumulator) error {
 			return err
 		}
 	}
-
-	tags := map[string]string{"path": dir}
+	fields["path"] = dir
 
 	acc.AddFields(metricName, fields, tags)
 


### PR DESCRIPTION
To reduce overall metric cardinality within the system, but to keep valuable metrics within reach, we're moving the path from a tag to a field for the same metric.

### Required for all PRs:

- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)

