### PR TITLE
fix timestamp parsing on prometheus plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ be deprecated eventually.
 - [#2541](https://github.com/influxdata/telegraf/issues/2541): Return error on unsupported serializer data format.
 - [#1827](https://github.com/influxdata/telegraf/issues/1827): Fix Windows Performance Counters multi instance identifier
 - [#2576](https://github.com/influxdata/telegraf/pull/2576): Add write timeout to Riemann output
+- [#2596](https://github.com/influxdata/telegraf/pull/2596): fix timestamp parsing on prometheus plugin
 
 
 ## v1.2.1 [2017-02-01]

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -3,14 +3,15 @@ package prometheus
 import (
 	"errors"
 	"fmt"
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/internal"
-	"github.com/influxdata/telegraf/plugins/inputs"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
 const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3`
@@ -91,7 +92,6 @@ var client = &http.Client{
 }
 
 func (p *Prometheus) gatherURL(url string, acc telegraf.Accumulator) error {
-	collectDate := time.Now()
 	var req, err = http.NewRequest("GET", url, nil)
 	req.Header.Add("Accept", acceptHeader)
 	var token []byte
@@ -145,7 +145,7 @@ func (p *Prometheus) gatherURL(url string, acc telegraf.Accumulator) error {
 	for _, metric := range metrics {
 		tags := metric.Tags()
 		tags["url"] = url
-		acc.AddFields(metric.Name(), metric.Fields(), tags, collectDate)
+		acc.AddFields(metric.Name(), metric.Fields(), tags, metric.Time())
 	}
 
 	return nil

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,9 @@ go_gc_duration_seconds_count 7
 # HELP go_goroutines Number of goroutines that currently exist.
 # TYPE go_goroutines gauge
 go_goroutines 15
+# HELP test_metric An untyped metric with a timestamp
+# TYPE test_metric untyped
+test_metric{label="value"} 1.0 1490802350000
 `
 
 func TestPrometheusGeneratesMetrics(t *testing.T) {
@@ -42,4 +46,7 @@ func TestPrometheusGeneratesMetrics(t *testing.T) {
 
 	assert.True(t, acc.HasFloatField("go_gc_duration_seconds", "count"))
 	assert.True(t, acc.HasFloatField("go_goroutines", "gauge"))
+	assert.True(t, acc.HasFloatField("test_metric", "value"))
+	assert.True(t, acc.HasTimestamp("test_metric", time.Unix(1490802350, 0)))
+
 }

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -275,6 +275,19 @@ func (a *Accumulator) AssertDoesNotContainMeasurement(t *testing.T, measurement 
 	}
 }
 
+// HasTimestamp returns true if the measurement has a matching Time value
+func (a *Accumulator) HasTimestamp(measurement string, timestamp time.Time) bool {
+	a.Lock()
+	defer a.Unlock()
+	for _, p := range a.Metrics {
+		if p.Measurement == measurement {
+			return timestamp.Equal(p.Time)
+		}
+	}
+
+	return false
+}
+
 // HasIntField returns true if the measurement has an Int value
 func (a *Accumulator) HasIntField(measurement string, field string) bool {
 	a.Lock()


### PR DESCRIPTION
This change exposes the parsed timestamp from the input metric when available, defaulting to current time when not provided.