### PR TITLE
Add trailing slash to jolokia context

### DIFF
--- a/plugins/inputs/jolokia/README.md
+++ b/plugins/inputs/jolokia/README.md
@@ -6,7 +6,8 @@
 # Read JMX metrics through Jolokia
 [[inputs.jolokia]]
   ## This is the context root used to compose the jolokia url
-  context = "/jolokia"
+  ## NOTE that Jolokia requires a trailing slash at the end of the context root
+  context = "/jolokia/"
 
   ## This specifies the mode used
   # mode = "proxy"

--- a/plugins/inputs/jolokia/jolokia.go
+++ b/plugins/inputs/jolokia/jolokia.go
@@ -52,8 +52,9 @@ type Jolokia struct {
 
 const sampleConfig = `
   ## This is the context root used to compose the jolokia url
+  ## NOTE that Jolokia requires a trailing slash at the end of the context root
   ## NOTE that your jolokia security policy must allow for POST requests.
-  context = "/jolokia"
+  context = "/jolokia/"
 
   ## This specifies the mode used
   # mode = "proxy"
@@ -148,7 +149,7 @@ func (j *Jolokia) doRequest(req *http.Request) (map[string]interface{}, error) {
 
 func (j *Jolokia) prepareRequest(server Server, metric Metric) (*http.Request, error) {
 	var jolokiaUrl *url.URL
-	context := j.Context // Usually "/jolokia"
+	context := j.Context // Usually "/jolokia/"
 
 	// Create bodyContent
 	bodyContent := map[string]interface{}{


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

If one is using the suggested Jolokia plugin configuration, the following will cause the plugin to fail:
```
context = "/jolokia"
```
The server requires a trailing slash (i.e. `http://127.0.0.1:8778/jolokia/`). This change adds a slash to the end of the context parameter if it is not present.