### PR TITLE
[Docs] Add link to ServiceInput interface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ and `Stop()` methods.
 ### Service Plugin Guidelines
 
 * Same as the `Plugin` guidelines, except that they must conform to the
-`inputs.ServiceInput` interface.
+[`telegraf.ServiceInput`](https://godoc.org/github.com/influxdata/telegraf#ServiceInput) interface.
 
 ## Output Plugins
 


### PR DESCRIPTION
Hello!

As I'm reading the Contribution section, I've seen that there was a [link](https://github.com/influxdata/telegraf/blob/master/CONTRIBUTING.md#input-plugin-guidelines) to the `telegraf.Input` interface, but not to the `telegraf.ServiceInput` interface.

This PR will add the link below to the `telegraf.ServiceInput` interface: https://godoc.org/github.com/influxdata/telegraf#ServiceInput

I'm looking forward to receiving your feedback

Thank you!

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated. (inapplicable?)
- [x] Has appropriate unit tests. (inapplicable?)
