### PR TITLE
Sanitize graphite characters in field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ consistent with the behavior of `collection_jitter`.
 - [#1600](https://github.com/influxdata/telegraf/issues/1600): Fix quoting with text values in postgresql_extensible plugin.
 - [#1425](https://github.com/influxdata/telegraf/issues/1425): Fix win_perf_counter "index out of range" panic.
 - [#1634](https://github.com/influxdata/telegraf/issues/1634): Fix ntpq panic when field is missing.
+- [#1637](https://github.com/influxdata/telegraf/issues/1637): Sanitize graphite output field names.
 
 ## v0.13.1 [2016-05-24]
 

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -12,7 +12,7 @@ const DEFAULT_TEMPLATE = "host.tags.measurement.field"
 
 var (
 	fieldDeleter   = strings.NewReplacer(".FIELDNAME", "", "FIELDNAME.", "")
-	sanitizedChars = strings.NewReplacer("/", "-", "@", "-", "*", "-", " ", "_", "..", ".")
+	sanitizedChars = strings.NewReplacer("/", "-", "@", "-", "*", "-", " ", "_", "..", ".", `\`, "")
 )
 
 type GraphiteSerializer struct {
@@ -36,8 +36,8 @@ func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]string, error)
 		valueS := fmt.Sprintf("%#v", value)
 		point := fmt.Sprintf("%s %s %d",
 			// insert "field" section of template
-			InsertField(bucket, fieldName),
-			valueS,
+			sanitizedChars.Replace(InsertField(bucket, fieldName)),
+			sanitizedChars.Replace(valueS),
 			timestamp)
 		out = append(out, point)
 	}
@@ -100,9 +100,9 @@ func SerializeBucketName(
 	}
 
 	if prefix == "" {
-		return sanitizedChars.Replace(strings.Join(out, "."))
+		return strings.Join(out, ".")
 	}
-	return sanitizedChars.Replace(prefix + "." + strings.Join(out, "."))
+	return prefix + "." + strings.Join(out, ".")
 }
 
 // InsertField takes the bucket string from SerializeBucketName and replaces the


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated

also sanitize the names at a higher scope for better clarity

closes #1637