### PR TITLE
RFC 5424 syslog parser

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -31,7 +31,7 @@ github.com/go-redis/redis 73b70592cdaa9e6abdfcfbf97b4a90d80728c836
 github.com/go-sql-driver/mysql 2e00b5cd70399450106cec6431c2e2ce3cae5034
 github.com/hailocab/go-hostpool e80d13ce29ede4452c43dea11e79b9bc8a15b478
 github.com/hashicorp/consul 63d2fc68239b996096a1c55a0d4b400ea4c2583f
-github.com/influxdata/go-syslog 3b5cb54a818c82787d48859b584539bbe5a3af40
+github.com/influxdata/go-syslog 1d8a596977d1fd28660caa54e675be0c3414fc02
 github.com/influxdata/tail c43482518d410361b6c383d7aebce33d0471d7bc
 github.com/influxdata/toml 5d1d907f22ead1cd47adde17ceec5bda9cacaf8f
 github.com/influxdata/wlog 7c63b0a71ef8300adc255344d275e10e5c3a71ec

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -112,8 +112,7 @@ func NewParser(config *Config) (Parser, error) {
 			config.DropwizardTimePath, config.DropwizardTimeFormat, config.DropwizardTagsPath, config.DropwizardTagPathsMap, config.DefaultTags,
 			config.Separator, config.Templates)
 	case "syslog":
-		// Always in best effort mode
-		parser, err = NewSyslogParser(config.MetricName, true)
+		parser, err = NewSyslogParser(config.MetricName)
 	default:
 		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
 	}
@@ -198,13 +197,13 @@ func NewDropwizardParser(
 
 // NewSyslogParser returns a parser to parse syslog entries.
 // The parameter `metricName` is optional.
-func NewSyslogParser(metricName string, bestEffort bool) (Parser, error) {
-	opts := []syslog.ParserOpt{}
+func NewSyslogParser(metricName string) (Parser, error) {
+	opts := []syslog.ParserOpt{
+		syslog.WithBestEffort() // Always in best effort mode
+	}
+
 	if metricName != "" {
 		opts = append(opts, syslog.WithName(metricName))
-	}
-	if bestEffort {
-		opts = append(opts, syslog.WithBestEffort())
 	}
 	return syslog.NewParser(opts...), nil
 }

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -199,7 +199,7 @@ func NewDropwizardParser(
 // The parameter `metricName` is optional.
 func NewSyslogParser(metricName string) (Parser, error) {
 	opts := []syslog.ParserOpt{
-		syslog.WithBestEffort() // Always in best effort mode
+		syslog.WithBestEffort(), // Always in best effort mode
 	}
 
 	if metricName != "" {

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -112,7 +112,8 @@ func NewParser(config *Config) (Parser, error) {
 			config.DropwizardTimePath, config.DropwizardTimeFormat, config.DropwizardTagsPath, config.DropwizardTagPathsMap, config.DefaultTags,
 			config.Separator, config.Templates)
 	case "syslog":
-		parser = NewSyslogParser(config.MetricName)
+		// Always in best effort mode
+		parser, err = NewSyslogParser(config.MetricName, true)
 	default:
 		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
 	}
@@ -196,11 +197,14 @@ func NewDropwizardParser(
 }
 
 // NewSyslogParser returns a parser to parse syslog entries.
-// metricName is optional
-func NewSyslogParser(metricName string) Parser {
+// The parameter `metricName` is optional.
+func NewSyslogParser(metricName string, bestEffort bool) (Parser, error) {
 	opts := []syslog.ParserOpt{}
 	if metricName != "" {
 		opts = append(opts, syslog.WithName(metricName))
 	}
-	return syslog.NewParser(opts...)
+	if bestEffort {
+		opts = append(opts, syslog.WithBestEffort())
+	}
+	return syslog.NewParser(opts...), nil
 }

--- a/plugins/parsers/syslog/parser.go
+++ b/plugins/parsers/syslog/parser.go
@@ -101,7 +101,7 @@ func (s *Parser) fields(msg *rfc5424.SyslogMessage) map[string]interface{} {
 			}
 			for name, value := range sdparams {
 				// Using whitespace as separator since it is not allowed by the grammar within SDID
-				flds[sdid+" "+name] = value
+				flds[sdid+`\ `+name] = value
 			}
 		}
 	}

--- a/plugins/parsers/syslog/parser.go
+++ b/plugins/parsers/syslog/parser.go
@@ -101,7 +101,7 @@ func (s *Parser) fields(msg *rfc5424.SyslogMessage) map[string]interface{} {
 			}
 			for name, value := range sdparams {
 				// Using whitespace as separator since it is not allowed by the grammar within SDID
-				flds[sdid+`\ `+name] = value
+				flds[sdid+" "+name] = value
 			}
 		}
 	}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

---

This PR introduces a parser plugin for syslog [RFC5424](https://tools.ietf.org/html/rfc5424)-compliant messages.

A syslog message is in the form.

`<priority>value timestamp hostname appname procid msgid structureddata message`

The [parser](https://github.com/influxdata/go-syslog) extracts info (also partially) from a syslog message organizing them in a struct containing:

- timestamp
- facility, severity (tags)
- hostname, appname (tags)
- msgid, message (fields)
- structured data id (fields)
- structured data parameters (fields)

This plugin does not provide at the moment any capability to distinguish structured data parameters that have to be stored as tags from others that have to be stored as fields.

This would be a neat feature to write advacend queries against the extracted data.

I think that primarily there are 2 ways to achive this:
1. via a configuration list listing parameters that should be stored as tags (or viceversa)
2. via a convention as part of the parameter key name (eg., `name:tag="paramval"`)

- [ ] Split structured data parameters in tag or fields depending on a convention or a configuration
