### PR TITLE
New processor Tagplugin

### DIFF
--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -2,4 +2,5 @@ package all
 
 import (
 	_ "github.com/influxdata/telegraf/plugins/processors/printer"
+	_ "github.com/influxdata/telegraf/plugins/processors/tagplugin"
 )

--- a/plugins/processors/tagplugin/README.md
+++ b/plugins/processors/tagplugin/README.md
@@ -1,0 +1,47 @@
+# Tagplugin
+
+This plugin makes it possible to add a new tag to metrics based on the value of an existing tag.
+
+This can be useful for example in cases where nodes running telegraf are configured differently, and their cpus 
+or network interfaces have different roles on each individual node.
+
+Tagging them at this level can thus make it easier to group them by category or role later.
+
+
+### Configuration:
+
+```toml
+# # Tag cpu metrics based on the cpu number.
+[[processors.tagplugin]]
+  ## Only metrics with a name in this list will be processed by this plugin.
+  ## If undefined all metrics will be processed.
+  namepass = ["net"]
+
+  ## The reference tag is the existing metric tag that is used to determine the value of the new tag.
+  ## A tag will not be added to the metric if reference_tag_name is missing or empty.
+  reference_tag_name = "interface"
+
+  ## Name of the new tag given to the metric.
+  ## A tag will not be added to the metric if new_tag_name is missing or empty.
+  new_tag_name = "category"
+
+  ## If the metric's value of reference_tag_name is not present in the map below, 
+  ## the metric will be tagged with the default_tag value.
+  ## However, the metric will not receive a tag if the default_tag is missing or empty.
+  new_tag_default_value = "other"
+
+  ## The keys in this map are the values to use for the new tag, when the reference tag value matches any
+  ## of the elements in the corresponding list.
+  ## All keys should be strings, and all values should be lists of strings.
+  ## If this map is empty or not defined, all metrics passed through this plugin will be tagged with the 
+  ## default_tag instead.
+  ## Do not repeat values in different lists, if this happens a random of the matching keys will be used.
+  ## Due to the way TOML is parsed, this map must be defined at the end of the plugin definition, 
+  ## otherwise subsequent plugin config options will be interpreted as part of this map.
+  [processors.tagplugin.new_tag_value_map]
+    management = ["en0", "en1"]
+    api = ["en2"]
+```
+
+It is possible to run multiple instances of this plugin with multiple metrics and independent tag value maps.
+To do so, just add additional versions of the config above to your telegraf config file.

--- a/plugins/processors/tagplugin/tagplugin.go
+++ b/plugins/processors/tagplugin/tagplugin.go
@@ -1,0 +1,90 @@
+package tagplugin
+
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+type TagPlugin struct {
+	ReferenceTagName	string `toml:"reference_tag_name"`
+	NewTagName			string `toml:"new_tag_name"`
+	NewTagValueMap		map[string][]string `toml:"new_tag_value_map"`
+	FlatTagValueMap		map[string]string
+	NewTagDefaultValue 	string `toml:"new_tag_default_value"`
+}
+
+var sampleConfig = `
+  ## Only metrics with a name in this list will be processed by this plugin.
+  ## If undefined all metrics will be processed.
+  namepass = ["net"]
+
+  ## The reference tag is the existing metric tag that is used to determine the value of the new tag.
+  ## A tag will not be added to the metric if reference_tag_name is missing or empty.
+  reference_tag_name = "interface"
+
+  ## Name of the new tag given to the metric.
+  ## A tag will not be added to the metric if new_tag_name is missing or empty.
+  new_tag_name = "category"
+
+  ## If the metric's value of reference_tag_name is not present in the map below,
+  ## the metric will be tagged with the default_tag value.
+  ## However, the metric will not receive a tag if the default_tag is missing or empty.
+  new_tag_default_value = "other"
+
+  ## The keys in this map are the values to use for the new tag, when the reference tag value matches any
+  ## of the elements in the corresponding list.
+  ## All keys should be strings, and all values should be lists of strings.
+  ## If this map is empty or not defined, all metrics passed through this plugin will be tagged with the
+  ## default_tag instead.
+  ## Do not repeat values in different lists, if this happens a random of the matching keys will be used.
+  ## Due to the way TOML is parsed, this map must be defined at the end of the plugin definition,
+  ## otherwise subsequent plugin config options will be interpreted as part of this map.
+  [processors.tagplugin.new_tag_value_map]
+    management = ["en0", "en1"]
+    api = ["en2"]
+`
+
+func newTagPlugin() *TagPlugin {
+	return &TagPlugin{}
+}
+
+func (t *TagPlugin) SampleConfig() string {
+	return sampleConfig
+}
+
+func (t *TagPlugin) Description() string {
+	return "Add a new tag to metrics based on the value of an existing tag."
+}
+
+func (t *TagPlugin) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	if t.ReferenceTagName == "" || t.NewTagName == "" { return in }
+
+	// Late initialization of a flat version of the new_tag_value_map defined in the config
+	if t.FlatTagValueMap == nil {
+		// This will only be run on the first invocation of this plugin
+		t.FlatTagValueMap = map[string]string{}
+		for tagName, tagValues := range t.NewTagValueMap {
+			for _, tag := range tagValues {
+				t.FlatTagValueMap[tag] = tagName
+			}
+		}
+	}
+
+	for _, metric := range in {
+		newTagValue := t.FlatTagValueMap[metric.Tags()[t.ReferenceTagName]]
+		if newTagValue == "" {
+			if t.NewTagDefaultValue == "" { continue }
+			newTagValue = t.NewTagDefaultValue
+		}
+		metric.AddTag(t.NewTagName, newTagValue)
+	}
+
+	return in
+}
+
+func init() {
+	processors.Add("tagplugin", func() telegraf.Processor {
+		return &TagPlugin{}
+	})
+}

--- a/plugins/processors/tagplugin/tagplugin_test.go
+++ b/plugins/processors/tagplugin/tagplugin_test.go
@@ -1,0 +1,181 @@
+package tagplugin
+
+import (
+	"testing"
+	"time"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test cases
+var m0, _ = metric.New("m0",
+	map[string]string{
+		"host": "localhost",
+		"cpu": "cpu0",
+	},
+	map[string]interface{}{
+		"usage_idle": float64(99),
+		"usage_busy": float64(1),
+	},
+	time.Now(),
+)
+
+var m1, _ = metric.New("m1",
+	map[string]string{
+		"host": "localhost",
+		"cpu": "cpu1",
+	},
+	map[string]interface{}{
+		"usage_idle": float64(50),
+		"usage_busy": float64(50),
+	},
+	time.Now(),
+)
+
+var m2, _ = metric.New("m2",
+	map[string]string{
+		"host": "localhost",
+		"cpu": "cpu2",
+	},
+	map[string]interface{}{
+		"usage_idle": float64(1),
+		"usage_busy": float64(99),
+	},
+	time.Now(),
+)
+
+var m3, _ = metric.New("m3",
+	map[string]string{
+		"host": "localhost",
+		"cpu": "cpu3",
+	},
+	map[string]interface{}{
+		"usage_idle": float64(70),
+		"usage_busy": float64(30),
+	},
+	time.Now(),
+)
+
+func TestApply(t *testing.T) {
+	tagplugin := newTagPlugin()
+	tagplugin.ReferenceTagName = "cpu"
+	tagplugin.NewTagName = "cpu_category"
+	tagplugin.NewTagValueMap = map[string][]string{"system":{"cpu0","cpu1"}, "user":{"cpu2"}}
+	tagplugin.NewTagDefaultValue = "vm"
+
+	taggedMetrics := tagplugin.Apply(m0, m1, m2, m3)
+
+	// Check that cpus get the tag they should have
+	assert.Equal(t, "system", taggedMetrics[0].Tags()["cpu_category"])
+	assert.Equal(t, "system", taggedMetrics[1].Tags()["cpu_category"])
+	assert.Equal(t, "user", taggedMetrics[2].Tags()["cpu_category"])
+
+	// Check that cpus not listed in the config gets the default tag
+	assert.Equal(t, "vm", taggedMetrics[3].Tags()["cpu_category"])
+}
+
+func TestApplyNoNewTagDefaultValue(t *testing.T) {
+	tagplugin := newTagPlugin()
+	tagplugin.ReferenceTagName = "cpu"
+	tagplugin.NewTagName = "cpu_category"
+	tagplugin.NewTagValueMap = map[string][]string{"system":{"cpu0","cpu1"}, "user":{"cpu2"}}
+
+	// Reset to no tags
+	m0.RemoveTag("cpu_category")
+	m1.RemoveTag("cpu_category")
+	m2.RemoveTag("cpu_category")
+	m3.RemoveTag("cpu_category")
+
+	taggedMetrics := tagplugin.Apply(m0, m1, m2, m3)
+
+	// Check that cpus get the tag they should have
+	assert.Equal(t, "system", taggedMetrics[0].Tags()["cpu_category"])
+	assert.Equal(t, "system", taggedMetrics[1].Tags()["cpu_category"])
+	assert.Equal(t, "user", taggedMetrics[2].Tags()["cpu_category"])
+
+	// Check that the cpu not listed in the config doesn't get a tag
+	assert.False(t, taggedMetrics[3].HasTag("cpu_category"))
+}
+
+func TestApplyNoNewTagValueMap(t *testing.T) {
+	tagplugin := newTagPlugin()
+	tagplugin.ReferenceTagName = "cpu"
+	tagplugin.NewTagName = "cpu_category"
+	tagplugin.NewTagDefaultValue = "vm"
+
+	// Reset to no tags
+	m0.RemoveTag("cpu_category")
+	m1.RemoveTag("cpu_category")
+	m2.RemoveTag("cpu_category")
+	m3.RemoveTag("cpu_category")
+
+	taggedMetrics := tagplugin.Apply(m0, m1, m2, m3)
+
+	// Check that all cpus get the default tag
+	assert.Equal(t, "vm", taggedMetrics[0].Tags()["cpu_category"])
+	assert.Equal(t, "vm", taggedMetrics[1].Tags()["cpu_category"])
+	assert.Equal(t, "vm", taggedMetrics[2].Tags()["cpu_category"])
+	assert.Equal(t, "vm", taggedMetrics[3].Tags()["cpu_category"])
+}
+
+func TestApplyNoNewTagValueMapNoNewTagDefaultValue(t *testing.T) {
+	tagplugin := newTagPlugin()
+	tagplugin.ReferenceTagName = "cpu"
+	tagplugin.NewTagName = "cpu_category"
+
+	// Reset to no tags
+	m0.RemoveTag("cpu_category")
+	m1.RemoveTag("cpu_category")
+	m2.RemoveTag("cpu_category")
+	m3.RemoveTag("cpu_category")
+
+	taggedMetrics := tagplugin.Apply(m0, m1, m2, m3)
+
+	// Check that cpus don't get tags when no config
+	assert.False(t, taggedMetrics[0].HasTag("cpu_category"))
+	assert.False(t, taggedMetrics[1].HasTag("cpu_category"))
+	assert.False(t, taggedMetrics[2].HasTag("cpu_category"))
+	assert.False(t, taggedMetrics[3].HasTag("cpu_category"))
+}
+
+func TestApplyNoNewTagName(t *testing.T) {
+	tagplugin := newTagPlugin()
+	tagplugin.ReferenceTagName = "cpu"
+	tagplugin.NewTagValueMap = map[string][]string{"system":{"cpu0","cpu1"}, "user":{"cpu2"}}
+	tagplugin.NewTagDefaultValue = "vm"
+
+	// Reset to no tags
+	m0.RemoveTag("cpu_category")
+	m1.RemoveTag("cpu_category")
+	m2.RemoveTag("cpu_category")
+	m3.RemoveTag("cpu_category")
+
+	taggedMetrics := tagplugin.Apply(m0, m1, m2, m3)
+
+	// Check that cpus don't get tags when no new tag name
+	assert.False(t, taggedMetrics[0].HasTag("cpu_category"))
+	assert.False(t, taggedMetrics[1].HasTag("cpu_category"))
+	assert.False(t, taggedMetrics[2].HasTag("cpu_category"))
+	assert.False(t, taggedMetrics[3].HasTag("cpu_category"))
+}
+
+func TestApplyNoReferenceTagName(t *testing.T) {
+	tagplugin := newTagPlugin()
+	tagplugin.NewTagName = "cpu"
+	tagplugin.NewTagValueMap = map[string][]string{"system":{"cpu0","cpu1"}, "user":{"cpu2"}}
+	tagplugin.NewTagDefaultValue = "vm"
+
+	// Reset to no tags
+	m0.RemoveTag("cpu_category")
+	m1.RemoveTag("cpu_category")
+	m2.RemoveTag("cpu_category")
+	m3.RemoveTag("cpu_category")
+
+	taggedMetrics := tagplugin.Apply(m0, m1, m2, m3)
+
+	// Check that cpus don't get tags when no reference tag name
+	assert.False(t, taggedMetrics[0].HasTag("cpu_category"))
+	assert.False(t, taggedMetrics[1].HasTag("cpu_category"))
+	assert.False(t, taggedMetrics[2].HasTag("cpu_category"))
+	assert.False(t, taggedMetrics[3].HasTag("cpu_category"))
+}


### PR DESCRIPTION
This plugin makes it possible to add a new tag to metrics based on the value of an existing tag.

This can be useful for example in cases where nodes running telegraf are configured differently, and their cpus or network interfaces have different roles on each individual node.

Tagging them at this level can thus make it easier to group them by category or role later.


### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
