### PR TITLE
Update wavefront.go

### DIFF
--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -122,7 +122,7 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 		return fmt.Errorf("Wavefront: TCP connect fail %s", err.Error())
 	}
 	defer connection.Close()
-	connection.SetWriteDeadline(time.Now().Add(5 * time.Second))	
+	connection.SetWriteDeadline(time.Now().Add(5 * time.Second))
 
 	for _, m := range metrics {
 		for _, metricPoint := range buildMetrics(m, w) {

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -122,6 +122,7 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 		return fmt.Errorf("Wavefront: TCP connect fail %s", err.Error())
 	}
 	defer connection.Close()
+	connection.SetWriteDeadline(time.Now().Add(5 * time.Second))	
 
 	for _, m := range metrics {
 		for _, metricPoint := range buildMetrics(m, w) {

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"
+	"time"
 )
 
 type Wavefront struct {
@@ -101,13 +102,11 @@ func (w *Wavefront) Connect() error {
 	uri := fmt.Sprintf("%s:%d", w.Host, w.Port)
 	_, err := net.ResolveTCPAddr("tcp", uri)
 	if err != nil {
-		log.Printf("Wavefront: TCP address cannot be resolved %s", err.Error())
-		return nil
+		return fmt.Errorf("Wavefront: TCP address cannot be resolved %s", err.Error())
 	}
 	connection, err := net.Dial("tcp", uri)
 	if err != nil {
-		log.Printf("Wavefront: TCP connect fail %s", err.Error())
-		return nil
+		return fmt.Errorf("Wavefront: TCP connect fail %s", err.Error())
 	}
 	defer connection.Close()
 	return nil


### PR DESCRIPTION
### Required for all PRs:

This fixes a potential issue where the output plugin could in some instances take more than 5 seconds causing all other input plugins to block.  

See #3710 and #2919 

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
