### PR TITLE
Performance tweaks for internal/buffer

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -14,9 +14,12 @@ var (
 
 // Buffer is an object for storing metrics in a circular buffer.
 type Buffer struct {
-	buf chan telegraf.Metric
-
-	mu sync.Mutex
+	sync.Mutex
+	buf   []telegraf.Metric
+	first int
+	last  int
+	size  int
+	empty bool
 }
 
 // NewBuffer returns a Buffer
@@ -24,47 +27,98 @@ type Buffer struct {
 //   called when the buffer is full, then the oldest metric(s) will be dropped.
 func NewBuffer(size int) *Buffer {
 	return &Buffer{
-		buf: make(chan telegraf.Metric, size),
+		buf:   make([]telegraf.Metric, size),
+		first: 0,
+		last:  0,
+		size:  size,
+		empty: true,
 	}
 }
 
 // IsEmpty returns true if Buffer is empty.
 func (b *Buffer) IsEmpty() bool {
-	return len(b.buf) == 0
+	return b.empty
 }
 
 // Len returns the current length of the buffer.
 func (b *Buffer) Len() int {
-	return len(b.buf)
+	if b.empty {
+		return 0
+	} else if b.first <= b.last {
+		return b.last - b.first + 1
+	}
+	// Spans the end of array.
+	// size - gap in the middle
+	return b.size - (b.first - b.last - 1) // size - gap
+}
+
+func (b *Buffer) push(m telegraf.Metric) {
+	// Empty
+	if b.empty {
+		b.last = b.first // Reset
+		b.buf[b.last] = m
+		b.empty = false
+		return
+	}
+
+	b.last++
+	b.last %= b.size
+
+	// Full
+	if b.first == b.last {
+		MetricsDropped.Incr(1)
+		b.first = (b.first + 1) % b.size
+	}
+	b.buf[b.last] = m
 }
 
 // Add adds metrics to the buffer.
 func (b *Buffer) Add(metrics ...telegraf.Metric) {
-	b.mu.Lock()
-	for i, _ := range metrics {
+	b.Lock()
+	defer b.Unlock()
+	for i := range metrics {
 		MetricsWritten.Incr(1)
-		select {
-		case b.buf <- metrics[i]:
-		default:
-			MetricsDropped.Incr(1)
-			<-b.buf
-			b.buf <- metrics[i]
-		}
+		b.push(metrics[i])
 	}
-	b.mu.Unlock()
 }
 
 // Batch returns a batch of metrics of size batchSize.
 // the batch will be of maximum length batchSize. It can be less than batchSize,
 // if the length of Buffer is less than batchSize.
 func (b *Buffer) Batch(batchSize int) []telegraf.Metric {
-	b.mu.Lock()
-	n := min(len(b.buf), batchSize)
-	out := make([]telegraf.Metric, n)
-	for i := 0; i < n; i++ {
-		out[i] = <-b.buf
+	b.Lock()
+	defer b.Unlock()
+	outLen := min(b.Len(), batchSize)
+	out := make([]telegraf.Metric, outLen)
+	if outLen == 0 {
+		return out
 	}
-	b.mu.Unlock()
+
+	// We copy everything right of first up to last, count or end
+	// b.last >= rightInd || b.last < b.first
+	// therefore wont copy past b.last
+	rightInd := min(b.size, b.first+outLen) - 1
+
+	copyCount := copy(out, b.buf[b.first:rightInd+1])
+
+	// We've emptied the ring
+	if rightInd == b.last {
+		b.empty = true
+	}
+	b.first = rightInd + 1
+	b.first %= b.size
+
+	// We circle back for the rest
+	if copyCount < outLen {
+		right := min(b.last, outLen-copyCount)
+		copy(out[copyCount:], b.buf[b.first:right+1])
+		// We've emptied the ring
+		if right == b.last {
+			b.empty = true
+		}
+		b.first = right + 1
+		b.first %= b.size
+	}
 	return out
 }
 


### PR DESCRIPTION
### Required for all PRs:

- [ x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated. (if plugin)
- [x ] Has appropriate unit tests.

Benchmark results for internal/buffer
```
Before:
$ go test -run='^$' -bench=.   -benchmem -race
goos: darwin
goarch: amd64
pkg: github.com/influxdata/telegraf/internal/buffer
BenchmarkBufferBatch5Add-8                   	  200000	      5454 ns/op	       2 B/op	       0 allocs/op
BenchmarkBufferBigInfrequentBatchCatchup-8   	 1000000	      1065 ns/op	       1 B/op	       0 allocs/op
BenchmarkBufferOftenBatch-8                  	 1000000	      1892 ns/op	      16 B/op	       0 allocs/op
BenchmarkBufferAlmostBatch-8                 	 1000000	      1543 ns/op	      14 B/op	       0 allocs/op
BenchmarkBufferSlowBatch-8                   	 1000000	      1381 ns/op	       1 B/op	       0 allocs/op
BenchmarkBufferBatchNoDrop-8                 	 1000000	      1792 ns/op	      16 B/op	       0 allocs/op
BenchmarkBufferCatchup-8                     	 1000000	      1230 ns/op	       0 B/op	       0 allocs/op
BenchmarkAddMetrics-8                        	 1000000	      1229 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/influxdata/telegraf/internal/buffer	13.145s

After:
$ go test -run='^$' -bench=.   -benchmem -race
goos: darwin
goarch: amd64
pkg: github.com/influxdata/telegraf/internal/buffer
BenchmarkBufferBatch5Add-8                   	 1000000	      2348 ns/op	       1 B/op	       0 allocs/op
BenchmarkBufferBigInfrequentBatchCatchup-8   	 2000000	       753 ns/op	       1 B/op	       0 allocs/op
BenchmarkBufferOftenBatch-8                  	 2000000	       747 ns/op	      16 B/op	       0 allocs/op
BenchmarkBufferAlmostBatch-8                 	 2000000	       700 ns/op	      14 B/op	       0 allocs/op
BenchmarkBufferSlowBatch-8                   	 2000000	       784 ns/op	       1 B/op	       0 allocs/op
BenchmarkBufferBatchNoDrop-8                 	 2000000	       771 ns/op	      16 B/op	       0 allocs/op
BenchmarkBufferCatchup-8                     	 2000000	       801 ns/op	       0 B/op	       0 allocs/op
BenchmarkAddMetrics-8                        	 2000000	       756 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/influxdata/telegraf/internal/buffer	20.158s


Diff required to make channel based buffer not deadlock:

$ git diff master -- buffer.go
diff --git a/internal/buffer/buffer.go b/internal/buffer/buffer.go
index cdc81fed..174d6632 100644
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -46,9 +46,14 @@ func (b *Buffer) Add(metrics ...telegraf.Metric) {
                case b.buf <- metrics[i]:
                default:
                        b.mu.Lock()
-                       MetricsDropped.Incr(1)
-                       <-b.buf
-                       b.buf <- metrics[i]
+                       select {
+                       case b.buf <- metrics[i]:
+                       case <-b.buf:
+                               MetricsDropped.Incr(1)
+                               b.buf <- metrics[i]
+                       }
                        b.mu.Unlock()
                }
        }

```
