### PR TITLE
Keep -config-directory when running as Windows service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2137](https://github.com/influxdata/telegraf/pull/2137): Added userstats to mysql input plugin.
 - [#2179](https://github.com/influxdata/telegraf/pull/2179): Added more InnoDB metric to MySQL plugin.
 - [#2251](https://github.com/influxdata/telegraf/pull/2251): InfluxDB output: use own client for improved through-put and less allocations.
+- [#2330](https://github.com/influxdata/telegraf/pull/2330): Keep -config-directory when running as Windows service.
 
 ### Bugfixes
 

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -327,6 +327,9 @@ func main() {
 			if *fConfig != "" {
 				(*svcConfig).Arguments = []string{"-config", *fConfig}
 			}
+			if *fConfigDirectory != "" {
+				(*svcConfig).Arguments = append((*svcConfig).Arguments, "-config-directory", *fConfigDirectory)
+			}
 			err := service.Control(s, *fService)
 			if err != nil {
 				log.Fatal("E! " + err.Error())


### PR DESCRIPTION
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

When installing a Windows service, the "-config" option is kept. But "-config-directory" was not kept.

The PR handle "-config-directory" the same way as "-config" and keep the value used when installing the service and when running the service.