### PR TITLE
Drop CI support for Go 1.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,6 @@
 defaults:
   defaults: &defaults
     working_directory: '/go/src/github.com/influxdata/telegraf'
-  go-1_8: &go-1_8
-    docker:
-      - image: 'circleci/golang:1.8.7'
   go-1_9: &go-1_9
     docker:
       - image: 'circleci/golang:1.9.7'
@@ -23,18 +20,13 @@ jobs:
           root: '/go/src'
           paths:
             - '*'
-  test-go-1.8:
-    <<: [ *defaults, *go-1_8 ]
-    steps:
-      - attach_workspace:
-          at: '/go/src'
-      - run: 'make test-ci'
   test-go-1.9:
     <<: [ *defaults, *go-1_9 ]
     steps:
       - attach_workspace:
           at: '/go/src'
       - run: 'make test-ci'
+      - run: 'GOARCH=386 make test-ci'
   test-go-1.10:
     <<: [ *defaults, *go-1_10 ]
     steps:
@@ -66,9 +58,6 @@ workflows:
   build_and_release:
     jobs:
       - 'deps'
-      - 'test-go-1.8':
-          requires:
-            - 'deps'
       - 'test-go-1.9':
           requires:
             - 'deps'
@@ -77,15 +66,11 @@ workflows:
             - 'deps'
       - 'release':
           requires:
-            - 'test-go-1.8'
             - 'test-go-1.9'
             - 'test-go-1.10'
   nightly:
     jobs:
       - 'deps'
-      - 'test-go-1.8':
-          requires:
-            - 'deps'
       - 'test-go-1.9':
           requires:
             - 'deps'
@@ -94,7 +79,6 @@ workflows:
             - 'deps'
       - 'nightly':
           requires:
-            - 'test-go-1.8'
             - 'test-go-1.9'
             - 'test-go-1.10'
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
       - attach_workspace:
           at: '/go/src'
       - run: 'make test-ci'
-      - run: 'GOARCH=386 make test-ci'
   test-go-1.10:
     <<: [ *defaults, *go-1_10 ]
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ defaults:
       - image: 'circleci/golang:1.8.7'
   go-1_9: &go-1_9
     docker:
-      - image: 'circleci/golang:1.9.5'
+      - image: 'circleci/golang:1.9.7'
   go-1_10: &go-1_10
     docker:
-      - image: 'circleci/golang:1.10.1'
+      - image: 'circleci/golang:1.10.3'
 
 version: 2
 jobs:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Ansible role: https://github.com/rossmcdonald/telegraf
 
 ### From Source:
 
-Telegraf requires golang version 1.8+, the Makefile requires GNU make.
+Telegraf requires golang version 1.9 or newer, the Makefile requires GNU make.
 
 Dependencies are managed with [gdm](https://github.com/sparrc/gdm),
 which is installed by the Makefile if you don't have it already.


### PR DESCRIPTION
The CircleCI docker images we are using have been removed for this version of Go, and the 1.8 release is no longer supported upstream.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
