### PR TITLE
Add Riemann TLS output

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -63,6 +63,7 @@ github.com/prometheus/client_model fa8ad6fec33561be4280a8f0514318c79d7f6cb6
 github.com/prometheus/common dd2f054febf4a6c00f2343686efb775948a8bff4
 github.com/prometheus/procfs 1878d9fbb537119d24b21ca07effd591627cd160
 github.com/rcrowley/go-metrics 1f30fe9094a513ce4c700b9a54458bbb0c96996c
+github.com/riemann/riemann-go-client 125d29d80a3e783e9b18c5115158436edcb8510e
 github.com/samuel/go-zookeeper 1d7be4effb13d2d908342d349d71a284a7542693
 github.com/satori/go.uuid 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 github.com/shirou/gopsutil 384a55110aa5ae052eb93ea94940548c1e305a99

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -619,8 +619,17 @@
 
 # # Configuration for the Riemann server to send metrics to
 # [[outputs.riemann]]
-#   ## The full TCP or UDP URL of the Riemann server
+#   ## The full TCP, UDP or TLS URL of the Riemann server
 #   url = "tcp://localhost:5555"
+#
+#   ## Certificate path for TLS connection
+#   # cert_path = "cert.pem"
+#
+#   ## Key path for TLS connection
+#   # key_path = "key.key"
+#
+#   ## Activate insecure TLS connection
+#   # insecure = false
 #
 #   ## Riemann event TTL, floating-point time in seconds.
 #   ## Defines how long that an event is considered valid for in Riemann
@@ -647,7 +656,7 @@
 #   ## Description for Riemann event
 #   # description_text = "metrics collected from telegraf"
 #
-#   ## Riemann client write timeout, defaults to "5s" if not set.
+#   ## Riemann client connect and write timeout, defaults to "5s" if not set.
 #   # timeout = "5s"
 
 

--- a/plugins/outputs/riemann/README.md
+++ b/plugins/outputs/riemann/README.md
@@ -7,8 +7,17 @@ This plugin writes to [Riemann](http://riemann.io/) via TCP or UDP.
 ```toml
 # Configuration for Riemann to send metrics to
 [[outputs.riemann]]
-  ## The full TCP or UDP URL of the Riemann server
+  ## The full TCP, UDP or TLS URL of the Riemann server
   url = "tcp://localhost:5555"
+
+  ## Certificate path for TLS connection
+  # cert_path = "cert.pem"
+
+  ## Key path for TLS connection
+  # key_path = "key.key"
+
+  ## Activate insecure TLS connection
+  # insecure = false
 
   ## Riemann event TTL, floating-point time in seconds.
   ## Defines how long that an event is considered valid for in Riemann

--- a/plugins/outputs/riemann/riemann.go
+++ b/plugins/outputs/riemann/riemann.go
@@ -9,14 +9,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/amir/raidman"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/outputs"
+	"github.com/riemann/riemann-go-client"
 )
 
 type Riemann struct {
 	URL                    string
+	CertPath               string
+	KeyPath                string
+	Insecure               bool
 	TTL                    float32
 	Separator              string
 	MeasurementAsAttribute bool
@@ -25,13 +28,21 @@ type Riemann struct {
 	Tags                   []string
 	DescriptionText        string
 	Timeout                internal.Duration
-
-	client *raidman.Client
+	client                 riemanngo.Client
 }
 
 var sampleConfig = `
-  ## The full TCP or UDP URL of the Riemann server
+  ## The full TCP, UDP or TLS URL of the Riemann server
   url = "tcp://localhost:5555"
+
+  ## Certificate path for TLS connection
+  # cert_path = "cert.pem"
+
+  ## Key path for TLS connection
+  # key_path = "key.key"
+
+  ## Activate insecure TLS connection
+  # insecure = false
 
   ## Riemann event TTL, floating-point time in seconds.
   ## Defines how long that an event is considered valid for in Riemann
@@ -58,7 +69,7 @@ var sampleConfig = `
   ## Description for Riemann event
   # description_text = "metrics collected from telegraf"
 
-  ## Riemann client write timeout, defaults to "5s" if not set.
+  ## Riemann client connect and write timeout, defaults to "5s" if not set.
   # timeout = "5s"
 `
 
@@ -68,7 +79,21 @@ func (r *Riemann) Connect() error {
 		return err
 	}
 
-	client, err := raidman.DialWithTimeout(parsed_url.Scheme, parsed_url.Host, r.Timeout.Duration)
+	var client riemanngo.Client
+
+	if parsed_url.Scheme == "udp" {
+		client = riemanngo.NewUdpClient(parsed_url.Host, r.Timeout.Duration)
+	} else if parsed_url.Scheme == "tcp" {
+		client = riemanngo.NewTcpClient(parsed_url.Host, r.Timeout.Duration)
+	} else if parsed_url.Scheme == "tls" {
+		client, err = riemanngo.NewTlsClient(parsed_url.Host, r.CertPath, r.KeyPath, r.Insecure, r.Timeout.Duration)
+		if err != nil {
+			return fmt.Errorf("Error creating TLS connection: %s", err.Error())
+		}
+	} else {
+		return fmt.Errorf("Unknown protocol %s", parsed_url.Scheme)
+	}
+	err = client.Connect()
 	if err != nil {
 		r.client = nil
 		return err
@@ -80,8 +105,11 @@ func (r *Riemann) Connect() error {
 
 func (r *Riemann) Close() error {
 	if r.client != nil {
-		r.client.Close()
+		err := r.client.Close()
 		r.client = nil
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -106,23 +134,26 @@ func (r *Riemann) Write(metrics []telegraf.Metric) error {
 	}
 
 	// build list of Riemann events to send
-	var events []*raidman.Event
+	var events []riemanngo.Event
 	for _, m := range metrics {
 		evs := r.buildRiemannEvents(m)
-		for _, ev := range evs {
-			events = append(events, ev)
-		}
+		events = append(events, evs...)
 	}
-
-	if err := r.client.SendMulti(events); err != nil {
-		r.Close()
-		return fmt.Errorf("Failed to send riemann message: %s", err)
+	_, err := riemanngo.SendEvents(r.client, &events)
+	if err != nil {
+		errclose := r.Close()
+		if errclose != nil {
+			return fmt.Errorf("Failed to send riemann message: %s "+
+				"and failed to close Connection : %s",
+				err.Error(), errclose.Error())
+		}
+		return fmt.Errorf("Failed to send riemann message: %s", err.Error())
 	}
 	return nil
 }
 
-func (r *Riemann) buildRiemannEvents(m telegraf.Metric) []*raidman.Event {
-	events := []*raidman.Event{}
+func (r *Riemann) buildRiemannEvents(m telegraf.Metric) []riemanngo.Event {
+	events := []riemanngo.Event{}
 	for fieldName, value := range m.Fields() {
 		// get host for Riemann event
 		host, ok := m.Tags()["host"]
@@ -134,11 +165,11 @@ func (r *Riemann) buildRiemannEvents(m telegraf.Metric) []*raidman.Event {
 			}
 		}
 
-		event := &raidman.Event{
+		event := riemanngo.Event{
 			Host:        host,
 			Ttl:         r.TTL,
 			Description: r.DescriptionText,
-			Time:        m.Time().Unix(),
+			Time:        m.Time(),
 
 			Attributes: r.attributes(m.Name(), m.Tags()),
 			Service:    r.service(m.Name(), fieldName),
@@ -153,7 +184,7 @@ func (r *Riemann) buildRiemannEvents(m telegraf.Metric) []*raidman.Event {
 				continue
 			}
 			event.State = value.(string)
-		case int, int64, uint64, float32, float64:
+		case int, int32, int64, uint, uint32, uint64, float32, float64:
 			event.Metric = value
 		default:
 			log.Printf("D! Riemann does not support metric value [%s]\n", value)

--- a/plugins/outputs/riemann/riemann_test.go
+++ b/plugins/outputs/riemann/riemann_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/amir/raidman"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/riemann/riemann-go-client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,9 +81,9 @@ func TestMetricEvents(t *testing.T) {
 	require.Len(t, events, 1)
 
 	// is event as expected?
-	expectedEvent := &raidman.Event{
+	expectedEvent := riemanngo.Event{
 		Ttl:         20.0,
-		Time:        1257894000,
+		Time:        time.Unix(1257894000, 0),
 		Tags:        []string{"telegraf", "value1"},
 		Host:        "abc123",
 		State:       "",
@@ -109,9 +109,9 @@ func TestMetricEvents(t *testing.T) {
 	require.Equal(t, expectedEvent, events[0])
 
 	// second event
-	expectedEvent = &raidman.Event{
+	expectedEvent = riemanngo.Event{
 		Ttl:         20.0,
-		Time:        1351825200,
+		Time:        time.Unix(1351825200, 0),
 		Tags:        []string{"telegraf"},
 		Host:        "xyz987",
 		State:       "",
@@ -146,9 +146,9 @@ func TestStateEvents(t *testing.T) {
 	require.Len(t, events, 1)
 
 	// is event as expected?
-	expectedEvent := &raidman.Event{
+	expectedEvent := riemanngo.Event{
 		Ttl:         0,
-		Time:        1447106400,
+		Time:        time.Unix(1447106400, 0),
 		Tags:        nil,
 		Host:        "host",
 		State:       "running",


### PR DESCRIPTION
- Replace raidman by riemann-go-client (https://github.com/riemann/riemann-go-client) which support TLS.
- Add support for TLS

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
