### PR TITLE
README: fix name_override by name_suffix + example consistency

### DIFF
--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -114,7 +114,7 @@ style concurrently:
      servers = ["tcp(127.0.0.1:3306)/"]
 
    [[inputs.mysql]]
-     name_override = "_2"
+     name_suffix = "_v2"
      metric_version = 2
 
      servers = ["tcp(127.0.0.1:3306)/"]
@@ -141,7 +141,7 @@ measurement name.
      metric_version = 2
 
    [[inputs.mysql]]
-     name_override = "_2"
+     name_suffix = "_v2"
      metric_version = 2
 
      servers = ["tcp(127.0.0.1:3306)/"]


### PR DESCRIPTION
* name_suffix will add a suffix to measurement where as name_override will replace measurement name. Here in the sample, it's name_suffix which should have been used
* fix naming consistency accross settings and examples

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
