### PR TITLE
Use counter time in win perf counters

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -57,6 +57,15 @@ It is recommended NOT to use this on OSes starting with Vista and newer because 
 Example for Windows Server 2003, this would be set to true:
 `PreVistaSupport=true`
 
+#### UsePerfCounterTime
+
+Bool, if set to `true` will request a timestamp along with the PerfCounter data. 
+If se to `false`, current time will be used.
+
+Supported on Windows Vista/Windows Server 2008 and newer
+Example:
+`UsePerfCounterTime=true`
+
 ### Object
 
 See Entry below.

--- a/plugins/inputs/win_perf_counters/kernel32.go
+++ b/plugins/inputs/win_perf_counters/kernel32.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2010 The win Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. The names of the authors may not be used to endorse or promote products
+//    derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// This is the official list of 'win' authors for copyright purposes.
+//
+// Alexander Neumann <an2048@googlemail.com>
+// Joseph Watson <jtwatson@linux-consulting.us>
+// Kevin Pors <krpors@gmail.com>
+
+// +build windows
+
+package win_perf_counters
+
+import (
+	"syscall"
+)
+
+type SYSTEMTIME struct {
+	wYear         uint16
+	wMonth        uint16
+	wDayOfWeek    uint16
+	wDay          uint16
+	wHour         uint16
+	wMinute       uint16
+	wSecond       uint16
+	wMilliseconds uint16
+}
+
+type FILETIME struct {
+	dwLowDateTime  uint32
+	dwHighDateTime uint32
+}
+
+var (
+	// Library
+	libkrnDll *syscall.DLL
+
+	// Functions
+	krn_FileTimeToSystemTime    *syscall.Proc
+	krn_FileTimeToLocalFileTime *syscall.Proc
+	krn_LocalFileTimeToFileTime *syscall.Proc
+	krn_WideCharToMultiByte     *syscall.Proc
+)
+
+func init() {
+	libkrnDll = syscall.MustLoadDLL("Kernel32.dll")
+
+	krn_FileTimeToSystemTime = libkrnDll.MustFindProc("FileTimeToSystemTime")
+	krn_FileTimeToLocalFileTime = libkrnDll.MustFindProc("FileTimeToLocalFileTime")
+	krn_LocalFileTimeToFileTime = libkrnDll.MustFindProc("LocalFileTimeToFileTime")
+	krn_WideCharToMultiByte = libkrnDll.MustFindProc("WideCharToMultiByte")
+}

--- a/plugins/inputs/win_perf_counters/pdh.go
+++ b/plugins/inputs/win_perf_counters/pdh.go
@@ -38,12 +38,15 @@ import (
 	"unsafe"
 
 	"golang.org/x/sys/windows"
+	"time"
 )
 
 // Error codes
 const (
-	ERROR_SUCCESS          = 0
-	ERROR_INVALID_FUNCTION = 1
+	ERROR_SUCCESS                 = 0
+	ERROR_FAILURE                 = 1
+	ERROR_INVALID_FUNCTION        = 1
+	EPOCH_DIFFERENCE_MICROS int64 = 11644473600000000
 )
 
 type (
@@ -170,6 +173,7 @@ var (
 	pdh_AddEnglishCounterW        *syscall.Proc
 	pdh_CloseQuery                *syscall.Proc
 	pdh_CollectQueryData          *syscall.Proc
+	pdh_CollectQueryDataWithTime  *syscall.Proc
 	pdh_GetFormattedCounterValue  *syscall.Proc
 	pdh_GetFormattedCounterArrayW *syscall.Proc
 	pdh_OpenQuery                 *syscall.Proc
@@ -187,6 +191,7 @@ func init() {
 	pdh_AddEnglishCounterW, _ = libpdhDll.FindProc("PdhAddEnglishCounterW") // XXX: only supported on versions > Vista.
 	pdh_CloseQuery = libpdhDll.MustFindProc("PdhCloseQuery")
 	pdh_CollectQueryData = libpdhDll.MustFindProc("PdhCollectQueryData")
+	pdh_CollectQueryDataWithTime, _ = libpdhDll.FindProc("PdhCollectQueryDataWithTime")
 	pdh_GetFormattedCounterValue = libpdhDll.MustFindProc("PdhGetFormattedCounterValue")
 	pdh_GetFormattedCounterArrayW = libpdhDll.MustFindProc("PdhGetFormattedCounterArrayW")
 	pdh_OpenQuery = libpdhDll.MustFindProc("PdhOpenQuery")
@@ -301,6 +306,37 @@ func PdhCollectQueryData(hQuery PDH_HQUERY) uint32 {
 	ret, _, _ := pdh_CollectQueryData.Call(uintptr(hQuery))
 
 	return uint32(ret)
+}
+
+// PdhCollectQueryDataWithTime queries data from perfmon, retrieving the device/windows timestamp from the node it was collected on.
+// Converts the filetime structure to a GO time class and returns the native time.
+//
+func PdhCollectQueryDataWithTime(hQuery PDH_HQUERY) (uint32, time.Time) {
+	var localFileTime FILETIME
+	ret, _, _ := pdh_CollectQueryDataWithTime.Call(uintptr(hQuery), uintptr(unsafe.Pointer(&localFileTime)))
+
+	if ret == ERROR_SUCCESS {
+		var utcFileTime FILETIME
+		ret, _, _ := krn_LocalFileTimeToFileTime.Call(
+			uintptr(unsafe.Pointer(&localFileTime)),
+			uintptr(unsafe.Pointer(&utcFileTime)))
+
+		if ret == 0 {
+			return uint32(ERROR_FAILURE), time.Now()
+		}
+
+		// First convert 100-ns intervals to microseconds, then adjust for the
+		// epoch difference
+		var totalMicroSeconds int64
+		totalMicroSeconds = ((int64(utcFileTime.dwHighDateTime) << 32) | int64(utcFileTime.dwLowDateTime)) / 10
+		totalMicroSeconds -= EPOCH_DIFFERENCE_MICROS
+
+		retTime := time.Unix(0, totalMicroSeconds*1000)
+
+		return uint32(ERROR_SUCCESS), retTime
+	}
+
+	return uint32(ret), time.Now()
 }
 
 // PdhGetFormattedCounterValueDouble formats the given hCounter using a 'double'. The result is set into the specialized union struct pValue.

--- a/plugins/inputs/win_perf_counters/performance_query.go
+++ b/plugins/inputs/win_perf_counters/performance_query.go
@@ -63,8 +63,8 @@ func (m *PerformanceQueryImpl) Open() error {
 		}
 	}
 	var handle PDH_HQUERY
-	ret := PdhOpenQuery(0, 0, &handle)
-	if ret != ERROR_SUCCESS {
+
+	if ret := PdhOpenQuery(0, 0, &handle); ret != ERROR_SUCCESS {
 		return NewPdhError(ret)
 	}
 	m.query = handle
@@ -76,8 +76,8 @@ func (m *PerformanceQueryImpl) Close() error {
 	if m.query == 0 {
 		return errors.New("uninitialised query")
 	}
-	ret := PdhCloseQuery(m.query)
-	if ret != ERROR_SUCCESS {
+
+	if ret := PdhCloseQuery(m.query); ret != ERROR_SUCCESS {
 		return NewPdhError(ret)
 	}
 	m.query = 0
@@ -89,8 +89,8 @@ func (m *PerformanceQueryImpl) AddCounterToQuery(counterPath string) (PDH_HCOUNT
 	if m.query == 0 {
 		return 0, errors.New("uninitialised query")
 	}
-	ret := PdhAddCounter(m.query, counterPath, 0, &counterHandle)
-	if ret != ERROR_SUCCESS {
+
+	if ret := PdhAddCounter(m.query, counterPath, 0, &counterHandle); ret != ERROR_SUCCESS {
 		return 0, NewPdhError(ret)
 	}
 	return counterHandle, nil
@@ -101,8 +101,7 @@ func (m *PerformanceQueryImpl) AddEnglishCounterToQuery(counterPath string) (PDH
 	if m.query == 0 {
 		return 0, errors.New("uninitialised query")
 	}
-	ret := PdhAddEnglishCounter(m.query, counterPath, 0, &counterHandle)
-	if ret != ERROR_SUCCESS {
+	if ret := PdhAddEnglishCounter(m.query, counterPath, 0, &counterHandle); ret != ERROR_SUCCESS {
 		return 0, NewPdhError(ret)
 	}
 	return counterHandle, nil
@@ -112,13 +111,11 @@ func (m *PerformanceQueryImpl) AddEnglishCounterToQuery(counterPath string) (PDH
 func (m *PerformanceQueryImpl) GetCounterPath(counterHandle PDH_HCOUNTER) (string, error) {
 	var bufSize uint32
 	var buff []byte
-
-	ret := PdhGetCounterInfo(counterHandle, 0, &bufSize, nil)
-	if ret == PDH_MORE_DATA {
+	var ret uint32
+	if ret = PdhGetCounterInfo(counterHandle, 0, &bufSize, nil); ret == PDH_MORE_DATA {
 		buff = make([]byte, bufSize)
 		bufSize = uint32(len(buff))
-		ret = PdhGetCounterInfo(counterHandle, 0, &bufSize, &buff[0])
-		if ret == ERROR_SUCCESS {
+		if ret = PdhGetCounterInfo(counterHandle, 0, &bufSize, &buff[0]); ret == ERROR_SUCCESS {
 			ci := (*PDH_COUNTER_INFO)(unsafe.Pointer(&buff[0]))
 			return UTF16PtrToString(ci.SzFullPath), nil
 		}
@@ -130,9 +127,9 @@ func (m *PerformanceQueryImpl) GetCounterPath(counterHandle PDH_HCOUNTER) (strin
 func (m *PerformanceQueryImpl) ExpandWildCardPath(counterPath string) ([]string, error) {
 	var bufSize uint32
 	var buff []uint16
+	var ret uint32
 
-	ret := PdhExpandWildCardPath(counterPath, nil, &bufSize)
-	if ret == PDH_MORE_DATA {
+	if ret = PdhExpandWildCardPath(counterPath, nil, &bufSize); ret == PDH_MORE_DATA {
 		buff = make([]uint16, bufSize)
 		bufSize = uint32(len(buff))
 		ret = PdhExpandWildCardPath(counterPath, &buff[0], &bufSize)
@@ -148,8 +145,9 @@ func (m *PerformanceQueryImpl) ExpandWildCardPath(counterPath string) ([]string,
 func (m *PerformanceQueryImpl) GetFormattedCounterValueDouble(hCounter PDH_HCOUNTER) (float64, error) {
 	var counterType uint32
 	var value PDH_FMT_COUNTERVALUE_DOUBLE
-	ret := PdhGetFormattedCounterValueDouble(hCounter, &counterType, &value)
-	if ret == ERROR_SUCCESS {
+	var ret uint32
+
+	if ret = PdhGetFormattedCounterValueDouble(hCounter, &counterType, &value); ret == ERROR_SUCCESS {
 		if value.CStatus == PDH_CSTATUS_VALID_DATA || value.CStatus == PDH_CSTATUS_NEW_DATA {
 			return value.DoubleValue, nil
 		} else {
@@ -163,11 +161,12 @@ func (m *PerformanceQueryImpl) GetFormattedCounterValueDouble(hCounter PDH_HCOUN
 func (m *PerformanceQueryImpl) GetFormattedCounterArrayDouble(hCounter PDH_HCOUNTER) ([]CounterValue, error) {
 	var buffSize uint32
 	var itemCount uint32
-	ret := PdhGetFormattedCounterArrayDouble(hCounter, &buffSize, &itemCount, nil)
-	if ret == PDH_MORE_DATA {
+	var ret uint32
+
+	if ret = PdhGetFormattedCounterArrayDouble(hCounter, &buffSize, &itemCount, nil); ret == PDH_MORE_DATA {
 		buff := make([]byte, buffSize)
-		ret = PdhGetFormattedCounterArrayDouble(hCounter, &buffSize, &itemCount, &buff[0])
-		if ret == ERROR_SUCCESS {
+
+		if ret = PdhGetFormattedCounterArrayDouble(hCounter, &buffSize, &itemCount, &buff[0]); ret == ERROR_SUCCESS {
 			items := (*[1 << 20]PDH_FMT_COUNTERVALUE_ITEM_DOUBLE)(unsafe.Pointer(&buff[0]))[:itemCount]
 			values := make([]CounterValue, 0, itemCount)
 			for _, item := range items {
@@ -183,11 +182,12 @@ func (m *PerformanceQueryImpl) GetFormattedCounterArrayDouble(hCounter PDH_HCOUN
 }
 
 func (m *PerformanceQueryImpl) CollectData() error {
+	var ret uint32
 	if m.query == 0 {
 		return errors.New("uninitialised query")
 	}
-	ret := PdhCollectQueryData(m.query)
-	if ret != ERROR_SUCCESS {
+
+	if ret = PdhCollectQueryData(m.query); ret != ERROR_SUCCESS {
 		return NewPdhError(ret)
 	}
 	return nil

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -353,6 +353,11 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 						collectFields[instance][sanitizedChars.Replace(metric.counter)] = float32(cValue.Value)
 					}
 				}
+			} else {
+				//ignore invalid data from as some counters from process instances returns this sometimes
+				if phderr, ok := err.(*PdhError); ok && phderr.ErrorCode != PDH_INVALID_DATA && phderr.ErrorCode != PDH_CALC_NEGATIVE_VALUE {
+					return fmt.Errorf("error while getting value for counter %s: %v", metric.counterPath, err)
+				}
 			}
 		}
 	}

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -254,18 +254,15 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 			m.counters = m.counters[:0]
 		}
 
-		err = m.query.Open()
-		if err != nil {
+		if err = m.query.Open(); err != nil {
 			return err
 		}
 
-		err = m.ParseConfig()
-		if err != nil {
+		if err = m.ParseConfig(); err != nil {
 			return err
 		}
 		//some counters need two data samples before computing a value
-		err = m.query.CollectData()
-		if err != nil {
+		if err = m.query.CollectData(); err != nil {
 			return err
 		}
 		m.lastRefreshed = time.Now()
@@ -289,8 +286,7 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 		}
 	} else {
 		timestamp = time.Now()
-		err = m.query.CollectData()
-		if err != nil {
+		if err = m.query.CollectData(); err != nil {
 			return err
 		}
 	}

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -153,7 +153,7 @@ func (m *Win_PerfCounters) AddItem(counterPath string, objectName string, instan
 	var err error
 	var counterHandle PDH_HCOUNTER
 	if !m.query.IsVistaOrNewer() {
-		_, err := m.query.AddCounterToQuery(counterPath)
+		counterHandle, err = m.query.AddCounterToQuery(counterPath)
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -605,7 +605,7 @@ func TestWinPerfcountersCollect2(t *testing.T) {
 
 	perfobjects[0] = PerfObject
 
-	m := Win_PerfCounters{PrintValid: false, Object: perfobjects, query: &PerformanceQueryImpl{}, UseWildcardsExpansion: true}
+	m := Win_PerfCounters{PrintValid: false, UsePerfCounterTime: true, Object: perfobjects, query: &PerformanceQueryImpl{}, UseWildcardsExpansion: true}
 	var acc testutil.Accumulator
 	err := m.Gather(&acc)
 	require.NoError(t, err)

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -70,6 +70,11 @@ func TestWinPerformanceQueryImpl(t *testing.T) {
 	_, err = query.GetFormattedCounterValueDouble(hCounter)
 	require.NoError(t, err)
 
+	now := time.Now()
+	mtime, err := query.CollectDataWithTime()
+	require.NoError(t, err)
+	assert.True(t, mtime.Sub(now) < time.Second)
+
 	counterPath = "\\Process(*)\\% Processor Time"
 	paths, err := query.ExpandWildCardPath(counterPath)
 	require.NoError(t, err)

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -103,6 +103,10 @@ func TestWinPerformanceQueryImpl(t *testing.T) {
 	require.NoError(t, err)
 
 	arr, err := query.GetFormattedCounterArrayDouble(hCounter)
+	if phderr, ok := err.(*PdhError); ok && phderr.ErrorCode != PDH_INVALID_DATA && phderr.ErrorCode != PDH_CALC_NEGATIVE_VALUE {
+		time.Sleep(time.Second)
+		arr, err = query.GetFormattedCounterArrayDouble(hCounter)
+	}
 	require.NoError(t, err)
 	assert.True(t, len(arr) > 0, "Too")
 


### PR DESCRIPTION
Trying to fix #4250: added possibility to use timestamp from performance counters

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
