### PR TITLE
Fix MySQL plugin not sending 0 value fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ consistent with the behavior of `collection_jitter`.
 - [#1425](https://github.com/influxdata/telegraf/issues/1425): Fix win_perf_counter "index out of range" panic.
 - [#1634](https://github.com/influxdata/telegraf/issues/1634): Fix ntpq panic when field is missing.
 - [#1637](https://github.com/influxdata/telegraf/issues/1637): Sanitize graphite output field names.
+- [#1695](https://github.com/influxdata/telegraf/pull/1695): Fix MySQL plugin not sending 0 value fields.
 
 ## v0.13.1 [2016-05-24]
 

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -1511,7 +1511,7 @@ func parseValue(value sql.RawBytes) (float64, bool) {
 	}
 
 	if bytes.Compare(value, []byte("No")) == 0 || bytes.Compare(value, []byte("OFF")) == 0 {
-		return 0, false
+		return 0, true
 	}
 	n, err := strconv.ParseFloat(string(value), 64)
 	return n, err == nil


### PR DESCRIPTION
We discovered that certain mysql booleans were only being written to our influxdb and cloudwatch outputs when they were true. This makes graphing difficult in grafana and alarms impossible in cloudwatch.

Looking at the code in `parseValue()`: In the case of `"Yes"` or `"ON"` the function returns `value=1, ok=true`, and in the case of `"No"` or `"OFF"` it returns `value=0, ok=false`. When `ok` is `false`, telegraf drops the field and doesn't report it. This appears to be a simple bug (which has been there since the `parseValue()` code was first committed).

This PR changes `ok` to `true` for false values so that they get written to the metrics outputs instead of dropped.

### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

