### PR TITLE
Add "value" output data_format

### DIFF
--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/influxdata/telegraf/plugins/serializers/json"
+	"github.com/influxdata/telegraf/plugins/serializers/value"
 )
 
 // SerializerOutput is an interface for output plugins that are able to
@@ -55,6 +56,8 @@ func NewSerializer(config *Config) (Serializer, error) {
 		serializer, err = NewGraphiteSerializer(config.Prefix, config.Template)
 	case "json":
 		serializer, err = NewJsonSerializer(config.TimestampUnits)
+	case "value":
+		serializer, err = NewValueSerializer()
 	default:
 		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
 	}
@@ -67,6 +70,10 @@ func NewJsonSerializer(timestampUnits time.Duration) (Serializer, error) {
 
 func NewInfluxSerializer() (Serializer, error) {
 	return &influx.InfluxSerializer{}, nil
+}
+
+func NewValueSerializer() (Serializer, error) {
+	return &value.ValueSerializer{}, nil
 }
 
 func NewGraphiteSerializer(prefix, template string) (Serializer, error) {

--- a/plugins/serializers/value/value.go
+++ b/plugins/serializers/value/value.go
@@ -1,0 +1,14 @@
+package value
+
+import (
+	"fmt"
+	"github.com/influxdata/telegraf"
+)
+
+type ValueSerializer struct {
+}
+
+func (s *ValueSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
+	result := fmt.Sprintf("%v", metric.Fields()["value"])
+	return []byte(result), nil
+}


### PR DESCRIPTION
This PR add feature to output data "as is"

For example:

```toml
[[outputs.file]]
  files = ["stdout", "/tmp/metrics.out"]
  data_format = "value"
```

Will just print as received (`value` field)

User cases:
* Kafka mirror
* Process logs and saving local copy (for debugging or archiving)
* Forwarding data without modifications

It's just a prof of concept (i'm new to go lang), if you guys like this idea I will add test and documentation.

Btw will it be useful to send any fields other then `value`? (hard coded now)