### PR TITLE
Make elasticsearch timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- [#1674](https://github.com/influxdata/telegraf/issues/1674): elasticsearch input: configurable timeout.
+
 ### Bugfixes
 
 

--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -8,9 +8,18 @@ and optionally [cluster](https://www.elastic.co/guide/en/elasticsearch/reference
 
 ```
 [[inputs.elasticsearch]]
+  ## specify a list of one or more Elasticsearch servers
   servers = ["http://localhost:9200"]
+
+  ## Timeout for HTTP requests to the elastic search server(s)
+  http_timeout = "5s"
+
+  ## set local to false when you want to read the indices stats from all nodes
+  ## within the cluster
   local = true
-  cluster_health = true
+
+  ## set cluster_health to true when you want to also obtain cluster level stats
+  cluster_health = false
 
   ## Optional SSL Config
   # ssl_ca = "/etc/telegraf/ca.pem"


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)


closes #1674