### PR TITLE
fix logic in tags/names/fields filtering

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -134,8 +134,8 @@ is tested on points after they have passed the `namepass` test.
 An array of glob pattern strings.  Only fields whose field key matches a
 pattern in this list are emitted.  Not available for outputs.
 * **fielddrop**:
-The inverse of `fieldpass`. Fields with a field key matching one of the
-patterns will be discarded from the point.  Not available for outputs.
+The inverse of `fieldpass`.  Fields with a field key matching one of the
+patterns will be discarded from the point.  This is tested on points after they have passed the `fieldpass` test.  Not available for outputs.
 * **tagpass**:
 A table mapping tag keys to arrays of glob pattern strings.  Only points
 that contain a tag key in the table and a tag value matching one of its

--- a/internal/models/filter_test.go
+++ b/internal/models/filter_test.go
@@ -358,6 +358,46 @@ func TestFilter_FilterTagsMatches(t *testing.T) {
 	}, pretags)
 }
 
+// TestFilter_FilterNamePassAndDrop used for check case when
+// both parameters were defined
+// see: https://github.com/influxdata/telegraf/issues/2860
+func TestFilter_FilterNamePassAndDrop(t *testing.T) {
+
+	inputData := []string{"name1", "name2", "name3", "name4"}
+	expectedResult := []bool{false, true, false, false}
+
+	f := Filter{
+		NamePass: []string{"name1", "name2"},
+		NameDrop: []string{"name1", "name3"},
+	}
+
+	require.NoError(t, f.Compile())
+
+	for i, name := range inputData {
+		assert.Equal(t, f.shouldNamePass(name), expectedResult[i])
+	}
+}
+
+// TestFilter_FilterFieldPassAndDrop used for check case when
+// both parameters were defined
+// see: https://github.com/influxdata/telegraf/issues/2860
+func TestFilter_FilterFieldPassAndDrop(t *testing.T) {
+
+	inputData := []string{"field1", "field2", "field3", "field4"}
+	expectedResult := []bool{false, true, false, false}
+
+	f := Filter{
+		FieldPass: []string{"field1", "field2"},
+		FieldDrop: []string{"field1", "field3"},
+	}
+
+	require.NoError(t, f.Compile())
+
+	for i, field := range inputData {
+		assert.Equal(t, f.shouldFieldPass(field), expectedResult[i])
+	}
+}
+
 // TestFilter_FilterTagsPassAndDrop used for check case when
 // both parameters were defined
 // see: https://github.com/influxdata/telegraf/issues/2860


### PR DESCRIPTION
This MR is the result of #2860 discussion/issue.

- Adjust logic in functions responsible for passing metrics (should Field/Name/Tags Pass) in order to be able to process them correctly in case where pass and drop are defined together.
- Change documentation to reflect this change
- Create additional Unit Tests to cover `shouldFieldPass` and `shouldNamePass`.
- Small refactor

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
