### PR TITLE
Doc error - Changed config example for SNMP plugin

### DIFF
--- a/plugins/inputs/snmp/CONFIG-EXAMPLES.md
+++ b/plugins/inputs/snmp/CONFIG-EXAMPLES.md
@@ -25,7 +25,7 @@ Here is the configuration that you add to your `telegraf.conf`:
 
   [[inputs.snmp.field]]
     name = "uptime"
-    oid = "DISMAN-EXPRESSION-MIB::sysUpTimeInstance"
+    oid = "DISMAN-EVENT-MIB::sysUpTimeInstance"
 
   # IF-MIB::ifTable contains counters on input and output traffic as well as errors and discards.
   [[inputs.snmp.table]]


### PR DESCRIPTION
Fixing documentation error.  Changed from `DISMAN-EXPRESSION-MIB::sysUpTime` to `DISMAN-EVENT-MIB::sysUpTimeInstance`.

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)
