### PR TITLE
Add support for self-signed certs to InfluxDB input plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Release Notes
 ### Features
+
+- [#2773](https://github.com/influxdata/telegraf/pull/2773): Add support for self-signed certs to InfluxDB input plugin
+
 ### Bugfixes
 
 - [#2749](https://github.com/influxdata/telegraf/pull/2749): Fixed sqlserver input to work with case sensitive server collation.

--- a/plugins/inputs/influxdb/README.md
+++ b/plugins/inputs/influxdb/README.md
@@ -19,6 +19,16 @@ InfluxDB-formatted endpoints. See below for more information.
   urls = [
     "http://localhost:8086/debug/vars"
   ]
+
+  ## Optional SSL Config
+  # ssl_ca = "/etc/telegraf/ca.pem"
+  # ssl_cert = "/etc/telegraf/cert.pem"
+  # ssl_key = "/etc/telegraf/key.pem"
+  ## Use SSL but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## http request & header timeout
+  timeout = "5s"
 ```
 
 ### Measurements & Fields


### PR DESCRIPTION
This adds initial support for using self-signed certs. It will default to `false` to preserve existing functionality but can be set to `true` if desired.

This PR solves issue https://github.com/influxdata/telegraf/issues/1274

### Required for all PRs:

- [X] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] README.md updated (if adding a new plugin)
