### PR TITLE
Update CI configs to Go 1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - [#3305](https://github.com/influxdata/telegraf/pull/3305): Add modification_time field to filestat input plugin.
 - [#2019](https://github.com/influxdata/telegraf/pull/2019): Add Solr input plugin.
 - [#3210](https://github.com/influxdata/telegraf/pull/3210): Add CrateDB output plugin.
+- [#3458](https://github.com/influxdata/telegraf/pull/3458): Update CI configs to Go 1.9.2
 
 ### Bugfixes
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,11 @@ platform: x64
 
 install:
   - IF NOT EXIST "C:\Cache" mkdir C:\Cache
-  - IF NOT EXIST "C:\Cache\go1.8.1.msi" curl -o "C:\Cache\go1.8.1.msi" https://storage.googleapis.com/golang/go1.8.1.windows-amd64.msi
+  - IF NOT EXIST "C:\Cache\go1.9.2.msi" curl -o "C:\Cache\go1.9.2.msi" https://storage.googleapis.com/golang/go1.9.2.windows-amd64.msi
   - IF NOT EXIST "C:\Cache\gnuwin32-bin.zip" curl -o "C:\Cache\gnuwin32-bin.zip" https://dl.influxdata.com/telegraf/ci/make-3.81-bin.zip
   - IF NOT EXIST "C:\Cache\gnuwin32-dep.zip" curl -o "C:\Cache\gnuwin32-dep.zip" https://dl.influxdata.com/telegraf/ci/make-3.81-dep.zip
   - IF EXIST "C:\Go" rmdir /S /Q C:\Go
-  - msiexec.exe /i "C:\Cache\go1.8.1.msi" /quiet
+  - msiexec.exe /i "C:\Cache\go1.9.2.msi" /quiet
   - 7z x "C:\Cache\gnuwin32-bin.zip" -oC:\GnuWin32 -y
   - 7z x "C:\Cache\gnuwin32-dep.zip" -oC:\GnuWin32 -y
   - go version

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,8 @@ machine:
     - rabbitmq-server
   post:
     - sudo rm -rf /usr/local/go
-    - wget https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz
-    - sudo tar -C /usr/local -xzf go1.9.1.linux-amd64.tar.gz
+    - wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz
+    - sudo tar -C /usr/local -xzf go1.9.2.linux-amd64.tar.gz
     - go version
 
 dependencies:


### PR DESCRIPTION
Updates both CircleCI and AppVeyor configs to Go 1.9.2.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
