### PR TITLE
Output kafka confluent

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -69,6 +69,7 @@ github.com/satori/go.uuid 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 github.com/shirou/gopsutil c95755e4bcd7a62bb8bd33f3a597a7c7f35e2cf3
 github.com/shirou/w32 3c9377fc6748f222729a8270fe2775d149a249ad
 github.com/Shopify/sarama 3b1b38866a79f06deddf0487d5c27ba0697ccd65
+github.com/confluentinc/confluent-kafka-go/kafka 3819f9a0e47107712ae9a6aebe31037c9536a2c6
 github.com/Sirupsen/logrus 61e43dc76f7ee59a82bdf3d71033dc12bea4c77d
 github.com/soniah/gosnmp f15472a4cd6f6ea7929e4c7d9f163c49f059924f
 github.com/StackExchange/wmi f3e2bae1e0cb5aef83e319133eabfee30013a4a5

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ clean:
 	rm -f telegraf.exe
 
 docker-image:
-	./scripts/build.py --package --platform=linux --arch=amd64
+	./scripts/build.py --package --platform=linux --arch=amd64 ${ARGS}
 	cp build/telegraf*$(COMMIT)*.deb .
 	docker build -f scripts/dev.docker --build-arg "package=telegraf*$(COMMIT)*.deb" -t "telegraf-dev:$(COMMIT)" .
 

--- a/plugins/outputs/all/all.go
+++ b/plugins/outputs/all/all.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/outputs/influxdb"
 	_ "github.com/influxdata/telegraf/plugins/outputs/instrumental"
 	_ "github.com/influxdata/telegraf/plugins/outputs/kafka"
+	_ "github.com/influxdata/telegraf/plugins/outputs/kafka_confluent"
 	_ "github.com/influxdata/telegraf/plugins/outputs/kinesis"
 	_ "github.com/influxdata/telegraf/plugins/outputs/librato"
 	_ "github.com/influxdata/telegraf/plugins/outputs/mqtt"

--- a/plugins/outputs/kafka_confluent/README.md
+++ b/plugins/outputs/kafka_confluent/README.md
@@ -1,0 +1,17 @@
+# Kafka Confluent Producer Output Plugin
+
+This plugin writes to a [Librdkafka](https://docs.confluent.io/2.0.0/clients/librdkafka/index.html) acting as a Kafka Producer.
+
+```
+[[outputs.kafka]]
+  ## URLs of kafka brokers
+  brokers = "localhost:9092,localhost:9093"
+  ## Kafka topic for producer messages
+  topic = "telegraf"
+
+```
+
+### Required parameters:
+
+* `brokers`: A string with all kafka brokers. URL should just include host and port e.g. -> `"{host}:{port},{host2}:{port2}"`
+* `topic`: The `kafka` topic to publish to.

--- a/plugins/outputs/kafka_confluent/kafka_confluent.go
+++ b/plugins/outputs/kafka_confluent/kafka_confluent.go
@@ -1,0 +1,97 @@
+package kafka_confluent
+
+import (
+	"fmt"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/outputs"
+	"github.com/influxdata/telegraf/plugins/serializers"
+)
+
+type (
+	KafkaConfluent struct {
+		// Kafka brokers to send metrics to
+		Brokers string
+		// Kafka topic
+		Topic string
+
+		producer   *kafka.Producer
+		serializer serializers.Serializer
+	}
+)
+
+var sampleConfig = `
+# Send metrics to PostgreSQL using COPY
+[[outputs.kafka_confluent]]
+  ## URLs of kafka brokers
+  brokers = "localhost:9092"
+  ## Kafka topic for producer messages
+  topic = "telegraf"
+`
+
+func (k *KafkaConfluent) SampleConfig() string {
+	return sampleConfig
+}
+
+func (k *KafkaConfluent) Description() string {
+	return "Configuration for the Kafka server to send metrics to"
+}
+
+func (k *KafkaConfluent) SetSerializer(serializer serializers.Serializer) {
+	k.serializer = serializer
+}
+
+func (k *KafkaConfluent) Connect() error {
+	producer, err := kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": k.Brokers})
+	if err != nil {
+		return err
+	}
+
+	k.producer = producer
+
+	go func() {
+		for e := range k.producer.Events() {
+			switch ev := e.(type) {
+			case *kafka.Message:
+				if ev.TopicPartition.Error != nil {
+					fmt.Printf("Delivery failed: %v\n", ev.TopicPartition)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (k *KafkaConfluent) Close() error {
+	k.producer.Close()
+	return nil
+}
+
+func (k *KafkaConfluent) Write(metrics []telegraf.Metric) error {
+	for _, metric := range metrics {
+		buf, err := k.serializer.Serialize(metric)
+		if err != nil {
+			return err
+		}
+		err = k.producer.Produce(
+			&kafka.Message{
+				TopicPartition: kafka.TopicPartition{Topic: &k.Topic, Partition: kafka.PartitionAny},
+				Value:          []byte(buf),
+			}, nil)
+
+		if err != nil {
+			fmt.Errorf("FAILED to send kafka message: %s\n", err)
+		}
+	}
+	k.producer.Flush(15 * 1000)
+
+	return nil
+}
+
+func init() {
+	outputs.Add("kafka_confluent", func() telegraf.Output {
+		return &KafkaConfluent{}
+	})
+}

--- a/scripts/Dockerfile-Librdkafka-Confluent
+++ b/scripts/Dockerfile-Librdkafka-Confluent
@@ -1,0 +1,23 @@
+FROM golang:1.10.1-stretch
+
+ARG LIBRDKAFKA_NAME="librdkafka"
+ARG LIBRDKAFKA_VER="0.11.4"
+
+# Install librdkafka
+RUN BUILD_DIR="$(mktemp -d)" && \
+    wget -O "$BUILD_DIR/$LIBRDKAFKA_NAME.tar.gz" "https://github.com/edenhill/librdkafka/archive/v$LIBRDKAFKA_VER.tar.gz" && \
+    mkdir -p $BUILD_DIR/$LIBRDKAFKA_NAME-$LIBRDKAFKA_VER && \
+    tar \
+      --extract \
+      --file "$BUILD_DIR/$LIBRDKAFKA_NAME.tar.gz" \
+      --directory "$BUILD_DIR/$LIBRDKAFKA_NAME-$LIBRDKAFKA_VER" \
+      --strip-components 1 && \
+    cd "$BUILD_DIR/$LIBRDKAFKA_NAME-$LIBRDKAFKA_VER" && \
+    ./configure \
+      --prefix=/usr && \
+    make -j "$(getconf _NPROCESSORS_ONLN)" && \
+    make install
+
+COPY ./scripts/librdafkaka-confluent_build_script.sh /script.sh
+
+ENTRYPOINT ["/script.sh"]

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -697,8 +697,6 @@ def main(args):
         logging.error("Invalid build platform: {}".format(args.platform))
         return 1
 
-    build_output = {}
-
     if args.branch != orig_branch and args.commit != orig_commit:
         logging.error("Can only specify one branch or commit to build from.")
         return 1
@@ -729,6 +727,7 @@ def main(args):
     else:
         platforms = [args.platform]
 
+    build_output = {}
     for platform in platforms:
         build_output.update( { platform : {} } )
         archs = []
@@ -742,16 +741,17 @@ def main(args):
             od = args.outdir
             if not single_build:
                 od = os.path.join(args.outdir, platform, arch)
-            if not build(version=args.version,
-                         platform=platform,
-                         arch=arch,
-                         nightly=args.nightly,
-                         race=args.race,
-                         clean=args.clean,
-                         outdir=od,
-                         tags=args.build_tags,
-                         static=args.static):
-                return 1
+            if not args.already_builded:
+                if not build(version=args.version,
+                             platform=platform,
+                             arch=arch,
+                             nightly=args.nightly,
+                             race=args.race,
+                             clean=args.clean,
+                             outdir=od,
+                             tags=args.build_tags,
+                             static=args.static):
+                    return 1
             build_output.get(platform).update( { arch : od } )
 
     # Build packages
@@ -917,6 +917,10 @@ if __name__ == '__main__':
                         metavar='<timeout>',
                         type=str,
                         help='Timeout for tests before failing')
+    parser.add_argument('--already-builded',
+                        action='store_true',
+                        default=False,
+                        help='Run without build package')
     args = parser.parse_args()
     print_banner()
     sys.exit(main(args))

--- a/scripts/librdafkaka-confluent_build_script.sh
+++ b/scripts/librdafkaka-confluent_build_script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -x
+cd /go/src/app
+go get -u github.com/golang/lint/golint
+go get github.com/sparrc/gdm
+gdm restore || (echo 'Error getting dependencies, retrying...' && gdm restore)
+ln -s /go/src/app /go/src/github.com/influxdata/telegraf
+cd /go/src/github.com/influxdata/telegraf
+export COMMIT="$(git log --pretty=format:'%h' -n 1)" 
+export BRANCH="$(git rev-parse --abbrev-ref HEAD)" 
+GOOS=linux GOARCH=amd64 go build -o ${PWD}/build/telegraf -ldflags="-w -s -X main.branch=${BRANCH} -X main.commit=${COMMIT}" -tags static ./cmd/telegraf


### PR DESCRIPTION
Hi,

# Overview
I created these plugins to handling with large number of metrics.
I'm using a library from Kafka Confluent called [librdkafka](https://docs.confluent.io/2.0.0/clients/librdkafka/index.html)
It was write in C/C++, so to create telegraf docker image, I had to build with static files on debian environment.
All files are in this pull request, but the image are [here](https://hub.docker.com/r/otherpirate/golang1.10.1-stretch-librdkafka/)

# Build
To build I'm follwing this steps (I'm not sure it's the best way, maybe Telegraf-team could help me improve it?)
1 - Go to Telegraf folder
2 - `docker run --name telegraf-librdkafka-deb -it -v $PWD:/go/src/app --rm otherpirate/golang1.10.1-stretch-librdkafka`
3 - `ARGS=--already-builded make docker-image`

# Benchmark
I tried the [kafka output](https://github.com/otherpirate/telegraf/tree/master/plugins/outputs/kafka), but it is too slow to large number of metrics per second.
All benchmark are running in the cloud.

```
# Test with 150 messages
2018-05-16T13:07:00Z D! Output [kafka] buffer fullness: 150 / 1000000 metrics.
2018-05-16T13:07:00Z D! Output [kafka_confluent] buffer fullness: 150 / 1000000 metrics.
2018-05-16T13:07:00Z D! Output [kafka_confluent] wrote batch of 150 metrics in 46.930293ms
2018-05-16T13:07:00Z D! Output [kafka] wrote batch of 150 metrics in 318.260897ms

# Test with 3000 messages
Output [kafka] buffer fullness: 2941 / 1000000 metrics.
Output [kafka_confluent] buffer fullness: 2941 / 1000000 metrics.
Output [kafka_confluent] wrote batch of 2941 metrics in 650.70158ms
Output [kafka] wrote batch of 2941 metrics in 6.185083317s

# Test with 15000 messages
Output [kafka] buffer fullness: 14627 / 1000000 metrics.
Output [kafka_confluent] buffer fullness: 14627 / 1000000 metrics.
Output [kafka_confluent] wrote batch of 14627 metrics in 2.411144316s
Output [kafka] wrote batch of 14627 metrics in 28.912976898s
```

Obs: Working on unit tests

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
