### PR TITLE
Add sqlserver_extensible input plugin

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -77,6 +77,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/snmp_legacy"
 	_ "github.com/influxdata/telegraf/plugins/inputs/socket_listener"
 	_ "github.com/influxdata/telegraf/plugins/inputs/sqlserver"
+	_ "github.com/influxdata/telegraf/plugins/inputs/sqlserver_extensible"
 	_ "github.com/influxdata/telegraf/plugins/inputs/statsd"
 	_ "github.com/influxdata/telegraf/plugins/inputs/sysstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/system"

--- a/plugins/inputs/sqlserver_extensible/README.md
+++ b/plugins/inputs/sqlserver_extensible/README.md
@@ -1,0 +1,173 @@
+# SQL Server Extensible Plugin
+
+This sqlserver plugin provides metrics for your SQL Server instance. 
+It has been designed to parse SQL statements defined in the plugin section of your `telegraf.conf` or imported from a file.
+
+The example below has two statements, one defined in the configuration file and one stored in an external script file, with the following parameters:
+
+* version: the minimum SQL Server Product Version able to run defined statements:
+	2008   = 10
+	2008R2 = 10.50
+	2012   = 11
+	2014   = 12
+	2016   = 13
+	2017   = 14
+  If the sqlserver instance version is lower, the statement will not be executed
+* statement:  T-SQL statement 
+* scriptfile: path to the script file (if statement is empty or not defined)
+* measurement: name of the measurement
+* tags: list of the columns to be defined as tags
+* fields: list of the columns to be defined as fields
+* fieldname: list of the columns to replace the field name, works only if one field defined (see sql_server_perf_counters example)
+
+```
+  [[inputs.sqlserver_extensible.query]]
+   version="11"
+   statement="select replace(rtrim(counter_name),' ','_') as counter_name, replace(rtrim(instance_name),' ','_') as instance_name, cntr_value from sys.dm_os_performance_counters where (counter_name in ('SQL Compilations/sec','SQL Re-Compilations/sec','User Connections','Batch Requests/sec','Logouts/sec','Logins/sec','Processes blocked','Latch Waits/sec','Full Scans/sec','Index Searches/sec','Page Splits/sec','Page Lookups/sec','Page Reads/sec','Page Writes/sec','Readahead Pages/sec','Lazy Writes/sec','Checkpoint Pages/sec','Database Cache Memory (KB)','Log Pool Memory (KB)','Optimizer Memory (KB)','SQL Cache Memory (KB)','Connection Memory (KB)','Lock Memory (KB)', 'Memory broker clerk size','Page life expectancy')) or (instance_name in ('_Total','Column store object pool') and counter_name in ('Transactions/sec','Write Transactions/sec','Log Flushes/sec','Log Flush Wait Time','Lock Timeouts/sec','Number of Deadlocks/sec','Lock Waits/sec','Latch Waits/sec','Memory broker clerk size','Log Bytes Flushed/sec','Bytes Sent to Replica/sec','Log Send Queue','Bytes Sent to Transport/sec','Sends to Replica/sec','Bytes Sent to Transport/sec','Sends to Transport/sec','Bytes Received from Replica/sec','Receives from Replica/sec','Flow Control Time (ms/sec)','Flow Control/sec','Resent Messages/sec','Redone Bytes/sec') or (object_name = 'SQLServer:Database Replica' and counter_name in ('Log Bytes Received/sec','Log Apply Pending Queue','Redone Bytes/sec','Recovery Queue','Log Apply Ready Queue') and instance_name = '_Total')) or (object_name = 'SQLServer:Database Replica' and counter_name in ('Transaction Delay'));"
+   measurement="sql_server_perf_counters"
+   tags=["server_name"]
+   fields=["cntr_value"]
+   fieldname=["counter_name", "instance_name"] # replace the field cntr_value
+
+  [[inputs.sqlserver_extensible.query]]
+  version="11"
+  scriptfile = "/path/to/memory_clerk.sql" 
+  tags=["counter_name", "server_name"]
+  fields=["Buffer pool", "Cache (objects)", "Cache (sql plans)", "Other"]
+```
+
+## Example output:
+```
+sql_server_memory_clerk,server_name=WIN8-DEV,host=CentosInfluxDB,counter_name=Memory\ breakdown\ (%) Cache\ (sql\ plans)="2.50",Other="72.90",Buffer\ pool="24.60",Cache\ (objects)="0.00" 1501270780000000000
+sql_server_memory_clerk,server_name=WIN8-DEV,host=CentosInfluxDB,counter_name=Memory\ breakdown\ (bytes) Buffer\ pool="26394624.00",Cache\ (objects)="8192.00",Cache\ (sql\ plans)="2695168.00",Other="78364672.00" 1501270780000000000
+
+# with the counter_name field replacement
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB Page_lookups/sec=568869i 1501270780000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB Lazy_writes/sec=0i 1501270780000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB Readahead_pages/sec=292i 1501270780000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB Page_reads/sec=3067i 1501270780000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB Page_writes/sec=17i 1501270780000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB Checkpoint_pages/sec=5i 1501270780000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB Page_life_expectancy=30356i 1501270780000000000
+
+# with the counter_name as tags
+sql_server_perf_counters,server_name=WIN8-DEV,counter_name=Page_lookups/sec,host=CentosInfluxDB cntr_value=577383i 1501271194000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB,counter_name=Lazy_writes/sec cntr_value=0i 1501271194000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB,counter_name=Readahead_pages/sec cntr_value=292i 1501271194000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB,counter_name=Page_reads/sec cntr_value=3227i 1501271194000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB,counter_name=Page_writes/sec cntr_value=17i 1501271194000000000
+sql_server_perf_counters,server_name=WIN8-DEV,host=CentosInfluxDB,counter_name=Checkpoint_pages/sec cntr_value=5i 1501271194000000000
+```
+
+## External script example:
+
+memory_clerk.sql
+
+```SQL
+SET NOCOUNT ON;
+DECLARE @sqlVers numeric(4,2)
+SELECT @sqlVers = LEFT(CAST(SERVERPROPERTY('productversion') as varchar), 4)
+
+IF OBJECT_ID('tempdb..#clerk') IS NOT NULL
+	DROP TABLE #clerk;
+CREATE TABLE #clerk (
+    ClerkCategory nvarchar(64) NOT NULL, 
+    UsedPercent decimal(9,2), 
+    UsedBytes bigint
+);
+DECLARE @DynamicClerkQuery AS nvarchar(max)
+IF @sqlVers < 11
+BEGIN
+    SET @DynamicClerkQuery = N'
+    INSERT #clerk (ClerkCategory, UsedPercent, UsedBytes)
+    SELECT ClerkCategory
+    , UsedPercent = SUM(UsedPercent)
+    , UsedBytes = SUM(UsedBytes)
+    FROM
+    (
+    SELECT ClerkCategory = CASE MC.[type]
+        WHEN ''MEMORYCLERK_SQLBUFFERPOOL'' THEN ''Buffer pool''
+        WHEN ''CACHESTORE_SQLCP'' THEN ''Cache (sql plans)''
+        WHEN ''CACHESTORE_OBJCP'' THEN ''Cache (objects)''
+        ELSE ''Other'' END
+    , SUM((single_pages_kb + multi_pages_kb) * 1024) AS UsedBytes
+    , Cast(100 * Sum((single_pages_kb + multi_pages_kb))*1.0/(Select Sum((single_pages_kb + multi_pages_kb)) From sys.dm_os_memory_clerks) as Decimal(7, 4)) UsedPercent
+    FROM sys.dm_os_memory_clerks MC
+    WHERE (single_pages_kb + multi_pages_kb) > 0
+    GROUP BY CASE MC.[type]
+        WHEN ''MEMORYCLERK_SQLBUFFERPOOL'' THEN ''Buffer pool''
+        WHEN ''CACHESTORE_SQLCP'' THEN ''Cache (sql plans)''
+        WHEN ''CACHESTORE_OBJCP'' THEN ''Cache (objects)''
+        ELSE ''Other'' END
+    ) as T
+    GROUP BY ClerkCategory;
+    '
+END
+ELSE
+BEGIN
+    SET @DynamicClerkQuery = N'
+    INSERT #clerk (ClerkCategory, UsedPercent, UsedBytes)
+    SELECT ClerkCategory
+    , UsedPercent = SUM(UsedPercent)
+    , UsedBytes = SUM(UsedBytes)
+    FROM
+    (
+    SELECT ClerkCategory = CASE MC.[type]
+        WHEN ''MEMORYCLERK_SQLBUFFERPOOL'' THEN ''Buffer pool''
+        WHEN ''CACHESTORE_SQLCP'' THEN ''Cache (sql plans)''
+        WHEN ''CACHESTORE_OBJCP'' THEN ''Cache (objects)''
+        ELSE ''Other'' END
+    , SUM(pages_kb * 1024) AS UsedBytes
+    , Cast(100 * Sum(pages_kb)*1.0/(Select Sum(pages_kb) From sys.dm_os_memory_clerks) as Decimal(7, 4)) UsedPercent
+    FROM sys.dm_os_memory_clerks MC
+    WHERE pages_kb > 0
+    GROUP BY CASE MC.[type]
+        WHEN ''MEMORYCLERK_SQLBUFFERPOOL'' THEN ''Buffer pool''
+        WHEN ''CACHESTORE_SQLCP'' THEN ''Cache (sql plans)''
+        WHEN ''CACHESTORE_OBJCP'' THEN ''Cache (objects)''
+        ELSE ''Other'' END
+    ) as T
+    GROUP BY ClerkCategory;
+    '
+END
+
+EXEC sp_executesql @DynamicClerkQuery;
+SELECT
+-- measurement
+  measurement = 'sql_server_memory_clerk'
+-- tags
+, server_name= REPLACE(@@SERVERNAME, '\', ':')
+, counter_name
+-- value
+, [Buffer pool]
+, [Cache (objects)]
+, [Cache (sql plans)]
+, [Other]
+FROM
+(
+SELECT counter_name = 'Memory breakdown (%)'
+, [Buffer pool] = ISNULL(ROUND([Buffer Pool], 1), 0)
+, [Cache (objects)] = ISNULL(ROUND([Cache (objects)], 1), 0)
+, [Cache (sql plans)] = ISNULL(ROUND([Cache (sql plans)], 1), 0)
+, [Other] = ISNULL(ROUND([Other], 1), 0)
+FROM (SELECT ClerkCategory, UsedPercent FROM #clerk) as G1
+PIVOT
+(
+	SUM(UsedPercent)
+	FOR ClerkCategory IN ([Buffer Pool], [Cache (objects)], [Cache (sql plans)], [Other])
+) AS PivotTable
+UNION ALL
+SELECT counter_name = 'Memory breakdown (bytes)'
+, [Buffer pool] = ISNULL(ROUND([Buffer Pool], 1), 0)
+, [Cache (objects)] = ISNULL(ROUND([Cache (objects)], 1), 0)
+, [Cache (sql plans)] = ISNULL(ROUND([Cache (sql plans)], 1), 0)
+, [Other] = ISNULL(ROUND([Other], 1), 0)
+FROM (SELECT ClerkCategory, UsedBytes FROM #clerk) as G2
+PIVOT
+(
+	SUM(UsedBytes)
+	FOR ClerkCategory IN ([Buffer Pool], [Cache (objects)], [Cache (sql plans)], [Other])
+) AS PivotTable
+) as T;
+```
+

--- a/plugins/inputs/sqlserver_extensible/sqlserver_extensible.go
+++ b/plugins/inputs/sqlserver_extensible/sqlserver_extensible.go
@@ -1,0 +1,352 @@
+package sqlserver_extensible
+
+import (
+	"bytes"
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"io/ioutil"
+	"log"
+	"regexp"
+	"sync"
+
+	// go-mssqldb initialization
+	_ "github.com/zensqlmonitor/go-mssqldb"
+)
+
+// SQLServer struct
+type SQLServer struct {
+	Servers []string
+	Query   []struct {
+		Server         string
+		Version        string
+		Statement      string
+		Scriptfile     string
+		Measurement    string
+		Tags           []string
+		Fields         []string
+		Fieldname      []string
+		OrderedColumns []string
+	}
+}
+
+// Query struct
+type Query struct {
+	Server         string
+	Version        string
+	Statement      string
+	Scriptfile     string
+	Measurement    string
+	Tags           []string
+	Fields         []string
+	Fieldname      []string
+	OrderedColumns []string
+}
+
+var defaultServer = "Server=.;app name=telegraf;log=1;"
+
+var sampleConfig = `
+  ## Specify instances to monitor with a list of connection strings.
+  ## All connection parameters are optional.
+  ## By default, the host is localhost, listening on default port, TCP 1433.
+  ##   for Windows, the user is the currently running AD user (SSO).
+  ##   See https://github.com/denisenkom/go-mssqldb for detailed connection
+  ##   parameters.
+  servers = [
+   "Server=192.168.1.30;Port=3333;User Id=telegraf;Password=telegraf;app name=telegraf;log=1;",
+  ]
+  ## Structure :
+  ## [[inputs.sqlserver_extensible.query]]
+  ## version string (10, 10.5, 11, 12, 13) - minimum version able to run statement
+  ## statement string
+  ## scriptfile string - use a script from a a file if statement is empty 
+  ## measurement string  
+  ## tags array of string, column(s) must be present in your query
+  ## fields array of string, column(s) must be present in your query
+  ## fieldname array of string to replace fieldname, column(s) must be present in your query
+
+  [[inputs.sqlserver_extensible.query]]
+  version="12"
+  statement="select replace(rtrim(counter_name),' ','_') as counter_name, replace(rtrim(instance_name),' ','_') as instance_name, cntr_value from sys.dm_os_performance_counters where (counter_name in ('SQL Compilations/sec','SQL Re-Compilations/sec','User Connections','Batch Requests/sec','Logouts/sec','Logins/sec','Processes blocked','Latch Waits/sec','Full Scans/sec','Index Searches/sec','Page Splits/sec','Page Lookups/sec','Page Reads/sec','Page Writes/sec','Readahead Pages/sec','Lazy Writes/sec','Checkpoint Pages/sec','Database Cache Memory (KB)','Log Pool Memory (KB)','Optimizer Memory (KB)','SQL Cache Memory (KB)','Connection Memory (KB)','Lock Memory (KB)', 'Memory broker clerk size','Page life expectancy')) or (instance_name in ('_Total','Column store object pool') and counter_name in ('Transactions/sec','Write Transactions/sec','Log Flushes/sec','Log Flush Wait Time','Lock Timeouts/sec','Number of Deadlocks/sec','Lock Waits/sec','Latch Waits/sec','Memory broker clerk size','Log Bytes Flushed/sec','Bytes Sent to Replica/sec','Log Send Queue','Bytes Sent to Transport/sec','Sends to Replica/sec','Bytes Sent to Transport/sec','Sends to Transport/sec','Bytes Received from Replica/sec','Receives from Replica/sec','Flow Control Time (ms/sec)','Flow Control/sec','Resent Messages/sec','Redone Bytes/sec') or (object_name = 'SQLServer:Database Replica' and counter_name in ('Log Bytes Received/sec','Log Apply Pending Queue','Redone Bytes/sec','Recovery Queue','Log Apply Ready Queue') and instance_name = '_Total')) or (object_name = 'SQLServer:Database Replica' and counter_name in ('Transaction Delay'));"
+  measurement="sql_server_perf_counters"
+  tags=["server_name"]
+  fields=["cntr_value"]
+  fieldname=["counter_name", "instance_name"]
+
+  [[inputs.sqlserver_extensible.query]]
+  version="12"
+  scriptfile = "/path/to/scripts_sql/memory_clerk.sql" 
+  tags=["counter_name", "server_name"]
+  fields=["Buffer pool", "Cache (objects)", "Cache (sql plans)", "Other"]
+`
+
+// SampleConfig return the sample configuration
+func (s *SQLServer) SampleConfig() string {
+	return sampleConfig
+}
+
+// Description return plugin description
+func (s *SQLServer) Description() string {
+	return "Read metrics from Microsoft SQL Server"
+}
+
+type scanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func feedStatement(version string, statement string) string {
+	var flags string = "SET NOCOUNT ON;"
+	var versionCheck string = "IF CAST(LEFT(CAST(SERVERPROPERTY('productversion') as varchar), 4) as numeric(4,2)) < " + version + "RETURN;"
+
+	// check flags
+	rexp1 := regexp.MustCompile(`(?i)SET NOCOUNT ON`)
+	if rexp1.MatchString(statement) {
+		flags = ""
+	}
+	return flags + versionCheck + statement
+}
+
+// Gather collect data from SQL Server
+func (s *SQLServer) Gather(acc telegraf.Accumulator) error {
+
+	if len(s.Servers) == 0 {
+		s.Servers = append(s.Servers, defaultServer)
+	}
+
+	var query Query
+	var wg sync.WaitGroup
+
+	// foreach server
+	for _, serv := range s.Servers {
+		query.Server = serv
+
+		// foreach query
+		for q := range s.Query {
+			var itemQ Query = s.Query[q]
+
+			// checks
+			if itemQ.Version == "" {
+				return errors.New("SQL Server product version is mandatory.")
+			}
+			if itemQ.Statement == "" && itemQ.Scriptfile == "" {
+				return errors.New("SQL statement is mandatory.")
+			}
+			if len(itemQ.Fields) > 1 && len(itemQ.Fieldname) > 0 {
+				return errors.New("Replacement of field name allowed only if one field returned.")
+			}
+			// stmt
+			if itemQ.Statement != "" {
+				query.Statement = feedStatement(itemQ.Version, itemQ.Statement)
+			} else {
+				scriptFromFile, err := ioutil.ReadFile(itemQ.Scriptfile)
+				query.Statement = feedStatement(itemQ.Version, string(scriptFromFile))
+				if err != nil {
+					var msg string = fmt.Sprintf("Error while reading script file %s: %s", itemQ.Scriptfile, err)
+					return errors.New(msg)
+				}
+			}
+			log.Printf("D! sqlserver_extensible: statement %s \n", query.Statement)
+
+			// tags
+			query.Tags = itemQ.Tags
+
+			// measurement
+			if itemQ.Measurement != "" {
+				query.Measurement = itemQ.Measurement
+			} else {
+				query.Measurement = ""
+			}
+			// fields
+			query.Fields = itemQ.Fields
+
+			// fieldname
+			query.Fieldname = itemQ.Fieldname
+
+			// go routines
+			wg.Add(1)
+			go func(serv string, query Query) {
+				defer wg.Done()
+				acc.AddError(s.gatherServer(serv, query, acc))
+			}(serv, query)
+		}
+	}
+
+	wg.Wait()
+	return nil
+}
+
+// query @@SERVERNAME if not specified
+func getServerName(server string) (interface{}, error) {
+	var servername string
+
+	// deferred opening
+	conn, err := sql.Open("mssql", server)
+	if err != nil {
+		return "", err
+	}
+	// verify that a connection can be made
+	err = conn.Ping()
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	// execute query
+	rows, err := conn.Query("SET NOCOUNT ON;SELECT REPLACE(@@SERVERNAME, '\\', ':') as server_name;")
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		if err := rows.Scan(&servername); err != nil {
+			return "", err
+		}
+	}
+	return servername, rows.Err()
+}
+
+func (s *SQLServer) gatherServer(server string, query Query, acc telegraf.Accumulator) error {
+	conn, err := sql.Open("mssql", server)
+	if err != nil {
+		return err
+	}
+	// verify that a connection can be made
+	err = conn.Ping()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	// execute query
+	rows, err := conn.Query(query.Statement)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	// grab the columns information
+	query.OrderedColumns, err = rows.Columns()
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		err = s.accRow(query, rows, acc)
+		if err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func (s *SQLServer) accRow(query Query, row scanner, acc telegraf.Accumulator) error {
+
+	var columnVars []interface{}
+	var measurementb bytes.Buffer
+	var measurement string
+	var fields = make(map[string]interface{})
+	tags := map[string]string{}
+
+	// store the column name with its *interface{}
+	columnMap := make(map[string]*interface{})
+	for _, column := range query.OrderedColumns {
+		columnMap[column] = new(interface{})
+	}
+	for i := 0; i < len(columnMap); i++ {
+		columnVars = append(columnVars, columnMap[query.OrderedColumns[i]])
+	}
+
+	// rows scan
+	err := row.Scan(columnVars...)
+	if err != nil {
+		return err
+	}
+
+	// check for server_name in the result
+	_, ok := columnMap["server_name"]
+	if !ok {
+		servername, err := getServerName(query.Server)
+		if err != nil {
+			return err
+		}
+		columnMap["server_name"] = &servername
+	}
+
+	// measurement
+	if query.Measurement == "" {
+		measurementb.WriteString((*columnMap["measurement"]).(string))
+		measurement = measurementb.String()
+		delete(columnMap, "measurement")
+	} else {
+		measurement = query.Measurement
+	}
+
+	// columnMap
+COLUMN:
+
+	for col, val := range columnMap {
+		log.Printf("D! sqlserver_extensible: column: %s = %T: %s\n", col, *val, *val)
+
+		// tags
+		for _, tag := range query.Tags {
+			if col != tag {
+				continue
+			}
+			switch v := (*val).(type) {
+			case string:
+				tags[col] = v
+			case []byte:
+				tags[col] = string(v)
+			case int64, int32, int:
+				tags[col] = fmt.Sprintf("%d", v)
+			default:
+				log.Println("Failed to add additional tag", col)
+			}
+			continue COLUMN
+		}
+
+		// fields
+		for _, field := range query.Fields {
+			if col != field {
+				continue
+			}
+			// default fieldname
+			var fieldheader string = col
+
+			// custom fieldname
+			if len(query.Fieldname) > 0 {
+				fieldheader = ""
+				for _, fname := range query.Fieldname {
+					_, ok := columnMap[fname]
+					if ok {
+						fheader := (*columnMap[fname]).(string)
+						if len(fheader) > 0 {
+							fieldheader += fheader + " | "
+						}
+					}
+				}
+				sz := len(fieldheader)
+				if sz > 0 && fieldheader[sz-2] == '|' {
+					fieldheader = fieldheader[:sz-3]
+				}
+			}
+			if v, ok := (*val).([]byte); ok {
+				fields[fieldheader] = string(v)
+			} else {
+				fields[fieldheader] = *val
+			}
+			continue COLUMN
+		}
+	}
+
+	acc.AddFields(measurement, fields, tags)
+	return nil
+}
+
+func init() {
+	inputs.Add("sqlserver_extensible", func() telegraf.Input {
+		return &SQLServer{}
+	})
+}

--- a/plugins/inputs/sqlserver_extensible/sqlserver_extensible_test.go
+++ b/plugins/inputs/sqlserver_extensible/sqlserver_extensible_test.go
@@ -1,0 +1,149 @@
+package sqlserver_extensible
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf/testutil"
+)
+
+// Query struct
+type Querytest struct {
+	Measurement string
+	Tags        []string
+	Fields      []string
+	Fieldname   []string
+	Result      string
+}
+
+// MapQuery type
+type MapQuery map[string]Querytest
+
+func TestSqlServer_ParseMetrics(t *testing.T) {
+
+	var acc testutil.Accumulator
+
+	queries := make(MapQuery)
+	queries["PerformanceCounters"] = Querytest{
+		Measurement: "sql_server_perf_counters",
+		Tags:        []string{"server_name", "counter_name", "instance_name"},
+		Fields:      []string{"cntr_value"},
+		Result:      mockPerformanceCounters}
+
+	queries["MemoryClerk"] = Querytest{
+		Measurement: "sql_server_memory_clerk",
+		Tags:        []string{"server_name", "counter_name"},
+		Fields:      []string{"Buffer pool", "Cache (objects)", "Cache (sql plans)", "Other"},
+		Result:      mockPerformanceCounters}
+
+	var headers, mock, cols []string
+	var tags = make(map[string]string)
+	var fields = make(map[string]interface{})
+
+	for _, query := range queries {
+		mock = strings.Split(query.Result, "\n")
+		idx := 0
+
+		for _, line := range mock {
+			if idx == 0 { // headers
+				headers = strings.Split(line, ";")
+				continue
+			}
+
+			// columnMap
+			cols = strings.Split(line, ";")
+			columnMap := make(map[string]*interface{})
+			jdx := 0
+			for _, column := range headers {
+				*columnMap[column] = cols[jdx]
+				jdx++
+			}
+
+			// measurement
+			var measurementb bytes.Buffer
+			var measurement string
+			if query.Measurement == "" {
+				measurementb.WriteString((*columnMap["measurement"]).(string))
+				measurement = measurementb.String()
+				delete(columnMap, "measurement")
+			} else {
+				measurement = query.Measurement
+			}
+
+		COLUMN:
+			for col, val := range columnMap {
+
+				// tags
+				for _, tag := range query.Tags {
+					if col != tag {
+						continue
+					}
+					switch v := (*val).(type) {
+					case string:
+						tags[col] = v
+					case []byte:
+						tags[col] = string(v)
+					case int64, int32, int:
+						tags[col] = fmt.Sprintf("%d", v)
+					default:
+						log.Println("Failed to add additional tag", col)
+					}
+					continue COLUMN
+				}
+
+				// fields
+				for _, field := range query.Fields {
+					if col != field {
+						continue
+					}
+					// default fieldname
+					var fieldheader string = col
+
+					// custom fieldname
+					if len(query.Fieldname) > 0 {
+						fieldheader = ""
+						for _, fname := range query.Fieldname {
+							_, ok := columnMap[fname]
+							if ok {
+								fheader := (*columnMap[fname]).(string)
+								if len(fheader) > 0 {
+									fieldheader += fheader + " | "
+								}
+							}
+						}
+						sz := len(fieldheader)
+						if sz > 0 && fieldheader[sz-2] == '|' {
+							fieldheader = fieldheader[:sz-3]
+						}
+					}
+					if v, ok := (*val).([]byte); ok {
+						fields[fieldheader] = string(v)
+					} else {
+						fields[fieldheader] = *val
+					}
+					continue COLUMN
+				}
+			}
+
+			acc.AddFields(measurement, fields, tags, time.Now())
+
+			// assert
+			acc.AssertContainsTaggedFields(t, measurement, fields, tags)
+
+			idx++
+		}
+	}
+}
+
+const mockPerformanceCounters string = `measurement;server_name;counter_name;instance_name;cntr_value
+sql_server_perf_counters;WIN8-DEV;Page_lookups/sec;"";1754431i 
+sql_server_perf_counters;WIN8-DEV;Lazy_writes/sec;"";0i 
+sql_server_perf_counters;WIN8-DEV;Readahead_pages/sec;"";595i`
+
+const mockMemoryClerk string = `measurement;server_name;type;counter_name;instance_name;Buffer\ pool;Cache\ (objects);Cache\ (sql\ plans);Other
+sql_server_memory_clerk;WIN8-DEV;Memory\ breakdown\ (%);31.40;0.30;8.50;59.80
+sql_server_memory_clerk;WIN8-DEV;Memory\ breakdown\ (bytes);475136.00;13991936.00;98820096.00;51871744.00`


### PR DESCRIPTION
This sqlserver plugin provides metrics for your SQL Server instance. 
It has been designed to parse SQL statements defined in the plugin section of your `telegraf.conf` or imported from a file.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
