### PR TITLE
Fix MQTT input exits if Broker is not available on startup 

### DIFF
--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -13,7 +13,7 @@ The plugin expects messages in the
   servers = ["localhost:1883"]
   ## MQTT QoS, must be 0, 1, or 2
   qos = 0
-  ## Connection timeout in seconds
+  ## Connection timeout for initial connection in seconds
   connection_timeout = 30
 
   ## Topics to subscribe to
@@ -46,9 +46,6 @@ The plugin expects messages in the
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
-
-  ## Print additional information
-  debug = "false"
 ```
 
 ### Tags:

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -13,6 +13,8 @@ The plugin expects messages in the
   servers = ["localhost:1883"]
   ## MQTT QoS, must be 0, 1, or 2
   qos = 0
+  ## Connection timeout in seconds
+  connection_timeout = 30
 
   ## Topics to subscribe to
   topics = [

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -46,6 +46,9 @@ The plugin expects messages in the
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
+
+  ## Print additional information
+  debug = "false"
 ```
 
 ### Tags:

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -50,14 +50,13 @@ type MQTTConsumer struct {
 	acc telegraf.Accumulator
 
 	connected bool
-	Debug     bool `toml:"debug"`
 }
 
 var sampleConfig = `
   servers = ["localhost:1883"]
   ## MQTT QoS, must be 0, 1, or 2
   qos = 0
-  ## Connection timeout in seconds
+  ## Connection timeout for initial connection in seconds
   connection_timeout = 30
 
   ## Topics to subscribe to
@@ -90,9 +89,6 @@ var sampleConfig = `
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
-
-  ## Print additional information
-  debug = "false"
 `
 
 func (m *MQTTConsumer) SampleConfig() string {
@@ -143,10 +139,7 @@ func (m *MQTTConsumer) Start(acc telegraf.Accumulator) error {
 func (m *MQTTConsumer) connect() error {
 	if token := m.client.Connect(); token.Wait() && token.Error() != nil {
 		err := token.Error()
-
-		if m.Debug {
-			log.Printf("MQTT Consumer, connection error - %v", err)
-		}
+		log.Printf("D! MQTT Consumer, connection error - %v", err)
 
 		return err
 	}

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -22,11 +22,12 @@ const (
 func newTestMQTTConsumer() (*MQTTConsumer, chan mqtt.Message) {
 	in := make(chan mqtt.Message, 100)
 	n := &MQTTConsumer{
-		Topics:  []string{"telegraf"},
-		Servers: []string{"localhost:1883"},
-		in:      in,
-		done:    make(chan struct{}),
-		started: true,
+		Topics:    []string{"telegraf"},
+		Servers:   []string{"localhost:1883"},
+		in:        in,
+		done:      make(chan struct{}),
+		connected: true,
+		Debug:     false,
 	}
 
 	return n, in

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -26,7 +26,9 @@ func newTestMQTTConsumer() (*MQTTConsumer, chan mqtt.Message) {
 		Servers: []string{"localhost:1883"},
 		in:      in,
 		done:    make(chan struct{}),
+		started: true,
 	}
+
 	return n, in
 }
 
@@ -131,6 +133,7 @@ func TestRunParserAndGather(t *testing.T) {
 	n, in := newTestMQTTConsumer()
 	acc := testutil.Accumulator{}
 	n.acc = &acc
+
 	defer close(n.done)
 
 	n.parser, _ = parsers.NewInfluxParser()

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -27,7 +27,6 @@ func newTestMQTTConsumer() (*MQTTConsumer, chan mqtt.Message) {
 		in:        in,
 		done:      make(chan struct{}),
 		connected: true,
-		Debug:     false,
 	}
 
 	return n, in


### PR DESCRIPTION
Add connection_timeout option that is corresponding with the same option in MQTT library.

Add connect() function in order to provide reconnect functionality and to remove requirement for initial connection to be available when telegraf starts.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
