### PR TITLE
Ignore more boring filesystems from disk plugin

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1077,7 +1077,7 @@
   # mount_points = ["/"]
 
   ## Ignore mount points by filesystem type.
-  ignore_fs = ["tmpfs", "devtmpfs", "devfs"]
+  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "overlay", "aufs", "squashfs"]
 
 
 # Read metrics about disk IO by device

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -242,7 +242,7 @@
 #
 #   ## Ignore some mountpoints by filesystem type. For example (dev)tmpfs (usually
 #   ## present on /run, /var/run, /dev/shm or /dev).
-#   # ignore_fs = ["tmpfs", "devtmpfs"]
+#   # ignore_fs = ["tmpfs", "devtmpfs", "devfs", "overlay", "aufs", "squashfs"]
 
 
 # # Read metrics about disk IO by device

--- a/plugins/inputs/system/DISK_README.md
+++ b/plugins/inputs/system/DISK_README.md
@@ -16,7 +16,7 @@ https://en.wikipedia.org/wiki/Df_(Unix) for more details.
   # mount_points = ["/"]
 
   ## Ignore mount points by filesystem type.
-  ignore_fs = ["tmpfs", "devtmpfs", "devfs"]
+  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "overlay", "aufs", "squashfs"]
 ```
 
 #### Docker container

--- a/plugins/inputs/system/disk.go
+++ b/plugins/inputs/system/disk.go
@@ -28,7 +28,7 @@ var diskSampleConfig = `
   # mount_points = ["/"]
 
   ## Ignore mount points by filesystem type.
-  ignore_fs = ["tmpfs", "devtmpfs", "devfs"]
+  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "overlay", "aufs", "squashfs"]
 `
 
 func (_ *DiskStats) SampleConfig() string {


### PR DESCRIPTION
Add more FS type to default ignore list.

* overlay: Used by Docker for overlay2 (and probably overlay). This filesystem is backed by another local directory, disk usage/free/total will be the same as backing filesystem.
* aufs: Used by Docker for aufs. Like overlay this is backed by a local filesystem
* squashfs: Used by snap. This is a read-only filesystem backed by a local file.

For all those filesystem, since the backing store is a local directory/file, the space used will be seen in the metrics of this filesystem.
