### PR TITLE
Add Kafka output plugin topic_suffix option

### DIFF
--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -8,6 +8,33 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
   brokers = ["localhost:9092"]
   ## Kafka topic for producer messages
   topic = "telegraf"
+
+  ## Optional topic suffix configuration.
+  ## If the section is omitted, no suffix is used.
+  ## Following topic suffix methods are supported:
+  ##   measurement - suffix equals to measurement's name
+  ##   tag         - suffix equals to specified tag's value
+  ##   tags        - suffix equals to specified tags' values
+  ##                 interleaved with key_separator
+
+  ## Suffix equals to measurement name to topic
+  # [outputs.kafka.topic_suffix]
+  #   method = "measurement"
+
+  ## Suffix equals to measurement's "foo" tag value.
+  ##   If there's no such a tag, suffix equals to an empty string
+  # [outputs.kafka.topic_suffix]
+  #   method = "tag"
+  #   key = "foo"
+
+  ## Suffix equals to measurement's "foo" and "bar"
+  ##   tag values, separated by "_". If there is no such tags,
+  ##   their values treated as empty strings.
+  # [outputs.kafka.topic_suffix]
+  #   method = "tags"
+  #   keys = ["foo", "bar"]
+  #   key_separator = "_"
+
   ## Telegraf tag to use as a routing key
   ##  ie, if this tag exists, its value will be used as the routing key
   routing_tag = "host"
@@ -57,10 +84,9 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
 * `brokers`: List of strings, this is for speaking to a cluster of `kafka` brokers. On each flush interval, Telegraf will randomly choose one of the urls to write to. Each URL should just include host and port e.g. -> `["{host}:{port}","{host2}:{port2}"]`
 * `topic`: The `kafka` topic to publish to.
 
-
 ### Optional parameters:
 
-* `routing_tag`:  if this tag exists, its value will be used as the routing key
+* `routing_tag`: If this tag exists, its value will be used as the routing key
 * `compression_codec`: What level of compression to use: `0` -> no compression, `1` -> gzip compression, `2` -> snappy compression
 * `required_acks`: a setting for how may `acks` required from the `kafka` broker cluster.
 * `max_retry`: Max number of times to retry failed write
@@ -69,3 +95,5 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
 * `ssl_key`: SSL key
 * `insecure_skip_verify`: Use SSL but skip chain & host verification (default: false)
 * `data_format`: [About Telegraf data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md)
+* `topic_suffix`: Which, if any, method of calculating `kafka` topic suffix to use.
+For examples, please refer to sample configuration.

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -12,21 +12,23 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
   ## Optional topic suffix configuration.
   ## If the section is omitted, no suffix is used.
   ## Following topic suffix methods are supported:
-  ##   measurement - suffix equals to measurement's name
-  ##   tags        - suffix equals to specified tags' values
+  ##   measurement - suffix equals to separator + measurement's name
+  ##   tags        - suffix equals to separator + specified tags' values
   ##                 interleaved with separator
 
-  ## Suffix equals to measurement name to topic
+  ## Suffix equals to "_" + measurement's name
   # [outputs.kafka.topic_suffix]
   #   method = "measurement"
+  #   separator = "_"
 
-  ## Suffix equals to measurement's "foo" tag value.
+  ## Suffix equals to "__" + measurement's "foo" tag value.
   ##   If there's no such a tag, suffix equals to an empty string
   # [outputs.kafka.topic_suffix]
   #   method = "tags"
   #   keys = ["foo"]
+  #   separator = "__"
 
-  ## Suffix equals to measurement's "foo" and "bar"
+  ## Suffix equals to "_" + measurement's "foo" and "bar"
   ##   tag values, separated by "_". If there is no such tags,
   ##   their values treated as empty strings.
   # [outputs.kafka.topic_suffix]

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -13,9 +13,8 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
   ## If the section is omitted, no suffix is used.
   ## Following topic suffix methods are supported:
   ##   measurement - suffix equals to measurement's name
-  ##   tag         - suffix equals to specified tag's value
   ##   tags        - suffix equals to specified tags' values
-  ##                 interleaved with key_separator
+  ##                 interleaved with separator
 
   ## Suffix equals to measurement name to topic
   # [outputs.kafka.topic_suffix]
@@ -24,8 +23,8 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
   ## Suffix equals to measurement's "foo" tag value.
   ##   If there's no such a tag, suffix equals to an empty string
   # [outputs.kafka.topic_suffix]
-  #   method = "tag"
-  #   key = "foo"
+  #   method = "tags"
+  #   keys = ["foo"]
 
   ## Suffix equals to measurement's "foo" and "bar"
   ##   tag values, separated by "_". If there is no such tags,
@@ -33,7 +32,7 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
   # [outputs.kafka.topic_suffix]
   #   method = "tags"
   #   keys = ["foo", "bar"]
-  #   key_separator = "_"
+  #   separator = "_"
 
   ## Telegraf tag to use as a routing key
   ##  ie, if this tag exists, its value will be used as the routing key

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	TOPIC_SUFFIX_METHOD_EMPTY       uint8 = iota
+	TOPIC_SUFFIX_METHOD_EMPTY uint8 = iota
 	TOPIC_SUFFIX_METHOD_MEASUREMENT
 	TOPIC_SUFFIX_METHOD_TAG
 	TOPIC_SUFFIX_METHOD_TAGS
@@ -75,10 +75,10 @@ type (
 		topicSuffixMethodUID uint8
 	}
 	TopicSuffix struct {
-		Method       string `toml:"method"`
-		Key          string `toml:"key"`
+		Method       string   `toml:"method"`
+		Key          string   `toml:"key"`
 		Keys         []string `toml:"keys"`
-		KeySeparator string `toml:"key_separator"`
+		KeySeparator string   `toml:"key_separator"`
 	}
 )
 

--- a/plugins/outputs/kafka/kafka_test.go
+++ b/plugins/outputs/kafka/kafka_test.go
@@ -41,7 +41,7 @@ func TestTopicSuffixes(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	topic := "Test_"
+	topic := "Test"
 
 	metric := testutil.TestMetric(1)
 	metricTagName := "tag1"
@@ -49,12 +49,20 @@ func TestTopicSuffixes(t *testing.T) {
 	metricName := metric.Name()
 
 	var testcases = []topicSuffixTestpair{
+		// This ensures empty separator is okay
 		{TopicSuffix{Method: "measurement"},
 			topic + metricName},
-		{TopicSuffix{Method: "tags", Keys: []string{metricTagName}},
-			topic + metricTagValue},
+		{TopicSuffix{Method: "measurement", Separator: "sep"},
+			topic + "sep" + metricName},
+		{TopicSuffix{Method: "tags", Keys: []string{metricTagName}, Separator: "_"},
+			topic + "_" + metricTagValue},
 		{TopicSuffix{Method: "tags", Keys: []string{metricTagName, metricTagName, metricTagName}, Separator: "___"},
-			topic + metricTagValue + "___" + metricTagValue + "___" + metricTagValue},
+			topic + "___" + metricTagValue + "___" + metricTagValue + "___" + metricTagValue},
+		{TopicSuffix{Method: "tags", Keys: []string{metricTagName, metricTagName, metricTagName}},
+			topic + metricTagValue + metricTagValue + metricTagValue},
+		// This ensures non-existing tags are ignored
+		{TopicSuffix{Method: "tags", Keys: []string{metricTagName, "non_existing_tag"}, Separator: "___"},
+			topic + "___" + metricTagValue},
 		// This ensures backward compatibility
 		{TopicSuffix{},
 			topic},

--- a/plugins/outputs/kafka/kafka_test.go
+++ b/plugins/outputs/kafka/kafka_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type topicSuffixTestpair struct {
+	topicSuffix   TopicSuffix
+	expectedTopic string
+}
+
 func TestConnectAndWrite(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -28,4 +33,51 @@ func TestConnectAndWrite(t *testing.T) {
 	// Verify that we can successfully write data to the kafka broker
 	err = k.Write(testutil.MockMetrics())
 	require.NoError(t, err)
+	k.Close()
+}
+
+func TestTopicSuffixes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	brokers := []string{testutil.GetLocalHost() + ":9092"}
+	s, _ := serializers.NewInfluxSerializer()
+
+	topic := "Test_"
+
+	metric := testutil.TestMetric(1)
+	metricTagName := "tag1"
+	metricTagValue := metric.Tags()[metricTagName]
+	metricName := metric.Name()
+
+	var testcases = []topicSuffixTestpair{
+		{TopicSuffix{Method: "measurement"},
+			topic + metricName},
+		{TopicSuffix{Method: "tag", Key: metricTagName},
+			topic + metricTagValue},
+		{TopicSuffix{Method: "tags", Keys: []string{metricTagName, metricTagName, metricTagName}, KeySeparator: "___"},
+			topic + metricTagValue + "___" + metricTagValue + "___" + metricTagValue},
+		// This ensures backward compatibility
+		{TopicSuffix{},
+			topic},
+	}
+
+	for _, testcase := range testcases {
+		topicSuffix := testcase.topicSuffix
+		expectedTopic := testcase.expectedTopic
+		k := &Kafka{
+			Brokers:     brokers,
+			Topic:       topic,
+			serializer:  s,
+			TopicSuffix: topicSuffix,
+		}
+
+		err := k.Connect()
+		require.NoError(t, err)
+
+		topic := k.GetTopicName(metric)
+		require.Equal(t, expectedTopic, topic)
+		k.Close()
+	}
 }

--- a/plugins/outputs/kafka/kafka_test.go
+++ b/plugins/outputs/kafka/kafka_test.go
@@ -61,6 +61,8 @@ func TestTopicSuffixes(t *testing.T) {
 		{TopicSuffix{Method: "tags", Keys: []string{metricTagName, metricTagName, metricTagName}},
 			topic + metricTagValue + metricTagValue + metricTagValue},
 		// This ensures non-existing tags are ignored
+		{TopicSuffix{Method: "tags", Keys: []string{"non_existing_tag", "non_existing_tag"}, Separator: "___"},
+			topic},
 		{TopicSuffix{Method: "tags", Keys: []string{metricTagName, "non_existing_tag"}, Separator: "___"},
 			topic + "___" + metricTagValue},
 		// This ensures backward compatibility


### PR DESCRIPTION
Add ability to the Kafka output plugin to send data to different topics, based on the metric name or tags

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This addresses #3177 