### PR TITLE
Limit wait time for writes in mqtt output

### DIFF
--- a/plugins/outputs/mqtt/mqtt.go
+++ b/plugins/outputs/mqtt/mqtt.go
@@ -153,7 +153,7 @@ func (m *MQTT) Write(metrics []telegraf.Metric) error {
 
 func (m *MQTT) publish(topic string, body []byte) error {
 	token := m.client.Publish(topic, byte(m.QoS), false, body)
-	token.Wait()
+	token.WaitTimeout(m.Timeout.Duration)
 	if token.Error() != nil {
 		return token.Error()
 	}

--- a/plugins/outputs/mqtt/mqtt.go
+++ b/plugins/outputs/mqtt/mqtt.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
@@ -24,6 +25,9 @@ var sampleConfig = `
   ## username and password to connect MQTT server.
   # username = "telegraf"
   # password = "metricsmetricsmetricsmetrics"
+
+  ## Timeout for write operations. default: 5s
+  # timeout = "5s"
 
   ## client ID, if not set a random ID is generated
   # client_id = ""
@@ -158,6 +162,11 @@ func (m *MQTT) publish(topic string, body []byte) error {
 
 func (m *MQTT) createOpts() (*paho.ClientOptions, error) {
 	opts := paho.NewClientOptions()
+
+	if m.Timeout.Duration < time.Second {
+		m.Timeout.Duration = 5 * time.Second
+	}
+	opts.WriteTimeout = m.Timeout.Duration
 
 	if m.ClientID != "" {
 		opts.SetClientID(m.ClientID)


### PR DESCRIPTION
By limiting the amount of time we will wait for message to be sent, we avoid deadlock in the mqtt output.

closes #3697 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
