### PR TITLE
Added support to SNMP-plugin to strip any characters or space from SNMP

### DIFF
--- a/plugins/inputs/snmp/README.md
+++ b/plugins/inputs/snmp/README.md
@@ -157,6 +157,9 @@ Converts the value according to the given specification.
     - `hwaddr`: Converts the value to a MAC address.
     - `ipaddr`: Converts the value to an IP address.
 
+* `strip`:
+set it true if you want to strip any characters (a-z,A-Z and space) from snmp value before conversion to int or float.
+
 #### Table parameters:
 * `oid`:
 Automatically populates the table's fields using data from the MIB.


### PR DESCRIPTION
Added support to SNMP-plugin to strip any characters or space from SNMP value before conversion to int or float.

Fixes Issue #2211 

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] README.md updated (if adding a new plugin)
