### PR TITLE
Fix syslog timestamp parsing with single digit day of month

### DIFF
--- a/plugins/inputs/logparser/grok/grok.go
+++ b/plugins/inputs/logparser/grok/grok.go
@@ -293,7 +293,7 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 				timestamp = time.Unix(0, iv)
 			}
 		case SYSLOG_TIMESTAMP:
-			ts, err := time.ParseInLocation("Jan 02 15:04:05", v, p.loc)
+			ts, err := time.ParseInLocation(time.Stamp, v, p.loc)
 			if err == nil {
 				if ts.Year() == 0 {
 					ts = ts.AddDate(timestamp.Year(), 0, 0)

--- a/plugins/inputs/logparser/grok/grok_test.go
+++ b/plugins/inputs/logparser/grok/grok_test.go
@@ -971,16 +971,41 @@ func TestNewlineInPatterns(t *testing.T) {
 	require.NotNil(t, m)
 }
 
-func TestSyslogTimestampParser(t *testing.T) {
-	p := &Parser{
-		Patterns: []string{`%{SYSLOGTIMESTAMP:timestamp:ts-syslog} value=%{NUMBER:value:int}`},
-		timeFunc: func() time.Time { return time.Date(2018, time.April, 1, 0, 0, 0, 0, nil) },
+func TestSyslogTimestamp(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		expected time.Time
+	}{
+		{
+			name:     "two digit day of month",
+			line:     "Sep 25 09:01:55 value=42",
+			expected: time.Date(2018, time.September, 25, 9, 1, 55, 0, time.UTC),
+		},
+		{
+			name:     "one digit day of month single space",
+			line:     "Sep 2 09:01:55 value=42",
+			expected: time.Date(2018, time.September, 2, 9, 1, 55, 0, time.UTC),
+		},
+		{
+			name:     "one digit day of month double space",
+			line:     "Sep  2 09:01:55 value=42",
+			expected: time.Date(2018, time.September, 2, 9, 1, 55, 0, time.UTC),
+		},
 	}
-	require.NoError(t, p.Compile())
-	m, err := p.ParseLine("Sep 25 09:01:55 value=42")
-	require.NoError(t, err)
-	require.NotNil(t, m)
-	require.Equal(t, 2018, m.Time().Year())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Parser{
+				Patterns: []string{`%{SYSLOGTIMESTAMP:timestamp:ts-syslog} value=%{NUMBER:value:int}`},
+				timeFunc: func() time.Time { return time.Date(2017, time.April, 1, 0, 0, 0, 0, time.UTC) },
+			}
+			require.NoError(t, p.Compile())
+			m, err := p.ParseLine(tt.line)
+			require.NoError(t, err)
+			require.NotNil(t, m)
+			require.Equal(t, tt.expected, m.Time())
+		})
+	}
 }
 
 func TestReplaceTimestampComma(t *testing.T) {


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] ~~Associated README.md updated.~~
- [x] Has appropriate unit tests.
