### PR TITLE
Improve win_perf_counters on non English systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ plugins, not just statsd.
 - [#1775](https://github.com/influxdata/telegraf/issues/1775): Cache & expire metrics for delivery to prometheus.
 - [#2146](https://github.com/influxdata/telegraf/issues/2146): Fix potential panic in aggregator plugin metric maker.
 - [#1843](https://github.com/influxdata/telegraf/pull/1843) & [#1668](https://github.com/influxdata/telegraf/issues/1668): Add optional ability to define PID as a tag.
-- [#1730](https://github.com/influxdata/telegraf/issues/1730): Fix win_perf_counters not gathering non-English counters.
+- [#1730](https://github.com/influxdata/telegraf/issues/1730) & [#2261](https://github.com/influxdata/telegraf/pull/2261): Fix win_perf_counters not gathering non-English counters.
 - [#2061](https://github.com/influxdata/telegraf/issues/2061): Fix panic when file stat info cannot be collected due to permissions or other issue(s).
 - [#2045](https://github.com/influxdata/telegraf/issues/2045): Graylog output should set short_message field.
 - [#1904](https://github.com/influxdata/telegraf/issues/1904): Hddtemp always put the value in the field temperature.


### PR DESCRIPTION
### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Another fix for #1730. This PR allows default configuration (with English names, like "Processor") to work on non-English Windows.

It re-add PreVistaSupport (as it use PdhAddEnglishCounter which existing only since Vista). It removes the validation using PdhValidatePath that only support localized names.

A validation is added by calling PdhCollectQueryData during configuration. This give fewer information than PdhValidatePath, it only say if the query exist or not. We no longer know if it was the object, instance or counter that does not exists.
