### PR TITLE
Adds an 'output_precision' configuration parameter

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -59,7 +59,7 @@ ie, a jitter of 5s and flush_interval 10s means flushes will happen every 10-15s
 * **precision**: By default, precision will be set to the same timestamp order
 as the collection interval, with the maximum being 1s. Precision will NOT
 be used for service inputs, such as logparser and statsd. Valid values are
-"ns", "us" (or "µs"), "ms", "s".
+"1ns", "1us" (or "1µs"), "1ms", "1s".
 * **logfile**: Specify the log file name. The empty string means to log to stdout.
 * **debug**: Run telegraf in debug mode.
 * **quiet**: Run telegraf in quiet mode (error messages only).

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -58,7 +58,7 @@
   ## By default, precision will be set to the same timestamp order as the
   ## collection interval, with the maximum being 1s.
   ## Precision will NOT be used for service inputs, such as logparser and statsd.
-  ## Valid values are "ns", "us" (or "µs"), "ms", "s".
+  ## Valid values are "1ns", "1us" (or "1µs"), "1ms", "1s".
   precision = ""
 
   ## Logging configuration:

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -67,7 +67,7 @@
   urls = ["http://localhost:8086"] # required
   # The target database for metrics (telegraf will create it if not exists)
   database = "telegraf" # required
-  # Precision of writes, valid values are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  # Precision of writes, valid values are "1ns", "1us" (or "1µs"), "1ms", "1s", "1m", "1h".
   # note: using second precision greatly helps InfluxDB compression
   precision = "s"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,7 +233,7 @@ var header = `# Telegraf Configuration
   ## By default, precision will be set to the same timestamp order as the
   ## collection interval, with the maximum being 1s.
   ## Precision will NOT be used for service inputs, such as logparser and statsd.
-  ## Valid values are "ns", "us" (or "µs"), "ms", "s".
+  ## Valid values are "1ns", "1us" (or "1µs"), "1ms", "1s".
   precision = ""
 
   ## Logging configuration:

--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -30,6 +30,9 @@ type AMQP struct {
 	RetentionPolicy string
 	// InfluxDB precision (DEPRECATED)
 	Precision string
+	// OutputPrecision string (parsed as a duration,
+	// only used for JSON output)
+	OutputPrecision string
 
 	// Path to CA file
 	SSLCA string `toml:"ssl_ca"`
@@ -77,6 +80,15 @@ var sampleConfig = `
   # retention_policy = "default"
   ## InfluxDB database
   # database = "telegraf"
+
+  ## The output_precision parameter can be used to specify the units that should
+  ## be used when creating timestamps and is only used when the data_format is
+  ## set to "json"; in that case valid values are "1ns", "1us" (or "1µs"), "1ms",
+  ## or "1s"; for the other supported data_format types, the precision will depend
+  ## on the data_format (seconds for "graphite" data, nanoseconds for "influx"
+  ## data); if unspecified, then the timestamps output with "json" data
+  ## will be in seconds
+  output_precision = ""
 
   ## Optional SSL Config
   # ssl_ca = "/etc/telegraf/ca.pem"
@@ -187,7 +199,7 @@ func (q *AMQP) Write(metrics []telegraf.Metric) error {
 			}
 		}
 
-		buf, err := q.serializer.Serialize(metric)
+		buf, err := q.serializer.Serialize(metric, q.OutputPrecision)
 		if err != nil {
 			return err
 		}

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -25,6 +25,9 @@ type Kafka struct {
 	RequiredAcks int
 	// MaxRetry Tag
 	MaxRetry int
+	// OutputPrecision string (parsed as a duration,
+	// only used for JSON output)
+	OutputPrecision string
 
 	// Legacy SSL config options
 	// TLS client certificate
@@ -84,6 +87,15 @@ var sampleConfig = `
 
   ##  The total number of times to retry sending a message
   max_retry = 3
+
+  ## The output_precision parameter can be used to specify the units that should
+  ## be used when creating timestamps and is only used when the data_format is
+  ## set to "json"; in that case valid values are "1ns", "1us" (or "1µs"), "1ms",
+  ## or "1s"; for the other supported data_format types, the precision will depend
+  ## on the data_format (seconds for "graphite" data, nanoseconds for "influx"
+  ## data); if unspecified, then the timestamps output with "json" data
+  ## will be in seconds
+  output_precision = ""
 
   ## Optional SSL Config
   # ssl_ca = "/etc/telegraf/ca.pem"
@@ -154,7 +166,7 @@ func (k *Kafka) Write(metrics []telegraf.Metric) error {
 	}
 
 	for _, metric := range metrics {
-		buf, err := k.serializer.Serialize(metric)
+		buf, err := k.serializer.Serialize(metric, k.OutputPrecision)
 		if err != nil {
 			return err
 		}

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -19,6 +19,9 @@ type NATS struct {
 	Password string
 	// NATS subject to publish metrics to
 	Subject string
+	// OutputPrecision string (parsed as a duration,
+	// only used for JSON output)
+	OutputPrecision string
 
 	// Path to CA file
 	SSLCA string `toml:"ssl_ca"`
@@ -41,6 +44,14 @@ var sampleConfig = `
   # password = ""
   ## NATS subject for producer messages
   subject = "telegraf"
+  ## The output_precision parameter can be used to specify the units that should
+  ## be used when creating timestamps and is only used when the data_format is
+  ## set to "json"; in that case valid values are "1ns", "1us" (or "1µs"), "1ms",
+  ## or "1s"; for the other supported data_format types, the precision will depend
+  ## on the data_format (seconds for "graphite" data, nanoseconds for "influx"
+  ## data); if unspecified, then the timestamps output with "json" data
+  ## will be in seconds
+  output_precision = ""
 
   ## Optional SSL Config
   # ssl_ca = "/etc/telegraf/ca.pem"
@@ -115,7 +126,7 @@ func (n *NATS) Write(metrics []telegraf.Metric) error {
 	}
 
 	for _, metric := range metrics {
-		buf, err := n.serializer.Serialize(metric)
+		buf, err := n.serializer.Serialize(metric, n.OutputPrecision)
 		if err != nil {
 			return err
 		}

--- a/plugins/outputs/nsq/nsq.go
+++ b/plugins/outputs/nsq/nsq.go
@@ -11,8 +11,12 @@ import (
 )
 
 type NSQ struct {
-	Server   string
-	Topic    string
+	Server string
+	Topic  string
+	// OutputPrecision string (parsed as a duration,
+	// only used for JSON output)
+	OutputPrecision string
+
 	producer *nsq.Producer
 
 	serializer serializers.Serializer
@@ -23,6 +27,14 @@ var sampleConfig = `
   server = "localhost:4150"
   ## NSQ topic for producer messages
   topic = "telegraf"
+  ## The output_precision parameter can be used to specify the units that should
+  ## be used when creating timestamps and is only used when the data_format is
+  ## set to "json"; in that case valid values are "1ns", "1us" (or "1µs"), "1ms",
+  ## or "1s"; for the other supported data_format types, the precision will depend
+  ## on the data_format (seconds for "graphite" data, nanoseconds for "influx"
+  ## data); if unspecified, then the timestamps output with "json" data
+  ## will be in seconds
+  output_precision = ""
 
   ## Data format to output.
   ## Each data format has it's own unique set of configuration options, read
@@ -66,7 +78,7 @@ func (n *NSQ) Write(metrics []telegraf.Metric) error {
 	}
 
 	for _, metric := range metrics {
-		buf, err := n.serializer.Serialize(metric)
+		buf, err := n.serializer.Serialize(metric, n.OutputPrecision)
 		if err != nil {
 			return err
 		}

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -20,7 +20,7 @@ type GraphiteSerializer struct {
 	Template string
 }
 
-func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
+func (s *GraphiteSerializer) Serialize(metric telegraf.Metric, output_precision ...string) ([]byte, error) {
 	out := []byte{}
 
 	// Convert UnixNano to Unix timestamps

--- a/plugins/serializers/influx/influx.go
+++ b/plugins/serializers/influx/influx.go
@@ -7,6 +7,6 @@ import (
 type InfluxSerializer struct {
 }
 
-func (s *InfluxSerializer) Serialize(m telegraf.Metric) ([]byte, error) {
+func (s *InfluxSerializer) Serialize(m telegraf.Metric, output_precision ...string) ([]byte, error) {
 	return m.Serialize(), nil
 }

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	ejson "encoding/json"
+	"time"
 
 	"github.com/influxdata/telegraf"
 )
@@ -9,12 +10,31 @@ import (
 type JsonSerializer struct {
 }
 
-func (s *JsonSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
+func (s *JsonSerializer) Serialize(metric telegraf.Metric, output_precision ...string) ([]byte, error) {
+	// if no duration is specified, or if the output_precision value passed
+	// in represents a duration that is not greater than zero, then default
+	// to an output resolution for our timestamp values of 1 second (timestamps
+	// will be returned to the nearest second)
+	default_val := "1s"
+	var output_resolution time.Duration
+	if len(output_precision) > 0 && len(output_precision[0]) > 0 {
+		parsed_val, err := time.ParseDuration(output_precision[0])
+		if err != nil {
+			return nil, err
+		}
+		if parsed_val > 0.0 {
+			output_resolution = parsed_val
+		} else {
+			output_resolution, _ = time.ParseDuration(default_val)
+		}
+	} else {
+		output_resolution, _ = time.ParseDuration(default_val)
+	}
 	m := make(map[string]interface{})
 	m["tags"] = metric.Tags()
 	m["fields"] = metric.Fields()
 	m["name"] = metric.Name()
-	m["timestamp"] = metric.UnixNano() / 1000000000
+	m["timestamp"] = metric.UnixNano() / output_resolution.Nanoseconds()
 	serialized, err := ejson.Marshal(m)
 	if err != nil {
 		return []byte{}, err

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -21,7 +21,7 @@ type Serializer interface {
 	// Serialize takes a single telegraf metric and turns it into a byte buffer.
 	// separate metrics should be separated by a newline, and there should be
 	// a newline at the end of the buffer.
-	Serialize(metric telegraf.Metric) ([]byte, error)
+	Serialize(metric telegraf.Metric, output_precision ...string) ([]byte, error)
 }
 
 // Config is a struct that covers the data types needed for all serializer types,


### PR DESCRIPTION
Resolves #2124 

The changes in this pull request add a new `output_precision` configuration parameter to the output plugins that utilize the `Serializer` interface to send `influx`, `graphite`, or `json` formatted data to various outputs (`amqp`, `file`, `kafka`, `mqtt`, `nats`, and `nsq`).

The format used to specify this precision value is the same format that is used to specify the precision of the timestamps used with the metrics collected by the agent (values like `"1ns"`, `"1us"`, `"1ms"` and `"1s"` are all supported), and the documentation in the comments for
the current Agent `precision` configuration parameter was changed a bit to reflect the real
value that should be set if you want to measure timestamps in times other than seconds
(choosing a value of `"ns"` for this parameter results in a precision of `0ns`, which is then
treated like a precision of `1s` by the code since `1s` is the default in the case where a
precision value was not specified).

The changes that are made in this pull request will only effect the output of data in a `json`
data_format (the timestamps for the `graphite` and `influx` data_formats remain as they were after this pull request is merged, with the timestamps returned in the `graphite` data_format having a fixed precision of `1s` and timestamps for the the `influx` data_format having a fixed precision of `1ns`, as they always have), and the outputs that use the `Serialize` method to output data in a `json` data_format are the only outputs that have been changed.  As was stated earlier, using this new code with an existing `telegraf.conf` file (where this new configuration parameter is not specified for any of those outputs) will result in the same behavior that is seen currently (where all data in a `json` data_format is output with timestamps that have been truncated to the nearest second, regardless of the precision with which they were measured).

The following output shows the result of these changes when an `output_precision` value is not specified in the configuration file for a `file` output with a `json` data_format (the equivalent to the current released behavior of the telegraf agent), in which case a default value of one second is used:
```bash
$ telegraf --config telegraf-sys-file.conf
2016-12-08T03:11:59Z I! Starting Telegraf (version dev-42-g7a1a91d)
2016-12-08T03:11:59Z I! Loaded outputs: file
2016-12-08T03:11:59Z I! Loaded inputs: inputs.system
2016-12-08T03:11:59Z I! Tags enabled: host=Toms-MacBook-Pro.local
2016-12-08T03:11:59Z I! Agent Config: Interval:10s, Quiet:false, Hostname:"Toms-MacBook-Pro.local", Flush Interval:10s
{"fields":{"load1":1.74,"load15":1.55,"load5":1.61,"n_cpus":8,"n_users":9},"name":"system","tags":{"host":"Toms-MacBook-Pro.local"},"timestamp":1481166720}
{"fields":{"uptime":2662650,"uptime_format":"30 days, 19:37"},"name":"system","tags":{"host":"Toms-MacBook-Pro.local"},"timestamp":1481166720}
{"fields":{"load1":1.63,"load15":1.54,"load5":1.59,"n_cpus":8,"n_users":9},"name":"system","tags":{"host":"Toms-MacBook-Pro.local"},"timestamp":1481166730}
{"fields":{"uptime":2662660,"uptime_format":"30 days, 19:37"},"name":"system","tags":{"host":"Toms-MacBook-Pro.local"},"timestamp":1481166730}
^C2016-12-08T03:12:48Z I! Hang on, flushing any cached metrics before shutdown

$ 
```
And this output shows the result when an `output_precision` value is specified, with the value chosen set to `1ns` (so that the timestamps are output in nanosecond precision):
```bash
$ telegraf --config telegraf-sys-file-1ns.conf
2016-12-08T03:12:24Z I! Starting Telegraf (version dev-42-g7a1a91d)
2016-12-08T03:12:24Z I! Loaded outputs: file
2016-12-08T03:12:24Z I! Loaded inputs: inputs.system
2016-12-08T03:12:24Z I! Tags enabled: host=Toms-MacBook-Pro.local
2016-12-08T03:12:24Z I! Agent Config: Interval:10s, Quiet:false, Hostname:"Toms-MacBook-Pro.local", Flush Interval:10s
{"fields":{"load1":1.86,"load15":1.56,"load5":1.64,"n_cpus":8,"n_users":9},"name":"system","tags":{"host":"Toms-MacBook-Pro.local"},"timestamp":1481166750050507703}
{"fields":{"uptime":2662680,"uptime_format":"30 days, 19:38"},"name":"system","tags":{"host":"Toms-MacBook-Pro.local"},"timestamp":1481166750050587563}
{"fields":{"load1":1.8,"load15":1.56,"load5":1.64,"n_cpus":8,"n_users":9},"name":"system","tags":{"host":"Toms-MacBook-Pro.local"},"timestamp":1481166760052514430}
{"fields":{"uptime":2662690,"uptime_format":"30 days, 19:38"},"name":"system","tags":{"host":"Toms-MacBook-Pro.local"},"timestamp":1481166760052566832}
^C2016-12-08T03:12:48Z I! Hang on, flushing any cached metrics before shutdown

$ 
```

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

