### PR TITLE
Sanitize password from couchbase metric #1680

### DIFF
--- a/plugins/inputs/couchbase/README.md
+++ b/plugins/inputs/couchbase/README.md
@@ -22,7 +22,7 @@
 ### couchbase_node
 
 Tags:
-- cluster: sanitized and scheme less string from `servers` configuration field e.g.: `http://user:password@couchbase-0.example.com:8091/endpoint` -> `couchbase-0.example.com:8091/endpoint`
+- cluster: sanitized string from `servers` configuration field e.g.: `http://user:password@couchbase-0.example.com:8091/endpoint` -> `http://couchbase-0.example.com:8091/endpoint`
 - hostname: Couchbase's name for the node and port, e.g., `172.16.10.187:8091`
 
 Fields:

--- a/plugins/inputs/couchbase/README.md
+++ b/plugins/inputs/couchbase/README.md
@@ -22,7 +22,7 @@
 ### couchbase_node
 
 Tags:
-- cluster: whatever you called it in `servers` in the configuration, e.g.: `http://couchbase-0.example.com/`
+- cluster: sanitized and scheme less string from `servers` configuration field e.g.: `http://user:password@couchbase-0.example.com:8091/endpoint` -> `couchbase-0.example.com:8091/endpoint`
 - hostname: Couchbase's name for the node and port, e.g., `172.16.10.187:8091`
 
 Fields:

--- a/plugins/inputs/couchbase/couchbase.go
+++ b/plugins/inputs/couchbase/couchbase.go
@@ -68,7 +68,7 @@ func sanitizeURI(uri string) (result string, err error) {
 		return
 	}
 
-	result = re.ReplaceAllString(uri, "")
+	result = re.ReplaceAllString(uri, "${1}")
 
 	return
 }

--- a/plugins/inputs/couchbase/couchbase_test.go
+++ b/plugins/inputs/couchbase/couchbase_test.go
@@ -23,10 +23,10 @@ func TestGatherServer(t *testing.T) {
 	cb.gatherServer("mycluster", &acc, &pool)
 	acc.AssertContainsTaggedFields(t, "couchbase_node",
 		map[string]interface{}{"memory_free": 23181365248.0, "memory_total": 64424656896.0},
-		map[string]string{"cluster": "mycluster", "hostname": "172.16.10.187:8091"})
+		map[string]string{"cluster": "http://172.16.10.187:8092/", "hostname": "172.16.10.187:8091"})
 	acc.AssertContainsTaggedFields(t, "couchbase_node",
 		map[string]interface{}{"memory_free": 23665811456.0, "memory_total": 64424656896.0},
-		map[string]string{"cluster": "mycluster", "hostname": "172.16.10.65:8091"})
+		map[string]string{"cluster": "http://172.16.10.65:8092/", "hostname": "172.16.10.65:8091"})
 	acc.AssertContainsTaggedFields(t, "couchbase_bucket",
 		map[string]interface{}{
 			"quota_percent_used": 68.85424936294555,

--- a/plugins/inputs/couchbase/couchbase_test.go
+++ b/plugins/inputs/couchbase/couchbase_test.go
@@ -23,10 +23,10 @@ func TestGatherServer(t *testing.T) {
 	cb.gatherServer("mycluster", &acc, &pool)
 	acc.AssertContainsTaggedFields(t, "couchbase_node",
 		map[string]interface{}{"memory_free": 23181365248.0, "memory_total": 64424656896.0},
-		map[string]string{"cluster": "http://172.16.10.187:8092/", "hostname": "172.16.10.187:8091"})
+		map[string]string{"cluster": "mycluster", "hostname": "172.16.10.187:8091"})
 	acc.AssertContainsTaggedFields(t, "couchbase_node",
 		map[string]interface{}{"memory_free": 23665811456.0, "memory_total": 64424656896.0},
-		map[string]string{"cluster": "http://172.16.10.65:8092/", "hostname": "172.16.10.65:8091"})
+		map[string]string{"cluster": "mycluster", "hostname": "172.16.10.65:8091"})
 	acc.AssertContainsTaggedFields(t, "couchbase_bucket",
 		map[string]interface{}{
 			"quota_percent_used": 68.85424936294555,
@@ -38,6 +38,32 @@ func TestGatherServer(t *testing.T) {
 			"mem_used":           202156957464.0,
 		},
 		map[string]string{"cluster": "mycluster", "bucket": "blastro-df"})
+}
+
+func TestSanitizeURI(t *testing.T) {
+
+	var sanitizeTest = []struct {
+		input    string
+		expected string
+	}{
+		{"http://user:password@localhost:121", "localhost:121"},
+		{"user:password@localhost:12/endpoint", "localhost:12/endpoint"},
+		{"https://mail@address.com:password@localhost", "localhost"},
+		{"localhost", "localhost"},
+		{"user:password@localhost:2321", "localhost:2321"},
+	}
+
+	for _, test := range sanitizeTest {
+		result, err := sanitizeURI(test.input)
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if result != test.expected {
+			t.Errorf("TestSanitizeAddress: input %s, expected %s, actual %s", test.input, test.expected, result)
+		}
+	}
 }
 
 // From `/pools/default` on a real cluster

--- a/plugins/inputs/couchbase/couchbase_test.go
+++ b/plugins/inputs/couchbase/couchbase_test.go
@@ -52,14 +52,11 @@ func TestSanitizeURI(t *testing.T) {
 		{"localhost", "localhost"},
 		{"user:password@localhost:2321", "localhost:2321"},
 		{"http://user:password@couchbase-0.example.com:8091/endpoint", "http://couchbase-0.example.com:8091/endpoint"},
+		{" ", " "},
 	}
 
 	for _, test := range sanitizeTest {
-		result, err := sanitizeURI(test.input)
-
-		if err != nil {
-			t.Error(err)
-		}
+		result := regexpURI.ReplaceAllString(test.input, "${1}")
 
 		if result != test.expected {
 			t.Errorf("TestSanitizeAddress: input %s, expected %s, actual %s", test.input, test.expected, result)

--- a/plugins/inputs/couchbase/couchbase_test.go
+++ b/plugins/inputs/couchbase/couchbase_test.go
@@ -46,11 +46,12 @@ func TestSanitizeURI(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"http://user:password@localhost:121", "localhost:121"},
+		{"http://user:password@localhost:121", "http://localhost:121"},
 		{"user:password@localhost:12/endpoint", "localhost:12/endpoint"},
-		{"https://mail@address.com:password@localhost", "localhost"},
+		{"https://mail@address.com:password@localhost", "https://localhost"},
 		{"localhost", "localhost"},
 		{"user:password@localhost:2321", "localhost:2321"},
+		{"http://user:password@couchbase-0.example.com:8091/endpoint", "http://couchbase-0.example.com:8091/endpoint"},
 	}
 
 	for _, test := range sanitizeTest {


### PR DESCRIPTION
Fix issue #1680
- In `cluster` tag, use information provided by CouchDB API instead of getting it from telegraf server configuration where user is able to provide credentials.
- Adjust Unit Tests to new values.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
