### PR TITLE
Remove blocking behavior and improve internal concurrency

### DIFF
--- a/plugins/inputs/statsd/aggregate.go
+++ b/plugins/inputs/statsd/aggregate.go
@@ -1,0 +1,286 @@
+package statsd
+
+func (s *Statsd) timingsC(percentileLimit int) (chan struct{}, chan *metric, chan map[string]cachedtimings) {
+	tC := make(chan map[string]cachedtimings)
+	mC := make(chan *metric)
+	tCReset := make(chan struct{})
+	timings := make(map[string]cachedtimings)
+
+	go func() {
+		for {
+			timingsCopy := make(map[string]cachedtimings, len(timings))
+			for key := range timings {
+
+				// Deep copy the maps
+				fieldsCopy := make(map[string]RunningStats, len(timings[key].fields))
+				for k := range timings[key].fields {
+					fieldsCopy[k] = timings[key].fields[k]
+				}
+
+				tagsCopy := make(map[string]string, len(timings[key].tags))
+				for k := range timings[key].tags {
+					tagsCopy[k] = timings[key].tags[k]
+				}
+
+				// Finally assign new copy of cachedtimings to the bucket
+				timingsCopy[key] = cachedtimings{
+					name:   timings[key].name,
+					fields: fieldsCopy,
+					tags:   tagsCopy,
+				}
+			}
+			select {
+			case <-tCReset:
+				for key := range timings {
+					timings[key] = cachedtimings{name: "", fields: nil, tags: nil}
+				}
+				timings = make(map[string]cachedtimings)
+
+				for key := range timingsCopy {
+					timingsCopy[key] = cachedtimings{name: "", fields: nil, tags: nil}
+				}
+				timingsCopy = make(map[string]cachedtimings)
+			case m, ok := <-mC:
+				if !ok {
+					return
+				}
+				// Check if the measurement exists
+				cached, ok := timings[m.hash]
+				if !ok {
+					cached = cachedtimings{
+						name:   m.name,
+						fields: make(map[string]RunningStats),
+						tags:   m.tags,
+					}
+				}
+				// Check if the field exist If we've not enabled multiple fields per timer
+				// this will be the default field name, eg. "value"
+				field, ok := cached.fields[m.field]
+				if !ok {
+					field = RunningStats{
+						PercLimit: percentileLimit,
+					}
+				}
+				if m.samplerate > 0 {
+					for i := 0; i < int(1.0/m.samplerate); i++ {
+						field.AddValue(m.floatvalue)
+					}
+				} else {
+					field.AddValue(m.floatvalue)
+				}
+				cached.fields[m.field] = field
+				timings[m.hash] = cached
+			case tC <- timingsCopy:
+			}
+		}
+	}()
+	return tCReset, mC, tC
+}
+
+func (s *Statsd) countersC() (chan struct{}, chan *metric, chan map[string]cachedcounter) {
+	cC := make(chan map[string]cachedcounter)
+	mC := make(chan *metric)
+	cCReset := make(chan struct{})
+	counters := make(map[string]cachedcounter)
+
+	go func() {
+		for {
+			countersCopy := make(map[string]cachedcounter, len(counters))
+			for key := range counters {
+
+				// Deep copy the maps
+				fieldsCopy := make(map[string]interface{}, len(counters[key].fields))
+				for k := range counters[key].fields {
+					fieldsCopy[k] = counters[key].fields[k]
+				}
+
+				tagsCopy := make(map[string]string, len(counters[key].tags))
+				for k := range counters[key].tags {
+					tagsCopy[k] = counters[key].tags[k]
+				}
+
+				// Finally assign new copy of cachedcounter to the bucket
+				countersCopy[key] = cachedcounter{
+					name:   counters[key].name,
+					fields: fieldsCopy,
+					tags:   tagsCopy,
+				}
+			}
+			select {
+			case <-cCReset:
+				for key := range counters {
+					counters[key] = cachedcounter{name: "", fields: nil, tags: nil}
+				}
+				counters = make(map[string]cachedcounter)
+
+				for key := range countersCopy {
+					countersCopy[key] = cachedcounter{name: "", fields: nil, tags: nil}
+				}
+				countersCopy = make(map[string]cachedcounter)
+			case m, ok := <-mC:
+				if !ok {
+					return
+				}
+
+				// check if the measurement exists
+				_, ok = counters[m.hash]
+				if !ok {
+					counters[m.hash] = cachedcounter{
+						name:   m.name,
+						fields: make(map[string]interface{}),
+						tags:   m.tags,
+					}
+				}
+				// check if the field exists
+				_, ok = counters[m.hash].fields[m.field]
+				if !ok {
+					counters[m.hash].fields[m.field] = int64(0)
+				}
+				counters[m.hash].fields[m.field] = counters[m.hash].fields[m.field].(int64) + m.intvalue
+			case cC <- countersCopy:
+			}
+		}
+	}()
+	return cCReset, mC, cC
+}
+
+func (s *Statsd) gaugesC() (chan struct{}, chan *metric, chan map[string]cachedgauge) {
+	gC := make(chan map[string]cachedgauge)
+	mC := make(chan *metric)
+	gCReset := make(chan struct{})
+	gauges := make(map[string]cachedgauge)
+
+	go func() {
+		for {
+			gaugesCopy := make(map[string]cachedgauge, len(gauges))
+			for key := range gauges {
+
+				// Deep copy the maps
+				fieldsCopy := make(map[string]interface{}, len(gauges[key].fields))
+				for k := range gauges[key].fields {
+					fieldsCopy[k] = gauges[key].fields[k]
+				}
+
+				tagsCopy := make(map[string]string, len(gauges[key].tags))
+				for k := range gauges[key].tags {
+					tagsCopy[k] = gauges[key].tags[k]
+				}
+
+				// Finally assign new copy of cachedgauge to the bucket
+				gaugesCopy[key] = cachedgauge{
+					name:   gauges[key].name,
+					fields: fieldsCopy,
+					tags:   tagsCopy,
+				}
+			}
+			select {
+			case <-gCReset:
+				for key := range gauges {
+					gauges[key] = cachedgauge{name: "", fields: nil, tags: nil}
+				}
+				gauges = make(map[string]cachedgauge)
+
+				for key := range gaugesCopy {
+					gaugesCopy[key] = cachedgauge{name: "", fields: nil, tags: nil}
+				}
+				gaugesCopy = make(map[string]cachedgauge)
+			case m, ok := <-mC:
+				if !ok {
+					return
+				}
+				// check if the measurement exists
+				_, ok = gauges[m.hash]
+				if !ok {
+					gauges[m.hash] = cachedgauge{
+						name:   m.name,
+						fields: make(map[string]interface{}),
+						tags:   m.tags,
+					}
+				}
+				// check if the field exists
+				_, ok = gauges[m.hash].fields[m.field]
+				if !ok {
+					gauges[m.hash].fields[m.field] = float64(0)
+				}
+				if m.additive {
+					gauges[m.hash].fields[m.field] =
+						gauges[m.hash].fields[m.field].(float64) + m.floatvalue
+				} else {
+					gauges[m.hash].fields[m.field] = m.floatvalue
+				}
+			case gC <- gaugesCopy:
+			}
+		}
+	}()
+	return gCReset, mC, gC
+}
+
+func (s *Statsd) setsC() (chan struct{}, chan *metric, chan map[string]cachedset) {
+	sC := make(chan map[string]cachedset)
+	mC := make(chan *metric)
+	sCReset := make(chan struct{})
+	sets := make(map[string]cachedset)
+
+	go func() {
+		for {
+			setsCopy := make(map[string]cachedset, len(sets))
+			for key := range sets {
+
+				// Deep copy the maps
+				fieldsCopy := make(map[string]map[string]bool, len(sets[key].fields))
+				for k := range sets[key].fields {
+					fieldsBoolCopy := make(map[string]bool, len(sets[key].fields[k]))
+					for iK := range sets[key].fields[k] {
+						fieldsBoolCopy[iK] = sets[key].fields[k][iK]
+					}
+					fieldsCopy[k] = fieldsBoolCopy
+				}
+
+				tagsCopy := make(map[string]string, len(sets[key].tags))
+				for k := range sets[key].tags {
+					tagsCopy[k] = sets[key].tags[k]
+				}
+
+				// Finally assign new copy of cachedset to the bucket
+				setsCopy[key] = cachedset{
+					name:   sets[key].name,
+					fields: fieldsCopy,
+					tags:   tagsCopy,
+				}
+			}
+			select {
+			case <-sCReset:
+				for key := range sets {
+					sets[key] = cachedset{name: "", fields: nil, tags: nil}
+				}
+				sets = make(map[string]cachedset)
+
+				for key := range setsCopy {
+					setsCopy[key] = cachedset{name: "", fields: nil, tags: nil}
+				}
+				setsCopy = make(map[string]cachedset)
+			case m, ok := <-mC:
+				if !ok {
+					return
+				}
+				// check if the measurement exists
+				_, ok = sets[m.hash]
+				if !ok {
+					sets[m.hash] = cachedset{
+						name:   m.name,
+						fields: make(map[string]map[string]bool),
+						tags:   m.tags,
+					}
+				}
+				// check if the field exists
+				_, ok = sets[m.hash].fields[m.field]
+				if !ok {
+					sets[m.hash].fields[m.field] = make(map[string]bool)
+				}
+				sets[m.hash].fields[m.field][m.strvalue] = true
+			case sC <- setsCopy:
+			}
+		}
+	}()
+	return sCReset, mC, sC
+}

--- a/plugins/inputs/statsd/gather.go
+++ b/plugins/inputs/statsd/gather.go
@@ -1,0 +1,119 @@
+package statsd
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+func (s *Statsd) gatherTimings(now time.Time) []*accumulator {
+	log.Println("D! Statsd.Gather() Starting range of s.timings")
+	t, ok := <-s.timings
+	if !ok {
+		panic("chan cachedtimings is closed")
+	}
+	log.Printf("D! Statsd.Gather().gatherTimings len=%d", len(t))
+	a := make([]*accumulator, 0, len(t))
+	for key := range t {
+		// Defining a template to parse field names for timers allows us to split
+		// out multiple fields per timer. In this case we prefix each stat with the
+		// field name and store these all in a single measurement.
+		fields := make(map[string]interface{})
+		for fieldName, stats := range t[key].fields {
+			var prefix string
+			if fieldName != defaultFieldName {
+				prefix = fieldName + "_"
+			}
+			fields[prefix+"mean"] = stats.Mean()
+			fields[prefix+"stddev"] = stats.Stddev()
+			fields[prefix+"upper"] = stats.Upper()
+			fields[prefix+"lower"] = stats.Lower()
+			fields[prefix+"count"] = stats.Count()
+			fmt.Println(s.Percentiles)
+			for _, percentile := range s.Percentiles {
+				name := fmt.Sprintf("%s%d_percentile", prefix, percentile)
+				fields[name] = stats.Percentile(percentile)
+			}
+		}
+		a = append(a, &accumulator{
+			measurement: t[key].name,
+			fields:      fields,
+			tags:        t[key].tags,
+			t:           []time.Time{now},
+		})
+	}
+	if s.DeleteTimings {
+		s.timingsReset <- struct{}{}
+	}
+	return a
+}
+
+func (s *Statsd) gatherGauges(now time.Time) []*accumulator {
+	log.Println("D! Statsd.Gather() Starting range of s.gauges")
+	g, ok := <-s.gauges
+	if !ok {
+		panic("chan cachedgauges is closed")
+	}
+	log.Printf("D! Statsd.Gather().gatherGauges len=%d", len(g))
+	a := make([]*accumulator, 0, len(g))
+	for key := range g {
+		a = append(a, &accumulator{
+			measurement: g[key].name,
+			fields:      g[key].fields,
+			tags:        g[key].tags,
+			t:           []time.Time{now},
+		})
+	}
+	if s.DeleteGauges {
+		s.gaugesReset <- struct{}{}
+	}
+	return a
+}
+
+func (s *Statsd) gatherCounters(now time.Time) []*accumulator {
+	log.Println("D! Statsd.Gather() Starting range of s.counters")
+	c, ok := <-s.counters
+	if !ok {
+		panic("chan cachedcounters is closed")
+	}
+	log.Printf("D! Statsd.Gather().gatherCounters len=%d", len(c))
+	a := make([]*accumulator, 0, len(c))
+	for key := range c {
+		a = append(a, &accumulator{
+			measurement: c[key].name,
+			fields:      c[key].fields,
+			tags:        c[key].tags,
+			t:           []time.Time{now},
+		})
+	}
+	if s.DeleteCounters {
+		s.countersReset <- struct{}{}
+	}
+	return a
+}
+
+func (s *Statsd) gatherSets(now time.Time) []*accumulator {
+	log.Println("D! Statsd.Gather() Starting range of s.sets")
+	sets, ok := <-s.sets
+	if !ok {
+		panic("chan cachedsets is closed")
+	}
+	log.Printf("D! Statsd.Gather().gatherSets len=%d", len(sets))
+	a := make([]*accumulator, 0, len(sets))
+	for key := range sets {
+		fields := make(map[string]interface{})
+		for field, set := range sets[key].fields {
+			fields[field] = int64(len(set))
+		}
+		a = append(a, &accumulator{
+			measurement: sets[key].name,
+			fields:      fields,
+			tags:        sets[key].tags,
+			t:           []time.Time{now},
+		})
+	}
+	if s.DeleteSets {
+		s.setsReset <- struct{}{}
+	}
+	return a
+}

--- a/plugins/inputs/statsd/running_stats.go
+++ b/plugins/inputs/statsd/running_stats.go
@@ -47,7 +47,7 @@ func (rs *RunningStats) AddValue(v float64) {
 	}
 
 	// These are used for the running mean and variance
-	rs.n += 1
+	rs.n++
 	rs.ex += v - rs.k
 	rs.ex2 += (v - rs.k) * (v - rs.k)
 


### PR DESCRIPTION
https://github.com/influxdata/telegraf/issues/2927

Maintains black box behavior while adjusting internals to minimize blocking. Individual line parsing went from 20us~ to 40~us though in my test env of 5000 instances parsing 20 million metrics; the majority of the gathers ended up being on par or quicker then prepatch.