### PR TITLE
Adds a new json_timestamp_units configuration parameter

### DIFF
--- a/docs/DATA_FORMATS_OUTPUT.md
+++ b/docs/DATA_FORMATS_OUTPUT.md
@@ -148,3 +148,34 @@ The JSON data format serialized Telegraf metrics in json format. The format is:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "json"
 ```
+
+By default, the timestamp that is output in JSON data format serialized Telegraf
+metrics is a timestamp in seconds. The precision of this timestamp can be adjusted
+for any output by adding the optional `json_timestamp_units` parameter to the
+configuration for that output. For example, the following configuration will
+output the same data shown above with a timestamp in nanoseconds:
+
+```toml
+[[outputs.file]]
+  ## Files to write to, "stdout" is a specially handled file.
+  files = ["stdout", "/tmp/metrics.out"]
+
+  ## Data format to output.
+  ## Each data format has it's own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "json"
+  json_timestamp_units = "1ns"
+```
+
+In addition to supporting output of the timestamp in nanoseconds, the units
+of the output timestamp can be changed to microseconds (by setting this
+parameter to `1us` or `1µs`) or milliseconds (by setting this parameter to `1ms`).
+Obviously, by adjusting the number of microseconds or milliseconds in this
+value it is quite simple to output the timestamps in hundredths of a second
+(`10ms`) or tenths of a second (`100ms`).
+
+Note that if a `json_timestamp_units` value is not defined, or if the duration
+defined by that timestamp is less than or equal to zero, then the timestamps
+output in the JSON data format serialized Telegraf metrics will be in seconds
+(the default units for these timestamps).

--- a/docs/DATA_FORMATS_OUTPUT.md
+++ b/docs/DATA_FORMATS_OUTPUT.md
@@ -147,35 +147,14 @@ The JSON data format serialized Telegraf metrics in json format. The format is:
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "json"
-```
-
-By default, the timestamp that is output in JSON data format serialized Telegraf
-metrics is a timestamp in seconds. The precision of this timestamp can be adjusted
-for any output by adding the optional `json_timestamp_units` parameter to the
-configuration for that output. For example, the following configuration will
-output the same data shown above with a timestamp in nanoseconds:
-
-```toml
-[[outputs.file]]
-  ## Files to write to, "stdout" is a specially handled file.
-  files = ["stdout", "/tmp/metrics.out"]
-
-  ## Data format to output.
-  ## Each data format has it's own unique set of configuration options, read
-  ## more about them here:
-  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
-  data_format = "json"
   json_timestamp_units = "1ns"
 ```
 
-In addition to supporting output of the timestamp in nanoseconds, the units
-of the output timestamp can be changed to microseconds (by setting this
-parameter to `1us` or `1µs`) or milliseconds (by setting this parameter to `1ms`).
-Obviously, by adjusting the number of microseconds or milliseconds in this
-value it is quite simple to output the timestamps in hundredths of a second
-(`10ms`) or tenths of a second (`100ms`).
-
-Note that if a `json_timestamp_units` value is not defined, or if the duration
-defined by that timestamp is less than or equal to zero, then the timestamps
-output in the JSON data format serialized Telegraf metrics will be in seconds
-(the default units for these timestamps).
+By default, the timestamp that is output in JSON data format serialized Telegraf
+metrics is in seconds. The precision of this timestamp can be adjusted for any output
+by adding the optional `json_timestamp_units` parameter to the configuration for
+that output. This parameter can be used to set the timestamp units to  nanoseconds (`ns`),
+microseconds (`us` or `µs`), milliseconds (`ms`), or seconds (`s`). Note that this
+parameter will be truncated to the nearest power of 10 that, so if the `json_timestamp_units`
+are set to `15ms` the timestamps for the JSON format serialized Telegraf metrics will be
+output in hundredths of a second (`10ms`).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1285,11 +1285,8 @@ func buildSerializer(name string, tbl *ast.Table, agentConfig *AgentConfig) (ser
 		}
 	}
 
-	// if the output data format is JSON, then set the timestamp
-	// units for the serializer configuration to the units that were
-	// defined in the AgentConfig
 	if c.DataFormat == "json" {
-		c.TimestampUnits = agentConfig.JsonTimestampUnits
+		c.TimestampUnits = agentConfig.JsonTimestampUnits.Duration
 	}
 
 	delete(tbl.Fields, "data_format")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1280,8 +1280,7 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 			if str, ok := kv.Value.(*ast.String); ok {
 				timestampVal, err := time.ParseDuration(str.Value)
 				if err != nil {
-					fmt.Errorf("Unable to parse json_timestamp_units as a duration, %s", err)
-					return nil, err
+					return nil, fmt.Errorf("Unable to parse json_timestamp_units as a duration, %s", err)
 				}
 				// now that we have a duration, truncate it to the nearest
 				// power of ten (just in case)

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -4,9 +4,11 @@ import (
 	ejson "encoding/json"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
 )
 
 type JsonSerializer struct {
+	TimestampUnits internal.Duration
 }
 
 func (s *JsonSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
@@ -14,7 +16,7 @@ func (s *JsonSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 	m["tags"] = metric.Tags()
 	m["fields"] = metric.Fields()
 	m["name"] = metric.Name()
-	m["timestamp"] = metric.UnixNano() / 1000000000
+	m["timestamp"] = metric.UnixNano() / s.TimestampUnits.Duration.Nanoseconds()
 	serialized, err := ejson.Marshal(m)
 	if err != nil {
 		return []byte{}, err

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -2,21 +2,27 @@ package json
 
 import (
 	ejson "encoding/json"
+	"time"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/internal"
 )
 
 type JsonSerializer struct {
-	TimestampUnits internal.Duration
+	TimestampUnits time.Duration
 }
 
 func (s *JsonSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 	m := make(map[string]interface{})
+	units_nanoseconds := s.TimestampUnits.Nanoseconds()
+	// if the units passed in were less than or equal to zero,
+	// then serialize the timestamp in seconds (the default)
+	if units_nanoseconds <= 0 {
+		units_nanoseconds = 1000000000
+	}
 	m["tags"] = metric.Tags()
 	m["fields"] = metric.Fields()
 	m["name"] = metric.Name()
-	m["timestamp"] = metric.UnixNano() / s.TimestampUnits.Duration.Nanoseconds()
+	m["timestamp"] = metric.UnixNano() / units_nanoseconds
 	serialized, err := ejson.Marshal(m)
 	if err != nil {
 		return []byte{}, err

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -2,10 +2,10 @@ package serializers
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/influxdata/telegraf"
 
-	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/influxdata/telegraf/plugins/serializers/json"
@@ -41,7 +41,7 @@ type Config struct {
 	Template string
 
 	// Timestamp units to use for JSON formatted output
-	TimestampUnits internal.Duration
+	TimestampUnits time.Duration
 }
 
 // NewSerializer a Serializer interface based on the given config.
@@ -61,7 +61,7 @@ func NewSerializer(config *Config) (Serializer, error) {
 	return serializer, err
 }
 
-func NewJsonSerializer(timestampUnits internal.Duration) (Serializer, error) {
+func NewJsonSerializer(timestampUnits time.Duration) (Serializer, error) {
 	return &json.JsonSerializer{TimestampUnits: timestampUnits}, nil
 }
 

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/influxdata/telegraf/plugins/serializers/json"
@@ -29,7 +30,7 @@ type Serializer interface {
 // Config is a struct that covers the data types needed for all serializer types,
 // and can be used to instantiate _any_ of the serializers.
 type Config struct {
-	// Dataformat can be one of: influx, graphite
+	// Dataformat can be one of: influx, graphite, or json
 	DataFormat string
 
 	// Prefix to add to all measurements, only supports Graphite
@@ -38,6 +39,9 @@ type Config struct {
 	// Template for converting telegraf metrics into Graphite
 	// only supports Graphite
 	Template string
+
+	// Timestamp units to use for JSON formatted output
+	TimestampUnits internal.Duration
 }
 
 // NewSerializer a Serializer interface based on the given config.
@@ -50,15 +54,15 @@ func NewSerializer(config *Config) (Serializer, error) {
 	case "graphite":
 		serializer, err = NewGraphiteSerializer(config.Prefix, config.Template)
 	case "json":
-		serializer, err = NewJsonSerializer()
+		serializer, err = NewJsonSerializer(config.TimestampUnits)
 	default:
 		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
 	}
 	return serializer, err
 }
 
-func NewJsonSerializer() (Serializer, error) {
-	return &json.JsonSerializer{}, nil
+func NewJsonSerializer(timestampUnits internal.Duration) (Serializer, error) {
+	return &json.JsonSerializer{TimestampUnits: timestampUnits}, nil
 }
 
 func NewInfluxSerializer() (Serializer, error) {


### PR DESCRIPTION
Resolves #2124

The changes in this pull request add a new `json_timestamp_units` parameter to the Telegraf agent configuration, giving users the ability to define the which units should be used when reporting back the timestamps associated with a given metric when that metric is output as JSON.  Currently, the Telegraf agent simply returns a timestamp for those metrics in seconds when the metrics are output in JSON format (regardless of the precision that was used in generating the timestamp itself), while the same timestamps are returned in nanoseconds for if those metrics are output in the InfluxDB format.  Specifically, this pull request changes the Telegraf configuration file and the JSON serializer as follows in order to enable reporting of the timestamps associated with JSON formatted metrics in units other than seconds:

* a new `JsonTimestampUnits` field has been added to the `AgentConfig` struct that is defined in the `internal/config/config.go` file, and that field is initialized to a default value of one second when a new instance of this struct is created (ensuring that when the changes in this pull request are merged into the master branch the new version of the Telegraf agent will still work with the `telegraf.conf` files that were generated by previous versions of the Telegraf agent).
* a new `json_timestamp_units` field has been added to the `[agent]` section of the header that is defined in that same `internal/config/config.go` file; this is the header that is used to fill in the `[agent]` section of a new Telegraf configuration file when generating that file using a `telegraf ... config` command.  Note that we have left this parameter commented out in the resulting configuration file to prove that if it is undefined the timestamps output for JSON formatted metrics will still be in seconds (the default), but the line is there as an example to the user of how they might set this parameter to a value other than the `1s` default that is shown.
* the `buildSerializer` function signature in that same file has been changed to take an additional argument (a pointer to the `AgentConfig` struct), and that struct is used within the `buildSerializer` function to set the new `TimestampUnits` field that we've added to the `Config` struct defined in the `plugins/serializers/registry.go` file; this is the same location where the `Prefix` and `Template` fields used by the Graphite serializer are defined, so we felt that the `TimestampUnits` used in outputting JSON formatted metrics should be added to this struct as well.
* the JSON serializer has been modified to include a new `TimestampUnits` field in the `JsonSerializer` struct defined in the `plugins/serializers/json/json.go` file, and that new field is used to ensure that the timestamps output by this serializer are in the correct units (by dividing by the number of nanoseconds in the defined `TimestampUnits` duration rather than simply dividing the nanoseconds in the metric timestamp by `1,000,000,000`).
* the `NewJsonSerializer` function defined in the `plugins/serializers/registry.go` file has been modified to accept an argument defining the timestampUnits that the serializer should use

This set of changes was the minimal set of changes that we felt we could make that would add the desired behavior while still maintaining the default behavior of the current system (where timestamps for JSON formatted metrics are output in seconds, by default).  We were also careful to ensure that the current Telegraf configuration files could still be used with the new version of the Telegraf agent.

To provide an example of how the changes in this pull request work, we first generated a configuration file that outputs the `system` metrics to the `file` output filter using the current released version of Telegraf (v1.2.1):

```bash
$ telegraf version
Telegraf v1.2.1 (git: release-1.2 3b6ffb344e5c03c1595d862282a6823ecb438cff)
$ telegraf -input-filter 'system' -output-filter 'file' config | tee telegraf-current.conf
# Telegraf Configuration
#
# Telegraf is entirely plugin driven. All metrics are gathered from the
# declared inputs, and sent to the declared outputs.
#
# Plugins must be declared in here to be active.
# To deactivate a plugin, comment out the name and any variables.
#
# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
# file would generate.
#
# Environment variables can be used anywhere in this config file, simply prepend
# them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
# for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)


# Global tags can be specified here in key="value" format.
[global_tags]
  # dc = "us-east-1" # will tag all metrics with dc=us-east-1
  # rack = "1a"
  ## Environment variables can be used as tags, and throughout the config file
  # user = "$USER"


# Configuration for telegraf agent
[agent]
  ## Default data collection interval for all inputs
  interval = "10s"
  ## Rounds collection interval to 'interval'
  ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
  round_interval = true

  ## Telegraf will send metrics to outputs in batches of at most
  ## metric_batch_size metrics.
  ## This controls the size of writes that Telegraf sends to output plugins.
  metric_batch_size = 1000

  ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
  ## output, and will flush this buffer on a successful write. Oldest metrics
  ## are dropped first when this buffer fills.
  ## This buffer only fills when writes fail to output plugin(s).
  metric_buffer_limit = 10000

  ## Collection jitter is used to jitter the collection by a random amount.
  ## Each plugin will sleep for a random time within jitter before collecting.
  ## This can be used to avoid many plugins querying things like sysfs at the
  ## same time, which can have a measurable effect on the system.
  collection_jitter = "0s"

  ## Default flushing interval for all outputs. You shouldn't set this below
  ## interval. Maximum flush_interval will be flush_interval + flush_jitter
  flush_interval = "10s"
  ## Jitter the flush interval by a random amount. This is primarily to avoid
  ## large write spikes for users running a large number of telegraf instances.
  ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
  flush_jitter = "0s"

  ## By default, precision will be set to the same timestamp order as the
  ## collection interval, with the maximum being 1s.
  ## Precision will NOT be used for service inputs, such as logparser and statsd.
  ## Valid values are "ns", "us" (or "µs"), "ms", "s".
  precision = ""

  ## Logging configuration:
  ## Run telegraf with debug log messages.
  debug = false
  ## Run telegraf in quiet mode (error log messages only).
  quiet = false
  ## Specify the log file name. The empty string means to log to stderr.
  logfile = ""

  ## Override default hostname, if empty use os.Hostname()
  hostname = ""
  ## If set to true, do no set the "host" tag in the telegraf agent.
  omit_hostname = false


###############################################################################
#                            OUTPUT PLUGINS                                   #
###############################################################################

# Send telegraf metrics to file(s)
[[outputs.file]]
  ## Files to write to, "stdout" is a specially handled file.
  files = ["stdout", "/tmp/metrics.out"]

  ## Data format to output.
  ## Each data format has it's own unique set of configuration options, read
  ## more about them here:
  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
  data_format = "influx"



###############################################################################
#                            PROCESSOR PLUGINS                                #
###############################################################################

# # Print all metrics that pass through this filter.
# [[processors.printer]]



###############################################################################
#                            AGGREGATOR PLUGINS                               #
###############################################################################

# # Keep the aggregate min/max of each metric passing through.
# [[aggregators.minmax]]
#   ## General Aggregator Arguments:
#   ## The period on which to flush & clear the aggregator.
#   period = "30s"
#   ## If true, the original metric will be dropped by the
#   ## aggregator and will not get sent to the output plugins.
#   drop_original = false



###############################################################################
#                            INPUT PLUGINS                                    #
###############################################################################

# Read metrics about system load & uptime
[[inputs.system]]
  # no configuration

$ 
```
We then modified the `precision` in the `[agent]` section of the configuration file so that the precision is in nanoseconds (i.e. we set the `precision` value to `1ns`), and started up the telegraf agent using the (slightly) modified configuration file, capturing the first set of metrics reported (note that the configuration file generated, above, has the `data_format` for the `file` output filter set to `influx`, so the timestamps shown in this snippet are in nanoseconds):
```bash
$ telegraf --config telegraf-current.conf
2017-03-28T23:52:22Z I! Starting Telegraf (version 1.2.1)
2017-03-28T23:52:22Z I! Loaded outputs: file
2017-03-28T23:52:22Z I! Loaded inputs: inputs.system
2017-03-28T23:52:22Z I! Tags enabled: host=localhost.localdomain
2017-03-28T23:52:22Z I! Agent Config: Interval:10s, Quiet:false, Hostname:"localhost.localdomain", Flush Interval:10s
system,host=localhost.localdomain load1=0,load5=0.01,load15=0.05,n_users=1i,n_cpus=1i 1490745150008486243
system,host=localhost.localdomain uptime=70723i,uptime_format="19:38" 1490745150008510607
system,host=localhost.localdomain n_users=1i,n_cpus=1i,load1=0,load5=0.01,load15=0.05 1490745160006246662
system,host=localhost.localdomain uptime=70733i,uptime_format="19:38" 1490745160006278303
...
$ 
```
Next, we modified the `data_format` in our `file` output filter so that the metrics would be output in a `json` data format and restarted the agent, the result was that the timestamps that were output by the same `file` output filter are now in seconds, rather than nanoseconds:
```bash
$ telegraf --config telegraf-current.conf
2017-03-28T23:54:27Z I! Starting Telegraf (version 1.2.1)
2017-03-28T23:54:27Z I! Loaded outputs: file
2017-03-28T23:54:27Z I! Loaded inputs: inputs.system
2017-03-28T23:54:27Z I! Tags enabled: host=localhost.localdomain
2017-03-28T23:54:27Z I! Agent Config: Interval:10s, Quiet:false, Hostname:"localhost.localdomain", Flush Interval:10s
{"fields":{"load1":0,"load15":0.05,"load5":0.01,"n_cpus":1,"n_users":1},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490745270}
{"fields":{"uptime":70843,"uptime_format":"19:40"},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490745270}
{"fields":{"load1":0,"load15":0.05,"load5":0.01,"n_cpus":1,"n_users":1},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490745280}
{"fields":{"uptime":70853,"uptime_format":"19:40"},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490745280}
...
$ 
```
So that demonstrates the issue we are resolving in this pull request.  Since there is no way to set the units associated with the timestamp for JSON formatted metrics, we cannot get the timestamps for our metrics in any units other than seconds, regardless of the precision with which that timestamp was measured when the metric was collected.

With the changes in this PR, we can generate a new configuration file that looks like this:
```bash
$ ./telegraf version
Telegraf vdev-102-g630e617 (git: tb/add-json-timestamp-units 630e617)
$ ./telegraf -input-filter 'system' -output-filter 'file' config | tee telegraf-new.conf
# Telegraf Configuration
#
# Telegraf is entirely plugin driven. All metrics are gathered from the
# declared inputs, and sent to the declared outputs.
#
# Plugins must be declared in here to be active.
# To deactivate a plugin, comment out the name and any variables.
#
# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
# file would generate.
#
# Environment variables can be used anywhere in this config file, simply prepend
# them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
# for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)


# Global tags can be specified here in key="value" format.
[global_tags]
  # dc = "us-east-1" # will tag all metrics with dc=us-east-1
  # rack = "1a"
  ## Environment variables can be used as tags, and throughout the config file
  # user = "$USER"


# Configuration for telegraf agent
[agent]
  ## Default data collection interval for all inputs
  interval = "10s"
  ## Rounds collection interval to 'interval'
  ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
  round_interval = true

  ## Telegraf will send metrics to outputs in batches of at most
  ## metric_batch_size metrics.
  ## This controls the size of writes that Telegraf sends to output plugins.
  metric_batch_size = 1000

  ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
  ## output, and will flush this buffer on a successful write. Oldest metrics
  ## are dropped first when this buffer fills.
  ## This buffer only fills when writes fail to output plugin(s).
  metric_buffer_limit = 10000

  ## Collection jitter is used to jitter the collection by a random amount.
  ## Each plugin will sleep for a random time within jitter before collecting.
  ## This can be used to avoid many plugins querying things like sysfs at the
  ## same time, which can have a measurable effect on the system.
  collection_jitter = "0s"

  ## Default flushing interval for all outputs. You shouldn't set this below
  ## interval. Maximum flush_interval will be flush_interval + flush_jitter
  flush_interval = "10s"
  ## Jitter the flush interval by a random amount. This is primarily to avoid
  ## large write spikes for users running a large number of telegraf instances.
  ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
  flush_jitter = "0s"

  ## By default, precision will be set to the same timestamp order as the
  ## collection interval, with the maximum being 1s.
  ## Precision will NOT be used for service inputs, such as logparser and statsd.
  ## Valid values are "ns", "us" (or "µs"), "ms", "s".
  precision = ""

  ## Logging configuration:
  ## Run telegraf with debug log messages.
  debug = false
  ## Run telegraf in quiet mode (error log messages only).
  quiet = false
  ## Specify the log file name. The empty string means to log to stderr.
  logfile = ""

  ## Override default hostname, if empty use os.Hostname()
  hostname = ""
  ## If set to true, do no set the "host" tag in the telegraf agent.
  omit_hostname = false

  ## used to set the timestamp units that should be used when the output is
  ## in JSON format; valid values are "ns", "us" (or "µs"), "ms", or "s",
  ## and the default units if not specified are "s"
  #json_timestamp_units = "1s"


###############################################################################
#                            OUTPUT PLUGINS                                   #
###############################################################################

# Send telegraf metrics to file(s)
[[outputs.file]]
  ## Files to write to, "stdout" is a specially handled file.
  files = ["stdout", "/tmp/metrics.out"]

  ## Data format to output.
  ## Each data format has it's own unique set of configuration options, read
  ## more about them here:
  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
  data_format = "influx"



###############################################################################
#                            PROCESSOR PLUGINS                                #
###############################################################################

# # Print all metrics that pass through this filter.
# [[processors.printer]]



###############################################################################
#                            AGGREGATOR PLUGINS                               #
###############################################################################

# # Keep the aggregate min/max of each metric passing through.
# [[aggregators.minmax]]
#   ## General Aggregator Arguments:
#   ## The period on which to flush & clear the aggregator.
#   period = "30s"
#   ## If true, the original metric will be dropped by the
#   ## aggregator and will not get sent to the output plugins.
#   drop_original = false



###############################################################################
#                            INPUT PLUGINS                                    #
###############################################################################

# Read metrics about system load & uptime
[[inputs.system]]
  # no configuration

$ 
```
Note that this version of the Telegraf agent includes the new parameter (and comments associated with it) in the `[agent]` section of the configuration file:
```bash
  ## used to set the timestamp units that should be used when the output is
  ## in JSON format; valid values are "ns", "us" (or "µs"), "ms", or "s",
  ## and the default units if not specified are "s"
  #json_timestamp_units = "1s"
```
Once again, we changed the precision to `1ns` in the agent configuration and we set the `data_format` for our `file` output filter to `json`; with these changes in place we got the same behavior that we've seen all along in the JSON formatted metrics that are reported by the new version of the Telegraf agent:
```bash
$ ./telegraf --config telegraf-new.conf
2017-03-29T00:26:51Z I! Starting Telegraf (version dev-102-g630e617)
2017-03-29T00:26:51Z I! Loaded outputs: file
2017-03-29T00:26:51Z I! Loaded inputs: inputs.system
2017-03-29T00:26:51Z I! Tags enabled: host=localhost.localdomain
2017-03-29T00:26:51Z I! Agent Config: Interval:10s, Quiet:false, Hostname:"localhost.localdomain", Flush Interval:10s
{"fields":{"load1":0,"load15":0.05,"load5":0.01,"n_cpus":1,"n_users":1},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490747220}
{"fields":{"uptime":72793,"uptime_format":"20:13"},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490747220}
{"fields":{"load1":0,"load15":0.05,"load5":0.01,"n_cpus":1,"n_users":1},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490747230}
{"fields":{"uptime":72803,"uptime_format":"20:13"},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490747230}
...
$ 
```
if, however, we uncomment the `json_timestamp_units` line in our new configuration file an set it to `1ns` as well, we will see these same timestamps output in nanoseconds instead of seconds:
```bash
$ ./telegraf --config telegraf-new.conf
2017-03-29T00:28:52Z I! Starting Telegraf (version dev-102-g630e617)
2017-03-29T00:28:52Z I! Loaded outputs: file
2017-03-29T00:28:52Z I! Loaded inputs: inputs.system
2017-03-29T00:28:52Z I! Tags enabled: host=localhost.localdomain
2017-03-29T00:28:52Z I! Agent Config: Interval:10s, Quiet:false, Hostname:"localhost.localdomain", Flush Interval:10s
{"fields":{"load1":0,"load15":0.05,"load5":0.01,"n_cpus":1,"n_users":1},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490747340016785814}
{"fields":{"uptime":72913,"uptime_format":"20:15"},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490747340016815131}
{"fields":{"load1":0,"load15":0.05,"load5":0.01,"n_cpus":1,"n_users":1},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490747350016392092}
{"fields":{"uptime":72923,"uptime_format":"20:15"},"name":"system","tags":{"host":"localhost.localdomain"},"timestamp":1490747350016446187}
...
$ 
```

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
