### PR TITLE
Add redis_version field to redis input

### DIFF
--- a/plugins/inputs/redis/README.md
+++ b/plugins/inputs/redis/README.md
@@ -30,6 +30,7 @@ Additionally the plugin also calculates the hit/miss ratio (keyspace\_hitrate) a
     **Server**
     - uptime(int, seconds)
     - lru_clock(int, number)
+    - redis_version(string)
 
     **Clients**
     - clients(int, number)

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -184,7 +184,7 @@ func gatherInfoOutput(
 		name := string(parts[0])
 
 		if section == "Server" {
-			if name != "lru_clock" && name != "uptime_in_seconds" {
+			if name != "lru_clock" && name != "uptime_in_seconds" && name != "redis_version" {
 				continue
 			}
 		}

--- a/plugins/inputs/redis/redis_test.go
+++ b/plugins/inputs/redis/redis_test.go
@@ -91,6 +91,7 @@ func TestRedis_ParseMetrics(t *testing.T) {
 		"used_cpu_sys_children":          float64(0.00),
 		"used_cpu_user_children":         float64(0.00),
 		"keyspace_hitrate":               float64(0.50),
+		"redis_version":                  "2.8.9",
 	}
 
 	// We have to test rdb_last_save_time_offset manually because the value is based on the time when gathered


### PR DESCRIPTION
closes #2982

### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
