### PR TITLE
display error message if  serve prometheus metric output failed

### DIFF
--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -78,7 +78,12 @@ func (p *PrometheusClient) Start() error {
 		Handler: mux,
 	}
 
-	go p.server.ListenAndServe()
+	go func() {
+		if err := p.server.ListenAndServe(); err != nil {
+			log.Printf("E! Error creating prometheus metric endpoint, err: %s\n",
+				err.Error())
+		}
+	}()
 	return nil
 }
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

I encounter this issue when I have a telegraf instance A already bind prometheus metric endpoint to  port 9216, while another telegraf instance B trying to bind port 9216 after that didn't show any clue its binding failed.

What makes it more confusing is that my visiting metrics endpoint at port 9216 still shows results. I didn't realize there's an old instance A there.

I think output error message from serve and listen method should be a help to this issue.