### PR TITLE
Docker host mount prefix

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,5 +1,24 @@
 # Frequently Asked Questions
 
+### Q: How can I monitor the Docker Engine Host from within a container?
+
+You will need to setup several volume mounts as well as some environment
+variables:
+```
+docker run --name telegraf
+	-v /:/hostfs:ro
+	-v /etc:/hostfs/etc:ro
+	-v /proc:/hostfs/proc:ro
+	-v /sys:/hostfs/sys:ro
+	-v /var/run/utmp:/var/run/utmp:ro
+	-e HOST_ETC=/hostfs/etc
+	-e HOST_PROC=/hostfs/proc
+	-e HOST_SYS=/hostfs/sys
+	-e HOST_MOUNT_PREFIX=/hostfs
+	telegraf
+```
+
+
 ### Q: Why do I get a "no such host" error resolving hostnames that other
 programs can resolve?
 

--- a/plugins/inputs/system/DISK_README.md
+++ b/plugins/inputs/system/DISK_README.md
@@ -20,9 +20,11 @@ Additionally, the behavior of resolving the `mount_points` can be configured by 
 When present, this variable is prepended to the mountpoints discovered by the plugin before retrieving stats.
 The prefix is stripped from the reported `path` in the measurement.
 This settings is useful when running `telegraf` inside a docker container to report host machine metrics.
-In this case, the host's root volume should be mounted into the container and the `HOST_MOUNT_PREFIX` and `HOST_ETC` environment variables set.
+In this case, the host's root volume should be mounted into the container and the `HOST_MOUNT_PREFIX` and `HOST_PROC` environment variables set.
 
-`docker run -v /:/hostfs:ro -e HOST_MOUNT_PREFIX=/hostfs -e HOST_ETC=/hostfs/etc telegraf`
+```
+docker run -v /:/hostfs:ro -e HOST_MOUNT_PREFIX=/hostfs -e HOST_PROC=/hostfs/proc telegraf
+```
 
 ### Measurements & Fields:
 

--- a/plugins/inputs/system/disk_test.go
+++ b/plugins/inputs/system/disk_test.go
@@ -62,8 +62,6 @@ func TestDiskUsage(t *testing.T) {
 
 	mps.On("Partitions", true).Return(psAll, nil)
 	mps.On("OSGetenv", "HOST_MOUNT_PREFIX").Return("")
-	mps.On("OSStat", "/").Return(MockFileInfo{}, nil)
-	mps.On("OSStat", "/home").Return(MockFileInfo{}, nil)
 	mps.On("PSDiskUsage", "/").Return(&duAll[0], nil)
 	mps.On("PSDiskUsage", "/home").Return(&duAll[1], nil)
 


### PR DESCRIPTION
Based on #2812, but only filters partitions if there is a conflict between the filesystem and the `HOST_MOUNT_PREFIX`, i.e.: `/mnt/foo` vs `/hostfs/mnt/foo`.

closes #1544
closes #2811
closes #3483

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
