### PR TITLE
Add shard server stats to the mongoDB input plugin

### DIFF
--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -49,6 +49,10 @@ and create a single measurement containing values e.g.
  * resident_megabytes
  * updates_per_sec
  * vsize_megabytes
+ * total_in_use
+ * total_available
+ * total_created
+ * total_refreshing
  * ttl_deletes_per_sec
  * ttl_passes_per_sec
  * repl_lag

--- a/plugins/inputs/mongodb/mongodb_data.go
+++ b/plugins/inputs/mongodb/mongodb_data.go
@@ -66,6 +66,13 @@ var DefaultClusterStats = map[string]string{
 	"jumbo_chunks": "JumboChunksCount",
 }
 
+var DefaultShardStats = map[string]string{
+	"total_in_use":     "TotalInUse",
+	"total_available":  "TotalAvailable",
+	"total_created":    "TotalCreated",
+	"total_refreshing": "TotalRefreshing",
+}
+
 var MmapStats = map[string]string{
 	"mapped_megabytes":     "Mapped",
 	"non-mapped_megabytes": "NonMapped",
@@ -127,6 +134,7 @@ func (d *MongodbData) AddDefaultStats() {
 		d.addStat(statLine, DefaultReplStats)
 	}
 	d.addStat(statLine, DefaultClusterStats)
+	d.addStat(statLine, DefaultShardStats)
 	if d.StatLine.StorageEngine == "mmapv1" {
 		d.addStat(statLine, MmapStats)
 	} else if d.StatLine.StorageEngine == "wiredTiger" {

--- a/plugins/inputs/mongodb/mongodb_data_test.go
+++ b/plugins/inputs/mongodb/mongodb_data_test.go
@@ -99,6 +99,27 @@ func TestAddWiredTigerStats(t *testing.T) {
 	}
 }
 
+func TestAddShardStats(t *testing.T) {
+	d := NewMongodbData(
+		&StatLine{
+			TotalInUse:      0,
+			TotalAvailable:  0,
+			TotalCreated:    0,
+			TotalRefreshing: 0,
+		},
+		tags,
+	)
+
+	var acc testutil.Accumulator
+
+	d.AddDefaultStats()
+	d.flush(&acc)
+
+	for key, _ := range DefaultShardStats {
+		assert.True(t, acc.HasInt64Field("mongodb", key))
+	}
+}
+
 func TestStateTag(t *testing.T) {
 	d := NewMongodbData(
 		&StatLine{
@@ -147,6 +168,10 @@ func TestStateTag(t *testing.T) {
 		"ttl_deletes_per_sec":   int64(0),
 		"ttl_passes_per_sec":    int64(0),
 		"jumbo_chunks":          int64(0),
+		"total_in_use":          int64(0),
+		"total_available":       int64(0),
+		"total_created":         int64(0),
+		"total_refreshing":      int64(0),
 	}
 	acc.AssertContainsTaggedFields(t, "mongodb", fields, stateTags)
 }

--- a/plugins/inputs/mongodb/mongodb_server.go
+++ b/plugins/inputs/mongodb/mongodb_server.go
@@ -55,8 +55,18 @@ func (s *Server) gatherData(acc telegraf.Accumulator, gatherDbStats bool) error 
 		JumboChunksCount: int64(jumbo_chunks),
 	}
 
-	result_db_stats := &DbStats{}
+	resultShards := &ShardStats{}
+	err = s.Session.DB("admin").Run(bson.D{
+		{
+			Name:  "shardConnPoolStats",
+			Value: 1,
+		},
+	}, &resultShards)
+	if err != nil {
+		log.Println("E! Error getting database shard stats (" + err.Error() + ")")
+	}
 
+	result_db_stats := &DbStats{}
 	if gatherDbStats == true {
 		names := []string{}
 		names, err = s.Session.DatabaseNames()
@@ -88,6 +98,7 @@ func (s *Server) gatherData(acc telegraf.Accumulator, gatherDbStats bool) error 
 		ReplSetStatus: result_repl,
 		ClusterStatus: result_cluster,
 		DbStats:       result_db_stats,
+		ShardStats:    resultShards,
 	}
 
 	defer func() {

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -34,6 +34,7 @@ type MongoStatus struct {
 	ReplSetStatus *ReplSetStatus
 	ClusterStatus *ClusterStatus
 	DbStats       *DbStats
+	ShardStats    *ShardStats
 }
 
 type ServerStatus struct {
@@ -114,6 +115,14 @@ type WiredTiger struct {
 	Transaction TransactionStats       `bson:"transaction"`
 	Concurrent  ConcurrentTransactions `bson:"concurrentTransactions"`
 	Cache       CacheStats             `bson:"cache"`
+}
+
+// ShardStats stores information from shardConnPoolStats.
+type ShardStats struct {
+	TotalInUse      int64 `bson:"totalInUse"`
+	TotalAvailable  int64 `bson:"totalAvailable"`
+	TotalCreated    int64 `bson:"totalCreated"`
+	TotalRefreshing int64 `bson:"totalRefreshing"`
 }
 
 type ConcurrentTransactions struct {
@@ -450,6 +459,9 @@ type StatLine struct {
 
 	// DB stats field
 	DbStatsLines []DbStatLine
+
+	// Shard stats
+	TotalInUse, TotalAvailable, TotalCreated, TotalRefreshing int64
 }
 
 type DbStatLine struct {
@@ -782,6 +794,13 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 		}
 		returnVal.DbStatsLines = append(returnVal.DbStatsLines, *dbStatLine)
 	}
+
+	// Set shard stats
+	newShardStats := *newMongo.ShardStats
+	returnVal.TotalInUse = newShardStats.TotalInUse
+	returnVal.TotalAvailable = newShardStats.TotalAvailable
+	returnVal.TotalCreated = newShardStats.TotalCreated
+	returnVal.TotalRefreshing = newShardStats.TotalRefreshing
 
 	return returnVal
 }


### PR DESCRIPTION
Adds total stats for a shard connection pool exposed via the
`shardConnPoolStats` database command.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
