### PR TITLE
Allow numeric and non-string values for tag_keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#1782](https://github.com/influxdata/telegraf/pull/1782): Allow numeric and non-string values for tag_keys.
 - [#1694](https://github.com/influxdata/telegraf/pull/1694): Adding Gauge and Counter metric types.
 - [#1606](https://github.com/influxdata/telegraf/pull/1606): Remove carraige returns from exec plugin output on Windows
 - [#1674](https://github.com/influxdata/telegraf/issues/1674): elasticsearch input: configurable timeout.
@@ -22,6 +23,7 @@
 
 ### Bugfixes
 
+- [#1746](https://github.com/influxdata/telegraf/issues/1746): Fix handling of non-string values for JSON keys listed in tag_keys.
 - [#1628](https://github.com/influxdata/telegraf/issues/1628): Fix mongodb input panic on version 2.2.
 - [#1733](https://github.com/influxdata/telegraf/issues/1733): Fix statsd scientific notation parsing
 - [#1716](https://github.com/influxdata/telegraf/issues/1716): Sensors plugin strconv.ParseFloat: parsing "": invalid syntax

--- a/plugins/parsers/json/parser.go
+++ b/plugins/parsers/json/parser.go
@@ -39,8 +39,6 @@ func (p *JSONParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 			tags[tag] = strconv.FormatBool(v)
 		case float64:
 			tags[tag] = strconv.FormatFloat(v, 'f', -1, 64)
-		case nil:
-			tags[tag] = "nil"
 		}
 		delete(jsonOut, tag)
 	}

--- a/plugins/parsers/json/parser.go
+++ b/plugins/parsers/json/parser.go
@@ -35,6 +35,12 @@ func (p *JSONParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		switch v := jsonOut[tag].(type) {
 		case string:
 			tags[tag] = v
+		case bool:
+			tags[tag] = strconv.FormatBool(v)
+		case float64:
+			tags[tag] = strconv.FormatFloat(v, 'f', -1, 64)
+		case nil:
+			tags[tag] = "nil"
 		}
 		delete(jsonOut, tag)
 	}


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

According to the go documentation the JSON deserializer only produces these
base types in output:
- string
- bool
- float64
- nil
With this patch bool, float64 and nil values get converted to a string when
their field key is specified in tag_keys. Previously the field was simply
discarded.