### PR TITLE
Replace newline (\n) by _ in graphite serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - [#3319](https://github.com/influxdata/telegraf/issues/3319): Fix cloudwatch output requires unneeded permissions.
 - [#3351](https://github.com/influxdata/telegraf/issues/3351): Fix prometheus passthrough for existing value types.
 - [#3430](https://github.com/influxdata/telegraf/issues/3430): Always ignore autofs filesystems in disk input.
+- [#3466](https://github.com/influxdata/telegraf/pull/3466): Fix issue with graphite output and Docker container label with newline.
 
 ## v1.4.4 [2017-11-08]
 

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -12,7 +12,7 @@ const DEFAULT_TEMPLATE = "host.tags.measurement.field"
 
 var (
 	fieldDeleter   = strings.NewReplacer(".FIELDNAME", "", "FIELDNAME.", "")
-	sanitizedChars = strings.NewReplacer("/", "-", "@", "-", "*", "-", " ", "_", "..", ".", `\`, "", ")", "_", "(", "_")
+	sanitizedChars = strings.NewReplacer("/", "-", "@", "-", "*", "-", " ", "_", "..", ".", `\`, "", ")", "_", "(", "_", "\n", "_")
 )
 
 type GraphiteSerializer struct {


### PR DESCRIPTION
When a Docker container has a label with "\n", the output in graphite also contains the newline. This break parsing graphite output, since the newline in graphite indicate end of metrics.

This PR add "\n" to list of sanitizedChars to avoid this issue.

Container with "\n" in their label happen (at least) with Kubernetes (in this case, kubeadm single node cluster, 1.8.3):

```
$ docker inspect k8s_POD_kube-dns-545bc4bfd4-4qczn_kube-system_343faed5-c854-11e7-9b74-346895edfc89_0
[...]
            "Labels": {
                "annotation.kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"kube-system\",\"name\":\"kube-dns-545bc4bfd4\",\"uid\":\"3439be46-c854-11e7-9b74-346895edfc89\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"270\"}}\n",
[...]
```

Result of telegraf before and after PR:

```
$ cat telegraf.conf 
[agent]
  interval = "10s"
[[outputs.file]]
   files = ["/tmp/metrics.out"]
   data_format = "graphite"
[[inputs.docker]]
   container_names = ["k8s_POD_kube-dns-545bc4bfd4-4qczn_kube-system_343faed5-c854-11e7-9b74-346895edfc89_0"]

$ ./telegraf --config telegraf.conf  # wait 10s and kill

-- Before PR
$ cat /tmp/metrics.out
[...]
xps-pierref.2017-11-13T10:22:58_788990165+01:00.api.{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"kube-system","name":"kube-dns-545bc4bfd4","uid":"3439be46-c854-11e7-9b74-346895edfc89","apiVersion":"extensions","resourceVersion":"270"}}
.gcr_io-google_containers-pause-amd64.k8s_POD_kube-dns-545bc4bfd4-4qczn_kube-system_343faed5-c854-11e7-9b74-346895edfc89_0.3_0.xps-pierref.POD.podsandbox.kube-dns-545bc4bfd4-4qczn.kube-system.343faed5-c854-11e7-9b74-346895edfc89.kube-dns.1016706980.docker_container_mem.active_anon 4096 1510565511
[...]

-- After PR
$ cat /tmp/metrics.out
[...]
xps-pierref.2017-11-13T10:22:58_788990165+01:00.api.{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"kube-system","name":"kube-dns-545bc4bfd4","uid":"3439be46-c854-11e7-9b74-346895edfc89","apiVersion":"extensions","resourceVersion":"270"}}_.gcr_io-google_containers-pause-amd64.k8s_POD_kube-dns-545bc4bfd4-4qczn_kube-system_343faed5-c854-11e7-9b74-346895edfc89_0.3_0.xps-pierref.POD.podsandbox.kube-dns-545bc4bfd4-4qczn.kube-system.343faed5-c854-11e7-9b74-346895edfc89.kube-dns.1016706980.docker_container_mem.unevictable 0 1510565651
[...]
```
