### PR TITLE
Fix timeout option in Windows ping input sample configuration

### DIFF
--- a/plugins/inputs/ping/ping_windows.go
+++ b/plugins/inputs/ping/ping_windows.go
@@ -44,8 +44,8 @@ const sampleConfig = `
 	## number of pings to send per collection (ping -n <COUNT>)
 	count = 4 # required
 
-	## Ping timeout, in seconds. 0 means default timeout (ping -w <TIMEOUT>)
-	Timeout = 0
+	## Ping timeout, in seconds. 0.0 means default timeout (ping -w <TIMEOUT>)
+	#timeout = 0.0
 `
 
 func (s *Ping) SampleConfig() string {

--- a/plugins/inputs/ping/ping_windows_test.go
+++ b/plugins/inputs/ping/ping_windows_test.go
@@ -163,9 +163,9 @@ func TestLossyPingGather(t *testing.T) {
 		"reply_received":      7,
 		"percent_packet_loss": 22.22222222222222,
 		"percent_reply_loss":  22.22222222222222,
-		"average_response_ms": 115,
-		"minimum_response_ms": 114,
-		"maximum_response_ms": 119,
+		"average_response_ms": 115.0,
+		"minimum_response_ms": 114.0,
+		"maximum_response_ms": 119.0,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 }


### PR DESCRIPTION
Fix problem with crash when using sample output configuration on Windows platform
**…line 617: ping.Ping.Timeout: `float64' is not any types of int"**

Timeout variable was set as integer and should be float. Broken after refactoring code to float variables some time ago. 

### Required for all PRs:

- [x ] Signed [CLA](https://influxdata.com/community/cla/).
- [x ] Associated README.md updated.
- [x ] Has appropriate unit tests.
