### PR TITLE
fix postfix plugin age to use ctime, not mtime

### DIFF
--- a/plugins/inputs/postfix/postfix_test.go
+++ b/plugins/inputs/postfix/postfix_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +25,6 @@ func TestGather(t *testing.T) {
 
 	require.NoError(t, ioutil.WriteFile(path.Join(td, "active", "01"), []byte("abc"), 0644))
 	require.NoError(t, ioutil.WriteFile(path.Join(td, "active", "02"), []byte("defg"), 0644))
-	require.NoError(t, os.Chtimes(path.Join(td, "active", "02"), time.Now(), time.Now().Add(-time.Hour)))
 	require.NoError(t, ioutil.WriteFile(path.Join(td, "hold", "01"), []byte("abc"), 0644))
 	require.NoError(t, ioutil.WriteFile(path.Join(td, "incoming", "01"), []byte("abcd"), 0644))
 	require.NoError(t, ioutil.WriteFile(path.Join(td, "deferred", "0", "01"), []byte("abc"), 0644))
@@ -46,7 +44,7 @@ func TestGather(t *testing.T) {
 
 	assert.Equal(t, int64(2), metrics["active"].Fields["length"])
 	assert.Equal(t, int64(7), metrics["active"].Fields["size"])
-	assert.InDelta(t, int64(time.Hour/time.Second), metrics["active"].Fields["age"], 10)
+	assert.InDelta(t, 0, metrics["active"].Fields["age"], 10)
 
 	assert.Equal(t, int64(1), metrics["hold"].Fields["length"])
 	assert.Equal(t, int64(3), metrics["hold"].Fields["size"])

--- a/plugins/inputs/postfix/stat_ctim.go
+++ b/plugins/inputs/postfix/stat_ctim.go
@@ -1,0 +1,16 @@
+// +build dragonfly linux netbsd openbsd solaris
+
+package postfix
+
+import (
+	"syscall"
+	"time"
+)
+
+func statCTime(sys interface{}) time.Time {
+	stat, ok := sys.(*syscall.Stat_t)
+	if !ok {
+		return time.Time{}
+	}
+	return time.Unix(stat.Ctim.Unix())
+}

--- a/plugins/inputs/postfix/stat_ctimespec.go
+++ b/plugins/inputs/postfix/stat_ctimespec.go
@@ -1,0 +1,16 @@
+// +build darwin freebsd
+
+package postfix
+
+import (
+	"syscall"
+	"time"
+)
+
+func statCTime(sys interface{}) time.Time {
+	stat, ok := sys.(*syscall.Stat_t)
+	if !ok {
+		return time.Time{}
+	}
+	return time.Unix(stat.Ctimespec.Unix())
+}

--- a/plugins/inputs/postfix/stat_none.go
+++ b/plugins/inputs/postfix/stat_none.go
@@ -1,0 +1,7 @@
+// +build !dragonfly,!linux,!netbsd,!openbsd,!solaris,!darwin,!freebsd
+
+package postfix
+
+func statCTime(_ interface{}) time.Time {
+	return time.Time{}
+}


### PR DESCRIPTION
Fixes #3521 

Unfortunately ctime is not supported on all platforms, but I think the only such platform is windows, which doesn't support postfix anyway. However there are 2 different methods of getting ctime among the unix platforms, so I had to add conditional build tags to the different methods. You also cannot manually set a file's ctime, so we can't test it very well :-/

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [X] Has appropriate unit tests.
