### PR TITLE
Add result_type field to net_response input plugin

### DIFF
--- a/plugins/inputs/net_response/README.md
+++ b/plugins/inputs/net_response/README.md
@@ -1,4 +1,4 @@
-# Example Input Plugin
+# Network Response Input Plugin
 
 The input plugin test UDP/TCP connections response time.
 It can also check response text.

--- a/plugins/inputs/net_response/README.md
+++ b/plugins/inputs/net_response/README.md
@@ -60,7 +60,7 @@ It can also check response text.
 - net_response
     - response_time (float, seconds)
     - result_type (string) # success, timeout, connection_failed, read_failed, string_mismatch
-    - [**DEPRECATED**] string_mismatch (boolean)
+    - [**DEPRECATED**] string_found (boolean)
 
 ### Tags:
 

--- a/plugins/inputs/net_response/README.md
+++ b/plugins/inputs/net_response/README.md
@@ -59,7 +59,7 @@ It can also check response text.
 
 - net_response
     - response_time (float, seconds)
-    - string_found (bool) # Only if "expected: option is set
+    - result_type (string) # success, timeout, connection_failed, read_failed, string_mismatch
 
 ### Tags:
 

--- a/plugins/inputs/net_response/README.md
+++ b/plugins/inputs/net_response/README.md
@@ -60,6 +60,7 @@ It can also check response text.
 - net_response
     - response_time (float, seconds)
     - result_type (string) # success, timeout, connection_failed, read_failed, string_mismatch
+    - [**DEPRECATED**] string_mismatch (boolean)
 
 ### Tags:
 
@@ -72,7 +73,11 @@ It can also check response text.
 
 ```
 $ ./telegraf --config telegraf.conf --input-filter net_response --test
-net_response,server=192.168.2.2,port=22,protocol=tcp response_time=0.18070360500000002,string_found=true 1454785464182527094
-net_response,server=192.168.2.2,port=2222,protocol=tcp response_time=1.090124776,string_found=false 1454784433658942325
-
+net_response,server=influxdata.com,port=8080,protocol=tcp,host=localhost result_type="timeout" 1499310361000000000
+net_response,server=influxdata.com,port=443,protocol=tcp,host=localhost result_type="success",response_time=0.088703864 1499310361000000000
+net_response,protocol=tcp,host=localhost,server=this.domain.does.not.exist,port=443 result_type="connection_failed" 1499310361000000000
+net_response,protocol=udp,host=localhost,server=influxdata.com,port=8080 result_type="read_failed" 1499310362000000000
+net_response,port=31338,protocol=udp,host=localhost,server=localhost result_type="string_mismatch",string_match=false,response_time=0.00242682 1499310362000000000
+net_response,protocol=udp,host=localhost,server=localhost,port=31338 response_time=0.001128598,result_type="success" 1499310362000000000
+net_response,server=this.domain.does.not.exist,port=443,protocol=udp,host=localhost result_type="connection_failed" 1499310362000000000
 ```

--- a/plugins/inputs/net_response/README.md
+++ b/plugins/inputs/net_response/README.md
@@ -77,7 +77,7 @@ net_response,server=influxdata.com,port=8080,protocol=tcp,host=localhost result_
 net_response,server=influxdata.com,port=443,protocol=tcp,host=localhost result_type="success",response_time=0.088703864 1499310361000000000
 net_response,protocol=tcp,host=localhost,server=this.domain.does.not.exist,port=443 result_type="connection_failed" 1499310361000000000
 net_response,protocol=udp,host=localhost,server=influxdata.com,port=8080 result_type="read_failed" 1499310362000000000
-net_response,port=31338,protocol=udp,host=localhost,server=localhost result_type="string_mismatch",string_match=false,response_time=0.00242682 1499310362000000000
+net_response,port=31338,protocol=udp,host=localhost,server=localhost result_type="string_mismatch",string_found=false,response_time=0.00242682 1499310362000000000
 net_response,protocol=udp,host=localhost,server=localhost,port=31338 response_time=0.001128598,result_type="success" 1499310362000000000
 net_response,server=this.domain.does.not.exist,port=443,protocol=udp,host=localhost result_type="connection_failed" 1499310362000000000
 ```

--- a/plugins/inputs/net_response/README.md
+++ b/plugins/inputs/net_response/README.md
@@ -78,6 +78,6 @@ net_response,server=influxdata.com,port=443,protocol=tcp,host=localhost result_t
 net_response,protocol=tcp,host=localhost,server=this.domain.does.not.exist,port=443 result_type="connection_failed" 1499310361000000000
 net_response,protocol=udp,host=localhost,server=influxdata.com,port=8080 result_type="read_failed" 1499310362000000000
 net_response,port=31338,protocol=udp,host=localhost,server=localhost result_type="string_mismatch",string_found=false,response_time=0.00242682 1499310362000000000
-net_response,protocol=udp,host=localhost,server=localhost,port=31338 response_time=0.001128598,result_type="success" 1499310362000000000
+net_response,protocol=udp,host=localhost,server=localhost,port=31338 response_time=0.001128598,result_type="success",string_found=true 1499310362000000000
 net_response,server=this.domain.does.not.exist,port=443,protocol=udp,host=localhost result_type="connection_failed" 1499310362000000000
 ```

--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -99,8 +99,10 @@ func (n *NetResponse) TcpGather() (map[string]interface{}, error) {
 			find := RegEx.FindString(string(data))
 			if find != "" {
 				fields["result_type"] = "success"
+				fields["string_match"] = true // WARNING: This field will be deprecated in a future release.
 			} else {
 				fields["result_type"] = "string_mismatch"
+				fields["string_match"] = false // WARNING: This field will be deprecated in a future release.
 			}
 		}
 	} else {
@@ -151,8 +153,10 @@ func (n *NetResponse) UdpGather() (map[string]interface{}, error) {
 		find := RegEx.FindString(string(buf))
 		if find != "" {
 			fields["result_type"] = "success"
+			fields["string_match"] = true // WARNING: This field will be deprecated in a future release.
 		} else {
 			fields["result_type"] = "string_mismatch"
+			fields["string_match"] = false // WARNING: This field will be deprecated in a future release.
 		}
 	}
 	fields["response_time"] = responseTime

--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -92,7 +92,8 @@ func (n *NetResponse) TcpGather() (map[string]interface{}, error) {
 		responseTime = time.Since(start).Seconds()
 		// Handle error
 		if err != nil {
-			fields["result_type"] = "string_mismatch"
+			fields["string_found"] = false
+			fields["result_type"] = "read_failed"
 		} else {
 			// Looking for string in answer
 			RegEx := regexp.MustCompile(`.*` + n.Expect + `.*`)
@@ -124,11 +125,7 @@ func (n *NetResponse) UdpGather() (map[string]interface{}, error) {
 	conn, err := net.DialUDP("udp", LocalAddr, udpAddr)
 	// Handle error
 	if err != nil {
-		if e, ok := err.(net.Error); ok && e.Timeout() {
-			fields["result_type"] = "timeout"
-		} else {
-			fields["result_type"] = "connection_failed"
-		}
+		fields["result_type"] = "connection_failed"
 		return fields, nil
 	}
 	defer conn.Close()

--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -99,10 +99,10 @@ func (n *NetResponse) TcpGather() (map[string]interface{}, error) {
 			find := RegEx.FindString(string(data))
 			if find != "" {
 				fields["result_type"] = "success"
-				fields["string_match"] = true // WARNING: This field will be deprecated in a future release.
+				fields["string_found"] = true // WARNING: This field will be deprecated in a future release.
 			} else {
 				fields["result_type"] = "string_mismatch"
-				fields["string_match"] = false // WARNING: This field will be deprecated in a future release.
+				fields["string_found"] = false // WARNING: This field will be deprecated in a future release.
 			}
 		}
 	} else {
@@ -153,10 +153,10 @@ func (n *NetResponse) UdpGather() (map[string]interface{}, error) {
 		find := RegEx.FindString(string(buf))
 		if find != "" {
 			fields["result_type"] = "success"
-			fields["string_match"] = true // WARNING: This field will be deprecated in a future release.
+			fields["string_found"] = true // WARNING: This field will be deprecated in a future release.
 		} else {
 			fields["result_type"] = "string_mismatch"
-			fields["string_match"] = false // WARNING: This field will be deprecated in a future release.
+			fields["string_found"] = false // WARNING: This field will be deprecated in a future release.
 		}
 	}
 	fields["response_time"] = responseTime

--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -92,17 +92,17 @@ func (n *NetResponse) TcpGather() (map[string]interface{}, error) {
 		responseTime = time.Since(start).Seconds()
 		// Handle error
 		if err != nil {
-			fields["result_type"] = "read_failed"
+			fields["result_type"] = "string_mismatch"
 		} else {
 			// Looking for string in answer
 			RegEx := regexp.MustCompile(`.*` + n.Expect + `.*`)
 			find := RegEx.FindString(string(data))
 			if find != "" {
 				fields["result_type"] = "success"
-				fields["string_found"] = true // WARNING: This field will be deprecated in a future release.
+				fields["string_found"] = true
 			} else {
 				fields["result_type"] = "string_mismatch"
-				fields["string_found"] = false // WARNING: This field will be deprecated in a future release.
+				fields["string_found"] = false
 			}
 		}
 	} else {
@@ -153,10 +153,10 @@ func (n *NetResponse) UdpGather() (map[string]interface{}, error) {
 		find := RegEx.FindString(string(buf))
 		if find != "" {
 			fields["result_type"] = "success"
-			fields["string_found"] = true // WARNING: This field will be deprecated in a future release.
+			fields["string_found"] = true
 		} else {
 			fields["result_type"] = "string_mismatch"
-			fields["string_found"] = false // WARNING: This field will be deprecated in a future release.
+			fields["string_found"] = false
 		}
 	}
 	fields["response_time"] = responseTime

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -78,6 +78,7 @@ func TestTCPOK1(t *testing.T) {
 		"net_response",
 		map[string]interface{}{
 			"result_type":   "success",
+                        "string_found":  true,
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",
@@ -118,6 +119,7 @@ func TestTCPOK2(t *testing.T) {
 		"net_response",
 		map[string]interface{}{
 			"result_type":   "string_mismatch",
+                        "string_found": false,
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",
@@ -189,6 +191,7 @@ func TestUDPOK1(t *testing.T) {
 		"net_response",
 		map[string]interface{}{
 			"result_type":   "success",
+                        "string_found": true,
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -78,7 +78,7 @@ func TestTCPOK1(t *testing.T) {
 		"net_response",
 		map[string]interface{}{
 			"result_type":   "success",
-                        "string_found":  true,
+			"string_found":  true,
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",
@@ -119,7 +119,7 @@ func TestTCPOK2(t *testing.T) {
 		"net_response",
 		map[string]interface{}{
 			"result_type":   "string_mismatch",
-                        "string_found": false,
+			"string_found":  false,
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",
@@ -191,7 +191,7 @@ func TestUDPOK1(t *testing.T) {
 		"net_response",
 		map[string]interface{}{
 			"result_type":   "success",
-                        "string_found": true,
+			"string_found":  true,
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -39,10 +39,10 @@ func TestTCPError(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":  "connection_failed",
+			"result_type": "connection_failed",
 		},
 		map[string]string{
-			"server": "",
+			"server":   "",
 			"port":     "9999",
 			"protocol": "tcp",
 		},
@@ -77,7 +77,7 @@ func TestTCPOK1(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":  "success",
+			"result_type":   "success",
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",
@@ -117,7 +117,7 @@ func TestTCPOK2(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":  "string_mismatch",
+			"result_type":   "string_mismatch",
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",
@@ -149,11 +149,11 @@ func TestUDPrror(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":  "read_failed",
+			"result_type":   "read_failed",
 			"response_time": 1.0,
 		},
 		map[string]string{
-			"server": "",
+			"server":   "",
 			"port":     "9999",
 			"protocol": "udp",
 		},
@@ -188,7 +188,7 @@ func TestUDPOK1(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":  "success",
+			"result_type":   "success",
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",


### PR DESCRIPTION
This PR adds a newly proposed field called `result_type` (inspired by the [http_response](https://github.com/influxdata/telegraf/pull/2814) input plugin) which indicates whether a collection was either successful or failed. This should be useful for alerting purposes, and also will fix #2794. In an effort to be consistent it also removes the `string_match` boolean field and replaces it with a `string_mismatch` result type (this is a breaking change, not sure if we should keep this for backward compatibility or not).

**Proposed result types**:
- **result_type (string)** # `success`, `timeout`, `connection_failed`, `read_failed`, `string_mismatch`
 
### Test results
```
* Plugin: inputs.net_response, Collection 1
> net_response,server=influxdata.com,port=8080,protocol=tcp,host=localhost result_type="timeout" 1499310361000000000
* Plugin: inputs.net_response, Collection 1
> net_response,server=influxdata.com,port=443,protocol=tcp,host=localhost result_type="success",response_time=0.088703864 1499310361000000000
* Plugin: inputs.net_response, Collection 1
> net_response,protocol=tcp,host=localhost,server=this.domain.does.not.exist,port=443 result_type="connection_failed" 1499310361000000000
* Plugin: inputs.net_response, Collection 1
> net_response,protocol=udp,host=localhost,server=influxdata.com,port=8080 result_type="read_failed" 1499310362000000000
* Plugin: inputs.net_response, Collection 1
> net_response,port=31338,protocol=udp,host=localhost,server=localhost result_type="string_mismatch",string_found=false,response_time=0.00242682 1499310362000000000
* Plugin: inputs.net_response, Collection 1
> net_response,protocol=udp,host=localhost,server=localhost,port=31338 response_time=0.001128598,result_type="success",string_found=true 1499310362000000000
* Plugin: inputs.net_response, Collection 1
> net_response,server=this.domain.does.not.exist,port=443,protocol=udp,host=localhost result_type="connection_failed" 1499310362000000000
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
