### PR TITLE
Use whitelisted docker env variables as metric tags

### DIFF
--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -384,6 +384,10 @@ func (d FakeDockerClient) ContainerStats(ctx context.Context, containerID string
 	return stat, nil
 }
 
+func (d FakeDockerClient) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+	return types.ContainerJSON{}, nil
+}
+
 func TestDockerGatherInfo(t *testing.T) {
 	var acc testutil.Accumulator
 	client := FakeDockerClient{}


### PR DESCRIPTION
We want to group container metrics of marathon applications in our DC/OS environment.
Mesos/Marathon exposes some marathon specific metadata as environment variables (mainly MESOS_TASK_ID, MARATHON_APP_ID, MARATHON_APP_VERSION) and this allows us to create metric dashboards for specific marathon apps.

I actually [copied the idea from cAdvisor](https://github.com/google/cadvisor/blob/v0.24.1/container/docker/factory.go#L51), but having the same feature in telegraf could save us from maintaining a new component (cAdvisor) on all nodes. Also current cAdvisor feature not yet working with influxdb storage: https://github.com/google/cadvisor/pull/1427

I'm new in go, so please comment if something seems wrong. (I also signed the [CLA](https://influxdata.com/community/cla/))

I'm not sure about how to implement tests for this particular feature. I thought it would be similar to docker label as metrics tags, but that as well doesn't seem like have tests. Adding test doesn't seem trivial.