### PR TITLE
 use MAX() instead of SUM() for latency measurements

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -539,7 +539,7 @@ SELECT DatabaseName,  ReadLatency
 FROM #baseline
 WHERE datafile_type = ''LOG''
 ) as V
-PIVOT(SUM(ReadLatency) FOR DatabaseName IN (' + @ColumnName + ')) AS PVTTable
+PIVOT(MAX(ReadLatency) FOR DatabaseName IN (' + @ColumnName + ')) AS PVTTable
 
 UNION ALL
 
@@ -550,7 +550,7 @@ SELECT DatabaseName,  WriteLatency
 FROM #baseline
 WHERE datafile_type = ''LOG''
 ) as V
-PIVOT(SUM(WriteLatency) FOR DatabaseName IN (' + @ColumnName + ')) AS PVTTable
+PIVOT(MAX(WriteLatency) FOR DatabaseName IN (' + @ColumnName + ')) AS PVTTable
 
 UNION ALL
 
@@ -561,7 +561,7 @@ SELECT DatabaseName,  ReadLatency
 FROM #baseline
 WHERE datafile_type = ''ROWS''
 ) as V
-PIVOT(SUM(ReadLatency) FOR DatabaseName IN (' + @ColumnName + ')) AS PVTTable
+PIVOT(MAX(ReadLatency) FOR DatabaseName IN (' + @ColumnName + ')) AS PVTTable
 
 UNION ALL
 
@@ -572,7 +572,7 @@ SELECT DatabaseName,  WriteLatency
 FROM #baseline
 WHERE datafile_type = ''ROWS''
 ) as V
-PIVOT(SUM(WriteLatency) FOR DatabaseName IN (' + @ColumnName + ')) AS PVTTable
+PIVOT(MAX(WriteLatency) FOR DatabaseName IN (' + @ColumnName + ')) AS PVTTable
 
 UNION ALL
 


### PR DESCRIPTION
Using SUM() results in multi-second latency measurements when multiple files are used for a database - which is typical for tempdb.  Using MAX() gives a more meaningful measurement.   AVG() can be used as well but will hide problems when one of the db files encounters a problem.  Example:

File0: 30ms
File1: 40ms
File2: 50ms
File3: 60ms
File4: 70ms
File5: 80ms
File6: 90ms

SUM (currently what is reported) results in 420 ms latency, MAX (current proposal) in 90ms and AVG in 60ms