### PR TITLE
Add newline to each metric for Wavefront output

### DIFF
--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -124,7 +124,7 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 	for _, m := range metrics {
 		for _, metricPoint := range buildMetrics(m, w) {
 			metricLine := formatMetricPoint(metricPoint, w)
-			//log.Printf("D! Output [wavefront] %s", metricLine)
+			log.Printf("D! Output [wavefront] %s", metricLine)
 			_, err := connection.Write([]byte(metricLine))
 			if err != nil {
 				return fmt.Errorf("Wavefront: TCP writing error %s", err.Error())
@@ -261,6 +261,8 @@ func formatMetricPoint(metricPoint *MetricPoint, w *Wavefront) string {
 		buffer.WriteString(tagValueReplacer.Replace(v))
 		buffer.WriteString("\"")
 	}
+
+	buffer.WriteString("\n")
 
 	return buffer.String()
 }

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -275,7 +275,7 @@ func TestFormatMetricPoint(t *testing.T) {
 		Tags:      map[string]string{"sp*c!@l\"-ch/rs": "sp*c!@l/ val\"ue"},
 	}
 
-	expected := "test.metric.something 123.456000 1257894000 source=\"testSource\" sp-c--l--ch-rs=\"sp-c!@l/ val\\\"ue\""
+	expected := "test.metric.something 123.456000 1257894000 source=\"testSource\" sp-c--l--ch-rs=\"sp-c!@l/ val\\\"ue\"\n"
 
 	received := formatMetricPoint(testpoint, w)
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Need to have a newline character at end of each metric sent to wavefront-proxy to work on all platforms properly.
