### PR TITLE
Added conversion = "watts". 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ plugins, not just statsd.
 - [#1942](https://github.com/influxdata/telegraf/pull/1942): Change Amazon Kinesis output plugin to use the built-in serializer plugins.
 - [#1980](https://github.com/influxdata/telegraf/issues/1980): Hide username/password from elasticsearch error log messages.
 - [#2097](https://github.com/influxdata/telegraf/issues/2097): Configurable HTTP timeouts in Jolokia plugin
+- [#2219](https://github.com/influxdata/telegraf/pull/2219): Add conversion="watts", convert SNMP values with W suffix to integer.
 
 ### Bugfixes
 

--- a/plugins/inputs/snmp/README.md
+++ b/plugins/inputs/snmp/README.md
@@ -148,7 +148,7 @@ If not specified, it defaults to the value of `oid`. If `oid` is numeric, an att
 * `is_tag`:
 Output this field as a tag.
 
-* `conversion`: Values: `"float(X)"`,`"float"`,`"int"`,`""`. Default: `""`
+* `conversion`: Values: `"watts"`,`"float(X)"`,`"float"`,`"int"`,`""`. Default: `""`
 Converts the value according to the given specification.
 
     - `float(X)`: Converts the input value into a float and divides by the Xth power of 10. Efficively just moves the decimal left X places. For example a value of `123` with `float(2)` will result in `1.23`.
@@ -156,6 +156,7 @@ Converts the value according to the given specification.
     - `int`: Convertes the value into an integer.
     - `hwaddr`: Converts the value to a MAC address.
     - `ipaddr`: Converts the value to an IP address.
+    - `watts`: Converts the value with W suffix to integer.
 
 #### Table parameters:
 * `oid`:

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -683,6 +683,7 @@ func (s *Snmp) getConnection(agent string) (snmpConnection, error) {
 //  "hwaddr" will convert the value into a MAC address.
 //  "ipaddr" will convert the value into into an IP address.
 //  "" will convert a byte slice into a string.
+//  "watts" will convert string with W suffix to integer.
 func fieldConvert(conv string, v interface{}) (interface{}, error) {
 	if conv == "" {
 		if bs, ok := v.([]byte); ok {
@@ -793,6 +794,18 @@ func fieldConvert(conv string, v interface{}) (interface{}, error) {
 			return nil, fmt.Errorf("invalid length (%d) for ipaddr conversion", len(ipbs))
 		}
 
+		return v, nil
+	}
+
+	if conv == "watts" {
+		switch vt := v.(type) {
+		case []byte:
+			v, _ = strconv.Atoi(strings.TrimSuffix(string(vt), "W"))
+		case string:
+			v, _ = strconv.Atoi(strings.TrimSuffix(vt, "W"))
+		default:
+			return nil, fmt.Errorf("invalid type (%T) for watts conversion", v)
+		}
 		return v, nil
 	}
 

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -637,6 +637,8 @@ func TestFieldConvert(t *testing.T) {
 		{[]byte("abcd"), "ipaddr", "97.98.99.100"},
 		{"abcd", "ipaddr", "97.98.99.100"},
 		{[]byte("abcdefghijklmnop"), "ipaddr", "6162:6364:6566:6768:696a:6b6c:6d6e:6f70"},
+		{[]byte("123W"), "watts", int64(123)},
+		{"321W", "watts", int64(321)},
 	}
 
 	for _, tc := range testTable {


### PR DESCRIPTION
This will convert snmp strings with W suffix to integer. 
IBM BladeCenter H will return power values as string with W
suffix, this will convert them to integers for later analysis and
monitoring.

Fixes issue #2211 
