### PR TITLE
ES Add basic authentication (Shield) + make it compatible with older ES versions

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -768,6 +768,12 @@
 #   # ssl_key = "/etc/telegraf/key.pem"
 #   ## Use SSL but skip chain & host verification
 #   # insecure_skip_verify = false
+#   ## Optional for authentication setup with Shield
+#   # username = "admin"
+#   # password = "admin123"
+
+##  ## cluster node stats API . Defaults to all of the options below
+#   #stats = ["indices", "os", "process", "jvm", "thread_pool","fs","transport","http","breakers"]
 
 
 # # Read metrics from one or more commands that can output to stdout


### PR DESCRIPTION
### Required for all PRs:
- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

Why
1. With ES 0.19.9 nodeStats doesn't return all the data
2. The plugin doesn't work with authentication set up for ES with Shield

How
1. gatherNodeStats()
     Include input parameter stats
    - stats = ["indices", "os", "process", "jvm", "thread_pool","fs","transport","http","breakers"]
    - https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html
     Reasons for the refactor
         - The syntax for printing out the the default option of all varies between versions
         - ES 0.19.9 requires all=true whereas later versions don't need that option to  print  defaults 
        - Gives flexibility to output fewer metrics
        - Added a switch statement in routine gatherNodeStats to construct url dynamically based on the input parameter stats from the config file
2. gatherData()
    Changes in routine gatherData to setup BasicAuth with the username passowrd from the config 
3. Gather()
     This ensure higher level metrics are not interrupted if any of the nodelevel stats error out
