### PR TITLE
Do not allow metrics with trailing slashes

### DIFF
--- a/internal/models/makemetric.go
+++ b/internal/models/makemetric.go
@@ -3,6 +3,7 @@ package models
 import (
 	"log"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -77,7 +78,27 @@ func makemetric(
 		}
 	}
 
+	for k, v := range tags {
+		if strings.HasSuffix(k, `\`) {
+			log.Printf("D! Measurement [%s] tag [%s] "+
+				"ends with a backslash, skipping", measurement, k)
+			delete(tags, k)
+			continue
+		} else if strings.HasSuffix(v, `\`) {
+			log.Printf("D! Measurement [%s] tag [%s] has a value "+
+				"ending with a backslash, skipping", measurement, k)
+			delete(tags, k)
+			continue
+		}
+	}
+
 	for k, v := range fields {
+		if strings.HasSuffix(k, `\`) {
+			log.Printf("D! Measurement [%s] field [%s] "+
+				"ends with a backslash, skipping", measurement, k)
+			delete(fields, k)
+			continue
+		}
 		// Validate uint64 and float64 fields
 		// convert all int & uint types to int64
 		switch val := v.(type) {
@@ -128,6 +149,14 @@ func makemetric(
 				delete(fields, k)
 				continue
 			}
+		case string:
+			if strings.HasSuffix(val, `\`) {
+				log.Printf("D! Measurement [%s] field [%s] has a value "+
+					"ending with a backslash, skipping", measurement, k)
+				delete(fields, k)
+				continue
+			}
+			fields[k] = v
 		default:
 			fields[k] = v
 		}

--- a/internal/models/running_input_test.go
+++ b/internal/models/running_input_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/telegraf"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMakeMetricNoFields(t *testing.T) {
@@ -330,6 +331,128 @@ func TestMakeMetricNameSuffix(t *testing.T) {
 		fmt.Sprintf("RITest_foobar value=101i %d\n", now.UnixNano()),
 		m.String(),
 	)
+}
+
+func TestMakeMetric_TrailingSlash(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name                string
+		measurement         string
+		fields              map[string]interface{}
+		tags                map[string]string
+		expectedNil         bool
+		expectedMeasurement string
+		expectedFields      map[string]interface{}
+		expectedTags        map[string]string
+	}{
+		{
+			name:        "Measurement cannot have trailing slash",
+			measurement: `cpu\`,
+			fields: map[string]interface{}{
+				"value": int64(42),
+			},
+			tags:        map[string]string{},
+			expectedNil: true,
+		},
+		{
+			name:        "Field key with trailing slash dropped",
+			measurement: `cpu`,
+			fields: map[string]interface{}{
+				"value": int64(42),
+				`bad\`:  `xyzzy`,
+			},
+			tags:                map[string]string{},
+			expectedMeasurement: `cpu`,
+			expectedFields: map[string]interface{}{
+				"value": int64(42),
+			},
+			expectedTags: map[string]string{},
+		},
+		{
+			name:        "Field value with trailing slash dropped",
+			measurement: `cpu`,
+			fields: map[string]interface{}{
+				"value": int64(42),
+				"bad":   `xyzzy\`,
+			},
+			tags:                map[string]string{},
+			expectedMeasurement: `cpu`,
+			expectedFields: map[string]interface{}{
+				"value": int64(42),
+			},
+			expectedTags: map[string]string{},
+		},
+		{
+			name:        "Must have one field after dropped",
+			measurement: `cpu`,
+			fields: map[string]interface{}{
+				"bad": `xyzzy\`,
+			},
+			tags:        map[string]string{},
+			expectedNil: true,
+		},
+		{
+			name:        "Tag key with trailing slash dropped",
+			measurement: `cpu`,
+			fields: map[string]interface{}{
+				"value": int64(42),
+			},
+			tags: map[string]string{
+				`host\`: "localhost",
+				"a":     "x",
+			},
+			expectedMeasurement: `cpu`,
+			expectedFields: map[string]interface{}{
+				"value": int64(42),
+			},
+			expectedTags: map[string]string{
+				"a": "x",
+			},
+		},
+		{
+			name:        "Tag value with trailing slash dropped",
+			measurement: `cpu`,
+			fields: map[string]interface{}{
+				"value": int64(42),
+			},
+			tags: map[string]string{
+				`host`: `localhost\`,
+				"a":    "x",
+			},
+			expectedMeasurement: `cpu`,
+			expectedFields: map[string]interface{}{
+				"value": int64(42),
+			},
+			expectedTags: map[string]string{
+				"a": "x",
+			},
+		},
+	}
+
+	ri := NewRunningInput(&testInput{}, &InputConfig{
+		Name: "TestRunningInput",
+	})
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := ri.MakeMetric(
+				tc.measurement,
+				tc.fields,
+				tc.tags,
+				telegraf.Untyped,
+				now)
+
+			if tc.expectedNil {
+				require.Nil(t, m)
+			} else {
+				require.NotNil(t, m)
+				require.Equal(t, tc.expectedMeasurement, m.Name())
+				require.Equal(t, tc.expectedFields, m.Fields())
+				require.Equal(t, tc.expectedTags, m.Tags())
+			}
+		})
+	}
 }
 
 type testInput struct{}

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -687,3 +687,55 @@ func TestEmptyTagValueOrKey(t *testing.T) {
 	assert.NoError(t, err)
 
 }
+
+func TestNewMetric_TrailingSlash(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		tags   map[string]string
+		fields map[string]interface{}
+	}{
+		{
+			name: `cpu\`,
+			fields: map[string]interface{}{
+				"value": int64(42),
+			},
+		},
+		{
+			name: "cpu",
+			fields: map[string]interface{}{
+				`value\`: "x",
+			},
+		},
+		{
+			name: "cpu",
+			fields: map[string]interface{}{
+				"value": `x\`,
+			},
+		},
+		{
+			name: "cpu",
+			tags: map[string]string{
+				`host\`: "localhost",
+			},
+			fields: map[string]interface{}{
+				"value": int64(42),
+			},
+		},
+		{
+			name: "cpu",
+			tags: map[string]string{
+				"host": `localhost\`,
+			},
+			fields: map[string]interface{}{
+				"value": int64(42),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		_, err := New(tc.name, tc.tags, tc.fields, now)
+		assert.Error(t, err)
+	}
+}


### PR DESCRIPTION
It is not possible to encode a measurement, tag, or field whose last
character is a backslash due to it being an unescapable character.
Because the tight coupling between line protocol and the internal metric
model, prevent metrics like this from being created.

Measurements with a trailing slash are not allowed and the point will be
dropped.  Tags and fields with a trailing a slash will be dropped from
the point.

closes #3004

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
