### PR TITLE
Added more Windows metrics

### DIFF
--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -105,10 +105,11 @@
       "% Privileged Time",
       "% User Time",
       "% Processor Time",
+      "% DPC Time",
     ]
     Measurement = "win_cpu"
     # Set to true to include _Total instance when querying for all (*).
-    #IncludeTotal=false
+    IncludeTotal=true
 
   [[inputs.win_perf_counters.object]]
     # Disk times and queues
@@ -118,12 +119,43 @@
       "% Idle Time",
       "% Disk Time","% Disk Read Time",
       "% Disk Write Time",
-      "% User Time",
       "Current Disk Queue Length",
+      "% Free Space",
+      "Free Megabytes",
     ]
     Measurement = "win_disk"
     # Set to true to include _Total instance when querying for all (*).
     #IncludeTotal=false
+
+  [[inputs.win_perf_counters.object]]
+    ObjectName = "PhysicalDisk"
+    Instances = ["*"]
+    Counters = [
+      "Disk Read Bytes/sec",
+      "Disk Write Bytes/sec",
+      "Current Disk Queue Length",
+      "Disk Reads/sec",
+      "Disk Writes/sec",
+      "% Disk Time",
+      "% Disk Read Time",
+      "% Disk Write Time",
+    ]
+    Measurement = "win_diskio"
+
+  [[inputs.win_perf_counters.object]]
+    ObjectName = "Network Interface"
+    Instances = ["*"]
+    Counters = [
+      "Bytes Received/sec",
+      "Bytes Sent/sec",
+      "Packets Received/sec",
+      "Packets Sent/sec",
+      "Packets Received Discarded",
+      "Packets Outbound Discarded",
+      "Packets Received Errors",
+      "Packets Outbound Errors",
+    ]
+    Measurement = "win_net"
 
   [[inputs.win_perf_counters.object]]
     ObjectName = "System"
@@ -131,6 +163,7 @@
       "Context Switches/sec",
       "System Calls/sec",
       "Processor Queue Length",
+      "System Up Time",
     ]
     Instances = ["------"]
     Measurement = "win_system"
@@ -150,12 +183,41 @@
       "Transition Faults/sec",
       "Pool Nonpaged Bytes",
       "Pool Paged Bytes",
+      "Standby Cache Reserve Bytes",
+      "Standby Cache Normal Priority Bytes",
+      "Standby Cache Core Bytes",
+
     ]
     # Use 6 x - to remove the Instance bit from the query.
     Instances = ["------"]
     Measurement = "win_mem"
     # Set to true to include _Total instance when querying for all (*).
     #IncludeTotal=false
+
+  [[inputs.win_perf_counters.object]]
+    # Example query where the Instance portion must be removed to get data back,
+    # such as from the Paging File object.
+    ObjectName = "Paging File"
+    Counters = [
+      "% Usage",
+    ]
+    Instances = ["_Total"]
+    Measurement = "win_swap"
+
+  [[inputs.win_perf_counters.object]]
+    ObjectName = "Network Interface"
+    Instances = ["*"]
+    Counters = [
+      "Bytes Sent/sec",
+      "Bytes Received/sec",
+      "Packets Sent/sec",
+      "Packets Received/sec",
+      "Packets Received Discarded",
+      "Packets Received Errors",
+      "Packets Outbound Discarded",
+      "Packets Outbound Errors",
+    ]
+
 
 
 # Windows system plugins using WMI (disabled by default, using


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Add more metrics in default Windows configuration. I trying to retrieve same metrics as a default Unix configuration.

* Processor: % DPC Time: seems to match softirq
* Memory: At least on Windows 7, the sum of the three Standby Cache match what task manager call "Cached"
* % User time is removed from LogicalDisk. It does not exists on Windows 7 and I suspect a copy/paste from Processor

Other entry should be clear enough. Tested this configuration on a Windows 7 (localized in French, so #2261 included) with FailOnMissing=true. Worked and all metrics were present. 