### PR TITLE
Remove print call in cassandra plugin

### DIFF
--- a/plugins/inputs/cassandra/cassandra.go
+++ b/plugins/inputs/cassandra/cassandra.go
@@ -289,7 +289,6 @@ func (c *Cassandra) Gather(acc telegraf.Accumulator) error {
 				requestUrl.User = url.UserPassword(serverTokens["user"],
 					serverTokens["passwd"])
 			}
-			fmt.Printf("host %s url %s\n", serverTokens["host"], requestUrl)
 
 			out, err := c.getAttr(requestUrl)
 			if out["status"] != 200.0 {


### PR DESCRIPTION
Hi everyone,

I would like to update the cassandra plugin, why ?
Because if you are retrieving 50 metrics every 10 seconds, it cause a lot of logs for the service ( ie : journald ) 
- I think it is not usefull for performances (write into log). 
- It does not remove errors from being seen.
