### PR TITLE
Adds a 'timestamp_units' configuration parameter

### DIFF
--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -4,9 +4,11 @@ import (
 	ejson "encoding/json"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
 )
 
 type JsonSerializer struct {
+	TimestampUnits internal.Duration
 }
 
 func (s *JsonSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
@@ -14,7 +16,7 @@ func (s *JsonSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 	m["tags"] = metric.Tags()
 	m["fields"] = metric.Fields()
 	m["name"] = metric.Name()
-	m["timestamp"] = metric.UnixNano() / 1000000000
+	m["timestamp"] = metric.UnixNano() / s.TimestampUnits.Duration.Nanoseconds()
 	serialized, err := ejson.Marshal(m)
 	if err != nil {
 		return []byte{}, err


### PR DESCRIPTION
Resolves #2124

The changes in this pull request add a new `timestamp_units` parameter to the agent configuration. This parameter only effects the timestamps output for the `json` data_format, and take the effect of a duration string (values like `1ns`, `1us`, `1ms` and `1s` are all supported).  If this parameter is not defined in the configuration file then the current behavior is preserved (the timestamps output as part of the `json` data_format are truncated to the nearest second).

The following output shows the effect of this parameter when it is unset (the current default) and when it is set to `1us` and `1ns` (so that the timestamps are output in microseconds and nanoseconds, respectively) for a configuration that is collecting `system` data to the default `file` output:
```bash
$ telegraf --config telegraf-sys-file.conf
2016-12-10T03:59:30Z I! Starting Telegraf (version dev-41-g4f6087a)
2016-12-10T03:59:30Z I! Loaded outputs: file
2016-12-10T03:59:30Z I! Loaded inputs: inputs.system
2016-12-10T03:59:30Z I! Tags enabled: host=Toms-MBP
2016-12-10T03:59:30Z I! Agent Config: Interval:10s, Quiet:false, Hostname:"Toms-MBP", Flush Interval:10s
{"fields":{"load1":1.8,"load15":1.55,"load5":1.59,"n_cpus":8,"n_users":8},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342380}
{"fields":{"uptime":2838305,"uptime_format":"32 days, 20:25"},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342380}
{"fields":{"load1":1.59,"load15":1.53,"load5":1.55,"n_cpus":8,"n_users":8},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342390}
{"fields":{"uptime":2838315,"uptime_format":"32 days, 20:25"},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342390}
^C2016-12-10T03:59:52Z I! Hang on, flushing any cached metrics before shutdown

$ telegraf --config telegraf-sys-file-1us.conf
2016-12-10T03:59:59Z I! Starting Telegraf (version dev-41-g4f6087a)
2016-12-10T03:59:59Z I! Loaded outputs: file
2016-12-10T03:59:59Z I! Loaded inputs: inputs.system
2016-12-10T03:59:59Z I! Tags enabled: host=Toms-MBP
2016-12-10T03:59:59Z I! Agent Config: Interval:10s, Quiet:false, Hostname:"Toms-MBP", Flush Interval:10s
{"fields":{"load1":1.58,"load15":1.53,"load5":1.55,"n_cpus":8,"n_users":8},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342400052393}
{"fields":{"uptime":2838325,"uptime_format":"32 days, 20:25"},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342400052466}
{"fields":{"load1":1.72,"load15":1.54,"load5":1.58,"n_cpus":8,"n_users":8},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342410057150}
{"fields":{"uptime":2838335,"uptime_format":"32 days, 20:25"},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342410057235}
^C2016-12-10T04:00:11Z I! Hang on, flushing any cached metrics before shutdown

$ telegraf --config telegraf-sys-file-1ns.conf
2016-12-10T04:00:15Z I! Starting Telegraf (version dev-41-g4f6087a)
2016-12-10T04:00:15Z I! Loaded outputs: file
2016-12-10T04:00:15Z I! Loaded inputs: inputs.system
2016-12-10T04:00:15Z I! Tags enabled: host=Toms-MBP
2016-12-10T04:00:15Z I! Agent Config: Interval:10s, Quiet:false, Hostname:"Toms-MBP", Flush Interval:10s
{"fields":{"load1":1.61,"load15":1.54,"load5":1.56,"n_cpus":8,"n_users":8},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342420052140075}
{"fields":{"uptime":2838345,"uptime_format":"32 days, 20:25"},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342420052209922}
{"fields":{"load1":1.6,"load15":1.53,"load5":1.56,"n_cpus":8,"n_users":8},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342430056069459}
{"fields":{"uptime":2838355,"uptime_format":"32 days, 20:25"},"name":"system","tags":{"host":"Toms-MBP"},"timestamp":1481342430056119581}
^C2016-12-10T04:00:31Z I! Hang on, flushing any cached metrics before shutdown

$
```

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

