### PR TITLE
input Elastic: added status_code metric

### DIFF
--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -327,3 +327,17 @@ Transport statistics about sent and received bytes in cluster communication meas
   - rx_size_in_bytes value=1380
   - tx_count value=6
   - tx_size_in_bytes value=1380
+
+Cluster health:
+- elasticsearch_indices
+- elasticsearch_clusterstats
+- elasticsearch_cluster_health
+  - status value=green
+  - status_code value=3 (1=red,2=yellow,3=green)
+  - number_of_shards value=6
+  - number_of_replicas value=2
+  - active_primary_shards value=4
+  - active_shards value=5
+  - relocating_shards value=0
+  - initializing_shards value=1
+  - unassigned_shards value=0

--- a/plugins/inputs/elasticsearch/elasticsearch_test.go
+++ b/plugins/inputs/elasticsearch/elasticsearch_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 
 	"fmt"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/plugins/inputs/elasticsearch/testdata_test.go
+++ b/plugins/inputs/elasticsearch/testdata_test.go
@@ -39,6 +39,7 @@ const clusterHealthResponse = `
 
 var clusterHealthExpected = map[string]interface{}{
 	"status":                "green",
+	"status_code":           3,
 	"timed_out":             false,
 	"number_of_nodes":       3,
 	"number_of_data_nodes":  3,
@@ -51,6 +52,7 @@ var clusterHealthExpected = map[string]interface{}{
 
 var v1IndexExpected = map[string]interface{}{
 	"status":                "green",
+	"status_code":           3,
 	"number_of_shards":      10,
 	"number_of_replicas":    1,
 	"active_primary_shards": 10,
@@ -62,6 +64,7 @@ var v1IndexExpected = map[string]interface{}{
 
 var v2IndexExpected = map[string]interface{}{
 	"status":                "red",
+	"status_code":           1,
 	"number_of_shards":      10,
 	"number_of_replicas":    1,
 	"active_primary_shards": 0,


### PR DESCRIPTION
This PR adds metric named `status_code` to allow ES cluster/indices' status to be exported to the Prometheus.

Statuses green/yellow/red are now converted to 3/2/1.