### PR TITLE
Added cpu_usage_total measurement in CPU input plugin

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -521,6 +521,8 @@
   totalcpu = true
   ## If true, collect raw CPU time metrics.
   collect_cpu_time = false
+  ## If true, collect summary CPU usage
+  collect_summary_cpu_usage = true
 
 
 # Read metrics about disk usage by mount point

--- a/plugins/inputs/system/CPU_README.md
+++ b/plugins/inputs/system/CPU_README.md
@@ -3,6 +3,8 @@
 #### Plugin arguments:
 - **totalcpu** boolean: If true, include `cpu-total` data
 - **percpu** boolean: If true, include data on a per-cpu basis `cpu0, cpu1, etc.`
+- **collect_cpu_time** boolean: If true, collect raw CPU time metrics `cpu_usage_total`
+- **collect_summary_cpu_usage** boolean: If true, include summary CPU usage `cpu_usage_total`
 
 #### Description
 
@@ -81,3 +83,4 @@ Measurement names:
 - cpu_usage_steal
 - cpu_usage_guest
 - cpu_usage_guest_nice
+- cpu_usage_total

--- a/plugins/inputs/system/cpu.go
+++ b/plugins/inputs/system/cpu.go
@@ -9,13 +9,33 @@ import (
 	"github.com/shirou/gopsutil/cpu"
 )
 
+// cpuCoreUsageStats is a CPU core usage in percents up to 100
+type cpuCoreUsageStats struct {
+	User      float64
+	System    float64
+	Idle      float64
+	Nice      float64
+	Iowait    float64
+	Irq       float64
+	Softirq   float64
+	Steal     float64
+	Guest     float64
+	GuestNice float64
+}
+
+// Total returns total CPU usage: 100% - idle
+func (s *cpuCoreUsageStats) Total() float64 {
+	return s.User + s.System + s.Nice + s.Iowait + s.Irq + s.Softirq + s.Steal + s.Guest + s.GuestNice
+}
+
 type CPUStats struct {
 	ps        PS
 	lastStats []cpu.TimesStat
 
-	PerCPU         bool `toml:"percpu"`
-	TotalCPU       bool `toml:"totalcpu"`
-	CollectCPUTime bool `toml:"collect_cpu_time"`
+	PerCPU                 bool `toml:"percpu"`
+	TotalCPU               bool `toml:"totalcpu"`
+	CollectCPUTime         bool `toml:"collect_cpu_time"`
+	CollectSummaryCPUUsage bool `toml:"collect_summary_cpu_usage"`
 }
 
 func NewCPUStats(ps PS) *CPUStats {
@@ -36,6 +56,8 @@ var sampleConfig = `
   totalcpu = true
   ## If true, collect raw CPU time metrics.
   collect_cpu_time = false
+  ## If true, collect summary CPU usage
+  collect_summary_cpu_usage = true
 `
 
 func (_ *CPUStats) SampleConfig() string {
@@ -43,6 +65,7 @@ func (_ *CPUStats) SampleConfig() string {
 }
 
 func (s *CPUStats) Gather(acc telegraf.Accumulator) error {
+	cpuCoreUsage := &cpuCoreUsageStats{}
 	times, err := s.ps.CPUTimes(s.PerCPU, s.TotalCPU)
 	if err != nil {
 		return fmt.Errorf("error getting CPU info: %s", err)
@@ -90,19 +113,38 @@ func (s *CPUStats) Gather(acc telegraf.Accumulator) error {
 		if totalDelta == 0 {
 			continue
 		}
+
+		cpuCoreUsage.User = 100 * (cts.User - lastCts.User - (cts.Guest - lastCts.Guest)) / totalDelta
+		cpuCoreUsage.System = 100 * (cts.System - lastCts.System) / totalDelta
+		cpuCoreUsage.Idle = 100 * (cts.Idle - lastCts.Idle) / totalDelta
+		cpuCoreUsage.Nice = 100 * (cts.Nice - lastCts.Nice - (cts.GuestNice - lastCts.GuestNice)) / totalDelta
+		cpuCoreUsage.Iowait = 100 * (cts.Iowait - lastCts.Iowait) / totalDelta
+		cpuCoreUsage.Irq = 100 * (cts.Irq - lastCts.Irq) / totalDelta
+		cpuCoreUsage.Softirq = 100 * (cts.Softirq - lastCts.Softirq) / totalDelta
+		cpuCoreUsage.Steal = 100 * (cts.Steal - lastCts.Steal) / totalDelta
+		cpuCoreUsage.Guest = 100 * (cts.Guest - lastCts.Guest) / totalDelta
+		cpuCoreUsage.GuestNice = 100 * (cts.GuestNice - lastCts.GuestNice) / totalDelta
+
 		fieldsG := map[string]interface{}{
-			"usage_user":       100 * (cts.User - lastCts.User - (cts.Guest - lastCts.Guest)) / totalDelta,
-			"usage_system":     100 * (cts.System - lastCts.System) / totalDelta,
-			"usage_idle":       100 * (cts.Idle - lastCts.Idle) / totalDelta,
-			"usage_nice":       100 * (cts.Nice - lastCts.Nice - (cts.GuestNice - lastCts.GuestNice)) / totalDelta,
-			"usage_iowait":     100 * (cts.Iowait - lastCts.Iowait) / totalDelta,
-			"usage_irq":        100 * (cts.Irq - lastCts.Irq) / totalDelta,
-			"usage_softirq":    100 * (cts.Softirq - lastCts.Softirq) / totalDelta,
-			"usage_steal":      100 * (cts.Steal - lastCts.Steal) / totalDelta,
-			"usage_guest":      100 * (cts.Guest - lastCts.Guest) / totalDelta,
-			"usage_guest_nice": 100 * (cts.GuestNice - lastCts.GuestNice) / totalDelta,
+			"usage_user":       cpuCoreUsage.User,
+			"usage_system":     cpuCoreUsage.System,
+			"usage_idle":       cpuCoreUsage.Idle,
+			"usage_nice":       cpuCoreUsage.Nice,
+			"usage_iowait":     cpuCoreUsage.Iowait,
+			"usage_irq":        cpuCoreUsage.Irq,
+			"usage_softirq":    cpuCoreUsage.Softirq,
+			"usage_steal":      cpuCoreUsage.Steal,
+			"usage_guest":      cpuCoreUsage.Guest,
+			"usage_guest_nice": cpuCoreUsage.GuestNice,
 		}
 		acc.AddGauge("cpu", fieldsG, tags, now)
+
+		if s.CollectSummaryCPUUsage {
+			fieldsSummary := map[string]interface{}{
+				"usage_total": cpuCoreUsage.Total(),
+			}
+			acc.AddGauge("cpu", fieldsSummary, tags, now)
+		}
 	}
 
 	s.lastStats = times


### PR DESCRIPTION
CPU input plugin: added `cpu_usage_total` measurement. This measurement is often used and it would be convenient to have possibility to enable it in config.