### PR TITLE
Add keep alive support to the TCP mode of statsd

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -3045,6 +3045,13 @@
 #
 #   ## MaxTCPConnection - applicable when protocol is set to tcp (default=250)
 #   max_tcp_connections = 250
+#   ## Enable TCP keep alive probes (default=false)
+#   tcp_keep_alive = false
+#
+#   ## Specifies the keep-alive period for an active network connection.
+#   ## Only applies to TCP sockets and will be ignored if tcp_keep_alive is false.
+#   ## Defaults to the OS configuration.
+#   # tcp_keep_alive_period = "2h"
 #
 #   ## Address and port to host UDP listener on
 #   service_address = ":8125"

--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -10,6 +10,14 @@
 
   ## MaxTCPConnection - applicable when protocol is set to tcp (default=250)
   max_tcp_connections = 250
+  
+  ## Enable TCP keep alive probes (default=false)
+  tcp_keep_alive = false
+
+  ## Specifies the keep-alive period for an active network connection.
+  ## Only applies to TCP sockets and will be ignored if tcp_keep_alive is false.
+  ## Defaults to the OS configuration.
+  # tcp_keep_alive_period = "2h"
 
   ## Address and port to host UDP listener on
   service_address = ":8125"
@@ -157,6 +165,8 @@ metric type:
 - **protocol** string: Protocol used in listener - tcp or udp options
 - **max_tcp_connections** []int: Maximum number of concurrent TCP connections
 to allow. Used when protocol is set to tcp.
+- **tcp_keep_alive** boolean: Enable TCP keep alive probes
+- **tcp_keep_alive_period** internal.Duration: Specifies the keep-alive period for an active network connection
 - **service_address** string: Address to listen for statsd UDP packets on
 - **delete_gauges** boolean: Delete gauges on every collection interval
 - **delete_counters** boolean: Delete counters on every collection interval


### PR DESCRIPTION
Similar implementation to the socket listener input plugin and its [original pull request](https://github.com/influxdata/telegraf/pull/2697). Found this was really necessary to keep the server connections clean, because you can't rely on clients always being able to close them (FIN), specially if you are running Telegraf behind a load balancer. Default behaviour is still false, so that it doesn't disrupt existing setups. 

Same as the pull request 2697, unit tests for this are hard to accomplish ("There's no ability to query a socket for its current keep-alive setting") but you can observe the behaviour using packet capturing.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
