### PR TITLE
Enable extracting tag values from MQTT topics

### DIFF
--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -27,6 +27,8 @@ type MQTTConsumer struct {
 	// Legacy metric buffer support
 	MetricBuffer int
 
+	TopicTags []TopicTag `toml:"topic_tags"`
+
 	PersistentSession bool
 	ClientID          string `toml:"client_id"`
 
@@ -49,6 +51,11 @@ type MQTTConsumer struct {
 	acc telegraf.Accumulator
 
 	started bool
+}
+
+type TopicTag struct {
+	Tag   string
+	Index int `toml:"topic_index"`
 }
 
 var sampleConfig = `
@@ -86,6 +93,17 @@ var sampleConfig = `
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
+
+  # Get tags from the topic
+  # the source of the metric comes from the first part of the topic
+  [[inputs.mqtt_consumer.topic_tags]]
+  tag = "source"
+  topic_index = 0
+
+  # Get the host from the second part of the topic
+  [[inputs.mqtt_consumer.topic_tags]]
+  tag = "host"
+  topic_index = 1
 `
 
 func (m *MQTTConsumer) SampleConfig() string {
@@ -113,6 +131,19 @@ func (m *MQTTConsumer) Start(acc telegraf.Accumulator) error {
 	m.acc = acc
 	if m.QoS > 2 || m.QoS < 0 {
 		return fmt.Errorf("MQTT Consumer, invalid QoS value: %d", m.QoS)
+	}
+
+	for _, tp := range m.TopicTags {
+		if tp.Index < 0 {
+			return fmt.Errorf("MQTT Consumer: tag index can't be negative")
+		}
+
+		for _, topic := range m.Topics {
+			parts := strings.Split(topic, "/")
+			if len(parts) <= tp.Index {
+				return fmt.Errorf("MQTT Consumer: Topic too short for tag part")
+			}
+		}
 	}
 
 	opts, err := m.createOpts()
@@ -173,10 +204,31 @@ func (m *MQTTConsumer) receiver() {
 			for _, metric := range metrics {
 				tags := metric.Tags()
 				tags["topic"] = topic
+
+				if err := m.setTopicTags(tags, topic); err != nil {
+					log.Printf("E! MQTT Parse Error\nmessage: %s\nerror: %s",
+						string(msg.Payload()), err.Error())
+					continue
+				}
+
 				m.acc.AddFields(metric.Name(), metric.Fields(), tags, metric.Time())
 			}
 		}
 	}
+}
+
+// setTopicTags sets tag values to topic parts
+func (m *MQTTConsumer) setTopicTags(tags map[string]string, topic string) error {
+	for _, tt := range m.TopicTags {
+		parts := strings.Split(topic, "/")
+		if len(parts) <= tt.Index {
+			return fmt.Errorf("index for topic tag out of range")
+		}
+
+		tags[tt.Tag] = parts[tt.Index]
+	}
+
+	return nil
 }
 
 func (m *MQTTConsumer) recvMessage(_ mqtt.Client, msg mqtt.Message) {

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -167,9 +167,65 @@ func TestRunParserAndGatherJSON(t *testing.T) {
 		})
 }
 
+func TestTopicTags(t *testing.T) {
+	m, in := newTestMQTTConsumer()
+	acc := testutil.Accumulator{}
+	m.acc = &acc
+	m.TopicTags = []TopicTag{
+		{Tag: "source", Index: 0},
+		{Tag: "device", Index: 1},
+	}
+	defer close(m.done)
+
+	m.parser, _ = parsers.NewInfluxParser()
+	go m.receiver()
+	in <- mqttTopicMsg("test/device1", testMsg)
+	time.Sleep(time.Millisecond * 25)
+
+	acc.AssertContainsTaggedFields(t,
+		"cpu_load_short",
+		map[string]interface{}{"value": 23422.0},
+		map[string]string{
+			"source": "test",
+			"device": "device1",
+			"host":   "server01",
+			"topic":  "test/device1",
+		},
+	)
+}
+
+func TestTopicTagsFail(t *testing.T) {
+	acc := testutil.Accumulator{}
+
+	m1 := &MQTTConsumer{
+		Topics: []string{"test"},
+		TopicTags: []TopicTag{
+			{Tag: "negative", Index: -1},
+		},
+	}
+	err := m1.Start(&acc)
+	assert.Error(t, err)
+
+	m2 := &MQTTConsumer{
+		Topics: []string{"test"},
+		TopicTags: []TopicTag{
+			{Tag: "outofrange", Index: 1},
+		},
+	}
+	err = m2.Start(&acc)
+	assert.Error(t, err)
+}
+
 func mqttMsg(val string) mqtt.Message {
 	return &message{
 		topic:   "telegraf/unit_test",
+		payload: []byte(val),
+	}
+}
+
+func mqttTopicMsg(topic, val string) mqtt.Message {
+	return &message{
+		topic:   topic,
 		payload: []byte(val),
 	}
 }


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

The MQTT topic as a whole is stored as a tag, but this is far too coarse
too be easily used when utilising the data further down the line.  This
change allows tag values to be extracted from the MQTT topic letting you
store the information provided in the topic in a meaningful way.  This
is especially (only, really) useful when subscribing to topics with
single level wildcards.  Multilevel wildcard are supported, but can
cause errors at runtime.  Metrics that cause an error will be dropped.

We have been using this for a week and it makes it a lot easier to manage MQTT data.

It would also be great to have some feedback on the config format, and the chosen names.