### PR TITLE
Skip fields that report "not supported" in nvidia-smi

### DIFF
--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -125,15 +125,20 @@ func parseLine(line string) (map[string]string, map[string]interface{}, error) {
 	// Make sure there are as many metrics in the line as there were queried.
 	if len(met) == len(metricNames) {
 		for i, m := range metricNames {
+			col := strings.TrimSpace(met[i])
 
 			// First handle the tags
 			if m[1] == "tag" {
-				tags[m[0]] = strings.TrimSpace(met[i])
+				tags[m[0]] = col
+				continue
+			}
+
+			if strings.Contains(col, "[Not Supported]") {
 				continue
 			}
 
 			// Then parse the integers out of the fields
-			out, err := strconv.ParseInt(strings.TrimSpace(met[i]), 10, 64)
+			out, err := strconv.ParseInt(col, 10, 64)
 			if err != nil {
 				return tags, fields, err
 			}

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -2,6 +2,8 @@ package nvidia_smi
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseLineStandard(t *testing.T) {
@@ -32,4 +34,11 @@ func TestParseLineBad(t *testing.T) {
 	if err == nil {
 		t.Fail()
 	}
+}
+
+func TestParseLineNotSupported(t *testing.T) {
+	line := "[Not Supported], 7606, 0, 7606, P0, 38, Tesla P4, GPU-xxx, Default, 0, 0, 0\n"
+	_, fields, err := parseLine(line)
+	require.NoError(t, err)
+	require.Equal(t, nil, fields["fan_speed"])
 }


### PR DESCRIPTION
I do have some concern that the nvidia-smi tool may localize this message, but I don't want to get overly aggressive is skipping unknown data.

closes: #4120

cc @jackzampolin 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
