### PR TITLE
deb-systemd-invoke restart

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -74,7 +74,7 @@ elif [[ -f /etc/debian_version ]]; then
     # Debian/Ubuntu logic
     if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
         install_systemd /lib/systemd/system/telegraf.service
-        systemctl restart telegraf || echo "WARNING: systemd not running."
+        deb-systemd-invoke restart telegraf.service || echo "WARNING: systemd not running."
     else
         # Assuming SysVinit
         install_init


### PR DESCRIPTION
From man page:
```
deb-systemd-invoke is a Debian-specific helper script which asks
       /usr/sbin/policy-rc.d before performing a systemctl call.

deb-systemd-invoke is intended to be used from maintscripts to start
       systemd unit files. It is specifically NOT intended to be used
       interactively by users. Instead, users should run systemd and use
       systemctl, or not bother about the systemd enabled state in case they
       are not running systemd.
```

This PR replace regular `systemctl` with `deb-systemd-invoke`.

Fix: #3448

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
