### PR TITLE
Force ipv4 or ipv6 for the ping plugin

### DIFF
--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -36,5 +36,5 @@ This input plugin will measures the round-trip
 ### Example Output:
 ```
 * Plugin: ping, Collection 1
-ping,host=WIN-PBAPLP511R7,url=www.google.com average_response_ms=7i,maximum_response_ms=9i,minimum_response_ms=7i,packets_received=4i,packets_transmitted=4i,percent_packet_loss=0,percent_reply_loss=0,reply_received=4i 1469879119000000000
+ping,host=WIN-PBAPLP511R7,ipversion=4,url=www.google.com average_response_ms=7i,maximum_response_ms=9i,minimum_response_ms=7i,packets_received=4i,packets_transmitted=4i,percent_packet_loss=0,percent_reply_loss=0,reply_received=4i 1469879119000000000
 ```

--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -13,6 +13,9 @@ This input plugin will measures the round-trip
 	
 	## Ping timeout, in seconds. 0 means default timeout (ping -w <TIMEOUT>)
 	Timeout = 0
+
+	## force ipv4 or ipv6 ('ping -6' or 'ping -4')
+	IPVersion = 6
 ```
 ### Measurements & Fields:
 - packets_transmitted ( from ping output )
@@ -28,6 +31,7 @@ This input plugin will measures the round-trip
 	
 ### Tags:
 - server
+- ipversion
 
 ### Example Output:
 ```

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -5,12 +5,12 @@ package ping
 import (
 	"errors"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-	"regexp"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
@@ -160,8 +160,10 @@ func (p *Ping) args(url string) []string {
 	}
 	args = append(args, url)
 	switch p.IPVersion {
-	case 4: args = append(args, "-4")
-	case 6: args = append(args, "-6")
+	case 4:
+		args = append(args, "-4")
+	case 6:
+		args = append(args, "-6")
 	}
 
 	return args
@@ -186,12 +188,12 @@ func processPingOutput(out string) (int, int, float64, int, error) {
 	var avg float64
 	// Set this error to nil if we find a 'transmitted' line
 	err := errors.New("Fatal error processing ping output")
-	re := regexp.MustCompile(`(?i)^ping.+\(([a-f0-9\.:]+)\)`)  // re[1] is the IP
+	re := regexp.MustCompile(`(?i)^ping.+\(([a-f0-9\.:]+)\)`) // re[1] is the IP
 	lines := strings.Split(out, "\n")
 	for _, line := range lines {
 		str := re.FindStringSubmatch(line)
 		if len(str) != 0 {
-			if strings.Contains(str[1],":") {
+			if strings.Contains(str[1], ":") {
 				ipversion = 6
 			} else {
 				ipversion = 4

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -48,13 +48,13 @@ ping: -i interval too short: Operation not permitted
 
 // Test that ping command output is processed properly
 func TestProcessPingOutput(t *testing.T) {
-	trans, rec, avg, err := processPingOutput(bsdPingOutput)
+	trans, rec, avg, ipversion, err := processPingOutput(bsdPingOutput)
 	assert.NoError(t, err)
 	assert.Equal(t, 5, trans, "5 packets were transmitted")
 	assert.Equal(t, 5, rec, "5 packets were transmitted")
 	assert.InDelta(t, 20.224, avg, 0.001)
 
-	trans, rec, avg, err = processPingOutput(linuxPingOutput)
+	trans, rec, avg, ipversion, err = processPingOutput(linuxPingOutput)
 	assert.NoError(t, err)
 	assert.Equal(t, 5, trans, "5 packets were transmitted")
 	assert.Equal(t, 5, rec, "5 packets were transmitted")
@@ -64,7 +64,7 @@ func TestProcessPingOutput(t *testing.T) {
 // Test that processPingOutput returns an error when 'ping' fails to run, such
 // as when an invalid argument is provided
 func TestErrorProcessPingOutput(t *testing.T) {
-	_, _, _, err := processPingOutput(fatalPingOutput)
+	_, _, _, _, err := processPingOutput(fatalPingOutput)
 	assert.Error(t, err, "Error was expected from processPingOutput")
 }
 


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

this is just a small addition to the ping-plugin to force ipv4 or ipv6
also adds a tag which one was used
