### PR TITLE
Extend sanitizedChars array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ should now look like:
 - [#1378](https://github.com/influxdata/telegraf/issues/1378): Trim BOM from config file for Windows support.
 - [#1339](https://github.com/influxdata/telegraf/issues/1339): Prometheus client output panic on service reload.
 - [#1461](https://github.com/influxdata/telegraf/pull/1461): Prometheus parser, protobuf format header fix.
+- [#1474](https://github.com/influxdata/telegraf/pull/1474): Extend sanitizedChars array
 
 ## v1.0 beta 2 [2016-06-21]
 

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	sanitizedChars = strings.NewReplacer("/", "_", "@", "_", " ", "_", "-", "_", ".", "_")
+	sanitizedChars = strings.NewReplacer("/", "_", "@", "_", " ", "_", "-", "_", ".", "_", "|", "_", "\\", "")
 
 	// Prometheus metric names must match this regex
 	// see https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)

We are using metrics names devided with | so, we have to name metrics with | and \.
lets extend that array to fix naming