### PR TITLE
add timestamp selector to JSON parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#1413](https://github.com/influxdata/telegraf/issues/1413): Separate container_version from container_image tag.
 - [#1525](https://github.com/influxdata/telegraf/pull/1525): Support setting per-device and total metrics for Docker network and blockio.
 - [#1466](https://github.com/influxdata/telegraf/pull/1466): MongoDB input plugin: adding per DB stats from db.stats()
+- [#1557](https://github.com/influxdata/telegraf/pull/1557): JSON Parser: Add timestamp selector, user can use timestamp when the data is generated
 
 ### Bugfixes
 

--- a/docs/DATA_FORMATS_INPUT.md
+++ b/docs/DATA_FORMATS_INPUT.md
@@ -106,6 +106,8 @@ The JSON data format supports specifying "tag keys". If specified, keys
 will be searched for in the root-level of the JSON blob. If the key(s) exist,
 they will be applied as tags to the Telegraf metrics.
 
+JSON data format can specify the timestamp by "timestamp_selector" and then parse it using "timestamp_formatter"; this could be useful when dealing with metrics not generated locally.
+
 For example, if you had this configuration:
 
 ```toml
@@ -127,6 +129,11 @@ For example, if you had this configuration:
     "my_tag_1",
     "my_tag_2"
   ]
+
+  timestamp_selector = "@timestamp"
+  ## for more information about timestamp formatter, please refer to:
+  ## https://golang.org/src/time/format.go
+  timestamp_formatter = "2006-01-02T15:04:05Z07:00"
 ```
 
 with this JSON output from a command:
@@ -137,14 +144,15 @@ with this JSON output from a command:
     "b": {
         "c": 6
     },
-    "my_tag_1": "foo"
+    "my_tag_1": "foo",
+    "@timestamp": "2016-07-27T16:46:00.554Z"
 }
 ```
 
-Your Telegraf metrics would get tagged with "my_tag_1"
+Your Telegraf metrics would get tagged with "my_tag_1" and timestamp
 
 ```
-exec_mycollector,my_tag_1=foo a=5,b_c=6
+exec_mycollector,my_tag_1=foo a=5,b_c=6 1469637960554000000
 ```
 
 # Value:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -916,6 +916,22 @@ func buildParser(name string, tbl *ast.Table) (parsers.Parser, error) {
 		}
 	}
 
+	if node, ok := tbl.Fields["timestamp_selector"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if str, ok := kv.Value.(*ast.String); ok {
+				c.TimestampSelector = str.Value
+			}
+		}
+	}
+
+	if node, ok := tbl.Fields["timestamp_formatter"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if str, ok := kv.Value.(*ast.String); ok {
+				c.TimestampFormatter = str.Value
+			}
+		}
+	}
+
 	c.MetricName = name
 
 	delete(tbl.Fields, "data_format")
@@ -923,6 +939,8 @@ func buildParser(name string, tbl *ast.Table) (parsers.Parser, error) {
 	delete(tbl.Fields, "templates")
 	delete(tbl.Fields, "tag_keys")
 	delete(tbl.Fields, "data_type")
+	delete(tbl.Fields, "timestamp_selector")
+	delete(tbl.Fields, "timestamp_formatter")
 
 	return parsers.NewParser(c)
 }

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -58,6 +58,12 @@ type Config struct {
 
 	// DefaultTags are the default tags that will be added to all parsed metrics.
 	DefaultTags map[string]string
+
+	// TimestampSelector only applies to JSON
+	TimestampSelector string
+
+	// TimestampFormatter only applies to JSON
+	TimestampFormatter string
 }
 
 // NewParser returns a Parser interface based on the given config.
@@ -67,7 +73,8 @@ func NewParser(config *Config) (Parser, error) {
 	switch config.DataFormat {
 	case "json":
 		parser, err = NewJSONParser(config.MetricName,
-			config.TagKeys, config.DefaultTags)
+			config.TagKeys, config.DefaultTags,
+			config.TimestampSelector, config.TimestampFormatter)
 	case "value":
 		parser, err = NewValueParser(config.MetricName,
 			config.DataType, config.DefaultTags)
@@ -88,11 +95,23 @@ func NewJSONParser(
 	metricName string,
 	tagKeys []string,
 	defaultTags map[string]string,
+	timestampParameters ...string,
 ) (Parser, error) {
+	timestampSelector, timestampFormatter := "", ""
+	switch len(timestampParameters) {
+	case 2:
+		timestampFormatter = timestampParameters[1]
+		fallthrough
+	case 1:
+		timestampSelector = timestampParameters[0]
+	}
+
 	parser := &json.JSONParser{
-		MetricName:  metricName,
-		TagKeys:     tagKeys,
-		DefaultTags: defaultTags,
+		MetricName:         metricName,
+		TagKeys:            tagKeys,
+		DefaultTags:        defaultTags,
+		TimestampSelector:  timestampSelector,
+		TimestampFormatter: timestampFormatter,
 	}
 	return parser, nil
 }


### PR DESCRIPTION
Allow user to specify timestamp field instead of being forced to use local time.
Add ability to select timestamp when parsing JSON format data.
Use case:

- when I use kafka consumer plugin to receive metrics from remote pods, I want to be able to set the timestamp as the generation time of these metrics instead of the timestamp these metrics gets received.

### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)