### PR TITLE
Add detect_leader config option to docker input plugin

### DIFF
--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -16,13 +16,9 @@ to gather stats from the [Engine API](https://docs.docker.com/engine/api/v1.24/)
   ##   To use environment variables (ie, docker-machine), set endpoint = "ENV"
   endpoint = "unix:///var/run/docker.sock"
 
-  ## Set to true to collect Swarm metrics(desired_replicas, running_replicas)
-  ## Note: configure this in one of the manager nodes in a Swarm cluster.
-  ## configuring in multiple Swarm managers results in duplication of metrics.
-  gather_services = false
-  ## If gather_services is true, only collect if this node is the leader. 
-  ## This allows the same configuration to be used on all nodes in a Swarm.
-  detect_leader = false
+  ## Sets the condition for collecting Swarm data.  Can be one of:
+  ## "leader", "always", or "never".
+  swarm_reporting = "never"
 
   ## Only collect metrics for these containers. Values will be appended to
   ## container_name_include.

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -20,6 +20,8 @@ to gather stats from the [Engine API](https://docs.docker.com/engine/api/v1.24/)
   ## Note: configure this in one of the manager nodes in a Swarm cluster.
   ## configuring in multiple Swarm managers results in duplication of metrics.
   gather_services = false
+  ## If gather_services is true, only collect if this node is the leader
+  detect_leader = false
 
   ## Only collect metrics for these containers. Values will be appended to
   ## container_name_include.

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -20,7 +20,8 @@ to gather stats from the [Engine API](https://docs.docker.com/engine/api/v1.24/)
   ## Note: configure this in one of the manager nodes in a Swarm cluster.
   ## configuring in multiple Swarm managers results in duplication of metrics.
   gather_services = false
-  ## If gather_services is true, only collect if this node is the leader
+  ## If gather_services is true, only collect if this node is the leader. 
+  ## This allows the same configuration to be used on all nodes in a Swarm.
   detect_leader = false
 
   ## Only collect metrics for these containers. Values will be appended to

--- a/plugins/inputs/docker/client.go
+++ b/plugins/inputs/docker/client.go
@@ -79,7 +79,7 @@ func (c *SocketClient) TaskList(ctx context.Context, options types.TaskListOptio
 func (c *SocketClient) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
 	return c.client.NodeList(ctx, options)
 }
-func (c *SocketClient) NodeInspect(ctx context.Context, nodeID string) (swarm.Node,  error) {
+func (c *SocketClient) NodeInspect(ctx context.Context, nodeID string) (swarm.Node, error) {
 	node, _, error := c.client.NodeInspectWithRaw(ctx, nodeID)
 	return node, error
 }

--- a/plugins/inputs/docker/client.go
+++ b/plugins/inputs/docker/client.go
@@ -24,7 +24,6 @@ type Client interface {
 	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
 	NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
-	NodeInspect(ctx context.Context, nodeID string) (swarm.Node, error)
 }
 
 func NewEnvClient() (Client, error) {
@@ -78,8 +77,4 @@ func (c *SocketClient) TaskList(ctx context.Context, options types.TaskListOptio
 }
 func (c *SocketClient) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
 	return c.client.NodeList(ctx, options)
-}
-func (c *SocketClient) NodeInspect(ctx context.Context, nodeID string) (swarm.Node, error) {
-	node, _, error := c.client.NodeInspectWithRaw(ctx, nodeID)
-	return node, error
 }

--- a/plugins/inputs/docker/client.go
+++ b/plugins/inputs/docker/client.go
@@ -79,6 +79,7 @@ func (c *SocketClient) TaskList(ctx context.Context, options types.TaskListOptio
 func (c *SocketClient) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
 	return c.client.NodeList(ctx, options)
 }
-func (c *SocketClient) NodeInspect(ctx context.Context, nodeID string) swarm.Node, error) {
-	return c.client.NodeInspect(ctx, nodeID)
+func (c *SocketClient) NodeInspect(ctx context.Context, nodeID string) (swarm.Node,  error) {
+	node, _, error := c.client.NodeInspectWithRaw(ctx, nodeID)
+	return node, error
 }

--- a/plugins/inputs/docker/client.go
+++ b/plugins/inputs/docker/client.go
@@ -24,6 +24,7 @@ type Client interface {
 	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
 	NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
+	NodeInspect(ctx context.Context, nodeID string) (swarm.Node, error)
 }
 
 func NewEnvClient() (Client, error) {
@@ -77,4 +78,7 @@ func (c *SocketClient) TaskList(ctx context.Context, options types.TaskListOptio
 }
 func (c *SocketClient) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
 	return c.client.NodeList(ctx, options)
+}
+func (c *SocketClient) NodeInspect(ctx context.Context, nodeID string) swarm.Node, error) {
+	return c.client.NodeInspect(ctx, nodeID)
 }

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -58,7 +58,7 @@ type Docker struct {
 	labelFilter     filter.Filter
 	containerFilter filter.Filter
 	stateFilter     filter.Filter
-	isLeader	bool
+	isLeader        bool
 }
 
 // KB, MB, GB, TB, PB...human friendly
@@ -182,7 +182,7 @@ func (d *Docker) Gather(acc telegraf.Accumulator) error {
 			err := d.gatherSwarmInfo(acc)
 			if err != nil {
 				acc.AddError(err)
-			}				
+			}
 		}
 	}
 

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -240,14 +240,19 @@ func (d *Docker) gatherSwarmInfo(acc telegraf.Accumulator) error {
 		return err
 	}
 
+	isLeader := false
 	activeNodes := make(map[string]struct{})
 	for _, n := range nodes {
-		if n.ID == d.nodeID && d.SwarmReporting == "leader" && !n.ManagerStatus.Leader {
-			return nil
+		if n.ID == d.nodeID {
+			isLeader = n.ManagerStatus.Leader
 		}
 		if n.Status.State != swarm.NodeStateDown {
 			activeNodes[n.ID] = struct{}{}
 		}
+	}
+
+	if d.SwarmReporting == "leader" && !isLeader {
+		return nil
 	}
 
 	services, err := d.client.ServiceList(ctx, types.ServiceListOptions{})

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -175,7 +175,7 @@ func (d *Docker) Gather(acc telegraf.Accumulator) error {
 	}
 
 	if d.GatherServices {
-		if !d.detectLeader || d.isLeader {
+		if !d.DetectLeader || d.isLeader {
 			err := d.gatherSwarmInfo(acc)
 			if err != nil {
 				acc.AddError(err)
@@ -308,9 +308,9 @@ func (d *Docker) gatherInfo(acc telegraf.Accumulator) error {
 
 	d.engine_host = info.Name
 	d.serverVersion = info.ServerVersion
-	
+
 	// Detect leader status in swarm
-	if info.Swarm != nil {
+	if info.Swarm.NodeID != "" {
 		r, err := d.client.NodeInspect(ctx, info.Swarm.NodeID)
 		if err == nil {
 			d.isLeader = r.ManagerStatus.Leader

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -84,8 +84,11 @@ var sampleConfig = `
   endpoint = "unix:///var/run/docker.sock"
 
   ## Set to true to collect Swarm metrics(desired_replicas, running_replicas)
+  ## Note: configure this in one of the manager nodes in a Swarm cluster.
+  ## configuring in multiple Swarm managers results in duplication of metrics.
   gather_services = false
-  ## If gather_services is true, only collect if this node is the leader
+  ## If gather_services is true, only collect if this node is the leader.
+  ## This allows the same configuration to be used on all nodes in a Swarm.
   detect_leader = false
 
   ## Only collect metrics for these containers, collect all if empty

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -21,7 +21,6 @@ type MockClient struct {
 	ServiceListF      func(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	TaskListF         func(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
 	NodeListF         func(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
-	NodeInspectF      func(ctx context.Context, swarmID string) (swarm.Node, error)
 }
 
 func (c *MockClient) Info(ctx context.Context) (types.Info, error) {
@@ -71,13 +70,6 @@ func (c *MockClient) NodeList(
 	return c.NodeListF(ctx, options)
 }
 
-func (c *MockClient) NodeInspect(
-	ctx context.Context,
-	nodeID string,
-) (swarm.Node, error) {
-	return c.NodeInspectF(ctx, nodeID)
-}
-
 var baseClient = MockClient{
 	InfoF: func(context.Context) (types.Info, error) {
 		return info, nil
@@ -99,9 +91,6 @@ var baseClient = MockClient{
 	},
 	NodeListF: func(context.Context, types.NodeListOptions) ([]swarm.Node, error) {
 		return NodeList, nil
-	},
-	NodeInspectF: func(context.Context, string) (swarm.Node, error) {
-		return nodeInspect, nil
 	},
 }
 
@@ -283,9 +272,6 @@ func TestDocker_WindowsMemoryContainerStats(t *testing.T) {
 				},
 				NodeListF: func(context.Context, types.NodeListOptions) ([]swarm.Node, error) {
 					return NodeList, nil
-				},
-				NodeInspectF: func(ctx context.Context, nodeID string) (swarm.Node, error) {
-					return nodeInspect, nil
 				},
 			}, nil
 		},
@@ -702,8 +688,8 @@ func TestDockerGatherSwarmInfo(t *testing.T) {
 
 	err := acc.GatherError(d.Gather)
 	require.NoError(t, err)
-	require.True(t, d.isLeader)
 
+	d.SwarmReporting = "leader"
 	d.gatherSwarmInfo(&acc)
 
 	// test docker_container_net measurement

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -690,6 +690,7 @@ func TestDockerGatherSwarmInfo(t *testing.T) {
 	require.NoError(t, err)
 
 	d.SwarmReporting = "leader"
+	d.nodeID = "k67qz4598weg5unwwffg6z1m1"
 	d.gatherSwarmInfo(&acc)
 
 	// test docker_container_net measurement

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -21,6 +21,7 @@ type MockClient struct {
 	ServiceListF      func(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	TaskListF         func(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
 	NodeListF         func(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
+	NodeInspectF      func(ctx context.Context, swarmID string) (swarm.Node, error)
 }
 
 func (c *MockClient) Info(ctx context.Context) (types.Info, error) {
@@ -70,6 +71,13 @@ func (c *MockClient) NodeList(
 	return c.NodeListF(ctx, options)
 }
 
+func (c *MockClient) NodeInspect(
+	ctx context.Context,
+	nodeID string,
+) (swarm.Node, error) {
+	return c.NodeInspectF(ctx, nodeID)
+}
+
 var baseClient = MockClient{
 	InfoF: func(context.Context) (types.Info, error) {
 		return info, nil
@@ -91,6 +99,9 @@ var baseClient = MockClient{
 	},
 	NodeListF: func(context.Context, types.NodeListOptions) ([]swarm.Node, error) {
 		return NodeList, nil
+	},
+	NodeInspectF: func(context.Context, string) (swarm.Node, error) {
+		return nodeInspect, nil
 	},
 }
 
@@ -272,6 +283,9 @@ func TestDocker_WindowsMemoryContainerStats(t *testing.T) {
 				},
 				NodeListF: func(context.Context, types.NodeListOptions) ([]swarm.Node, error) {
 					return NodeList, nil
+				},
+				NodeInspectF: func(ctx context.Context, nodeID string) (swarm.Node, error) {
+					return nodeInspect, nil
 				},
 			}, nil
 		},
@@ -688,6 +702,7 @@ func TestDockerGatherSwarmInfo(t *testing.T) {
 
 	err := acc.GatherError(d.Gather)
 	require.NoError(t, err)
+	require.True(t, d.isLeader)
 
 	d.gatherSwarmInfo(&acc)
 

--- a/plugins/inputs/docker/docker_testdata.go
+++ b/plugins/inputs/docker/docker_testdata.go
@@ -56,8 +56,8 @@ var info = types.Info{
 	NoProxy:           "",
 	BridgeNfIP6tables: true,
 	ServerVersion:     "17.09.0-ce",
-	Swarm:  swarm.Info{
-		NodeID:	   "k67qz4598weg5unwwffg6z1m1",
+	Swarm: swarm.Info{
+		NodeID: "k67qz4598weg5unwwffg6z1m1",
 	},
 }
 

--- a/plugins/inputs/docker/docker_testdata.go
+++ b/plugins/inputs/docker/docker_testdata.go
@@ -56,6 +56,9 @@ var info = types.Info{
 	NoProxy:           "",
 	BridgeNfIP6tables: true,
 	ServerVersion:     "17.09.0-ce",
+	Swarm:  swarm.Info{
+		NodeID:	   "k67qz4598weg5unwwffg6z1m1",
+	},
 }
 
 var containerList = []types.Container{
@@ -485,5 +488,11 @@ var containerInspect = types.ContainerJSON{
 				Status:        "Unhealthy",
 			},
 		},
+	},
+}
+
+var nodeInspect = swarm.Node{
+	ManagerStatus: &swarm.ManagerStatus{
+		Leader: true,
 	},
 }

--- a/plugins/inputs/docker/docker_testdata.go
+++ b/plugins/inputs/docker/docker_testdata.go
@@ -198,9 +198,12 @@ var TaskList = []swarm.Task{
 
 var NodeList = []swarm.Node{
 	swarm.Node{
-		ID: "0cl4jturcyd1ks3fwpd010kor",
+		ID: "k67qz4598weg5unwwffg6z1m1",
 		Status: swarm.NodeStatus{
 			State: "ready",
+		},
+		ManagerStatus: &swarm.ManagerStatus{
+			Leader: true,
 		},
 	},
 	swarm.Node{
@@ -488,11 +491,5 @@ var containerInspect = types.ContainerJSON{
 				Status:        "Unhealthy",
 			},
 		},
-	},
-}
-
-var nodeInspect = swarm.Node{
-	ManagerStatus: &swarm.ManagerStatus{
-		Leader: true,
 	},
 }


### PR DESCRIPTION
This option causes Swarm data (gather_services) to only be collected if the current node is the leader. By doing so I can use the same config on all nodes in the Swarm.

It might make sense to make this default to true, but I didn't want to introduce any changes to existing behavior on my own.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.