### PR TITLE
Documentation for load balancing on graphite output servers

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -197,6 +197,7 @@
 # # Configuration for Graphite server to send metrics to
 # [[outputs.graphite]]
 #   ## TCP endpoint for your graphite instance.
+#   ## If multiple endpoints are configured the output will be load balanced.
 #   servers = ["localhost:2003"]
 #   ## Prefix metrics name
 #   prefix = ""

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -197,7 +197,8 @@
 # # Configuration for Graphite server to send metrics to
 # [[outputs.graphite]]
 #   ## TCP endpoint for your graphite instance.
-#   ## If multiple endpoints are configured the output will be load balanced.
+#   ## If multiple endpoints are configured, output will be load balanced.
+#   ## Only one of the endpoints will be written to with each iteration.
 #   servers = ["localhost:2003"]
 #   ## Prefix metrics name
 #   prefix = ""

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -197,7 +197,7 @@
 # # Configuration for Graphite server to send metrics to
 # [[outputs.graphite]]
 #   ## TCP endpoint for your graphite instance.
-#   ## If multiple endpoints are configured, output will be load balanced.
+#   ## If multiple endpoints are configured, the output will be load balanced.
 #   ## Only one of the endpoints will be written to with each iteration.
 #   servers = ["localhost:2003"]
 #   ## Prefix metrics name

--- a/plugins/outputs/graphite/README.md
+++ b/plugins/outputs/graphite/README.md
@@ -9,7 +9,8 @@ via raw TCP.
 # Configuration for Graphite server to send metrics to
 [[outputs.graphite]]
   ## TCP endpoint for your graphite instance.
-  ## If multiple endpoints are configured the output will be load balanced.
+  ## If multiple endpoints are configured, the output will be load balanced.
+  ## Only one of the endpoints will be written to with each iteration.
   servers = ["localhost:2003"]
   ## Prefix metrics name
   prefix = ""

--- a/plugins/outputs/graphite/README.md
+++ b/plugins/outputs/graphite/README.md
@@ -9,6 +9,7 @@ via raw TCP.
 # Configuration for Graphite server to send metrics to
 [[outputs.graphite]]
   ## TCP endpoint for your graphite instance.
+  ## If multiple endpoints are configured the output will be load balanced.
   servers = ["localhost:2003"]
   ## Prefix metrics name
   prefix = ""

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -25,6 +25,7 @@ type Graphite struct {
 
 var sampleConfig = `
   ## TCP endpoint for your graphite instance.
+  ## If multiple endpoints are configured the output will be load balanced.
   servers = ["localhost:2003"]
   ## Prefix metrics name
   prefix = ""

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -25,7 +25,8 @@ type Graphite struct {
 
 var sampleConfig = `
   ## TCP endpoint for your graphite instance.
-  ## If multiple endpoints are configured the output will be load balanced.
+  ## If multiple endpoints are configured, output will be load balanced.
+  ## Only one of the endpoints will be written to with each iteration.
   servers = ["localhost:2003"]
   ## Prefix metrics name
   prefix = ""


### PR DESCRIPTION
Adding multiple endpoints in the servers sections of graphite output, load balances the output points in a random way. This was not documented so there have been cases where end users assumed that all endpoints receive all metrics. This should make it clear by clarifying this behavior of the graphite output plugin.