### PR TITLE
win_perf_counters: Format errors reported by pdh.dll in human-readable format

### DIFF
--- a/plugins/inputs/win_perf_counters/pdh.go
+++ b/plugins/inputs/win_perf_counters/pdh.go
@@ -33,8 +33,11 @@
 package win_perf_counters
 
 import (
+	"fmt"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // Error codes
@@ -416,4 +419,14 @@ func UTF16PtrToString(s *uint16) string {
 		return ""
 	}
 	return syscall.UTF16ToString((*[1 << 29]uint16)(unsafe.Pointer(s))[0:])
+}
+
+func PdhFormatError(msgId uint32) string {
+	var flags uint32 = windows.FORMAT_MESSAGE_FROM_HMODULE | windows.FORMAT_MESSAGE_ARGUMENT_ARRAY | windows.FORMAT_MESSAGE_IGNORE_INSERTS
+	buf := make([]uint16, 300)
+	_, err := windows.FormatMessage(flags, uintptr(libpdhDll.Handle), msgId, 0, buf, nil)
+	if err == nil {
+		return fmt.Sprintf("%s", UTF16PtrToString(&buf[0]))
+	}
+	return fmt.Sprintf("(pdhErr=%d) %s", msgId, err.Error())
 }

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -174,7 +174,7 @@ func (m *Win_PerfCounters) ParseConfig(metrics *itemList) error {
 						}
 					} else {
 						if PerfObject.FailOnMissing || PerfObject.WarnOnMissing {
-							fmt.Printf("Invalid query: '%s'. Error: '%s'", query, err.Error())
+							fmt.Printf("Invalid query: '%s'. Error: %s", query, err.Error())
 						}
 						if PerfObject.FailOnMissing {
 							return err

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -12,7 +12,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-var sampleConfig string = `
+var sampleConfig = `
   ## By default this plugin returns basic CPU and Disk statistics.
   ## See the README file for more examples.
   ## Uncomment examples below or write your own as you see fit. If the system
@@ -124,8 +124,8 @@ func (m *Win_PerfCounters) AddItem(metrics *itemList, query string, objectName s
 	// Call PdhCollectQueryData one time to check existance of the counter
 	ret = PdhCollectQueryData(handle)
 	if ret != ERROR_SUCCESS {
-		ret = PdhCloseQuery(handle)
-		return errors.New("Invalid query for Performance Counters")
+		PdhCloseQuery(handle)
+		return errors.New(PdhFormatError(ret))
 	}
 
 	temp := &item{query, objectName, counter, instance, measurement,
@@ -174,7 +174,7 @@ func (m *Win_PerfCounters) ParseConfig(metrics *itemList) error {
 						}
 					} else {
 						if PerfObject.FailOnMissing || PerfObject.WarnOnMissing {
-							fmt.Printf("Invalid query: %s\n", query)
+							fmt.Printf("Invalid query: '%s'. Error: '%s'", query, err.Error())
 						}
 						if PerfObject.FailOnMissing {
 							return err
@@ -293,7 +293,8 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 				bufCount = 0
 				bufSize = 0
 			}
-
+		} else {
+			// handle error
 		}
 	}
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -293,8 +293,6 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 				bufCount = 0
 				bufSize = 0
 			}
-		} else {
-			// handle error
 		}
 	}
 


### PR DESCRIPTION
The change uses WinAPI call FormatMessage() to format errors reported by pdh.dll in human-readable format.
With the change user gets error messages, which make more sense:
Invalid query: '\.NET CLR Memory(xxx)\Large Object Heap size'. Error: No data to return.
The "No data to return" is the error message "deciphered" from error code by FormatMessage.

I wonder if we should also add an "else" branch on win_perf_counters.go:296 and report errors there?
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [ X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
