### PR TITLE
Ceph: sample config should reflect actual defaults

### DIFF
--- a/plugins/inputs/ceph/README.md
+++ b/plugins/inputs/ceph/README.md
@@ -82,7 +82,7 @@ the cluster.  The currently supported commands are:
 
   ## Whether to gather statistics via ceph commands, requires ceph_user and ceph_config
   ## to be specified
-  gather_cluster_stats = true
+  gather_cluster_stats = false
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/ceph/ceph.go
+++ b/plugins/inputs/ceph/ceph.go
@@ -68,7 +68,7 @@ var sampleConfig = `
   gather_admin_socket_stats = true
 
   ## Whether to gather statistics via ceph commands
-  gather_cluster_stats = true
+  gather_cluster_stats = false
 `
 
 func (c *Ceph) SampleConfig() string {


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes the sample config for the ceph input plugin (source code & readme). Sample stated that, using default values, the plugin would gather cluster stats, whereas default config has that option disabled.
