### PR TITLE
Remove AWS credential check from cloudwatch output

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/aws/aws-sdk-go/service/sts"
 
 	"github.com/influxdata/telegraf"
 	internalaws "github.com/influxdata/telegraf/internal/config/aws"
@@ -71,20 +70,7 @@ func (c *CloudWatch) Connect() error {
 		Token:     c.Token,
 	}
 	configProvider := credentialConfig.Credentials()
-
-	stsService := sts.New(configProvider)
-
-	params := &sts.GetSessionTokenInput{}
-
-	_, err := stsService.GetSessionToken(params)
-
-	if err != nil {
-		log.Printf("E! cloudwatch: Cannot use credentials to connect to AWS : %+v \n", err.Error())
-		return err
-	}
-
 	c.svc = cloudwatch.New(configProvider)
-
 	return nil
 }
 


### PR DESCRIPTION
This method is reported to not work with IAM Instance Profiles, and we
do not want to make any calls that would require additional permissions.

closes #3474 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] ~~Associated README.md updated.~~
- [ ] Has appropriate unit tests.
