### PR TITLE
Update win_pref_counter to include Processor Queue Length in examples.

### DIFF
--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -130,6 +130,7 @@
     Counters = [
       "Context Switches/sec",
       "System Calls/sec",
+      "Processor Queue Length",
     ]
     Instances = ["------"]
     Measurement = "win_system"

--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -144,7 +144,7 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
 
   [[inputs.win_perf_counters.object]]
     ObjectName = "System"
-    Counters = ["Context Switches/sec","System Calls/sec"]
+    Counters = ["Context Switches/sec","System Calls/sec", "Processor Queue Length"]
     Instances = ["------"]
     Measurement = "win_system"
     #IncludeTotal=false #Set to true to include _Total instance when querying for all (*).


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

Similar to unix load, Windows' `Processor Queue Length` indicates how many threads are ready in the processor queue, but not currently able to use the processor.  It is different than unix load in that it is an instantaneous measurement and needs to be tracked over time.

Monitoring this counter is especially important on machines with SQL Server as it is used to help tune the *lightweight threading* option (fibers).