### PR TITLE
Docker: optionally add labels as tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ be deprecated eventually.
 - [#2332](https://github.com/influxdata/telegraf/pull/2332): Add Elasticsearch 5.x output
 - [#2587](https://github.com/influxdata/telegraf/pull/2587): Add json timestamp units configurability
 - [#2597](https://github.com/influxdata/telegraf/issues/2597): Add support for Linux sysctl-fs metrics.
+- [#2425](https://github.com/influxdata/telegraf/pull/2425): Support to include/exclude docker container labels as tags
 
 ### Bugfixes
 

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -30,11 +30,12 @@ for the stat structure can be found
   perdevice = true
   ## Whether to report for each container total blkio and network stats or not
   total = false
-  # Add container labels as tags
-  addlabels = true
-  # If addlabels is set to true, optional array to add specific lables.
-  #   Empty array adds all labels
-  label_names = []
+  
+  ## docker labels to include and exclude as tags.  Globs accepted.
+  ## Note that an empty array for both will include all labels as tags
+  docker_label_include = []
+  docker_label_exclude = []
+  
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -30,6 +30,11 @@ for the stat structure can be found
   perdevice = true
   ## Whether to report for each container total blkio and network stats or not
   total = false
+  # Add container labels as tags
+  addlabels = true
+  # If addlabels is set to true, optional array to add specific lables.
+  #   Empty array adds all labels
+  label_names = []
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -135,30 +135,31 @@ based on the availability of per-cpu stats on your system.
 
 
 ### Tags:
-
+#### Docker Engine tags
 - docker (memory_total)
     - unit=bytes
+    - engine_host
 - docker (pool_blocksize)
     - unit=bytes
+    - engine_host
 - docker_data
     - unit=bytes
+    - engine_host
 - docker_metadata
     - unit=bytes
 
+#### Docker Container tags
+- Tags on all containers:
+    - engine_host
+    - container_image
+    - container_name
+    - container_version
 - docker_container_mem specific:
-    - container_image
-    - container_name
 - docker_container_cpu specific:
-    - container_image
-    - container_name
     - cpu
 - docker_container_net specific:
-    - container_image
-    - container_name
     - network
 - docker_container_blkio specific:
-    - container_image
-    - container_name
     - device
 
 ### Example Output:

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -148,6 +148,7 @@ based on the availability of per-cpu stats on your system.
     - engine_host
 - docker_metadata
     - unit=bytes
+    - engine_host
 
 #### Docker Container tags
 - Tags on all containers:

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -25,9 +25,9 @@ type Docker struct {
 	Endpoint       string
 	ContainerNames []string
 	Timeout        internal.Duration
-	PerDevice      bool `toml:"perdevice"`
-	Total          bool `toml:"total"`
-	AddLabels      bool `toml:"addlabels"`
+	PerDevice      bool     `toml:"perdevice"`
+	Total          bool     `toml:"total"`
+	AddLabels      bool     `toml:"addlabels"`
 	LabelNames     []string `toml:"label_names"`
 
 	client      *client.Client
@@ -300,12 +300,9 @@ func (d *Docker) gatherContainer(
 	}
 
 	// Add labels to tags if addlabels is true
-	//fmt.Printf("AddLabels is %t:  len of labelnames is %d\n", d.AddLabels, len(d.LabelNames))
 	if d.AddLabels {
 		for k, label := range container.Labels {
-	//		fmt.Printf("Checking tag %s with value %s\n", k, label)
-			if (len(d.LabelNames) == 0 ) || (len(d.LabelNames) > 0 && sliceContains(k, d.LabelNames))  {
-	//			fmt.Printf("Adding tag %s with value %s\n", k, label)
+			if (len(d.LabelNames) == 0) || (len(d.LabelNames) > 0 && sliceContains(k, d.LabelNames)) {
 				tags[k] = label
 			}
 		}

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -14,15 +14,15 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
 type DockerLabelFilter struct {
-	labelInclude   filter.Filter
-	labelExclude   filter.Filter
+	labelInclude filter.Filter
+	labelExclude filter.Filter
 }
 
 // Docker object
@@ -35,7 +35,7 @@ type Docker struct {
 	LabelInclude   []string `toml:"docker_label_include"`
 	LabelExclude   []string `toml:"docker_label_exclude"`
 
-	LabelFilter    DockerLabelFilter
+	LabelFilter DockerLabelFilter
 
 	client      *client.Client
 	engine_host string
@@ -153,7 +153,7 @@ func (d *Docker) Gather(acc telegraf.Accumulator) error {
 		d.LabelFilter.labelInclude, _ = filter.Compile(d.LabelInclude)
 	}
 
-	if len(d.LabelExclude) != 0  {
+	if len(d.LabelExclude) != 0 {
 		d.LabelFilter.labelExclude, _ = filter.Compile(d.LabelExclude)
 	}
 

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -112,7 +112,6 @@ var sampleConfig = `
   ## Note that an empty array for both will include all labels as tags
   docker_label_include = []
   docker_label_exclude = []
-
 `
 
 // Description returns input description
@@ -150,11 +149,19 @@ func (d *Docker) Gather(acc telegraf.Accumulator) error {
 
 	// Create label filters
 	if len(d.LabelInclude) != 0 {
-		d.LabelFilter.labelInclude, _ = filter.Compile(d.LabelInclude)
+		var err error
+		d.LabelFilter.labelInclude, err = filter.Compile(d.LabelInclude)
+		if err != nil {
+			return err
+		}
 	}
 
 	if len(d.LabelExclude) != 0 {
-		d.LabelFilter.labelExclude, _ = filter.Compile(d.LabelExclude)
+		var err error
+		d.LabelFilter.labelExclude, err = filter.Compile(d.LabelExclude)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Get daemon info
@@ -631,7 +638,6 @@ func init() {
 		return &Docker{
 			PerDevice: true,
 			Timeout:   internal.Duration{Duration: time.Second * 5},
-			//AddLabels: true,
 		}
 	})
 }

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -247,7 +247,7 @@ func testStats() *types.StatsJSON {
 func TestDockerGatherLabels(t *testing.T) {
 	var acc testutil.Accumulator
 	d := Docker{
-		client: nil,
+		client:  nil,
 		testing: true,
 	}
 

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/influxdata/telegraf/testutil"
 
+	"fmt"
 	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/require"
-	"fmt"
 )
 
 func TestDockerGatherContainerStats(t *testing.T) {
@@ -251,16 +251,15 @@ var gatherLabelsTests = []struct {
 	expected    []string
 	notexpected []string
 }{
-	{[]string{},          []string{},         []string{"label1","label2"}, []string{}},
-	{[]string{"*"},       []string{},         []string{"label1","label2"}, []string{}},
-	{[]string{"lab*"},    []string{},         []string{"label1","label2"}, []string{}},
-	{[]string{"label1"},  []string{},         []string{"label1"},          []string{"label2"}},
-	{[]string{"label1*"}, []string{},         []string{"label1"},          []string{"label2"}},
-	{[]string{},          []string{"*"},      []string{},                  []string{"label1","label2"}},
-	{[]string{},          []string{"lab*"},   []string{},                  []string{"label1","label2"}},
-	{[]string{},          []string{"label1"}, []string{"label2"},          []string{"label1"}},
-	{[]string{"*"},       []string{"*"},      []string{},                  []string{"label1","label2"}},
-
+	{[]string{}, []string{}, []string{"label1", "label2"}, []string{}},
+	{[]string{"*"}, []string{}, []string{"label1", "label2"}, []string{}},
+	{[]string{"lab*"}, []string{}, []string{"label1", "label2"}, []string{}},
+	{[]string{"label1"}, []string{}, []string{"label1"}, []string{"label2"}},
+	{[]string{"label1*"}, []string{}, []string{"label1"}, []string{"label2"}},
+	{[]string{}, []string{"*"}, []string{}, []string{"label1", "label2"}},
+	{[]string{}, []string{"lab*"}, []string{}, []string{"label1", "label2"}},
+	{[]string{}, []string{"label1"}, []string{"label2"}, []string{"label1"}},
+	{[]string{"*"}, []string{"*"}, []string{}, []string{"label1", "label2"}},
 }
 
 func TestDockerGatherLabels(t *testing.T) {

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/influxdata/telegraf/testutil"
 
-	"fmt"
 	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/require"
 )
@@ -280,22 +279,18 @@ func TestDockerGatherLabels(t *testing.T) {
 		err := d.Gather(&acc)
 		require.NoError(t, err)
 
-		var expectedErrors []string
 		for _, label := range tt.expected {
 			if !acc.HasTag("docker_container_cpu", label) {
-				expectedErrors = append(expectedErrors, fmt.Sprintf("%s ", label))
+				t.Errorf("Didn't get expected label of %s.  Test was:  Include: %s  Exclude %s",
+					label, tt.include, tt.exclude)
 			}
 		}
 
-		var notexpectedErrors []string
 		for _, label := range tt.notexpected {
 			if acc.HasTag("docker_container_cpu", label) {
-				notexpectedErrors = append(notexpectedErrors, fmt.Sprintf("%s ", label))
+				t.Errorf("Got unexpected label of %s.  Test was:  Include: %s  Exclude %s",
+					label, tt.include, tt.exclude)
 			}
-		}
-
-		if len(expectedErrors) > 0 || len(notexpectedErrors) > 0 {
-			t.Errorf("Failed test for: Include: %s  Exclude:  %s", tt.include, tt.exclude)
 		}
 	}
 }

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -269,8 +269,8 @@ func TestDockerGatherLabels(t *testing.T) {
 			"cpu":               "cpu3",
 			"container_version": "v2.2.2",
 			"engine_host":       "absol",
-			"label1":           "test_value_1",
-			"label2":           "test_value_2",
+			"label1":            "test_value_1",
+			"label2":            "test_value_2",
 		},
 	)
 
@@ -290,7 +290,7 @@ func TestDockerGatherLabels(t *testing.T) {
 			"cpu":               "cpu3",
 			"container_version": "v2.2.2",
 			"engine_host":       "absol",
-			"label1":           "test_value_1",
+			"label1":            "test_value_1",
 		},
 	)
 
@@ -305,7 +305,7 @@ func TestDockerGatherInfo(t *testing.T) {
 
 	/* In order to not modify code here, we set this to false since the container structure now has
 	   labels and the default is true.
-	   */
+	*/
 	d.AddLabels = false
 	err := d.Gather(&acc)
 	require.NoError(t, err)

--- a/plugins/inputs/docker/fake_client.go
+++ b/plugins/inputs/docker/fake_client.go
@@ -92,6 +92,10 @@ func (d FakeDockerClient) ContainerList(octx context.Context, options types.Cont
 				IP:          "0.0.0.0",
 			},
 		},
+		Labels: map[string]string{
+			"label1": "test_value_1",
+			"label2": "test_value_2",
+		},
 		SizeRw:     0,
 		SizeRootFs: 0,
 	}
@@ -124,6 +128,10 @@ func (d FakeDockerClient) ContainerList(octx context.Context, options types.Cont
 				Type:        "tcp",
 				IP:          "0.0.0.0",
 			},
+		},
+		Labels: map[string]string{
+			"label1": "test_value_1",
+			"label2": "test_value_2",
 		},
 		SizeRw:     0,
 		SizeRootFs: 0,


### PR DESCRIPTION
The default in the docker input is to add all labels as tags.  This created a couple problems for us:
1.  Using OpenTSDB as the backend, only 8 tags are allowed.  If you combine this with AWS ECS, you run out of tags very quickly.
2.  Not all of the labels are useful, but some are.

This addresses the ability to both disable label's being added as tags (default is to add them) and optionally only select specific labels to add.

### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)
