### PR TITLE
Fix metric splitting edge cases

### DIFF
--- a/metric/metric.go
+++ b/metric/metric.go
@@ -218,7 +218,7 @@ func (m *metric) SerializeTo(dst []byte) int {
 }
 
 func (m *metric) Split(maxSize int) []telegraf.Metric {
-	if m.Len() < maxSize {
+	if m.Len() <= maxSize {
 		return []telegraf.Metric{m}
 	}
 	var out []telegraf.Metric
@@ -248,7 +248,7 @@ func (m *metric) Split(maxSize int) []telegraf.Metric {
 
 		// if true, then we need to create a metric _not_ including the currently
 		// selected field
-		if len(m.fields[i:j])+len(fields)+constant > maxSize {
+		if len(m.fields[i:j])+len(fields)+constant >= maxSize {
 			// if false, then we'll create a metric including the currently
 			// selected field anyways. This means that the given maxSize is too
 			// small for a single field to fit.


### PR DESCRIPTION
Additional fix for #2862.

Metrics needing one extra byte to fit the output buffer would not be split, so we would emit lines without a line ending.  Metrics which overflowed by exactly one field length would be split one field too late, causing truncated fields.

### Required for all PRs:

- [x] Has appropriate unit tests.
