### PR TITLE
docker engine-api library is deprecated(2071)

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -10,8 +10,8 @@ github.com/couchbase/gomemcached 4a25d2f4e1dea9ea7dd76dfd943407abf9b07d29
 github.com/couchbase/goutils 5823a0cbaaa9008406021dc5daf80125ea30bba6
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution fb0bebc4b64e3881cc52a2478d749845ed76d2a8
-github.com/docker/engine-api 4290f40c056686fcaa5c9caf02eac1dde9315adf
-github.com/docker/go-connections 9670439d95da2651d9dfc7acc5d2ed92d3f25ee6
+github.com/docker/docker/client f538c4bd3c203a4d49711fd7807cdd4bb4182e70
+github.com/docker/go-connections 7da10c8c50cad14494ec818dcdfb6506265c0086
 github.com/docker/go-units 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 github.com/eapache/go-resiliency b86b1ec0dd4209a588dc1285cdd471e73525c0b3
 github.com/eapache/go-xerial-snappy bb955e01b9346ac19dc29eb16586c90ded99a98c

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -13,8 +13,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/client"
-	"github.com/docker/engine-api/types"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -36,7 +36,7 @@ type Docker struct {
 type DockerClient interface {
 	Info(ctx context.Context) (types.Info, error)
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
-	ContainerStats(ctx context.Context, containerID string, stream bool) (io.ReadCloser, error)
+	ContainerStats(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error)
 }
 
 // KB, MB, GB, TB, PB...human friendly
@@ -251,8 +251,8 @@ func (d *Docker) gatherContainer(
 	if err != nil {
 		return fmt.Errorf("Error getting docker stats: %s", err.Error())
 	}
-	defer r.Close()
-	dec := json.NewDecoder(r)
+	defer r.Body.Close()
+	dec := json.NewDecoder(r.Body)
 	if err = dec.Decode(&v); err != nil {
 		if err == io.EOF {
 			return nil

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -9,8 +9,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/registry"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/influxdata/telegraf/testutil"
 
 	"github.com/stretchr/testify/require"
@@ -376,11 +376,12 @@ func (d FakeDockerClient) ContainerList(octx context.Context, options types.Cont
 	//#{e6a96c84ca91a5258b7cb752579fb68826b68b49ff957487695cd4d13c343b44 titilambert/snmpsim /bin/sh -c 'snmpsimd --agent-udpv4-endpoint=0.0.0.0:31161 --process-user=root --process-group=user' 1455724831 Up 4 hours [{31161 31161 udp 0.0.0.0}] 0 0 [/snmp] map[]}]2016/02/24 01:05:01 Gathered metrics, (3s interval), from 1 inputs in 1.233836656s
 }
 
-func (d FakeDockerClient) ContainerStats(ctx context.Context, containerID string, stream bool) (io.ReadCloser, error) {
+func (d FakeDockerClient) ContainerStats(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error) {
 	var stat io.ReadCloser
 	jsonStat := `{"read":"2016-02-24T11:42:27.472459608-05:00","memory_stats":{"stats":{},"limit":18935443456},"blkio_stats":{"io_service_bytes_recursive":[{"major":252,"minor":1,"op":"Read","value":753664},{"major":252,"minor":1,"op":"Write"},{"major":252,"minor":1,"op":"Sync"},{"major":252,"minor":1,"op":"Async","value":753664},{"major":252,"minor":1,"op":"Total","value":753664}],"io_serviced_recursive":[{"major":252,"minor":1,"op":"Read","value":26},{"major":252,"minor":1,"op":"Write"},{"major":252,"minor":1,"op":"Sync"},{"major":252,"minor":1,"op":"Async","value":26},{"major":252,"minor":1,"op":"Total","value":26}]},"cpu_stats":{"cpu_usage":{"percpu_usage":[17871,4959158,1646137,1231652,11829401,244656,369972,0],"usage_in_usermode":10000000,"total_usage":20298847},"system_cpu_usage":24052607520000000,"throttling_data":{}},"precpu_stats":{"cpu_usage":{"percpu_usage":[17871,4959158,1646137,1231652,11829401,244656,369972,0],"usage_in_usermode":10000000,"total_usage":20298847},"system_cpu_usage":24052599550000000,"throttling_data":{}}}`
 	stat = ioutil.NopCloser(strings.NewReader(jsonStat))
-	return stat, nil
+	containerStats := types.ContainerStats{Body: stat, OSType: "LINUX"}
+	return containerStats, nil
 }
 
 func TestDockerGatherInfo(t *testing.T) {


### PR DESCRIPTION
I have made the changes in code and test file and all tests are also passed
`go test -v *.go
=== RUN   TestDockerGatherContainerStats
--- PASS: TestDockerGatherContainerStats (0.00s)
=== RUN   TestDockerGatherInfo
--- PASS: TestDockerGatherInfo (0.00s)
PASS
ok      command-line-arguments  0.008s`

After adding my changes  following error was coming  `go install -ldflags \
        "-X main.version=dev-49-gc8cc01b -X main.commit=c8cc01b -X main.branch=master" ./...
 github.com/influxdata/telegraf/plugins/inputs/docker
plugins/inputs/docker/docker.go:103: cannot use c (type *client.Client) as type DockerClient in assignment:
        *client.Client does not implement DockerClient (wrong type for ContainerList method)
                have ContainerList("github.com/docker/docker/vendor/golang.org/x/net/context".Context, types.ContainerListOptions) ([]types.Container, error)
                want ContainerList("golang.org/x/net/context".Context, types.ContainerListOptions) ([]types.Container, error)
make: *** [build] Error 2`

This was because somewhere in code the vendor context was being referred and telegraf refers the vendor context in the first place. I renamed the folder, after wards make ran succesfully. I am new to go, couldn't get solution for that.



