### PR TITLE
Use device name instead of abs path for devices tag

### DIFF
--- a/plugins/inputs/smart/README.md
+++ b/plugins/inputs/smart/README.md
@@ -129,7 +129,7 @@ the configuration to execute that.
 
 Example output from an _Apple SSD_:
 ```
-> smart_attribute,serial_no=S1K5NYCD964433,wwn=5002538655584d30,id=199,name=UDMA_CRC_Error_Count,flags=-O-RC-,fail=-,host=mbpro.local,device=/dev/rdisk0 threshold=0i,raw_value=0i,exit_status=0i,value=200i,worst=200i 1502536854000000000
-> smart_attribute,device=/dev/rdisk0,serial_no=S1K5NYCD964433,wwn=5002538655584d30,id=240,name=Unknown_SSD_Attribute,flags=-O---K,fail=-,host=mbpro.local exit_status=0i,value=100i,worst=100i,threshold=0i,raw_value=0i 1502536854000000000
-> smart_device,enabled=Enabled,host=mbpro.local,device=/dev/rdisk0,model=APPLE\ SSD\ SM0512F,serial_no=S1K5NYCD964433,wwn=5002538655584d30,capacity=500277790720 udma_crc_errors=0i,exit_status=0i,health_ok=true,read_error_rate=0i,temp_c=40i 1502536854000000000
+> smart_attribute,serial_no=S1K5NYCD964433,wwn=5002538655584d30,id=199,name=UDMA_CRC_Error_Count,flags=-O-RC-,fail=-,host=mbpro.local,device=rdisk0 threshold=0i,raw_value=0i,exit_status=0i,value=200i,worst=200i 1502536854000000000
+> smart_attribute,device=rdisk0,serial_no=S1K5NYCD964433,wwn=5002538655584d30,id=240,name=Unknown_SSD_Attribute,flags=-O---K,fail=-,host=mbpro.local exit_status=0i,value=100i,worst=100i,threshold=0i,raw_value=0i 1502536854000000000
+> smart_device,enabled=Enabled,host=mbpro.local,device=rdisk0,model=APPLE\ SSD\ SM0512F,serial_no=S1K5NYCD964433,wwn=5002538655584d30,capacity=500277790720 udma_crc_errors=0i,exit_status=0i,health_ok=true,read_error_rate=0i,temp_c=40i 1502536854000000000
 ```

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -89,7 +89,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "1",
@@ -107,7 +107,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "5",
@@ -125,7 +125,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "9",
@@ -143,7 +143,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "12",
@@ -161,7 +161,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "169",
@@ -179,7 +179,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "173",
@@ -197,7 +197,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "190",
@@ -215,7 +215,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "192",
@@ -233,7 +233,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "194",
@@ -251,7 +251,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "197",
@@ -269,7 +269,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "199",
@@ -287,7 +287,7 @@ func TestGatherAttributes(t *testing.T) {
 				"exit_status": int(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
 				"id":        "240",
@@ -317,7 +317,7 @@ func TestGatherAttributes(t *testing.T) {
 				"udma_crc_errors": int64(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"model":     "APPLE SSD SM256E",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",
@@ -363,7 +363,7 @@ func TestGatherNoAttributes(t *testing.T) {
 				"udma_crc_errors": int64(0),
 			},
 			map[string]string{
-				"device":    "/dev/ada0",
+				"device":    "ada0",
 				"model":     "APPLE SSD SM256E",
 				"serial_no": "S0X5NZBC422720",
 				"wwn":       "5002538043584d30",


### PR DESCRIPTION
To be consistent with diskio and /proc entries

cc @rickard-von-essen

closes #3541

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
