### PR TITLE
Disable keepalive in mqtt output.

### DIFF
--- a/plugins/outputs/mqtt/mqtt.go
+++ b/plugins/outputs/mqtt/mqtt.go
@@ -162,6 +162,7 @@ func (m *MQTT) publish(topic string, body []byte) error {
 
 func (m *MQTT) createOpts() (*paho.ClientOptions, error) {
 	opts := paho.NewClientOptions()
+	opts.KeepAlive = 0 * time.Second
 
 	if m.Timeout.Duration < time.Second {
 		m.Timeout.Duration = 5 * time.Second


### PR DESCRIPTION
This functionality currently has race conditions that can result in the
output deadlocking.

#3697

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
