### PR TITLE
update to latest gosnmp

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -48,7 +48,7 @@ github.com/prometheus/common e8eabff8812b05acf522b45fdcd725a785188e37
 github.com/prometheus/procfs 406e5b7bfd8201a36e2bb5f7bdae0b03380c2ce8
 github.com/samuel/go-zookeeper 218e9c81c0dd8b3b18172b2bbfad92cc7d6db55f
 github.com/shirou/gopsutil 4d0c402af66c78735c5ccf820dc2ca7de5e4ff08
-github.com/soniah/gosnmp eb32571c2410868d85849ad67d1e51d01273eb84
+github.com/soniah/gosnmp 3fe3beb30fa9700988893c56a63b1df8e1b68c26
 github.com/streadway/amqp b4f3ceab0337f013208d31348b578d83c0064744
 github.com/stretchr/testify 1f4a1643a57e798696635ea4c126e9127adb7d3c
 github.com/vjeantet/grok 83bfdfdfd1a8146795b28e547a8e3c8b28a466c2

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -109,7 +109,7 @@ type Snmp struct {
 	Community string
 
 	// Parameters for Version 2 & 3
-	MaxRepetitions int
+	MaxRepetitions uint8
 
 	// Parameters for Version 3
 	ContextName string


### PR DESCRIPTION
Previous fix (#1848) for #1835 didn't catch all empty string cases. There's another caused by a bug in the gosnmp lib. So this updates the lib. In fact this was probably the original issue reported in #1835, and while #1848 fixed some potential issues, they weren't the actual problem reported.