### PR TITLE
Added SSL configuration for input haproxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ be deprecated eventually.
 
 ### Features
 
+- [#2723](https://github.com/influxdata/telegraf/pull/2723): Added SSL configuration for input haproxy.
 - [#2494](https://github.com/influxdata/telegraf/pull/2494): Add interrupts input plugin.
 - [#2094](https://github.com/influxdata/telegraf/pull/2094): Add generic socket listener & writer.
 - [#2204](https://github.com/influxdata/telegraf/pull/2204): Extend http_response to support searching for a substring in response. Return 1 if found, else 0.

--- a/plugins/inputs/haproxy/README.md
+++ b/plugins/inputs/haproxy/README.md
@@ -8,6 +8,12 @@
 # SampleConfig
 [[inputs.haproxy]]
   servers = ["http://1.2.3.4/haproxy?stats", "/var/run/haproxy*.sock"]
+#  ssl_ca = "/etc/telegraf/ca.pem"
+#  ssl_cert = "/etc/telegraf/cert.pem"
+#  ssl_key = "/etc/telegraf/key.pem"
+## Use SSL but skip chain & host verification
+#  insecure_skip_verify = false
+
 ```
 
 #### `servers`


### PR DESCRIPTION
In my company, we use haproxy as an ssl endpoint with internal certificate authority.
So I've added TLS configuration in the haproxy input plugin to allow configuration of the `ssl_ca`. 

### Required for all PRs:
- [x] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] README.md updated
