### PR TITLE
sanitize parenthesis for graphite output

### DIFF
--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -12,7 +12,7 @@ const DEFAULT_TEMPLATE = "host.tags.measurement.field"
 
 var (
 	fieldDeleter   = strings.NewReplacer(".FIELDNAME", "", "FIELDNAME.", "")
-	sanitizedChars = strings.NewReplacer("/", "-", "@", "-", "*", "-", " ", "_", "..", ".", `\`, "")
+	sanitizedChars = strings.NewReplacer("/", "-", "@", "-", "*", "-", " ", "_", "..", ".", `\`, "", ")", "_", "(", "_")
 )
 
 type GraphiteSerializer struct {


### PR DESCRIPTION
- [x] Sign CLA (if not already signed)

This is a quick, and potentially _dirty_ fix that accounts for parenthesis in metric names, which are **especially** prevalent in the windows performance counters plugin and also in the sqlserver plugin.

From grafana these metrics are unable to be queried because of the parens.

Thoughts?  Concerns?

Thanks,

Phil