### PR TITLE
Update MySQL Readme to clarify connection string examples.

### DIFF
--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -25,8 +25,8 @@ This plugin gathers the statistic data from MySQL server
   ##  [username[:password]@][protocol[(address)]]/[?tls=[true|false|skip-verify]]
   ##  see https://github.com/go-sql-driver/mysql#dsn-data-source-name
   ##  e.g.
-  ##    db_user:passwd@tcp(127.0.0.1:3306)/?tls=false
-  ##    db_user@tcp(127.0.0.1:3306)/?tls=false
+  ##    servers = ["user:passwd@tcp(127.0.0.1:3306)/?tls=false"]
+  ##    servers = ["user@tcp(127.0.0.1:3306)/?tls=false"]
   #
   ## If no servers are specified, then localhost is used as the host.
   servers = ["tcp(127.0.0.1:3306)/"]

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -41,8 +41,8 @@ var sampleConfig = `
   ##  [username[:password]@][protocol[(address)]]/[?tls=[true|false|skip-verify]]
   ##  see https://github.com/go-sql-driver/mysql#dsn-data-source-name
   ##  e.g.
-  ##    db_user:passwd@tcp(127.0.0.1:3306)/?tls=false
-  ##    db_user@tcp(127.0.0.1:3306)/?tls=false
+  ##    servers = ["user:passwd@tcp(127.0.0.1:3306)/?tls=false"]
+  ##    servers = ["user@tcp(127.0.0.1:3306)/?tls=false"]
   #
   ## If no servers are specified, then localhost is used as the host.
   servers = ["tcp(127.0.0.1:3306)/"]


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)

The e.g. section did not have the "servers = " portion included but did have "db_" included. This confused me as I tried to use the mysql inputs plugin. I changed the look of the examples to include "servers =" and removed the "db_" so the examples now look like:
```servers = ["user:passwd@tcp(127.0.0.1:3306)/?tls=false"]```
```servers = ["user@tcp(127.0.0.1:3306)/?tls=false"]```
As opposed to the examples that had me confused which looked like:
```db_user:passwd@tcp(127.0.0.1:3306)/?tls=false```
```db_user@tcp(127.0.0.1:3306)/?tls=false```