### PR TITLE
allow changing jolokia delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ plugins, not just statsd.
 - [#1942](https://github.com/influxdata/telegraf/pull/1942): Change Amazon Kinesis output plugin to use the built-in serializer plugins.
 - [#1980](https://github.com/influxdata/telegraf/issues/1980): Hide username/password from elasticsearch error log messages.
 - [#2097](https://github.com/influxdata/telegraf/issues/2097): Configurable HTTP timeouts in Jolokia plugin
+- [#2255](https://github.com/influxdata/telegraf/pull/2255): Allow changing jolokia attribute delimiter
 
 ### Bugfixes
 

--- a/plugins/inputs/jolokia/jolokia_test.go
+++ b/plugins/inputs/jolokia/jolokia_test.go
@@ -104,9 +104,10 @@ func (c jolokiaClientStub) MakeRequest(req *http.Request) (*http.Response, error
 //     *HttpJson: Pointer to an HttpJson object that uses the generated mock HTTP client
 func genJolokiaClientStub(response string, statusCode int, servers []Server, metrics []Metric) *Jolokia {
 	return &Jolokia{
-		jClient: jolokiaClientStub{responseBody: response, statusCode: statusCode},
-		Servers: servers,
-		Metrics: metrics,
+		jClient:   jolokiaClientStub{responseBody: response, statusCode: statusCode},
+		Servers:   servers,
+		Metrics:   metrics,
+		Delimiter: "_",
 	}
 }
 


### PR DESCRIPTION
### Required for all PRs:

- [X] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This allows changing the delimiter jolokia uses for concatenating metric names & attribute keys. It is very common for an attribute key to contain an underscore, thus using an underscore as the delimiter makes the field names rather ambiguous.

Personally I use a dot (`.`) as my delimiter, as it is very rare to see a dot in an attribute key, but I've been doing so by explicitly specifying each attribute as a separate `[inputs.jolokia.metric]`.