### PR TITLE
Snmp strip components

### DIFF
--- a/plugins/inputs/snmp/README.md
+++ b/plugins/inputs/snmp/README.md
@@ -141,6 +141,9 @@ OID to get. May be a numeric or textual OID.
 * `oid_index_suffix`:
 The OID sub-identifier to strip off so that the index can be matched against other fields in the table.
 
+* `oid_strip_index_components`:
+For variable OID sub-identifiers, this will strip the specified number of MIB components from the end of the OID so the index can be matched against other fields in the table.
+
 * `name`:
 Output field/tag name.
 If not specified, it defaults to the value of `oid`. If `oid` is numeric, an attempt to translate the numeric OID into a texual OID will be made.

--- a/plugins/inputs/snmp/README.md
+++ b/plugins/inputs/snmp/README.md
@@ -141,8 +141,8 @@ OID to get. May be a numeric or textual OID.
 * `oid_index_suffix`:
 The OID sub-identifier to strip off so that the index can be matched against other fields in the table.
 
-* `oid_strip_index_components`:
-For variable OID sub-identifiers, this will strip the specified number of MIB components from the end of the OID so the index can be matched against other fields in the table.
+* `oid_index_length`:
+Specifies the length of the index after the supplied table OID (in OID path segments). Truncates the index after this point to remove non-fixed value or length index suffixes.
 
 * `name`:
 Output field/tag name.

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -237,6 +237,8 @@ type Field struct {
 	Oid string
 	// OidIndexSuffix is the trailing sub-identifier on a table record OID that will be stripped off to get the record's index.
 	OidIndexSuffix string
+	// OidIndexStripComponents is an alternative to OidIndexSuffix to strip variable trailing components. It is an integer of how many trailing OID sections to strip.
+	OidIndexStripComponents int
 	// IsTag controls whether this OID is output as a tag or a value.
 	IsTag bool
 	// Conversion controls any type conversion that is done on the value.
@@ -461,6 +463,11 @@ func (t Table) Build(gs snmpConnection, walk bool) (*RTable, error) {
 						return nil
 					}
 					idx = idx[:len(idx)-len(f.OidIndexSuffix)]
+				}
+				if f.OidIndexStripComponents != 0 {
+					for i := 0; i < f.OidIndexStripComponents; i++ {
+						idx = idx[:strings.LastIndexByte(idx, '.')]
+					}
 				}
 
 				fv, err := fieldConvert(f.Conversion, ent.Value)

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -454,9 +454,9 @@ func TestTableBuild_walk(t *testing.T) {
 				OidIndexSuffix: ".9.9",
 			},
 			{
-				Name: "myfield5",
-				Oid:  ".1.0.0.2.1.5",
-				OidIndexStripComponents: 2,
+				Name:           "myfield5",
+				Oid:            ".1.0.0.2.1.5",
+				OidIndexLength: 1,
 			},
 		},
 	}

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -453,6 +453,11 @@ func TestTableBuild_walk(t *testing.T) {
 				Oid:            ".1.0.0.2.1.5",
 				OidIndexSuffix: ".9.9",
 			},
+			{
+				Name: "myfield5",
+				Oid:  ".1.0.0.2.1.5",
+				OidIndexStripComponents: 2,
+			},
 		},
 	}
 
@@ -469,6 +474,7 @@ func TestTableBuild_walk(t *testing.T) {
 			"myfield2": 1,
 			"myfield3": float64(0.123),
 			"myfield4": 11,
+			"myfield5": 11,
 		},
 	}
 	rtr2 := RTableRow{
@@ -480,6 +486,7 @@ func TestTableBuild_walk(t *testing.T) {
 			"myfield2": 2,
 			"myfield3": float64(0.456),
 			"myfield4": 22,
+			"myfield5": 22,
 		},
 	}
 	rtr3 := RTableRow{


### PR DESCRIPTION
Adds an oid_strip_index_components option to the snmp input to allow for stripping variable trailing OID sub-indexes (e.g. CISCO-IETF-ISIS-MIB L2 circuits)

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.