### PR TITLE
Fix crash when allow pending messgae wasn't set

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -24,7 +24,8 @@ const (
 
 	defaultFieldName = "value"
 
-	defaultSeparator = "_"
+	defaultSeparator           = "_"
+	defaultAllowPendingMessage = 10000
 )
 
 var dropwarn = "ERROR: statsd message queue full. " +
@@ -297,7 +298,7 @@ func (s *Statsd) udpListen() error {
 			case s.in <- bufCopy:
 			default:
 				s.drops++
-				if s.drops == 1 || s.drops%s.AllowedPendingMessages == 0 {
+				if s.drops == 1 || s.AllowedPendingMessages == 0 || s.drops%s.AllowedPendingMessages == 0 {
 					log.Printf(dropwarn, s.drops)
 				}
 			}
@@ -650,7 +651,8 @@ func (s *Statsd) Stop() {
 func init() {
 	inputs.Add("statsd", func() telegraf.Input {
 		return &Statsd{
-			MetricSeparator: "_",
+			MetricSeparator:        "_",
+			AllowedPendingMessages: defaultAllowPendingMessage,
 		}
 	})
 }


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

I got this error when forgetting to set allow_pending_message on 1.0.0 version.

```
2016/09/19 00:14:36 ERROR: statsd message queue full. We have dropped 1 messages so far. You may want to increase allowed_pending_messages in the config
panic: runtime error: integer divide by zero
[signal 0x8 code=0x1 addr=0x621709 pc=0x621709]

goroutine 21 [running]:
panic(0x12cefe0, 0xc82000a060)
    /usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/influxdata/telegraf/plugins/inputs/statsd.(*Statsd).udpListen(0xc8200cc0d0, 0x0, 0x0)
    /home/ubuntu/telegraf-build/src/github.com/influxdata/telegraf/plugins/inputs/statsd/statsd.go:298 +0x7d9
created by github.com/influxdata/telegraf/plugins/inputs/statsd.(*Statsd).Start
    /home/ubuntu/telegraf-build/src/github.com/influxdata/telegraf/plugins/inputs/statsd/statsd.go:261 +0x2a7
```
The default is 0 so we hit a division by 0 error and crash. This checks
ensure we will not crash and `log` and continue to let telegraf run
