### PR TITLE
Add Kafka output plugin dynamic topic name generation option

### DIFF
--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -8,6 +8,10 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
   brokers = ["localhost:9092"]
   ## Kafka topic for producer messages
   topic = "telegraf"
+  ## If true, topic name will be substituted with topic_prefix + metric name
+  use_metric_name_as_topic = false
+  ## Prefix to use if the above option is true
+  topic_prefix = "my_beautiful_metrics"
   ## Telegraf tag to use as a routing key
   ##  ie, if this tag exists, its value will be used as the routing key
   routing_tag = "host"
@@ -57,6 +61,8 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
 * `brokers`: List of strings, this is for speaking to a cluster of `kafka` brokers. On each flush interval, Telegraf will randomly choose one of the urls to write to. Each URL should just include host and port e.g. -> `["{host}:{port}","{host2}:{port2}"]`
 * `topic`: The `kafka` topic to publish to.
 
+You can also set `use_metric_name_as_topic` to true, then topic is chosen in a dynamic manner and `topic` parameter is not required.
+
 
 ### Optional parameters:
 
@@ -69,3 +75,5 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
 * `ssl_key`: SSL key
 * `insecure_skip_verify`: Use SSL but skip chain & host verification (default: false)
 * `data_format`: [About Telegraf data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md)
+* `use_metric_name_as_topic`:  If true, topic name will be substituted with topic_prefix + metric name
+* `topic_prefix`: Prefix to use if the use_metric_name_as_topic option is enabled

--- a/plugins/outputs/kafka/kafka_test.go
+++ b/plugins/outputs/kafka/kafka_test.go
@@ -28,4 +28,20 @@ func TestConnectAndWrite(t *testing.T) {
 	// Verify that we can successfully write data to the kafka broker
 	err = k.Write(testutil.MockMetrics())
 	require.NoError(t, err)
+	k.Close()
+
+	// Test with UseMetricNameAsTopic set to true, without Topic
+	k = &Kafka{
+		Brokers:    brokers,
+		serializer: s,
+		UseMetricNameAsTopic: true,
+	}
+
+	// Verify that we can connect to the Kafka broker
+	err = k.Connect()
+	require.NoError(t, err)
+
+	// Verify that we can successfully write data to the kafka broker
+	err = k.Write(testutil.MockMetrics())
+	require.NoError(t, err)
 }

--- a/plugins/outputs/kafka/kafka_test.go
+++ b/plugins/outputs/kafka/kafka_test.go
@@ -32,8 +32,8 @@ func TestConnectAndWrite(t *testing.T) {
 
 	// Test with UseMetricNameAsTopic set to true, without Topic
 	k = &Kafka{
-		Brokers:    brokers,
-		serializer: s,
+		Brokers:              brokers,
+		serializer:           s,
 		UseMetricNameAsTopic: true,
 	}
 


### PR DESCRIPTION
Add ability to the Kafka output plugin to send data to different topics, based on the metric name

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This addresses Issue #3177 
