### PR TITLE
udp_listener & tcp_listener set default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ continue sending logs to /var/log/telegraf/telegraf.log.
 ### Bugfixes
 
 - [#1955](https://github.com/influxdata/telegraf/issues/1955): Fix NATS plug-ins reconnection logic.
+- [#1936](https://github.com/influxdata/telegraf/issues/1936): Set required default values in udp_listener & tcp_listener.
 - [#1926](https://github.com/influxdata/telegraf/issues/1926): Fix toml unmarshal panic in Duration objects.
 - [#1746](https://github.com/influxdata/telegraf/issues/1746): Fix handling of non-string values for JSON keys listed in tag_keys.
 - [#1628](https://github.com/influxdata/telegraf/issues/1628): Fix mongodb input panic on version 2.2.

--- a/plugins/inputs/tcp_listener/tcp_listener.go
+++ b/plugins/inputs/tcp_listener/tcp_listener.go
@@ -52,14 +52,14 @@ var malformedwarn = "E! tcp_listener has received %d malformed packets" +
 
 const sampleConfig = `
   ## Address and port to host TCP listener on
-  service_address = ":8094"
+  # service_address = ":8094"
 
   ## Number of TCP messages allowed to queue up. Once filled, the
   ## TCP listener will start dropping packets.
-  allowed_pending_messages = 10000
+  # allowed_pending_messages = 10000
 
   ## Maximum number of concurrent TCP connections to allow
-  max_tcp_connections = 250
+  # max_tcp_connections = 250
 
   ## Data format to consume.
   ## Each data format has it's own unique set of configuration options, read
@@ -276,6 +276,10 @@ func (t *TcpListener) remember(id string, conn *net.TCPConn) {
 
 func init() {
 	inputs.Add("tcp_listener", func() telegraf.Input {
-		return &TcpListener{}
+		return &TcpListener{
+			ServiceAddress:         ":8094",
+			AllowedPendingMessages: 10000,
+			MaxTCPConnections:      250,
+		}
 	})
 }

--- a/plugins/inputs/udp_listener/udp_listener.go
+++ b/plugins/inputs/udp_listener/udp_listener.go
@@ -51,11 +51,11 @@ var malformedwarn = "E! udp_listener has received %d malformed packets" +
 
 const sampleConfig = `
   ## Address and port to host UDP listener on
-  service_address = ":8092"
+  # service_address = ":8092"
 
   ## Number of UDP messages allowed to queue up. Once filled, the
   ## UDP listener will start dropping packets.
-  allowed_pending_messages = 10000
+  # allowed_pending_messages = 10000
 
   ## Data format to consume.
   ## Each data format has it's own unique set of configuration options, read
@@ -178,6 +178,9 @@ func (u *UdpListener) udpParser() error {
 
 func init() {
 	inputs.Add("udp_listener", func() telegraf.Input {
-		return &UdpListener{}
+		return &UdpListener{
+			ServiceAddress:         ":8092",
+			AllowedPendingMessages: 10000,
+		}
 	})
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)


closes #1936