### PR TITLE
Add uint support to cratedb output

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,15 +79,15 @@ services:
       - "389:389"
       - "636:636"
   crate:
-   image: crate/crate
-   ports:
-    - "4200:4200"
-    - "4230:4230"
-   command:
-    - crate
-    - -Cnetwork.host=0.0.0.0
-    - -Ctransport.host=localhost
-    - -Clicense.enterprise=false
-   environment:
-    - CRATE_HEAP_SIZE=128m
-    - JAVA_OPTS='-Xms256m -Xmx256m'
+    image: crate/crate
+    ports:
+      - "4200:4200"
+      - "4230:4230"
+      - "5432:5432"
+    command:
+      - crate
+      - -Cnetwork.host=0.0.0.0
+      - -Ctransport.host=localhost
+      - -Clicense.enterprise=false
+    environment:
+      - CRATE_HEAP_SIZE=128m

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -121,6 +121,9 @@ func escapeValue(val interface{}) (string, error) {
 	case int64, float64:
 		return fmt.Sprint(t), nil
 	case uint64:
+		// The long type is the largest integer type in CrateDB and is the
+		// size of a signed int64.  If our value is too large send the largest
+		// possible value.
 		if t <= uint64(MaxInt64) {
 			return strconv.FormatInt(int64(t), 10), nil
 		} else {

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -130,10 +130,7 @@ func escapeValue(val interface{}) (string, error) {
 			return strconv.FormatInt(MaxInt64, 10), nil
 		}
 	case bool:
-		if t {
-			return "1", nil
-		}
-		return "0", nil
+		return strconv.FormatBool(t), nil
 	case time.Time:
 		// see https://crate.io/docs/crate/reference/sql/data_types.html#timestamp
 		return escapeValue(t.Format("2006-01-02T15:04:05.999-0700"))

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	_ "github.com/jackc/pgx/stdlib"
 )
+
+const MaxInt64 = int64(^uint64(0) >> 1)
 
 type CrateDB struct {
 	URL         string
@@ -115,11 +118,19 @@ func escapeValue(val interface{}) (string, error) {
 	switch t := val.(type) {
 	case string:
 		return escapeString(t, `'`), nil
-	// We don't handle uint, uint32 and uint64 here because CrateDB doesn't
-	// seem to support unsigned types. But it seems like input plugins don't
-	// produce those types, so it's hopefully ok.
-	case int, int32, int64, float32, float64:
+	case int64, float64:
 		return fmt.Sprint(t), nil
+	case uint64:
+		if t <= uint64(MaxInt64) {
+			return strconv.FormatInt(int64(t), 10), nil
+		} else {
+			return strconv.FormatInt(MaxInt64, 10), nil
+		}
+	case bool:
+		if t {
+			return "1", nil
+		}
+		return "0", nil
 	case time.Time:
 		// see https://crate.io/docs/crate/reference/sql/data_types.html#timestamp
 		return escapeValue(t.Format("2006-01-02T15:04:05.999-0700"))

--- a/plugins/outputs/cratedb/cratedb_test.go
+++ b/plugins/outputs/cratedb/cratedb_test.go
@@ -111,12 +111,12 @@ func Test_escapeValue(t *testing.T) {
 		{`foo`, `'foo'`},
 		{`foo'bar 'yeah`, `'foo''bar ''yeah'`},
 		// int types
-		{123, `123`}, // int
 		{int64(123), `123`},
-		{int32(123), `123`},
+		{uint64(123), `123`},
+		{uint64(MaxInt64) + 1, `9223372036854775807`},
+		{true, `1`},
+		{false, `0`},
 		// float types
-		{123.456, `123.456`},
-		{float32(123.456), `123.456`}, // floating point SNAFU
 		{float64(123.456), `123.456`},
 		// time.Time
 		{time.Date(2017, 8, 7, 16, 44, 52, 123*1000*1000, time.FixedZone("Dreamland", 5400)), `'2017-08-07T16:44:52.123+0130'`},

--- a/plugins/outputs/cratedb/cratedb_test.go
+++ b/plugins/outputs/cratedb/cratedb_test.go
@@ -114,8 +114,8 @@ func Test_escapeValue(t *testing.T) {
 		{int64(123), `123`},
 		{uint64(123), `123`},
 		{uint64(MaxInt64) + 1, `9223372036854775807`},
-		{true, `1`},
-		{false, `0`},
+		{true, `true`},
+		{false, `false`},
 		// float types
 		{float64(123.456), `123.456`},
 		// time.Time


### PR DESCRIPTION
Since 1.6, fields can be int64, uint64, float64, bool, string.

For uint64 values too large to store in CrateDB, we save as the maximum int64 value.

@felixge Can you review?

closes: #4110

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
