### PR TITLE
lowercase processor plugin

### DIFF
--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -3,4 +3,5 @@ package all
 import (
 	_ "github.com/influxdata/telegraf/plugins/processors/override"
 	_ "github.com/influxdata/telegraf/plugins/processors/printer"
+	_ "github.com/influxdata/telegraf/plugins/processors/lowercase"
 )

--- a/plugins/processors/lowercase/README.md
+++ b/plugins/processors/lowercase/README.md
@@ -1,0 +1,32 @@
+# Lowercase Processor Plugin
+
+The `lowercase` plugin transforms tag and field values to lower case. If `result_key` parameter is present, it can produce new tags and fields from existing ones.
+
+### Configuration:
+
+```toml
+[[processors.lowercase]]
+  namepass = ["uri_stem"]
+
+  # Tag and field conversions defined in a separate sub-tables
+  [[processors.lowercase.tags]]
+    ## Tag to change
+    key = "uri_stem"
+
+  [[processors.lowercase.tags]]
+    ## Multiple tags or fields may be defined
+    key = "method"
+
+  [[processors.lowercase.fields]]
+    key = "cs-host"
+    result_key = "cs-host_normalised"
+```
+
+### Tags:
+
+No tags are applied by this processor.
+
+### Example Output:
+```
+iis_log,method=get,uri_stem=/api/healthcheck cs-host="MIXEDCASE_host",cs-host_normalised="mixedcase_host",referrer="-",ident="-",http_version=1.1,agent="UserAgent",resp_bytes=270i 1519652321000000000
+```

--- a/plugins/processors/lowercase/lowercase.go
+++ b/plugins/processors/lowercase/lowercase.go
@@ -1,0 +1,77 @@
+package lowercase
+
+import (
+	"strings"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+type Lowercase struct {
+	Tags   []converter
+	Fields []converter
+}
+
+type converter struct {
+	Key         string
+	ResultKey   string
+}
+
+const sampleConfig = `
+  ## Tag and field conversions defined in a separate sub-tables
+  # [[processors.lowercase.tags]]
+  #   ## Tag to change
+  #   key = "method"
+
+  # [[processors.lowercase.fields]]
+  #   key = "uri_stem"
+  #   result_key = "uri_stem_normalised"
+`
+
+func (r *Lowercase) SampleConfig() string {
+	return sampleConfig
+}
+
+func (r *Lowercase) Description() string {
+	return "Transforms tag and field values to lower case"
+}
+
+func (r *Lowercase) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	for _, metric := range in {
+		for _, converter := range r.Tags {
+			if value, ok := metric.Tags()[converter.Key]; ok {
+				metric.AddTag(
+					getKey(converter),
+                    strings.ToLower(value),
+				)
+			}
+		}
+
+		for _, converter := range r.Fields {
+			if value, ok := metric.Fields()[converter.Key]; ok {
+				switch value := value.(type) {
+				case string:
+					metric.AddField(
+						getKey(converter),
+                        strings.ToLower(value),
+					)
+				}
+			}
+		}
+	}
+
+	return in
+}
+
+func getKey(c converter) string {
+	if c.ResultKey != "" {
+		return c.ResultKey
+	}
+	return c.Key
+}
+
+func init() {
+	processors.Add("lowercase", func() telegraf.Processor {
+		return &Lowercase{}
+	})
+}

--- a/plugins/processors/lowercase/lowercase_test.go
+++ b/plugins/processors/lowercase/lowercase_test.go
@@ -1,0 +1,205 @@
+package lowercase
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+)
+
+func newM1() telegraf.Metric {
+	m1, _ := metric.New("IIS_log",
+		map[string]string{
+			"verb":           "GET",
+            "s-computername": "MIXEDCASE_hostname",
+		},
+		map[string]interface{}{
+            "request": "/mixed/CASE/paTH/?from=-1D&to=now",
+		},
+		time.Now(),
+	)
+	return m1
+}
+
+func newM2() telegraf.Metric {
+	m2, _ := metric.New("IIS_log",
+		map[string]string{
+			"verb":           "GET",
+			"resp_code":      "200",
+            "s-computername": "MIXEDCASE_hostname",
+		},
+		map[string]interface{}{
+            "request":       "/mixed/CASE/paTH/?from=-1D&to=now",
+            "cs-host":       "AAAbbb",
+			"ignore_number": int64(200),
+			"ignore_bool":   true,
+		},
+		time.Now(),
+	)
+	return m2
+}
+
+func TestFieldConversions(t *testing.T) {
+	tests := []struct {
+		message        string
+		converter      converter
+		expectedFields map[string]interface{}
+	}{
+		{
+			message: "Should change existing field",
+			converter: converter{
+				Key:         "request",
+			},
+			expectedFields: map[string]interface{}{
+                "request": "/mixed/case/path/?from=-1d&to=now",
+			},
+		},
+		{
+			message: "Should add new field",
+			converter: converter{
+				Key:         "request",
+				ResultKey:   "lowercase_request",
+			},
+			expectedFields: map[string]interface{}{
+                "request": "/mixed/CASE/paTH/?from=-1D&to=now",
+                "lowercase_request": "/mixed/case/path/?from=-1d&to=now",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		lowercase := &Lowercase{}
+		lowercase.Fields = []converter{
+			test.converter,
+		}
+
+		processed := lowercase.Apply(newM1())
+
+		expectedTags := map[string]string{
+			"verb":           "GET",
+            "s-computername": "MIXEDCASE_hostname",
+		}
+
+		assert.Equal(t, test.expectedFields, processed[0].Fields(), test.message)
+		assert.Equal(t, expectedTags, processed[0].Tags(), "Should not change tags")
+		assert.Equal(t, "IIS_log", processed[0].Name(), "Should not change name")
+	}
+}
+
+func TestTagConversions(t *testing.T) {
+	tests := []struct {
+		message      string
+		converter    converter
+		expectedTags map[string]string
+	}{
+		{
+			message: "Should change existing tag",
+			converter: converter{
+				Key:         "s-computername",
+			},
+			expectedTags: map[string]string{
+				"verb":    "GET",
+                "s-computername": "mixedcase_hostname",
+			},
+		},
+		{
+			message: "Should add new tag",
+			converter: converter{
+				Key:         "s-computername",
+				ResultKey:   "s-computername_lowercase",
+			},
+			expectedTags: map[string]string{
+				"verb":       "GET",
+                "s-computername": "MIXEDCASE_hostname",
+                "s-computername_lowercase": "mixedcase_hostname",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		lowercase := &Lowercase{}
+		lowercase.Tags = []converter{
+			test.converter,
+		}
+
+		processed := lowercase.Apply(newM1())
+
+		expectedFields := map[string]interface{}{
+            "request": "/mixed/CASE/paTH/?from=-1D&to=now",
+		}
+
+		assert.Equal(t, expectedFields, processed[0].Fields(), test.message, "Should not change fields")
+		assert.Equal(t, test.expectedTags, processed[0].Tags(), test.message)
+		assert.Equal(t, "IIS_log", processed[0].Name(), "Should not change name")
+	}
+}
+
+func TestMultipleConversions(t *testing.T) {
+	lowercase := &Lowercase{}
+	lowercase.Tags = []converter{
+		{
+			Key:         "verb",
+		},
+		{
+			Key:         "s-computername",
+		},
+	}
+	lowercase.Fields = []converter{
+		{
+			Key:         "request",
+		},
+		{
+			Key:         "cs-host",
+			ResultKey:   "cs-host_lowercase",
+		},
+	}
+
+	processed := lowercase.Apply(newM2())
+
+	expectedFields := map[string]interface{}{
+        "request":           "/mixed/case/path/?from=-1d&to=now",
+		"ignore_number":     int64(200),
+		"ignore_bool":       true,
+        "cs-host":           "AAAbbb",
+        "cs-host_lowercase": "aaabbb",
+	}
+	expectedTags := map[string]string{
+		"verb":           "get",
+        "resp_code":      "200",
+        "s-computername": "mixedcase_hostname",
+	}
+
+	assert.Equal(t, expectedFields, processed[0].Fields())
+	assert.Equal(t, expectedTags, processed[0].Tags())
+}
+
+func TestNoKey(t *testing.T) {
+	tests := []struct {
+		message        string
+		converter      converter
+		expectedFields map[string]interface{}
+	}{
+		{
+			message: "Should not change anything if there is no field with given key",
+			converter: converter{
+				Key:         "not_exists",
+			},
+			expectedFields: map[string]interface{}{
+                "request": "/mixed/CASE/paTH/?from=-1D&to=now",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		lowercase := &Lowercase{}
+		lowercase.Fields = []converter{
+			test.converter,
+		}
+
+		processed := lowercase.Apply(newM1())
+
+		assert.Equal(t, test.expectedFields, processed[0].Fields(), test.message)
+	}
+}


### PR DESCRIPTION
My own use case means I need to convert the values of tags from upper case to lower case (or vice versa) because IIS logs I've been working with contain the character case originally expressed in each request, but this means statistics are not aggregated together by the basicstats aggregator.

I tried building and using the regex processor, #3839 , but regex in golang doesn't support the case transformations available in Perl with \L and \U. Everything else about the plugin was a perfect fit so I copied its structure and want to credit @44px for most of the hard work. The plugin just calls strings.ToLower on the tags and fields specified.

### Configuration Example
```
[[processors.lowercase]]
  namepass = "iis_log"
  [[processors.lowercase.tags]]
    key = "01_uriStem"
```

### Source metric from logparser
```
iis_log,host=MYMACHINE,02_method=GET,01_uriStem=/api/Healthcheck,03_response=200 port="7314",protocolVersion="HTTP
/1.1",serverName="MYHOST",log_timestamp="2018-03-08 00:02:59",clientIP="fe80::beef:beef:feeb:9071%12",bytesSent=436i,req
uestHost="THEIRHOST:7314",referer="-",userAgent="Mozilla/5.0+(Windows+NT;+Windows+NT+6.3;+en-GB)+WindowsPowerShell/5.1.1
4409.1012",serverIP="fe80::beef:beef:beef:9071%12",timetaken=1781i,username="-",serviceName="W3SVC11",win32response="0",
uriQuery="-",bytesReceived=178i,subresponse="0" 1521122773998868100
iis_log,02_method=GET,01_uriStem=/API/healthcheck,03_response=200,host=MYMACHINE uriQuery="-",username="-",bytesSe
nt=436i,bytesReceived=178i,clientIP="fe80::beef:beef:feeb:9071%12",serverName="MYHOST",serverIP="fe80::beef:beef:beef:90
71%12",userAgent="Mozilla/5.0+(Windows+NT;+Windows+NT+6.3;+en-GB)+WindowsPowerShell/5.1.14409.1012",subresponse="0",log_
timestamp="2018-03-08 00:03:00",protocolVersion="HTTP/1.1",serviceName="W3SVC11",port="7314",timetaken=1781i,referer="-"
,requestHost="THEIRHOST:7314",win32response="0" 1521122773998868101
```

### Results
```
iis_log,host=LAPTOP-A5GCJ6G9,03_response=200,02_method=GET,01_uriStem=/api/healthcheck uriQuery="-",requestHost="THEIRHO
ST:7314",timetaken=1781i,bytesReceived=178i,userAgent="Mozilla/5.0+(Windows+NT;+Windows+NT+6.3;+en-GB)+WindowsPowerShell
/5.1.14409.1012",serverName="MYHOST",bytesSent=436i,username="-",clientIP="fe80::beef:beef:feeb:9071%12",log_timestamp="
2018-03-08 00:02:59",subresponse="0",serverIP="fe80::beef:beef:beef:9071%12",port="7314",win32response="0",referer="-",s
erviceName="W3SVC11",protocolVersion="HTTP/1.1" 1521122905846447300
iis_log,02_method=GET,03_response=200,host=LAPTOP-A5GCJ6G9,01_uriStem=/api/healthcheck subresponse="0",serviceName="W3SV
C11",protocolVersion="HTTP/1.1",serverName="MYHOST",bytesSent=436i,port="7314",serverIP="fe80::beef:beef:beef:9071%12",b
ytesReceived=178i,clientIP="fe80::beef:beef:feeb:9071%12",username="-",uriQuery="-",win32response="0",log_timestamp="201
8-03-08 00:03:00",userAgent="Mozilla/5.0+(Windows+NT;+Windows+NT+6.3;+en-GB)+WindowsPowerShell/5.1.14409.1012",requestHo
st="THEIRHOST:7314",timetaken=1781i,referer="-" 1521122905846447301
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
