### PR TITLE
Enable quiet log in default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#1564](https://github.com/influxdata/telegraf/issues/1564): Use RFC3339 timestamps in log output.
+- [#2026](https://github.com/influxdata/telegraf/pull/2026): Log quietly by default.
 
 ### Bugfixes
 

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -65,7 +65,7 @@
   ## Run telegraf with debug log messages.
   debug = false
   ## Run telegraf in quiet mode (error log messages only).
-  quiet = false
+  quiet = true
   ## Specify the log file name. The empty string means to log to stderr.
   logfile = ""
 

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -46,7 +46,7 @@
   ## Run telegraf in debug mode
   debug = false
   ## Run telegraf in quiet mode
-  quiet = false
+  quiet = true
   ## Specify the log file name. The empty string means to log to stdout.
   logfile = "/Program Files/Telegraf/telegraf.log"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -240,7 +240,7 @@ var header = `# Telegraf Configuration
   ## Run telegraf with debug log messages.
   debug = false
   ## Run telegraf in quiet mode (error log messages only).
-  quiet = false
+  quiet = true
   ## Specify the log file name. The empty string means to log to stderr.
   logfile = ""
 


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


This PR enable quiet in default configuration file.

Without this, the default configuration will logs something like:
```
nov. 10 11:48:35 xps-pierref telegraf[24823]: 2016/11/10 11:48:35 I! Output [graphite] wrote batch of 101 metrics in 6.844691ms
nov. 10 11:48:45 xps-pierref telegraf[24823]: 2016/11/10 11:48:45 I! Output [graphite] buffer fullness: 101 / 10000 metrics. Total gathered metrics: 195792. Total drop
ped metrics: 0.
```
every 10 seconds... which is rather noisy. Most user don't need this.

I think it would be better to disable this log by default, and if user need those log it could still re-enable it by updating configuration.