### PR TITLE
Add influxdb gzip support

### DIFF
--- a/plugins/outputs/influxdb/README.md
+++ b/plugins/outputs/influxdb/README.md
@@ -43,6 +43,9 @@ This plugin writes to [InfluxDB](https://www.influxdb.com) via HTTP or UDP.
 
   ## HTTP Proxy Config
   # http_proxy = "http://corporate.proxy:3128"
+
+  ## Compress each HTTP request payload using GZIP, defaults to false.
+  # gzip = false
 ```
 
 ### Required parameters:
@@ -67,3 +70,4 @@ to write to. Each URL should start with either `http://` or `udp://`
 * `ssl_key`: SSL key
 * `insecure_skip_verify`: Use SSL but skip chain & host verification (default: false)
 * `http_proxy`: HTTP Proxy URI
+* `gzip`: Compress each HTTP request payload using gzip (default: false)

--- a/plugins/outputs/influxdb/README.md
+++ b/plugins/outputs/influxdb/README.md
@@ -44,8 +44,8 @@ This plugin writes to [InfluxDB](https://www.influxdb.com) via HTTP or UDP.
   ## HTTP Proxy Config
   # http_proxy = "http://corporate.proxy:3128"
 
-  ## Compress each HTTP request payload using GZIP, defaults to false.
-  # gzip = false
+  ## Compress each HTTP request payload using GZIP.
+  # content_encoding = "gzip"
 ```
 
 ### Required parameters:
@@ -70,4 +70,4 @@ to write to. Each URL should start with either `http://` or `udp://`
 * `ssl_key`: SSL key
 * `insecure_skip_verify`: Use SSL but skip chain & host verification (default: false)
 * `http_proxy`: HTTP Proxy URI
-* `gzip`: Compress each HTTP request payload using gzip (default: false)
+* `content_encoding`: Compress each HTTP request payload using gzip if set to: "gzip"

--- a/plugins/outputs/influxdb/client/http.go
+++ b/plugins/outputs/influxdb/client/http.go
@@ -95,8 +95,8 @@ type HTTPConfig struct {
 	// Proxy URL should be of the form "http://host:port"
 	HTTPProxy string
 
-	// Gzip, if true, compresses each payload using gzip.
-	Gzip bool
+	// The content encoding mechanism to use for each request.
+	ContentEncoding string
 }
 
 // Response represents a list of statement results.
@@ -232,9 +232,10 @@ func (c *httpClient) makeWriteRequest(
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Length", fmt.Sprint(contentLength))
-	if c.config.Gzip {
+	if c.config.ContentEncoding == "gzip" {
 		req.Header.Set("Content-Encoding", "gzip")
+	} else {
+		req.Header.Set("Content-Length", fmt.Sprint(contentLength))
 	}
 	return req, nil
 }
@@ -242,9 +243,7 @@ func (c *httpClient) makeWriteRequest(
 func (c *httpClient) makeRequest(uri string, body io.Reader) (*http.Request, error) {
 	var req *http.Request
 	var err error
-	if c.config.Gzip {
-		// If gzip is set to true, then compress
-		// the payload.
+	if c.config.ContentEncoding == "gzip" {
 		body, err = compressWithGzip(body)
 		if err != nil {
 			return nil, err

--- a/plugins/outputs/influxdb/client/http_test.go
+++ b/plugins/outputs/influxdb/client/http_test.go
@@ -344,20 +344,22 @@ func TestHTTPClient_Query_JSONDecodeError(t *testing.T) {
 }
 
 func TestGzipCompression(t *testing.T) {
+	influxLine := "cpu value=99\n"
+
 	// Compress the payload using GZIP.
-	payload := []byte("cpu value=99\n")
+	payload := bytes.NewReader([]byte(influxLine))
 	compressed, err := compressWithGzip(payload)
 	assert.Nil(t, err)
 
-	// GUNZIP the compressed payload and make sure
+	// Decompress the compressed payload and make sure
 	// that its original value has not changed.
-	r, err := gzip.NewReader(bytes.NewReader(compressed))
+	gr, err := gzip.NewReader(compressed)
 	assert.Nil(t, err)
-	r.Close()
+	gr.Close()
 
 	var uncompressed bytes.Buffer
-	_, err = uncompressed.ReadFrom(r)
+	_, err = uncompressed.ReadFrom(gr)
 	assert.Nil(t, err)
 
-	assert.Equal(t, payload, uncompressed.Bytes())
+	assert.Equal(t, []byte(influxLine), uncompressed.Bytes())
 }

--- a/plugins/outputs/influxdb/client/http_test.go
+++ b/plugins/outputs/influxdb/client/http_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -340,4 +341,23 @@ func TestHTTPClient_Query_JSONDecodeError(t *testing.T) {
 	err = client.Query(command)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "json")
+}
+
+func TestGzipCompression(t *testing.T) {
+	// Compress the payload using GZIP.
+	payload := []byte("cpu value=99\n")
+	compressed, err := compressWithGzip(payload)
+	assert.Nil(t, err)
+
+	// GUNZIP the compressed payload and make sure
+	// that its original value has not changed.
+	r, err := gzip.NewReader(bytes.NewReader(compressed))
+	assert.Nil(t, err)
+	r.Close()
+
+	var uncompressed bytes.Buffer
+	_, err = uncompressed.ReadFrom(r)
+	assert.Nil(t, err)
+
+	assert.Equal(t, payload, uncompressed.Bytes())
 }

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -34,7 +34,7 @@ type InfluxDB struct {
 	Timeout          internal.Duration
 	UDPPayload       int    `toml:"udp_payload"`
 	HTTPProxy        string `toml:"http_proxy"`
-	Gzip             bool
+	ContentEncoding  string `toml:"content_encoding"`
 
 	// Path to CA file
 	SSLCA string `toml:"ssl_ca"`
@@ -89,8 +89,8 @@ var sampleConfig = `
   ## HTTP Proxy Config
   # http_proxy = "http://corporate.proxy:3128"
   
-  ## Compress each HTTP request payload using GZIP, defaults to false.
-  # gzip = false
+  ## Compress each HTTP request payload using GZIP.
+  # content_encoding = "gzip"
 `
 
 // Connect initiates the primary connection to the range of provided URLs
@@ -125,14 +125,14 @@ func (i *InfluxDB) Connect() error {
 		default:
 			// If URL doesn't start with "udp", assume HTTP client
 			config := client.HTTPConfig{
-				URL:       u,
-				Timeout:   i.Timeout.Duration,
-				TLSConfig: tlsConfig,
-				UserAgent: i.UserAgent,
-				Username:  i.Username,
-				Password:  i.Password,
-				HTTPProxy: i.HTTPProxy,
-				Gzip:      i.Gzip,
+				URL:             u,
+				Timeout:         i.Timeout.Duration,
+				TLSConfig:       tlsConfig,
+				UserAgent:       i.UserAgent,
+				Username:        i.Username,
+				Password:        i.Password,
+				HTTPProxy:       i.HTTPProxy,
+				ContentEncoding: i.ContentEncoding,
 			}
 			wp := client.WriteParams{
 				Database:        i.Database,

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -34,6 +34,7 @@ type InfluxDB struct {
 	Timeout          internal.Duration
 	UDPPayload       int    `toml:"udp_payload"`
 	HTTPProxy        string `toml:"http_proxy"`
+	Gzip             bool
 
 	// Path to CA file
 	SSLCA string `toml:"ssl_ca"`
@@ -87,6 +88,9 @@ var sampleConfig = `
 
   ## HTTP Proxy Config
   # http_proxy = "http://corporate.proxy:3128"
+  
+  ## Compress each HTTP request payload using GZIP, defaults to false.
+  # gzip = false
 `
 
 // Connect initiates the primary connection to the range of provided URLs
@@ -128,6 +132,7 @@ func (i *InfluxDB) Connect() error {
 				Username:  i.Username,
 				Password:  i.Password,
 				HTTPProxy: i.HTTPProxy,
+				Gzip:      i.Gzip,
 			}
 			wp := client.WriteParams{
 				Database:        i.Database,


### PR DESCRIPTION
An approach for fixing #2802. Adds an optional parameter `gzip` (default: `false`), which if enabled, will compress the payload of each HTTP request sent to InfluxDB using GZIP.

While testing I was able to get on average 67% space savings when comparing the content length of the compressed vs. uncompressed payloads using the default sample `telegraf.conf` with no input filters.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.