### PR TITLE
WINDOWS_SERVICE.md

### DIFF
--- a/docs/WINDOWS_SERVICE.md
+++ b/docs/WINDOWS_SERVICE.md
@@ -37,3 +37,9 @@ Telegraf can manage its own service through the --service flag:
 | `telegraf.exe --service start`     | Start the telegraf service    |
 | `telegraf.exe --service stop`      | Stop the telegraf service     |
 
+
+Trobleshooting  common error #1067
+
+When installing as service in Windows, always double check to specify full path of the config file, otherwise windows service will fail to start
+
+ --config C:\"Program Files"\Telegraf\telegraf.conf


### PR DESCRIPTION
Troubleshooting  error #1067  "failed to start service"

When installing as service, always double check to specify full path of the config file:  --config C:\"Program Files"\Telegraf\telegraf.conf
Otherwise windows service will fail to start

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
