### PR TITLE
scripts: systemd - Kill also telegraf MAINPID child (stop,restart,reload)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#1430](https://github.com/influxdata/telegraf/issues/1430): Fix prometheus character sanitizing. Sanitize more win_perf_counters characters.
 - [#1534](https://github.com/influxdata/telegraf/pull/1534): Add diskio io_time to FreeBSD & report timing metrics as ms (as linux does).
 - [#1379](https://github.com/influxdata/telegraf/issues/1379): Fix covering Amazon Linux for post remove flow.
+- [#1576](https://github.com/influxdata/telegraf/issues/1576): Fix systemd unit (kill also telegraf child process).
 
 ## v1.0 beta 3 [2016-07-18]
 

--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -9,7 +9,8 @@ User=telegraf
 Environment='STDOUT=/var/log/telegraf/telegraf.log'
 Environment='STDERR=/var/log/telegraf/telegraf.log'
 ExecStart=/bin/sh -c "exec /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d ${TELEGRAF_OPTS} >>${STDOUT} 2>>${STDERR}"
-ExecReload=/bin/kill -HUP $MAINPID
+ExecStop=/usr/bin/killall telegraf
+ExecReload=/usr/bin/killall telegraf
 Restart=on-failure
 KillMode=control-group
 


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

`killall` binary is included in the package `psmisc`.
we maybe have another way to solve this issue with « standard » tools
https://stackoverflow.com/questions/392022/best-way-to-kill-all-child-processes

Refs: #1576
