### PR TITLE
 AMQP Consumer - Allow turning on exchange passive mode

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -2176,7 +2176,7 @@
 #   reverse_metric_names = true
 
 
-# # A plugin to collect stats from Opensmtpd - a validating, recursive, and caching DNS resolver 
+# # A plugin to collect stats from Opensmtpd - a validating, recursive, and caching DNS resolver
 # [[inputs.opensmtpd]]
 #   ## If running as a restricted user you can prepend sudo for additional access:
 #   #use_sudo = false
@@ -2881,6 +2881,8 @@
 #   url = "amqp://localhost:5672/influxdb"
 #   ## AMQP exchange
 #   exchange = "telegraf"
+#   ## Exchange passive mode
+#   exchange_passive = false
 #   ## AMQP queue name
 #   queue = "telegraf"
 #   ## Binding Key
@@ -3403,4 +3405,3 @@
 # [[inputs.zipkin]]
 #   # path = "/api/v1/spans" # URL path for span data
 #   # port = 9411            # Port on which Telegraf listens
-

--- a/plugins/inputs/amqp_consumer/README.md
+++ b/plugins/inputs/amqp_consumer/README.md
@@ -19,6 +19,8 @@ The following defaults are known to work with RabbitMQ:
   url = "amqp://localhost:5672/influxdb"
   ## AMQP exchange
   exchange = "telegraf"
+  ## Exchange passive mode
+  exchange_passive = false
   ## AMQP queue name
   queue = "telegraf"
   ## Binding Key

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -20,6 +20,8 @@ type AMQPConsumer struct {
 	URL string
 	// AMQP exchange
 	Exchange string
+	// Exchange passive mode
+	ExchangePassive bool
 	// Queue Name
 	Queue string
 	// Binding Key
@@ -65,6 +67,8 @@ func (a *AMQPConsumer) SampleConfig() string {
   url = "amqp://localhost:5672/influxdb"
   ## AMQP exchange
   exchange = "telegraf"
+  ## Exchange passive mode
+  exchange_passive = false
   ## AMQP queue name
   queue = "telegraf"
   ## Binding Key
@@ -182,15 +186,27 @@ func (a *AMQPConsumer) connect(amqpConf *amqp.Config) (<-chan amqp.Delivery, err
 		return nil, fmt.Errorf("Failed to open a channel: %s", err)
 	}
 
-	err = ch.ExchangeDeclare(
-		a.Exchange, // name
-		"topic",    // type
-		true,       // durable
-		false,      // auto-deleted
-		false,      // internal
-		false,      // no-wait
-		nil,        // arguments
-	)
+	if a.ExchangePassive == true {
+		err = ch.ExchangeDeclarePassive(
+			a.Exchange, // name
+			"topic",    // type
+			true,       // durable
+			false,      // auto-deleted
+			false,      // internal
+			false,      // no-wait
+			nil,        // arguments
+		)
+	} else {
+		err = ch.ExchangeDeclare(
+			a.Exchange, // name
+			"topic",    // type
+			true,       // durable
+			false,      // auto-deleted
+			false,      // internal
+			false,      // no-wait
+			nil,        // arguments
+		)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("Failed to declare an exchange: %s", err)
 	}


### PR DESCRIPTION
#3785 

* New configuration option exchange_passive, defaults to false

### Required for all PRs:
- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
