### PR TITLE
Prevent loading config twice in K8S

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -519,7 +519,13 @@ func (c *Config) LoadDirectory(path string) error {
 			log.Printf("W! Telegraf is not permitted to read %s", thispath)
 			return nil
 		}
+
 		if info.IsDir() {
+			if strings.HasPrefix(info.Name(), "..") {
+				// skip Kubernetes mounts, prevening loading the same config twice
+				return filepath.SkipDir
+			}
+
 			return nil
 		}
 		name := info.Name()

--- a/internal/config/testdata/subconfig/..4984_10_04_08_28_06.119/invalid-config.conf
+++ b/internal/config/testdata/subconfig/..4984_10_04_08_28_06.119/invalid-config.conf
@@ -1,0 +1,4 @@
+# This invalid config file should be skipped during testing
+# as it is an ..data folder
+
+[[outputs.influxdb


### PR DESCRIPTION
When config dir is mounted from configmap, filepath.Walk() find the same
.conf file twice as 20-acme.conf is a link to
..data/20-acme.conf for example.

This patch skips all folder names starting with '..' which is pretty
uncommon and mainly used by Kubernetes mounts.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
