### PR TITLE
Fix bug parsing default timestamps with precision set

### DIFF
--- a/metric/parse.go
+++ b/metric/parse.go
@@ -129,7 +129,7 @@ func parseMetric(buf []byte,
 	// apply precision multiplier
 	var nsec int64
 	multiplier := getPrecisionMultiplier(precision)
-	if multiplier > 1 {
+	if len(ts) > 0 && multiplier > 1 {
 		tsint, err := parseIntBytes(ts, 10, 64)
 		if err != nil {
 			return nil, err

--- a/metric/parse_test.go
+++ b/metric/parse_test.go
@@ -380,8 +380,22 @@ func TestParsePrecision(t *testing.T) {
 	} {
 		metrics, err := ParseWithDefaultTimePrecision(
 			[]byte(tt.line+"\n"), time.Now(), tt.precision)
-		assert.NoError(t, err, tt)
+		assert.NoError(t, err)
 		assert.Equal(t, tt.expected, metrics[0].UnixNano())
+	}
+}
+
+func TestParsePrecisionUnsetTime(t *testing.T) {
+	for _, tt := range []struct {
+		line      string
+		precision string
+	}{
+		{"test v=42", "s"},
+		{"test v=42", "ns"},
+	} {
+		_, err := ParseWithDefaultTimePrecision(
+			[]byte(tt.line+"\n"), time.Now(), tt.precision)
+		assert.NoError(t, err)
 	}
 }
 


### PR DESCRIPTION
fixes #2948

### Required for all PRs:

- [x] Has appropriate unit tests.
