### PR TITLE
Log connect error only in wavefront output

### DIFF
--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -101,11 +101,13 @@ func (w *Wavefront) Connect() error {
 	uri := fmt.Sprintf("%s:%d", w.Host, w.Port)
 	_, err := net.ResolveTCPAddr("tcp", uri)
 	if err != nil {
-		return fmt.Errorf("Wavefront: TCP address cannot be resolved %s", err.Error())
+		log.Printf("Wavefront: TCP address cannot be resolved %s", err.Error())
+		return nil
 	}
 	connection, err := net.Dial("tcp", uri)
 	if err != nil {
-		return fmt.Errorf("Wavefront: TCP connect fail %s", err.Error())
+		log.Printf("Wavefront: TCP connect fail %s", err.Error())
+		return nil
 	}
 	defer connection.Close()
 	return nil


### PR DESCRIPTION
If an error is returned from an output plugins Connect function, the Agent will connect once and if it fails again the agent will exit.  This behavior should probably be altered in the Output interface, so that the Connect function becomes an initialization function.  I'm planning to add an initialization function in #272 and will then revisit if the Connect function should then be removed.

In the meantime, we can log the error and return nil.  This plugin will attempt reconnect on every Write.

cc @puckpuck 

closes #3545

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] ~~Associated README.md updated.~~
- [ ] Has appropriate unit tests.
