### PR TITLE
Since unbound 1.7 the `-s` argument must come first

### DIFF
--- a/plugins/inputs/unbound/unbound.go
+++ b/plugins/inputs/unbound/unbound.go
@@ -87,7 +87,7 @@ func unboundRunner(cmdName string, Timeout internal.Duration, UseSudo bool, Serv
 			server = server + "@" + port
 		}
 
-		cmdArgs = append(cmdArgs, "-s", server)
+		cmdArgs = append([]string{"-s", server}, cmdArgs...)
 	}
 
 	cmd := exec.Command(cmdName, cmdArgs...)
@@ -101,7 +101,7 @@ func unboundRunner(cmdName string, Timeout internal.Duration, UseSudo bool, Serv
 	cmd.Stdout = &out
 	err := internal.RunTimeout(cmd, Timeout.Duration)
 	if err != nil {
-		return &out, fmt.Errorf("error running unbound-control: %s", err)
+		return &out, fmt.Errorf("error running unbound-control: %s (%s %v)", err, cmdName, cmdArgs)
 	}
 
 	return &out, nil


### PR DESCRIPTION
Unfortunately I dont see anything in the unbound change log to support this claim, but the code doesnt work anymore

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
