### PR TITLE
Prevent possible deadlock when using aggregators

### DIFF
--- a/internal/models/running_processor.go
+++ b/internal/models/running_processor.go
@@ -1,11 +1,15 @@
 package models
 
 import (
+	"sync"
+
 	"github.com/influxdata/telegraf"
 )
 
 type RunningProcessor struct {
-	Name      string
+	Name string
+
+	sync.Mutex
 	Processor telegraf.Processor
 	Config    *ProcessorConfig
 }
@@ -24,6 +28,9 @@ type ProcessorConfig struct {
 }
 
 func (rp *RunningProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	rp.Lock()
+	defer rp.Unlock()
+
 	ret := []telegraf.Metric{}
 
 	for _, metric := range in {


### PR DESCRIPTION
Looping the metrics back through the same channel could result in a
deadlock, by using a new channel and locking the processor we can ensure
that all stages can make continual progress.

closes #2914

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
