### PR TITLE
Exact name matching for pgrep in procstat

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1350,6 +1350,8 @@
 #   # exe = "nginx"
 #   ## pattern as argument for pgrep (ie, pgrep -f <pattern>)
 #   # pattern = "nginx"
+#   ## match the exact name of the process (ie, pgrep -xf <pattern>)
+#   # exact = false
 #   ## user as argument for pgrep (ie, pgrep -u <user>)
 #   # user = "nginx"
 #


### PR DESCRIPTION
This PR enables the "exact" option for the procstat plugin which allows to only match a particular process name with `pgrep -xf` instead of the greedy default pattern matching behavior of `pgrep -f`.

From the manpage of pgrep:

```
-x, --exact
Only match processes whose names (or command line if -f is specified) exactly match the pattern.

```

### Pending:
- Update CHANGELOG.md


