### PR TITLE
Fix token usage in consul input plugin (#3375)

### DIFF
--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -69,6 +69,10 @@ func (c *Consul) createAPIClient() (*api.Client, error) {
 		config.Datacenter = c.Datacentre
 	}
 
+	if c.Token != "" {
+		config.Token = c.Token
+	}
+
 	if c.Username != "" {
 		config.HttpAuth = &api.HttpBasicAuth{
 			Username: c.Username,

--- a/plugins/inputs/consul/consul_test.go
+++ b/plugins/inputs/consul/consul_test.go
@@ -20,7 +20,7 @@ var sampleChecks = []*api.HealthCheck{
 	},
 }
 
-func TestGatherHealtCheck(t *testing.T) {
+func TestGatherHealthCheck(t *testing.T) {
 	expectedFields := map[string]interface{}{
 		"check_name": "foo.health",
 		"status":     "passing",


### PR DESCRIPTION
Consul input plugin has been fixed to set ACL token in API client config so that it will be included into API requests as `X-Consul-Token` header.

Closes #3375