### PR TITLE
add kafka new consumer support

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -4,6 +4,7 @@ github.com/aerospike/aerospike-client-go 45863b7fd8640dc12f7fdd397104d97e1986f25
 github.com/amir/raidman 53c1b967405155bfc8758557863bf2e14f814687
 github.com/aws/aws-sdk-go 13a12060f716145019378a10e2806c174356b857
 github.com/beorn7/perks 3ac7bf7a47d159a033b107610db8a1b6575507a4
+github.com/bsm/sarama-cluster dc1a390cf63c40d0a20ee9f79c4be120f79110e5
 github.com/cenkalti/backoff 4dc77674aceaabba2c7e3da25d4c823edfb73f99
 github.com/couchbase/go-couchbase cb664315a324d87d19c879d9cc67fda6be8c2ac1
 github.com/couchbase/gomemcached a5ea6356f648fec6ab89add00edd09151455b4b2

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -6,11 +6,15 @@ line protocol. [Consumer Group](http://godoc.org/github.com/wvanbergen/kafka/con
 is used to talk to the Kafka cluster so multiple instances of telegraf can read
 from the same topic in parallel.
 
-## Configuration
+Now supports kafka new consumer (version 0.9+) with TLS
+
+## Configuration[0.8]
 
 ```toml
 # Read metrics from Kafka topic(s)
 [[inputs.kafka_consumer]]
+  ## is new consumer?
+  new_consumer = false
   ## topic(s) to consume
   topics = ["telegraf"]
   ## an array of Zookeeper connection strings
@@ -29,6 +33,41 @@ from the same topic in parallel.
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
 ```
+
+
+
+## Configuration[0.9+]
+
+```toml
+# Read metrics from Kafka topic(s)
+[[inputs.kafka_consumer]]
+  ## is new consumer?
+  new_consumer = true
+  ## topic(s) to consume
+  topics = ["telegraf"]
+  ## an array of kafka 0.9+ brokers
+  broker_list = ["localhost:9092"]
+  ## the name of the consumer group
+  consumer_group = "telegraf_kafka_consumer_group"
+  ## Offset (must be either "oldest" or "newest")
+  offset = "oldest"
+  
+  ## Optional SSL Config
+  ssl_ca = "/etc/telegraf/ca.pem"
+  ssl_cert = "/etc/telegraf/cert.pem"
+  ssl_key = "/etc/telegraf/cert.key"
+  ## Use SSL but skip chain & host verification
+  insecure_skip_verify = false
+
+  ## Data format to consume.
+  
+  ## Each data format has it's own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"
+```
+
+
 
 ## Testing
 


### PR DESCRIPTION
add supports of kafka 0.9+ new consumer with TLS

Some information:
Since kafka 0.9, they begin to provide 2 types of consumers, old consumers are what we have in the existing consumer plugin which I'm not sure if they have TLS support and the new consumers. What I am trying to fix is the compatibility of kafka_consumer plugin to Kafka 0.9+.
### Required for all PRs:
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
