### PR TITLE
Log to systemd journal

### DIFF
--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -6,9 +6,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/default/telegraf
 User=telegraf
-Environment='STDOUT=/var/log/telegraf/telegraf.log'
-Environment='STDERR=/var/log/telegraf/telegraf.log'
-ExecStart=/bin/sh -c "exec /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d ${TELEGRAF_OPTS} >>${STDOUT} 2>>${STDERR}"
+ExecStart=/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d ${TELEGRAF_OPTS}
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 KillMode=control-group


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

Let's align to InfluxDB 1.0 logging policy and log to systemd journal by
default. See https://github.com/influxdata/influxdb/pull/6839 for more information.

I know there have been several discussions about this for Influx and for Telegraf. I will not debate about pros and cons : systemd is flexible enough to let users choose between a file and journald.
This is just about consistency.

Please kindly review the change with ExecStart. I am not sure about the need to have /bin/sh -c "exec ..."

Thank you very much in advance.
Cheers.