### PR TITLE
[jolokia2] [cassandra] Metrics values should have same names than old cassandra plugin

### DIFF
--- a/plugins/inputs/jolokia2/examples/cassandra.conf
+++ b/plugins/inputs/jolokia2/examples/cassandra.conf
@@ -10,6 +10,7 @@
     name  = "GarbageCollector"
     mbean = "java.lang:name=*,type=GarbageCollector"
     tag_keys = ["name"]
+    field_prefix = "$1_"
 
 [[inputs.jolokia2_agent]]
   urls = ["http://localhost:8778/jolokia"]
@@ -19,67 +20,76 @@
     name  = "Cache"
     mbean = "org.apache.cassandra.metrics:name=*,scope=*,type=Cache"
     tag_keys = ["name", "scope"]
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "Client"
     mbean = "org.apache.cassandra.metrics:name=*,type=Client"
     tag_keys = ["name"]
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ClientRequestMetrics"
     mbean = "org.apache.cassandra.metrics:name=*,type=ClientRequestMetrics"
     tag_keys = ["name"]
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ClientRequest"
     mbean = "org.apache.cassandra.metrics:name=*,scope=*,type=ClientRequest"
     tag_keys = ["name", "scope"]
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ColumnFamily"
     mbean = "org.apache.cassandra.metrics:keyspace=*,name=*,scope=*,type=ColumnFamily"
     tag_keys = ["keyspace", "name", "scope"]
+    field_prefix = "$2_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "CommitLog"
     mbean = "org.apache.cassandra.metrics:name=*,type=CommitLog"
     tag_keys = ["name"]
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "Compaction"
     mbean = "org.apache.cassandra.metrics:name=*,type=Compaction"
     tag_keys = ["name"]
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "CQL"
     mbean = "org.apache.cassandra.metrics:name=*,type=CQL"
     tag_keys = ["name"]
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "DroppedMessage"
     mbean = "org.apache.cassandra.metrics:name=*,scope=*,type=DroppedMessage"
     tag_keys = ["name", "scope"]
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "FileCache"
     mbean = "org.apache.cassandra.metrics:name=*,type=FileCache"
     tag_keys = ["name"]
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ReadRepair"
     mbean = "org.apache.cassandra.metrics:name=*,type=ReadRepair"
     tag_keys = ["name"]
-
-  [[inputs.jolokia2_agent.metric]]
-    name  = "HintedHandoffManager"
-    mbean = "org.apache.cassandra.metrics:type=HintedHandoffManager"
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "Storage"
     mbean = "org.apache.cassandra.metrics:name=*,type=Storage"
     tag_keys = ["name"]
+    field_prefix = "$1_"
 
   [[inputs.jolokia2_agent.metric]]
     name  = "ThreadPools"
     mbean = "org.apache.cassandra.metrics:name=*,path=*,scope=*,type=ThreadPools"
     tag_keys = ["name", "path", "scope"]
+    field_prefix = "$1_"


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

The modifications are important as after working with the old version, it's better to add the prefix of the metrics name.
Here an example with the output of the deprecated cassandra plugin:

```
cassandraThreadPools,cassandra_host=localhost,dc=dc1,env=prod,host=my_hostname.com,mname=MaxPoolSize,path=transport,rack=rack1,scope=Native-Transport-Requests MaxPoolSize_Value=256 1524670394000000000
```

Here the same output with the current version of the cassandra.conf of jolokia2:
```
cassandra_ThreadPools,dc=dc1,env=prod,host=my_hostname.com,jolokia_agent_url=http://localhost:8778/jolokia,name=MaxPoolSize,path=transport,rack=rack1,scope=Native-Transport-Requests Value=256 1524670394000000000
```
As you can see the value name `MaxPoolSize_Value` has been renamed to `Value` only

With the version of this pull request, the output will be like this:
```
cassandra_ThreadPools,dc=dc1,env=prod,host=my_hostname.com,jolokia_agent_url=http://localhost:8778/jolokia,name=MaxPoolSize,path=transport,rack=rack1,scope=Native-Transport-Requests MaxPoolSize_Value=256 1524670394000000000
```
The value name `MaxPoolSize_Value` is now identical.

It will just remain the tag `mname` in deprecated cassandra which is now called `name`.

The "price" to migrate to jolokia2 (and migrate boards!!) from deprecated cassandra plugin will be much lower.

