### PR TITLE
Add support for additional Consul checks' tags and splitting them by a delimiter

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -30,7 +30,7 @@ github.com/gorilla/mux 53c1911da2b537f792e7cafcb446b05ffe33b996
 github.com/go-redis/redis 73b70592cdaa9e6abdfcfbf97b4a90d80728c836
 github.com/go-sql-driver/mysql 2e00b5cd70399450106cec6431c2e2ce3cae5034
 github.com/hailocab/go-hostpool e80d13ce29ede4452c43dea11e79b9bc8a15b478
-github.com/hashicorp/consul 63d2fc68239b996096a1c55a0d4b400ea4c2583f
+github.com/hashicorp/consul cf57a23bb1698dde5365aafeffd8bcf88d95d646
 github.com/influxdata/tail c43482518d410361b6c383d7aebce33d0471d7bc
 github.com/influxdata/toml 5d1d907f22ead1cd47adde17ceec5bda9cacaf8f
 github.com/influxdata/wlog 7c63b0a71ef8300adc255344d275e10e5c3a71ec

--- a/plugins/inputs/consul/README.md
+++ b/plugins/inputs/consul/README.md
@@ -33,6 +33,14 @@ report those stats already using StatsD protocol if needed.
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = true
+
+  ## Gather all Consul checks' tags
+  # gather_all_tags = false
+
+  ## Consul checks' tag splitting
+  # When tags are formatted like "key:value" with ":" as a delimiter then
+  # they will be splitted and reported as proper key:value in Telegraf
+  # tag_delimiter = ":"
 ```
 
 ### Metrics:

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -98,7 +98,7 @@ func (c *Consul) createAPIClient() (*api.Client, error) {
 		return nil, err
 	}
 
-	config.HttpClient.Transport = &http.Transport{
+	config.Transport = &http.Transport{
 		TLSClientConfig: tlsCfg,
 	}
 

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -110,6 +110,9 @@ func (c *Consul) GatherHealthCheck(acc telegraf.Accumulator, checks []*api.Healt
 		tags["node"] = check.Node
 		tags["service_name"] = check.ServiceName
 		tags["check_id"] = check.CheckID
+		for _, checkTag := range check.ServiceTags {
+			tags[checkTag] = checkTag
+		}
 
 		acc.AddFields("consul_health_checks", record, tags)
 	}

--- a/plugins/inputs/consul/consul_test.go
+++ b/plugins/inputs/consul/consul_test.go
@@ -17,6 +17,7 @@ var sampleChecks = []*api.HealthCheck{
 		Output:      "OK",
 		ServiceID:   "foo.123",
 		ServiceName: "foo",
+		ServiceTags: []string{"bar", "baz"},
 	},
 }
 
@@ -34,6 +35,8 @@ func TestGatherHealthCheck(t *testing.T) {
 		"node":         "localhost",
 		"service_name": "foo",
 		"check_id":     "foo.health123",
+		"bar":          "bar",
+		"baz":          "baz",
 	}
 
 	var acc testutil.Accumulator

--- a/plugins/inputs/consul/consul_test.go
+++ b/plugins/inputs/consul/consul_test.go
@@ -17,7 +17,7 @@ var sampleChecks = []*api.HealthCheck{
 		Output:      "OK",
 		ServiceID:   "foo.123",
 		ServiceName: "foo",
-		ServiceTags: []string{"bar", "baz"},
+		ServiceTags: []string{"bar", "env:sandbox"},
 	},
 }
 
@@ -35,13 +35,40 @@ func TestGatherHealthCheck(t *testing.T) {
 		"node":         "localhost",
 		"service_name": "foo",
 		"check_id":     "foo.health123",
-		"bar":          "bar",
-		"baz":          "baz",
 	}
 
 	var acc testutil.Accumulator
 
 	consul := &Consul{}
+	consul.GatherHealthCheck(&acc, sampleChecks)
+
+	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
+}
+
+func TestGatherHealthCheckWithDelimitedTags(t *testing.T) {
+	expectedFields := map[string]interface{}{
+		"check_name": "foo.health",
+		"status":     "passing",
+		"passing":    1,
+		"critical":   0,
+		"warning":    0,
+		"service_id": "foo.123",
+	}
+
+	expectedTags := map[string]string{
+		"node":         "localhost",
+		"service_name": "foo",
+		"check_id":     "foo.health123",
+		"bar":          "bar",
+		"env":          "sandbox",
+	}
+
+	var acc testutil.Accumulator
+
+	consul := &Consul{
+		GatherAllTags: true,
+		TagDelimiter:  ":",
+	}
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)


### PR DESCRIPTION
This PR introduces 2 new options:
1) Gathering all Consul check's tags, not only node, service_name and check_id.
If a check's tag is a single word then Telegraf will send this tag's value as a key and a value. This probably isn't the best option, but that's why there's another one below.
2) Splitting check's tag by a specified delimiter.
It's useful if Consul checks have tags formatted like: "env:production". After setting tag_delimiter = ":" these tags will be sent as proper Telegraf tags.

Example:
`consul_health_checks,cluster=bigcluster,host=11.22.33.44,release=2612cb161526038358,service=testservice,service_name=http-testservice-bigcluster,task_type=http check_name="service_tcp_port_check",critical=0i,passing=1i,service_id="ewpft7gojkilm2exq2mldlhpzrabzfkl",status="passing",warning=0i 1526477851000000000`

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
