### PR TITLE
New parameter to force the interval of gather for sysstat

### DIFF
--- a/plugins/inputs/sysstat/sysstat.go
+++ b/plugins/inputs/sysstat/sysstat.go
@@ -33,6 +33,9 @@ type Sysstat struct {
 	// Sadc represents the path to the sadc collector utility.
 	Sadc string `toml:"sadc_path"`
 
+	// Force the execution time of sadc
+	SadcInterval internal.Duration `toml:"sadc_interval"`
+
 	// Sadf represents the path to the sadf cmd.
 	Sadf string `toml:"sadf_path"`
 
@@ -136,6 +139,11 @@ func (*Sysstat) SampleConfig() string {
 }
 
 func (s *Sysstat) Gather(acc telegraf.Accumulator) error {
+	if s.SadcInterval.Duration != 0 {
+		// Collect interval is calculated as interval - parseInterval
+		s.interval = int(s.SadcInterval.Duration.Seconds()) + parseInterval
+	}
+
 	if s.interval == 0 {
 		if firstTimestamp.IsZero() {
 			firstTimestamp = time.Now()


### PR DESCRIPTION
Added new config parameter for sysstat plugin, sadc_interval, to force
the gather interval of the sadc command.

This is useful when we have configured jitter in the agent, because
jitter breaks the measurement of the interval used in sadc.

Example:
 - agent with interval=10, jitter=5
 - sysstat is started in t=0 and runs sadc with interval=1
 - next execution of sysstat is in t=14 (interval + some jitter)
 - sysstat plugin set the value of "s.interval" to 14s
 - sadc is run with interval=13 (s.interval - parseInterval)
 - sysstat plugin is killed because is taking longer that collection
 interval

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
