### PR TITLE
Fix nvidia_gpu timeout parsing bug

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -65,6 +65,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/nsq_consumer"
 	_ "github.com/influxdata/telegraf/plugins/inputs/nstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/ntpq"
+	_ "github.com/influxdata/telegraf/plugins/inputs/nvidia_smi"
 	_ "github.com/influxdata/telegraf/plugins/inputs/openldap"
 	_ "github.com/influxdata/telegraf/plugins/inputs/opensmtpd"
 	_ "github.com/influxdata/telegraf/plugins/inputs/passenger"

--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -1,7 +1,25 @@
 # `nvidia-smi` Input Plugin
 
-This plugin uses a query on the `nvidia-smi` binary to pull GPU stats including memory and GPU usage, temp and other.
+This plugin uses a query on the [`nvidia-smi`](https://developer.nvidia.com/nvidia-system-management-interface) binary to pull GPU stats including memory and GPU usage, temp and other.
 
 ```
 nvidia-smi --query-gpu=fan.speed,memory.total,memory.used,memory.free,pstate,temperature.gpu,name,uuid,compute_mode,utilization.gpu,utilization.memory,index --id={{ gpu_index }} --format=csv,noheader,nounits
 ```
+
+#### Tags
+
+- `name`: The type of GPU e.g. `GeForce GTX 170 Ti`
+- `compute_mode`: The compute mode of the GPU e.g. `Default`
+- `index`: The port index where the GPU is connected to the motherboard e.g. `1`
+- `pstate`: Overclocking state for the GPU e.g. `P0`
+- `uuid`: A unique identifier for the GPU e.g. `GPU-f9ba66fc-a7f5-94c5-da19-019ef2f9c665`
+
+#### Fields
+
+- `fan_speed`: Fan speed as a percentage of max speed e.g. `80`
+- `memory_free`: Amount of memory the GPU has free in kb e.g. `7650`
+- `memory_used`:  Amount of memory the GPU is using in kb e.g. `550`
+- `memory_total`:  Amount of memory the GPU is using in kb e.g. `8110`
+- `temperature_gpu`: The temperature of the GPU in Degrees C
+- `utilization_gpu`: The % utilization of the GPU
+- `utilization_memory`: The % utilization of the GPU memory

--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -1,0 +1,7 @@
+# `nvidia-smi` Input Plugin
+
+This plugin uses a query on the `nvidia-smi` binary to pull GPU stats including memory and GPU usage, temp and other.
+
+```
+nvidia-smi --query-gpu=fan.speed,memory.total,memory.used,memory.free,pstate,temperature.gpu,name,uuid,compute_mode,utilization.gpu,utilization.memory,index --id={{ gpu_index }} --format=csv,noheader,nounits
+```

--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -2,24 +2,46 @@
 
 This plugin uses a query on the [`nvidia-smi`](https://developer.nvidia.com/nvidia-system-management-interface) binary to pull GPU stats including memory and GPU usage, temp and other.
 
+### Configuration
+
+```toml
+# Pulls statistics from nvidia GPUs attached to the host
+[[inputs.nvidia_smi]]
+## Optional: path to nvidia-smi binary, defaults to $PATH via exec.LookPath
+# bin_path = /usr/bin/nvidia-smi
+
+## Optional: timeout for GPU polling
+# timeout = 5s
 ```
-nvidia-smi --query-gpu=fan.speed,memory.total,memory.used,memory.free,pstate,temperature.gpu,name,uuid,compute_mode,utilization.gpu,utilization.memory,index --id={{ gpu_index }} --format=csv,noheader,nounits
+
+### Metrics
+- measurement: `nvidia_smi`
+  - tags
+    - `name` (type of GPU e.g. `GeForce GTX 170 Ti`)
+    - `compute_mode` (The compute mode of the GPU e.g. `Default`)
+    - `index` (The port index where the GPU is connected to the motherboard e.g. `1`)
+    - `pstate` (Overclocking state for the GPU e.g. `P0`)
+    - `uuid` (A unique identifier for the GPU e.g. `GPU-f9ba66fc-a7f5-94c5-da19-019ef2f9c665`)
+  - fields
+    - `fan_speed` (integer, percentage)
+    - `memory_free` (integer, KB)
+    - `memory_used` (integer, KB)
+    - `memory_total` (integer, KB)
+    - `temperature_gpu` (integer, degrees C)
+    - `utilization_gpu` (integer, percentage)
+    - `utilization_memory` (integer, percentage)
+
+### Sample Query
+
+The below query could be used to alert on the average temperature of the your GPUs over the last minute
+
+```
+SELECT mean("temperature_gpu") FROM "nvidia_smi" WHERE time > now() - 5m GROUP BY time(1m), "index", "name", "host"
 ```
 
-#### Tags
-
-- `name`: The type of GPU e.g. `GeForce GTX 170 Ti`
-- `compute_mode`: The compute mode of the GPU e.g. `Default`
-- `index`: The port index where the GPU is connected to the motherboard e.g. `1`
-- `pstate`: Overclocking state for the GPU e.g. `P0`
-- `uuid`: A unique identifier for the GPU e.g. `GPU-f9ba66fc-a7f5-94c5-da19-019ef2f9c665`
-
-#### Fields
-
-- `fan_speed`: Fan speed as a percentage of max speed e.g. `80`
-- `memory_free`: Amount of memory the GPU has free in kb e.g. `7650`
-- `memory_used`:  Amount of memory the GPU is using in kb e.g. `550`
-- `memory_total`:  Amount of memory the GPU is using in kb e.g. `8110`
-- `temperature_gpu`: The temperature of the GPU in Degrees C
-- `utilization_gpu`: The % utilization of the GPU
-- `utilization_memory`: The % utilization of the GPU memory
+### Example Output
+```
+nvidia_smi,compute_mode=Default,host=8218cf,index=0,name=GeForce\ GTX\ 1070,pstate=P2,uuid=GPU-823bc202-6279-6f2c-d729-868a30f14d96 fan_speed=100i,memory_free=7563i,memory_total=8112i,memory_used=549i,temperature_gpu=53i,utilization_gpu=100i,utilization_memory=90i 1523991122000000000
+nvidia_smi,compute_mode=Default,host=8218cf,index=1,name=GeForce\ GTX\ 1080,pstate=P2,uuid=GPU-f9ba66fc-a7f5-94c5-da19-019ef2f9c665 fan_speed=100i,memory_free=7557i,memory_total=8114i,memory_used=557i,temperature_gpu=50i,utilization_gpu=100i,utilization_memory=85i 1523991122000000000
+nvidia_smi,compute_mode=Default,host=8218cf,index=2,name=GeForce\ GTX\ 1080,pstate=P2,uuid=GPU-d4cfc28d-0481-8d07-b81a-ddfc63d74adf fan_speed=100i,memory_free=7557i,memory_total=8114i,memory_used=557i,temperature_gpu=58i,utilization_gpu=100i,utilization_memory=86i 1523991122000000000
+```

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -80,11 +80,15 @@ func (smi *NvidiaSMI) getResult(gpuID int) (map[string]string, map[string]interf
 	met := strings.Split(string(ret), ", ")
 	for i, m := range metricNames {
 		if m[1] == "tag" {
-			tags[m[0]] = met[i]
+			tags[m[0]] = strings.TrimSuffix(met[i], "\n")
 			continue
 		}
+		out, err := strconv.ParseInt(met[i], 10, 64)
+		if err != nil {
+			return tags, fields, err
+		}
 
-		fields[m[0]] = fmt.Sprintf("%si", met[i])
+		fields[m[0]] = out
 	}
 
 	return tags, fields, nil
@@ -114,7 +118,7 @@ func (smi *NvidiaSMI) Gather(acc telegraf.Accumulator) error {
 }
 
 func init() {
-	inputs.Add("simple", func() telegraf.Input {
+	inputs.Add("nvidia_smi", func() telegraf.Input {
 		return &NvidiaSMI{
 			BinPath: "/usr/bin/nvidia-smi",
 			metrics: metrics,

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -1,0 +1,123 @@
+package nvidia_smi
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+var (
+	measurement = "nvidia_smi"
+	metrics     = "fan.speed,memory.total,memory.used,memory.free,pstate,temperature.gpu,name,uuid,compute_mode,utilization.gpu,utilization.memory,index"
+	metricNames = [][]string{
+		[]string{"fan_speed", "field"},
+		[]string{"memory_total", "field"},
+		[]string{"memory_used", "field"},
+		[]string{"memory_free", "field"},
+		[]string{"pstate", "tag"},
+		[]string{"temperature_gpu", "field"},
+		[]string{"name", "tag"},
+		[]string{"uuid", "tag"},
+		[]string{"compute_mode", "tag"},
+		[]string{"utilization_gpu", "field"},
+		[]string{"utilization_memory", "field"},
+		[]string{"index", "tag"},
+	}
+)
+
+// NvidiaSMI holds the methods for this plugin
+type NvidiaSMI struct {
+	BinPath string
+
+	metrics string
+}
+
+// Description returns the description of the NvidiaSMI plugin
+func (smi *NvidiaSMI) Description() string {
+	return ""
+}
+
+// SampleConfig returns the sample configuration for the NvidiaSMI plugin
+func (smi *NvidiaSMI) SampleConfig() string {
+	return `
+## Path to nvidia-smi
+bin_path = /usr/bin/nvidia-smi
+`
+}
+
+func (smi *NvidiaSMI) getGPUCount() (int, error) {
+	opts := []string{"--format=noheader,nounits,csv", "--query-gpu=count", "--id=0"}
+	ret, err := exec.Command(smi.BinPath, opts...).CombinedOutput()
+	if err != nil {
+		return 0, err
+	}
+
+	retS := strings.TrimSuffix(string(ret), "\n")
+	retI, errI := strconv.Atoi(retS)
+	if errI != nil {
+		return 0, err
+	}
+	return retI, nil
+}
+
+func (smi *NvidiaSMI) getResult(gpuID int) (map[string]string, map[string]interface{}, error) {
+	tags := make(map[string]string, 0)
+	fields := make(map[string]interface{}, 0)
+
+	// Construct and execute metrics query
+	opts := []string{"--format=noheader,nounits,csv", fmt.Sprintf("--query-gpu=%s", smi.metrics), fmt.Sprintf("--id=%d", gpuID)}
+	ret, err := exec.Command(smi.BinPath, opts...).CombinedOutput()
+	if err != nil {
+		return tags, fields, err
+	}
+
+	// Format the metrics into tags and fields
+	met := strings.Split(string(ret), ", ")
+	for i, m := range metricNames {
+		if m[1] == "tag" {
+			tags[m[0]] = met[i]
+			continue
+		}
+
+		fields[m[0]] = fmt.Sprintf("%si", met[i])
+	}
+
+	return tags, fields, nil
+}
+
+// Gather implements the telegraf interface
+func (smi *NvidiaSMI) Gather(acc telegraf.Accumulator) error {
+
+	if _, err := os.Stat(smi.BinPath); os.IsNotExist(err) {
+		return fmt.Errorf("nvidia-smi binary not at path %s, cannot gather GPU data", smi.BinPath)
+	}
+
+	gpuCount, err := smi.getGPUCount()
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < gpuCount; i++ {
+		tags, fields, err := smi.getResult(i)
+		if err != nil {
+			return fmt.Errorf("Error getting GPU stats: %s", err)
+		}
+		acc.AddFields(measurement, fields, tags)
+	}
+
+	return nil
+}
+
+func init() {
+	inputs.Add("simple", func() telegraf.Input {
+		return &NvidiaSMI{
+			BinPath: "/usr/bin/nvidia-smi",
+			metrics: metrics,
+		}
+	})
+}

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -36,7 +36,7 @@ var (
 // NvidiaSMI holds the methods for this plugin
 type NvidiaSMI struct {
 	BinPath string
-	Timeout time.Duration
+	Timeout internal.Duration
 
 	metrics string
 }
@@ -81,7 +81,7 @@ func init() {
 	inputs.Add("nvidia_smi", func() telegraf.Input {
 		return &NvidiaSMI{
 			BinPath: "/usr/bin/nvidia-smi",
-			Timeout: 5 * time.Second,
+			Timeout: internal.Duration{Duration: 5 * time.Second},
 			metrics: metrics,
 		}
 	})
@@ -90,7 +90,7 @@ func init() {
 func (smi *NvidiaSMI) pollSMI() (string, error) {
 	// Construct and execute metrics query
 	opts := []string{"--format=noheader,nounits,csv", fmt.Sprintf("--query-gpu=%s", smi.metrics)}
-	ret, err := internal.CombinedOutputTimeout(exec.Command(smi.BinPath, opts...), smi.Timeout)
+	ret, err := internal.CombinedOutputTimeout(exec.Command(smi.BinPath, opts...), smi.Timeout.Duration)
 	if err != nil {
 		return "", err
 	}

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -21,7 +21,7 @@ func TestParseLineStandard(t *testing.T) {
 func TestParseLineEmptyLine(t *testing.T) {
 	line := "\n"
 	_, _, err := parseLine(line)
-	if err.Error() != "EOF" {
+	if err == nil {
 		t.Fail()
 	}
 }

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -1,0 +1,35 @@
+package nvidia_smi
+
+import (
+	"testing"
+)
+
+func TestParseLineStandard(t *testing.T) {
+	line := "85, 8114, 553, 7561, P2, 61, GeForce GTX 1070 Ti, GPU-d1911b8a-f5c8-5e66-057c-486561269de8, Default, 100, 93, 1\n"
+	tags, fields, err := parseLine(line)
+	if err != nil {
+		t.Fail()
+	}
+	if tags["name"] != "GeForce GTX 1070 Ti" {
+		t.Fail()
+	}
+	if temp, ok := fields["temperature_gpu"].(int); ok && temp == 61 {
+		t.Fail()
+	}
+}
+
+func TestParseLineEmptyLine(t *testing.T) {
+	line := "\n"
+	_, _, err := parseLine(line)
+	if err.Error() != "EOF" {
+		t.Fail()
+	}
+}
+
+func TestParseLineBad(t *testing.T) {
+	line := "the quick brown fox jumped over the lazy dog"
+	_, _, err := parseLine(line)
+	if err == nil {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Fixes timeout parsing issue by changing timeout field type from `time.Duration` to `internal.Duration`

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
