### PR TITLE
Generalize the output of the sensors input plugin

### DIFF
--- a/plugins/inputs/sensors/README.md
+++ b/plugins/inputs/sensors/README.md
@@ -9,13 +9,14 @@ This plugin collects sensor metrics with the `sensors` executable from the lm-se
 ```
 # Monitor sensors, requires lm-sensors package
 [[inputs.sensors]]
-  ## Remove numbers from field names.
-  ## If true, a field name like 'temp1_input' will be changed to 'temp_input'.
-  # remove_numbers = true
 ```
 
 ### Measurements & Fields:
-Fields are created dynamicaly depending on the sensors. All fields are float.
+- All measurements have the following fields:
+	- reading - This is the value of the sensor
+	- unit - The unit of the sensor's value, C for temperature, V for voltage, RPM for fan speed
+
+Fields are also generated for the additional information for each sensor (high, min, max, historical values).
 
 ### Tags:
 
@@ -23,25 +24,40 @@ Fields are created dynamicaly depending on the sensors. All fields are float.
     - chip
     - feature
 
+### Sample Queries:
+
+You can use the following query to get all temperature readings:
+
+```
+SELECT reading, chip, feature FROM sensors WHERE unit = 'C' GROUP BY chip, feature
+```
+
 ### Example Output:
 
-#### Default
 ```
 $ telegraf -config telegraf.conf -input-filter sensors -test
-* Plugin: sensors, Collection 1
-> sensors,chip=power_meter-acpi-0,feature=power1 power_average=0,power_average_interval=300 1466751326000000000
-> sensors,chip=k10temp-pci-00c3,feature=temp1 temp_crit=70,temp_crit_hyst=65,temp_input=29,temp_max=70 1466751326000000000
-> sensors,chip=k10temp-pci-00cb,feature=temp1 temp_input=29,temp_max=70 1466751326000000000
-> sensors,chip=k10temp-pci-00d3,feature=temp1 temp_input=27.5,temp_max=70 1466751326000000000
-> sensors,chip=k10temp-pci-00db,feature=temp1 temp_crit=70,temp_crit_hyst=65,temp_input=29.5,temp_max=70 1466751326000000000
-```
-
-#### With remove_numbers=false
-```
-* Plugin: sensors, Collection 1
-> sensors,chip=power_meter-acpi-0,feature=power1 power1_average=0,power1_average_interval=300 1466753424000000000
-> sensors,chip=k10temp-pci-00c3,feature=temp1 temp1_crit=70,temp1_crit_hyst=65,temp1_input=29.125,temp1_max=70 1466753424000000000
-> sensors,chip=k10temp-pci-00cb,feature=temp1 temp1_input=29,temp1_max=70 1466753424000000000
-> sensors,chip=k10temp-pci-00d3,feature=temp1 temp1_input=29.5,temp1_max=70 1466753424000000000
-> sensors,chip=k10temp-pci-00db,feature=temp1 temp1_crit=70,temp1_crit_hyst=65,temp1_input=30,temp1_max=70 1466753424000000000
+* Plugin: inputs.sensors, Collection 1
+> sensors,chip=coretemp-isa-0000,feature=Core\ 0,host=HOST reading=50,unit="C",high=99 1494146884000000000
+> sensors,feature=Core\ 1,host=HOST,chip=coretemp-isa-0001 reading=44,unit="C",high=99 1494146884000000000
+> sensors,chip=coretemp-isa-0002,feature=Core\ 2,host=HOST reading=46,unit="C",high=99 1494146884000000000
+> sensors,chip=coretemp-isa-0003,feature=Core\ 3,host=HOST reading=45,unit="C",high=99 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=VCore,host=HOST unit="V",min=0.6,max=1.49,reading=0.91 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=in1,host=HOST reading=11.88,unit="V",min=10.72,max=13.15 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=AVCC,host=HOST unit="V",min=2.96,max=3.63,reading=3.3 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=3VCC,host=HOST min=2.96,max=3.63,reading=3.3,unit="V" 1494146884000000000
+> sensors,feature=in4,host=HOST,chip=w83627dhg-isa-0a10 max=1.65,reading=1.54,unit="V",min=1.35 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=in5,host=HOST min=1.13,max=1.38,reading=1.26,unit="V" 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=in6,host=HOST reading=4.66,unit="V",min=4.53,max=0 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=VSB,host=HOST unit="V",min=2.96,max=3.63,reading=3.3 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=VBAT,host=HOST min=2.96,max=3.63,reading=3.2,unit="V" 1494146884000000000
+> sensors,feature=Case\ Fan,host=HOST,chip=w83627dhg-isa-0a10 reading=0,unit="RPM",min=10546,div=128 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=CPU\ Fan,host=HOST reading=5192,unit="RPM",min=5720,div=2 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=Aux\ Fan,host=HOST reading=0,unit="RPM",min=10546,div=128 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=fan4,host=HOST unit="RPM",min=10546,div=128,reading=0 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=fan5,host=HOST reading=0,unit="RPM",min=10546,div=128 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=Sys\ Temp,host=HOST reading=47,unit="C",high=60,hyst=55 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=CPU\ Temp,host=HOST reading=46.5,unit="C",high=95,hyst=92 1494146884000000000
+> sensors,host=HOST,chip=w83627dhg-isa-0a10,feature=AUX\ Temp reading=46,unit="C",high=80,hyst=75 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=vid,host=HOST reading=1.3,unit="V" 1494146884000000000
+> sensors,chip=w83627dhg-isa-0a10,feature=vid,host=HOST reading=1.3,unit="V" 1494146884000000000
 ```

--- a/plugins/inputs/sensors/sensors.go
+++ b/plugins/inputs/sensors/sensors.go
@@ -18,12 +18,33 @@ import (
 
 var (
 	execCommand = exec.Command // execCommand is used to mock commands in tests.
-	numberRegp  = regexp.MustCompile("[0-9]+")
+
+	// Main Regex, which is used to parse each line of the sensors output
+	// SAMPLE: VCore:     +0.90 V  (min =  +0.60 V, max =  +1.49 V)
+	readingsRe = regexp.MustCompile(
+		`(.*)` + // Match the feature, group 1
+			`:\s*.*?` + // Match everything after the reading, including + signs
+			`([0-9.]+)` + // The actual reading, group 2
+			`\s*.*?` + // Optional whitespace or C sign (°)
+			`([a-zA-Z]+)` + // Unit of reading, could be C, V, RPM group 3
+			`\s*` + // Optional whitespace
+			`(\(.*?\))?`, // The options part after the reading, i.e (min = +0.60 V, max = +1.49 V), group 4
+	)
+
+	// Regex used for the options part, matches key/value paris
+	// SAMPLE: min = +0.60 V
+	optionsRe = regexp.MustCompile(
+		`(` +
+			`[^=\s\(\)]*?)` + // Option name, group 1
+			`\s*=\s*.*?` + // Match everything until the value, including + signs
+			`([0-9.]+)` + // Actual value of the option, group 2
+			`.?` + // Whitespace or C sign ((°)
+			`([a-zA-Z]*)`, // Unit of reading, could be C, V, RPM
+	)
 )
 
 type Sensors struct {
-	RemoveNumbers bool `toml:"remove_numbers"`
-	path          string
+	path string
 }
 
 func (*Sensors) Description() string {
@@ -31,12 +52,7 @@ func (*Sensors) Description() string {
 }
 
 func (*Sensors) SampleConfig() string {
-	return `
-  ## Remove numbers from field names.
-  ## If true, a field name like 'temp1_input' will be changed to 'temp_input'.
-  # remove_numbers = true
-`
-
+	return ``
 }
 
 func (s *Sensors) Gather(acc telegraf.Accumulator) error {
@@ -48,71 +64,85 @@ func (s *Sensors) Gather(acc telegraf.Accumulator) error {
 }
 
 // parse forks the command:
-//     sensors -u -A
+//     sensors -A
 // and parses the output to add it to the telegraf.Accumulator.
 func (s *Sensors) parse(acc telegraf.Accumulator) error {
 	tags := map[string]string{}
 	fields := map[string]interface{}{}
 	chip := ""
-	cmd := execCommand(s.path, "-A", "-u")
+
+	cmd := execCommand(s.path, "-A")
 	out, err := internal.CombinedOutputTimeout(cmd, time.Second*5)
 	if err != nil {
 		return fmt.Errorf("failed to run command %s: %s - %s", strings.Join(cmd.Args, " "), err, string(out))
 	}
+
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
 	for _, line := range lines {
+		// Next adapter reached
 		if len(line) == 0 {
-			acc.AddFields("sensors", fields, tags)
 			chip = ""
 			tags = map[string]string{}
 			fields = map[string]interface{}{}
 			continue
 		}
+
+		// First line is the chip line
 		if len(chip) == 0 {
 			chip = line
 			tags["chip"] = chip
 			continue
 		}
-		if !strings.HasPrefix(line, "  ") {
-			if len(tags) > 1 {
-				acc.AddFields("sensors", fields, tags)
-			}
-			fields = map[string]interface{}{}
-			tags = map[string]string{
-				"chip":    chip,
-				"feature": strings.TrimRight(snake(line), ":"),
-			}
-		} else {
-			splitted := strings.Split(line, ":")
-			fieldName := strings.TrimSpace(splitted[0])
-			if s.RemoveNumbers {
-				fieldName = numberRegp.ReplaceAllString(fieldName, "")
-			}
-			fieldValue, err := strconv.ParseFloat(strings.TrimSpace(splitted[1]), 64)
-			if err != nil {
-				return err
-			}
-			fields[fieldName] = fieldValue
+
+		// Group 1 => feature
+		// Group 2 => reading
+		// Group 3 => unit
+		// Group 4 => options
+		parsed := readingsRe.FindAllStringSubmatch(line, -1)
+		if parsed == nil {
+			continue
 		}
+
+		fields = map[string]interface{}{}
+		tags = map[string]string{
+			"chip":    chip,
+			"feature": strings.TrimSpace(parsed[0][1]),
+		}
+
+		fields["reading"], err = strconv.ParseFloat(parsed[0][2], 64)
+		if err != nil {
+			return err
+		}
+
+		fields["unit"] = parsed[0][3]
+
+		if len(parsed[0][4]) > 0 {
+			// Group 1 => option name
+			// Group 2 => option value
+			parsed = optionsRe.FindAllStringSubmatch(parsed[0][4], -1)
+			for _, item := range parsed {
+				fields[item[1]], err = strconv.ParseFloat(item[2], 64)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		acc.AddFields("sensors", fields, tags)
 	}
+
 	acc.AddFields("sensors", fields, tags)
 	return nil
 }
 
 func init() {
-	s := Sensors{
-		RemoveNumbers: true,
-	}
+	s := Sensors{}
 	path, _ := exec.LookPath("sensors")
 	if len(path) > 0 {
 		s.path = path
 	}
+
 	inputs.Add("sensors", func() telegraf.Input {
 		return &s
 	})
-}
-
-// snake converts string to snake case
-func snake(input string) string {
-	return strings.ToLower(strings.Replace(strings.TrimSpace(input), " ", "_", -1))
 }

--- a/plugins/inputs/sensors/sensors_test.go
+++ b/plugins/inputs/sensors/sensors_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func TestGatherDefault(t *testing.T) {
+func TestGather(t *testing.T) {
 	s := Sensors{
-		RemoveNumbers: true,
-		path:          "sensors",
+		path: "sensors",
 	}
 	// overwriting exec commands with mock commands
 	execCommand = fakeExecCommand
@@ -32,259 +31,264 @@ func TestGatherDefault(t *testing.T) {
 	}{
 		{
 			map[string]string{
-				"chip":    "acpitz-virtual-0",
-				"feature": "temp1",
-			},
-			map[string]interface{}{
-				"temp_input": 8.3,
-				"temp_crit":  31.3,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "power_meter-acpi-0",
-				"feature": "power1",
-			},
-			map[string]interface{}{
-				"power_average":          0.0,
-				"power_average_interval": 300.0,
-			},
-		},
-		{
-			map[string]string{
 				"chip":    "coretemp-isa-0000",
-				"feature": "physical_id_0",
+				"feature": "Core 0",
 			},
 			map[string]interface{}{
-				"temp_input":      77.0,
-				"temp_max":        82.0,
-				"temp_crit":       92.0,
-				"temp_crit_alarm": 0.0,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "coretemp-isa-0000",
-				"feature": "core_0",
-			},
-			map[string]interface{}{
-				"temp_input":      75.0,
-				"temp_max":        82.0,
-				"temp_crit":       92.0,
-				"temp_crit_alarm": 0.0,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "coretemp-isa-0000",
-				"feature": "core_1",
-			},
-			map[string]interface{}{
-				"temp_input":      77.0,
-				"temp_max":        82.0,
-				"temp_crit":       92.0,
-				"temp_crit_alarm": 0.0,
+				"reading": 45.00,
+				"unit":    "C",
+				"high":    99.00,
 			},
 		},
 		{
 			map[string]string{
 				"chip":    "coretemp-isa-0001",
-				"feature": "physical_id_1",
+				"feature": "Core 1",
 			},
 			map[string]interface{}{
-				"temp_input":      70.0,
-				"temp_max":        82.0,
-				"temp_crit":       92.0,
-				"temp_crit_alarm": 0.0,
+				"reading": 44.00,
+				"unit":    "C",
+				"high":    99.00,
 			},
 		},
 		{
 			map[string]string{
-				"chip":    "coretemp-isa-0001",
-				"feature": "core_0",
+				"chip":    "coretemp-isa-0002",
+				"feature": "Core 2",
 			},
 			map[string]interface{}{
-				"temp_input":      66.0,
-				"temp_max":        82.0,
-				"temp_crit":       92.0,
-				"temp_crit_alarm": 0.0,
+				"reading": 45.00,
+				"unit":    "C",
+				"high":    99.00,
 			},
 		},
 		{
 			map[string]string{
-				"chip":    "coretemp-isa-0001",
-				"feature": "core_1",
+				"chip":    "coretemp-isa-0003",
+				"feature": "Core 3",
 			},
 			map[string]interface{}{
-				"temp_input":      70.0,
-				"temp_max":        82.0,
-				"temp_crit":       92.0,
-				"temp_crit_alarm": 0.0,
+				"reading": 43.00,
+				"unit":    "C",
+				"high":    99.00,
 			},
 		},
 		{
 			map[string]string{
-				"chip":    "atk0110-acpi-0",
-				"feature": "vcore_voltage",
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "VCore",
 			},
 			map[string]interface{}{
-				"in_input": 1.136,
-				"in_min":   0.800,
-				"in_max":   1.600,
+				"reading": 0.90,
+				"unit":    "V",
+				"min":     0.60,
+				"max":     1.49,
 			},
 		},
 		{
 			map[string]string{
-				"chip":    "atk0110-acpi-0",
-				"feature": "+3.3_voltage",
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "in1",
 			},
 			map[string]interface{}{
-				"in_input": 3.360,
-				"in_min":   2.970,
-				"in_max":   3.630,
+				"reading": 11.88,
+				"unit":    "V",
+				"min":     10.72,
+				"max":     13.15,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "AVCC",
+			},
+			map[string]interface{}{
+				"reading": 3.30,
+				"unit":    "V",
+				"min":     2.96,
+				"max":     3.63,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "3VCC",
+			},
+			map[string]interface{}{
+				"reading": 3.30,
+				"unit":    "V",
+				"min":     2.96,
+				"max":     3.63,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "in4",
+			},
+			map[string]interface{}{
+				"reading": 1.54,
+				"unit":    "V",
+				"min":     1.35,
+				"max":     1.65,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "in5",
+			},
+			map[string]interface{}{
+				"reading": 1.26,
+				"unit":    "V",
+				"min":     1.13,
+				"max":     1.38,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "in6",
+			},
+			map[string]interface{}{
+				"reading": 4.66,
+				"unit":    "V",
+				"min":     4.53,
+				"max":     4.86,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "VSB",
+			},
+			map[string]interface{}{
+				"reading": 3.30,
+				"unit":    "V",
+				"min":     2.96,
+				"max":     3.63,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "VBAT",
+			},
+			map[string]interface{}{
+				"reading": 3.20,
+				"unit":    "V",
+				"min":     2.96,
+				"max":     3.63,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "Case Fan",
+			},
+			map[string]interface{}{
+				"reading": 0.00,
+				"unit":    "RPM",
+				"min":     753.00,
+				"div":     128.00,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "CPU Fan",
+			},
+			map[string]interface{}{
+				"reading": 3835.00,
+				"unit":    "RPM",
+				"min":     712.00,
+				"div":     8.00,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "Aux Fan",
+			},
+			map[string]interface{}{
+				"reading": 0.00,
+				"unit":    "RPM",
+				"min":     753.00,
+				"div":     128.00,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "fan4",
+			},
+			map[string]interface{}{
+				"reading": 0.00,
+				"unit":    "RPM",
+				"min":     753.00,
+				"div":     128.00,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "fan5",
+			},
+			map[string]interface{}{
+				"reading": 0.00,
+				"unit":    "RPM",
+				"min":     753.00,
+				"div":     128.00,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "Sys Temp",
+			},
+			map[string]interface{}{
+				"reading": 48.00,
+				"unit":    "C",
+				"high":    60.00,
+				"hyst":    55.00,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "CPU Temp",
+			},
+			map[string]interface{}{
+				"reading": 46.00,
+				"unit":    "C",
+				"high":    95.00,
+				"hyst":    92.00,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "AUX Temp",
+			},
+			map[string]interface{}{
+				"reading": 46.00,
+				"unit":    "C",
+				"high":    80.00,
+				"hyst":    75.00,
+			},
+		},
+		{
+			map[string]string{
+				"chip":    "w83627dhg-isa-0a10",
+				"feature": "vid",
+			},
+			map[string]interface{}{
+				"reading": 1.300,
+				"unit":    "V",
 			},
 		},
 	}
 
-	for _, test := range tests {
-		acc.AssertContainsTaggedFields(t, "sensors", test.fields, test.tags)
-	}
-}
-
-func TestGatherNotRemoveNumbers(t *testing.T) {
-	s := Sensors{
-		RemoveNumbers: false,
-		path:          "sensors",
-	}
-	// overwriting exec commands with mock commands
-	execCommand = fakeExecCommand
-	defer func() { execCommand = exec.Command }()
-	var acc testutil.Accumulator
-
-	err := s.Gather(&acc)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var tests = []struct {
-		tags   map[string]string
-		fields map[string]interface{}
-	}{
-		{
-			map[string]string{
-				"chip":    "acpitz-virtual-0",
-				"feature": "temp1",
-			},
-			map[string]interface{}{
-				"temp1_input": 8.3,
-				"temp1_crit":  31.3,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "power_meter-acpi-0",
-				"feature": "power1",
-			},
-			map[string]interface{}{
-				"power1_average":          0.0,
-				"power1_average_interval": 300.0,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "coretemp-isa-0000",
-				"feature": "physical_id_0",
-			},
-			map[string]interface{}{
-				"temp1_input":      77.0,
-				"temp1_max":        82.0,
-				"temp1_crit":       92.0,
-				"temp1_crit_alarm": 0.0,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "coretemp-isa-0000",
-				"feature": "core_0",
-			},
-			map[string]interface{}{
-				"temp2_input":      75.0,
-				"temp2_max":        82.0,
-				"temp2_crit":       92.0,
-				"temp2_crit_alarm": 0.0,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "coretemp-isa-0000",
-				"feature": "core_1",
-			},
-			map[string]interface{}{
-				"temp3_input":      77.0,
-				"temp3_max":        82.0,
-				"temp3_crit":       92.0,
-				"temp3_crit_alarm": 0.0,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "coretemp-isa-0001",
-				"feature": "physical_id_1",
-			},
-			map[string]interface{}{
-				"temp1_input":      70.0,
-				"temp1_max":        82.0,
-				"temp1_crit":       92.0,
-				"temp1_crit_alarm": 0.0,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "coretemp-isa-0001",
-				"feature": "core_0",
-			},
-			map[string]interface{}{
-				"temp2_input":      66.0,
-				"temp2_max":        82.0,
-				"temp2_crit":       92.0,
-				"temp2_crit_alarm": 0.0,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "coretemp-isa-0001",
-				"feature": "core_1",
-			},
-			map[string]interface{}{
-				"temp3_input":      70.0,
-				"temp3_max":        82.0,
-				"temp3_crit":       92.0,
-				"temp3_crit_alarm": 0.0,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "atk0110-acpi-0",
-				"feature": "vcore_voltage",
-			},
-			map[string]interface{}{
-				"in0_input": 1.136,
-				"in0_min":   0.800,
-				"in0_max":   1.600,
-			},
-		},
-		{
-			map[string]string{
-				"chip":    "atk0110-acpi-0",
-				"feature": "+3.3_voltage",
-			},
-			map[string]interface{}{
-				"in1_input": 3.360,
-				"in1_min":   2.970,
-				"in1_max":   3.630,
-			},
-		},
-	}
 	for _, test := range tests {
 		acc.AssertContainsTaggedFields(t, "sensors", test.fields, test.tags)
 	}
@@ -309,59 +313,38 @@ func TestHelperProcess(t *testing.T) {
 		return
 	}
 
-	mockData := `acpitz-virtual-0
-temp1:
-  temp1_input: 8.300
-  temp1_crit: 31.300
-
-power_meter-acpi-0
-power1:
-  power1_average: 0.000
-  power1_average_interval: 300.000
-
+	mockData := `
 coretemp-isa-0000
-Physical id 0:
-  temp1_input: 77.000
-  temp1_max: 82.000
-  temp1_crit: 92.000
-  temp1_crit_alarm: 0.000
-Core 0:
-  temp2_input: 75.000
-  temp2_max: 82.000
-  temp2_crit: 92.000
-  temp2_crit_alarm: 0.000
-Core 1:
-  temp3_input: 77.000
-  temp3_max: 82.000
-  temp3_crit: 92.000
-  temp3_crit_alarm: 0.000
+Core 0:      +45°C  (high =   +99°C)
 
 coretemp-isa-0001
-Physical id 1:
-  temp1_input: 70.000
-  temp1_max: 82.000
-  temp1_crit: 92.000
-  temp1_crit_alarm: 0.000
-Core 0:
-  temp2_input: 66.000
-  temp2_max: 82.000
-  temp2_crit: 92.000
-  temp2_crit_alarm: 0.000
-Core 1:
-  temp3_input: 70.000
-  temp3_max: 82.000
-  temp3_crit: 92.000
-  temp3_crit_alarm: 0.000
+Core 1:      +44°C  (high =   +99°C)
 
-atk0110-acpi-0
-Vcore Voltage:
-  in0_input: 1.136
-  in0_min: 0.800
-  in0_max: 1.600
- +3.3 Voltage:
-  in1_input: 3.360
-  in1_min: 2.970
-  in1_max: 3.630
+coretemp-isa-0002
+Core 2:      +45°C  (high =   +99°C)
+
+coretemp-isa-0003
+Core 3:      +43°C  (high =   +99°C)
+
+w83627dhg-isa-0a10
+VCore:     +0.90 V  (min =  +0.60 V, max =  +1.49 V)
+in1:      +11.88 V  (min = +10.72 V, max = +13.15 V)
+AVCC:      +3.30 V  (min =  +2.96 V, max =  +3.63 V)
+3VCC:      +3.30 V  (min =  +2.96 V, max =  +3.63 V)
+in4:       +1.54 V  (min =  +1.35 V, max =  +1.65 V)
+in5:       +1.26 V  (min =  +1.13 V, max =  +1.38 V)
+in6:       +4.66 V  (min =  +4.53 V, max =  +4.86 V)
+VSB:       +3.30 V  (min =  +2.96 V, max =  +3.63 V)
+VBAT:      +3.20 V  (min =  +2.96 V, max =  +3.63 V)
+Case Fan:    0 RPM  (min =  753 RPM, div = 128) ALARM
+CPU Fan:  3835 RPM  (min =  712 RPM, div = 8)
+Aux Fan:     0 RPM  (min =  753 RPM, div = 128) ALARM
+fan4:        0 RPM  (min =  753 RPM, div = 128) ALARM
+fan5:        0 RPM  (min =  753 RPM, div = 128) ALARM
+Sys Temp:    +48°C  (high =   +60°C, hyst =   +55°C)  [thermistor]
+CPU Temp:  +46.0°C  (high = +95.0°C, hyst = +92.0°C)  [CPU diode ]
+AUX Temp:  +46.0°C  (high = +80.0°C, hyst = +75.0°C)  [CPU diode ]
+vid:      +1.300 V
 `
 
 	args := os.Args


### PR DESCRIPTION
This removes the usage of the -u flag, which makes the output of the
sensors command unreliable.

Additionally it tries to reorganize the fields and make them more
readable.

An additional unit field has been added so that different type of
measurements can be filtered (temeprature, voltages, RPM, etc.)

Discussion: https://community.influxdata.com/t/sensors-input-plugin/847

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [x] README.md updated (if adding a new plugin)
