### PR TITLE
Fix CPU system plugin that get stuck after suspend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [#3136](https://github.com/influxdata/telegraf/issues/3136): Fix webhooks input address in use during reload.
 - [#3258](https://github.com/influxdata/telegraf/issues/3258): Unlock Statsd when stopping to prevent deadlock.
 - [#3319](https://github.com/influxdata/telegraf/issues/3319): Fix cloudwatch output requires unneeded permissions.
+- [#3342](https://github.com/influxdata/telegraf/pull/3342): Fix CPU input plugin stuck after suspend on Linux.
 
 ## v1.4.3 [unreleased]
 

--- a/plugins/inputs/system/cpu.go
+++ b/plugins/inputs/system/cpu.go
@@ -96,7 +96,8 @@ func (s *CPUStats) Gather(acc telegraf.Accumulator) error {
 		totalDelta := total - lastTotal
 
 		if totalDelta < 0 {
-			return fmt.Errorf("Error: current total CPU time is less than previous total CPU time")
+			err = fmt.Errorf("Error: current total CPU time is less than previous total CPU time")
+			break
 		}
 
 		if totalDelta == 0 {
@@ -126,7 +127,7 @@ func (s *CPUStats) Gather(acc telegraf.Accumulator) error {
 		s.lastStats[cts.CPU] = cts
 	}
 
-	return nil
+	return err
 }
 
 func totalCpuTime(t cpu.TimesStat) float64 {

--- a/plugins/inputs/system/cpu_test.go
+++ b/plugins/inputs/system/cpu_test.go
@@ -184,3 +184,72 @@ func TestCPUCountIncrease(t *testing.T) {
 	err = cs.Gather(&acc)
 	require.NoError(t, err)
 }
+
+// TestCPUTimesDecrease tests that telegraf continue to works after
+// CPU times decrease, which seems to occur when Linux system is suspended.
+func TestCPUTimesDecrease(t *testing.T) {
+	var mps MockPS
+	defer mps.AssertExpectations(t)
+	var acc testutil.Accumulator
+
+	cts := cpu.TimesStat{
+		CPU:    "cpu0",
+		User:   18,
+		Idle:   80,
+		Iowait: 2,
+	}
+
+	cts2 := cpu.TimesStat{
+		CPU:    "cpu0",
+		User:   38, // increased by 20
+		Idle:   40, // decreased by 40
+		Iowait: 1,  // decreased by 1
+	}
+
+	cts3 := cpu.TimesStat{
+		CPU:    "cpu0",
+		User:   56,  // increased by 18
+		Idle:   120, // increased by 80
+		Iowait: 3,   // increased by 2
+	}
+
+	mps.On("CPUTimes").Return([]cpu.TimesStat{cts}, nil)
+
+	cs := NewCPUStats(&mps)
+
+	cputags := map[string]string{
+		"cpu": "cpu0",
+	}
+
+	err := cs.Gather(&acc)
+	require.NoError(t, err)
+
+	// Computed values are checked with delta > 0 becasue of floating point arithmatic
+	// imprecision
+	assertContainsTaggedFloat(t, &acc, "cpu", "time_user", 18, 0, cputags)
+	assertContainsTaggedFloat(t, &acc, "cpu", "time_idle", 80, 0, cputags)
+	assertContainsTaggedFloat(t, &acc, "cpu", "time_iowait", 2, 0, cputags)
+
+	mps2 := MockPS{}
+	mps2.On("CPUTimes").Return([]cpu.TimesStat{cts2}, nil)
+	cs.ps = &mps2
+
+	// CPU times decreased. An error should be raised
+	err = cs.Gather(&acc)
+	require.Error(t, err)
+
+	mps3 := MockPS{}
+	mps3.On("CPUTimes").Return([]cpu.TimesStat{cts3}, nil)
+	cs.ps = &mps3
+
+	err = cs.Gather(&acc)
+	require.NoError(t, err)
+
+	assertContainsTaggedFloat(t, &acc, "cpu", "time_user", 56, 0, cputags)
+	assertContainsTaggedFloat(t, &acc, "cpu", "time_idle", 120, 0, cputags)
+	assertContainsTaggedFloat(t, &acc, "cpu", "time_iowait", 3, 0, cputags)
+
+	assertContainsTaggedFloat(t, &acc, "cpu", "usage_user", 18, 0.0005, cputags)
+	assertContainsTaggedFloat(t, &acc, "cpu", "usage_idle", 80, 0.0005, cputags)
+	assertContainsTaggedFloat(t, &acc, "cpu", "usage_iowait", 2, 0.0005, cputags)
+}


### PR DESCRIPTION
- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.

This fix an issue when a Linux system is suspended, after resuming, Telegraf no longer send CPU metrics and log:
```
oct. 16 11:09:12 xps-pierref telegraf[8363]: 2017-10-16T09:09:12Z E! Error in plugin [inputs.cpu]: Error: current total CPU time is less than previous total CPU time
oct. 16 11:09:22 xps-pierref telegraf[8363]: 2017-10-16T09:09:22Z E! Error in plugin [inputs.cpu]: Error: current total CPU time is less than previous total CPU time
[...]
```

This occur after a suspend, because /proc/stat counter decrease ! [1]
On previous Telegraf version this issue did not occured  because it updated lastStats and complained only ONCE. PR #3306 [changed this behavior](https://github.com/influxdata/telegraf/pull/3306/files#diff-ad280c07b9dc22406895aad96d9b41e7L95).

This PR restore the old behavior: If total CPU time decrease, still update lastStat (so next metrics gather should work) and complain.



[1]: Result of cat /proc/stat before and after a system suspend:
```
cpu  136963790 9176378 61945301 138764848 806738 0 2044968 0 0 0
cpu0 34341664 2336158 15383085 138710292 803998 0 682240 0 0 0
cpu1 34505950 2339404 15716869 17092 898 0 481592 0 0 0
cpu2 34076860 2258930 15290613 19244 944 0 518477 0 0 0
cpu3 34039314 2241884 15554733 18218 896 0 362658 0 0 0

## After a suspend of ~30 seconds

cpu  136964299 9176378 61945616 138711862 804044 0 2044977 0 0 0
cpu0 34341802 2336158 15383149 138710907 804014 0 682247 0 0 0
cpu1 34506062 2339404 15716962 303 30 0 481594 0 0 0
cpu2 34076987 2258930 15290694 325 0 0 518477 0 0 0
cpu3 34039446 2241884 15554810 326 0 0 362658 0 0 0
```
4th field (idle) and 5th field (iowait) of cpu1, cpu2, cpu3 are reseted to 0 after suspend. Which cause them for decrease.