### PR TITLE
Ignore empty lines in Graphite plaintext

### DIFF
--- a/plugins/parsers/graphite/parser.go
+++ b/plugins/parsers/graphite/parser.go
@@ -86,8 +86,11 @@ func (p *GraphiteParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 
 		// Trim the buffer, even though there should be no padding
 		line := strings.TrimSpace(string(buf))
-		metric, err := p.ParseLine(line)
+		if line == "" {
+			continue
+		}
 
+		metric, err := p.ParseLine(line)
 		if err == nil {
 			metrics = append(metrics, metric)
 		} else {


### PR DESCRIPTION
Updates the Graphite parser to ignore empty lines in incoming Graphite plaintext.

Currently, empty lines result in an error and Telegraf fails to parse the incoming packet.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
