### PR TITLE
Fix dropwizard parsing error for metrics that need escaped

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -54,6 +54,8 @@ type Metric interface {
 	AddField(key string, value interface{})
 	RemoveField(key string)
 
+	SetTime(t time.Time)
+
 	// HashID returns an unique identifier for the series.
 	HashID() uint64
 

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -202,6 +202,10 @@ func (m *metric) RemoveField(key string) {
 	}
 }
 
+func (m *metric) SetTime(t time.Time) {
+	m.tm = t
+}
+
 func (m *metric) Copy() telegraf.Metric {
 	m2 := &metric{
 		name:      m.name,

--- a/plugins/parsers/dropwizard/parser.go
+++ b/plugins/parsers/dropwizard/parser.go
@@ -1,7 +1,6 @@
 package dropwizard
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/templating"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/tidwall/gjson"
 )
@@ -19,8 +19,8 @@ var keyEscaper = strings.NewReplacer(" ", "\\ ", ",", "\\,", "=", "\\=")
 
 // Parser parses json inputs containing dropwizard metrics,
 // either top-level or embedded inside a json field.
-// This parser is using gjon for retrieving paths within the json file.
-type Parser struct {
+// This parser is using gjson for retrieving paths within the json file.
+type parser struct {
 
 	// an optional json path containing the metric registry object
 	// if left empty, the whole json object is parsed as a metric registry
@@ -45,15 +45,28 @@ type Parser struct {
 	// an optional map of default tags to use for metrics
 	DefaultTags map[string]string
 
-	// templating configuration
-	Separator string
-	Templates []string
-
+	separator      string
 	templateEngine *templating.Engine
+
+	timeFunc metric.TimeFunc
+
+	// seriesParser parses line protocol measurement + tags
+	seriesParser *influx.Parser
+}
+
+func NewParser() *parser {
+	handler := influx.NewMetricHandler()
+	seriesParser := influx.NewSeriesParser(handler)
+
+	parser := &parser{
+		timeFunc:     time.Now,
+		seriesParser: seriesParser,
+	}
+	return parser
 }
 
 // Parse parses the input bytes to an array of metrics
-func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
+func (p *parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 
 	metrics := make([]telegraf.Metric, 0)
 
@@ -100,28 +113,38 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	return metrics, nil
 }
 
-// InitTemplating initializes the templating support
-func (p *Parser) InitTemplating() error {
-	if len(p.Templates) > 0 {
-		defaultTemplate, _ := templating.NewDefaultTemplateWithPattern("measurement*")
-		templateEngine, err := templating.NewEngine(p.Separator, defaultTemplate, p.Templates)
-		p.templateEngine = templateEngine
+func (p *parser) SetTemplates(separator string, templates []string) error {
+	if len(templates) == 0 {
+		p.templateEngine = nil
+		return nil
+	}
+
+	defaultTemplate, err := templating.NewDefaultTemplateWithPattern("measurement*")
+	if err != nil {
 		return err
 	}
+
+	templateEngine, err := templating.NewEngine(separator, defaultTemplate, templates)
+	if err != nil {
+		return err
+	}
+
+	p.separator = separator
+	p.templateEngine = templateEngine
 	return nil
 }
 
 // ParseLine is not supported by the dropwizard format
-func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
+func (p *parser) ParseLine(line string) (telegraf.Metric, error) {
 	return nil, fmt.Errorf("ParseLine not supported: %s, for data format: dropwizard", line)
 }
 
 // SetDefaultTags sets the default tags
-func (p *Parser) SetDefaultTags(tags map[string]string) {
+func (p *parser) SetDefaultTags(tags map[string]string) {
 	p.DefaultTags = tags
 }
 
-func (p *Parser) readTags(buf []byte) map[string]string {
+func (p *parser) readTags(buf []byte) map[string]string {
 
 	if p.TagsPath != "" {
 		var tagsBytes []byte
@@ -147,7 +170,7 @@ func (p *Parser) readTags(buf []byte) map[string]string {
 	return tags
 }
 
-func (p *Parser) parseTime(buf []byte) (time.Time, error) {
+func (p *parser) parseTime(buf []byte) (time.Time, error) {
 
 	if p.TimePath != "" {
 		timeFormat := p.TimeFormat
@@ -157,19 +180,19 @@ func (p *Parser) parseTime(buf []byte) (time.Time, error) {
 		timeString := gjson.GetBytes(buf, p.TimePath).String()
 		if timeString == "" {
 			err := fmt.Errorf("time not found in JSON path %s", p.TimePath)
-			return time.Now().UTC(), err
+			return p.timeFunc(), err
 		}
 		t, err := time.Parse(timeFormat, timeString)
 		if err != nil {
 			err = fmt.Errorf("time %s cannot be parsed with format %s, %s", timeString, timeFormat, err)
-			return time.Now().UTC(), err
+			return p.timeFunc(), err
 		}
 		return t.UTC(), nil
 	}
-	return time.Now().UTC(), nil
+	return p.timeFunc(), nil
 }
 
-func (p *Parser) unmarshalMetrics(buf []byte) (map[string]interface{}, error) {
+func (p *parser) unmarshalMetrics(buf []byte) (map[string]interface{}, error) {
 
 	var registryBytes []byte
 	if p.MetricRegistryPath != "" {
@@ -195,11 +218,8 @@ func (p *Parser) unmarshalMetrics(buf []byte) (map[string]interface{}, error) {
 	return jsonOut, nil
 }
 
-func (p *Parser) readDWMetrics(metricType string, dwms interface{}, metrics []telegraf.Metric, tm time.Time) []telegraf.Metric {
-
-	switch dwmsTyped := dwms.(type) {
-	case map[string]interface{}:
-		var metricsBuffer bytes.Buffer
+func (p *parser) readDWMetrics(metricType string, dwms interface{}, metrics []telegraf.Metric, tm time.Time) []telegraf.Metric {
+	if dwmsTyped, ok := dwms.(map[string]interface{}); ok {
 		for dwmName, dwmFields := range dwmsTyped {
 			measurementName := dwmName
 			tags := make(map[string]string)
@@ -207,59 +227,46 @@ func (p *Parser) readDWMetrics(metricType string, dwms interface{}, metrics []te
 			if p.templateEngine != nil {
 				measurementName, tags, fieldPrefix, _ = p.templateEngine.Apply(dwmName)
 				if len(fieldPrefix) > 0 {
-					fieldPrefix = fmt.Sprintf("%s%s", fieldPrefix, p.Separator)
+					fieldPrefix = fmt.Sprintf("%s%s", fieldPrefix, p.separator)
 				}
 			}
-			tags["metric_type"] = metricType
 
-			measurementWithTags := measurementName
-			for tagName, tagValue := range tags {
-				tagKeyValue := fmt.Sprintf("%s=%s", keyEscaper.Replace(tagName), keyEscaper.Replace(tagValue))
-				measurementWithTags = fmt.Sprintf("%s,%s", measurementWithTags, tagKeyValue)
+			parsed, err := p.seriesParser.Parse([]byte(measurementName))
+			var m telegraf.Metric
+			if err != nil || len(parsed) != 1 {
+				m, err = metric.New(measurementName, map[string]string{}, map[string]interface{}{}, tm)
+				if err != nil {
+					log.Printf("W! failed to create metric of type '%s': %s\n", metricType, err)
+					continue
+				}
+			} else {
+				m = parsed[0]
+				m.SetTime(tm)
 			}
 
-			fields := make([]string, 0)
-			switch t := dwmFields.(type) {
-			case map[string]interface{}: // json object
-				for fieldName, fieldValue := range t {
-					key := keyEscaper.Replace(fieldPrefix + fieldName)
-					switch v := fieldValue.(type) {
-					case float64:
-						fields = append(fields, fmt.Sprintf("%s=%f", key, v))
-					case string:
-						fields = append(fields, fmt.Sprintf("%s=\"%s\"", key, fieldEscaper.Replace(v)))
-					case bool:
-						fields = append(fields, fmt.Sprintf("%s=%t", key, v))
-					default: // ignore
+			m.AddTag("metric_type", metricType)
+			for k, v := range tags {
+				m.AddTag(k, v)
+			}
+
+			if fields, ok := dwmFields.(map[string]interface{}); ok {
+				for k, v := range fields {
+					switch v := v.(type) {
+					case float64, string, bool:
+						m.AddField(fieldPrefix+k, v)
+					default:
+						// ignore
 					}
 				}
-			default: // ignore
 			}
 
-			metricsBuffer.WriteString(fmt.Sprintf("%s,metric_type=%s ", measurementWithTags, metricType))
-			metricsBuffer.WriteString(strings.Join(fields, ","))
-			metricsBuffer.WriteString("\n")
+			metrics = append(metrics, m)
 		}
-
-		handler := influx.NewMetricHandler()
-		handler.SetTimeFunc(func() time.Time { return tm })
-		parser := influx.NewParser(handler)
-		newMetrics, err := parser.Parse(metricsBuffer.Bytes())
-		if err != nil {
-			log.Printf("W! failed to create metric of type '%s': %s\n", metricType, err)
-		}
-
-		return append(metrics, newMetrics...)
-	default:
-		return metrics
 	}
 
+	return metrics
 }
 
-func arraymap(vs []string, f func(string) string) []string {
-	vsm := make([]string, len(vs))
-	for i, v := range vs {
-		vsm[i] = f(v)
-	}
-	return vsm
+func (p *parser) SetTimeFunc(f metric.TimeFunc) {
+	p.timeFunc = f
 }

--- a/plugins/parsers/influx/machine.go
+++ b/plugins/parsers/influx/machine.go
@@ -15,21 +15,22 @@ var (
 )
 
 
-//line plugins/parsers/influx/machine.go.rl:224
+//line plugins/parsers/influx/machine.go.rl:226
 
 
 
 //line plugins/parsers/influx/machine.go:23
 const LineProtocol_start int = 1
-const LineProtocol_first_final int = 199
+const LineProtocol_first_final int = 206
 const LineProtocol_error int = 0
 
 const LineProtocol_en_main int = 1
 const LineProtocol_en_discard_line int = 195
 const LineProtocol_en_align int = 196
+const LineProtocol_en_series int = 199
 
 
-//line plugins/parsers/influx/machine.go.rl:227
+//line plugins/parsers/influx/machine.go.rl:229
 
 type Handler interface {
 	SetMeasurement(name []byte)
@@ -48,31 +49,60 @@ type machine struct {
 	p, pe, eof int
 	pb         int
 	handler    Handler
+	initState  int
 	err        error
 }
 
 func NewMachine(handler Handler) *machine {
 	m := &machine{
 		handler: handler,
+		initState: LineProtocol_en_align,
 	}
 
 	
-//line plugins/parsers/influx/machine.go.rl:254
-	
-//line plugins/parsers/influx/machine.go.rl:255
-	
-//line plugins/parsers/influx/machine.go.rl:256
-	
-//line plugins/parsers/influx/machine.go.rl:257
-	
 //line plugins/parsers/influx/machine.go.rl:258
 	
-//line plugins/parsers/influx/machine.go:71
+//line plugins/parsers/influx/machine.go.rl:259
+	
+//line plugins/parsers/influx/machine.go.rl:260
+	
+//line plugins/parsers/influx/machine.go.rl:261
+	
+//line plugins/parsers/influx/machine.go.rl:262
+	
+//line plugins/parsers/influx/machine.go:74
 	{
 	 m.cs = LineProtocol_start
 	}
 
-//line plugins/parsers/influx/machine.go.rl:259
+//line plugins/parsers/influx/machine.go.rl:263
+
+	return m
+}
+
+func NewSeriesMachine(handler Handler) *machine {
+	m := &machine{
+		handler: handler,
+		initState: LineProtocol_en_series,
+	}
+
+	
+//line plugins/parsers/influx/machine.go.rl:274
+	
+//line plugins/parsers/influx/machine.go.rl:275
+	
+//line plugins/parsers/influx/machine.go.rl:276
+	
+//line plugins/parsers/influx/machine.go.rl:277
+	
+//line plugins/parsers/influx/machine.go.rl:278
+	
+//line plugins/parsers/influx/machine.go:101
+	{
+	 m.cs = LineProtocol_start
+	}
+
+//line plugins/parsers/influx/machine.go.rl:279
 
 	return m
 }
@@ -86,13 +116,13 @@ func (m *machine) SetData(data []byte) {
 	m.err = nil
 
 	
-//line plugins/parsers/influx/machine.go:90
+//line plugins/parsers/influx/machine.go:120
 	{
 	 m.cs = LineProtocol_start
 	}
 
-//line plugins/parsers/influx/machine.go.rl:272
-	m.cs = LineProtocol_en_align
+//line plugins/parsers/influx/machine.go.rl:292
+	m.cs = m.initState
 }
 
 // ParseLine parses a line of input and returns true if more data can be
@@ -108,7 +138,7 @@ func (m *machine) ParseLine() bool {
 	var yield bool
 
 	
-//line plugins/parsers/influx/machine.go:112
+//line plugins/parsers/influx/machine.go:142
 	{
 	if ( m.p) == ( m.pe) {
 		goto _test_eof
@@ -133,28 +163,14 @@ _again:
 		goto st6
 	case 7:
 		goto st7
-	case 199:
-		goto st199
-	case 200:
-		goto st200
-	case 201:
-		goto st201
-	case 8:
-		goto st8
-	case 202:
-		goto st202
-	case 203:
-		goto st203
-	case 204:
-		goto st204
-	case 205:
-		goto st205
 	case 206:
 		goto st206
 	case 207:
 		goto st207
 	case 208:
 		goto st208
+	case 8:
+		goto st8
 	case 209:
 		goto st209
 	case 210:
@@ -181,22 +197,8 @@ _again:
 		goto st220
 	case 221:
 		goto st221
-	case 9:
-		goto st9
-	case 10:
-		goto st10
-	case 11:
-		goto st11
-	case 12:
-		goto st12
-	case 13:
-		goto st13
 	case 222:
 		goto st222
-	case 14:
-		goto st14
-	case 15:
-		goto st15
 	case 223:
 		goto st223
 	case 224:
@@ -209,36 +211,64 @@ _again:
 		goto st227
 	case 228:
 		goto st228
+	case 9:
+		goto st9
+	case 10:
+		goto st10
+	case 11:
+		goto st11
+	case 12:
+		goto st12
+	case 13:
+		goto st13
 	case 229:
 		goto st229
+	case 14:
+		goto st14
+	case 15:
+		goto st15
 	case 230:
 		goto st230
 	case 231:
 		goto st231
+	case 232:
+		goto st232
+	case 233:
+		goto st233
+	case 234:
+		goto st234
+	case 235:
+		goto st235
+	case 236:
+		goto st236
+	case 237:
+		goto st237
+	case 238:
+		goto st238
 	case 16:
 		goto st16
 	case 17:
 		goto st17
 	case 18:
 		goto st18
-	case 232:
-		goto st232
+	case 239:
+		goto st239
 	case 19:
 		goto st19
 	case 20:
 		goto st20
 	case 21:
 		goto st21
-	case 233:
-		goto st233
+	case 240:
+		goto st240
 	case 22:
 		goto st22
 	case 23:
 		goto st23
-	case 234:
-		goto st234
-	case 235:
-		goto st235
+	case 241:
+		goto st241
+	case 242:
+		goto st242
 	case 24:
 		goto st24
 	case 25:
@@ -277,26 +307,12 @@ _again:
 		goto st41
 	case 42:
 		goto st42
-	case 236:
-		goto st236
-	case 237:
-		goto st237
-	case 43:
-		goto st43
-	case 238:
-		goto st238
-	case 239:
-		goto st239
-	case 240:
-		goto st240
-	case 241:
-		goto st241
-	case 242:
-		goto st242
 	case 243:
 		goto st243
 	case 244:
 		goto st244
+	case 43:
+		goto st43
 	case 245:
 		goto st245
 	case 246:
@@ -323,14 +339,10 @@ _again:
 		goto st256
 	case 257:
 		goto st257
-	case 44:
-		goto st44
 	case 258:
 		goto st258
 	case 259:
 		goto st259
-	case 45:
-		goto st45
 	case 260:
 		goto st260
 	case 261:
@@ -341,10 +353,14 @@ _again:
 		goto st263
 	case 264:
 		goto st264
+	case 44:
+		goto st44
 	case 265:
 		goto st265
 	case 266:
 		goto st266
+	case 45:
+		goto st45
 	case 267:
 		goto st267
 	case 268:
@@ -371,14 +387,28 @@ _again:
 		goto st278
 	case 279:
 		goto st279
+	case 280:
+		goto st280
+	case 281:
+		goto st281
+	case 282:
+		goto st282
+	case 283:
+		goto st283
+	case 284:
+		goto st284
+	case 285:
+		goto st285
+	case 286:
+		goto st286
 	case 46:
 		goto st46
 	case 47:
 		goto st47
 	case 48:
 		goto st48
-	case 280:
-		goto st280
+	case 287:
+		goto st287
 	case 49:
 		goto st49
 	case 50:
@@ -389,110 +419,110 @@ _again:
 		goto st52
 	case 53:
 		goto st53
-	case 281:
-		goto st281
-	case 54:
-		goto st54
-	case 282:
-		goto st282
-	case 55:
-		goto st55
-	case 283:
-		goto st283
-	case 284:
-		goto st284
-	case 285:
-		goto st285
-	case 286:
-		goto st286
-	case 287:
-		goto st287
 	case 288:
 		goto st288
+	case 54:
+		goto st54
 	case 289:
 		goto st289
+	case 55:
+		goto st55
 	case 290:
 		goto st290
 	case 291:
 		goto st291
+	case 292:
+		goto st292
+	case 293:
+		goto st293
+	case 294:
+		goto st294
+	case 295:
+		goto st295
+	case 296:
+		goto st296
+	case 297:
+		goto st297
+	case 298:
+		goto st298
 	case 56:
 		goto st56
 	case 57:
 		goto st57
 	case 58:
 		goto st58
-	case 292:
-		goto st292
+	case 299:
+		goto st299
 	case 59:
 		goto st59
 	case 60:
 		goto st60
 	case 61:
 		goto st61
-	case 293:
-		goto st293
+	case 300:
+		goto st300
 	case 62:
 		goto st62
 	case 63:
 		goto st63
-	case 294:
-		goto st294
-	case 295:
-		goto st295
+	case 301:
+		goto st301
+	case 302:
+		goto st302
 	case 64:
 		goto st64
 	case 65:
 		goto st65
 	case 66:
 		goto st66
-	case 296:
-		goto st296
+	case 303:
+		goto st303
 	case 67:
 		goto st67
 	case 68:
 		goto st68
-	case 297:
-		goto st297
-	case 298:
-		goto st298
-	case 299:
-		goto st299
-	case 300:
-		goto st300
-	case 301:
-		goto st301
-	case 302:
-		goto st302
-	case 303:
-		goto st303
 	case 304:
 		goto st304
 	case 305:
 		goto st305
+	case 306:
+		goto st306
+	case 307:
+		goto st307
+	case 308:
+		goto st308
+	case 309:
+		goto st309
+	case 310:
+		goto st310
+	case 311:
+		goto st311
+	case 312:
+		goto st312
 	case 69:
 		goto st69
 	case 70:
 		goto st70
 	case 71:
 		goto st71
-	case 306:
-		goto st306
+	case 313:
+		goto st313
 	case 72:
 		goto st72
 	case 73:
 		goto st73
 	case 74:
 		goto st74
-	case 307:
-		goto st307
+	case 314:
+		goto st314
 	case 75:
 		goto st75
 	case 76:
 		goto st76
-	case 308:
-		goto st308
-	case 309:
-		goto st309
+	case 315:
+		goto st315
+	case 316:
+		goto st316
 	case 77:
 		goto st77
 	case 78:
@@ -505,32 +535,16 @@ _again:
 		goto st81
 	case 82:
 		goto st82
-	case 310:
-		goto st310
-	case 311:
-		goto st311
-	case 312:
-		goto st312
-	case 313:
-		goto st313
-	case 83:
-		goto st83
-	case 314:
-		goto st314
-	case 315:
-		goto st315
-	case 316:
-		goto st316
 	case 317:
 		goto st317
-	case 84:
-		goto st84
 	case 318:
 		goto st318
 	case 319:
 		goto st319
 	case 320:
 		goto st320
+	case 83:
+		goto st83
 	case 321:
 		goto st321
 	case 322:
@@ -539,6 +553,8 @@ _again:
 		goto st323
 	case 324:
 		goto st324
+	case 84:
+		goto st84
 	case 325:
 		goto st325
 	case 326:
@@ -561,6 +577,20 @@ _again:
 		goto st334
 	case 335:
 		goto st335
+	case 336:
+		goto st336
+	case 337:
+		goto st337
+	case 338:
+		goto st338
+	case 339:
+		goto st339
+	case 340:
+		goto st340
+	case 341:
+		goto st341
+	case 342:
+		goto st342
 	case 85:
 		goto st85
 	case 86:
@@ -587,26 +617,12 @@ _again:
 		goto st96
 	case 97:
 		goto st97
-	case 336:
-		goto st336
-	case 337:
-		goto st337
-	case 98:
-		goto st98
-	case 338:
-		goto st338
-	case 339:
-		goto st339
-	case 340:
-		goto st340
-	case 341:
-		goto st341
-	case 342:
-		goto st342
 	case 343:
 		goto st343
 	case 344:
 		goto st344
+	case 98:
+		goto st98
 	case 345:
 		goto st345
 	case 346:
@@ -633,16 +649,10 @@ _again:
 		goto st356
 	case 357:
 		goto st357
-	case 99:
-		goto st99
-	case 100:
-		goto st100
 	case 358:
 		goto st358
 	case 359:
 		goto st359
-	case 101:
-		goto st101
 	case 360:
 		goto st360
 	case 361:
@@ -653,10 +663,16 @@ _again:
 		goto st363
 	case 364:
 		goto st364
+	case 99:
+		goto st99
+	case 100:
+		goto st100
 	case 365:
 		goto st365
 	case 366:
 		goto st366
+	case 101:
+		goto st101
 	case 367:
 		goto st367
 	case 368:
@@ -683,12 +699,26 @@ _again:
 		goto st378
 	case 379:
 		goto st379
-	case 102:
-		goto st102
 	case 380:
 		goto st380
 	case 381:
 		goto st381
+	case 382:
+		goto st382
+	case 383:
+		goto st383
+	case 384:
+		goto st384
+	case 385:
+		goto st385
+	case 386:
+		goto st386
+	case 102:
+		goto st102
+	case 387:
+		goto st387
+	case 388:
+		goto st388
 	case 103:
 		goto st103
 	case 104:
@@ -699,54 +729,54 @@ _again:
 		goto st106
 	case 107:
 		goto st107
-	case 382:
-		goto st382
+	case 389:
+		goto st389
 	case 108:
 		goto st108
 	case 109:
 		goto st109
-	case 383:
-		goto st383
-	case 384:
-		goto st384
-	case 385:
-		goto st385
-	case 386:
-		goto st386
-	case 387:
-		goto st387
-	case 388:
-		goto st388
-	case 389:
-		goto st389
 	case 390:
 		goto st390
 	case 391:
 		goto st391
+	case 392:
+		goto st392
+	case 393:
+		goto st393
+	case 394:
+		goto st394
+	case 395:
+		goto st395
+	case 396:
+		goto st396
+	case 397:
+		goto st397
+	case 398:
+		goto st398
 	case 110:
 		goto st110
 	case 111:
 		goto st111
 	case 112:
 		goto st112
-	case 392:
-		goto st392
+	case 399:
+		goto st399
 	case 113:
 		goto st113
 	case 114:
 		goto st114
 	case 115:
 		goto st115
-	case 393:
-		goto st393
+	case 400:
+		goto st400
 	case 116:
 		goto st116
 	case 117:
 		goto st117
-	case 394:
-		goto st394
-	case 395:
-		goto st395
+	case 401:
+		goto st401
+	case 402:
+		goto st402
 	case 118:
 		goto st118
 	case 119:
@@ -771,28 +801,14 @@ _again:
 		goto st128
 	case 129:
 		goto st129
-	case 396:
-		goto st396
-	case 397:
-		goto st397
-	case 398:
-		goto st398
-	case 130:
-		goto st130
-	case 399:
-		goto st399
-	case 400:
-		goto st400
-	case 401:
-		goto st401
-	case 402:
-		goto st402
 	case 403:
 		goto st403
 	case 404:
 		goto st404
 	case 405:
 		goto st405
+	case 130:
+		goto st130
 	case 406:
 		goto st406
 	case 407:
@@ -823,8 +839,6 @@ _again:
 		goto st419
 	case 420:
 		goto st420
-	case 131:
-		goto st131
 	case 421:
 		goto st421
 	case 422:
@@ -833,14 +847,14 @@ _again:
 		goto st423
 	case 424:
 		goto st424
-	case 132:
-		goto st132
 	case 425:
 		goto st425
 	case 426:
 		goto st426
 	case 427:
 		goto st427
+	case 131:
+		goto st131
 	case 428:
 		goto st428
 	case 429:
@@ -849,6 +863,8 @@ _again:
 		goto st430
 	case 431:
 		goto st431
+	case 132:
+		goto st132
 	case 432:
 		goto st432
 	case 433:
@@ -875,18 +891,10 @@ _again:
 		goto st443
 	case 444:
 		goto st444
-	case 133:
-		goto st133
-	case 134:
-		goto st134
-	case 135:
-		goto st135
 	case 445:
 		goto st445
 	case 446:
 		goto st446
-	case 136:
-		goto st136
 	case 447:
 		goto st447
 	case 448:
@@ -897,10 +905,18 @@ _again:
 		goto st450
 	case 451:
 		goto st451
+	case 133:
+		goto st133
+	case 134:
+		goto st134
+	case 135:
+		goto st135
 	case 452:
 		goto st452
 	case 453:
 		goto st453
+	case 136:
+		goto st136
 	case 454:
 		goto st454
 	case 455:
@@ -927,16 +943,12 @@ _again:
 		goto st465
 	case 466:
 		goto st466
-	case 137:
-		goto st137
 	case 467:
 		goto st467
 	case 468:
 		goto st468
 	case 469:
 		goto st469
-	case 138:
-		goto st138
 	case 470:
 		goto st470
 	case 471:
@@ -945,12 +957,16 @@ _again:
 		goto st472
 	case 473:
 		goto st473
+	case 137:
+		goto st137
 	case 474:
 		goto st474
 	case 475:
 		goto st475
 	case 476:
 		goto st476
+	case 138:
+		goto st138
 	case 477:
 		goto st477
 	case 478:
@@ -981,8 +997,6 @@ _again:
 		goto st490
 	case 491:
 		goto st491
-	case 139:
-		goto st139
 	case 492:
 		goto st492
 	case 493:
@@ -997,6 +1011,8 @@ _again:
 		goto st497
 	case 498:
 		goto st498
+	case 139:
+		goto st139
 	case 499:
 		goto st499
 	case 500:
@@ -1027,24 +1043,10 @@ _again:
 		goto st512
 	case 513:
 		goto st513
-	case 140:
-		goto st140
-	case 141:
-		goto st141
-	case 142:
-		goto st142
-	case 143:
-		goto st143
-	case 144:
-		goto st144
 	case 514:
 		goto st514
-	case 145:
-		goto st145
 	case 515:
 		goto st515
-	case 146:
-		goto st146
 	case 516:
 		goto st516
 	case 517:
@@ -1055,66 +1057,80 @@ _again:
 		goto st519
 	case 520:
 		goto st520
+	case 140:
+		goto st140
+	case 141:
+		goto st141
+	case 142:
+		goto st142
+	case 143:
+		goto st143
+	case 144:
+		goto st144
 	case 521:
 		goto st521
+	case 145:
+		goto st145
 	case 522:
 		goto st522
+	case 146:
+		goto st146
 	case 523:
 		goto st523
 	case 524:
 		goto st524
-	case 147:
-		goto st147
-	case 148:
-		goto st148
-	case 149:
-		goto st149
 	case 525:
 		goto st525
-	case 150:
-		goto st150
-	case 151:
-		goto st151
-	case 152:
-		goto st152
 	case 526:
 		goto st526
-	case 153:
-		goto st153
-	case 154:
-		goto st154
 	case 527:
 		goto st527
 	case 528:
 		goto st528
-	case 155:
-		goto st155
-	case 156:
-		goto st156
-	case 157:
-		goto st157
 	case 529:
 		goto st529
 	case 530:
 		goto st530
 	case 531:
 		goto st531
-	case 158:
-		goto st158
+	case 147:
+		goto st147
+	case 148:
+		goto st148
+	case 149:
+		goto st149
 	case 532:
 		goto st532
+	case 150:
+		goto st150
+	case 151:
+		goto st151
+	case 152:
+		goto st152
 	case 533:
 		goto st533
+	case 153:
+		goto st153
+	case 154:
+		goto st154
 	case 534:
 		goto st534
 	case 535:
 		goto st535
+	case 155:
+		goto st155
+	case 156:
+		goto st156
+	case 157:
+		goto st157
 	case 536:
 		goto st536
 	case 537:
 		goto st537
 	case 538:
 		goto st538
+	case 158:
+		goto st158
 	case 539:
 		goto st539
 	case 540:
@@ -1141,10 +1157,6 @@ _again:
 		goto st550
 	case 551:
 		goto st551
-	case 159:
-		goto st159
-	case 160:
-		goto st160
 	case 552:
 		goto st552
 	case 553:
@@ -1159,34 +1171,52 @@ _again:
 		goto st557
 	case 558:
 		goto st558
+	case 159:
+		goto st159
+	case 160:
+		goto st160
 	case 559:
 		goto st559
 	case 560:
 		goto st560
+	case 561:
+		goto st561
+	case 562:
+		goto st562
+	case 563:
+		goto st563
+	case 564:
+		goto st564
+	case 565:
+		goto st565
+	case 566:
+		goto st566
+	case 567:
+		goto st567
 	case 161:
 		goto st161
 	case 162:
 		goto st162
 	case 163:
 		goto st163
-	case 561:
-		goto st561
+	case 568:
+		goto st568
 	case 164:
 		goto st164
 	case 165:
 		goto st165
 	case 166:
 		goto st166
-	case 562:
-		goto st562
+	case 569:
+		goto st569
 	case 167:
 		goto st167
 	case 168:
 		goto st168
-	case 563:
-		goto st563
-	case 564:
-		goto st564
+	case 570:
+		goto st570
+	case 571:
+		goto st571
 	case 169:
 		goto st169
 	case 170:
@@ -1195,122 +1225,144 @@ _again:
 		goto st171
 	case 172:
 		goto st172
-	case 565:
-		goto st565
-	case 173:
-		goto st173
-	case 566:
-		goto st566
-	case 567:
-		goto st567
-	case 174:
-		goto st174
-	case 568:
-		goto st568
-	case 569:
-		goto st569
-	case 570:
-		goto st570
-	case 571:
-		goto st571
 	case 572:
 		goto st572
+	case 173:
+		goto st173
 	case 573:
 		goto st573
 	case 574:
 		goto st574
+	case 174:
+		goto st174
 	case 575:
 		goto st575
 	case 576:
 		goto st576
+	case 577:
+		goto st577
+	case 578:
+		goto st578
+	case 579:
+		goto st579
+	case 580:
+		goto st580
+	case 581:
+		goto st581
+	case 582:
+		goto st582
+	case 583:
+		goto st583
 	case 175:
 		goto st175
 	case 176:
 		goto st176
 	case 177:
 		goto st177
-	case 577:
-		goto st577
+	case 584:
+		goto st584
 	case 178:
 		goto st178
 	case 179:
 		goto st179
 	case 180:
 		goto st180
-	case 578:
-		goto st578
+	case 585:
+		goto st585
 	case 181:
 		goto st181
 	case 182:
 		goto st182
-	case 579:
-		goto st579
-	case 580:
-		goto st580
-	case 183:
-		goto st183
-	case 184:
-		goto st184
-	case 581:
-		goto st581
-	case 185:
-		goto st185
-	case 186:
-		goto st186
-	case 582:
-		goto st582
-	case 583:
-		goto st583
-	case 584:
-		goto st584
-	case 585:
-		goto st585
 	case 586:
 		goto st586
 	case 587:
 		goto st587
+	case 183:
+		goto st183
+	case 184:
+		goto st184
 	case 588:
 		goto st588
+	case 185:
+		goto st185
+	case 186:
+		goto st186
 	case 589:
 		goto st589
+	case 590:
+		goto st590
+	case 591:
+		goto st591
+	case 592:
+		goto st592
+	case 593:
+		goto st593
+	case 594:
+		goto st594
+	case 595:
+		goto st595
+	case 596:
+		goto st596
 	case 187:
 		goto st187
 	case 188:
 		goto st188
 	case 189:
 		goto st189
-	case 590:
-		goto st590
+	case 597:
+		goto st597
 	case 190:
 		goto st190
 	case 191:
 		goto st191
 	case 192:
 		goto st192
-	case 591:
-		goto st591
+	case 598:
+		goto st598
 	case 193:
 		goto st193
 	case 194:
 		goto st194
-	case 592:
-		goto st592
-	case 593:
-		goto st593
+	case 599:
+		goto st599
+	case 600:
+		goto st600
 	case 195:
 		goto st195
-	case 594:
-		goto st594
+	case 601:
+		goto st601
 	case 196:
 		goto st196
-	case 595:
-		goto st595
-	case 596:
-		goto st596
+	case 602:
+		goto st602
+	case 603:
+		goto st603
 	case 197:
 		goto st197
 	case 198:
 		goto st198
+	case 199:
+		goto st199
+	case 604:
+		goto st604
+	case 605:
+		goto st605
+	case 606:
+		goto st606
+	case 200:
+		goto st200
+	case 201:
+		goto st201
+	case 202:
+		goto st202
+	case 607:
+		goto st607
+	case 203:
+		goto st203
+	case 204:
+		goto st204
+	case 205:
+		goto st205
 	}
 
 	if ( m.p)++; ( m.p) == ( m.pe) {
@@ -1334,28 +1386,14 @@ _resume:
 		goto st_case_6
 	case 7:
 		goto st_case_7
-	case 199:
-		goto st_case_199
-	case 200:
-		goto st_case_200
-	case 201:
-		goto st_case_201
-	case 8:
-		goto st_case_8
-	case 202:
-		goto st_case_202
-	case 203:
-		goto st_case_203
-	case 204:
-		goto st_case_204
-	case 205:
-		goto st_case_205
 	case 206:
 		goto st_case_206
 	case 207:
 		goto st_case_207
 	case 208:
 		goto st_case_208
+	case 8:
+		goto st_case_8
 	case 209:
 		goto st_case_209
 	case 210:
@@ -1382,22 +1420,8 @@ _resume:
 		goto st_case_220
 	case 221:
 		goto st_case_221
-	case 9:
-		goto st_case_9
-	case 10:
-		goto st_case_10
-	case 11:
-		goto st_case_11
-	case 12:
-		goto st_case_12
-	case 13:
-		goto st_case_13
 	case 222:
 		goto st_case_222
-	case 14:
-		goto st_case_14
-	case 15:
-		goto st_case_15
 	case 223:
 		goto st_case_223
 	case 224:
@@ -1410,36 +1434,64 @@ _resume:
 		goto st_case_227
 	case 228:
 		goto st_case_228
+	case 9:
+		goto st_case_9
+	case 10:
+		goto st_case_10
+	case 11:
+		goto st_case_11
+	case 12:
+		goto st_case_12
+	case 13:
+		goto st_case_13
 	case 229:
 		goto st_case_229
+	case 14:
+		goto st_case_14
+	case 15:
+		goto st_case_15
 	case 230:
 		goto st_case_230
 	case 231:
 		goto st_case_231
+	case 232:
+		goto st_case_232
+	case 233:
+		goto st_case_233
+	case 234:
+		goto st_case_234
+	case 235:
+		goto st_case_235
+	case 236:
+		goto st_case_236
+	case 237:
+		goto st_case_237
+	case 238:
+		goto st_case_238
 	case 16:
 		goto st_case_16
 	case 17:
 		goto st_case_17
 	case 18:
 		goto st_case_18
-	case 232:
-		goto st_case_232
+	case 239:
+		goto st_case_239
 	case 19:
 		goto st_case_19
 	case 20:
 		goto st_case_20
 	case 21:
 		goto st_case_21
-	case 233:
-		goto st_case_233
+	case 240:
+		goto st_case_240
 	case 22:
 		goto st_case_22
 	case 23:
 		goto st_case_23
-	case 234:
-		goto st_case_234
-	case 235:
-		goto st_case_235
+	case 241:
+		goto st_case_241
+	case 242:
+		goto st_case_242
 	case 24:
 		goto st_case_24
 	case 25:
@@ -1478,26 +1530,12 @@ _resume:
 		goto st_case_41
 	case 42:
 		goto st_case_42
-	case 236:
-		goto st_case_236
-	case 237:
-		goto st_case_237
-	case 43:
-		goto st_case_43
-	case 238:
-		goto st_case_238
-	case 239:
-		goto st_case_239
-	case 240:
-		goto st_case_240
-	case 241:
-		goto st_case_241
-	case 242:
-		goto st_case_242
 	case 243:
 		goto st_case_243
 	case 244:
 		goto st_case_244
+	case 43:
+		goto st_case_43
 	case 245:
 		goto st_case_245
 	case 246:
@@ -1524,14 +1562,10 @@ _resume:
 		goto st_case_256
 	case 257:
 		goto st_case_257
-	case 44:
-		goto st_case_44
 	case 258:
 		goto st_case_258
 	case 259:
 		goto st_case_259
-	case 45:
-		goto st_case_45
 	case 260:
 		goto st_case_260
 	case 261:
@@ -1542,10 +1576,14 @@ _resume:
 		goto st_case_263
 	case 264:
 		goto st_case_264
+	case 44:
+		goto st_case_44
 	case 265:
 		goto st_case_265
 	case 266:
 		goto st_case_266
+	case 45:
+		goto st_case_45
 	case 267:
 		goto st_case_267
 	case 268:
@@ -1572,14 +1610,28 @@ _resume:
 		goto st_case_278
 	case 279:
 		goto st_case_279
+	case 280:
+		goto st_case_280
+	case 281:
+		goto st_case_281
+	case 282:
+		goto st_case_282
+	case 283:
+		goto st_case_283
+	case 284:
+		goto st_case_284
+	case 285:
+		goto st_case_285
+	case 286:
+		goto st_case_286
 	case 46:
 		goto st_case_46
 	case 47:
 		goto st_case_47
 	case 48:
 		goto st_case_48
-	case 280:
-		goto st_case_280
+	case 287:
+		goto st_case_287
 	case 49:
 		goto st_case_49
 	case 50:
@@ -1590,110 +1642,110 @@ _resume:
 		goto st_case_52
 	case 53:
 		goto st_case_53
-	case 281:
-		goto st_case_281
-	case 54:
-		goto st_case_54
-	case 282:
-		goto st_case_282
-	case 55:
-		goto st_case_55
-	case 283:
-		goto st_case_283
-	case 284:
-		goto st_case_284
-	case 285:
-		goto st_case_285
-	case 286:
-		goto st_case_286
-	case 287:
-		goto st_case_287
 	case 288:
 		goto st_case_288
+	case 54:
+		goto st_case_54
 	case 289:
 		goto st_case_289
+	case 55:
+		goto st_case_55
 	case 290:
 		goto st_case_290
 	case 291:
 		goto st_case_291
+	case 292:
+		goto st_case_292
+	case 293:
+		goto st_case_293
+	case 294:
+		goto st_case_294
+	case 295:
+		goto st_case_295
+	case 296:
+		goto st_case_296
+	case 297:
+		goto st_case_297
+	case 298:
+		goto st_case_298
 	case 56:
 		goto st_case_56
 	case 57:
 		goto st_case_57
 	case 58:
 		goto st_case_58
-	case 292:
-		goto st_case_292
+	case 299:
+		goto st_case_299
 	case 59:
 		goto st_case_59
 	case 60:
 		goto st_case_60
 	case 61:
 		goto st_case_61
-	case 293:
-		goto st_case_293
+	case 300:
+		goto st_case_300
 	case 62:
 		goto st_case_62
 	case 63:
 		goto st_case_63
-	case 294:
-		goto st_case_294
-	case 295:
-		goto st_case_295
+	case 301:
+		goto st_case_301
+	case 302:
+		goto st_case_302
 	case 64:
 		goto st_case_64
 	case 65:
 		goto st_case_65
 	case 66:
 		goto st_case_66
-	case 296:
-		goto st_case_296
+	case 303:
+		goto st_case_303
 	case 67:
 		goto st_case_67
 	case 68:
 		goto st_case_68
-	case 297:
-		goto st_case_297
-	case 298:
-		goto st_case_298
-	case 299:
-		goto st_case_299
-	case 300:
-		goto st_case_300
-	case 301:
-		goto st_case_301
-	case 302:
-		goto st_case_302
-	case 303:
-		goto st_case_303
 	case 304:
 		goto st_case_304
 	case 305:
 		goto st_case_305
+	case 306:
+		goto st_case_306
+	case 307:
+		goto st_case_307
+	case 308:
+		goto st_case_308
+	case 309:
+		goto st_case_309
+	case 310:
+		goto st_case_310
+	case 311:
+		goto st_case_311
+	case 312:
+		goto st_case_312
 	case 69:
 		goto st_case_69
 	case 70:
 		goto st_case_70
 	case 71:
 		goto st_case_71
-	case 306:
-		goto st_case_306
+	case 313:
+		goto st_case_313
 	case 72:
 		goto st_case_72
 	case 73:
 		goto st_case_73
 	case 74:
 		goto st_case_74
-	case 307:
-		goto st_case_307
+	case 314:
+		goto st_case_314
 	case 75:
 		goto st_case_75
 	case 76:
 		goto st_case_76
-	case 308:
-		goto st_case_308
-	case 309:
-		goto st_case_309
+	case 315:
+		goto st_case_315
+	case 316:
+		goto st_case_316
 	case 77:
 		goto st_case_77
 	case 78:
@@ -1706,32 +1758,16 @@ _resume:
 		goto st_case_81
 	case 82:
 		goto st_case_82
-	case 310:
-		goto st_case_310
-	case 311:
-		goto st_case_311
-	case 312:
-		goto st_case_312
-	case 313:
-		goto st_case_313
-	case 83:
-		goto st_case_83
-	case 314:
-		goto st_case_314
-	case 315:
-		goto st_case_315
-	case 316:
-		goto st_case_316
 	case 317:
 		goto st_case_317
-	case 84:
-		goto st_case_84
 	case 318:
 		goto st_case_318
 	case 319:
 		goto st_case_319
 	case 320:
 		goto st_case_320
+	case 83:
+		goto st_case_83
 	case 321:
 		goto st_case_321
 	case 322:
@@ -1740,6 +1776,8 @@ _resume:
 		goto st_case_323
 	case 324:
 		goto st_case_324
+	case 84:
+		goto st_case_84
 	case 325:
 		goto st_case_325
 	case 326:
@@ -1762,6 +1800,20 @@ _resume:
 		goto st_case_334
 	case 335:
 		goto st_case_335
+	case 336:
+		goto st_case_336
+	case 337:
+		goto st_case_337
+	case 338:
+		goto st_case_338
+	case 339:
+		goto st_case_339
+	case 340:
+		goto st_case_340
+	case 341:
+		goto st_case_341
+	case 342:
+		goto st_case_342
 	case 85:
 		goto st_case_85
 	case 86:
@@ -1788,26 +1840,12 @@ _resume:
 		goto st_case_96
 	case 97:
 		goto st_case_97
-	case 336:
-		goto st_case_336
-	case 337:
-		goto st_case_337
-	case 98:
-		goto st_case_98
-	case 338:
-		goto st_case_338
-	case 339:
-		goto st_case_339
-	case 340:
-		goto st_case_340
-	case 341:
-		goto st_case_341
-	case 342:
-		goto st_case_342
 	case 343:
 		goto st_case_343
 	case 344:
 		goto st_case_344
+	case 98:
+		goto st_case_98
 	case 345:
 		goto st_case_345
 	case 346:
@@ -1834,16 +1872,10 @@ _resume:
 		goto st_case_356
 	case 357:
 		goto st_case_357
-	case 99:
-		goto st_case_99
-	case 100:
-		goto st_case_100
 	case 358:
 		goto st_case_358
 	case 359:
 		goto st_case_359
-	case 101:
-		goto st_case_101
 	case 360:
 		goto st_case_360
 	case 361:
@@ -1854,10 +1886,16 @@ _resume:
 		goto st_case_363
 	case 364:
 		goto st_case_364
+	case 99:
+		goto st_case_99
+	case 100:
+		goto st_case_100
 	case 365:
 		goto st_case_365
 	case 366:
 		goto st_case_366
+	case 101:
+		goto st_case_101
 	case 367:
 		goto st_case_367
 	case 368:
@@ -1884,12 +1922,26 @@ _resume:
 		goto st_case_378
 	case 379:
 		goto st_case_379
-	case 102:
-		goto st_case_102
 	case 380:
 		goto st_case_380
 	case 381:
 		goto st_case_381
+	case 382:
+		goto st_case_382
+	case 383:
+		goto st_case_383
+	case 384:
+		goto st_case_384
+	case 385:
+		goto st_case_385
+	case 386:
+		goto st_case_386
+	case 102:
+		goto st_case_102
+	case 387:
+		goto st_case_387
+	case 388:
+		goto st_case_388
 	case 103:
 		goto st_case_103
 	case 104:
@@ -1900,54 +1952,54 @@ _resume:
 		goto st_case_106
 	case 107:
 		goto st_case_107
-	case 382:
-		goto st_case_382
+	case 389:
+		goto st_case_389
 	case 108:
 		goto st_case_108
 	case 109:
 		goto st_case_109
-	case 383:
-		goto st_case_383
-	case 384:
-		goto st_case_384
-	case 385:
-		goto st_case_385
-	case 386:
-		goto st_case_386
-	case 387:
-		goto st_case_387
-	case 388:
-		goto st_case_388
-	case 389:
-		goto st_case_389
 	case 390:
 		goto st_case_390
 	case 391:
 		goto st_case_391
+	case 392:
+		goto st_case_392
+	case 393:
+		goto st_case_393
+	case 394:
+		goto st_case_394
+	case 395:
+		goto st_case_395
+	case 396:
+		goto st_case_396
+	case 397:
+		goto st_case_397
+	case 398:
+		goto st_case_398
 	case 110:
 		goto st_case_110
 	case 111:
 		goto st_case_111
 	case 112:
 		goto st_case_112
-	case 392:
-		goto st_case_392
+	case 399:
+		goto st_case_399
 	case 113:
 		goto st_case_113
 	case 114:
 		goto st_case_114
 	case 115:
 		goto st_case_115
-	case 393:
-		goto st_case_393
+	case 400:
+		goto st_case_400
 	case 116:
 		goto st_case_116
 	case 117:
 		goto st_case_117
-	case 394:
-		goto st_case_394
-	case 395:
-		goto st_case_395
+	case 401:
+		goto st_case_401
+	case 402:
+		goto st_case_402
 	case 118:
 		goto st_case_118
 	case 119:
@@ -1972,28 +2024,14 @@ _resume:
 		goto st_case_128
 	case 129:
 		goto st_case_129
-	case 396:
-		goto st_case_396
-	case 397:
-		goto st_case_397
-	case 398:
-		goto st_case_398
-	case 130:
-		goto st_case_130
-	case 399:
-		goto st_case_399
-	case 400:
-		goto st_case_400
-	case 401:
-		goto st_case_401
-	case 402:
-		goto st_case_402
 	case 403:
 		goto st_case_403
 	case 404:
 		goto st_case_404
 	case 405:
 		goto st_case_405
+	case 130:
+		goto st_case_130
 	case 406:
 		goto st_case_406
 	case 407:
@@ -2024,8 +2062,6 @@ _resume:
 		goto st_case_419
 	case 420:
 		goto st_case_420
-	case 131:
-		goto st_case_131
 	case 421:
 		goto st_case_421
 	case 422:
@@ -2034,14 +2070,14 @@ _resume:
 		goto st_case_423
 	case 424:
 		goto st_case_424
-	case 132:
-		goto st_case_132
 	case 425:
 		goto st_case_425
 	case 426:
 		goto st_case_426
 	case 427:
 		goto st_case_427
+	case 131:
+		goto st_case_131
 	case 428:
 		goto st_case_428
 	case 429:
@@ -2050,6 +2086,8 @@ _resume:
 		goto st_case_430
 	case 431:
 		goto st_case_431
+	case 132:
+		goto st_case_132
 	case 432:
 		goto st_case_432
 	case 433:
@@ -2076,18 +2114,10 @@ _resume:
 		goto st_case_443
 	case 444:
 		goto st_case_444
-	case 133:
-		goto st_case_133
-	case 134:
-		goto st_case_134
-	case 135:
-		goto st_case_135
 	case 445:
 		goto st_case_445
 	case 446:
 		goto st_case_446
-	case 136:
-		goto st_case_136
 	case 447:
 		goto st_case_447
 	case 448:
@@ -2098,10 +2128,18 @@ _resume:
 		goto st_case_450
 	case 451:
 		goto st_case_451
+	case 133:
+		goto st_case_133
+	case 134:
+		goto st_case_134
+	case 135:
+		goto st_case_135
 	case 452:
 		goto st_case_452
 	case 453:
 		goto st_case_453
+	case 136:
+		goto st_case_136
 	case 454:
 		goto st_case_454
 	case 455:
@@ -2128,16 +2166,12 @@ _resume:
 		goto st_case_465
 	case 466:
 		goto st_case_466
-	case 137:
-		goto st_case_137
 	case 467:
 		goto st_case_467
 	case 468:
 		goto st_case_468
 	case 469:
 		goto st_case_469
-	case 138:
-		goto st_case_138
 	case 470:
 		goto st_case_470
 	case 471:
@@ -2146,12 +2180,16 @@ _resume:
 		goto st_case_472
 	case 473:
 		goto st_case_473
+	case 137:
+		goto st_case_137
 	case 474:
 		goto st_case_474
 	case 475:
 		goto st_case_475
 	case 476:
 		goto st_case_476
+	case 138:
+		goto st_case_138
 	case 477:
 		goto st_case_477
 	case 478:
@@ -2182,8 +2220,6 @@ _resume:
 		goto st_case_490
 	case 491:
 		goto st_case_491
-	case 139:
-		goto st_case_139
 	case 492:
 		goto st_case_492
 	case 493:
@@ -2198,6 +2234,8 @@ _resume:
 		goto st_case_497
 	case 498:
 		goto st_case_498
+	case 139:
+		goto st_case_139
 	case 499:
 		goto st_case_499
 	case 500:
@@ -2228,24 +2266,10 @@ _resume:
 		goto st_case_512
 	case 513:
 		goto st_case_513
-	case 140:
-		goto st_case_140
-	case 141:
-		goto st_case_141
-	case 142:
-		goto st_case_142
-	case 143:
-		goto st_case_143
-	case 144:
-		goto st_case_144
 	case 514:
 		goto st_case_514
-	case 145:
-		goto st_case_145
 	case 515:
 		goto st_case_515
-	case 146:
-		goto st_case_146
 	case 516:
 		goto st_case_516
 	case 517:
@@ -2256,66 +2280,80 @@ _resume:
 		goto st_case_519
 	case 520:
 		goto st_case_520
+	case 140:
+		goto st_case_140
+	case 141:
+		goto st_case_141
+	case 142:
+		goto st_case_142
+	case 143:
+		goto st_case_143
+	case 144:
+		goto st_case_144
 	case 521:
 		goto st_case_521
+	case 145:
+		goto st_case_145
 	case 522:
 		goto st_case_522
+	case 146:
+		goto st_case_146
 	case 523:
 		goto st_case_523
 	case 524:
 		goto st_case_524
-	case 147:
-		goto st_case_147
-	case 148:
-		goto st_case_148
-	case 149:
-		goto st_case_149
 	case 525:
 		goto st_case_525
-	case 150:
-		goto st_case_150
-	case 151:
-		goto st_case_151
-	case 152:
-		goto st_case_152
 	case 526:
 		goto st_case_526
-	case 153:
-		goto st_case_153
-	case 154:
-		goto st_case_154
 	case 527:
 		goto st_case_527
 	case 528:
 		goto st_case_528
-	case 155:
-		goto st_case_155
-	case 156:
-		goto st_case_156
-	case 157:
-		goto st_case_157
 	case 529:
 		goto st_case_529
 	case 530:
 		goto st_case_530
 	case 531:
 		goto st_case_531
-	case 158:
-		goto st_case_158
+	case 147:
+		goto st_case_147
+	case 148:
+		goto st_case_148
+	case 149:
+		goto st_case_149
 	case 532:
 		goto st_case_532
+	case 150:
+		goto st_case_150
+	case 151:
+		goto st_case_151
+	case 152:
+		goto st_case_152
 	case 533:
 		goto st_case_533
+	case 153:
+		goto st_case_153
+	case 154:
+		goto st_case_154
 	case 534:
 		goto st_case_534
 	case 535:
 		goto st_case_535
+	case 155:
+		goto st_case_155
+	case 156:
+		goto st_case_156
+	case 157:
+		goto st_case_157
 	case 536:
 		goto st_case_536
 	case 537:
 		goto st_case_537
 	case 538:
 		goto st_case_538
+	case 158:
+		goto st_case_158
 	case 539:
 		goto st_case_539
 	case 540:
@@ -2342,10 +2380,6 @@ _resume:
 		goto st_case_550
 	case 551:
 		goto st_case_551
-	case 159:
-		goto st_case_159
-	case 160:
-		goto st_case_160
 	case 552:
 		goto st_case_552
 	case 553:
@@ -2360,34 +2394,52 @@ _resume:
 		goto st_case_557
 	case 558:
 		goto st_case_558
+	case 159:
+		goto st_case_159
+	case 160:
+		goto st_case_160
 	case 559:
 		goto st_case_559
 	case 560:
 		goto st_case_560
+	case 561:
+		goto st_case_561
+	case 562:
+		goto st_case_562
+	case 563:
+		goto st_case_563
+	case 564:
+		goto st_case_564
+	case 565:
+		goto st_case_565
+	case 566:
+		goto st_case_566
+	case 567:
+		goto st_case_567
 	case 161:
 		goto st_case_161
 	case 162:
 		goto st_case_162
 	case 163:
 		goto st_case_163
-	case 561:
-		goto st_case_561
+	case 568:
+		goto st_case_568
 	case 164:
 		goto st_case_164
 	case 165:
 		goto st_case_165
 	case 166:
 		goto st_case_166
-	case 562:
-		goto st_case_562
+	case 569:
+		goto st_case_569
 	case 167:
 		goto st_case_167
 	case 168:
 		goto st_case_168
-	case 563:
-		goto st_case_563
-	case 564:
-		goto st_case_564
+	case 570:
+		goto st_case_570
+	case 571:
+		goto st_case_571
 	case 169:
 		goto st_case_169
 	case 170:
@@ -2396,122 +2448,144 @@ _resume:
 		goto st_case_171
 	case 172:
 		goto st_case_172
-	case 565:
-		goto st_case_565
-	case 173:
-		goto st_case_173
-	case 566:
-		goto st_case_566
-	case 567:
-		goto st_case_567
-	case 174:
-		goto st_case_174
-	case 568:
-		goto st_case_568
-	case 569:
-		goto st_case_569
-	case 570:
-		goto st_case_570
-	case 571:
-		goto st_case_571
 	case 572:
 		goto st_case_572
+	case 173:
+		goto st_case_173
 	case 573:
 		goto st_case_573
 	case 574:
 		goto st_case_574
+	case 174:
+		goto st_case_174
 	case 575:
 		goto st_case_575
 	case 576:
 		goto st_case_576
+	case 577:
+		goto st_case_577
+	case 578:
+		goto st_case_578
+	case 579:
+		goto st_case_579
+	case 580:
+		goto st_case_580
+	case 581:
+		goto st_case_581
+	case 582:
+		goto st_case_582
+	case 583:
+		goto st_case_583
 	case 175:
 		goto st_case_175
 	case 176:
 		goto st_case_176
 	case 177:
 		goto st_case_177
-	case 577:
-		goto st_case_577
+	case 584:
+		goto st_case_584
 	case 178:
 		goto st_case_178
 	case 179:
 		goto st_case_179
 	case 180:
 		goto st_case_180
-	case 578:
-		goto st_case_578
+	case 585:
+		goto st_case_585
 	case 181:
 		goto st_case_181
 	case 182:
 		goto st_case_182
-	case 579:
-		goto st_case_579
-	case 580:
-		goto st_case_580
-	case 183:
-		goto st_case_183
-	case 184:
-		goto st_case_184
-	case 581:
-		goto st_case_581
-	case 185:
-		goto st_case_185
-	case 186:
-		goto st_case_186
-	case 582:
-		goto st_case_582
-	case 583:
-		goto st_case_583
-	case 584:
-		goto st_case_584
-	case 585:
-		goto st_case_585
 	case 586:
 		goto st_case_586
 	case 587:
 		goto st_case_587
+	case 183:
+		goto st_case_183
+	case 184:
+		goto st_case_184
 	case 588:
 		goto st_case_588
+	case 185:
+		goto st_case_185
+	case 186:
+		goto st_case_186
 	case 589:
 		goto st_case_589
+	case 590:
+		goto st_case_590
+	case 591:
+		goto st_case_591
+	case 592:
+		goto st_case_592
+	case 593:
+		goto st_case_593
+	case 594:
+		goto st_case_594
+	case 595:
+		goto st_case_595
+	case 596:
+		goto st_case_596
 	case 187:
 		goto st_case_187
 	case 188:
 		goto st_case_188
 	case 189:
 		goto st_case_189
-	case 590:
-		goto st_case_590
+	case 597:
+		goto st_case_597
 	case 190:
 		goto st_case_190
 	case 191:
 		goto st_case_191
 	case 192:
 		goto st_case_192
-	case 591:
-		goto st_case_591
+	case 598:
+		goto st_case_598
 	case 193:
 		goto st_case_193
 	case 194:
 		goto st_case_194
-	case 592:
-		goto st_case_592
-	case 593:
-		goto st_case_593
+	case 599:
+		goto st_case_599
+	case 600:
+		goto st_case_600
 	case 195:
 		goto st_case_195
-	case 594:
-		goto st_case_594
+	case 601:
+		goto st_case_601
 	case 196:
 		goto st_case_196
-	case 595:
-		goto st_case_595
-	case 596:
-		goto st_case_596
+	case 602:
+		goto st_case_602
+	case 603:
+		goto st_case_603
 	case 197:
 		goto st_case_197
 	case 198:
 		goto st_case_198
+	case 199:
+		goto st_case_199
+	case 604:
+		goto st_case_604
+	case 605:
+		goto st_case_605
+	case 606:
+		goto st_case_606
+	case 200:
+		goto st_case_200
+	case 201:
+		goto st_case_201
+	case 202:
+		goto st_case_202
+	case 607:
+		goto st_case_607
+	case 203:
+		goto st_case_203
+	case 204:
+		goto st_case_204
+	case 205:
+		goto st_case_205
 	}
 	goto st_out
 	st1:
@@ -2549,7 +2623,7 @@ tr0:
 			goto _test_eof2
 		}
 	st_case_2:
-//line plugins/parsers/influx/machine.go:2553
+//line plugins/parsers/influx/machine.go:2627
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -2585,7 +2659,7 @@ tr60:
 			goto _test_eof3
 		}
 	st_case_3:
-//line plugins/parsers/influx/machine.go:2589
+//line plugins/parsers/influx/machine.go:2663
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -2617,7 +2691,7 @@ tr9:
 			goto _test_eof4
 		}
 	st_case_4:
-//line plugins/parsers/influx/machine.go:2621
+//line plugins/parsers/influx/machine.go:2695
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr5
@@ -2821,7 +2895,7 @@ tr216:
 	{( m.p)++; goto _out }
 
 	goto _again
-//line plugins/parsers/influx/machine.go:2825
+//line plugins/parsers/influx/machine.go:2899
 st_case_0:
 	st0:
 		 m.cs = 0
@@ -2837,7 +2911,7 @@ tr14:
 			goto _test_eof5
 		}
 	st_case_5:
-//line plugins/parsers/influx/machine.go:2841
+//line plugins/parsers/influx/machine.go:2915
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st6
@@ -2888,7 +2962,7 @@ tr25:
 			goto _test_eof7
 		}
 	st_case_7:
-//line plugins/parsers/influx/machine.go:2892
+//line plugins/parsers/influx/machine.go:2966
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -2910,84 +2984,84 @@ tr26:
 
 	m.handler.AddString(key, m.text())
 
-	goto st199
+	goto st206
 tr29:
 //line plugins/parsers/influx/machine.go.rl:104
 
 	m.handler.AddString(key, m.text())
 
-	goto st199
-	st199:
+	goto st206
+	st206:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof199
+			goto _test_eof206
 		}
-	st_case_199:
-//line plugins/parsers/influx/machine.go:2926
+	st_case_206:
+//line plugins/parsers/influx/machine.go:3000
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st200
+			goto st207
 		case 44:
 			goto st9
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st200
+			goto st207
 		}
 		goto tr101
-tr371:
+tr382:
 //line plugins/parsers/influx/machine.go.rl:96
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st200
-tr377:
+	goto st207
+tr388:
 //line plugins/parsers/influx/machine.go.rl:88
 
 	m.handler.AddInt(key, m.text())
 
-	goto st200
-tr381:
+	goto st207
+tr392:
 //line plugins/parsers/influx/machine.go.rl:92
 
 	m.handler.AddUint(key, m.text())
 
-	goto st200
-tr385:
+	goto st207
+tr396:
 //line plugins/parsers/influx/machine.go.rl:100
 
 	m.handler.AddBool(key, m.text())
 
-	goto st200
-	st200:
+	goto st207
+	st207:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof200
+			goto _test_eof207
 		}
-	st_case_200:
-//line plugins/parsers/influx/machine.go:2970
+	st_case_207:
+//line plugins/parsers/influx/machine.go:3044
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st200
+			goto st207
 		case 45:
-			goto tr348
+			goto tr359
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr349
+				goto tr360
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st200
+			goto st207
 		}
 		goto tr31
-tr346:
-	 m.cs = 201
+tr357:
+	 m.cs = 208
 //line plugins/parsers/influx/machine.go.rl:22
 
 	yield = true
@@ -2995,8 +3069,8 @@ tr346:
 	{( m.p)++; goto _out }
 
 	goto _again
-tr351:
-	 m.cs = 201
+tr362:
+	 m.cs = 208
 //line plugins/parsers/influx/machine.go.rl:108
 
 	m.handler.SetTimestamp(m.text())
@@ -3008,8 +3082,8 @@ tr351:
 	{( m.p)++; goto _out }
 
 	goto _again
-tr372:
-	 m.cs = 201
+tr383:
+	 m.cs = 208
 //line plugins/parsers/influx/machine.go.rl:96
 
 	m.handler.AddFloat(key, m.text())
@@ -3021,8 +3095,8 @@ tr372:
 	{( m.p)++; goto _out }
 
 	goto _again
-tr378:
-	 m.cs = 201
+tr389:
+	 m.cs = 208
 //line plugins/parsers/influx/machine.go.rl:88
 
 	m.handler.AddInt(key, m.text())
@@ -3034,8 +3108,8 @@ tr378:
 	{( m.p)++; goto _out }
 
 	goto _again
-tr382:
-	 m.cs = 201
+tr393:
+	 m.cs = 208
 //line plugins/parsers/influx/machine.go.rl:92
 
 	m.handler.AddUint(key, m.text())
@@ -3047,8 +3121,8 @@ tr382:
 	{( m.p)++; goto _out }
 
 	goto _again
-tr386:
-	 m.cs = 201
+tr397:
+	 m.cs = 208
 //line plugins/parsers/influx/machine.go.rl:100
 
 	m.handler.AddBool(key, m.text())
@@ -3060,14 +3134,14 @@ tr386:
 	{( m.p)++; goto _out }
 
 	goto _again
-	st201:
+	st208:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof201
+			goto _test_eof208
 		}
-	st_case_201:
-//line plugins/parsers/influx/machine.go:3069
+	st_case_208:
+//line plugins/parsers/influx/machine.go:3143
 		goto tr1
-tr348:
+tr359:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -3078,208 +3152,30 @@ tr348:
 			goto _test_eof8
 		}
 	st_case_8:
-//line plugins/parsers/influx/machine.go:3082
+//line plugins/parsers/influx/machine.go:3156
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st202
+			goto st209
 		}
 		goto tr31
-tr349:
+tr360:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st202
-	st202:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof202
-		}
-	st_case_202:
-//line plugins/parsers/influx/machine.go:3098
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st204
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto tr31
-tr350:
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st203
-	st203:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof203
-		}
-	st_case_203:
-//line plugins/parsers/influx/machine.go:3127
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr346
-		case 13:
-			goto tr346
-		case 32:
-			goto st203
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st203
-		}
-		goto tr1
-	st204:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof204
-		}
-	st_case_204:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st205
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto tr31
-	st205:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof205
-		}
-	st_case_205:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st206
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto tr31
-	st206:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof206
-		}
-	st_case_206:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st207
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto tr31
-	st207:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof207
-		}
-	st_case_207:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st208
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto tr31
-	st208:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof208
-		}
-	st_case_208:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st209
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto tr31
+	goto st209
 	st209:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof209
 		}
 	st_case_209:
+//line plugins/parsers/influx/machine.go:3172
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st210
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto tr31
-	st210:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof210
-		}
-	st_case_210:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3287,9 +3183,33 @@ tr350:
 				goto st211
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
+tr361:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st210
+	st210:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof210
+		}
+	st_case_210:
+//line plugins/parsers/influx/machine.go:3201
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr357
+		case 13:
+			goto tr357
+		case 32:
+			goto st210
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st210
+		}
+		goto tr1
 	st211:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof211
@@ -3297,11 +3217,11 @@ tr350:
 	st_case_211:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3309,7 +3229,7 @@ tr350:
 				goto st212
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
 	st212:
@@ -3319,11 +3239,11 @@ tr350:
 	st_case_212:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3331,7 +3251,7 @@ tr350:
 				goto st213
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
 	st213:
@@ -3341,11 +3261,11 @@ tr350:
 	st_case_213:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3353,7 +3273,7 @@ tr350:
 				goto st214
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
 	st214:
@@ -3363,11 +3283,11 @@ tr350:
 	st_case_214:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3375,7 +3295,7 @@ tr350:
 				goto st215
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
 	st215:
@@ -3385,11 +3305,11 @@ tr350:
 	st_case_215:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3397,7 +3317,7 @@ tr350:
 				goto st216
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
 	st216:
@@ -3407,11 +3327,11 @@ tr350:
 	st_case_216:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3419,7 +3339,7 @@ tr350:
 				goto st217
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
 	st217:
@@ -3429,11 +3349,11 @@ tr350:
 	st_case_217:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3441,7 +3361,7 @@ tr350:
 				goto st218
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
 	st218:
@@ -3451,11 +3371,11 @@ tr350:
 	st_case_218:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3463,7 +3383,7 @@ tr350:
 				goto st219
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
 	st219:
@@ -3473,11 +3393,11 @@ tr350:
 	st_case_219:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3485,7 +3405,7 @@ tr350:
 				goto st220
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
 	st220:
@@ -3495,11 +3415,11 @@ tr350:
 	st_case_220:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3507,7 +3427,7 @@ tr350:
 				goto st221
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto tr31
 	st221:
@@ -3517,35 +3437,189 @@ tr350:
 	st_case_221:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr350
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st222
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
 		}
 		goto tr31
-tr373:
+	st222:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof222
+		}
+	st_case_222:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st223
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto tr31
+	st223:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof223
+		}
+	st_case_223:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st224
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto tr31
+	st224:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof224
+		}
+	st_case_224:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st225
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto tr31
+	st225:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof225
+		}
+	st_case_225:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st226
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto tr31
+	st226:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof226
+		}
+	st_case_226:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st227
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto tr31
+	st227:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof227
+		}
+	st_case_227:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st228
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto tr31
+	st228:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof228
+		}
+	st_case_228:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr361
+		}
+		goto tr31
+tr384:
 //line plugins/parsers/influx/machine.go.rl:96
 
 	m.handler.AddFloat(key, m.text())
 
 	goto st9
-tr379:
+tr390:
 //line plugins/parsers/influx/machine.go.rl:88
 
 	m.handler.AddInt(key, m.text())
 
 	goto st9
-tr383:
+tr394:
 //line plugins/parsers/influx/machine.go.rl:92
 
 	m.handler.AddUint(key, m.text())
 
 	goto st9
-tr387:
+tr398:
 //line plugins/parsers/influx/machine.go.rl:100
 
 	m.handler.AddBool(key, m.text())
@@ -3556,7 +3630,7 @@ tr387:
 			goto _test_eof9
 		}
 	st_case_9:
-//line plugins/parsers/influx/machine.go:3560
+//line plugins/parsers/influx/machine.go:3634
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr5
@@ -3587,7 +3661,7 @@ tr12:
 			goto _test_eof10
 		}
 	st_case_10:
-//line plugins/parsers/influx/machine.go:3591
+//line plugins/parsers/influx/machine.go:3665
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -3608,7 +3682,7 @@ tr27:
 			goto _test_eof11
 		}
 	st_case_11:
-//line plugins/parsers/influx/machine.go:3612
+//line plugins/parsers/influx/machine.go:3686
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st7
@@ -3627,15 +3701,15 @@ tr17:
 			goto _test_eof12
 		}
 	st_case_12:
-//line plugins/parsers/influx/machine.go:3631
+//line plugins/parsers/influx/machine.go:3705
 		switch ( m.data)[( m.p)] {
 		case 46:
 			goto st13
 		case 48:
-			goto st224
+			goto st231
 		}
 		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st227
+			goto st234
 		}
 		goto tr5
 tr18:
@@ -3649,25 +3723,25 @@ tr18:
 			goto _test_eof13
 		}
 	st_case_13:
-//line plugins/parsers/influx/machine.go:3653
+//line plugins/parsers/influx/machine.go:3727
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st222
+			goto st229
 		}
 		goto tr5
-	st222:
+	st229:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof222
+			goto _test_eof229
 		}
-	st_case_222:
+	st_case_229:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr371
+			goto tr382
 		case 44:
-			goto tr373
+			goto tr384
 		case 69:
 			goto st14
 		case 101:
@@ -3676,10 +3750,10 @@ tr18:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st222
+				goto st229
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr371
+			goto tr382
 		}
 		goto tr101
 	st14:
@@ -3696,7 +3770,7 @@ tr18:
 			goto st15
 		}
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st223
+			goto st230
 		}
 		goto tr5
 	st15:
@@ -3705,237 +3779,23 @@ tr18:
 		}
 	st_case_15:
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st223
+			goto st230
 		}
 		goto tr5
-	st223:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof223
-		}
-	st_case_223:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 13:
-			goto tr372
-		case 32:
-			goto tr371
-		case 44:
-			goto tr373
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st223
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr371
-		}
-		goto tr101
-	st224:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof224
-		}
-	st_case_224:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 13:
-			goto tr372
-		case 32:
-			goto tr371
-		case 44:
-			goto tr373
-		case 46:
-			goto st222
-		case 69:
-			goto st14
-		case 101:
-			goto st14
-		case 105:
-			goto st226
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st225
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr371
-		}
-		goto tr101
-	st225:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof225
-		}
-	st_case_225:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 13:
-			goto tr372
-		case 32:
-			goto tr371
-		case 44:
-			goto tr373
-		case 46:
-			goto st222
-		case 69:
-			goto st14
-		case 101:
-			goto st14
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st225
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr371
-		}
-		goto tr101
-	st226:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof226
-		}
-	st_case_226:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr378
-		case 13:
-			goto tr378
-		case 32:
-			goto tr377
-		case 44:
-			goto tr379
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr377
-		}
-		goto tr101
-	st227:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof227
-		}
-	st_case_227:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 13:
-			goto tr372
-		case 32:
-			goto tr371
-		case 44:
-			goto tr373
-		case 46:
-			goto st222
-		case 69:
-			goto st14
-		case 101:
-			goto st14
-		case 105:
-			goto st226
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st227
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr371
-		}
-		goto tr101
-tr19:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st228
-	st228:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof228
-		}
-	st_case_228:
-//line plugins/parsers/influx/machine.go:3860
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 13:
-			goto tr372
-		case 32:
-			goto tr371
-		case 44:
-			goto tr373
-		case 46:
-			goto st222
-		case 69:
-			goto st14
-		case 101:
-			goto st14
-		case 105:
-			goto st226
-		case 117:
-			goto st229
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st225
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr371
-		}
-		goto tr101
-	st229:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof229
-		}
-	st_case_229:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr382
-		case 13:
-			goto tr382
-		case 32:
-			goto tr381
-		case 44:
-			goto tr383
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr381
-		}
-		goto tr101
-tr20:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st230
 	st230:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof230
 		}
 	st_case_230:
-//line plugins/parsers/influx/machine.go:3920
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr371
+			goto tr382
 		case 44:
-			goto tr373
-		case 46:
-			goto st222
-		case 69:
-			goto st14
-		case 101:
-			goto st14
-		case 105:
-			goto st226
-		case 117:
-			goto st229
+			goto tr384
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -3943,7 +3803,221 @@ tr20:
 				goto st230
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr371
+			goto tr382
+		}
+		goto tr101
+	st231:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof231
+		}
+	st_case_231:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 13:
+			goto tr383
+		case 32:
+			goto tr382
+		case 44:
+			goto tr384
+		case 46:
+			goto st229
+		case 69:
+			goto st14
+		case 101:
+			goto st14
+		case 105:
+			goto st233
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st232
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr382
+		}
+		goto tr101
+	st232:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof232
+		}
+	st_case_232:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 13:
+			goto tr383
+		case 32:
+			goto tr382
+		case 44:
+			goto tr384
+		case 46:
+			goto st229
+		case 69:
+			goto st14
+		case 101:
+			goto st14
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st232
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr382
+		}
+		goto tr101
+	st233:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof233
+		}
+	st_case_233:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr389
+		case 13:
+			goto tr389
+		case 32:
+			goto tr388
+		case 44:
+			goto tr390
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr388
+		}
+		goto tr101
+	st234:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof234
+		}
+	st_case_234:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 13:
+			goto tr383
+		case 32:
+			goto tr382
+		case 44:
+			goto tr384
+		case 46:
+			goto st229
+		case 69:
+			goto st14
+		case 101:
+			goto st14
+		case 105:
+			goto st233
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st234
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr382
+		}
+		goto tr101
+tr19:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st235
+	st235:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof235
+		}
+	st_case_235:
+//line plugins/parsers/influx/machine.go:3934
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 13:
+			goto tr383
+		case 32:
+			goto tr382
+		case 44:
+			goto tr384
+		case 46:
+			goto st229
+		case 69:
+			goto st14
+		case 101:
+			goto st14
+		case 105:
+			goto st233
+		case 117:
+			goto st236
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st232
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr382
+		}
+		goto tr101
+	st236:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof236
+		}
+	st_case_236:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr393
+		case 13:
+			goto tr393
+		case 32:
+			goto tr392
+		case 44:
+			goto tr394
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr392
+		}
+		goto tr101
+tr20:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st237
+	st237:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof237
+		}
+	st_case_237:
+//line plugins/parsers/influx/machine.go:3994
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 13:
+			goto tr383
+		case 32:
+			goto tr382
+		case 44:
+			goto tr384
+		case 46:
+			goto st229
+		case 69:
+			goto st14
+		case 101:
+			goto st14
+		case 105:
+			goto st233
+		case 117:
+			goto st236
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st237
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr382
 		}
 		goto tr101
 tr21:
@@ -3951,29 +4025,29 @@ tr21:
 
 	m.pb = m.p
 
-	goto st231
-	st231:
+	goto st238
+	st238:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof231
+			goto _test_eof238
 		}
-	st_case_231:
-//line plugins/parsers/influx/machine.go:3961
+	st_case_238:
+//line plugins/parsers/influx/machine.go:4035
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr385
+			goto tr396
 		case 44:
-			goto tr387
+			goto tr398
 		case 65:
 			goto st16
 		case 97:
 			goto st19
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr385
+			goto tr396
 		}
 		goto tr101
 	st16:
@@ -4000,26 +4074,26 @@ tr21:
 		}
 	st_case_18:
 		if ( m.data)[( m.p)] == 69 {
-			goto st232
+			goto st239
 		}
 		goto tr5
-	st232:
+	st239:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof232
+			goto _test_eof239
 		}
-	st_case_232:
+	st_case_239:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr385
+			goto tr396
 		case 44:
-			goto tr387
+			goto tr398
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr385
+			goto tr396
 		}
 		goto tr101
 	st19:
@@ -4046,7 +4120,7 @@ tr21:
 		}
 	st_case_21:
 		if ( m.data)[( m.p)] == 101 {
-			goto st232
+			goto st239
 		}
 		goto tr5
 tr22:
@@ -4054,29 +4128,29 @@ tr22:
 
 	m.pb = m.p
 
-	goto st233
-	st233:
+	goto st240
+	st240:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof233
+			goto _test_eof240
 		}
-	st_case_233:
-//line plugins/parsers/influx/machine.go:4064
+	st_case_240:
+//line plugins/parsers/influx/machine.go:4138
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr385
+			goto tr396
 		case 44:
-			goto tr387
+			goto tr398
 		case 82:
 			goto st22
 		case 114:
 			goto st23
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr385
+			goto tr396
 		}
 		goto tr101
 	st22:
@@ -4102,27 +4176,27 @@ tr23:
 
 	m.pb = m.p
 
-	goto st234
-	st234:
+	goto st241
+	st241:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof234
+			goto _test_eof241
 		}
-	st_case_234:
-//line plugins/parsers/influx/machine.go:4112
+	st_case_241:
+//line plugins/parsers/influx/machine.go:4186
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr385
+			goto tr396
 		case 44:
-			goto tr387
+			goto tr398
 		case 97:
 			goto st19
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr385
+			goto tr396
 		}
 		goto tr101
 tr24:
@@ -4130,27 +4204,27 @@ tr24:
 
 	m.pb = m.p
 
-	goto st235
-	st235:
+	goto st242
+	st242:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof235
+			goto _test_eof242
 		}
-	st_case_235:
-//line plugins/parsers/influx/machine.go:4140
+	st_case_242:
+//line plugins/parsers/influx/machine.go:4214
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr385
+			goto tr396
 		case 44:
-			goto tr387
+			goto tr398
 		case 114:
 			goto st23
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr385
+			goto tr396
 		}
 		goto tr101
 tr11:
@@ -4164,7 +4238,7 @@ tr11:
 			goto _test_eof24
 		}
 	st_case_24:
-//line plugins/parsers/influx/machine.go:4168
+//line plugins/parsers/influx/machine.go:4242
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -4196,7 +4270,7 @@ tr6:
 			goto _test_eof25
 		}
 	st_case_25:
-//line plugins/parsers/influx/machine.go:4200
+//line plugins/parsers/influx/machine.go:4274
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -4228,7 +4302,7 @@ tr44:
 			goto _test_eof26
 		}
 	st_case_26:
-//line plugins/parsers/influx/machine.go:4232
+//line plugins/parsers/influx/machine.go:4306
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -4270,7 +4344,7 @@ tr45:
 			goto _test_eof27
 		}
 	st_case_27:
-//line plugins/parsers/influx/machine.go:4274
+//line plugins/parsers/influx/machine.go:4348
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -4308,7 +4382,7 @@ tr63:
 			goto _test_eof28
 		}
 	st_case_28:
-//line plugins/parsers/influx/machine.go:4312
+//line plugins/parsers/influx/machine.go:4386
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr52
@@ -4339,7 +4413,7 @@ tr51:
 			goto _test_eof29
 		}
 	st_case_29:
-//line plugins/parsers/influx/machine.go:4343
+//line plugins/parsers/influx/machine.go:4417
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr52
@@ -4370,7 +4444,7 @@ tr55:
 			goto _test_eof30
 		}
 	st_case_30:
-//line plugins/parsers/influx/machine.go:4374
+//line plugins/parsers/influx/machine.go:4448
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr52
@@ -4401,7 +4475,7 @@ tr57:
 			goto _test_eof31
 		}
 	st_case_31:
-//line plugins/parsers/influx/machine.go:4405
+//line plugins/parsers/influx/machine.go:4479
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr61
@@ -4433,7 +4507,7 @@ tr62:
 			goto _test_eof32
 		}
 	st_case_32:
-//line plugins/parsers/influx/machine.go:4437
+//line plugins/parsers/influx/machine.go:4511
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr61
@@ -4465,7 +4539,7 @@ tr65:
 			goto _test_eof33
 		}
 	st_case_33:
-//line plugins/parsers/influx/machine.go:4469
+//line plugins/parsers/influx/machine.go:4543
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr61
@@ -4507,7 +4581,7 @@ tr66:
 			goto _test_eof34
 		}
 	st_case_34:
-//line plugins/parsers/influx/machine.go:4511
+//line plugins/parsers/influx/machine.go:4585
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr61
@@ -4539,7 +4613,7 @@ tr67:
 			goto _test_eof35
 		}
 	st_case_35:
-//line plugins/parsers/influx/machine.go:4543
+//line plugins/parsers/influx/machine.go:4617
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -4560,7 +4634,7 @@ tr58:
 			goto _test_eof36
 		}
 	st_case_36:
-//line plugins/parsers/influx/machine.go:4564
+//line plugins/parsers/influx/machine.go:4638
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -4581,7 +4655,7 @@ tr53:
 			goto _test_eof37
 		}
 	st_case_37:
-//line plugins/parsers/influx/machine.go:4585
+//line plugins/parsers/influx/machine.go:4659
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -4602,7 +4676,7 @@ tr49:
 			goto _test_eof38
 		}
 	st_case_38:
-//line plugins/parsers/influx/machine.go:4606
+//line plugins/parsers/influx/machine.go:4680
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -4678,7 +4752,7 @@ tr80:
 			goto _test_eof40
 		}
 	st_case_40:
-//line plugins/parsers/influx/machine.go:4682
+//line plugins/parsers/influx/machine.go:4756
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr87
@@ -4726,7 +4800,7 @@ tr237:
 			goto _test_eof41
 		}
 	st_case_41:
-//line plugins/parsers/influx/machine.go:4730
+//line plugins/parsers/influx/machine.go:4804
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st41
@@ -4760,7 +4834,7 @@ tr92:
 			goto _test_eof42
 		}
 	st_case_42:
-//line plugins/parsers/influx/machine.go:4764
+//line plugins/parsers/influx/machine.go:4838
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -4790,13 +4864,13 @@ tr95:
 
 	m.handler.AddString(key, m.text())
 
-	goto st236
+	goto st243
 tr98:
 //line plugins/parsers/influx/machine.go.rl:104
 
 	m.handler.AddString(key, m.text())
 
-	goto st236
+	goto st243
 tr114:
 //line plugins/parsers/influx/machine.go.rl:104
 
@@ -4806,22 +4880,22 @@ tr114:
 
 	m.pb = m.p
 
-	goto st236
-	st236:
+	goto st243
+	st243:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof236
+			goto _test_eof243
 		}
-	st_case_236:
-//line plugins/parsers/influx/machine.go:4816
+	st_case_243:
+//line plugins/parsers/influx/machine.go:4890
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto st237
+			goto st244
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st200
+			goto st207
 		case 44:
 			goto st9
 		case 61:
@@ -4830,27 +4904,27 @@ tr114:
 			goto st10
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st200
+			goto st207
 		}
 		goto st4
-	st237:
+	st244:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof237
+			goto _test_eof244
 		}
-	st_case_237:
+	st_case_244:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto st237
+			goto st244
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st200
+			goto st207
 		case 44:
 			goto tr101
 		case 45:
-			goto tr393
+			goto tr404
 		case 61:
 			goto tr14
 		case 92:
@@ -4859,13 +4933,13 @@ tr114:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr394
+				goto tr405
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st200
+			goto st207
 		}
 		goto st4
-tr393:
+tr404:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -4876,7 +4950,7 @@ tr393:
 			goto _test_eof43
 		}
 	st_case_43:
-//line plugins/parsers/influx/machine.go:4880
+//line plugins/parsers/influx/machine.go:4954
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr101
@@ -4894,275 +4968,33 @@ tr393:
 			}
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st238
+				goto st245
 			}
 		default:
 			goto tr101
 		}
 		goto st4
-tr394:
+tr405:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st238
-	st238:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof238
-		}
-	st_case_238:
-//line plugins/parsers/influx/machine.go:4915
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr395
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr101
-		case 61:
-			goto tr14
-		case 92:
-			goto st10
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st240
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st4
-tr395:
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st239
-	st239:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof239
-		}
-	st_case_239:
-//line plugins/parsers/influx/machine.go:4952
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr346
-		case 11:
-			goto st239
-		case 13:
-			goto tr346
-		case 32:
-			goto st203
-		case 44:
-			goto tr5
-		case 61:
-			goto tr14
-		case 92:
-			goto st10
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st203
-		}
-		goto st4
-	st240:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof240
-		}
-	st_case_240:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr395
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr101
-		case 61:
-			goto tr14
-		case 92:
-			goto st10
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st241
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st4
-	st241:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof241
-		}
-	st_case_241:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr395
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr101
-		case 61:
-			goto tr14
-		case 92:
-			goto st10
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st242
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st4
-	st242:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof242
-		}
-	st_case_242:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr395
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr101
-		case 61:
-			goto tr14
-		case 92:
-			goto st10
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st243
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st4
-	st243:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof243
-		}
-	st_case_243:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr395
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr101
-		case 61:
-			goto tr14
-		case 92:
-			goto st10
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st244
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st4
-	st244:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof244
-		}
-	st_case_244:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr395
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr101
-		case 61:
-			goto tr14
-		case 92:
-			goto st10
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st245
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st4
+	goto st245
 	st245:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof245
 		}
 	st_case_245:
+//line plugins/parsers/influx/machine.go:4989
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
-		case 44:
-			goto tr101
-		case 61:
-			goto tr14
-		case 92:
-			goto st10
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st246
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st4
-	st246:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof246
-		}
-	st_case_246:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr395
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5176,7 +5008,39 @@ tr395:
 				goto st247
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
+		}
+		goto st4
+tr406:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st246
+	st246:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof246
+		}
+	st_case_246:
+//line plugins/parsers/influx/machine.go:5026
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr357
+		case 11:
+			goto st246
+		case 13:
+			goto tr357
+		case 32:
+			goto st210
+		case 44:
+			goto tr5
+		case 61:
+			goto tr14
+		case 92:
+			goto st10
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st210
 		}
 		goto st4
 	st247:
@@ -5186,13 +5050,13 @@ tr395:
 	st_case_247:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5206,7 +5070,7 @@ tr395:
 				goto st248
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st4
 	st248:
@@ -5216,13 +5080,13 @@ tr395:
 	st_case_248:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5236,7 +5100,7 @@ tr395:
 				goto st249
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st4
 	st249:
@@ -5246,13 +5110,13 @@ tr395:
 	st_case_249:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5266,7 +5130,7 @@ tr395:
 				goto st250
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st4
 	st250:
@@ -5276,13 +5140,13 @@ tr395:
 	st_case_250:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5296,7 +5160,7 @@ tr395:
 				goto st251
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st4
 	st251:
@@ -5306,13 +5170,13 @@ tr395:
 	st_case_251:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5326,7 +5190,7 @@ tr395:
 				goto st252
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st4
 	st252:
@@ -5336,13 +5200,13 @@ tr395:
 	st_case_252:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5356,7 +5220,7 @@ tr395:
 				goto st253
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st4
 	st253:
@@ -5366,13 +5230,13 @@ tr395:
 	st_case_253:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5386,7 +5250,7 @@ tr395:
 				goto st254
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st4
 	st254:
@@ -5396,13 +5260,13 @@ tr395:
 	st_case_254:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5416,7 +5280,7 @@ tr395:
 				goto st255
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st4
 	st255:
@@ -5426,13 +5290,13 @@ tr395:
 	st_case_255:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5446,7 +5310,7 @@ tr395:
 				goto st256
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st4
 	st256:
@@ -5456,13 +5320,13 @@ tr395:
 	st_case_256:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5476,7 +5340,7 @@ tr395:
 				goto st257
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st4
 	st257:
@@ -5486,13 +5350,223 @@ tr395:
 	st_case_257:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr395
+			goto tr406
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
+		case 44:
+			goto tr101
+		case 61:
+			goto tr14
+		case 92:
+			goto st10
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st258
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st4
+	st258:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof258
+		}
+	st_case_258:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr406
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr101
+		case 61:
+			goto tr14
+		case 92:
+			goto st10
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st259
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st4
+	st259:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof259
+		}
+	st_case_259:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr406
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr101
+		case 61:
+			goto tr14
+		case 92:
+			goto st10
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st260
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st4
+	st260:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof260
+		}
+	st_case_260:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr406
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr101
+		case 61:
+			goto tr14
+		case 92:
+			goto st10
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st261
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st4
+	st261:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof261
+		}
+	st_case_261:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr406
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr101
+		case 61:
+			goto tr14
+		case 92:
+			goto st10
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st262
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st4
+	st262:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof262
+		}
+	st_case_262:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr406
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr101
+		case 61:
+			goto tr14
+		case 92:
+			goto st10
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st263
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st4
+	st263:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof263
+		}
+	st_case_263:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr406
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr101
+		case 61:
+			goto tr14
+		case 92:
+			goto st10
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st264
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st4
+	st264:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof264
+		}
+	st_case_264:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr406
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
 		case 44:
 			goto tr101
 		case 61:
@@ -5501,7 +5575,7 @@ tr395:
 			goto st10
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr350
+			goto tr361
 		}
 		goto st4
 tr99:
@@ -5515,7 +5589,7 @@ tr99:
 			goto _test_eof44
 		}
 	st_case_44:
-//line plugins/parsers/influx/machine.go:5519
+//line plugins/parsers/influx/machine.go:5593
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -5552,95 +5626,95 @@ tr103:
 
 	m.handler.AddString(key, m.text())
 
-	goto st258
-	st258:
+	goto st265
+	st265:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof258
+			goto _test_eof265
 		}
-	st_case_258:
-//line plugins/parsers/influx/machine.go:5562
+	st_case_265:
+//line plugins/parsers/influx/machine.go:5636
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 12:
-			goto st200
+			goto st207
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr415
+			goto tr426
 		case 34:
 			goto tr26
 		case 44:
-			goto tr416
+			goto tr427
 		case 92:
 			goto tr27
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr415
+			goto tr426
 		}
 		goto tr25
-tr415:
+tr426:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st259
-tr441:
+	goto st266
+tr452:
 //line plugins/parsers/influx/machine.go.rl:96
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st259
-tr446:
+	goto st266
+tr457:
 //line plugins/parsers/influx/machine.go.rl:88
 
 	m.handler.AddInt(key, m.text())
 
-	goto st259
-tr449:
+	goto st266
+tr460:
 //line plugins/parsers/influx/machine.go.rl:92
 
 	m.handler.AddUint(key, m.text())
 
-	goto st259
-tr452:
+	goto st266
+tr463:
 //line plugins/parsers/influx/machine.go.rl:100
 
 	m.handler.AddBool(key, m.text())
 
-	goto st259
-	st259:
+	goto st266
+	st266:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof259
+			goto _test_eof266
 		}
-	st_case_259:
-//line plugins/parsers/influx/machine.go:5618
+	st_case_266:
+//line plugins/parsers/influx/machine.go:5692
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 12:
-			goto st200
+			goto st207
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st259
+			goto st266
 		case 34:
 			goto tr29
 		case 45:
-			goto tr418
+			goto tr429
 		case 92:
 			goto st11
 		}
 		switch {
 		case ( m.data)[( m.p)] > 11:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr419
+				goto tr430
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st259
+			goto st266
 		}
 		goto st7
-tr418:
+tr429:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -5651,7 +5725,7 @@ tr418:
 			goto _test_eof45
 		}
 	st_case_45:
-//line plugins/parsers/influx/machine.go:5655
+//line plugins/parsers/influx/machine.go:5729
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr101
@@ -5663,259 +5737,33 @@ tr418:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st260
+				goto st267
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr101
 		}
 		goto st7
-tr419:
+tr430:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st260
-	st260:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof260
-		}
-	st_case_260:
-//line plugins/parsers/influx/machine.go:5684
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 12:
-			goto tr350
-		case 13:
-			goto tr351
-		case 32:
-			goto tr420
-		case 34:
-			goto tr29
-		case 92:
-			goto st11
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st262
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr420
-		}
-		goto st7
-tr420:
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st261
-	st261:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof261
-		}
-	st_case_261:
-//line plugins/parsers/influx/machine.go:5719
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr346
-		case 12:
-			goto st203
-		case 13:
-			goto tr346
-		case 32:
-			goto st261
-		case 34:
-			goto tr29
-		case 92:
-			goto st11
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto st261
-		}
-		goto st7
-	st262:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof262
-		}
-	st_case_262:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 12:
-			goto tr350
-		case 13:
-			goto tr351
-		case 32:
-			goto tr420
-		case 34:
-			goto tr29
-		case 92:
-			goto st11
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st263
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr420
-		}
-		goto st7
-	st263:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof263
-		}
-	st_case_263:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 12:
-			goto tr350
-		case 13:
-			goto tr351
-		case 32:
-			goto tr420
-		case 34:
-			goto tr29
-		case 92:
-			goto st11
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st264
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr420
-		}
-		goto st7
-	st264:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof264
-		}
-	st_case_264:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 12:
-			goto tr350
-		case 13:
-			goto tr351
-		case 32:
-			goto tr420
-		case 34:
-			goto tr29
-		case 92:
-			goto st11
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st265
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr420
-		}
-		goto st7
-	st265:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof265
-		}
-	st_case_265:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 12:
-			goto tr350
-		case 13:
-			goto tr351
-		case 32:
-			goto tr420
-		case 34:
-			goto tr29
-		case 92:
-			goto st11
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st266
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr420
-		}
-		goto st7
-	st266:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof266
-		}
-	st_case_266:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 12:
-			goto tr350
-		case 13:
-			goto tr351
-		case 32:
-			goto tr420
-		case 34:
-			goto tr29
-		case 92:
-			goto st11
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st267
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr420
-		}
-		goto st7
+	goto st267
 	st267:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof267
 		}
 	st_case_267:
+//line plugins/parsers/influx/machine.go:5758
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
-		case 34:
-			goto tr29
-		case 92:
-			goto st11
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st268
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr420
-		}
-		goto st7
-	st268:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof268
-		}
-	st_case_268:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 12:
-			goto tr350
-		case 13:
-			goto tr351
-		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -5927,7 +5775,37 @@ tr420:
 				goto st269
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
+		}
+		goto st7
+tr431:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st268
+	st268:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof268
+		}
+	st_case_268:
+//line plugins/parsers/influx/machine.go:5793
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr357
+		case 12:
+			goto st210
+		case 13:
+			goto tr357
+		case 32:
+			goto st268
+		case 34:
+			goto tr29
+		case 92:
+			goto st11
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
+			goto st268
 		}
 		goto st7
 	st269:
@@ -5937,13 +5815,13 @@ tr420:
 	st_case_269:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -5955,7 +5833,7 @@ tr420:
 				goto st270
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
 		}
 		goto st7
 	st270:
@@ -5965,13 +5843,13 @@ tr420:
 	st_case_270:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -5983,7 +5861,7 @@ tr420:
 				goto st271
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
 		}
 		goto st7
 	st271:
@@ -5993,13 +5871,13 @@ tr420:
 	st_case_271:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -6011,7 +5889,7 @@ tr420:
 				goto st272
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
 		}
 		goto st7
 	st272:
@@ -6021,13 +5899,13 @@ tr420:
 	st_case_272:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -6039,7 +5917,7 @@ tr420:
 				goto st273
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
 		}
 		goto st7
 	st273:
@@ -6049,13 +5927,13 @@ tr420:
 	st_case_273:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -6067,7 +5945,7 @@ tr420:
 				goto st274
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
 		}
 		goto st7
 	st274:
@@ -6077,13 +5955,13 @@ tr420:
 	st_case_274:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -6095,7 +5973,7 @@ tr420:
 				goto st275
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
 		}
 		goto st7
 	st275:
@@ -6105,13 +5983,13 @@ tr420:
 	st_case_275:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -6123,7 +6001,7 @@ tr420:
 				goto st276
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
 		}
 		goto st7
 	st276:
@@ -6133,13 +6011,13 @@ tr420:
 	st_case_276:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -6151,7 +6029,7 @@ tr420:
 				goto st277
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
 		}
 		goto st7
 	st277:
@@ -6161,13 +6039,13 @@ tr420:
 	st_case_277:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -6179,7 +6057,7 @@ tr420:
 				goto st278
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
 		}
 		goto st7
 	st278:
@@ -6189,13 +6067,13 @@ tr420:
 	st_case_278:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
@@ -6207,7 +6085,7 @@ tr420:
 				goto st279
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr420
+			goto tr431
 		}
 		goto st7
 	st279:
@@ -6217,47 +6095,243 @@ tr420:
 	st_case_279:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 12:
-			goto tr350
+			goto tr361
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr420
+			goto tr431
+		case 34:
+			goto tr29
+		case 92:
+			goto st11
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st280
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr431
+		}
+		goto st7
+	st280:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof280
+		}
+	st_case_280:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 12:
+			goto tr361
+		case 13:
+			goto tr362
+		case 32:
+			goto tr431
+		case 34:
+			goto tr29
+		case 92:
+			goto st11
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st281
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr431
+		}
+		goto st7
+	st281:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof281
+		}
+	st_case_281:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 12:
+			goto tr361
+		case 13:
+			goto tr362
+		case 32:
+			goto tr431
+		case 34:
+			goto tr29
+		case 92:
+			goto st11
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st282
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr431
+		}
+		goto st7
+	st282:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof282
+		}
+	st_case_282:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 12:
+			goto tr361
+		case 13:
+			goto tr362
+		case 32:
+			goto tr431
+		case 34:
+			goto tr29
+		case 92:
+			goto st11
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st283
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr431
+		}
+		goto st7
+	st283:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof283
+		}
+	st_case_283:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 12:
+			goto tr361
+		case 13:
+			goto tr362
+		case 32:
+			goto tr431
+		case 34:
+			goto tr29
+		case 92:
+			goto st11
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st284
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr431
+		}
+		goto st7
+	st284:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof284
+		}
+	st_case_284:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 12:
+			goto tr361
+		case 13:
+			goto tr362
+		case 32:
+			goto tr431
+		case 34:
+			goto tr29
+		case 92:
+			goto st11
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st285
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr431
+		}
+		goto st7
+	st285:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof285
+		}
+	st_case_285:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 12:
+			goto tr361
+		case 13:
+			goto tr362
+		case 32:
+			goto tr431
+		case 34:
+			goto tr29
+		case 92:
+			goto st11
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st286
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr431
+		}
+		goto st7
+	st286:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof286
+		}
+	st_case_286:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 12:
+			goto tr361
+		case 13:
+			goto tr362
+		case 32:
+			goto tr431
 		case 34:
 			goto tr29
 		case 92:
 			goto st11
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr420
+			goto tr431
 		}
 		goto st7
-tr416:
+tr427:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
 	goto st46
-tr458:
+tr469:
 //line plugins/parsers/influx/machine.go.rl:96
 
 	m.handler.AddFloat(key, m.text())
 
 	goto st46
-tr462:
+tr473:
 //line plugins/parsers/influx/machine.go.rl:88
 
 	m.handler.AddInt(key, m.text())
 
 	goto st46
-tr464:
+tr475:
 //line plugins/parsers/influx/machine.go.rl:92
 
 	m.handler.AddUint(key, m.text())
 
 	goto st46
-tr466:
+tr477:
 //line plugins/parsers/influx/machine.go.rl:100
 
 	m.handler.AddBool(key, m.text())
@@ -6268,7 +6342,7 @@ tr466:
 			goto _test_eof46
 		}
 	st_case_46:
-//line plugins/parsers/influx/machine.go:6272
+//line plugins/parsers/influx/machine.go:6346
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -6300,7 +6374,7 @@ tr113:
 			goto _test_eof47
 		}
 	st_case_47:
-//line plugins/parsers/influx/machine.go:6304
+//line plugins/parsers/influx/machine.go:6378
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -6332,7 +6406,7 @@ tr117:
 			goto _test_eof48
 		}
 	st_case_48:
-//line plugins/parsers/influx/machine.go:6336
+//line plugins/parsers/influx/machine.go:6410
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -6369,58 +6443,58 @@ tr119:
 
 	m.handler.AddString(key, m.text())
 
-	goto st280
-	st280:
+	goto st287
+	st287:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof280
+			goto _test_eof287
 		}
-	st_case_280:
-//line plugins/parsers/influx/machine.go:6379
+	st_case_287:
+//line plugins/parsers/influx/machine.go:6453
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 12:
-			goto st200
+			goto st207
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr415
+			goto tr426
 		case 34:
 			goto tr26
 		case 44:
-			goto tr440
+			goto tr451
 		case 92:
 			goto tr27
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr415
+			goto tr426
 		}
 		goto tr25
-tr440:
+tr451:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
 	goto st49
-tr442:
+tr453:
 //line plugins/parsers/influx/machine.go.rl:96
 
 	m.handler.AddFloat(key, m.text())
 
 	goto st49
-tr447:
+tr458:
 //line plugins/parsers/influx/machine.go.rl:88
 
 	m.handler.AddInt(key, m.text())
 
 	goto st49
-tr450:
+tr461:
 //line plugins/parsers/influx/machine.go.rl:92
 
 	m.handler.AddUint(key, m.text())
 
 	goto st49
-tr453:
+tr464:
 //line plugins/parsers/influx/machine.go.rl:100
 
 	m.handler.AddBool(key, m.text())
@@ -6431,7 +6505,7 @@ tr453:
 			goto _test_eof49
 		}
 	st_case_49:
-//line plugins/parsers/influx/machine.go:6435
+//line plugins/parsers/influx/machine.go:6509
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -6463,7 +6537,7 @@ tr120:
 			goto _test_eof50
 		}
 	st_case_50:
-//line plugins/parsers/influx/machine.go:6467
+//line plugins/parsers/influx/machine.go:6541
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -6495,7 +6569,7 @@ tr123:
 			goto _test_eof51
 		}
 	st_case_51:
-//line plugins/parsers/influx/machine.go:6499
+//line plugins/parsers/influx/machine.go:6573
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -6538,7 +6612,7 @@ tr125:
 			goto _test_eof52
 		}
 	st_case_52:
-//line plugins/parsers/influx/machine.go:6542
+//line plugins/parsers/influx/machine.go:6616
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -6547,14 +6621,14 @@ tr125:
 		case 46:
 			goto st53
 		case 48:
-			goto st284
+			goto st291
 		case 92:
 			goto st11
 		}
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st287
+				goto st294
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr5
@@ -6571,7 +6645,7 @@ tr126:
 			goto _test_eof53
 		}
 	st_case_53:
-//line plugins/parsers/influx/machine.go:6575
+//line plugins/parsers/influx/machine.go:6649
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -6583,30 +6657,30 @@ tr126:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st281
+				goto st288
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr5
 		}
 		goto st7
-	st281:
+	st288:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof281
+			goto _test_eof288
 		}
-	st_case_281:
+	st_case_288:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 12:
-			goto tr371
+			goto tr382
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr441
+			goto tr452
 		case 34:
 			goto tr29
 		case 44:
-			goto tr442
+			goto tr453
 		case 69:
 			goto st54
 		case 92:
@@ -6617,10 +6691,10 @@ tr126:
 		switch {
 		case ( m.data)[( m.p)] > 11:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st281
+				goto st288
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr441
+			goto tr452
 		}
 		goto st7
 	st54:
@@ -6643,7 +6717,7 @@ tr126:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st283
+				goto st290
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr5
@@ -6654,30 +6728,30 @@ tr137:
 
 	m.handler.AddString(key, m.text())
 
-	goto st282
-	st282:
+	goto st289
+	st289:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof282
+			goto _test_eof289
 		}
-	st_case_282:
-//line plugins/parsers/influx/machine.go:6664
+	st_case_289:
+//line plugins/parsers/influx/machine.go:6738
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st200
+			goto st207
 		case 44:
 			goto st9
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st223
+				goto st230
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st200
+			goto st207
 		}
 		goto tr101
 	st55:
@@ -6696,288 +6770,32 @@ tr137:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st283
+				goto st290
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr5
 		}
 		goto st7
-	st283:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof283
-		}
-	st_case_283:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 12:
-			goto tr371
-		case 13:
-			goto tr372
-		case 32:
-			goto tr441
-		case 34:
-			goto tr29
-		case 44:
-			goto tr442
-		case 92:
-			goto st11
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st283
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr441
-		}
-		goto st7
-	st284:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof284
-		}
-	st_case_284:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 12:
-			goto tr371
-		case 13:
-			goto tr372
-		case 32:
-			goto tr441
-		case 34:
-			goto tr29
-		case 44:
-			goto tr442
-		case 46:
-			goto st281
-		case 69:
-			goto st54
-		case 92:
-			goto st11
-		case 101:
-			goto st54
-		case 105:
-			goto st286
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st285
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr441
-		}
-		goto st7
-	st285:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof285
-		}
-	st_case_285:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 12:
-			goto tr371
-		case 13:
-			goto tr372
-		case 32:
-			goto tr441
-		case 34:
-			goto tr29
-		case 44:
-			goto tr442
-		case 46:
-			goto st281
-		case 69:
-			goto st54
-		case 92:
-			goto st11
-		case 101:
-			goto st54
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st285
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr441
-		}
-		goto st7
-	st286:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof286
-		}
-	st_case_286:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr378
-		case 12:
-			goto tr377
-		case 13:
-			goto tr378
-		case 32:
-			goto tr446
-		case 34:
-			goto tr29
-		case 44:
-			goto tr447
-		case 92:
-			goto st11
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr446
-		}
-		goto st7
-	st287:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof287
-		}
-	st_case_287:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 12:
-			goto tr371
-		case 13:
-			goto tr372
-		case 32:
-			goto tr441
-		case 34:
-			goto tr29
-		case 44:
-			goto tr442
-		case 46:
-			goto st281
-		case 69:
-			goto st54
-		case 92:
-			goto st11
-		case 101:
-			goto st54
-		case 105:
-			goto st286
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st287
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr441
-		}
-		goto st7
-tr127:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st288
-	st288:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof288
-		}
-	st_case_288:
-//line plugins/parsers/influx/machine.go:6884
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 12:
-			goto tr371
-		case 13:
-			goto tr372
-		case 32:
-			goto tr441
-		case 34:
-			goto tr29
-		case 44:
-			goto tr442
-		case 46:
-			goto st281
-		case 69:
-			goto st54
-		case 92:
-			goto st11
-		case 101:
-			goto st54
-		case 105:
-			goto st286
-		case 117:
-			goto st289
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st285
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr441
-		}
-		goto st7
-	st289:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof289
-		}
-	st_case_289:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr382
-		case 12:
-			goto tr381
-		case 13:
-			goto tr382
-		case 32:
-			goto tr449
-		case 34:
-			goto tr29
-		case 44:
-			goto tr450
-		case 92:
-			goto st11
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr449
-		}
-		goto st7
-tr128:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st290
 	st290:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof290
 		}
 	st_case_290:
-//line plugins/parsers/influx/machine.go:6956
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 12:
-			goto tr371
+			goto tr382
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr441
+			goto tr452
 		case 34:
 			goto tr29
 		case 44:
-			goto tr442
-		case 46:
-			goto st281
-		case 69:
-			goto st54
+			goto tr453
 		case 92:
 			goto st11
-		case 101:
-			goto st54
-		case 105:
-			goto st286
-		case 117:
-			goto st289
 		}
 		switch {
 		case ( m.data)[( m.p)] > 11:
@@ -6985,7 +6803,263 @@ tr128:
 				goto st290
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr441
+			goto tr452
+		}
+		goto st7
+	st291:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof291
+		}
+	st_case_291:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 12:
+			goto tr382
+		case 13:
+			goto tr383
+		case 32:
+			goto tr452
+		case 34:
+			goto tr29
+		case 44:
+			goto tr453
+		case 46:
+			goto st288
+		case 69:
+			goto st54
+		case 92:
+			goto st11
+		case 101:
+			goto st54
+		case 105:
+			goto st293
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st292
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr452
+		}
+		goto st7
+	st292:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof292
+		}
+	st_case_292:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 12:
+			goto tr382
+		case 13:
+			goto tr383
+		case 32:
+			goto tr452
+		case 34:
+			goto tr29
+		case 44:
+			goto tr453
+		case 46:
+			goto st288
+		case 69:
+			goto st54
+		case 92:
+			goto st11
+		case 101:
+			goto st54
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st292
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr452
+		}
+		goto st7
+	st293:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof293
+		}
+	st_case_293:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr389
+		case 12:
+			goto tr388
+		case 13:
+			goto tr389
+		case 32:
+			goto tr457
+		case 34:
+			goto tr29
+		case 44:
+			goto tr458
+		case 92:
+			goto st11
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
+			goto tr457
+		}
+		goto st7
+	st294:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof294
+		}
+	st_case_294:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 12:
+			goto tr382
+		case 13:
+			goto tr383
+		case 32:
+			goto tr452
+		case 34:
+			goto tr29
+		case 44:
+			goto tr453
+		case 46:
+			goto st288
+		case 69:
+			goto st54
+		case 92:
+			goto st11
+		case 101:
+			goto st54
+		case 105:
+			goto st293
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st294
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr452
+		}
+		goto st7
+tr127:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st295
+	st295:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof295
+		}
+	st_case_295:
+//line plugins/parsers/influx/machine.go:6958
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 12:
+			goto tr382
+		case 13:
+			goto tr383
+		case 32:
+			goto tr452
+		case 34:
+			goto tr29
+		case 44:
+			goto tr453
+		case 46:
+			goto st288
+		case 69:
+			goto st54
+		case 92:
+			goto st11
+		case 101:
+			goto st54
+		case 105:
+			goto st293
+		case 117:
+			goto st296
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st292
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr452
+		}
+		goto st7
+	st296:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof296
+		}
+	st_case_296:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr393
+		case 12:
+			goto tr392
+		case 13:
+			goto tr393
+		case 32:
+			goto tr460
+		case 34:
+			goto tr29
+		case 44:
+			goto tr461
+		case 92:
+			goto st11
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
+			goto tr460
+		}
+		goto st7
+tr128:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st297
+	st297:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof297
+		}
+	st_case_297:
+//line plugins/parsers/influx/machine.go:7030
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 12:
+			goto tr382
+		case 13:
+			goto tr383
+		case 32:
+			goto tr452
+		case 34:
+			goto tr29
+		case 44:
+			goto tr453
+		case 46:
+			goto st288
+		case 69:
+			goto st54
+		case 92:
+			goto st11
+		case 101:
+			goto st54
+		case 105:
+			goto st293
+		case 117:
+			goto st296
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st297
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr452
 		}
 		goto st7
 tr129:
@@ -6993,26 +7067,26 @@ tr129:
 
 	m.pb = m.p
 
-	goto st291
-	st291:
+	goto st298
+	st298:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof291
+			goto _test_eof298
 		}
-	st_case_291:
-//line plugins/parsers/influx/machine.go:7003
+	st_case_298:
+//line plugins/parsers/influx/machine.go:7077
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 12:
-			goto tr385
+			goto tr396
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr452
+			goto tr463
 		case 34:
 			goto tr29
 		case 44:
-			goto tr453
+			goto tr464
 		case 65:
 			goto st56
 		case 92:
@@ -7021,7 +7095,7 @@ tr129:
 			goto st59
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr452
+			goto tr463
 		}
 		goto st7
 	st56:
@@ -7073,7 +7147,7 @@ tr129:
 		case 34:
 			goto tr29
 		case 69:
-			goto st292
+			goto st299
 		case 92:
 			goto st11
 		}
@@ -7081,29 +7155,29 @@ tr129:
 			goto tr5
 		}
 		goto st7
-	st292:
+	st299:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof292
+			goto _test_eof299
 		}
-	st_case_292:
+	st_case_299:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 12:
-			goto tr385
+			goto tr396
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr452
+			goto tr463
 		case 34:
 			goto tr29
 		case 44:
-			goto tr453
+			goto tr464
 		case 92:
 			goto st11
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr452
+			goto tr463
 		}
 		goto st7
 	st59:
@@ -7157,7 +7231,7 @@ tr129:
 		case 92:
 			goto st11
 		case 101:
-			goto st292
+			goto st299
 		}
 		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
 			goto tr5
@@ -7168,26 +7242,26 @@ tr130:
 
 	m.pb = m.p
 
-	goto st293
-	st293:
+	goto st300
+	st300:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof293
+			goto _test_eof300
 		}
-	st_case_293:
-//line plugins/parsers/influx/machine.go:7178
+	st_case_300:
+//line plugins/parsers/influx/machine.go:7252
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 12:
-			goto tr385
+			goto tr396
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr452
+			goto tr463
 		case 34:
 			goto tr29
 		case 44:
-			goto tr453
+			goto tr464
 		case 82:
 			goto st62
 		case 92:
@@ -7196,7 +7270,7 @@ tr130:
 			goto st63
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr452
+			goto tr463
 		}
 		goto st7
 	st62:
@@ -7242,33 +7316,33 @@ tr131:
 
 	m.pb = m.p
 
-	goto st294
-	st294:
+	goto st301
+	st301:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof294
+			goto _test_eof301
 		}
-	st_case_294:
-//line plugins/parsers/influx/machine.go:7252
+	st_case_301:
+//line plugins/parsers/influx/machine.go:7326
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 12:
-			goto tr385
+			goto tr396
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr452
+			goto tr463
 		case 34:
 			goto tr29
 		case 44:
-			goto tr453
+			goto tr464
 		case 92:
 			goto st11
 		case 97:
 			goto st59
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr452
+			goto tr463
 		}
 		goto st7
 tr132:
@@ -7276,33 +7350,33 @@ tr132:
 
 	m.pb = m.p
 
-	goto st295
-	st295:
+	goto st302
+	st302:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof295
+			goto _test_eof302
 		}
-	st_case_295:
-//line plugins/parsers/influx/machine.go:7286
+	st_case_302:
+//line plugins/parsers/influx/machine.go:7360
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 12:
-			goto tr385
+			goto tr396
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr452
+			goto tr463
 		case 34:
 			goto tr29
 		case 44:
-			goto tr453
+			goto tr464
 		case 92:
 			goto st11
 		case 114:
 			goto st63
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr452
+			goto tr463
 		}
 		goto st7
 tr121:
@@ -7316,7 +7390,7 @@ tr121:
 			goto _test_eof64
 		}
 	st_case_64:
-//line plugins/parsers/influx/machine.go:7320
+//line plugins/parsers/influx/machine.go:7394
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st50
@@ -7343,7 +7417,7 @@ tr104:
 			goto _test_eof65
 		}
 	st_case_65:
-//line plugins/parsers/influx/machine.go:7347
+//line plugins/parsers/influx/machine.go:7421
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -7352,14 +7426,14 @@ tr104:
 		case 46:
 			goto st66
 		case 48:
-			goto st298
+			goto st305
 		case 92:
 			goto st11
 		}
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st301
+				goto st308
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr5
@@ -7376,7 +7450,7 @@ tr105:
 			goto _test_eof66
 		}
 	st_case_66:
-//line plugins/parsers/influx/machine.go:7380
+//line plugins/parsers/influx/machine.go:7454
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -7388,30 +7462,30 @@ tr105:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st296
+				goto st303
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr5
 		}
 		goto st7
-	st296:
+	st303:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof296
+			goto _test_eof303
 		}
-	st_case_296:
+	st_case_303:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 12:
-			goto tr371
+			goto tr382
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr441
+			goto tr452
 		case 34:
 			goto tr29
 		case 44:
-			goto tr458
+			goto tr469
 		case 69:
 			goto st67
 		case 92:
@@ -7422,10 +7496,10 @@ tr105:
 		switch {
 		case ( m.data)[( m.p)] > 11:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st296
+				goto st303
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr441
+			goto tr452
 		}
 		goto st7
 	st67:
@@ -7448,7 +7522,7 @@ tr105:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st297
+				goto st304
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr5
@@ -7470,288 +7544,32 @@ tr105:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st297
+				goto st304
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr5
 		}
 		goto st7
-	st297:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof297
-		}
-	st_case_297:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 12:
-			goto tr371
-		case 13:
-			goto tr372
-		case 32:
-			goto tr441
-		case 34:
-			goto tr29
-		case 44:
-			goto tr458
-		case 92:
-			goto st11
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st297
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr441
-		}
-		goto st7
-	st298:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof298
-		}
-	st_case_298:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 12:
-			goto tr371
-		case 13:
-			goto tr372
-		case 32:
-			goto tr441
-		case 34:
-			goto tr29
-		case 44:
-			goto tr458
-		case 46:
-			goto st296
-		case 69:
-			goto st67
-		case 92:
-			goto st11
-		case 101:
-			goto st67
-		case 105:
-			goto st300
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st299
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr441
-		}
-		goto st7
-	st299:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof299
-		}
-	st_case_299:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 12:
-			goto tr371
-		case 13:
-			goto tr372
-		case 32:
-			goto tr441
-		case 34:
-			goto tr29
-		case 44:
-			goto tr458
-		case 46:
-			goto st296
-		case 69:
-			goto st67
-		case 92:
-			goto st11
-		case 101:
-			goto st67
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st299
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr441
-		}
-		goto st7
-	st300:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof300
-		}
-	st_case_300:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr378
-		case 12:
-			goto tr377
-		case 13:
-			goto tr378
-		case 32:
-			goto tr446
-		case 34:
-			goto tr29
-		case 44:
-			goto tr462
-		case 92:
-			goto st11
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr446
-		}
-		goto st7
-	st301:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof301
-		}
-	st_case_301:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 12:
-			goto tr371
-		case 13:
-			goto tr372
-		case 32:
-			goto tr441
-		case 34:
-			goto tr29
-		case 44:
-			goto tr458
-		case 46:
-			goto st296
-		case 69:
-			goto st67
-		case 92:
-			goto st11
-		case 101:
-			goto st67
-		case 105:
-			goto st300
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st301
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr441
-		}
-		goto st7
-tr106:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st302
-	st302:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof302
-		}
-	st_case_302:
-//line plugins/parsers/influx/machine.go:7658
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 12:
-			goto tr371
-		case 13:
-			goto tr372
-		case 32:
-			goto tr441
-		case 34:
-			goto tr29
-		case 44:
-			goto tr458
-		case 46:
-			goto st296
-		case 69:
-			goto st67
-		case 92:
-			goto st11
-		case 101:
-			goto st67
-		case 105:
-			goto st300
-		case 117:
-			goto st303
-		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st299
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr441
-		}
-		goto st7
-	st303:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof303
-		}
-	st_case_303:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr382
-		case 12:
-			goto tr381
-		case 13:
-			goto tr382
-		case 32:
-			goto tr449
-		case 34:
-			goto tr29
-		case 44:
-			goto tr464
-		case 92:
-			goto st11
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr449
-		}
-		goto st7
-tr107:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st304
 	st304:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof304
 		}
 	st_case_304:
-//line plugins/parsers/influx/machine.go:7730
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 12:
-			goto tr371
+			goto tr382
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr441
+			goto tr452
 		case 34:
 			goto tr29
 		case 44:
-			goto tr458
-		case 46:
-			goto st296
-		case 69:
-			goto st67
+			goto tr469
 		case 92:
 			goto st11
-		case 101:
-			goto st67
-		case 105:
-			goto st300
-		case 117:
-			goto st303
 		}
 		switch {
 		case ( m.data)[( m.p)] > 11:
@@ -7759,7 +7577,263 @@ tr107:
 				goto st304
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr441
+			goto tr452
+		}
+		goto st7
+	st305:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof305
+		}
+	st_case_305:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 12:
+			goto tr382
+		case 13:
+			goto tr383
+		case 32:
+			goto tr452
+		case 34:
+			goto tr29
+		case 44:
+			goto tr469
+		case 46:
+			goto st303
+		case 69:
+			goto st67
+		case 92:
+			goto st11
+		case 101:
+			goto st67
+		case 105:
+			goto st307
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st306
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr452
+		}
+		goto st7
+	st306:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof306
+		}
+	st_case_306:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 12:
+			goto tr382
+		case 13:
+			goto tr383
+		case 32:
+			goto tr452
+		case 34:
+			goto tr29
+		case 44:
+			goto tr469
+		case 46:
+			goto st303
+		case 69:
+			goto st67
+		case 92:
+			goto st11
+		case 101:
+			goto st67
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st306
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr452
+		}
+		goto st7
+	st307:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof307
+		}
+	st_case_307:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr389
+		case 12:
+			goto tr388
+		case 13:
+			goto tr389
+		case 32:
+			goto tr457
+		case 34:
+			goto tr29
+		case 44:
+			goto tr473
+		case 92:
+			goto st11
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
+			goto tr457
+		}
+		goto st7
+	st308:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof308
+		}
+	st_case_308:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 12:
+			goto tr382
+		case 13:
+			goto tr383
+		case 32:
+			goto tr452
+		case 34:
+			goto tr29
+		case 44:
+			goto tr469
+		case 46:
+			goto st303
+		case 69:
+			goto st67
+		case 92:
+			goto st11
+		case 101:
+			goto st67
+		case 105:
+			goto st307
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st308
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr452
+		}
+		goto st7
+tr106:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st309
+	st309:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof309
+		}
+	st_case_309:
+//line plugins/parsers/influx/machine.go:7732
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 12:
+			goto tr382
+		case 13:
+			goto tr383
+		case 32:
+			goto tr452
+		case 34:
+			goto tr29
+		case 44:
+			goto tr469
+		case 46:
+			goto st303
+		case 69:
+			goto st67
+		case 92:
+			goto st11
+		case 101:
+			goto st67
+		case 105:
+			goto st307
+		case 117:
+			goto st310
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st306
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr452
+		}
+		goto st7
+	st310:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof310
+		}
+	st_case_310:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr393
+		case 12:
+			goto tr392
+		case 13:
+			goto tr393
+		case 32:
+			goto tr460
+		case 34:
+			goto tr29
+		case 44:
+			goto tr475
+		case 92:
+			goto st11
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
+			goto tr460
+		}
+		goto st7
+tr107:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st311
+	st311:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof311
+		}
+	st_case_311:
+//line plugins/parsers/influx/machine.go:7804
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 12:
+			goto tr382
+		case 13:
+			goto tr383
+		case 32:
+			goto tr452
+		case 34:
+			goto tr29
+		case 44:
+			goto tr469
+		case 46:
+			goto st303
+		case 69:
+			goto st67
+		case 92:
+			goto st11
+		case 101:
+			goto st67
+		case 105:
+			goto st307
+		case 117:
+			goto st310
+		}
+		switch {
+		case ( m.data)[( m.p)] > 11:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st311
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr452
 		}
 		goto st7
 tr108:
@@ -7767,26 +7841,26 @@ tr108:
 
 	m.pb = m.p
 
-	goto st305
-	st305:
+	goto st312
+	st312:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof305
+			goto _test_eof312
 		}
-	st_case_305:
-//line plugins/parsers/influx/machine.go:7777
+	st_case_312:
+//line plugins/parsers/influx/machine.go:7851
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 12:
-			goto tr385
+			goto tr396
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr452
+			goto tr463
 		case 34:
 			goto tr29
 		case 44:
-			goto tr466
+			goto tr477
 		case 65:
 			goto st69
 		case 92:
@@ -7795,7 +7869,7 @@ tr108:
 			goto st72
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr452
+			goto tr463
 		}
 		goto st7
 	st69:
@@ -7847,7 +7921,7 @@ tr108:
 		case 34:
 			goto tr29
 		case 69:
-			goto st306
+			goto st313
 		case 92:
 			goto st11
 		}
@@ -7855,29 +7929,29 @@ tr108:
 			goto tr5
 		}
 		goto st7
-	st306:
+	st313:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof306
+			goto _test_eof313
 		}
-	st_case_306:
+	st_case_313:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 12:
-			goto tr385
+			goto tr396
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr452
+			goto tr463
 		case 34:
 			goto tr29
 		case 44:
-			goto tr466
+			goto tr477
 		case 92:
 			goto st11
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr452
+			goto tr463
 		}
 		goto st7
 	st72:
@@ -7931,7 +8005,7 @@ tr108:
 		case 92:
 			goto st11
 		case 101:
-			goto st306
+			goto st313
 		}
 		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
 			goto tr5
@@ -7942,26 +8016,26 @@ tr109:
 
 	m.pb = m.p
 
-	goto st307
-	st307:
+	goto st314
+	st314:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof307
+			goto _test_eof314
 		}
-	st_case_307:
-//line plugins/parsers/influx/machine.go:7952
+	st_case_314:
+//line plugins/parsers/influx/machine.go:8026
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 12:
-			goto tr385
+			goto tr396
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr452
+			goto tr463
 		case 34:
 			goto tr29
 		case 44:
-			goto tr466
+			goto tr477
 		case 82:
 			goto st75
 		case 92:
@@ -7970,7 +8044,7 @@ tr109:
 			goto st76
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr452
+			goto tr463
 		}
 		goto st7
 	st75:
@@ -8016,33 +8090,33 @@ tr110:
 
 	m.pb = m.p
 
-	goto st308
-	st308:
+	goto st315
+	st315:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof308
+			goto _test_eof315
 		}
-	st_case_308:
-//line plugins/parsers/influx/machine.go:8026
+	st_case_315:
+//line plugins/parsers/influx/machine.go:8100
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 12:
-			goto tr385
+			goto tr396
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr452
+			goto tr463
 		case 34:
 			goto tr29
 		case 44:
-			goto tr466
+			goto tr477
 		case 92:
 			goto st11
 		case 97:
 			goto st72
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr452
+			goto tr463
 		}
 		goto st7
 tr111:
@@ -8050,33 +8124,33 @@ tr111:
 
 	m.pb = m.p
 
-	goto st309
-	st309:
+	goto st316
+	st316:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof309
+			goto _test_eof316
 		}
-	st_case_309:
-//line plugins/parsers/influx/machine.go:8060
+	st_case_316:
+//line plugins/parsers/influx/machine.go:8134
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 12:
-			goto tr385
+			goto tr396
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr452
+			goto tr463
 		case 34:
 			goto tr29
 		case 44:
-			goto tr466
+			goto tr477
 		case 92:
 			goto st11
 		case 114:
 			goto st76
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr452
+			goto tr463
 		}
 		goto st7
 tr115:
@@ -8090,7 +8164,7 @@ tr115:
 			goto _test_eof77
 		}
 	st_case_77:
-//line plugins/parsers/influx/machine.go:8094
+//line plugins/parsers/influx/machine.go:8168
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st47
@@ -8117,7 +8191,7 @@ tr96:
 			goto _test_eof78
 		}
 	st_case_78:
-//line plugins/parsers/influx/machine.go:8121
+//line plugins/parsers/influx/machine.go:8195
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st42
@@ -8144,7 +8218,7 @@ tr94:
 			goto _test_eof79
 		}
 	st_case_79:
-//line plugins/parsers/influx/machine.go:8148
+//line plugins/parsers/influx/machine.go:8222
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st41
@@ -8188,7 +8262,7 @@ tr82:
 			goto _test_eof80
 		}
 	st_case_80:
-//line plugins/parsers/influx/machine.go:8192
+//line plugins/parsers/influx/machine.go:8266
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr87
@@ -8222,7 +8296,7 @@ tr156:
 			goto _test_eof81
 		}
 	st_case_81:
-//line plugins/parsers/influx/machine.go:8226
+//line plugins/parsers/influx/machine.go:8300
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr87
@@ -8266,7 +8340,7 @@ tr157:
 			goto _test_eof82
 		}
 	st_case_82:
-//line plugins/parsers/influx/machine.go:8270
+//line plugins/parsers/influx/machine.go:8344
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr87
@@ -8298,52 +8372,52 @@ tr158:
 
 	m.handler.AddString(key, m.text())
 
-	goto st310
+	goto st317
 tr162:
 //line plugins/parsers/influx/machine.go.rl:104
 
 	m.handler.AddString(key, m.text())
 
-	goto st310
-	st310:
+	goto st317
+	st317:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof310
+			goto _test_eof317
 		}
-	st_case_310:
-//line plugins/parsers/influx/machine.go:8314
+	st_case_317:
+//line plugins/parsers/influx/machine.go:8388
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr472
+			goto tr483
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr471
+			goto tr482
 		case 44:
-			goto tr473
+			goto tr484
 		case 61:
 			goto tr49
 		case 92:
 			goto st84
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr471
+			goto tr482
 		}
 		goto st26
-tr471:
+tr482:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
 
-	goto st311
-tr503:
+	goto st318
+tr514:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
 
-	goto st311
-tr555:
+	goto st318
+tr566:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -8352,8 +8426,8 @@ tr555:
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st311
-tr561:
+	goto st318
+tr572:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -8362,8 +8436,8 @@ tr561:
 
 	m.handler.AddInt(key, m.text())
 
-	goto st311
-tr565:
+	goto st318
+tr576:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -8372,8 +8446,8 @@ tr565:
 
 	m.handler.AddUint(key, m.text())
 
-	goto st311
-tr569:
+	goto st318
+tr580:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -8382,8 +8456,8 @@ tr569:
 
 	m.handler.AddBool(key, m.text())
 
-	goto st311
-tr780:
+	goto st318
+tr791:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -8392,8 +8466,8 @@ tr780:
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st311
-tr789:
+	goto st318
+tr800:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -8402,8 +8476,8 @@ tr789:
 
 	m.handler.AddInt(key, m.text())
 
-	goto st311
-tr794:
+	goto st318
+tr805:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -8412,8 +8486,8 @@ tr794:
 
 	m.handler.AddUint(key, m.text())
 
-	goto st311
-tr799:
+	goto st318
+tr810:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -8422,26 +8496,26 @@ tr799:
 
 	m.handler.AddBool(key, m.text())
 
-	goto st311
-	st311:
+	goto st318
+	st318:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof311
+			goto _test_eof318
 		}
-	st_case_311:
-//line plugins/parsers/influx/machine.go:8432
+	st_case_318:
+//line plugins/parsers/influx/machine.go:8506
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr475
+			goto tr486
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st311
+			goto st318
 		case 44:
 			goto tr101
 		case 45:
-			goto tr393
+			goto tr404
 		case 61:
 			goto tr101
 		case 92:
@@ -8450,37 +8524,37 @@ tr799:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr394
+				goto tr405
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st311
+			goto st318
 		}
 		goto tr9
-tr475:
+tr486:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st312
-	st312:
+	goto st319
+	st319:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof312
+			goto _test_eof319
 		}
-	st_case_312:
-//line plugins/parsers/influx/machine.go:8471
+	st_case_319:
+//line plugins/parsers/influx/machine.go:8545
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr475
+			goto tr486
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st311
+			goto st318
 		case 44:
 			goto tr101
 		case 45:
-			goto tr393
+			goto tr404
 		case 61:
 			goto tr14
 		case 92:
@@ -8489,19 +8563,19 @@ tr475:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr394
+				goto tr405
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st311
+			goto st318
 		}
 		goto tr9
-tr472:
+tr483:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
 
-	goto st313
-tr476:
+	goto st320
+tr487:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -8510,26 +8584,26 @@ tr476:
 
 	m.pb = m.p
 
-	goto st313
-	st313:
+	goto st320
+	st320:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof313
+			goto _test_eof320
 		}
-	st_case_313:
-//line plugins/parsers/influx/machine.go:8520
+	st_case_320:
+//line plugins/parsers/influx/machine.go:8594
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr476
+			goto tr487
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr471
+			goto tr482
 		case 44:
 			goto tr7
 		case 45:
-			goto tr477
+			goto tr488
 		case 61:
 			goto tr49
 		case 92:
@@ -8538,13 +8612,13 @@ tr476:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr478
+				goto tr489
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr471
+			goto tr482
 		}
 		goto tr44
-tr477:
+tr488:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -8555,7 +8629,7 @@ tr477:
 			goto _test_eof83
 		}
 	st_case_83:
-//line plugins/parsers/influx/machine.go:8559
+//line plugins/parsers/influx/machine.go:8633
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr101
@@ -8575,400 +8649,33 @@ tr477:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st314
+				goto st321
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr4
 		}
 		goto st26
-tr478:
+tr489:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st314
-	st314:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof314
-		}
-	st_case_314:
-//line plugins/parsers/influx/machine.go:8596
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr480
-		case 13:
-			goto tr351
-		case 32:
-			goto tr479
-		case 44:
-			goto tr7
-		case 61:
-			goto tr49
-		case 92:
-			goto st84
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st318
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr479
-		}
-		goto st26
-tr484:
-//line plugins/parsers/influx/machine.go.rl:72
-
-	m.handler.SetMeasurement(m.text())
-
-	goto st315
-tr512:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-	goto st315
-tr479:
-//line plugins/parsers/influx/machine.go.rl:72
-
-	m.handler.SetMeasurement(m.text())
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st315
-tr509:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st315
-	st315:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof315
-		}
-	st_case_315:
-//line plugins/parsers/influx/machine.go:8659
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr346
-		case 11:
-			goto tr483
-		case 13:
-			goto tr346
-		case 32:
-			goto st315
-		case 44:
-			goto tr5
-		case 61:
-			goto tr5
-		case 92:
-			goto tr12
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st315
-		}
-		goto tr9
-tr483:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st316
-	st316:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof316
-		}
-	st_case_316:
-//line plugins/parsers/influx/machine.go:8691
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr346
-		case 11:
-			goto tr483
-		case 13:
-			goto tr346
-		case 32:
-			goto st315
-		case 44:
-			goto tr5
-		case 61:
-			goto tr14
-		case 92:
-			goto tr12
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st315
-		}
-		goto tr9
-tr485:
-//line plugins/parsers/influx/machine.go.rl:72
-
-	m.handler.SetMeasurement(m.text())
-
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st317
-tr480:
-//line plugins/parsers/influx/machine.go.rl:72
-
-	m.handler.SetMeasurement(m.text())
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st317
-	st317:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof317
-		}
-	st_case_317:
-//line plugins/parsers/influx/machine.go:8737
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr346
-		case 11:
-			goto tr485
-		case 13:
-			goto tr346
-		case 32:
-			goto tr484
-		case 44:
-			goto tr7
-		case 61:
-			goto tr49
-		case 92:
-			goto tr46
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr484
-		}
-		goto tr44
-tr46:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st84
-	st84:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof84
-		}
-	st_case_84:
-//line plugins/parsers/influx/machine.go:8769
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr5
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr5
-		}
-		goto st26
-	st318:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof318
-		}
-	st_case_318:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr480
-		case 13:
-			goto tr351
-		case 32:
-			goto tr479
-		case 44:
-			goto tr7
-		case 61:
-			goto tr49
-		case 92:
-			goto st84
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st319
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr479
-		}
-		goto st26
-	st319:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof319
-		}
-	st_case_319:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr480
-		case 13:
-			goto tr351
-		case 32:
-			goto tr479
-		case 44:
-			goto tr7
-		case 61:
-			goto tr49
-		case 92:
-			goto st84
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st320
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr479
-		}
-		goto st26
-	st320:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof320
-		}
-	st_case_320:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr480
-		case 13:
-			goto tr351
-		case 32:
-			goto tr479
-		case 44:
-			goto tr7
-		case 61:
-			goto tr49
-		case 92:
-			goto st84
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st321
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr479
-		}
-		goto st26
+	goto st321
 	st321:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof321
 		}
 	st_case_321:
+//line plugins/parsers/influx/machine.go:8670
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
-		case 44:
-			goto tr7
-		case 61:
-			goto tr49
-		case 92:
-			goto st84
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st322
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr479
-		}
-		goto st26
-	st322:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof322
-		}
-	st_case_322:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr480
-		case 13:
-			goto tr351
-		case 32:
-			goto tr479
-		case 44:
-			goto tr7
-		case 61:
-			goto tr49
-		case 92:
-			goto st84
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st323
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr479
-		}
-		goto st26
-	st323:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof323
-		}
-	st_case_323:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr480
-		case 13:
-			goto tr351
-		case 32:
-			goto tr479
-		case 44:
-			goto tr7
-		case 61:
-			goto tr49
-		case 92:
-			goto st84
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st324
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr479
-		}
-		goto st26
-	st324:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof324
-		}
-	st_case_324:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr480
-		case 13:
-			goto tr351
-		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -8982,7 +8689,164 @@ tr46:
 				goto st325
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
+		}
+		goto st26
+tr495:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+	goto st322
+tr523:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+	goto st322
+tr490:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st322
+tr520:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st322
+	st322:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof322
+		}
+	st_case_322:
+//line plugins/parsers/influx/machine.go:8733
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr357
+		case 11:
+			goto tr494
+		case 13:
+			goto tr357
+		case 32:
+			goto st322
+		case 44:
+			goto tr5
+		case 61:
+			goto tr5
+		case 92:
+			goto tr12
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st322
+		}
+		goto tr9
+tr494:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st323
+	st323:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof323
+		}
+	st_case_323:
+//line plugins/parsers/influx/machine.go:8765
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr357
+		case 11:
+			goto tr494
+		case 13:
+			goto tr357
+		case 32:
+			goto st322
+		case 44:
+			goto tr5
+		case 61:
+			goto tr14
+		case 92:
+			goto tr12
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st322
+		}
+		goto tr9
+tr496:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st324
+tr491:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st324
+	st324:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof324
+		}
+	st_case_324:
+//line plugins/parsers/influx/machine.go:8811
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr357
+		case 11:
+			goto tr496
+		case 13:
+			goto tr357
+		case 32:
+			goto tr495
+		case 44:
+			goto tr7
+		case 61:
+			goto tr49
+		case 92:
+			goto tr46
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr495
+		}
+		goto tr44
+tr46:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st84
+	st84:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof84
+		}
+	st_case_84:
+//line plugins/parsers/influx/machine.go:8843
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr5
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr5
 		}
 		goto st26
 	st325:
@@ -8992,13 +8856,13 @@ tr46:
 	st_case_325:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9012,7 +8876,7 @@ tr46:
 				goto st326
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
 		}
 		goto st26
 	st326:
@@ -9022,13 +8886,13 @@ tr46:
 	st_case_326:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9042,7 +8906,7 @@ tr46:
 				goto st327
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
 		}
 		goto st26
 	st327:
@@ -9052,13 +8916,13 @@ tr46:
 	st_case_327:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9072,7 +8936,7 @@ tr46:
 				goto st328
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
 		}
 		goto st26
 	st328:
@@ -9082,13 +8946,13 @@ tr46:
 	st_case_328:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9102,7 +8966,7 @@ tr46:
 				goto st329
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
 		}
 		goto st26
 	st329:
@@ -9112,13 +8976,13 @@ tr46:
 	st_case_329:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9132,7 +8996,7 @@ tr46:
 				goto st330
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
 		}
 		goto st26
 	st330:
@@ -9142,13 +9006,13 @@ tr46:
 	st_case_330:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9162,7 +9026,7 @@ tr46:
 				goto st331
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
 		}
 		goto st26
 	st331:
@@ -9172,13 +9036,13 @@ tr46:
 	st_case_331:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9192,7 +9056,7 @@ tr46:
 				goto st332
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
 		}
 		goto st26
 	st332:
@@ -9202,13 +9066,13 @@ tr46:
 	st_case_332:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9222,7 +9086,7 @@ tr46:
 				goto st333
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
 		}
 		goto st26
 	st333:
@@ -9232,13 +9096,13 @@ tr46:
 	st_case_333:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9252,7 +9116,7 @@ tr46:
 				goto st334
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
 		}
 		goto st26
 	st334:
@@ -9262,13 +9126,13 @@ tr46:
 	st_case_334:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9282,7 +9146,7 @@ tr46:
 				goto st335
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr479
+			goto tr490
 		}
 		goto st26
 	st335:
@@ -9292,13 +9156,223 @@ tr46:
 	st_case_335:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr480
+			goto tr491
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr479
+			goto tr490
+		case 44:
+			goto tr7
+		case 61:
+			goto tr49
+		case 92:
+			goto st84
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st336
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr490
+		}
+		goto st26
+	st336:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof336
+		}
+	st_case_336:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr491
+		case 13:
+			goto tr362
+		case 32:
+			goto tr490
+		case 44:
+			goto tr7
+		case 61:
+			goto tr49
+		case 92:
+			goto st84
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st337
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr490
+		}
+		goto st26
+	st337:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof337
+		}
+	st_case_337:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr491
+		case 13:
+			goto tr362
+		case 32:
+			goto tr490
+		case 44:
+			goto tr7
+		case 61:
+			goto tr49
+		case 92:
+			goto st84
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st338
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr490
+		}
+		goto st26
+	st338:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof338
+		}
+	st_case_338:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr491
+		case 13:
+			goto tr362
+		case 32:
+			goto tr490
+		case 44:
+			goto tr7
+		case 61:
+			goto tr49
+		case 92:
+			goto st84
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st339
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr490
+		}
+		goto st26
+	st339:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof339
+		}
+	st_case_339:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr491
+		case 13:
+			goto tr362
+		case 32:
+			goto tr490
+		case 44:
+			goto tr7
+		case 61:
+			goto tr49
+		case 92:
+			goto st84
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st340
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr490
+		}
+		goto st26
+	st340:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof340
+		}
+	st_case_340:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr491
+		case 13:
+			goto tr362
+		case 32:
+			goto tr490
+		case 44:
+			goto tr7
+		case 61:
+			goto tr49
+		case 92:
+			goto st84
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st341
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr490
+		}
+		goto st26
+	st341:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof341
+		}
+	st_case_341:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr491
+		case 13:
+			goto tr362
+		case 32:
+			goto tr490
+		case 44:
+			goto tr7
+		case 61:
+			goto tr49
+		case 92:
+			goto st84
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st342
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr490
+		}
+		goto st26
+	st342:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof342
+		}
+	st_case_342:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr491
+		case 13:
+			goto tr362
+		case 32:
+			goto tr490
 		case 44:
 			goto tr7
 		case 61:
@@ -9307,22 +9381,22 @@ tr46:
 			goto st84
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr479
+			goto tr490
 		}
 		goto st26
-tr473:
+tr484:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
 
 	goto st85
-tr505:
+tr516:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
 
 	goto st85
-tr557:
+tr568:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -9332,7 +9406,7 @@ tr557:
 	m.handler.AddFloat(key, m.text())
 
 	goto st85
-tr563:
+tr574:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -9342,7 +9416,7 @@ tr563:
 	m.handler.AddInt(key, m.text())
 
 	goto st85
-tr567:
+tr578:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -9352,7 +9426,7 @@ tr567:
 	m.handler.AddUint(key, m.text())
 
 	goto st85
-tr571:
+tr582:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -9362,7 +9436,7 @@ tr571:
 	m.handler.AddBool(key, m.text())
 
 	goto st85
-tr784:
+tr795:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -9372,7 +9446,7 @@ tr784:
 	m.handler.AddFloat(key, m.text())
 
 	goto st85
-tr809:
+tr820:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -9382,7 +9456,7 @@ tr809:
 	m.handler.AddInt(key, m.text())
 
 	goto st85
-tr812:
+tr823:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -9392,7 +9466,7 @@ tr812:
 	m.handler.AddUint(key, m.text())
 
 	goto st85
-tr815:
+tr826:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -9407,7 +9481,7 @@ tr815:
 			goto _test_eof85
 		}
 	st_case_85:
-//line plugins/parsers/influx/machine.go:9411
+//line plugins/parsers/influx/machine.go:9485
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr61
@@ -9438,7 +9512,7 @@ tr166:
 			goto _test_eof86
 		}
 	st_case_86:
-//line plugins/parsers/influx/machine.go:9442
+//line plugins/parsers/influx/machine.go:9516
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr61
@@ -9473,7 +9547,7 @@ tr169:
 			goto _test_eof87
 		}
 	st_case_87:
-//line plugins/parsers/influx/machine.go:9477
+//line plugins/parsers/influx/machine.go:9551
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr61
@@ -9524,7 +9598,7 @@ tr171:
 			goto _test_eof88
 		}
 	st_case_88:
-//line plugins/parsers/influx/machine.go:9528
+//line plugins/parsers/influx/machine.go:9602
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr181
@@ -9558,7 +9632,7 @@ tr180:
 			goto _test_eof89
 		}
 	st_case_89:
-//line plugins/parsers/influx/machine.go:9562
+//line plugins/parsers/influx/machine.go:9636
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr187
@@ -9602,7 +9676,7 @@ tr181:
 			goto _test_eof90
 		}
 	st_case_90:
-//line plugins/parsers/influx/machine.go:9606
+//line plugins/parsers/influx/machine.go:9680
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st90
@@ -9636,7 +9710,7 @@ tr192:
 			goto _test_eof91
 		}
 	st_case_91:
-//line plugins/parsers/influx/machine.go:9640
+//line plugins/parsers/influx/machine.go:9714
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -9668,7 +9742,7 @@ tr197:
 			goto _test_eof92
 		}
 	st_case_92:
-//line plugins/parsers/influx/machine.go:9672
+//line plugins/parsers/influx/machine.go:9746
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -9711,7 +9785,7 @@ tr195:
 			goto _test_eof93
 		}
 	st_case_93:
-//line plugins/parsers/influx/machine.go:9715
+//line plugins/parsers/influx/machine.go:9789
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st91
@@ -9738,7 +9812,7 @@ tr194:
 			goto _test_eof94
 		}
 	st_case_94:
-//line plugins/parsers/influx/machine.go:9742
+//line plugins/parsers/influx/machine.go:9816
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st90
@@ -9782,7 +9856,7 @@ tr182:
 			goto _test_eof95
 		}
 	st_case_95:
-//line plugins/parsers/influx/machine.go:9786
+//line plugins/parsers/influx/machine.go:9860
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr187
@@ -9816,7 +9890,7 @@ tr199:
 			goto _test_eof96
 		}
 	st_case_96:
-//line plugins/parsers/influx/machine.go:9820
+//line plugins/parsers/influx/machine.go:9894
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr187
@@ -9860,7 +9934,7 @@ tr200:
 			goto _test_eof97
 		}
 	st_case_97:
-//line plugins/parsers/influx/machine.go:9864
+//line plugins/parsers/influx/machine.go:9938
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr187
@@ -9892,46 +9966,46 @@ tr201:
 
 	m.handler.AddString(key, m.text())
 
-	goto st336
+	goto st343
 tr205:
 //line plugins/parsers/influx/machine.go.rl:104
 
 	m.handler.AddString(key, m.text())
 
-	goto st336
-	st336:
+	goto st343
+	st343:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof336
+			goto _test_eof343
 		}
-	st_case_336:
-//line plugins/parsers/influx/machine.go:9908
+	st_case_343:
+//line plugins/parsers/influx/machine.go:9982
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr504
+			goto tr515
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr503
+			goto tr514
 		case 44:
-			goto tr505
+			goto tr516
 		case 61:
 			goto tr14
 		case 92:
 			goto st35
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr503
+			goto tr514
 		}
 		goto st33
-tr504:
+tr515:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
 
-	goto st337
-tr506:
+	goto st344
+tr517:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -9940,26 +10014,26 @@ tr506:
 
 	m.pb = m.p
 
-	goto st337
-	st337:
+	goto st344
+	st344:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof337
+			goto _test_eof344
 		}
-	st_case_337:
-//line plugins/parsers/influx/machine.go:9950
+	st_case_344:
+//line plugins/parsers/influx/machine.go:10024
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr506
+			goto tr517
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr503
+			goto tr514
 		case 44:
 			goto tr63
 		case 45:
-			goto tr507
+			goto tr518
 		case 61:
 			goto tr14
 		case 92:
@@ -9968,13 +10042,13 @@ tr506:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr508
+				goto tr519
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr503
+			goto tr514
 		}
 		goto tr65
-tr507:
+tr518:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -9985,7 +10059,7 @@ tr507:
 			goto _test_eof98
 		}
 	st_case_98:
-//line plugins/parsers/influx/machine.go:9989
+//line plugins/parsers/influx/machine.go:10063
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr207
@@ -10005,289 +10079,33 @@ tr507:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st338
+				goto st345
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr60
 		}
 		goto st33
-tr508:
+tr519:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st338
-	st338:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof338
-		}
-	st_case_338:
-//line plugins/parsers/influx/machine.go:10026
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr510
-		case 13:
-			goto tr351
-		case 32:
-			goto tr509
-		case 44:
-			goto tr63
-		case 61:
-			goto tr14
-		case 92:
-			goto st35
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st340
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr509
-		}
-		goto st33
-tr513:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st339
-tr510:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st339
-	st339:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof339
-		}
-	st_case_339:
-//line plugins/parsers/influx/machine.go:10077
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr346
-		case 11:
-			goto tr513
-		case 13:
-			goto tr346
-		case 32:
-			goto tr512
-		case 44:
-			goto tr63
-		case 61:
-			goto tr14
-		case 92:
-			goto tr67
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr512
-		}
-		goto tr65
-	st340:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof340
-		}
-	st_case_340:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr510
-		case 13:
-			goto tr351
-		case 32:
-			goto tr509
-		case 44:
-			goto tr63
-		case 61:
-			goto tr14
-		case 92:
-			goto st35
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st341
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr509
-		}
-		goto st33
-	st341:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof341
-		}
-	st_case_341:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr510
-		case 13:
-			goto tr351
-		case 32:
-			goto tr509
-		case 44:
-			goto tr63
-		case 61:
-			goto tr14
-		case 92:
-			goto st35
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st342
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr509
-		}
-		goto st33
-	st342:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof342
-		}
-	st_case_342:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr510
-		case 13:
-			goto tr351
-		case 32:
-			goto tr509
-		case 44:
-			goto tr63
-		case 61:
-			goto tr14
-		case 92:
-			goto st35
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st343
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr509
-		}
-		goto st33
-	st343:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof343
-		}
-	st_case_343:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr510
-		case 13:
-			goto tr351
-		case 32:
-			goto tr509
-		case 44:
-			goto tr63
-		case 61:
-			goto tr14
-		case 92:
-			goto st35
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st344
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr509
-		}
-		goto st33
-	st344:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof344
-		}
-	st_case_344:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr510
-		case 13:
-			goto tr351
-		case 32:
-			goto tr509
-		case 44:
-			goto tr63
-		case 61:
-			goto tr14
-		case 92:
-			goto st35
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st345
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr509
-		}
-		goto st33
+	goto st345
 	st345:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof345
 		}
 	st_case_345:
+//line plugins/parsers/influx/machine.go:10100
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
-		case 44:
-			goto tr63
-		case 61:
-			goto tr14
-		case 92:
-			goto st35
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st346
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr509
-		}
-		goto st33
-	st346:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof346
-		}
-	st_case_346:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr510
-		case 13:
-			goto tr351
-		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10301,9 +10119,55 @@ tr510:
 				goto st347
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
+tr524:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st346
+tr521:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st346
+	st346:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof346
+		}
+	st_case_346:
+//line plugins/parsers/influx/machine.go:10151
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr357
+		case 11:
+			goto tr524
+		case 13:
+			goto tr357
+		case 32:
+			goto tr523
+		case 44:
+			goto tr63
+		case 61:
+			goto tr14
+		case 92:
+			goto tr67
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr523
+		}
+		goto tr65
 	st347:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof347
@@ -10311,13 +10175,13 @@ tr510:
 	st_case_347:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10331,7 +10195,7 @@ tr510:
 				goto st348
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
 	st348:
@@ -10341,13 +10205,13 @@ tr510:
 	st_case_348:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10361,7 +10225,7 @@ tr510:
 				goto st349
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
 	st349:
@@ -10371,13 +10235,13 @@ tr510:
 	st_case_349:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10391,7 +10255,7 @@ tr510:
 				goto st350
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
 	st350:
@@ -10401,13 +10265,13 @@ tr510:
 	st_case_350:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10421,7 +10285,7 @@ tr510:
 				goto st351
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
 	st351:
@@ -10431,13 +10295,13 @@ tr510:
 	st_case_351:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10451,7 +10315,7 @@ tr510:
 				goto st352
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
 	st352:
@@ -10461,13 +10325,13 @@ tr510:
 	st_case_352:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10481,7 +10345,7 @@ tr510:
 				goto st353
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
 	st353:
@@ -10491,13 +10355,13 @@ tr510:
 	st_case_353:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10511,7 +10375,7 @@ tr510:
 				goto st354
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
 	st354:
@@ -10521,13 +10385,13 @@ tr510:
 	st_case_354:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10541,7 +10405,7 @@ tr510:
 				goto st355
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
 	st355:
@@ -10551,13 +10415,13 @@ tr510:
 	st_case_355:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10571,7 +10435,7 @@ tr510:
 				goto st356
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
 	st356:
@@ -10581,13 +10445,13 @@ tr510:
 	st_case_356:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10601,7 +10465,7 @@ tr510:
 				goto st357
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr520
 		}
 		goto st33
 	st357:
@@ -10611,13 +10475,223 @@ tr510:
 	st_case_357:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr510
+			goto tr521
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr509
+			goto tr520
+		case 44:
+			goto tr63
+		case 61:
+			goto tr14
+		case 92:
+			goto st35
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st358
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr520
+		}
+		goto st33
+	st358:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof358
+		}
+	st_case_358:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr521
+		case 13:
+			goto tr362
+		case 32:
+			goto tr520
+		case 44:
+			goto tr63
+		case 61:
+			goto tr14
+		case 92:
+			goto st35
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st359
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr520
+		}
+		goto st33
+	st359:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof359
+		}
+	st_case_359:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr521
+		case 13:
+			goto tr362
+		case 32:
+			goto tr520
+		case 44:
+			goto tr63
+		case 61:
+			goto tr14
+		case 92:
+			goto st35
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st360
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr520
+		}
+		goto st33
+	st360:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof360
+		}
+	st_case_360:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr521
+		case 13:
+			goto tr362
+		case 32:
+			goto tr520
+		case 44:
+			goto tr63
+		case 61:
+			goto tr14
+		case 92:
+			goto st35
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st361
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr520
+		}
+		goto st33
+	st361:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof361
+		}
+	st_case_361:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr521
+		case 13:
+			goto tr362
+		case 32:
+			goto tr520
+		case 44:
+			goto tr63
+		case 61:
+			goto tr14
+		case 92:
+			goto st35
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st362
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr520
+		}
+		goto st33
+	st362:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof362
+		}
+	st_case_362:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr521
+		case 13:
+			goto tr362
+		case 32:
+			goto tr520
+		case 44:
+			goto tr63
+		case 61:
+			goto tr14
+		case 92:
+			goto st35
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st363
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr520
+		}
+		goto st33
+	st363:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof363
+		}
+	st_case_363:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr521
+		case 13:
+			goto tr362
+		case 32:
+			goto tr520
+		case 44:
+			goto tr63
+		case 61:
+			goto tr14
+		case 92:
+			goto st35
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st364
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr520
+		}
+		goto st33
+	st364:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof364
+		}
+	st_case_364:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr521
+		case 13:
+			goto tr362
+		case 32:
+			goto tr520
 		case 44:
 			goto tr63
 		case 61:
@@ -10626,7 +10700,7 @@ tr510:
 			goto st35
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr509
+			goto tr520
 		}
 		goto st33
 tr190:
@@ -10650,7 +10724,7 @@ tr184:
 			goto _test_eof99
 		}
 	st_case_99:
-//line plugins/parsers/influx/machine.go:10654
+//line plugins/parsers/influx/machine.go:10728
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -10682,7 +10756,7 @@ tr209:
 			goto _test_eof100
 		}
 	st_case_100:
-//line plugins/parsers/influx/machine.go:10686
+//line plugins/parsers/influx/machine.go:10760
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -10712,28 +10786,28 @@ tr210:
 
 	m.handler.AddString(key, m.text())
 
-	goto st358
+	goto st365
 tr213:
 //line plugins/parsers/influx/machine.go.rl:104
 
 	m.handler.AddString(key, m.text())
 
-	goto st358
-	st358:
+	goto st365
+	st365:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof358
+			goto _test_eof365
 		}
-	st_case_358:
-//line plugins/parsers/influx/machine.go:10728
+	st_case_365:
+//line plugins/parsers/influx/machine.go:10802
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto st359
+			goto st366
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st200
+			goto st207
 		case 44:
 			goto st9
 		case 61:
@@ -10742,27 +10816,27 @@ tr213:
 			goto st37
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st200
+			goto st207
 		}
 		goto st29
-	st359:
+	st366:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof359
+			goto _test_eof366
 		}
-	st_case_359:
+	st_case_366:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto st359
+			goto st366
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st200
+			goto st207
 		case 44:
 			goto tr216
 		case 45:
-			goto tr532
+			goto tr543
 		case 61:
 			goto tr55
 		case 92:
@@ -10771,13 +10845,13 @@ tr213:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr533
+				goto tr544
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st200
+			goto st207
 		}
 		goto st29
-tr532:
+tr543:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -10788,7 +10862,7 @@ tr532:
 			goto _test_eof101
 		}
 	st_case_101:
-//line plugins/parsers/influx/machine.go:10792
+//line plugins/parsers/influx/machine.go:10866
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr216
@@ -10806,275 +10880,33 @@ tr532:
 			}
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st360
+				goto st367
 			}
 		default:
 			goto tr216
 		}
 		goto st29
-tr533:
+tr544:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st360
-	st360:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof360
-		}
-	st_case_360:
-//line plugins/parsers/influx/machine.go:10827
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr534
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr216
-		case 61:
-			goto tr55
-		case 92:
-			goto st37
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st362
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st29
-tr534:
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st361
-	st361:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof361
-		}
-	st_case_361:
-//line plugins/parsers/influx/machine.go:10864
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr346
-		case 11:
-			goto st361
-		case 13:
-			goto tr346
-		case 32:
-			goto st203
-		case 44:
-			goto tr52
-		case 61:
-			goto tr55
-		case 92:
-			goto st37
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st203
-		}
-		goto st29
-	st362:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof362
-		}
-	st_case_362:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr534
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr216
-		case 61:
-			goto tr55
-		case 92:
-			goto st37
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st363
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st29
-	st363:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof363
-		}
-	st_case_363:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr534
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr216
-		case 61:
-			goto tr55
-		case 92:
-			goto st37
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st364
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st29
-	st364:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof364
-		}
-	st_case_364:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr534
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr216
-		case 61:
-			goto tr55
-		case 92:
-			goto st37
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st365
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st29
-	st365:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof365
-		}
-	st_case_365:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr534
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr216
-		case 61:
-			goto tr55
-		case 92:
-			goto st37
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st366
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st29
-	st366:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof366
-		}
-	st_case_366:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr534
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr216
-		case 61:
-			goto tr55
-		case 92:
-			goto st37
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st367
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st29
+	goto st367
 	st367:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof367
 		}
 	st_case_367:
+//line plugins/parsers/influx/machine.go:10901
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
-		case 44:
-			goto tr216
-		case 61:
-			goto tr55
-		case 92:
-			goto st37
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st368
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st29
-	st368:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof368
-		}
-	st_case_368:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr534
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11088,7 +10920,39 @@ tr534:
 				goto st369
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
+		}
+		goto st29
+tr545:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st368
+	st368:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof368
+		}
+	st_case_368:
+//line plugins/parsers/influx/machine.go:10938
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr357
+		case 11:
+			goto st368
+		case 13:
+			goto tr357
+		case 32:
+			goto st210
+		case 44:
+			goto tr52
+		case 61:
+			goto tr55
+		case 92:
+			goto st37
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st210
 		}
 		goto st29
 	st369:
@@ -11098,13 +10962,13 @@ tr534:
 	st_case_369:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11118,7 +10982,7 @@ tr534:
 				goto st370
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st29
 	st370:
@@ -11128,13 +10992,13 @@ tr534:
 	st_case_370:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11148,7 +11012,7 @@ tr534:
 				goto st371
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st29
 	st371:
@@ -11158,13 +11022,13 @@ tr534:
 	st_case_371:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11178,7 +11042,7 @@ tr534:
 				goto st372
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st29
 	st372:
@@ -11188,13 +11052,13 @@ tr534:
 	st_case_372:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11208,7 +11072,7 @@ tr534:
 				goto st373
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st29
 	st373:
@@ -11218,13 +11082,13 @@ tr534:
 	st_case_373:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11238,7 +11102,7 @@ tr534:
 				goto st374
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st29
 	st374:
@@ -11248,13 +11112,13 @@ tr534:
 	st_case_374:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11268,7 +11132,7 @@ tr534:
 				goto st375
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st29
 	st375:
@@ -11278,13 +11142,13 @@ tr534:
 	st_case_375:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11298,7 +11162,7 @@ tr534:
 				goto st376
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st29
 	st376:
@@ -11308,13 +11172,13 @@ tr534:
 	st_case_376:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11328,7 +11192,7 @@ tr534:
 				goto st377
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st29
 	st377:
@@ -11338,13 +11202,13 @@ tr534:
 	st_case_377:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11358,7 +11222,7 @@ tr534:
 				goto st378
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st29
 	st378:
@@ -11368,13 +11232,13 @@ tr534:
 	st_case_378:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11388,7 +11252,7 @@ tr534:
 				goto st379
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st29
 	st379:
@@ -11398,13 +11262,223 @@ tr534:
 	st_case_379:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr534
+			goto tr545
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
+		case 44:
+			goto tr216
+		case 61:
+			goto tr55
+		case 92:
+			goto st37
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st380
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st29
+	st380:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof380
+		}
+	st_case_380:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr545
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr216
+		case 61:
+			goto tr55
+		case 92:
+			goto st37
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st381
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st29
+	st381:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof381
+		}
+	st_case_381:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr545
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr216
+		case 61:
+			goto tr55
+		case 92:
+			goto st37
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st382
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st29
+	st382:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof382
+		}
+	st_case_382:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr545
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr216
+		case 61:
+			goto tr55
+		case 92:
+			goto st37
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st383
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st29
+	st383:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof383
+		}
+	st_case_383:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr545
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr216
+		case 61:
+			goto tr55
+		case 92:
+			goto st37
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st384
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st29
+	st384:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof384
+		}
+	st_case_384:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr545
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr216
+		case 61:
+			goto tr55
+		case 92:
+			goto st37
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st385
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st29
+	st385:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof385
+		}
+	st_case_385:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr545
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr216
+		case 61:
+			goto tr55
+		case 92:
+			goto st37
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st386
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st29
+	st386:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof386
+		}
+	st_case_386:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr545
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
 		case 44:
 			goto tr216
 		case 61:
@@ -11413,7 +11487,7 @@ tr534:
 			goto st37
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr350
+			goto tr361
 		}
 		goto st29
 tr214:
@@ -11427,7 +11501,7 @@ tr214:
 			goto _test_eof102
 		}
 	st_case_102:
-//line plugins/parsers/influx/machine.go:11431
+//line plugins/parsers/influx/machine.go:11505
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -11457,46 +11531,46 @@ tr183:
 
 	m.handler.AddString(key, m.text())
 
-	goto st380
+	goto st387
 tr189:
 //line plugins/parsers/influx/machine.go.rl:104
 
 	m.handler.AddString(key, m.text())
 
-	goto st380
-	st380:
+	goto st387
+	st387:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof380
+			goto _test_eof387
 		}
-	st_case_380:
-//line plugins/parsers/influx/machine.go:11473
+	st_case_387:
+//line plugins/parsers/influx/machine.go:11547
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr554
+			goto tr565
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr503
+			goto tr514
 		case 44:
-			goto tr505
+			goto tr516
 		case 61:
 			goto tr207
 		case 92:
 			goto st36
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr503
+			goto tr514
 		}
 		goto st31
-tr554:
+tr565:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
 
-	goto st381
-tr556:
+	goto st388
+tr567:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -11505,8 +11579,8 @@ tr556:
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st381
-tr562:
+	goto st388
+tr573:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -11515,8 +11589,8 @@ tr562:
 
 	m.handler.AddInt(key, m.text())
 
-	goto st381
-tr566:
+	goto st388
+tr577:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -11525,8 +11599,8 @@ tr566:
 
 	m.handler.AddUint(key, m.text())
 
-	goto st381
-tr570:
+	goto st388
+tr581:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -11535,26 +11609,26 @@ tr570:
 
 	m.handler.AddBool(key, m.text())
 
-	goto st381
-	st381:
+	goto st388
+	st388:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof381
+			goto _test_eof388
 		}
-	st_case_381:
-//line plugins/parsers/influx/machine.go:11545
+	st_case_388:
+//line plugins/parsers/influx/machine.go:11619
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr506
+			goto tr517
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr503
+			goto tr514
 		case 44:
 			goto tr63
 		case 45:
-			goto tr507
+			goto tr518
 		case 61:
 			goto tr207
 		case 92:
@@ -11563,10 +11637,10 @@ tr570:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr508
+				goto tr519
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr503
+			goto tr514
 		}
 		goto tr65
 tr185:
@@ -11580,7 +11654,7 @@ tr185:
 			goto _test_eof103
 		}
 	st_case_103:
-//line plugins/parsers/influx/machine.go:11584
+//line plugins/parsers/influx/machine.go:11658
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st89
@@ -11607,7 +11681,7 @@ tr211:
 			goto _test_eof104
 		}
 	st_case_104:
-//line plugins/parsers/influx/machine.go:11611
+//line plugins/parsers/influx/machine.go:11685
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st100
@@ -11634,7 +11708,7 @@ tr202:
 			goto _test_eof105
 		}
 	st_case_105:
-//line plugins/parsers/influx/machine.go:11638
+//line plugins/parsers/influx/machine.go:11712
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st96
@@ -11661,7 +11735,7 @@ tr172:
 			goto _test_eof106
 		}
 	st_case_106:
-//line plugins/parsers/influx/machine.go:11665
+//line plugins/parsers/influx/machine.go:11739
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr61
@@ -11676,7 +11750,7 @@ tr172:
 		case 46:
 			goto st107
 		case 48:
-			goto st384
+			goto st391
 		case 61:
 			goto tr61
 		case 92:
@@ -11685,7 +11759,7 @@ tr172:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st387
+				goto st394
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr60
@@ -11702,7 +11776,7 @@ tr173:
 			goto _test_eof107
 		}
 	st_case_107:
-//line plugins/parsers/influx/machine.go:11706
+//line plugins/parsers/influx/machine.go:11780
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr61
@@ -11722,28 +11796,28 @@ tr173:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st382
+				goto st389
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr60
 		}
 		goto st31
-	st382:
+	st389:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof382
+			goto _test_eof389
 		}
-	st_case_382:
+	st_case_389:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 11:
-			goto tr556
+			goto tr567
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr555
+			goto tr566
 		case 44:
-			goto tr557
+			goto tr568
 		case 61:
 			goto tr207
 		case 69:
@@ -11756,10 +11830,10 @@ tr173:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st382
+				goto st389
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr555
+			goto tr566
 		}
 		goto st31
 	st108:
@@ -11792,7 +11866,7 @@ tr173:
 			}
 		case ( m.data)[( m.p)] > 45:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st383
+				goto st390
 			}
 		default:
 			goto st109
@@ -11822,288 +11896,32 @@ tr173:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st383
+				goto st390
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr60
 		}
 		goto st31
-	st383:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof383
-		}
-	st_case_383:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 11:
-			goto tr556
-		case 13:
-			goto tr372
-		case 32:
-			goto tr555
-		case 44:
-			goto tr557
-		case 61:
-			goto tr207
-		case 92:
-			goto st36
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st383
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr555
-		}
-		goto st31
-	st384:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof384
-		}
-	st_case_384:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 11:
-			goto tr556
-		case 13:
-			goto tr372
-		case 32:
-			goto tr555
-		case 44:
-			goto tr557
-		case 46:
-			goto st382
-		case 61:
-			goto tr207
-		case 69:
-			goto st108
-		case 92:
-			goto st36
-		case 101:
-			goto st108
-		case 105:
-			goto st386
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st385
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr555
-		}
-		goto st31
-	st385:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof385
-		}
-	st_case_385:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 11:
-			goto tr556
-		case 13:
-			goto tr372
-		case 32:
-			goto tr555
-		case 44:
-			goto tr557
-		case 46:
-			goto st382
-		case 61:
-			goto tr207
-		case 69:
-			goto st108
-		case 92:
-			goto st36
-		case 101:
-			goto st108
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st385
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr555
-		}
-		goto st31
-	st386:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof386
-		}
-	st_case_386:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr378
-		case 11:
-			goto tr562
-		case 13:
-			goto tr378
-		case 32:
-			goto tr561
-		case 44:
-			goto tr563
-		case 61:
-			goto tr207
-		case 92:
-			goto st36
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr561
-		}
-		goto st31
-	st387:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof387
-		}
-	st_case_387:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 11:
-			goto tr556
-		case 13:
-			goto tr372
-		case 32:
-			goto tr555
-		case 44:
-			goto tr557
-		case 46:
-			goto st382
-		case 61:
-			goto tr207
-		case 69:
-			goto st108
-		case 92:
-			goto st36
-		case 101:
-			goto st108
-		case 105:
-			goto st386
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st387
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr555
-		}
-		goto st31
-tr174:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st388
-	st388:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof388
-		}
-	st_case_388:
-//line plugins/parsers/influx/machine.go:12010
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr372
-		case 11:
-			goto tr556
-		case 13:
-			goto tr372
-		case 32:
-			goto tr555
-		case 44:
-			goto tr557
-		case 46:
-			goto st382
-		case 61:
-			goto tr207
-		case 69:
-			goto st108
-		case 92:
-			goto st36
-		case 101:
-			goto st108
-		case 105:
-			goto st386
-		case 117:
-			goto st389
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st385
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr555
-		}
-		goto st31
-	st389:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof389
-		}
-	st_case_389:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr382
-		case 11:
-			goto tr566
-		case 13:
-			goto tr382
-		case 32:
-			goto tr565
-		case 44:
-			goto tr567
-		case 61:
-			goto tr207
-		case 92:
-			goto st36
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr565
-		}
-		goto st31
-tr175:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st390
 	st390:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof390
 		}
 	st_case_390:
-//line plugins/parsers/influx/machine.go:12082
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 11:
-			goto tr556
+			goto tr567
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr555
+			goto tr566
 		case 44:
-			goto tr557
-		case 46:
-			goto st382
+			goto tr568
 		case 61:
 			goto tr207
-		case 69:
-			goto st108
 		case 92:
 			goto st36
-		case 101:
-			goto st108
-		case 105:
-			goto st386
-		case 117:
-			goto st389
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -12111,7 +11929,263 @@ tr175:
 				goto st390
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr555
+			goto tr566
+		}
+		goto st31
+	st391:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof391
+		}
+	st_case_391:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 11:
+			goto tr567
+		case 13:
+			goto tr383
+		case 32:
+			goto tr566
+		case 44:
+			goto tr568
+		case 46:
+			goto st389
+		case 61:
+			goto tr207
+		case 69:
+			goto st108
+		case 92:
+			goto st36
+		case 101:
+			goto st108
+		case 105:
+			goto st393
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st392
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr566
+		}
+		goto st31
+	st392:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof392
+		}
+	st_case_392:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 11:
+			goto tr567
+		case 13:
+			goto tr383
+		case 32:
+			goto tr566
+		case 44:
+			goto tr568
+		case 46:
+			goto st389
+		case 61:
+			goto tr207
+		case 69:
+			goto st108
+		case 92:
+			goto st36
+		case 101:
+			goto st108
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st392
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr566
+		}
+		goto st31
+	st393:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof393
+		}
+	st_case_393:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr389
+		case 11:
+			goto tr573
+		case 13:
+			goto tr389
+		case 32:
+			goto tr572
+		case 44:
+			goto tr574
+		case 61:
+			goto tr207
+		case 92:
+			goto st36
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr572
+		}
+		goto st31
+	st394:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof394
+		}
+	st_case_394:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 11:
+			goto tr567
+		case 13:
+			goto tr383
+		case 32:
+			goto tr566
+		case 44:
+			goto tr568
+		case 46:
+			goto st389
+		case 61:
+			goto tr207
+		case 69:
+			goto st108
+		case 92:
+			goto st36
+		case 101:
+			goto st108
+		case 105:
+			goto st393
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st394
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr566
+		}
+		goto st31
+tr174:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st395
+	st395:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof395
+		}
+	st_case_395:
+//line plugins/parsers/influx/machine.go:12084
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 11:
+			goto tr567
+		case 13:
+			goto tr383
+		case 32:
+			goto tr566
+		case 44:
+			goto tr568
+		case 46:
+			goto st389
+		case 61:
+			goto tr207
+		case 69:
+			goto st108
+		case 92:
+			goto st36
+		case 101:
+			goto st108
+		case 105:
+			goto st393
+		case 117:
+			goto st396
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st392
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr566
+		}
+		goto st31
+	st396:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof396
+		}
+	st_case_396:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr393
+		case 11:
+			goto tr577
+		case 13:
+			goto tr393
+		case 32:
+			goto tr576
+		case 44:
+			goto tr578
+		case 61:
+			goto tr207
+		case 92:
+			goto st36
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr576
+		}
+		goto st31
+tr175:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st397
+	st397:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof397
+		}
+	st_case_397:
+//line plugins/parsers/influx/machine.go:12156
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr383
+		case 11:
+			goto tr567
+		case 13:
+			goto tr383
+		case 32:
+			goto tr566
+		case 44:
+			goto tr568
+		case 46:
+			goto st389
+		case 61:
+			goto tr207
+		case 69:
+			goto st108
+		case 92:
+			goto st36
+		case 101:
+			goto st108
+		case 105:
+			goto st393
+		case 117:
+			goto st396
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st397
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr566
 		}
 		goto st31
 tr176:
@@ -12119,24 +12193,24 @@ tr176:
 
 	m.pb = m.p
 
-	goto st391
-	st391:
+	goto st398
+	st398:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof391
+			goto _test_eof398
 		}
-	st_case_391:
-//line plugins/parsers/influx/machine.go:12129
+	st_case_398:
+//line plugins/parsers/influx/machine.go:12203
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 11:
-			goto tr570
+			goto tr581
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr569
+			goto tr580
 		case 44:
-			goto tr571
+			goto tr582
 		case 61:
 			goto tr207
 		case 65:
@@ -12147,7 +12221,7 @@ tr176:
 			goto st113
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr569
+			goto tr580
 		}
 		goto st31
 	st110:
@@ -12223,7 +12297,7 @@ tr176:
 		case 61:
 			goto tr61
 		case 69:
-			goto st392
+			goto st399
 		case 92:
 			goto st36
 		}
@@ -12231,29 +12305,29 @@ tr176:
 			goto tr60
 		}
 		goto st31
-	st392:
+	st399:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof392
+			goto _test_eof399
 		}
-	st_case_392:
+	st_case_399:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 11:
-			goto tr570
+			goto tr581
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr569
+			goto tr580
 		case 44:
-			goto tr571
+			goto tr582
 		case 61:
 			goto tr207
 		case 92:
 			goto st36
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr569
+			goto tr580
 		}
 		goto st31
 	st113:
@@ -12331,7 +12405,7 @@ tr176:
 		case 92:
 			goto st36
 		case 101:
-			goto st392
+			goto st399
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr60
@@ -12342,24 +12416,24 @@ tr177:
 
 	m.pb = m.p
 
-	goto st393
-	st393:
+	goto st400
+	st400:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof393
+			goto _test_eof400
 		}
-	st_case_393:
-//line plugins/parsers/influx/machine.go:12352
+	st_case_400:
+//line plugins/parsers/influx/machine.go:12426
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 11:
-			goto tr570
+			goto tr581
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr569
+			goto tr580
 		case 44:
-			goto tr571
+			goto tr582
 		case 61:
 			goto tr207
 		case 82:
@@ -12370,7 +12444,7 @@ tr177:
 			goto st117
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr569
+			goto tr580
 		}
 		goto st31
 	st116:
@@ -12432,24 +12506,24 @@ tr178:
 
 	m.pb = m.p
 
-	goto st394
-	st394:
+	goto st401
+	st401:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof394
+			goto _test_eof401
 		}
-	st_case_394:
-//line plugins/parsers/influx/machine.go:12442
+	st_case_401:
+//line plugins/parsers/influx/machine.go:12516
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 11:
-			goto tr570
+			goto tr581
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr569
+			goto tr580
 		case 44:
-			goto tr571
+			goto tr582
 		case 61:
 			goto tr207
 		case 92:
@@ -12458,7 +12532,7 @@ tr178:
 			goto st113
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr569
+			goto tr580
 		}
 		goto st31
 tr179:
@@ -12466,24 +12540,24 @@ tr179:
 
 	m.pb = m.p
 
-	goto st395
-	st395:
+	goto st402
+	st402:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof395
+			goto _test_eof402
 		}
-	st_case_395:
-//line plugins/parsers/influx/machine.go:12476
+	st_case_402:
+//line plugins/parsers/influx/machine.go:12550
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 11:
-			goto tr570
+			goto tr581
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr569
+			goto tr580
 		case 44:
-			goto tr571
+			goto tr582
 		case 61:
 			goto tr207
 		case 92:
@@ -12492,7 +12566,7 @@ tr179:
 			goto st117
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr569
+			goto tr580
 		}
 		goto st31
 tr167:
@@ -12506,7 +12580,7 @@ tr167:
 			goto _test_eof118
 		}
 	st_case_118:
-//line plugins/parsers/influx/machine.go:12510
+//line plugins/parsers/influx/machine.go:12584
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -12543,7 +12617,7 @@ tr239:
 			goto _test_eof119
 		}
 	st_case_119:
-//line plugins/parsers/influx/machine.go:12547
+//line plugins/parsers/influx/machine.go:12621
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -12575,7 +12649,7 @@ tr229:
 			goto _test_eof120
 		}
 	st_case_120:
-//line plugins/parsers/influx/machine.go:12579
+//line plugins/parsers/influx/machine.go:12653
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -12607,7 +12681,7 @@ tr232:
 			goto _test_eof121
 		}
 	st_case_121:
-//line plugins/parsers/influx/machine.go:12611
+//line plugins/parsers/influx/machine.go:12685
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -12639,7 +12713,7 @@ tr234:
 			goto _test_eof122
 		}
 	st_case_122:
-//line plugins/parsers/influx/machine.go:12643
+//line plugins/parsers/influx/machine.go:12717
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr237
@@ -12673,7 +12747,7 @@ tr238:
 			goto _test_eof123
 		}
 	st_case_123:
-//line plugins/parsers/influx/machine.go:12677
+//line plugins/parsers/influx/machine.go:12751
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr237
@@ -12707,7 +12781,7 @@ tr241:
 			goto _test_eof124
 		}
 	st_case_124:
-//line plugins/parsers/influx/machine.go:12711
+//line plugins/parsers/influx/machine.go:12785
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr237
@@ -12751,7 +12825,7 @@ tr242:
 			goto _test_eof125
 		}
 	st_case_125:
-//line plugins/parsers/influx/machine.go:12755
+//line plugins/parsers/influx/machine.go:12829
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr237
@@ -12785,7 +12859,7 @@ tr243:
 			goto _test_eof126
 		}
 	st_case_126:
-//line plugins/parsers/influx/machine.go:12789
+//line plugins/parsers/influx/machine.go:12863
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st124
@@ -12812,7 +12886,7 @@ tr235:
 			goto _test_eof127
 		}
 	st_case_127:
-//line plugins/parsers/influx/machine.go:12816
+//line plugins/parsers/influx/machine.go:12890
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st122
@@ -12839,7 +12913,7 @@ tr230:
 			goto _test_eof128
 		}
 	st_case_128:
-//line plugins/parsers/influx/machine.go:12843
+//line plugins/parsers/influx/machine.go:12917
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st120
@@ -12866,7 +12940,7 @@ tr163:
 			goto _test_eof129
 		}
 	st_case_129:
-//line plugins/parsers/influx/machine.go:12870
+//line plugins/parsers/influx/machine.go:12944
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr87
@@ -12911,40 +12985,40 @@ tr247:
 
 	m.handler.AddString(key, m.text())
 
-	goto st396
-	st396:
+	goto st403
+	st403:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof396
+			goto _test_eof403
 		}
-	st_case_396:
-//line plugins/parsers/influx/machine.go:12921
+	st_case_403:
+//line plugins/parsers/influx/machine.go:12995
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr576
+			goto tr587
 		case 11:
-			goto tr577
+			goto tr588
 		case 12:
-			goto tr471
+			goto tr482
 		case 32:
-			goto tr576
+			goto tr587
 		case 34:
 			goto tr83
 		case 44:
-			goto tr578
+			goto tr589
 		case 92:
 			goto tr85
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
+			goto tr357
 		}
 		goto tr80
-tr603:
+tr614:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
 
-	goto st397
-tr576:
+	goto st404
+tr587:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -12953,14 +13027,14 @@ tr576:
 
 	m.pb = m.p
 
-	goto st397
-tr735:
+	goto st404
+tr746:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
 
-	goto st397
-tr731:
+	goto st404
+tr742:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -12969,8 +13043,8 @@ tr731:
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st397
-tr763:
+	goto st404
+tr774:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -12979,28 +13053,28 @@ tr763:
 
 	m.handler.AddInt(key, m.text())
 
-	goto st397
-tr767:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:92
-
-	m.handler.AddUint(key, m.text())
-
-	goto st397
-tr771:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:100
-
-	m.handler.AddBool(key, m.text())
-
-	goto st397
+	goto st404
 tr778:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:92
+
+	m.handler.AddUint(key, m.text())
+
+	goto st404
+tr782:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:100
+
+	m.handler.AddBool(key, m.text())
+
+	goto st404
+tr789:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -13009,8 +13083,8 @@ tr778:
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st397
-tr787:
+	goto st404
+tr798:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -13019,8 +13093,8 @@ tr787:
 
 	m.handler.AddInt(key, m.text())
 
-	goto st397
-tr792:
+	goto st404
+tr803:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -13029,8 +13103,8 @@ tr792:
 
 	m.handler.AddUint(key, m.text())
 
-	goto st397
-tr797:
+	goto st404
+tr808:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -13039,28 +13113,28 @@ tr797:
 
 	m.handler.AddBool(key, m.text())
 
-	goto st397
-	st397:
+	goto st404
+	st404:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof397
+			goto _test_eof404
 		}
-	st_case_397:
-//line plugins/parsers/influx/machine.go:13049
+	st_case_404:
+//line plugins/parsers/influx/machine.go:13123
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto st397
+			goto st404
 		case 11:
-			goto tr580
+			goto tr591
 		case 12:
-			goto st311
+			goto st318
 		case 32:
-			goto st397
+			goto st404
 		case 34:
 			goto tr95
 		case 44:
 			goto st7
 		case 45:
-			goto tr581
+			goto tr592
 		case 61:
 			goto st7
 		case 92:
@@ -13069,39 +13143,39 @@ tr797:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr582
+				goto tr593
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr346
+			goto tr357
 		}
 		goto tr92
-tr580:
+tr591:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st398
-	st398:
+	goto st405
+	st405:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof398
+			goto _test_eof405
 		}
-	st_case_398:
-//line plugins/parsers/influx/machine.go:13090
+	st_case_405:
+//line plugins/parsers/influx/machine.go:13164
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto st397
+			goto st404
 		case 11:
-			goto tr580
+			goto tr591
 		case 12:
-			goto st311
+			goto st318
 		case 32:
-			goto st397
+			goto st404
 		case 34:
 			goto tr95
 		case 44:
 			goto st7
 		case 45:
-			goto tr581
+			goto tr592
 		case 61:
 			goto tr99
 		case 92:
@@ -13110,13 +13184,13 @@ tr580:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr582
+				goto tr593
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr346
+			goto tr357
 		}
 		goto tr92
-tr581:
+tr592:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -13127,7 +13201,7 @@ tr581:
 			goto _test_eof130
 		}
 	st_case_130:
-//line plugins/parsers/influx/machine.go:13131
+//line plugins/parsers/influx/machine.go:13205
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -13147,291 +13221,33 @@ tr581:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st399
+				goto st406
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr101
 		}
 		goto st42
-tr582:
+tr593:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st399
-	st399:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof399
-		}
-	st_case_399:
-//line plugins/parsers/influx/machine.go:13168
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr583
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr99
-		case 92:
-			goto st78
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st401
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st42
-tr583:
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st400
-	st400:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof400
-		}
-	st_case_400:
-//line plugins/parsers/influx/machine.go:13207
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st261
-		case 11:
-			goto st400
-		case 12:
-			goto st203
-		case 32:
-			goto st261
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr99
-		case 92:
-			goto st78
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
-		}
-		goto st42
-	st401:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof401
-		}
-	st_case_401:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr583
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr99
-		case 92:
-			goto st78
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st402
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st42
-	st402:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof402
-		}
-	st_case_402:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr583
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr99
-		case 92:
-			goto st78
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st403
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st42
-	st403:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof403
-		}
-	st_case_403:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr583
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr99
-		case 92:
-			goto st78
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st404
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st42
-	st404:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof404
-		}
-	st_case_404:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr583
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr99
-		case 92:
-			goto st78
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st405
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st42
-	st405:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof405
-		}
-	st_case_405:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr583
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr99
-		case 92:
-			goto st78
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st406
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st42
+	goto st406
 	st406:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof406
 		}
 	st_case_406:
+//line plugins/parsers/influx/machine.go:13242
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr99
-		case 92:
-			goto st78
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st407
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st42
-	st407:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof407
-		}
-	st_case_407:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr583
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13447,7 +13263,41 @@ tr583:
 				goto st408
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
+		}
+		goto st42
+tr594:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st407
+	st407:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof407
+		}
+	st_case_407:
+//line plugins/parsers/influx/machine.go:13281
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st268
+		case 11:
+			goto st407
+		case 12:
+			goto st210
+		case 32:
+			goto st268
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr99
+		case 92:
+			goto st78
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr357
 		}
 		goto st42
 	st408:
@@ -13457,13 +13307,13 @@ tr583:
 	st_case_408:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13479,7 +13329,7 @@ tr583:
 				goto st409
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st42
 	st409:
@@ -13489,13 +13339,13 @@ tr583:
 	st_case_409:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13511,7 +13361,7 @@ tr583:
 				goto st410
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st42
 	st410:
@@ -13521,13 +13371,13 @@ tr583:
 	st_case_410:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13543,7 +13393,7 @@ tr583:
 				goto st411
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st42
 	st411:
@@ -13553,13 +13403,13 @@ tr583:
 	st_case_411:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13575,7 +13425,7 @@ tr583:
 				goto st412
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st42
 	st412:
@@ -13585,13 +13435,13 @@ tr583:
 	st_case_412:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13607,7 +13457,7 @@ tr583:
 				goto st413
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st42
 	st413:
@@ -13617,13 +13467,13 @@ tr583:
 	st_case_413:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13639,7 +13489,7 @@ tr583:
 				goto st414
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st42
 	st414:
@@ -13649,13 +13499,13 @@ tr583:
 	st_case_414:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13671,7 +13521,7 @@ tr583:
 				goto st415
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st42
 	st415:
@@ -13681,13 +13531,13 @@ tr583:
 	st_case_415:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13703,7 +13553,7 @@ tr583:
 				goto st416
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st42
 	st416:
@@ -13713,13 +13563,13 @@ tr583:
 	st_case_416:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13735,7 +13585,7 @@ tr583:
 				goto st417
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st42
 	st417:
@@ -13745,13 +13595,13 @@ tr583:
 	st_case_417:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13767,7 +13617,7 @@ tr583:
 				goto st418
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st42
 	st418:
@@ -13777,13 +13627,237 @@ tr583:
 	st_case_418:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr583
+			goto tr594
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr99
+		case 92:
+			goto st78
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st419
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st42
+	st419:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof419
+		}
+	st_case_419:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr594
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr99
+		case 92:
+			goto st78
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st420
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st42
+	st420:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof420
+		}
+	st_case_420:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr594
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr99
+		case 92:
+			goto st78
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st421
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st42
+	st421:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof421
+		}
+	st_case_421:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr594
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr99
+		case 92:
+			goto st78
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st422
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st42
+	st422:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof422
+		}
+	st_case_422:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr594
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr99
+		case 92:
+			goto st78
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st423
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st42
+	st423:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof423
+		}
+	st_case_423:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr594
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr99
+		case 92:
+			goto st78
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st424
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st42
+	st424:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof424
+		}
+	st_case_424:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr594
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr99
+		case 92:
+			goto st78
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st425
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st42
+	st425:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof425
+		}
+	st_case_425:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr594
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -13794,10 +13868,10 @@ tr583:
 			goto st78
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr351
+			goto tr362
 		}
 		goto st42
-tr577:
+tr588:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -13806,8 +13880,8 @@ tr577:
 
 	m.pb = m.p
 
-	goto st419
-tr779:
+	goto st426
+tr790:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -13816,8 +13890,8 @@ tr779:
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st419
-tr788:
+	goto st426
+tr799:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -13826,8 +13900,8 @@ tr788:
 
 	m.handler.AddInt(key, m.text())
 
-	goto st419
-tr793:
+	goto st426
+tr804:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -13836,8 +13910,8 @@ tr793:
 
 	m.handler.AddUint(key, m.text())
 
-	goto st419
-tr798:
+	goto st426
+tr809:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -13846,28 +13920,28 @@ tr798:
 
 	m.handler.AddBool(key, m.text())
 
-	goto st419
-	st419:
+	goto st426
+	st426:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof419
+			goto _test_eof426
 		}
-	st_case_419:
-//line plugins/parsers/influx/machine.go:13856
+	st_case_426:
+//line plugins/parsers/influx/machine.go:13930
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr603
+			goto tr614
 		case 11:
-			goto tr604
+			goto tr615
 		case 12:
-			goto tr471
+			goto tr482
 		case 32:
-			goto tr603
+			goto tr614
 		case 34:
 			goto tr158
 		case 44:
 			goto tr90
 		case 45:
-			goto tr605
+			goto tr616
 		case 61:
 			goto st40
 		case 92:
@@ -13876,13 +13950,13 @@ tr798:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr606
+				goto tr617
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr346
+			goto tr357
 		}
 		goto tr156
-tr604:
+tr615:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -13891,28 +13965,28 @@ tr604:
 
 	m.pb = m.p
 
-	goto st420
-	st420:
+	goto st427
+	st427:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof420
+			goto _test_eof427
 		}
-	st_case_420:
-//line plugins/parsers/influx/machine.go:13901
+	st_case_427:
+//line plugins/parsers/influx/machine.go:13975
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr603
+			goto tr614
 		case 11:
-			goto tr604
+			goto tr615
 		case 12:
-			goto tr471
+			goto tr482
 		case 32:
-			goto tr603
+			goto tr614
 		case 34:
 			goto tr158
 		case 44:
 			goto tr90
 		case 45:
-			goto tr605
+			goto tr616
 		case 61:
 			goto tr163
 		case 92:
@@ -13921,13 +13995,13 @@ tr604:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr606
+				goto tr617
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr346
+			goto tr357
 		}
 		goto tr156
-tr605:
+tr616:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -13938,7 +14012,7 @@ tr605:
 			goto _test_eof131
 		}
 	st_case_131:
-//line plugins/parsers/influx/machine.go:13942
+//line plugins/parsers/influx/machine.go:14016
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr87
@@ -13960,426 +14034,33 @@ tr605:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st421
+				goto st428
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr101
 		}
 		goto st81
-tr606:
+tr617:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st421
-	st421:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof421
-		}
-	st_case_421:
-//line plugins/parsers/influx/machine.go:13981
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr607
-		case 11:
-			goto tr608
-		case 12:
-			goto tr479
-		case 32:
-			goto tr607
-		case 34:
-			goto tr162
-		case 44:
-			goto tr90
-		case 61:
-			goto tr163
-		case 92:
-			goto st132
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st425
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st81
-tr612:
-//line plugins/parsers/influx/machine.go.rl:72
-
-	m.handler.SetMeasurement(m.text())
-
-	goto st422
-tr742:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-	goto st422
-tr607:
-//line plugins/parsers/influx/machine.go.rl:72
-
-	m.handler.SetMeasurement(m.text())
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st422
-tr739:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st422
-	st422:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof422
-		}
-	st_case_422:
-//line plugins/parsers/influx/machine.go:14046
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st422
-		case 11:
-			goto tr611
-		case 12:
-			goto st315
-		case 32:
-			goto st422
-		case 34:
-			goto tr95
-		case 44:
-			goto st7
-		case 61:
-			goto st7
-		case 92:
-			goto tr96
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
-		}
-		goto tr92
-tr611:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st423
-	st423:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof423
-		}
-	st_case_423:
-//line plugins/parsers/influx/machine.go:14080
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st422
-		case 11:
-			goto tr611
-		case 12:
-			goto st315
-		case 32:
-			goto st422
-		case 34:
-			goto tr95
-		case 44:
-			goto st7
-		case 61:
-			goto tr99
-		case 92:
-			goto tr96
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
-		}
-		goto tr92
-tr613:
-//line plugins/parsers/influx/machine.go.rl:72
-
-	m.handler.SetMeasurement(m.text())
-
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st424
-tr608:
-//line plugins/parsers/influx/machine.go.rl:72
-
-	m.handler.SetMeasurement(m.text())
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st424
-	st424:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof424
-		}
-	st_case_424:
-//line plugins/parsers/influx/machine.go:14128
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr612
-		case 11:
-			goto tr613
-		case 12:
-			goto tr484
-		case 32:
-			goto tr612
-		case 34:
-			goto tr158
-		case 44:
-			goto tr90
-		case 61:
-			goto tr163
-		case 92:
-			goto tr159
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
-		}
-		goto tr156
-tr159:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st132
-	st132:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof132
-		}
-	st_case_132:
-//line plugins/parsers/influx/machine.go:14162
-		switch ( m.data)[( m.p)] {
-		case 34:
-			goto st81
-		case 92:
-			goto st81
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr5
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr5
-		}
-		goto st26
-	st425:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof425
-		}
-	st_case_425:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr607
-		case 11:
-			goto tr608
-		case 12:
-			goto tr479
-		case 32:
-			goto tr607
-		case 34:
-			goto tr162
-		case 44:
-			goto tr90
-		case 61:
-			goto tr163
-		case 92:
-			goto st132
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st426
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st81
-	st426:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof426
-		}
-	st_case_426:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr607
-		case 11:
-			goto tr608
-		case 12:
-			goto tr479
-		case 32:
-			goto tr607
-		case 34:
-			goto tr162
-		case 44:
-			goto tr90
-		case 61:
-			goto tr163
-		case 92:
-			goto st132
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st427
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st81
-	st427:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof427
-		}
-	st_case_427:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr607
-		case 11:
-			goto tr608
-		case 12:
-			goto tr479
-		case 32:
-			goto tr607
-		case 34:
-			goto tr162
-		case 44:
-			goto tr90
-		case 61:
-			goto tr163
-		case 92:
-			goto st132
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st428
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st81
+	goto st428
 	st428:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof428
 		}
 	st_case_428:
+//line plugins/parsers/influx/machine.go:14055
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
-		case 34:
-			goto tr162
-		case 44:
-			goto tr90
-		case 61:
-			goto tr163
-		case 92:
-			goto st132
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st429
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st81
-	st429:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof429
-		}
-	st_case_429:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr607
-		case 11:
-			goto tr608
-		case 12:
-			goto tr479
-		case 32:
-			goto tr607
-		case 34:
-			goto tr162
-		case 44:
-			goto tr90
-		case 61:
-			goto tr163
-		case 92:
-			goto st132
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st430
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st81
-	st430:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof430
-		}
-	st_case_430:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr607
-		case 11:
-			goto tr608
-		case 12:
-			goto tr479
-		case 32:
-			goto tr607
-		case 34:
-			goto tr162
-		case 44:
-			goto tr90
-		case 61:
-			goto tr163
-		case 92:
-			goto st132
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st431
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st81
-	st431:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof431
-		}
-	st_case_431:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr607
-		case 11:
-			goto tr608
-		case 12:
-			goto tr479
-		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14395,9 +14076,178 @@ tr159:
 				goto st432
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
+tr623:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+	goto st429
+tr753:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+	goto st429
+tr618:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st429
+tr750:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st429
+	st429:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof429
+		}
+	st_case_429:
+//line plugins/parsers/influx/machine.go:14120
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st429
+		case 11:
+			goto tr622
+		case 12:
+			goto st322
+		case 32:
+			goto st429
+		case 34:
+			goto tr95
+		case 44:
+			goto st7
+		case 61:
+			goto st7
+		case 92:
+			goto tr96
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr357
+		}
+		goto tr92
+tr622:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st430
+	st430:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof430
+		}
+	st_case_430:
+//line plugins/parsers/influx/machine.go:14154
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st429
+		case 11:
+			goto tr622
+		case 12:
+			goto st322
+		case 32:
+			goto st429
+		case 34:
+			goto tr95
+		case 44:
+			goto st7
+		case 61:
+			goto tr99
+		case 92:
+			goto tr96
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr357
+		}
+		goto tr92
+tr624:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st431
+tr619:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st431
+	st431:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof431
+		}
+	st_case_431:
+//line plugins/parsers/influx/machine.go:14202
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr623
+		case 11:
+			goto tr624
+		case 12:
+			goto tr495
+		case 32:
+			goto tr623
+		case 34:
+			goto tr158
+		case 44:
+			goto tr90
+		case 61:
+			goto tr163
+		case 92:
+			goto tr159
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr357
+		}
+		goto tr156
+tr159:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st132
+	st132:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof132
+		}
+	st_case_132:
+//line plugins/parsers/influx/machine.go:14236
+		switch ( m.data)[( m.p)] {
+		case 34:
+			goto st81
+		case 92:
+			goto st81
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr5
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr5
+		}
+		goto st26
 	st432:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof432
@@ -14405,13 +14255,13 @@ tr159:
 	st_case_432:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14427,7 +14277,7 @@ tr159:
 				goto st433
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
 	st433:
@@ -14437,13 +14287,13 @@ tr159:
 	st_case_433:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14459,7 +14309,7 @@ tr159:
 				goto st434
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
 	st434:
@@ -14469,13 +14319,13 @@ tr159:
 	st_case_434:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14491,7 +14341,7 @@ tr159:
 				goto st435
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
 	st435:
@@ -14501,13 +14351,13 @@ tr159:
 	st_case_435:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14523,7 +14373,7 @@ tr159:
 				goto st436
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
 	st436:
@@ -14533,13 +14383,13 @@ tr159:
 	st_case_436:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14555,7 +14405,7 @@ tr159:
 				goto st437
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
 	st437:
@@ -14565,13 +14415,13 @@ tr159:
 	st_case_437:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14587,7 +14437,7 @@ tr159:
 				goto st438
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
 	st438:
@@ -14597,13 +14447,13 @@ tr159:
 	st_case_438:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14619,7 +14469,7 @@ tr159:
 				goto st439
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
 	st439:
@@ -14629,13 +14479,13 @@ tr159:
 	st_case_439:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14651,7 +14501,7 @@ tr159:
 				goto st440
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
 	st440:
@@ -14661,13 +14511,13 @@ tr159:
 	st_case_440:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14683,7 +14533,7 @@ tr159:
 				goto st441
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
 	st441:
@@ -14693,13 +14543,13 @@ tr159:
 	st_case_441:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14715,7 +14565,7 @@ tr159:
 				goto st442
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st81
 	st442:
@@ -14725,13 +14575,237 @@ tr159:
 	st_case_442:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr607
+			goto tr618
 		case 11:
-			goto tr608
+			goto tr619
 		case 12:
-			goto tr479
+			goto tr490
 		case 32:
-			goto tr607
+			goto tr618
+		case 34:
+			goto tr162
+		case 44:
+			goto tr90
+		case 61:
+			goto tr163
+		case 92:
+			goto st132
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st443
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st81
+	st443:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof443
+		}
+	st_case_443:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr618
+		case 11:
+			goto tr619
+		case 12:
+			goto tr490
+		case 32:
+			goto tr618
+		case 34:
+			goto tr162
+		case 44:
+			goto tr90
+		case 61:
+			goto tr163
+		case 92:
+			goto st132
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st444
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st81
+	st444:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof444
+		}
+	st_case_444:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr618
+		case 11:
+			goto tr619
+		case 12:
+			goto tr490
+		case 32:
+			goto tr618
+		case 34:
+			goto tr162
+		case 44:
+			goto tr90
+		case 61:
+			goto tr163
+		case 92:
+			goto st132
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st445
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st81
+	st445:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof445
+		}
+	st_case_445:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr618
+		case 11:
+			goto tr619
+		case 12:
+			goto tr490
+		case 32:
+			goto tr618
+		case 34:
+			goto tr162
+		case 44:
+			goto tr90
+		case 61:
+			goto tr163
+		case 92:
+			goto st132
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st446
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st81
+	st446:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof446
+		}
+	st_case_446:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr618
+		case 11:
+			goto tr619
+		case 12:
+			goto tr490
+		case 32:
+			goto tr618
+		case 34:
+			goto tr162
+		case 44:
+			goto tr90
+		case 61:
+			goto tr163
+		case 92:
+			goto st132
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st447
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st81
+	st447:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof447
+		}
+	st_case_447:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr618
+		case 11:
+			goto tr619
+		case 12:
+			goto tr490
+		case 32:
+			goto tr618
+		case 34:
+			goto tr162
+		case 44:
+			goto tr90
+		case 61:
+			goto tr163
+		case 92:
+			goto st132
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st448
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st81
+	st448:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof448
+		}
+	st_case_448:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr618
+		case 11:
+			goto tr619
+		case 12:
+			goto tr490
+		case 32:
+			goto tr618
+		case 34:
+			goto tr162
+		case 44:
+			goto tr90
+		case 61:
+			goto tr163
+		case 92:
+			goto st132
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st449
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st81
+	st449:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof449
+		}
+	st_case_449:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr618
+		case 11:
+			goto tr619
+		case 12:
+			goto tr490
+		case 32:
+			goto tr618
 		case 34:
 			goto tr162
 		case 44:
@@ -14742,7 +14816,7 @@ tr159:
 			goto st132
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr351
+			goto tr362
 		}
 		goto st81
 tr83:
@@ -14754,44 +14828,44 @@ tr83:
 
 	m.handler.AddString(key, m.text())
 
-	goto st443
+	goto st450
 tr89:
 //line plugins/parsers/influx/machine.go.rl:104
 
 	m.handler.AddString(key, m.text())
 
-	goto st443
-	st443:
+	goto st450
+	st450:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof443
+			goto _test_eof450
 		}
-	st_case_443:
-//line plugins/parsers/influx/machine.go:14770
+	st_case_450:
+//line plugins/parsers/influx/machine.go:14844
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr631
+			goto tr642
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr471
+			goto tr482
 		case 44:
-			goto tr473
+			goto tr484
 		case 92:
 			goto st133
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr471
+			goto tr482
 		}
 		goto st2
-tr631:
+tr642:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
 
-	goto st444
-tr783:
+	goto st451
+tr794:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -14800,8 +14874,8 @@ tr783:
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st444
-tr808:
+	goto st451
+tr819:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -14810,8 +14884,8 @@ tr808:
 
 	m.handler.AddInt(key, m.text())
 
-	goto st444
-tr811:
+	goto st451
+tr822:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -14820,8 +14894,8 @@ tr811:
 
 	m.handler.AddUint(key, m.text())
 
-	goto st444
-tr814:
+	goto st451
+tr825:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -14830,26 +14904,26 @@ tr814:
 
 	m.handler.AddBool(key, m.text())
 
-	goto st444
-	st444:
+	goto st451
+	st451:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof444
+			goto _test_eof451
 		}
-	st_case_444:
-//line plugins/parsers/influx/machine.go:14840
+	st_case_451:
+//line plugins/parsers/influx/machine.go:14914
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr476
+			goto tr487
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr471
+			goto tr482
 		case 44:
 			goto tr7
 		case 45:
-			goto tr477
+			goto tr488
 		case 61:
 			goto st2
 		case 92:
@@ -14858,10 +14932,10 @@ tr814:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr478
+				goto tr489
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr471
+			goto tr482
 		}
 		goto tr44
 tr2:
@@ -14875,7 +14949,7 @@ tr2:
 			goto _test_eof133
 		}
 	st_case_133:
-//line plugins/parsers/influx/machine.go:14879
+//line plugins/parsers/influx/machine.go:14953
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -14885,7 +14959,7 @@ tr2:
 			goto tr1
 		}
 		goto st2
-tr578:
+tr589:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -14895,7 +14969,7 @@ tr578:
 	m.pb = m.p
 
 	goto st134
-tr733:
+tr744:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -14905,7 +14979,7 @@ tr733:
 	m.handler.AddFloat(key, m.text())
 
 	goto st134
-tr765:
+tr776:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -14915,7 +14989,7 @@ tr765:
 	m.handler.AddInt(key, m.text())
 
 	goto st134
-tr769:
+tr780:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -14925,7 +14999,7 @@ tr769:
 	m.handler.AddUint(key, m.text())
 
 	goto st134
-tr773:
+tr784:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -14935,7 +15009,7 @@ tr773:
 	m.handler.AddBool(key, m.text())
 
 	goto st134
-tr781:
+tr792:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -14945,7 +15019,7 @@ tr781:
 	m.handler.AddFloat(key, m.text())
 
 	goto st134
-tr790:
+tr801:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -14955,7 +15029,7 @@ tr790:
 	m.handler.AddInt(key, m.text())
 
 	goto st134
-tr795:
+tr806:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -14965,7 +15039,7 @@ tr795:
 	m.handler.AddUint(key, m.text())
 
 	goto st134
-tr800:
+tr811:
 //line plugins/parsers/influx/machine.go.rl:72
 
 	m.handler.SetMeasurement(m.text())
@@ -14980,7 +15054,7 @@ tr800:
 			goto _test_eof134
 		}
 	st_case_134:
-//line plugins/parsers/influx/machine.go:14984
+//line plugins/parsers/influx/machine.go:15058
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -15012,7 +15086,7 @@ tr258:
 			goto _test_eof135
 		}
 	st_case_135:
-//line plugins/parsers/influx/machine.go:15016
+//line plugins/parsers/influx/machine.go:15090
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -15042,28 +15116,28 @@ tr259:
 
 	m.handler.AddString(key, m.text())
 
-	goto st445
+	goto st452
 tr262:
 //line plugins/parsers/influx/machine.go.rl:104
 
 	m.handler.AddString(key, m.text())
 
-	goto st445
-	st445:
+	goto st452
+	st452:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof445
+			goto _test_eof452
 		}
-	st_case_445:
-//line plugins/parsers/influx/machine.go:15058
+	st_case_452:
+//line plugins/parsers/influx/machine.go:15132
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto st446
+			goto st453
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st200
+			goto st207
 		case 44:
 			goto st9
 		case 61:
@@ -15072,27 +15146,27 @@ tr262:
 			goto st118
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st200
+			goto st207
 		}
 		goto st86
-	st446:
+	st453:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof446
+			goto _test_eof453
 		}
-	st_case_446:
+	st_case_453:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto st446
+			goto st453
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto st200
+			goto st207
 		case 44:
 			goto tr207
 		case 45:
-			goto tr633
+			goto tr644
 		case 61:
 			goto tr169
 		case 92:
@@ -15101,13 +15175,13 @@ tr262:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr634
+				goto tr645
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st200
+			goto st207
 		}
 		goto st86
-tr633:
+tr644:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -15118,7 +15192,7 @@ tr633:
 			goto _test_eof136
 		}
 	st_case_136:
-//line plugins/parsers/influx/machine.go:15122
+//line plugins/parsers/influx/machine.go:15196
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr207
@@ -15136,275 +15210,33 @@ tr633:
 			}
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st447
+				goto st454
 			}
 		default:
 			goto tr207
 		}
 		goto st86
-tr634:
+tr645:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st447
-	st447:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof447
-		}
-	st_case_447:
-//line plugins/parsers/influx/machine.go:15157
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr635
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr207
-		case 61:
-			goto tr169
-		case 92:
-			goto st118
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st449
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st86
-tr635:
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st448
-	st448:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof448
-		}
-	st_case_448:
-//line plugins/parsers/influx/machine.go:15194
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr346
-		case 11:
-			goto st448
-		case 13:
-			goto tr346
-		case 32:
-			goto st203
-		case 44:
-			goto tr61
-		case 61:
-			goto tr169
-		case 92:
-			goto st118
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st203
-		}
-		goto st86
-	st449:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof449
-		}
-	st_case_449:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr635
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr207
-		case 61:
-			goto tr169
-		case 92:
-			goto st118
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st450
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st86
-	st450:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof450
-		}
-	st_case_450:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr635
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr207
-		case 61:
-			goto tr169
-		case 92:
-			goto st118
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st451
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st86
-	st451:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof451
-		}
-	st_case_451:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr635
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr207
-		case 61:
-			goto tr169
-		case 92:
-			goto st118
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st452
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st86
-	st452:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof452
-		}
-	st_case_452:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr635
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr207
-		case 61:
-			goto tr169
-		case 92:
-			goto st118
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st453
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st86
-	st453:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof453
-		}
-	st_case_453:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr635
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
-		case 44:
-			goto tr207
-		case 61:
-			goto tr169
-		case 92:
-			goto st118
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st454
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st86
+	goto st454
 	st454:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof454
 		}
 	st_case_454:
+//line plugins/parsers/influx/machine.go:15231
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
-		case 44:
-			goto tr207
-		case 61:
-			goto tr169
-		case 92:
-			goto st118
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st455
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr350
-		}
-		goto st86
-	st455:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof455
-		}
-	st_case_455:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr351
-		case 11:
-			goto tr635
-		case 13:
-			goto tr351
-		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15418,7 +15250,39 @@ tr635:
 				goto st456
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
+		}
+		goto st86
+tr646:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st455
+	st455:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof455
+		}
+	st_case_455:
+//line plugins/parsers/influx/machine.go:15268
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr357
+		case 11:
+			goto st455
+		case 13:
+			goto tr357
+		case 32:
+			goto st210
+		case 44:
+			goto tr61
+		case 61:
+			goto tr169
+		case 92:
+			goto st118
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st210
 		}
 		goto st86
 	st456:
@@ -15428,13 +15292,13 @@ tr635:
 	st_case_456:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15448,7 +15312,7 @@ tr635:
 				goto st457
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st86
 	st457:
@@ -15458,13 +15322,13 @@ tr635:
 	st_case_457:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15478,7 +15342,7 @@ tr635:
 				goto st458
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st86
 	st458:
@@ -15488,13 +15352,13 @@ tr635:
 	st_case_458:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15508,7 +15372,7 @@ tr635:
 				goto st459
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st86
 	st459:
@@ -15518,13 +15382,13 @@ tr635:
 	st_case_459:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15538,7 +15402,7 @@ tr635:
 				goto st460
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st86
 	st460:
@@ -15548,13 +15412,13 @@ tr635:
 	st_case_460:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15568,7 +15432,7 @@ tr635:
 				goto st461
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st86
 	st461:
@@ -15578,13 +15442,13 @@ tr635:
 	st_case_461:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15598,7 +15462,7 @@ tr635:
 				goto st462
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st86
 	st462:
@@ -15608,13 +15472,13 @@ tr635:
 	st_case_462:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15628,7 +15492,7 @@ tr635:
 				goto st463
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st86
 	st463:
@@ -15638,13 +15502,13 @@ tr635:
 	st_case_463:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15658,7 +15522,7 @@ tr635:
 				goto st464
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st86
 	st464:
@@ -15668,13 +15532,13 @@ tr635:
 	st_case_464:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15688,7 +15552,7 @@ tr635:
 				goto st465
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st86
 	st465:
@@ -15698,13 +15562,13 @@ tr635:
 	st_case_465:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15718,7 +15582,7 @@ tr635:
 				goto st466
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr350
+			goto tr361
 		}
 		goto st86
 	st466:
@@ -15728,13 +15592,223 @@ tr635:
 	st_case_466:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr351
+			goto tr362
 		case 11:
-			goto tr635
+			goto tr646
 		case 13:
-			goto tr351
+			goto tr362
 		case 32:
-			goto tr350
+			goto tr361
+		case 44:
+			goto tr207
+		case 61:
+			goto tr169
+		case 92:
+			goto st118
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st467
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st86
+	st467:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof467
+		}
+	st_case_467:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr646
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr207
+		case 61:
+			goto tr169
+		case 92:
+			goto st118
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st468
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st86
+	st468:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof468
+		}
+	st_case_468:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr646
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr207
+		case 61:
+			goto tr169
+		case 92:
+			goto st118
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st469
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st86
+	st469:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof469
+		}
+	st_case_469:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr646
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr207
+		case 61:
+			goto tr169
+		case 92:
+			goto st118
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st470
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st86
+	st470:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof470
+		}
+	st_case_470:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr646
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr207
+		case 61:
+			goto tr169
+		case 92:
+			goto st118
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st471
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st86
+	st471:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof471
+		}
+	st_case_471:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr646
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr207
+		case 61:
+			goto tr169
+		case 92:
+			goto st118
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st472
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st86
+	st472:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof472
+		}
+	st_case_472:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr646
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
+		case 44:
+			goto tr207
+		case 61:
+			goto tr169
+		case 92:
+			goto st118
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st473
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr361
+		}
+		goto st86
+	st473:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof473
+		}
+	st_case_473:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr362
+		case 11:
+			goto tr646
+		case 13:
+			goto tr362
+		case 32:
+			goto tr361
 		case 44:
 			goto tr207
 		case 61:
@@ -15743,7 +15817,7 @@ tr635:
 			goto st118
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr350
+			goto tr361
 		}
 		goto st86
 tr263:
@@ -15761,7 +15835,7 @@ tr263:
 			goto _test_eof137
 		}
 	st_case_137:
-//line plugins/parsers/influx/machine.go:15765
+//line plugins/parsers/influx/machine.go:15839
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -15810,42 +15884,42 @@ tr266:
 
 	m.handler.AddString(key, m.text())
 
-	goto st467
-	st467:
+	goto st474
+	st474:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof467
+			goto _test_eof474
 		}
-	st_case_467:
-//line plugins/parsers/influx/machine.go:15820
+	st_case_474:
+//line plugins/parsers/influx/machine.go:15894
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr655
+			goto tr666
 		case 11:
-			goto tr656
+			goto tr667
 		case 12:
-			goto tr503
+			goto tr514
 		case 32:
-			goto tr655
+			goto tr666
 		case 34:
 			goto tr183
 		case 44:
-			goto tr657
+			goto tr668
 		case 61:
 			goto tr25
 		case 92:
 			goto tr185
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
+			goto tr357
 		}
 		goto tr180
-tr682:
+tr693:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
 
-	goto st468
-tr655:
+	goto st475
+tr666:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -15854,8 +15928,8 @@ tr655:
 
 	m.pb = m.p
 
-	goto st468
-tr710:
+	goto st475
+tr721:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -15864,8 +15938,8 @@ tr710:
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st468
-tr716:
+	goto st475
+tr727:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -15874,8 +15948,8 @@ tr716:
 
 	m.handler.AddInt(key, m.text())
 
-	goto st468
-tr720:
+	goto st475
+tr731:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -15884,8 +15958,8 @@ tr720:
 
 	m.handler.AddUint(key, m.text())
 
-	goto st468
-tr724:
+	goto st475
+tr735:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -15894,28 +15968,28 @@ tr724:
 
 	m.handler.AddBool(key, m.text())
 
-	goto st468
-	st468:
+	goto st475
+	st475:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof468
+			goto _test_eof475
 		}
-	st_case_468:
-//line plugins/parsers/influx/machine.go:15904
+	st_case_475:
+//line plugins/parsers/influx/machine.go:15978
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto st468
+			goto st475
 		case 11:
-			goto tr659
+			goto tr670
 		case 12:
-			goto st311
+			goto st318
 		case 32:
-			goto st468
+			goto st475
 		case 34:
 			goto tr95
 		case 44:
 			goto st7
 		case 45:
-			goto tr660
+			goto tr671
 		case 61:
 			goto st7
 		case 92:
@@ -15924,39 +15998,39 @@ tr724:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr661
+				goto tr672
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr346
+			goto tr357
 		}
 		goto tr192
-tr659:
+tr670:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st469
-	st469:
+	goto st476
+	st476:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof469
+			goto _test_eof476
 		}
-	st_case_469:
-//line plugins/parsers/influx/machine.go:15945
+	st_case_476:
+//line plugins/parsers/influx/machine.go:16019
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto st468
+			goto st475
 		case 11:
-			goto tr659
+			goto tr670
 		case 12:
-			goto st311
+			goto st318
 		case 32:
-			goto st468
+			goto st475
 		case 34:
 			goto tr95
 		case 44:
 			goto st7
 		case 45:
-			goto tr660
+			goto tr671
 		case 61:
 			goto tr197
 		case 92:
@@ -15965,13 +16039,13 @@ tr659:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr661
+				goto tr672
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr346
+			goto tr357
 		}
 		goto tr192
-tr660:
+tr671:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -15982,7 +16056,7 @@ tr660:
 			goto _test_eof138
 		}
 	st_case_138:
-//line plugins/parsers/influx/machine.go:15986
+//line plugins/parsers/influx/machine.go:16060
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -16002,291 +16076,33 @@ tr660:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st470
+				goto st477
 			}
 		case ( m.data)[( m.p)] >= 12:
 			goto tr101
 		}
 		goto st91
-tr661:
+tr672:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st470
-	st470:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof470
-		}
-	st_case_470:
-//line plugins/parsers/influx/machine.go:16023
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr662
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr197
-		case 92:
-			goto st93
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st472
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st91
-tr662:
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st471
-	st471:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof471
-		}
-	st_case_471:
-//line plugins/parsers/influx/machine.go:16062
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st261
-		case 11:
-			goto st471
-		case 12:
-			goto st203
-		case 32:
-			goto st261
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr197
-		case 92:
-			goto st93
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
-		}
-		goto st91
-	st472:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof472
-		}
-	st_case_472:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr662
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr197
-		case 92:
-			goto st93
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st473
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st91
-	st473:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof473
-		}
-	st_case_473:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr662
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr197
-		case 92:
-			goto st93
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st474
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st91
-	st474:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof474
-		}
-	st_case_474:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr662
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr197
-		case 92:
-			goto st93
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st475
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st91
-	st475:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof475
-		}
-	st_case_475:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr662
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr197
-		case 92:
-			goto st93
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st476
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st91
-	st476:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof476
-		}
-	st_case_476:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr662
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr197
-		case 92:
-			goto st93
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st477
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st91
+	goto st477
 	st477:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof477
 		}
 	st_case_477:
+//line plugins/parsers/influx/machine.go:16097
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
-		case 34:
-			goto tr98
-		case 44:
-			goto st7
-		case 61:
-			goto tr197
-		case 92:
-			goto st93
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st478
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st91
-	st478:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof478
-		}
-	st_case_478:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr420
-		case 11:
-			goto tr662
-		case 12:
-			goto tr350
-		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16302,7 +16118,41 @@ tr662:
 				goto st479
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
+		}
+		goto st91
+tr673:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st478
+	st478:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof478
+		}
+	st_case_478:
+//line plugins/parsers/influx/machine.go:16136
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st268
+		case 11:
+			goto st478
+		case 12:
+			goto st210
+		case 32:
+			goto st268
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr197
+		case 92:
+			goto st93
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr357
 		}
 		goto st91
 	st479:
@@ -16312,13 +16162,13 @@ tr662:
 	st_case_479:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16334,7 +16184,7 @@ tr662:
 				goto st480
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st91
 	st480:
@@ -16344,13 +16194,13 @@ tr662:
 	st_case_480:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16366,7 +16216,7 @@ tr662:
 				goto st481
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st91
 	st481:
@@ -16376,13 +16226,13 @@ tr662:
 	st_case_481:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16398,7 +16248,7 @@ tr662:
 				goto st482
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st91
 	st482:
@@ -16408,13 +16258,13 @@ tr662:
 	st_case_482:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16430,7 +16280,7 @@ tr662:
 				goto st483
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st91
 	st483:
@@ -16440,13 +16290,13 @@ tr662:
 	st_case_483:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16462,7 +16312,7 @@ tr662:
 				goto st484
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st91
 	st484:
@@ -16472,13 +16322,13 @@ tr662:
 	st_case_484:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16494,7 +16344,7 @@ tr662:
 				goto st485
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st91
 	st485:
@@ -16504,13 +16354,13 @@ tr662:
 	st_case_485:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16526,7 +16376,7 @@ tr662:
 				goto st486
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st91
 	st486:
@@ -16536,13 +16386,13 @@ tr662:
 	st_case_486:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16558,7 +16408,7 @@ tr662:
 				goto st487
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st91
 	st487:
@@ -16568,13 +16418,13 @@ tr662:
 	st_case_487:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16590,7 +16440,7 @@ tr662:
 				goto st488
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st91
 	st488:
@@ -16600,13 +16450,13 @@ tr662:
 	st_case_488:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16622,7 +16472,7 @@ tr662:
 				goto st489
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st91
 	st489:
@@ -16632,13 +16482,237 @@ tr662:
 	st_case_489:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr420
+			goto tr431
 		case 11:
-			goto tr662
+			goto tr673
 		case 12:
-			goto tr350
+			goto tr361
 		case 32:
-			goto tr420
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr197
+		case 92:
+			goto st93
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st490
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st91
+	st490:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof490
+		}
+	st_case_490:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr673
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr197
+		case 92:
+			goto st93
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st491
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st91
+	st491:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof491
+		}
+	st_case_491:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr673
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr197
+		case 92:
+			goto st93
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st492
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st91
+	st492:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof492
+		}
+	st_case_492:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr673
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr197
+		case 92:
+			goto st93
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st493
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st91
+	st493:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof493
+		}
+	st_case_493:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr673
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr197
+		case 92:
+			goto st93
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st494
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st91
+	st494:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof494
+		}
+	st_case_494:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr673
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr197
+		case 92:
+			goto st93
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st495
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st91
+	st495:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof495
+		}
+	st_case_495:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr673
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
+		case 34:
+			goto tr98
+		case 44:
+			goto st7
+		case 61:
+			goto tr197
+		case 92:
+			goto st93
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st496
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st91
+	st496:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof496
+		}
+	st_case_496:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr431
+		case 11:
+			goto tr673
+		case 12:
+			goto tr361
+		case 32:
+			goto tr431
 		case 34:
 			goto tr98
 		case 44:
@@ -16649,10 +16723,10 @@ tr662:
 			goto st93
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr351
+			goto tr362
 		}
 		goto st91
-tr656:
+tr667:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -16661,8 +16735,8 @@ tr656:
 
 	m.pb = m.p
 
-	goto st490
-tr711:
+	goto st497
+tr722:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -16671,8 +16745,8 @@ tr711:
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st490
-tr717:
+	goto st497
+tr728:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -16681,8 +16755,8 @@ tr717:
 
 	m.handler.AddInt(key, m.text())
 
-	goto st490
-tr721:
+	goto st497
+tr732:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -16691,8 +16765,8 @@ tr721:
 
 	m.handler.AddUint(key, m.text())
 
-	goto st490
-tr725:
+	goto st497
+tr736:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -16701,28 +16775,28 @@ tr725:
 
 	m.handler.AddBool(key, m.text())
 
-	goto st490
-	st490:
+	goto st497
+	st497:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof490
+			goto _test_eof497
 		}
-	st_case_490:
-//line plugins/parsers/influx/machine.go:16711
+	st_case_497:
+//line plugins/parsers/influx/machine.go:16785
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr682
+			goto tr693
 		case 11:
-			goto tr683
+			goto tr694
 		case 12:
-			goto tr503
+			goto tr514
 		case 32:
-			goto tr682
+			goto tr693
 		case 34:
 			goto tr201
 		case 44:
 			goto tr190
 		case 45:
-			goto tr684
+			goto tr695
 		case 61:
 			goto st7
 		case 92:
@@ -16731,13 +16805,13 @@ tr725:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr685
+				goto tr696
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr346
+			goto tr357
 		}
 		goto tr199
-tr683:
+tr694:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -16746,28 +16820,28 @@ tr683:
 
 	m.pb = m.p
 
-	goto st491
-	st491:
+	goto st498
+	st498:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof491
+			goto _test_eof498
 		}
-	st_case_491:
-//line plugins/parsers/influx/machine.go:16756
+	st_case_498:
+//line plugins/parsers/influx/machine.go:16830
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr682
+			goto tr693
 		case 11:
-			goto tr683
+			goto tr694
 		case 12:
-			goto tr503
+			goto tr514
 		case 32:
-			goto tr682
+			goto tr693
 		case 34:
 			goto tr201
 		case 44:
 			goto tr190
 		case 45:
-			goto tr684
+			goto tr695
 		case 61:
 			goto tr197
 		case 92:
@@ -16776,13 +16850,13 @@ tr683:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr685
+				goto tr696
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr346
+			goto tr357
 		}
 		goto tr199
-tr684:
+tr695:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -16793,7 +16867,7 @@ tr684:
 			goto _test_eof139
 		}
 	st_case_139:
-//line plugins/parsers/influx/machine.go:16797
+//line plugins/parsers/influx/machine.go:16871
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr187
@@ -16815,383 +16889,33 @@ tr684:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st492
+				goto st499
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr207
 		}
 		goto st96
-tr685:
+tr696:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st492
-	st492:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof492
-		}
-	st_case_492:
-//line plugins/parsers/influx/machine.go:16836
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr686
-		case 11:
-			goto tr687
-		case 12:
-			goto tr509
-		case 32:
-			goto tr686
-		case 34:
-			goto tr205
-		case 44:
-			goto tr190
-		case 61:
-			goto tr197
-		case 92:
-			goto st105
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st496
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st96
-tr691:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-	goto st493
-tr686:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st493
-	st493:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof493
-		}
-	st_case_493:
-//line plugins/parsers/influx/machine.go:16885
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st493
-		case 11:
-			goto tr690
-		case 12:
-			goto st315
-		case 32:
-			goto st493
-		case 34:
-			goto tr95
-		case 44:
-			goto st7
-		case 61:
-			goto st7
-		case 92:
-			goto tr195
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
-		}
-		goto tr192
-tr690:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st494
-	st494:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof494
-		}
-	st_case_494:
-//line plugins/parsers/influx/machine.go:16919
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st493
-		case 11:
-			goto tr690
-		case 12:
-			goto st315
-		case 32:
-			goto st493
-		case 34:
-			goto tr95
-		case 44:
-			goto st7
-		case 61:
-			goto tr197
-		case 92:
-			goto tr195
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
-		}
-		goto tr192
-tr692:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st495
-tr687:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st495
-	st495:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof495
-		}
-	st_case_495:
-//line plugins/parsers/influx/machine.go:16967
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr691
-		case 11:
-			goto tr692
-		case 12:
-			goto tr512
-		case 32:
-			goto tr691
-		case 34:
-			goto tr201
-		case 44:
-			goto tr190
-		case 61:
-			goto tr197
-		case 92:
-			goto tr202
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
-		}
-		goto tr199
-	st496:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof496
-		}
-	st_case_496:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr686
-		case 11:
-			goto tr687
-		case 12:
-			goto tr509
-		case 32:
-			goto tr686
-		case 34:
-			goto tr205
-		case 44:
-			goto tr190
-		case 61:
-			goto tr197
-		case 92:
-			goto st105
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st497
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st96
-	st497:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof497
-		}
-	st_case_497:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr686
-		case 11:
-			goto tr687
-		case 12:
-			goto tr509
-		case 32:
-			goto tr686
-		case 34:
-			goto tr205
-		case 44:
-			goto tr190
-		case 61:
-			goto tr197
-		case 92:
-			goto st105
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st498
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st96
-	st498:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof498
-		}
-	st_case_498:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr686
-		case 11:
-			goto tr687
-		case 12:
-			goto tr509
-		case 32:
-			goto tr686
-		case 34:
-			goto tr205
-		case 44:
-			goto tr190
-		case 61:
-			goto tr197
-		case 92:
-			goto st105
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st499
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st96
+	goto st499
 	st499:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof499
 		}
 	st_case_499:
+//line plugins/parsers/influx/machine.go:16910
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
-		case 34:
-			goto tr205
-		case 44:
-			goto tr190
-		case 61:
-			goto tr197
-		case 92:
-			goto st105
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st500
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st96
-	st500:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof500
-		}
-	st_case_500:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr686
-		case 11:
-			goto tr687
-		case 12:
-			goto tr509
-		case 32:
-			goto tr686
-		case 34:
-			goto tr205
-		case 44:
-			goto tr190
-		case 61:
-			goto tr197
-		case 92:
-			goto st105
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st501
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st96
-	st501:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof501
-		}
-	st_case_501:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr686
-		case 11:
-			goto tr687
-		case 12:
-			goto tr509
-		case 32:
-			goto tr686
-		case 34:
-			goto tr205
-		case 44:
-			goto tr190
-		case 61:
-			goto tr197
-		case 92:
-			goto st105
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st502
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st96
-	st502:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof502
-		}
-	st_case_502:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr686
-		case 11:
-			goto tr687
-		case 12:
-			goto tr509
-		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17207,9 +16931,135 @@ tr687:
 				goto st503
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
+tr702:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+	goto st500
+tr697:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st500
+	st500:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof500
+		}
+	st_case_500:
+//line plugins/parsers/influx/machine.go:16959
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st500
+		case 11:
+			goto tr701
+		case 12:
+			goto st322
+		case 32:
+			goto st500
+		case 34:
+			goto tr95
+		case 44:
+			goto st7
+		case 61:
+			goto st7
+		case 92:
+			goto tr195
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr357
+		}
+		goto tr192
+tr701:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st501
+	st501:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof501
+		}
+	st_case_501:
+//line plugins/parsers/influx/machine.go:16993
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st500
+		case 11:
+			goto tr701
+		case 12:
+			goto st322
+		case 32:
+			goto st500
+		case 34:
+			goto tr95
+		case 44:
+			goto st7
+		case 61:
+			goto tr197
+		case 92:
+			goto tr195
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr357
+		}
+		goto tr192
+tr703:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st502
+tr698:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st502
+	st502:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof502
+		}
+	st_case_502:
+//line plugins/parsers/influx/machine.go:17041
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr702
+		case 11:
+			goto tr703
+		case 12:
+			goto tr523
+		case 32:
+			goto tr702
+		case 34:
+			goto tr201
+		case 44:
+			goto tr190
+		case 61:
+			goto tr197
+		case 92:
+			goto tr202
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr357
+		}
+		goto tr199
 	st503:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof503
@@ -17217,13 +17067,13 @@ tr687:
 	st_case_503:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17239,7 +17089,7 @@ tr687:
 				goto st504
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
 	st504:
@@ -17249,13 +17099,13 @@ tr687:
 	st_case_504:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17271,7 +17121,7 @@ tr687:
 				goto st505
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
 	st505:
@@ -17281,13 +17131,13 @@ tr687:
 	st_case_505:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17303,7 +17153,7 @@ tr687:
 				goto st506
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
 	st506:
@@ -17313,13 +17163,13 @@ tr687:
 	st_case_506:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17335,7 +17185,7 @@ tr687:
 				goto st507
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
 	st507:
@@ -17345,13 +17195,13 @@ tr687:
 	st_case_507:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17367,7 +17217,7 @@ tr687:
 				goto st508
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
 	st508:
@@ -17377,13 +17227,13 @@ tr687:
 	st_case_508:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17399,7 +17249,7 @@ tr687:
 				goto st509
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
 	st509:
@@ -17409,13 +17259,13 @@ tr687:
 	st_case_509:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17431,7 +17281,7 @@ tr687:
 				goto st510
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
 	st510:
@@ -17441,13 +17291,13 @@ tr687:
 	st_case_510:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17463,7 +17313,7 @@ tr687:
 				goto st511
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
 	st511:
@@ -17473,13 +17323,13 @@ tr687:
 	st_case_511:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17495,7 +17345,7 @@ tr687:
 				goto st512
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
 	st512:
@@ -17505,13 +17355,13 @@ tr687:
 	st_case_512:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17527,7 +17377,7 @@ tr687:
 				goto st513
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st96
 	st513:
@@ -17537,13 +17387,237 @@ tr687:
 	st_case_513:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr686
+			goto tr697
 		case 11:
-			goto tr687
+			goto tr698
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr686
+			goto tr697
+		case 34:
+			goto tr205
+		case 44:
+			goto tr190
+		case 61:
+			goto tr197
+		case 92:
+			goto st105
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st514
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st96
+	st514:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof514
+		}
+	st_case_514:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr697
+		case 11:
+			goto tr698
+		case 12:
+			goto tr520
+		case 32:
+			goto tr697
+		case 34:
+			goto tr205
+		case 44:
+			goto tr190
+		case 61:
+			goto tr197
+		case 92:
+			goto st105
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st515
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st96
+	st515:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof515
+		}
+	st_case_515:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr697
+		case 11:
+			goto tr698
+		case 12:
+			goto tr520
+		case 32:
+			goto tr697
+		case 34:
+			goto tr205
+		case 44:
+			goto tr190
+		case 61:
+			goto tr197
+		case 92:
+			goto st105
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st516
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st96
+	st516:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof516
+		}
+	st_case_516:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr697
+		case 11:
+			goto tr698
+		case 12:
+			goto tr520
+		case 32:
+			goto tr697
+		case 34:
+			goto tr205
+		case 44:
+			goto tr190
+		case 61:
+			goto tr197
+		case 92:
+			goto st105
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st517
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st96
+	st517:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof517
+		}
+	st_case_517:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr697
+		case 11:
+			goto tr698
+		case 12:
+			goto tr520
+		case 32:
+			goto tr697
+		case 34:
+			goto tr205
+		case 44:
+			goto tr190
+		case 61:
+			goto tr197
+		case 92:
+			goto st105
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st518
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st96
+	st518:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof518
+		}
+	st_case_518:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr697
+		case 11:
+			goto tr698
+		case 12:
+			goto tr520
+		case 32:
+			goto tr697
+		case 34:
+			goto tr205
+		case 44:
+			goto tr190
+		case 61:
+			goto tr197
+		case 92:
+			goto st105
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st519
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st96
+	st519:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof519
+		}
+	st_case_519:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr697
+		case 11:
+			goto tr698
+		case 12:
+			goto tr520
+		case 32:
+			goto tr697
+		case 34:
+			goto tr205
+		case 44:
+			goto tr190
+		case 61:
+			goto tr197
+		case 92:
+			goto st105
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st520
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st96
+	st520:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof520
+		}
+	st_case_520:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr697
+		case 11:
+			goto tr698
+		case 12:
+			goto tr520
+		case 32:
+			goto tr697
 		case 34:
 			goto tr205
 		case 44:
@@ -17554,10 +17628,10 @@ tr687:
 			goto st105
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr351
+			goto tr362
 		}
 		goto st96
-tr657:
+tr668:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -17567,7 +17641,7 @@ tr657:
 	m.pb = m.p
 
 	goto st140
-tr712:
+tr723:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -17577,7 +17651,7 @@ tr712:
 	m.handler.AddFloat(key, m.text())
 
 	goto st140
-tr718:
+tr729:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -17587,7 +17661,7 @@ tr718:
 	m.handler.AddInt(key, m.text())
 
 	goto st140
-tr722:
+tr733:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -17597,7 +17671,7 @@ tr722:
 	m.handler.AddUint(key, m.text())
 
 	goto st140
-tr726:
+tr737:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -17612,7 +17686,7 @@ tr726:
 			goto _test_eof140
 		}
 	st_case_140:
-//line plugins/parsers/influx/machine.go:17616
+//line plugins/parsers/influx/machine.go:17690
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -17644,7 +17718,7 @@ tr277:
 			goto _test_eof141
 		}
 	st_case_141:
-//line plugins/parsers/influx/machine.go:17648
+//line plugins/parsers/influx/machine.go:17722
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -17680,7 +17754,7 @@ tr280:
 			goto _test_eof142
 		}
 	st_case_142:
-//line plugins/parsers/influx/machine.go:17684
+//line plugins/parsers/influx/machine.go:17758
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st7
@@ -17731,7 +17805,7 @@ tr282:
 			goto _test_eof143
 		}
 	st_case_143:
-//line plugins/parsers/influx/machine.go:17735
+//line plugins/parsers/influx/machine.go:17809
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr187
@@ -17748,7 +17822,7 @@ tr282:
 		case 46:
 			goto st144
 		case 48:
-			goto st517
+			goto st524
 		case 61:
 			goto st7
 		case 92:
@@ -17757,7 +17831,7 @@ tr282:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st520
+				goto st527
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr61
@@ -17774,7 +17848,7 @@ tr283:
 			goto _test_eof144
 		}
 	st_case_144:
-//line plugins/parsers/influx/machine.go:17778
+//line plugins/parsers/influx/machine.go:17852
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr187
@@ -17796,30 +17870,30 @@ tr283:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st514
+				goto st521
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr61
 		}
 		goto st89
-	st514:
+	st521:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof514
+			goto _test_eof521
 		}
-	st_case_514:
+	st_case_521:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr710
+			goto tr721
 		case 11:
-			goto tr711
+			goto tr722
 		case 12:
-			goto tr555
+			goto tr566
 		case 32:
-			goto tr710
+			goto tr721
 		case 34:
 			goto tr189
 		case 44:
-			goto tr712
+			goto tr723
 		case 61:
 			goto st7
 		case 69:
@@ -17832,10 +17906,10 @@ tr283:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st514
+				goto st521
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr372
+			goto tr383
 		}
 		goto st89
 	st145:
@@ -17868,7 +17942,7 @@ tr283:
 			}
 		case ( m.data)[( m.p)] > 45:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st516
+				goto st523
 			}
 		default:
 			goto st146
@@ -17879,24 +17953,24 @@ tr294:
 
 	m.handler.AddString(key, m.text())
 
-	goto st515
-	st515:
+	goto st522
+	st522:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof515
+			goto _test_eof522
 		}
-	st_case_515:
-//line plugins/parsers/influx/machine.go:17889
+	st_case_522:
+//line plugins/parsers/influx/machine.go:17963
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr554
+			goto tr565
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr503
+			goto tr514
 		case 44:
-			goto tr505
+			goto tr516
 		case 61:
 			goto tr207
 		case 92:
@@ -17905,10 +17979,10 @@ tr294:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st383
+				goto st390
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr503
+			goto tr514
 		}
 		goto st31
 	st146:
@@ -17937,304 +18011,34 @@ tr294:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st516
+				goto st523
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr61
 		}
 		goto st89
-	st516:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof516
-		}
-	st_case_516:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr710
-		case 11:
-			goto tr711
-		case 12:
-			goto tr555
-		case 32:
-			goto tr710
-		case 34:
-			goto tr189
-		case 44:
-			goto tr712
-		case 61:
-			goto st7
-		case 92:
-			goto st103
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st516
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st89
-	st517:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof517
-		}
-	st_case_517:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr710
-		case 11:
-			goto tr711
-		case 12:
-			goto tr555
-		case 32:
-			goto tr710
-		case 34:
-			goto tr189
-		case 44:
-			goto tr712
-		case 46:
-			goto st514
-		case 61:
-			goto st7
-		case 69:
-			goto st145
-		case 92:
-			goto st103
-		case 101:
-			goto st145
-		case 105:
-			goto st519
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st518
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st89
-	st518:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof518
-		}
-	st_case_518:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr710
-		case 11:
-			goto tr711
-		case 12:
-			goto tr555
-		case 32:
-			goto tr710
-		case 34:
-			goto tr189
-		case 44:
-			goto tr712
-		case 46:
-			goto st514
-		case 61:
-			goto st7
-		case 69:
-			goto st145
-		case 92:
-			goto st103
-		case 101:
-			goto st145
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st518
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st89
-	st519:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof519
-		}
-	st_case_519:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr716
-		case 11:
-			goto tr717
-		case 12:
-			goto tr561
-		case 32:
-			goto tr716
-		case 34:
-			goto tr189
-		case 44:
-			goto tr718
-		case 61:
-			goto st7
-		case 92:
-			goto st103
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr378
-		}
-		goto st89
-	st520:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof520
-		}
-	st_case_520:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr710
-		case 11:
-			goto tr711
-		case 12:
-			goto tr555
-		case 32:
-			goto tr710
-		case 34:
-			goto tr189
-		case 44:
-			goto tr712
-		case 46:
-			goto st514
-		case 61:
-			goto st7
-		case 69:
-			goto st145
-		case 92:
-			goto st103
-		case 101:
-			goto st145
-		case 105:
-			goto st519
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st520
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st89
-tr284:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st521
-	st521:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof521
-		}
-	st_case_521:
-//line plugins/parsers/influx/machine.go:18135
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr710
-		case 11:
-			goto tr711
-		case 12:
-			goto tr555
-		case 32:
-			goto tr710
-		case 34:
-			goto tr189
-		case 44:
-			goto tr712
-		case 46:
-			goto st514
-		case 61:
-			goto st7
-		case 69:
-			goto st145
-		case 92:
-			goto st103
-		case 101:
-			goto st145
-		case 105:
-			goto st519
-		case 117:
-			goto st522
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st518
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st89
-	st522:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof522
-		}
-	st_case_522:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr720
-		case 11:
-			goto tr721
-		case 12:
-			goto tr565
-		case 32:
-			goto tr720
-		case 34:
-			goto tr189
-		case 44:
-			goto tr722
-		case 61:
-			goto st7
-		case 92:
-			goto st103
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr382
-		}
-		goto st89
-tr285:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st523
 	st523:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof523
 		}
 	st_case_523:
-//line plugins/parsers/influx/machine.go:18211
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr710
+			goto tr721
 		case 11:
-			goto tr711
+			goto tr722
 		case 12:
-			goto tr555
+			goto tr566
 		case 32:
-			goto tr710
+			goto tr721
 		case 34:
 			goto tr189
 		case 44:
-			goto tr712
-		case 46:
-			goto st514
+			goto tr723
 		case 61:
 			goto st7
-		case 69:
-			goto st145
 		case 92:
 			goto st103
-		case 101:
-			goto st145
-		case 105:
-			goto st519
-		case 117:
-			goto st522
 		}
 		switch {
 		case ( m.data)[( m.p)] > 13:
@@ -18242,7 +18046,277 @@ tr285:
 				goto st523
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr372
+			goto tr383
+		}
+		goto st89
+	st524:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof524
+		}
+	st_case_524:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr721
+		case 11:
+			goto tr722
+		case 12:
+			goto tr566
+		case 32:
+			goto tr721
+		case 34:
+			goto tr189
+		case 44:
+			goto tr723
+		case 46:
+			goto st521
+		case 61:
+			goto st7
+		case 69:
+			goto st145
+		case 92:
+			goto st103
+		case 101:
+			goto st145
+		case 105:
+			goto st526
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st525
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st89
+	st525:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof525
+		}
+	st_case_525:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr721
+		case 11:
+			goto tr722
+		case 12:
+			goto tr566
+		case 32:
+			goto tr721
+		case 34:
+			goto tr189
+		case 44:
+			goto tr723
+		case 46:
+			goto st521
+		case 61:
+			goto st7
+		case 69:
+			goto st145
+		case 92:
+			goto st103
+		case 101:
+			goto st145
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st525
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st89
+	st526:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof526
+		}
+	st_case_526:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr727
+		case 11:
+			goto tr728
+		case 12:
+			goto tr572
+		case 32:
+			goto tr727
+		case 34:
+			goto tr189
+		case 44:
+			goto tr729
+		case 61:
+			goto st7
+		case 92:
+			goto st103
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr389
+		}
+		goto st89
+	st527:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof527
+		}
+	st_case_527:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr721
+		case 11:
+			goto tr722
+		case 12:
+			goto tr566
+		case 32:
+			goto tr721
+		case 34:
+			goto tr189
+		case 44:
+			goto tr723
+		case 46:
+			goto st521
+		case 61:
+			goto st7
+		case 69:
+			goto st145
+		case 92:
+			goto st103
+		case 101:
+			goto st145
+		case 105:
+			goto st526
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st527
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st89
+tr284:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st528
+	st528:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof528
+		}
+	st_case_528:
+//line plugins/parsers/influx/machine.go:18209
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr721
+		case 11:
+			goto tr722
+		case 12:
+			goto tr566
+		case 32:
+			goto tr721
+		case 34:
+			goto tr189
+		case 44:
+			goto tr723
+		case 46:
+			goto st521
+		case 61:
+			goto st7
+		case 69:
+			goto st145
+		case 92:
+			goto st103
+		case 101:
+			goto st145
+		case 105:
+			goto st526
+		case 117:
+			goto st529
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st525
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st89
+	st529:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof529
+		}
+	st_case_529:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr731
+		case 11:
+			goto tr732
+		case 12:
+			goto tr576
+		case 32:
+			goto tr731
+		case 34:
+			goto tr189
+		case 44:
+			goto tr733
+		case 61:
+			goto st7
+		case 92:
+			goto st103
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr393
+		}
+		goto st89
+tr285:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st530
+	st530:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof530
+		}
+	st_case_530:
+//line plugins/parsers/influx/machine.go:18285
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr721
+		case 11:
+			goto tr722
+		case 12:
+			goto tr566
+		case 32:
+			goto tr721
+		case 34:
+			goto tr189
+		case 44:
+			goto tr723
+		case 46:
+			goto st521
+		case 61:
+			goto st7
+		case 69:
+			goto st145
+		case 92:
+			goto st103
+		case 101:
+			goto st145
+		case 105:
+			goto st526
+		case 117:
+			goto st529
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st530
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
 		}
 		goto st89
 tr286:
@@ -18250,26 +18324,26 @@ tr286:
 
 	m.pb = m.p
 
-	goto st524
-	st524:
+	goto st531
+	st531:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof524
+			goto _test_eof531
 		}
-	st_case_524:
-//line plugins/parsers/influx/machine.go:18260
+	st_case_531:
+//line plugins/parsers/influx/machine.go:18334
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr724
+			goto tr735
 		case 11:
-			goto tr725
+			goto tr736
 		case 12:
-			goto tr569
+			goto tr580
 		case 32:
-			goto tr724
+			goto tr735
 		case 34:
 			goto tr189
 		case 44:
-			goto tr726
+			goto tr737
 		case 61:
 			goto st7
 		case 65:
@@ -18280,7 +18354,7 @@ tr286:
 			goto st150
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st89
 	st147:
@@ -18362,7 +18436,7 @@ tr286:
 		case 61:
 			goto st7
 		case 69:
-			goto st525
+			goto st532
 		case 92:
 			goto st103
 		}
@@ -18370,31 +18444,31 @@ tr286:
 			goto tr61
 		}
 		goto st89
-	st525:
+	st532:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof525
+			goto _test_eof532
 		}
-	st_case_525:
+	st_case_532:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr724
+			goto tr735
 		case 11:
-			goto tr725
+			goto tr736
 		case 12:
-			goto tr569
+			goto tr580
 		case 32:
-			goto tr724
+			goto tr735
 		case 34:
 			goto tr189
 		case 44:
-			goto tr726
+			goto tr737
 		case 61:
 			goto st7
 		case 92:
 			goto st103
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st89
 	st150:
@@ -18478,7 +18552,7 @@ tr286:
 		case 92:
 			goto st103
 		case 101:
-			goto st525
+			goto st532
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
 			goto tr61
@@ -18489,26 +18563,26 @@ tr287:
 
 	m.pb = m.p
 
-	goto st526
-	st526:
+	goto st533
+	st533:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof526
+			goto _test_eof533
 		}
-	st_case_526:
-//line plugins/parsers/influx/machine.go:18499
+	st_case_533:
+//line plugins/parsers/influx/machine.go:18573
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr724
+			goto tr735
 		case 11:
-			goto tr725
+			goto tr736
 		case 12:
-			goto tr569
+			goto tr580
 		case 32:
-			goto tr724
+			goto tr735
 		case 34:
 			goto tr189
 		case 44:
-			goto tr726
+			goto tr737
 		case 61:
 			goto st7
 		case 82:
@@ -18519,7 +18593,7 @@ tr287:
 			goto st154
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st89
 	st153:
@@ -18585,26 +18659,26 @@ tr288:
 
 	m.pb = m.p
 
-	goto st527
-	st527:
+	goto st534
+	st534:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof527
+			goto _test_eof534
 		}
-	st_case_527:
-//line plugins/parsers/influx/machine.go:18595
+	st_case_534:
+//line plugins/parsers/influx/machine.go:18669
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr724
+			goto tr735
 		case 11:
-			goto tr725
+			goto tr736
 		case 12:
-			goto tr569
+			goto tr580
 		case 32:
-			goto tr724
+			goto tr735
 		case 34:
 			goto tr189
 		case 44:
-			goto tr726
+			goto tr737
 		case 61:
 			goto st7
 		case 92:
@@ -18613,7 +18687,7 @@ tr288:
 			goto st150
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st89
 tr289:
@@ -18621,26 +18695,26 @@ tr289:
 
 	m.pb = m.p
 
-	goto st528
-	st528:
+	goto st535
+	st535:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof528
+			goto _test_eof535
 		}
-	st_case_528:
-//line plugins/parsers/influx/machine.go:18631
+	st_case_535:
+//line plugins/parsers/influx/machine.go:18705
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr724
+			goto tr735
 		case 11:
-			goto tr725
+			goto tr736
 		case 12:
-			goto tr569
+			goto tr580
 		case 32:
-			goto tr724
+			goto tr735
 		case 34:
 			goto tr189
 		case 44:
-			goto tr726
+			goto tr737
 		case 61:
 			goto st7
 		case 92:
@@ -18649,7 +18723,7 @@ tr289:
 			goto st154
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st89
 tr278:
@@ -18663,7 +18737,7 @@ tr278:
 			goto _test_eof155
 		}
 	st_case_155:
-//line plugins/parsers/influx/machine.go:18667
+//line plugins/parsers/influx/machine.go:18741
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st141
@@ -18690,7 +18764,7 @@ tr267:
 			goto _test_eof156
 		}
 	st_case_156:
-//line plugins/parsers/influx/machine.go:18694
+//line plugins/parsers/influx/machine.go:18768
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr237
@@ -18707,7 +18781,7 @@ tr267:
 		case 46:
 			goto st157
 		case 48:
-			goto st553
+			goto st560
 		case 61:
 			goto st7
 		case 92:
@@ -18716,7 +18790,7 @@ tr267:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st556
+				goto st563
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr61
@@ -18733,7 +18807,7 @@ tr268:
 			goto _test_eof157
 		}
 	st_case_157:
-//line plugins/parsers/influx/machine.go:18737
+//line plugins/parsers/influx/machine.go:18811
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr237
@@ -18755,30 +18829,30 @@ tr268:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st529
+				goto st536
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr61
 		}
 		goto st122
-	st529:
+	st536:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof529
+			goto _test_eof536
 		}
-	st_case_529:
+	st_case_536:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr731
+			goto tr742
 		case 11:
-			goto tr732
+			goto tr743
 		case 12:
-			goto tr555
+			goto tr566
 		case 32:
-			goto tr731
+			goto tr742
 		case 34:
 			goto tr189
 		case 44:
-			goto tr733
+			goto tr744
 		case 61:
 			goto st7
 		case 69:
@@ -18791,13 +18865,13 @@ tr268:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st529
+				goto st536
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr372
+			goto tr383
 		}
 		goto st122
-tr732:
+tr743:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -18806,8 +18880,8 @@ tr732:
 
 	m.handler.AddFloat(key, m.text())
 
-	goto st530
-tr764:
+	goto st537
+tr775:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -18816,8 +18890,8 @@ tr764:
 
 	m.handler.AddInt(key, m.text())
 
-	goto st530
-tr768:
+	goto st537
+tr779:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -18826,8 +18900,8 @@ tr768:
 
 	m.handler.AddUint(key, m.text())
 
-	goto st530
-tr772:
+	goto st537
+tr783:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -18836,28 +18910,28 @@ tr772:
 
 	m.handler.AddBool(key, m.text())
 
-	goto st530
-	st530:
+	goto st537
+	st537:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof530
+			goto _test_eof537
 		}
-	st_case_530:
-//line plugins/parsers/influx/machine.go:18846
+	st_case_537:
+//line plugins/parsers/influx/machine.go:18920
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr735
+			goto tr746
 		case 11:
-			goto tr736
+			goto tr747
 		case 12:
-			goto tr503
+			goto tr514
 		case 32:
-			goto tr735
+			goto tr746
 		case 34:
 			goto tr201
 		case 44:
 			goto tr239
 		case 45:
-			goto tr737
+			goto tr748
 		case 61:
 			goto st7
 		case 92:
@@ -18866,13 +18940,13 @@ tr772:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr738
+				goto tr749
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr346
+			goto tr357
 		}
 		goto tr241
-tr736:
+tr747:
 //line plugins/parsers/influx/machine.go.rl:80
 
 	m.handler.AddTag(key, m.text())
@@ -18881,28 +18955,28 @@ tr736:
 
 	m.pb = m.p
 
-	goto st531
-	st531:
+	goto st538
+	st538:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof531
+			goto _test_eof538
 		}
-	st_case_531:
-//line plugins/parsers/influx/machine.go:18891
+	st_case_538:
+//line plugins/parsers/influx/machine.go:18965
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr735
+			goto tr746
 		case 11:
-			goto tr736
+			goto tr747
 		case 12:
-			goto tr503
+			goto tr514
 		case 32:
-			goto tr735
+			goto tr746
 		case 34:
 			goto tr201
 		case 44:
 			goto tr239
 		case 45:
-			goto tr737
+			goto tr748
 		case 61:
 			goto tr99
 		case 92:
@@ -18911,13 +18985,13 @@ tr736:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr738
+				goto tr749
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr346
+			goto tr357
 		}
 		goto tr241
-tr737:
+tr748:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
@@ -18928,7 +19002,7 @@ tr737:
 			goto _test_eof158
 		}
 	st_case_158:
-//line plugins/parsers/influx/machine.go:18932
+//line plugins/parsers/influx/machine.go:19006
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr237
@@ -18950,305 +19024,33 @@ tr737:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st532
+				goto st539
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr207
 		}
 		goto st124
-tr738:
+tr749:
 //line plugins/parsers/influx/machine.go.rl:18
 
 	m.pb = m.p
 
-	goto st532
-	st532:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof532
-		}
-	st_case_532:
-//line plugins/parsers/influx/machine.go:18971
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr739
-		case 11:
-			goto tr740
-		case 12:
-			goto tr509
-		case 32:
-			goto tr739
-		case 34:
-			goto tr205
-		case 44:
-			goto tr239
-		case 61:
-			goto tr99
-		case 92:
-			goto st126
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st534
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st124
-tr743:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st533
-tr740:
-//line plugins/parsers/influx/machine.go.rl:80
-
-	m.handler.AddTag(key, m.text())
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.handler.SetTimestamp(m.text())
-
-	goto st533
-	st533:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof533
-		}
-	st_case_533:
-//line plugins/parsers/influx/machine.go:19024
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr742
-		case 11:
-			goto tr743
-		case 12:
-			goto tr512
-		case 32:
-			goto tr742
-		case 34:
-			goto tr201
-		case 44:
-			goto tr239
-		case 61:
-			goto tr99
-		case 92:
-			goto tr243
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr346
-		}
-		goto tr241
-	st534:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof534
-		}
-	st_case_534:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr739
-		case 11:
-			goto tr740
-		case 12:
-			goto tr509
-		case 32:
-			goto tr739
-		case 34:
-			goto tr205
-		case 44:
-			goto tr239
-		case 61:
-			goto tr99
-		case 92:
-			goto st126
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st535
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st124
-	st535:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof535
-		}
-	st_case_535:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr739
-		case 11:
-			goto tr740
-		case 12:
-			goto tr509
-		case 32:
-			goto tr739
-		case 34:
-			goto tr205
-		case 44:
-			goto tr239
-		case 61:
-			goto tr99
-		case 92:
-			goto st126
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st536
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st124
-	st536:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof536
-		}
-	st_case_536:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr739
-		case 11:
-			goto tr740
-		case 12:
-			goto tr509
-		case 32:
-			goto tr739
-		case 34:
-			goto tr205
-		case 44:
-			goto tr239
-		case 61:
-			goto tr99
-		case 92:
-			goto st126
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st537
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st124
-	st537:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof537
-		}
-	st_case_537:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr739
-		case 11:
-			goto tr740
-		case 12:
-			goto tr509
-		case 32:
-			goto tr739
-		case 34:
-			goto tr205
-		case 44:
-			goto tr239
-		case 61:
-			goto tr99
-		case 92:
-			goto st126
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st538
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st124
-	st538:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof538
-		}
-	st_case_538:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr739
-		case 11:
-			goto tr740
-		case 12:
-			goto tr509
-		case 32:
-			goto tr739
-		case 34:
-			goto tr205
-		case 44:
-			goto tr239
-		case 61:
-			goto tr99
-		case 92:
-			goto st126
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st539
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st124
+	goto st539
 	st539:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof539
 		}
 	st_case_539:
+//line plugins/parsers/influx/machine.go:19045
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
-		case 34:
-			goto tr205
-		case 44:
-			goto tr239
-		case 61:
-			goto tr99
-		case 92:
-			goto st126
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st540
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr351
-		}
-		goto st124
-	st540:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof540
-		}
-	st_case_540:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr739
-		case 11:
-			goto tr740
-		case 12:
-			goto tr509
-		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19264,9 +19066,57 @@ tr740:
 				goto st541
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
+tr754:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st540
+tr751:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.handler.SetTimestamp(m.text())
+
+	goto st540
+	st540:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof540
+		}
+	st_case_540:
+//line plugins/parsers/influx/machine.go:19098
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr753
+		case 11:
+			goto tr754
+		case 12:
+			goto tr523
+		case 32:
+			goto tr753
+		case 34:
+			goto tr201
+		case 44:
+			goto tr239
+		case 61:
+			goto tr99
+		case 92:
+			goto tr243
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr357
+		}
+		goto tr241
 	st541:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof541
@@ -19274,13 +19124,13 @@ tr740:
 	st_case_541:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19296,7 +19146,7 @@ tr740:
 				goto st542
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st542:
@@ -19306,13 +19156,13 @@ tr740:
 	st_case_542:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19328,7 +19178,7 @@ tr740:
 				goto st543
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st543:
@@ -19338,13 +19188,13 @@ tr740:
 	st_case_543:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19360,7 +19210,7 @@ tr740:
 				goto st544
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st544:
@@ -19370,13 +19220,13 @@ tr740:
 	st_case_544:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19392,7 +19242,7 @@ tr740:
 				goto st545
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st545:
@@ -19402,13 +19252,13 @@ tr740:
 	st_case_545:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19424,7 +19274,7 @@ tr740:
 				goto st546
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st546:
@@ -19434,13 +19284,13 @@ tr740:
 	st_case_546:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19456,7 +19306,7 @@ tr740:
 				goto st547
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st547:
@@ -19466,13 +19316,13 @@ tr740:
 	st_case_547:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19488,7 +19338,7 @@ tr740:
 				goto st548
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st548:
@@ -19498,13 +19348,13 @@ tr740:
 	st_case_548:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19520,7 +19370,7 @@ tr740:
 				goto st549
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st549:
@@ -19530,13 +19380,13 @@ tr740:
 	st_case_549:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19552,7 +19402,7 @@ tr740:
 				goto st550
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st550:
@@ -19562,13 +19412,13 @@ tr740:
 	st_case_550:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19584,7 +19434,7 @@ tr740:
 				goto st551
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st551:
@@ -19594,13 +19444,237 @@ tr740:
 	st_case_551:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr739
+			goto tr750
 		case 11:
-			goto tr740
+			goto tr751
 		case 12:
-			goto tr509
+			goto tr520
 		case 32:
-			goto tr739
+			goto tr750
+		case 34:
+			goto tr205
+		case 44:
+			goto tr239
+		case 61:
+			goto tr99
+		case 92:
+			goto st126
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st552
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st124
+	st552:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof552
+		}
+	st_case_552:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr750
+		case 11:
+			goto tr751
+		case 12:
+			goto tr520
+		case 32:
+			goto tr750
+		case 34:
+			goto tr205
+		case 44:
+			goto tr239
+		case 61:
+			goto tr99
+		case 92:
+			goto st126
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st553
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st124
+	st553:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof553
+		}
+	st_case_553:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr750
+		case 11:
+			goto tr751
+		case 12:
+			goto tr520
+		case 32:
+			goto tr750
+		case 34:
+			goto tr205
+		case 44:
+			goto tr239
+		case 61:
+			goto tr99
+		case 92:
+			goto st126
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st554
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st124
+	st554:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof554
+		}
+	st_case_554:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr750
+		case 11:
+			goto tr751
+		case 12:
+			goto tr520
+		case 32:
+			goto tr750
+		case 34:
+			goto tr205
+		case 44:
+			goto tr239
+		case 61:
+			goto tr99
+		case 92:
+			goto st126
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st555
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st124
+	st555:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof555
+		}
+	st_case_555:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr750
+		case 11:
+			goto tr751
+		case 12:
+			goto tr520
+		case 32:
+			goto tr750
+		case 34:
+			goto tr205
+		case 44:
+			goto tr239
+		case 61:
+			goto tr99
+		case 92:
+			goto st126
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st556
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st124
+	st556:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof556
+		}
+	st_case_556:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr750
+		case 11:
+			goto tr751
+		case 12:
+			goto tr520
+		case 32:
+			goto tr750
+		case 34:
+			goto tr205
+		case 44:
+			goto tr239
+		case 61:
+			goto tr99
+		case 92:
+			goto st126
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st557
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st124
+	st557:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof557
+		}
+	st_case_557:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr750
+		case 11:
+			goto tr751
+		case 12:
+			goto tr520
+		case 32:
+			goto tr750
+		case 34:
+			goto tr205
+		case 44:
+			goto tr239
+		case 61:
+			goto tr99
+		case 92:
+			goto st126
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st558
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr362
+		}
+		goto st124
+	st558:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof558
+		}
+	st_case_558:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr750
+		case 11:
+			goto tr751
+		case 12:
+			goto tr520
+		case 32:
+			goto tr750
 		case 34:
 			goto tr205
 		case 44:
@@ -19611,7 +19685,7 @@ tr740:
 			goto st126
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr351
+			goto tr362
 		}
 		goto st124
 	st159:
@@ -19644,7 +19718,7 @@ tr740:
 			}
 		case ( m.data)[( m.p)] > 45:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st552
+				goto st559
 			}
 		default:
 			goto st160
@@ -19676,304 +19750,34 @@ tr740:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st552
+				goto st559
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr61
 		}
 		goto st122
-	st552:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof552
-		}
-	st_case_552:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr731
-		case 11:
-			goto tr732
-		case 12:
-			goto tr555
-		case 32:
-			goto tr731
-		case 34:
-			goto tr189
-		case 44:
-			goto tr733
-		case 61:
-			goto st7
-		case 92:
-			goto st127
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st552
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st122
-	st553:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof553
-		}
-	st_case_553:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr731
-		case 11:
-			goto tr732
-		case 12:
-			goto tr555
-		case 32:
-			goto tr731
-		case 34:
-			goto tr189
-		case 44:
-			goto tr733
-		case 46:
-			goto st529
-		case 61:
-			goto st7
-		case 69:
-			goto st159
-		case 92:
-			goto st127
-		case 101:
-			goto st159
-		case 105:
-			goto st555
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st554
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st122
-	st554:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof554
-		}
-	st_case_554:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr731
-		case 11:
-			goto tr732
-		case 12:
-			goto tr555
-		case 32:
-			goto tr731
-		case 34:
-			goto tr189
-		case 44:
-			goto tr733
-		case 46:
-			goto st529
-		case 61:
-			goto st7
-		case 69:
-			goto st159
-		case 92:
-			goto st127
-		case 101:
-			goto st159
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st554
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st122
-	st555:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof555
-		}
-	st_case_555:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr763
-		case 11:
-			goto tr764
-		case 12:
-			goto tr561
-		case 32:
-			goto tr763
-		case 34:
-			goto tr189
-		case 44:
-			goto tr765
-		case 61:
-			goto st7
-		case 92:
-			goto st127
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr378
-		}
-		goto st122
-	st556:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof556
-		}
-	st_case_556:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr731
-		case 11:
-			goto tr732
-		case 12:
-			goto tr555
-		case 32:
-			goto tr731
-		case 34:
-			goto tr189
-		case 44:
-			goto tr733
-		case 46:
-			goto st529
-		case 61:
-			goto st7
-		case 69:
-			goto st159
-		case 92:
-			goto st127
-		case 101:
-			goto st159
-		case 105:
-			goto st555
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st556
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st122
-tr269:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st557
-	st557:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof557
-		}
-	st_case_557:
-//line plugins/parsers/influx/machine.go:19874
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr731
-		case 11:
-			goto tr732
-		case 12:
-			goto tr555
-		case 32:
-			goto tr731
-		case 34:
-			goto tr189
-		case 44:
-			goto tr733
-		case 46:
-			goto st529
-		case 61:
-			goto st7
-		case 69:
-			goto st159
-		case 92:
-			goto st127
-		case 101:
-			goto st159
-		case 105:
-			goto st555
-		case 117:
-			goto st558
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st554
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st122
-	st558:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof558
-		}
-	st_case_558:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr767
-		case 11:
-			goto tr768
-		case 12:
-			goto tr565
-		case 32:
-			goto tr767
-		case 34:
-			goto tr189
-		case 44:
-			goto tr769
-		case 61:
-			goto st7
-		case 92:
-			goto st127
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr382
-		}
-		goto st122
-tr270:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st559
 	st559:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof559
 		}
 	st_case_559:
-//line plugins/parsers/influx/machine.go:19950
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr731
+			goto tr742
 		case 11:
-			goto tr732
+			goto tr743
 		case 12:
-			goto tr555
+			goto tr566
 		case 32:
-			goto tr731
+			goto tr742
 		case 34:
 			goto tr189
 		case 44:
-			goto tr733
-		case 46:
-			goto st529
+			goto tr744
 		case 61:
 			goto st7
-		case 69:
-			goto st159
 		case 92:
 			goto st127
-		case 101:
-			goto st159
-		case 105:
-			goto st555
-		case 117:
-			goto st558
 		}
 		switch {
 		case ( m.data)[( m.p)] > 13:
@@ -19981,7 +19785,277 @@ tr270:
 				goto st559
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr372
+			goto tr383
+		}
+		goto st122
+	st560:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof560
+		}
+	st_case_560:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr742
+		case 11:
+			goto tr743
+		case 12:
+			goto tr566
+		case 32:
+			goto tr742
+		case 34:
+			goto tr189
+		case 44:
+			goto tr744
+		case 46:
+			goto st536
+		case 61:
+			goto st7
+		case 69:
+			goto st159
+		case 92:
+			goto st127
+		case 101:
+			goto st159
+		case 105:
+			goto st562
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st561
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st122
+	st561:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof561
+		}
+	st_case_561:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr742
+		case 11:
+			goto tr743
+		case 12:
+			goto tr566
+		case 32:
+			goto tr742
+		case 34:
+			goto tr189
+		case 44:
+			goto tr744
+		case 46:
+			goto st536
+		case 61:
+			goto st7
+		case 69:
+			goto st159
+		case 92:
+			goto st127
+		case 101:
+			goto st159
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st561
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st122
+	st562:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof562
+		}
+	st_case_562:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr774
+		case 11:
+			goto tr775
+		case 12:
+			goto tr572
+		case 32:
+			goto tr774
+		case 34:
+			goto tr189
+		case 44:
+			goto tr776
+		case 61:
+			goto st7
+		case 92:
+			goto st127
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr389
+		}
+		goto st122
+	st563:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof563
+		}
+	st_case_563:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr742
+		case 11:
+			goto tr743
+		case 12:
+			goto tr566
+		case 32:
+			goto tr742
+		case 34:
+			goto tr189
+		case 44:
+			goto tr744
+		case 46:
+			goto st536
+		case 61:
+			goto st7
+		case 69:
+			goto st159
+		case 92:
+			goto st127
+		case 101:
+			goto st159
+		case 105:
+			goto st562
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st563
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st122
+tr269:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st564
+	st564:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof564
+		}
+	st_case_564:
+//line plugins/parsers/influx/machine.go:19948
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr742
+		case 11:
+			goto tr743
+		case 12:
+			goto tr566
+		case 32:
+			goto tr742
+		case 34:
+			goto tr189
+		case 44:
+			goto tr744
+		case 46:
+			goto st536
+		case 61:
+			goto st7
+		case 69:
+			goto st159
+		case 92:
+			goto st127
+		case 101:
+			goto st159
+		case 105:
+			goto st562
+		case 117:
+			goto st565
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st561
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st122
+	st565:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof565
+		}
+	st_case_565:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr778
+		case 11:
+			goto tr779
+		case 12:
+			goto tr576
+		case 32:
+			goto tr778
+		case 34:
+			goto tr189
+		case 44:
+			goto tr780
+		case 61:
+			goto st7
+		case 92:
+			goto st127
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr393
+		}
+		goto st122
+tr270:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st566
+	st566:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof566
+		}
+	st_case_566:
+//line plugins/parsers/influx/machine.go:20024
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr742
+		case 11:
+			goto tr743
+		case 12:
+			goto tr566
+		case 32:
+			goto tr742
+		case 34:
+			goto tr189
+		case 44:
+			goto tr744
+		case 46:
+			goto st536
+		case 61:
+			goto st7
+		case 69:
+			goto st159
+		case 92:
+			goto st127
+		case 101:
+			goto st159
+		case 105:
+			goto st562
+		case 117:
+			goto st565
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st566
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
 		}
 		goto st122
 tr271:
@@ -19989,26 +20063,26 @@ tr271:
 
 	m.pb = m.p
 
-	goto st560
-	st560:
+	goto st567
+	st567:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof560
+			goto _test_eof567
 		}
-	st_case_560:
-//line plugins/parsers/influx/machine.go:19999
+	st_case_567:
+//line plugins/parsers/influx/machine.go:20073
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr771
+			goto tr782
 		case 11:
-			goto tr772
+			goto tr783
 		case 12:
-			goto tr569
+			goto tr580
 		case 32:
-			goto tr771
+			goto tr782
 		case 34:
 			goto tr189
 		case 44:
-			goto tr773
+			goto tr784
 		case 61:
 			goto st7
 		case 65:
@@ -20019,7 +20093,7 @@ tr271:
 			goto st164
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st122
 	st161:
@@ -20101,7 +20175,7 @@ tr271:
 		case 61:
 			goto st7
 		case 69:
-			goto st561
+			goto st568
 		case 92:
 			goto st127
 		}
@@ -20109,31 +20183,31 @@ tr271:
 			goto tr61
 		}
 		goto st122
-	st561:
+	st568:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof561
+			goto _test_eof568
 		}
-	st_case_561:
+	st_case_568:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr771
+			goto tr782
 		case 11:
-			goto tr772
+			goto tr783
 		case 12:
-			goto tr569
+			goto tr580
 		case 32:
-			goto tr771
+			goto tr782
 		case 34:
 			goto tr189
 		case 44:
-			goto tr773
+			goto tr784
 		case 61:
 			goto st7
 		case 92:
 			goto st127
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st122
 	st164:
@@ -20217,7 +20291,7 @@ tr271:
 		case 92:
 			goto st127
 		case 101:
-			goto st561
+			goto st568
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
 			goto tr61
@@ -20228,26 +20302,26 @@ tr272:
 
 	m.pb = m.p
 
-	goto st562
-	st562:
+	goto st569
+	st569:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof562
+			goto _test_eof569
 		}
-	st_case_562:
-//line plugins/parsers/influx/machine.go:20238
+	st_case_569:
+//line plugins/parsers/influx/machine.go:20312
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr771
+			goto tr782
 		case 11:
-			goto tr772
+			goto tr783
 		case 12:
-			goto tr569
+			goto tr580
 		case 32:
-			goto tr771
+			goto tr782
 		case 34:
 			goto tr189
 		case 44:
-			goto tr773
+			goto tr784
 		case 61:
 			goto st7
 		case 82:
@@ -20258,7 +20332,7 @@ tr272:
 			goto st168
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st122
 	st167:
@@ -20324,26 +20398,26 @@ tr273:
 
 	m.pb = m.p
 
-	goto st563
-	st563:
+	goto st570
+	st570:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof563
+			goto _test_eof570
 		}
-	st_case_563:
-//line plugins/parsers/influx/machine.go:20334
+	st_case_570:
+//line plugins/parsers/influx/machine.go:20408
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr771
+			goto tr782
 		case 11:
-			goto tr772
+			goto tr783
 		case 12:
-			goto tr569
+			goto tr580
 		case 32:
-			goto tr771
+			goto tr782
 		case 34:
 			goto tr189
 		case 44:
-			goto tr773
+			goto tr784
 		case 61:
 			goto st7
 		case 92:
@@ -20352,7 +20426,7 @@ tr273:
 			goto st164
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st122
 tr274:
@@ -20360,26 +20434,26 @@ tr274:
 
 	m.pb = m.p
 
-	goto st564
-	st564:
+	goto st571
+	st571:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof564
+			goto _test_eof571
 		}
-	st_case_564:
-//line plugins/parsers/influx/machine.go:20370
+	st_case_571:
+//line plugins/parsers/influx/machine.go:20444
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr771
+			goto tr782
 		case 11:
-			goto tr772
+			goto tr783
 		case 12:
-			goto tr569
+			goto tr580
 		case 32:
-			goto tr771
+			goto tr782
 		case 34:
 			goto tr189
 		case 44:
-			goto tr773
+			goto tr784
 		case 61:
 			goto st7
 		case 92:
@@ -20388,7 +20462,7 @@ tr274:
 			goto st168
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st122
 tr260:
@@ -20402,7 +20476,7 @@ tr260:
 			goto _test_eof169
 		}
 	st_case_169:
-//line plugins/parsers/influx/machine.go:20406
+//line plugins/parsers/influx/machine.go:20480
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st135
@@ -20429,7 +20503,7 @@ tr85:
 			goto _test_eof170
 		}
 	st_case_170:
-//line plugins/parsers/influx/machine.go:20433
+//line plugins/parsers/influx/machine.go:20507
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st40
@@ -20456,7 +20530,7 @@ tr248:
 			goto _test_eof171
 		}
 	st_case_171:
-//line plugins/parsers/influx/machine.go:20460
+//line plugins/parsers/influx/machine.go:20534
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr87
@@ -20473,14 +20547,14 @@ tr248:
 		case 46:
 			goto st172
 		case 48:
-			goto st569
+			goto st576
 		case 92:
 			goto st170
 		}
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st572
+				goto st579
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr5
@@ -20497,7 +20571,7 @@ tr249:
 			goto _test_eof172
 		}
 	st_case_172:
-//line plugins/parsers/influx/machine.go:20501
+//line plugins/parsers/influx/machine.go:20575
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr87
@@ -20517,30 +20591,30 @@ tr249:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st565
+				goto st572
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr5
 		}
 		goto st40
-	st565:
+	st572:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof565
+			goto _test_eof572
 		}
-	st_case_565:
+	st_case_572:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr778
+			goto tr789
 		case 11:
-			goto tr779
+			goto tr790
 		case 12:
-			goto tr780
+			goto tr791
 		case 32:
-			goto tr778
+			goto tr789
 		case 34:
 			goto tr89
 		case 44:
-			goto tr781
+			goto tr792
 		case 69:
 			goto st173
 		case 92:
@@ -20551,10 +20625,10 @@ tr249:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st565
+				goto st572
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr372
+			goto tr383
 		}
 		goto st40
 	st173:
@@ -20585,7 +20659,7 @@ tr249:
 			}
 		case ( m.data)[( m.p)] > 45:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st568
+				goto st575
 			}
 		default:
 			goto st174
@@ -20596,62 +20670,62 @@ tr318:
 
 	m.handler.AddString(key, m.text())
 
-	goto st566
-	st566:
+	goto st573
+	st573:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof566
+			goto _test_eof573
 		}
-	st_case_566:
-//line plugins/parsers/influx/machine.go:20606
+	st_case_573:
+//line plugins/parsers/influx/machine.go:20680
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr346
+			goto tr357
 		case 11:
-			goto tr631
+			goto tr642
 		case 13:
-			goto tr346
+			goto tr357
 		case 32:
-			goto tr471
+			goto tr482
 		case 44:
-			goto tr473
+			goto tr484
 		case 92:
 			goto st133
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st567
+				goto st574
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr471
+			goto tr482
 		}
 		goto st2
-	st567:
+	st574:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof567
+			goto _test_eof574
 		}
-	st_case_567:
+	st_case_574:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 11:
-			goto tr783
+			goto tr794
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr780
+			goto tr791
 		case 44:
-			goto tr784
+			goto tr795
 		case 92:
 			goto st133
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st567
+				goto st574
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr780
+			goto tr791
 		}
 		goto st2
 	st174:
@@ -20678,288 +20752,32 @@ tr318:
 		switch {
 		case ( m.data)[( m.p)] > 13:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st568
+				goto st575
 			}
 		case ( m.data)[( m.p)] >= 10:
 			goto tr5
 		}
 		goto st40
-	st568:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof568
-		}
-	st_case_568:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr778
-		case 11:
-			goto tr779
-		case 12:
-			goto tr780
-		case 32:
-			goto tr778
-		case 34:
-			goto tr89
-		case 44:
-			goto tr781
-		case 92:
-			goto st170
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st568
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st40
-	st569:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof569
-		}
-	st_case_569:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr778
-		case 11:
-			goto tr779
-		case 12:
-			goto tr780
-		case 32:
-			goto tr778
-		case 34:
-			goto tr89
-		case 44:
-			goto tr781
-		case 46:
-			goto st565
-		case 69:
-			goto st173
-		case 92:
-			goto st170
-		case 101:
-			goto st173
-		case 105:
-			goto st571
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st570
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st40
-	st570:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof570
-		}
-	st_case_570:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr778
-		case 11:
-			goto tr779
-		case 12:
-			goto tr780
-		case 32:
-			goto tr778
-		case 34:
-			goto tr89
-		case 44:
-			goto tr781
-		case 46:
-			goto st565
-		case 69:
-			goto st173
-		case 92:
-			goto st170
-		case 101:
-			goto st173
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st570
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st40
-	st571:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof571
-		}
-	st_case_571:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr787
-		case 11:
-			goto tr788
-		case 12:
-			goto tr789
-		case 32:
-			goto tr787
-		case 34:
-			goto tr89
-		case 44:
-			goto tr790
-		case 92:
-			goto st170
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr378
-		}
-		goto st40
-	st572:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof572
-		}
-	st_case_572:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr778
-		case 11:
-			goto tr779
-		case 12:
-			goto tr780
-		case 32:
-			goto tr778
-		case 34:
-			goto tr89
-		case 44:
-			goto tr781
-		case 46:
-			goto st565
-		case 69:
-			goto st173
-		case 92:
-			goto st170
-		case 101:
-			goto st173
-		case 105:
-			goto st571
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st572
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st40
-tr250:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st573
-	st573:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof573
-		}
-	st_case_573:
-//line plugins/parsers/influx/machine.go:20866
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr778
-		case 11:
-			goto tr779
-		case 12:
-			goto tr780
-		case 32:
-			goto tr778
-		case 34:
-			goto tr89
-		case 44:
-			goto tr781
-		case 46:
-			goto st565
-		case 69:
-			goto st173
-		case 92:
-			goto st170
-		case 101:
-			goto st173
-		case 105:
-			goto st571
-		case 117:
-			goto st574
-		}
-		switch {
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st570
-			}
-		case ( m.data)[( m.p)] >= 10:
-			goto tr372
-		}
-		goto st40
-	st574:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof574
-		}
-	st_case_574:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr792
-		case 11:
-			goto tr793
-		case 12:
-			goto tr794
-		case 32:
-			goto tr792
-		case 34:
-			goto tr89
-		case 44:
-			goto tr795
-		case 92:
-			goto st170
-		}
-		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr382
-		}
-		goto st40
-tr251:
-//line plugins/parsers/influx/machine.go.rl:18
-
-	m.pb = m.p
-
-	goto st575
 	st575:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof575
 		}
 	st_case_575:
-//line plugins/parsers/influx/machine.go:20938
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr778
+			goto tr789
 		case 11:
-			goto tr779
+			goto tr790
 		case 12:
-			goto tr780
+			goto tr791
 		case 32:
-			goto tr778
+			goto tr789
 		case 34:
 			goto tr89
 		case 44:
-			goto tr781
-		case 46:
-			goto st565
-		case 69:
-			goto st173
+			goto tr792
 		case 92:
 			goto st170
-		case 101:
-			goto st173
-		case 105:
-			goto st571
-		case 117:
-			goto st574
 		}
 		switch {
 		case ( m.data)[( m.p)] > 13:
@@ -20967,7 +20785,263 @@ tr251:
 				goto st575
 			}
 		case ( m.data)[( m.p)] >= 10:
-			goto tr372
+			goto tr383
+		}
+		goto st40
+	st576:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof576
+		}
+	st_case_576:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr789
+		case 11:
+			goto tr790
+		case 12:
+			goto tr791
+		case 32:
+			goto tr789
+		case 34:
+			goto tr89
+		case 44:
+			goto tr792
+		case 46:
+			goto st572
+		case 69:
+			goto st173
+		case 92:
+			goto st170
+		case 101:
+			goto st173
+		case 105:
+			goto st578
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st577
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st40
+	st577:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof577
+		}
+	st_case_577:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr789
+		case 11:
+			goto tr790
+		case 12:
+			goto tr791
+		case 32:
+			goto tr789
+		case 34:
+			goto tr89
+		case 44:
+			goto tr792
+		case 46:
+			goto st572
+		case 69:
+			goto st173
+		case 92:
+			goto st170
+		case 101:
+			goto st173
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st577
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st40
+	st578:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof578
+		}
+	st_case_578:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr798
+		case 11:
+			goto tr799
+		case 12:
+			goto tr800
+		case 32:
+			goto tr798
+		case 34:
+			goto tr89
+		case 44:
+			goto tr801
+		case 92:
+			goto st170
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr389
+		}
+		goto st40
+	st579:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof579
+		}
+	st_case_579:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr789
+		case 11:
+			goto tr790
+		case 12:
+			goto tr791
+		case 32:
+			goto tr789
+		case 34:
+			goto tr89
+		case 44:
+			goto tr792
+		case 46:
+			goto st572
+		case 69:
+			goto st173
+		case 92:
+			goto st170
+		case 101:
+			goto st173
+		case 105:
+			goto st578
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st579
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st40
+tr250:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st580
+	st580:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof580
+		}
+	st_case_580:
+//line plugins/parsers/influx/machine.go:20940
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr789
+		case 11:
+			goto tr790
+		case 12:
+			goto tr791
+		case 32:
+			goto tr789
+		case 34:
+			goto tr89
+		case 44:
+			goto tr792
+		case 46:
+			goto st572
+		case 69:
+			goto st173
+		case 92:
+			goto st170
+		case 101:
+			goto st173
+		case 105:
+			goto st578
+		case 117:
+			goto st581
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st577
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
+		}
+		goto st40
+	st581:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof581
+		}
+	st_case_581:
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr803
+		case 11:
+			goto tr804
+		case 12:
+			goto tr805
+		case 32:
+			goto tr803
+		case 34:
+			goto tr89
+		case 44:
+			goto tr806
+		case 92:
+			goto st170
+		}
+		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto tr393
+		}
+		goto st40
+tr251:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st582
+	st582:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof582
+		}
+	st_case_582:
+//line plugins/parsers/influx/machine.go:21012
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr789
+		case 11:
+			goto tr790
+		case 12:
+			goto tr791
+		case 32:
+			goto tr789
+		case 34:
+			goto tr89
+		case 44:
+			goto tr792
+		case 46:
+			goto st572
+		case 69:
+			goto st173
+		case 92:
+			goto st170
+		case 101:
+			goto st173
+		case 105:
+			goto st578
+		case 117:
+			goto st581
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st582
+			}
+		case ( m.data)[( m.p)] >= 10:
+			goto tr383
 		}
 		goto st40
 tr252:
@@ -20975,26 +21049,26 @@ tr252:
 
 	m.pb = m.p
 
-	goto st576
-	st576:
+	goto st583
+	st583:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof576
+			goto _test_eof583
 		}
-	st_case_576:
-//line plugins/parsers/influx/machine.go:20985
+	st_case_583:
+//line plugins/parsers/influx/machine.go:21059
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr797
+			goto tr808
 		case 11:
-			goto tr798
+			goto tr809
 		case 12:
-			goto tr799
+			goto tr810
 		case 32:
-			goto tr797
+			goto tr808
 		case 34:
 			goto tr89
 		case 44:
-			goto tr800
+			goto tr811
 		case 65:
 			goto st175
 		case 92:
@@ -21003,7 +21077,7 @@ tr252:
 			goto st178
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st40
 	st175:
@@ -21079,7 +21153,7 @@ tr252:
 		case 44:
 			goto tr90
 		case 69:
-			goto st577
+			goto st584
 		case 92:
 			goto st170
 		}
@@ -21087,29 +21161,29 @@ tr252:
 			goto tr5
 		}
 		goto st40
-	st577:
+	st584:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof577
+			goto _test_eof584
 		}
-	st_case_577:
+	st_case_584:
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr797
+			goto tr808
 		case 11:
-			goto tr798
+			goto tr809
 		case 12:
-			goto tr799
+			goto tr810
 		case 32:
-			goto tr797
+			goto tr808
 		case 34:
 			goto tr89
 		case 44:
-			goto tr800
+			goto tr811
 		case 92:
 			goto st170
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st40
 	st178:
@@ -21187,7 +21261,7 @@ tr252:
 		case 92:
 			goto st170
 		case 101:
-			goto st577
+			goto st584
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
 			goto tr5
@@ -21198,26 +21272,26 @@ tr253:
 
 	m.pb = m.p
 
-	goto st578
-	st578:
+	goto st585
+	st585:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof578
+			goto _test_eof585
 		}
-	st_case_578:
-//line plugins/parsers/influx/machine.go:21208
+	st_case_585:
+//line plugins/parsers/influx/machine.go:21282
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr797
+			goto tr808
 		case 11:
-			goto tr798
+			goto tr809
 		case 12:
-			goto tr799
+			goto tr810
 		case 32:
-			goto tr797
+			goto tr808
 		case 34:
 			goto tr89
 		case 44:
-			goto tr800
+			goto tr811
 		case 82:
 			goto st181
 		case 92:
@@ -21226,7 +21300,7 @@ tr253:
 			goto st182
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st40
 	st181:
@@ -21288,33 +21362,33 @@ tr254:
 
 	m.pb = m.p
 
-	goto st579
-	st579:
+	goto st586
+	st586:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof579
+			goto _test_eof586
 		}
-	st_case_579:
-//line plugins/parsers/influx/machine.go:21298
+	st_case_586:
+//line plugins/parsers/influx/machine.go:21372
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr797
+			goto tr808
 		case 11:
-			goto tr798
+			goto tr809
 		case 12:
-			goto tr799
+			goto tr810
 		case 32:
-			goto tr797
+			goto tr808
 		case 34:
 			goto tr89
 		case 44:
-			goto tr800
+			goto tr811
 		case 92:
 			goto st170
 		case 97:
 			goto st178
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st40
 tr255:
@@ -21322,33 +21396,33 @@ tr255:
 
 	m.pb = m.p
 
-	goto st580
-	st580:
+	goto st587
+	st587:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof580
+			goto _test_eof587
 		}
-	st_case_580:
-//line plugins/parsers/influx/machine.go:21332
+	st_case_587:
+//line plugins/parsers/influx/machine.go:21406
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr797
+			goto tr808
 		case 11:
-			goto tr798
+			goto tr809
 		case 12:
-			goto tr799
+			goto tr810
 		case 32:
-			goto tr797
+			goto tr808
 		case 34:
 			goto tr89
 		case 44:
-			goto tr800
+			goto tr811
 		case 92:
 			goto st170
 		case 114:
 			goto st182
 		}
 		if 10 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-			goto tr386
+			goto tr397
 		}
 		goto st40
 tr72:
@@ -21362,7 +21436,7 @@ tr72:
 			goto _test_eof183
 		}
 	st_case_183:
-//line plugins/parsers/influx/machine.go:21366
+//line plugins/parsers/influx/machine.go:21440
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -21377,14 +21451,14 @@ tr72:
 		case 46:
 			goto st184
 		case 48:
-			goto st582
+			goto st589
 		case 92:
 			goto st133
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st585
+				goto st592
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr4
@@ -21401,7 +21475,7 @@ tr73:
 			goto _test_eof184
 		}
 	st_case_184:
-//line plugins/parsers/influx/machine.go:21405
+//line plugins/parsers/influx/machine.go:21479
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr5
@@ -21419,28 +21493,28 @@ tr73:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st581
+				goto st588
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr4
 		}
 		goto st2
-	st581:
+	st588:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof581
+			goto _test_eof588
 		}
-	st_case_581:
+	st_case_588:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 11:
-			goto tr783
+			goto tr794
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr780
+			goto tr791
 		case 44:
-			goto tr784
+			goto tr795
 		case 69:
 			goto st185
 		case 92:
@@ -21451,10 +21525,10 @@ tr73:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st581
+				goto st588
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr780
+			goto tr791
 		}
 		goto st2
 	st185:
@@ -21485,7 +21559,7 @@ tr73:
 			}
 		case ( m.data)[( m.p)] > 45:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st567
+				goto st574
 			}
 		default:
 			goto st186
@@ -21513,30 +21587,30 @@ tr73:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st567
+				goto st574
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr4
 		}
 		goto st2
-	st582:
+	st589:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof582
+			goto _test_eof589
 		}
-	st_case_582:
+	st_case_589:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 11:
-			goto tr783
+			goto tr794
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr780
+			goto tr791
 		case 44:
-			goto tr784
+			goto tr795
 		case 46:
-			goto st581
+			goto st588
 		case 69:
 			goto st185
 		case 92:
@@ -21544,35 +21618,35 @@ tr73:
 		case 101:
 			goto st185
 		case 105:
-			goto st584
+			goto st591
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st583
+				goto st590
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr780
+			goto tr791
 		}
 		goto st2
-	st583:
+	st590:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof583
+			goto _test_eof590
 		}
-	st_case_583:
+	st_case_590:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 11:
-			goto tr783
+			goto tr794
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr780
+			goto tr791
 		case 44:
-			goto tr784
+			goto tr795
 		case 46:
-			goto st581
+			goto st588
 		case 69:
 			goto st185
 		case 92:
@@ -21583,53 +21657,53 @@ tr73:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st583
+				goto st590
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr780
+			goto tr791
 		}
 		goto st2
-	st584:
+	st591:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof584
+			goto _test_eof591
 		}
-	st_case_584:
+	st_case_591:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr378
+			goto tr389
 		case 11:
-			goto tr808
+			goto tr819
 		case 13:
-			goto tr378
+			goto tr389
 		case 32:
-			goto tr789
+			goto tr800
 		case 44:
-			goto tr809
+			goto tr820
 		case 92:
 			goto st133
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr789
+			goto tr800
 		}
 		goto st2
-	st585:
+	st592:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof585
+			goto _test_eof592
 		}
-	st_case_585:
+	st_case_592:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 11:
-			goto tr783
+			goto tr794
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr780
+			goto tr791
 		case 44:
-			goto tr784
+			goto tr795
 		case 46:
-			goto st581
+			goto st588
 		case 69:
 			goto st185
 		case 92:
@@ -21637,15 +21711,15 @@ tr73:
 		case 101:
 			goto st185
 		case 105:
-			goto st584
+			goto st591
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st585
+				goto st592
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr780
+			goto tr791
 		}
 		goto st2
 tr74:
@@ -21653,26 +21727,26 @@ tr74:
 
 	m.pb = m.p
 
-	goto st586
-	st586:
+	goto st593
+	st593:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof586
+			goto _test_eof593
 		}
-	st_case_586:
-//line plugins/parsers/influx/machine.go:21663
+	st_case_593:
+//line plugins/parsers/influx/machine.go:21737
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 11:
-			goto tr783
+			goto tr794
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr780
+			goto tr791
 		case 44:
-			goto tr784
+			goto tr795
 		case 46:
-			goto st581
+			goto st588
 		case 69:
 			goto st185
 		case 92:
@@ -21680,40 +21754,40 @@ tr74:
 		case 101:
 			goto st185
 		case 105:
-			goto st584
+			goto st591
 		case 117:
-			goto st587
+			goto st594
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st583
+				goto st590
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr780
+			goto tr791
 		}
 		goto st2
-	st587:
+	st594:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof587
+			goto _test_eof594
 		}
-	st_case_587:
+	st_case_594:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr382
+			goto tr393
 		case 11:
-			goto tr811
+			goto tr822
 		case 13:
-			goto tr382
+			goto tr393
 		case 32:
-			goto tr794
+			goto tr805
 		case 44:
-			goto tr812
+			goto tr823
 		case 92:
 			goto st133
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr794
+			goto tr805
 		}
 		goto st2
 tr75:
@@ -21721,26 +21795,26 @@ tr75:
 
 	m.pb = m.p
 
-	goto st588
-	st588:
+	goto st595
+	st595:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof588
+			goto _test_eof595
 		}
-	st_case_588:
-//line plugins/parsers/influx/machine.go:21731
+	st_case_595:
+//line plugins/parsers/influx/machine.go:21805
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr372
+			goto tr383
 		case 11:
-			goto tr783
+			goto tr794
 		case 13:
-			goto tr372
+			goto tr383
 		case 32:
-			goto tr780
+			goto tr791
 		case 44:
-			goto tr784
+			goto tr795
 		case 46:
-			goto st581
+			goto st588
 		case 69:
 			goto st185
 		case 92:
@@ -21748,17 +21822,17 @@ tr75:
 		case 101:
 			goto st185
 		case 105:
-			goto st584
+			goto st591
 		case 117:
-			goto st587
+			goto st594
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st588
+				goto st595
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr780
+			goto tr791
 		}
 		goto st2
 tr76:
@@ -21766,24 +21840,24 @@ tr76:
 
 	m.pb = m.p
 
-	goto st589
-	st589:
+	goto st596
+	st596:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof589
+			goto _test_eof596
 		}
-	st_case_589:
-//line plugins/parsers/influx/machine.go:21776
+	st_case_596:
+//line plugins/parsers/influx/machine.go:21850
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 11:
-			goto tr814
+			goto tr825
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr799
+			goto tr810
 		case 44:
-			goto tr815
+			goto tr826
 		case 65:
 			goto st187
 		case 92:
@@ -21792,7 +21866,7 @@ tr76:
 			goto st190
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr799
+			goto tr810
 		}
 		goto st2
 	st187:
@@ -21862,7 +21936,7 @@ tr76:
 		case 44:
 			goto tr7
 		case 69:
-			goto st590
+			goto st597
 		case 92:
 			goto st133
 		}
@@ -21870,27 +21944,27 @@ tr76:
 			goto tr4
 		}
 		goto st2
-	st590:
+	st597:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof590
+			goto _test_eof597
 		}
-	st_case_590:
+	st_case_597:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 11:
-			goto tr814
+			goto tr825
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr799
+			goto tr810
 		case 44:
-			goto tr815
+			goto tr826
 		case 92:
 			goto st133
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr799
+			goto tr810
 		}
 		goto st2
 	st190:
@@ -21962,7 +22036,7 @@ tr76:
 		case 92:
 			goto st133
 		case 101:
-			goto st590
+			goto st597
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr4
@@ -21973,24 +22047,24 @@ tr77:
 
 	m.pb = m.p
 
-	goto st591
-	st591:
+	goto st598
+	st598:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof591
+			goto _test_eof598
 		}
-	st_case_591:
-//line plugins/parsers/influx/machine.go:21983
+	st_case_598:
+//line plugins/parsers/influx/machine.go:22057
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 11:
-			goto tr814
+			goto tr825
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr799
+			goto tr810
 		case 44:
-			goto tr815
+			goto tr826
 		case 82:
 			goto st193
 		case 92:
@@ -21999,7 +22073,7 @@ tr77:
 			goto st194
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr799
+			goto tr810
 		}
 		goto st2
 	st193:
@@ -22057,31 +22131,31 @@ tr78:
 
 	m.pb = m.p
 
-	goto st592
-	st592:
+	goto st599
+	st599:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof592
+			goto _test_eof599
 		}
-	st_case_592:
-//line plugins/parsers/influx/machine.go:22067
+	st_case_599:
+//line plugins/parsers/influx/machine.go:22141
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 11:
-			goto tr814
+			goto tr825
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr799
+			goto tr810
 		case 44:
-			goto tr815
+			goto tr826
 		case 92:
 			goto st133
 		case 97:
 			goto st190
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr799
+			goto tr810
 		}
 		goto st2
 tr79:
@@ -22089,31 +22163,31 @@ tr79:
 
 	m.pb = m.p
 
-	goto st593
-	st593:
+	goto st600
+	st600:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof593
+			goto _test_eof600
 		}
-	st_case_593:
-//line plugins/parsers/influx/machine.go:22099
+	st_case_600:
+//line plugins/parsers/influx/machine.go:22173
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr386
+			goto tr397
 		case 11:
-			goto tr814
+			goto tr825
 		case 13:
-			goto tr386
+			goto tr397
 		case 32:
-			goto tr799
+			goto tr810
 		case 44:
-			goto tr815
+			goto tr826
 		case 92:
 			goto st133
 		case 114:
 			goto st194
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr799
+			goto tr810
 		}
 		goto st2
 	st195:
@@ -22133,13 +22207,13 @@ tr338:
 
 	{goto st196 }
 
-	goto st594
-	st594:
+	goto st601
+	st601:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof594
+			goto _test_eof601
 		}
-	st_case_594:
-//line plugins/parsers/influx/machine.go:22143
+	st_case_601:
+//line plugins/parsers/influx/machine.go:22217
 		goto st0
 	st196:
 		if ( m.p)++; ( m.p) == ( m.pe) {
@@ -22169,13 +22243,13 @@ tr339:
 
 	{goto st1 }
 
-	goto st595
-	st595:
+	goto st602
+	st602:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof595
+			goto _test_eof602
 		}
-	st_case_595:
-//line plugins/parsers/influx/machine.go:22179
+	st_case_602:
+//line plugins/parsers/influx/machine.go:22253
 		goto st0
 tr341:
 //line plugins/parsers/influx/machine.go.rl:63
@@ -22184,13 +22258,13 @@ tr341:
 
 	{goto st1 }
 
-	goto st596
-	st596:
+	goto st603
+	st603:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof596
+			goto _test_eof603
 		}
-	st_case_596:
-//line plugins/parsers/influx/machine.go:22194
+	st_case_603:
+//line plugins/parsers/influx/machine.go:22268
 		switch ( m.data)[( m.p)] {
 		case 11:
 			goto tr341
@@ -22233,6 +22307,338 @@ tr341:
 			goto st0
 		}
 		goto tr339
+	st199:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof199
+		}
+	st_case_199:
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto st0
+		case 35:
+			goto st0
+		case 44:
+			goto st0
+		case 92:
+			goto tr346
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto st0
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto st0
+		}
+		goto tr345
+tr345:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st604
+tr833:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+	goto st604
+	st604:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof604
+		}
+	st_case_604:
+//line plugins/parsers/influx/machine.go:22352
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr832
+		case 11:
+			goto tr833
+		case 13:
+			goto tr832
+		case 32:
+			goto tr831
+		case 44:
+			goto tr834
+		case 92:
+			goto st205
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr831
+		}
+		goto st604
+tr831:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+	goto st605
+tr838:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+	goto st605
+	st605:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof605
+		}
+	st_case_605:
+//line plugins/parsers/influx/machine.go:22388
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr837
+		case 13:
+			goto tr837
+		case 32:
+			goto st605
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st605
+		}
+		goto st0
+tr837:
+	 m.cs = 606
+//line plugins/parsers/influx/machine.go.rl:22
+
+	yield = true
+	 m.cs = 196;
+	{( m.p)++; goto _out }
+
+	goto _again
+tr832:
+	 m.cs = 606
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+//line plugins/parsers/influx/machine.go.rl:22
+
+	yield = true
+	 m.cs = 196;
+	{( m.p)++; goto _out }
+
+	goto _again
+tr839:
+	 m.cs = 606
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:22
+
+	yield = true
+	 m.cs = 196;
+	{( m.p)++; goto _out }
+
+	goto _again
+	st606:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof606
+		}
+	st_case_606:
+//line plugins/parsers/influx/machine.go:22441
+		goto st0
+tr834:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+	goto st200
+tr841:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+	goto st200
+	st200:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof200
+		}
+	st_case_200:
+//line plugins/parsers/influx/machine.go:22460
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto tr52
+		case 44:
+			goto tr52
+		case 61:
+			goto tr52
+		case 92:
+			goto tr348
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr52
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr52
+		}
+		goto tr347
+tr347:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st201
+	st201:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof201
+		}
+	st_case_201:
+//line plugins/parsers/influx/machine.go:22491
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto tr52
+		case 44:
+			goto tr52
+		case 61:
+			goto tr350
+		case 92:
+			goto st204
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr52
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr52
+		}
+		goto st201
+tr350:
+//line plugins/parsers/influx/machine.go.rl:76
+
+	key = m.text()
+
+	goto st202
+	st202:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof202
+		}
+	st_case_202:
+//line plugins/parsers/influx/machine.go:22522
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto tr52
+		case 44:
+			goto tr52
+		case 61:
+			goto tr52
+		case 92:
+			goto tr353
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr52
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr52
+		}
+		goto tr352
+tr352:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st607
+tr840:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+	goto st607
+	st607:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof607
+		}
+	st_case_607:
+//line plugins/parsers/influx/machine.go:22559
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr839
+		case 11:
+			goto tr840
+		case 13:
+			goto tr839
+		case 32:
+			goto tr838
+		case 44:
+			goto tr841
+		case 61:
+			goto tr52
+		case 92:
+			goto st203
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr838
+		}
+		goto st607
+tr353:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st203
+	st203:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof203
+		}
+	st_case_203:
+//line plugins/parsers/influx/machine.go:22591
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr52
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr52
+		}
+		goto st607
+tr348:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st204
+	st204:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof204
+		}
+	st_case_204:
+//line plugins/parsers/influx/machine.go:22612
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr52
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr52
+		}
+		goto st201
+tr346:
+//line plugins/parsers/influx/machine.go.rl:18
+
+	m.pb = m.p
+
+	goto st205
+	st205:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof205
+		}
+	st_case_205:
+//line plugins/parsers/influx/machine.go:22633
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto st0
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto st0
+		}
+		goto st604
 	st_out:
 	_test_eof1:  m.cs = 1; goto _test_eof
 	_test_eof2:  m.cs = 2; goto _test_eof
@@ -22241,17 +22647,10 @@ tr341:
 	_test_eof5:  m.cs = 5; goto _test_eof
 	_test_eof6:  m.cs = 6; goto _test_eof
 	_test_eof7:  m.cs = 7; goto _test_eof
-	_test_eof199:  m.cs = 199; goto _test_eof
-	_test_eof200:  m.cs = 200; goto _test_eof
-	_test_eof201:  m.cs = 201; goto _test_eof
-	_test_eof8:  m.cs = 8; goto _test_eof
-	_test_eof202:  m.cs = 202; goto _test_eof
-	_test_eof203:  m.cs = 203; goto _test_eof
-	_test_eof204:  m.cs = 204; goto _test_eof
-	_test_eof205:  m.cs = 205; goto _test_eof
 	_test_eof206:  m.cs = 206; goto _test_eof
 	_test_eof207:  m.cs = 207; goto _test_eof
 	_test_eof208:  m.cs = 208; goto _test_eof
+	_test_eof8:  m.cs = 8; goto _test_eof
 	_test_eof209:  m.cs = 209; goto _test_eof
 	_test_eof210:  m.cs = 210; goto _test_eof
 	_test_eof211:  m.cs = 211; goto _test_eof
@@ -22265,35 +22664,42 @@ tr341:
 	_test_eof219:  m.cs = 219; goto _test_eof
 	_test_eof220:  m.cs = 220; goto _test_eof
 	_test_eof221:  m.cs = 221; goto _test_eof
-	_test_eof9:  m.cs = 9; goto _test_eof
-	_test_eof10:  m.cs = 10; goto _test_eof
-	_test_eof11:  m.cs = 11; goto _test_eof
-	_test_eof12:  m.cs = 12; goto _test_eof
-	_test_eof13:  m.cs = 13; goto _test_eof
 	_test_eof222:  m.cs = 222; goto _test_eof
-	_test_eof14:  m.cs = 14; goto _test_eof
-	_test_eof15:  m.cs = 15; goto _test_eof
 	_test_eof223:  m.cs = 223; goto _test_eof
 	_test_eof224:  m.cs = 224; goto _test_eof
 	_test_eof225:  m.cs = 225; goto _test_eof
 	_test_eof226:  m.cs = 226; goto _test_eof
 	_test_eof227:  m.cs = 227; goto _test_eof
 	_test_eof228:  m.cs = 228; goto _test_eof
+	_test_eof9:  m.cs = 9; goto _test_eof
+	_test_eof10:  m.cs = 10; goto _test_eof
+	_test_eof11:  m.cs = 11; goto _test_eof
+	_test_eof12:  m.cs = 12; goto _test_eof
+	_test_eof13:  m.cs = 13; goto _test_eof
 	_test_eof229:  m.cs = 229; goto _test_eof
+	_test_eof14:  m.cs = 14; goto _test_eof
+	_test_eof15:  m.cs = 15; goto _test_eof
 	_test_eof230:  m.cs = 230; goto _test_eof
 	_test_eof231:  m.cs = 231; goto _test_eof
+	_test_eof232:  m.cs = 232; goto _test_eof
+	_test_eof233:  m.cs = 233; goto _test_eof
+	_test_eof234:  m.cs = 234; goto _test_eof
+	_test_eof235:  m.cs = 235; goto _test_eof
+	_test_eof236:  m.cs = 236; goto _test_eof
+	_test_eof237:  m.cs = 237; goto _test_eof
+	_test_eof238:  m.cs = 238; goto _test_eof
 	_test_eof16:  m.cs = 16; goto _test_eof
 	_test_eof17:  m.cs = 17; goto _test_eof
 	_test_eof18:  m.cs = 18; goto _test_eof
-	_test_eof232:  m.cs = 232; goto _test_eof
+	_test_eof239:  m.cs = 239; goto _test_eof
 	_test_eof19:  m.cs = 19; goto _test_eof
 	_test_eof20:  m.cs = 20; goto _test_eof
 	_test_eof21:  m.cs = 21; goto _test_eof
-	_test_eof233:  m.cs = 233; goto _test_eof
+	_test_eof240:  m.cs = 240; goto _test_eof
 	_test_eof22:  m.cs = 22; goto _test_eof
 	_test_eof23:  m.cs = 23; goto _test_eof
-	_test_eof234:  m.cs = 234; goto _test_eof
-	_test_eof235:  m.cs = 235; goto _test_eof
+	_test_eof241:  m.cs = 241; goto _test_eof
+	_test_eof242:  m.cs = 242; goto _test_eof
 	_test_eof24:  m.cs = 24; goto _test_eof
 	_test_eof25:  m.cs = 25; goto _test_eof
 	_test_eof26:  m.cs = 26; goto _test_eof
@@ -22313,16 +22719,9 @@ tr341:
 	_test_eof40:  m.cs = 40; goto _test_eof
 	_test_eof41:  m.cs = 41; goto _test_eof
 	_test_eof42:  m.cs = 42; goto _test_eof
-	_test_eof236:  m.cs = 236; goto _test_eof
-	_test_eof237:  m.cs = 237; goto _test_eof
-	_test_eof43:  m.cs = 43; goto _test_eof
-	_test_eof238:  m.cs = 238; goto _test_eof
-	_test_eof239:  m.cs = 239; goto _test_eof
-	_test_eof240:  m.cs = 240; goto _test_eof
-	_test_eof241:  m.cs = 241; goto _test_eof
-	_test_eof242:  m.cs = 242; goto _test_eof
 	_test_eof243:  m.cs = 243; goto _test_eof
 	_test_eof244:  m.cs = 244; goto _test_eof
+	_test_eof43:  m.cs = 43; goto _test_eof
 	_test_eof245:  m.cs = 245; goto _test_eof
 	_test_eof246:  m.cs = 246; goto _test_eof
 	_test_eof247:  m.cs = 247; goto _test_eof
@@ -22336,17 +22735,17 @@ tr341:
 	_test_eof255:  m.cs = 255; goto _test_eof
 	_test_eof256:  m.cs = 256; goto _test_eof
 	_test_eof257:  m.cs = 257; goto _test_eof
-	_test_eof44:  m.cs = 44; goto _test_eof
 	_test_eof258:  m.cs = 258; goto _test_eof
 	_test_eof259:  m.cs = 259; goto _test_eof
-	_test_eof45:  m.cs = 45; goto _test_eof
 	_test_eof260:  m.cs = 260; goto _test_eof
 	_test_eof261:  m.cs = 261; goto _test_eof
 	_test_eof262:  m.cs = 262; goto _test_eof
 	_test_eof263:  m.cs = 263; goto _test_eof
 	_test_eof264:  m.cs = 264; goto _test_eof
+	_test_eof44:  m.cs = 44; goto _test_eof
 	_test_eof265:  m.cs = 265; goto _test_eof
 	_test_eof266:  m.cs = 266; goto _test_eof
+	_test_eof45:  m.cs = 45; goto _test_eof
 	_test_eof267:  m.cs = 267; goto _test_eof
 	_test_eof268:  m.cs = 268; goto _test_eof
 	_test_eof269:  m.cs = 269; goto _test_eof
@@ -22360,90 +22759,90 @@ tr341:
 	_test_eof277:  m.cs = 277; goto _test_eof
 	_test_eof278:  m.cs = 278; goto _test_eof
 	_test_eof279:  m.cs = 279; goto _test_eof
+	_test_eof280:  m.cs = 280; goto _test_eof
+	_test_eof281:  m.cs = 281; goto _test_eof
+	_test_eof282:  m.cs = 282; goto _test_eof
+	_test_eof283:  m.cs = 283; goto _test_eof
+	_test_eof284:  m.cs = 284; goto _test_eof
+	_test_eof285:  m.cs = 285; goto _test_eof
+	_test_eof286:  m.cs = 286; goto _test_eof
 	_test_eof46:  m.cs = 46; goto _test_eof
 	_test_eof47:  m.cs = 47; goto _test_eof
 	_test_eof48:  m.cs = 48; goto _test_eof
-	_test_eof280:  m.cs = 280; goto _test_eof
+	_test_eof287:  m.cs = 287; goto _test_eof
 	_test_eof49:  m.cs = 49; goto _test_eof
 	_test_eof50:  m.cs = 50; goto _test_eof
 	_test_eof51:  m.cs = 51; goto _test_eof
 	_test_eof52:  m.cs = 52; goto _test_eof
 	_test_eof53:  m.cs = 53; goto _test_eof
-	_test_eof281:  m.cs = 281; goto _test_eof
-	_test_eof54:  m.cs = 54; goto _test_eof
-	_test_eof282:  m.cs = 282; goto _test_eof
-	_test_eof55:  m.cs = 55; goto _test_eof
-	_test_eof283:  m.cs = 283; goto _test_eof
-	_test_eof284:  m.cs = 284; goto _test_eof
-	_test_eof285:  m.cs = 285; goto _test_eof
-	_test_eof286:  m.cs = 286; goto _test_eof
-	_test_eof287:  m.cs = 287; goto _test_eof
 	_test_eof288:  m.cs = 288; goto _test_eof
+	_test_eof54:  m.cs = 54; goto _test_eof
 	_test_eof289:  m.cs = 289; goto _test_eof
+	_test_eof55:  m.cs = 55; goto _test_eof
 	_test_eof290:  m.cs = 290; goto _test_eof
 	_test_eof291:  m.cs = 291; goto _test_eof
+	_test_eof292:  m.cs = 292; goto _test_eof
+	_test_eof293:  m.cs = 293; goto _test_eof
+	_test_eof294:  m.cs = 294; goto _test_eof
+	_test_eof295:  m.cs = 295; goto _test_eof
+	_test_eof296:  m.cs = 296; goto _test_eof
+	_test_eof297:  m.cs = 297; goto _test_eof
+	_test_eof298:  m.cs = 298; goto _test_eof
 	_test_eof56:  m.cs = 56; goto _test_eof
 	_test_eof57:  m.cs = 57; goto _test_eof
 	_test_eof58:  m.cs = 58; goto _test_eof
-	_test_eof292:  m.cs = 292; goto _test_eof
+	_test_eof299:  m.cs = 299; goto _test_eof
 	_test_eof59:  m.cs = 59; goto _test_eof
 	_test_eof60:  m.cs = 60; goto _test_eof
 	_test_eof61:  m.cs = 61; goto _test_eof
-	_test_eof293:  m.cs = 293; goto _test_eof
+	_test_eof300:  m.cs = 300; goto _test_eof
 	_test_eof62:  m.cs = 62; goto _test_eof
 	_test_eof63:  m.cs = 63; goto _test_eof
-	_test_eof294:  m.cs = 294; goto _test_eof
-	_test_eof295:  m.cs = 295; goto _test_eof
+	_test_eof301:  m.cs = 301; goto _test_eof
+	_test_eof302:  m.cs = 302; goto _test_eof
 	_test_eof64:  m.cs = 64; goto _test_eof
 	_test_eof65:  m.cs = 65; goto _test_eof
 	_test_eof66:  m.cs = 66; goto _test_eof
-	_test_eof296:  m.cs = 296; goto _test_eof
+	_test_eof303:  m.cs = 303; goto _test_eof
 	_test_eof67:  m.cs = 67; goto _test_eof
 	_test_eof68:  m.cs = 68; goto _test_eof
-	_test_eof297:  m.cs = 297; goto _test_eof
-	_test_eof298:  m.cs = 298; goto _test_eof
-	_test_eof299:  m.cs = 299; goto _test_eof
-	_test_eof300:  m.cs = 300; goto _test_eof
-	_test_eof301:  m.cs = 301; goto _test_eof
-	_test_eof302:  m.cs = 302; goto _test_eof
-	_test_eof303:  m.cs = 303; goto _test_eof
 	_test_eof304:  m.cs = 304; goto _test_eof
 	_test_eof305:  m.cs = 305; goto _test_eof
+	_test_eof306:  m.cs = 306; goto _test_eof
+	_test_eof307:  m.cs = 307; goto _test_eof
+	_test_eof308:  m.cs = 308; goto _test_eof
+	_test_eof309:  m.cs = 309; goto _test_eof
+	_test_eof310:  m.cs = 310; goto _test_eof
+	_test_eof311:  m.cs = 311; goto _test_eof
+	_test_eof312:  m.cs = 312; goto _test_eof
 	_test_eof69:  m.cs = 69; goto _test_eof
 	_test_eof70:  m.cs = 70; goto _test_eof
 	_test_eof71:  m.cs = 71; goto _test_eof
-	_test_eof306:  m.cs = 306; goto _test_eof
+	_test_eof313:  m.cs = 313; goto _test_eof
 	_test_eof72:  m.cs = 72; goto _test_eof
 	_test_eof73:  m.cs = 73; goto _test_eof
 	_test_eof74:  m.cs = 74; goto _test_eof
-	_test_eof307:  m.cs = 307; goto _test_eof
+	_test_eof314:  m.cs = 314; goto _test_eof
 	_test_eof75:  m.cs = 75; goto _test_eof
 	_test_eof76:  m.cs = 76; goto _test_eof
-	_test_eof308:  m.cs = 308; goto _test_eof
-	_test_eof309:  m.cs = 309; goto _test_eof
+	_test_eof315:  m.cs = 315; goto _test_eof
+	_test_eof316:  m.cs = 316; goto _test_eof
 	_test_eof77:  m.cs = 77; goto _test_eof
 	_test_eof78:  m.cs = 78; goto _test_eof
 	_test_eof79:  m.cs = 79; goto _test_eof
 	_test_eof80:  m.cs = 80; goto _test_eof
 	_test_eof81:  m.cs = 81; goto _test_eof
 	_test_eof82:  m.cs = 82; goto _test_eof
-	_test_eof310:  m.cs = 310; goto _test_eof
-	_test_eof311:  m.cs = 311; goto _test_eof
-	_test_eof312:  m.cs = 312; goto _test_eof
-	_test_eof313:  m.cs = 313; goto _test_eof
-	_test_eof83:  m.cs = 83; goto _test_eof
-	_test_eof314:  m.cs = 314; goto _test_eof
-	_test_eof315:  m.cs = 315; goto _test_eof
-	_test_eof316:  m.cs = 316; goto _test_eof
 	_test_eof317:  m.cs = 317; goto _test_eof
-	_test_eof84:  m.cs = 84; goto _test_eof
 	_test_eof318:  m.cs = 318; goto _test_eof
 	_test_eof319:  m.cs = 319; goto _test_eof
 	_test_eof320:  m.cs = 320; goto _test_eof
+	_test_eof83:  m.cs = 83; goto _test_eof
 	_test_eof321:  m.cs = 321; goto _test_eof
 	_test_eof322:  m.cs = 322; goto _test_eof
 	_test_eof323:  m.cs = 323; goto _test_eof
 	_test_eof324:  m.cs = 324; goto _test_eof
+	_test_eof84:  m.cs = 84; goto _test_eof
 	_test_eof325:  m.cs = 325; goto _test_eof
 	_test_eof326:  m.cs = 326; goto _test_eof
 	_test_eof327:  m.cs = 327; goto _test_eof
@@ -22455,6 +22854,13 @@ tr341:
 	_test_eof333:  m.cs = 333; goto _test_eof
 	_test_eof334:  m.cs = 334; goto _test_eof
 	_test_eof335:  m.cs = 335; goto _test_eof
+	_test_eof336:  m.cs = 336; goto _test_eof
+	_test_eof337:  m.cs = 337; goto _test_eof
+	_test_eof338:  m.cs = 338; goto _test_eof
+	_test_eof339:  m.cs = 339; goto _test_eof
+	_test_eof340:  m.cs = 340; goto _test_eof
+	_test_eof341:  m.cs = 341; goto _test_eof
+	_test_eof342:  m.cs = 342; goto _test_eof
 	_test_eof85:  m.cs = 85; goto _test_eof
 	_test_eof86:  m.cs = 86; goto _test_eof
 	_test_eof87:  m.cs = 87; goto _test_eof
@@ -22468,16 +22874,9 @@ tr341:
 	_test_eof95:  m.cs = 95; goto _test_eof
 	_test_eof96:  m.cs = 96; goto _test_eof
 	_test_eof97:  m.cs = 97; goto _test_eof
-	_test_eof336:  m.cs = 336; goto _test_eof
-	_test_eof337:  m.cs = 337; goto _test_eof
-	_test_eof98:  m.cs = 98; goto _test_eof
-	_test_eof338:  m.cs = 338; goto _test_eof
-	_test_eof339:  m.cs = 339; goto _test_eof
-	_test_eof340:  m.cs = 340; goto _test_eof
-	_test_eof341:  m.cs = 341; goto _test_eof
-	_test_eof342:  m.cs = 342; goto _test_eof
 	_test_eof343:  m.cs = 343; goto _test_eof
 	_test_eof344:  m.cs = 344; goto _test_eof
+	_test_eof98:  m.cs = 98; goto _test_eof
 	_test_eof345:  m.cs = 345; goto _test_eof
 	_test_eof346:  m.cs = 346; goto _test_eof
 	_test_eof347:  m.cs = 347; goto _test_eof
@@ -22491,18 +22890,18 @@ tr341:
 	_test_eof355:  m.cs = 355; goto _test_eof
 	_test_eof356:  m.cs = 356; goto _test_eof
 	_test_eof357:  m.cs = 357; goto _test_eof
-	_test_eof99:  m.cs = 99; goto _test_eof
-	_test_eof100:  m.cs = 100; goto _test_eof
 	_test_eof358:  m.cs = 358; goto _test_eof
 	_test_eof359:  m.cs = 359; goto _test_eof
-	_test_eof101:  m.cs = 101; goto _test_eof
 	_test_eof360:  m.cs = 360; goto _test_eof
 	_test_eof361:  m.cs = 361; goto _test_eof
 	_test_eof362:  m.cs = 362; goto _test_eof
 	_test_eof363:  m.cs = 363; goto _test_eof
 	_test_eof364:  m.cs = 364; goto _test_eof
+	_test_eof99:  m.cs = 99; goto _test_eof
+	_test_eof100:  m.cs = 100; goto _test_eof
 	_test_eof365:  m.cs = 365; goto _test_eof
 	_test_eof366:  m.cs = 366; goto _test_eof
+	_test_eof101:  m.cs = 101; goto _test_eof
 	_test_eof367:  m.cs = 367; goto _test_eof
 	_test_eof368:  m.cs = 368; goto _test_eof
 	_test_eof369:  m.cs = 369; goto _test_eof
@@ -22516,38 +22915,45 @@ tr341:
 	_test_eof377:  m.cs = 377; goto _test_eof
 	_test_eof378:  m.cs = 378; goto _test_eof
 	_test_eof379:  m.cs = 379; goto _test_eof
-	_test_eof102:  m.cs = 102; goto _test_eof
 	_test_eof380:  m.cs = 380; goto _test_eof
 	_test_eof381:  m.cs = 381; goto _test_eof
+	_test_eof382:  m.cs = 382; goto _test_eof
+	_test_eof383:  m.cs = 383; goto _test_eof
+	_test_eof384:  m.cs = 384; goto _test_eof
+	_test_eof385:  m.cs = 385; goto _test_eof
+	_test_eof386:  m.cs = 386; goto _test_eof
+	_test_eof102:  m.cs = 102; goto _test_eof
+	_test_eof387:  m.cs = 387; goto _test_eof
+	_test_eof388:  m.cs = 388; goto _test_eof
 	_test_eof103:  m.cs = 103; goto _test_eof
 	_test_eof104:  m.cs = 104; goto _test_eof
 	_test_eof105:  m.cs = 105; goto _test_eof
 	_test_eof106:  m.cs = 106; goto _test_eof
 	_test_eof107:  m.cs = 107; goto _test_eof
-	_test_eof382:  m.cs = 382; goto _test_eof
+	_test_eof389:  m.cs = 389; goto _test_eof
 	_test_eof108:  m.cs = 108; goto _test_eof
 	_test_eof109:  m.cs = 109; goto _test_eof
-	_test_eof383:  m.cs = 383; goto _test_eof
-	_test_eof384:  m.cs = 384; goto _test_eof
-	_test_eof385:  m.cs = 385; goto _test_eof
-	_test_eof386:  m.cs = 386; goto _test_eof
-	_test_eof387:  m.cs = 387; goto _test_eof
-	_test_eof388:  m.cs = 388; goto _test_eof
-	_test_eof389:  m.cs = 389; goto _test_eof
 	_test_eof390:  m.cs = 390; goto _test_eof
 	_test_eof391:  m.cs = 391; goto _test_eof
+	_test_eof392:  m.cs = 392; goto _test_eof
+	_test_eof393:  m.cs = 393; goto _test_eof
+	_test_eof394:  m.cs = 394; goto _test_eof
+	_test_eof395:  m.cs = 395; goto _test_eof
+	_test_eof396:  m.cs = 396; goto _test_eof
+	_test_eof397:  m.cs = 397; goto _test_eof
+	_test_eof398:  m.cs = 398; goto _test_eof
 	_test_eof110:  m.cs = 110; goto _test_eof
 	_test_eof111:  m.cs = 111; goto _test_eof
 	_test_eof112:  m.cs = 112; goto _test_eof
-	_test_eof392:  m.cs = 392; goto _test_eof
+	_test_eof399:  m.cs = 399; goto _test_eof
 	_test_eof113:  m.cs = 113; goto _test_eof
 	_test_eof114:  m.cs = 114; goto _test_eof
 	_test_eof115:  m.cs = 115; goto _test_eof
-	_test_eof393:  m.cs = 393; goto _test_eof
+	_test_eof400:  m.cs = 400; goto _test_eof
 	_test_eof116:  m.cs = 116; goto _test_eof
 	_test_eof117:  m.cs = 117; goto _test_eof
-	_test_eof394:  m.cs = 394; goto _test_eof
-	_test_eof395:  m.cs = 395; goto _test_eof
+	_test_eof401:  m.cs = 401; goto _test_eof
+	_test_eof402:  m.cs = 402; goto _test_eof
 	_test_eof118:  m.cs = 118; goto _test_eof
 	_test_eof119:  m.cs = 119; goto _test_eof
 	_test_eof120:  m.cs = 120; goto _test_eof
@@ -22560,17 +22966,10 @@ tr341:
 	_test_eof127:  m.cs = 127; goto _test_eof
 	_test_eof128:  m.cs = 128; goto _test_eof
 	_test_eof129:  m.cs = 129; goto _test_eof
-	_test_eof396:  m.cs = 396; goto _test_eof
-	_test_eof397:  m.cs = 397; goto _test_eof
-	_test_eof398:  m.cs = 398; goto _test_eof
-	_test_eof130:  m.cs = 130; goto _test_eof
-	_test_eof399:  m.cs = 399; goto _test_eof
-	_test_eof400:  m.cs = 400; goto _test_eof
-	_test_eof401:  m.cs = 401; goto _test_eof
-	_test_eof402:  m.cs = 402; goto _test_eof
 	_test_eof403:  m.cs = 403; goto _test_eof
 	_test_eof404:  m.cs = 404; goto _test_eof
 	_test_eof405:  m.cs = 405; goto _test_eof
+	_test_eof130:  m.cs = 130; goto _test_eof
 	_test_eof406:  m.cs = 406; goto _test_eof
 	_test_eof407:  m.cs = 407; goto _test_eof
 	_test_eof408:  m.cs = 408; goto _test_eof
@@ -22586,19 +22985,19 @@ tr341:
 	_test_eof418:  m.cs = 418; goto _test_eof
 	_test_eof419:  m.cs = 419; goto _test_eof
 	_test_eof420:  m.cs = 420; goto _test_eof
-	_test_eof131:  m.cs = 131; goto _test_eof
 	_test_eof421:  m.cs = 421; goto _test_eof
 	_test_eof422:  m.cs = 422; goto _test_eof
 	_test_eof423:  m.cs = 423; goto _test_eof
 	_test_eof424:  m.cs = 424; goto _test_eof
-	_test_eof132:  m.cs = 132; goto _test_eof
 	_test_eof425:  m.cs = 425; goto _test_eof
 	_test_eof426:  m.cs = 426; goto _test_eof
 	_test_eof427:  m.cs = 427; goto _test_eof
+	_test_eof131:  m.cs = 131; goto _test_eof
 	_test_eof428:  m.cs = 428; goto _test_eof
 	_test_eof429:  m.cs = 429; goto _test_eof
 	_test_eof430:  m.cs = 430; goto _test_eof
 	_test_eof431:  m.cs = 431; goto _test_eof
+	_test_eof132:  m.cs = 132; goto _test_eof
 	_test_eof432:  m.cs = 432; goto _test_eof
 	_test_eof433:  m.cs = 433; goto _test_eof
 	_test_eof434:  m.cs = 434; goto _test_eof
@@ -22612,19 +23011,19 @@ tr341:
 	_test_eof442:  m.cs = 442; goto _test_eof
 	_test_eof443:  m.cs = 443; goto _test_eof
 	_test_eof444:  m.cs = 444; goto _test_eof
-	_test_eof133:  m.cs = 133; goto _test_eof
-	_test_eof134:  m.cs = 134; goto _test_eof
-	_test_eof135:  m.cs = 135; goto _test_eof
 	_test_eof445:  m.cs = 445; goto _test_eof
 	_test_eof446:  m.cs = 446; goto _test_eof
-	_test_eof136:  m.cs = 136; goto _test_eof
 	_test_eof447:  m.cs = 447; goto _test_eof
 	_test_eof448:  m.cs = 448; goto _test_eof
 	_test_eof449:  m.cs = 449; goto _test_eof
 	_test_eof450:  m.cs = 450; goto _test_eof
 	_test_eof451:  m.cs = 451; goto _test_eof
+	_test_eof133:  m.cs = 133; goto _test_eof
+	_test_eof134:  m.cs = 134; goto _test_eof
+	_test_eof135:  m.cs = 135; goto _test_eof
 	_test_eof452:  m.cs = 452; goto _test_eof
 	_test_eof453:  m.cs = 453; goto _test_eof
+	_test_eof136:  m.cs = 136; goto _test_eof
 	_test_eof454:  m.cs = 454; goto _test_eof
 	_test_eof455:  m.cs = 455; goto _test_eof
 	_test_eof456:  m.cs = 456; goto _test_eof
@@ -22638,18 +23037,18 @@ tr341:
 	_test_eof464:  m.cs = 464; goto _test_eof
 	_test_eof465:  m.cs = 465; goto _test_eof
 	_test_eof466:  m.cs = 466; goto _test_eof
-	_test_eof137:  m.cs = 137; goto _test_eof
 	_test_eof467:  m.cs = 467; goto _test_eof
 	_test_eof468:  m.cs = 468; goto _test_eof
 	_test_eof469:  m.cs = 469; goto _test_eof
-	_test_eof138:  m.cs = 138; goto _test_eof
 	_test_eof470:  m.cs = 470; goto _test_eof
 	_test_eof471:  m.cs = 471; goto _test_eof
 	_test_eof472:  m.cs = 472; goto _test_eof
 	_test_eof473:  m.cs = 473; goto _test_eof
+	_test_eof137:  m.cs = 137; goto _test_eof
 	_test_eof474:  m.cs = 474; goto _test_eof
 	_test_eof475:  m.cs = 475; goto _test_eof
 	_test_eof476:  m.cs = 476; goto _test_eof
+	_test_eof138:  m.cs = 138; goto _test_eof
 	_test_eof477:  m.cs = 477; goto _test_eof
 	_test_eof478:  m.cs = 478; goto _test_eof
 	_test_eof479:  m.cs = 479; goto _test_eof
@@ -22665,7 +23064,6 @@ tr341:
 	_test_eof489:  m.cs = 489; goto _test_eof
 	_test_eof490:  m.cs = 490; goto _test_eof
 	_test_eof491:  m.cs = 491; goto _test_eof
-	_test_eof139:  m.cs = 139; goto _test_eof
 	_test_eof492:  m.cs = 492; goto _test_eof
 	_test_eof493:  m.cs = 493; goto _test_eof
 	_test_eof494:  m.cs = 494; goto _test_eof
@@ -22673,6 +23071,7 @@ tr341:
 	_test_eof496:  m.cs = 496; goto _test_eof
 	_test_eof497:  m.cs = 497; goto _test_eof
 	_test_eof498:  m.cs = 498; goto _test_eof
+	_test_eof139:  m.cs = 139; goto _test_eof
 	_test_eof499:  m.cs = 499; goto _test_eof
 	_test_eof500:  m.cs = 500; goto _test_eof
 	_test_eof501:  m.cs = 501; goto _test_eof
@@ -22688,50 +23087,50 @@ tr341:
 	_test_eof511:  m.cs = 511; goto _test_eof
 	_test_eof512:  m.cs = 512; goto _test_eof
 	_test_eof513:  m.cs = 513; goto _test_eof
-	_test_eof140:  m.cs = 140; goto _test_eof
-	_test_eof141:  m.cs = 141; goto _test_eof
-	_test_eof142:  m.cs = 142; goto _test_eof
-	_test_eof143:  m.cs = 143; goto _test_eof
-	_test_eof144:  m.cs = 144; goto _test_eof
 	_test_eof514:  m.cs = 514; goto _test_eof
-	_test_eof145:  m.cs = 145; goto _test_eof
 	_test_eof515:  m.cs = 515; goto _test_eof
-	_test_eof146:  m.cs = 146; goto _test_eof
 	_test_eof516:  m.cs = 516; goto _test_eof
 	_test_eof517:  m.cs = 517; goto _test_eof
 	_test_eof518:  m.cs = 518; goto _test_eof
 	_test_eof519:  m.cs = 519; goto _test_eof
 	_test_eof520:  m.cs = 520; goto _test_eof
+	_test_eof140:  m.cs = 140; goto _test_eof
+	_test_eof141:  m.cs = 141; goto _test_eof
+	_test_eof142:  m.cs = 142; goto _test_eof
+	_test_eof143:  m.cs = 143; goto _test_eof
+	_test_eof144:  m.cs = 144; goto _test_eof
 	_test_eof521:  m.cs = 521; goto _test_eof
+	_test_eof145:  m.cs = 145; goto _test_eof
 	_test_eof522:  m.cs = 522; goto _test_eof
+	_test_eof146:  m.cs = 146; goto _test_eof
 	_test_eof523:  m.cs = 523; goto _test_eof
 	_test_eof524:  m.cs = 524; goto _test_eof
-	_test_eof147:  m.cs = 147; goto _test_eof
-	_test_eof148:  m.cs = 148; goto _test_eof
-	_test_eof149:  m.cs = 149; goto _test_eof
 	_test_eof525:  m.cs = 525; goto _test_eof
-	_test_eof150:  m.cs = 150; goto _test_eof
-	_test_eof151:  m.cs = 151; goto _test_eof
-	_test_eof152:  m.cs = 152; goto _test_eof
 	_test_eof526:  m.cs = 526; goto _test_eof
-	_test_eof153:  m.cs = 153; goto _test_eof
-	_test_eof154:  m.cs = 154; goto _test_eof
 	_test_eof527:  m.cs = 527; goto _test_eof
 	_test_eof528:  m.cs = 528; goto _test_eof
-	_test_eof155:  m.cs = 155; goto _test_eof
-	_test_eof156:  m.cs = 156; goto _test_eof
-	_test_eof157:  m.cs = 157; goto _test_eof
 	_test_eof529:  m.cs = 529; goto _test_eof
 	_test_eof530:  m.cs = 530; goto _test_eof
 	_test_eof531:  m.cs = 531; goto _test_eof
-	_test_eof158:  m.cs = 158; goto _test_eof
+	_test_eof147:  m.cs = 147; goto _test_eof
+	_test_eof148:  m.cs = 148; goto _test_eof
+	_test_eof149:  m.cs = 149; goto _test_eof
 	_test_eof532:  m.cs = 532; goto _test_eof
+	_test_eof150:  m.cs = 150; goto _test_eof
+	_test_eof151:  m.cs = 151; goto _test_eof
+	_test_eof152:  m.cs = 152; goto _test_eof
 	_test_eof533:  m.cs = 533; goto _test_eof
+	_test_eof153:  m.cs = 153; goto _test_eof
+	_test_eof154:  m.cs = 154; goto _test_eof
 	_test_eof534:  m.cs = 534; goto _test_eof
 	_test_eof535:  m.cs = 535; goto _test_eof
+	_test_eof155:  m.cs = 155; goto _test_eof
+	_test_eof156:  m.cs = 156; goto _test_eof
+	_test_eof157:  m.cs = 157; goto _test_eof
 	_test_eof536:  m.cs = 536; goto _test_eof
 	_test_eof537:  m.cs = 537; goto _test_eof
 	_test_eof538:  m.cs = 538; goto _test_eof
+	_test_eof158:  m.cs = 158; goto _test_eof
 	_test_eof539:  m.cs = 539; goto _test_eof
 	_test_eof540:  m.cs = 540; goto _test_eof
 	_test_eof541:  m.cs = 541; goto _test_eof
@@ -22745,8 +23144,6 @@ tr341:
 	_test_eof549:  m.cs = 549; goto _test_eof
 	_test_eof550:  m.cs = 550; goto _test_eof
 	_test_eof551:  m.cs = 551; goto _test_eof
-	_test_eof159:  m.cs = 159; goto _test_eof
-	_test_eof160:  m.cs = 160; goto _test_eof
 	_test_eof552:  m.cs = 552; goto _test_eof
 	_test_eof553:  m.cs = 553; goto _test_eof
 	_test_eof554:  m.cs = 554; goto _test_eof
@@ -22754,87 +23151,107 @@ tr341:
 	_test_eof556:  m.cs = 556; goto _test_eof
 	_test_eof557:  m.cs = 557; goto _test_eof
 	_test_eof558:  m.cs = 558; goto _test_eof
+	_test_eof159:  m.cs = 159; goto _test_eof
+	_test_eof160:  m.cs = 160; goto _test_eof
 	_test_eof559:  m.cs = 559; goto _test_eof
 	_test_eof560:  m.cs = 560; goto _test_eof
+	_test_eof561:  m.cs = 561; goto _test_eof
+	_test_eof562:  m.cs = 562; goto _test_eof
+	_test_eof563:  m.cs = 563; goto _test_eof
+	_test_eof564:  m.cs = 564; goto _test_eof
+	_test_eof565:  m.cs = 565; goto _test_eof
+	_test_eof566:  m.cs = 566; goto _test_eof
+	_test_eof567:  m.cs = 567; goto _test_eof
 	_test_eof161:  m.cs = 161; goto _test_eof
 	_test_eof162:  m.cs = 162; goto _test_eof
 	_test_eof163:  m.cs = 163; goto _test_eof
-	_test_eof561:  m.cs = 561; goto _test_eof
+	_test_eof568:  m.cs = 568; goto _test_eof
 	_test_eof164:  m.cs = 164; goto _test_eof
 	_test_eof165:  m.cs = 165; goto _test_eof
 	_test_eof166:  m.cs = 166; goto _test_eof
-	_test_eof562:  m.cs = 562; goto _test_eof
+	_test_eof569:  m.cs = 569; goto _test_eof
 	_test_eof167:  m.cs = 167; goto _test_eof
 	_test_eof168:  m.cs = 168; goto _test_eof
-	_test_eof563:  m.cs = 563; goto _test_eof
-	_test_eof564:  m.cs = 564; goto _test_eof
+	_test_eof570:  m.cs = 570; goto _test_eof
+	_test_eof571:  m.cs = 571; goto _test_eof
 	_test_eof169:  m.cs = 169; goto _test_eof
 	_test_eof170:  m.cs = 170; goto _test_eof
 	_test_eof171:  m.cs = 171; goto _test_eof
 	_test_eof172:  m.cs = 172; goto _test_eof
-	_test_eof565:  m.cs = 565; goto _test_eof
-	_test_eof173:  m.cs = 173; goto _test_eof
-	_test_eof566:  m.cs = 566; goto _test_eof
-	_test_eof567:  m.cs = 567; goto _test_eof
-	_test_eof174:  m.cs = 174; goto _test_eof
-	_test_eof568:  m.cs = 568; goto _test_eof
-	_test_eof569:  m.cs = 569; goto _test_eof
-	_test_eof570:  m.cs = 570; goto _test_eof
-	_test_eof571:  m.cs = 571; goto _test_eof
 	_test_eof572:  m.cs = 572; goto _test_eof
+	_test_eof173:  m.cs = 173; goto _test_eof
 	_test_eof573:  m.cs = 573; goto _test_eof
 	_test_eof574:  m.cs = 574; goto _test_eof
+	_test_eof174:  m.cs = 174; goto _test_eof
 	_test_eof575:  m.cs = 575; goto _test_eof
 	_test_eof576:  m.cs = 576; goto _test_eof
+	_test_eof577:  m.cs = 577; goto _test_eof
+	_test_eof578:  m.cs = 578; goto _test_eof
+	_test_eof579:  m.cs = 579; goto _test_eof
+	_test_eof580:  m.cs = 580; goto _test_eof
+	_test_eof581:  m.cs = 581; goto _test_eof
+	_test_eof582:  m.cs = 582; goto _test_eof
+	_test_eof583:  m.cs = 583; goto _test_eof
 	_test_eof175:  m.cs = 175; goto _test_eof
 	_test_eof176:  m.cs = 176; goto _test_eof
 	_test_eof177:  m.cs = 177; goto _test_eof
-	_test_eof577:  m.cs = 577; goto _test_eof
+	_test_eof584:  m.cs = 584; goto _test_eof
 	_test_eof178:  m.cs = 178; goto _test_eof
 	_test_eof179:  m.cs = 179; goto _test_eof
 	_test_eof180:  m.cs = 180; goto _test_eof
-	_test_eof578:  m.cs = 578; goto _test_eof
+	_test_eof585:  m.cs = 585; goto _test_eof
 	_test_eof181:  m.cs = 181; goto _test_eof
 	_test_eof182:  m.cs = 182; goto _test_eof
-	_test_eof579:  m.cs = 579; goto _test_eof
-	_test_eof580:  m.cs = 580; goto _test_eof
-	_test_eof183:  m.cs = 183; goto _test_eof
-	_test_eof184:  m.cs = 184; goto _test_eof
-	_test_eof581:  m.cs = 581; goto _test_eof
-	_test_eof185:  m.cs = 185; goto _test_eof
-	_test_eof186:  m.cs = 186; goto _test_eof
-	_test_eof582:  m.cs = 582; goto _test_eof
-	_test_eof583:  m.cs = 583; goto _test_eof
-	_test_eof584:  m.cs = 584; goto _test_eof
-	_test_eof585:  m.cs = 585; goto _test_eof
 	_test_eof586:  m.cs = 586; goto _test_eof
 	_test_eof587:  m.cs = 587; goto _test_eof
+	_test_eof183:  m.cs = 183; goto _test_eof
+	_test_eof184:  m.cs = 184; goto _test_eof
 	_test_eof588:  m.cs = 588; goto _test_eof
+	_test_eof185:  m.cs = 185; goto _test_eof
+	_test_eof186:  m.cs = 186; goto _test_eof
 	_test_eof589:  m.cs = 589; goto _test_eof
+	_test_eof590:  m.cs = 590; goto _test_eof
+	_test_eof591:  m.cs = 591; goto _test_eof
+	_test_eof592:  m.cs = 592; goto _test_eof
+	_test_eof593:  m.cs = 593; goto _test_eof
+	_test_eof594:  m.cs = 594; goto _test_eof
+	_test_eof595:  m.cs = 595; goto _test_eof
+	_test_eof596:  m.cs = 596; goto _test_eof
 	_test_eof187:  m.cs = 187; goto _test_eof
 	_test_eof188:  m.cs = 188; goto _test_eof
 	_test_eof189:  m.cs = 189; goto _test_eof
-	_test_eof590:  m.cs = 590; goto _test_eof
+	_test_eof597:  m.cs = 597; goto _test_eof
 	_test_eof190:  m.cs = 190; goto _test_eof
 	_test_eof191:  m.cs = 191; goto _test_eof
 	_test_eof192:  m.cs = 192; goto _test_eof
-	_test_eof591:  m.cs = 591; goto _test_eof
+	_test_eof598:  m.cs = 598; goto _test_eof
 	_test_eof193:  m.cs = 193; goto _test_eof
 	_test_eof194:  m.cs = 194; goto _test_eof
-	_test_eof592:  m.cs = 592; goto _test_eof
-	_test_eof593:  m.cs = 593; goto _test_eof
+	_test_eof599:  m.cs = 599; goto _test_eof
+	_test_eof600:  m.cs = 600; goto _test_eof
 	_test_eof195:  m.cs = 195; goto _test_eof
-	_test_eof594:  m.cs = 594; goto _test_eof
+	_test_eof601:  m.cs = 601; goto _test_eof
 	_test_eof196:  m.cs = 196; goto _test_eof
-	_test_eof595:  m.cs = 595; goto _test_eof
-	_test_eof596:  m.cs = 596; goto _test_eof
+	_test_eof602:  m.cs = 602; goto _test_eof
+	_test_eof603:  m.cs = 603; goto _test_eof
 	_test_eof197:  m.cs = 197; goto _test_eof
 	_test_eof198:  m.cs = 198; goto _test_eof
+	_test_eof199:  m.cs = 199; goto _test_eof
+	_test_eof604:  m.cs = 604; goto _test_eof
+	_test_eof605:  m.cs = 605; goto _test_eof
+	_test_eof606:  m.cs = 606; goto _test_eof
+	_test_eof200:  m.cs = 200; goto _test_eof
+	_test_eof201:  m.cs = 201; goto _test_eof
+	_test_eof202:  m.cs = 202; goto _test_eof
+	_test_eof607:  m.cs = 607; goto _test_eof
+	_test_eof203:  m.cs = 203; goto _test_eof
+	_test_eof204:  m.cs = 204; goto _test_eof
+	_test_eof205:  m.cs = 205; goto _test_eof
 
 	_test_eof: {}
 	if ( m.p) == ( m.eof) {
 		switch  m.cs {
-		case 199, 200, 201, 203, 236, 237, 239, 258, 259, 261, 280, 282, 310, 311, 312, 313, 315, 316, 317, 336, 337, 339, 358, 359, 361, 380, 381, 396, 397, 398, 400, 419, 420, 422, 423, 424, 443, 444, 445, 446, 448, 467, 468, 469, 471, 490, 491, 493, 494, 495, 515, 530, 531, 533, 566, 595, 596:
+		case 206, 207, 208, 210, 243, 244, 246, 265, 266, 268, 287, 289, 317, 318, 319, 320, 322, 323, 324, 343, 344, 346, 365, 366, 368, 387, 388, 403, 404, 405, 407, 426, 427, 429, 430, 431, 450, 451, 452, 453, 455, 474, 475, 476, 478, 497, 498, 500, 501, 502, 522, 537, 538, 540, 573, 602, 603, 605, 606:
 //line plugins/parsers/influx/machine.go.rl:22
 
 	yield = true
@@ -22867,7 +23284,7 @@ tr341:
 	 m.cs = 195;
 	{( m.p)++;  m.cs = 0; goto _out }
 
-		case 28, 29, 30, 36, 37:
+		case 28, 29, 30, 36, 37, 200, 201, 202, 203, 204:
 //line plugins/parsers/influx/machine.go.rl:42
 
 	m.err = ErrTagParse
@@ -22901,7 +23318,29 @@ tr341:
 	 m.cs = 195;
 	{( m.p)++;  m.cs = 0; goto _out }
 
-		case 226, 286, 300, 386, 519, 555, 571, 584:
+		case 604:
+//line plugins/parsers/influx/machine.go.rl:72
+
+	m.handler.SetMeasurement(m.text())
+
+//line plugins/parsers/influx/machine.go.rl:22
+
+	yield = true
+	 m.cs = 196;
+	{( m.p)++;  m.cs = 0; goto _out }
+
+		case 607:
+//line plugins/parsers/influx/machine.go.rl:80
+
+	m.handler.AddTag(key, m.text())
+
+//line plugins/parsers/influx/machine.go.rl:22
+
+	yield = true
+	 m.cs = 196;
+	{( m.p)++;  m.cs = 0; goto _out }
+
+		case 233, 293, 307, 393, 526, 562, 578, 591:
 //line plugins/parsers/influx/machine.go.rl:88
 
 	m.handler.AddInt(key, m.text())
@@ -22912,7 +23351,7 @@ tr341:
 	 m.cs = 196;
 	{( m.p)++;  m.cs = 0; goto _out }
 
-		case 229, 289, 303, 389, 522, 558, 574, 587:
+		case 236, 296, 310, 396, 529, 565, 581, 594:
 //line plugins/parsers/influx/machine.go.rl:92
 
 	m.handler.AddUint(key, m.text())
@@ -22923,7 +23362,7 @@ tr341:
 	 m.cs = 196;
 	{( m.p)++;  m.cs = 0; goto _out }
 
-		case 222, 223, 224, 225, 227, 228, 230, 281, 283, 284, 285, 287, 288, 290, 296, 297, 298, 299, 301, 302, 304, 382, 383, 384, 385, 387, 388, 390, 514, 516, 517, 518, 520, 521, 523, 529, 552, 553, 554, 556, 557, 559, 565, 567, 568, 569, 570, 572, 573, 575, 581, 582, 583, 585, 586, 588:
+		case 229, 230, 231, 232, 234, 235, 237, 288, 290, 291, 292, 294, 295, 297, 303, 304, 305, 306, 308, 309, 311, 389, 390, 391, 392, 394, 395, 397, 521, 523, 524, 525, 527, 528, 530, 536, 559, 560, 561, 563, 564, 566, 572, 574, 575, 576, 577, 579, 580, 582, 588, 589, 590, 592, 593, 595:
 //line plugins/parsers/influx/machine.go.rl:96
 
 	m.handler.AddFloat(key, m.text())
@@ -22934,7 +23373,7 @@ tr341:
 	 m.cs = 196;
 	{( m.p)++;  m.cs = 0; goto _out }
 
-		case 231, 232, 233, 234, 235, 291, 292, 293, 294, 295, 305, 306, 307, 308, 309, 391, 392, 393, 394, 395, 524, 525, 526, 527, 528, 560, 561, 562, 563, 564, 576, 577, 578, 579, 580, 589, 590, 591, 592, 593:
+		case 238, 239, 240, 241, 242, 298, 299, 300, 301, 302, 312, 313, 314, 315, 316, 398, 399, 400, 401, 402, 531, 532, 533, 534, 535, 567, 568, 569, 570, 571, 583, 584, 585, 586, 587, 596, 597, 598, 599, 600:
 //line plugins/parsers/influx/machine.go.rl:100
 
 	m.handler.AddBool(key, m.text())
@@ -22945,7 +23384,7 @@ tr341:
 	 m.cs = 196;
 	{( m.p)++;  m.cs = 0; goto _out }
 
-		case 202, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 238, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 260, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 314, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 338, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 360, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 399, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 421, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 447, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 470, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 492, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 532, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551:
+		case 209, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 245, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 267, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 321, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 345, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 367, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 406, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 428, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 454, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 477, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 499, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 539, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558:
 //line plugins/parsers/influx/machine.go.rl:108
 
 	m.handler.SetTimestamp(m.text())
@@ -23064,14 +23503,14 @@ tr341:
 	 m.cs = 195;
 	{( m.p)++;  m.cs = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go:23068
+//line plugins/parsers/influx/machine.go:23507
 		}
 	}
 
 	_out: {}
 	}
 
-//line plugins/parsers/influx/machine.go.rl:288
+//line plugins/parsers/influx/machine.go.rl:308
 
 	// Even if there was an error, return true. On the next call to this
 	// function we will attempt to scan to the next line of input and recover.

--- a/plugins/parsers/influx/machine.go.rl
+++ b/plugins/parsers/influx/machine.go.rl
@@ -221,6 +221,8 @@ discard_line :=
 # main machine.
 align :=
 	(space* comment)* space* measurement_start @hold_recover %eof(yield);
+
+series := measurement tagset $err(parse_error) eol;
 }%%
 
 %% write data;
@@ -242,12 +244,30 @@ type machine struct {
 	p, pe, eof int
 	pb         int
 	handler    Handler
+	initState  int
 	err        error
 }
 
 func NewMachine(handler Handler) *machine {
 	m := &machine{
 		handler: handler,
+		initState: LineProtocol_en_align,
+	}
+
+	%% access m.;
+	%% variable p m.p;
+	%% variable pe m.pe;
+	%% variable eof m.eof;
+	%% variable data m.data;
+	%% write init;
+
+	return m
+}
+
+func NewSeriesMachine(handler Handler) *machine {
+	m := &machine{
+		handler: handler,
+		initState: LineProtocol_en_series,
 	}
 
 	%% access m.;
@@ -269,7 +289,7 @@ func (m *machine) SetData(data []byte) {
 	m.err = nil
 
 	%% write init;
-	m.cs = LineProtocol_en_align
+	m.cs = m.initState
 }
 
 // ParseLine parses a line of input and returns true if more data can be

--- a/plugins/parsers/influx/parser.go
+++ b/plugins/parsers/influx/parser.go
@@ -38,9 +38,18 @@ type Parser struct {
 	handler *MetricHandler
 }
 
+// NewParser returns a Parser than accepts line protocol
 func NewParser(handler *MetricHandler) *Parser {
 	return &Parser{
 		machine: NewMachine(handler),
+		handler: handler,
+	}
+}
+
+// NewSeriesParser returns a Parser than accepts a measurement and tagset
+func NewSeriesParser(handler *MetricHandler) *Parser {
+	return &Parser{
+		machine: NewSeriesMachine(handler),
 		handler: handler,
 	}
 }

--- a/plugins/parsers/influx/parser_test.go
+++ b/plugins/parsers/influx/parser_test.go
@@ -616,3 +616,83 @@ func BenchmarkParser(b *testing.B) {
 		})
 	}
 }
+
+func TestSeriesParser(t *testing.T) {
+	var tests = []struct {
+		name      string
+		input     []byte
+		timeFunc  func() time.Time
+		precision time.Duration
+		metrics   []telegraf.Metric
+		err       error
+	}{
+		{
+			name:    "empty",
+			input:   []byte(""),
+			metrics: []telegraf.Metric{},
+		},
+		{
+			name:  "minimal",
+			input: []byte("cpu"),
+			metrics: []telegraf.Metric{
+				Metric(
+					metric.New(
+						"cpu",
+						map[string]string{},
+						map[string]interface{}{},
+						time.Unix(0, 0),
+					),
+				),
+			},
+		},
+		{
+			name:  "tags",
+			input: []byte("cpu,a=x,b=y"),
+			metrics: []telegraf.Metric{
+				Metric(
+					metric.New(
+						"cpu",
+						map[string]string{
+							"a": "x",
+							"b": "y",
+						},
+						map[string]interface{}{},
+						time.Unix(0, 0),
+					),
+				),
+			},
+		},
+		{
+			name:    "missing tag value",
+			input:   []byte("cpu,a="),
+			metrics: []telegraf.Metric{},
+			err: &ParseError{
+				Offset: 6,
+				msg:    ErrTagParse.Error(),
+				buf:    "cpu,a=",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewMetricHandler()
+			handler.SetTimeFunc(DefaultTime)
+			if tt.timeFunc != nil {
+				handler.SetTimeFunc(tt.timeFunc)
+			}
+			if tt.precision > 0 {
+				handler.SetTimePrecision(tt.precision)
+			}
+			parser := NewSeriesParser(handler)
+
+			metrics, err := parser.Parse(tt.input)
+			require.Equal(t, tt.err, err)
+
+			require.Equal(t, len(tt.metrics), len(metrics))
+			for i, expected := range tt.metrics {
+				require.Equal(t, expected.Name(), metrics[i].Name())
+				require.Equal(t, expected.Tags(), metrics[i].Tags())
+			}
+		})
+	}
+}


### PR DESCRIPTION
If the dropwizard parser cannot convert the metric name into a valid line protocol series then we will accept the name as is.

This adds a way to parse only the `<measurement>,<tagset>` portion of line protocol and uses it to create new metrics instead of serializing the entire dropwizard metric to line protocol.  Anything that would require escaping to be valid cannot be converted, because escaping it fully would prevent tags from being extracted.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
