### PR TITLE
HTTP Proxy in influxdb output plugin

### DIFF
--- a/plugins/outputs/influxdb/README.md
+++ b/plugins/outputs/influxdb/README.md
@@ -40,6 +40,9 @@ This plugin writes to [InfluxDB](https://www.influxdb.com) via HTTP or UDP.
   # ssl_key = "/etc/telegraf/key.pem"
   ## Use SSL but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## HTTP Proxy Config
+  # proxy = "http://corporate.proxy:3128"
 ```
 
 ### Required parameters:
@@ -63,3 +66,4 @@ to write to. Each URL should start with either `http://` or `udp://`
 * `ssl_cert`: SSL CERT
 * `ssl_key`: SSL key
 * `insecure_skip_verify`: Use SSL but skip chain & host verification (default: false)
+* `proxy`: HTTP Proxy URI

--- a/plugins/outputs/influxdb/README.md
+++ b/plugins/outputs/influxdb/README.md
@@ -42,7 +42,7 @@ This plugin writes to [InfluxDB](https://www.influxdb.com) via HTTP or UDP.
   # insecure_skip_verify = false
 
   ## HTTP Proxy Config
-  # proxy = "http://corporate.proxy:3128"
+  # http_proxy = "http://corporate.proxy:3128"
 ```
 
 ### Required parameters:
@@ -66,4 +66,4 @@ to write to. Each URL should start with either `http://` or `udp://`
 * `ssl_cert`: SSL CERT
 * `ssl_key`: SSL key
 * `insecure_skip_verify`: Use SSL but skip chain & host verification (default: false)
-* `proxy`: HTTP Proxy URI
+* `http_proxy`: HTTP Proxy URI

--- a/plugins/outputs/influxdb/client/http.go
+++ b/plugins/outputs/influxdb/client/http.go
@@ -39,29 +39,29 @@ func NewHTTP(config HTTPConfig, defaultWP WriteParams) (Client, error) {
 		return nil, fmt.Errorf("config.URL scheme must be http(s), got %s", u.Scheme)
 	}
 
-        var transport http.Transport
-	if len(config.Proxy) > 0 {
-            proxyURL, err := url.Parse(config.Proxy)
-            if err != nil {
-		return nil, fmt.Errorf("error parsing config.Proxy: %s", err)
-            }
+	var transport http.Transport
+	if len(config.HTTPProxy) > 0 {
+		proxyURL, err := url.Parse(config.HTTPProxy)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing config.HTTPProxy: %s", err)
+		}
 
-            transport = http.Transport{
-                Proxy: http.ProxyURL(proxyURL),
-                TLSClientConfig: config.TLSConfig,
-            }
+		transport = http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: config.TLSConfig,
+		}
 	} else {
-            transport = http.Transport{
-                TLSClientConfig: config.TLSConfig,
-            }
-        }
+		transport = http.Transport{
+			TLSClientConfig: config.TLSConfig,
+		}
+	}
 
 	return &httpClient{
 		writeURL: writeURL(u, defaultWP),
 		config:   config,
 		url:      u,
 		client: &http.Client{
-			Timeout: config.Timeout,
+			Timeout:   config.Timeout,
 			Transport: &transport,
 		},
 	}, nil
@@ -92,7 +92,7 @@ type HTTPConfig struct {
 	TLSConfig *tls.Config
 
 	// Proxy URL should be of the form "http://host:port"
-	Proxy string
+	HTTPProxy string
 
 	// Gzip, if true, compresses each payload using gzip.
 	// TODO

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -33,6 +33,7 @@ type InfluxDB struct {
 	WriteConsistency string
 	Timeout          internal.Duration
 	UDPPayload       int `toml:"udp_payload"`
+	Proxy            string
 
 	// Path to CA file
 	SSLCA string `toml:"ssl_ca"`
@@ -83,6 +84,9 @@ var sampleConfig = `
   # ssl_key = "/etc/telegraf/key.pem"
   ## Use SSL but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## HTTP Proxy Config
+  # proxy = "http://corporate.proxy:3128"
 `
 
 // Connect initiates the primary connection to the range of provided URLs
@@ -123,6 +127,7 @@ func (i *InfluxDB) Connect() error {
 				UserAgent: i.UserAgent,
 				Username:  i.Username,
 				Password:  i.Password,
+				Proxy:     i.Proxy,
 			}
 			wp := client.WriteParams{
 				Database:        i.Database,

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -32,8 +32,8 @@ type InfluxDB struct {
 	RetentionPolicy  string
 	WriteConsistency string
 	Timeout          internal.Duration
-	UDPPayload       int `toml:"udp_payload"`
-	Proxy            string
+	UDPPayload       int    `toml:"udp_payload"`
+	HTTPProxy        string `toml:"http_proxy"`
 
 	// Path to CA file
 	SSLCA string `toml:"ssl_ca"`
@@ -86,7 +86,7 @@ var sampleConfig = `
   # insecure_skip_verify = false
 
   ## HTTP Proxy Config
-  # proxy = "http://corporate.proxy:3128"
+  # http_proxy = "http://corporate.proxy:3128"
 `
 
 // Connect initiates the primary connection to the range of provided URLs
@@ -127,7 +127,7 @@ func (i *InfluxDB) Connect() error {
 				UserAgent: i.UserAgent,
 				Username:  i.Username,
 				Password:  i.Password,
-				Proxy:     i.Proxy,
+				HTTPProxy: i.HTTPProxy,
 			}
 			wp := client.WriteParams{
 				Database:        i.Database,


### PR DESCRIPTION
As in issue #1588 
Influxdb output plugin does not works with http proxy.
This patch solve the issue.


### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [ ] Has appropriate unit tests.
