### PR TITLE
Add instance option to varnish plugin

### DIFF
--- a/plugins/inputs/varnish/varnish_test.go
+++ b/plugins/inputs/varnish/varnish_test.go
@@ -5,14 +5,15 @@ package varnish
 import (
 	"bytes"
 	"fmt"
-	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
-func fakeVarnishStat(output string, useSudo bool) func(string, bool) (*bytes.Buffer, error) {
-	return func(string, bool) (*bytes.Buffer, error) {
+func fakeVarnishStat(output string, useSudo bool, InstanceName string) func(string, bool, string) (*bytes.Buffer, error) {
+	return func(string, bool, string) (*bytes.Buffer, error) {
 		return bytes.NewBuffer([]byte(output)), nil
 	}
 }
@@ -20,7 +21,7 @@ func fakeVarnishStat(output string, useSudo bool) func(string, bool) (*bytes.Buf
 func TestGather(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Varnish{
-		run:   fakeVarnishStat(smOutput, false),
+		run:   fakeVarnishStat(smOutput, false, ""),
 		Stats: []string{"*"},
 	}
 	v.Gather(acc)
@@ -36,7 +37,7 @@ func TestGather(t *testing.T) {
 func TestParseFullOutput(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Varnish{
-		run:   fakeVarnishStat(fullOutput, true),
+		run:   fakeVarnishStat(fullOutput, true, ""),
 		Stats: []string{"*"},
 	}
 	err := v.Gather(acc)
@@ -51,7 +52,7 @@ func TestParseFullOutput(t *testing.T) {
 func TestFilterSomeStats(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Varnish{
-		run:   fakeVarnishStat(fullOutput, false),
+		run:   fakeVarnishStat(fullOutput, false, ""),
 		Stats: []string{"MGT.*", "VBE.*"},
 	}
 	err := v.Gather(acc)
@@ -74,7 +75,7 @@ func TestFieldConfig(t *testing.T) {
 	for fieldCfg, expected := range expect {
 		acc := &testutil.Accumulator{}
 		v := &Varnish{
-			run:   fakeVarnishStat(fullOutput, true),
+			run:   fakeVarnishStat(fullOutput, true, ""),
 			Stats: strings.Split(fieldCfg, ","),
 		}
 		err := v.Gather(acc)


### PR DESCRIPTION
This change add a new configuration option to allow probing of
namespaced varnish instances, usually reached using the '-n' switch on
the varnish cli.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
