### PR TITLE
Remove systemd Install alias

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -37,6 +37,10 @@ chmod 755 $LOG_DIR
 if [[ -L /etc/init.d/telegraf ]]; then
     rm -f /etc/init.d/telegraf
 fi
+# Remove legacy symlink, if it exists
+if [[ -L /etc/systemd/system/telegraf.service ]]; then
+    rm -f /etc/systemd/system/telegraf.service
+fi
 
 # Add defaults file, if it doesn't exist
 if [[ ! -f /etc/default/telegraf ]]; then

--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -15,4 +15,3 @@ KillMode=control-group
 
 [Install]
 WantedBy=multi-user.target
-Alias=telegraf.service


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

With current telegraf, when updating package we got the following error (at least on Debian/Ubuntu):
```
Setting up telegraf (1.0.0~beta2) ...
Failed to execute operation: Too many levels of symbolic links
```

It is caused by systemctl enable telegraf:
```
# systemctl enable telegraf
Failed to execute operation: Too many levels of symbolic links
```

It seems to be due to Alias in Install section of telegraf.service. From my understanding of manpage systemd.unit, alias should only contains *additional* name.

Removing the alias (and the symlink /etc/systemd/system/telegraf.service created) fix this issue, after this PR systemctl enable telegraf show no warning. Obviously telegraf is still started on boot & could be controlled with systemctl {start|stop|status} telegraf
