### PR TITLE
Fixing snmp input doc

### DIFF
--- a/plugins/inputs/snmp/README.md
+++ b/plugins/inputs/snmp/README.md
@@ -85,7 +85,7 @@ Telegraf config:
 
   [[inputs.snmp.table]]
     oid = "TEST::testTable"
-    inherit_tags = "hostname"
+    inherit_tags = [ "hostname" ]
 ```
 
 Resulting output:


### PR DESCRIPTION
This PR is fixing the type of the `inherit_tags` option in one of the examples. It must be `[]string` and not `string`.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
