### PR TITLE
Moving cgroup path name to field from tag to reduce cardinality

### DIFF
--- a/plugins/inputs/cgroup/README.md
+++ b/plugins/inputs/cgroup/README.md
@@ -33,8 +33,9 @@ KEY1 VAL1\n
 
 ### Tags:
 
-All measurements have the following tags:
-  - path
+Measurements don't have any specific tags unless you define them at the telegraf level (defaults). We
+used to have the path listed as a tag, but to keep cardinality in check it's easier to move this 
+value to a field. Thanks @sebito91!
 
 
 ### Configuration:

--- a/plugins/inputs/cgroup/cgroup_linux.go
+++ b/plugins/inputs/cgroup/cgroup_linux.go
@@ -56,10 +56,9 @@ func (g *CGroup) gatherDir(dir string, acc telegraf.Accumulator) error {
 			return err
 		}
 	}
+	fields["path"] = dir
 
-	tags := map[string]string{"path": dir}
-
-	acc.AddFields(metricName, fields, tags)
+	acc.AddFields(metricName, fields, nil)
 
 	return nil
 }


### PR DESCRIPTION
Revised commit that moves the cgroup path name away from tags and into the fields. This information is quite useful to debug jobs, processes, other things that live under the cgroup headings in distinct folders. Having the value listed as a tag drastically increases cardinality so moving it to a field allows it to remain as a a value we can query.

### Required for all PRs:

- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)

