### PR TITLE
Change default prometheus_client port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - In the `aerospike` input the `node_name` field has been changed to be a tag
   for both the `aerospike_node` and `aerospike_namespace` measurements.
 
+- **breaking change** Change default prometheus_client port to 9273. To play well with Prometheus [port-allocations](https://github.com/prometheus/prometheus/wiki/Default-port-allocations)
+
 ### New Plugins
 
 - [fail2ban](./plugins/inputs/fail2ban/README.md)

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -505,7 +505,7 @@
 # # Configuration for the Prometheus client to spawn
 # [[outputs.prometheus_client]]
 #   ## Address to listen on
-#   # listen = ":9126"
+#   # listen = ":9273"
 #
 #   ## Interval to expire metrics and not deliver to prometheus, 0 == no expiration
 #   # expiration_interval = "60s"

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -8,7 +8,7 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
 # Publish all metrics to /metrics for Prometheus to scrape
 [[outputs.prometheus_client]]
   # Address to listen on
-  listen = ":9126"
+  listen = ":9273"
 
   # Expiration interval for each metric. 0 == no expiration
   expiration_interval = "60s"

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -57,7 +57,7 @@ type PrometheusClient struct {
 
 var sampleConfig = `
   ## Address to listen on
-  # listen = ":9126"
+  # listen = ":9273"
 
   ## Interval to expire metrics and not deliver to prometheus, 0 == no expiration
   # expiration_interval = "60s"
@@ -67,7 +67,7 @@ func (p *PrometheusClient) Start() error {
 	prometheus.Register(p)
 
 	if p.Listen == "" {
-		p.Listen = "localhost:9126"
+		p.Listen = "localhost:9273"
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

According to https://prometheus.io/docs/instrumenting/writing_exporters/#port-numbers we have to use that port table to avoid collisions. That PR fixes previous incompatibility with that table.