### PR TITLE
Use a plugin specific transport for each cloudwatch input

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -76,6 +76,7 @@ github.com/yuin/gopher-lua 66c871e454fcf10251c61bf8eff02d0978cae75a
 github.com/zensqlmonitor/go-mssqldb ffe5510c6fa5e15e6d983210ab501c815b56b363
 golang.org/x/crypto dc137beb6cce2043eb6b5f223ab8bf51c32459f4
 golang.org/x/net f2499483f923065a842d38eb4c7f1927e6fc6e6d
+golang.org/x/sync f52d1811a62927559de87708c8913c1650ce4f26
 golang.org/x/sys 739734461d1c916b6c72a63d7efda2b27edb369f
 golang.org/x/text 506f9d5c962f284575e88337e7d9296d27e729d3
 gopkg.in/asn1-ber.v1 4e86f4367175e39f69d9358a5f17b4dda270378d

--- a/Godeps
+++ b/Godeps
@@ -2,7 +2,7 @@ collectd.org 2ce144541b8903101fb8f1483cc0497a68798122
 github.com/aerospike/aerospike-client-go 95e1ad7791bdbca44707fedbb29be42024900d9c
 github.com/amir/raidman c74861fe6a7bb8ede0a010ce4485bdbb4fc4c985
 github.com/apache/thrift 4aaa92ece8503a6da9bc6701604f69acf2b99d07
-github.com/aws/aws-sdk-go c861d27d0304a79f727e9a8a4e2ac1e74602fdc0
+github.com/aws/aws-sdk-go 5615d2ed566a09d326f681c789310a2e5ba5de5d
 github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/bsm/sarama-cluster ccdc0803695fbce22f1706d04ded46cd518fd832
 github.com/cenkalti/backoff b02f2bbce11d7ea6b97f282ef1771b0fe2f65ef3

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -209,7 +209,7 @@ func (c *CloudWatch) Gather(acc telegraf.Accumulator) error {
 
 func init() {
 	inputs.Add("cloudwatch", func() telegraf.Input {
-		ttl, _ := time.ParseDuration("1hr")
+		ttl, _ := time.ParseDuration("1h")
 		return &CloudWatch{
 			CacheTTL:  internal.Duration{Duration: ttl},
 			RateLimit: 200,

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -1,10 +1,15 @@
 package cloudwatch
 
 import (
+	"context"
 	"fmt"
+	"net"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/semaphore"
 
 	"github.com/aws/aws-sdk-go/aws"
 
@@ -15,6 +20,10 @@ import (
 	internalaws "github.com/influxdata/telegraf/internal/config/aws"
 	"github.com/influxdata/telegraf/internal/limiter"
 	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+const (
+	maxConns = 10
 )
 
 type (
@@ -188,6 +197,9 @@ func (c *CloudWatch) Gather(acc telegraf.Accumulator) error {
 
 	now := time.Now()
 
+	ctx := context.TODO()
+	sem := semaphore.NewWeighted(maxConns)
+
 	// limit concurrency or we can easily exhaust user connection limit
 	// see cloudwatch API request limits:
 	// http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html
@@ -197,9 +209,11 @@ func (c *CloudWatch) Gather(acc telegraf.Accumulator) error {
 	wg.Add(len(metrics))
 	for _, m := range metrics {
 		<-lmtr.C
+		sem.Acquire(ctx, 1)
 		go func(inm *cloudwatch.Metric) {
 			defer wg.Done()
 			acc.AddError(c.gatherMetric(acc, inm, now))
+			sem.Release(1)
 		}(m)
 	}
 	wg.Wait()
@@ -232,7 +246,24 @@ func (c *CloudWatch) initializeCloudWatch() error {
 	}
 	configProvider := credentialConfig.Credentials()
 
-	c.client = cloudwatch.New(configProvider)
+	config := &aws.Config{
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+					DualStack: true,
+				}).DialContext,
+				MaxIdleConns:          maxConns,
+				MaxIdleConnsPerHost:   maxConns,
+				IdleConnTimeout:       90 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		},
+	}
+	c.client = cloudwatch.New(configProvider, config)
 	return nil
 }
 


### PR DESCRIPTION
Instead of using the default transport, create one for each plugin and cap metric gathering at 10/input.  Also fixed a bug in the default metric cache_ttl that could cause it to always be expired.

In my testing, with a single cloudwatch metric, I still see closed connections.  I expected that with this configuration there should be no closed connections, since with each gather we should just reuse the open connection.

@druchoo Can you test this and compare with before?  [rpm package](https://8320-33258973-gh.circle-artifacts.com/0/tmp/circle-artifacts.ARa5iae/build/linux/amd64/telegraf-1.5.0%257E19d4472-0.x86_64.rpm)

#3255

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
