### PR TITLE
Adding support for global fields

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -201,6 +201,7 @@ func (a *Agent) Test() error {
 		acc.SetPrecision(a.Config.Agent.Precision.Duration,
 			a.Config.Agent.Interval.Duration)
 		input.SetTrace(true)
+		input.SetDefaultFields(a.Config.Fields)
 		input.SetDefaultTags(a.Config.Tags)
 
 		fmt.Printf("* Plugin: %s, Collection 1\n", input.Name())
@@ -342,6 +343,7 @@ func (a *Agent) Run(shutdown chan struct{}) error {
 
 	// Start all ServicePlugins
 	for _, input := range a.Config.Inputs {
+		input.SetDefaultFields(a.Config.Fields)
 		input.SetDefaultTags(a.Config.Tags)
 		switch p := input.Input.(type) {
 		case telegraf.ServiceInput:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -30,6 +30,12 @@ Global tags can be specified in the `[global_tags]` section of the config file
 in key="value" format. All metrics being gathered on this host will be tagged
 with the tags specified here.
 
+# Global Fields
+
+Global fields can be specified in the `[global_fields]` section of the config file
+in key="value" format. All metrics being gathered on this host will be appended
+with the fields specified here.
+
 ## Agent Configuration
 
 Telegraf has a few options you can configure under the `[agent]` section of the
@@ -150,6 +156,9 @@ fields which begin with `time_`.
 ```toml
 [global_tags]
   dc = "denver-1"
+
+[global_fields]
+  git-sha = "a3537ef2a8e56f9647c1c281d88e092b651c392c"
 
 [agent]
   interval = "10s"

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -21,6 +21,8 @@
   ## Environment variables can be used as tags, and throughout the config file
   # user = "$USER"
 
+[global_fields]
+  # git-sha = "a3537ef2a8e56f9647c1c281d88e092b651c392c"
 
 # Configuration for telegraf agent
 [agent]

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -14,6 +14,9 @@
   # dc = "us-east-1" # will tag all metrics with dc=us-east-1
   # rack = "1a"
 
+[global_fields]
+  # git-sha = "a3537ef2a8e56f9647c1c281d88e092b651c392c"
+
 # Configuration for telegraf agent
 [agent]
   ## Default data collection interval for all inputs

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -174,3 +174,19 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	assert.Equal(t, pConfig, c.Inputs[3].Config,
 		"Merged Testdata did not produce correct procstat metadata.")
 }
+
+func TestConfig_GlobalIntField(t *testing.T) {
+	c := NewConfig()
+	c.LoadConfig("./testdata/global_int_field.toml")
+
+	assert.Equal(t, int64(383), c.Fields["version"],
+		"Integer field should be loaded")
+}
+
+func TestConfig_GlobalStringField(t *testing.T) {
+	c := NewConfig()
+	c.LoadConfig("./testdata/global_string_field.toml")
+
+	assert.Equal(t, "bar", c.Fields["foo"],
+		"String field should be loaded")
+}

--- a/internal/config/testdata/global_int_field.toml
+++ b/internal/config/testdata/global_int_field.toml
@@ -1,0 +1,2 @@
+[global_fields]
+  version = 383

--- a/internal/config/testdata/global_string_field.toml
+++ b/internal/config/testdata/global_string_field.toml
@@ -1,0 +1,2 @@
+[global_fields]
+  foo = "bar"

--- a/internal/config/testdata/telegraf-agent.toml
+++ b/internal/config/testdata/telegraf-agent.toml
@@ -23,6 +23,9 @@
 [global_tags]
   dc = "us-east-1"
 
+[global_fields]
+  git-sha = "a3537ef2a8e56f9647c1c281d88e092b651c392c"
+
 # Configuration for telegraf agent
 [agent]
   # Default data collection interval for all plugins

--- a/internal/models/makemetric.go
+++ b/internal/models/makemetric.go
@@ -29,6 +29,7 @@ func makemetric(
 	namePrefix string,
 	nameSuffix string,
 	pluginTags map[string]string,
+	daemonFields map[string]interface{},
 	daemonTags map[string]string,
 	filter Filter,
 	applyFilter bool,
@@ -52,6 +53,13 @@ func makemetric(
 	}
 	if len(nameSuffix) != 0 {
 		measurement = measurement + nameSuffix
+	}
+
+	// Apply daemon-wide fields if set
+	for k, v := range daemonFields {
+		if _, ok := fields[k]; !ok {
+			fields[k] = v
+		}
 	}
 
 	// Apply plugin-wide tags if set

--- a/internal/models/running_aggregator.go
+++ b/internal/models/running_aggregator.go
@@ -64,6 +64,7 @@ func (r *RunningAggregator) MakeMetric(
 		r.Config.MeasurementSuffix,
 		r.Config.Tags,
 		nil,
+		nil,
 		r.Config.Filter,
 		false,
 		mType,

--- a/internal/models/running_input.go
+++ b/internal/models/running_input.go
@@ -14,8 +14,9 @@ type RunningInput struct {
 	Input  telegraf.Input
 	Config *InputConfig
 
-	trace       bool
-	defaultTags map[string]string
+	trace         bool
+	defaultFields map[string]interface{}
+	defaultTags   map[string]string
 
 	MetricsGathered selfstat.Stat
 }
@@ -67,6 +68,7 @@ func (r *RunningInput) MakeMetric(
 		r.Config.MeasurementPrefix,
 		r.Config.MeasurementSuffix,
 		r.Config.Tags,
+		r.defaultFields,
 		r.defaultTags,
 		r.Config.Filter,
 		true,
@@ -89,6 +91,10 @@ func (r *RunningInput) Trace() bool {
 
 func (r *RunningInput) SetTrace(trace bool) {
 	r.trace = trace
+}
+
+func (r *RunningInput) SetDefaultFields(fields map[string]interface{}) {
+	r.defaultFields = fields
 }
 
 func (r *RunningInput) SetDefaultTags(tags map[string]string) {


### PR DESCRIPTION
Feature request captured in https://github.com/influxdata/telegraf/issues/2427

This pull requests adds configuration support for global_fields so that tag-like data with high-cardinality can still be captured:

```
[global_tags]
  region = "us-east-1"

[global_fields]
  git-sha = "a3537ef2a8e56f9647c1c281d88e092b651c392c"
```