### PR TITLE
Fix setting the username and the password to the influxdb output.

### DIFF
--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -112,6 +112,8 @@ func (i *InfluxDB) Connect() error {
 				Timeout:   i.Timeout.Duration,
 				TLSConfig: tlsConfig,
 				UserAgent: i.UserAgent,
+				Username:  i.Username,
+				Password:  i.Password,
 			}
 			wp := client.WriteParams{
 				Database:        i.Database,


### PR DESCRIPTION
HI,

I tested the HEAD version of telegraf, and I could not connect to my influxdb server because the authentification was not set since #2251.

This should fix the issue.