### PR TITLE
Trim null characters in Value data format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugfixes
 
+- [#2049](https://github.com/influxdata/telegraf/pull/2049): Fix the Value data format not trimming null characters from input.
 - [#1949](https://github.com/influxdata/telegraf/issues/1949): Fix windows `net` plugin.
 - [#1775](https://github.com/influxdata/telegraf/issues/1775): Cache & expire metrics for delivery to prometheus
 

--- a/plugins/parsers/value/parser.go
+++ b/plugins/parsers/value/parser.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -16,13 +17,12 @@ type ValueParser struct {
 }
 
 func (v *ValueParser) Parse(buf []byte) ([]telegraf.Metric, error) {
-	buf = bytes.TrimSpace(bytes.Trim(buf, "\x00"))
+	vStr := string(bytes.TrimSpace(bytes.Trim(buf, "\x00")))
 
 	// unless it's a string, separate out any fields in the buffer,
 	// ignore anything but the last.
-	vStr := string(buf)
 	if v.DataType != "string" {
-		values := bytes.Fields(buf)
+		values := strings.Fields(vStr)
 		if len(values) < 1 {
 			return []telegraf.Metric{}, nil
 		}

--- a/plugins/parsers/value/parser.go
+++ b/plugins/parsers/value/parser.go
@@ -23,6 +23,7 @@ func (v *ValueParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	if v.DataType == "string" {
 		vStr = strings.TrimSpace(string(buf))
 	} else {
+		buf = bytes.Trim(buf, "\x00")
 		values := bytes.Fields(buf)
 		if len(values) < 1 {
 			return []telegraf.Metric{}, nil

--- a/plugins/parsers/value/parser.go
+++ b/plugins/parsers/value/parser.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -17,13 +16,12 @@ type ValueParser struct {
 }
 
 func (v *ValueParser) Parse(buf []byte) ([]telegraf.Metric, error) {
+	buf = bytes.TrimSpace(bytes.Trim(buf, "\x00"))
+
 	// unless it's a string, separate out any fields in the buffer,
 	// ignore anything but the last.
-	var vStr string
-	if v.DataType == "string" {
-		vStr = strings.TrimSpace(string(buf))
-	} else {
-		buf = bytes.Trim(buf, "\x00")
+	vStr := string(buf)
+	if v.DataType != "string" {
 		values := bytes.Fields(buf)
 		if len(values) < 1 {
 			return []telegraf.Metric{}, nil

--- a/plugins/parsers/value/parser_test.go
+++ b/plugins/parsers/value/parser_test.go
@@ -236,3 +236,18 @@ func TestParseValidValuesDefaultTags(t *testing.T) {
 	}, metrics[0].Fields())
 	assert.Equal(t, map[string]string{"test": "tag"}, metrics[0].Tags())
 }
+
+func TestParseValuesWithNullCharacter(t *testing.T) {
+	parser := ValueParser{
+		MetricName: "value_test",
+		DataType:   "integer",
+	}
+	metrics, err := parser.Parse([]byte("55\x00"))
+	assert.NoError(t, err)
+	assert.Len(t, metrics, 1)
+	assert.Equal(t, "value_test", metrics[0].Name())
+	assert.Equal(t, map[string]interface{}{
+		"value": int64(55),
+	}, metrics[0].Fields())
+	assert.Equal(t, map[string]string{}, metrics[0].Tags())
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

Some producers (such as the paho embedded c mqtt client) add a null
character "\x00" to the end of a message.  The Value parser fails on
any message from such a producer.