### PR TITLE
Added `--no-service` flag to skip windows service components

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -54,6 +54,8 @@ var fUsage = flag.String("usage", "",
 	"print usage for a plugin, ie, 'telegraf -usage mysql'")
 var fService = flag.String("service", "",
 	"operate on the service")
+var fNoService = flag.Bool("no-service", false,
+	"bypass windows service components and execute directly")
 
 // Telegraf version, populated linker.
 //   ie, -ldflags "-X main.version=`git describe --always --tags`"
@@ -342,7 +344,7 @@ func main() {
 		return
 	}
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" && *fNoService == false {
 		svcConfig := &service.Config{
 			Name:        "telegraf",
 			DisplayName: "Telegraf Data Collector Service",


### PR DESCRIPTION
Partially mitigates https://github.com/influxdata/telegraf/issues/2827, allowing telegraf to run on nano server.

This adds a --no-service flag, which bypasses the service configuration code block on Windows.

### Required for all PRs:

- [not done yet] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [not needed] README.md updated (if adding a new plugin)
