### PR TITLE
Fix for broken librato output

### DIFF
--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -17,8 +17,8 @@ import (
 
 // Librato structure for configuration and client
 type Librato struct {
-	APIUser   string toml:"api_user"
-	APIToken  string toml:"api_token"
+	APIUser   string `toml:"api_user"`
+	APIToken  string `toml:"api_token"`
 	Debug     bool
 	SourceTag string // Deprecated, keeping for backward-compatibility
 	Timeout   internal.Duration

--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -17,8 +17,8 @@ import (
 
 // Librato structure for configuration and client
 type Librato struct {
-	APIUser   string
-	APIToken  string
+	APIUser   string toml:"api_user"
+	APIToken  string toml:"api_token"
 	Debug     bool
 	SourceTag string // Deprecated, keeping for backward-compatibility
 	Timeout   internal.Duration


### PR DESCRIPTION
These errors are delightful, but I'd rather avoid them:

```
Error parsing /etc/telegraf/telegraf.conf, line 2: field corresponding to `api_user' is not defined in `*librato.Librato'
```

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
