### PR TITLE
Add full parser support of all Telegraf input data formats to http_listener input plugin

### DIFF
--- a/plugins/inputs/http_listener/README.md
+++ b/plugins/inputs/http_listener/README.md
@@ -1,7 +1,7 @@
 # HTTP listener service input plugin
 
 The HTTP listener is a service input plugin that listens for messages sent via HTTP POST.
-The plugin expects messages in the InfluxDB line-protocol ONLY, other Telegraf input data formats are not supported.
+The plugin expects messages in the one of the Telegraf input data formats.
 The intent of the plugin is to allow Telegraf to serve as a proxy/router for the `/write` endpoint of the InfluxDB HTTP API.
 
 The `/write` endpoint supports the `precision` query parameter and can be set to one of `ns`, `u`, `ms`, `s`, `m`, `h`.  All other parameters are ignored and defer to the output plugins configuration.

--- a/plugins/inputs/http_listener/http_listener_test.go
+++ b/plugins/inputs/http_listener/http_listener_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf/testutil"
+	"github.com/mazebuhu/telegraf/plugins/parsers"
 
 	"github.com/stretchr/testify/require"
 )
@@ -179,8 +180,10 @@ var (
 )
 
 func newTestHTTPListener() *HTTPListener {
+	parser, _ := parsers.NewInfluxParser()
 	listener := &HTTPListener{
 		ServiceAddress: ":0",
+		parser:         parser,
 	}
 	return listener
 }
@@ -220,11 +223,13 @@ func newTestHTTPSListener() *HTTPListener {
 		serviceKeyFile = skf.Name()
 	})
 
+	parser, _ := parsers.NewInfluxParser()
 	listener := &HTTPListener{
 		ServiceAddress:    ":0",
 		TlsAllowedCacerts: allowedCAFiles,
 		TlsCert:           serviceCertFile,
 		TlsKey:            serviceKeyFile,
+		parser:            parser,
 	}
 
 	return listener
@@ -374,10 +379,8 @@ func TestWriteHTTPNoNewline(t *testing.T) {
 }
 
 func TestWriteHTTPMaxLineSizeIncrease(t *testing.T) {
-	listener := &HTTPListener{
-		ServiceAddress: ":0",
-		MaxLineSize:    128 * 1000,
-	}
+	listener := newTestHTTPListener()
+	listener.MaxLineSize = 128 * 1000
 
 	acc := &testutil.Accumulator{}
 	require.NoError(t, listener.Start(acc))
@@ -391,10 +394,8 @@ func TestWriteHTTPMaxLineSizeIncrease(t *testing.T) {
 }
 
 func TestWriteHTTPVerySmallMaxBody(t *testing.T) {
-	listener := &HTTPListener{
-		ServiceAddress: ":0",
-		MaxBodySize:    4096,
-	}
+	listener := newTestHTTPListener()
+	listener.MaxBodySize = 4096
 
 	acc := &testutil.Accumulator{}
 	require.NoError(t, listener.Start(acc))
@@ -407,10 +408,8 @@ func TestWriteHTTPVerySmallMaxBody(t *testing.T) {
 }
 
 func TestWriteHTTPVerySmallMaxLineSize(t *testing.T) {
-	listener := &HTTPListener{
-		ServiceAddress: ":0",
-		MaxLineSize:    70,
-	}
+	listener := newTestHTTPListener()
+	listener.MaxLineSize = 70
 
 	acc := &testutil.Accumulator{}
 	require.NoError(t, listener.Start(acc))
@@ -433,10 +432,8 @@ func TestWriteHTTPVerySmallMaxLineSize(t *testing.T) {
 }
 
 func TestWriteHTTPLargeLinesSkipped(t *testing.T) {
-	listener := &HTTPListener{
-		ServiceAddress: ":0",
-		MaxLineSize:    100,
-	}
+	listener := newTestHTTPListener()
+	listener.MaxLineSize = 100
 
 	acc := &testutil.Accumulator{}
 	require.NoError(t, listener.Start(acc))


### PR DESCRIPTION
This is a proposal for adding full parser support of all [Telegraf input data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md) to the http_listener plugin as suggested by issue #684.

Note: Currently the test covers only Influx Line Protocol data.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.