### PR TITLE
ignore redis info when key name contain "replid"

### DIFF
--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -207,6 +207,11 @@ func gatherInfoOutput(
 			}
 		}
 
+		// drop section when name contain "replid"
+		if strings.Contains(section, "replid"){
+			continue
+		}
+
 		if name == "mem_allocator" {
 			continue
 		}
@@ -249,7 +254,6 @@ func gatherInfoOutput(
 		}
 
 		// Treat it as a string
-
 		if name == "role" {
 			tags["replication_role"] = val
 			continue

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -208,7 +208,7 @@ func gatherInfoOutput(
 		}
 
 		// drop section when name contain "replid"
-		if strings.Contains(section, "replid"){
+		if strings.Contains(section, "replid") {
 			continue
 		}
 


### PR DESCRIPTION
when grab information from multiple redis nodes, some nodes' xx_replid
are sha1 string like '34055853fce268cfc81aadd5686e1dd79b21b5bf', but
some nodes' xx_replid are just
'0000000000000000000000000000000000000000',
when the all zero string get parsed in golang, it's a int 0, however
sha1 string is parsed as a string, so the type difference cause a type
conflict, which lead to drop of point when write to influxdb.
whatsmore the xx_replid section is useless, so drop this section is
harmless.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
