### PR TITLE
Online cpus

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -11,7 +11,7 @@ github.com/couchbase/go-couchbase bfe555a140d53dc1adf390f1a1d4b0fd4ceadb28
 github.com/couchbase/gomemcached 4a25d2f4e1dea9ea7dd76dfd943407abf9b07d29
 github.com/couchbase/goutils 5823a0cbaaa9008406021dc5daf80125ea30bba6
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
-github.com/docker/docker b89aff1afa1f61993ab2ba18fd62d9375a195f5d
+github.com/docker/docker f5ec1e2936dcbe7b5001c2b817188b095c700c27
 github.com/eapache/go-resiliency b86b1ec0dd4209a588dc1285cdd471e73525c0b3
 github.com/eapache/go-xerial-snappy bb955e01b9346ac19dc29eb16586c90ded99a98c
 github.com/eapache/queue 44cc805cf13205b55f69e14bcb69867d1ae92f98

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -142,7 +142,7 @@ func TestDockerGatherContainerStats(t *testing.T) {
 	}
 	acc.AssertContainsTaggedFields(t, "docker_container_cpu", cpu1fields, cputags)
 	
-    // Those tagged filed should not be present because of offline CPUs
+	// Those tagged filed should not be present because of offline CPUs
 	cputags["cpu"] = "cpu2"
 	cpu2fields := map[string]interface{}{
 		"usage_total":  uint64(0),

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -147,8 +147,8 @@ func testStats() *types.StatsJSON {
 	stats := &types.StatsJSON{}
 	stats.Read = time.Now()
 	stats.Networks = make(map[string]types.NetworkStats)
-
-	stats.CPUStats.CPUUsage.PercpuUsage = []uint64{1, 1002}
+	stats.CPUStats.OnlineCPUs = 2
+	stats.CPUStats.CPUUsage.PercpuUsage = []uint64{1, 1002, 0, 0}
 	stats.CPUStats.CPUUsage.UsageInUsermode = 100
 	stats.CPUStats.CPUUsage.TotalUsage = 500
 	stats.CPUStats.CPUUsage.UsageInKernelmode = 200

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -141,7 +141,7 @@ func TestDockerGatherContainerStats(t *testing.T) {
 		"container_id": "123456789",
 	}
 	acc.AssertContainsTaggedFields(t, "docker_container_cpu", cpu1fields, cputags)
-	
+
 	// Those tagged filed should not be present because of offline CPUs
 	cputags["cpu"] = "cpu2"
 	cpu2fields := map[string]interface{}{

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -141,6 +141,21 @@ func TestDockerGatherContainerStats(t *testing.T) {
 		"container_id": "123456789",
 	}
 	acc.AssertContainsTaggedFields(t, "docker_container_cpu", cpu1fields, cputags)
+	
+    // Those tagged filed should not be present because of offline CPUs
+	cputags["cpu"] = "cpu2"
+	cpu2fields := map[string]interface{}{
+		"usage_total":  uint64(0),
+		"container_id": "123456789",
+	}
+	acc.AssertDoesNotContainsTaggedFields(t, "docker_container_cpu", cpu2fields, cputags)
+
+	cputags["cpu"] = "cpu3"
+	cpu3fields := map[string]interface{}{
+		"usage_total":  uint64(0),
+		"container_id": "123456789",
+	}
+	acc.AssertDoesNotContainsTaggedFields(t, "docker_container_cpu", cpu3fields, cputags)
 }
 
 func testStats() *types.StatsJSON {

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -258,6 +258,28 @@ func (a *Accumulator) AssertContainsTaggedFields(
 	assert.Fail(t, msg)
 }
 
+func (a *Accumulator) AssertDoesNotContainsTaggedFields(
+	t *testing.T,
+	measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+) {
+	a.Lock()
+	defer a.Unlock()
+	for _, p := range a.Metrics {
+		if !reflect.DeepEqual(tags, p.Tags) {
+			continue
+		}
+
+		if p.Measurement == measurement {
+			assert.Equal(t, fields, p.Fields)
+			msg := fmt.Sprintf("found measurement %s with tags %v which shloud not be there", measurement, tags)
+			assert.Fail(t, msg)
+		}
+	}
+	return
+}
+
 func (a *Accumulator) AssertContainsFields(
 	t *testing.T,
 	measurement string,

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -273,7 +273,7 @@ func (a *Accumulator) AssertDoesNotContainsTaggedFields(
 
 		if p.Measurement == measurement {
 			assert.Equal(t, fields, p.Fields)
-			msg := fmt.Sprintf("found measurement %s with tags %v which shloud not be there", measurement, tags)
+			msg := fmt.Sprintf("found measurement %s with tags %v which should not be there", measurement, tags)
 			assert.Fail(t, msg)
 		}
 	}


### PR DESCRIPTION
This patch fixes #2964 
It take cares of the OnlineCPUs info that is returned by recent docker daemons (and which is set to number of CPU by the client if the daemon does not return it).
It updates the docker client to 17.03.2-ce.
I have added an assertion test method to check that telegraf does not added tagged metrics for offline cpu.

The cpu usage percentage calculation takes also cares of the online cpus.