### PR TITLE
Remove log message on ping timeout

### DIFF
--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -211,7 +211,8 @@ Request timeout for icmp_seq 0
 `
 
 func mockErrorHostPinger(timeout float64, args ...string) (string, error) {
-	return errorPingOutput, errors.New("No packets received")
+	// This error will not trigger correct error paths
+	return errorPingOutput, nil
 }
 
 // Test that Gather works on a ping with no transmitted packets, even though the


### PR DESCRIPTION
If the ping executable returns with exit status 1, don't report an error yet and try to parse output.  If the exit status is not 1 return without trying to parse, this is a change from the current behavior.

Here are some output examples:
```
[[inputs.ping]]
  urls = ["timeout.example.org", "8.8.8.8"]
  count = 1
```

```
$ ./telegraf --test
> ping,url=8.8.8.8 packets_transmitted=1i,packets_received=1i,percent_packet_loss=0,minimum_response_ms=14.791,average_response_ms=14.791,maximum_response_ms=14.791 1502758914000000000
> ping,url=timeout.example.org packets_transmitted=1i,packets_received=0i,percent_packet_loss=100 1502758915000000000
```

```
$ PATH= ./telegraf --test
2017-08-15T01:02:07Z E! Error in plugin [inputs.ping]: exec: "ping": executable file not found in $PATH
2017-08-15T01:02:07Z E! Error in plugin [inputs.ping]: exec: "ping": executable file not found in $PATH
```

```
$ cat ping
#!/bin/sh
echo not the right output

$ PATH=. ./telegraf --test
2017-08-15T00:47:26Z E! Error in plugin [inputs.ping]: Fatal error processing ping output: timeout.example.org
2017-08-15T00:47:26Z E! Error in plugin [inputs.ping]: Fatal error processing ping output: 8.8.8.8

$ chmod -r ping
$ PATH=. ./telegraf --test
2017-08-15T01:02:24Z E! Error in plugin [inputs.ping]: /bin/sh: ping: Permission denied, exit status 126
2017-08-15T01:02:24Z E! Error in plugin [inputs.ping]: /bin/sh: ping: Permission denied, exit status 126
```

closes #1654

### Required for all PRs:

- [ ] Has appropriate unit tests.
