### PR TITLE
Update net response

### DIFF
--- a/plugins/inputs/net_response/README.md
+++ b/plugins/inputs/net_response/README.md
@@ -59,7 +59,9 @@ It can also check response text.
 
 - net_response
     - response_time (float, seconds)
-    - result_type (string) # success, timeout, connection_failed, read_failed, string_mismatch
+    - success (int) # success 0, failure 1
+    - result_code (int) # success = 0, Failure = 1
+    - [**DEPRECATED**] result_type (string) # success, timeout, connection_failed, read_failed, string_mismatch
     - [**DEPRECATED**] string_found (boolean)
 
 ### Tags:
@@ -68,16 +70,17 @@ It can also check response text.
     - server
     - port
     - protocol
+    - result_type (string) # success, timeout, connection_failed, read_failed, string_mismatch
+    - result_text # This will contain the text from the now deprecated result_type
 
 ### Example Output:
 
 ```
-$ ./telegraf --config telegraf.conf --input-filter net_response --test
-net_response,server=influxdata.com,port=8080,protocol=tcp,host=localhost result_type="timeout" 1499310361000000000
-net_response,server=influxdata.com,port=443,protocol=tcp,host=localhost result_type="success",response_time=0.088703864 1499310361000000000
-net_response,protocol=tcp,host=localhost,server=this.domain.does.not.exist,port=443 result_type="connection_failed" 1499310361000000000
-net_response,protocol=udp,host=localhost,server=influxdata.com,port=8080 result_type="read_failed" 1499310362000000000
-net_response,port=31338,protocol=udp,host=localhost,server=localhost result_type="string_mismatch",string_found=false,response_time=0.00242682 1499310362000000000
-net_response,protocol=udp,host=localhost,server=localhost,port=31338 response_time=0.001128598,result_type="success",string_found=true 1499310362000000000
-net_response,server=this.domain.does.not.exist,port=443,protocol=udp,host=localhost result_type="connection_failed" 1499310362000000000
+net_response,server=influxdata.com,port=8080,protocol=tcp,host=localhost,result_text="timeout" result_code=1i,result_type="timeout" 1499310361000000000
+net_response,server=influxdata.com,port=443,protocol=tcp,host=localhost,result_text="success" result_code=0i,result_type="success",response_time=0.088703864 1499310361000000000
+net_response,protocol=tcp,host=localhost,server=this.domain.does.not.exist,port=443,result_text="connection_failed" result_code=1i,result_type="connection_failed" 1499310361000000000
+net_response,protocol=udp,host=localhost,server=influxdata.com,port=8080,result_text="read_failed" result_code=1i,result_type="read_failed" 1499310362000000000
+net_response,port=31338,protocol=udp,host=localhost,server=localhost,result_text="string_mismatch" result_code=1i,result_type="string_mismatch",string_found=false,response_time=0.00242682 1499310362000000000
+net_response,protocol=udp,host=localhost,server=localhost,port=31338,result_text="success" response_time=0.001128598,result_code=0i,result_type="success",string_found=true 1499310362000000000
+net_response,server=this.domain.does.not.exist,port=443,protocol=udp,host=localhost,result_text="connection_failed" result_code=1i,result_type="connection_failed" 1499310362000000000
 ```

--- a/plugins/inputs/net_response/README.md
+++ b/plugins/inputs/net_response/README.md
@@ -70,8 +70,7 @@ It can also check response text.
     - server
     - port
     - protocol
-    - result_type (string) # success, timeout, connection_failed, read_failed, string_mismatch
-    - result_text # This will contain the text from the now deprecated result_type
+    - result_text (string) # This will contain the text from the now deprecated result_type
 
 ### Example Output:
 


### PR DESCRIPTION
Deprecating result_type as a field value in favor of result_text as a tag value.
Adding a field value called result_code which is an int in the fields.
Updating tests to reflect changes.
Adding new tests to test other sections of the code.
Updating the README.me file to reflect the changes.

### Required for all PRs:

- [ x ] Signed [CLA](https://influxdata.com/community/cla/).
- [ x ] Associated README.md updated.
- [ x ] Has appropriate unit tests.
