### PR TITLE
enable new udp buffer limits

### DIFF
--- a/plugins/inputs/udp_listener/README.md
+++ b/plugins/inputs/udp_listener/README.md
@@ -57,6 +57,12 @@ sysctl -w net.core.rmem_max=8388608
 sysctl -w net.core.rmem_default=8388608
 ```
 
+To enable the new values without a system restart, type the following command as root:
+
+```
+sysctl -p
+```
+
 ### BSD/Darwin
 
 On BSD/Darwin systems you need to add about a 15% padding to the kernel limit


### PR DESCRIPTION
sysctl -w only updates sysctl.conf with new values

For the OS to start using the new values (force read sysctl.conf), sysctl -p is required.