### PR TITLE
32-bit binary for windows and freebsd

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -83,9 +83,9 @@ targets = {
 }
 
 supported_builds = {
-    "windows": [ "amd64" ],
+    "windows": [ "amd64", "i386" ],
     "linux": [ "amd64", "i386", "armhf", "armel", "arm64", "static_amd64" ],
-    "freebsd": [ "amd64" ]
+    "freebsd": [ "amd64", "i386" ]
 }
 
 supported_packages = {


### PR DESCRIPTION
closes #1346
closes #2218

with this PR the next release will include 32-bit binaries for Windows and FreeBSD

### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)
