### PR TITLE
Updating net_response as discussed in #2990

### DIFF
--- a/plugins/inputs/net_response/README.md
+++ b/plugins/inputs/net_response/README.md
@@ -59,7 +59,7 @@ It can also check response text.
 
 - net_response
     - response_time (float, seconds)
-    - result_type (string) # success, timeout, connection_failed, read_failed, string_mismatch
+    - result_type (int) # success 0, failure 1
     - [**DEPRECATED**] string_found (boolean)
 
 ### Tags:
@@ -68,16 +68,17 @@ It can also check response text.
     - server
     - port
     - protocol
+    - result_type (string) # success, timeout, connection_failed, read_failed, string_mismatch
 
 ### Example Output:
 
 ```
 $ ./telegraf --config telegraf.conf --input-filter net_response --test
-net_response,server=influxdata.com,port=8080,protocol=tcp,host=localhost result_type="timeout" 1499310361000000000
-net_response,server=influxdata.com,port=443,protocol=tcp,host=localhost result_type="success",response_time=0.088703864 1499310361000000000
-net_response,protocol=tcp,host=localhost,server=this.domain.does.not.exist,port=443 result_type="connection_failed" 1499310361000000000
-net_response,protocol=udp,host=localhost,server=influxdata.com,port=8080 result_type="read_failed" 1499310362000000000
-net_response,port=31338,protocol=udp,host=localhost,server=localhost result_type="string_mismatch",string_found=false,response_time=0.00242682 1499310362000000000
-net_response,protocol=udp,host=localhost,server=localhost,port=31338 response_time=0.001128598,result_type="success",string_found=true 1499310362000000000
-net_response,server=this.domain.does.not.exist,port=443,protocol=udp,host=localhost result_type="connection_failed" 1499310362000000000
+net_response,server=influxdata.com,port=8080,protocol=tcp,host=localhost,result_type="timeout" result_type=1i, 1499310361000000000
+net_response,server=influxdata.com,port=443,protocol=tcp,host=localhost,result_type="success", result_type=0i,response_time=0.088703864 1499310361000000000
+net_response,protocol=tcp,host=localhost,server=this.domain.does.not.exist,port=443,result_type="connection_failed" result_type=1i, 1499310361000000000
+net_response,protocol=udp,host=localhost,server=influxdata.com,port=8080,result_type="read_failed" result_type=1i, 1499310362000000000
+net_response,port=31338,protocol=udp,host=localhost,server=localhost,result_type="string_mismatch", result_type=1i,string_found=false,response_time=0.00242682 1499310362000000000
+net_response,protocol=udp,host=localhost,server=localhost,port=31338,result_type="success" result_type=0i,response_time=0.001128598,string_found=true 1499310362000000000
+net_response,server=this.domain.does.not.exist,port=443,protocol=udp,host=localhost,result_type="connection_failed" result_type=1i, 1499310362000000000
 ```

--- a/plugins/inputs/net_response/README.md
+++ b/plugins/inputs/net_response/README.md
@@ -59,7 +59,7 @@ It can also check response text.
 
 - net_response
     - response_time (float, seconds)
-    - result_type (int) # success 0, failure 1
+    - success (int) # success 0, failure 1
     - [**DEPRECATED**] string_found (boolean)
 
 ### Tags:
@@ -74,11 +74,11 @@ It can also check response text.
 
 ```
 $ ./telegraf --config telegraf.conf --input-filter net_response --test
-net_response,server=influxdata.com,port=8080,protocol=tcp,host=localhost,result_type="timeout" result_type=1i, 1499310361000000000
-net_response,server=influxdata.com,port=443,protocol=tcp,host=localhost,result_type="success", result_type=0i,response_time=0.088703864 1499310361000000000
-net_response,protocol=tcp,host=localhost,server=this.domain.does.not.exist,port=443,result_type="connection_failed" result_type=1i, 1499310361000000000
-net_response,protocol=udp,host=localhost,server=influxdata.com,port=8080,result_type="read_failed" result_type=1i, 1499310362000000000
-net_response,port=31338,protocol=udp,host=localhost,server=localhost,result_type="string_mismatch", result_type=1i,string_found=false,response_time=0.00242682 1499310362000000000
-net_response,protocol=udp,host=localhost,server=localhost,port=31338,result_type="success" result_type=0i,response_time=0.001128598,string_found=true 1499310362000000000
-net_response,server=this.domain.does.not.exist,port=443,protocol=udp,host=localhost,result_type="connection_failed" result_type=1i, 1499310362000000000
+net_response,server=influxdata.com,port=8080,protocol=tcp,host=localhost,result_type="timeout" success=1i, 1499310361000000000
+net_response,server=influxdata.com,port=443,protocol=tcp,host=localhost,result_type="success", success=0i,response_time=0.088703864 1499310361000000000
+net_response,protocol=tcp,host=localhost,server=this.domain.does.not.exist,port=443,result_type="connection_failed" success=1i, 1499310361000000000
+net_response,protocol=udp,host=localhost,server=influxdata.com,port=8080,result_type="read_failed" success=1i, 1499310362000000000
+net_response,port=31338,protocol=udp,host=localhost,server=localhost,result_type="string_mismatch", success=1i,string_found=false,response_time=0.00242682 1499310362000000000
+net_response,protocol=udp,host=localhost,server=localhost,port=31338,result_type="success" success=0i,response_time=0.001128598,string_found=true 1499310362000000000
+net_response,server=this.domain.does.not.exist,port=443,protocol=udp,host=localhost,result_type="connection_failed" success=1i, 1499310362000000000
 ```

--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -13,7 +13,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-// NetResponses struct
+// NetResponse struct
 type NetResponse struct {
 	Address     string
 	Timeout     internal.Duration
@@ -23,7 +23,8 @@ type NetResponse struct {
 	Protocol    string
 }
 
-func (_ *NetResponse) Description() string {
+// Description will return a string with a description of the plugin
+func (*NetResponse) Description() string {
 	return "TCP or UDP 'ping' given url and collect response time in seconds"
 }
 
@@ -49,13 +50,17 @@ var sampleConfig = `
   # expect = "ssh"
 `
 
-func (_ *NetResponse) SampleConfig() string {
+// SampleConfig will return a string with a full config example
+func (*NetResponse) SampleConfig() string {
 	return sampleConfig
 }
 
-func (n *NetResponse) TcpGather() (map[string]interface{}, error) {
+// TCPGather will start the gather process for tcp requests
+func (n *NetResponse) TCPGather() (tags map[string]string, fields map[string]interface{}) {
 	// Prepare fields
-	fields := make(map[string]interface{})
+	fields = make(map[string]interface{})
+	// Prepare tags
+	tags = make(map[string]string)
 	// Start Timer
 	start := time.Now()
 	// Connecting
@@ -65,11 +70,13 @@ func (n *NetResponse) TcpGather() (map[string]interface{}, error) {
 	// Handle error
 	if err != nil {
 		if e, ok := err.(net.Error); ok && e.Timeout() {
-			fields["result_type"] = "timeout"
+			tags["result_type"] = "timeout"
+			fields["result_type"] = 1
 		} else {
-			fields["result_type"] = "connection_failed"
+			tags["result_type"] = "connection_failed"
+			fields["result_type"] = 1
 		}
-		return fields, nil
+		return tags, fields
 	}
 	defer conn.Close()
 	// Send string if needed
@@ -93,29 +100,37 @@ func (n *NetResponse) TcpGather() (map[string]interface{}, error) {
 		// Handle error
 		if err != nil {
 			fields["string_found"] = false
-			fields["result_type"] = "read_failed"
+			tags["result_type"] = "read_failed"
+			fields["result_type"] = 1
 		} else {
 			// Looking for string in answer
 			RegEx := regexp.MustCompile(`.*` + n.Expect + `.*`)
 			find := RegEx.FindString(string(data))
 			if find != "" {
-				fields["result_type"] = "success"
+				fields["result_type"] = 0
+				tags["result_type"] = "success"
 				fields["string_found"] = true
 			} else {
-				fields["result_type"] = "string_mismatch"
+				tags["result_type"] = "string_mismatch"
+				fields["result_type"] = 1
 				fields["string_found"] = false
 			}
 		}
 	} else {
-		fields["result_type"] = "success"
+		tags["result_type"] = "success"
+		fields["result_type"] = 0
 	}
 	fields["response_time"] = responseTime
-	return fields, nil
+	return tags, fields
 }
 
-func (n *NetResponse) UdpGather() (map[string]interface{}, error) {
+// UDPGather will start the gather process for UDP requests
+// it will return the feilds and an error.
+func (n *NetResponse) UDPGather() (tags map[string]string, fields map[string]interface{}) {
 	// Prepare fields
-	fields := make(map[string]interface{})
+	fields = make(map[string]interface{})
+	// Prepare tags
+	tags = make(map[string]string)
 	// Start Timer
 	start := time.Now()
 	// Resolving
@@ -125,8 +140,9 @@ func (n *NetResponse) UdpGather() (map[string]interface{}, error) {
 	conn, err := net.DialUDP("udp", LocalAddr, udpAddr)
 	// Handle error
 	if err != nil {
-		fields["result_type"] = "connection_failed"
-		return fields, nil
+		tags["result_type"] = "connection_failed"
+		fields["result_type"] = 1
+		return tags, fields
 	}
 	defer conn.Close()
 	// Send string
@@ -142,24 +158,30 @@ func (n *NetResponse) UdpGather() (map[string]interface{}, error) {
 	responseTime := time.Since(start).Seconds()
 	// Handle error
 	if err != nil {
-		fields["result_type"] = "read_failed"
-		return fields, nil
-	} else {
-		// Looking for string in answer
-		RegEx := regexp.MustCompile(`.*` + n.Expect + `.*`)
-		find := RegEx.FindString(string(buf))
-		if find != "" {
-			fields["result_type"] = "success"
-			fields["string_found"] = true
-		} else {
-			fields["result_type"] = "string_mismatch"
-			fields["string_found"] = false
-		}
+		tags["result_type"] = "read_failed"
+		fields["result_type"] = 1
+		return tags, fields
 	}
+
+	// Looking for string in answer
+	RegEx := regexp.MustCompile(`.*` + n.Expect + `.*`)
+	find := RegEx.FindString(string(buf))
+	if find != "" {
+		tags["result_type"] = "success"
+		fields["result_type"] = 0
+		fields["string_found"] = true
+	} else {
+		tags["result_type"] = "string_mismatch"
+		fields["result_type"] = 1
+		fields["string_found"] = false
+	}
+
 	fields["response_time"] = responseTime
-	return fields, nil
+	return tags, fields
 }
 
+// Gather is fulfils the plugin package requirements for telegraf.
+// It is called on every interval for metric gathering.
 func (n *NetResponse) Gather(acc telegraf.Accumulator) error {
 	// Set default values
 	if n.Timeout.Duration == 0 {
@@ -189,18 +211,23 @@ func (n *NetResponse) Gather(acc telegraf.Accumulator) error {
 	// Prepare data
 	tags := map[string]string{"server": host, "port": port}
 	var fields map[string]interface{}
+	var returnedTags map[string]string
 	// Gather data
 	if n.Protocol == "tcp" {
-		fields, err = n.TcpGather()
+		returnedTags, fields = n.TCPGather()
 		tags["protocol"] = "tcp"
 	} else if n.Protocol == "udp" {
-		fields, err = n.UdpGather()
+		returnedTags, fields = n.UDPGather()
 		tags["protocol"] = "udp"
 	} else {
 		return errors.New("Bad protocol")
 	}
 	if err != nil {
 		return err
+	}
+	// Merge the tags
+	for k, v := range returnedTags {
+		tags[k] = v
 	}
 	// Add metrics
 	acc.AddFields("net_response", fields, tags)

--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -71,10 +71,10 @@ func (n *NetResponse) TCPGather() (tags map[string]string, fields map[string]int
 	if err != nil {
 		if e, ok := err.(net.Error); ok && e.Timeout() {
 			tags["result_type"] = "timeout"
-			fields["result_type"] = 1
+			fields["success"] = 1
 		} else {
 			tags["result_type"] = "connection_failed"
-			fields["result_type"] = 1
+			fields["success"] = 1
 		}
 		return tags, fields
 	}
@@ -101,24 +101,24 @@ func (n *NetResponse) TCPGather() (tags map[string]string, fields map[string]int
 		if err != nil {
 			fields["string_found"] = false
 			tags["result_type"] = "read_failed"
-			fields["result_type"] = 1
+			fields["success"] = 1
 		} else {
 			// Looking for string in answer
 			RegEx := regexp.MustCompile(`.*` + n.Expect + `.*`)
 			find := RegEx.FindString(string(data))
 			if find != "" {
-				fields["result_type"] = 0
+				fields["success"] = 0
 				tags["result_type"] = "success"
 				fields["string_found"] = true
 			} else {
 				tags["result_type"] = "string_mismatch"
-				fields["result_type"] = 1
+				fields["success"] = 1
 				fields["string_found"] = false
 			}
 		}
 	} else {
 		tags["result_type"] = "success"
-		fields["result_type"] = 0
+		fields["success"] = 0
 	}
 	fields["response_time"] = responseTime
 	return tags, fields
@@ -141,7 +141,7 @@ func (n *NetResponse) UDPGather() (tags map[string]string, fields map[string]int
 	// Handle error
 	if err != nil {
 		tags["result_type"] = "connection_failed"
-		fields["result_type"] = 1
+		fields["success"] = 1
 		return tags, fields
 	}
 	defer conn.Close()
@@ -159,7 +159,7 @@ func (n *NetResponse) UDPGather() (tags map[string]string, fields map[string]int
 	// Handle error
 	if err != nil {
 		tags["result_type"] = "read_failed"
-		fields["result_type"] = 1
+		fields["success"] = 1
 		return tags, fields
 	}
 
@@ -168,11 +168,11 @@ func (n *NetResponse) UDPGather() (tags map[string]string, fields map[string]int
 	find := RegEx.FindString(string(buf))
 	if find != "" {
 		tags["result_type"] = "success"
-		fields["result_type"] = 0
+		fields["success"] = 0
 		fields["string_found"] = true
 	} else {
 		tags["result_type"] = "string_mismatch"
-		fields["result_type"] = 1
+		fields["success"] = 1
 		fields["string_found"] = false
 	}
 

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -39,12 +39,13 @@ func TestTCPError(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type": "connection_failed",
+			"result_type": 1,
 		},
 		map[string]string{
-			"server":   "",
-			"port":     "9999",
-			"protocol": "tcp",
+			"server":      "",
+			"port":        "9999",
+			"protocol":    "tcp",
+			"result_type": "connection_failed",
 		},
 	)
 }
@@ -77,13 +78,14 @@ func TestTCPOK1(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":   "success",
+			"result_type":   0,
 			"string_found":  true,
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",
-			"port":     "2004",
-			"protocol": "tcp",
+			"port":        "2004",
+			"protocol":    "tcp",
+			"result_type": "success",
 		},
 	)
 	// Waiting TCPserver
@@ -118,13 +120,14 @@ func TestTCPOK2(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":   "string_mismatch",
+			"result_type":   1,
 			"string_found":  false,
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",
-			"port":     "2004",
-			"protocol": "tcp",
+			"port":        "2004",
+			"protocol":    "tcp",
+			"result_type": "string_mismatch",
 		},
 	)
 	// Waiting TCPserver
@@ -151,13 +154,14 @@ func TestUDPrror(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":   "read_failed",
+			"result_type":   1,
 			"response_time": 1.0,
 		},
 		map[string]string{
-			"server":   "",
-			"port":     "9999",
-			"protocol": "udp",
+			"server":      "",
+			"port":        "9999",
+			"protocol":    "udp",
+			"result_type": "read_failed",
 		},
 	)
 }
@@ -190,13 +194,14 @@ func TestUDPOK1(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":   "success",
+			"result_type":   0,
 			"string_found":  true,
 			"response_time": 1.0,
 		},
 		map[string]string{"server": "127.0.0.1",
-			"port":     "2004",
-			"protocol": "udp",
+			"port":        "2004",
+			"protocol":    "udp",
+			"result_type": "success",
 		},
 	)
 	// Waiting TCPserver

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -39,7 +39,7 @@ func TestTCPError(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type": 1,
+			"success": 1,
 		},
 		map[string]string{
 			"server":      "",
@@ -78,7 +78,7 @@ func TestTCPOK1(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":   0,
+			"success":       0,
 			"string_found":  true,
 			"response_time": 1.0,
 		},
@@ -120,7 +120,7 @@ func TestTCPOK2(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":   1,
+			"success":       1,
 			"string_found":  false,
 			"response_time": 1.0,
 		},
@@ -154,7 +154,7 @@ func TestUDPrror(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":   1,
+			"success":       1,
 			"response_time": 1.0,
 		},
 		map[string]string{
@@ -194,7 +194,7 @@ func TestUDPOK1(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
 		map[string]interface{}{
-			"result_type":   0,
+			"success":       0,
 			"string_found":  true,
 			"response_time": 1.0,
 		},


### PR DESCRIPTION
Updating the net_response plugin to send the field result_type as a int and moved the current result_type string value to a tag.

Fixing go linting issues.
Updating tests to reflect the changes.
Updating README.md to reflect the changes.

### Required for all PRs:

- [ x ] Signed [CLA](https://influxdata.com/community/cla/).
- [ x ] Associated README.md updated.
- [ x  ] Has appropriate unit tests.
