### PR TITLE
Fix prom client output

### DIFF
--- a/accumulator.go
+++ b/accumulator.go
@@ -28,6 +28,18 @@ type Accumulator interface {
 		tags map[string]string,
 		t ...time.Time)
 
+	// AddSummary is the same as AddFields, but will add the metric as a "Summary" type
+	AddSummary(measurement string,
+		fields map[string]interface{},
+		tags map[string]string,
+		t ...time.Time)
+
+	// AddHistogram is the same as AddFields, but will add the metric as a "Histogram" type
+	AddHistogram(measurement string,
+		fields map[string]interface{},
+		tags map[string]string,
+		t ...time.Time)
+
 	SetPrecision(precision, interval time.Duration)
 
 	AddError(err error)

--- a/agent/accumulator.go
+++ b/agent/accumulator.go
@@ -76,6 +76,28 @@ func (ac *accumulator) AddCounter(
 	}
 }
 
+func (ac *accumulator) AddSummary(
+	measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+	t ...time.Time,
+) {
+	if m := ac.maker.MakeMetric(measurement, fields, tags, telegraf.Summary, ac.getTime(t)); m != nil {
+		ac.metrics <- m
+	}
+}
+
+func (ac *accumulator) AddHistogram(
+	measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+	t ...time.Time,
+) {
+	if m := ac.maker.MakeMetric(measurement, fields, tags, telegraf.Histogram, ac.getTime(t)); m != nil {
+		ac.metrics <- m
+	}
+}
+
 // AddError passes a runtime error to the accumulator.
 // The error will be tagged with the plugin name and written to the log.
 func (ac *accumulator) AddError(err error) {

--- a/metric.go
+++ b/metric.go
@@ -13,6 +13,8 @@ const (
 	Counter
 	Gauge
 	Untyped
+	Summary
+	Histogram
 )
 
 type Metric interface {

--- a/plugins/inputs/prometheus/parser.go
+++ b/plugins/inputs/prometheus/parser.go
@@ -103,6 +103,10 @@ func valueType(mt dto.MetricType) telegraf.ValueType {
 		return telegraf.Counter
 	case dto.MetricType_GAUGE:
 		return telegraf.Gauge
+	case dto.MetricType_SUMMARY:
+		return telegraf.Summary
+	case dto.MetricType_HISTOGRAM:
+		return telegraf.Histogram
 	default:
 		return telegraf.Untyped
 	}
@@ -145,11 +149,11 @@ func getNameAndValue(m *dto.Metric) map[string]interface{} {
 			fields["gauge"] = float64(m.GetGauge().GetValue())
 		}
 	} else if m.Counter != nil {
-		if !math.IsNaN(m.GetGauge().GetValue()) {
+		if !math.IsNaN(m.GetCounter().GetValue()) {
 			fields["counter"] = float64(m.GetCounter().GetValue())
 		}
 	} else if m.Untyped != nil {
-		if !math.IsNaN(m.GetGauge().GetValue()) {
+		if !math.IsNaN(m.GetUntyped().GetValue()) {
 			fields["value"] = float64(m.GetUntyped().GetValue())
 		}
 	}

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -224,6 +224,10 @@ func (p *Prometheus) gatherURL(url UrlAndAddress, acc telegraf.Accumulator) erro
 			acc.AddCounter(metric.Name(), metric.Fields(), tags, metric.Time())
 		case telegraf.Gauge:
 			acc.AddGauge(metric.Name(), metric.Fields(), tags, metric.Time())
+		case telegraf.Summary:
+			acc.AddSummary(metric.Name(), metric.Fields(), tags, metric.Time())
+		case telegraf.Histogram:
+			acc.AddHistogram(metric.Name(), metric.Fields(), tags, metric.Time())
 		default:
 			acc.AddFields(metric.Name(), metric.Fields(), tags, metric.Time())
 		}

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -122,6 +122,24 @@ func (a *Accumulator) AddMetrics(metrics []telegraf.Metric) {
 	}
 }
 
+func (a *Accumulator) AddSummary(
+	measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+	timestamp ...time.Time,
+) {
+	a.AddFields(measurement, fields, tags, timestamp...)
+}
+
+func (a *Accumulator) AddHistogram(
+	measurement string,
+	fields map[string]interface{},
+	tags map[string]string,
+	timestamp ...time.Time,
+) {
+	a.AddFields(measurement, fields, tags, timestamp...)
+}
+
 // AddError appends the given error to Accumulator.Errors.
 func (a *Accumulator) AddError(err error) {
 	if err == nil {


### PR DESCRIPTION
### Required for all PRs:

- [X ] Signed [CLA](https://influxdata.com/community/cla/).
- [X ] Associated README.md updated.
- [X ] Has appropriate unit tests.

UPDATE: After the merge of #3351, this PR now only addresses the handling of history and summary types.

---

This contains a couple fixes for the prometheus_client output.

- The prometheus.http module is deprecated.  Updated to use prometheus/promhttp.
- The plugin renamed metrics by appending field names, even when that didn't make sense.
  For example, when using the prometheus input plugin, field names of "counter" and "gauge" were created (instead of just "value"), and then the metrics would have "counter" and "gauge" appended to them on the output.
- When the prometheus input was used, the histogram and summary types were not handled gracefully.  For histograms, bucket names were appended to the metrics and lost all meaning.  For summarys, quantile names were appended to the metrics.

Upon de-mangling the metric names, it became apparent that when using the prometheus input in association with the prometheus output that the metrics created by the prometheus client library were in direct conflict with the same metrics from other scraped prometheus clients.  (go_* and process_*).  The conflict is not from the metric name itself, but the combination of the metric and the "HELP" text.  The internal prometheus client library would generate the metrics with its default (and appropriate) HELP text, and then when a prometheus target was scraped and output by the prometheus client library in the plugin, it gives those same metric names a generic HELP text (because that text isn't saved anywhere in the telegraf data structures).  Since the original HELP text doesn't match the generic HELP text for the same metric, the prometheus client library rejects it.

The fix presented is to disable to the collection of the internal client library metrics.  They would be a bit conflated with the main telegraf process anyway, and not sure if they'd be directly meaningful.

However, I've put the unregistering of the metrics under the control of a configuration variable, which is false by default so as not to adversely affect existing installations any more than necessary.
