### PR TITLE
Graylog output should set short_message field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [#1843](https://github.com/influxdata/telegraf/pull/1843) & [#1668](https://github.com/influxdata/telegraf/issues/1668): Add optional ability to define PID as a tag.
 - [#1730](https://github.com/influxdata/telegraf/issues/1730): Fix win_perf_counters not gathering non-English counters.
 - [#2061](https://github.com/influxdata/telegraf/issues/2061): Fix panic when file stat info cannot be collected due to permissions or other issue(s).
+- [#2045](https://github.com/influxdata/telegraf/issues/2045): Graylog output should set short_message field.
 
 ## v1.1.2 [2016-12-12]
 

--- a/plugins/outputs/graylog/README.md
+++ b/plugins/outputs/graylog/README.md
@@ -9,6 +9,6 @@ It requires a `servers` name.
 ```toml
 # Send telegraf metrics to graylog(s)
 [[outputs.graylog]]
-  ## Udp endpoint for your graylog instance.
+  ## UDP endpoint for your graylog instance(s).
   servers = ["127.0.0.1:12201", "192.168.1.1:12201"]
 ```

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -154,7 +154,7 @@ type Graylog struct {
 }
 
 var sampleConfig = `
-  ## Udp endpoint for your graylog instance.
+  ## UDP endpoint for your graylog instance.
   servers = ["127.0.0.1:12201", "192.168.1.1:12201"]
 `
 
@@ -213,7 +213,7 @@ func serialize(metric telegraf.Metric) ([]string, error) {
 	m := make(map[string]interface{})
 	m["version"] = "1.1"
 	m["timestamp"] = metric.UnixNano() / 1000000000
-	m["short_message"] = " "
+	m["short_message"] = "telegraf"
 	m["name"] = metric.Name()
 
 	if host, ok := metric.Tags()["host"]; ok {


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)

closes #2045