### PR TITLE
prometheus_client plugin: Add transport encryption via TLS and authentication via http basic_auth

### DIFF
--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -10,6 +10,16 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
   # Address to listen on
   listen = ":9273"
 
+  # Use TLS
+  tls = true
+  tls_crt = "/etc/ssl/telegraf.crt"
+  tls_key = "/etc/ssl/telegraf.key"
+
+  # Use http basic authentication
+  basic_auth = true
+  username = "Foo"
+  password = "Bar"
+
   # Path to publish the metrics on, defaults to /metrics
   path = "/metrics"   
 

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -11,7 +11,6 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
   listen = ":9273"
 
   # Use TLS
-  tls = true
   tls_cert = "/etc/ssl/telegraf.crt"
   tls_key = "/etc/ssl/telegraf.key"
 

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -12,7 +12,7 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
 
   # Use TLS
   tls = true
-  tls_crt = "/etc/ssl/telegraf.crt"
+  tls_cert = "/etc/ssl/telegraf.crt"
   tls_key = "/etc/ssl/telegraf.key"
 
   # Use http basic authentication

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -15,9 +15,8 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
   tls_key = "/etc/ssl/telegraf.key"
 
   # Use http basic authentication
-  basic_auth = true
-  username = "Foo"
-  password = "Bar"
+  basic_username = "Foo"
+  basic_password = "Bar"
 
   # Path to publish the metrics on, defaults to /metrics
   path = "/metrics"   

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -149,8 +149,7 @@ func (p *PrometheusClient) Start() error {
 
 	mux := http.NewServeMux()
 	mux.Handle(p.Path, p.basicAuth(promhttp.HandlerFor(
-		prometheus.DefaultGatherer,
-		promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError})))
+		registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError})))
 
 	if p.TLS {
 		p.server = &http.Server{

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -55,7 +55,7 @@ type MetricFamily struct {
 type PrometheusClient struct {
 	Listen             string
 	TLS                bool              `toml:"tls"`
-	TLSCrt             string            `toml:"tls_crt"`
+	TLSCert            string            `toml:"tls_cert"`
 	TLSKey             string            `toml:"tls_key"`
 	BasicAuth          bool              `toml:"basic_auth"`
 	Username           string            `toml:"username"`
@@ -79,7 +79,7 @@ var sampleConfig = `
 
   ## Use TLS
   # tls = true
-  tls_crt = "/etc/ssl/telegraf.crt"
+  tls_cert = "/etc/ssl/telegraf.crt"
   tls_key = "/etc/ssl/telegraf.key"
 
   ## Use http basic authentication
@@ -165,7 +165,7 @@ func (p *PrometheusClient) Start() error {
 		}
 
 		go func() {
-			if err := p.server.ListenAndServeTLS(p.TLSCrt, p.TLSKey); err != nil {
+			if err := p.server.ListenAndServeTLS(p.TLSCert, p.TLSKey); err != nil {
 				if err != http.ErrServerClosed {
 					log.Printf("E! Error creating prometheus tls secured metric endpoint, err: %s\n",
 						err.Error())


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Hello community,
this commit adds support for TLS transport encryption and http basic_auth for authentication in prometheus_client output plugin.

Configurations:
Prometheus:
```
- job_name: 'ssl_test'
    scheme: 'https'
    tls_config:
      #insecure_skip_verify: true
    basic_auth:
      username: 'Foo'
      password: 'Bar'
    static_configs:
      - targets: ['localhost:9200']`
```
Telegraf configuration:
```
[[outputs.prometheus_client]]
  listen = ":9200"
  tls_cert = "test.crt"
  tls_key = "test.key"
  basic_username = "Foo"
  basic_password = "Bar"
  path = "/metrics"
  expiration_interval = "60s"
```

Greetings,
Philipp