### PR TITLE
Add link to full fail2ban plugin docs

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1301,6 +1301,9 @@
 # # Read metrics from fail2ban.
 # [[inputs.fail2ban]]
 #   ## Use sudo to run fail2ban-client
+#   ## Generally the fail2ban-client requires root access but running telegraf
+#   ## as root is not recommended. Learn more here:
+#   ## https://github.com/influxdata/telegraf/tree/master/plugins/inputs/fail2ban
 #   use_sudo = false
 
 


### PR DESCRIPTION
I think this qualifies as a de minimus documentation fix. Hope you enjoy it
