### PR TITLE
Add system_uptime_format as Field, not as Counter

### DIFF
--- a/plugins/inputs/system/SYSTEM_README.md
+++ b/plugins/inputs/system/SYSTEM_README.md
@@ -34,5 +34,6 @@ $ telegraf --config ~/ws/telegraf.conf --input-filter system --test
 * Plugin: system, Collection 1
 * Plugin: inputs.system, Collection 1
 > system,host=tyrion load1=3.72,load5=2.4,load15=2.1,n_users=3i,n_cpus=4i 1483964144000000000
-> system,host=tyrion uptime=1249632i,uptime_format="14 days, 11:07" 1483964144000000000
+> system,host=tyrion uptime=1249632i 1483964144000000000
+> system,host=tyrion uptime_format="14 days, 11:07" 1483964144000000000
 ```

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -46,7 +46,9 @@ func (_ *SystemStats) Gather(acc telegraf.Accumulator) error {
 		"n_cpus":  runtime.NumCPU(),
 	}, nil)
 	acc.AddCounter("system", map[string]interface{}{
-		"uptime":        hostinfo.Uptime,
+		"uptime": hostinfo.Uptime,
+	}, nil)
+	acc.AddFields("system", map[string]interface{}{
 		"uptime_format": format_uptime(hostinfo.Uptime),
 	}, nil)
 


### PR DESCRIPTION
Prometheus doesn't support string fields, let's split system_uptime and system_uptime_format.
Issue #3577 
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
