### PR TITLE
Add support for NTLM auth on Windows for the OpenTSDB plugin.

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -20,6 +20,7 @@ github.com/gobwas/glob bea32b9cd2d6f55753d94a28e959b13f0244797a
 github.com/golang/protobuf 8ee79997227bf9b34611aee7946ae64735e6fd93
 github.com/golang/snappy 7db9049039a047d955fe8c19b83c8ff5abd765c7
 github.com/gorilla/mux 392c28fe23e1c45ddba891b0320b3b5df220beea
+github.com/gropensourcedev/go-ntlm-auth 6314d66e1d8ffd12a8da4be59eb4467b60dde719
 github.com/hailocab/go-hostpool e80d13ce29ede4452c43dea11e79b9bc8a15b478
 github.com/hashicorp/consul 63d2fc68239b996096a1c55a0d4b400ea4c2583f
 github.com/influxdata/tail a395bf99fe07c233f41fba0735fa2b13b58588ea

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -16,8 +16,9 @@ import (
 type OpenTSDB struct {
 	Prefix string
 
-	Host string
-	Port int
+	Host    string
+	Port    int
+	UseNtlm bool
 
 	HttpBatchSize int
 
@@ -38,6 +39,9 @@ var sampleConfig = `
 
   ## Port of the OpenTSDB server
   port = 4242
+
+  ## Whether to use NTLM to authenticate with OpenTSDB (Windows only)
+  useNtlm = false
 
   ## Number of data points to send to OpenTSDB in Http requests.
   ## Not used with telnet API.
@@ -105,6 +109,7 @@ func (o *OpenTSDB) WriteHttp(metrics []telegraf.Metric, u *url.URL) error {
 		Host:      u.Host,
 		Port:      o.Port,
 		Scheme:    u.Scheme,
+		UseNtlm:   o.UseNtlm,
 		User:      u.User,
 		BatchSize: o.HttpBatchSize,
 		Debug:     o.Debug,


### PR DESCRIPTION
This is required if your OpenTSDB infrastructure is behind an NTLM authenticated proxy.
