### PR TITLE
Fix up AWS plugin docs so they don't use single quotes.

### DIFF
--- a/plugins/inputs/cloudwatch/README.md
+++ b/plugins/inputs/cloudwatch/README.md
@@ -18,21 +18,21 @@ API endpoint. In the following order the plugin will attempt to authenticate.
 ```toml
 [[inputs.cloudwatch]]
   ## Amazon Region (required)
-  region = 'us-east-1'
+  region = "us-east-1"
 
   ## Requested CloudWatch aggregation Period (required - must be a multiple of 60s)
-  period = '1m'
+  period = "1m"
 
   ## Collection Delay (required - must account for metrics availability via CloudWatch API)
-  delay = '1m'
+  delay = "1m"
 
   ## Override global run interval (optional - defaults to global interval)
   ## Recomended: use metric 'interval' that is a multiple of 'period' to avoid
   ## gaps or overlap in pulled data
-  interval = '1m'
+  interval = "1m"
 
   ## Metric Statistic Namespace (required)
-  namespace = 'AWS/ELB'
+  namespace = "AWS/ELB"
 
   ## Maximum requests per second. Note that the global default AWS rate limit is
   ## 10 reqs/sec, so if you define multiple namespaces, these should add up to a
@@ -43,16 +43,16 @@ API endpoint. In the following order the plugin will attempt to authenticate.
   ## Defaults to all Metrics in Namespace if nothing is provided
   ## Refreshes Namespace available metrics every 1h
   [[inputs.cloudwatch.metrics]]
-    names = ['Latency', 'RequestCount']
+    names = ["Latency", "RequestCount"]
 
     ## Dimension filters for Metric (optional)
     [[inputs.cloudwatch.metrics.dimensions]]
-      name = 'LoadBalancerName'
-      value = 'p-example'
+      name = "LoadBalancerName"
+      value = "p-example"
 
     [[inputs.cloudwatch.metrics.dimensions]]
-      name = 'AvailabilityZone'
-      value = '*'
+      name = "AvailabilityZone"
+      value = "*"
 ```
 #### Requirements and Terminology
 

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -63,7 +63,7 @@ type (
 func (c *CloudWatch) SampleConfig() string {
 	return `
   ## Amazon Region
-  region = 'us-east-1'
+  region = "us-east-1"
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
@@ -81,21 +81,21 @@ func (c *CloudWatch) SampleConfig() string {
   #shared_credential_file = ""
 
   ## Requested CloudWatch aggregation Period (required - must be a multiple of 60s)
-  period = '1m'
+  period = "1m"
 
   ## Collection Delay (required - must account for metrics availability via CloudWatch API)
-  delay = '1m'
+  delay = "1m"
 
   ## Recomended: use metric 'interval' that is a multiple of 'period' to avoid
   ## gaps or overlap in pulled data
-  interval = '1m'
+  interval = "1m"
 
   ## Configure the TTL for the internal cache of metrics.
   ## Defaults to 1 hr if not specified
-  #cache_ttl = '10m'
+  #cache_ttl = "10m"
 
   ## Metric Statistic Namespace (required)
-  namespace = 'AWS/ELB'
+  namespace = "AWS/ELB"
 
   ## Maximum requests per second. Note that the global default AWS rate limit is
   ## 10 reqs/sec, so if you define multiple namespaces, these should add up to a
@@ -106,12 +106,12 @@ func (c *CloudWatch) SampleConfig() string {
   ## Defaults to all Metrics in Namespace if nothing is provided
   ## Refreshes Namespace available metrics every 1h
   #[[inputs.cloudwatch.metrics]]
-  #  names = ['Latency', 'RequestCount']
+  #  names = ["Latency", "RequestCount"]
   #
   #  ## Dimension filters for Metric (optional)
   #  [[inputs.cloudwatch.metrics.dimensions]]
-  #    name = 'LoadBalancerName'
-  #    value = 'p-example'
+  #    name = "LoadBalancerName"
+  #    value = "p-example"
 `
 }
 
@@ -133,7 +133,6 @@ func (c *CloudWatch) Gather(acc telegraf.Accumulator) error {
 			if !hasWilcard(m.Dimensions) {
 				dimensions := make([]*cloudwatch.Dimension, len(m.Dimensions))
 				for k, d := range m.Dimensions {
-					fmt.Printf("Dimension [%s]:[%s]\n", d.Name, d.Value)
 					dimensions[k] = &cloudwatch.Dimension{
 						Name:  aws.String(d.Name),
 						Value: aws.String(d.Value),
@@ -229,13 +228,12 @@ func (c *CloudWatch) initializeCloudWatch() error {
 /*
  * Fetch available metrics for given CloudWatch Namespace
  */
-func (c *CloudWatch) fetchNamespaceMetrics() (metrics []*cloudwatch.Metric, err error) {
+func (c *CloudWatch) fetchNamespaceMetrics() ([]*cloudwatch.Metric, error) {
 	if c.metricCache != nil && c.metricCache.IsValid() {
-		metrics = c.metricCache.Metrics
-		return
+		return c.metricCache.Metrics, nil
 	}
 
-	metrics = []*cloudwatch.Metric{}
+	metrics := []*cloudwatch.Metric{}
 
 	var token *string
 	for more := true; more; {
@@ -263,7 +261,7 @@ func (c *CloudWatch) fetchNamespaceMetrics() (metrics []*cloudwatch.Metric, err 
 		TTL:     c.CacheTTL.Duration,
 	}
 
-	return
+	return metrics, nil
 }
 
 /*

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -30,7 +30,7 @@ type CloudWatch struct {
 
 var sampleConfig = `
   ## Amazon REGION
-  region = 'us-east-1'
+  region = "us-east-1"
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
@@ -48,7 +48,7 @@ var sampleConfig = `
   #shared_credential_file = ""
 
   ## Namespace for the CloudWatch MetricDatums
-  namespace = 'InfluxData/Telegraf'
+  namespace = "InfluxData/Telegraf"
 `
 
 func (c *CloudWatch) SampleConfig() string {


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)

Also don't use named returns in fetchNamespaceMetrics since it's
non-standard for the rest of the codebase.