### PR TITLE
Added more InnoDB metric to MySQL plugin

### DIFF
--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -8,6 +8,7 @@ This plugin gathers the statistic data from MySQL server
 * Binlog size
 * Process list
 * Info schema auto increment columns
+* InnoDB metrics
 * Table I/O waits
 * Index I/O waits
 * Perf Schema table lock waits
@@ -46,6 +47,9 @@ This plugin gathers the statistic data from MySQL server
   #
   ## gather auto_increment columns and max values from information schema
   gather_info_schema_auto_inc               = true
+  #
+  ## gather metrics from INFORMATION_SCHEMA.INNODB_METRICS
+  gather_innodb_metrics                     = true
   #
   ## gather metrics from SHOW SLAVE STATUS command output
   gather_slave_status                       = true
@@ -113,6 +117,7 @@ and process. It has following fields:
 for them. It has following fields:
     * auto_increment_column(int, number)
     * auto_increment_column_max(int, number)
+* InnoDB metrics - all metrics of information_schema.INNODB_METRICS with a status "enabled"
 * Perf table lock waits - gathers total number and time for SQL and external
 lock waits events for each table and operation. It has following fields.
 The unit of fields varies by the tags.


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Add more metrics from INFORMATION_SCHEMA.INNODB_METRICS. As other extended metrics of MySQL this is enalbed or not using gather_innodb_metrics option.