### PR TITLE
Fix for loop over value array range issue.

### DIFF
--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -73,7 +73,10 @@ func (s *systemPS) DiskUsage(
 	var usage []*disk.UsageStat
 	var partitions []*disk.PartitionStat
 
-	for _, p := range parts {
+	for i := range parts {
+
+		p := parts[i]
+
 		if len(mountPointFilter) > 0 {
 			// If the mount point is not a member of the filter set,
 			// don't gather info on it.


### PR DESCRIPTION
### Required for all PRs:

- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This loop is assigning a value to p then creating a pointer to it, as the value of p is switched for each loop iteration the result is all the pointers point to the last item.

This results in the value of the "device" in the disks plugin being the same as the last partition device. see https://github.com/Versent/telegraf/blob/fix_disk_by_value_loop/plugins/inputs/system/disk.go#L57


