### PR TITLE
Adding Varnish sudo rules for unprivileged users

### DIFF
--- a/plugins/inputs/varnish/README.md
+++ b/plugins/inputs/varnish/README.md
@@ -7,6 +7,9 @@ This plugin gathers stats from [Varnish HTTP Cache](https://varnish-cache.org/)
 ```toml
  # A plugin to collect stats from Varnish HTTP Cache
  [[inputs.varnish]]
+   ## If running as a restricted user you can prepend sudo for additional access:
+   #use_sudo = false
+
    ## The default location of the varnishstat binary can be overridden with:
    binary = "/usr/bin/varnishstat"
 
@@ -330,6 +333,63 @@ the following values:
   - LCK
   
   
+
+### Permissions:
+
+It's important to note that this plugin references varnishstat, which may require additional permissions to execute successfully.
+Depending on the user/group permissions of the telegraf user executing this plugin, you may need to alter the group membership, set facls, or use sudo.
+
+**Group membership (Recommended)**:
+```bash
+$ groups telegraf
+telegraf : telegraf
+
+$ usermod -a -G varnish telegraf
+
+$ groups telegraf
+telegraf : telegraf varnish
+```
+
+**Extended filesystem ACL's**:
+```bash
+$ getfacl /var/lib/varnish/<hostname>/_.vsm
+# file: var/lib/varnish/<hostname>/_.vsm
+# owner: root
+# group: root
+user::rw-
+group::r--
+other::---
+
+$ setfacl -m u:telegraf:r /var/lib/varnish/<hostname>/_.vsm
+
+$ getfacl /var/lib/varnish/<hostname>/_.vsm
+# file: var/lib/varnish/<hostname>/_.vsm
+# owner: root
+# group: root
+user::rw-
+user:telegraf:r--
+group::r--
+mask::r--
+other::---
+```
+
+**Sudo privileges**:
+```bash
+# If you use this method, you will need the following in your telegraf config:
+[[inputs.varnish]]
+  use_sudo = true
+
+$ visudo
+
+# Add the following line:
+telegraf ALL=(ALL) NOPASSWD: /usr/bin/varnishstat
+
+$ grep varnish /etc/sudoers
+telegraf ALL = NOPASSWD: /usr/bin/varnishstat
+```
+
+Please use the solution you see as most appropriate.
+
 ### Example Output:
 
 ```

--- a/plugins/inputs/varnish/varnish_test.go
+++ b/plugins/inputs/varnish/varnish_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 )
 
-func fakeVarnishStat(output string) func(string) (*bytes.Buffer, error) {
-	return func(string) (*bytes.Buffer, error) {
+func fakeVarnishStat(output string, useSudo bool) func(string, bool) (*bytes.Buffer, error) {
+	return func(string, bool) (*bytes.Buffer, error) {
 		return bytes.NewBuffer([]byte(output)), nil
 	}
 }
@@ -20,7 +20,7 @@ func fakeVarnishStat(output string) func(string) (*bytes.Buffer, error) {
 func TestGather(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Varnish{
-		run:   fakeVarnishStat(smOutput),
+		run:   fakeVarnishStat(smOutput, false),
 		Stats: []string{"*"},
 	}
 	v.Gather(acc)
@@ -36,7 +36,7 @@ func TestGather(t *testing.T) {
 func TestParseFullOutput(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Varnish{
-		run:   fakeVarnishStat(fullOutput),
+		run:   fakeVarnishStat(fullOutput, true),
 		Stats: []string{"*"},
 	}
 	err := v.Gather(acc)
@@ -51,7 +51,7 @@ func TestParseFullOutput(t *testing.T) {
 func TestFilterSomeStats(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Varnish{
-		run:   fakeVarnishStat(fullOutput),
+		run:   fakeVarnishStat(fullOutput, false),
 		Stats: []string{"MGT.*", "VBE.*"},
 	}
 	err := v.Gather(acc)
@@ -74,7 +74,7 @@ func TestFieldConfig(t *testing.T) {
 	for fieldCfg, expected := range expect {
 		acc := &testutil.Accumulator{}
 		v := &Varnish{
-			run:   fakeVarnishStat(fullOutput),
+			run:   fakeVarnishStat(fullOutput, true),
 			Stats: strings.Split(fieldCfg, ","),
 		}
 		err := v.Gather(acc)


### PR DESCRIPTION
### Required for all PRs:
- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
##

Varnishstat requires read access to the underlying varnish libs at /var/lib/varnish. Since some users don't run telegraf as root we either need to setfacls on this directory or enable sudo to execute this command (default is false).

Looking back in history a bit, it seems sudo is the preferred method:
https://www.varnish-cache.org/lists/pipermail/varnish-misc/2011-November/021426.html

sudo = false
```
$ telegraf --config /etc/telegraf/telegraf.conf --input-filter varnish --test
* Plugin: inputs.varnish, Collection 1
2017-08-07T18:33:17Z E! error gathering metrics: error running varnishstat: Command timed out.
```

sudo = true
```
$ telegraf --config /etc/telegraf/telegraf.conf --input-filter varnish --test
* Plugin: inputs.varnish, Collection 1
> varnish,section=MAIN backend_req=61925i,cache_hit=521i,cache_miss=1120i 1502130756000000000
```