### PR TITLE
Fix panic in internal.Duration UnmarshalTOML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ continue sending logs to /var/log/telegraf/telegraf.log.
 
 ### Bugfixes
 
+- [#1926](https://github.com/influxdata/telegraf/issues/1926): Fix toml unmarshal panic in Duration objects.
 - [#1746](https://github.com/influxdata/telegraf/issues/1746): Fix handling of non-string values for JSON keys listed in tag_keys.
 - [#1628](https://github.com/influxdata/telegraf/issues/1628): Fix mongodb input panic on version 2.2.
 - [#1733](https://github.com/influxdata/telegraf/issues/1733): Fix statsd scientific notation parsing

--- a/circle.yml
+++ b/circle.yml
@@ -12,9 +12,6 @@ machine:
 dependencies:
   override:
     - docker info
-  post:
-    - gem install fpm
-    - sudo apt-get install -y rpm python-boto
 
 test:
   override:

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -36,6 +36,12 @@ type Duration struct {
 func (d *Duration) UnmarshalTOML(b []byte) error {
 	var err error
 
+	// see if we can straight convert it
+	d.Duration, err = time.ParseDuration(string(b))
+	if err == nil {
+		return nil
+	}
+
 	// Parse string duration, ie, "1s"
 	if uq, err := strconv.Unquote(string(b)); err == nil && len(uq) > 0 {
 		d.Duration, err = time.ParseDuration(uq)

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -35,10 +35,13 @@ type Duration struct {
 // UnmarshalTOML parses the duration from the TOML config file
 func (d *Duration) UnmarshalTOML(b []byte) error {
 	var err error
+
 	// Parse string duration, ie, "1s"
-	d.Duration, err = time.ParseDuration(string(b[1 : len(b)-1]))
-	if err == nil {
-		return nil
+	if uq, err := strconv.Unquote(string(b)); err == nil && len(uq) > 0 {
+		d.Duration, err = time.ParseDuration(uq)
+		if err == nil {
+			return nil
+		}
 	}
 
 	// First try parsing as integer seconds

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -131,3 +131,22 @@ func TestRandomSleep(t *testing.T) {
 	elapsed = time.Since(s)
 	assert.True(t, elapsed < time.Millisecond*150)
 }
+
+func TestDuration(t *testing.T) {
+	var d Duration
+
+	d.UnmarshalTOML([]byte(`"1s"`))
+	assert.Equal(t, time.Second, d.Duration)
+
+	d = Duration{}
+	d.UnmarshalTOML([]byte(`1s`))
+	assert.Equal(t, time.Second, d.Duration)
+
+	d = Duration{}
+	d.UnmarshalTOML([]byte(`10`))
+	assert.Equal(t, 10*time.Second, d.Duration)
+
+	d = Duration{}
+	d.UnmarshalTOML([]byte(`1.5`))
+	assert.Equal(t, time.Second, d.Duration)
+}

--- a/scripts/circle-test.sh
+++ b/scripts/circle-test.sh
@@ -75,6 +75,10 @@ cat telegraf-race | gzip > $CIRCLE_ARTIFACTS/telegraf-race.gz
 
 eval "git describe --exact-match HEAD"
 if [ $? -eq 0 ]; then
+    # install fpm (packaging dependency)
+    exit_if_fail gem install fpm
+    # install boto & rpm (packaging & AWS dependencies)
+    exit_if_fail sudo apt-get install -y rpm python-boto
     unset GOGC
     tag=$(git describe --exact-match HEAD)
     echo $tag


### PR DESCRIPTION
`internal.Duration` unmarshaler will cause Telegraf to panic if you pass it something like `1` in `telegraf.toml`.

### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

