### PR TITLE
Allow to configure whether to gather global variables and statuses in input/mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ consistent with the behavior of `collection_jitter`.
 - [#1600](https://github.com/influxdata/telegraf/issues/1600): Fix quoting with text values in postgresql_extensible plugin.
 - [#1425](https://github.com/influxdata/telegraf/issues/1425): Fix win_perf_counter "index out of range" panic.
 - [#1634](https://github.com/influxdata/telegraf/issues/1634): Fix ntpq panic when field is missing.
-- [#1641](https://github.com/influxdata/telegraf/pull/1641): input/mysql: Allow to configure whether to gather global variables and statuses
+- [#1642](https://github.com/influxdata/telegraf/pull/1642): input/mysql: Allow to configure whether to gather global variables and statuses
 
 ## v0.13.1 [2016-05-24]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ consistent with the behavior of `collection_jitter`.
 - [#1600](https://github.com/influxdata/telegraf/issues/1600): Fix quoting with text values in postgresql_extensible plugin.
 - [#1425](https://github.com/influxdata/telegraf/issues/1425): Fix win_perf_counter "index out of range" panic.
 - [#1634](https://github.com/influxdata/telegraf/issues/1634): Fix ntpq panic when field is missing.
+- [#1641](https://github.com/influxdata/telegraf/pull/1641): input/mysql: Allow to configure whether to gather global variables and statuses
 
 ## v0.13.1 [2016-05-24]
 

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -16,7 +16,8 @@ func TestMysqlDefaultsToLocal(t *testing.T) {
 	}
 
 	m := &Mysql{
-		Servers: []string{fmt.Sprintf("root@tcp(%s:3306)/", testutil.GetLocalHost())},
+		Servers:              []string{fmt.Sprintf("root@tcp(%s:3306)/", testutil.GetLocalHost())},
+		GatherGlobalStatuses: true,
 	}
 
 	var acc testutil.Accumulator


### PR DESCRIPTION
### Required for all PRs:
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
