### PR TITLE
Fix go get golint url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,10 @@ all:
 	$(MAKE) telegraf
 
 deps:
-	go get -u github.com/golang/lint/golint
+	mkdir -p $(GOPATH)/src/golang.org/x 
+	rm -rf $(GOPATH)/src/golang.org/x/lint
+	git clone --depth=1 https://github.com/golang/lint.git $(GOPATH)/src/golang.org/x/lint 
+	go get -u golang.org/x/lint/golint
 	go get github.com/sparrc/gdm
 	gdm restore
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

Should fix current issues running `make`

```
go get -u github.com/golang/lint/golint
package golang.org/x/lint: unrecognized import path "golang.org/x/lint" (parse https://golang.org/x/lint?go-get=1: no go-import meta tags ())
Makefile:25: recipe for target 'deps' failed
```