### PR TITLE
Fix unit testing w/ go 1.7.1 and support enhanced wildcard dimensions

### DIFF
--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -88,12 +88,14 @@ func TestCombinedOutputError(t *testing.T) {
 		t.Skip("'sleep' binary not available on OS, skipping.")
 	}
 	cmd := exec.Command(sleepbin, "foo")
-	expected, err := cmd.CombinedOutput()
+	expected, expectedErr := cmd.CombinedOutput()
 
 	cmd2 := exec.Command(sleepbin, "foo")
-	actual, err := CombinedOutputTimeout(cmd2, time.Second)
+	actual, actualErr := CombinedOutputTimeout(cmd2, time.Second)
 
-	assert.Error(t, err)
+	if expectedErr != nil {
+		assert.Error(t, actualErr)
+	}
 	assert.Equal(t, expected, actual)
 }
 
@@ -102,9 +104,14 @@ func TestRunError(t *testing.T) {
 		t.Skip("'sleep' binary not available on OS, skipping.")
 	}
 	cmd := exec.Command(sleepbin, "foo")
-	err := RunTimeout(cmd, time.Second)
+	expectedErr := cmd.Run()
 
-	assert.Error(t, err)
+	cmd2 := exec.Command(sleepbin, "foo")
+	actualErr := RunTimeout(cmd2, time.Second)
+
+	if expectedErr != nil {
+		assert.Error(t, actualErr)
+	}
 }
 
 func TestRandomSleep(t *testing.T) {

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -185,6 +185,23 @@ func (a *Accumulator) AssertContainsTaggedFields(
 	assert.Fail(t, msg)
 }
 
+func (a *Accumulator) CountTaggedMeasurements(
+	measurement string,
+	tags map[string]string,
+) int {
+	a.Lock()
+	defer a.Unlock()
+
+	cnt := 0
+	for _, p := range a.Metrics {
+		if reflect.DeepEqual(tags, p.Tags) &&
+			p.Measurement == measurement {
+			cnt++
+		}
+	}
+	return cnt
+}
+
 func (a *Accumulator) AssertContainsFields(
 	t *testing.T,
 	measurement string,


### PR DESCRIPTION
### Required for all PRs:
- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)
### Changes
1. Fixed unit testing on go 1.7.1, see #1696 
2. Currently dimension wildcards use an all-or-nothing approach.  Added support for partial wildcarding (ie. value = 'foo*' matches all values starting with foo)
