### PR TITLE
Adding ability to exclude ObjectName from perfmon counters (v2)

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -22,6 +22,11 @@ as counters used when performance monitoring
 
 Plugin wide entries are underneath `[[inputs.win_perf_counters]]`.
 
+#### ExcludeObjectNames
+*Optional*
+
+Bool, if set to `true` will not tag the ObjectName of the counters.
+
 #### PrintValid
 
 Bool, if set to `true` will print out all matching performance objects.

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -73,10 +73,11 @@ var testConfigParsed bool
 var testObject string
 
 type Win_PerfCounters struct {
-	PrintValid      bool
-	TestName        string
-	PreVistaSupport bool
-	Object          []perfobject
+	PrintValid         bool
+	TestName           string
+	PreVistaSupport    bool
+	Object             []perfobject
+	ExcludeObjectNames bool
 }
 
 type perfobject struct {
@@ -275,7 +276,9 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 						if s != "" {
 							tags["instance"] = s
 						}
-						tags["objectname"] = metric.objectName
+						if !m.ExcludeObjectNames {
+							tags["objectname"] = metric.objectName
+						}
 						fields[sanitizedChars.Replace(metric.counter)] =
 							float32(c.FmtValue.DoubleValue)
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -523,5 +523,56 @@ func TestWinPerfcountersCollect2(t *testing.T) {
 		counters[0]: float32(0),
 	}
 	acc.AssertContainsTaggedFields(t, measurement, fields, tags)
+}
 
+func TestWinPerfcountersCollectExcludeObjectNames(t *testing.T) {
+
+	var instances = make([]string, 1)
+	var counters = make([]string, 1)
+	var perfobjects = make([]perfobject, 1)
+
+	objectname := "Processor Information"
+	instances[0] = "_Total"
+	counters[0] = "Parking Status"
+
+	var expectedCounterName = "Parking_Status"
+
+	var measurement string = "test"
+	var warnonmissing bool = false
+	var failonmissing bool = true
+	var includetotal bool = false
+
+	PerfObject := perfobject{
+		ObjectName:    objectname,
+		Instances:     instances,
+		Counters:      counters,
+		Measurement:   measurement,
+		WarnOnMissing: warnonmissing,
+		FailOnMissing: failonmissing,
+		IncludeTotal:  includetotal,
+	}
+
+	perfobjects[0] = PerfObject
+
+	m := Win_PerfCounters{
+		ExcludeObjectNames: true,
+		PrintValid:         false,
+		TestName:           "CollectExcludeObjectName",
+		Object:             perfobjects,
+	}
+	var acc testutil.Accumulator
+	err := m.Gather(&acc)
+	require.NoError(t, err)
+
+	time.Sleep(2000 * time.Millisecond)
+	err = m.Gather(&acc)
+
+	tags := map[string]string{
+		"instance": instances[0],
+	}
+	fields := map[string]interface{}{
+		expectedCounterName: float32(0),
+	}
+
+	acc.AssertContainsTaggedFields(t, measurement, fields, tags)
 }


### PR DESCRIPTION
Another pull request for feature https://github.com/influxdata/telegraf/issues/2438

Adds `ExcludeObjectNames` to perfmon counter plugin, as way to prevent the object name from being tagged for all counters. 

```
[[inputs.win_perf_counters]]
  ExcludeObjectNames = true

  [[inputs.win_perf_counters.object]]
    ObjectName = "Processor"
    Instances = ["*"]
    Counters = ["% Idle Time", "% Interrupt Time", "% Privileged Time", "% User Time", "% Processor Time"]
    Measurement = "win_cpu"
```