### PR TITLE
[unbound] add option to reset stats each time they are collected

### DIFF
--- a/plugins/inputs/unbound/README.md
+++ b/plugins/inputs/unbound/README.md
@@ -27,6 +27,9 @@ a validating, recursive, and caching DNS resolver.
   ## true in a future version.  It is recommended to set to true on new
   ## deployments.
   thread_as_tag = false
+
+  ## When set to true metrics are reset each time they are collected
+  reset_stats = false
 ```
 
 #### Permissions:

--- a/plugins/inputs/unbound/unbound_test.go
+++ b/plugins/inputs/unbound/unbound_test.go
@@ -12,8 +12,8 @@ import (
 
 var TestTimeout = internal.Duration{Duration: time.Second}
 
-func UnboundControl(output string, Timeout internal.Duration, useSudo bool, Server string, ThreadAsTag bool) func(string, internal.Duration, bool, string, bool) (*bytes.Buffer, error) {
-	return func(string, internal.Duration, bool, string, bool) (*bytes.Buffer, error) {
+func UnboundControl(output string, Timeout internal.Duration, useSudo bool, Server string, ThreadAsTag bool, ResetStats bool) func(string, internal.Duration, bool, string, bool, bool) (*bytes.Buffer, error) {
+	return func(string, internal.Duration, bool, string, bool, bool) (*bytes.Buffer, error) {
 		return bytes.NewBuffer([]byte(output)), nil
 	}
 }
@@ -21,7 +21,7 @@ func UnboundControl(output string, Timeout internal.Duration, useSudo bool, Serv
 func TestParseFullOutput(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Unbound{
-		run: UnboundControl(fullOutput, TestTimeout, true, "", false),
+		run: UnboundControl(fullOutput, TestTimeout, true, "", false, false),
 	}
 	err := v.Gather(acc)
 
@@ -38,7 +38,7 @@ func TestParseFullOutput(t *testing.T) {
 func TestParseFullOutputThreadAsTag(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Unbound{
-		run:         UnboundControl(fullOutput, TestTimeout, true, "", true),
+		run:         UnboundControl(fullOutput, TestTimeout, true, "", true, false),
 		ThreadAsTag: true,
 	}
 	err := v.Gather(acc)


### PR DESCRIPTION
Unbound stats normally collected cumulatively by the plugin, but for some setups its more useful to collect stats for the time period. This change adds option to change the command used.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
