### PR TITLE
Don't log error creating database on connect

### DIFF
--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -132,7 +132,9 @@ func (i *InfluxDB) Connect() error {
 
 			err = c.Query("CREATE DATABASE " + i.Database)
 			if err != nil {
-				log.Println("E! Database creation failed: " + err.Error())
+				if !strings.Contains(err.Error(), "Status Code [403]") {
+					log.Println("I! Database creation failed: " + err.Error())
+				}
 				continue
 			}
 		}


### PR DESCRIPTION
If the database creation fails on Connect for authorization failure, don't report anything.

Sadly needed to do `strings.Contains` to detect this error.  I think we should start using https://github.com/pkg/errors to append context.

If the user is also not authorized to write to the database you get:
```
E! InfluxDB Output Error: Response Error: Status Code [403], expected [204], ["xyzzy" user is not authorized to write to database "foobar2"]
E! Error writing to output [influxdb]: Could not write to any InfluxDB server in cluster
```

And if the database does not exist at all:
```
E! InfluxDB Output Error: Response Error: Status Code [404], expected [204], [database not found: "foobar3"]
E! Error writing to output [influxdb]: Could not write to any InfluxDB server in cluster
```

closes #2739

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
