### PR TITLE
Adding ability to exclude ObjectName from perfmon counters (v1) 

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -104,6 +104,13 @@ and you would also like all instances containg _Total returned,
 like "_Total", "0,_Total" and so on where applicable
 (Processor Information is one example).
 
+#### ExcludeObjectName
+*Optional*
+
+This key is optional, it is a simple bool.
+If it is not set to true or included, it is treated as false.
+If true then the ObjectName tag will be excluded.
+
 #### WarnOnMissing
 *Optional*
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -26,15 +26,17 @@ func TestWinPerfcountersConfigGet1(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -60,15 +62,17 @@ func TestWinPerfcountersConfigGet2(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -107,15 +111,17 @@ func TestWinPerfcountersConfigGet3(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -156,15 +162,17 @@ func TestWinPerfcountersConfigGet4(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -206,15 +214,17 @@ func TestWinPerfcountersConfigGet5(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -254,15 +264,17 @@ func TestWinPerfcountersConfigGet6(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -290,15 +302,17 @@ func TestWinPerfcountersConfigGet7(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = false
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -338,15 +352,17 @@ func TestWinPerfcountersConfigError1(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -372,15 +388,17 @@ func TestWinPerfcountersConfigError2(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -406,15 +424,17 @@ func TestWinPerfcountersConfigError3(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -439,15 +459,17 @@ func TestWinPerfcountersCollect1(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -485,15 +507,17 @@ func TestWinPerfcountersCollect2(t *testing.T) {
 	var warnonmissing bool = false
 	var failonmissing bool = true
 	var includetotal bool = false
+	var excludeobjectname bool = false
 
 	PerfObject := perfobject{
-		ObjectName:    objectname,
-		Instances:     instances,
-		Counters:      counters,
-		Measurement:   measurement,
-		WarnOnMissing: warnonmissing,
-		FailOnMissing: failonmissing,
-		IncludeTotal:  includetotal,
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
 	}
 
 	perfobjects[0] = PerfObject
@@ -523,5 +547,53 @@ func TestWinPerfcountersCollect2(t *testing.T) {
 		counters[0]: float32(0),
 	}
 	acc.AssertContainsTaggedFields(t, measurement, fields, tags)
+}
 
+func TestWinPerfcountersCollectExcludeObjectName(t *testing.T) {
+
+	var instances = make([]string, 1)
+	var counters = make([]string, 1)
+	var perfobjects = make([]perfobject, 1)
+
+	objectname := "Processor Information"
+	instances[0] = "_Total"
+	counters[0] = "Parking Status"
+
+	var expectedCounterName = "Parking_Status"
+
+	var measurement string = "test"
+	var warnonmissing bool = false
+	var failonmissing bool = true
+	var includetotal bool = false
+	var excludeobjectname bool = true
+
+	PerfObject := perfobject{
+		ObjectName:        objectname,
+		Instances:         instances,
+		Counters:          counters,
+		Measurement:       measurement,
+		WarnOnMissing:     warnonmissing,
+		FailOnMissing:     failonmissing,
+		IncludeTotal:      includetotal,
+		ExcludeObjectName: excludeobjectname,
+	}
+
+	perfobjects[0] = PerfObject
+
+	m := Win_PerfCounters{PrintValid: false, TestName: "CollectExcludeObjectName", Object: perfobjects}
+	var acc testutil.Accumulator
+	err := m.Gather(&acc)
+	require.NoError(t, err)
+
+	time.Sleep(2000 * time.Millisecond)
+	err = m.Gather(&acc)
+
+	tags := map[string]string{
+		"instance": instances[0],
+	}
+	fields := map[string]interface{}{
+		expectedCounterName: float32(0),
+	}
+
+	acc.AssertContainsTaggedFields(t, measurement, fields, tags)
 }


### PR DESCRIPTION
Pull request for feature https://github.com/influxdata/telegraf/issues/2438

Adds `ExcludeObjectName` to perfmon counter objects, as way to prevent the object name from being tagged. 

```
[[inputs.win_perf_counters]]

  [[inputs.win_perf_counters.object]]
    ObjectName = "Processor"
    Instances = ["*"]
    Counters = ["% Idle Time", "% Interrupt Time", "% Privileged Time", "% User Time", "% Processor Time"]
    Measurement = "win_cpu"
    ExcludeObjectName = true
```
