### PR TITLE
Increment gather_errors for all errors emitted by inputs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -157,7 +157,7 @@ func gatherWithTimeout(
 		select {
 		case err := <-done:
 			if err != nil {
-				log.Printf("E! ERROR in input [%s]: %s", input.Name(), err)
+				acc.AddError(err)
 			}
 			return
 		case <-ticker.C:


### PR DESCRIPTION
- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] ~~README.md updated (if adding a new plugin)~~

I'm not sure if the change made here is the correct way to go about this, but I figured a PR would be better way to start a discussion than an issue or groups post.

Most Telegraf input plugins don't currently seem to provide a metric that can be used to determine if the gather operation is running successfully. For example, the prometheus input plugin logs an error if given a target address that returns HTTP 401, but won't return any metrics. That makes it difficult to tell whether a particular Prometheus client is "up".

I'd thought of deploying http_response inputs alongside httpjson/prometheus inputs, but that's a fair bit of extra configuration and doesn't handle endpoints that return 200 but with invalid data, etc. Adding a new metric to the prometheus input was another option but it looks like some other plugins behave similarly and it would be nice to have a more generic solution.

Telegraf 1.2 added the internal plugin, which exposes an `internal_agent_gather_errors` metric. That seems like a reasonable thing to monitor, however as far as I can tell it's only incremented by the SNMP plugin. This PR aims to increment the metric whenever any input emits an error. This won't catch **all** errors, as quite a number of plugins handle and log errors internally. I can update those too, but that's probably best in a separate PR.