### PR TITLE
Adding tags to inputs (CloudWatch example)

### DIFF
--- a/plugins/inputs/cloudwatch/README.md
+++ b/plugins/inputs/cloudwatch/README.md
@@ -47,6 +47,10 @@ API endpoint. In the following order the plugin will attempt to authenticate.
   ## See http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
   ratelimit = 200
 
+  ## Additional tags to add to the metric
+  [inputs.cloudwatch.tags]
+    tag_name = "value"
+
   ## Metrics to Pull (optional)
   ## Defaults to all Metrics in Namespace if nothing is provided
   ## Refreshes Namespace available metrics every 1h

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -32,6 +32,7 @@ type (
 		Delay       internal.Duration `toml:"delay"`
 		Namespace   string            `toml:"namespace"`
 		Metrics     []*Metric         `toml:"metrics"`
+		Tags        map[string]string `toml:"tags"`
 		CacheTTL    internal.Duration `toml:"cache_ttl"`
 		RateLimit   int               `toml:"ratelimit"`
 		client      cloudwatchClient
@@ -109,6 +110,10 @@ func (c *CloudWatch) SampleConfig() string {
   ## maximum of 400. Optional - default value is 200.
   ## See http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
   ratelimit = 200
+
+	## Additional tags to add to the metric
+	#[inputs.cloudwatch.tags]
+	#  tag_name = "value"
 
   ## Metrics to Pull (optional)
   ## Defaults to all Metrics in Namespace if nothing is provided
@@ -302,6 +307,11 @@ func (c *CloudWatch) gatherMetric(
 
 		for _, d := range metric.Dimensions {
 			tags[snakeCase(*d.Name)] = *d.Value
+		}
+
+		// merge tags from inputs.cloudwatch.tags config
+		for k, v := range c.Tags {
+			tags[k] = v
 		}
 
 		// record field for each statistic

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -59,6 +59,9 @@ func TestGather(t *testing.T) {
 		Delay:     internalDuration,
 		Period:    internalDuration,
 		RateLimit: 200,
+		Tags: map[string]string{
+			"top_level_tag": "tag_value",
+		},
 	}
 
 	var acc testutil.Accumulator
@@ -77,6 +80,7 @@ func TestGather(t *testing.T) {
 	tags["unit"] = "seconds"
 	tags["region"] = "us-east-1"
 	tags["load_balancer_name"] = "p-example"
+	tags["top_level_tag"] = "tag_value"
 
 	assert.True(t, acc.HasMeasurement("cloudwatch_aws_elb"))
 	acc.AssertContainsTaggedFields(t, "cloudwatch_aws_elb", fields, tags)


### PR DESCRIPTION
Hey folks,

This is an example of fixing #2582 for one input (and a step towards #2572), which are about adding user specified tags from the input config (e.g. fixed value tags like hostname, environment, version, etc...).

Could somebody check this over and see if it's the right thing to do? Presumably, if the expectation is each input should have some generic support for adding tags, this work will need to be replicated across each input.