### PR TITLE
Fixing https urls in Influxdb Output Plugin

### DIFF
--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -418,6 +418,7 @@ func makeWriteURL(loc *url.URL, db, rp, consistency string) string {
 		u.Host = "127.0.0.1"
 		u.Path = "/write"
 	case "http":
+	case "https":
 		u.Path = path.Join(u.Path, "write")
 	}
 	u.RawQuery = params.Encode()
@@ -432,6 +433,7 @@ func makeQueryURL(loc *url.URL) string {
 		u.Host = "127.0.0.1"
 		u.Path = "/query"
 	case "http":
+	case "https":
 		u.Path = path.Join(u.Path, "query")
 	}
 	return u.String()


### PR DESCRIPTION
Fixing https://github.com/influxdata/telegraf/issues/3975, where the influxdb output plugin now longer formats valid write/query urls for https scheme.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
