### PR TITLE
Re-add AWS credential check from cloudwatch output

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/sts"
 
 	"github.com/influxdata/telegraf"
 	internalaws "github.com/influxdata/telegraf/internal/config/aws"
@@ -70,7 +71,20 @@ func (c *CloudWatch) Connect() error {
 		Token:     c.Token,
 	}
 	configProvider := credentialConfig.Credentials()
+
+	stsService := sts.New(configProvider)
+
+	params := &sts.GetCallerIdentityInput{}
+
+	_, err := stsService.GetCallerIdentity(params)
+
+	if err != nil {
+		log.Printf("E! cloudwatch: Cannot use credentials to connect to AWS : %+v \n", err.Error())
+		return err
+	}
+
 	c.svc = cloudwatch.New(configProvider)
+
 	return nil
 }
 


### PR DESCRIPTION
Re-add the check removed in #3583, but this time using the right API call that doesn't require any additional permissions. Fixes #3474.

I tested this by running telegraf locally with my personal credentials, and also running `$ aws sts get-caller-identity` on an EC2 instance that had an IAM Role/instance profile with zero permissions.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- -[ ] Associated README.md updated.-
- [ ] Has appropriate unit tests.
