### PR TITLE
Fix StatsD counter and gauge metric types

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -251,14 +251,14 @@ func (s *Statsd) Gather(acc telegraf.Accumulator) error {
 	}
 
 	for _, metric := range s.gauges {
-		acc.AddFields(metric.name, metric.fields, metric.tags, now)
+		acc.AddGauge(metric.name, metric.fields, metric.tags, now)
 	}
 	if s.DeleteGauges {
 		s.gauges = make(map[string]cachedgauge)
 	}
 
 	for _, metric := range s.counters {
-		acc.AddFields(metric.name, metric.fields, metric.tags, now)
+		acc.AddCounter(metric.name, metric.fields, metric.tags, now)
 	}
 	if s.DeleteCounters {
 		s.counters = make(map[string]cachedcounter)


### PR DESCRIPTION
Correctly categorizes StatsD counter and gauge metric types.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] ~~Associated README.md updated.~~ (N/A)
- [ ] Has appropriate unit tests.
