### PR TITLE
Remove call to os.Stat before getting disk usage

### DIFF
--- a/plugins/inputs/system/disk.go
+++ b/plugins/inputs/system/disk.go
@@ -52,6 +52,7 @@ func (s *DiskStats) Gather(acc telegraf.Accumulator) error {
 	for i, du := range disks {
 		if du.Total == 0 {
 			// Skip dummy filesystem (procfs, cgroupfs, ...)
+			log.Printf("D! skipping dummy filesystem: %s", du.Path)
 			continue
 		}
 		mountOpts := parseOptions(partitions[i].Opts)

--- a/plugins/inputs/system/disk_test.go
+++ b/plugins/inputs/system/disk_test.go
@@ -62,8 +62,6 @@ func TestDiskUsage(t *testing.T) {
 
 	mps.On("Partitions", true).Return(psAll, nil)
 	mps.On("OSGetenv", "HOST_MOUNT_PREFIX").Return("")
-	mps.On("OSStat", "/").Return(MockFileInfo{}, nil)
-	mps.On("OSStat", "/home").Return(MockFileInfo{}, nil)
 	mps.On("PSDiskUsage", "/").Return(&duAll[0], nil)
 	mps.On("PSDiskUsage", "/home").Return(&duAll[1], nil)
 

--- a/plugins/inputs/system/mock_PS.go
+++ b/plugins/inputs/system/mock_PS.go
@@ -1,8 +1,6 @@
 package system
 
 import (
-	"os"
-
 	"github.com/stretchr/testify/mock"
 
 	"github.com/shirou/gopsutil/cpu"
@@ -121,15 +119,6 @@ func (m *mockDiskUsage) Partitions(all bool) ([]disk.PartitionStat, error) {
 func (m *mockDiskUsage) OSGetenv(key string) string {
 	ret := m.Called(key)
 	return ret.Get(0).(string)
-}
-
-func (m *mockDiskUsage) OSStat(name string) (os.FileInfo, error) {
-	ret := m.Called(name)
-
-	r0 := ret.Get(0).(os.FileInfo)
-	r1 := ret.Error(1)
-
-	return r0, r1
 }
 
 func (m *mockDiskUsage) PSDiskUsage(path string) (*disk.UsageStat, error) {

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -74,6 +74,7 @@ func (s *systemPS) DiskUsage(
 	if err != nil {
 		return nil, nil, err
 	}
+	log.Printf("D! partitions found: %v", parts)
 
 	// Make a "set" out of the filter slice
 	mountPointFilterSet := make(map[string]bool)
@@ -95,11 +96,13 @@ func (s *systemPS) DiskUsage(
 
 	for i := range parts {
 		p := parts[i]
+		log.Printf("D! getting usage for: %v", p)
 
 		if len(mountPointFilter) > 0 {
 			// If the mount point is not a member of the filter set,
 			// don't gather info on it.
 			if _, ok := mountPointFilterSet[p.Mountpoint]; !ok {
+				log.Printf("D! filesystem mountpoint excluded: %s", p.Mountpoint)
 				continue
 			}
 		}
@@ -107,6 +110,7 @@ func (s *systemPS) DiskUsage(
 		// If the mount point is a member of the exclude set,
 		// don't gather info on it.
 		if _, ok := fstypeExcludeSet[p.Fstype]; ok {
+			log.Printf("D! filesystem type excluded: %s: %v", p.Mountpoint, p.Fstype)
 			continue
 		}
 

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"log"
 	"os"
 
 	"github.com/influxdata/telegraf"
@@ -26,7 +27,6 @@ type PS interface {
 type PSDiskDeps interface {
 	Partitions(all bool) ([]disk.PartitionStat, error)
 	OSGetenv(key string) string
-	OSStat(name string) (os.FileInfo, error)
 	PSDiskUsage(path string) (*disk.UsageStat, error)
 }
 
@@ -111,11 +111,9 @@ func (s *systemPS) DiskUsage(
 		}
 
 		mountpoint := s.OSGetenv("HOST_MOUNT_PREFIX") + p.Mountpoint
-		if _, err := s.OSStat(mountpoint); err != nil {
-			continue
-		}
 		du, err := s.PSDiskUsage(mountpoint)
 		if err != nil {
+			log.Printf("D! error getting disk usage: %s: %v", mountpoint, du)
 			continue
 		}
 		du.Path = p.Mountpoint
@@ -162,10 +160,6 @@ func (s *systemPSDisk) Partitions(all bool) ([]disk.PartitionStat, error) {
 
 func (s *systemPSDisk) OSGetenv(key string) string {
 	return os.Getenv(key)
-}
-
-func (s *systemPSDisk) OSStat(name string) (os.FileInfo, error) {
-	return os.Stat(name)
 }
 
 func (s *systemPSDisk) PSDiskUsage(path string) (*disk.UsageStat, error) {

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -113,7 +113,7 @@ func (s *systemPS) DiskUsage(
 		mountpoint := s.OSGetenv("HOST_MOUNT_PREFIX") + p.Mountpoint
 		du, err := s.PSDiskUsage(mountpoint)
 		if err != nil {
-			log.Printf("D! error getting disk usage: %s: %v", mountpoint, du)
+			log.Printf("D! error getting disk usage: %s: %v", mountpoint, err)
 			continue
 		}
 		du.Path = p.Mountpoint


### PR DESCRIPTION
This is not needed because it is handled in the disk usage call, and is potentially causing the problem in #3483.  

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
