### PR TITLE
NSQLookupd support for nsq_consumer

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -44,7 +44,7 @@ github.com/naoina/go-stringutil 6b638e95a32d0c1131db0e7fe83775cbea4a0d0b
 github.com/nats-io/go-nats ea9585611a4ab58a205b9b125ebd74c389a6b898
 github.com/nats-io/nats ea9585611a4ab58a205b9b125ebd74c389a6b898
 github.com/nats-io/nuid 289cccf02c178dc782430d534e3c1f5b72af807f
-github.com/nsqio/go-nsq a53d495e81424aaf7a7665a9d32a97715c40e953
+github.com/nsqio/go-nsq eee57a3ac4174c55924125bb15eeeda8cffb6e6f
 github.com/opencontainers/runc 89ab7f2ccc1e45ddf6485eaa802c35dcf321dfc8
 github.com/opentracing-contrib/go-observer a52f2342449246d5bcc273e65cbdcfa5f7d6c63c
 github.com/opentracing/opentracing-go 06f47b42c792fef2796e9681353e1d908c417827

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -2597,13 +2597,15 @@
 
 # # Read NSQ topic for metrics.
 # [[inputs.nsq_consumer]]
-#   ## An string representing the NSQD TCP/NSQLookupd HTTP Endpoints
-#   server = ["localhost:4150"]
+#   ## Server option still works but is deprecated, we just prepend it to the nsqd array.
+#   # server = "localhost:4150"
+#   ## An array representing the NSQD TCP HTTP Endpoints
+#   nsqd = ["localhost:4150"]
+#   ## An array representing the NSQLookupd HTTP Endpoints
+#   nsqlookupd = ["localhost:4161"]
 #   topic = "telegraf"
 #   channel = "consumer"
 #   max_in_flight = 100
-#   ## If nsqlookupd = true, servers are NSQLookupd HTTP API endpoints
-#   nsqlookupd = false
 #
 #   ## Data format to consume.
 #   ## Each data format has its own unique set of configuration options, read

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -2597,11 +2597,13 @@
 
 # # Read NSQ topic for metrics.
 # [[inputs.nsq_consumer]]
-#   ## An string representing the NSQD TCP Endpoint
-#   server = "localhost:4150"
+#   ## An string representing the NSQD TCP/NSQLookupd HTTP Endpoints
+#   server = ["localhost:4150"]
 #   topic = "telegraf"
 #   channel = "consumer"
 #   max_in_flight = 100
+#   ## If nsqlookupd = true, servers are NSQLookupd HTTP API endpoints
+#   nsqlookupd = false
 #
 #   ## Data format to consume.
 #   ## Each data format has its own unique set of configuration options, read
@@ -2766,4 +2768,3 @@
 # [[inputs.zipkin]]
 #   # path = "/api/v1/spans" # URL path for span data
 #   # port = 9411            # Port on which Telegraf listens
-

--- a/plugins/inputs/nsq_consumer/README.md
+++ b/plugins/inputs/nsq_consumer/README.md
@@ -8,13 +8,15 @@ topic and adds messages to InfluxDB. This plugin allows a message to be in any o
 ```toml
 # Read metrics from NSQD topic(s)
 [[inputs.nsq_consumer]]
-  ## An string representing the NSQD TCP/NSQLookupd HTTP Endpoints
-  server = ["localhost:4150"]
+  ## Server option still works but is deprecated, we just prepend it to the nsqd array.
+  # server = "localhost:4150"
+  ## An array representing the NSQD TCP HTTP Endpoints
+  nsqd = ["localhost:4150"]
+  ## An array representing the NSQLookupd HTTP Endpoints
+  nsqlookupd = ["localhost:4161"]
   topic = "telegraf"
   channel = "consumer"
   max_in_flight = 100
-  ## If nsqlookupd = true, servers are NSQLookupd HTTP API endpoints
-  nsqlookupd = false
 
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/inputs/nsq_consumer/README.md
+++ b/plugins/inputs/nsq_consumer/README.md
@@ -1,18 +1,20 @@
 # NSQ Consumer Input Plugin
 
 The [NSQ](http://nsq.io/) consumer plugin polls a specified NSQD
-topic and adds messages to InfluxDB. This plugin allows a message to be in any of the supported `data_format` types. 
+topic and adds messages to InfluxDB. This plugin allows a message to be in any of the supported `data_format` types.
 
 ## Configuration
 
 ```toml
 # Read metrics from NSQD topic(s)
 [[inputs.nsq_consumer]]
-  ## An array of NSQD HTTP API endpoints
-  server = "localhost:4150"
+  ## An string representing the NSQD TCP/NSQLookupd HTTP Endpoints
+  server = ["localhost:4150"]
   topic = "telegraf"
   channel = "consumer"
   max_in_flight = 100
+  ## If nsqlookupd = true, servers are NSQLookupd HTTP API endpoints
+  nsqlookupd = false
 
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/inputs/nsq_consumer/nsq_consumer_test.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer_test.go
@@ -36,10 +36,11 @@ func TestReadsMetricsFromNSQ(t *testing.T) {
 	newMockNSQD(script, addr.String())
 
 	consumer := &NSQConsumer{
-		Server:      "127.0.0.1:4155",
+		Server:      []string{"127.0.0.1:4155"},
 		Topic:       "telegraf",
 		Channel:     "consume",
 		MaxInFlight: 1,
+		Nsqlookupd:  false,
 	}
 
 	p, _ := parsers.NewInfluxParser()

--- a/plugins/inputs/nsq_consumer/nsq_consumer_test.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer_test.go
@@ -36,11 +36,11 @@ func TestReadsMetricsFromNSQ(t *testing.T) {
 	newMockNSQD(script, addr.String())
 
 	consumer := &NSQConsumer{
-		Server:      []string{"127.0.0.1:4155"},
+		Server:      "127.0.0.1:4155",
 		Topic:       "telegraf",
 		Channel:     "consume",
 		MaxInFlight: 1,
-		Nsqlookupd:  false,
+		Nsqd:        []string{"127.0.0.1:4155"},
 	}
 
 	p, _ := parsers.NewInfluxParser()


### PR DESCRIPTION
This PR adds support for NSQLookupd in `nsq_consumer`.

Why:
Existing solution where `nsq_consumer` reads only from a single NSQD server limits ability to take advantages from distributed nature of NSQ.

NSQ godocs suggest to use `nsqlookupd` as a prefered method for connection (https://godoc.org/github.com/nsqio/go-nsq#Consumer.ConnectToNSQD):
> It is recommended to use ConnectToNSQLookupd so that topics are discovered automatically. This method is useful when you want to connect to a single, local, instance.

`nsqlookupd` is the daemon that manages topology information. Clients query nsqlookupd to discover nsqd producers for a specific topic and nsqd nodes broadcasts topic and channel information.

With `nsqLookupd` support `nsq_consumer` will detect all avaiable nsqd producers and connects to all.

Additionally sync with the latest stable release of `go-nsq` (https://github.com/nsqio/go-nsq/blob/master/ChangeLog.md#107---2017-08-04)

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
