### PR TITLE
elasticsearch input: ability to get base cluster health information without querying for indices health

### DIFF
--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -23,8 +23,11 @@ or [cluster-stats](https://www.elastic.co/guide/en/elasticsearch/reference/curre
   ## Set cluster_health to true when you want to also obtain cluster health stats
   cluster_health = false
 
-  ## Set indices_health to true when you want to also obtain detailed index health stats
-  indices_health = false
+  ## Adjust cluster_health_level when you want to also obtain detailed health stats
+  ## The options are
+  ##  - indices (default)
+  ##  - cluster
+  # cluster_health_level = "indices"
 
   ## Set cluster_stats to true when you want to also obtain cluster stats from the
   ## Master node.

--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -23,8 +23,11 @@ or [cluster-stats](https://www.elastic.co/guide/en/elasticsearch/reference/curre
   ## Set cluster_health to true when you want to also obtain cluster health stats
   cluster_health = false
 
-  ## Set cluster_stats to true when you want to obtain cluster stats from the 
-  ## Master node. 
+  ## Set indices_health to true when you want to also obtain detailed index health stats
+  indices_health = false
+
+  ## Set cluster_stats to true when you want to also obtain cluster stats from the
+  ## Master node.
   cluster_stats = false
 
   ## Optional SSL Config

--- a/plugins/inputs/elasticsearch/testdata_test.go
+++ b/plugins/inputs/elasticsearch/testdata_test.go
@@ -11,6 +11,21 @@ const clusterHealthResponse = `
    "active_shards": 15,
    "relocating_shards": 0,
    "initializing_shards": 0,
+   "unassigned_shards": 0
+}
+`
+
+const clusterHealthResponseWithIndices = `
+{
+   "cluster_name": "elasticsearch_telegraf",
+   "status": "green",
+   "timed_out": false,
+   "number_of_nodes": 3,
+   "number_of_data_nodes": 3,
+   "active_primary_shards": 5,
+   "active_shards": 15,
+   "relocating_shards": 0,
+   "initializing_shards": 0,
    "unassigned_shards": 0,
    "indices": {
       "v1": {


### PR DESCRIPTION
We found that the plugin generates a lot of data and also makes Elasticsearch work quite hard to generate the data (in some cases not necessary, if you are not interested in all the data).

New configurability:
- ability to get base cluster health information without querying for indices health

```toml
## Set cluster_health to true when you want to also obtain cluster health stats
cluster_health = false

## Adjust cluster_health_level when you want to also obtain detailed health stats
## The options are
##  - indices (default)
##  - cluster
# cluster_health_level = "indices"
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.