### PR TITLE
jolokia: handle multiple multi-dimensional attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#1519](https://github.com/influxdata/telegraf/pull/1519): Fix error race conditions and partial failures.
 - [#1477](https://github.com/influxdata/telegraf/issues/1477): nstat: fix inaccurate config panic.
+- [#1481](https://github.com/influxdata/telegraf/issues/1481): jolokia: fix handling multiple multi-dimensional attributes.
 
 ## v1.0 beta 3 [2016-07-18]
 

--- a/plugins/inputs/jolokia/jolokia.go
+++ b/plugins/inputs/jolokia/jolokia.go
@@ -249,7 +249,14 @@ func (j *Jolokia) Gather(acc telegraf.Accumulator) error {
 					switch t := values.(type) {
 					case map[string]interface{}:
 						for k, v := range t {
-							fields[measurement+"_"+k] = v
+							switch t2 := v.(type) {
+							case map[string]interface{}:
+								for k2, v2 := range t2 {
+									fields[measurement+"_"+k+"_"+k2] = v2
+								}
+							case interface{}:
+								fields[measurement+"_"+k] = t2
+							}
 						}
 					case interface{}:
 						fields[measurement] = t


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

fixes #1481

DISCLAIMER: I don't know anything about Go. This ain't pretty, but it works on my machines. Feel free to throw this PR away if you can think of a better way to do this and/or know how to write tests.

After two days on the brink of insanity trying to come to terms with Go's type system, I have found the underlying issue for #1481. It's pretty simple actually.

The bug occurs when more than one multi-dimensional attribute is requested:

```
  [[inputs.jolokia.metrics]]
    name = "heap_memory_usage"
    mbean  = "java.lang:type=Memory"
    attribute = "HeapMemoryUsage,NonHeapMemoryUsage"
```

This leads to `out` being structured like this, which is not handled properly:

```json
{
	"value": {
		"HeapMemoryUsage": {
			"max": 1,
			[...]
		},
		"NonHeapMemoryUsage": {
			"max": 1,
			[...]
		}
	}
}
```

The extra level of maps is not recognized. This PR tries to fix that.