### PR TITLE
win_perf_counters: Handle "dynamic" counters with the new KeepAlive counter option

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -104,6 +104,25 @@ and you would also like all instances containg _Total returned,
 like "_Total", "0,_Total" and so on where applicable
 (Processor Information is one example).
 
+#### KeepAlive
+*Optional*
+
+This key is optional, it is a simple bool.
+If it is not set to true or included it is treated as false.
+By default Telegraf reads all counters definitions from the config file
+at start and looks if the specified counters do actually exist in the 
+system. If the given counter doesn't exist at the start time, then Telegraf
+ignores is and never collects from the counter.
+The flag allows to change the behaviour and tells Telegraf to poll existence
+of the counter periodically (each 10th collection interval). If Telegraf 
+founds the counter during the poll, then Telegraph will collect statistics from 
+the counter in the same way as from the rest of counters which were available
+from the Telegraf's start.
+The flag is useful for "dynamic" counters, which exists only for a certain period 
+of time: e.g. process-level counters (where Instance is a process name). If the 
+process will start after Telegraf's start, then you should specify KeepAlive=true
+for its counter(s).
+
 #### WarnOnMissing
 *Optional*
 


### PR DESCRIPTION
Hello,

The change introduces a new counter option KeepAlive which allows Telegraf to collect statistics from counters which don't exist at the moment of Telegraf start.

By default Telegraf reads all counters definitions from the config file
at start and looks if the specified counters do actually exist in the 
system. If the given counter doesn't exist at the start time, then Telegraf
ignores is and never collects from the counter.
The flag allows to change the behaviour and tells Telegraf to poll existence
of the counter periodically (each 10th collection interval). If Telegraf 
founds the counter during the poll, then Telegraph will collect statistics from 
the counter in the same way as from the rest of counters which were available
from the Telegraf's start.
The flag is useful for "dynamic" counters, which exists only for a certain period 
of time: e.g. process-level counters (where Instance is a process name). If the 
process will start after Telegraf's start, then you should specify KeepAlive=true
for its counter(s).

The change partially addresses #1291, and combined with #2336 it solves #1291 completly.

Technically my solution creates a dedicated goroutine which polls the KeepAlive counters. The main thread asks the goroutine to poll KeepAlive counters each 10th Gather call. Then the main thread incorporates results of the goroutine into the global list of counters. 
I have tested it with 11 KeepAlive counters and the goroutine spends 50ms on the poll in total. The main thread doesn't become blocked (well, it blocks only for sending the goroutine the command for polling, but the blocking is negligible). I didn't notice any spikes in CPU consumption by Telegraf.

Here is how I have tested my change:


- Configured my process-specific counter (process name is "xxx"): 

>     [[inputs.win_perf_counters.object]]
>     ObjectName = ".NET CLR Memory"
>     Instances = ["xxx"]
>     Counters = ["# Bytes in all Heaps", "# Gen 0 Collections", "# Gen 1 Collections", "# Gen 2 Collections", "# of Sink Blocks in use", "# Total committed Bytes", "% Time in GC", "Gen 0 heap size", "Gen 1 heap size", "Gen 2 heap size", "Large Object Heap size"]
>     Measurement = "bottleneck_clr_xx"
>     WarnOnMissing = true 
> 	KeepAlive = true

- Started Telegraf. My process "xxx" is not running, therefore Telegraf doesn't collect statistics from the given counters.
- Started my process "xxx"
- After 10 collection iterations the Telegraf has detected the xxx's counters and started to report statistics on them.
- I have stopped "xxx" and Telegraf stopped reporting statistics on the counters.
- Then I have started "xxx" again and then after 10 collection iterations Telegraf started to report statistics again.

Everything as expected.


### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x ] README.md updated (if adding a new plugin)
