### PR TITLE
Jolokia2 handles unordered mbean object name properties

### DIFF
--- a/plugins/inputs/jolokia2/gatherer.go
+++ b/plugins/inputs/jolokia2/gatherer.go
@@ -127,8 +127,7 @@ func mergeTags(metricTags, outerTags map[string]string) map[string]string {
 // of a Metric match the corresponding elements in a ReadResponse object
 // returned by a Jolokia agent.
 func metricMatchesResponse(metric Metric, response ReadResponse) bool {
-
-	if metric.Mbean != response.RequestMbean {
+	if !metric.MatchObjectName(response.RequestMbean) {
 		return false
 	}
 
@@ -136,19 +135,9 @@ func metricMatchesResponse(metric Metric, response ReadResponse) bool {
 		return len(response.RequestAttributes) == 0
 	}
 
-	for _, fullPath := range metric.Paths {
-		segments := strings.SplitN(fullPath, "/", 2)
-		attribute := segments[0]
-
-		var path string
-		if len(segments) == 2 {
-			path = segments[1]
-		}
-
-		for _, rattr := range response.RequestAttributes {
-			if attribute == rattr && path == response.RequestPath {
-				return true
-			}
+	for _, attribute := range response.RequestAttributes {
+		if metric.MatchAttributeAndPath(attribute, response.RequestPath) {
+			return true
 		}
 	}
 

--- a/plugins/inputs/jolokia2/metric.go
+++ b/plugins/inputs/jolokia2/metric.go
@@ -1,5 +1,7 @@
 package jolokia2
 
+import "strings"
+
 // A MetricConfig represents a TOML form of
 // a Metric with some optional fields.
 type MetricConfig struct {
@@ -25,6 +27,9 @@ type Metric struct {
 	FieldSeparator string
 	TagPrefix      string
 	TagKeys        []string
+
+	mbeanDomain     string
+	mbeanProperties []string
 }
 
 func NewMetric(config MetricConfig, defaultFieldPrefix, defaultFieldSeparator, defaultTagPrefix string) Metric {
@@ -57,5 +62,67 @@ func NewMetric(config MetricConfig, defaultFieldPrefix, defaultFieldSeparator, d
 		metric.TagPrefix = *config.TagPrefix
 	}
 
+	mbeanDomain, mbeanProperties := parseMbeanObjectName(config.Mbean)
+	metric.mbeanDomain = mbeanDomain
+	metric.mbeanProperties = mbeanProperties
+
 	return metric
+}
+
+func (m Metric) MatchObjectName(name string) bool {
+	if name == m.Mbean {
+		return true
+	}
+
+	mbeanDomain, mbeanProperties := parseMbeanObjectName(name)
+	if mbeanDomain != m.mbeanDomain {
+		return false
+	}
+
+	if len(mbeanProperties) != len(m.mbeanProperties) {
+		return false
+	}
+
+NEXT_PROPERTY:
+	for _, mbeanProperty := range m.mbeanProperties {
+		for i := range mbeanProperties {
+			if mbeanProperties[i] == mbeanProperty {
+				continue NEXT_PROPERTY
+			}
+		}
+
+		return false
+	}
+
+	return true
+}
+
+func (m Metric) MatchAttributeAndPath(attribute, innerPath string) bool {
+	path := attribute
+	if innerPath != "" {
+		path = path + "/" + innerPath
+	}
+
+	for i := range m.Paths {
+		if path == m.Paths[i] {
+			return true
+		}
+	}
+
+	return false
+}
+
+func parseMbeanObjectName(name string) (string, []string) {
+	index := strings.Index(name, ":")
+	if index == -1 {
+		return name, []string{}
+	}
+
+	domain := name[:index]
+
+	if index+1 > len(name) {
+		return domain, []string{}
+	}
+
+	return domain, strings.Split(name[index+1:], ",")
 }


### PR DESCRIPTION
Addressing issue #3435 the Jolokia2 plugin can match mbeans with object name properties that are coming back in a different order than specified in the toml config.

For example, it shouldn't matter if a metric mbean was declared as
```
[[inputs.jolokia2_agent.metric]]
  mbean = "Catalina:host=localhost,context=*,type=Manager"
```
or as 
```
[[inputs.jolokia2_agent.metric]]
  mbean = "Catalina:type=Manager,host=localhost,context=*"
```

This update will greatly reduce confusion when working with the plugin.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
