### PR TITLE
added config flag to skip collection of network protocol metrics

### DIFF
--- a/plugins/inputs/system/NET_README.md
+++ b/plugins/inputs/system/NET_README.md
@@ -14,6 +14,11 @@ This plugin gathers metrics about network interface and protocol usage (Linux on
   ##
   # interfaces = ["eth*", "enp0s[0-1]", "lo"]
   ##
+  ## On linux systems telegraf also collects protocol stats.
+  ## Setting ignore_protocol_stats to true will skip reporting of protocol metrics.
+  ##
+  # ignore_protocol_stats = false
+  ##
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/system/net_test.go
+++ b/plugins/inputs/system/net_test.go
@@ -106,4 +106,10 @@ func TestNetStats(t *testing.T) {
 		"udp_socket":      1,
 	}
 	acc.AssertContainsTaggedFields(t, "netstat", fields3, make(map[string]string))
+
+	acc.Metrics = nil
+	err = (&NetIOStats{ps: &mps, IgnoreProtocolStats: true}).Gather(&acc)
+	require.NoError(t, err)
+
+	acc.AssertDoesNotContainsTaggedFields(t, "netstat", fields3, make(map[string]string))
 }


### PR DESCRIPTION
Added config flag to system net (inputs.net) to ignore collection of protocol stats.
Provides feature requested in #3879

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.