### PR TITLE
Fix "su clears ALL environment variables on start

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -140,7 +140,7 @@ case $1 in
         elif which start-stop-daemon > /dev/null 2>&1; then
             start-stop-daemon --chuid $USER:$GROUP --start --quiet --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $config -config-directory $confdir $TELEGRAF_OPTS >>$STDOUT 2>>$STDERR &
         else
-            su -s /bin/sh -c "nohup $daemon -pidfile $pidfile -config $config -config-directory $confdir $TELEGRAF_OPTS >>$STDOUT 2>>$STDERR &" $USER
+            su - -s /bin/sh -c "nohup $daemon -pidfile $pidfile -config $config -config-directory $confdir $TELEGRAF_OPTS >>$STDOUT 2>>$STDERR &" $USER
         fi
         log_success_msg "$name process was started"
         ;;


### PR DESCRIPTION
On Amazon linux init system is upstart.
su clears ALL environment variables except HOME, SHELL, USER,  LOGNAME (man su)
So current scripts on startup execute line 143 "su -s /bin/sh -c "nohup $daemon ..."
Whis clears environment variables for telegraf then it starts. So impossible to use environment variables in telegraf config.
Fix add option to su to save variables

