### PR TITLE
Add support for glob patterns in net input plugin

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -27,7 +27,6 @@ github.com/go-ole/go-ole be49f7c07711fcb603cff39e1de7c67926dc0ba7
 github.com/google/go-cmp f94e52cad91c65a63acc1e75d4be223ea22e99bc
 github.com/gorilla/mux 392c28fe23e1c45ddba891b0320b3b5df220beea
 github.com/go-sql-driver/mysql 2e00b5cd70399450106cec6431c2e2ce3cae5034
-github.com/gobwas/glob bea32b9cd2d6f55753d94a28e959b13f0244797a
 github.com/hailocab/go-hostpool e80d13ce29ede4452c43dea11e79b9bc8a15b478
 github.com/hashicorp/consul 63d2fc68239b996096a1c55a0d4b400ea4c2583f
 github.com/influxdata/tail a395bf99fe07c233f41fba0735fa2b13b58588ea

--- a/Godeps
+++ b/Godeps
@@ -27,6 +27,7 @@ github.com/go-ole/go-ole be49f7c07711fcb603cff39e1de7c67926dc0ba7
 github.com/google/go-cmp f94e52cad91c65a63acc1e75d4be223ea22e99bc
 github.com/gorilla/mux 392c28fe23e1c45ddba891b0320b3b5df220beea
 github.com/go-sql-driver/mysql 2e00b5cd70399450106cec6431c2e2ce3cae5034
+github.com/gobwas/glob bea32b9cd2d6f55753d94a28e959b13f0244797a
 github.com/hailocab/go-hostpool e80d13ce29ede4452c43dea11e79b9bc8a15b478
 github.com/hashicorp/consul 63d2fc68239b996096a1c55a0d4b400ea4c2583f
 github.com/influxdata/tail a395bf99fe07c233f41fba0735fa2b13b58588ea

--- a/plugins/inputs/system/NET_README.md
+++ b/plugins/inputs/system/NET_README.md
@@ -9,9 +9,11 @@ This plugin gathers metrics about network interface and protocol usage (Linux on
 [[inputs.net]]
   ## By default, telegraf gathers stats from any up interface (excluding loopback)
   ## Setting interfaces will tell it to gather these explicit interfaces,
-  ## regardless of status.
+  ## regardless of status. When specifying an interface, glob-style
+  ## patterns are also supported.
   ##
-  # interfaces = ["eth0"]
+  # interfaces = ["eth*", "enp0s[0-1]", "lo"]
+  ##
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/system/net.go
+++ b/plugins/inputs/system/net.go
@@ -12,7 +12,7 @@ import (
 
 type NetIOStats struct {
 	patterns []glob.Glob
-	ps PS
+	ps       PS
 
 	skipChecks bool
 	Interfaces []string

--- a/plugins/inputs/system/net.go
+++ b/plugins/inputs/system/net.go
@@ -11,8 +11,8 @@ import (
 )
 
 type NetIOStats struct {
-	filter   filter.Filter
-	ps       PS
+	filter filter.Filter
+	ps     PS
 
 	skipChecks bool
 	Interfaces []string


### PR DESCRIPTION
An approach for fixing #1073.

Adds support for specifying [golang glob](https://github.com/gobwas/glob)-style patterns.

**Example**
```
[[inputs.net]]
   interfaces = ["en*", "utun[0-1]", "lo0"]
```

```
$ ./telegraf --input-filter net --config telegraf.conf --test
* Plugin: inputs.net, Collection 1
> net,interface=lo0,host=mac bytes_sent=103240327i,packets_sent=227866i,drop_in=0i,drop_out=0i,bytes_recv=103240327i,packets_recv=227866i,err_in=0i,err_out=0i 1503126134000000000
> net,interface=en0,host=macbook packets_sent=13568823i,packets_recv=23715254i,err_in=0i,err_out=0i,drop_out=3193i,bytes_sent=2411560838i,bytes_recv=30527805468i,drop_in=0i 1503126134000000000
> net,interface=en1,host=macbook bytes_sent=0i,drop_out=0i,bytes_recv=0i,packets_sent=0i,packets_recv=0i,err_in=0i,err_out=0i,drop_in=0i 1503126134000000000
> net,interface=en2,host=macbook bytes_recv=0i,packets_sent=0i,packets_recv=0i,err_in=0i,err_out=0i,drop_in=0i,bytes_sent=0i,drop_out=0i 1503126134000000000
> net,interface=utun0,host=macbook bytes_sent=268i,packets_sent=3i,err_in=0i,drop_in=0i,drop_out=0i,bytes_recv=0i,packets_recv=0i,err_out=0i 1503126134000000000
> net,interface=utun1,host=macbook bytes_sent=22156i,packets_recv=115i,drop_in=0i,drop_out=0i,bytes_recv=20275i,packets_sent=108i,err_in=0i,err_out=0i 1503126134000000000
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
