### PR TITLE
WIP: smart: Gather S.M.A.R.T. information from storage devices

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -64,6 +64,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/rethinkdb"
 	_ "github.com/influxdata/telegraf/plugins/inputs/riak"
 	_ "github.com/influxdata/telegraf/plugins/inputs/sensors"
+	_ "github.com/influxdata/telegraf/plugins/inputs/smart"
 	_ "github.com/influxdata/telegraf/plugins/inputs/snmp"
 	_ "github.com/influxdata/telegraf/plugins/inputs/snmp_legacy"
 	_ "github.com/influxdata/telegraf/plugins/inputs/socket_listener"

--- a/plugins/inputs/smart/README.md
+++ b/plugins/inputs/smart/README.md
@@ -1,0 +1,76 @@
+# Telegraf S.M.A.R.T. plugin
+
+Get metrics using the command line utility `smartctl` for S.M.A.R.T. (Self-Monitoring, Analysis and Reporting Technology) storage devices. SMART is a monitoring system included in computer hard disk drives (HDDs) and solid-state drives (SSDs)[1] that detects and reports on various indicators of drive reliability, with the intent of enabling the anticipation of hardware failures.
+See smartmontools(https://www.smartmontools.org/).
+
+If no devices are specified, the plugin will scan for SMART devices via the following command:
+
+```
+smartctl --scan
+```
+
+On some platforms (e.g. Darwin/macOS) this doesn't return a useful list of devices and you must instead specify which devices to collect metrics from in the configuration file.
+
+Metrics will be reported from the following `smartctl` command:
+
+```
+smartctl --info --attributes --nocheck=standby --format=brief <device>
+```
+
+## Measurements
+
+- smart:
+
+    * Tags:
+      - `device`
+      - `device_model`
+      - `serial_no`
+      - `capacity`
+      - `enabled`
+      - `id`
+      - `name`
+      - `flags`
+      - `fail`
+    * Fields:
+      - `value`
+      - `worst`
+      - `threshold`
+      - `raw_value`
+
+### Flags
+
+The interpretation of the tag `flags` is:
+ - *K* auto-keep
+ - *C* event count
+ - *R* error rate
+ - *S* speed/performance
+ - *O* updated online
+ - *P* prefailure warning
+
+## Configuration
+
+```toml
+# Read metrics from storage devices supporting S.M.A.R.T.
+[[inputs.smart]]
+  ## optionally specify the path to the smartctl executable
+  # path = "/usr/bin/smartctl"
+  #
+  ## optionally specify devices to exclude from reporting.
+  # exclude = [ "/dev/pass6" ]
+  #
+  ## optionally specify devices, if unset all S.M.A.R.T. devices
+  ## will be included
+  # devices = [ "/dev/ada0" ]
+```
+
+## Output
+
+When retrieving stats from the local machine (no server specified):
+```
+> smart,serial_no=WD-WMC4N0900000,id=1,name=Raw_Read_Error_Rate,flags=POSR-K,fail=-,host=example,device=/dev/ada0,device_model=WDC\ WD30EFRX-68EUZN0,capacity=3000592982016,enabled=Enabled value=200i,worst=200i,threshold=51i,raw_value=0i 1486892929000000000
+> smart,serial_no=WD-WMC4N0900000,device=/dev/ada0,device_model=WDC\ WD30EFRX-68EUZN0,capacity=3000592982016,enabled=Enabled,id=3,name=Spin_Up_Time,flags=POS--K,fail=-,host=example value=181i,worst=180i,threshold=21i,raw_value=5916i 1486892929000000000
+> smart,device_model=WDC\ WD30EFRX-68EUZN0,capacity=3000592982016,enabled=Enabled,name=Start_Stop_Count,flags=-O--CK,fail=-,device=/dev/ada0,serial_no=WD-WMC4N0900000,id=4,host=example value=100i,worst=100i,threshold=0i,raw_value=18i 1486892929000000000
+> smart,enabled=Enabled,device_model=WDC\ WD30EFRX-68EUZN0,id=5,name=Reallocated_Sector_Ct,capacity=3000592982016,device=/dev/ada0,serial_no=WD-WMC4N0900000,flags=PO--CK,fail=-,host=example value=200i,worst=200i,threshold=140i,raw_value=0i 1486892929000000000
+> smart,serial_no=WD-WMC4N0900000,capacity=3000592982016,enabled=Enabled,name=Seek_Error_Rate,host=example,device=/dev/ada0,id=7,flags=-OSR-K,fail=-,device_model=WDC\ WD30EFRX-68EUZN0 value=200i,worst=200i,threshold=0i,raw_value=0i 1486892929000000000
+> smart,flags=-O--CK,device_model=WDC\ WD30EFRX-68EUZN0,capacity=3000592982016,enabled=Enabled,id=9,name=Power_On_Hours,fail=-,host=example,device=/dev/ada0,serial_no=WD-WMC4N0900000 value=65i,worst=65i,threshold=0i,raw_value=25998i 1486892929000000000
+```

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -1,0 +1,235 @@
+package smart
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+var (
+	execCommand = exec.Command // execCommand is used to mock commands in tests.
+
+	deviceInScan = regexp.MustCompile("^(/dev/\\w*)\\s+.*")
+	// Device Model:     APPLE SSD SM256E
+	modelInInfo = regexp.MustCompile("^Device Model:\\s+(.*)$")
+	// Serial Number:    S0X5NZBC422720
+	serialInInfo = regexp.MustCompile("^Serial Number:\\s+(.*)$")
+	// User Capacity:    251,000,193,024 bytes [251 GB]
+	usercapacityInInfo = regexp.MustCompile("^User Capacity:\\s+([0-9,]+)\\s+bytes.*$")
+	// SMART support is: Enabled
+	smartEnabledInInfo = regexp.MustCompile("^SMART support is:\\s+(\\w+)$")
+
+	// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
+	//   1 Raw_Read_Error_Rate     -O-RC-   200   200   000    -    0
+	//   5 Reallocated_Sector_Ct   PO--CK   100   100   000    -    0
+	// 192 Power-Off_Retract_Count -O--C-   097   097   000    -    14716
+	attribute = regexp.MustCompile("^\\s*([0-9]+)\\s(\\S+)\\s+([-P][-O][-S][-R][-C][-K])\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9]+)\\s+([-\\w]+)\\s+([\\w\\+\\.]+).*$")
+)
+
+type Smart struct {
+	Path     string
+	Excludes []string
+	Devices  []string
+}
+
+var sampleConfig = `
+  ## optionally specify the path to the smartctl executable
+  # path = "/usr/bin/smartctl"
+  #
+  ## optionally specify devices to exclude from reporting.
+  # excludes = [ "/dev/pass6" ]
+  #
+  ## optionally specify devices, if unset a scan (smartctl --scan)
+  ## for S.M.A.R.T. devices will done and all found will be included.
+  # devices = [ "/dev/ada0" ]
+`
+
+func (m *Smart) SampleConfig() string {
+	return sampleConfig
+}
+
+func (m *Smart) Description() string {
+	return "Read metrics from storage devices supporting S.M.A.R.T."
+}
+
+func (m *Smart) Gather(acc telegraf.Accumulator) error {
+	fmt.Printf("Config: %v\n", m)
+	if len(m.Path) == 0 {
+		return fmt.Errorf("smartctl not found: verify that smartctl is installed and that smartctl is in your PATH")
+	}
+
+	devices := m.Devices
+	if len(devices) == 0 {
+		var err error
+		devices, err = m.scan()
+		if err != nil {
+			return err
+		}
+	}
+
+	err := m.getAttributes(acc, devices)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Scan for S.M.A.R.T. devices
+func (m *Smart) scan() ([]string, error) {
+
+	cmd := execCommand(m.Path, "--scan")
+	out, err := internal.CombinedOutputTimeout(cmd, time.Second*5)
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to run command %s: %s - %s", strings.Join(cmd.Args, " "), err, string(out))
+	}
+
+	devices := []string{}
+	for _, line := range strings.Split(string(out), "\n") {
+		dev := deviceInScan.FindStringSubmatch(line)
+		if len(dev) == 2 && !excludedDev(m.Excludes, dev[1]) {
+			devices = append(devices, dev[1])
+		}
+	}
+	return devices, nil
+}
+
+func excludedDev(excludes []string, device string) bool {
+	fmt.Printf("DEBUG: %s in %v?\n", device, excludes)
+	for _, exclude := range excludes {
+		if device == exclude {
+			fmt.Printf("DEBUG: filtered: %s\n", device)
+			return true
+		}
+	}
+	return false
+}
+
+// Get info and attributes for each S.M.A.R.T. device
+func (m *Smart) getAttributes(acc telegraf.Accumulator, devices []string) error {
+
+	for _, device := range devices {
+		cmd := execCommand(m.Path, "--info", "--attributes", "--tolerance=verypermissive", "--nocheck=standby", "--format=brief", device)
+		out, err := internal.CombinedOutputTimeout(cmd, time.Second*5)
+		if err != nil {
+			return fmt.Errorf("failed to run command %s: %s - %s", strings.Join(cmd.Args, " "), err, string(out))
+		}
+
+		device_tags := map[string]string{}
+		device_tags["device"] = device
+
+		for _, line := range strings.Split(string(out), "\n") {
+			model := modelInInfo.FindStringSubmatch(line)
+			if len(model) > 1 {
+				device_tags["device_model"] = model[1]
+			}
+
+			serial := serialInInfo.FindStringSubmatch(line)
+			if len(serial) > 1 {
+				device_tags["serial_no"] = serial[1]
+			}
+
+			capacity := usercapacityInInfo.FindStringSubmatch(line)
+			if len(capacity) > 1 {
+				device_tags["capacity"] = strings.Replace(capacity[1], ",", "", -1)
+			}
+
+			enabled := smartEnabledInInfo.FindStringSubmatch(line)
+			if len(enabled) > 1 {
+				device_tags["enabled"] = enabled[1]
+			}
+
+			attr := attribute.FindStringSubmatch(line)
+
+			if len(attr) > 1 {
+				tags := map[string]string{}
+				for k, v := range device_tags {
+					tags[k] = v
+				}
+				fields := make(map[string]interface{})
+
+				tags["id"] = attr[1]
+				tags["name"] = attr[2]
+				tags["flags"] = attr[3]
+
+				if i, err := strconv.Atoi(attr[4]); err == nil {
+					fields["value"] = i
+				}
+				if i, err := strconv.Atoi(attr[5]); err == nil {
+					fields["worst"] = i
+				}
+				if i, err := strconv.Atoi(attr[6]); err == nil {
+					fields["threshold"] = i
+				}
+
+				tags["fail"] = attr[7]
+				if val, err := parseRawValue(attr[8]); err == nil {
+					fields["raw_value"] = val
+				}
+
+				acc.AddFields("smart", fields, tags)
+			}
+		}
+	}
+	return nil
+}
+
+func parseRawValue(rawVal string) (int, error) {
+
+	// Integer
+	if i, err := strconv.Atoi(rawVal); err == nil {
+		return i, nil
+	}
+
+	// Duration: 65h+33m+09.259s
+	unit := regexp.MustCompile("^(.*)([hms])$")
+	parts := strings.Split(rawVal, "+")
+	if len(parts) == 0 {
+		return 0, fmt.Errorf("Couldn't parse RAW_VALUE '%s'", rawVal)
+	}
+
+	duration := 0
+	for _, part := range parts {
+		timePart := unit.FindStringSubmatch(part)
+		if len(timePart) == 0 {
+			continue
+		}
+		switch timePart[2] {
+		case "h":
+			duration += atoi(timePart[1]) * 3600
+		case "m":
+			duration += atoi(timePart[1]) * 60
+		case "s":
+			// drop fractions of seconds
+			duration += atoi(strings.Split(timePart[1], ".")[0])
+		default:
+			// Unknown, ignore
+		}
+	}
+	return duration, nil
+}
+
+func atoi(str string) int {
+	if i, err := strconv.Atoi(str); err == nil {
+		return i
+	}
+	return 0
+}
+
+func init() {
+	m := Smart{}
+	path, _ := exec.LookPath("smartctl")
+	if len(path) > 0 {
+		m.Path = path
+	}
+	inputs.Add("smart", func() telegraf.Input {
+		return &m
+	})
+}

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -1,0 +1,310 @@
+package smart
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	mockScanData = `/dev/ada0 -d atacam # /dev/ada0, ATA device
+`
+	mockInfoAttributeData = `smartctl 6.5 2016-05-07 r4318 [Darwin 16.4.0 x86_64] (local build)
+Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org
+
+CHECK POWER MODE not implemented, ignoring -n option
+=== START OF INFORMATION SECTION ===
+Model Family:     Apple SD/SM/TS...E/F SSDs
+Device Model:     APPLE SSD SM256E
+Serial Number:    S0X5NZBC422720
+LU WWN Device Id: 5 002538 043584d30
+Firmware Version: CXM09A1Q
+User Capacity:    251,000,193,024 bytes [251 GB]
+Sector Sizes:     512 bytes logical, 4096 bytes physical
+Rotation Rate:    Solid State Device
+Device is:        In smartctl database [for details use: -P show]
+ATA Version is:   ATA8-ACS T13/1699-D revision 4c
+SATA Version is:  SATA 3.0, 6.0 Gb/s (current: 6.0 Gb/s)
+Local Time is:    Thu Feb  9 16:48:45 2017 CET
+SMART support is: Available - device has SMART capability.
+SMART support is: Enabled
+
+=== START OF READ SMART DATA SECTION ===
+SMART Attributes Data Structure revision number: 1
+Vendor Specific SMART Attributes with Thresholds:
+ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
+  1 Raw_Read_Error_Rate     -O-RC-   200   200   000    -    0
+  5 Reallocated_Sector_Ct   PO--CK   100   100   000    -    0
+  9 Power_On_Hours          -O--CK   099   099   000    -    2988
+ 12 Power_Cycle_Count       -O--CK   085   085   000    -    14879
+169 Unknown_Attribute       PO--C-   253   253   010    -    2044932921600
+173 Wear_Leveling_Count     -O--CK   185   185   100    -    957808640337
+190 Airflow_Temperature_Cel -O---K   055   040   045    Past 45 (Min/Max 43/57 #2689)
+192 Power-Off_Retract_Count -O--C-   097   097   000    -    14716
+194 Temperature_Celsius     -O---K   066   021   000    -    34 (Min/Max 14/79)
+197 Current_Pending_Sector  -O---K   100   100   000    -    0
+199 UDMA_CRC_Error_Count    -O-RC-   200   200   000    -    0
+240 Head_Flying_Hours       ------   100   253   000    -    6585h+55m+23.234s
+                            ||||||_ K auto-keep
+                            |||||__ C event count
+                            ||||___ R error rate
+                            |||____ S speed/performance
+                            ||_____ O updated online
+                            |______ P prefailure warning
+`
+)
+
+func TestGather(t *testing.T) {
+	s := &Smart{
+		path: "smartctl",
+	}
+	// overwriting exec commands with mock commands
+	execCommand = fakeExecCommand
+	var acc testutil.Accumulator
+
+	err := s.Gather(&acc)
+
+	require.NoError(t, err)
+	assert.Equal(t, 48, acc.NFields(), "Wrong number of fields gathered")
+
+	device_tags := map[string]string{
+		"device":       "/dev/ada0",
+		"device_model": "APPLE SSD SM256E",
+		"serial_no":    "S0X5NZBC422720",
+		"enabled":      "Enabled",
+		"capacity":     "251000193024",
+	}
+
+	var testsAda0Device = []struct {
+		fields map[string]interface{}
+		tags   map[string]string
+	}{
+		{
+			map[string]interface{}{
+				"value":     int(200),
+				"worst":     int(200),
+				"threshold": int(0),
+				"raw_value": int(0),
+			},
+			map[string]string{
+				"id":    "1",
+				"name":  "Raw_Read_Error_Rate",
+				"flags": "-O-RC-",
+				"fail":  "-",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(100),
+				"worst":     int(100),
+				"threshold": int(0),
+				"raw_value": int(0),
+			},
+			map[string]string{
+				"id":    "5",
+				"name":  "Reallocated_Sector_Ct",
+				"flags": "PO--CK",
+				"fail":  "-",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(99),
+				"worst":     int(99),
+				"threshold": int(0),
+				"raw_value": int(2988),
+			},
+			map[string]string{
+				"id":    "9",
+				"name":  "Power_On_Hours",
+				"flags": "-O--CK",
+				"fail":  "-",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(85),
+				"worst":     int(85),
+				"threshold": int(0),
+				"raw_value": int(14879),
+			},
+			map[string]string{
+				"id":    "12",
+				"name":  "Power_Cycle_Count",
+				"flags": "-O--CK",
+				"fail":  "-",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(253),
+				"worst":     int(253),
+				"threshold": int(10),
+				"raw_value": int(2044932921600),
+			},
+			map[string]string{
+				"id":    "169",
+				"name":  "Unknown_Attribute",
+				"flags": "PO--C-",
+				"fail":  "-",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(185),
+				"worst":     int(185),
+				"threshold": int(100),
+				"raw_value": int(957808640337),
+			},
+			map[string]string{
+				"id":    "173",
+				"name":  "Wear_Leveling_Count",
+				"flags": "-O--CK",
+				"fail":  "-",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(55),
+				"worst":     int(40),
+				"threshold": int(45),
+				"raw_value": int(45),
+			},
+			map[string]string{
+				"id":    "190",
+				"name":  "Airflow_Temperature_Cel",
+				"flags": "-O---K",
+				"fail":  "Past",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(97),
+				"worst":     int(97),
+				"threshold": int(0),
+				"raw_value": int(14716),
+			},
+			map[string]string{
+				"id":    "192",
+				"name":  "Power-Off_Retract_Count",
+				"flags": "-O--C-",
+				"fail":  "-",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(66),
+				"worst":     int(21),
+				"threshold": int(0),
+				"raw_value": int(34),
+			},
+			map[string]string{
+				"id":    "194",
+				"name":  "Temperature_Celsius",
+				"flags": "-O---K",
+				"fail":  "-",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(100),
+				"worst":     int(100),
+				"threshold": int(0),
+				"raw_value": int(0),
+			},
+			map[string]string{
+				"id":    "197",
+				"name":  "Current_Pending_Sector",
+				"flags": "-O---K",
+				"fail":  "-",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(200),
+				"worst":     int(200),
+				"threshold": int(0),
+				"raw_value": int(0),
+			},
+			map[string]string{
+				"id":    "199",
+				"name":  "UDMA_CRC_Error_Count",
+				"flags": "-O-RC-",
+				"fail":  "-",
+			},
+		},
+		{
+			map[string]interface{}{
+				"value":     int(100),
+				"worst":     int(253),
+				"threshold": int(0),
+				"raw_value": int(23709323),
+			},
+			map[string]string{
+				"id":    "240",
+				"name":  "Head_Flying_Hours",
+				"flags": "------",
+				"fail":  "-",
+			},
+		},
+	}
+
+	for _, test := range testsAda0Device {
+		for k, v := range device_tags {
+			test.tags[k] = v
+		}
+
+		acc.AssertContainsTaggedFields(t, "smart", test.fields, test.tags)
+	}
+}
+
+func TestExcludedDev(t *testing.T) {
+	assert.Equal(t, true, excludedDev([]string{"/dev/pass6"}, "/dev/pass6"), "Should be excluded.")
+	assert.Equal(t, false, excludedDev([]string{}, "/dev/pass6"), "Shouldn't be excluded.")
+	assert.Equal(t, false, excludedDev([]string{"/dev/pass6"}, "/dev/pass1"), "Shouldn't be excluded.")
+
+}
+
+// fackeExecCommand is a helper function that mock
+// the exec.Command call (and call the test binary)
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+// TestHelperProcess isn't a real test. It's used to mock exec.Command
+// For example, if you run:
+// GO_WANT_HELPER_PROCESS=1 go test -test.run=TestHelperProcess -- --scan
+// it returns below mockScanData.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+
+	// Previous arguments are tests stuff, that looks like :
+	// /tmp/go-build970079519/…/_test/integration.test -test.run=TestHelperProcess --
+	cmd, arg1, args := args[3], args[4], args[5:]
+
+	if cmd == "smartctl" {
+		if arg1 == "--scan" {
+			fmt.Fprint(os.Stdout, mockScanData)
+		}
+		if arg1 == "--info" {
+			fmt.Fprint(os.Stdout, mockInfoAttributeData)
+		}
+	} else {
+		fmt.Fprint(os.Stdout, "command not found")
+		os.Exit(1)
+	}
+	os.Exit(0)
+}


### PR DESCRIPTION
This adds a new input plugin which uses the `smartctl` utility from the
smartmontools package to gather metrics from S.M.A.R.T. storage devices.

Signed-off-by: Rickard von Essen <rickard.von.essen@gmail.com>

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)
