### PR TITLE
Fixed content-type header in output plugin OpenTSDB

### DIFF
--- a/plugins/outputs/opentsdb/opentsdb_http.go
+++ b/plugins/outputs/opentsdb/opentsdb_http.go
@@ -134,7 +134,7 @@ func (o *openTSDBHttp) flush() error {
 	if err != nil {
 		return fmt.Errorf("Error when building request: %s", err.Error())
 	}
-	req.Header.Set("Content-Type", "applicaton/json")
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Encoding", "gzip")
 
 	if o.Debug {


### PR DESCRIPTION
Minor fix for Content-Type header, there was a misspelling