### PR TITLE
Support for deletion of gauge for statsd plugin.

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -84,7 +84,7 @@ targets = {
 
 supported_builds = {
     "windows": [ "amd64" ],
-    "linux": [ "amd64", "i386", "armhf", "armel", "arm64", "static_amd64" ],
+    "linux": [ "static_amd64", "amd64", "i386", "armhf", "armel", "arm64"  ],
     "freebsd": [ "amd64" ]
 }
 


### PR DESCRIPTION
I have added support to delete individual gauge elements from telegraf so that one can have "delete_gauge=false" globally and still be able to delete some gauge. For that I added "gd" flag. as in the following example. Here the value +10 is a dummy value.

e.g: echo "mytable,mymeas=1:+10|gd" | nc -w 1 -u localhost 8125


### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X ] README.md updated (if adding a new plugin)

