### PR TITLE
Prometheus client & win_perf_counters char changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1519](https://github.com/influxdata/telegraf/pull/1519): Fix error race conditions and partial failures.
 - [#1477](https://github.com/influxdata/telegraf/issues/1477): nstat: fix inaccurate config panic.
 - [#1481](https://github.com/influxdata/telegraf/issues/1481): jolokia: fix handling multiple multi-dimensional attributes.
+- [#1430](https://github.com/influxdata/telegraf/issues/1430): Fix prometheus character sanitizing. Sanitize more win_perf_counters characters.
 
 ## v1.0 beta 3 [2016-07-18]
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -107,7 +107,8 @@ type item struct {
 	counterHandle win.PDH_HCOUNTER
 }
 
-var sanitizedChars = strings.NewReplacer("/sec", "_persec", "/Sec", "_persec", " ", "_")
+var sanitizedChars = strings.NewReplacer("/sec", "_persec", "/Sec", "_persec",
+	" ", "_", "%", "Percent", `\`, "")
 
 func (m *Win_PerfCounters) AddItem(metrics *itemList, query string, objectName string, counter string, instance string,
 	measurement string, include_total bool) {
@@ -299,13 +300,12 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 							tags["instance"] = s
 						}
 						tags["objectname"] = metric.objectName
-						fields[sanitizedChars.Replace(string(metric.counter))] = float32(c.FmtValue.DoubleValue)
+						fields[sanitizedChars.Replace(metric.counter)] =
+							float32(c.FmtValue.DoubleValue)
 
-						var measurement string
-						if metric.measurement == "" {
+						measurement := sanitizedChars.Replace(metric.measurement)
+						if measurement == "" {
 							measurement = "win_perf_counters"
-						} else {
-							measurement = metric.measurement
 						}
 						acc.AddFields(measurement, fields, tags)
 					}

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -12,17 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var (
-	invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
-
-	// Prometheus metric names must match this regex
-	// see https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-	metricName = regexp.MustCompile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
-
-	// Prometheus labels must match this regex
-	// see https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-	labelName = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
-)
+var invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 type PrometheusClient struct {
 	Listen string
@@ -119,9 +109,6 @@ func (p *PrometheusClient) Write(metrics []telegraf.Metric) error {
 			if len(k) == 0 {
 				continue
 			}
-			if !labelName.MatchString(k) {
-				continue
-			}
 			labels = append(labels, k)
 			l[k] = v
 		}
@@ -142,11 +129,6 @@ func (p *PrometheusClient) Write(metrics []telegraf.Metric) error {
 				mname = key
 			} else {
 				mname = fmt.Sprintf("%s_%s", key, n)
-			}
-
-			// verify that it is a valid measurement name
-			if !metricName.MatchString(mname) {
-				continue
 			}
 
 			desc := prometheus.NewDesc(mname, "Telegraf collected metric", nil, l)


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated

1. in prometheus client, do not check for invalid characters anymore,
because we are already replacing all invalid characters with regex
anyways.
2. in win_perf_counters, sanitize field name _and_ measurement name.
Also add '%' to the list of sanitized characters, because this character
is invalid for most output plugins, and can also easily cause string
formatting issues throughout the stack.
3. All '%' will now be translated to 'Percent'

closes #1430