### PR TITLE
Disk counter array newline

### DIFF
--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -117,7 +117,8 @@
     Instances = ["*"]
     Counters = [
       "% Idle Time",
-      "% Disk Time","% Disk Read Time",
+      "% Disk Time",
+      "% Disk Read Time",
       "% Disk Write Time",
       "Current Disk Queue Length",
       "% Free Space",


### PR DESCRIPTION
Tweak formatting of `LogicalDisk` counter array to have one entry per
line.

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
