### PR TITLE
DEAD (X) State Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ be deprecated eventually.
 - [#2339](https://github.com/influxdata/telegraf/pull/2339): Increment gather_errors for all errors emitted by inputs.
 - [#2071](https://github.com/influxdata/telegraf/issues/2071): Use official docker SDK.
 - [#1678](https://github.com/influxdata/telegraf/pull/1678): Add AMQP consumer input plugin
+- [#2501](https://github.com/influxdata/telegraf/pull/2501): Support DEAD(X) state in system input plugin.
 
 ### Bugfixes
 

--- a/plugins/inputs/system/PROCESSES_README.md
+++ b/plugins/inputs/system/PROCESSES_README.md
@@ -23,6 +23,7 @@ it requires access to execute `ps`.
     - stopped
     - total
     - zombie
+    - dead
     - wait (freebsd only)
     - idle (bsd only)
     - paging (linux only)
@@ -39,6 +40,7 @@ Linux  FreeBSD  Darwin  meaning
   R       R       R     running
   S       S       S     sleeping
   Z       Z       Z     zombie
+  X       X       X     dead
   T       T       T     stopped
  none     I       I     idle (sleeping for longer than about 20 seconds)
   D      D,L      U     blocked (waiting in uninterruptible sleep, or locked)

--- a/plugins/inputs/system/PROCESSES_README.md
+++ b/plugins/inputs/system/PROCESSES_README.md
@@ -56,5 +56,5 @@ None
 ```
 $ telegraf -config ~/ws/telegraf.conf -input-filter processes -test
 * Plugin: processes, Collection 1
-> processes blocked=8i,running=1i,sleeping=265i,stopped=0i,total=274i,zombie=0i,paging=0i,total_threads=687i 1457478636980905042
+> processes blocked=8i,running=1i,sleeping=265i,stopped=0i,total=274i,zombie=0i,dead=0i,paging=0i,total_threads=687i 1457478636980905042
 ```

--- a/plugins/inputs/system/PROCESSES_README.md
+++ b/plugins/inputs/system/PROCESSES_README.md
@@ -40,7 +40,7 @@ Linux  FreeBSD  Darwin  meaning
   R       R       R     running
   S       S       S     sleeping
   Z       Z       Z     zombie
-  X       X       X     dead
+  X      none    none   dead
   T       T       T     stopped
  none     I       I     idle (sleeping for longer than about 20 seconds)
   D      D,L      U     blocked (waiting in uninterruptible sleep, or locked)

--- a/plugins/inputs/system/processes.go
+++ b/plugins/inputs/system/processes.go
@@ -105,7 +105,7 @@ func (p *Processes) gatherFromPS(fields map[string]interface{}) error {
 		case 'U', 'D', 'L':
 			// Also known as uninterruptible sleep or disk sleep
 			fields["blocked"] = fields["blocked"].(int64) + int64(1)
-		case 'Z':
+		case 'Z', 'X':
 			fields["zombies"] = fields["zombies"].(int64) + int64(1)
 		case 'T':
 			fields["stopped"] = fields["stopped"].(int64) + int64(1)
@@ -162,7 +162,7 @@ func (p *Processes) gatherFromProc(fields map[string]interface{}) error {
 			fields["sleeping"] = fields["sleeping"].(int64) + int64(1)
 		case 'D':
 			fields["blocked"] = fields["blocked"].(int64) + int64(1)
-		case 'Z':
+		case 'Z','X':
 			fields["zombies"] = fields["zombies"].(int64) + int64(1)
 		case 'T', 't':
 			fields["stopped"] = fields["stopped"].(int64) + int64(1)

--- a/plugins/inputs/system/processes.go
+++ b/plugins/inputs/system/processes.go
@@ -162,7 +162,7 @@ func (p *Processes) gatherFromProc(fields map[string]interface{}) error {
 			fields["sleeping"] = fields["sleeping"].(int64) + int64(1)
 		case 'D':
 			fields["blocked"] = fields["blocked"].(int64) + int64(1)
-		case 'Z','X':
+		case 'Z', 'X':
 			fields["zombies"] = fields["zombies"].(int64) + int64(1)
 		case 'T', 't':
 			fields["stopped"] = fields["stopped"].(int64) + int64(1)

--- a/plugins/inputs/system/processes.go
+++ b/plugins/inputs/system/processes.go
@@ -66,6 +66,7 @@ func getEmptyFields() map[string]interface{} {
 	fields := map[string]interface{}{
 		"blocked":  int64(0),
 		"zombies":  int64(0),
+		"dead":     int64(0),
 		"stopped":  int64(0),
 		"running":  int64(0),
 		"sleeping": int64(0),
@@ -105,8 +106,10 @@ func (p *Processes) gatherFromPS(fields map[string]interface{}) error {
 		case 'U', 'D', 'L':
 			// Also known as uninterruptible sleep or disk sleep
 			fields["blocked"] = fields["blocked"].(int64) + int64(1)
-		case 'Z', 'X':
+		case 'Z':
 			fields["zombies"] = fields["zombies"].(int64) + int64(1)
+		case 'X':
+			fields["dead"] = fields["dead"].(int64) + int64(1)
 		case 'T':
 			fields["stopped"] = fields["stopped"].(int64) + int64(1)
 		case 'R':
@@ -162,8 +165,10 @@ func (p *Processes) gatherFromProc(fields map[string]interface{}) error {
 			fields["sleeping"] = fields["sleeping"].(int64) + int64(1)
 		case 'D':
 			fields["blocked"] = fields["blocked"].(int64) + int64(1)
-		case 'Z', 'X':
+		case 'Z':
 			fields["zombies"] = fields["zombies"].(int64) + int64(1)
+		case 'X':
+			fields["dead"] = fields["dead"].(int64) + int64(1)
 		case 'T', 't':
 			fields["stopped"] = fields["stopped"].(int64) + int64(1)
 		case 'W':

--- a/plugins/inputs/system/processes.go
+++ b/plugins/inputs/system/processes.go
@@ -66,7 +66,6 @@ func getEmptyFields() map[string]interface{} {
 	fields := map[string]interface{}{
 		"blocked":  int64(0),
 		"zombies":  int64(0),
-		"dead":     int64(0),
 		"stopped":  int64(0),
 		"running":  int64(0),
 		"sleeping": int64(0),
@@ -82,6 +81,7 @@ func getEmptyFields() map[string]interface{} {
 	case "openbsd":
 		fields["idle"] = int64(0)
 	case "linux":
+		fields["dead"] = int64(0)
 		fields["paging"] = int64(0)
 		fields["total_threads"] = int64(0)
 	}


### PR DESCRIPTION
Following https://github.com/torvalds/linux/blob/master/fs/proc/array.c#L126 telegraf plugin should handle DEAD state process and possibility to see it (http://unix.stackexchange.com/questions/126101/possible-to-see-dead-proccesses) specially in Docker context, the X state should be handle (I think this should be process like zombies but if you consider another metrics is necessary I can add it to interface)

### Required for all PRs:

- [X] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
