### PR TITLE
Added filename tag to tail input plugin.

### DIFF
--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -146,7 +146,11 @@ func (t *Tail) receiver(tailer *tail.Tail) {
 
 		m, err = t.parser.ParseLine(text)
 		if err == nil {
-			t.acc.AddFields(m.Name(), m.Fields(), m.Tags(), m.Time())
+			if m != nil {
+				tags := m.Tags()
+				tags["path"] = tailer.Filename
+				t.acc.AddFields(m.Name(), m.Fields(), tags, m.Time())
+			}
 		} else {
 			t.acc.AddError(fmt.Errorf("E! Malformed log line in %s: [%s], Error: %s\n",
 				tailer.Filename, line.Text, err))


### PR DESCRIPTION
### Required for all PRs:

- [v] Signed [CLA](https://influxdata.com/community/cla/).
- [v] Associated README.md updated.
- [v] Has appropriate unit tests.

Added filename tag for tail input plugin.
This information is needed when the case telegraf captures log from multiple files in the directory structure and there's a need to identify source.