### PR TITLE
Support I (idle) process state on procfs+Linux

### DIFF
--- a/plugins/inputs/system/PROCESSES_README.md
+++ b/plugins/inputs/system/PROCESSES_README.md
@@ -30,7 +30,7 @@ Using the environment variable `HOST_PROC` the plugin will retrieve process info
     - zombie
     - dead
     - wait (freebsd only)
-    - idle (bsd only)
+    - idle (bsd and Linux 4+ only)
     - paging (linux only)
     - total_threads (linux only)
 
@@ -47,7 +47,7 @@ Linux  FreeBSD  Darwin  meaning
   Z       Z       Z     zombie
   X      none    none   dead
   T       T       T     stopped
- none     I       I     idle (sleeping for longer than about 20 seconds)
+  I       I       I     idle (sleeping for longer than about 20 seconds)
   D      D,L      U     blocked (waiting in uninterruptible sleep, or locked)
   W       W      none   paging (linux kernel < 2.6 only), wait (freebsd)
 ```

--- a/plugins/inputs/system/processes.go
+++ b/plugins/inputs/system/processes.go
@@ -85,6 +85,7 @@ func getEmptyFields() map[string]interface{} {
 		fields["dead"] = int64(0)
 		fields["paging"] = int64(0)
 		fields["total_threads"] = int64(0)
+		fields["idle"] = int64(0)
 	}
 	return fields
 }
@@ -174,6 +175,8 @@ func (p *Processes) gatherFromProc(fields map[string]interface{}) error {
 			fields["stopped"] = fields["stopped"].(int64) + int64(1)
 		case 'W':
 			fields["paging"] = fields["paging"].(int64) + int64(1)
+		case 'I':
+			fields["idle"] = fields["idle"].(int64) + int64(1)
 		default:
 			log.Printf("I! processes: Unknown state [ %s ] in file %s",
 				string(stats[0][0]), filename)


### PR DESCRIPTION
`I` is a Linux process state: https://github.com/torvalds/linux/blob/master/fs/proc/array.c#L135

This is a fairly recent change but causes lots of Telegraf log noise with 4.x kernels.

I'll do the rest of the paperwork for the PR if the underlying idea is acceptable.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
