### PR TITLE
Fix StatsD p100 calculation

### DIFF
--- a/plugins/inputs/statsd/running_stats.go
+++ b/plugins/inputs/statsd/running_stats.go
@@ -101,8 +101,15 @@ func (rs *RunningStats) Percentile(n int) float64 {
 	}
 
 	i := int(float64(len(rs.perc)) * float64(n) / float64(100))
-	if i < 0 {
-		i = 0
+	return rs.perc[clamp(i, 0, len(rs.perc)-1)]
+}
+
+func clamp(i int, min int, max int) int {
+	if i < min {
+		return min
 	}
-	return rs.perc[i]
+	if i > max {
+		return max
+	}
+	return i
 }

--- a/plugins/inputs/statsd/running_stats_test.go
+++ b/plugins/inputs/statsd/running_stats_test.go
@@ -23,11 +23,17 @@ func TestRunningStats_Single(t *testing.T) {
 	if rs.Lower() != 10.1 {
 		t.Errorf("Expected %v, got %v", 10.1, rs.Lower())
 	}
+	if rs.Percentile(100) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(100))
+	}
 	if rs.Percentile(90) != 10.1 {
 		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(90))
 	}
 	if rs.Percentile(50) != 10.1 {
 		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(50))
+	}
+	if rs.Percentile(0) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(0))
 	}
 	if rs.Count() != 1 {
 		t.Errorf("Expected %v, got %v", 1, rs.Count())
@@ -58,11 +64,17 @@ func TestRunningStats_Duplicate(t *testing.T) {
 	if rs.Lower() != 10.1 {
 		t.Errorf("Expected %v, got %v", 10.1, rs.Lower())
 	}
+	if rs.Percentile(100) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(100))
+	}
 	if rs.Percentile(90) != 10.1 {
 		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(90))
 	}
 	if rs.Percentile(50) != 10.1 {
 		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(50))
+	}
+	if rs.Percentile(0) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(0))
 	}
 	if rs.Count() != 4 {
 		t.Errorf("Expected %v, got %v", 4, rs.Count())
@@ -93,11 +105,17 @@ func TestRunningStats(t *testing.T) {
 	if rs.Lower() != 5 {
 		t.Errorf("Expected %v, got %v", 5, rs.Lower())
 	}
+	if rs.Percentile(100) != 45 {
+		t.Errorf("Expected %v, got %v", 45, rs.Percentile(100))
+	}
 	if rs.Percentile(90) != 32 {
 		t.Errorf("Expected %v, got %v", 32, rs.Percentile(90))
 	}
 	if rs.Percentile(50) != 11 {
 		t.Errorf("Expected %v, got %v", 11, rs.Percentile(50))
+	}
+	if rs.Percentile(0) != 5 {
+		t.Errorf("Expected %v, got %v", 5, rs.Percentile(0))
 	}
 	if rs.Count() != 16 {
 		t.Errorf("Expected %v, got %v", 4, rs.Count())


### PR DESCRIPTION
Fixes an index out of range panic when calculating p100. The following line evaluates to the length of the array when n = 100.

```Go
i := int(float64(len(rs.perc)) * float64(n) / float64(100))
```

I've updated the existing tests to check p0 and p100 boundary conditions.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] ~~Associated README.md updated.~~ (N/A)
- [X] Has appropriate unit tests.