### PR TITLE
Exporting Ipmi.Path to be set by config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ be deprecated eventually.
 - [#2178](https://github.com/influxdata/telegraf/issues/2178): logparser: regexp with lookahead.
 - [#2466](https://github.com/influxdata/telegraf/issues/2466): Telegraf can crash in LoadDirectory on 0600 files.
 - [#2215](https://github.com/influxdata/telegraf/issues/2215): Iptables input: document better that rules without a comment are ignored.
+- [#2498](https://github.com/influxdata/telegraf/pull/2498): Exporting Ipmi.Path to be set by config.
 
 ## v1.2.1 [2017-02-01]
 

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -17,7 +17,7 @@ var (
 )
 
 type Ipmi struct {
-	path    string
+	Path    string
 	Servers []string
 }
 
@@ -44,7 +44,7 @@ func (m *Ipmi) Description() string {
 }
 
 func (m *Ipmi) Gather(acc telegraf.Accumulator) error {
-	if len(m.path) == 0 {
+	if len(m.Path) == 0 {
 		return fmt.Errorf("ipmitool not found: verify that ipmitool is installed and that ipmitool is in your PATH")
 	}
 
@@ -76,7 +76,7 @@ func (m *Ipmi) parse(acc telegraf.Accumulator, server string) error {
 	}
 
 	opts = append(opts, "sdr")
-	cmd := execCommand(m.path, opts...)
+	cmd := execCommand(m.Path, opts...)
 	out, err := internal.CombinedOutputTimeout(cmd, time.Second*5)
 	if err != nil {
 		return fmt.Errorf("failed to run command %s: %s - %s", strings.Join(cmd.Args, " "), err, string(out))
@@ -149,7 +149,7 @@ func init() {
 	m := Ipmi{}
 	path, _ := exec.LookPath("ipmitool")
 	if len(path) > 0 {
-		m.path = path
+		m.Path = path
 	}
 	inputs.Add("ipmi_sensor", func() telegraf.Input {
 		return &m

--- a/plugins/inputs/ipmi_sensor/ipmi_test.go
+++ b/plugins/inputs/ipmi_sensor/ipmi_test.go
@@ -14,7 +14,7 @@ import (
 func TestGather(t *testing.T) {
 	i := &Ipmi{
 		Servers: []string{"USERID:PASSW0RD@lan(192.168.1.1)"},
-		path:    "ipmitool",
+		Path:    "ipmitool",
 	}
 	// overwriting exec commands with mock commands
 	execCommand = fakeExecCommand
@@ -118,7 +118,7 @@ func TestGather(t *testing.T) {
 	}
 
 	i = &Ipmi{
-		path: "ipmitool",
+		Path: "ipmitool",
 	}
 
 	err = i.Gather(&acc)


### PR DESCRIPTION
Currently "path" is not exported, giving this error when users try to
override the variable via telegraf.conf as per the sample config:

`field corresponding to `path' is not defined in `*ipmi_sensor.Ipmi'`

Exporting the variable solves the problem.

Config:

```ini
[[inputs.ipmi_sensor]]
  path = "/usr/local/bin/ipmitool_sdr_f"
```

Before:

```
$ sudo telegraf -test
2017/03/06 17:09:12 I! Using config file: /etc/telegraf/telegraf.conf
2017/03/06 17:09:12 E! Error parsing /etc/telegraf/telegraf.conf, line 50: field corresponding to `path' is not defined in `*ipmi_sensor.Ipmi'
```

After:

```
$ sudo telegraf -test
2017/03/06 17:17:15 I! Using config file: /etc/telegraf/telegraf.conf
[...]
* Plugin: inputs.ipmi_sensor, Collection 1
> ipmi_sensor,unit=degrees_f,host=filesrv.rob86.net,name=cpu_temp status=1i,value=102.2 1488849436000000000
> ipmi_sensor,name=system_temp,unit=degrees_f,host=filesrv.rob86.net value=98.6,status=1i 1488849436000000000
[...]
```

### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
