### PR TITLE
Added the the option to include the AWS instance ID as a tag.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/config"
@@ -37,6 +39,17 @@ func NewAgent(config *config.Config) (*Agent, error) {
 		}
 
 		config.Tags["host"] = a.Config.Agent.Hostname
+	}
+
+	if a.Config.Agent.AWSInstanceID {
+		svc := ec2metadata.New(session.New())
+		if svc.Available() {
+			instanceid, err := svc.GetMetadata("instance-id")
+			if err != nil {
+				return nil, err
+			}
+			config.Tags["InstanceId"] = instanceid
+		}
 	}
 
 	return a, nil

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -65,6 +65,7 @@ be used for service inputs, such as logparser and statsd. Valid values are
 * **quiet**: Run telegraf in quiet mode (error messages only).
 * **hostname**: Override default hostname, if empty use os.Hostname().
 * **omit_hostname**: If true, do no set the "host" tag in the telegraf agent.
+* **aws_instance_id**: If true, query the AWS meta data API for the instance ID and add the "InstanceId" tag.
 
 ## Input Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,6 +139,9 @@ type AgentConfig struct {
 	Quiet        bool
 	Hostname     string
 	OmitHostname bool
+
+	// query the AWS instance ID using the metadata API
+	AWSInstanceID bool `toml:"aws_instance_id"`
 }
 
 // Inputs returns a list of strings of the configured inputs.


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)

When enabled feature includes the AWS `InstanceId` as a tag with your metrics.

We use this in preference to hostname when pushing  metrics to cloudwatch so they can be correlated with the inbuilt metrics which also use this tag.