### PR TITLE
Added response_timeout property to prometheus input plugin

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -13,6 +13,17 @@ Example for Kubernetes apiserver
   urls = ["http://my-kube-apiserver:8080/metrics"]
 ```
 
+Specify a 10 second timeout for slower/over-loaded clients
+```toml
+# Get all metrics from Kube-apiserver
+[[inputs.prometheus]]
+  # An array of urls to scrape metrics from.
+  urls = ["http://my-kube-apiserver:8080/metrics"]
+  
+  # Specify timeout in seconds for slower prometheus clients (default is 3)
+  response_timeout = 10
+```
+
 You can use more complex configuration
 to filter and some tags
 

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -20,8 +20,8 @@ Specify a 10 second timeout for slower/over-loaded clients
   # An array of urls to scrape metrics from.
   urls = ["http://my-kube-apiserver:8080/metrics"]
   
-  # Specify timeout in seconds for slower prometheus clients (default is 3)
-  response_timeout = 10
+  # Specify timeout duration for slower prometheus clients (default is 3s)
+  response_timeout = 10s
 ```
 
 You can use more complex configuration

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -21,6 +21,8 @@ type Prometheus struct {
 	// Bearer Token authorization file path
 	BearerToken string `toml:"bearer_token"`
 
+	ResponseTimeout int `toml:"response_timeout"`
+
 	// Path to CA file
 	SSLCA string `toml:"ssl_ca"`
 	// Path to host cert file
@@ -37,6 +39,9 @@ var sampleConfig = `
 
   ## Use bearer token for authorization
   # bearer_token = /path/to/bearer/token
+
+  ## Specify timeout in seconds for slower prometheus clients (default is 3)
+  # response_timeout = 3
 
   ## Optional SSL Config
   # ssl_ca = /path/to/cafile
@@ -105,7 +110,7 @@ func (p *Prometheus) gatherURL(url string, acc telegraf.Accumulator) error {
 		}).Dial,
 		TLSHandshakeTimeout:   5 * time.Second,
 		TLSClientConfig:       tlsCfg,
-		ResponseHeaderTimeout: time.Duration(3 * time.Second),
+		ResponseHeaderTimeout: time.Duration(time.Duration(p.ResponseTimeout) * time.Second),
 		DisableKeepAlives:     true,
 	}
 
@@ -148,6 +153,6 @@ func (p *Prometheus) gatherURL(url string, acc telegraf.Accumulator) error {
 
 func init() {
 	inputs.Add("prometheus", func() telegraf.Input {
-		return &Prometheus{}
+		return &Prometheus{ResponseTimeout: 3}
 	})
 }

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -21,7 +21,7 @@ type Prometheus struct {
 	// Bearer Token authorization file path
 	BearerToken string `toml:"bearer_token"`
 
-	ResponseTimeout int `toml:"response_timeout"`
+	ResponseTimeout internal.Duration `toml:"response_timeout"`
 
 	// Path to CA file
 	SSLCA string `toml:"ssl_ca"`
@@ -40,8 +40,8 @@ var sampleConfig = `
   ## Use bearer token for authorization
   # bearer_token = /path/to/bearer/token
 
-  ## Specify timeout in seconds for slower prometheus clients (default is 3)
-  # response_timeout = 3
+  ## Specify timeout duration for slower prometheus clients (default is 3s)
+  # response_timeout = 3s
 
   ## Optional SSL Config
   # ssl_ca = /path/to/cafile
@@ -110,7 +110,7 @@ func (p *Prometheus) gatherURL(url string, acc telegraf.Accumulator) error {
 		}).Dial,
 		TLSHandshakeTimeout:   5 * time.Second,
 		TLSClientConfig:       tlsCfg,
-		ResponseHeaderTimeout: time.Duration(time.Duration(p.ResponseTimeout) * time.Second),
+		ResponseHeaderTimeout: p.ResponseTimeout.Duration,
 		DisableKeepAlives:     true,
 	}
 
@@ -153,6 +153,6 @@ func (p *Prometheus) gatherURL(url string, acc telegraf.Accumulator) error {
 
 func init() {
 	inputs.Add("prometheus", func() telegraf.Input {
-		return &Prometheus{ResponseTimeout: 3}
+		return &Prometheus{ResponseTimeout: "3s"}
 	})
 }


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)

While working with a customer to setup monitoring, leveraging their existing Prometheus endpoints to gather metrics, we were getting numerous timeout errors in the logs.  Upon further investigation, the prometheus input plugin has a 3 second timeout hard coded.  The issue is that some of the prometheus endpoints were taking much longer than 3 seconds to return all available metrics.  We converted this to a configuration property, with a default value of 3 seconds, which ultimately solved the problem.

Since the default is still 3 seconds, this should be a non-breaking change.  