### PR TITLE
Fix Graphite boolean serialization test's non-deterministic behavior

### DIFF
--- a/plugins/serializers/graphite/graphite_test.go
+++ b/plugins/serializers/graphite/graphite_test.go
@@ -212,6 +212,10 @@ func TestSerializeValueBoolean(t *testing.T) {
 		fmt.Sprintf("localhost.enabled.cpu0.us-west-2.cpu 1 %d", now.Unix()),
 		fmt.Sprintf("localhost.disabled.cpu0.us-west-2.cpu 0 %d", now.Unix()),
 	}
+
+	sort.Strings(expS)
+	sort.Strings(mS)
+
 	assert.Equal(t, expS, mS)
 }
 


### PR DESCRIPTION
Due to using map in test data generation, precise order fields in generated metric, and consequentially in serialised data, is undetermined. Thus Graphite plugin boolean serialisation tests may or may not fail, seemingly randomly.

There seems to be a PR in testify (https://github.com/stretchr/testify/pull/491) that addresses asserting for equality of two slices disregarding order of items, which would help here. Until it's merged, a working solution would be to just sort both slices.

- [x] Signed [CLA](https://influxdata.com/community/cla/).
README.md and unit tests are not applicable
