### PR TITLE
elasticsearch plugin: specify include or exclude filtering for specific measurements

### DIFF
--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -27,6 +27,11 @@ or [cluster-stats](https://www.elastic.co/guide/en/elasticsearch/reference/curre
   ## Master node. 
   cluster_stats = false
 
+  ## Optional measurement filtering
+  ## Use measurement names and specify whether to use an include or exclude filtering
+  # filter = ["elasticsearch_jvm"]
+  # exclude_filter = false
+
   ## Optional SSL Config
   # ssl_ca = "/etc/telegraf/ca.pem"
   # ssl_cert = "/etc/telegraf/cert.pem"


### PR DESCRIPTION
Although the plugin is already pretty configurable, the amount of data generated can be very big if you configured it to contain all the data you are interested in.

For instance, if you only want information on cluster health and the JVM but do not care about any index information at all, you generate far more data than you are interested in.

In order to satisfy these specific needs, I propose these new configuration values:

 * `filter`: specify a set of measurements you want to filter for
 * `filter_exclude`: specify whether you want to whitelist or blacklist measurements

The example for the situation above would be:

```yaml
[[inputs.elasticsearch]]
  cluster_health = true
  cluster_stats = true
  exclude_filter = false
  filter = ["elasticsearch_cluster_health", "elasticsearch_jvm"]
  local = false
  servers = ["http://example.com:9200"]
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
