### PR TITLE
fix documented equation for diskio average queue depth

### DIFF
--- a/plugins/inputs/system/DISK_README.md
+++ b/plugins/inputs/system/DISK_README.md
@@ -140,7 +140,7 @@ SELECT derivative(last("io_time"),1ms) FROM "diskio" WHERE time > now() - 30m GR
 #### Calculate average queue depth:
 `iops_in_progress` will give you an instantaneous value. This will give you the average between polling intervals.
 ```
-SELECT derivative(last("weighted_io_time",1ms))/1000 from "diskio" WHERE time > now() - 30m GROUP BY "host","name",time(60s)
+SELECT derivative(last("weighted_io_time",1ms)) from "diskio" WHERE time > now() - 30m GROUP BY "host","name",time(60s)
 ```
 
 ### Example Output:


### PR DESCRIPTION
I got the documented equation wrong for calculating the average queue depth. I based it off [the equation in iostat](https://github.com/sysstat/sysstat/blob/33557c3db463ac6efb337a67dd5f099609d62b30/iostat.c#L1042:L1044), but the iostat `/1000` was for the time unit conversion. For us this is handled by the `derivative(..., 1ms)`.

Demonstration of the correct equation:
![image](https://user-images.githubusercontent.com/1826947/31519325-178a370a-af70-11e7-87d5-93d436ab6281.png)


```
# iostat -t -d -x 15 /dev/sdb
Linux 3.10.0-514.21.2.el7.x86_64 (fll2gdbs10stg) 	10/12/17 	_x86_64_	(2 CPU)

...

10/12/17 17:08:32
Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
sdb               0.00     4.47 1479.13   12.33 756996.80   117.33  1015.26     9.39    6.30    6.34    1.26   0.65  96.96

10/12/17 17:08:47
Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
sdb               0.00     3.13 1602.20   13.07 820326.40   129.87  1015.88    10.37    6.42    6.47    0.91   0.60  97.19

10/12/17 17:09:02
Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
sdb               0.00     2.60 1741.87   10.80 891801.87   105.07  1017.77    10.57    6.03    6.06    0.83   0.55  96.77
```