### PR TITLE
GitHub webhooks: check signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ be deprecated eventually.
 - [#2636](https://github.com/influxdata/telegraf/pull/2636): Add `message_len_max` option to `kafka_consumer` input
 - [#1100](https://github.com/influxdata/telegraf/issues/1100): Add collectd parser
 - [#1820](https://github.com/influxdata/telegraf/issues/1820): easier plugin testing without outputs
+- [#2493](https://github.com/influxdata/telegraf/pull/2493): Check signature in the GitHub webhook plugin
 
 ### Bugfixes
 

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -2382,6 +2382,7 @@
 #
 #   [inputs.webhooks.github]
 #     path = "/github"
+#     # secret = ""
 #
 #   [inputs.webhooks.mandrill]
 #     path = "/mandrill"

--- a/plugins/inputs/webhooks/github/README.md
+++ b/plugins/inputs/webhooks/github/README.md
@@ -2,6 +2,8 @@
 
 You should configure your Organization's Webhooks to point at the `webhooks` service. To do this go to `github.com/{my_organization}` and click `Settings > Webhooks > Add webhook`. In the resulting menu set `Payload URL` to `http://<my_ip>:1619/github`, `Content type` to `application/json` and under the section `Which events would you like to trigger this webhook?` select 'Send me <b>everything</b>'. By default all of the events will write to the `github_webhooks` measurement, this is configurable by setting the `measurement_name` in the config file.
 
+You can also add a secret that will be used by telegraf to verify the authenticity of the requests.
+
 ## Events
 
 The titles of the following sections are links to the full payloads and details for each event. The body contains what information from the event is persisted. The format is as follows:

--- a/plugins/inputs/webhooks/github/github_webhooks.go
+++ b/plugins/inputs/webhooks/github/github_webhooks.go
@@ -35,6 +35,7 @@ func (gh *GithubWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if gh.Secret != "" && !checkSignature(gh.Secret, data, r.Header["X-Hub-Signature"][0]) {
+		log.Printf("I! Fail to check the github webhook signature\n")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/plugins/inputs/webhooks/github/github_webhooks.go
+++ b/plugins/inputs/webhooks/github/github_webhooks.go
@@ -35,7 +35,7 @@ func (gh *GithubWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if gh.Secret != "" && !checkSignature(gh.Secret, data, r.Header.Get("X-Hub-Signature")) {
-		log.Printf("I! Fail to check the github webhook signature\n")
+		log.Printf("E! Fail to check the github webhook signature\n")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/plugins/inputs/webhooks/github/github_webhooks.go
+++ b/plugins/inputs/webhooks/github/github_webhooks.go
@@ -27,14 +27,14 @@ func (gh *GithubWebhook) Register(router *mux.Router, acc telegraf.Accumulator) 
 
 func (gh *GithubWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	eventType := r.Header["X-Github-Event"][0]
+	eventType := r.Header.Get("X-Github-Event")
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	if gh.Secret != "" && !checkSignature(gh.Secret, data, r.Header["X-Hub-Signature"][0]) {
+	if gh.Secret != "" && !checkSignature(gh.Secret, data, r.Header.Get("X-Hub-Signature")) {
 		log.Printf("I! Fail to check the github webhook signature\n")
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/plugins/inputs/webhooks/webhooks.go
+++ b/plugins/inputs/webhooks/webhooks.go
@@ -47,6 +47,7 @@ func (wb *Webhooks) SampleConfig() string {
 
   [inputs.webhooks.github]
     path = "/github"
+    # secret = ""
 
   [inputs.webhooks.mandrill]
     path = "/mandrill"


### PR DESCRIPTION
Fix #1661  

I added the check of the signature to github webhooks. If no secret is set in the config file, no check is performed (make it backward compatible).

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
