### PR TITLE
Update default logfile destination to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ formats may be used with input plugins supporting the `data_format` option:
 
 Please see the
 [contributing guide](CONTRIBUTING.md)
-for details on contributing a plugin to Telegraf.
+for details on contributing a plugin to Telegraf

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -37,7 +37,7 @@ func (t *telegrafLog) Write(b []byte) (n int, err error) {
 //   debug   will set the log level to DEBUG
 //   quiet   will set the log level to ERROR
 //   logfile will direct the logging output to a file. Empty string is
-//           interpreted as stderr. If there is an error opening the file the
+//           interpreted as stdout. If there is an error opening the file the
 //           logger will fallback to stderr.
 func SetupLogging(debug, quiet bool, logfile string) {
 	log.SetFlags(0)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -62,7 +62,7 @@ func SetupLogging(debug, quiet bool, logfile string) {
 			}
 		}
 	} else {
-		oFile = os.Stderr
+		oFile = os.Stdout
 	}
 
 	log.SetOutput(newTelegrafWriter(oFile))


### PR DESCRIPTION
Absence or empty value of **logfile** param should default to STDOUT, as described in docs/CONFIGURATION.md: 
> **logfile**: Specify the log file name. The empty string means to log to stdout.

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
