### PR TITLE
add AddError method to accumulator

### DIFF
--- a/accumulator.go
+++ b/accumulator.go
@@ -16,6 +16,8 @@ type Accumulator interface {
 		tags map[string]string,
 		t ...time.Time)
 
+	AddError(err error)
+
 	Debug() bool
 	SetDebug(enabled bool)
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -215,6 +215,9 @@ func (a *Agent) Test() error {
 		if err := input.Input.Gather(acc); err != nil {
 			return err
 		}
+		if acc.errCount > 0 {
+			return fmt.Errorf("Errors encountered during processing")
+		}
 
 		// Special instructions for some inputs. cpu, for example, needs to be
 		// run twice in order to return cpu usage percentages.

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -28,6 +28,7 @@ type Accumulator struct {
 	sync.Mutex
 
 	Metrics []*Metric
+	Errors  []error
 	debug   bool
 }
 
@@ -82,6 +83,16 @@ func (a *Accumulator) AddFields(
 	}
 
 	a.Metrics = append(a.Metrics, p)
+}
+
+// AddError appends the given error to Accumulator.Errors.
+func (a *Accumulator) AddError(err error) {
+	if err == nil {
+		return
+	}
+	a.Lock()
+	a.Errors = append(a.Errors, err)
+	a.Unlock()
 }
 
 func (a *Accumulator) SetPrecision(precision, interval time.Duration) {


### PR DESCRIPTION
This adds an `AddError()` method to the accumulator. Ref #1446

As opposed to the original POC in #1446, I instead just implemented it so that `AddError()` immediately writes out to the log instead of sending it into a `chan` just so that a goroutine could then write it out to the log. This approach is much simpler.

I also added an `errCount` to the accumulator which will increment each time an error is generated. This was done for 2 reasons:

1. So that the `Test()` function could tell if any errors were generated during the run. 
2. To pave the way for #1348.  
It would be very useful to know when a plugin starts throwing errors. You could then write a kapacitor alert to trigger when such starts happening.

Haven't updated CHANGELOG since the code in this PR is unused, and thus there is no user visible change.