### PR TITLE
plugins/inputs/statsd: enforce minimum allowed_pending_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ continue sending logs to /var/log/telegraf/telegraf.log.
 
 ### Bugfixes
 
+- [#1870](https://github.com/influxdata/telegraf/pull/1870): plugins/inputs/statsd: enforce minimum allowed_pending_messages
 - [#1746](https://github.com/influxdata/telegraf/issues/1746): Fix handling of non-string values for JSON keys listed in tag_keys.
 - [#1628](https://github.com/influxdata/telegraf/issues/1628): Fix mongodb input panic on version 2.2.
 - [#1733](https://github.com/influxdata/telegraf/issues/1733): Fix statsd scientific notation parsing

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -236,6 +236,11 @@ func (s *Statsd) Gather(acc telegraf.Accumulator) error {
 func (s *Statsd) Start(_ telegraf.Accumulator) error {
 	// Make data structures
 	s.done = make(chan struct{})
+
+	if s.AllowedPendingMessages < 1 {
+		log.Printf("I! statsd: allowed_pending_messages < 1 not allowed (%v) set to 1", s.AllowedPendingMessages)
+		s.AllowedPendingMessages = 1
+	}
 	s.in = make(chan []byte, s.AllowedPendingMessages)
 
 	if prevInstance == nil {


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

