### PR TITLE
Don't match pattern on any error

### DIFF
--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -45,7 +45,7 @@ func (g *GlobPath) Match() map[string]os.FileInfo {
 	if !g.hasMeta {
 		out := make(map[string]os.FileInfo)
 		info, err := os.Stat(g.path)
-		if !os.IsNotExist(err) {
+		if err == nil {
 			out[g.path] = info
 		}
 		return out
@@ -55,7 +55,7 @@ func (g *GlobPath) Match() map[string]os.FileInfo {
 		files, _ := filepath.Glob(g.path)
 		for _, file := range files {
 			info, err := os.Stat(file)
-			if !os.IsNotExist(err) {
+			if err == nil {
 				out[file] = info
 			}
 		}

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -1,6 +1,7 @@
 package globpath
 
 import (
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -69,4 +70,21 @@ func TestFindNestedTextFile(t *testing.T) {
 func getTestdataDir() string {
 	_, filename, _, _ := runtime.Caller(1)
 	return strings.Replace(filename, "globpath_test.go", "testdata", 1)
+}
+
+func TestMatch_ErrPermission(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected map[string]os.FileInfo
+	}{
+		{"/root/foo", map[string]os.FileInfo{}},
+		{"/root/f*", map[string]os.FileInfo{}},
+	}
+
+	for _, test := range tests {
+		glob, err := Compile(test.input)
+		require.NoError(t, err)
+		actual := glob.Match()
+		require.Equal(t, test.expected, actual)
+	}
 }


### PR DESCRIPTION
This prevents a pattern with no wildcards from matching in case
permissions is denied.

closes #3037 

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
