### PR TITLE
Improved Cloudwatch output plugin Connect()

### DIFF
--- a/plugins/outputs/cloudwatch/README.md
+++ b/plugins/outputs/cloudwatch/README.md
@@ -13,6 +13,8 @@ API endpoint. In the following order the plugin will attempt to authenticate.
 5. [Shared Credentials](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file)
 6. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
+The IAM user needs only the `cloudwatch:PutMetricData` permission.
+
 ## Config
 
 For this output plugin to function correctly the following variables

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/sts"
 
 	"github.com/influxdata/telegraf"
 	internalaws "github.com/influxdata/telegraf/internal/config/aws"
@@ -71,21 +72,20 @@ func (c *CloudWatch) Connect() error {
 	}
 	configProvider := credentialConfig.Credentials()
 
-	svc := cloudwatch.New(configProvider)
+	stsService := sts.New(configProvider)
 
-	params := &cloudwatch.ListMetricsInput{
-		Namespace: aws.String(c.Namespace),
-	}
+	params := &sts.GetSessionTokenInput{}
 
-	_, err := svc.ListMetrics(params) // Try a read-only call to test connection.
+	_, err := stsService.GetSessionToken(params)
 
 	if err != nil {
-		log.Printf("E! cloudwatch: Error in ListMetrics API call : %+v \n", err.Error())
+		log.Printf("E! cloudwatch: Cannot use credentials to connect to AWS : %+v \n", err.Error())
+		return err
 	}
 
-	c.svc = svc
+	c.svc = cloudwatch.New(configProvider)
 
-	return err
+	return nil
 }
 
 func (c *CloudWatch) Close() error {


### PR DESCRIPTION
Fixes #3319. Use STS to validate the provided credentials work, rather than `ListMetricData` which requires a separate permission, and document the required permission.

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

I'm not sure about unit tests since none exist using mock AWS, but I did some manual testing.

I made a test IAM user with only `cloudwatch:PutMetricData` permission, policy:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "cloudwatch:PutMetricData"
            ],
            "Resource": [
                "*"
            ]
        }
    ]
}
```

I then used its access key as environment variables locally and ran telegraf in this environment, with this config:

```ini
[agent]
  debug = "true"

[[outputs.cloudwatch]]
  region = "eu-west-1"
  namespace = "InfluxData/Telegraf"

[[inputs.cpu]]
```

I then successfully saw data flushed when running telegraf like so:

```
$ ./telegraf --config test.conf
2017-10-12T22:23:07Z D! Attempting connection to output: cloudwatch
2017-10-12T22:23:07Z D! Successfully connected to output: cloudwatch
2017-10-12T22:23:07Z I! Starting Telegraf v1.5.0~c74c29b1
2017-10-12T22:23:07Z I! Loaded outputs: cloudwatch
2017-10-12T22:23:07Z I! Loaded inputs: inputs.cpu
2017-10-12T22:23:07Z I! Tags enabled: host=Adams-MacBook-Pro-2.local
2017-10-12T22:23:07Z I! Agent Config: Interval:10s, Quiet:false, Hostname:"Adams-MacBook-Pro-2.local", Flush Interval:10s
2017-10-12T22:23:20Z D! Output [cloudwatch] buffer fullness: 9 / 10000 metrics.
2017-10-12T22:23:21Z D! Output [cloudwatch] wrote batch of 9 metrics in 976.776485ms
^C2017-10-12T22:23:26Z I! Hang on, flushing any cached metrics before shutdown
2017-10-12T22:23:26Z D! Output [cloudwatch] buffer fullness: 0 / 10000 metrics.
```

And I also checked with bad credentials and saw the error message:

```
$ AWS_ACCESS_KEY_ID=foobar ./telegraf --config test.conf
2017-10-12T22:24:50Z E! cloudwatch: Cannot use credentials to connect to AWS : InvalidClientTokenId: The security token included in the request is invalid.
    status code: 403, request id: 2824d227-af9c-11e7-aa9b-f5e6ab3e0c4c
2017-10-12T22:24:50Z E! Failed to connect to output cloudwatch, retrying in 15s, error was 'InvalidClientTokenId: The security token included in the request is invalid.
    status code: 403, request id: 2824d227-af9c-11e7-aa9b-f5e6ab3e0c4c'
```
