### PR TITLE
win_perf_counters: New option "Expand" expands wildcards in counter definitions.

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -121,6 +121,15 @@ It is a simple bool, if it is not set to true or included this is treaded as fal
 If this is set to true, the plugin will abort and end prematurely
 if any of the combinations of ObjectName/Instances/Counters are invalid.
 
+#### Expand
+*Optional*
+
+This key is optional, it is a simple bool.
+If it is not set to true or included it is treated as false.
+When the option is set to true Telegraf will expand wildcards "*"
+used in defintions of ObjectName/Instance/Counter.
+Read more about wildcards in https://msdn.microsoft.com/en-us/library/windows/desktop/aa372605(v=vs.85).aspx
+
 ## Examples
 
 ### Generic Queries


### PR DESCRIPTION
The change introduces a new a new option "Expand" to a definition of Windows counter which allows to expand wildcards in ObjectName, Instance and Counter.
Read "Remarks" in https://msdn.microsoft.com/en-us/library/windows/desktop/aa372605(v=vs.85).aspx about how the wildcards are expanded and how they can be used.

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ x] README.md updated (if adding a new plugin)
