### PR TITLE
Procstat: Allow multiple PIDs in one pidfile

### DIFF
--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -8,9 +8,10 @@ individual process using their /proc data.
 The plugin will tag processes by their PID and their process name.
 
 Processes can be specified either by pid file, by executable name, by command
-line pattern matching, or by username (in this order or priority. Procstat
-plugin will use `pgrep` when executable name is provided to obtain the pid.
-Procstat plugin will transmit IO, memory, cpu, file descriptor related
+line pattern matching, or by username. The pid file should contain one or more
+pid integers separated by whitespace.
+The plugin will use `pgrep` to obtain the pid, except when given a pid file.
+The plugin will transmit IO, memory, cpu, file descriptor related
 measurements for every process specified. A prefix can be set to isolate
 individual process specific measurements.
 

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -109,13 +109,16 @@ func (p *Procstat) pidsFromFile() ([]int32, error) {
 		outerr = fmt.Errorf("Failed to read pidfile '%s'. Error: '%s'",
 			p.PidFile, err)
 	} else {
-		pid, err := strconv.Atoi(strings.TrimSpace(string(pidString)))
-		if err != nil {
-			outerr = err
-		} else {
-			out = append(out, int32(pid))
-			p.tagmap[int32(pid)] = map[string]string{
-				"pidfile": p.PidFile,
+		pids := strings.Fields(string(pidString))
+		for _, pid := range pids {
+			ipid, err := strconv.Atoi(pid)
+			if err == nil {
+				out = append(out, int32(ipid))
+				p.tagmap[int32(ipid)] = map[string]string{
+					"pidfile": p.PidFile,
+				}
+			} else {
+				outerr = err
 			}
 		}
 	}

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -21,14 +21,10 @@ type Procstat struct {
 	User        string
 	PidTag      bool
 
-	// tagmap maps a pid to a map of tags for that pid
-	tagmap map[int32]map[string]string
-}
-
-func NewProcstat() *Procstat {
-	return &Procstat{
-		tagmap: make(map[int32]map[string]string),
-	}
+	// source is how we got the info - pidfile, exe, etc.
+	// we keep it to add a tag
+	sourceKey   string
+	sourceValue string
 }
 
 var sampleConfig = `
@@ -68,10 +64,12 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 			p.Exe, p.PidFile, p.Pattern, p.User, err.Error())
 	} else {
 		for _, pid := range pids {
+			tags := map[string]string{
+				p.sourceKey: p.sourceValue}
 			if p.PidTag {
-				p.tagmap[pid]["pid"] = fmt.Sprint(pid)
+				tags["pid"] = fmt.Sprint(pid)
 			}
-			p := NewSpecProcessor(p.ProcessName, p.Prefix, pid, acc, p.tagmap[pid])
+			p := NewSpecProcessor(p.ProcessName, p.Prefix, pid, acc, tags)
 			err := p.pushMetrics()
 			if err != nil {
 				log.Printf("E! Error: procstat: %s", err.Error())
@@ -101,113 +99,83 @@ func (p *Procstat) getAllPids() ([]int32, error) {
 	return pids, err
 }
 
-func (p *Procstat) pidsFromFile() ([]int32, error) {
+func pidFromList(pids []string) ([]int32, error) {
 	var out []int32
-	var outerr error
-	pidString, err := ioutil.ReadFile(p.PidFile)
-	if err != nil {
-		outerr = fmt.Errorf("Failed to read pidfile '%s'. Error: '%s'",
-			p.PidFile, err)
-	} else {
-		pids := strings.Fields(string(pidString))
-		for _, pid := range pids {
-			ipid, err := strconv.Atoi(pid)
-			if err == nil {
-				out = append(out, int32(ipid))
-				p.tagmap[int32(ipid)] = map[string]string{
-					"pidfile": p.PidFile,
-				}
-			} else {
-				outerr = err
-			}
+	for _, pid := range pids {
+		ipid, err := strconv.Atoi(pid)
+		if err == nil {
+			out = append(out, int32(ipid))
+		} else {
+			return nil, err
 		}
 	}
-	return out, outerr
+	return out, nil
+}
+
+func (p *Procstat) pidsFromFile() ([]int32, error) {
+	p.sourceKey = "pidfile"
+	p.sourceValue = p.PidFile
+	pidString, err := ioutil.ReadFile(p.PidFile)
+	if err != nil {
+		outerr := fmt.Errorf("Failed to read pidfile '%s'. Error: '%s'",
+			p.PidFile, err)
+		return nil, outerr
+	}
+	pids := strings.Fields(string(pidString))
+	out, err := pidFromList(pids)
+	return out, err
 }
 
 func (p *Procstat) pidsFromExe() ([]int32, error) {
-	var out []int32
-	var outerr error
+	p.sourceKey = "exe"
+	p.sourceValue = p.Exe
 	bin, err := exec.LookPath("pgrep")
 	if err != nil {
-		return out, fmt.Errorf("Couldn't find pgrep binary: %s", err)
+		return nil, fmt.Errorf("Couldn't find pgrep binary: %s", err)
 	}
 	pgrep, err := exec.Command(bin, p.Exe).Output()
 	if err != nil {
-		return out, fmt.Errorf("Failed to execute %s. Error: '%s'", bin, err)
-	} else {
-		pids := strings.Fields(string(pgrep))
-		for _, pid := range pids {
-			ipid, err := strconv.Atoi(pid)
-			if err == nil {
-				out = append(out, int32(ipid))
-				p.tagmap[int32(ipid)] = map[string]string{
-					"exe": p.Exe,
-				}
-			} else {
-				outerr = err
-			}
-		}
+		return nil, fmt.Errorf("Failed to execute %s. Error: '%s'", bin, err)
 	}
-	return out, outerr
+	pids := strings.Fields(string(pgrep))
+	out, err := pidFromList(pids)
+	return out, err
 }
 
 func (p *Procstat) pidsFromPattern() ([]int32, error) {
-	var out []int32
-	var outerr error
+	p.sourceKey = "pattern"
+	p.sourceValue = p.Pattern
 	bin, err := exec.LookPath("pgrep")
 	if err != nil {
-		return out, fmt.Errorf("Couldn't find pgrep binary: %s", err)
+		return nil, fmt.Errorf("Couldn't find pgrep binary: %s", err)
 	}
 	pgrep, err := exec.Command(bin, "-f", p.Pattern).Output()
 	if err != nil {
-		return out, fmt.Errorf("Failed to execute %s. Error: '%s'", bin, err)
-	} else {
-		pids := strings.Fields(string(pgrep))
-		for _, pid := range pids {
-			ipid, err := strconv.Atoi(pid)
-			if err == nil {
-				out = append(out, int32(ipid))
-				p.tagmap[int32(ipid)] = map[string]string{
-					"pattern": p.Pattern,
-				}
-			} else {
-				outerr = err
-			}
-		}
+		return nil, fmt.Errorf("Failed to execute %s. Error: '%s'", bin, err)
 	}
-	return out, outerr
+	pids := strings.Fields(string(pgrep))
+	out, err := pidFromList(pids)
+	return out, err
 }
 
 func (p *Procstat) pidsFromUser() ([]int32, error) {
-	var out []int32
-	var outerr error
+	p.sourceKey = "user"
+	p.sourceValue = p.User
 	bin, err := exec.LookPath("pgrep")
 	if err != nil {
-		return out, fmt.Errorf("Couldn't find pgrep binary: %s", err)
+		return nil, fmt.Errorf("Couldn't find pgrep binary: %s", err)
 	}
 	pgrep, err := exec.Command(bin, "-u", p.User).Output()
 	if err != nil {
-		return out, fmt.Errorf("Failed to execute %s. Error: '%s'", bin, err)
-	} else {
-		pids := strings.Fields(string(pgrep))
-		for _, pid := range pids {
-			ipid, err := strconv.Atoi(pid)
-			if err == nil {
-				out = append(out, int32(ipid))
-				p.tagmap[int32(ipid)] = map[string]string{
-					"user": p.User,
-				}
-			} else {
-				outerr = err
-			}
-		}
+		return nil, fmt.Errorf("Failed to execute %s. Error: '%s'", bin, err)
 	}
-	return out, outerr
+	pids := strings.Fields(string(pgrep))
+	out, err := pidFromList(pids)
+	return out, err
 }
 
 func init() {
 	inputs.Add("procstat", func() telegraf.Input {
-		return NewProcstat()
+		return &Procstat{}
 	})
 }

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -23,7 +23,6 @@ func TestGather(t *testing.T) {
 	p := Procstat{
 		PidFile: file.Name(),
 		Prefix:  "foo",
-		tagmap:  make(map[int32]map[string]string),
 	}
 	p.Gather(&acc)
 	assert.True(t, acc.HasFloatField("procstat", "foo_cpu_time_user"))


### PR DESCRIPTION
A pid file can now contain one single pid, or multiple pids separated
by whitespace (including newlines).

One example use case could be a user populated pid list.
Another example is using cgroup proc lists, e.g.:

    /sys/fs/cgroup/systemd/system.slice/NetworkManager.service/cgroup.procs


Since this change caused all pid collectors to iterate over lists, some parts were refactored. Those are two separate commits, and I am willing to separate them to two pull requests if prefer.

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
