### PR TITLE
Parse string type values in Dropwizard parser

### DIFF
--- a/plugins/parsers/dropwizard/parser.go
+++ b/plugins/parsers/dropwizard/parser.go
@@ -220,9 +220,11 @@ func (p *Parser) readDWMetrics(metricType string, dwms interface{}, metrics []te
 			case map[string]interface{}: // json object
 				for fieldName, fieldValue := range t {
 
-					switch v := fieldValue.(type) {
+					switch fieldValue.(type) {
 					case float64:
-						fields = append(fields, fmt.Sprintf("%s%s=%f", fieldPrefix, fieldName, v))
+						fields = append(fields, fmt.Sprintf("%s%s=%f", fieldPrefix, fieldName, fieldValue))
+					case string:
+						fields = append(fields, fmt.Sprintf("%s%s=\"%s\"", fieldPrefix, fieldName, fieldValue))
 					default: // ignore
 					}
 				}

--- a/plugins/parsers/dropwizard/parser_test.go
+++ b/plugins/parsers/dropwizard/parser_test.go
@@ -36,14 +36,14 @@ func TestParseValidEmptyJSON(t *testing.T) {
 const validCounterJSON = `
 {
 	"version": 		"3.0.0",
-	"counters" : 	{ 
+	"counters" : 	{
 		"measurement" : {
 			"count" : 1
 		}
 	},
 	"meters" : 		{},
 	"gauges" : 		{},
-	"histograms" : 	{},
+	"histograms" : 		{},
 	"timers" : 		{}
 }
 `
@@ -147,6 +147,7 @@ func TestParseValidMeterJSON1(t *testing.T) {
 		"m1_rate":   float64(1),
 		"m5_rate":   float64(1),
 		"mean_rate": float64(1),
+		"units":     "events/second",
 	}, metrics[0].Fields())
 
 	assert.Equal(t, map[string]string{"metric_type": "meter"}, metrics[0].Tags())
@@ -186,6 +187,7 @@ func TestParseValidMeterJSON2(t *testing.T) {
 		"m1_rate":   float64(2),
 		"m5_rate":   float64(2),
 		"mean_rate": float64(2),
+		"units":     "events/second",
 	}, metrics[0].Fields())
 	assert.Equal(t, map[string]string{"metric_type": "meter", "key": "value"}, metrics[0].Tags())
 }
@@ -197,8 +199,8 @@ const validGaugeJSON = `
 	"counters" : 	{},
 	"meters" : 		{},
 	"gauges" : 		{
-		"measurement" : {
-			"value" : 0
+		"measurement" :	{
+			"value" : "a string"
 		}
 	},
 	"histograms" : 	{},
@@ -214,7 +216,7 @@ func TestParseValidGaugeJSON(t *testing.T) {
 	assert.Len(t, metrics, 1)
 	assert.Equal(t, "measurement", metrics[0].Name())
 	assert.Equal(t, map[string]interface{}{
-		"value": float64(0),
+		"value": "a string",
 	}, metrics[0].Fields())
 	assert.Equal(t, map[string]string{"metric_type": "gauge"}, metrics[0].Tags())
 }
@@ -308,21 +310,23 @@ func TestParseValidTimerJSON(t *testing.T) {
 	assert.Len(t, metrics, 1)
 	assert.Equal(t, "measurement", metrics[0].Name())
 	assert.Equal(t, map[string]interface{}{
-		"count":     float64(1),
-		"max":       float64(2),
-		"mean":      float64(3),
-		"min":       float64(4),
-		"p50":       float64(5),
-		"p75":       float64(6),
-		"p95":       float64(7),
-		"p98":       float64(8),
-		"p99":       float64(9),
-		"p999":      float64(10),
-		"stddev":    float64(11),
-		"m15_rate":  float64(12),
-		"m1_rate":   float64(13),
-		"m5_rate":   float64(14),
-		"mean_rate": float64(15),
+		"count":          float64(1),
+		"max":            float64(2),
+		"mean":           float64(3),
+		"min":            float64(4),
+		"p50":            float64(5),
+		"p75":            float64(6),
+		"p95":            float64(7),
+		"p98":            float64(8),
+		"p99":            float64(9),
+		"p999":           float64(10),
+		"stddev":         float64(11),
+		"m15_rate":       float64(12),
+		"m1_rate":        float64(13),
+		"m5_rate":        float64(14),
+		"mean_rate":      float64(15),
+		"duration_units": "seconds",
+		"rate_units":     "calls/second",
 	}, metrics[0].Fields())
 	assert.Equal(t, map[string]string{"metric_type": "timer"}, metrics[0].Tags())
 }


### PR DESCRIPTION
Handle parsing of a Dropwizard metric with string values e.g.

```json
{
  "version": "3.0.0",
  "gauges": {
    "measurement": {
      "value": "a string"
    }
  }
}
```

```
> measurement,metric_type=gauge value="a string" <timestamp>
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
