### PR TITLE
Telegraph Docker Input Plugin : per docker running status support

### DIFF
--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -437,16 +437,16 @@ func (d *Docker) gatherContainer(
 	}
 	if info.State != nil {
 		statefields := map[string]interface{}{
-			"status":  info.State.Status,
-			"running": info.State.Running,
-			"paused": info.State.Paused,
+			"status":     info.State.Status,
+			"running":    info.State.Running,
+			"paused":     info.State.Paused,
 			"restarting": info.State.Restarting,
-			"oomkilled": info.State.OOMKilled,
-			"dead": info.State.Dead,
-			"pid": info.State.Pid,
-			"exitcode": info.State.ExitCode,
-			"error": info.State.Error,
-			"startedat": info.State.StartedAt,
+			"oomkilled":  info.State.OOMKilled,
+			"dead":       info.State.Dead,
+			"pid":        info.State.Pid,
+			"exitcode":   info.State.ExitCode,
+			"error":      info.State.Error,
+			"startedat":  info.State.StartedAt,
 			"finishedat": info.State.FinishedAt,
 		}
 		acc.AddFields("docker_container_status", statefields, tags, time.Now())

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -438,14 +438,9 @@ func (d *Docker) gatherContainer(
 	if info.State != nil {
 		statefields := map[string]interface{}{
 			"status":     info.State.Status,
-			"running":    info.State.Running,
-			"paused":     info.State.Paused,
-			"restarting": info.State.Restarting,
 			"oomkilled":  info.State.OOMKilled,
-			"dead":       info.State.Dead,
 			"pid":        info.State.Pid,
 			"exitcode":   info.State.ExitCode,
-			"error":      info.State.Error,
 			"startedat":  info.State.StartedAt,
 			"finishedat": info.State.FinishedAt,
 		}

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -436,13 +436,13 @@ func (d *Docker) gatherContainer(
 		}
 	}
 	if info.State != nil {
+		tags["container_status"] = info.State.Status
 		statefields := map[string]interface{}{
-			"status":     info.State.Status,
-			"oomkilled":  info.State.OOMKilled,
-			"pid":        info.State.Pid,
-			"exitcode":   info.State.ExitCode,
-			"startedat":  info.State.StartedAt,
-			"finishedat": info.State.FinishedAt,
+			"oomkilled":   info.State.OOMKilled,
+			"pid":         info.State.Pid,
+			"exitcode":    info.State.ExitCode,
+			"started_at":  info.State.StartedAt,
+			"finished_at": info.State.FinishedAt,
 		}
 		acc.AddFields("docker_container_status", statefields, tags, time.Now())
 	}

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -438,11 +438,17 @@ func (d *Docker) gatherContainer(
 	if info.State != nil {
 		tags["container_status"] = info.State.Status
 		statefields := map[string]interface{}{
-			"oomkilled":   info.State.OOMKilled,
-			"pid":         info.State.Pid,
-			"exitcode":    info.State.ExitCode,
-			"started_at":  info.State.StartedAt,
-			"finished_at": info.State.FinishedAt,
+			"oomkilled": info.State.OOMKilled,
+			"pid":       info.State.Pid,
+			"exitcode":  info.State.ExitCode,
+		}
+		container_time, err := time.Parse(time.RFC3339, info.State.StartedAt)
+		if err == nil && !container_time.IsZero() {
+			statefields["started_at"] = container_time.UnixNano()
+		}
+		container_time, err = time.Parse(time.RFC3339, info.State.FinishedAt)
+		if err == nil && !container_time.IsZero() {
+			statefields["finished_at"] = container_time.UnixNano()
 		}
 		acc.AddFields("docker_container_status", statefields, tags, time.Now())
 	}

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -435,6 +435,22 @@ func (d *Docker) gatherContainer(
 			}
 		}
 	}
+	if info.State != nil {
+		statefields := map[string]interface{}{
+			"status":  info.State.Status,
+			"running": info.State.Running,
+			"paused": info.State.Paused,
+			"restarting": info.State.Restarting,
+			"oomkilled": info.State.OOMKilled,
+			"dead": info.State.Dead,
+			"pid": info.State.Pid,
+			"exitcode": info.State.ExitCode,
+			"error": info.State.Error,
+			"startedat": info.State.StartedAt,
+			"finishedat": info.State.FinishedAt,
+		}
+		acc.AddFields("docker_container_status", statefields, tags, time.Now())
+	}
 
 	if info.State.Health != nil {
 		healthfields := map[string]interface{}{

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -653,6 +653,7 @@ func TestDockerGatherInfo(t *testing.T) {
 			"label1":            "test_value_1",
 			"label2":            "test_value_2",
 			"server_version":    "17.09.0-ce",
+			"container_status":  "running",
 		},
 	)
 	acc.AssertContainsTaggedFields(t,
@@ -676,6 +677,7 @@ func TestDockerGatherInfo(t *testing.T) {
 			"label1":            "test_value_1",
 			"label2":            "test_value_2",
 			"server_version":    "17.09.0-ce",
+			"container_status":  "running",
 		},
 	)
 }

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -653,7 +653,6 @@ func TestDockerGatherInfo(t *testing.T) {
 			"label1":            "test_value_1",
 			"label2":            "test_value_2",
 			"server_version":    "17.09.0-ce",
-			"container_status":  "running",
 		},
 	)
 	acc.AssertContainsTaggedFields(t,
@@ -677,7 +676,6 @@ func TestDockerGatherInfo(t *testing.T) {
 			"label1":            "test_value_1",
 			"label2":            "test_value_2",
 			"server_version":    "17.09.0-ce",
-			"container_status":  "running",
 		},
 	)
 }

--- a/plugins/inputs/docker/docker_testdata.go
+++ b/plugins/inputs/docker/docker_testdata.go
@@ -484,6 +484,12 @@ var containerInspect = types.ContainerJSON{
 				FailingStreak: 1,
 				Status:        "Unhealthy",
 			},
+			Status:     "running",
+			OOMKilled:  false,
+			Pid:        1234,
+			ExitCode:   0,
+			StartedAt:  "2018-06-14T05:48:53.266176036Z",
+			FinishedAt: "0001-01-01T00:00:00Z",
 		},
 	},
 }


### PR DESCRIPTION
Currently the docker input plugin does not provide the running status of the docker . It does provide health status of the docker but that is only retrieved if the docker application supports it . This enhancement extends the plugin to give out the running status of the docker which is taken from the Docker Container Inspect API.
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
