### PR TITLE
Optional "ticker" field for logparser plugin

### DIFF
--- a/plugins/inputs/logparser/README.md
+++ b/plugins/inputs/logparser/README.md
@@ -35,6 +35,13 @@ regex patterns.
     ## Custom patterns can also be defined here. Put one pattern per line.
     custom_patterns = '''
     '''
+    # This will enrich the measurement with a field with the preset name
+    # and a constant numeric value (one). 
+    # This is helpful when using custom log patterns on log lines that do
+    # not parse numerical fields and only the acknowledgemnt of the matched 
+    # tags is necessary, thus acting as a simple tick.
+    # Optional, adds the tick if the property is not empty.
+    tick_field = "count"
 ```
 
 ## Grok Parser

--- a/plugins/inputs/logparser/grok/grok.go
+++ b/plugins/inputs/logparser/grok/grok.go
@@ -69,6 +69,7 @@ type Parser struct {
 	CustomPatterns     string
 	CustomPatternFiles []string
 	Measurement        string
+	TickField          string
 
 	// typeMap is a map of patterns -> capture name -> modifier,
 	//   ie, {
@@ -149,6 +150,13 @@ func (p *Parser) Compile() error {
 	}
 
 	return p.compileCustomPatterns()
+}
+
+func (p *Parser) enrichTick(fields map[string]interface{}) map[string]interface{} {
+	if p.TickField != "" {
+		fields[p.TickField] = 1
+	}
+	return fields
 }
 
 func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
@@ -281,7 +289,7 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 		}
 	}
 
-	return metric.New(p.Measurement, tags, fields, p.tsModder.tsMod(timestamp))
+	return metric.New(p.Measurement, tags, p.enrichTick(fields), p.tsModder.tsMod(timestamp))
 }
 
 func (p *Parser) addCustomPatterns(scanner *bufio.Scanner) {

--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -66,6 +66,13 @@ const sampleConfig = `
     ## Custom patterns can also be defined here. Put one pattern per line.
     custom_patterns = '''
     '''
+	# This will enrich the measurement with a field with the preset name
+	# and a constant numeric value (one). 
+	# This is helpful when using custom log patterns on log lines that do
+	# not parse numerical fields and only the acknowledgemnt of the matched 
+	# tags is necessary, thus acting as a simple tick.
+	# Optional, adds the tick if the property is not empty.
+	tick_field = "count"
 `
 
 func (l *LogParserPlugin) SampleConfig() string {


### PR DESCRIPTION
This change adds an optional numeric field with settable field name.
It's applicable when using custom logging patterns to detect the existence of certain non-numeric text patterns (turned into tags), whose log lines do not have content to extract any usable fields.

Please let me know if there's anything I can add or need to change - naming, etc.

