### PR TITLE
Unlock Statsd when stopping to prevent deadlock

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -814,7 +814,6 @@ func (s *Statsd) remember(id string, conn *net.TCPConn) {
 
 func (s *Statsd) Stop() {
 	s.Lock()
-	defer s.Unlock()
 	log.Println("I! Stopping the statsd service")
 	close(s.done)
 	switch s.Protocol {
@@ -838,9 +837,14 @@ func (s *Statsd) Stop() {
 	default:
 		s.UDPlistener.Close()
 	}
+	s.Unlock()
+
 	s.wg.Wait()
+
+	s.Lock()
 	close(s.in)
 	log.Println("I! Stopped Statsd listener service on ", s.ServiceAddress)
+	s.Unlock()
 }
 
 func init() {


### PR DESCRIPTION
I noticed we have a TCP Benchmark but not one for UDP, which would be useful for #3254 so I added one based on the existing test.  When running this I found that the plugin can deadlock on shutdown if there are messages pending on the input channel.

cc @agnivade

### Required for all PRs:

- [x] ~~Associated README.md updated.~~ NA
- [x] Has appropriate unit tests.
