### PR TITLE
Add support for standard proxy env vars in outputs.

### DIFF
--- a/plugins/outputs/amon/amon.go
+++ b/plugins/outputs/amon/amon.go
@@ -48,6 +48,9 @@ func (a *Amon) Connect() error {
 		return fmt.Errorf("serverkey and amon_instance are required fields for amon output")
 	}
 	a.client = &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
 		Timeout: a.Timeout.Duration,
 	}
 	return nil

--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -55,7 +55,11 @@ func (d *Datadog) Connect() error {
 	if d.Apikey == "" {
 		return fmt.Errorf("apikey is a required field for datadog output")
 	}
+
 	d.client = &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
 		Timeout: d.Timeout.Duration,
 	}
 	return nil

--- a/plugins/outputs/influxdb/client/http.go
+++ b/plugins/outputs/influxdb/client/http.go
@@ -53,6 +53,7 @@ func NewHTTP(config HTTPConfig, defaultWP WriteParams) (Client, error) {
 		}
 	} else {
 		transport = http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: config.TLSConfig,
 		}
 	}

--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -80,6 +80,9 @@ func (l *Librato) Connect() error {
 			"api_user and api_token are required fields for librato output")
 	}
 	l.client = &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
 		Timeout: l.Timeout.Duration,
 	}
 	return nil


### PR DESCRIPTION
Add support for the normal proxy environment variables to all of the output plugins.

closes #1588

### Required for all PRs:

- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
