### PR TITLE
add HTTP basic auth support to the http_listener input plugin

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -2574,6 +2574,11 @@
 #   ## Add service certificate and key
 #   tls_cert = "/etc/telegraf/cert.pem"
 #   tls_key = "/etc/telegraf/key.pem"
+#
+#   ## Optional username and password to accept for HTTP basic authentication.
+#   ## You probably want to make sure you have TLS configured above for this.
+#   basic_username = "foobar"
+#   basic_password = "barfoo"
 
 
 # # Read metrics from Kafka topic(s)

--- a/plugins/inputs/http_listener/README.md
+++ b/plugins/inputs/http_listener/README.md
@@ -12,6 +12,8 @@ Enable TLS by specifying the file names of a service TLS certificate and key.
 
 Enable mutually authenticated TLS and authorize client connections by signing certificate authority by including a list of allowed CA certificate file names in ````tls_allowed_cacerts````.
 
+Enable basic HTTP authentication of clients by specifying a username and password to check for. These credentials will be received from the client _as plain text_ if TLS is not configured.
+
 See: [Telegraf Input Data Formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md#influx).
 
 **Example:**
@@ -39,4 +41,8 @@ This is a sample configuration for the plugin.
 
   ## MTLS
   tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Basic authentication
+  basic_username = "foobar"
+  basic_password = "barfoo"
 ```

--- a/plugins/inputs/http_listener/http_listener_test.go
+++ b/plugins/inputs/http_listener/http_listener_test.go
@@ -100,6 +100,9 @@ NsFlcGACj+/TvacFYlA6N2nyFeokzoqLX28Ddxdh2erXqJ4hYIhT1ik9tkLggs2z
 1T1084BquCuO6lIcOwJBALX4xChoMUF9k0IxSQzlz//seQYDkQNsE7y9IgAOXkzp
 RaR4pzgPbnKj7atG+2dBnffWfE+1Mcy0INDAO6WxPg0=
 -----END RSA PRIVATE KEY-----`
+
+	basicUsername = "test-username-please-ignore"
+	basicPassword = "super-secure-password!"
 )
 
 var (
@@ -116,6 +119,13 @@ func newTestHTTPListener() *HTTPListener {
 	listener := &HTTPListener{
 		ServiceAddress: ":0",
 	}
+	return listener
+}
+
+func newTestHTTPAuthListener() *HTTPListener {
+	listener := newTestHTTPListener()
+	listener.BasicUsername = basicUsername
+	listener.BasicPassword = basicPassword
 	return listener
 }
 
@@ -236,6 +246,24 @@ func TestWriteHTTPSWithClientAuth(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 	require.EqualValues(t, 204, resp.StatusCode)
+}
+
+func TestWriteHTTPBasicAuth(t *testing.T) {
+	listener := newTestHTTPAuthListener()
+
+	acc := &testutil.Accumulator{}
+	require.NoError(t, listener.Start(acc))
+	defer listener.Stop()
+
+	client := &http.Client{}
+
+	req, err := http.NewRequest("POST", createURL(listener, "http", "/write", "db=mydb"), bytes.NewBuffer([]byte(testMsg)))
+	require.NoError(t, err)
+	req.SetBasicAuth(basicUsername, basicPassword)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.EqualValues(t, http.StatusNoContent, resp.StatusCode)
 }
 
 func TestWriteHTTP(t *testing.T) {


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Does what it says on the tin. Needed it for a specific use case, and saw no reason for it to not be there, so here we are.