### PR TITLE
Add SSL/TLS support to nginx input plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2773](https://github.com/influxdata/telegraf/pull/2773): Add support for self-signed certs to InfluxDB input plugin
 - [#2581](https://github.com/influxdata/telegraf/pull/2581): Add Docker container environment variables as tags. Only whitelisted
 - [#2817](https://github.com/influxdata/telegraf/pull/2817): Added timeout option to IPMI sensor plugin
+- [#2883](https://github.com/influxdata/telegraf/pull/2883): Add support for an optional SSL/TLS configuration to nginx input plugin
 
 ### Bugfixes
 

--- a/plugins/inputs/nginx/README.md
+++ b/plugins/inputs/nginx/README.md
@@ -14,6 +14,9 @@
   # ssl_key = "/etc/telegraf/key.pem"
   ## Use SSL but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## HTTP response timeout (default: 5s)
+  response_timeout = "5s"
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/nginx/README.md
+++ b/plugins/inputs/nginx/README.md
@@ -7,6 +7,13 @@
 [[inputs.nginx]]
   ## An array of Nginx stub_status URI to gather stats.
   urls = ["http://localhost/server_status"]
+
+  ## Optional SSL Config
+  # ssl_ca = "/etc/telegraf/ca.pem"
+  # ssl_cert = "/etc/telegraf/cert.pem"
+  # ssl_key = "/etc/telegraf/key.pem"
+  ## Use SSL but skip chain & host verification
+  # insecure_skip_verify = false
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/nginx/nginx.go
+++ b/plugins/inputs/nginx/nginx.go
@@ -34,19 +34,17 @@ type Nginx struct {
 }
 
 var sampleConfig = `
-  # Read Nginx's basic status information (ngx_http_stub_status_module)
-  [[inputs.nginx]]
-    # An array of Nginx stub_status URI to gather stats.
-    urls = ["http://localhost/server_status"]
+  # An array of Nginx stub_status URI to gather stats.
+  urls = ["http://localhost/server_status"]
 
-    # TLS/SSL configuration
-    ssl_ca = "var/security/ca.pem"
-    ssl_cert = "var/security/cert.cer"
-    ssl_key = "var/security/key.key"
-    insecure_skip_verify = false
+  # TLS/SSL configuration
+  ssl_ca = "/etc/telegraf/ca.pem"
+  ssl_cert = "/etc/telegraf/cert.cer"
+  ssl_key = "/etc/telegraf/key.key"
+  insecure_skip_verify = false
 
-    # HTTP response timeout (default: 5s)
-    response_timeout = "10s"
+  # HTTP response timeout (default: 5s)
+  response_timeout = "5s"
 `
 
 func (n *Nginx) SampleConfig() string {


### PR DESCRIPTION
This PR adds support for an optional SSL/TLS config in the nginx input plugin.
 
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.


