### PR TITLE
ping plugin: Add cases to interface parameter

### DIFF
--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -17,7 +17,8 @@ urls = ["www.google.com"] # required
 # ping_interval = 1.0
 ## per-ping timeout, in s. 0 == no timeout (ping -W <TIMEOUT>)
 # timeout = 1.0
-## interface to send ping from (ping -I <INTERFACE>)
+## interface or source address to send ping from (ping -I <INTERFACE/SRC_ADDR>)
+## on Darwin and Freebsd only source address possible: (ping -S <SRC_ADDR>)
 # interface = ""
 ```
 


### PR DESCRIPTION
Fixes issue https://github.com/influxdata/telegraf/issues/3721.

Linux supports defining the source address or source interface with paramter **I**.
FreeBSD and Darwin do only support specifying the source address and also use a different parameter **S** to set it: see [manpage](https://www.freebsd.org/cgi/man.cgi?ping(8)). 

This commit adds cases to support pings from a defined source address on other operating systems than Linux. Source interface is linux only.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
