### PR TITLE
Fix handling of uint64 in datadog output

### DIFF
--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -179,13 +179,9 @@ func verifyValue(v interface{}) bool {
 
 func (p *Point) setValue(v interface{}) error {
 	switch d := v.(type) {
-	case int:
-		p[1] = float64(int(d))
-	case int32:
-		p[1] = float64(int32(d))
 	case int64:
-		p[1] = float64(int64(d))
-	case float32:
+		p[1] = float64(d)
+	case uint64:
 		p[1] = float64(d)
 	case float64:
 		p[1] = float64(d)
@@ -195,7 +191,7 @@ func (p *Point) setValue(v interface{}) error {
 			p[1] = float64(1)
 		}
 	default:
-		return fmt.Errorf("undeterminable type")
+		return fmt.Errorf("undeterminable field type: %T", v)
 	}
 	return nil
 }

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -168,6 +168,30 @@ func TestBuildPoint(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			testutil.TestMetric(int64(0), "test int64"),
+			Point{
+				float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+				0.0,
+			},
+			nil,
+		},
+		{
+			testutil.TestMetric(uint64(0), "test uint64"),
+			Point{
+				float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+				0.0,
+			},
+			nil,
+		},
+		{
+			testutil.TestMetric(true, "test bool"),
+			Point{
+				float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+				1.0,
+			},
+			nil,
+		},
 	}
 	for _, tt := range tagtests {
 		pt, err := buildMetrics(tt.ptIn)


### PR DESCRIPTION
closes #4090

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
