### PR TITLE
Use chunked transfer encoding in InfluxDB output

### DIFF
--- a/plugins/outputs/influxdb/client/client.go
+++ b/plugins/outputs/influxdb/client/client.go
@@ -4,13 +4,7 @@ import "io"
 
 type Client interface {
 	Query(command string) error
-
-	Write(b []byte) (int, error)
-	WriteWithParams(b []byte, params WriteParams) (int, error)
-
-	WriteStream(b io.Reader, contentLength int) (int, error)
-	WriteStreamWithParams(b io.Reader, contentLength int, params WriteParams) (int, error)
-
+	WriteStream(b io.Reader) error
 	Close() error
 }
 

--- a/plugins/outputs/influxdb/client/http.go
+++ b/plugins/outputs/influxdb/client/http.go
@@ -137,60 +137,13 @@ func (c *httpClient) Query(command string) error {
 	return c.doRequest(req, http.StatusOK)
 }
 
-func (c *httpClient) Write(b []byte) (int, error) {
-	req, err := c.makeWriteRequest(bytes.NewReader(b), len(b), c.writeURL)
+func (c *httpClient) WriteStream(r io.Reader) error {
+	req, err := c.makeWriteRequest(r, c.writeURL)
 	if err != nil {
-		return 0, nil
+		return err
 	}
 
-	err = c.doRequest(req, http.StatusNoContent)
-	if err == nil {
-		return len(b), nil
-	}
-	return 0, err
-}
-
-func (c *httpClient) WriteWithParams(b []byte, wp WriteParams) (int, error) {
-	req, err := c.makeWriteRequest(bytes.NewReader(b), len(b), writeURL(c.url, wp))
-	if err != nil {
-		return 0, nil
-	}
-
-	err = c.doRequest(req, http.StatusNoContent)
-	if err == nil {
-		return len(b), nil
-	}
-	return 0, err
-}
-
-func (c *httpClient) WriteStream(r io.Reader, contentLength int) (int, error) {
-	req, err := c.makeWriteRequest(r, contentLength, c.writeURL)
-	if err != nil {
-		return 0, nil
-	}
-
-	err = c.doRequest(req, http.StatusNoContent)
-	if err == nil {
-		return contentLength, nil
-	}
-	return 0, err
-}
-
-func (c *httpClient) WriteStreamWithParams(
-	r io.Reader,
-	contentLength int,
-	wp WriteParams,
-) (int, error) {
-	req, err := c.makeWriteRequest(r, contentLength, writeURL(c.url, wp))
-	if err != nil {
-		return 0, nil
-	}
-
-	err = c.doRequest(req, http.StatusNoContent)
-	if err == nil {
-		return contentLength, nil
-	}
-	return 0, err
+	return c.doRequest(req, http.StatusNoContent)
 }
 
 func (c *httpClient) doRequest(
@@ -232,7 +185,6 @@ func (c *httpClient) doRequest(
 
 func (c *httpClient) makeWriteRequest(
 	body io.Reader,
-	contentLength int,
 	writeURL string,
 ) (*http.Request, error) {
 	req, err := c.makeRequest(writeURL, body)

--- a/plugins/outputs/influxdb/client/http.go
+++ b/plugins/outputs/influxdb/client/http.go
@@ -241,8 +241,6 @@ func (c *httpClient) makeWriteRequest(
 	}
 	if c.config.ContentEncoding == "gzip" {
 		req.Header.Set("Content-Encoding", "gzip")
-	} else {
-		req.Header.Set("Content-Length", fmt.Sprint(contentLength))
 	}
 	return req, nil
 }

--- a/plugins/outputs/influxdb/client/http_test.go
+++ b/plugins/outputs/influxdb/client/http_test.go
@@ -110,66 +110,8 @@ func TestHTTPClient_Write(t *testing.T) {
 	client, err := NewHTTP(config, wp)
 	defer client.Close()
 	assert.NoError(t, err)
-	n, err := client.Write([]byte("cpu value=99\n"))
-	assert.Equal(t, 13, n)
-	assert.NoError(t, err)
 
-	_, err = client.WriteStream(bytes.NewReader([]byte("cpu value=99\n")), 13)
-	assert.NoError(t, err)
-}
-
-func TestHTTPClient_WriteParamsOverride(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/write":
-			// test that database is set properly
-			if r.FormValue("db") != "override" {
-				w.WriteHeader(http.StatusTeapot)
-				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprintln(w, `{"results":[{}],"error":"wrong db name"}`)
-			}
-
-			// Validate the request body:
-			buf := make([]byte, 100)
-			n, _ := r.Body.Read(buf)
-			expected := "cpu value=99"
-			got := string(buf[0 : n-1])
-			if expected != got {
-				w.WriteHeader(http.StatusTeapot)
-				w.Header().Set("Content-Type", "application/json")
-				msg := fmt.Sprintf(`{"results":[{}],"error":"expected [%s], got [%s]"}`, expected, got)
-				fmt.Fprintln(w, msg)
-			}
-
-			w.WriteHeader(http.StatusNoContent)
-			w.Header().Set("Content-Type", "application/json")
-		case "/query":
-			w.WriteHeader(http.StatusOK)
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintln(w, `{"results":[{}]}`)
-		}
-	}))
-	defer ts.Close()
-
-	config := HTTPConfig{
-		URL: ts.URL,
-	}
-	defaultWP := WriteParams{
-		Database: "test",
-	}
-	client, err := NewHTTP(config, defaultWP)
-	defer client.Close()
-	assert.NoError(t, err)
-
-	// test that WriteWithParams overrides the default write params
-	wp := WriteParams{
-		Database: "override",
-	}
-	n, err := client.WriteWithParams([]byte("cpu value=99\n"), wp)
-	assert.Equal(t, 13, n)
-	assert.NoError(t, err)
-
-	_, err = client.WriteStreamWithParams(bytes.NewReader([]byte("cpu value=99\n")), 13, wp)
+	err = client.WriteStream(bytes.NewReader([]byte("cpu value=99\n")))
 	assert.NoError(t, err)
 }
 
@@ -197,23 +139,7 @@ func TestHTTPClient_Write_Errors(t *testing.T) {
 	assert.NoError(t, err)
 
 	lp := []byte("cpu value=99\n")
-	n, err := client.Write(lp)
-	assert.Equal(t, 0, n)
-	assert.Error(t, err)
-
-	n, err = client.WriteStream(bytes.NewReader(lp), 13)
-	assert.Equal(t, 0, n)
-	assert.Error(t, err)
-
-	wp := WriteParams{
-		Database: "override",
-	}
-	n, err = client.WriteWithParams(lp, wp)
-	assert.Equal(t, 0, n)
-	assert.Error(t, err)
-
-	n, err = client.WriteStreamWithParams(bytes.NewReader(lp), 13, wp)
-	assert.Equal(t, 0, n)
+	err = client.WriteStream(bytes.NewReader(lp))
 	assert.Error(t, err)
 }
 
@@ -404,8 +330,6 @@ func TestHTTPClient_PathPrefix(t *testing.T) {
 	assert.NoError(t, err)
 	err = client.Query("CREATE DATABASE test")
 	assert.NoError(t, err)
-	_, err = client.Write([]byte("cpu value=99\n"))
-	assert.NoError(t, err)
-	_, err = client.WriteStream(bytes.NewReader([]byte("cpu value=99\n")), 13)
+	err = client.WriteStream(bytes.NewReader([]byte("cpu value=99\n")))
 	assert.NoError(t, err)
 }

--- a/plugins/outputs/influxdb/client/udp_test.go
+++ b/plugins/outputs/influxdb/client/udp_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/influxdata/telegraf/metric"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUDPClient(t *testing.T) {
@@ -65,43 +64,6 @@ func TestUDPClient_Write(t *testing.T) {
 		}
 	}()
 
-	// test sending simple metric
-	n, err := client.Write([]byte("cpu value=99\n"))
-	assert.Equal(t, n, 13)
-	assert.NoError(t, err)
-	pkt := <-packets
-	assert.Equal(t, "cpu value=99\n", pkt)
-
-	wp := WriteParams{}
-	//
-	// Using WriteStream() & a metric.Reader:
-	config3 := UDPConfig{
-		URL:         "udp://localhost:8199",
-		PayloadSize: 40,
-	}
-	client3, err := NewUDP(config3)
-	assert.NoError(t, err)
-
-	now := time.Unix(1484142942, 0)
-	m1, _ := metric.New("test", map[string]string{},
-		map[string]interface{}{"value": 1.1}, now)
-	m2, _ := metric.New("test", map[string]string{},
-		map[string]interface{}{"value": 1.1}, now)
-	m3, _ := metric.New("test", map[string]string{},
-		map[string]interface{}{"value": 1.1}, now)
-	ms := []telegraf.Metric{m1, m2, m3}
-	mReader := metric.NewReader(ms)
-	n, err = client3.WriteStreamWithParams(mReader, 10, wp)
-	// 3 metrics at 35 bytes each (including the newline)
-	assert.Equal(t, 105, n)
-	assert.NoError(t, err)
-	pkt = <-packets
-	assert.Equal(t, "test value=1.1 1484142942000000000\n", pkt)
-	pkt = <-packets
-	assert.Equal(t, "test value=1.1 1484142942000000000\n", pkt)
-	pkt = <-packets
-	assert.Equal(t, "test value=1.1 1484142942000000000\n", pkt)
-
 	assert.NoError(t, client.Close())
 
 	config = UDPConfig{
@@ -112,17 +74,15 @@ func TestUDPClient_Write(t *testing.T) {
 	assert.NoError(t, err)
 
 	ts := time.Unix(1484142943, 0)
-	m1, _ = metric.New("test", map[string]string{},
+	m1, _ := metric.New("test", map[string]string{},
 		map[string]interface{}{"this_is_a_very_long_field_name": 1.1}, ts)
-	m2, _ = metric.New("test", map[string]string{},
+	m2, _ := metric.New("test", map[string]string{},
 		map[string]interface{}{"value": 1.1}, ts)
-	ms = []telegraf.Metric{m1, m2}
+	ms := []telegraf.Metric{m1, m2}
 	reader := metric.NewReader(ms)
-	n, err = client4.WriteStream(reader, 0)
+	err = client4.WriteStream(reader)
 	assert.NoError(t, err)
-	require.Equal(t, 35, n)
-	assert.NoError(t, err)
-	pkt = <-packets
+	pkt := <-packets
 	assert.Equal(t, "test value=1.1 1484142943000000000\n", pkt)
 
 	assert.NoError(t, client4.Close())


### PR DESCRIPTION
Remove the Content-Length header from all POSTs to InfluxDB.

With the current metrics.Reader the content length cannot be determined without buffering the full request body.  Our choice to fix this issue then are:
- Replace metrics.Reader with a static length serializer regardless of buffer size.
- Buffer the full request to get the actual size.
- Remove the Content-Length header and use chunked transfer encoding.

The later was the quickest and least risk, so I went with that for now.  In the future, I think we should replace the metrics.Reader with a more appropriate abstraction, as it doesn't allow for the line based structure of line protocol very well.

closes #2854 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] ~Associated README.md updated.~ N/A
- [x] Has appropriate unit tests.
