### PR TITLE
Update README with missing Redis measurements

### DIFF
--- a/plugins/inputs/redis/README.md
+++ b/plugins/inputs/redis/README.md
@@ -87,6 +87,8 @@ Additionally the plugin also calculates the hit/miss ratio (keyspace\_hitrate) a
 
     **Replication**
     - connected_slaves(int, number)
+    - master_link_down_since_seconds(int, number)
+    - master_link_status(string)
     - master_repl_offset(int, number)
     - repl_backlog_active(int, number)
     - repl_backlog_size(int, bytes)


### PR DESCRIPTION
Add `master_link_status` and `master_link_down_since_seconds` to the replication measurements for Redis. These measurements are provided by the plugin, but not included in the README.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
