### PR TITLE
Return an error if no valid patterns.

### DIFF
--- a/plugins/inputs/logparser/grok/grok.go
+++ b/plugins/inputs/logparser/grok/grok.go
@@ -118,11 +118,18 @@ func (p *Parser) Compile() error {
 
 	// Give Patterns fake names so that they can be treated as named
 	// "custom patterns"
-	p.namedPatterns = make([]string, len(p.Patterns))
+	p.namedPatterns = make([]string, 0, len(p.Patterns))
 	for i, pattern := range p.Patterns {
+		if pattern == "" {
+			continue
+		}
 		name := fmt.Sprintf("GROK_INTERNAL_PATTERN_%d", i)
 		p.CustomPatterns += "\n" + name + " " + pattern + "\n"
-		p.namedPatterns[i] = "%{" + name + "}"
+		p.namedPatterns = append(p.namedPatterns, "%{"+name+"}")
+	}
+
+	if len(p.namedPatterns) == 0 {
+		return fmt.Errorf("pattern required")
 	}
 
 	// Combine user-supplied CustomPatterns with DEFAULT_PATTERNS and parse

--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -117,15 +117,10 @@ func (l *LogParserPlugin) Start(acc telegraf.Accumulator) error {
 	}
 
 	// compile log parser patterns:
-	var haveError bool
 	for _, parser := range l.parsers {
 		if err := parser.Compile(); err != nil {
-			acc.AddError(err)
-			haveError = true
+			return err
 		}
-	}
-	if haveError {
-		return nil
 	}
 
 	l.wg.Add(1)

--- a/plugins/inputs/logparser/logparser_test.go
+++ b/plugins/inputs/logparser/logparser_test.go
@@ -38,12 +38,8 @@ func TestGrokParseLogFilesNonExistPattern(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	logparser.Start(&acc)
-	if assert.NotEmpty(t, acc.Errors) {
-		assert.Error(t, acc.Errors[0])
-	}
-
-	logparser.Stop()
+	err := logparser.Start(&acc)
+	assert.Error(t, err)
 }
 
 func TestGrokParseLogFiles(t *testing.T) {


### PR DESCRIPTION
With this fix Telegraf will not start if the pattern is not valid.  This is a hard failure since the configuration is invalid.  This was a regression during the 1.3 dev cycle.

Here is the how the errors look, not crazy about the multiline logging, I'll probably change it in the near future.

If you have an undefined pattern:
```
2017-05-02T21:06:49Z E! Service for input inputs.logparser failed to start, exiting
no pattern found for %{FOOBAR}
```
If there are no patterns which are not the empty string:
```
2017-05-02T21:06:41Z E! Service for input inputs.logparser failed to start, exiting
pattern required
```

fixes #2742
### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)
