### PR TITLE
prometheus_client path is not defined error

### DIFF
--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -10,9 +10,6 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
   # Address to listen on
   listen = ":9273"
 
-  # Path to publish the metrics on, defaults to /metrics
-  path = "/metrics"   
-
   # Expiration interval for each metric. 0 == no expiration
   expiration_interval = "60s"
 ```


### PR DESCRIPTION
Adding the path string into my config file, produces an error.

telegraf.conf
```
[[outputs.prometheus_client]]
  listen = ":9273"
  path = "/metrics"
  expiration_interval = "60s"
```
root@try:/etc/telegraf# telegraf --test
```
I! Using config file: /etc/telegraf/telegraf.conf
E! Error parsing /etc/telegraf/telegraf.conf, line 19: field corresponding to `path' is not defined in `*prometheus_client.PrometheusClient'
```
