### PR TITLE
Escape backslash within a string field

### DIFF
--- a/metric/escape.go
+++ b/metric/escape.go
@@ -20,8 +20,14 @@ var (
 
 	// stringFieldEscaper is for escaping string field values only.
 	// see https://docs.influxdata.com/influxdb/v1.0/write_protocols/line_protocol_tutorial/#special-characters-and-keywords
-	stringFieldEscaper   = strings.NewReplacer(`"`, `\"`)
-	stringFieldUnEscaper = strings.NewReplacer(`\"`, `"`)
+	stringFieldEscaper = strings.NewReplacer(
+		`"`, `\"`,
+		`\`, `\\`,
+	)
+	stringFieldUnEscaper = strings.NewReplacer(
+		`\"`, `"`,
+		`\\`, `\`,
+	)
 )
 
 func escape(s string, t string) string {

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -77,15 +77,9 @@ func New(
 
 	// pre-allocate capacity of the fields slice
 	fieldlen := 0
-	for k, v := range fields {
+	for k, _ := range fields {
 		if strings.HasSuffix(k, `\`) {
 			return nil, fmt.Errorf("Metric cannot have field key ending with a backslash")
-		}
-		switch val := v.(type) {
-		case string:
-			if strings.HasSuffix(val, `\`) {
-				return nil, fmt.Errorf("Metric cannot have field value ending with a backslash")
-			}
 		}
 
 		// 10 bytes is completely arbitrary, but will at least prevent some

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -257,6 +257,7 @@ func TestNewMetric_Fields(t *testing.T) {
 		"string":                 "test",
 		"quote_string":           `x"y`,
 		"backslash_quote_string": `x\"y`,
+		"backslash":              `x\y`,
 	}
 	m, err := New("cpu", tags, fields, now)
 	assert.NoError(t, err)
@@ -706,12 +707,6 @@ func TestNewMetric_TrailingSlash(t *testing.T) {
 			name: "cpu",
 			fields: map[string]interface{}{
 				`value\`: "x",
-			},
-		},
-		{
-			name: "cpu",
-			fields: map[string]interface{}{
-				"value": `x\`,
 			},
 		},
 		{

--- a/metric/reader_test.go
+++ b/metric/reader_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -617,6 +618,83 @@ func TestMetricReader_SplitMetricChangingBuffer2(t *testing.T) {
 		re := regexp.MustCompile(test.expRegex)
 		assert.True(t, re.MatchString(string(test.buf[0:n])), string(test.buf[0:n]))
 		assert.Equal(t, test.err, err, test.expRegex)
+	}
+}
+
+func TestReader_Read(t *testing.T) {
+	epoch := time.Unix(0, 0)
+
+	type args struct {
+		name   string
+		tags   map[string]string
+		fields map[string]interface{}
+		t      time.Time
+		mType  []telegraf.ValueType
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected []byte
+	}{
+		{
+			name: "escape backslashes in string field",
+			args: args{
+				name:   "cpu",
+				tags:   map[string]string{},
+				fields: map[string]interface{}{"value": `test\`},
+				t:      epoch,
+			},
+			expected: []byte(`cpu value="test\\" 0`),
+		},
+		{
+			name: "escape quote in string field",
+			args: args{
+				name:   "cpu",
+				tags:   map[string]string{},
+				fields: map[string]interface{}{"value": `test"`},
+				t:      epoch,
+			},
+			expected: []byte(`cpu value="test\"" 0`),
+		},
+		{
+			name: "escape quote and backslash in string field",
+			args: args{
+				name:   "cpu",
+				tags:   map[string]string{},
+				fields: map[string]interface{}{"value": `test\"`},
+				t:      epoch,
+			},
+			expected: []byte(`cpu value="test\\\"" 0`),
+		},
+		{
+			name: "escape multiple backslash in string field",
+			args: args{
+				name:   "cpu",
+				tags:   map[string]string{},
+				fields: map[string]interface{}{"value": `test\\`},
+				t:      epoch,
+			},
+			expected: []byte(`cpu value="test\\\\" 0`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := make([]byte, 512)
+			m, err := New(tt.args.name, tt.args.tags, tt.args.fields, tt.args.t, tt.args.mType...)
+			require.NoError(t, err)
+
+			r := NewReader([]telegraf.Metric{m})
+			num, err := r.Read(buf)
+			if err != io.EOF {
+				require.NoError(t, err)
+			}
+			line := string(buf[:num])
+			// This is done so that we can use raw strings in the test spec
+			noeol := strings.TrimRight(line, "\n")
+			require.Equal(t, string(tt.expected), noeol)
+			require.Equal(t, len(tt.expected)+1, num)
+		})
 	}
 }
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Has appropriate unit tests.
