### PR TITLE
Update CI configs to Go 1.10.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 defaults: &defaults
   docker:
-    - image: 'circleci/golang:1.9.4'
+    - image: 'circleci/golang:1.10'
   working_directory: '/go/src/github.com/influxdata/telegraf'
 version: 2
 jobs:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,11 @@ platform: x64
 
 install:
   - IF NOT EXIST "C:\Cache" mkdir C:\Cache
-  - IF NOT EXIST "C:\Cache\go1.9.4.msi" curl -o "C:\Cache\go1.9.4.msi" https://storage.googleapis.com/golang/go1.9.4.windows-amd64.msi
+  - IF NOT EXIST "C:\Cache\go1.10.msi" curl -o "C:\Cache\go1.10.msi" https://storage.googleapis.com/golang/go1.10.windows-amd64.msi
   - IF NOT EXIST "C:\Cache\gnuwin32-bin.zip" curl -o "C:\Cache\gnuwin32-bin.zip" https://dl.influxdata.com/telegraf/ci/make-3.81-bin.zip
   - IF NOT EXIST "C:\Cache\gnuwin32-dep.zip" curl -o "C:\Cache\gnuwin32-dep.zip" https://dl.influxdata.com/telegraf/ci/make-3.81-dep.zip
   - IF EXIST "C:\Go" rmdir /S /Q C:\Go
-  - msiexec.exe /i "C:\Cache\go1.9.4.msi" /quiet
+  - msiexec.exe /i "C:\Cache\go1.10.msi" /quiet
   - 7z x "C:\Cache\gnuwin32-bin.zip" -oC:\GnuWin32 -y
   - 7z x "C:\Cache\gnuwin32-dep.zip" -oC:\GnuWin32 -y
   - go version


### PR DESCRIPTION
Updates CircleCI and AppVeyor config changes to Go 1.10. Similar to previous Go 1.9 update in #3458.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
