### PR TITLE
move pid tag to fields

### DIFF
--- a/plugins/inputs/passenger/README.md
+++ b/plugins/inputs/passenger/README.md
@@ -76,7 +76,6 @@ Telegraf must have permission to execute the `passenger-status` command.  On mos
     - group_name
     - app_root
     - supergroup_name
-    - pid
     - code_revision
     - life_status
     - process_group_id
@@ -97,6 +96,7 @@ Telegraf must have permission to execute the `passenger-status` command.  On mos
     - swap
     - real_memory
     - vmsize
+    - pid
 
 ### Example Output:
 ```

--- a/plugins/inputs/passenger/passenger.go
+++ b/plugins/inputs/passenger/passenger.go
@@ -212,7 +212,6 @@ func importMetric(stat []byte, acc telegraf.Accumulator) error {
 					"group_name":       group.Name,
 					"app_root":         group.AppRoot,
 					"supergroup_name":  sg.Name,
-					"pid":              fmt.Sprintf("%d", process.Pid),
 					"code_revision":    process.Code_revision,
 					"life_status":      process.Life_status,
 					"process_group_id": process.Process_group_id,
@@ -234,6 +233,7 @@ func importMetric(stat []byte, acc telegraf.Accumulator) error {
 					"swap":                  process.Swap,
 					"real_memory":           process.Real_memory,
 					"vmsize":                process.Vmsize,
+					"pid":                   fmt.Sprintf("%d", process.Pid),
 				}
 				acc.AddFields("passenger_process", fields, tags)
 			}

--- a/plugins/inputs/passenger/passenger_test.go
+++ b/plugins/inputs/passenger/passenger_test.go
@@ -112,7 +112,6 @@ func TestPassengerGenerateMetric(t *testing.T) {
 		"app_root":         "/var/app/current",
 		"group_name":       "/var/app/current/public",
 		"supergroup_name":  "/var/app/current/public",
-		"pid":              "11553",
 		"code_revision":    "899ac7f",
 		"life_status":      "ALIVE",
 		"process_group_id": "13608",
@@ -134,6 +133,7 @@ func TestPassengerGenerateMetric(t *testing.T) {
 		"swap":                  int64(0),
 		"real_memory":           int64(314900),
 		"vmsize":                int64(1563580),
+		"pid":                   "11553",
 	}
 	acc.AssertContainsTaggedFields(t, "passenger_process", fields, tags)
 }


### PR DESCRIPTION
Having pid in tags creates lot of influxdb series on some architecture with severals passengers apps on severals front servers, then we get an influxdb error : max series per database exceeded.
Don't think pid is useful in tags, so putting it in fields can avoid to change max series per database value on influxdb side.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
