### PR TITLE
Configurable metrics endpoint for prometheus output

### DIFF
--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -1,6 +1,6 @@
 # Prometheus Client Service Output Plugin
 
-This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all metrics on `/metrics` to be polled by a Prometheus server.
+This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all metrics on `/metrics` (default) to be polled by a Prometheus server.
 
 ## Configuration
 
@@ -9,6 +9,9 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
 [[outputs.prometheus_client]]
   # Address to listen on
   listen = ":9273"
+
+  # Path to publish the metrics on, defaults to /metrics
+  path = "/metrics"   
 
   # Expiration interval for each metric. 0 == no expiration
   expiration_interval = "60s"

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -45,6 +45,7 @@ type MetricFamily struct {
 type PrometheusClient struct {
 	Listen             string
 	ExpirationInterval internal.Duration `toml:"expiration_interval"`
+	Path               string            `toml:"path"`
 
 	server *http.Server
 
@@ -70,8 +71,12 @@ func (p *PrometheusClient) Start() error {
 		p.Listen = "localhost:9273"
 	}
 
+	if p.Path == "" {
+		p.Path = "/metrics"
+	}
+
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", prometheus.Handler())
+	mux.Handle(p.Path, prometheus.Handler())
 
 	p.server = &http.Server{
 		Addr:    p.Listen,

--- a/plugins/outputs/prometheus_client/prometheus_client_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_test.go
@@ -445,6 +445,7 @@ func setupPrometheus() (*PrometheusClient, *prometheus_input.Prometheus, error) 
 	if pTesting == nil {
 		pTesting = NewClient()
 		pTesting.Listen = "localhost:9127"
+		pTesting.Path = "/metrics"
 		err := pTesting.Start()
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Make the metrics path configurable but /metrics by default. Using a non
default value can be useful when used in k8s pods with multiple containers
that have non standard prometheus metric paths.
Some apps already use /metrics for something else.

### Required for all PRs:

- [*] Signed [CLA](https://influxdata.com/community/cla/).
- [*] Associated README.md updated.
- [*] Has appropriate unit tests.
