### PR TITLE
Prometheus plugin: Tagging original URL in case of Kubernetes services

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -93,14 +93,15 @@ func (p *Prometheus) AddressToURL(u *url.URL, address string) string {
 }
 
 type UrlAndAddress struct {
-	Url     string
-	Address string
+	OriginalUrl string
+	Url         string
+	Address     string
 }
 
 func (p *Prometheus) GetAllURLs() ([]UrlAndAddress, error) {
 	allUrls := make([]UrlAndAddress, 0)
 	for _, url := range p.Urls {
-		allUrls = append(allUrls, UrlAndAddress{Url: url})
+		allUrls = append(allUrls, UrlAndAddress{Url: url, OriginalUrl: url})
 	}
 	for _, service := range p.KubernetesServices {
 		u, err := url.Parse(service)
@@ -114,7 +115,7 @@ func (p *Prometheus) GetAllURLs() ([]UrlAndAddress, error) {
 		}
 		for _, resolved := range resolvedAddresses {
 			serviceUrl := p.AddressToURL(u, resolved)
-			allUrls = append(allUrls, UrlAndAddress{Url: serviceUrl, Address: resolved})
+			allUrls = append(allUrls, UrlAndAddress{Url: serviceUrl, Address: resolved, OriginalUrl: service})
 		}
 	}
 	return allUrls, nil
@@ -213,7 +214,7 @@ func (p *Prometheus) gatherURL(url UrlAndAddress, acc telegraf.Accumulator) erro
 	// Add (or not) collected metrics
 	for _, metric := range metrics {
 		tags := metric.Tags()
-		tags["url"] = url.Url
+		tags["url"] = url.OriginalUrl
 		if url.Address != "" {
 			tags["address"] = url.Address
 		}

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -50,6 +50,7 @@ func TestPrometheusGeneratesMetrics(t *testing.T) {
 	assert.True(t, acc.HasFloatField("test_metric", "value"))
 	assert.True(t, acc.HasTimestamp("test_metric", time.Unix(1490802350, 0)))
 	assert.False(t, acc.HasTag("test_metric", "address"))
+	assert.True(t, acc.TagValue("test_metric", "url") == ts.URL)
 }
 
 func TestPrometheusGeneratesMetricsWithHostNameTag(t *testing.T) {
@@ -74,6 +75,7 @@ func TestPrometheusGeneratesMetricsWithHostNameTag(t *testing.T) {
 	assert.True(t, acc.HasFloatField("test_metric", "value"))
 	assert.True(t, acc.HasTimestamp("test_metric", time.Unix(1490802350, 0)))
 	assert.True(t, acc.TagValue("test_metric", "address") == tsAddress)
+	assert.True(t, acc.TagValue("test_metric", "url") == ts.URL)
 }
 
 func TestPrometheusGeneratesMetricsAlthoughFirstDNSFails(t *testing.T) {


### PR DESCRIPTION
Follow-up PR for https://github.com/influxdata/telegraf/pull/3236

- for `kubernetes_services` URLs, the `url` tag will have the value of the original service URL (as you already have the `address` tag created)
- for `url` URLs, the `url` tag will have the URL value

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.