### PR TITLE
Kubernetes input: Handle null startTime for stopped pods

### DIFF
--- a/plugins/inputs/kubernetes/kubernetes_metrics.go
+++ b/plugins/inputs/kubernetes/kubernetes_metrics.go
@@ -45,7 +45,7 @@ type CPUMetrics struct {
 // PodMetrics contains metric data on a given pod
 type PodMetrics struct {
 	PodRef     PodReference       `json:"podRef"`
-	StartTime  time.Time          `json:"startTime"`
+	StartTime  *time.Time         `json:"startTime"`
 	Containers []ContainerMetrics `json:"containers"`
 	Network    NetworkMetrics     `json:"network"`
 	Volumes    []VolumeMetrics    `json:"volume"`

--- a/plugins/inputs/kubernetes/kubernetes_test.go
+++ b/plugins/inputs/kubernetes/kubernetes_test.go
@@ -93,6 +93,29 @@ func TestKubernetesStats(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "kubernetes_pod_container", fields, tags)
 
 	fields = map[string]interface{}{
+		"cpu_usage_nanocores":        int64(846503),
+		"cpu_usage_core_nanoseconds": int64(56507553554),
+		"memory_usage_bytes":         int64(0),
+		"memory_working_set_bytes":   int64(0),
+		"memory_rss_bytes":           int64(0),
+		"memory_page_faults":         int64(0),
+		"memory_major_page_faults":   int64(0),
+		"rootfs_available_bytes":     int64(0),
+		"rootfs_capacity_bytes":      int64(0),
+		"rootfs_used_bytes":          int64(0),
+		"logsfs_avaialble_bytes":     int64(0),
+		"logsfs_capacity_bytes":      int64(0),
+		"logsfs_used_bytes":          int64(0),
+	}
+	tags = map[string]string{
+		"node_name":      "node1",
+		"container_name": "stopped-container",
+		"namespace":      "foons",
+		"pod_name":       "stopped-pod",
+	}
+	acc.AssertContainsTaggedFields(t, "kubernetes_pod_container", fields, tags)
+
+	fields = map[string]interface{}{
 		"available_bytes": int64(7903948800),
 		"capacity_bytes":  int64(7903961088),
 		"used_bytes":      int64(12288),
@@ -282,6 +305,25 @@ var response = `
       "capacityBytes": 7903961088,
       "usedBytes": 8192,
       "name": "volume4"
+     }
+    ]
+   },
+   {
+    "podRef": {
+     "name": "stopped-pod",
+     "namespace": "foons",
+     "uid": "da7c1865-d67d-4688-b679-c485ed44b2aa"
+    },
+    "startTime": null,
+    "containers": [
+     {
+      "name": "stopped-container",
+      "startTime": "2016-09-26T18:46:43Z",
+      "cpu": {
+       "time": "2016-09-27T16:57:32Z",
+       "usageNanoCores": 846503,
+       "usageCoreNanoSeconds": 56507553554
+      }
      }
     ]
    }


### PR DESCRIPTION
Fixes #2287 - can't deserialise null `startTime` in Kubernetes responses for stopped pods.

Added a test which covers this scenario.

I can't see any usages of `PodMetrics.StartTime`, which I would normally also want to check for regressions from making `StartTime` a pointer. Please let me know if there's something else I should test.

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
