### PR TITLE
Calculate StatsD timing metric type sum

### DIFF
--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -143,6 +143,8 @@ metric type:
         for that stat during that interval.
         - `statsd_<name>_stddev`: The stddev is the sample standard deviation
         of all values statsd saw for that stat during that interval.
+        - `statsd_<name>_sum`: The sum is the sample sum of all values statsd saw
+        for that stat during that interval.
         - `statsd_<name>_count`: The count is the number of timings statsd saw
         for that stat during that interval. It is not averaged.
         - `statsd_<name>_percentile_<P>` The `Pth` percentile is a value x such

--- a/plugins/inputs/statsd/running_stats.go
+++ b/plugins/inputs/statsd/running_stats.go
@@ -24,8 +24,10 @@ type RunningStats struct {
 	perc      []float64
 	PercLimit int
 
-	upper float64
+	sum float64
+
 	lower float64
+	upper float64
 
 	// cache if we have sorted the list so that we never re-sort a sorted list,
 	// which can have very bad performance.
@@ -50,6 +52,9 @@ func (rs *RunningStats) AddValue(v float64) {
 	rs.n += 1
 	rs.ex += v - rs.k
 	rs.ex2 += (v - rs.k) * (v - rs.k)
+
+	// add to running sum
+	rs.sum += v
 
 	// track upper and lower bounds
 	if v > rs.upper {
@@ -76,6 +81,10 @@ func (rs *RunningStats) Variance() float64 {
 
 func (rs *RunningStats) Stddev() float64 {
 	return math.Sqrt(rs.Variance())
+}
+
+func (rs *RunningStats) Sum() float64 {
+	return rs.sum
 }
 
 func (rs *RunningStats) Upper() float64 {

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -235,6 +235,7 @@ func (s *Statsd) Gather(acc telegraf.Accumulator) error {
 			}
 			fields[prefix+"mean"] = stats.Mean()
 			fields[prefix+"stddev"] = stats.Stddev()
+			fields[prefix+"sum"] = stats.Sum()
 			fields[prefix+"upper"] = stats.Upper()
 			fields[prefix+"lower"] = stats.Lower()
 			fields[prefix+"count"] = stats.Count()

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -407,6 +407,7 @@ func TestParse_Timings(t *testing.T) {
 		"lower":         float64(1),
 		"mean":          float64(3),
 		"stddev":        float64(4),
+		"sum":           float64(15),
 		"upper":         float64(11),
 	}
 
@@ -1154,6 +1155,7 @@ func TestParse_Timings_MultipleFieldsWithTemplate(t *testing.T) {
 		"success_lower":         float64(1),
 		"success_mean":          float64(3),
 		"success_stddev":        float64(4),
+		"success_sum":           float64(15),
 		"success_upper":         float64(11),
 
 		"error_90_percentile": float64(22),
@@ -1161,6 +1163,7 @@ func TestParse_Timings_MultipleFieldsWithTemplate(t *testing.T) {
 		"error_lower":         float64(2),
 		"error_mean":          float64(6),
 		"error_stddev":        float64(8),
+		"error_sum":           float64(30),
 		"error_upper":         float64(22),
 	}
 
@@ -1203,6 +1206,7 @@ func TestParse_Timings_MultipleFieldsWithoutTemplate(t *testing.T) {
 		"lower":         float64(1),
 		"mean":          float64(3),
 		"stddev":        float64(4),
+		"sum":           float64(15),
 		"upper":         float64(11),
 	}
 	expectedError := map[string]interface{}{
@@ -1211,6 +1215,7 @@ func TestParse_Timings_MultipleFieldsWithoutTemplate(t *testing.T) {
 		"lower":         float64(2),
 		"mean":          float64(6),
 		"stddev":        float64(8),
+		"sum":           float64(30),
 		"upper":         float64(22),
 	}
 


### PR DESCRIPTION
Adds support to calculate StatsD timing sums as requested by #2823.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
