### PR TITLE
speed up statsd parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#1716](https://github.com/influxdata/telegraf/issues/1716): Sensors plugin strconv.ParseFloat: parsing "": invalid syntax
 - [#1530](https://github.com/influxdata/telegraf/issues/1530): Fix prometheus_client reload panic
 - [#1764](https://github.com/influxdata/telegraf/issues/1764): Fix kafka consumer panic when nil error is returned down errs channel.
+- [#1768](https://github.com/influxdata/telegraf/pull/1768): Speed up statsd parsing.
 
 ## v1.0 [2016-09-08]
 

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -85,6 +85,8 @@ type Statsd struct {
 	Templates []string
 
 	listener *net.UDPConn
+
+	graphiteParser *graphite.GraphiteParser
 }
 
 // One statsd metric, form is <bucket>:<value>|<mtype>|@<samplerate>
@@ -505,7 +507,15 @@ func (s *Statsd) parseName(bucket string) (string, string, map[string]string) {
 
 	var field string
 	name := bucketparts[0]
-	p, err := graphite.NewGraphiteParser(s.MetricSeparator, s.Templates, nil)
+
+	p := s.graphiteParser
+	var err error
+
+	if p == nil || s.graphiteParser.Separator != s.MetricSeparator {
+		p, err = graphite.NewGraphiteParser(s.MetricSeparator, s.Templates, nil)
+		s.graphiteParser = p
+	}
+
 	if err == nil {
 		p.DefaultTags = tags
 		name, tags, field, _ = p.ApplyTemplate(name)


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated

### Before
```
BenchmarkParse-4                                      50000         35152 ns/op
BenchmarkParseWithTemplate-4                          30000         45953 ns/op
BenchmarkParseWithTemplateAndFilter-4                 30000         50166 ns/op
BenchmarkParseWith2TemplatesAndFilter-4               20000         64277 ns/op
BenchmarkParseWith2Templates3TagsAndFilter-4          20000         81050 ns/op
```

### After
```
BenchmarkParse-4                               	  100000	     20525 ns/op
BenchmarkParseWithTemplate-4                   	  100000	     20438 ns/op
BenchmarkParseWithTemplateAndFilter-4          	  100000	     20692 ns/op
BenchmarkParseWith2TemplatesAndFilter-4        	  100000	     20724 ns/op
BenchmarkParseWith2Templates3TagsAndFilter-4   	  100000	     22354 ns/op
```