### PR TITLE
Add metric_version option to mysql input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 ### Release Notes
 
-- The `mysql` input plugin has been updated to convert values to the
-  correct data type.  This may cause a `field type error` when inserting into
-  InfluxDB due the change of types.  It is recommended to drop the `mysql`,
-  `mysql_variables`, and `mysql_innodb`:
-  ```
-  DROP MEASUREMENT mysql
-  DROP MEASUREMENT mysql_variables
-  DROP MEASUREMENT mysql_innodb
-  ```
+- The `mysql` input plugin has been updated fix a number of type convertion
+  issues.  This may cause a `field type error` when inserting into InfluxDB due
+  the change of types.
+
+  To address this we have introduced a new `metric_version` option to control
+  enabling the new format.  For in depth recommendations on upgrading please
+  reference the [mysql plugin documentation](./plugins/inputs/mysql/README.md#metric-version).
+
+  It is encouraged to migrate to the new model when possible as the old version
+  is deprecated and will be removed in a future version.
 
 - The `postgresql` plugins now defaults to using a persistent connection to the database.
   In environments where TCP connections are terminated the `max_lifetime`
@@ -26,7 +27,8 @@
   is set.  It is encouraged to enable this option when possible as the old
   ordering is deprecated.
 
-- The `httpjson` is now deprecated, please migrate to the new `http` input.
+- The new `http` input configured with `data_format = "json"` can perform the
+  same task as the, now deprecated, `httpjson` input.
 
 
 ### New Inputs

--- a/plugins/inputs/mysql/v1/mysql.go
+++ b/plugins/inputs/mysql/v1/mysql.go
@@ -1,0 +1,195 @@
+package v1
+
+import (
+	"bytes"
+	"database/sql"
+	"strconv"
+)
+
+type Mapping struct {
+	OnServer string
+	InExport string
+}
+
+var Mappings = []*Mapping{
+	{
+		OnServer: "Aborted_",
+		InExport: "aborted_",
+	},
+	{
+		OnServer: "Bytes_",
+		InExport: "bytes_",
+	},
+	{
+		OnServer: "Com_",
+		InExport: "commands_",
+	},
+	{
+		OnServer: "Created_",
+		InExport: "created_",
+	},
+	{
+		OnServer: "Handler_",
+		InExport: "handler_",
+	},
+	{
+		OnServer: "Innodb_",
+		InExport: "innodb_",
+	},
+	{
+		OnServer: "Key_",
+		InExport: "key_",
+	},
+	{
+		OnServer: "Open_",
+		InExport: "open_",
+	},
+	{
+		OnServer: "Opened_",
+		InExport: "opened_",
+	},
+	{
+		OnServer: "Qcache_",
+		InExport: "qcache_",
+	},
+	{
+		OnServer: "Table_",
+		InExport: "table_",
+	},
+	{
+		OnServer: "Tokudb_",
+		InExport: "tokudb_",
+	},
+	{
+		OnServer: "Threads_",
+		InExport: "threads_",
+	},
+	{
+		OnServer: "Access_",
+		InExport: "access_",
+	},
+	{
+		OnServer: "Aria__",
+		InExport: "aria_",
+	},
+	{
+		OnServer: "Binlog__",
+		InExport: "binlog_",
+	},
+	{
+		OnServer: "Busy_",
+		InExport: "busy_",
+	},
+	{
+		OnServer: "Connection_",
+		InExport: "connection_",
+	},
+	{
+		OnServer: "Delayed_",
+		InExport: "delayed_",
+	},
+	{
+		OnServer: "Empty_",
+		InExport: "empty_",
+	},
+	{
+		OnServer: "Executed_",
+		InExport: "executed_",
+	},
+	{
+		OnServer: "Executed_",
+		InExport: "executed_",
+	},
+	{
+		OnServer: "Feature_",
+		InExport: "feature_",
+	},
+	{
+		OnServer: "Flush_",
+		InExport: "flush_",
+	},
+	{
+		OnServer: "Last_",
+		InExport: "last_",
+	},
+	{
+		OnServer: "Master_",
+		InExport: "master_",
+	},
+	{
+		OnServer: "Max_",
+		InExport: "max_",
+	},
+	{
+		OnServer: "Memory_",
+		InExport: "memory_",
+	},
+	{
+		OnServer: "Not_",
+		InExport: "not_",
+	},
+	{
+		OnServer: "Performance_",
+		InExport: "performance_",
+	},
+	{
+		OnServer: "Prepared_",
+		InExport: "prepared_",
+	},
+	{
+		OnServer: "Rows_",
+		InExport: "rows_",
+	},
+	{
+		OnServer: "Rpl_",
+		InExport: "rpl_",
+	},
+	{
+		OnServer: "Select_",
+		InExport: "select_",
+	},
+	{
+		OnServer: "Slave_",
+		InExport: "slave_",
+	},
+	{
+		OnServer: "Slow_",
+		InExport: "slow_",
+	},
+	{
+		OnServer: "Sort_",
+		InExport: "sort_",
+	},
+	{
+		OnServer: "Subquery_",
+		InExport: "subquery_",
+	},
+	{
+		OnServer: "Tc_",
+		InExport: "tc_",
+	},
+	{
+		OnServer: "Threadpool_",
+		InExport: "threadpool_",
+	},
+	{
+		OnServer: "wsrep_",
+		InExport: "wsrep_",
+	},
+	{
+		OnServer: "Uptime_",
+		InExport: "uptime_",
+	},
+}
+
+func ParseValue(value sql.RawBytes) (float64, bool) {
+	if bytes.Compare(value, []byte("Yes")) == 0 || bytes.Compare(value, []byte("ON")) == 0 {
+		return 1, true
+	}
+
+	if bytes.Compare(value, []byte("No")) == 0 || bytes.Compare(value, []byte("OFF")) == 0 {
+		return 0, true
+	}
+	n, err := strconv.ParseFloat(string(value), 64)
+	return n, err == nil
+}


### PR DESCRIPTION
This attempts to smooth over migration with the metric type changes to the mysql input for existing users of the plugin and especially those with many Telegraf instances and supporting code.

By default, metrics will remain in the old format and must be opted into by setting `metric_version = 2`.  An in depth migration recommendation is included in the mysql/README.md.

@skord Would be great if you could review the code.

@oplehto I hope this provides a reasonable upgrade path, though it won't be fully painless, please let me know if this will work for you.

closes #3858

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
