### PR TITLE
Have all test listeners listen only on localhost

### DIFF
--- a/plugins/inputs/http_listener/http_listener_test.go
+++ b/plugins/inputs/http_listener/http_listener_test.go
@@ -114,7 +114,7 @@ var (
 
 func newTestHTTPListener() *HTTPListener {
 	listener := &HTTPListener{
-		ServiceAddress: ":0",
+		ServiceAddress: "localhost:0",
 	}
 	return listener
 }
@@ -155,7 +155,7 @@ func newTestHTTPSListener() *HTTPListener {
 	})
 
 	listener := &HTTPListener{
-		ServiceAddress:    ":0",
+		ServiceAddress:    "localhost:0",
 		TlsAllowedCacerts: allowedCAFiles,
 		TlsCert:           serviceCertFile,
 		TlsKey:            serviceKeyFile,
@@ -309,7 +309,7 @@ func TestWriteHTTPNoNewline(t *testing.T) {
 
 func TestWriteHTTPMaxLineSizeIncrease(t *testing.T) {
 	listener := &HTTPListener{
-		ServiceAddress: ":0",
+		ServiceAddress: "localhost:0",
 		MaxLineSize:    128 * 1000,
 	}
 
@@ -326,7 +326,7 @@ func TestWriteHTTPMaxLineSizeIncrease(t *testing.T) {
 
 func TestWriteHTTPVerySmallMaxBody(t *testing.T) {
 	listener := &HTTPListener{
-		ServiceAddress: ":0",
+		ServiceAddress: "localhost:0",
 		MaxBodySize:    4096,
 	}
 
@@ -342,7 +342,7 @@ func TestWriteHTTPVerySmallMaxBody(t *testing.T) {
 
 func TestWriteHTTPVerySmallMaxLineSize(t *testing.T) {
 	listener := &HTTPListener{
-		ServiceAddress: ":0",
+		ServiceAddress: "localhost:0",
 		MaxLineSize:    70,
 	}
 
@@ -368,7 +368,7 @@ func TestWriteHTTPVerySmallMaxLineSize(t *testing.T) {
 
 func TestWriteHTTPLargeLinesSkipped(t *testing.T) {
 	listener := &HTTPListener{
-		ServiceAddress: ":0",
+		ServiceAddress: "localhost:0",
 		MaxLineSize:    100,
 	}
 

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -21,7 +21,7 @@ func newTestTcpListener() (*Statsd, chan *bytes.Buffer) {
 	in := make(chan *bytes.Buffer, 1500)
 	listener := &Statsd{
 		Protocol:               "tcp",
-		ServiceAddress:         ":8125",
+		ServiceAddress:         "localhost:8125",
 		AllowedPendingMessages: 10000,
 		MaxTCPConnections:      250,
 		in:                     in,
@@ -50,7 +50,7 @@ func NewTestStatsd() *Statsd {
 func TestConcurrentConns(t *testing.T) {
 	listener := Statsd{
 		Protocol:               "tcp",
-		ServiceAddress:         ":8125",
+		ServiceAddress:         "localhost:8125",
 		AllowedPendingMessages: 10000,
 		MaxTCPConnections:      2,
 	}
@@ -80,7 +80,7 @@ func TestConcurrentConns(t *testing.T) {
 func TestConcurrentConns1(t *testing.T) {
 	listener := Statsd{
 		Protocol:               "tcp",
-		ServiceAddress:         ":8125",
+		ServiceAddress:         "localhost:8125",
 		AllowedPendingMessages: 10000,
 		MaxTCPConnections:      1,
 	}
@@ -108,7 +108,7 @@ func TestConcurrentConns1(t *testing.T) {
 func TestCloseConcurrentConns(t *testing.T) {
 	listener := Statsd{
 		Protocol:               "tcp",
-		ServiceAddress:         ":8125",
+		ServiceAddress:         "localhost:8125",
 		AllowedPendingMessages: 10000,
 		MaxTCPConnections:      2,
 	}
@@ -129,7 +129,7 @@ func TestCloseConcurrentConns(t *testing.T) {
 func BenchmarkUDP(b *testing.B) {
 	listener := Statsd{
 		Protocol:               "udp",
-		ServiceAddress:         ":8125",
+		ServiceAddress:         "localhost:8125",
 		AllowedPendingMessages: 250000,
 	}
 	acc := &testutil.Accumulator{Discard: true}
@@ -159,7 +159,7 @@ func BenchmarkUDP(b *testing.B) {
 func BenchmarkTCP(b *testing.B) {
 	listener := Statsd{
 		Protocol:               "tcp",
-		ServiceAddress:         ":8125",
+		ServiceAddress:         "localhost:8125",
 		AllowedPendingMessages: 250000,
 		MaxTCPConnections:      250,
 	}

--- a/plugins/inputs/tcp_listener/tcp_listener_test.go
+++ b/plugins/inputs/tcp_listener/tcp_listener_test.go
@@ -33,7 +33,7 @@ cpu_load_short,host=server06 value=12.0 1422568543702900257
 func newTestTcpListener() (*TcpListener, chan []byte) {
 	in := make(chan []byte, 1500)
 	listener := &TcpListener{
-		ServiceAddress:         ":8194",
+		ServiceAddress:         "localhost:8194",
 		AllowedPendingMessages: 10000,
 		MaxTCPConnections:      250,
 		in:                     in,
@@ -45,7 +45,7 @@ func newTestTcpListener() (*TcpListener, chan []byte) {
 // benchmark how long it takes to accept & process 100,000 metrics:
 func BenchmarkTCP(b *testing.B) {
 	listener := TcpListener{
-		ServiceAddress:         ":8198",
+		ServiceAddress:         "localhost:8198",
 		AllowedPendingMessages: 100000,
 		MaxTCPConnections:      250,
 	}
@@ -76,7 +76,7 @@ func BenchmarkTCP(b *testing.B) {
 
 func TestHighTrafficTCP(t *testing.T) {
 	listener := TcpListener{
-		ServiceAddress:         ":8199",
+		ServiceAddress:         "localhost:8199",
 		AllowedPendingMessages: 100000,
 		MaxTCPConnections:      250,
 	}
@@ -103,7 +103,7 @@ func TestHighTrafficTCP(t *testing.T) {
 
 func TestConnectTCP(t *testing.T) {
 	listener := TcpListener{
-		ServiceAddress:         ":8194",
+		ServiceAddress:         "localhost:8194",
 		AllowedPendingMessages: 10000,
 		MaxTCPConnections:      250,
 	}
@@ -140,7 +140,7 @@ func TestConnectTCP(t *testing.T) {
 // Test that MaxTCPConections is respected
 func TestConcurrentConns(t *testing.T) {
 	listener := TcpListener{
-		ServiceAddress:         ":8195",
+		ServiceAddress:         "localhost:8195",
 		AllowedPendingMessages: 10000,
 		MaxTCPConnections:      2,
 	}
@@ -175,7 +175,7 @@ func TestConcurrentConns(t *testing.T) {
 // Test that MaxTCPConections is respected when max==1
 func TestConcurrentConns1(t *testing.T) {
 	listener := TcpListener{
-		ServiceAddress:         ":8196",
+		ServiceAddress:         "localhost:8196",
 		AllowedPendingMessages: 10000,
 		MaxTCPConnections:      1,
 	}
@@ -208,7 +208,7 @@ func TestConcurrentConns1(t *testing.T) {
 // Test that MaxTCPConections is respected
 func TestCloseConcurrentConns(t *testing.T) {
 	listener := TcpListener{
-		ServiceAddress:         ":8195",
+		ServiceAddress:         "localhost:8195",
 		AllowedPendingMessages: 10000,
 		MaxTCPConnections:      2,
 	}


### PR DESCRIPTION
Update to have all test listeners listen only on localhost to prevent macOSX firewall prompts to "allow incoming connections" on the listeners.

This is per https://medium.com/@leeprovoost/suppressing-accept-incoming-network-connections-warnings-on-osx-7665b33927ca

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated. - No update required
- [x] Has appropriate unit tests.