### PR TITLE
Add link to Graylog input to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ configuration options.
 * [exec](./plugins/inputs/exec) (generic executable plugin, support JSON, influx, graphite and nagios)
 * [fail2ban](./plugins/inputs/fail2ban)
 * [filestat](./plugins/inputs/filestat)
+* [graylog](./plugins/inputs/graylog)
 * [haproxy](./plugins/inputs/haproxy)
 * [hddtemp](./plugins/inputs/hddtemp)
 * [http_response](./plugins/inputs/http_response)


### PR DESCRIPTION
I noticed it was missing, so I thought I'd add in real quick.