### PR TITLE
http_response : Add in support for looking for substring in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ plugins, not just statsd.
 
 ### Features
 
+- [#2204](https://github.com/influxdata/telegraf/pull/2204): Extend http_response to support searching for a substring in response. Return 1 if found, else 0.
 - [#2123](https://github.com/influxdata/telegraf/pull/2123): Fix improper calculation of CPU percentages
 - [#1564](https://github.com/influxdata/telegraf/issues/1564): Use RFC3339 timestamps in log output.
 - [#1997](https://github.com/influxdata/telegraf/issues/1997): Non-default HTTP timeouts for RabbitMQ plugin.

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -23,6 +23,11 @@ This input plugin will test HTTP/HTTPS connections.
   # {'fake':'data'}
   # '''
 
+  ## Optional : Look for substring in body of the response
+  # response_string_match = "\"service_status\": \"up\""
+  #  or
+  # response_string_match = "ok"
+
   ## Optional SSL Config
   # ssl_ca = "/etc/telegraf/ca.pem"
   # ssl_cert = "/etc/telegraf/cert.pem"

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -23,10 +23,10 @@ This input plugin will test HTTP/HTTPS connections.
   # {'fake':'data'}
   # '''
 
-  ## Optional : Look for substring in body of the response
-  # response_string_match = "\"service_status\": \"up\""
-  #  or
-  # response_string_match = "ok"
+  ## Optional substring or regex match in body of the response
+  ## response_string_match = "\"service_status\": \"up\""
+  ## response_string_match = "ok"
+  ## response_string_match = "\".*_status\".?:.?\"up\""
 
   ## Optional SSL Config
   # ssl_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -148,17 +149,19 @@ func (h *HTTPResponse) HTTPGather() (map[string]interface{}, error) {
 
 	// Check the response for a regex match
 	if h.ResponseStringMatch != "" {
-		regex, compile_err := regexp.Compile(h.ResponseStringMatch)
-		if compile_err != nil {
+		regex, err := regexp.Compile(h.ResponseStringMatch)
+		if err != nil {
+			log.Printf("E! Failed to compile regular expression %s : %s", h.ResponseStringMatch, err)
 			fields["response_string_match"] = 0
-		}
-
-		bodyBytes, _ := ioutil.ReadAll(resp.Body)
-		bodyString := string(bodyBytes)
-		if regex.MatchString(bodyString) {
-			fields["response_string_match"] = 1
 		} else {
-			fields["response_string_match"] = 0
+
+			bodyBytes, _ := ioutil.ReadAll(resp.Body)
+			bodyString := string(bodyBytes)
+			if regex.MatchString(bodyString) {
+				fields["response_string_match"] = 1
+			} else {
+				fields["response_string_match"] = 0
+			}
 		}
 	}
 

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -338,30 +338,3 @@ func TestTimeout(t *testing.T) {
 	_, err := h.HTTPGather()
 	require.Error(t, err)
 }
-
-func TestStringRegexMatch(t *testing.T) {
-	mux := setUpTestMux()
-	ts := httptest.NewServer(mux)
-	defer ts.Close()
-
-	h := &HTTPResponse{
-		Address:             ts.URL + "/jsonresponse",
-		Body:                "{ 'test': 'data'}",
-		Method:              "GET",
-		ResponseStringMatch: "\".*_status\".?:.?\"up\"",
-		ResponseTimeout:     internal.Duration{Duration: time.Second * 20},
-		Headers: map[string]string{
-			"Content-Type": "application/json",
-		},
-		FollowRedirects: true,
-	}
-	fields, err := h.HTTPGather()
-	require.NoError(t, err)
-	assert.NotEmpty(t, fields)
-	if assert.NotNil(t, fields["http_response_code"]) {
-		assert.Equal(t, http.StatusOK, fields["http_response_code"])
-	}
-	assert.Equal(t, 1, fields["response_string_match"])
-	assert.NotNil(t, fields["response_time"])
-
-}

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -22,6 +22,9 @@ func setUpTestMux() http.Handler {
 	mux.HandleFunc("/good", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "hit the good page!")
 	})
+	mux.HandleFunc("/jsonresponse", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "\"service_status\": \"up\"")
+	})
 	mux.HandleFunc("/badredirect", func(w http.ResponseWriter, req *http.Request) {
 		http.Redirect(w, req, "/badredirect", http.StatusMovedPermanently)
 	})
@@ -234,6 +237,87 @@ func TestBody(t *testing.T) {
 	if assert.NotNil(t, fields["http_response_code"]) {
 		assert.Equal(t, http.StatusBadRequest, fields["http_response_code"])
 	}
+}
+
+func TestStringMatch(t *testing.T) {
+	mux := setUpTestMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	h := &HTTPResponse{
+		Address:             ts.URL + "/good",
+		Body:                "{ 'test': 'data'}",
+		Method:              "GET",
+		ResponseStringMatch: "hit the good page",
+		ResponseTimeout:     internal.Duration{Duration: time.Second * 20},
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		FollowRedirects: true,
+	}
+	fields, err := h.HTTPGather()
+	require.NoError(t, err)
+	assert.NotEmpty(t, fields)
+	if assert.NotNil(t, fields["http_response_code"]) {
+		assert.Equal(t, http.StatusOK, fields["http_response_code"])
+	}
+	assert.Equal(t, 1, fields["response_string_match"])
+	assert.NotNil(t, fields["response_time"])
+
+}
+
+func TestStringMatchJson(t *testing.T) {
+	mux := setUpTestMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	h := &HTTPResponse{
+		Address:             ts.URL + "/jsonresponse",
+		Body:                "{ 'test': 'data'}",
+		Method:              "GET",
+		ResponseStringMatch: "\"service_status\": \"up\"",
+		ResponseTimeout:     internal.Duration{Duration: time.Second * 20},
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		FollowRedirects: true,
+	}
+	fields, err := h.HTTPGather()
+	require.NoError(t, err)
+	assert.NotEmpty(t, fields)
+	if assert.NotNil(t, fields["http_response_code"]) {
+		assert.Equal(t, http.StatusOK, fields["http_response_code"])
+	}
+	assert.Equal(t, 1, fields["response_string_match"])
+	assert.NotNil(t, fields["response_time"])
+
+}
+
+func TestStringMatchFail(t *testing.T) {
+	mux := setUpTestMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	h := &HTTPResponse{
+		Address:             ts.URL + "/good",
+		Body:                "{ 'test': 'data'}",
+		Method:              "GET",
+		ResponseStringMatch: "hit the bad page",
+		ResponseTimeout:     internal.Duration{Duration: time.Second * 20},
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		FollowRedirects: true,
+	}
+	fields, err := h.HTTPGather()
+	require.NoError(t, err)
+	assert.NotEmpty(t, fields)
+	if assert.NotNil(t, fields["http_response_code"]) {
+		assert.Equal(t, http.StatusOK, fields["http_response_code"])
+	}
+	assert.Equal(t, 0, fields["response_string_match"])
+	assert.NotNil(t, fields["response_time"])
+
 }
 
 func TestTimeout(t *testing.T) {


### PR DESCRIPTION
When hitting a HTTP health_check it will return a valid HTTP status but will have an "healthy" or "un-healthy" message in the response. I've extended http_response to allow to specify a substring to search for in the HTTP response and return a metric of 1 if found, 0 if not. This would allow the metric to be passed or be pulled by monitoring.

### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] README.md updated (if adding a new plugin)
