### PR TITLE
fix issue with SNMP source config default is incorrect

### DIFF
--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -32,7 +32,7 @@ This plugin writes to a [Wavefront](https://www.wavefront.com) proxy, in Wavefro
   #use_regex = false
 
   ## point tags to use as the source name for Wavefront (if none found, host will be used)
-  #source_override = ["hostname", "snmp_host", "node_host"]
+  #source_override = ["hostname", "agent_host", "node_host"]
 
   ## whether to convert boolean values to numeric values, with false -> 0.0 and true -> 1.0. default is true
   #convert_bool = true

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -68,7 +68,7 @@ var sampleConfig = `
   #use_regex = false
 
   ## point tags to use as the source name for Wavefront (if none found, host will be used)
-  #source_override = ["hostname", "snmp_host", "node_host"]
+  #source_override = ["hostname", "agent_host", "node_host"]
 
   ## whether to convert boolean values to numeric values, with false -> 0.0 and true -> 1.0.  default true
   #convert_bool = true


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

default sample config and readme recommended the wrong point tag to be used for source within wavefront when SNMP input plugin is used.