### PR TITLE
Fix panic in elasticsearch input plugin

### DIFF
--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -1,14 +1,14 @@
 package elasticsearch
 
 import (
-	"errors"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
 	"sync"
 	"time"
-	
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/inputs"


### PR DESCRIPTION
This introduces a fix for #2893.

If the situation that previously triggered the panic (a master node not discovered exception) occurs, then cluster stats collection will be skipped for the current interval and an error will be logged:

```
2017-06-23T05:11:15Z E! Error in plugin [inputs.elasticsearch]: Unable to retrieve master node information. Cluster stats collection was skipped for this interval.
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
