### PR TITLE
Add wired field to mem input

### DIFF
--- a/plugins/inputs/system/MEM_README.md
+++ b/plugins/inputs/system/MEM_README.md
@@ -27,6 +27,7 @@ For a more complete explanation of the difference between *used* and
   	- used (int)
   	- available_percent (float)
   	- used_percent (float)
+  	- wired (int)
 
 ### Example Output:
 ```

--- a/plugins/inputs/system/memory.go
+++ b/plugins/inputs/system/memory.go
@@ -32,6 +32,7 @@ func (s *MemStats) Gather(acc telegraf.Accumulator) error {
 		"buffered":          vm.Buffers,
 		"active":            vm.Active,
 		"inactive":          vm.Inactive,
+		"wired":             vm.Wired,
 		"slab":              vm.Slab,
 		"used_percent":      100 * float64(vm.Used) / float64(vm.Total),
 		"available_percent": 100 * float64(vm.Available) / float64(vm.Total),

--- a/plugins/inputs/system/memory_test.go
+++ b/plugins/inputs/system/memory_test.go
@@ -22,9 +22,9 @@ func TestMemStats(t *testing.T) {
 		Active:    8134,
 		Inactive:  1124,
 		Slab:      1234,
+		Wired:     134,
 		// Buffers:     771,
 		// Cached:      4312,
-		// Wired:       134,
 		// Shared:      2142,
 	}
 
@@ -55,6 +55,7 @@ func TestMemStats(t *testing.T) {
 		"buffered":          uint64(0),
 		"active":            uint64(8134),
 		"inactive":          uint64(1124),
+		"wired":             uint64(134),
 		"slab":              uint64(1234),
 	}
 	acc.AssertContainsTaggedFields(t, "mem", memfields, make(map[string]string))


### PR DESCRIPTION
closes #3628

Ideally this patch would not report wired on systems that do not have this field, however I think this is an acceptable change since we are already reporting active and inactive.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
