### PR TITLE
Fix multiple plugin loading in win_perf_counters

### DIFF
--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -65,12 +65,8 @@ var sampleConfig = `
     Measurement = "win_mem"
 `
 
-var testConfigParsed bool
-var testObject string
-
 type Win_PerfCounters struct {
 	PrintValid      bool
-	TestName        string
 	PreVistaSupport bool
 	Object          []perfobject
 
@@ -86,12 +82,6 @@ type perfobject struct {
 	WarnOnMissing bool
 	FailOnMissing bool
 	IncludeTotal  bool
-}
-
-// Parsed configuration ends up here after it has been validated for valid
-// Performance Counter paths
-type itemList struct {
-	items map[int]*item
 }
 
 type item struct {
@@ -183,24 +173,7 @@ func (m *Win_PerfCounters) ParseConfig() error {
 	}
 }
 
-func (m *Win_PerfCounters) CleanupTestMode() {
-	// Cleanup for the testmode.
-	for _, metric := range m.itemCache {
-		ret := PdhCloseQuery(metric.handle)
-		_ = ret
-	}
-}
-
 func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
-	// Both values are empty in normal use.
-	if m.TestName != testObject {
-		// Cleanup any handles before emptying the global variable containing valid queries.
-		m.CleanupTestMode()
-		m.itemCache = m.itemCache[:0]
-		testObject = m.TestName
-		testConfigParsed = true
-	}
-
 	// Parse the config once
 	if !m.configParsed {
 		err := m.ParseConfig()

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -95,6 +95,19 @@ type itemList struct {
 	items map[int]*item
 }
 
+func (i *itemList) ItemExists(query, objectName, counter, instance string) bool {
+	for _, item := range i.items {
+		if item.query == query &&
+			item.objectName == objectName &&
+			item.counter == counter &&
+			item.instance == instance {
+			return true
+		}
+	}
+
+	return false
+}
+
 type item struct {
 	query         string
 	objectName    string
@@ -111,6 +124,10 @@ var sanitizedChars = strings.NewReplacer("/sec", "_persec", "/Sec", "_persec",
 
 func (m *Win_PerfCounters) AddItem(query string, objectName string, counter string, instance string,
 	measurement string, include_total bool) error {
+
+	if gItemList.ItemExists(query, objectName, counter, instance) {
+		return nil
+	}
 
 	var handle PDH_HQUERY
 	var counterHandle PDH_HCOUNTER

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -109,7 +109,7 @@ type item struct {
 var sanitizedChars = strings.NewReplacer("/sec", "_persec", "/Sec", "_persec",
 	" ", "_", "%", "Percent", `\`, "")
 
-func (m *Win_PerfCounters) AddItem(metrics *itemList, query string, objectName string, counter string, instance string,
+func (m *Win_PerfCounters) AddItem(query string, objectName string, counter string, instance string,
 	measurement string, include_total bool) error {
 
 	var handle PDH_HQUERY
@@ -133,10 +133,6 @@ func (m *Win_PerfCounters) AddItem(metrics *itemList, query string, objectName s
 	index := len(gItemList)
 	gItemList[index] = temp
 
-	if metrics.items == nil {
-		metrics.items = make(map[int]*item)
-	}
-	metrics.items[index] = temp
 	return nil
 }
 
@@ -148,7 +144,7 @@ func (m *Win_PerfCounters) SampleConfig() string {
 	return sampleConfig
 }
 
-func (m *Win_PerfCounters) ParseConfig(metrics *itemList) error {
+func (m *Win_PerfCounters) ParseConfig() error {
 	var query string
 
 	configParsed = true
@@ -165,7 +161,7 @@ func (m *Win_PerfCounters) ParseConfig(metrics *itemList) error {
 						query = "\\" + objectname + "(" + instance + ")\\" + counter
 					}
 
-					err := m.AddItem(metrics, query, objectname, counter, instance,
+					err := m.AddItem(query, objectname, counter, instance,
 						PerfObject.Measurement, PerfObject.IncludeTotal)
 
 					if err == nil {
@@ -210,8 +206,6 @@ func (m *Win_PerfCounters) CleanupTestMode() {
 }
 
 func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
-	metrics := itemList{}
-
 	// Both values are empty in normal use.
 	if m.TestName != testObject {
 		// Cleanup any handles before emptying the global variable containing valid queries.
@@ -225,7 +219,7 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 	// We only need to parse the config during the init, it uses the global variable after.
 	if configParsed == false {
 
-		err := m.ParseConfig(&metrics)
+		err := m.ParseConfig()
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -68,7 +68,6 @@ var sampleConfig = `
 // Valid queries end up in this map.
 var gItemList itemList
 
-var configParsed bool
 var testConfigParsed bool
 var testObject string
 
@@ -164,8 +163,6 @@ func (m *Win_PerfCounters) SampleConfig() string {
 func (m *Win_PerfCounters) ParseConfig() error {
 	var query string
 
-	configParsed = true
-
 	if len(m.Object) > 0 {
 		for _, PerfObject := range m.Object {
 			for _, counter := range PerfObject.Counters {
@@ -225,16 +222,12 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 		gItemList.items = make(map[int]*item)
 		testObject = m.TestName
 		testConfigParsed = true
-		configParsed = false
 	}
 
-	// We only need to parse the config during the init, it uses the global variable after.
-	if configParsed == false {
-
-		err := m.ParseConfig()
-		if err != nil {
-			return err
-		}
+	// Parse the config
+	err := m.ParseConfig()
+	if err != nil {
+		return err
 	}
 
 	var bufSize uint32


### PR DESCRIPTION
Fixes #1137 

The root of the problem for #1137 is that all items are maintained in a global map, but the map is only populated by one config file. Once one config file is parsed, then a flag is set and the plugin will not populate items from any other config.

~~To fix this, I've removed the flag that checks if a config file has been parsed. Instead, the check for duplicates is done within the `AddItem` function. An item is considered a duplicate if it has the same `query`, `objectName`, `counter`, and `instance`.~~

To fix this, I've removed the global map and instead store items in the main plugin struct.

I've also cleaned up a couple other aspects of this plugin:

- Removed a local `metrics` variable
  - In the code, this variable was being populated as if it was going to be used for iterating and querying, but it never was. It was populated but never used, and the global variable was used instead.
~~- Converted the global `gItemList` from `map[int]*item` to `itemList`, which is an already defined type equivalent to `map[int]*item`~~

 Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
