### PR TITLE
Wavefront output: remove empty tags 

### DIFF
--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -180,6 +180,14 @@ func buildMetrics(m telegraf.Metric, w *Wavefront) []*MetricPoint {
 }
 
 func buildTags(mTags map[string]string, w *Wavefront) (string, map[string]string) {
+
+	// Remove all empty tags.
+	for k, v := range mTags {
+		if v == "" {
+			delete(mTags, k)
+		}
+	}
+
 	var source string
 	sourceTagFound := false
 


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.

Wavefront Proxy will block metrics that have empty tags.  This PR will remove the tag from the output instead. Some output plugins now emit empty tags (prometheus, mysql).