### PR TITLE
Add nats streaming output plugin

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -46,6 +46,7 @@ github.com/mitchellh/mapstructure d0303fe809921458f417bcf828397a65db30a7e4
 github.com/multiplay/go-ts3 07477f49b8dfa3ada231afc7b7b17617d42afe8e
 github.com/naoina/go-stringutil 6b638e95a32d0c1131db0e7fe83775cbea4a0d0b
 github.com/nats-io/go-nats ea9585611a4ab58a205b9b125ebd74c389a6b898
+github.com/nats-io/go-nats-streaming ad2984cc18491c7674c7f69196b854fb71337738
 github.com/nats-io/nats ea9585611a4ab58a205b9b125ebd74c389a6b898
 github.com/nats-io/nuid 289cccf02c178dc782430d534e3c1f5b72af807f
 github.com/nsqio/go-nsq eee57a3ac4174c55924125bb15eeeda8cffb6e6f

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ docker-run:
 	docker run --name mqtt -p "1883:1883" -d ncarlier/mqtt
 	docker run --name riemann -p "5555:5555" -d stealthly/docker-riemann
 	docker run --name nats -p "4222:4222" -d nats
+	docker run --name nats-streaming --link nats -d nats-streaming -ns nats://nats:4222
 	docker run --name openldap \
 		-e SLAPD_CONFIG_ROOTDN="cn=manager,cn=config" \
 		-e SLAPD_CONFIG_ROOTPW="secret" \
@@ -111,6 +112,7 @@ docker-run-circle:
 	docker run --name mqtt -p "1883:1883" -d ncarlier/mqtt
 	docker run --name riemann -p "5555:5555" -d stealthly/docker-riemann
 	docker run --name nats -p "4222:4222" -d nats
+	docker run --name nats-streaming --link nats -d nats-streaming -ns nats://nats:4222
 	docker run --name openldap \
 		-e SLAPD_CONFIG_ROOTDN="cn=manager,cn=config" \
 		-e SLAPD_CONFIG_ROOTPW="secret" \
@@ -119,9 +121,9 @@ docker-run-circle:
 
 docker-kill:
 	-docker kill aerospike elasticsearch kafka memcached mqtt mysql nats nsq \
-		openldap postgres rabbitmq redis riemann zookeeper cratedb
+		nats-streaming openldap postgres rabbitmq redis riemann zookeeper cratedb
 	-docker rm aerospike elasticsearch kafka memcached mqtt mysql nats nsq \
-		openldap postgres rabbitmq redis riemann zookeeper cratedb
+		nats-streaming openldap postgres rabbitmq redis riemann zookeeper cratedb
 
 .PHONY: deps telegraf telegraf.exe install test test-windows lint test-all \
 	package clean docker-run docker-run-circle docker-kill docker-image

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -673,6 +673,34 @@
 #   # data_format = "influx"
 
 
+# # Configuration for NATS Streaming server to send metrics to
+# [[outputs.stan]]
+#   ## NATS Streaming Cluster ID
+#   cluster_id = "test-cluster"
+#   ## Client ID
+#   client_id = "telegraf-client-id"
+#   ## URLs of NATS servers
+#   servers = ["nats://localhost:4222"]
+#   ## Optional credentials
+#   # username = ""
+#   # password = ""
+#   ## NATS subject for producer messages
+#   subject = "telegraf"
+# 
+#   ## Optional SSL Config
+#   # ssl_ca = "/etc/telegraf/ca.pem"
+#   # ssl_cert = "/etc/telegraf/cert.pem"
+#   # ssl_key = "/etc/telegraf/key.pem"
+#   ## Use SSL but skip chain & host verification
+#   # insecure_skip_verify = false
+# 
+#   ## Data format to output.
+#   ## Each data format has its own unique set of configuration options, read
+#   ## more about them here:
+#   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+#   data_format = "influx"
+
+
 # # Configuration for Wavefront server to send metrics to
 # [[outputs.wavefront]]
 #   ## DNS name of the wavefront proxy server

--- a/plugins/outputs/all/all.go
+++ b/plugins/outputs/all/all.go
@@ -24,5 +24,6 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/outputs/riemann"
 	_ "github.com/influxdata/telegraf/plugins/outputs/riemann_legacy"
 	_ "github.com/influxdata/telegraf/plugins/outputs/socket_writer"
+	_ "github.com/influxdata/telegraf/plugins/outputs/stan"
 	_ "github.com/influxdata/telegraf/plugins/outputs/wavefront"
 )

--- a/plugins/outputs/stan/README.md
+++ b/plugins/outputs/stan/README.md
@@ -1,0 +1,48 @@
+# NATS Streaming Output Plugin
+
+This plugin writes to a (list of) specified NATS Streaming instance(s).
+
+```
+[[outputs.stan]]
+  ## NATS Streaming Cluster ID
+  cluster_id = "test-cluster"
+  ## Client ID
+  client_id = "telegraf-client-id"
+  ## URLs of NATS servers
+  servers = ["nats://localhost:4222"]
+  ## Optional credentials
+  # username = ""
+  # password = ""
+  ## NATS subject for producer messages
+  subject = "telegraf"
+  ## Optional NATS Streaming discover prefix
+  # discover_prefix = "_STAN.discover"
+
+  ## Optional SSL Config
+  # ssl_ca = "/etc/telegraf/ca.pem"
+  # ssl_cert = "/etc/telegraf/cert.pem"
+  # ssl_key = "/etc/telegraf/key.pem"
+  ## Use SSL but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## Data format to output.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "influx"
+```
+
+### Required parameters:
+
+* `cluster_id`: The NATS Streaming cluster ID.
+* `client_id`: A unique identifier of this client sent to the NATS server.
+* `servers`:  List of strings, this is for NATS clustering support. Each URL should start with `nats://`.
+* `subject`: The NATS subject to publish to.
+
+### Optional parameters:
+
+* `username`: Username for NATS
+* `password`: Password for NATS
+* `tls_ca`: TLS CA
+* `insecure_skip_verify`: Use SSL but skip chain & host verification (default: false)
+* `discover_prefix`: The prefix used to discover NATS Streaming servers.

--- a/plugins/outputs/stan/stan.go
+++ b/plugins/outputs/stan/stan.go
@@ -140,7 +140,7 @@ func (n *Stan) Write(metrics []telegraf.Metric) error {
 			return fmt.Errorf("FAILED to send NATS Streaming message: %s", err)
 		}
 	}
-	
+
 	return nil
 }
 

--- a/plugins/outputs/stan/stan.go
+++ b/plugins/outputs/stan/stan.go
@@ -1,0 +1,152 @@
+package stan
+
+import (
+	"fmt"
+
+	nats_client "github.com/nats-io/go-nats"
+	stan_client "github.com/nats-io/go-nats-streaming"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/outputs"
+	"github.com/influxdata/telegraf/plugins/serializers"
+)
+
+type STAN struct {
+	// NATS Streaming Cluster ID
+	ClusterID string `toml:"cluster_id"`
+
+	// NATS Streaming Client ID
+	ClientID string `toml:"client_id"`
+
+	// Servers is the NATS server pool to connect to
+	Servers []string
+	// Credentials
+	Username string
+	Password string
+
+	// STAN subject to publish metrics to
+	Subject string
+
+	// Path to CA file
+	SSLCA string `toml:"ssl_ca"`
+	// Path to host cert file
+	SSLCert string `toml:"ssl_cert"`
+	// Path to cert key file
+	SSLKey string `toml:"ssl_key"`
+	// Use SSL but skip chain & host verification
+	InsecureSkipVerify bool
+
+	conn       stan_client.Conn
+	serializer serializers.Serializer
+}
+
+var sampleConfig = `
+  ## NATS Streaming Cluster ID
+  cluster_id = "test-cluster"
+  ## Client ID
+  client_id = "telegraf-client-id"
+  ## URLs of NATS servers
+  servers = ["nats://localhost:4222"]
+  ## Optional credentials
+  # username = ""
+  # password = ""
+  ## NATS subject for producer messages
+  subject = "telegraf"
+
+  ## Optional SSL Config
+  # ssl_ca = "/etc/telegraf/ca.pem"
+  # ssl_cert = "/etc/telegraf/cert.pem"
+  # ssl_key = "/etc/telegraf/key.pem"
+  ## Use SSL but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## Data format to output.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "influx"
+`
+
+func (n *STAN) SetSerializer(serializer serializers.Serializer) {
+	n.serializer = serializer
+}
+
+func (n *STAN) Connect() error {
+	var err error
+
+	natsOpts := nats_client.DefaultOptions
+
+	// override max reconnection tries
+	natsOpts.MaxReconnect = -1
+
+	// override servers, if any were specified
+	natsOpts.Servers = n.Servers
+
+	// override authentication, if any was specified
+	if n.Username != "" {
+		natsOpts.User = n.Username
+		natsOpts.Password = n.Password
+	}
+
+	// override TLS, if it was specified
+	tlsConfig, err := internal.GetTLSConfig(
+		n.SSLCert, n.SSLKey, n.SSLCA, n.InsecureSkipVerify)
+	if err != nil {
+		return err
+	}
+	if tlsConfig != nil {
+		// set NATS connection TLS options
+		natsOpts.Secure = true
+		natsOpts.TLSConfig = tlsConfig
+	}
+
+	// try and connect to the NATS server
+	natsConn, err := natsOpts.Connect()
+	if err != nil {
+		return err
+	}
+
+	// try and connect to the NATS Streaming cluster
+	n.conn, err = stan_client.Connect(n.ClusterID, n.ClientID, stan_client.NatsConn(natsConn))
+
+	return err
+}
+
+func (n *STAN) Close() error {
+	n.conn.Close()
+	return nil
+}
+
+func (n *STAN) SampleConfig() string {
+	return sampleConfig
+}
+
+func (n *STAN) Description() string {
+	return "Send telegraf measurements to NATS Streaming"
+}
+
+func (n *STAN) Write(metrics []telegraf.Metric) error {
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	for _, metric := range metrics {
+		buf, err := n.serializer.Serialize(metric)
+		if err != nil {
+			return err
+		}
+
+		err = n.conn.Publish(n.Subject, buf)
+		if err != nil {
+			return fmt.Errorf("FAILED to send NATS Streaming message: %s", err)
+		}
+	}
+	return nil
+}
+
+func init() {
+	outputs.Add("stan", func() telegraf.Output {
+		return &STAN{}
+	})
+}

--- a/plugins/outputs/stan/stan_test.go
+++ b/plugins/outputs/stan/stan_test.go
@@ -1,0 +1,33 @@
+package stan
+
+import (
+	"testing"
+
+	"github.com/influxdata/telegraf/plugins/serializers"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectAndWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	server := []string{"nats://" + testutil.GetLocalHost() + ":4222"}
+	s, _ := serializers.NewInfluxSerializer()
+	n := &STAN{
+		Servers:    server,
+		ClusterID:  "test-cluster",
+		ClientID:   "telegraf-test-client",
+		Subject:    "telegraf",
+		serializer: s,
+	}
+
+	// Verify that we can connect to the NATS Streaming daemon
+	err := n.Connect()
+	require.NoError(t, err)
+
+	// Verify that we can successfully write data to the NATS Streaming daemon
+	err = n.Write(testutil.MockMetrics())
+	require.NoError(t, err)
+}

--- a/plugins/outputs/stan/stan_test.go
+++ b/plugins/outputs/stan/stan_test.go
@@ -15,7 +15,7 @@ func TestConnectAndWrite(t *testing.T) {
 
 	server := []string{"nats://" + testutil.GetLocalHost() + ":4222"}
 	s, _ := serializers.NewInfluxSerializer()
-	n := &STAN{
+	n := &Stan{
 		Servers:    server,
 		ClusterID:  "test-cluster",
 		ClientID:   "telegraf-test-client",


### PR DESCRIPTION
This adds [NATS Streaming](https://github.com/nats-io/go-nats-streaming) support as an output option (mirroring the existing NATS output plugin).

I broke out the godeps update into its own commit, as there were more changes than just the addition of go-nats-streaming, and I'm not experienced enough with go to judge the correctness of the other changes.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
