### PR TITLE
Check for nil on mongo input, fix for panic.

### DIFF
--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -564,7 +564,7 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 		// BEGIN code modification
 		if newStat.Repl.IsMaster.(bool) {
 			returnVal.NodeType = "PRI"
-		} else if newStat.Repl.Secondary.(bool) {
+		} else if newStat.Repl.Secondary != nil && newStat.Repl.Secondary.(bool) {
 			returnVal.NodeType = "SEC"
 		} else if newStat.Repl.ArbiterOnly != nil && newStat.Repl.ArbiterOnly.(bool) {
 			returnVal.NodeType = "ARB"


### PR DESCRIPTION
Upgraded to telegraf 1.3, mongo input is generating panics in our environment:

panic: interface conversion: interface {} is nil, not bool

goroutine 238 [running]:
github.com/influxdata/telegraf/plugins/inputs/mongodb.NewStatLine(0xed0b6827e, 0xc5670ba, 0x1bea540, 0xc4204700f0, 0xc42
03024a0, 0xc420b95668, 0xc4201746c0, 0xed0b68288, 0x568a97d, 0x1bea540, ...)
        /home/ubuntu/telegraf-build/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongostat.go:567 +0x1bb2
github.com/influxdata/telegraf/plugins/inputs/mongodb.(*Server).gatherData(0xc420175000, 0x1b01540, 0xc420174f40, 0x4060
01, 0x0, 0x0)
        /home/ubuntu/telegraf-build/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongodb_server.go:107 +0xd
0f
github.com/influxdata/telegraf/plugins/inputs/mongodb.(*MongoDB).gatherServer(0xc42013c080, 0xc420175000, 0x1b01540, 0xc
420174f40, 0x1144780, 0xc420402e40)
        /home/ubuntu/telegraf-build/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongodb.go:163 +0x89
github.com/influxdata/telegraf/plugins/inputs/mongodb.(*MongoDB).Gather.func1(0xc421025230, 0x1b01540, 0xc420174f40, 0xc
42013c080, 0xc420175000)
        /home/ubuntu/telegraf-build/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongodb.go:91 +0x73
created by github.com/influxdata/telegraf/plugins/inputs/mongodb.(*MongoDB).Gather
        /home/ubuntu/telegraf-build/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongodb.go:92 +0x352

============================== 05/23/2017 15:20:50

PR resolves the issue for us. Thanks.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
