### PR TITLE
added user privilege level setting to IPMI sensors

### DIFF
--- a/plugins/inputs/ipmi_sensor/README.md
+++ b/plugins/inputs/ipmi_sensor/README.md
@@ -34,7 +34,10 @@ The `server` tag will be made available when retrieving stats from remote server
 [[inputs.ipmi_sensor]]
   ## optionally specify the path to the ipmitool executable
   # path = "/usr/bin/ipmitool"
-  #
+  ##
+  ## optionally force session privilege level. Can be CALLBACK, USER, OPERATOR, ADMINISTRATOR
+  # privilege = "ADMINISTRATOR"
+  ##
   ## optionally specify one or more servers via a url matching
   ##  [username[:password]@][protocol[(address)]]
   ##  e.g.

--- a/plugins/inputs/ipmi_sensor/connection.go
+++ b/plugins/inputs/ipmi_sensor/connection.go
@@ -14,10 +14,12 @@ type Connection struct {
 	Password  string
 	Port      int
 	Interface string
+	Privilege string
 }
 
-func NewConnection(server string) *Connection {
+func NewConnection(server string, privilege string) *Connection {
 	conn := &Connection{}
+	conn.Privilege = privilege
 	inx1 := strings.Index(server, "@")
 	inx2 := strings.Index(server, "(")
 	inx3 := strings.Index(server, ")")
@@ -59,7 +61,9 @@ func (t *Connection) options() []string {
 	if t.Port != 0 {
 		options = append(options, "-p", strconv.Itoa(t.Port))
 	}
-
+	if t.Privilege != "" {
+		options = append(options, "-L", t.Privilege)
+	}
 	return options
 }
 

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -17,14 +17,18 @@ var (
 )
 
 type Ipmi struct {
-	path    string
-	Servers []string
+	Path      string
+	Privilege string
+	Servers   []string
 }
 
 var sampleConfig = `
   ## optionally specify the path to the ipmitool executable
   # path = "/usr/bin/ipmitool"
-  #
+  ##
+  ## optionally force session privilege level. Can be CALLBACK, USER, OPERATOR, ADMINISTRATOR
+  # privilege = "ADMINISTRATOR"
+  ##
   ## optionally specify one or more servers via a url matching
   ##  [username[:password]@][protocol[(address)]]
   ##  e.g.
@@ -44,7 +48,7 @@ func (m *Ipmi) Description() string {
 }
 
 func (m *Ipmi) Gather(acc telegraf.Accumulator) error {
-	if len(m.path) == 0 {
+	if len(m.Path) == 0 {
 		return fmt.Errorf("ipmitool not found: verify that ipmitool is installed and that ipmitool is in your PATH")
 	}
 
@@ -68,15 +72,13 @@ func (m *Ipmi) Gather(acc telegraf.Accumulator) error {
 func (m *Ipmi) parse(acc telegraf.Accumulator, server string) error {
 	opts := make([]string, 0)
 	hostname := ""
-
 	if server != "" {
-		conn := NewConnection(server)
+		conn := NewConnection(server, m.Privilege)
 		hostname = conn.Hostname
 		opts = conn.options()
 	}
-
 	opts = append(opts, "sdr")
-	cmd := execCommand(m.path, opts...)
+	cmd := execCommand(m.Path, opts...)
 	out, err := internal.CombinedOutputTimeout(cmd, time.Second*5)
 	if err != nil {
 		return fmt.Errorf("failed to run command %s: %s - %s", strings.Join(cmd.Args, " "), err, string(out))
@@ -149,7 +151,7 @@ func init() {
 	m := Ipmi{}
 	path, _ := exec.LookPath("ipmitool")
 	if len(path) > 0 {
-		m.path = path
+		m.Path = path
 	}
 	inputs.Add("ipmi_sensor", func() telegraf.Input {
 		return &m

--- a/plugins/inputs/ipmi_sensor/ipmi_test.go
+++ b/plugins/inputs/ipmi_sensor/ipmi_test.go
@@ -13,8 +13,9 @@ import (
 
 func TestGather(t *testing.T) {
 	i := &Ipmi{
-		Servers: []string{"USERID:PASSW0RD@lan(192.168.1.1)"},
-		path:    "ipmitool",
+		Servers:   []string{"USERID:PASSW0RD@lan(192.168.1.1)"},
+		Path:      "ipmitool",
+		Privilege: "USER",
 	}
 	// overwriting exec commands with mock commands
 	execCommand = fakeExecCommand
@@ -26,7 +27,7 @@ func TestGather(t *testing.T) {
 
 	assert.Equal(t, acc.NFields(), 266, "non-numeric measurements should be ignored")
 
-	conn := NewConnection(i.Servers[0])
+	conn := NewConnection(i.Servers[0], i.Privilege)
 	assert.Equal(t, "USERID", conn.Username)
 	assert.Equal(t, "lan", conn.Interface)
 
@@ -118,7 +119,7 @@ func TestGather(t *testing.T) {
 	}
 
 	i = &Ipmi{
-		path: "ipmitool",
+		Path: "ipmitool",
 	}
 
 	err = i.Gather(&acc)


### PR DESCRIPTION
Proposed fix for #2284 
This allows using an unprivileged user for gathering remote IPMI sensor stats.
<pre>ipmitool -H host -U user -P password <b>-L privilege_level</b> -I lan sdr</pre>

Also, setting the path for `ipmitool` was broken because of capitalization?
`field corresponding to 'path' is not defined in '*ipmi_sensor.Ipmi'`
I think I fixed that, too.

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated