### PR TITLE
Use git sha1 as version if not tagged

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -57,10 +57,12 @@ var fService = flag.String("service", "",
 
 // Telegraf version, populated linker.
 //   ie, -ldflags "-X main.version=`git describe --always --tags`"
+
 var (
-	version string
-	commit  string
-	branch  string
+	nextVersion = "1.4.0"
+	version     string
+	commit      string
+	branch      string
 )
 
 func init() {
@@ -196,7 +198,7 @@ func reloadLoop(
 			}
 		}()
 
-		log.Printf("I! Starting Telegraf (version %s)\n", version)
+		log.Printf("I! Starting Telegraf %s\n", displayVersion())
 		log.Printf("I! Loaded outputs: %s", strings.Join(c.OutputNames(), " "))
 		log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))
 		log.Printf("I! Tags enabled: %s", c.ListTags())
@@ -254,6 +256,13 @@ func (p *program) Stop(s service.Service) error {
 	return nil
 }
 
+func displayVersion() string {
+	if version == "" {
+		return fmt.Sprintf("v%s~pre%s", nextVersion, commit)
+	}
+	return "v" + version
+}
+
 func main() {
 	flag.Usage = func() { usageExit(0) }
 	flag.Parse()
@@ -295,7 +304,7 @@ func main() {
 	if len(args) > 0 {
 		switch args[0] {
 		case "version":
-			fmt.Printf("Telegraf v%s (git: %s %s)\n", version, branch, commit)
+			fmt.Printf("Telegraf %s (git: %s %s)\n", displayVersion(), branch, commit)
 			return
 		case "config":
 			config.PrintSampleConfig(
@@ -323,7 +332,7 @@ func main() {
 		}
 		return
 	case *fVersion:
-		fmt.Printf("Telegraf v%s (git: %s %s)\n", version, branch, commit)
+		fmt.Printf("Telegraf %s (git: %s %s)\n", displayVersion(), branch, commit)
 		return
 	case *fSampleConfig:
 		config.PrintSampleConfig(


### PR DESCRIPTION
closes #2942 

On this branch
```
$ telegraf --version
Telegraf v1.4.0~pre8f2d9233 (git: fix-version 8f2d9233)
```

Release should look something like:
```
Telegraf v1.4.0 (git: release-1.4 8f2d9233)
```

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
