### PR TITLE
Export all vars defined in /etc/default/telegraf

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -34,7 +34,9 @@ fi
 DEFAULT=/etc/default/telegraf
 
 if [ -r $DEFAULT ]; then
+    set -o allexport
     source $DEFAULT
+    set +o allexport
 fi
 
 if [ -z "$STDOUT" ]; then


### PR DESCRIPTION
This keeps the format of this file the same between systemd and
sysvinit.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
