### PR TITLE
when tag includes ":", split won't behave as expected.

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -488,7 +488,8 @@ func (s *Statsd) parseStatsdLine(line string) error {
 	}
 
 	// Extract bucket name from individual metric bits
-	bucketName, bits := bits[0], bits[1:]
+    bucketName := strings.Join(bits[:len(bits)-1], ":")  // join all but the last split
+    bits = bits[len(bits)-1]  // only the last split
 
 	// Add a metric for each bit available
 	for _, bit := range bits {


### PR DESCRIPTION
so "bits" would simply be the last split section, and bucketName is join of all-but-the-last sections

### Required for all PRs:

- [V] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
