### PR TITLE
Added additional SQL Server performance counters

### DIFF
--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -89,9 +89,45 @@ The new (version 2) metrics provide:
   - *Log activity*: Log bytes flushed/sec, Log flushes/sec, Log Flush Wait Time
   - *Memory*: PLE, Page reads/sec, Page writes/sec, + more
   - *TempDB*: Free space, Version store usage, Active temp tables, temp table creation rate, + more
-  - *Resource Governor*: CPU Usage, Requests/sec, Queued Requests, and Blocked tasks per workload group
+  - *Resource Governor*: CPU Usage, Requests/sec, Queued Requests, and Blocked tasks per workload group + more
 - *Server properties*: Number of databases in all possible states (online, offline, suspect, etc.), cpu count, physical memory, SQL Server service uptime, and SQL Server version
 - *Wait stats*: Wait time in ms, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the sasme categories used in Query Store.
+
+The following metrics can be used directly, with no delta calculations:
+ - SQLServer:Buffer Manager\Buffer cache hit ratio
+ - SQLServer:Buffer Manager\Page life expectancy
+ - SQLServer:Buffer Node\Page life expectancy
+ - SQLServer:Database Replica\Log Apply Pending Queue
+ - SQLServer:Database Replica\Log Apply Ready Queue
+ - SQLServer:Database Replica\Log Send Queue
+ - SQLServer:Database Replica\Recovery Queue
+ - SQLServer:Databases\Data File(s) Size (KB)
+ - SQLServer:Databases\Log File(s) Size (KB)
+ - SQLServer:Databases\Log File(s) Used Size (KB)
+ - SQLServer:Databases\XTP Memory Used (KB)
+ - SQLServer:General Statistics\Active Temp Tables
+ - SQLServer:General Statistics\Processes blocked
+ - SQLServer:General Statistics\Temp Tables For Destruction
+ - SQLServer:General Statistics\User Connections
+ - SQLServer:Memory Broker Clerks\Memory broker clerk size
+ - SQLServer:Memory Manager\Memory Grants Pending
+ - SQLServer:Memory Manager\Target Server Memory (KB)
+ - SQLServer:Memory Manager\Total Server Memory (KB)
+ - SQLServer:Resource Pool Stats\Active memory grant amount (KB)
+ - SQLServer:Resource Pool Stats\Disk Read Bytes/sec
+ - SQLServer:Resource Pool Stats\Disk Read IO Throttled/sec
+ - SQLServer:Resource Pool Stats\Disk Read IO/sec
+ - SQLServer:Resource Pool Stats\Disk Write Bytes/sec
+ - SQLServer:Resource Pool Stats\Disk Write IO Throttled/sec
+ - SQLServer:Resource Pool Stats\Disk Write IO/sec
+ - SQLServer:Resource Pool Stats\Used memory (KB)
+ - SQLServer:Transactions\Free Space in tempdb (KB)
+ - SQLServer:Transactions\Version Store Size (KB)
+ - SQLServer:User Settable\Query
+ - SQLServer:Workload Group Stats\Blocked tasks
+ - SQLServer:Workload Group Stats\CPU usage %
+ - SQLServer:Workload Group Stats\Queued requests
+ - SQLServer:Workload Group Stats\Requests completed/sec
 
 Version 2 queries have the following tags:
 - `host`: Physical host name

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -494,6 +494,18 @@ WHERE	(
 				'Requests completed/sec',
 				'Blocked tasks'
 			)
+		) OR (
+			object_name = 'SQLServer:Resource Pool Stats'
+			AND counter_name IN (
+				'Active memory grant amount (KB)',
+				'Disk Read Bytes/sec',
+				'Disk Read IO Throttled/sec',
+				'Disk Read IO/sec',
+				'Disk Write Bytes/sec',
+				'Disk Write IO Throttled/sec',
+				'Disk Write IO/sec',
+				'Used memory (KB)'
+			)
 		) OR object_name IN (
 			'SQLServer:User Settable',
 			'SQLServer:SQL Errors'

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -519,12 +519,7 @@ SELECT	'sqlserver_performance' AS [measurement],
 		pc.object_name AS [object],
 		pc.counter_name AS [counter],
 		CASE pc.instance_name WHEN '_Total' THEN 'Total' ELSE ISNULL(pc.instance_name,'') END AS [instance],
-		CASE WHEN pc.cntr_type = 537003264 AND pc1.cntr_value > 0 THEN (pc.cntr_value * 1.0) / (pc1.cntr_value * 1.0) * 100 ELSE pc.cntr_value END AS [value],
-		CASE 
-			WHEN pc.cntr_type = 272696576 THEN 'rate'
-			WHEN pc.cntr_type IN (65792,537003264) THEN 'raw'
-			ELSE 'unknown'
-		END AS c_type
+		CASE WHEN pc.cntr_type = 537003264 AND pc1.cntr_value > 0 THEN (pc.cntr_value * 1.0) / (pc1.cntr_value * 1.0) * 100 ELSE pc.cntr_value END AS [value]
 FROM	@PCounters AS pc
 		LEFT OUTER JOIN @PCounters AS pc1
 			ON (

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -390,7 +390,6 @@ CROSS APPLY (
 	SELECT	*
 	FROM	@sys_info
 ) AS sinfo
-WHERE	database_id > 4
 OPTION( RECOMPILE );
 `
 
@@ -445,7 +444,8 @@ WHERE	(
 			'Memory Grants Pending',
 			'Free list stalls/sec',
 			'Buffer cache hit ratio',
-			'Buffer cache hit ratio base'
+			'Buffer cache hit ratio base',
+			'Backup/Restore Throughput/sec'
 		)
 		) OR (
 			instance_name IN ('_Total','Column store object pool')
@@ -494,6 +494,9 @@ WHERE	(
 				'Requests completed/sec',
 				'Blocked tasks'
 			)
+		) OR object_name IN (
+			'SQLServer:User Settable',
+			'SQLServer:SQL Errors'
 		)
 
 SELECT	'sqlserver_performance' AS [measurement],

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -445,7 +445,9 @@ WHERE	(
 			'Free list stalls/sec',
 			'Buffer cache hit ratio',
 			'Buffer cache hit ratio base',
-			'Backup/Restore Throughput/sec'
+			'Backup/Restore Throughput/sec',
+			'Total Server Memory (KB)',
+			'Target Server Memory (KB)'
 		)
 		) OR (
 			instance_name IN ('_Total','Column store object pool')


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

I added the following new counters to the performance counter query:
- SQLServer:Resource Pool Stats
  - Active memory grant amount (KB)
  - Disk Read Bytes/sec
  - Disk Read IO Throttled/sec
  - Disk Read IO/sec
  - Disk Write Bytes/sec
  - Disk Write IO Throttled/sec
  - Disk Write IO/sec
  - Used memory (KB)
- SQLServer:User Settable
  - All
- SQLServer:SQL Errors
  - All
- SQLServer:Databases\Backup/Restore Throughput/sec
- SQLServer:Memory Manager\Target Server Memory (KB)
- SQLServer:Memory Manager\Total Server Memory (KB)

This was based on feedback from my previous pull request and internal feedback. I also removed the 'c_type' tag from the performance counter query and add documentation to the readme about which counters need delta calculations and which dont.