### PR TITLE
Fix typos in comments across repository

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -252,7 +252,7 @@ func (a *Agent) flusher(shutdown chan struct{}, metricC chan telegraf.Metric, ag
 	// the flusher will flush after metrics are collected.
 	time.Sleep(time.Millisecond * 300)
 
-	// create an output metric channel and a gorouting that continously passes
+	// create an output metric channel and a gorouting that continuously passes
 	// each metric onto the output plugins & aggregators.
 	outMetricC := make(chan telegraf.Metric, 100)
 	var wg sync.WaitGroup

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,7 +126,7 @@ type AgentConfig struct {
 
 	// TODO(cam): Remove UTC and parameter, they are no longer
 	// valid for the agent config. Leaving them here for now for backwards-
-	// compatability
+	// compatibility
 	UTC bool `toml:"utc"`
 
 	// Debug is the option for running in debug mode
@@ -683,7 +683,7 @@ func (c *Config) LoadConfig(path string) error {
 }
 
 // trimBOM trims the Byte-Order-Marks from the beginning of the file.
-// this is for Windows compatability only.
+// this is for Windows compatibility only.
 // see https://github.com/influxdata/telegraf/issues/1378
 func trimBOM(f []byte) []byte {
 	return bytes.TrimPrefix(f, []byte("\xef\xbb\xbf"))

--- a/metric/parse.go
+++ b/metric/parse.go
@@ -647,7 +647,7 @@ func skipWhitespace(buf []byte, i int) int {
 }
 
 // makeError is a helper function for making a metric parsing error.
-//   reason is the reason that the error occured.
+//   reason is the reason why the error occurred.
 //   buf should be the current buffer we are parsing.
 //   i is the current index, to give some context on where in the buffer we are.
 func makeError(reason string, buf []byte, i int) error {

--- a/metric/reader_test.go
+++ b/metric/reader_test.go
@@ -181,7 +181,7 @@ func TestMetricReader_SplitWithExactLengthSplit(t *testing.T) {
 	}
 }
 
-// Regresssion test for when a metric requires to be split and one of the
+// Regression test for when a metric requires to be split and one of the
 // split metrics is larger than the buffer.
 //
 // Previously the metric index would be set incorrectly causing a panic.
@@ -218,7 +218,7 @@ func TestMetricReader_SplitOverflowOversized(t *testing.T) {
 	}
 }
 
-// Regresssion test for when a split metric exactly fits in the buffer.
+// Regression test for when a split metric exactly fits in the buffer.
 //
 // Previously the metric would be overflow split when not required.
 func TestMetricReader_SplitOverflowUneeded(t *testing.T) {

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -92,7 +92,7 @@ func (c *CloudWatch) SampleConfig() string {
   ## Collection Delay (required - must account for metrics availability via CloudWatch API)
   delay = "5m"
 
-  ## Recomended: use metric 'interval' that is a multiple of 'period' to avoid
+  ## Recommended: use metric 'interval' that is a multiple of 'period' to avoid
   ## gaps or overlap in pulled data
   interval = "5m"
 

--- a/plugins/inputs/couchbase/couchbase.go
+++ b/plugins/inputs/couchbase/couchbase.go
@@ -21,7 +21,7 @@ var sampleConfig = `
   ##    http://admin:secret@couchbase-0.example.com:8091/
   ##
   ## If no servers are specified, then localhost is used as the host.
-  ## If no protocol is specifed, HTTP is used.
+  ## If no protocol is specified, HTTP is used.
   ## If no port is specified, 8091 is used.
   servers = ["http://localhost:8091"]
 `

--- a/plugins/inputs/dns_query/dns_query.go
+++ b/plugins/inputs/dns_query/dns_query.go
@@ -17,7 +17,7 @@ type DnsQuery struct {
 	// Domains or subdomains to query
 	Domains []string
 
-	// Network protocl name
+	// Network protocol name
 	Network string
 
 	// Server to query

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -35,7 +35,7 @@ var sampleConfig = `
   ##
   # servers = ["USERID:PASSW0RD@lan(192.168.1.1)"]
 
-  ## Recomended: use metric 'interval' that is a multiple of 'timeout' to avoid
+  ## Recommended: use metric 'interval' that is a multiple of 'timeout' to avoid
   ## gaps or overlap in pulled data
   interval = "30s"
 

--- a/plugins/inputs/iptables/iptables_test.go
+++ b/plugins/inputs/iptables/iptables_test.go
@@ -81,7 +81,7 @@ func TestIptables_Gather(t *testing.T) {
 		                K     4520 RETURN     tcp  --  *      *       0.0.0.0/0            0.0.0.0/0
             `},
 		},
-		{ // 8 - Multiple rows, multipe chains => no error
+		{ // 8 - Multiple rows, multiple chains => no error
 			table:  "filter",
 			chains: []string{"INPUT", "FORWARD"},
 			values: []string{

--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -367,7 +367,7 @@ func getMetrics(role Role, group string) []string {
 	ret, ok := m[group]
 
 	if !ok {
-		log.Printf("I! [mesos] Unkown %s metrics group: %s\n", role, group)
+		log.Printf("I! [mesos] Unknown %s metrics group: %s\n", role, group)
 		return []string{}
 	}
 

--- a/plugins/inputs/minecraft/internal/rcon/rcon.go
+++ b/plugins/inputs/minecraft/internal/rcon/rcon.go
@@ -197,7 +197,7 @@ func (c *Client) Send(typ int32, command string) (response *Packet, err error) {
 }
 
 // NewClient creates a new Client type, creating the connection
-// to the server specified by the host and port arguements. If
+// to the server specified by the host and port arguments. If
 // the connection fails, an error is returned.
 func NewClient(host string, port int) (client *Client, err error) {
 	client = new(Client)

--- a/plugins/inputs/minecraft/minecraft.go
+++ b/plugins/inputs/minecraft/minecraft.go
@@ -47,7 +47,7 @@ func (s *Minecraft) SampleConfig() string {
 	return sampleConfig
 }
 
-// Gather uses the RCON protocal to collect player and
+// Gather uses the RCON protocol to collect player and
 // scoreboard stats from a minecraft server.
 //var hasClient bool = false
 func (s *Minecraft) Gather(acc telegraf.Accumulator) error {

--- a/plugins/inputs/minecraft/rcon.go
+++ b/plugins/inputs/minecraft/rcon.go
@@ -76,7 +76,7 @@ func newClient(server, port string) (*rcon.Client, error) {
 	return client, nil
 }
 
-// Gather recieves all player scoreboard information and returns it per player.
+// Gather receives all player scoreboard information and returns it per player.
 func (r *RCON) Gather(producer RCONClientProducer) ([]string, error) {
 	if r.client == nil {
 		var err error

--- a/plugins/inputs/phpfpm/fcgi_client.go
+++ b/plugins/inputs/phpfpm/fcgi_client.go
@@ -59,7 +59,7 @@ func (client *conn) Request(
 	rec := &record{}
 	var err1 error
 
-	// recive untill EOF or FCGI_END_REQUEST
+	// recive until EOF or FCGI_END_REQUEST
 READ_LOOP:
 	for {
 		err1 = rec.read(client.rwc)

--- a/plugins/inputs/phpfpm/phpfpm_test.go
+++ b/plugins/inputs/phpfpm/phpfpm_test.go
@@ -62,7 +62,7 @@ func TestPhpFpmGeneratesMetrics_From_Fcgi(t *testing.T) {
 	// Let OS find an available port
 	tcp, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatal("Cannot initalize test server")
+		t.Fatal("Cannot initialize test server")
 	}
 	defer tcp.Close()
 
@@ -106,7 +106,7 @@ func TestPhpFpmGeneratesMetrics_From_Socket(t *testing.T) {
 	binary.Read(rand.Reader, binary.LittleEndian, &randomNumber)
 	tcp, err := net.Listen("unix", fmt.Sprintf("/tmp/test-fpm%d.sock", randomNumber))
 	if err != nil {
-		t.Fatal("Cannot initalize server on port ")
+		t.Fatal("Cannot initialize server on port ")
 	}
 
 	defer tcp.Close()
@@ -150,7 +150,7 @@ func TestPhpFpmGeneratesMetrics_From_Socket_Custom_Status_Path(t *testing.T) {
 	binary.Read(rand.Reader, binary.LittleEndian, &randomNumber)
 	tcp, err := net.Listen("unix", fmt.Sprintf("/tmp/test-fpm%d.sock", randomNumber))
 	if err != nil {
-		t.Fatal("Cannot initalize server on port ")
+		t.Fatal("Cannot initialize server on port ")
 	}
 
 	defer tcp.Close()

--- a/plugins/inputs/ping/ping_windows.go
+++ b/plugins/inputs/ping/ping_windows.go
@@ -175,7 +175,7 @@ func (p *Ping) Gather(acc telegraf.Accumulator) error {
 			totalTimeout := p.timeout() * float64(p.Count)
 			out, err := p.pingHost(totalTimeout, args...)
 			// ping host return exitcode != 0 also when there was no response from host
-			// but command was execute succesfully
+			// but command was execute successfully
 			if err != nil {
 				// Combine go err + stderr output
 				pendingError = errors.New(strings.TrimSpace(out) + ", " + err.Error())

--- a/plugins/inputs/powerdns/powerdns_test.go
+++ b/plugins/inputs/powerdns/powerdns_test.go
@@ -76,7 +76,7 @@ func TestMemcachedGeneratesMetrics(t *testing.T) {
 	binary.Read(rand.Reader, binary.LittleEndian, &randomNumber)
 	socket, err := net.Listen("unix", fmt.Sprintf("/tmp/pdns%d.controlsocket", randomNumber))
 	if err != nil {
-		t.Fatal("Cannot initalize server on port ")
+		t.Fatal("Cannot initialize server on port ")
 	}
 
 	defer socket.Close()

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -66,7 +66,7 @@ type Statsd struct {
 
 	// MetricSeparator is the separator between parts of the metric name.
 	MetricSeparator string
-	// This flag enables parsing of tags in the dogstatsd extention to the
+	// This flag enables parsing of tags in the dogstatsd extension to the
 	// statsd protocol (http://docs.datadoghq.com/guides/dogstatsd/)
 	ParseDataDogTags bool
 

--- a/plugins/inputs/sysstat/sysstat.go
+++ b/plugins/inputs/sysstat/sysstat.go
@@ -100,7 +100,7 @@ var sampleConfig = `
   #
   #
   ## Options for the sadf command. The values on the left represent the sadf
-  ## options and the values on the right their description (wich are used for
+  ## options and the values on the right their description (which are used for
   ## grouping and prefixing metrics).
   ##
   ## Run 'sar -h' or 'man sar' to find out the supported options for your

--- a/plugins/inputs/system/cpu_test.go
+++ b/plugins/inputs/system/cpu_test.go
@@ -54,7 +54,7 @@ func TestCPUStats(t *testing.T) {
 	err := cs.Gather(&acc)
 	require.NoError(t, err)
 
-	// Computed values are checked with delta > 0 becasue of floating point arithmatic
+	// Computed values are checked with delta > 0 because of floating point arithmatic
 	// imprecision
 	assertContainsTaggedFloat(t, &acc, "cpu", "time_user", 8.8, 0, cputags)
 	assertContainsTaggedFloat(t, &acc, "cpu", "time_system", 8.2, 0, cputags)
@@ -105,7 +105,7 @@ func TestCPUStats(t *testing.T) {
 // specific tags within a certain distance of a given expected value. Asserts a failure
 // if the measurement is of the wrong type, or if no matching measurements are found
 //
-// Paramaters:
+// Parameters:
 //     t *testing.T            : Testing object to use
 //     acc testutil.Accumulator: Accumulator to examine
 //     measurement string      : Name of the measurement to examine
@@ -224,7 +224,7 @@ func TestCPUTimesDecrease(t *testing.T) {
 	err := cs.Gather(&acc)
 	require.NoError(t, err)
 
-	// Computed values are checked with delta > 0 becasue of floating point arithmatic
+	// Computed values are checked with delta > 0 because of floating point arithmatic
 	// imprecision
 	assertContainsTaggedFloat(t, &acc, "cpu", "time_user", 18, 0, cputags)
 	assertContainsTaggedFloat(t, &acc, "cpu", "time_idle", 80, 0, cputags)

--- a/plugins/inputs/win_perf_counters/pdh.go
+++ b/plugins/inputs/win_perf_counters/pdh.go
@@ -347,7 +347,7 @@ func PdhGetFormattedCounterValueDouble(hCounter PDH_HCOUNTER, lpdwType *uint32, 
 //
 //	okPath := "\\Process(*)\\% Processor Time" // notice the wildcard * character
 //
-//	// ommitted all necessary stuff ...
+//	// omitted all necessary stuff ...
 //
 //	var bufSize uint32
 //	var bufCount uint32

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -110,7 +110,7 @@ func (m *Win_PerfCounters) AddItem(query string, objectName string, counter stri
 		ret = PdhAddEnglishCounter(handle, query, 0, &counterHandle)
 	}
 
-	// Call PdhCollectQueryData one time to check existance of the counter
+	// Call PdhCollectQueryData one time to check existence of the counter
 	ret = PdhCollectQueryData(handle)
 	if ret != ERROR_SUCCESS {
 		PdhCloseQuery(handle)

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Graphite struct {
-	// URL is only for backwards compatability
+	// URL is only for backwards compatibility
 	Servers  []string
 	Prefix   string
 	Template string

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -22,7 +22,7 @@ var (
 
 // InfluxDB struct is the primary data structure for the plugin
 type InfluxDB struct {
-	// URL is only for backwards compatability
+	// URL is only for backwards compatibility
 	URL              string
 	URLs             []string `toml:"urls"`
 	Username         string
@@ -100,7 +100,7 @@ func (i *InfluxDB) Connect() error {
 	var urls []string
 	urls = append(urls, i.URLs...)
 
-	// Backward-compatability with single Influx URL config files
+	// Backward-compatibility with single Influx URL config files
 	// This could eventually be removed in favor of specifying the urls as a list
 	if i.URL != "" {
 		urls = append(urls, i.URL)

--- a/plugins/outputs/opentsdb/opentsdb_test.go
+++ b/plugins/outputs/opentsdb/opentsdb_test.go
@@ -183,7 +183,7 @@ func BenchmarkHttpSend(b *testing.B) {
 // 	err = o.Write(testutil.MockMetrics())
 // 	require.NoError(t, err)
 
-// 	// Verify postive and negative test cases of writing data
+// 	// Verify positive and negative test cases of writing data
 // 	metrics := testutil.MockMetrics()
 // 	metrics = append(metrics, testutil.TestMetric(float64(1.0),
 // 		"justametric.float"))

--- a/plugins/outputs/riemann_legacy/riemann.go
+++ b/plugins/outputs/riemann_legacy/riemann.go
@@ -84,7 +84,7 @@ func (r *Riemann) Write(metrics []telegraf.Metric) error {
 
 	var senderr = r.client.SendMulti(events)
 	if senderr != nil {
-		r.Close() // always retuns nil
+		r.Close() // always returns nil
 		return fmt.Errorf("FAILED to send riemann message (will try to reconnect). Error: %s\n",
 			senderr)
 	}


### PR DESCRIPTION
This was fixed running the `misspell` linter in fix mode using `gometalinter`. The exact command I ran was :
```
gometalinter --vendor --disable-all -E misspell --linter='misspell:misspell -w {path}:^(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$' ./...
```
Plus some typo were fixed by hand on top of it.
I reviewed the diff, no code is affected (just some error logs).

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
