### PR TITLE
Use internal.Duration for jolokia timeouts

### DIFF
--- a/plugins/inputs/jolokia2/jolokia_agent.go
+++ b/plugins/inputs/jolokia2/jolokia_agent.go
@@ -3,9 +3,9 @@ package jolokia2
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/tls"
 )
 
@@ -17,7 +17,7 @@ type JolokiaAgent struct {
 	URLs            []string `toml:"urls"`
 	Username        string
 	Password        string
-	ResponseTimeout time.Duration `toml:"response_timeout"`
+	ResponseTimeout internal.Duration `toml:"response_timeout"`
 
 	tls.ClientConfig
 
@@ -101,7 +101,7 @@ func (ja *JolokiaAgent) createClient(url string) (*Client, error) {
 	return NewClient(url, &ClientConfig{
 		Username:        ja.Username,
 		Password:        ja.Password,
-		ResponseTimeout: ja.ResponseTimeout,
+		ResponseTimeout: ja.ResponseTimeout.Duration,
 		ClientConfig:    ja.ClientConfig,
 	})
 }

--- a/plugins/inputs/jolokia2/jolokia_proxy.go
+++ b/plugins/inputs/jolokia2/jolokia_proxy.go
@@ -1,9 +1,8 @@
 package jolokia2
 
 import (
-	"time"
-
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/tls"
 )
 
@@ -19,7 +18,7 @@ type JolokiaProxy struct {
 
 	Username        string
 	Password        string
-	ResponseTimeout time.Duration `toml:"response_timeout"`
+	ResponseTimeout internal.Duration `toml:"response_timeout"`
 	tls.ClientConfig
 
 	Metrics  []MetricConfig `toml:"metric"`
@@ -117,7 +116,7 @@ func (jp *JolokiaProxy) createClient() (*Client, error) {
 	return NewClient(jp.URL, &ClientConfig{
 		Username:        jp.Username,
 		Password:        jp.Password,
-		ResponseTimeout: jp.ResponseTimeout,
+		ResponseTimeout: jp.ResponseTimeout.Duration,
 		ClientConfig:    jp.ClientConfig,
 		ProxyConfig:     proxyConfig,
 	})


### PR DESCRIPTION
Using internal.Duration is required in order to specify the timeout as a duration string.

```
# Read JMX metrics from a Jolokia REST endpoint
[[inputs.jolokia2_agent]]
  name_override = "howdy"
  # default_tag_prefix      = ""
  # default_field_prefix    = ""
  # default_field_separator = "."

  ## Add agents to query
  urls = ["http://debian-stretch-tomcat:8080/jolokia"]
  # username = ""
  # password = ""
  response_timeout = "5s"

  ## Optional SSL config
  # ssl_ca   = "/var/private/ca.pem"
  # ssl_cert = "/var/private/client.pem"
  # ssl_key  = "/var/private/client-key.pem"
  # insecure_skip_verify = false

  ## Add metrics to read
  [[inputs.jolokia2_agent.metric]]
    name  = "java_runtime"
    mbean = "java.lang:type=Runtime"
    paths = ["Uptime"]
```


```
E! Error parsing /home/dbn/.telegraf/telegraf.d/input.jolokia2.conf, line 12: jolokia2.JolokiaAgent.ResponseTimeout: `string' type is not assignable to `time.Duration' type
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
