### PR TITLE
Fix Redis url, an extra "tcp://" was added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ should now look like:
 - [#1436](https://github.com/influxdata/telegraf/issues/1436): logparser: honor modifiers in "pattern" config.
 - [#1418](https://github.com/influxdata/telegraf/issues/1418): logparser: error and exit on file permissions/missing errors.
 - [#1499](https://github.com/influxdata/telegraf/pull/1499): Make the user able to specify full path for HAproxy stats
+- [#1521](https://github.com/influxdata/telegraf/pull/1521): Fix Redis url, an extra "tcp://" was added.
 
 ## v1.0 beta 2 [2016-06-21]
 

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -99,7 +99,7 @@ func (r *Redis) Gather(acc telegraf.Accumulator) error {
 	var wg sync.WaitGroup
 	errChan := errchan.New(len(r.Servers))
 	for _, serv := range r.Servers {
-		if !strings.HasPrefix(serv, "tcp://") || !strings.HasPrefix(serv, "unix://") {
+		if !strings.HasPrefix(serv, "tcp://") && !strings.HasPrefix(serv, "unix://") {
 			serv = "tcp://" + serv
 		}
 


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


In PR #1480 a extra "tcp://" was added in default configuration. It was due to a OR instead of AND used in [if test](https://github.com/influxdata/telegraf/blob/d54b169d6798e160a4ecfd5061e568fc4d3c8a88/plugins/inputs/redis/redis.go#L102).

It result in:
```
$ ./build/telegraf -input-filter redis -output-filter influxdb -sample-config > sample.conf
$ ./build/telegraf -config sample.conf -test
* Plugin: redis, Collection 1
2016/07/19 15:50:06 Errors encountered: [Unable to connect to redis server 'tcp:': dial tcp: lookup tcp on 127.0.1.1:53: no such host]
```