### PR TITLE
added linux/darwin min/max ping values to match windows plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Bugfixes
 
 - [#2862](https://github.com/influxdata/telegraf/issue/2862): Fix InfluxDB UDP metric splitting.
+- [#2888](https://github.com/influxdata/telegraf/issue/2888): Fix mongodb/leofs urls without scheme.
 
 ## v1.3.1 [2017-05-31]
 

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -154,9 +154,9 @@ func TestPingGather(t *testing.T) {
 		"packets_transmitted":   5,
 		"packets_received":      5,
 		"percent_packet_loss":   0.0,
-		"minimum_response_ms":	 35.225,
+		"minimum_response_ms":   35.225,
 		"average_response_ms":   43.628,
-		"maximum_response_ms":	 51.806,
+		"maximum_response_ms":   51.806,
 		"standard_deviation_ms": 5.325,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
@@ -194,9 +194,9 @@ func TestLossyPingGather(t *testing.T) {
 		"packets_transmitted":   5,
 		"packets_received":      3,
 		"percent_packet_loss":   40.0,
-		"minimum_response_ms":	 35.225,
+		"minimum_response_ms":   35.225,
 		"average_response_ms":   44.033,
-		"maximum_response_ms":	 51.806,
+		"maximum_response_ms":   51.806,
 		"standard_deviation_ms": 5.325,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)


### PR DESCRIPTION
I noticed that the Linux ping pluging was missing values for min and max. Wanted to capture that data since we already have it in the ping output.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
