### PR TITLE
Override some settings in service startup scripts

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -22,10 +22,16 @@
 
 # Command-line options that can be set in /etc/default/telegraf.  These will override
 # any config file values.
+CONFIG=/etc/telegraf/telegraf.conf
+CONFDIR=/etc/telegraf/telegraf.d
+
+PIDFILE=/var/run/telegraf/telegraf.pid
+
 TELEGRAF_OPTS=
 
 USER=telegraf
 GROUP=telegraf
+
 
 if [ -r /lib/lsb/init-functions ]; then
     source /lib/lsb/init-functions
@@ -64,11 +70,11 @@ function pidofproc() {
 
     local pidfile=`cat $2`
 
-    if [ "x$pidfile" == "x" ]; then
+    if [ "x$PIDFILE" == "x" ]; then
         return 1
     fi
 
-    if ps --pid "$pidfile" | grep -q $(basename $3); then
+    if ps --pid "$PIDFILE" | grep -q $(basename $3); then
         return 0
     fi
 
@@ -99,18 +105,13 @@ name=telegraf
 # Daemon name, where is the actual executable
 daemon=/usr/bin/telegraf
 
-# pid file for the daemon
-pidfile=/var/run/telegraf/telegraf.pid
-piddir=`dirname $pidfile`
+# pid directory for the daemon
+piddir=`dirname $PIDFILE`
 
 if [ ! -d "$piddir" ]; then
     mkdir -p $piddir
     chown $USER:$GROUP $piddir
 fi
-
-# Configuration file
-config=/etc/telegraf/telegraf.conf
-confdir=/etc/telegraf/telegraf.d
 
 # If the daemon is not there, then exit.
 [ -x $daemon ] || exit 5
@@ -118,8 +119,8 @@ confdir=/etc/telegraf/telegraf.d
 case $1 in
     start)
         # Checked the PID file exists and check the actual status of process
-        if [ -e $pidfile ]; then
-            pidofproc -p $pidfile $daemon > /dev/null 2>&1 && status="0" || status="$?"
+        if [ -e $PIDFILE ]; then
+            pidofproc -p $PIDFILE $daemon > /dev/null 2>&1 && status="0" || status="$?"
             # If the status is SUCCESS then don't need to start again.
             if [ "x$status" = "x0" ]; then
                 log_failure_msg "$name process is running"
@@ -136,21 +137,21 @@ case $1 in
 
         log_success_msg "Starting the process" "$name"
         if command -v startproc >/dev/null; then
-            startproc -u "$USER" -g "$GROUP" -p "$pidfile" -q -- "$daemon" -pidfile "$pidfile" -config "$config" -config-directory "$confdir" $TELEGRAF_OPTS
+            startproc -u "$USER" -g "$GROUP" -p "$PIDFILE" -q -- "$daemon" -pidfile "$PIDFILE" -config "$CONFIG" -config-directory "$CONFDIR" $TELEGRAF_OPTS
         elif which start-stop-daemon > /dev/null 2>&1; then
-            start-stop-daemon --chuid $USER:$GROUP --start --quiet --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $config -config-directory $confdir $TELEGRAF_OPTS >>$STDOUT 2>>$STDERR &
+            start-stop-daemon --chuid $USER:$GROUP --start --quiet --pidfile $PIDFILE --exec $daemon -- -pidfile $PIDFILE -config $CONFIG -config-directory $CONFDIR $TELEGRAF_OPTS >>$STDOUT 2>>$STDERR &
         else
-            su -s /bin/sh -c "nohup $daemon -pidfile $pidfile -config $config -config-directory $confdir $TELEGRAF_OPTS >>$STDOUT 2>>$STDERR &" $USER
+            su -s /bin/sh -c "nohup $daemon -pidfile $PIDFILE -config $CONFIG -config-directory $CONFDIR $TELEGRAF_OPTS >>$STDOUT 2>>$STDERR &" $USER
         fi
         log_success_msg "$name process was started"
         ;;
 
     stop)
         # Stop the daemon.
-        if [ -e $pidfile ]; then
-            pidofproc -p $pidfile $daemon > /dev/null 2>&1 && status="0" || status="$?"
+        if [ -e $PIDFILE ]; then
+            pidofproc -p $PIDFILE $daemon > /dev/null 2>&1 && status="0" || status="$?"
             if [ "$status" = 0 ]; then
-                if killproc -p $pidfile SIGTERM && /bin/rm -rf $pidfile; then
+                if killproc -p $PIDFILE SIGTERM && /bin/rm -rf $PIDFILE; then
                     log_success_msg "$name process was stopped"
                 else
                     log_failure_msg "$name failed to stop service"
@@ -163,10 +164,10 @@ case $1 in
 
     reload)
         # Reload the daemon.
-        if [ -e $pidfile ]; then
-            pidofproc -p $pidfile $daemon > /dev/null 2>&1 && status="0" || status="$?"
+        if [ -e $PIDFILE ]; then
+            pidofproc -p $PIDFILE $daemon > /dev/null 2>&1 && status="0" || status="$?"
             if [ "$status" = 0 ]; then
-                if killproc -p $pidfile SIGHUP; then
+                if killproc -p $PIDFILE SIGHUP; then
                     log_success_msg "$name process was reloaded"
                 else
                     log_failure_msg "$name failed to reload service"
@@ -184,8 +185,8 @@ case $1 in
 
     status)
         # Check the status of the process.
-        if [ -e $pidfile ]; then
-            if pidofproc -p $pidfile $daemon > /dev/null; then
+        if [ -e $PIDFILE ]; then
+            if pidofproc -p $PIDFILE $daemon > /dev/null; then
                 log_success_msg "$name Process is running"
                 exit 0
             else

--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -4,9 +4,11 @@ Documentation=https://github.com/influxdata/telegraf
 After=network.target
 
 [Service]
+Environment=CONFIG=/etc/telegraf/telegraf.conf
+Environment=CONFDIR=/etc/telegraf/telegraf.d
 EnvironmentFile=-/etc/default/telegraf
 User=telegraf
-ExecStart=/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d $TELEGRAF_OPTS
+ExecStart=/usr/bin/telegraf -config $CONFIG -config-directory $CONFDIR $TELEGRAF_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE


### PR DESCRIPTION
#3849

* SysV: CONFIG, CONFDIR, and PIDFILE are now env vars and can be overridden
* Systemd: CONFIG and CONFDIR are now env vars and can be overridden
* Note: Systemd does not allow setting the User from env vars

### Required for all PRs:
- [x] Signed [CLA](https://influxdata.com/community/cla/).

No README or unit tests for these changes. Would you like a new README to cover overrides?

