### PR TITLE
Allow dos line endings in tail and logparser.

### DIFF
--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -2,6 +2,7 @@ package tail
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/influxdata/tail"
@@ -123,7 +124,10 @@ func (t *Tail) receiver(tailer *tail.Tail) {
 				tailer.Filename, err))
 			continue
 		}
-		m, err = t.parser.ParseLine(line.Text)
+		// Fix up files with Windows line endings.
+		text := strings.TrimRight(line.Text, "\r")
+
+		m, err = t.parser.ParseLine(text)
 		if err == nil {
 			t.acc.AddFields(m.Name(), m.Fields(), m.Tags(), m.Time())
 		} else {

--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -103,3 +103,33 @@ func TestTailBadLine(t *testing.T) {
 	acc.WaitError(1)
 	assert.Contains(t, acc.Errors[0].Error(), "E! Malformed log line")
 }
+
+func TestTailDosLineendings(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+	_, err = tmpfile.WriteString("cpu usage_idle=100\r\ncpu2 usage_idle=200\r\n")
+	require.NoError(t, err)
+
+	tt := NewTail()
+	tt.FromBeginning = true
+	tt.Files = []string{tmpfile.Name()}
+	p, _ := parsers.NewInfluxParser()
+	tt.SetParser(p)
+	defer tt.Stop()
+	defer tmpfile.Close()
+
+	acc := testutil.Accumulator{}
+	require.NoError(t, tt.Start(&acc))
+	require.NoError(t, acc.GatherError(tt.Gather))
+
+	acc.Wait(2)
+	acc.AssertContainsFields(t, "cpu",
+		map[string]interface{}{
+			"usage_idle": float64(100),
+		})
+	acc.AssertContainsFields(t, "cpu2",
+		map[string]interface{}{
+			"usage_idle": float64(200),
+		})
+}


### PR DESCRIPTION
Parsing dos line ending delimited line protocol is still illegal in most
cases.

fixes #2915

### Required for all PRs:

- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
