### PR TITLE
postgresql_extensible / extend README explaining the tagvalue Option

### DIFF
--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -43,7 +43,11 @@ The example below has two queries are specified, with the following parameters:
   # withdbname was true.
   # Be careful that if the withdbname is set to false you don't have to define
   # the where clause (aka with the dbname)
-  # the tagvalue field is used to define custom tags (separated by comas)
+  #
+  # the tagvalue field is used to define custom tags (separated by comas).
+  # the query is expected to return columns which match the names of the
+  # defined tags. The values in these columns must be of a string-type,
+  # a number-type or a blob-type.
   #
   # Structure :
   # [[inputs.postgresql_extensible.query]]
@@ -109,6 +113,15 @@ using postgreql extensions ([pg_stat_statements](http://www.postgresql.org/docs/
   version=901
   withdbname=false
   tagvalue="db"
+[[inputs.postgresql_extensible.query]]
+  sqlquery="""
+    SELECT type, (enabled || '') AS enabled, COUNT(*)
+      FROM application_users
+      GROUP BY type, enabled
+  """
+  version=901
+  withdbname=false
+  tagvalue="type,enabled"
 ```
 
 # Postgresql Side


### PR DESCRIPTION
I had some issues understanding what the tagvalue-Option in the postgresql_extensible-Plugin does, especially as the README suggest that it is just a list of Tags added literally to the result-Row:
> the tagvalue field is used to define custom tags (separated by comas)

Neither does the README have an example on how the tagvalue can be used in conjunction with `GROUP BY` to add multiple result-rows to one measurement.

This PR extends the README wiith both, a more detailed explanation and such an example.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
