### PR TITLE
Add ProxySQL input plugin

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -76,6 +76,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/powerdns"
 	_ "github.com/influxdata/telegraf/plugins/inputs/procstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/prometheus"
+	_ "github.com/influxdata/telegraf/plugins/inputs/proxysql"
 	_ "github.com/influxdata/telegraf/plugins/inputs/puppetagent"
 	_ "github.com/influxdata/telegraf/plugins/inputs/rabbitmq"
 	_ "github.com/influxdata/telegraf/plugins/inputs/raindrops"

--- a/plugins/inputs/proxysql/README.md
+++ b/plugins/inputs/proxysql/README.md
@@ -1,0 +1,169 @@
+# ProxySQL Input Plugin
+
+The ProxySQL plugin reports metrics from ProxySQL's admin interface
+
+* Global status
+* Connection pool info
+* Command timing
+
+(https://github.com/sysown/proxysql/blob/master/doc/admin_tables.md)
+
+### Configuration:
+
+```toml
+[[inputs.proxysql]]
+  servers = ["admin:admin@tcp(127.0.0.1:6032)/"]
+  # servers = ["admin:admin@unix(/tmp/proxysql_admin.sock)/"]
+```
+### Measurements & Fields:
+
+- proxysql
+    - active_transactions (integer, count)
+    - backend_query_time_nsec (integer, count)
+    - client_connections_aborted (integer, count)
+    - client_connections_connected (integer, count)
+    - client_connections_created (integer, count)
+    - client_connections_non_idle (integer, count)
+    - com_autocommit (integer, count)
+    - com_autocommit_filtered (integer, count)
+    - com_commit (integer, count)
+    - com_commit_filtered (integer, count)
+    - com_rollback (integer, count)
+    - com_rollback_filtered (integer, count)
+    - com_stmt_close (integer, count)
+    - com_stmt_execute (integer, count)
+    - com_stmt_prepare (integer, count)
+    - connpool_get_conn_failure (integer, count)
+    - connpool_get_conn_immediate (integer, count)
+    - connpool_get_conn_success (integer, count)
+    - connpool_memory_bytes (integer, count)
+    - mysql_monitor_workers (integer, count)
+    - mysql_thread_workers (integer, count)
+    - proxysql_uptime (integer, count)
+    - queries_backends_bytes_recv (integer, count)
+    - queries_backends_bytes_sent (integer, count)
+    - query_cache_entries (integer, count)
+    - query_cache_memory_bytes (integer, count)
+    - query_cache_purged (integer, count)
+    - query_cache_bytes_in (integer, count)
+    - query_cache_bytes_out (integer, count)
+    - query_cache_count_get (integer, count)
+    - query_cache_count_get_ok (integer, count)
+    - query_cache_count_set (integer, count)
+    - query_processor_time_nsec (integer, count)
+    - questions (integer, count)
+    - sqlite3_memory_bytes (integer, count)
+    - server_connections_aborted (integer, count)
+    - server_connections_connected (integer, count)
+    - server_connections_created (integer, count)
+    - servers_table_version (integer, count)
+    - slow_queries (integer, count)
+    - stmt_active_total (integer, count)
+    - stmt_active_unique (integer, count)
+    - stmt_max_stmt_id (integer, gauge) 
+    - mysql_backend_buffers_bytes (integer, count)
+    - mysql_frontend_buffers_bytes (integer, count)
+    - mysql_session_internal_bytes (integer, count)
+- proxysql_connection_pool
+    - connections_used (integer, count)
+    - connections_free (integer, count)
+    - connections_ok (integer, count)
+    - connections_err (integer, count)
+    - queries (integer, count)
+    - bytes_sent (integer, count)
+    - bytes_received (integer, count)
+- proxysql_commands
+    - total_time (integer, count)
+    - count_total (integer, count)
+    - count_100us (integer, count)
+    - count_500us (integer, count)
+    - count_1ms (integer, count)
+	- count_5ms   (integer, count)
+	- count_10ms (integer, count)
+	- count_50ms (integer, count)
+	- count_100ms (integer, count)
+	- count_500ms (integer, count)
+	- count_1s (integer, count)
+	- count_5s (integer, count)
+	- count_10s (integer, count)
+	- count_inf (integer, count)
+
+**NOTE** The `count_` metrics (other than `count_total`) are counting all the queries that took at most that long but
+took longer than the previous bucket. For example, a value in `count_1ms` means that number of queries took less than 1ms
+but took longer than 500us
+
+### Tags:
+
+- All measurements:
+    - server
+    
+- proxysql_connection_pool
+    - hostgroup
+    - server (ip:port)
+    - status (eg. ONLINE, OFFLINE)
+
+- proxysql_commands
+    - command (eg. SELECT, UPDATE)
+
+### Example Output:
+
+```
+$ ./telegraf --config telegraf.conf --input-filter proxysql --test
+> proxysql,host=localhost,server=127.0.0.1:6032 active_transactions=0i,backend_query_time_nsec=761516438i,client_connections_aborted=0i,client_connections_connected=12i,client_connections_created=2745i,client_connections_non_idle=8i,com_autocommit=12i,com_autocommit_filtered=12i,com_commit=2735i,com_commit_filtered=1597i,mysql_backend_buffers_bytes=567296i,mysql_frontend_buffers_bytes=786432i,mysql_session_internal_bytes=42232i,proxysql_uptime=82130i,queries_backends_bytes_recv=2285374i,queries_backends_bytes_sent=2161652i,query_processor_time_nsec=84388416i,server_connections_aborted=88i,server_connections_connected=22i,server_connections_created=2780i 1523048942000000000
+> proxysql,host=localhost,server=127.0.0.1:6032 com_rollback=0i,com_rollback_filtered=0i,com_stmt_close=5400i,com_stmt_execute=5400i,com_stmt_prepare=5400i,connpool_get_conn_failure=221505i,connpool_get_conn_immediate=65i,connpool_get_conn_success=9865i,connpool_memory_bytes=997440i,mysql_monitor_workers=8i,mysql_thread_workers=4i,query_cache_count_get=0i,query_cache_memory_bytes=0i,questions=30048i,servers_table_version=140064i,slow_queries=24i,sqlite3_memory_bytes=1575488i,stmt_active_total=0i,stmt_active_unique=0i,stmt_max_stmt_id=103i 1523048942000000000
+> proxysql,host=localhost,server=127.0.0.1:6032 query_cache_bytes_in=0i,query_cache_bytes_out=0i,query_cache_count_get_ok=0i,query_cache_count_set=0i,query_cache_entries=0i,query_cache_purged=0i 1523048942000000000
+> proxysql_connection_pool,host=localhost,hostgroup=0,hostgroup_host=127.0.0.1:3307,server=127.0.0.1:6032,status=ONLINE bytes_received=568885i,bytes_sent=529267i,connections_err=88i,connections_free=0i,connections_ok=2704i,connections_used=8i,queries=8206i 1523048942000000000
+> proxysql_connection_pool,host=localhost,hostgroup=1,hostgroup_host=127.0.0.1:3307,server=127.0.0.1:6032,status=ONLINE bytes_received=1716489i,bytes_sent=1632385i,connections_err=0i,connections_free=14i,connections_ok=32i,connections_used=0i,queries=7730i 1523048942000000000
+> proxysql_commands,command=ALTER_TABLE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=1i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=9i,count_5s=0i,count_inf=0i,count_total=10i,total_time=24463i 1523048942000000000
+> proxysql_commands,command=ALTER_VIEW,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=ANALYZE_TABLE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=BEGIN,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=CALL,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=CHANGE_MASTER,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=COMMIT,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=1648i,count_10ms=2i,count_10s=0i,count_1ms=930i,count_1s=0i,count_500ms=0i,count_500us=50i,count_50ms=0i,count_5ms=105i,count_5s=0i,count_inf=0i,count_total=2735i,total_time=874358i 1523048942000000000
+> proxysql_commands,command=CREATE_DATABASE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=CREATE_INDEX,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=CREATE_TABLE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=70i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=6i,count_5ms=1i,count_5s=0i,count_inf=0i,count_total=77i,total_time=719380i 1523048942000000000
+> proxysql_commands,command=CREATE_TEMPORARY,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=CREATE_TRIGGER,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=CREATE_USER,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=CREATE_VIEW,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=DEALLOCATE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=DELETE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=1i,count_10ms=0i,count_10s=0i,count_1ms=1i,count_1s=0i,count_500ms=0i,count_500us=18i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=20i,total_time=4001i 1523048942000000000
+> proxysql_commands,command=DESCRIBE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=DROP_DATABASE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=DROP_INDEX,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=DROP_TABLE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=77i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=77i,count_5s=0i,count_inf=0i,count_total=154i,total_time=621399i 1523048942000000000
+> proxysql_commands,command=DROP_TRIGGER,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=DROP_USER,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=DROP_VIEW,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=GRANT,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=EXECUTE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=EXPLAIN,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=FLUSH,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=INSERT,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=88i,count_10ms=0i,count_10s=0i,count_1ms=88i,count_1s=0i,count_500ms=0i,count_500us=98i,count_50ms=0i,count_5ms=47i,count_5s=0i,count_inf=0i,count_total=321i,total_time=166798i 1523048942000000000
+> proxysql_commands,command=KILL,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=LOAD,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=LOCK_TABLE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=OPTIMIZE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=PREPARE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=PURGE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=RENAME_TABLE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=RESET_MASTER,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=RESET_SLAVE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=REPLACE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=REVOKE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=ROLLBACK,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=SAVEPOINT,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=SELECT,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=5119i,count_10ms=6i,count_10s=0i,count_1ms=1392i,count_1s=0i,count_500ms=0i,count_500us=8003i,count_50ms=3i,count_5ms=295i,count_5s=0i,count_inf=23i,count_total=14841i,total_time=234864094i 1523048942000000000
+> proxysql_commands,command=SELECT_FOR_UPDATE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=SET,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=2763i,count_10ms=0i,count_10s=0i,count_1ms=2i,count_1s=0i,count_500ms=0i,count_500us=266i,count_50ms=0i,count_5ms=5i,count_5s=0i,count_inf=0i,count_total=3036i,total_time=72572i 1523048942000000000
+> proxysql_commands,command=SHOW_TABLE_STATUS,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=5i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=5i,total_time=2968i 1523048942000000000
+> proxysql_commands,command=START_TRANSACTION,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=837i,count_10ms=0i,count_10s=0i,count_1ms=4i,count_1s=0i,count_500ms=0i,count_500us=129i,count_50ms=0i,count_5ms=1i,count_5s=0i,count_inf=0i,count_total=971i,total_time=81879i 1523048942000000000
+> proxysql_commands,command=TRUNCATE_TABLE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=UNLOCK_TABLES,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=5i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=5i,total_time=935i 1523048942000000000
+> proxysql_commands,command=UPDATE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=1038i,count_10ms=0i,count_10s=0i,count_1ms=29i,count_1s=0i,count_500ms=0i,count_500us=940i,count_50ms=0i,count_5ms=4i,count_5s=0i,count_inf=0i,count_total=2011i,total_time=232319i 1523048942000000000
+> proxysql_commands,command=USE,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+> proxysql_commands,command=SHOW,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=22i,count_10ms=3i,count_10s=0i,count_1ms=373i,count_1s=0i,count_500ms=0i,count_500us=46i,count_50ms=0i,count_5ms=11i,count_5s=0i,count_inf=1i,count_total=456i,total_time=10295773i 1523048942000000000
+> proxysql_commands,command=UNKNOWN,host=localhost,server=127.0.0.1:6032 count_100ms=0i,count_100us=0i,count_10ms=0i,count_10s=0i,count_1ms=0i,count_1s=0i,count_500ms=0i,count_500us=0i,count_50ms=0i,count_5ms=0i,count_5s=0i,count_inf=0i,count_total=0i,total_time=0i 1523048942000000000
+```

--- a/plugins/inputs/proxysql/proxysql.go
+++ b/plugins/inputs/proxysql/proxysql.go
@@ -1,0 +1,324 @@
+package proxysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+var (
+	errNoServersSpecified = fmt.Errorf("no servers specified")
+
+	defaultTimeout = 5 * time.Second
+	sampleConfig   = `
+  ## specify servers via a url matching:
+  ##  username:password@protocol(address)/
+  ##  see https://github.com/go-sql-driver/mysql#dsn-data-source-name
+  ##  e.g.
+  ##	servers = ["admin:admin@tcp(127.0.0.1:6032)/"]
+  ##	servers = ["admin:admin@unix(/tmp/proxysql_admin.sock)/"]
+  ## NOTE: Connection options are not supported
+  servers = ["admin:admin@tcp(127.0.0.1:6032)/"]
+`
+)
+
+const (
+	globalStatsQuery    = `SELECT * FROM stats.stats_mysql_global`
+	connectionPoolQuery = `		
+		SELECT
+			hostgroup,
+			srv_host,
+			srv_port,
+			status,
+			ConnUsed,
+			ConnFree,
+			ConnOK,
+			ConnERR,
+			Queries,
+			Bytes_data_sent,
+			Bytes_data_recv
+		FROM stats.stats_mysql_connection_pool
+	`
+	commandCounterQuery = `
+		SELECT
+			Command,
+			Total_Time_us,
+			Total_cnt,
+			cnt_100us,
+			cnt_500us,
+			cnt_1ms,
+			cnt_5ms,
+			cnt_10ms,
+			cnt_50ms,
+			cnt_100ms,
+			cnt_500ms,
+			cnt_1s,
+			cnt_5s,
+			cnt_10s,
+			cnt_INFs
+		FROM stats.stats_mysql_commands_counters
+	`
+)
+
+type database interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (databaseRows, error)
+}
+
+type databaseRows interface {
+	Next() bool
+	Close() error
+	Scan(dest ...interface{}) error
+}
+
+type dbWrapper struct {
+	database *sql.DB
+}
+
+func (d *dbWrapper) QueryContext(ctx context.Context, query string, args ...interface{}) (databaseRows, error) {
+	return d.database.QueryContext(ctx, query, args...)
+}
+
+type ProxySQL struct {
+	Servers []string `toml:"servers"`
+}
+
+func (p *ProxySQL) SampleConfig() string {
+	return sampleConfig
+}
+
+func (p *ProxySQL) Description() string {
+	return "Read metrics from one or more ProxySQL hosts"
+}
+
+func (p *ProxySQL) Gather(acc telegraf.Accumulator) error {
+	// Bail out if there are no servers specified
+	if len(p.Servers) == 0 {
+		return errNoServersSpecified
+	}
+
+	// Since we can't get the agent interval, we are going to set a default timeout of 5 seconds
+	// for all SQL commands (using a context object)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	wg := &sync.WaitGroup{}
+	for _, server := range p.Servers {
+		wg.Add(1)
+		go func(s string) {
+			acc.AddError(p.gatherStats(ctx, acc, s))
+			wg.Done()
+		}(server)
+	}
+
+	// Wait for all the servers to be gathered, this should not lock because we are using
+	// a timeout context in our sql commands
+	wg.Wait()
+	return nil
+}
+
+// gatherStats gathers all the stats
+func (p *ProxySQL) gatherStats(ctx context.Context, acc telegraf.Accumulator, server string) error {
+	dsn, err := mysql.ParseDSN(server)
+	if err != nil {
+		return err
+	}
+
+	// Set a dial timeout
+	dsn.Timeout = defaultTimeout
+
+	db, err := sql.Open("mysql", dsn.FormatDSN())
+	if err != nil {
+		return fmt.Errorf("Error opening mysql connection: %v", err)
+	}
+
+	defer db.Close()
+	wrapper := &dbWrapper{
+		database: db,
+	}
+
+	// Add server by default to all metrics
+	defaultTags := map[string]string{
+		"server": dsn.Addr,
+	}
+
+	// Gather the global stats
+	if err := p.gatherGlobalStats(ctx, wrapper, acc, defaultTags); err != nil {
+		return fmt.Errorf("Error gathering global stats: %v", err)
+	}
+
+	// Gather the connection pool stats
+	if err := p.gatherConnectionPoolStats(ctx, wrapper, acc, defaultTags); err != nil {
+		return fmt.Errorf("Error gathering connection pool stats: %v", err)
+	}
+
+	// Gather the command counter stats
+	if err := p.gatherCommandCounterStats(ctx, wrapper, acc, defaultTags); err != nil {
+		return fmt.Errorf("Error gathering command counter stats: %v", err)
+	}
+	return nil
+}
+
+// gatherGlobalStats gathers *all* the global stats ProxySQL provides and lower cases the keys
+func (p *ProxySQL) gatherGlobalStats(ctx context.Context, db database, acc telegraf.Accumulator, defaultTags map[string]string) error {
+	rows, err := db.QueryContext(ctx, globalStatsQuery)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var (
+		key string
+		val int64
+	)
+
+	tags := copyTags(defaultTags)
+	fields := map[string]interface{}{}
+	for rows.Next() {
+		if err := rows.Scan(&key, &val); err != nil {
+			return err
+		}
+		key = strings.ToLower(key)
+		fields[key] = val
+
+		// Send 20 fields at a time
+		if len(fields) >= 20 {
+			acc.AddFields("proxysql", fields, tags)
+			fields = map[string]interface{}{}
+		}
+	}
+
+	if len(fields) > 0 {
+		acc.AddFields("proxysql", fields, tags)
+	}
+	return nil
+}
+
+// gatherConnectionPoolStats gathers the connection pool stats, reporting them by hostgroup and each host that ProxySQL is proxying to
+func (p *ProxySQL) gatherConnectionPoolStats(ctx context.Context, db database, acc telegraf.Accumulator, defaultTags map[string]string) error {
+	rows, err := db.QueryContext(ctx, connectionPoolQuery)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var (
+		hostgroup     string
+		srvHost       string
+		srvPort       string
+		status        string
+		connUsed      int64
+		connFree      int64
+		connOK        int64
+		connErr       int64
+		queries       int64
+		bytesDataSent int64
+		bytesDataRecv int64
+	)
+
+	for rows.Next() {
+		if err := rows.Scan(
+			&hostgroup, &srvHost, &srvPort, &status, &connUsed, &connFree,
+			&connOK, &connErr, &queries, &bytesDataSent, &bytesDataRecv,
+		); err != nil {
+			return err
+		}
+
+		tags := copyTags(defaultTags)
+		tags["hostgroup"] = hostgroup
+		tags["hostgroup_host"] = fmt.Sprintf("%s:%s", srvHost, srvPort)
+		tags["status"] = status
+
+		fields := map[string]interface{}{
+			"connections_used": connUsed,
+			"connections_free": connFree,
+			"connections_ok":   connOK,
+			"connections_err":  connErr,
+			"queries":          queries,
+			"bytes_sent":       bytesDataSent,
+			"bytes_received":   bytesDataRecv,
+		}
+		acc.AddFields("proxysql_connection_pool", fields, tags)
+	}
+	return nil
+}
+
+// gatherCommandCounterStats gathers stats for each type of command, note that the time-based counts are for commands that took at least
+// that long but longer than the previous bucket. eg. a 400us query will ONLY be registered in the count_500us field (and the count_total field)
+func (p *ProxySQL) gatherCommandCounterStats(ctx context.Context, db database, acc telegraf.Accumulator, defaultTags map[string]string) error {
+	rows, err := db.QueryContext(ctx, commandCounterQuery)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var (
+		command       string
+		totalTime     int64
+		totalCount    int64
+		count100us    int64
+		count500us    int64
+		count1ms      int64
+		count5ms      int64
+		count10ms     int64
+		count50ms     int64
+		count100ms    int64
+		count500ms    int64
+		count1s       int64
+		count5s       int64
+		count10s      int64
+		countInfinite int64
+	)
+
+	for rows.Next() {
+		if err := rows.Scan(
+			&command, &totalTime, &totalCount, &count100us, &count500us,
+			&count1ms, &count5ms, &count10ms, &count50ms, &count100ms,
+			&count500ms, &count1s, &count5s, &count10s, &countInfinite,
+		); err != nil {
+			return err
+		}
+
+		tags := copyTags(defaultTags)
+		tags["command"] = command
+
+		fields := map[string]interface{}{
+			"total_time":  totalTime,
+			"count_total": totalCount,
+			"count_100us": count100us,
+			"count_500us": count500us,
+			"count_1ms":   count1ms,
+			"count_5ms":   count5ms,
+			"count_10ms":  count10ms,
+			"count_50ms":  count50ms,
+			"count_100ms": count100ms,
+			"count_500ms": count500ms,
+			"count_1s":    count1s,
+			"count_5s":    count5s,
+			"count_10s":   count10s,
+			"count_inf":   countInfinite,
+		}
+		acc.AddFields("proxysql_commands", fields, tags)
+	}
+	return nil
+}
+
+// copyTags copies the default tags so we can modify them
+func copyTags(def map[string]string) map[string]string {
+	tags := map[string]string{}
+	for k, v := range def {
+		tags[k] = v
+	}
+	return tags
+}
+
+func init() {
+	inputs.Add("proxysql", func() telegraf.Input {
+		return &ProxySQL{}
+	})
+}

--- a/plugins/inputs/proxysql/proxysql_test.go
+++ b/plugins/inputs/proxysql/proxysql_test.go
@@ -1,0 +1,424 @@
+package proxysql
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDatabase struct {
+	queryErr error
+	rows     *mockDatabaseRows
+}
+
+func (d *mockDatabase) QueryContext(ctx context.Context, query string, args ...interface{}) (databaseRows, error) {
+	return d.rows, d.queryErr
+}
+
+type mockDatabaseRows struct {
+	scanErr error
+	values  [][]interface{}
+}
+
+func (r *mockDatabaseRows) Scan(dest ...interface{}) error {
+	if r.scanErr != nil {
+		return r.scanErr
+	}
+
+	// Pop the value off the list and use it
+	value := r.values[0]
+	r.values = r.values[1:]
+	if len(value) != len(dest) {
+		panic(fmt.Errorf("invalid number of args given"))
+	}
+
+	for i := range dest {
+		src := reflect.ValueOf(value[i])
+		// Dest is gonna be a pointer
+		dest := reflect.ValueOf(dest[i]).Elem()
+		dest.Set(src)
+	}
+	return nil
+}
+
+func (r *mockDatabaseRows) Next() bool {
+	return len(r.values) > 0
+}
+
+func (r *mockDatabaseRows) Close() error {
+	return nil
+}
+
+func newMockDatabaseReturn(queryErr, scanErr error, values ...[]interface{}) *mockDatabase {
+	return &mockDatabase{
+		queryErr: queryErr,
+		rows: &mockDatabaseRows{
+			scanErr: scanErr,
+			values:  values,
+		},
+	}
+}
+
+func TestProxySQLGatherGlobalStats(t *testing.T) {
+	tests := []struct {
+		description string
+		queryErr    error
+		scanErr     error
+		values      [][]interface{}
+		defaultTags map[string]string
+		expErr      error
+		expFields   map[string]interface{}
+		expTags     map[string]string
+	}{
+		{
+			description: "query fails",
+			queryErr:    fmt.Errorf("failure"),
+			expErr:      fmt.Errorf("failure"),
+		},
+		{
+			description: "scan fails",
+			values: [][]interface{}{
+				{
+					"some_counter",
+					int64(2018),
+				},
+				{
+					"some_other_counter",
+					int64(20180),
+				},
+			},
+			scanErr: fmt.Errorf("scan failure"),
+			expErr:  fmt.Errorf("scan failure"),
+		},
+		{
+			description: "some fields added",
+			values: [][]interface{}{
+				{
+					"some_counter",
+					int64(2018),
+				},
+				{
+					"some_other_counter",
+					int64(20180),
+				},
+			},
+			defaultTags: map[string]string{
+				"server": "127.0.0.1:3306",
+			},
+			expFields: map[string]interface{}{
+				"some_counter":       int64(2018),
+				"some_other_counter": int64(20180),
+			},
+			expTags: map[string]string{
+				"server": "127.0.0.1:3306",
+			},
+		},
+		{
+			description: "21 fields added",
+			values: func() [][]interface{} {
+				vals := [][]interface{}{}
+				for i := 0; i < 22; i++ {
+					vals = append(vals, []interface{}{
+						fmt.Sprintf("field%d", i),
+						int64(i),
+					})
+				}
+				return vals
+			}(),
+
+			defaultTags: map[string]string{
+				"server": "127.0.0.1:3306",
+			},
+			expFields: func() map[string]interface{} {
+				fields := map[string]interface{}{}
+				for i := 0; i < 22; i++ {
+					fields[fmt.Sprintf("field%d", i)] = int64(i)
+				}
+				return fields
+			}(),
+			expTags: map[string]string{
+				"server": "127.0.0.1:3306",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			db := newMockDatabaseReturn(tc.queryErr, tc.scanErr, tc.values...)
+			p := &ProxySQL{}
+			acc := &testutil.Accumulator{}
+			require.Equal(t, tc.expErr, p.gatherGlobalStats(context.Background(), db, acc, tc.defaultTags))
+			if tc.expErr == nil {
+				acc.AssertContainsTaggedFields(t, "proxysql", tc.expFields, tc.expTags)
+			}
+		})
+	}
+}
+
+func TestProxySQLGatherConnectionPoolStats(t *testing.T) {
+	tests := []struct {
+		description string
+		queryErr    error
+		scanErr     error
+		values      [][]interface{}
+		defaultTags map[string]string
+		expErr      error
+		expFields   []map[string]interface{}
+		expTags     []map[string]string
+	}{
+		{
+			description: "query fails",
+			queryErr:    fmt.Errorf("failure"),
+			expErr:      fmt.Errorf("failure"),
+		},
+		{
+			description: "scan fails",
+			values: [][]interface{}{
+				{
+					"0",
+					"127.0.0.1",
+					"3306",
+					"ONLINE",
+					int64(1),
+					int64(0),
+					int64(12),
+					int64(4),
+					int64(10),
+					int64(1289389),
+					int64(1023012),
+				},
+			},
+			scanErr: fmt.Errorf("scan failure"),
+			expErr:  fmt.Errorf("scan failure"),
+		},
+		{
+			description: "some fields added",
+			values: [][]interface{}{
+				{
+					"0",
+					"127.0.0.2",
+					"3306",
+					"ONLINE",
+					int64(1),
+					int64(0),
+					int64(12),
+					int64(4),
+					int64(10),
+					int64(1289389),
+					int64(1023012),
+				},
+				{
+					"1",
+					"127.0.0.2",
+					"3306",
+					"ONLINE",
+					int64(2),
+					int64(0),
+					int64(12),
+					int64(4),
+					int64(100),
+					int64(128129389),
+					int64(102302312),
+				},
+			},
+			defaultTags: map[string]string{
+				"server": "127.0.0.1:3306",
+			},
+			expFields: []map[string]interface{}{
+				{
+					"connections_used": int64(1),
+					"connections_free": int64(0),
+					"connections_ok":   int64(12),
+					"connections_err":  int64(4),
+					"queries":          int64(10),
+					"bytes_sent":       int64(1289389),
+					"bytes_received":   int64(1023012),
+				},
+				{
+					"connections_used": int64(2),
+					"connections_free": int64(0),
+					"connections_ok":   int64(12),
+					"connections_err":  int64(4),
+					"queries":          int64(100),
+					"bytes_sent":       int64(128129389),
+					"bytes_received":   int64(102302312),
+				},
+			},
+			expTags: []map[string]string{
+				{
+					"server":         "127.0.0.1:3306",
+					"hostgroup":      "0",
+					"hostgroup_host": "127.0.0.2:3306",
+					"status":         "ONLINE",
+				},
+				{
+					"server":         "127.0.0.1:3306",
+					"hostgroup":      "1",
+					"hostgroup_host": "127.0.0.2:3306",
+					"status":         "ONLINE",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			db := newMockDatabaseReturn(tc.queryErr, tc.scanErr, tc.values...)
+			p := &ProxySQL{}
+			acc := &testutil.Accumulator{}
+			require.Equal(t, tc.expErr, p.gatherConnectionPoolStats(context.Background(), db, acc, tc.defaultTags))
+			if tc.expErr == nil {
+				for i := range tc.expFields {
+					acc.AssertContainsTaggedFields(t, "proxysql_connection_pool", tc.expFields[i], tc.expTags[i])
+				}
+			}
+		})
+	}
+}
+
+func TestProxySQLGatherCommandCounterStats(t *testing.T) {
+	tests := []struct {
+		description string
+		queryErr    error
+		scanErr     error
+		values      [][]interface{}
+		defaultTags map[string]string
+		expErr      error
+		expFields   []map[string]interface{}
+		expTags     []map[string]string
+	}{
+		{
+			description: "query fails",
+			queryErr:    fmt.Errorf("failure"),
+			expErr:      fmt.Errorf("failure"),
+		},
+		{
+			description: "scan fails",
+			values: [][]interface{}{
+				{
+					"SELECT",
+					int64(120),
+					int64(76),
+					int64(0),
+					int64(1),
+					int64(5),
+					int64(0),
+					int64(60),
+					int64(0),
+					int64(10),
+					int64(0),
+					int64(0),
+					int64(0),
+					int64(0),
+					int64(0),
+				},
+			},
+			scanErr: fmt.Errorf("scan failure"),
+			expErr:  fmt.Errorf("scan failure"),
+		},
+		{
+			description: "some fields added",
+			values: [][]interface{}{
+				{
+					"SELECT",
+					int64(120),
+					int64(76),
+					int64(0),
+					int64(1),
+					int64(5),
+					int64(0),
+					int64(60),
+					int64(0),
+					int64(10),
+					int64(0),
+					int64(0),
+					int64(0),
+					int64(0),
+					int64(0),
+				},
+				{
+					"UPDATE",
+					int64(12005),
+					int64(396),
+					int64(0),
+					int64(1),
+					int64(5),
+					int64(0),
+					int64(60),
+					int64(0),
+					int64(100),
+					int64(0),
+					int64(230),
+					int64(0),
+					int64(0),
+					int64(0),
+				},
+			},
+			defaultTags: map[string]string{
+				"server": "127.0.0.1:3306",
+			},
+			expFields: []map[string]interface{}{
+				{
+					"total_time":  int64(120),
+					"count_total": int64(76),
+					"count_100us": int64(0),
+					"count_500us": int64(1),
+					"count_1ms":   int64(5),
+					"count_5ms":   int64(0),
+					"count_10ms":  int64(60),
+					"count_50ms":  int64(0),
+					"count_100ms": int64(10),
+					"count_500ms": int64(0),
+					"count_1s":    int64(0),
+					"count_5s":    int64(0),
+					"count_10s":   int64(0),
+					"count_inf":   int64(0),
+				},
+				{
+					"total_time":  int64(12005),
+					"count_total": int64(396),
+					"count_100us": int64(0),
+					"count_500us": int64(1),
+					"count_1ms":   int64(5),
+					"count_5ms":   int64(0),
+					"count_10ms":  int64(60),
+					"count_50ms":  int64(0),
+					"count_100ms": int64(100),
+					"count_500ms": int64(0),
+					"count_1s":    int64(230),
+					"count_5s":    int64(0),
+					"count_10s":   int64(0),
+					"count_inf":   int64(0),
+				},
+			},
+			expTags: []map[string]string{
+				{
+					"server":  "127.0.0.1:3306",
+					"command": "SELECT",
+				},
+				{
+					"server":  "127.0.0.1:3306",
+					"command": "UPDATE",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			db := newMockDatabaseReturn(tc.queryErr, tc.scanErr, tc.values...)
+			p := &ProxySQL{}
+			acc := &testutil.Accumulator{}
+			require.Equal(t, tc.expErr, p.gatherCommandCounterStats(context.Background(), db, acc, tc.defaultTags))
+			if tc.expErr == nil {
+				for i := range tc.expFields {
+					acc.AssertContainsTaggedFields(t, "proxysql_commands", tc.expFields[i], tc.expTags[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Adds stat gathering capabilities for ProxySQL
- Gathers general metric stats as well as information on the
  connection pool (to the mysql servers it is proxying for) as well
  as command timing and counting
- Also changes testutil.AssertContainsTaggedFields to combine all fields
  for a given measurement before comparing them (in the case that fields
  were split up)

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
