### PR TITLE
fix race in testutil Accumulator.Wait()

### DIFF
--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -43,9 +43,9 @@ func (a *Accumulator) NMetrics() uint64 {
 }
 
 func (a *Accumulator) ClearMetrics() {
-	atomic.StoreUint64(&a.nMetrics, 0)
 	a.Lock()
 	defer a.Unlock()
+	atomic.StoreUint64(&a.nMetrics, 0)
 	a.Metrics = make([]*Metric, 0)
 }
 
@@ -56,9 +56,9 @@ func (a *Accumulator) AddFields(
 	tags map[string]string,
 	timestamp ...time.Time,
 ) {
-	atomic.AddUint64(&a.nMetrics, 1)
 	a.Lock()
 	defer a.Unlock()
+	atomic.AddUint64(&a.nMetrics, 1)
 	if a.Cond != nil {
 		a.Cond.Broadcast()
 	}


### PR DESCRIPTION
Noticed this in a test result for #2587: https://circleci.com/gh/influxdata/telegraf/6432?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

What happens is that the accumulator has 2 metrics in it, `Wait(3)` is called and grabs a lock. Then another goroutine adds a metric, increments the atomic counter, and blocks waiting for the lock. The first goroutine, which is still running, gets to the point in the code where it checks the atomic counter, sees `3`, and returns, releasing the lock. This frees up the second goroutine, but it doesn't get scheduled on the CPU yet. The caller of `Wait(3)` then tries to access the 3rd metric, but the second goroutine didn't get a chance to add it yet.

### Required for all PRs:

- [X] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)