### PR TITLE
update gopsutil for FreeBSD disk time metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1477](https://github.com/influxdata/telegraf/issues/1477): nstat: fix inaccurate config panic.
 - [#1481](https://github.com/influxdata/telegraf/issues/1481): jolokia: fix handling multiple multi-dimensional attributes.
 - [#1430](https://github.com/influxdata/telegraf/issues/1430): Fix prometheus character sanitizing. Sanitize more win_perf_counters characters.
+- [#1534](https://github.com/influxdata/telegraf/pull/1534): Add diskio io_time to FreeBSD & report timing metrics as ms (as linux does).
 
 ## v1.0 beta 3 [2016-07-18]
 

--- a/Godeps
+++ b/Godeps
@@ -44,7 +44,7 @@ github.com/prometheus/client_model fa8ad6fec33561be4280a8f0514318c79d7f6cb6
 github.com/prometheus/common e8eabff8812b05acf522b45fdcd725a785188e37
 github.com/prometheus/procfs 406e5b7bfd8201a36e2bb5f7bdae0b03380c2ce8
 github.com/samuel/go-zookeeper 218e9c81c0dd8b3b18172b2bbfad92cc7d6db55f
-github.com/shirou/gopsutil 586bb697f3ec9f8ec08ffefe18f521a64534037c
+github.com/shirou/gopsutil ee66bc560c366dd33b9a4046ba0b644caba46bed
 github.com/soniah/gosnmp b1b4f885b12c5dcbd021c5cee1c904110de6db7d
 github.com/sparrc/aerospike-client-go d4bb42d2c2d39dae68e054116f4538af189e05d5
 github.com/streadway/amqp b4f3ceab0337f013208d31348b578d83c0064744


### PR DESCRIPTION
I submitted a patch upstream to gopsutil to fix some diskio time issues on FreeBSD: shirou/gopsutil#232
The issue was that the `read_time` and `write_time` metrics on Linux were reported in milliseconds, but on FreeBSD they were in seconds. The `io_time` metric was also missing entirely. The upstream PR fixed both these issues.
While the `io_time` might be considered a feature, the inconsistent time units between Linux & FreeBSD I would consider a bug, and so I have classified this as a bug fix in the CHANGELOG.

This is all the upstream changes that will be pulled in: https://github.com/shirou/gopsutil/compare/586bb697f3ec9f8ec08ffefe18f521a64534037c...ee66bc560c366dd33b9a4046ba0b644caba46bed
### Required for all PRs:

- [X] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
