### PR TITLE
Fix typo from 'Proctstas' to 'Procstat' in procstat plugin's README

### DIFF
--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -10,7 +10,7 @@ The plugin will tag processes by their PID and their process name.
 Processes can be specified either by pid file, by executable name, by command
 line pattern matching, or by username (in this order or priority. Procstat
 plugin will use `pgrep` when executable name is provided to obtain the pid.
-Proctstas plugin will transmit IO, memory, cpu, file descriptor related
+Procstat plugin will transmit IO, memory, cpu, file descriptor related
 measurements for every process specified. A prefix can be set to isolate
 individual process specific measurements.
 


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

