### PR TITLE
Include mount options in disk metrics

### DIFF
--- a/plugins/inputs/system/DISK_README.md
+++ b/plugins/inputs/system/DISK_README.md
@@ -40,16 +40,17 @@ In this case, the host's root volume should be mounted into the container and th
 - All measurements have the following tags:
     - fstype (filesystem type)
     - path (mount point path)
+    - mode (whether the mount is rw or ro)
 
 ### Example Output:
 
 ```
 % ./telegraf --config ~/ws/telegraf.conf --input-filter disk --test
 * Plugin: disk, Collection 1
-> disk,fstype=hfs,path=/ free=398407520256i,inodes_free=97267461i,inodes_total=121847806i,inodes_used=24580345i,total=499088621568i,used=100418957312i,used_percent=20.131039916242397 1453832006274071563
-> disk,fstype=devfs,path=/dev free=0i,inodes_free=0i,inodes_total=628i,inodes_used=628i,total=185856i,used=185856i,used_percent=100 1453832006274137913
-> disk,fstype=autofs,path=/net free=0i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=0i,used=0i,used_percent=0 1453832006274157077
-> disk,fstype=autofs,path=/home free=0i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=0i,used=0i,used_percent=0 1453832006274169688
+> disk,fstype=hfs,mode=ro,path=/ free=398407520256i,inodes_free=97267461i,inodes_total=121847806i,inodes_used=24580345i,total=499088621568i,used=100418957312i,used_percent=20.131039916242397 1453832006274071563
+> disk,fstype=devfs,mode=rw,path=/dev free=0i,inodes_free=0i,inodes_total=628i,inodes_used=628i,total=185856i,used=185856i,used_percent=100 1453832006274137913
+> disk,fstype=autofs,mode=rw,path=/net free=0i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=0i,used=0i,used_percent=0 1453832006274157077
+> disk,fstype=autofs,mode=rw,path=/home free=0i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=0i,used=0i,used_percent=0 1453832006274169688
 ```
 
 

--- a/plugins/inputs/system/disk.go
+++ b/plugins/inputs/system/disk.go
@@ -53,10 +53,12 @@ func (s *DiskStats) Gather(acc telegraf.Accumulator) error {
 			// Skip dummy filesystem (procfs, cgroupfs, ...)
 			continue
 		}
+		mountOpts := parseOptions(partitions[i].Opts)
 		tags := map[string]string{
 			"path":   du.Path,
 			"device": strings.Replace(partitions[i].Device, "/dev/", "", -1),
 			"fstype": du.Fstype,
+			"mode":   mountOpts.Mode(),
 		}
 		var used_percent float64
 		if du.Used+du.Free > 0 {
@@ -217,6 +219,31 @@ func (s *DiskIOStats) diskTags(devName string) map[string]string {
 	}
 
 	return tags
+}
+
+type MountOptions []string
+
+func (opts MountOptions) Mode() string {
+	if opts.exists("rw") {
+		return "rw"
+	} else if opts.exists("ro") {
+		return "ro"
+	} else {
+		return "unknown"
+	}
+}
+
+func (opts MountOptions) exists(opt string) bool {
+	for _, o := range opts {
+		if o == opt {
+			return true
+		}
+	}
+	return false
+}
+
+func parseOptions(opts string) MountOptions {
+	return strings.Split(opts, ",")
 }
 
 func init() {

--- a/plugins/inputs/system/disk_test.go
+++ b/plugins/inputs/system/disk_test.go
@@ -28,13 +28,13 @@ func TestDiskUsage(t *testing.T) {
 			Device:     "/dev/sda",
 			Mountpoint: "/",
 			Fstype:     "ext4",
-			Opts:       "",
+			Opts:       "ro,noatime,nodiratime",
 		},
 		{
 			Device:     "/dev/sdb",
 			Mountpoint: "/home",
 			Fstype:     "ext4",
-			Opts:       "",
+			Opts:       "rw,noatime,nodiratime,errors=remount-ro",
 		},
 	}
 	duAll := []disk.UsageStat{
@@ -78,11 +78,13 @@ func TestDiskUsage(t *testing.T) {
 		"path":   "/",
 		"fstype": "ext4",
 		"device": "sda",
+		"mode":   "ro",
 	}
 	tags2 := map[string]string{
 		"path":   "/home",
 		"fstype": "ext4",
 		"device": "sdb",
+		"mode":   "rw",
 	}
 
 	fields1 := map[string]interface{}{
@@ -163,13 +165,13 @@ func TestDiskStats(t *testing.T) {
 			Device:     "/dev/sda",
 			Mountpoint: "/",
 			Fstype:     "ext4",
-			Opts:       "",
+			Opts:       "ro,noatime,nodiratime",
 		},
 		{
 			Device:     "/dev/sdb",
 			Mountpoint: "/home",
 			Fstype:     "ext4",
-			Opts:       "",
+			Opts:       "rw,noatime,nodiratime,errors=remount-ro",
 		},
 	}
 
@@ -178,7 +180,7 @@ func TestDiskStats(t *testing.T) {
 			Device:     "/dev/sda",
 			Mountpoint: "/",
 			Fstype:     "ext4",
-			Opts:       "",
+			Opts:       "ro,noatime,nodiratime",
 		},
 	}
 
@@ -197,11 +199,13 @@ func TestDiskStats(t *testing.T) {
 		"path":   "/",
 		"fstype": "ext4",
 		"device": "sda",
+		"mode":   "ro",
 	}
 	tags2 := map[string]string{
 		"path":   "/home",
 		"fstype": "ext4",
 		"device": "sdb",
+		"mode":   "rw",
 	}
 
 	fields1 := map[string]interface{}{


### PR DESCRIPTION
This patch just adds the mount options to the disk metrics. This is useful for alerting, for example, when a partition gets remounted as read only due an error.

### Required for all PRs:

- [*] Signed [CLA](https://influxdata.com/community/cla/).
- [*] Associated README.md updated.
- [*] Has appropriate unit tests.
