### PR TITLE
Fixed json serialization for OpenTSDB http output

### DIFF
--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -114,7 +114,9 @@ func (o *OpenTSDB) WriteHttp(metrics []telegraf.Metric, u *url.URL) error {
 			case uint64:
 			case float64:
 			default:
-				fmt.Printf("OpenTSDB does not support metric value: [%s] of type [%T].\n", value, value)
+				if o.Debug {
+					fmt.Printf("OpenTSDB does not support metric value: [%s] of type [%T].\n", value, value)
+				}
 				continue
 			}
 

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -109,9 +109,12 @@ func (o *OpenTSDB) WriteHttp(metrics []telegraf.Metric, u *url.URL) error {
 		tags := cleanTags(m.Tags())
 
 		for fieldName, value := range m.Fields() {
-			metricValue, buildError := buildValue(value)
-			if buildError != nil {
-				fmt.Printf("OpenTSDB: %s\n", buildError.Error())
+			switch value.(type) {
+			case int64:
+			case uint64:
+			case float64:
+			default:
+				fmt.Printf("OpenTSDB does not support metric value: [%s] of type [%T].\n", value, value)
 				continue
 			}
 
@@ -120,7 +123,7 @@ func (o *OpenTSDB) WriteHttp(metrics []telegraf.Metric, u *url.URL) error {
 					o.Prefix, m.Name(), fieldName)),
 				Tags:      tags,
 				Timestamp: now,
-				Value:     metricValue,
+				Value:     value,
 			}
 
 			if err := http.sendDataPoint(metric); err != nil {

--- a/plugins/outputs/opentsdb/opentsdb_http.go
+++ b/plugins/outputs/opentsdb/opentsdb_http.go
@@ -16,7 +16,7 @@ import (
 type HttpMetric struct {
 	Metric    string            `json:"metric"`
 	Timestamp int64             `json:"timestamp"`
-	Value     string            `json:"value"`
+	Value     interface{}       `json:"value"`
 	Tags      map[string]string `json:"tags"`
 }
 


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)

Fixed json serialization to make sure only value types supported by OpenTSDB are sent and made sure we send numbers un-quoted event though OpenTSDB API accepts them as this is not clean json.