### PR TITLE
fixes #1987 custom docker repos with non-standard port

### DIFF
--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -221,14 +221,17 @@ func (d *Docker) gatherContainer(
 		cname = strings.TrimPrefix(container.Names[0], "/")
 	}
 
-	// the image name sometimes has a version part.
-	//   ie, rabbitmq:3-management
-	imageParts := strings.Split(container.Image, ":")
-	imageName := imageParts[0]
+	// the image name sometimes has a version part, or a private repo
+	//   ie, rabbitmq:3-management or docker.someco.net:4443/rabbitmq:3-management
+	imageName := ""
 	imageVersion := "unknown"
-	if len(imageParts) > 1 {
-		imageVersion = imageParts[1]
+	if (strings.LastIndex(container.Image, ":") > -1) {
+		imageVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
+		imageName = container.Image[:strings.LastIndex(container.Image, ":")]
+	} else {
+		imageName = container.Image
 	}
+	
 	tags := map[string]string{
 		"engine_host":       d.engine_host,
 		"container_name":    cname,

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -225,10 +225,10 @@ func (d *Docker) gatherContainer(
 	//   ie, rabbitmq:3-management or docker.someco.net:4443/rabbitmq:3-management
 	imageName := ""
 	imageVersion := "unknown"
-	imageVersionMarkerIndex := strings.LastIndex(container.Image, ":")
-	if imageVersionMarkerIndex > -1 {
-		imageVersion = container.Image[imageVersionMarkerIndex+1:]
-		imageName = container.Image[:imageVersionMarkerIndex]
+	i := strings.LastIndex(container.Image, ":") // index of last ':' character
+	if i > -1 {
+		imageVersion = container.Image[i+1:]
+		imageName = container.Image[:i]
 	} else {
 		imageName = container.Image
 	}

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -225,13 +225,14 @@ func (d *Docker) gatherContainer(
 	//   ie, rabbitmq:3-management or docker.someco.net:4443/rabbitmq:3-management
 	imageName := ""
 	imageVersion := "unknown"
-	if (strings.LastIndex(container.Image, ":") > -1) {
-		imageVersion = container.Image[strings.LastIndex(container.Image, ":")+1:]
-		imageName = container.Image[:strings.LastIndex(container.Image, ":")]
+	imageVersionMarkerIndex := strings.LastIndex(container.Image, ":")
+	if imageVersionMarkerIndex > -1 {
+		imageVersion = container.Image[imageVersionMarkerIndex+1:]
+		imageName = container.Image[:imageVersionMarkerIndex]
 	} else {
 		imageName = container.Image
 	}
-	
+
 	tags := map[string]string{
 		"engine_host":       d.engine_host,
 		"container_name":    cname,

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -340,7 +340,7 @@ func (d FakeDockerClient) ContainerList(octx context.Context, options types.Cont
 	container2 := types.Container{
 		ID:      "b7dfbb9478a6ae55e237d4d74f8bbb753f0817192b5081334dc78476296e2173",
 		Names:   []string{"/etcd2"},
-		Image:   "quay.io/coreos/etcd:v2.2.2",
+		Image:   "quay.io:4443/coreos/etcd:v2.2.2",
 		Command: "/etcd -name etcd2 -advertise-client-urls http://localhost:2379 -listen-client-urls http://0.0.0.0:2379",
 		Created: 1455941933,
 		Status:  "Up 4 hours",
@@ -429,7 +429,7 @@ func TestDockerGatherInfo(t *testing.T) {
 		},
 		map[string]string{
 			"container_name":    "etcd2",
-			"container_image":   "quay.io/coreos/etcd",
+			"container_image":   "quay.io:4443/coreos/etcd",
 			"cpu":               "cpu3",
 			"container_version": "v2.2.2",
 			"engine_host":       "absol",
@@ -477,7 +477,7 @@ func TestDockerGatherInfo(t *testing.T) {
 		map[string]string{
 			"engine_host":       "absol",
 			"container_name":    "etcd2",
-			"container_image":   "quay.io/coreos/etcd",
+			"container_image":   "quay.io:4443/coreos/etcd",
 			"container_version": "v2.2.2",
 		},
 	)


### PR DESCRIPTION
Fixed for parsing docker image name / image version to account for the case of a custom docker repo which uses a non-standard port, for example `mycompany.net:4443/someimage:sometag`