### PR TITLE
Updated readme, now requires Go 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Ansible role: https://github.com/rossmcdonald/telegraf
 
 Telegraf manages dependencies via [gdm](https://github.com/sparrc/gdm),
 which gets installed via the Makefile
-if you don't have it already. You also must build with golang version 1.7+.
+if you don't have it already. You also must build with golang version 1.8+.
 
 1. [Install Go](https://golang.org/doc/install)
 2. [Setup your GOPATH](https://golang.org/doc/code.html#GOPATH)


### PR DESCRIPTION
Commit 54c9a385d introduced a requirement on Go version 1.8, updating the
README.md accordingly.