### PR TITLE
MySQL plugin should not collect global variables at each telegraf data collection interval

### DIFF
--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -588,17 +588,12 @@ func (m *Mysql) gatherServer(serv string, acc telegraf.Accumulator) error {
 
 	// Global Variables may be gathered less often
 	if len(m.IntervalSlow) > 0 {
-		if uint32(time.Since(lastT).Seconds()) > scanIntervalSlow {
+		if uint32(time.Since(lastT).Seconds()) >= scanIntervalSlow {
 			err = m.gatherGlobalVariables(db, serv, acc)
 			if err != nil {
 				return err
 			}
 			lastT = time.Now()
-		} else {
-			err = m.gatherGlobalVariables(db, serv, acc)
-			if err != nil {
-				return err
-			}
 		}
 	}
 


### PR DESCRIPTION
When you set `interval_slow` (to a positive value), MySQL plugin starts gathering the global variables.

What is expected (in accordance with the README.md): The gathering of variables occurs at a slower pace than the regular telegraf data collection interval. And the pace would be the value `interval_slow` (+ an eventual jitter of 1 telegraf interval).

What is actually happening: The plugin collects the global variable at every single data collection interval.

The fix is not to call the gathering when it was done less than `interval_slow` duration ago.

Note:
- I've signed the CLA
- I did not change the README.md. This pull request is to make the code behave as advertised in the README.md.
- I don't know how to produce a unit test that validates the timing. I've checked by looking at the timestamps in influxdb.

