### PR TITLE
Added capability to send metrics through Http API for OpenTSDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1572](https://github.com/influxdata/telegraf/pull/1572): mesos improvements.
 - [#1513](https://github.com/influxdata/telegraf/issues/1513): Add Ceph Cluster Performance Statistics
 - [#1650](https://github.com/influxdata/telegraf/issues/1650): Ability to configure response_timeout in httpjson input.
+- [#1539](https://github.com/influxdata/telegraf/pull/1539): Added capability to send metrics through Http API for OpenTSDB.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@
 
 ## v1.0 [unreleased]
 
+### Features
+
+- [#1413](https://github.com/influxdata/telegraf/issues/1413): Separate container_version from container_image tag.
+- [#1525](https://github.com/influxdata/telegraf/pull/1525): Support setting per-device and total metrics for Docker network and blockio.
+- [#1466](https://github.com/influxdata/telegraf/pull/1466): MongoDB input plugin: adding per DB stats from db.stats()
+- [#1539](https://github.com/influxdata/telegraf/pull/1539): Added capability to send metrics through Http API for OpenTSDB.
+
+### Bugfixes
+
+- [#1519](https://github.com/influxdata/telegraf/pull/1519): Fix error race conditions and partial failures.
+- [#1477](https://github.com/influxdata/telegraf/issues/1477): nstat: fix inaccurate config panic.
+- [#1481](https://github.com/influxdata/telegraf/issues/1481): jolokia: fix handling multiple multi-dimensional attributes.
+- [#1430](https://github.com/influxdata/telegraf/issues/1430): Fix prometheus character sanitizing. Sanitize more win_perf_counters characters.
+- [#1534](https://github.com/influxdata/telegraf/pull/1534): Add diskio io_time to FreeBSD & report timing metrics as ms (as linux does).
+
+## v1.0 beta 3 [2016-07-18]
+
 ### Release Notes
 
 **Breaking Change** The SNMP plugin is being deprecated in it's current form.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,23 +15,6 @@
 
 ## v1.0 [unreleased]
 
-### Features
-
-- [#1413](https://github.com/influxdata/telegraf/issues/1413): Separate container_version from container_image tag.
-- [#1525](https://github.com/influxdata/telegraf/pull/1525): Support setting per-device and total metrics for Docker network and blockio.
-- [#1466](https://github.com/influxdata/telegraf/pull/1466): MongoDB input plugin: adding per DB stats from db.stats()
-- [#1539](https://github.com/influxdata/telegraf/pull/1539): Added capability to send metrics through Http API for OpenTSDB.
-
-### Bugfixes
-
-- [#1519](https://github.com/influxdata/telegraf/pull/1519): Fix error race conditions and partial failures.
-- [#1477](https://github.com/influxdata/telegraf/issues/1477): nstat: fix inaccurate config panic.
-- [#1481](https://github.com/influxdata/telegraf/issues/1481): jolokia: fix handling multiple multi-dimensional attributes.
-- [#1430](https://github.com/influxdata/telegraf/issues/1430): Fix prometheus character sanitizing. Sanitize more win_perf_counters characters.
-- [#1534](https://github.com/influxdata/telegraf/pull/1534): Add diskio io_time to FreeBSD & report timing metrics as ms (as linux does).
-
-## v1.0 beta 3 [2016-07-18]
-
 ### Release Notes
 
 **Breaking Change** The SNMP plugin is being deprecated in it's current form.

--- a/plugins/outputs/opentsdb/README.md
+++ b/plugins/outputs/opentsdb/README.md
@@ -1,6 +1,12 @@
 # OpenTSDB Output Plugin
 
-This plugin writes to a OpenTSDB instance using the "telnet" mode
+This plugin writes to an OpenTSDB instance using either the "telnet" or Http mode.
+
+Using the Http API is the recommended way of writing metrics since OpenTSDB 2.0
+To use Http mode, set useHttp to true in config. You can also control how many
+metrics is sent in each http request by setting batchSize in config.
+
+See http://opentsdb.net/docs/build/html/api_http/put.html for details.
 
 ## Transfer "Protocol" in the telnet mode
 
@@ -10,14 +16,14 @@ The expected input from OpenTSDB is specified in the following way:
 put <metric> <timestamp> <value> <tagk1=tagv1[ tagk2=tagv2 ...tagkN=tagvN]>
 ```
 
-The telegraf output plugin adds an optional prefix to the metric keys so 
+The telegraf output plugin adds an optional prefix to the metric keys so
 that a subamount can be selected.
 
 ```
 put <[prefix.]metric> <timestamp> <value> <tagk1=tagv1[ tagk2=tagv2 ...tagkN=tagvN]>
 ```
 
-### Example 
+### Example
 
 ```
 put nine.telegraf.system_load1 1441910356 0.430000 dc=homeoffice host=irimame scope=green
@@ -38,12 +44,12 @@ put nine.telegraf.ping_average_response_ms 1441910366 24.006000 dc=homeoffice ho
 ...
 ```
 
-## 
+##
 
-The OpenTSDB interface can be simulated with this reader:
+The OpenTSDB telnet interface can be simulated with this reader:
 
 ```
-// opentsdb_telnet_mode_mock.go 
+// opentsdb_telnet_mode_mock.go
 package main
 
 import (

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -89,7 +89,6 @@ func (o *OpenTSDB) Write(metrics []telegraf.Metric) error {
 		return fmt.Errorf("Error in parsing host url: %s", err.Error())
 	}
 
-
 	if u.Scheme == "" || u.Scheme == "tcp" {
 		return o.WriteTelnet(metrics, u)
 	} else if u.Scheme == "http" {

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -46,17 +46,15 @@ var sampleConfig = `
   debug = false
 `
 
-type TagSet map[string]string
-
-func (t TagSet) ToLineFormat() string {
-	tags := make([]string, len(t))
+func ToLineFormat(tags map[string]string) string {
+	tagsArray := make([]string, len(tags))
 	index := 0
-	for k, v := range t {
-		tags[index] = fmt.Sprintf("%s=%s", k, v)
+	for k, v := range tags {
+		tagsArray[index] = fmt.Sprintf("%s=%s", k, v)
 		index++
 	}
-	sort.Strings(tags)
-	return strings.Join(tags, " ")
+	sort.Strings(tagsArray)
+	return strings.Join(tagsArray, " ")
 }
 
 func (o *OpenTSDB) Connect() error {
@@ -150,7 +148,7 @@ func (o *OpenTSDB) WriteTelnet(metrics []telegraf.Metric, u *url.URL) error {
 
 	for _, m := range metrics {
 		now := m.UnixNano() / 1000000000
-		tags := cleanTags(m.Tags()).ToLineFormat()
+		tags := ToLineFormat(cleanTags(m.Tags()))
 
 		for fieldName, value := range m.Fields() {
 			metricValue, buildError := buildValue(value)
@@ -176,7 +174,7 @@ func (o *OpenTSDB) WriteTelnet(metrics []telegraf.Metric, u *url.URL) error {
 	return nil
 }
 
-func cleanTags(tags map[string]string) TagSet {
+func cleanTags(tags map[string]string) map[string]string {
 	tagSet := make(map[string]string, len(tags))
 	for k, v := range tags {
 		tagSet[sanitizedChars.Replace(k)] = sanitizedChars.Replace(v)

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -17,7 +17,7 @@ type OpenTSDB struct {
 	Host string
 	Port int
 
-	UseHttp bool
+	UseHttp   bool
 	BatchSize int
 
 	Debug bool
@@ -47,6 +47,7 @@ var sampleConfig = `
   ## Debug true - Prints OpenTSDB communication
   debug = false
 `
+
 type TagSet map[string]string
 
 func (t TagSet) ToLineFormat() string {
@@ -89,10 +90,10 @@ func (o *OpenTSDB) Write(metrics []telegraf.Metric) error {
 
 func (o *OpenTSDB) WriteHttp(metrics []telegraf.Metric) error {
 	http := openTSDBHttp{
-		Host: o.Host,
-		Port: o.Port,
+		Host:      o.Host,
+		Port:      o.Port,
 		BatchSize: o.BatchSize,
-		Debug: o.Debug,
+		Debug:     o.Debug,
 	}
 
 	for _, m := range metrics {
@@ -106,21 +107,21 @@ func (o *OpenTSDB) WriteHttp(metrics []telegraf.Metric) error {
 				continue
 			}
 
-            metric := &HttpMetric{
-                Metric: sanitizedChars.Replace(fmt.Sprintf("%s%s_%s",
-                        o.Prefix, m.Name(), fieldName)),
-				Tags: tags,
+			metric := &HttpMetric{
+				Metric: sanitizedChars.Replace(fmt.Sprintf("%s%s_%s",
+					o.Prefix, m.Name(), fieldName)),
+				Tags:      tags,
 				Timestamp: now,
-				Value: metricValue,
-            }
+				Value:     metricValue,
+			}
 
-			if err:= http.sendDataPoint(metric); err != nil {
+			if err := http.sendDataPoint(metric); err != nil {
 				return err
 			}
 		}
 	}
 
-	if err:= http.flush(); err != nil {
+	if err := http.flush(); err != nil {
 		return err
 	}
 
@@ -149,7 +150,7 @@ func (o *OpenTSDB) WriteTelnet(metrics []telegraf.Metric) error {
 			}
 
 			messageLine := fmt.Sprintf("put %s %v %s %s\n",
-				sanitizedChars.Replace(fmt.Sprintf("%s%s_%s",o.Prefix, m.Name(), fieldName)),
+				sanitizedChars.Replace(fmt.Sprintf("%s%s_%s", o.Prefix, m.Name(), fieldName)),
 				now, metricValue, tags)
 
 			if o.Debug {

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -3,6 +3,7 @@ package opentsdb
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -49,12 +50,14 @@ var sampleConfig = `
 type TagSet map[string]string
 
 func (t TagSet) ToLineFormat() string {
-	var line string
+	tags := make([]string, len(t))
+	index := 0
 	for k, v := range t {
-		line += fmt.Sprintf(" %s=%s", k, v)
+		tags[index] = fmt.Sprintf("%s=%s", k, v)
+		index++
 	}
-
-	return strings.TrimLeft(line, " ")
+	sort.Strings(tags)
+	return strings.Join(tags, " ")
 }
 
 func (o *OpenTSDB) Connect() error {

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -57,13 +57,6 @@ func (t TagSet) ToLineFormat() string {
 	return strings.TrimLeft(line, " ")
 }
 
-type MetricLine struct {
-	Metric    string
-	Timestamp int64
-	Value     string
-	Tags      TagSet
-}
-
 func (o *OpenTSDB) Connect() error {
 	// Test Connection to OpenTSDB Server
 	uri := fmt.Sprintf("%s:%d", o.Host, o.Port)

--- a/plugins/outputs/opentsdb/opentsdb_http.go
+++ b/plugins/outputs/opentsdb/opentsdb_http.go
@@ -1,0 +1,179 @@
+package opentsdb
+
+import (
+    "fmt"
+    "encoding/json"
+	//"os"
+	"io"
+	//"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"bytes"
+	"compress/gzip"
+	"log"
+)
+
+type HttpMetric struct {
+	Metric    string `json:"metric"`
+	Timestamp int64 `json:"timestamp"`
+	Value     string `json:"value"`
+	Tags      map[string]string `json:"tags"`
+}
+
+
+type openTSDBHttp struct {
+	Host string
+	Port int
+    BatchSize int
+	Debug bool
+
+    metricCounter int
+    body requestBody
+}
+
+type requestBody struct {
+    b bytes.Buffer
+    g *gzip.Writer
+
+    dbgB bytes.Buffer
+
+    w io.Writer
+    enc *json.Encoder
+
+    empty bool
+}
+
+func (r *requestBody) reset(debug bool) {
+    r.b.Reset()
+    r.dbgB.Reset()
+
+    if r.g == nil {
+        r.g = gzip.NewWriter(&r.b)
+    } else {
+        r.g.Reset(&r.b)
+    }
+
+    if debug {
+        r.w = io.MultiWriter(r.g, &r.dbgB)
+    } else {
+        r.w = r.g
+    }
+
+    r.enc = json.NewEncoder(r.w)
+
+    io.WriteString(r.w, "[")
+
+    r.empty = true
+}
+
+func (r *requestBody) addMetric(metric *HttpMetric) error {
+    if !r.empty {
+        io.WriteString(r.w, ",")
+    }
+
+    if err := r.enc.Encode(metric); err != nil {
+        return fmt.Errorf("Metric serialization error %s", err.Error())
+    }
+
+    r.empty = false
+
+    return nil
+}
+
+func (r *requestBody) close() error {
+    io.WriteString(r.w, "]")
+
+    if err := r.g.Close(); err != nil {
+        return fmt.Errorf("Error when closing gzip writer: %s", err.Error())
+    }
+
+    return nil
+}
+
+func (o *openTSDBHttp) startNewRequest() error {
+    o.body.reset(o.Debug)
+
+    return nil
+}
+
+func (o *openTSDBHttp) sendDataPoint(metric *HttpMetric) error {
+    if o.metricCounter == 0 {
+        o.startNewRequest()
+    }
+
+    if err := o.body.addMetric(metric); err != nil {
+        return err
+    }
+
+    o.metricCounter++
+    if o.metricCounter == o.BatchSize {
+        if err := o.flush(); err != nil {
+            return err
+        }
+
+        o.metricCounter = 0
+    }
+
+    return nil
+}
+
+func (o *openTSDBHttp) flush() error {
+    if o.metricCounter == 0 {
+        return nil
+    }
+
+    o.body.close()
+
+    u := url.URL {
+		Scheme: "http",
+		Host:   fmt.Sprintf("%s:%d", o.Host, o.Port),
+		Path:   "/api/put",
+	}
+
+	if (o.Debug) {
+		u.RawQuery = "details"
+	}
+
+	req, err := http.NewRequest("POST", u.String(), &o.body.b)
+	if err != nil {
+		return fmt.Errorf("Error when building request: %s", err.Error())
+	}
+	req.Header.Add("Content-Type", "applicaton/json")
+	req.Header.Set("Content-Encoding", "gzip")
+
+	if (o.Debug) {
+		dump, err := httputil.DumpRequestOut(req, false)
+		if err != nil {
+			return fmt.Errorf("Error when dumping request: %s", err.Error())
+		}
+
+		fmt.Printf("Sending metrics:\n%s", dump)
+		fmt.Printf("Body:\n%s\n\n", o.body.dbgB.String())
+	}
+
+    resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("Error when sending metrics: %s", err.Error())
+	}
+	defer resp.Body.Close()
+
+	if o.Debug {
+		dump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return fmt.Errorf("Error when dumping response: %s", err.Error())
+		}
+
+		fmt.Printf("Received response\n%s\n\n", dump)
+	}
+
+	if resp.StatusCode/100 != 2 {
+		if resp.StatusCode/100 == 4 {
+			log.Printf("WARNING: Received %d status code. Dropping metrics to avoid overflowing buffer.", resp.StatusCode)
+		} else {
+			return fmt.Errorf("Error when sending metrics.Received status %d", resp.StatusCode)
+		}
+	}
+
+	return nil
+}

--- a/plugins/outputs/opentsdb/opentsdb_test.go
+++ b/plugins/outputs/opentsdb/opentsdb_test.go
@@ -18,23 +18,23 @@ import (
 func TestCleanTags(t *testing.T) {
 	var tagtests = []struct {
 		ptIn    map[string]string
-		outTags TagSet
+		outTags map[string]string
 	}{
 		{
 			map[string]string{"one": "two", "three": "four"},
-			TagSet{"one": "two", "three": "four"},
+			map[string]string{"one": "two", "three": "four"},
 		},
 		{
 			map[string]string{"aaa": "bbb"},
-			TagSet{"aaa": "bbb"},
+			map[string]string{"aaa": "bbb"},
 		},
 		{
 			map[string]string{"Sp%ci@l Chars": "g$t repl#ced"},
-			TagSet{"Sp-ci-l_Chars": "g-t_repl-ced"},
+			map[string]string{"Sp-ci-l_Chars": "g-t_repl-ced"},
 		},
 		{
 			map[string]string{},
-			TagSet{},
+			map[string]string{},
 		},
 	}
 	for _, tt := range tagtests {
@@ -47,28 +47,28 @@ func TestCleanTags(t *testing.T) {
 
 func TestBuildTagsTelnet(t *testing.T) {
 	var tagtests = []struct {
-		ptIn    TagSet
+		ptIn    map[string]string
 		outTags string
 	}{
 		{
-			TagSet{"one": "two", "three": "four"},
+			map[string]string{"one": "two", "three": "four"},
 			"one=two three=four",
 		},
 		{
-			TagSet{"aaa": "bbb"},
+			map[string]string{"aaa": "bbb"},
 			"aaa=bbb",
 		},
 		{
-			TagSet{"one": "two", "aaa": "bbb"},
+			map[string]string{"one": "two", "aaa": "bbb"},
 			"aaa=bbb one=two",
 		},
 		{
-			TagSet{},
+			map[string]string{},
 			"",
 		},
 	}
 	for _, tt := range tagtests {
-		tags := tt.ptIn.ToLineFormat()
+		tags := ToLineFormat(tt.ptIn)
 		if !reflect.DeepEqual(tags, tt.outTags) {
 			t.Errorf("\nexpected %+v\ngot %+v\n", tt.outTags, tags)
 		}

--- a/plugins/outputs/opentsdb/opentsdb_test.go
+++ b/plugins/outputs/opentsdb/opentsdb_test.go
@@ -94,7 +94,7 @@ func BenchmarkHttpSend(b *testing.B) {
 		panic(err)
 	}
 
-	host, p, _ := net.SplitHostPort(u.Host)
+	_, p, _ := net.SplitHostPort(u.Host)
 
 	port, err := strconv.Atoi(p)
 	if err != nil {
@@ -102,11 +102,10 @@ func BenchmarkHttpSend(b *testing.B) {
 	}
 
 	o := &OpenTSDB{
-		Host:      host,
+		Host:      ts.URL,
 		Port:      port,
 		Prefix:    "",
-		UseHttp:   true,
-		BatchSize: BatchSize,
+		HttpBatchSize: BatchSize,
 	}
 
 	b.ResetTimer()

--- a/plugins/outputs/opentsdb/opentsdb_test.go
+++ b/plugins/outputs/opentsdb/opentsdb_test.go
@@ -102,9 +102,9 @@ func BenchmarkHttpSend(b *testing.B) {
 	}
 
 	o := &OpenTSDB{
-		Host:      ts.URL,
-		Port:      port,
-		Prefix:    "",
+		Host:          ts.URL,
+		Port:          port,
+		Prefix:        "",
 		HttpBatchSize: BatchSize,
 	}
 

--- a/plugins/outputs/opentsdb/opentsdb_test.go
+++ b/plugins/outputs/opentsdb/opentsdb_test.go
@@ -7,34 +7,60 @@ import (
 	// "github.com/stretchr/testify/require"
 )
 
-func TestBuildTagsTelnet(t *testing.T) {
+func TestCleanTags(t *testing.T) {
 	var tagtests = []struct {
 		ptIn    map[string]string
-		outTags []string
+		outTags TagSet
 	}{
 		{
 			map[string]string{"one": "two", "three": "four"},
-			[]string{"one=two", "three=four"},
+			TagSet{"one": "two", "three": "four"},
 		},
 		{
 			map[string]string{"aaa": "bbb"},
-			[]string{"aaa=bbb"},
-		},
-		{
-			map[string]string{"one": "two", "aaa": "bbb"},
-			[]string{"aaa=bbb", "one=two"},
+			TagSet{"aaa": "bbb"},
 		},
 		{
 			map[string]string{"Sp%ci@l Chars": "g$t repl#ced"},
-			[]string{"Sp-ci-l_Chars=g-t_repl-ced"},
+			TagSet{"Sp-ci-l_Chars": "g-t_repl-ced"},
 		},
 		{
 			map[string]string{},
-			[]string{},
+			TagSet{},
 		},
 	}
 	for _, tt := range tagtests {
-		tags := buildTags(tt.ptIn)
+		tags := cleanTags(tt.ptIn)
+		if !reflect.DeepEqual(tags, tt.outTags) {
+			t.Errorf("\nexpected %+v\ngot %+v\n", tt.outTags, tags)
+		}
+	}
+}
+
+func TestBuildTagsTelnet(t *testing.T) {
+	var tagtests = []struct {
+		ptIn    TagSet
+		outTags string
+	}{
+		{
+			TagSet{"one": "two", "three": "four"},
+			"one=two three=four",
+		},
+		{
+			TagSet{"aaa": "bbb"},
+			"aaa=bbb",
+		},
+		{
+			TagSet{"one": "two", "aaa": "bbb"},
+			"aaa=bbb one=two",
+		},
+		{
+			TagSet{},
+			"",
+		},
+	}
+	for _, tt := range tagtests {
+		tags := tt.ptIn.ToLineFormat()
 		if !reflect.DeepEqual(tags, tt.outTags) {
 			t.Errorf("\nexpected %+v\ngot %+v\n", tt.outTags, tags)
 		}

--- a/plugins/outputs/opentsdb/opentsdb_test.go
+++ b/plugins/outputs/opentsdb/opentsdb_test.go
@@ -1,14 +1,14 @@
 package opentsdb
 
 import (
-	"reflect"
-	"testing"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strconv"
+	"testing"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
@@ -77,18 +77,17 @@ func TestBuildTagsTelnet(t *testing.T) {
 
 func BenchmarkHttpSend(b *testing.B) {
 	const BatchSize = 50
-	const MetricsCount = 4*BatchSize
+	const MetricsCount = 4 * BatchSize
 	metrics := make([]telegraf.Metric, MetricsCount)
-	for i:=0; i<MetricsCount; i++ {
+	for i := 0; i < MetricsCount; i++ {
 		metrics[i] = testutil.TestMetric(1.0)
 	}
 
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        w.Header().Set("Content-Type", "application/json")
-        fmt.Fprintln(w, "{}")
-    }))
-    defer ts.Close()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, "{}")
+	}))
+	defer ts.Close()
 
 	u, err := url.Parse(ts.URL)
 	if err != nil {
@@ -103,17 +102,17 @@ func BenchmarkHttpSend(b *testing.B) {
 	}
 
 	o := &OpenTSDB{
-	 		Host:   host,
-	 		Port:   port,
-	 		Prefix: "",
-			UseHttp: true,
-			BatchSize: BatchSize,
-	 }
+		Host:      host,
+		Port:      port,
+		Prefix:    "",
+		UseHttp:   true,
+		BatchSize: BatchSize,
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		o.Write(metrics)
-    }
+	}
 }
 
 // func TestWrite(t *testing.T) {


### PR DESCRIPTION
Modified the opentsdb output plugin so it can also use Http API to send metrics. The Http API has better error management and is easier to debug. Should I squash my changes ? First time contributing.

### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)