### PR TITLE
Add queues to rabbitmq documentation

### DIFF
--- a/plugins/inputs/rabbitmq/README.md
+++ b/plugins/inputs/rabbitmq/README.md
@@ -33,9 +33,13 @@ For additional details reference the [RabbitMQ Management HTTP Stats](https://cd
   ## Includes connection time, any redirects, and reading the response body.
   # client_timeout = "4s"
 
-  ## A list of nodes to pull metrics about. If not specified, metrics for
-  ## all nodes are gathered.
+  ## A list of nodes to gather as the rabbitmq_node measurement. If not
+  ## specified, metrics for all nodes are gathered.
   # nodes = ["rabbit@node1", "rabbit@node2"]
+
+  ## A list of queues to gather as the rabbitmq_queue measurement. If not
+  ## specified, metrics for all queues are gathered.
+  # queues = ["telegraf"]
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -48,7 +48,6 @@ type RabbitMQ struct {
 	ResponseHeaderTimeout internal.Duration `toml:"header_timeout"`
 	ClientTimeout         internal.Duration `toml:"client_timeout"`
 
-	// InsecureSkipVerify bool
 	Nodes  []string
 	Queues []string
 
@@ -165,9 +164,13 @@ var sampleConfig = `
   ## Includes connection time, any redirects, and reading the response body.
   # client_timeout = "4s"
 
-  ## A list of nodes to pull metrics about. If not specified, metrics for
-  ## all nodes are gathered.
+  ## A list of nodes to gather as the rabbitmq_node measurement. If not
+  ## specified, metrics for all nodes are gathered.
   # nodes = ["rabbit@node1", "rabbit@node2"]
+
+  ## A list of queues to gather as the rabbitmq_queue measurement. If not
+  ## specified, metrics for all queues are gathered.
+  # queues = ["telegraf"]
 `
 
 // SampleConfig ...


### PR DESCRIPTION
@phemmer I don't see a Connections parameter, but this documents the queue parameter.

closes #2165 

### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
