### PR TITLE
Fix ipmi_sensor config is shared between all plugin instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ be deprecated eventually.
 - [#2628](https://github.com/influxdata/telegraf/issues/2628): Set default measurement name for snmp input.
 - [#2649](https://github.com/influxdata/telegraf/pull/2649): Improve performance of diskio with many disks
 - [#2671](https://github.com/influxdata/telegraf/issues/2671): The internal input plugin uses the wrong units for `heap_objects`
+- [#2684](https://github.com/influxdata/telegraf/pull/2684): Fix ipmi_sensor config is shared between all plugin instances
 
 ## v1.2.1 [2017-02-01]
 

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -146,12 +146,13 @@ func transform(s string) string {
 }
 
 func init() {
+	m := Ipmi{}
+	path, _ := exec.LookPath("ipmitool")
+	if len(path) > 0 {
+		m.Path = path
+	}
 	inputs.Add("ipmi_sensor", func() telegraf.Input {
-		m := Ipmi{}
-		path, _ := exec.LookPath("ipmitool")
-		if len(path) > 0 {
-			m.Path = path
-		}
+		m := m
 		return &m
 	})
 }

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -146,12 +146,12 @@ func transform(s string) string {
 }
 
 func init() {
-	m := Ipmi{}
-	path, _ := exec.LookPath("ipmitool")
-	if len(path) > 0 {
-		m.Path = path
-	}
 	inputs.Add("ipmi_sensor", func() telegraf.Input {
+		m := Ipmi{}
+		path, _ := exec.LookPath("ipmitool")
+		if len(path) > 0 {
+			m.Path = path
+		}
 		return &m
 	})
 }


### PR DESCRIPTION
I noticed ipmi_sensor always returns the same struct instance.  This prevents having separate ipmi_sensor plugins active with different configs.

### Required for all PRs:

- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
