### PR TITLE
MongoDB: Add cursor Metrics

### DIFF
--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -48,6 +48,10 @@ Error in input [mongodb]: not authorized on admin to execute command { serverSta
     - active_reads (integer)
     - active_writes (integer)
     - commands_per_sec (integer)
+    - cursor_timed_out (integer)
+    - cursor_no_timeout (integer)
+    - cursor_pinned (integer)
+    - cursor_total (integer)
     - deletes_per_sec (integer)
     - flushes_per_sec (integer)
     - getmores_per_sec (integer)
@@ -120,7 +124,7 @@ Error in input [mongodb]: not authorized on admin to execute command { serverSta
 
 ### Example Output:
 ```
-mongodb,hostname=127.0.0.1:27017 active_reads=0i,active_writes=0i,commands_per_sec=6i,deletes_per_sec=0i,flushes_per_sec=0i,getmores_per_sec=1i,inserts_per_sec=0i,jumbo_chunks=0i,member_status="PRI",net_in_bytes=851i,net_out_bytes=23904i,open_connections=6i,percent_cache_dirty=0,percent_cache_used=0,queries_per_sec=2i,queued_reads=0i,queued_writes=0i,repl_commands_per_sec=0i,repl_deletes_per_sec=0i,repl_getmores_per_sec=0i,repl_inserts_per_sec=0i,repl_lag=0i,repl_queries_per_sec=0i,repl_updates_per_sec=0i,resident_megabytes=67i,state="PRIMARY",total_available=0i,total_created=0i,total_in_use=0i,total_refreshing=0i,ttl_deletes_per_sec=0i,ttl_passes_per_sec=0i,updates_per_sec=0i,vsize_megabytes=729i,wtcache_app_threads_page_read_count=4i,wtcache_app_threads_page_read_time=18i,wtcache_app_threads_page_write_count=6i,wtcache_bytes_read_into=10075i,wtcache_bytes_written_from=115711i,wtcache_current_bytes=86038i,wtcache_max_bytes_configured=1073741824i,wtcache_pages_evicted_by_app_thread=0i,wtcache_pages_queued_for_eviction=0i,wtcache_server_evicting_pages=0i,wtcache_tracked_dirty_bytes=0i,wtcache_worker_thread_evictingpages=0i 1522798796000000000
+mongodb,hostname=127.0.0.1:27017 active_reads=0i,active_writes=0i,commands_per_sec=6i,cursor_no_timeout=0i,cursor_pinned=0i,cursor_timed_out=0i,cursor_total=0i,deletes_per_sec=0i,flushes_per_sec=0i,getmores_per_sec=1i,inserts_per_sec=0i,jumbo_chunks=0i,member_status="PRI",net_in_bytes=851i,net_out_bytes=23904i,open_connections=6i,percent_cache_dirty=0,percent_cache_used=0,queries_per_sec=2i,queued_reads=0i,queued_writes=0i,repl_commands_per_sec=0i,repl_deletes_per_sec=0i,repl_getmores_per_sec=0i,repl_inserts_per_sec=0i,repl_lag=0i,repl_queries_per_sec=0i,repl_updates_per_sec=0i,resident_megabytes=67i,state="PRIMARY",total_available=0i,total_created=0i,total_in_use=0i,total_refreshing=0i,ttl_deletes_per_sec=0i,ttl_passes_per_sec=0i,updates_per_sec=0i,vsize_megabytes=729i,wtcache_app_threads_page_read_count=4i,wtcache_app_threads_page_read_time=18i,wtcache_app_threads_page_write_count=6i,wtcache_bytes_read_into=10075i,wtcache_bytes_written_from=115711i,wtcache_current_bytes=86038i,wtcache_max_bytes_configured=1073741824i,wtcache_pages_evicted_by_app_thread=0i,wtcache_pages_queued_for_eviction=0i,wtcache_server_evicting_pages=0i,wtcache_tracked_dirty_bytes=0i,wtcache_worker_thread_evictingpages=0i 1522798796000000000
 mongodb_db_stats,db_name=local,hostname=127.0.0.1:27017 avg_obj_size=818.625,collections=5i,data_size=6549i,index_size=86016i,indexes=4i,num_extents=0i,objects=8i,ok=1i,storage_size=118784i,type="db_stat" 1522799074000000000
 mongodb_shard_stats,hostname=127.0.0.1:27017,in_use=3i,available=3i,created=4i,refreshing=0i 1522799074000000000
 ```

--- a/plugins/inputs/mongodb/mongodb_data.go
+++ b/plugins/inputs/mongodb/mongodb_data.go
@@ -49,6 +49,10 @@ var DefaultStats = map[string]string{
 	"open_connections":    "NumConnections",
 	"ttl_deletes_per_sec": "DeletedDocuments",
 	"ttl_passes_per_sec":  "Passes",
+	"cursor_timed_out":    "TimedOutC",
+	"cursor_no_timeout":   "NoTimeoutC",
+	"cursor_pinned":       "PinnedC",
+	"cursor_total":        "TotalC",
 }
 
 var DefaultReplStats = map[string]string{

--- a/plugins/inputs/mongodb/mongodb_data_test.go
+++ b/plugins/inputs/mongodb/mongodb_data_test.go
@@ -34,6 +34,10 @@ func TestAddNonReplStats(t *testing.T) {
 			NumConnections:   0,
 			Passes:           0,
 			DeletedDocuments: 0,
+			TimedOutC:        0,
+			NoTimeoutC:       0,
+			PinnedC:          0,
+			TotalC:           0,
 		},
 		tags,
 	)
@@ -211,6 +215,10 @@ func TestStateTag(t *testing.T) {
 		"total_available":       int64(0),
 		"total_created":         int64(0),
 		"total_refreshing":      int64(0),
+		"cursor_timed_out":      int64(0),
+		"cursor_no_timeout":     int64(0),
+		"cursor_pinned":         int64(0),
+		"cursor_total":          int64(0),
 	}
 	acc.AssertContainsTaggedFields(t, "mongodb", fields, stateTags)
 }


### PR DESCRIPTION
Fixes: #3480

```
$ GOCACHE=off go test -v -tags=integration ./...
=== RUN   TestAddNonReplStats
--- PASS: TestAddNonReplStats (0.00s)
=== RUN   TestAddReplStats
--- PASS: TestAddReplStats (0.00s)
=== RUN   TestAddWiredTigerStats
--- PASS: TestAddWiredTigerStats (0.00s)
=== RUN   TestAddShardStats
--- PASS: TestAddShardStats (0.00s)
=== RUN   TestAddShardHostStats
--- PASS: TestAddShardHostStats (0.00s)
=== RUN   TestStateTag
--- PASS: TestStateTag (0.00s)
=== RUN   TestGetDefaultTags
--- PASS: TestGetDefaultTags (0.00s)
=== RUN   TestAddDefaultStats
--- PASS: TestAddDefaultStats (0.01s)
PASS
ok      github.com/influxdata/telegraf/plugins/inputs/mongodb   0.012s
```

```
$ ./telegraf --config ~/tele-conf --test
> mongodb,host=foo,hostname=127.0.0.1:27017 active_reads=1i,active_writes=0i,commands_per_sec=4i,cursor_no_timeout=0i,cursor_pinned=0i,cursor_timed_out=0i,cursor_total=0i,deletes_per_sec=0i,flushes_per_sec=0i,getmores_per_sec=0i,inserts_per_sec=0i,jumbo_chunks=0i,net_in_bytes=639i,net_out_bytes=27185i,open_connections=2i,percent_cache_dirty=0,percent_cache_used=0,queries_per_sec=2i,queued_reads=0i,queued_writes=0i,resident_megabytes=66i,total_available=0i,total_created=0i,total_in_use=0i,total_refreshing=0i,ttl_deletes_per_sec=0i,ttl_passes_per_sec=0i,updates_per_sec=0i,vsize_megabytes=1013i,wtcache_app_threads_page_read_count=0i,wtcache_app_threads_page_read_time=0i,wtcache_app_threads_page_write_count=22i,wtcache_bytes_read_into=0i,wtcache_bytes_written_from=39880i,wtcache_current_bytes=39003i,wtcache_max_bytes_configured=7778336768i,wtcache_pages_evicted_by_app_thread=0i,wtcache_pages_queued_for_eviction=0i,wtcache_server_evicting_pages=0i,wtcache_tracked_dirty_bytes=0i,wtcache_worker_thread_evictingpages=0i 1525703381000000000
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
