### PR TITLE
JSON serializer emits metric type information

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -17,6 +17,20 @@ const (
 	Histogram
 )
 
+var (
+	ValueTypeToName = map[ValueType]string{
+		Counter:   "counter",
+		Gauge:     "gauge",
+		Untyped:   "untyped",
+		Summary:   "summary",
+		Histogram: "histogram",
+	}
+)
+
+func (v ValueType) String() string {
+	return ValueTypeToName[v]
+}
+
 type Metric interface {
 	// Serialize serializes the metric into a line-protocol byte buffer,
 	// including a newline at the end.

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -23,6 +23,7 @@ func (s *JsonSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 	m["fields"] = metric.Fields()
 	m["name"] = metric.Name()
 	m["timestamp"] = metric.UnixNano() / units_nanoseconds
+	m["type"] = metric.Type().String()
 	serialized, err := ejson.Marshal(m)
 	if err != nil {
 		return []byte{}, err


### PR DESCRIPTION
JSON serializer now includes type information in the string it emits.

Also riding on this patch - ValueType now exposes a String()
method that returns the name of the ValueType. This is useful
when we print the metric type information (e.g. when serializing)
since the reader does not need to be aware of the enum types used
within telegraf.

### Required for all PRs:

- [ :heavy_check_mark: ] Signed [CLA](https://influxdata.com/community/cla/).
- [ :x: ] Associated README.md updated (<-- not needed)
- [ :heavy_check_mark: ] Has appropriate unit tests.
