### PR TITLE
Add lock option to the IPtables input plugin

### DIFF
--- a/plugins/inputs/iptables/README.md
+++ b/plugins/inputs/iptables/README.md
@@ -30,11 +30,17 @@ You may edit your sudo configuration with the following:
 telegraf ALL=(root) NOPASSWD: /usr/bin/iptables -nvL *
 ```
 
+### Using IPtables lock feature
+
+Defining multiple instances of this plugin in telegraf.conf can lead to concurrent IPtables access resulting in "ERROR in input [inputs.iptables]: exit status 4" messages in telegraf.log and missing metrics. Setting 'use_lock = true' in the plugin configuration will run IPtables with the '-w' switch, allowing a lock usage to prevent this error.
+
 ### Configuration:
 
 ```toml
   # use sudo to run iptables
   use_sudo = false
+  # run iptables with the lock option
+  use_lock = false
   # defines the table to monitor:
   table = "filter"
   # defines the chains to monitor:

--- a/plugins/inputs/iptables/iptables.go
+++ b/plugins/inputs/iptables/iptables.go
@@ -16,6 +16,7 @@ import (
 // Iptables is a telegraf plugin to gather packets and bytes throughput from Linux's iptables packet filter.
 type Iptables struct {
 	UseSudo bool
+	UseLock bool
 	Table   string
 	Chains  []string
 	lister  chainLister
@@ -32,8 +33,11 @@ func (ipt *Iptables) SampleConfig() string {
   ## iptables require root access on most systems.
   ## Setting 'use_sudo' to true will make use of sudo to run iptables.
   ## Users must configure sudo to allow telegraf user to run iptables with no password.
-  ## iptables can be restricted to only list command  "iptables -nvL"
+  ## iptables can be restricted to only list command  "iptables -nvL" or "iptables -wnvl" if using 'use_lock = true'
   use_sudo = false
+  ## Setting 'use_lock' to true will run iptables with xtables lock support.
+  ## This option is useful to avoid iptables concurrency errors when running multiple instances of this plugin.
+  use_lock = false
   ## defines the table to monitor:
   table = "filter"
   ## defines the chains to monitor:
@@ -75,7 +79,11 @@ func (ipt *Iptables) chainList(table, chain string) (string, error) {
 		name = "sudo"
 		args = append(args, iptablePath)
 	}
-	args = append(args, "-nvL", chain, "-t", table, "-x")
+	iptablesBaseArgs := "-nvL"
+	if ipt.UseLock {
+		iptablesBaseArgs = "-wnvL"
+	}
+	args = append(args, iptablesBaseArgs, chain, "-t", table, "-x")
 	c := exec.Command(name, args...)
 	out, err := c.Output()
 	return string(out), err

--- a/plugins/inputs/iptables/iptables.go
+++ b/plugins/inputs/iptables/iptables.go
@@ -33,10 +33,10 @@ func (ipt *Iptables) SampleConfig() string {
   ## iptables require root access on most systems.
   ## Setting 'use_sudo' to true will make use of sudo to run iptables.
   ## Users must configure sudo to allow telegraf user to run iptables with no password.
-  ## iptables can be restricted to only list command  "iptables -nvL" or "iptables -wnvl" if using 'use_lock = true'
+  ## iptables can be restricted to only list command "iptables -nvL"
   use_sudo = false
-  ## Setting 'use_lock' to true will run iptables with xtables lock support.
-  ## This option is useful to avoid iptables concurrency errors when running multiple instances of this plugin.
+  ## Setting 'use_lock' to true runs iptables with the "-w" option.
+  ## Adjust your sudo settings appropriately if using this option ("iptables -wnvl")
   use_lock = false
   ## defines the table to monitor:
   table = "filter"


### PR DESCRIPTION
This PR adds IPtables lock support to the input plugin, related to https://github.com/influxdata/telegraf/issues/2144

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] README.md updated (if adding a new plugin)
