### PR TITLE
socket_listener: clean up unix socket file on start & stop

### DIFF
--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -18,6 +18,7 @@ func TestSocketListener_tcp(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	err := sl.Start(acc)
 	require.NoError(t, err)
+	defer sl.Stop()
 
 	client, err := net.Dial("tcp", sl.Closer.(net.Listener).Addr().String())
 	require.NoError(t, err)
@@ -32,6 +33,7 @@ func TestSocketListener_udp(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	err := sl.Start(acc)
 	require.NoError(t, err)
+	defer sl.Stop()
 
 	client, err := net.Dial("udp", sl.Closer.(net.PacketConn).LocalAddr().String())
 	require.NoError(t, err)
@@ -40,13 +42,14 @@ func TestSocketListener_udp(t *testing.T) {
 }
 
 func TestSocketListener_unix(t *testing.T) {
-	defer os.Remove("/tmp/telegraf_test.sock")
+	os.Create("/tmp/telegraf_test.sock")
 	sl := newSocketListener()
 	sl.ServiceAddress = "unix:///tmp/telegraf_test.sock"
 
 	acc := &testutil.Accumulator{}
 	err := sl.Start(acc)
 	require.NoError(t, err)
+	defer sl.Stop()
 
 	client, err := net.Dial("unix", "/tmp/telegraf_test.sock")
 	require.NoError(t, err)
@@ -55,13 +58,14 @@ func TestSocketListener_unix(t *testing.T) {
 }
 
 func TestSocketListener_unixgram(t *testing.T) {
-	defer os.Remove("/tmp/telegraf_test.sock")
+	os.Create("/tmp/telegraf_test.sock")
 	sl := newSocketListener()
 	sl.ServiceAddress = "unixgram:///tmp/telegraf_test.sock"
 
 	acc := &testutil.Accumulator{}
 	err := sl.Start(acc)
 	require.NoError(t, err)
+	defer sl.Stop()
 
 	client, err := net.Dial("unixgram", "/tmp/telegraf_test.sock")
 	require.NoError(t, err)

--- a/plugins/outputs/socket_writer/socket_writer_test.go
+++ b/plugins/outputs/socket_writer/socket_writer_test.go
@@ -44,6 +44,7 @@ func TestSocketWriter_udp(t *testing.T) {
 }
 
 func TestSocketWriter_unix(t *testing.T) {
+	os.Remove("/tmp/telegraf_test.sock")
 	defer os.Remove("/tmp/telegraf_test.sock")
 	listener, err := net.Listen("unix", "/tmp/telegraf_test.sock")
 	require.NoError(t, err)
@@ -61,6 +62,7 @@ func TestSocketWriter_unix(t *testing.T) {
 }
 
 func TestSocketWriter_unixgram(t *testing.T) {
+	os.Remove("/tmp/telegraf_test.sock")
 	defer os.Remove("/tmp/telegraf_test.sock")
 	listener, err := net.ListenPacket("unixgram", "/tmp/telegraf_test.sock")
 	require.NoError(t, err)


### PR DESCRIPTION
Includes 2 fixes for the `socket_listener`:

1. On unix* sockets, unlink the file before start and after stop.  
This is the critical fix. When writing, I forgot about this step :-(
2. Suppress "use of closed network connection" error on shutdown.  
On shutdown, we kill off the listener & reader goroutines by just shutting down the sockets they're using. But this was causing them to log the result as an error.


No change log entry since the plugin isn't in a released version yet.

### Required for all PRs:

- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
