### PR TITLE
Fix error handling escaped field strings

### DIFF
--- a/metric/metric.go
+++ b/metric/metric.go
@@ -98,31 +98,13 @@ func indexUnescapedByte(buf []byte, b byte) int {
 			break
 		}
 		keyi += i
-		if countBackslashes(buf, keyi-1)%2 == 0 {
+		if buf[keyi-1] != '\\' {
 			break
 		} else {
 			keyi++
 		}
 	}
 	return keyi
-}
-
-// countBackslashes counts the number of preceding backslashes starting at
-// the 'start' index.
-func countBackslashes(buf []byte, index int) int {
-	var count int
-	for {
-		if index < 0 {
-			return count
-		}
-		if buf[index] == '\\' {
-			count++
-			index--
-		} else {
-			break
-		}
-	}
-	return count
 }
 
 type metric struct {

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -250,11 +250,13 @@ func TestNewMetric_Fields(t *testing.T) {
 		"host": "localhost",
 	}
 	fields := map[string]interface{}{
-		"float":  float64(1),
-		"int":    int64(1),
-		"bool":   true,
-		"false":  false,
-		"string": "test",
+		"float":                  float64(1),
+		"int":                    int64(1),
+		"bool":                   true,
+		"false":                  false,
+		"string":                 "test",
+		"quote_string":           `x"y`,
+		"backslash_quote_string": `x\"y`,
 	}
 	m, err := New("cpu", tags, fields, now)
 	assert.NoError(t, err)
@@ -367,7 +369,7 @@ func TestIndexUnescapedByte(t *testing.T) {
 		{
 			in:       []byte(`foo\\bar`),
 			b:        'b',
-			expected: 5,
+			expected: -1,
 		},
 		{
 			in:       []byte(`foobar`),


### PR DESCRIPTION
Line protocol does not require or allow escaping of backslash, the only
requirement for a byte to be escaped is if it is an escapable char and
preceeded immediately by a slash.

closes #3001

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
