### PR TITLE
Add Enum Processor

### DIFF
--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -2,6 +2,7 @@ package all
 
 import (
 	_ "github.com/influxdata/telegraf/plugins/processors/converter"
+	_ "github.com/influxdata/telegraf/plugins/processors/enum"
 	_ "github.com/influxdata/telegraf/plugins/processors/override"
 	_ "github.com/influxdata/telegraf/plugins/processors/printer"
 	_ "github.com/influxdata/telegraf/plugins/processors/regex"

--- a/plugins/processors/enum/README.md
+++ b/plugins/processors/enum/README.md
@@ -1,0 +1,27 @@
+# Enum Processor Plugin
+
+The Enum Processor allows the configuration of value mappings for metric fields.
+The main use-case for this is to rewrite status codes such as _red_, _amber_ and
+_green_ by numeric values such as 0, 1, 2. The plugin supports string and bool
+types for the field values. Multiple Fields can be configured with separate
+value mappings for each field.
+
+### Configuration
+Configuration using table syntax:
+`toml
+# Configure a status mapping for field 'status'
+[[processors.enum.fields]]
+  key = "status"
+  [processors.enum.fields.value_mappings]
+    green = 0
+    yellow = 1
+    red = 2
+`
+
+Configuration using inline syntax:
+`toml
+# Configure a status mapping for field 'status'
+[[processors.enum.fields]]
+  key = "status"
+  value_mappings = {green = 0, yellow = 1, red = 2 }
+`

--- a/plugins/processors/enum/README.md
+++ b/plugins/processors/enum/README.md
@@ -11,7 +11,7 @@ Configuration using table syntax:
 `toml
 # Configure a status mapping for field 'status'
 [[processors.enum.fields]]
-  key = "status"
+  source = "status"
   [processors.enum.fields.value_mappings]
     green = 0
     yellow = 1
@@ -22,6 +22,6 @@ Configuration using inline syntax:
 `toml
 # Configure a status mapping for field 'status'
 [[processors.enum.fields]]
-  key = "status"
+  source = "status"
   value_mappings = {green = 0, yellow = 1, red = 2 }
 `

--- a/plugins/processors/enum/README.md
+++ b/plugins/processors/enum/README.md
@@ -4,7 +4,8 @@ The Enum Processor allows the configuration of value mappings for metric fields.
 The main use-case for this is to rewrite status codes such as _red_, _amber_ and
 _green_ by numeric values such as 0, 1, 2. The plugin supports string and bool
 types for the field values. Multiple Fields can be configured with separate
-value mappings for each field.
+value mappings for each field. Default mapping values can be configured to be
+used for all values, which are not contained in the value_mappings.
 
 ### Configuration
 Configuration using table syntax:
@@ -12,6 +13,7 @@ Configuration using table syntax:
 # Configure a status mapping for field 'status'
 [[processors.enum.fields]]
   source = "status"
+  default = -1
   [processors.enum.fields.value_mappings]
     green = 0
     yellow = 1
@@ -23,5 +25,6 @@ Configuration using inline syntax:
 # Configure a status mapping for field 'status'
 [[processors.enum.fields]]
   source = "status"
+  default = -1
   value_mappings = {green = 0, yellow = 1, red = 2 }
 `

--- a/plugins/processors/enum/README.md
+++ b/plugins/processors/enum/README.md
@@ -5,7 +5,9 @@ The main use-case for this is to rewrite status codes such as _red_, _amber_ and
 _green_ by numeric values such as 0, 1, 2. The plugin supports string and bool
 types for the field values. Multiple Fields can be configured with separate
 value mappings for each field. Default mapping values can be configured to be
-used for all values, which are not contained in the value_mappings.
+used for all values, which are not contained in the value_mappings. The
+processor supports explicit configuration of a destination field. By default the
+source field is overwritten.
 
 ### Configuration
 Configuration using table syntax:
@@ -13,6 +15,7 @@ Configuration using table syntax:
 # Configure a status mapping for field 'status'
 [[processors.enum.fields]]
   source = "status"
+  destination = "code"
   default = -1
   [processors.enum.fields.value_mappings]
     green = 0
@@ -25,6 +28,7 @@ Configuration using inline syntax:
 # Configure a status mapping for field 'status'
 [[processors.enum.fields]]
   source = "status"
+  destination = "code"
   default = -1
   value_mappings = {green = 0, yellow = 1, red = 2 }
 `

--- a/plugins/processors/enum/enum.go
+++ b/plugins/processors/enum/enum.go
@@ -14,8 +14,8 @@ var sampleConfig = `
 ## Fields to be considered
 # [[processors.enum.fields]]
 #
-# Name of the field
-#   key = "name"
+# Name of the field source field to map
+#   source = "name"
 #
 # Value Mapping Table
 #   [processors.enum.value_mappings]
@@ -31,7 +31,7 @@ type EnumMapper struct {
 }
 
 type Mapping struct {
-	Key           string
+	Source        string
 	ValueMappings map[string]interface{}
 }
 
@@ -52,11 +52,11 @@ func (mapper *EnumMapper) Apply(in ...telegraf.Metric) []telegraf.Metric {
 
 func (mapper *EnumMapper) applyMappings(metric telegraf.Metric) telegraf.Metric {
 	for _, mapping := range mapper.Fields {
-		if originalValue, isPresent := metric.GetField(mapping.Key); isPresent == true {
+		if originalValue, isPresent := metric.GetField(mapping.Source); isPresent == true {
 			if adjustedValue, isString := adjustBoolValue(originalValue).(string); isString == true {
 				if mappedValue, isMappedValuePresent := mapping.ValueMappings[adjustedValue]; isMappedValuePresent == true {
-					metric.RemoveField(mapping.Key)
-					metric.AddField(mapping.Key, mappedValue)
+					metric.RemoveField(mapping.Source)
+					metric.AddField(mapping.Source, mappedValue)
 				}
 			}
 		}

--- a/plugins/processors/enum/enum.go
+++ b/plugins/processors/enum/enum.go
@@ -1,0 +1,110 @@
+package enum
+
+import (
+	"strconv"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+var sampleConfig = `
+## NOTE This processor will map metric values to different values. It is aimed
+## to map enum values to numeric values.
+
+## Fields to be considered
+# [[processors.enum.fields]]
+#
+# Name of the field
+#   key = "name"
+#
+# Value Mapping Table
+#   [processors.enum.value_mappings]
+#     value1 = 1
+#     value2 = 2
+#
+## Alternatively the mapping table can be given in inline notation
+#   value_mappings = {value1 = 1, value2 = 2}
+`
+
+type EnumMapper struct {
+	Fields []Mapping
+}
+
+type Mapping struct {
+	Key           string
+	ValueMappings map[string]interface{}
+}
+
+func (mapper *EnumMapper) SampleConfig() string {
+	return sampleConfig
+}
+
+func (mapper *EnumMapper) Description() string {
+	return "Map enum values according to given table."
+}
+
+func (mapper *EnumMapper) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	out := make([]telegraf.Metric, 0, len(in))
+	for _, source := range in {
+		target, error := mapper.applyMappings(source)
+		if error == nil {
+			out = append(out, target)
+		} else {
+			out = append(out, source)
+		}
+	}
+	return out
+}
+
+func (mapper *EnumMapper) applyMappings(source telegraf.Metric) (telegraf.Metric, error) {
+	if fields, changed := mapper.applyFieldMappings(source.Fields()); changed == true {
+		return metric.New(
+			source.Name(),
+			source.Tags(),
+			fields,
+			source.Time(),
+			source.Type())
+	} else {
+		return source, nil
+	}
+}
+
+func (mapper *EnumMapper) applyFieldMappings(in map[string]interface{}) (map[string]interface{}, bool) {
+	out := make(map[string]interface{}, len(in))
+	changed := false
+	for key, value := range in {
+		var isMapped bool
+		out[key], isMapped = mapper.determineMappedValue(key, value)
+		changed = changed || isMapped
+	}
+	return out, changed
+}
+
+func (mapper *EnumMapper) determineMappedValue(key string, value interface{}) (interface{}, bool) {
+	adjustedValue := adjustBoolValue(value)
+	if _, isString := adjustedValue.(string); isString == false {
+		return value, false
+	}
+	for _, mapping := range mapper.Fields {
+		if mapping.Key == key {
+			if mappedValue, isMappedValuePresent := mapping.ValueMappings[adjustedValue.(string)]; isMappedValuePresent == true {
+				return mappedValue, true
+			}
+		}
+	}
+	return value, false
+}
+
+func adjustBoolValue(in interface{}) interface{} {
+	if mappedBool, isBool := in.(bool); isBool == true {
+		return strconv.FormatBool(mappedBool)
+	}
+	return in
+}
+
+func init() {
+	processors.Add("enum", func() telegraf.Processor {
+		return &EnumMapper{}
+	})
+}

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -71,3 +71,27 @@ func TestMapSingleBoolValue(t *testing.T) {
 
 	assertFieldValue(t, 1, "true_value", fields)
 }
+
+func TestMapsToDefaultValueOnUnknownSourceValue(t *testing.T) {
+	mapper := EnumMapper{Fields: []Mapping{{Source: "string_value", Default: int64(42), ValueMappings: map[string]interface{}{"other": int64(1)}}}}
+
+	fields := calculateProcessedValues(mapper, createTestMetric())
+
+	assertFieldValue(t, 42, "string_value", fields)
+}
+
+func TestDoNotMapToDefaultValueKnownSourceValue(t *testing.T) {
+	mapper := EnumMapper{Fields: []Mapping{{Source: "string_value", Default: int64(42), ValueMappings: map[string]interface{}{"test": int64(1)}}}}
+
+	fields := calculateProcessedValues(mapper, createTestMetric())
+
+	assertFieldValue(t, 1, "string_value", fields)
+}
+
+func TestNoMappingWithoutDefaultOrDefinedMappingValue(t *testing.T) {
+	mapper := EnumMapper{Fields: []Mapping{{Source: "string_value", ValueMappings: map[string]interface{}{"other": int64(1)}}}}
+
+	fields := calculateProcessedValues(mapper, createTestMetric())
+
+	assertFieldValue(t, "test", "string_value", fields)
+}

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -49,7 +49,7 @@ func TestRetainsMetric(t *testing.T) {
 }
 
 func TestMapsSingleStringValue(t *testing.T) {
-	mapper := EnumMapper{Fields: []Mapping{{Key: "string_value", ValueMappings: map[string]interface{}{"test": int64(1)}}}}
+	mapper := EnumMapper{Fields: []Mapping{{Source: "string_value", ValueMappings: map[string]interface{}{"test": int64(1)}}}}
 
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
@@ -57,7 +57,7 @@ func TestMapsSingleStringValue(t *testing.T) {
 }
 
 func TestNoFailureOnMappingsOnNonStringValuedFields(t *testing.T) {
-	mapper := EnumMapper{Fields: []Mapping{{Key: "int_value", ValueMappings: map[string]interface{}{"13i": int64(7)}}}}
+	mapper := EnumMapper{Fields: []Mapping{{Source: "int_value", ValueMappings: map[string]interface{}{"13i": int64(7)}}}}
 
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
@@ -65,7 +65,7 @@ func TestNoFailureOnMappingsOnNonStringValuedFields(t *testing.T) {
 }
 
 func TestMapSingleBoolValue(t *testing.T) {
-	mapper := EnumMapper{Fields: []Mapping{{Key: "true_value", ValueMappings: map[string]interface{}{"true": int64(1)}}}}
+	mapper := EnumMapper{Fields: []Mapping{{Source: "true_value", ValueMappings: map[string]interface{}{"true": int64(1)}}}}
 
 	fields := calculateProcessedValues(mapper, createTestMetric())
 

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -1,0 +1,73 @@
+package enum
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestMetric() telegraf.Metric {
+	metric, _ := metric.New("m1",
+		map[string]string{"tag": "tag_value"},
+		map[string]interface{}{
+			"string_value": "test",
+			"int_value":    int(13),
+			"true_value":   true,
+		},
+		time.Now(),
+	)
+	return metric
+}
+
+func calculateProcessedValues(mapper EnumMapper, metric telegraf.Metric) map[string]interface{} {
+	processed := mapper.Apply(metric)
+	return processed[0].Fields()
+}
+
+func assertFieldValue(t *testing.T, expected interface{}, field string, fields map[string]interface{}) {
+	value, present := fields[field]
+	assert.True(t, present, "value of field '"+field+"' was not present")
+	assert.EqualValues(t, expected, value)
+}
+
+func TestRetainsMetric(t *testing.T) {
+	mapper := EnumMapper{}
+	source := createTestMetric()
+
+	target := mapper.Apply(source)[0]
+	fields := target.Fields()
+
+	assertFieldValue(t, "test", "string_value", fields)
+	assertFieldValue(t, 13, "int_value", fields)
+	assertFieldValue(t, true, "true_value", fields)
+	assert.Equal(t, "m1", target.Name())
+	assert.Equal(t, source.Tags(), target.Tags())
+	assert.Equal(t, source.Time(), target.Time())
+}
+
+func TestMapsSingleStringValue(t *testing.T) {
+	mapper := EnumMapper{Fields: []Mapping{{Key: "string_value", ValueMappings: map[string]interface{}{"test": int64(1)}}}}
+
+	fields := calculateProcessedValues(mapper, createTestMetric())
+
+	assertFieldValue(t, 1, "string_value", fields)
+}
+
+func TestNoFailureOnMappingsOnNonStringValuedFields(t *testing.T) {
+	mapper := EnumMapper{Fields: []Mapping{{Key: "int_value", ValueMappings: map[string]interface{}{"13i": int64(7)}}}}
+
+	fields := calculateProcessedValues(mapper, createTestMetric())
+
+	assertFieldValue(t, 13, "int_value", fields)
+}
+
+func TestMapSingleBoolValue(t *testing.T) {
+	mapper := EnumMapper{Fields: []Mapping{{Key: "true_value", ValueMappings: map[string]interface{}{"true": int64(1)}}}}
+
+	fields := calculateProcessedValues(mapper, createTestMetric())
+
+	assertFieldValue(t, 1, "true_value", fields)
+}

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -95,3 +95,12 @@ func TestNoMappingWithoutDefaultOrDefinedMappingValue(t *testing.T) {
 
 	assertFieldValue(t, "test", "string_value", fields)
 }
+
+func TestWritesToDestination(t *testing.T) {
+	mapper := EnumMapper{Fields: []Mapping{{Source: "string_value", Destination: "string_code", ValueMappings: map[string]interface{}{"test": int64(1)}}}}
+
+	fields := calculateProcessedValues(mapper, createTestMetric())
+
+	assertFieldValue(t, "test", "string_value", fields)
+	assertFieldValue(t, 1, "string_code", fields)
+}


### PR DESCRIPTION
This processor allows substitution of field values of string or bool type with
numeric values. It can be used, e.g. to map status codes such as "red", "amber"
and "green" to values such as 0, 1, 2. Multiple fields can be configured, each
with its own mapping table.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
