### PR TITLE
Add disk input plugin ignore_mount_points property

### DIFF
--- a/plugins/inputs/system/DISK_README.md
+++ b/plugins/inputs/system/DISK_README.md
@@ -17,6 +17,9 @@ https://en.wikipedia.org/wiki/Df_(Unix) for more details.
 
   ## Ignore mount points by filesystem type.
   ignore_fs = ["tmpfs", "devtmpfs", "devfs"]
+  
+  ## Ignore some mountpoints by mount point. 
+  # ignore_mount_points = ["/dev", "/sys/fs/cgroup", "/dev/shm", "/run", "/run/lock", "/sys/fs/cgroup", "/proc/kcore", "/proc/timer_list", "/proc/timer_stats", "/proc/sched_debug"]
 ```
 
 #### Docker container

--- a/plugins/inputs/system/disk_test.go
+++ b/plugins/inputs/system/disk_test.go
@@ -370,4 +370,10 @@ func TestDiskStats(t *testing.T) {
 	// / and /home
 	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/home"}}).Gather(&acc)
 	assert.Equal(t, 2*expectedAllDiskMetrics+7, acc.NFields())
+
+	// We should see remain root diskpoints as MountPoints ignore /home.
+	// include / and ignore /home
+	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/home"}, IgnoreMountPoints: []string{"/home"}}).Gather(&acc)
+	rootMetrics := 7
+	assert.Equal(t, 2*expectedAllDiskMetrics+7+rootMetrics, acc.NFields())
 }


### PR DESCRIPTION
### disk input plugin
If we use tmpfs file system, metrics for unnecessary mount points are also collected. 

### Feature
I have added the ignore_mount_points property to ignore unnecessary mount point metric.

### Test Code
Wrote the test code.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
