### PR TITLE
Add messages_delivered_get to rabbitmq_overview

### DIFF
--- a/plugins/inputs/rabbitmq/README.md
+++ b/plugins/inputs/rabbitmq/README.md
@@ -52,6 +52,7 @@ For additional details reference the [RabbitMQ Management HTTP Stats](https://cd
   - messages (int, messages)
   - messages_acked (int, messages)
   - messages_delivered (int, messages)
+  - messages_delivered_get (int, messages)
   - messages_published (int, messages)
   - messages_ready (int, messages)
   - messages_unacked (int, messages)
@@ -115,6 +116,12 @@ For additional details reference the [RabbitMQ Management HTTP Stats](https://cd
 
 ### Sample Queries:
 
+Message rates for the entire node can be calculated from total message counts. For instance, to get the rate of messages published per minute, use this query:
+
+```
+SELECT NON_NEGATIVE_DIFFERENCE(LAST("messages_published")) AS messages_published_rate
+FROM rabbitmq_overview WHERE time > now() - 10m GROUP BY time(1m)
+```
 
 ### Example Output:
 

--- a/plugins/inputs/rabbitmq/README.md
+++ b/plugins/inputs/rabbitmq/README.md
@@ -119,7 +119,7 @@ For additional details reference the [RabbitMQ Management HTTP Stats](https://cd
 Message rates for the entire node can be calculated from total message counts. For instance, to get the rate of messages published per minute, use this query:
 
 ```
-SELECT NON_NEGATIVE_DIFFERENCE(LAST("messages_published")) AS messages_published_rate
+SELECT NON_NEGATIVE_DERIVATIVE(LAST("messages_published"), 1m) AS messages_published_rate
 FROM rabbitmq_overview WHERE time > now() - 10m GROUP BY time(1m)
 ```
 

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -268,17 +268,18 @@ func gatherOverview(r *RabbitMQ, acc telegraf.Accumulator) {
 		tags["name"] = r.Name
 	}
 	fields := map[string]interface{}{
-		"messages":           overview.QueueTotals.Messages,
-		"messages_ready":     overview.QueueTotals.MessagesReady,
-		"messages_unacked":   overview.QueueTotals.MessagesUnacknowledged,
-		"channels":           overview.ObjectTotals.Channels,
-		"connections":        overview.ObjectTotals.Connections,
-		"consumers":          overview.ObjectTotals.Consumers,
-		"exchanges":          overview.ObjectTotals.Exchanges,
-		"queues":             overview.ObjectTotals.Queues,
-		"messages_acked":     overview.MessageStats.Ack,
-		"messages_delivered": overview.MessageStats.Deliver,
-		"messages_published": overview.MessageStats.Publish,
+		"messages":               overview.QueueTotals.Messages,
+		"messages_ready":         overview.QueueTotals.MessagesReady,
+		"messages_unacked":       overview.QueueTotals.MessagesUnacknowledged,
+		"channels":               overview.ObjectTotals.Channels,
+		"connections":            overview.ObjectTotals.Connections,
+		"consumers":              overview.ObjectTotals.Consumers,
+		"exchanges":              overview.ObjectTotals.Exchanges,
+		"queues":                 overview.ObjectTotals.Queues,
+		"messages_acked":         overview.MessageStats.Ack,
+		"messages_delivered":     overview.MessageStats.Deliver,
+		"messages_delivered_get": overview.MessageStats.DeliverGet,
+		"messages_published":     overview.MessageStats.Publish,
 	}
 	acc.AddFields("rabbitmq_overview", fields, tags)
 }


### PR DESCRIPTION
As discussed in #3586. `messages_delivered_get` represents the grand total of messages delivered since the node's startup.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
