### PR TITLE
Add support for the new occurrence webhook event from rollbar

### DIFF
--- a/plugins/inputs/webhooks/rollbar/README.md
+++ b/plugins/inputs/webhooks/rollbar/README.md
@@ -27,6 +27,18 @@ See [webhook doc](https://rollbar.com/docs/webhooks/)
 **Fields:**
 * 'id' = `event.data.item.id` int
 
+#### `occurrence` event
+
+**Tags:**
+* 'event' = `event.event_name` string
+* 'environment' = `event.data.item.environment` string
+* 'project_id = `event.data.item.project_id` int
+* 'language' = `event.data.occurrence.language` string
+* 'level' = `event.data.occurrence.level` string
+
+**Fields:**
+* 'id' = `event.data.item.id` int
+
 #### `deploy` event
 
 **Tags:**

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks.go
@@ -61,6 +61,8 @@ func NewEvent(dummyEvent *DummyEvent, data []byte) (Event, error) {
 	switch dummyEvent.EventName {
 	case "new_item":
 		return generateEvent(&NewItem{}, data)
+	case "occurrence":
+		return generateEvent(&Occurrence{}, data)
 	case "deploy":
 		return generateEvent(&Deploy{}, data)
 	default:

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks_events.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks_events.go
@@ -48,6 +48,43 @@ func (ni *NewItem) Fields() map[string]interface{} {
 	}
 }
 
+type OccurrenceDataOccurrence struct {
+	Language string `json:"language"`
+	Level    string `json:"level"`
+}
+
+type OccurrenceDataItem struct {
+	Id          int    `json:"id"`
+	Environment string `json:"environment"`
+	ProjectId   int    `json:"project_id"`
+}
+
+type OccurrenceData struct {
+	Item       OccurrenceDataItem       `json:"item"`
+	Occurrence OccurrenceDataOccurrence `json:"occurrence"`
+}
+
+type Occurrence struct {
+	EventName string         `json:"event_name"`
+	Data      OccurrenceData `json:"data"`
+}
+
+func (o *Occurrence) Tags() map[string]string {
+	return map[string]string{
+		"event":       o.EventName,
+		"environment": o.Data.Item.Environment,
+		"project_id":  strconv.Itoa(o.Data.Item.ProjectId),
+		"language":    o.Data.Occurrence.Language,
+		"level":       o.Data.Occurrence.Level,
+	}
+}
+
+func (o *Occurrence) Fields() map[string]interface{} {
+	return map[string]interface{}{
+		"id": o.Data.Item.Id,
+	}
+}
+
 type DeployDataDeploy struct {
 	Id          int    `json:"id"`
 	Environment string `json:"environment"`

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks_events_json_test.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks_events_json_test.go
@@ -68,6 +68,70 @@ func NewItemJSON() string {
 	}`
 }
 
+func OccurrenceJSON() string {
+	return `
+	{
+	  "event_name": "occurrence",
+	  "data": {
+		"item": {
+		  "public_item_id": null,
+		  "integrations_data": {},
+		  "level_lock": 0,
+		  "last_activated_timestamp": 1471624512,
+		  "assigned_user_id": null,
+		  "hash": "188fc37fa6e641a4d4a3d0198938a1937d31ddbe",
+		  "id": 402860571,
+		  "environment": "production",
+		  "title": "Exception: test exception",
+		  "last_occurrence_id": 16298872829,
+		  "last_occurrence_timestamp": 1472226345,
+		  "platform": 0,
+		  "first_occurrence_timestamp": 1471624512,
+		  "project_id": 78234,
+		  "resolved_in_version": null,
+		  "status": 1,
+		  "unique_occurrences": null,
+		  "title_lock": 0,
+		  "framework": 6,
+		  "total_occurrences": 8,
+		  "level": 40,
+		  "counter": 2,
+		  "last_modified_by": 8247,
+		  "first_occurrence_id": 16103102935,
+		  "activating_occurrence_id": 16103102935
+                },
+		"occurrence": {
+		  "body": {
+		    "trace": {
+		    "frames": [{"method": "<main>", "lineno": 27, "filename": "/Users/rebeccastandig/Desktop/Dev/php-rollbar-app/index.php"}], "exception": {
+		    "message": "test 2",
+		    "class": "Exception"}
+		    }
+		  },
+		  "uuid": "84d4eccd-b24d-47ae-a42b-1a2f9a82fb82",
+		  "language": "php",
+		  "level": "error",
+		  "timestamp": 1472226345,
+		  "php_context": "cli",
+		  "environment": "production",
+		  "framework": "php",
+		  "person": null,
+		  "server": {
+		    "host": "Rebeccas-MacBook-Pro.local",
+		    "argv": ["index.php"]
+		  },
+		  "notifier": {
+		    "version": "0.18.2",
+		    "name": "rollbar-php"
+		  },
+		  "metadata": {
+		    "customer_timestamp": 1472226359
+		  }
+		}
+	  }
+	}`
+}
+
 func DeployJSON() string {
 	return `
     {

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks_test.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks_test.go
@@ -42,6 +42,29 @@ func TestNewItem(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "rollbar_webhooks", fields, tags)
 }
 
+func TestOccurrence(t *testing.T) {
+	var acc testutil.Accumulator
+	rb := &RollbarWebhook{Path: "/rollbar", acc: &acc}
+	resp := postWebhooks(rb, OccurrenceJSON())
+	if resp.Code != http.StatusOK {
+		t.Errorf("POST occurrence returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
+	}
+
+	fields := map[string]interface{}{
+		"id": 402860571,
+	}
+
+	tags := map[string]string{
+		"event":       "occurrence",
+		"environment": "production",
+		"project_id":  "78234",
+		"language":    "php",
+		"level":       "error",
+	}
+
+	acc.AssertContainsTaggedFields(t, "rollbar_webhooks", fields, tags)
+}
+
 func TestDeploy(t *testing.T) {
 	var acc testutil.Accumulator
 	rb := &RollbarWebhook{Path: "/rollbar", acc: &acc}


### PR DESCRIPTION
Rollbar added a new event triggered on each occurrences. 

Tested in production, my number of occurrences matche the ones from rollbar ;)
### Required for all PRs:
- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
