### PR TITLE
Convert boolean metric values to float. More verbose message when failing to build a metric

### DIFF
--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -97,7 +97,7 @@ func (d *Datadog) Write(metrics []telegraf.Metric) error {
 				metricCounter++
 			}
 		} else {
-			log.Printf("I! unable to build Metric for %s, skipping\n", m.Name())
+			log.Printf("I! unable to build Metric for %s due to error '%v', skipping\n", m.Name(), err)
 		}
 	}
 
@@ -150,7 +150,7 @@ func buildMetrics(m telegraf.Metric) (map[string]Point, error) {
 		}
 		var p Point
 		if err := p.setValue(v); err != nil {
-			return ms, fmt.Errorf("unable to extract value from Fields, %s", err.Error())
+			return ms, fmt.Errorf("unable to extract value from Fields %v error %v", k, err.Error())
 		}
 		p[0] = float64(m.Time().Unix())
 		ms[k] = p
@@ -189,6 +189,11 @@ func (p *Point) setValue(v interface{}) error {
 		p[1] = float64(d)
 	case float64:
 		p[1] = float64(d)
+	case bool:
+		p[1] = float64(0)
+		if d {
+			p[1] = float64(1)
+		}
 	default:
 		return fmt.Errorf("undeterminable type")
 	}

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -152,6 +152,22 @@ func TestBuildPoint(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			testutil.TestMetric(bool(true), "test7"),
+			Point{
+				float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+				1.0,
+			},
+			nil,
+		},
+		{
+			testutil.TestMetric(bool(false), "test8"),
+			Point{
+				float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+				0.0,
+			},
+			nil,
+		},
 	}
 	for _, tt := range tagtests {
 		pt, err := buildMetrics(tt.ptIn)


### PR DESCRIPTION
Boolean metric values from plugins converted to float for datadog output. For example `health_ok` in
[smart](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/smart/smart.go#L234) plugin.

Added more verbose error logging to make it easier to debug, sample error output

```
2018-02-18T17:14:41Z I! unable to build Metric for smart_device due to error 'unable to extract value from Fields health_ok error undeterminable type', skipping
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
