### PR TITLE
Couchdb : use per-db statistics

### DIFF
--- a/plugins/inputs/couchdb/README.md
+++ b/plugins/inputs/couchdb/README.md
@@ -1,14 +1,22 @@
 # CouchDB Input Plugin
 ---
 
-The CouchDB plugin gathers metrics of CouchDB using [_stats](http://docs.couchdb.org/en/1.6.1/api/server/common.html?highlight=stats#get--_stats) endpoint.
+The CouchDB plugin gathers metrics of CouchDB using [_stats](http://docs.couchdb.org/en/2.1.1/api/server/common.html?highlight=stats#get--_stats) endpoint.
+
+It also can handle the database specific stats using the [db](http://docs.couchdb.org/en/2.1.1/api/database/common.html) endpoint
 
 ### Configuration:
 
 ```
-# Sample Config:
+# Sample Config (backwards compabitle or server only):
 [[inputs.couchdb]]
   hosts = ["http://localhost:5984/_stats"]
+```
+
+```
+# Sample Config for both server and db stats:
+[[inputs.couchdb]]
+  hosts = ["http://localhost:5984/_stats","http://localhost:5984/_all_dbs"]
 ```
 
 ### Measurements & Fields:
@@ -56,9 +64,18 @@ httpd statistics:
 - httpd_bulk_requests
 - httpd_view_reads
 
+statistics per database (will be tagged with the DB name) :
+- doc_count
+- doc_del_count
+- compact_running
+- file_size
+- external_size
+- active_size
+
 ### Tags:
 
 - server (url of the couchdb _stats endpoint)
+- db (for the db statistics)
 
 ### Example output:
 

--- a/plugins/inputs/couchdb/couchdb.go
+++ b/plugins/inputs/couchdb/couchdb.go
@@ -119,7 +119,6 @@ var client = &http.Client{
 
 func (c *CouchDB) fetchAndInsertServerData(accumulator telegraf.Accumulator, host string) error {
 
-	println("Fetch stats for " + host)
 	response, error := client.Get(host)
 	if error != nil {
 		return error
@@ -180,7 +179,6 @@ func (c *CouchDB) fetchAndInsertServerData(accumulator telegraf.Accumulator, hos
 
 func (c *CouchDB) fetchAndInsertDbData(accumulator telegraf.Accumulator, host string) error {
 
-	println("Fetch db info for " + host)
 	response, error := client.Get(host)
 	if error != nil {
 		return error
@@ -222,8 +220,6 @@ func (c *CouchDB) fetchAndInsertDbData(accumulator telegraf.Accumulator, host st
 			"db":     db,
 		}
 
-		//println("doccount for " + db)
-		//fmt.Println("%i", dat["doc_count"])
 		accumulator.AddFields("couchdb", fields, tags)
 	}
 


### PR DESCRIPTION
Hey all,

I'm not a go developer, so I do struggle a bit with the build/test system, so please consider this as a proposal and if you like it, please give me a hand with the required administration :-)

The idea of this enhancement is not only to use the server stats endpoint, but also to use the per-DB statistics. It fetches the list of databases and then per database reads the statistics. This adds important statistics like the number of documents and the size per database. 
This can help a lot in checking that your replication is working like it should by comparing the number of documents per replicated server... 
It will also give you a visual representation on which database is responsible for the disk size used.

I tested it with couchdb 2.1.1 (also updated the documentation to point to those documentation pages).

Jef



### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
