### PR TITLE
Added modification_field timestamp

### DIFF
--- a/plugins/inputs/filestat/README.md
+++ b/plugins/inputs/filestat/README.md
@@ -20,6 +20,7 @@ The filestat plugin gathers metrics about file existence, size, and other stats.
 - filestat
     - exists (int, 0 | 1)
     - size_bytes (int, bytes)
+    - modification_time (int, unixtime)
     - md5 (optional, string)
 
 ### Tags:
@@ -33,5 +34,5 @@ The filestat plugin gathers metrics about file existence, size, and other stats.
 $ telegraf -config /etc/telegraf/telegraf.conf -input-filter filestat -test
 * Plugin: filestat, Collection 1
 > filestat,file=/tmp/foo/bar,host=tyrion exists=0i 1461203374493128216
-> filestat,file=/Users/sparrc/ws/telegraf.conf,host=tyrion exists=1i,size=47894i 1461203374493199335
+> filestat,file=/Users/sparrc/ws/telegraf.conf,host=tyrion exists=1i,size=47894i,modification_time=1470234221i 1461203374493199335,
 ```

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -78,8 +78,8 @@ func (f *FileStat) Gather(acc telegraf.Accumulator) error {
 				"file": fileName,
 			}
 			fields := map[string]interface{}{
-				"exists":     int64(1),
-				"size_bytes": fileInfo.Size(),
+				"exists":            int64(1),
+				"size_bytes":        fileInfo.Size(),
 				"modification_time": fileInfo.ModTime().Unix(),
 			}
 

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -80,6 +80,7 @@ func (f *FileStat) Gather(acc telegraf.Accumulator) error {
 			fields := map[string]interface{}{
 				"exists":     int64(1),
 				"size_bytes": fileInfo.Size(),
+				"modification_time": fileInfo.ModTime().Unix(),
 			}
 
 			if f.Md5 {

--- a/plugins/inputs/filestat/filestat_test.go
+++ b/plugins/inputs/filestat/filestat_test.go
@@ -25,9 +25,8 @@ func TestGatherNoMd5(t *testing.T) {
 		"file": dir + "log1.log",
 	}
 	fields1 := map[string]interface{}{
-		"size_bytes": 				int64(0),
-		"exists":     				int64(1),
-		"modification_time": 	int64(1)
+		"size_bytes": int64(0),
+		"exists":     int64(1),
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields1, tags1)
 
@@ -35,9 +34,8 @@ func TestGatherNoMd5(t *testing.T) {
 		"file": dir + "log2.log",
 	}
 	fields2 := map[string]interface{}{
-		"size_bytes": 				int64(0),
-		"exists":     				int64(1),
-		"modification_time": 	int64(1)
+		"size_bytes": int64(0),
+		"exists":     int64(1),
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields2, tags2)
 
@@ -67,10 +65,9 @@ func TestGatherExplicitFiles(t *testing.T) {
 		"file": dir + "log1.log",
 	}
 	fields1 := map[string]interface{}{
-		"size_bytes":					int64(0),
-		"exists":     				int64(1),
-		"modification_time": 	int64(1)
-		"md5_sum":    				"d41d8cd98f00b204e9800998ecf8427e",
+		"size_bytes": int64(0),
+		"exists":     int64(1),
+		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields1, tags1)
 
@@ -78,9 +75,8 @@ func TestGatherExplicitFiles(t *testing.T) {
 		"file": dir + "log2.log",
 	}
 	fields2 := map[string]interface{}{
-		"size_bytes": 				int64(0),
-		"exists":     				int64(1),
-		"modification_time": 	int64(1)
+		"size_bytes": int64(0),
+		"exists":     int64(1),
 		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields2, tags2)
@@ -109,9 +105,8 @@ func TestGatherGlob(t *testing.T) {
 		"file": dir + "log1.log",
 	}
 	fields1 := map[string]interface{}{
-		"size_bytes": 				int64(0),
-		"exists":     				int64(1),
-		"modification_time": 	int64(1)
+		"size_bytes": int64(0),
+		"exists":     int64(1),
 		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields1, tags1)
@@ -120,9 +115,8 @@ func TestGatherGlob(t *testing.T) {
 		"file": dir + "log2.log",
 	}
 	fields2 := map[string]interface{}{
-		"size_bytes": 				int64(0),
-		"exists":     				int64(1),
-		"modification_time": 	int64(1)
+		"size_bytes": int64(0),
+		"exists":     int64(1),
 		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields2, tags2)
@@ -143,9 +137,8 @@ func TestGatherSuperAsterisk(t *testing.T) {
 		"file": dir + "log1.log",
 	}
 	fields1 := map[string]interface{}{
-		"size_bytes": 				int64(0),
-		"exists":     				int64(1),
-		"modification_time": 	int64(1)
+		"size_bytes": int64(0),
+		"exists":     int64(1),
 		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields1, tags1)
@@ -154,9 +147,8 @@ func TestGatherSuperAsterisk(t *testing.T) {
 		"file": dir + "log2.log",
 	}
 	fields2 := map[string]interface{}{
-		"size_bytes": 				int64(0),
-		"exists":     				int64(1),
-		"modification_time": 	int64(1)
+		"size_bytes": int64(0),
+		"exists":     int64(1),
 		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields2, tags2)
@@ -165,10 +157,9 @@ func TestGatherSuperAsterisk(t *testing.T) {
 		"file": dir + "test.conf",
 	}
 	fields3 := map[string]interface{}{
-		"size_bytes": 				int64(104),
-		"exists":     				int64(1),
-		"modification_time": 	int64(1)
-		"md5_sum":    				"5a7e9b77fa25e7bb411dbd17cf403c1f",
+		"size_bytes": int64(104),
+		"exists":     int64(1),
+		"md5_sum":    "5a7e9b77fa25e7bb411dbd17cf403c1f",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields3, tags3)
 }

--- a/plugins/inputs/filestat/filestat_test.go
+++ b/plugins/inputs/filestat/filestat_test.go
@@ -25,8 +25,9 @@ func TestGatherNoMd5(t *testing.T) {
 		"file": dir + "log1.log",
 	}
 	fields1 := map[string]interface{}{
-		"size_bytes": int64(0),
-		"exists":     int64(1),
+		"size_bytes": 				int64(0),
+		"exists":     				int64(1),
+		"modification_time": 	int64(1)
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields1, tags1)
 
@@ -34,8 +35,9 @@ func TestGatherNoMd5(t *testing.T) {
 		"file": dir + "log2.log",
 	}
 	fields2 := map[string]interface{}{
-		"size_bytes": int64(0),
-		"exists":     int64(1),
+		"size_bytes": 				int64(0),
+		"exists":     				int64(1),
+		"modification_time": 	int64(1)
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields2, tags2)
 
@@ -65,9 +67,10 @@ func TestGatherExplicitFiles(t *testing.T) {
 		"file": dir + "log1.log",
 	}
 	fields1 := map[string]interface{}{
-		"size_bytes": int64(0),
-		"exists":     int64(1),
-		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
+		"size_bytes":					int64(0),
+		"exists":     				int64(1),
+		"modification_time": 	int64(1)
+		"md5_sum":    				"d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields1, tags1)
 
@@ -75,8 +78,9 @@ func TestGatherExplicitFiles(t *testing.T) {
 		"file": dir + "log2.log",
 	}
 	fields2 := map[string]interface{}{
-		"size_bytes": int64(0),
-		"exists":     int64(1),
+		"size_bytes": 				int64(0),
+		"exists":     				int64(1),
+		"modification_time": 	int64(1)
 		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields2, tags2)
@@ -105,8 +109,9 @@ func TestGatherGlob(t *testing.T) {
 		"file": dir + "log1.log",
 	}
 	fields1 := map[string]interface{}{
-		"size_bytes": int64(0),
-		"exists":     int64(1),
+		"size_bytes": 				int64(0),
+		"exists":     				int64(1),
+		"modification_time": 	int64(1)
 		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields1, tags1)
@@ -115,8 +120,9 @@ func TestGatherGlob(t *testing.T) {
 		"file": dir + "log2.log",
 	}
 	fields2 := map[string]interface{}{
-		"size_bytes": int64(0),
-		"exists":     int64(1),
+		"size_bytes": 				int64(0),
+		"exists":     				int64(1),
+		"modification_time": 	int64(1)
 		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields2, tags2)
@@ -137,8 +143,9 @@ func TestGatherSuperAsterisk(t *testing.T) {
 		"file": dir + "log1.log",
 	}
 	fields1 := map[string]interface{}{
-		"size_bytes": int64(0),
-		"exists":     int64(1),
+		"size_bytes": 				int64(0),
+		"exists":     				int64(1),
+		"modification_time": 	int64(1)
 		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields1, tags1)
@@ -147,8 +154,9 @@ func TestGatherSuperAsterisk(t *testing.T) {
 		"file": dir + "log2.log",
 	}
 	fields2 := map[string]interface{}{
-		"size_bytes": int64(0),
-		"exists":     int64(1),
+		"size_bytes": 				int64(0),
+		"exists":     				int64(1),
+		"modification_time": 	int64(1)
 		"md5_sum":    "d41d8cd98f00b204e9800998ecf8427e",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields2, tags2)
@@ -157,9 +165,10 @@ func TestGatherSuperAsterisk(t *testing.T) {
 		"file": dir + "test.conf",
 	}
 	fields3 := map[string]interface{}{
-		"size_bytes": int64(104),
-		"exists":     int64(1),
-		"md5_sum":    "5a7e9b77fa25e7bb411dbd17cf403c1f",
+		"size_bytes": 				int64(104),
+		"exists":     				int64(1),
+		"modification_time": 	int64(1)
+		"md5_sum":    				"5a7e9b77fa25e7bb411dbd17cf403c1f",
 	}
 	acc.AssertContainsTaggedFields(t, "filestat", fields3, tags3)
 }


### PR DESCRIPTION
Also made some initial changes to filestat_test.go, but have reverted these as the last modified time of the test files can't be known as this is the time that they are written to disk (i.e. after cloning the repo).

As such, the timestamp can't be baked into the test.  I'm open to suggestion as to how to implement this test