### PR TITLE
Providing option to disable labels in prometheus output for string fields

### DIFF
--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -23,4 +23,11 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
 
   # Expiration interval for each metric. 0 == no expiration
   expiration_interval = "60s"
+
+  # Disable labels in prometheus output for all string fields. (Default: false)
+  disable_string_to_label = false
+
+  # Enable labels in prometheus output for certain string fields.
+  # Won't work when disable_string_to_label is set to true.
+  string_to_label_names = []
 ```

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -24,10 +24,7 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
   # Expiration interval for each metric. 0 == no expiration
   expiration_interval = "60s"
 
-  # Disable labels in prometheus output for all string fields. (Default: false)
-  disable_string_to_label = false
-
-  # Enable labels in prometheus output for certain string fields.
-  # Won't work when disable_string_to_label is set to true.
-  string_to_label_names = []
+  # Send string metrics as Prometheus labels.
+  # Unless set to false all string metrics will be sent as labels.
+  string_as_label = true
 ```

--- a/plugins/outputs/prometheus_client/prometheus_client_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_test.go
@@ -450,6 +450,40 @@ func TestWrite_StringFields(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestDoNotWrite_StringFields(t *testing.T) {
+	now := time.Now()
+	p1, err := metric.New(
+		"foo",
+		make(map[string]string),
+		map[string]interface{}{"value": 1.0, "status": "good"},
+		now,
+		telegraf.Counter)
+	p2, err := metric.New(
+		"bar",
+		make(map[string]string),
+		map[string]interface{}{"status": "needs numeric field"},
+		now,
+		telegraf.Gauge)
+	var metrics = []telegraf.Metric{p1, p2}
+
+	client := &PrometheusClient{
+		ExpirationInterval:   internal.Duration{Duration: time.Second * 60},
+		DisableStringToLabel: true,
+		fam:                  make(map[string]*MetricFamily),
+		now:                  time.Now,
+	}
+
+	err = client.Write(metrics)
+	require.NoError(t, err)
+
+	fam, ok := client.fam["foo"]
+	require.True(t, ok)
+	require.Equal(t, 0, fam.LabelSet["status"])
+
+	fam, ok = client.fam["bar"]
+	require.False(t, ok)
+}
+
 func TestExpire(t *testing.T) {
 	client := NewClient()
 

--- a/plugins/outputs/prometheus_client/prometheus_client_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_test.go
@@ -22,6 +22,7 @@ func setUnixTime(client *PrometheusClient, sec int64) {
 func NewClient() *PrometheusClient {
 	return &PrometheusClient{
 		ExpirationInterval: internal.Duration{Duration: time.Second * 60},
+		StringAsLabel:      true,
 		fam:                make(map[string]*MetricFamily),
 		now:                time.Now,
 	}
@@ -467,10 +468,10 @@ func TestDoNotWrite_StringFields(t *testing.T) {
 	var metrics = []telegraf.Metric{p1, p2}
 
 	client := &PrometheusClient{
-		ExpirationInterval:   internal.Duration{Duration: time.Second * 60},
-		DisableStringToLabel: true,
-		fam:                  make(map[string]*MetricFamily),
-		now:                  time.Now,
+		ExpirationInterval: internal.Duration{Duration: time.Second * 60},
+		StringAsLabel:      false,
+		fam:                make(map[string]*MetricFamily),
+		now:                time.Now,
 	}
 
 	err = client.Write(metrics)


### PR DESCRIPTION
#3350 introduced a change where all string fields are turned to labels. However in certain cases where string value changes, it introduces a new metric due to the change in label value.

Hence this will provide an option to disable as well as enable only for certain string values. The default behavior doesn't change with this commit. 
