### PR TITLE
Disk plugin expose inodes_used_percent.

### DIFF
--- a/plugins/inputs/system/disk.go
+++ b/plugins/inputs/system/disk.go
@@ -59,13 +59,14 @@ func (s *DiskStats) Gather(acc telegraf.Accumulator) error {
 			"fstype": du.Fstype,
 		}
 		var used_percent float64
-		if du.Total > 0 {
-			used_percent = float64(du.Used) / float64(du.Total) * 100
+		if du.Used+du.Free > 0 {
+			used_percent = float64(du.Used) /
+				(float64(du.Used) + float64(du.Free)) * 100
 		}
 
 		var inodes_used_percent float64
-		if du.InodesTotal > 0 {
-			inodes_used_percent = float64(du.InodesUsed) / float64(du.InodesTotal) * 100
+		if du.InodesUsed+du.InodesFree > 0 {
+			inodes_used_percent = float64(du.InodesUsed) / (float64(du.InodesUsed) + float64(du.InodesFree)) * 100
 		}
 
 		fields := map[string]interface{}{

--- a/plugins/inputs/system/disk.go
+++ b/plugins/inputs/system/disk.go
@@ -59,19 +59,24 @@ func (s *DiskStats) Gather(acc telegraf.Accumulator) error {
 			"fstype": du.Fstype,
 		}
 		var used_percent float64
-		if du.Used+du.Free > 0 {
-			used_percent = float64(du.Used) /
-				(float64(du.Used) + float64(du.Free)) * 100
+		if du.Total > 0 {
+			used_percent = float64(du.Used) / float64(du.Total) * 100
+		}
+
+		var inodes_used_percent float64
+		if du.InodesTotal > 0 {
+			inodes_used_percent = float64(du.InodesUsed) / float64(du.InodesTotal) * 100
 		}
 
 		fields := map[string]interface{}{
-			"total":        du.Total,
-			"free":         du.Free,
-			"used":         du.Used,
-			"used_percent": used_percent,
-			"inodes_total": du.InodesTotal,
-			"inodes_free":  du.InodesFree,
-			"inodes_used":  du.InodesUsed,
+			"total":               du.Total,
+			"free":                du.Free,
+			"used":                du.Used,
+			"used_percent":        used_percent,
+			"inodes_total":        du.InodesTotal,
+			"inodes_free":         du.InodesFree,
+			"inodes_used":         du.InodesUsed,
+			"inodes_used_percent": inodes_used_percent,
 		}
 		acc.AddGauge("disk", fields, tags)
 	}

--- a/plugins/inputs/system/disk_test.go
+++ b/plugins/inputs/system/disk_test.go
@@ -82,7 +82,7 @@ func TestDiskStats(t *testing.T) {
 	require.NoError(t, err)
 
 	numDiskMetrics := acc.NFields()
-	expectedAllDiskMetrics := 14
+	expectedAllDiskMetrics := 16
 	assert.Equal(t, expectedAllDiskMetrics, numDiskMetrics)
 
 	tags1 := map[string]string{
@@ -97,22 +97,24 @@ func TestDiskStats(t *testing.T) {
 	}
 
 	fields1 := map[string]interface{}{
-		"total":        uint64(128),
-		"used":         uint64(100),
-		"free":         uint64(23),
-		"inodes_total": uint64(1234),
-		"inodes_free":  uint64(234),
-		"inodes_used":  uint64(1000),
-		"used_percent": float64(81.30081300813008),
+		"total":               uint64(128),
+		"used":                uint64(100),
+		"free":                uint64(23),
+		"inodes_total":        uint64(1234),
+		"inodes_free":         uint64(234),
+		"inodes_used":         uint64(1000),
+		"inodes_used_percent": float64(81.03727714748784),
+		"used_percent":        float64(81.30081300813008),
 	}
 	fields2 := map[string]interface{}{
-		"total":        uint64(256),
-		"used":         uint64(200),
-		"free":         uint64(46),
-		"inodes_total": uint64(2468),
-		"inodes_free":  uint64(468),
-		"inodes_used":  uint64(2000),
-		"used_percent": float64(81.30081300813008),
+		"total":               uint64(256),
+		"used":                uint64(200),
+		"free":                uint64(46),
+		"inodes_total":        uint64(2468),
+		"inodes_free":         uint64(468),
+		"inodes_used":         uint64(2000),
+		"inodes_used_percent": float64(81.03727714748784),
+		"used_percent":        float64(81.30081300813008),
 	}
 	acc.AssertContainsTaggedFields(t, "disk", fields1, tags1)
 	acc.AssertContainsTaggedFields(t, "disk", fields2, tags2)
@@ -120,12 +122,12 @@ func TestDiskStats(t *testing.T) {
 	// We expect 6 more DiskMetrics to show up with an explicit match on "/"
 	// and /home not matching the /dev in MountPoints
 	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/dev"}}).Gather(&acc)
-	assert.Equal(t, expectedAllDiskMetrics+7, acc.NFields())
+	assert.Equal(t, expectedAllDiskMetrics+8, acc.NFields())
 
 	// We should see all the diskpoints as MountPoints includes both
 	// / and /home
 	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/home"}}).Gather(&acc)
-	assert.Equal(t, 2*expectedAllDiskMetrics+7, acc.NFields())
+	assert.Equal(t, 2*expectedAllDiskMetrics+8, acc.NFields())
 }
 
 // func TestDiskIOStats(t *testing.T) {


### PR DESCRIPTION
### Feature
The disk plugin does not expose percent used information for the inode.
It is more intuitive for developers to look at percentages. Accordingly, I added that.

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
