### PR TITLE
Fix RPM architecture for armhf

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -583,6 +583,8 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                     if "static_" in arch:
                         # Remove the "static_" from the displayed arch on the package
                         package_arch = arch.replace("static_", "")
+                    elif package_type == "rpm" and arch == 'armhf':
+                        package_arch = 'armv6hl'
                     else:
                         package_arch = arch
                     if not release and not nightly:


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

RPM for armhf are using the wrong architecture name. Fedora/CentOS (and OpenSuse also) does not use "armhf" like Debian/Ubuntu. They use "armv6hl" or "armv7hl".

This PR fix the name for armhf and use armv6hl for RPM.

This PR only fix names for armhf:
* For armel, name should probably be an armv5-something, but I don't known the "-something"
* For arm64, I didn't searched and I think currently it's build as armv7hl (32-bits). From my understanding, for 64-bits, GOARCH should be arm64 and GOARM seems unused. Since I don't have any arm64 I can't test.

Issue with current armhf:
```
# dnf install ./telegraf-dev.armhf.rpm
Error: package telegraf-dev-1.armhf is not installable
(try to add '--allowerasing' to command line to replace conflicting packages)

# rpm -i ./telegraf-dev.armhf.rpm
        package telegraf-dev-1.armhf is intended for a different architecture
```

With armv6hl:
```
dnf install ./telegraf-dev.armv6hl.rpm 
Last metadata expiration check: 1:01:37 ago on Mon Nov  7 08:52:20 2016.
Dependencies resolved.
================================================================================
 Package           Arch             Version         Repository             Size
================================================================================
Installing:
 telegraf          armv6hl          dev-1           @commandline          8.9 M

Transaction Summary
================================================================================
Install  1 Package

Total size: 8.9 M
Installed size: 31 M
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
warning: Unable to get systemd shutdown inhibition lock
  Installing  : telegraf-dev-1.armv6hl                                      1/1 
  Verifying   : telegraf-dev-1.armv6hl                                      1/1 

Installed:
  telegraf.armv6hl dev-1                                                        

Complete!
```