### PR TITLE
Add server option to unbound plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ configuration options.
 * [teamspeak](./plugins/inputs/teamspeak)
 * [tomcat](./plugins/inputs/tomcat)
 * [twemproxy](./plugins/inputs/twemproxy)
-* [unbound](./plugins/input/unbound)
+* [unbound](./plugins/inputs/unbound)
 * [varnish](./plugins/inputs/varnish)
 * [zfs](./plugins/inputs/zfs)
 * [zookeeper](./plugins/inputs/zookeeper)

--- a/plugins/inputs/unbound/README.md
+++ b/plugins/inputs/unbound/README.md
@@ -18,6 +18,10 @@ This plugin gathers stats from [Unbound - a validating, recursive, and caching D
 
    ## Use the builtin fielddrop/fieldpass telegraf filters in order to keep only specific fields
    fieldpass = ["total_*", "num_*","time_up", "mem_*"]
+
+   ## IP of server to connect to, read from unbound conf default, optionally '@port'
+   ## Will lookup IP if given a hostname
+   server = "127.0.0.1@8953"
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/unbound/README.md
+++ b/plugins/inputs/unbound/README.md
@@ -19,9 +19,9 @@ This plugin gathers stats from [Unbound - a validating, recursive, and caching D
    ## Use the builtin fielddrop/fieldpass telegraf filters in order to keep only specific fields
    fieldpass = ["total_*", "num_*","time_up", "mem_*"]
 
-   ## IP of server to connect to, read from unbound conf default, optionally '@port'
+   ## IP of server to connect to, read from unbound conf default, optionally ':port'
    ## Will lookup IP if given a hostname
-   server = "127.0.0.1@8953"
+   server = "127.0.0.1:8953"
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/unbound/unbound.go
+++ b/plugins/inputs/unbound/unbound.go
@@ -73,7 +73,8 @@ func unboundRunner(cmdName string, Timeout internal.Duration, UseSudo bool, Serv
 
 		// Unbound control requires an IP address, and we want to be nice to the user
 		resolver := net.Resolver{}
-		ctx, _ := context.WithTimeout(context.Background(), Timeout.Duration)
+		ctx, lookUpCancel := context.WithTimeout(context.Background(), Timeout.Duration)
+		defer lookUpCancel()
 		serverIps, err := resolver.LookupIPAddr(ctx, host)
 		if err != nil {
 			return nil, fmt.Errorf("error looking up ip for server: %s: %s", Server, err)

--- a/plugins/inputs/unbound/unbound_test.go
+++ b/plugins/inputs/unbound/unbound_test.go
@@ -12,8 +12,8 @@ import (
 
 var TestTimeout = internal.Duration{Duration: time.Second}
 
-func UnboundControl(output string, Timeout internal.Duration, useSudo bool) func(string, internal.Duration, bool) (*bytes.Buffer, error) {
-	return func(string, internal.Duration, bool) (*bytes.Buffer, error) {
+func UnboundControl(output string, Timeout internal.Duration, useSudo bool, Server string) func(string, internal.Duration, bool, string) (*bytes.Buffer, error) {
+	return func(string, internal.Duration, bool, string) (*bytes.Buffer, error) {
 		return bytes.NewBuffer([]byte(output)), nil
 	}
 }
@@ -21,7 +21,7 @@ func UnboundControl(output string, Timeout internal.Duration, useSudo bool) func
 func TestParseFullOutput(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Unbound{
-		run: UnboundControl(fullOutput, TestTimeout, true),
+		run: UnboundControl(fullOutput, TestTimeout, true, ""),
 	}
 	err := v.Gather(acc)
 


### PR DESCRIPTION
This allows unbound plugin to connect to other servers

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
