### PR TITLE
Fix platform not supported error

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -694,7 +694,7 @@ def main(args):
     orig_branch = get_current_branch()
 
     if args.platform not in supported_builds and args.platform != 'all':
-        logging.error("Invalid build platform: {}".format(target_platform))
+        logging.error("Invalid build platform: {}".format(args.platform))
         return 1
 
     build_output = {}


### PR DESCRIPTION
Error in build WITHOUT --platform parameter (from macosx/darwin)
```
[INFO] check_prereqs: Checking for dependencies...
Traceback (most recent call last):
  File "./scripts/build.py", line 922, in <module>
    sys.exit(main(args))
  File "./scripts/build.py", line 697, in main
    logging.error("Invalid build platform: {}".format(target_platform))
NameError: global name 'target_platform' is not defined
```

After fix:
```
[INFO] check_prereqs: Checking for dependencies...
[ERROR] main: Invalid build platform: darwin
```

- [x] Signed [CLA](https://influxdata.com/community/cla/).
