### PR TITLE
Libvirt plugin

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -2,6 +2,8 @@ collectd.org 2ce144541b8903101fb8f1483cc0497a68798122
 github.com/aerospike/aerospike-client-go 95e1ad7791bdbca44707fedbb29be42024900d9c
 github.com/amir/raidman c74861fe6a7bb8ede0a010ce4485bdbb4fc4c985
 github.com/apache/thrift 4aaa92ece8503a6da9bc6701604f69acf2b99d07
+github.com/antchfx/xpath b5c552e1acbdd77b5e369eab0efd1e0f9d7090e4
+github.com/antchfx/xquery 0b2a6d901a1d9022b9a9f0ec8ed2a58c1b7fe383
 github.com/aws/aws-sdk-go c861d27d0304a79f727e9a8a4e2ac1e74602fdc0
 github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/bsm/sarama-cluster ccdc0803695fbce22f1706d04ded46cd518fd832
@@ -37,6 +39,7 @@ github.com/jmespath/go-jmespath bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 github.com/kardianos/osext c2c54e542fb797ad986b31721e1baedf214ca413
 github.com/kardianos/service 6d3a0ee7d3425d9d835debc51a0ca1ffa28f4893
 github.com/kballard/go-shellquote d8ec1a69a250a17bb0e419c386eac1f3711dc142
+github.com/libvirt/libvirt-go 2289a2978f30e8dda7cf54fe6129f87bdc4cd091
 github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c
 github.com/Microsoft/go-winio ce2922f643c8fd76b46cadc7f404a06282678b34
 github.com/miekg/dns 99f84ae56e75126dd77e5de4fae2ea034a468ca1

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ docker-run:
 		-e SLAPD_CONFIG_ROOTPW="secret" \
 		-p "389:389" -p "636:636" \
 		-d cobaugh/openldap-alpine
+	docker run --name libvirt -p "16509:16509" -d owlet123/libvirt:latest
 
 # Run docker containers necessary for integration tests; skipping services provided
 # by CircleCI
@@ -99,19 +100,20 @@ docker-run-circle:
 	docker run --name elasticsearch -p "9200:9200" -p "9300:9300" -d elasticsearch:5
 	docker run --name nsq -p "4150:4150" -d nsqio/nsq /nsqd
 	docker run --name mqtt -p "1883:1883" -d ncarlier/mqtt
-	docker run --name riemann -p "5555:5555" -d stealthly/docker-riemann
+	docker run --name riemann -p "5555:5555" -d steal thly/docker-riemann
 	docker run --name nats -p "4222:4222" -d nats
 	docker run --name openldap \
 		-e SLAPD_CONFIG_ROOTDN="cn=manager,cn=config" \
 		-e SLAPD_CONFIG_ROOTPW="secret" \
 		-p "389:389" -p "636:636" \
 		-d cobaugh/openldap-alpine
+	docker run --name libvirt -p "16509:16509" -d owlet123/libvirt
 
 docker-kill:
 	-docker kill aerospike elasticsearch kafka memcached mqtt mysql nats nsq \
-		openldap postgres rabbitmq redis riemann zookeeper
+		openldap postgres rabbitmq redis riemann zookeeper libvirt
 	-docker rm aerospike elasticsearch kafka memcached mqtt mysql nats nsq \
-		openldap postgres rabbitmq redis riemann zookeeper
+		openldap postgres rabbitmq redis riemann zookeeper libvirt
 
 .PHONY: deps telegraf telegraf.exe install test test-windows lint test-all \
 	package clean docker-run docker-run-circle docker-kill

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ configuration options.
 * [kapacitor](./plugins/inputs/kapacitor)
 * [kubernetes](./plugins/inputs/kubernetes)
 * [leofs](./plugins/inputs/leofs)
+* [libvirt](./plugins/inputs/libvirt)
 * [lustre2](./plugins/inputs/lustre2)
 * [mailchimp](./plugins/inputs/mailchimp)
 * [memcached](./plugins/inputs/memcached)

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/kapacitor"
 	_ "github.com/influxdata/telegraf/plugins/inputs/kubernetes"
 	_ "github.com/influxdata/telegraf/plugins/inputs/leofs"
+	_ "github.com/influxdata/telegraf/plugins/inputs/libvirt"
 	_ "github.com/influxdata/telegraf/plugins/inputs/logparser"
 	_ "github.com/influxdata/telegraf/plugins/inputs/lustre2"
 	_ "github.com/influxdata/telegraf/plugins/inputs/mailchimp"

--- a/plugins/inputs/libvirt/README.md
+++ b/plugins/inputs/libvirt/README.md
@@ -1,0 +1,45 @@
+# Telegraf Plugin: libvirt
+
+#### Description
+
+The libvirt plugin collects libvirt statistics.
+
+Metrics this collector generates:
+libvirt.vm.count - number of running VMs
+libvirt.vm.cpu.load - VM's current CPU load (can be higher than 100%)
+libvirt.vm.cpu.time - CPU time spent by VM
+libvirt.vm.disk.read.requests - number of total VM's read requests
+libvirt.vm.disk.read.bytes - number of total VM's read bytes
+libvirt.vm.disk.write.requests - number of total VM's write requests
+libvirt.vm.disk.write.bytes - number of total VM's write bytes
+libvirt.vm.disk.total.requests - number of total VM's read + write requests
+libvirt.vm.disk.total.bytes - number of total VM's read + write bytes
+libvirt.vm.disk.current.read.requests - number of VM's current read requests
+libvirt.vm.disk.current.read.bytes - number of VM's current read bytes
+libvirt.vm.disk.current.write.requests - number of VM's current write requests
+libvirt.vm.disk.current.write.bytes - number of VM's current write bytes
+libvirt.vm.disk.current.total.requests - number of VM's current read + write requests
+libvirt.vm.disk.current.total.bytes - number of VM's current read + write bytes
+libvirt.vm.memory - memory used by VM in kB
+libvirt.vm.max.memory - memory requested in VM's template in kB
+libvirt.vm.max.vcpus - number of CPU requested in VM's template
+libvirt.vm.network.rx - number of VM's received bytes via network
+libvirt.vm.network.tx - number of VM's transmitted bytes via network
+libvirt.vm.network.current.rx - VM's current network incoming bandwidth
+libvirt.vm.network.current.tx - VM's current network outcoming bandwidth
+libvirt.vm.cpustat.count - number of CPUs
+libvirt.vm.cpustat.cpu.mhz - CPU's MHz
+libvirt.vm.cpustat.cpu.cores - CPU's number of cores
+
+
+#### To test this plugin set the following configuration:
+
+This mocks a libvirt deamon with one running domain. The URI for a connection to a local qemu would be
+`qemu:///system`.
+
+The libvirt Test driver is a per-process fake hypervisor driver,
+with a driver name of 'test'. The driver maintains all its state in memory.
+`test:///default`
+
+Metrics from test file in docker owlet123/libvirt
+`test+tcp://127.0.0.1/root/test.xml`

--- a/plugins/inputs/libvirt/libvirt.go
+++ b/plugins/inputs/libvirt/libvirt.go
@@ -1,0 +1,368 @@
+package libvirt
+
+import (
+	"fmt"
+	"github.com/antchfx/xquery/xml"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	libvirt "github.com/libvirt/libvirt-go"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/process"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const DATA_RETRIEVAL_WAIT = 0.3 //number of seconds between two data requests
+
+//const LIBVIRT_URI = "qemu:///system"
+//const LIBVIRT_URI = "test:///default"
+//const LIBVIRT_URI = "test+tcp://127.0.0.1/root/test.xml"
+
+type Libvirt struct {
+	Libvirt_uri string
+}
+
+func (l *Libvirt) Description() string {
+	return `VM metrics collector
+# Metrics this collector generates:
+# libvirt.vm.count - number of running VMs
+# libvirt.vm.cpu.load - VM's current CPU load (can be higher than 100%)
+# libvirt.vm.cpu.time - CPU time spent by VM
+# libvirt.vm.disk.read.requests - number of total VM's read requests
+# libvirt.vm.disk.read.bytes - number of total VM's read bytes
+# libvirt.vm.disk.write.requests - number of total VM's write requests
+# libvirt.vm.disk.write.bytes - number of total VM's write bytes
+# libvirt.vm.disk.total.requests - number of total VM's read + write requests
+# libvirt.vm.disk.total.bytes - number of total VM's read + write bytes
+# libvirt.vm.disk.current.read.requests - number of VM's current read requests
+# libvirt.vm.disk.current.read.bytes - number of VM's current read bytes
+# libvirt.vm.disk.current.write.requests - number of VM's current write requests
+# libvirt.vm.disk.current.write.bytes - number of VM's current write bytes
+# libvirt.vm.disk.current.total.requests - number of VM's current read + write requests
+# libvirt.vm.disk.current.total.bytes - number of VM's current read + write bytes
+# libvirt.vm.memory - memory used by VM in kB
+# libvirt.vm.max.memory - memory requested in VM's template in kB
+# libvirt.vm.max.vcpus - number of CPU requested in VM's template
+# libvirt.vm.network.rx - number of VM's received bytes via network
+# libvirt.vm.network.tx - number of VM's transmitted bytes via network
+# libvirt.vm.network.current.rx - VM's current network incoming bandwidth
+# libvirt.vm.network.current.tx - VM's current network outcoming bandwidth
+# libvirt.vm.cpustat.count - number of CPUs
+# libvirt.vm.cpustat.cpu.mhz - CPU's MHz
+# libvirt.vm.cpustat.cpu.cores - CPU's number of cores`
+}
+
+func (l *Libvirt) SampleConfig() string {
+	return `## Metrics from:
+  ## The libvirt Test driver is a per-process fake hypervisor driver,
+  ## with a driver name of 'test'. The driver maintains all its state in memory.
+  # libvirt_uri = "test:///default"
+
+  ## Metrics from qemu
+  # libvirt_uri = "qemu:///system"
+
+  ## Metrics from test file in docker libvirt
+  libvirt_uri = "test+tcp://127.0.0.1/root/test.xml"
+`
+}
+
+func (l *Libvirt) Gather(acc telegraf.Accumulator) error {
+	conn, err := libvirt.NewConnect(l.Libvirt_uri)
+	if err != nil {
+		acc.AddError(fmt.Errorf("Error while creating connection."))
+		return err
+	}
+
+	doms := get_domains(conn, acc)
+
+	get_VM_count(len(doms), acc)
+	pids := get_pids(acc)
+
+	for uuid, pid := range pids {
+		load := get_cpu_load(pid, acc)
+
+		dom, err := conn.LookupDomainByUUIDString(uuid)
+		if err != nil {
+			acc.AddError(fmt.Errorf("Error while looking up domain by UUID (string): %s\n", err))
+			continue
+		}
+
+		name, err := dom.GetName()
+		if err != nil {
+			acc.AddError(fmt.Errorf("Error while getting name: %s\n", err))
+			continue
+		}
+
+		tags := map[string]string{
+			"deploy_id": name,
+		}
+
+		fields := map[string]interface{}{
+			"load": load,
+		}
+		acc.AddFields("cpu", fields, tags)
+	}
+
+	for _, dom := range doms {
+		get_cpu_info(dom, acc)
+		get_disks_info(dom, acc)
+		get_memory_info(dom, acc)
+		get_network_info(dom, acc)
+
+		dom.Free()
+	}
+	defer conn.Close()
+
+	get_cpustat(acc)
+
+	return nil
+}
+
+func init() {
+	inputs.Add("libvirt", func() telegraf.Input {
+		return &Libvirt{}
+	})
+}
+
+func get_domains(conn *libvirt.Connect, acc telegraf.Accumulator) []libvirt.Domain {
+	doms, err := conn.ListAllDomains(libvirt.CONNECT_LIST_DOMAINS_ACTIVE)
+	checkerr(acc, "Error while listing all domains", err)
+
+	return doms
+}
+
+func get_VM_count(count int, acc telegraf.Accumulator) {
+	tags := map[string]string{}
+
+	fields := map[string]interface{}{
+		"count": count,
+	}
+
+	acc.AddFields("", fields, tags)
+}
+
+func get_pids(acc telegraf.Accumulator) map[string]int {
+	out, err := exec.Command("ps", "-ewwo", "pid,command").Output()
+	if err != nil {
+		acc.AddError(fmt.Errorf("Error while exec command:%s", err))
+		return nil
+	}
+
+	regex, err := regexp.Compile("-uuid ([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})")
+	if err != nil {
+		acc.AddError(fmt.Errorf("Error while regexp compilation:%s", err))
+		return nil
+	}
+
+	pids := map[string]int{}
+
+	lines := strings.Split(string(out), "\n")
+
+	for _, line := range lines {
+		match := regex.FindString(line)
+
+		if match != "" {
+			m := strings.TrimSpace(line)
+			uuid := strings.Split(match, " ")[1]
+			//fmt.Println("uuid ", uuid)
+			pid := strings.Split(m, " ")[0]
+			//fmt.Println("pid ", pid)
+
+			pids[uuid], err = strconv.Atoi(pid)
+			checkerr(acc, "Error while converting string pid to int", err)
+		}
+	}
+
+	return pids
+}
+
+func get_cpu_load(pid int, acc telegraf.Accumulator) float64 {
+	proc, err := process.NewProcess(int32(pid))
+	checkerr(acc, "Error while getting process by pid", err)
+
+	percent, err := proc.Percent((DATA_RETRIEVAL_WAIT * 1000) * time.Millisecond)
+	checkerr(acc, "Error while getting cpu load", err)
+
+	return percent
+}
+
+func get_cpu_info(dom libvirt.Domain, acc telegraf.Accumulator) {
+	cpuinfo, err := dom.GetVcpus()
+	if err != nil {
+		acc.AddError(fmt.Errorf("Error while getting cpu info:%s", err))
+		return
+	}
+
+	name, err := dom.GetName()
+	checkerr(acc, "Error while getting name", err)
+
+	for j := 0; j < len(cpuinfo); j++ {
+		tags := map[string]string{
+			"deploy_id": name,
+		}
+
+		cpu_time_fields := map[string]interface{}{
+			"time": cpuinfo[j].CpuTime,
+		}
+
+		acc.AddFields("cpu", cpu_time_fields, tags, time.Now())
+	}
+}
+
+func get_disks_info(dom libvirt.Domain, acc telegraf.Accumulator) {
+	dxml, err := dom.GetXMLDesc(libvirt.DOMAIN_XML_SECURE)
+	if err != nil {
+		acc.AddError(fmt.Errorf("Error while getting xml to disk info:%s", err))
+		return
+	}
+
+	name, err := dom.GetName()
+	checkerr(acc, "Error while getting name", err)
+
+	root, err := xmlquery.Parse(strings.NewReader(dxml))
+	if err != nil {
+		acc.AddError(fmt.Errorf("Error while parsing xml:%s", err))
+		return
+	}
+
+	for _, n := range xmlquery.Find(root, "//domain/devices/disk/target") {
+		path := n.SelectAttr("dev")
+
+		dbs, err := dom.BlockStats(path)
+		if err != nil {
+			acc.AddError(fmt.Errorf("Error while getting disk info:%s", err))
+			continue
+		}
+
+		time.Sleep((DATA_RETRIEVAL_WAIT * 1000) * time.Millisecond)
+		dbs2, err := dom.BlockStats(path)
+		if err != nil {
+			acc.AddError(fmt.Errorf("Error while getting disk info:%s", err))
+			continue
+		}
+
+		tags := map[string]string{
+			"deploy_id": name,
+			"device":    path,
+		}
+
+		disk_info_fields := map[string]interface{}{
+			"read.request":   dbs.RdReq,
+			"read.bytes":     dbs.RdBytes,
+			"write.request":  dbs.WrReq,
+			"write.bytes":    dbs.WrBytes,
+			"total.requests": dbs.RdReq + dbs.WrReq,
+			"total.bytes":    dbs.RdBytes + dbs.WrBytes,
+
+			"current.read.request":  dataPerSecond(dbs.RdReq, dbs2.RdReq),
+			"current.read.bytes":    dataPerSecond(dbs.RdBytes, dbs2.RdBytes),
+			"current.write.request": dataPerSecond(dbs.WrReq, dbs2.WrReq),
+			"current.write.bytes": dataPerSecond(dbs.RdReq, dbs2.RdReq) +
+				dataPerSecond(dbs.WrReq, dbs2.WrReq),
+			"current.total.requests": dataPerSecond(dbs.RdReq, dbs2.RdReq) +
+				dataPerSecond(dbs.WrReq, dbs2.WrReq),
+			"current.total.bytes": dataPerSecond(dbs.RdBytes, dbs2.RdBytes) +
+				dataPerSecond(dbs.WrBytes, dbs2.WrBytes),
+		}
+		acc.AddFields("disk", disk_info_fields, tags, time.Now())
+	}
+}
+
+func dataPerSecond(d1, d2 int64) float64 {
+	return float64(d2-d1) / DATA_RETRIEVAL_WAIT
+}
+
+func get_memory_info(dom libvirt.Domain, acc telegraf.Accumulator) {
+	domainInfo, err := dom.GetInfo()
+	if err != nil {
+		acc.AddError(fmt.Errorf("Error while getting memory info:%s", err))
+		return
+	}
+
+	name, err := dom.GetName()
+	checkerr(acc, "Error while getting name", err)
+
+	tags := map[string]string{
+		"deploy_id": name,
+	}
+
+	fields := map[string]interface{}{
+		"memory": domainInfo.Memory,
+	}
+	acc.AddFields("", fields, tags, time.Now())
+
+	fields_max := map[string]interface{}{
+		"memory": domainInfo.MaxMem,
+		"vcpus":  domainInfo.NrVirtCpu,
+	}
+	acc.AddFields("max", fields_max, tags, time.Now())
+}
+
+func get_network_info(dom libvirt.Domain, acc telegraf.Accumulator) {
+	dxml, err := dom.GetXMLDesc(libvirt.DOMAIN_XML_SECURE)
+	checkerr(acc, "Error while getting xml to network info", err)
+
+	name, err := dom.GetName()
+	checkerr(acc, "Error while getting name", err)
+
+	root, err := xmlquery.Parse(strings.NewReader(dxml))
+	checkerr(acc, "Error while parsing xml", err)
+
+	for _, n := range xmlquery.Find(root, "//domain/devices/interface/target") {
+		path := n.SelectAttr("dev")
+
+		dis, err := dom.InterfaceStats(path)
+		checkerr(acc, "Error while getting network info", err)
+		time.Sleep((DATA_RETRIEVAL_WAIT * 1000) * time.Millisecond)
+		dis2, err := dom.InterfaceStats(path)
+		checkerr(acc, "Error while getting network info", err)
+
+		tags := map[string]string{
+			"deploy_id": name,
+		}
+
+		fields := map[string]interface{}{
+			"rx":         dis.RxBytes,
+			"tx":         dis.TxBytes,
+			"current.rx": dataPerSecond(dis.RxBytes, dis2.RxBytes),
+			"current.tx": dataPerSecond(dis.TxBytes, dis2.TxBytes),
+		}
+		acc.AddFields("network", fields, tags, time.Now())
+	}
+}
+
+func get_cpustat(acc telegraf.Accumulator) {
+	cpus, err := cpu.Info()
+	checkerr(acc, "Error while getting cpu info", err)
+
+	tags := map[string]string{}
+
+	fields := map[string]interface{}{
+		"count": len(cpus),
+	}
+
+	acc.AddFields("cpustat", fields, tags, time.Now())
+
+	for _, c := range cpus {
+		tags := map[string]string{
+			"model":     c.ModelName,
+			"processor": fmt.Sprint(c.CPU),
+		}
+
+		fields := map[string]interface{}{
+			"cpu.cores": c.Cores,
+			"cpu.mhz":   c.Mhz,
+		}
+
+		acc.AddFields("cpustat", fields, tags, time.Now())
+	}
+}
+
+func checkerr(acc telegraf.Accumulator, text string, err error) {
+	if err != nil {
+		acc.AddError(fmt.Errorf("%s: %s\n", text, err))
+	}
+}

--- a/plugins/inputs/libvirt/libvirt_test.go
+++ b/plugins/inputs/libvirt/libvirt_test.go
@@ -1,0 +1,115 @@
+package libvirt
+
+import (
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_disk(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping libvirt integration tests.")
+	}
+
+	var acc testutil.Accumulator
+
+	l := &Libvirt{Libvirt_uri: "test+tcp://127.0.0.1/root/test.xml"}
+
+	err := acc.GatherError(l.Gather)
+	require.NoError(t, err)
+
+	assert.True(t, acc.HasMeasurement("disk"))
+	assert.True(t, acc.HasTag("disk", "deploy_id"))
+	assert.True(t, acc.HasTag("disk", "device"))
+
+	assert.True(t, acc.HasInt64Field("disk", "read.request"))
+	assert.True(t, acc.HasInt64Field("disk", "read.bytes"))
+	assert.True(t, acc.HasInt64Field("disk", "write.request"))
+	assert.True(t, acc.HasInt64Field("disk", "write.bytes"))
+	assert.True(t, acc.HasInt64Field("disk", "total.requests"))
+	assert.True(t, acc.HasInt64Field("disk", "total.bytes"))
+	assert.True(t, acc.HasFloatField("disk", "current.read.request"))
+	assert.True(t, acc.HasFloatField("disk", "current.write.bytes"))
+	assert.True(t, acc.HasFloatField("disk", "current.total.requests"))
+	assert.True(t, acc.HasFloatField("disk", "current.total.bytes"))
+}
+
+func Test_cpu(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping libvirt integration tests.")
+	}
+
+	var acc testutil.Accumulator
+
+	l := &Libvirt{Libvirt_uri: "test+tcp://127.0.0.1/root/test.xml"}
+
+	err := acc.GatherError(l.Gather)
+	require.NoError(t, err)
+
+	assert.True(t, acc.HasMeasurement("cpu"))
+	assert.True(t, acc.HasTag("cpu", "deploy_id"))
+
+	assert.True(t, acc.HasFloatField("cpu", "load"))
+	assert.True(t, acc.HasUIntField("cpu", "time"))
+}
+
+func Test_net(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping libvirt integration tests.")
+	}
+
+	var acc testutil.Accumulator
+
+	l := &Libvirt{Libvirt_uri: "test+tcp://127.0.0.1/root/test.xml"}
+
+	err := acc.GatherError(l.Gather)
+	require.NoError(t, err)
+
+	assert.True(t, acc.HasMeasurement("network"))
+	assert.True(t, acc.HasTag("network", "deploy_id"))
+
+	assert.True(t, acc.HasInt64Field("network", "rx"))
+	assert.True(t, acc.HasInt64Field("network", "tx"))
+	assert.True(t, acc.HasFloatField("network", "current.rx"))
+	assert.True(t, acc.HasFloatField("network", "current.tx"))
+}
+
+func Test_cpustat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping libvirt integration tests.")
+	}
+
+	var acc testutil.Accumulator
+
+	l := &Libvirt{Libvirt_uri: "test+tcp://127.0.0.1/root/test.xml"}
+
+	err := acc.GatherError(l.Gather)
+	require.NoError(t, err)
+
+	assert.True(t, acc.HasIntField("cpustat", "count"))
+
+	assert.True(t, acc.HasMeasurement("cpustat"))
+
+	assert.True(t, acc.HasInt32Field("cpustat", "cpu.cores"))
+	assert.True(t, acc.HasFloatField("cpustat", "cpu.mhz"))
+}
+
+func Test_memory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping libvirt integration tests.")
+	}
+
+	var acc testutil.Accumulator
+
+	l := &Libvirt{Libvirt_uri: "test+tcp://127.0.0.1/root/test.xml"}
+
+	err := acc.GatherError(l.Gather)
+	require.NoError(t, err)
+
+	assert.True(t, acc.HasMeasurement("max"))
+	assert.True(t, acc.HasTag("max", "deploy_id"))
+
+	assert.True(t, acc.HasUIntField("max", "memory"))
+	//assert.True(t, acc.HasUIntField("max", "vcpus"))
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Libvirt input plugin collects libvirt statistics - cpu, disk, memory and network info and cpustats. For more details about metrics read README.md. For collecting metrics, there is used github.com/libvirt/libvirt-go. 
Plugin also contains unit tests run in docker. 