### PR TITLE
Fix type conflict on windows ping plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Release Notes
 
+- Users of the windows `ping` plugin will need to drop or migrate their
+measurements in order to continue using the plugin. The reason for this is that
+the windows plugin was outputting a different type than the linux plugin. This
+made it impossible to use the `ping` plugin for both windows and linux
+machines.
+
 - Ceph: the `ceph_pgmap_state` metric content has been modified to use a unique field `count`, with each state expressed as a `state` tag.
 
 Telegraf < 1.3:
@@ -65,6 +71,7 @@ be deprecated eventually.
 - [#2390](https://github.com/influxdata/telegraf/issues/2390): Empty tag value causes error on InfluxDB output.
 - [#2380](https://github.com/influxdata/telegraf/issues/2380): buffer_size field value is negative number from "internal" plugin.
 - [#2414](https://github.com/influxdata/telegraf/issues/2414): Missing error handling in the MySQL plugin leads to segmentation violation.
+- [#2462](https://github.com/influxdata/telegraf/pull/2462): Fix type conflict in windows ping plugin.
 
 ## v1.2.1 [2017-02-01]
 

--- a/plugins/inputs/ping/ping_windows.go
+++ b/plugins/inputs/ping/ping_windows.go
@@ -40,10 +40,10 @@ func (s *Ping) Description() string {
 const sampleConfig = `
 	## urls to ping
 	urls = ["www.google.com"] # required
-	
+
 	## number of pings to send per collection (ping -n <COUNT>)
 	count = 4 # required
-	
+
 	## Ping timeout, in seconds. 0 means default timeout (ping -w <TIMEOUT>)
 	Timeout = 0
 `
@@ -64,7 +64,7 @@ func hostPinger(timeout float64, args ...string) (string, error) {
 }
 
 // processPingOutput takes in a string output from the ping command
-// based on linux implementation but using regex ( multilanguage support ) ( shouldn't affect the performance of the program )
+// based on linux implementation but using regex ( multilanguage support )
 // It returns (<transmitted packets>, <received reply>, <received packet>, <average response>, <min response>, <max response>)
 func processPingOutput(out string) (int, int, int, int, int, int, error) {
 	// So find a line contain 3 numbers except reply lines
@@ -189,13 +189,13 @@ func (p *Ping) Gather(acc telegraf.Accumulator) error {
 				"percent_reply_loss":  lossReply,
 			}
 			if avg > 0 {
-				fields["average_response_ms"] = avg
+				fields["average_response_ms"] = float64(avg)
 			}
 			if min > 0 {
-				fields["minimum_response_ms"] = min
+				fields["minimum_response_ms"] = float64(min)
 			}
 			if max > 0 {
-				fields["maximum_response_ms"] = max
+				fields["maximum_response_ms"] = float64(max)
 			}
 			acc.AddFields("ping", fields, tags)
 		}(url)

--- a/plugins/inputs/ping/ping_windows_test.go
+++ b/plugins/inputs/ping/ping_windows_test.go
@@ -77,9 +77,9 @@ func TestPingGather(t *testing.T) {
 		"reply_received":      4,
 		"percent_packet_loss": 0.0,
 		"percent_reply_loss":  0.0,
-		"average_response_ms": 50,
-		"minimum_response_ms": 50,
-		"maximum_response_ms": 52,
+		"average_response_ms": 50.0,
+		"minimum_response_ms": 50.0,
+		"maximum_response_ms": 52.0,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 


### PR DESCRIPTION
closes #1433

### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)

this is going to require a note in the changelog release notes, because it will break current users of only the windows plugin.