### PR TITLE
Remove '-K' option from post-install script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ be deprecated eventually.
 - [#2390](https://github.com/influxdata/telegraf/issues/2390): Empty tag value causes error on InfluxDB output.
 - [#2380](https://github.com/influxdata/telegraf/issues/2380): buffer_size field value is negative number from "internal" plugin.
 - [#2414](https://github.com/influxdata/telegraf/issues/2414): Missing error handling in the MySQL plugin leads to segmentation violation.
+- [#2474](https://github.com/influxdata/telegraf/issues/1232): Remove -K option from useradd call in the post-installation script.
 
 ## v1.2.1 [2017-02-01]
 

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -28,9 +28,9 @@ id telegraf &>/dev/null
 if [[ $? -ne 0 ]]; then
     grep "^telegraf:" /etc/group &>/dev/null
     if [[ $? -ne 0 ]]; then
-        useradd -r -K USERGROUPS_ENAB=yes -M telegraf -s /bin/false -d /etc/telegraf
+        useradd -r -M telegraf -s /bin/false -d /etc/telegraf
     else
-        useradd -r -K USERGROUPS_ENAB=yes -M telegraf -s /bin/false -d /etc/telegraf -g telegraf
+        useradd -r -M telegraf -s /bin/false -d /etc/telegraf -g telegraf
     fi
 fi
 


### PR DESCRIPTION
Remove -K option from the post-installation script 'useradd' call, fixing issue #1232.

### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
