### PR TITLE
Support for Kubernetes Audit webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Telegraf can also collect metrics via the following service plugins:
 * [webhooks](./plugins/inputs/webhooks)
   * [filestack](./plugins/inputs/webhooks/filestack)
   * [github](./plugins/inputs/webhooks/github)
+  * [kubernetes-audit](./plugins/inputs/kubernetes_audit)
   * [mandrill](./plugins/inputs/webhooks/mandrill)
   * [papertrail](./plugins/inputs/webhooks/papertrail)
   * [particle](./plugins/inputs/webhooks/particle)

--- a/plugins/inputs/webhooks/kubernetes_audit/README.md
+++ b/plugins/inputs/webhooks/kubernetes_audit/README.md
@@ -1,0 +1,63 @@
+Kubernetes auditing provides a security-relevant chronological set of records
+documenting the sequence of activities that have affected system by individual
+users, administrators or other components of the system. It allows cluster
+administrator to answer the following questions:
+
+* what happened?
+* when did it happen?
+* who initiated it?
+* on what did it happen?
+* where was it observed?
+* from where was it initiated?
+* to where was it going?
+
+You can keep reading the [official
+docs](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/) to know
+more about Kubernetes Audit log.
+
+There are two different ways to get audit logs, one is tailing a file, the other
+one is configuring a webhook. This plugin catch the webhooks sends from the
+kube-apiserver and it stores them in InfluxDB.
+
+## How to try it
+
+### 0. Requirements:
+
+* minikube installed
+* an influxdb running on port 8086
+* you need a way to make telegraf available from minikube network. I used ngrok
+  to proxy telegraf to the outside
+
+### 1. Start telegraf
+
+When you have the proxied URL for your telegraf you should replace the url [the kubeconfig
+here](./example/webhook.yaml) with the right one.
+
+Now you can start  telegraf using [this
+configuration](./example/telegraf.config).
+
+### 2. Kubernetes via minikube
+
+First of all you need to start the VM passing few other flags to expose the
+audit log from the apiserver:
+
+```
+minikube start \
+    --extra-config=apiserver.audit-webhook-config-file=/var/lib/localkube/certs/hack/example/webhook.yaml \
+    --extra-config=apiserver.audit-policy-file=/var/lib/localkube/certs/hack/example/policy.yaml \
+    --extra-config=apiserver.audit-webhook-mode=batch
+```
+
+We also need to mount the example directory inside the VM or the
+apiserver won't be able to load the audit policy and the kubeconfig.
+
+```
+minikube mount $TELEGRAF_PATH/pluigins/inputs/webhooks/kubernetes_audit/example:/var/lib/localkube/certs/hack/example
+```
+
+The mount location inside the VM is currently an hack explain
+[here](https://github.com/kubernetes/minikube/issues/2741#issuecomment-398683171).
+
+### 3. The end
+If everything is working right you should be able to query the audit logs in
+your influxdb.

--- a/plugins/inputs/webhooks/kubernetes_audit/audit_webhooks.go
+++ b/plugins/inputs/webhooks/kubernetes_audit/audit_webhooks.go
@@ -41,7 +41,6 @@ func (k *KubeAuditWebhook) eventHandler(w http.ResponseWriter, r *http.Request) 
 		tags := map[string]string{}
 		fields := map[string]interface{}{}
 		audit := audits.Items[ii]
-		tags["audit_id"] = string(audit.AuditID)
 		tags["level"] = string(audit.Level)
 		tags["stage"] = string(audit.Stage)
 		tags["verb"] = string(audit.Verb)
@@ -60,6 +59,7 @@ func (k *KubeAuditWebhook) eventHandler(w http.ResponseWriter, r *http.Request) 
 		// "sourceIPs": ["192.168.99.100"],
 		//audit.SourceIPs
 
+		fields["audit_id"] = string(audit.AuditID)
 		fields["request_uri"] = string(audit.RequestURI)
 		k.acc.AddFields("kubernetes_audit", fields, tags, audit.RequestReceivedTimestamp.Time)
 	}

--- a/plugins/inputs/webhooks/kubernetes_audit/audit_webhooks.go
+++ b/plugins/inputs/webhooks/kubernetes_audit/audit_webhooks.go
@@ -1,0 +1,67 @@
+package kubernetes_audit
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/influxdata/telegraf"
+	"k8s.io/apiserver/pkg/apis/audit"
+)
+
+type KubeAuditWebhook struct {
+	Path string
+	acc  telegraf.Accumulator
+}
+
+func (k *KubeAuditWebhook) Register(router *mux.Router, acc telegraf.Accumulator) {
+	router.HandleFunc(k.Path, k.eventHandler).Methods("POST")
+	log.Printf("I! Started the kubernetest_audit_webhook on %s", k.Path)
+	k.acc = acc
+}
+
+func (k *KubeAuditWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
+	var audits audit.EventList
+	// Read body
+	b, err := ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	err = json.Unmarshal(b, &audits)
+	if err != nil {
+		http.Error(w, string(b), http.StatusInternalServerError)
+		return
+	}
+	for ii := 0; ii < len(audits.Items); ii++ {
+		tags := map[string]string{}
+		fields := map[string]interface{}{}
+		audit := audits.Items[ii]
+		tags["audit_id"] = string(audit.AuditID)
+		tags["level"] = string(audit.Level)
+		tags["stage"] = string(audit.Stage)
+		tags["verb"] = string(audit.Verb)
+		tags["user_username"] = audit.User.Username
+		tags["user_uid"] = audit.User.UID
+		if audit.ObjectRef != nil {
+			tags["resource_name"] = audit.ObjectRef.Name
+			tags["namespace"] = audit.ObjectRef.Namespace
+			tags["resource_type"] = audit.ObjectRef.Resource
+			tags["resource_version"] = audit.ObjectRef.ResourceVersion
+		}
+
+		//"groups": ["system:authenticated"]
+		//audit.User.Groups
+
+		// "sourceIPs": ["192.168.99.100"],
+		//audit.SourceIPs
+
+		fields["request_uri"] = string(audit.RequestURI)
+		k.acc.AddFields("kubernetes_audit", fields, tags, audit.RequestReceivedTimestamp.Time)
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/plugins/inputs/webhooks/kubernetes_audit/audit_webhooks_test.go
+++ b/plugins/inputs/webhooks/kubernetes_audit/audit_webhooks_test.go
@@ -1,0 +1,539 @@
+package kubernetes_audit
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+)
+
+var fakeWebhook = `{
+    "kind": "EventList",
+    "apiVersion": "audit.k8s.io/v1beta1",
+    "metadata": {},
+    "items": [
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:17Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:17Z",
+            "auditID": "bdffd78c-91e3-40f9-8226-912760d95a64",
+            "stage": "RequestReceived",
+            "requestURI": "/api/v1/namespaces/kube-system/endpoints/kube-scheduler",
+            "verb": "get",
+            "user": {
+                "username": "system:kube-scheduler",
+                "groups": [
+                    "system:authenticated"
+                ]
+            },
+            "sourceIPs": [
+                "192.168.99.100"
+            ],
+            "objectRef": {
+                "resource": "endpoints",
+                "namespace": "kube-system",
+                "name": "kube-scheduler",
+                "apiVersion": "v1"
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:17.415464Z",
+            "stageTimestamp": "2018-06-20T11:16:17.415464Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:17Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:17Z",
+            "auditID": "bdffd78c-91e3-40f9-8226-912760d95a64",
+            "stage": "ResponseComplete",
+            "requestURI": "/api/v1/namespaces/kube-system/endpoints/kube-scheduler",
+            "verb": "get",
+            "user": {
+                "username": "system:kube-scheduler",
+                "groups": [
+                    "system:authenticated"
+                ]
+            },
+            "sourceIPs": [
+                "192.168.99.100"
+            ],
+            "objectRef": {
+                "resource": "endpoints",
+                "namespace": "kube-system",
+                "name": "kube-scheduler",
+                "apiVersion": "v1"
+            },
+            "responseStatus": {
+                "metadata": {},
+                "code": 200
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:17.415464Z",
+            "stageTimestamp": "2018-06-20T11:16:17.418944Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:17Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:17Z",
+            "auditID": "f34fbe4c-ffc6-4074-94bf-961d3273fb5d",
+            "stage": "RequestReceived",
+            "requestURI": "/api/v1/namespaces/kube-system/endpoints/kube-scheduler",
+            "verb": "update",
+            "user": {
+                "username": "system:kube-scheduler",
+                "groups": [
+                    "system:authenticated"
+                ]
+            },
+            "sourceIPs": [
+                "192.168.99.100"
+            ],
+            "objectRef": {
+                "resource": "endpoints",
+                "namespace": "kube-system",
+                "name": "kube-scheduler",
+                "apiVersion": "v1"
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:17.421414Z",
+            "stageTimestamp": "2018-06-20T11:16:17.421414Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:17Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:17Z",
+            "auditID": "f34fbe4c-ffc6-4074-94bf-961d3273fb5d",
+            "stage": "ResponseComplete",
+            "requestURI": "/api/v1/namespaces/kube-system/endpoints/kube-scheduler",
+            "verb": "update",
+            "user": {
+                "username": "system:kube-scheduler",
+                "groups": [
+                    "system:authenticated"
+                ]
+            },
+            "sourceIPs": [
+                "192.168.99.100"
+            ],
+            "objectRef": {
+                "resource": "endpoints",
+                "namespace": "kube-system",
+                "name": "kube-scheduler",
+                "uid": "93eab84f-746c-11e8-a34b-080027191022",
+                "apiVersion": "v1",
+                "resourceVersion": "7661"
+            },
+            "responseStatus": {
+                "metadata": {},
+                "code": 200
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:17.421414Z",
+            "stageTimestamp": "2018-06-20T11:16:17.429819Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:17Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:10:26Z",
+            "auditID": "b9f2b2cc-49e7-471c-85fa-fdf87088ecb7",
+            "stage": "ResponseComplete",
+            "requestURI": "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations?resourceVersion=1256&timeoutSeconds=351&watch=true",
+            "verb": "watch",
+            "user": {
+                "username": "system:kube-controller-manager",
+                "groups": [
+                    "system:authenticated"
+                ]
+            },
+            "sourceIPs": [
+                "192.168.99.100"
+            ],
+            "objectRef": {
+                "resource": "mutatingwebhookconfigurations",
+                "apiGroup": "admissionregistration.k8s.io",
+                "apiVersion": "v1beta1"
+            },
+            "responseStatus": {
+                "metadata": {},
+                "code": 200
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:10:26.948720Z",
+            "stageTimestamp": "2018-06-20T11:16:17.949180Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:17Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:17Z",
+            "auditID": "7d498301-476f-4569-ad0e-e908d22380b7",
+            "stage": "RequestReceived",
+            "requestURI": "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations?resourceVersion=1256&timeoutSeconds=423&watch=true",
+            "verb": "watch",
+            "user": {
+                "username": "system:kube-controller-manager",
+                "groups": [
+                    "system:authenticated"
+                ]
+            },
+            "sourceIPs": [
+                "192.168.99.100"
+            ],
+            "objectRef": {
+                "resource": "mutatingwebhookconfigurations",
+                "apiGroup": "admissionregistration.k8s.io",
+                "apiVersion": "v1beta1"
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:17.949885Z",
+            "stageTimestamp": "2018-06-20T11:16:17.949885Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:17Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:17Z",
+            "auditID": "7d498301-476f-4569-ad0e-e908d22380b7",
+            "stage": "ResponseStarted",
+            "requestURI": "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations?resourceVersion=1256&timeoutSeconds=423&watch=true",
+            "verb": "watch",
+            "user": {
+                "username": "system:kube-controller-manager",
+                "groups": [
+                    "system:authenticated"
+                ]
+            },
+            "sourceIPs": [
+                "192.168.99.100"
+            ],
+            "objectRef": {
+                "resource": "mutatingwebhookconfigurations",
+                "apiGroup": "admissionregistration.k8s.io",
+                "apiVersion": "v1beta1"
+            },
+            "responseStatus": {
+                "metadata": {},
+                "code": 200
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:17.949885Z",
+            "stageTimestamp": "2018-06-20T11:16:17.950127Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:18Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:18Z",
+            "auditID": "a305ebd8-0705-42da-9130-7d39c44aeb8b",
+            "stage": "RequestReceived",
+            "requestURI": "/apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations",
+            "verb": "list",
+            "user": {
+                "username": "system:apiserver",
+                "uid": "069ab130-1661-4682-a231-b6e0c11b10ea",
+                "groups": [
+                    "system:masters"
+                ]
+            },
+            "sourceIPs": [
+                "127.0.0.1"
+            ],
+            "objectRef": {
+                "resource": "initializerconfigurations",
+                "apiGroup": "admissionregistration.k8s.io",
+                "apiVersion": "v1alpha1"
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:18.094223Z",
+            "stageTimestamp": "2018-06-20T11:16:18.094223Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:18Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:18Z",
+            "auditID": "a305ebd8-0705-42da-9130-7d39c44aeb8b",
+            "stage": "ResponseComplete",
+            "requestURI": "/apis/admissionregistration.k8s.io/v1alpha1/initializerconfigurations",
+            "verb": "list",
+            "user": {
+                "username": "system:apiserver",
+                "uid": "069ab130-1661-4682-a231-b6e0c11b10ea",
+                "groups": [
+                    "system:masters"
+                ]
+            },
+            "sourceIPs": [
+                "127.0.0.1"
+            ],
+            "objectRef": {
+                "resource": "initializerconfigurations",
+                "apiGroup": "admissionregistration.k8s.io",
+                "apiVersion": "v1alpha1"
+            },
+            "responseStatus": {
+                "kind": "Status",
+                "apiVersion": "v1",
+                "metadata": {},
+                "status": "Failure",
+                "message": "the server could not find the requested resource",
+                "reason": "NotFound",
+                "details": {},
+                "code": 404
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:18.094223Z",
+            "stageTimestamp": "2018-06-20T11:16:18.094490Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:18Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:18Z",
+            "auditID": "a9ebfc7b-3fc7-486b-b1ec-4dd0adebba6b",
+            "stage": "RequestReceived",
+            "requestURI": "/api/v1/namespaces/default",
+            "verb": "get",
+            "user": {
+                "username": "system:apiserver",
+                "uid": "069ab130-1661-4682-a231-b6e0c11b10ea",
+                "groups": [
+                    "system:masters"
+                ]
+            },
+            "sourceIPs": [
+                "127.0.0.1"
+            ],
+            "objectRef": {
+                "resource": "namespaces",
+                "namespace": "default",
+                "name": "default",
+                "apiVersion": "v1"
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:18.239925Z",
+            "stageTimestamp": "2018-06-20T11:16:18.239925Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:18Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:18Z",
+            "auditID": "a9ebfc7b-3fc7-486b-b1ec-4dd0adebba6b",
+            "stage": "ResponseComplete",
+            "requestURI": "/api/v1/namespaces/default",
+            "verb": "get",
+            "user": {
+                "username": "system:apiserver",
+                "uid": "069ab130-1661-4682-a231-b6e0c11b10ea",
+                "groups": [
+                    "system:masters"
+                ]
+            },
+            "sourceIPs": [
+                "127.0.0.1"
+            ],
+            "objectRef": {
+                "resource": "namespaces",
+                "namespace": "default",
+                "name": "default",
+                "apiVersion": "v1"
+            },
+            "responseStatus": {
+                "metadata": {},
+                "code": 200
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:18.239925Z",
+            "stageTimestamp": "2018-06-20T11:16:18.245890Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:18Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:18Z",
+            "auditID": "0e878cf4-2ec6-409b-9713-13090a7b460f",
+            "stage": "RequestReceived",
+            "requestURI": "/api/v1/namespaces/default/services/kubernetes",
+            "verb": "get",
+            "user": {
+                "username": "system:apiserver",
+                "uid": "069ab130-1661-4682-a231-b6e0c11b10ea",
+                "groups": [
+                    "system:masters"
+                ]
+            },
+            "sourceIPs": [
+                "127.0.0.1"
+            ],
+            "objectRef": {
+                "resource": "services",
+                "namespace": "default",
+                "name": "kubernetes",
+                "apiVersion": "v1"
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:18.247179Z",
+            "stageTimestamp": "2018-06-20T11:16:18.247179Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:18Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:18Z",
+            "auditID": "0e878cf4-2ec6-409b-9713-13090a7b460f",
+            "stage": "ResponseComplete",
+            "requestURI": "/api/v1/namespaces/default/services/kubernetes",
+            "verb": "get",
+            "user": {
+                "username": "system:apiserver",
+                "uid": "069ab130-1661-4682-a231-b6e0c11b10ea",
+                "groups": [
+                    "system:masters"
+                ]
+            },
+            "sourceIPs": [
+                "127.0.0.1"
+            ],
+            "objectRef": {
+                "resource": "services",
+                "namespace": "default",
+                "name": "kubernetes",
+                "apiVersion": "v1"
+            },
+            "responseStatus": {
+                "metadata": {},
+                "code": 200
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:18.247179Z",
+            "stageTimestamp": "2018-06-20T11:16:18.251173Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:18Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:18Z",
+            "auditID": "6bdff7de-3c9d-47fc-ba7a-41c5a6341836",
+            "stage": "RequestReceived",
+            "requestURI": "/api/v1/namespaces/default/endpoints/kubernetes",
+            "verb": "get",
+            "user": {
+                "username": "system:apiserver",
+                "uid": "069ab130-1661-4682-a231-b6e0c11b10ea",
+                "groups": [
+                    "system:masters"
+                ]
+            },
+            "sourceIPs": [
+                "127.0.0.1"
+            ],
+            "objectRef": {
+                "resource": "endpoints",
+                "namespace": "default",
+                "name": "kubernetes",
+                "apiVersion": "v1"
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:18.252898Z",
+            "stageTimestamp": "2018-06-20T11:16:18.252898Z"
+        },
+        {
+            "metadata": {
+                "creationTimestamp": "2018-06-20T11:16:18Z"
+            },
+            "level": "Metadata",
+            "timestamp": "2018-06-20T11:16:18Z",
+            "auditID": "6bdff7de-3c9d-47fc-ba7a-41c5a6341836",
+            "stage": "ResponseComplete",
+            "requestURI": "/api/v1/namespaces/default/endpoints/kubernetes",
+            "verb": "get",
+            "user": {
+                "username": "system:apiserver",
+                "uid": "069ab130-1661-4682-a231-b6e0c11b10ea",
+                "groups": [
+                    "system:masters"
+                ]
+            },
+            "sourceIPs": [
+                "127.0.0.1"
+            ],
+            "objectRef": {
+                "resource": "endpoints",
+                "namespace": "default",
+                "name": "kubernetes",
+                "apiVersion": "v1"
+            },
+            "responseStatus": {
+                "metadata": {},
+                "code": 200
+            },
+            "requestReceivedTimestamp": "2018-06-20T11:16:18.252898Z",
+            "stageTimestamp": "2018-06-20T11:16:18.258116Z"
+        }
+	]
+}`
+
+func postWebhooks(md *KubeAuditWebhook, eventBody string) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest("POST", "/kubernestes-audit", strings.NewReader(eventBody))
+	w := httptest.NewRecorder()
+
+	md.eventHandler(w, req)
+
+	return w
+}
+
+func TestBadWebHookFormat(t *testing.T) {
+	fixture := map[string]string{
+		"random-string": "agrer",
+		"empty-string":  "",
+	}
+	for k, f := range fixture {
+		t.Run(k, func(t *testing.T) {
+			k := &KubeAuditWebhook{Path: "/kubernetes-audit"}
+			resp := postWebhooks(k, f)
+			if resp.Code != http.StatusInternalServerError {
+				t.Errorf("Expected internal server error but we got status code %d.", resp.Code)
+			}
+		})
+	}
+}
+
+func TestBorderlineWebHookFormat(t *testing.T) {
+	fixture := map[string]string{
+		"empty-json":     "{}",
+		"empity-webhook": "{\"items\":[]}",
+	}
+	for k, f := range fixture {
+		t.Run(k, func(t *testing.T) {
+			k := &KubeAuditWebhook{Path: "/kubernetes-audit"}
+			resp := postWebhooks(k, f)
+			if resp.Code != http.StatusOK {
+				t.Errorf("Expected status code %d error but we got status code %d.", http.StatusOK, resp.Code)
+			}
+		})
+	}
+}
+
+func TestFakeWebhook(t *testing.T) {
+	var acc testutil.Accumulator
+	k := &KubeAuditWebhook{
+		Path: "/kubernetes-audit",
+		acc:  &acc,
+	}
+	resp := postWebhooks(k, fakeWebhook)
+	b, _ := ioutil.ReadAll(resp.Body)
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d. Err: %s", http.StatusOK, resp.Code, b)
+	}
+	if len(acc.Metrics) != 15 {
+		t.Errorf("Expected 15 pints inside the accumulator but we got %d.", len(acc.Metrics))
+	}
+}

--- a/plugins/inputs/webhooks/kubernetes_audit/example/policy.yaml
+++ b/plugins/inputs/webhooks/kubernetes_audit/example/policy.yaml
@@ -1,0 +1,5 @@
+# Log all requests at the Metadata level.
+apiVersion: audit.k8s.io/v1beta1
+kind: Policy
+rules:
+- level: Metadata

--- a/plugins/inputs/webhooks/kubernetes_audit/example/telegraf.config
+++ b/plugins/inputs/webhooks/kubernetes_audit/example/telegraf.config
@@ -1,0 +1,25 @@
+[agent]
+  interval = "10s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "10s"
+  flush_jitter = "0s"
+  precision = ""
+  debug = true
+  quiet = false
+  logfile = ""
+  hostname = ""
+  omit_hostname = false
+
+
+[[outputs.influxdb]]
+
+# A Webhooks Event collector
+[[inputs.webhooks]]
+## Address and port to host Webhook listener on
+  service_address = ":1619"
+
+  [inputs.webhooks.kubernetes_audit]
+    path = "/kubernetes-audit"

--- a/plugins/inputs/webhooks/kubernetes_audit/example/webhook.yaml
+++ b/plugins/inputs/webhooks/kubernetes_audit/example/webhook.yaml
@@ -1,0 +1,17 @@
+# clusters refers to the remote service.
+clusters:
+  - name: telegraf
+    cluster:
+      server: https://your-telegraf.internal/kubernetes-audit # URL of remote service to query. Must use 'https'.
+
+# users refers to the API server's webhook configuration.
+users:
+  - name: test-apiserver
+
+# kubeconfig files require a context. Provide one for the API server.
+current-context: webhook
+contexts:
+- context:
+    cluster: telegraf
+    user: test-apiserver
+  name: webhook

--- a/plugins/inputs/webhooks/webhooks.go
+++ b/plugins/inputs/webhooks/webhooks.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/filestack"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/github"
+	"github.com/influxdata/telegraf/plugins/inputs/webhooks/kubernetes_audit"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/mandrill"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/papertrail"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/particle"
@@ -30,12 +31,13 @@ func init() {
 type Webhooks struct {
 	ServiceAddress string
 
-	Github     *github.GithubWebhook
-	Filestack  *filestack.FilestackWebhook
-	Mandrill   *mandrill.MandrillWebhook
-	Rollbar    *rollbar.RollbarWebhook
-	Papertrail *papertrail.PapertrailWebhook
-	Particle   *particle.ParticleWebhook
+	Github          *github.GithubWebhook
+	Filestack       *filestack.FilestackWebhook
+	Mandrill        *mandrill.MandrillWebhook
+	Rollbar         *rollbar.RollbarWebhook
+	Papertrail      *papertrail.PapertrailWebhook
+	KubernetesAudit *kubernetes_audit.KubeAuditWebhook
+	Particle        *particle.ParticleWebhook
 
 	srv *http.Server
 }
@@ -51,6 +53,9 @@ func (wb *Webhooks) SampleConfig() string {
 
   [inputs.webhooks.filestack]
     path = "/filestack"
+
+  [inputs.webhooks.kubernetes_audit]
+    path = "/kubernetes-audit"
 
   [inputs.webhooks.github]
     path = "/github"


### PR DESCRIPTION
This PR adds a new webhook to catch Kubernetes audit logs.
There is a README.md with more information about how to try it and how
Kubernetes Audit works.

TODO:
- [x] Verify if the generated point has sense /cc @goller 
- [ ] I still need to add few more fields and tags inside the point

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
