### PR TITLE
Splunk Metrics serializer

### DIFF
--- a/docs/DATA_FORMATS_OUTPUT.md
+++ b/docs/DATA_FORMATS_OUTPUT.md
@@ -7,7 +7,7 @@ plugins.
 1. [InfluxDB Line Protocol](#influx)
 1. [JSON](#json)
 1. [Graphite](#graphite)
-1. [SplunkMetric](#splunkmetric)
+1. [SplunkMetric](../plugins/serializers/splunkmetric/README.md)
 
 You will be able to identify the plugins with support by the presence of a
 `data_format` config option, for example, in the `file` output plugin:
@@ -210,67 +210,3 @@ reference the documentation for the specific plugin.
   ## the power of 10 less than the specified units.
   json_timestamp_units = "1s"
 ```
-
-## SplunkMetric
-
-The SplunkMetric format translates the telegraf metrics into a JSON format compatible
-with a Splunk Metrics index. Normally you would use this to send the metrics to a
-HTTP Event Collector (HEC), it follows the format specified in the document [here.](http://dev.splunk.com/view/SP-CAAAFDN#json)
-
-```toml
-[[outputs.http]]
-   ## URL is the address to send metrics to
-   url = "https://localhost:8088/services/collector"
-
-   ## Timeout for HTTP message
-   # timeout = "5s"
-
-   ## HTTP method, one of: "POST" or "PUT"
-   # method = "POST"
-
-   ## HTTP Basic Auth credentials
-   # username = "username"
-   # password = "pa$$word"
-
-   ## Optional TLS Config
-   # tls_ca = "/etc/telegraf/ca.pem"
-   # tls_cert = "/etc/telegraf/cert.pem"
-   # tls_key = "/etc/telegraf/key.pem"
-   ## Use TLS but skip chain & host verification
-   # insecure_skip_verify = false
-
-   ## Data format to output.
-   ## Each data format has it's own unique set of configuration options, read
-   ## more about them here:
-   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
-   data_format = "splunkmetric"
-   # Enable hec_routing 
-   hec_routing = true
-
-   ## Additional HTTP headers
-   [outputs.http.headers]
-   # Should be set manually to "application/json" for json data_format
-      Content-Type = "application/json"
-      Authorization = "Splunk xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-      X-Splunk-Request-Channel = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-```
-
-It also has the option to output a more basic JSON structure that can be used by a
-Splunk Universal Forwarder or modular input.
-
-```toml
-[[outputs.file]]
-  ## Files to write to, "stdout" is a specially handled file.
-  files = ["stdout", "/tmp/metrics.out"]
-
-  ## Data format to output.
-  ## Each data format has its own unique set of configuration options, read
-  ## more about them here:
-  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
-  data_format = "json"
-  ## hec_routing defaults to false
-  # hec_routing = false
-```
-
-Please see the [Splunk Metrics README](../plugins/serializers/splunkmetric/README.md) for additional
-information.

--- a/docs/DATA_FORMATS_OUTPUT.md
+++ b/docs/DATA_FORMATS_OUTPUT.md
@@ -7,6 +7,7 @@ plugins.
 1. [InfluxDB Line Protocol](#influx)
 1. [JSON](#json)
 1. [Graphite](#graphite)
+1. [SplunkMetric](#splunkmetric)
 
 You will be able to identify the plugins with support by the presence of a
 `data_format` config option, for example, in the `file` output plugin:
@@ -209,3 +210,67 @@ reference the documentation for the specific plugin.
   ## the power of 10 less than the specified units.
   json_timestamp_units = "1s"
 ```
+
+## SplunkMetric
+
+The SplunkMetric format translates the telegraf metrics into a JSON format compatible
+with a Splunk Metrics index. Normally you would use this to send the metrics to a
+HTTP Event Collector (HEC), it follows the format specified in the document [here.](http://dev.splunk.com/view/SP-CAAAFDN#json)
+
+```toml
+[[outputs.http]]
+#   ## URL is the address to send metrics to
+   url = "https://localhost:8088/services/collector"
+#
+#   ## Timeout for HTTP message
+#   # timeout = "5s"
+#
+#   ## HTTP method, one of: "POST" or "PUT"
+#   # method = "POST"
+#
+#   ## HTTP Basic Auth credentials
+#   # username = "username"
+#   # password = "pa$$word"
+#
+#   ## Optional TLS Config
+#   # tls_ca = "/etc/telegraf/ca.pem"
+#   # tls_cert = "/etc/telegraf/cert.pem"
+#   # tls_key = "/etc/telegraf/key.pem"
+#   ## Use TLS but skip chain & host verification
+#   # insecure_skip_verify = false
+#
+#   ## Data format to output.
+#   ## Each data format has it's own unique set of configuration options, read
+#   ## more about them here:
+#   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+   data_format = "splunkmetric"
+   # Enable hec_routing 
+   hec_routing = true
+#
+#   ## Additional HTTP headers
+    [outputs.http.headers]
+#   # Should be set manually to "application/json" for json data_format
+      Content-Type = "application/json"
+      Authorization = "Splunk xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      X-Splunk-Request-Channel = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+It also has the option to output a more basic JSON structure that can be used by a
+Splunk Universal Forwarder or modular input.
+
+```toml
+[[outputs.file]]
+  ## Files to write to, "stdout" is a specially handled file.
+  files = ["stdout", "/tmp/metrics.out"]
+
+  ## Data format to output.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "json"
+  ## hec_routing defaults to false
+  # hec_routing = false
+```
+
+Please see the [Splunk Metrics README](../plugins/serializers/splunkmetric/README.md) for additional
+information.

--- a/docs/DATA_FORMATS_OUTPUT.md
+++ b/docs/DATA_FORMATS_OUTPUT.md
@@ -219,37 +219,37 @@ HTTP Event Collector (HEC), it follows the format specified in the document [her
 
 ```toml
 [[outputs.http]]
-#   ## URL is the address to send metrics to
+   ## URL is the address to send metrics to
    url = "https://localhost:8088/services/collector"
-#
-#   ## Timeout for HTTP message
-#   # timeout = "5s"
-#
-#   ## HTTP method, one of: "POST" or "PUT"
-#   # method = "POST"
-#
-#   ## HTTP Basic Auth credentials
-#   # username = "username"
-#   # password = "pa$$word"
-#
-#   ## Optional TLS Config
-#   # tls_ca = "/etc/telegraf/ca.pem"
-#   # tls_cert = "/etc/telegraf/cert.pem"
-#   # tls_key = "/etc/telegraf/key.pem"
-#   ## Use TLS but skip chain & host verification
-#   # insecure_skip_verify = false
-#
-#   ## Data format to output.
-#   ## Each data format has it's own unique set of configuration options, read
-#   ## more about them here:
-#   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+
+   ## Timeout for HTTP message
+   # timeout = "5s"
+
+   ## HTTP method, one of: "POST" or "PUT"
+   # method = "POST"
+
+   ## HTTP Basic Auth credentials
+   # username = "username"
+   # password = "pa$$word"
+
+   ## Optional TLS Config
+   # tls_ca = "/etc/telegraf/ca.pem"
+   # tls_cert = "/etc/telegraf/cert.pem"
+   # tls_key = "/etc/telegraf/key.pem"
+   ## Use TLS but skip chain & host verification
+   # insecure_skip_verify = false
+
+   ## Data format to output.
+   ## Each data format has it's own unique set of configuration options, read
+   ## more about them here:
+   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
    data_format = "splunkmetric"
    # Enable hec_routing 
    hec_routing = true
-#
-#   ## Additional HTTP headers
-    [outputs.http.headers]
-#   # Should be set manually to "application/json" for json data_format
+
+   ## Additional HTTP headers
+   [outputs.http.headers]
+   # Should be set manually to "application/json" for json data_format
       Content-Type = "application/json"
       Authorization = "Splunk xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       X-Splunk-Request-Channel = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1455,6 +1455,18 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 		}
 	}
 
+	if node, ok := tbl.Fields["hec_routing"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if b, ok := kv.Value.(*ast.Boolean); ok {
+				var err error
+				c.HecRouting, err = b.Boolean()
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
 	delete(tbl.Fields, "influx_max_line_bytes")
 	delete(tbl.Fields, "influx_sort_fields")
 	delete(tbl.Fields, "influx_uint_support")
@@ -1463,6 +1475,7 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 	delete(tbl.Fields, "prefix")
 	delete(tbl.Fields, "template")
 	delete(tbl.Fields, "json_timestamp_units")
+	delete(tbl.Fields, "hec_routing")
 	return serializers.NewSerializer(c)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1455,7 +1455,7 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 		}
 	}
 
-	if node, ok := tbl.Fields["hec_routing"]; ok {
+	if node, ok := tbl.Fields["splunkmetric_hec_routing"]; ok {
 		if kv, ok := node.(*ast.KeyValue); ok {
 			if b, ok := kv.Value.(*ast.Boolean); ok {
 				var err error
@@ -1475,7 +1475,7 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 	delete(tbl.Fields, "prefix")
 	delete(tbl.Fields, "template")
 	delete(tbl.Fields, "json_timestamp_units")
-	delete(tbl.Fields, "hec_routing")
+	delete(tbl.Fields, "splunkmetric_hec_routing")
 	return serializers.NewSerializer(c)
 }
 

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -61,6 +61,9 @@ type Config struct {
 
 	// Timestamp units to use for JSON formatted output
 	TimestampUnits time.Duration
+
+    // Include HEC routing fields for splunkmetric output
+    HecRouting bool
 }
 
 // NewSerializer a Serializer interface based on the given config.
@@ -75,7 +78,7 @@ func NewSerializer(config *Config) (Serializer, error) {
 	case "json":
 		serializer, err = NewJsonSerializer(config.TimestampUnits)
 	case "splunkmetric":
-		serializer, err = NewSplunkmetricSerializer(config.TimestampUnits)
+		serializer, err = NewSplunkmetricSerializer(config.HecRouting)
 	default:
 		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
 	}
@@ -86,8 +89,8 @@ func NewJsonSerializer(timestampUnits time.Duration) (Serializer, error) {
 	return json.NewSerializer(timestampUnits)
 }
 
-func NewSplunkmetricSerializer(timestampUnits time.Duration) (Serializer, error) {
-	return splunkmetric.NewSerializer(timestampUnits)
+func NewSplunkmetricSerializer(hec_routing bool) (Serializer, error) {
+	return splunkmetric.NewSerializer(hec_routing)
 }
 
 func NewInfluxSerializerConfig(config *Config) (Serializer, error) {

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -62,8 +62,8 @@ type Config struct {
 	// Timestamp units to use for JSON formatted output
 	TimestampUnits time.Duration
 
-    // Include HEC routing fields for splunkmetric output
-    HecRouting bool
+	// Include HEC routing fields for splunkmetric output
+	HecRouting bool
 }
 
 // NewSerializer a Serializer interface based on the given config.

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -89,8 +89,8 @@ func NewJsonSerializer(timestampUnits time.Duration) (Serializer, error) {
 	return json.NewSerializer(timestampUnits)
 }
 
-func NewSplunkmetricSerializer(hec_routing bool) (Serializer, error) {
-	return splunkmetric.NewSerializer(hec_routing)
+func NewSplunkmetricSerializer(splunkmetric_hec_routing bool) (Serializer, error) {
+	return splunkmetric.NewSerializer(splunkmetric_hec_routing)
 }
 
 func NewInfluxSerializerConfig(config *Config) (Serializer, error) {

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/influxdata/telegraf/plugins/serializers/json"
+	"github.com/influxdata/telegraf/plugins/serializers/splunkmetric"
 )
 
 // SerializerOutput is an interface for output plugins that are able to
@@ -73,6 +74,8 @@ func NewSerializer(config *Config) (Serializer, error) {
 		serializer, err = NewGraphiteSerializer(config.Prefix, config.Template, config.GraphiteTagSupport)
 	case "json":
 		serializer, err = NewJsonSerializer(config.TimestampUnits)
+	case "splunkmetric":
+		serializer, err = NewSplunkmetricSerializer(config.TimestampUnits)
 	default:
 		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
 	}
@@ -81,6 +84,10 @@ func NewSerializer(config *Config) (Serializer, error) {
 
 func NewJsonSerializer(timestampUnits time.Duration) (Serializer, error) {
 	return json.NewSerializer(timestampUnits)
+}
+
+func NewSplunkmetricSerializer(timestampUnits time.Duration) (Serializer, error) {
+	return splunkmetric.NewSerializer(timestampUnits)
 }
 
 func NewInfluxSerializerConfig(config *Config) (Serializer, error) {

--- a/plugins/serializers/splunkmetric/README.md
+++ b/plugins/serializers/splunkmetric/README.md
@@ -31,37 +31,37 @@ to manage the HEC authorization, here's a sample config for an HTTP output:
 
 ```toml
 [[outputs.http]]
-#   ## URL is the address to send metrics to
+   ## URL is the address to send metrics to
    url = "https://localhost:8088/services/collector"
-#
-#   ## Timeout for HTTP message
-#   # timeout = "5s"
-#
-#   ## HTTP method, one of: "POST" or "PUT"
-#   # method = "POST"
-#
-#   ## HTTP Basic Auth credentials
-#   # username = "username"
-#   # password = "pa$$word"
-#
-#   ## Optional TLS Config
-#   # tls_ca = "/etc/telegraf/ca.pem"
-#   # tls_cert = "/etc/telegraf/cert.pem"
-#   # tls_key = "/etc/telegraf/key.pem"
-#   ## Use TLS but skip chain & host verification
-#   # insecure_skip_verify = false
-#
-#   ## Data format to output.
-#   ## Each data format has it's own unique set of configuration options, read
-#   ## more about them here:
-#   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+
+   ## Timeout for HTTP message
+   # timeout = "5s"
+
+   ## HTTP method, one of: "POST" or "PUT"
+   # method = "POST"
+
+   ## HTTP Basic Auth credentials
+   # username = "username"
+   # password = "pa$$word"
+
+   ## Optional TLS Config
+   # tls_ca = "/etc/telegraf/ca.pem"
+   # tls_cert = "/etc/telegraf/cert.pem"
+   # tls_key = "/etc/telegraf/key.pem"
+   ## Use TLS but skip chain & host verification
+   # insecure_skip_verify = false
+
+   ## Data format to output.
+   ## Each data format has it's own unique set of configuration options, read
+   ## more about them here:
+   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
    data_format = "splunkmetric"
     ## Provides time, index, source overrides for the HEC
    hec_routing = true
-#
-#   ## Additional HTTP headers
+
+   ## Additional HTTP headers
     [outputs.http.headers]
-#   # Should be set manually to "application/json" for json data_format
+   # Should be set manually to "application/json" for json data_format
       Content-Type = "application/json"
       Authorization = "Splunk xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       X-Splunk-Request-Channel = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
@@ -121,15 +121,15 @@ TIME_FORMAT = %s.%3N
 An example configuration of a file based output is: 
 
 ```toml
-# # Send telegraf metrics to file(s)
+ # Send telegraf metrics to file(s)
 [[outputs.file]]
-#   ## Files to write to, "stdout" is a specially handled file.
+   ## Files to write to, "stdout" is a specially handled file.
    files = ["/tmp/metrics.out"]
-#
-#   ## Data format to output.
-#   ## Each data format has its own unique set of configuration options, read
-#   ## more about them here:
-#   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+
+   ## Data format to output.
+   ## Each data format has its own unique set of configuration options, read
+   ## more about them here:
+   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
    data_format = "splunkmetric"
    hec_routing = false
 ```

--- a/plugins/serializers/splunkmetric/README.md
+++ b/plugins/serializers/splunkmetric/README.md
@@ -56,6 +56,7 @@ to manage the HEC authorization, here's a sample config for an HTTP output:
 #   ## more about them here:
 #   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
    data_format = "splunkmetric"
+    ## Provides time, index, source overrides for the HEC
    hec_routing = true
 #
 #   ## Additional HTTP headers

--- a/plugins/serializers/splunkmetric/README.md
+++ b/plugins/serializers/splunkmetric/README.md
@@ -1,4 +1,4 @@
-# Splunk Metrics serialzier
+# Splunk Metrics serializer
 
 This serializer formats and outputs the metric data in a format that can be consumed by a Splunk metrics index.
 It can be used to write to a file using the file output, or for sending metrics to a HEC using the standard telegraf HTTP output.
@@ -61,7 +61,7 @@ to manage the HEC authorization, here's a sample config for an HTTP output:
    ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
    data_format = "splunkmetric"
     ## Provides time, index, source overrides for the HEC
-   hec_routing = true
+   splunkmetric_hec_routing = true
 
    ## Additional HTTP headers
     [outputs.http.headers]

--- a/plugins/serializers/splunkmetric/README.md
+++ b/plugins/serializers/splunkmetric/README.md
@@ -1,0 +1,85 @@
+# Splunk Metrics serialzier
+
+This serializer formats and outputs the metric data in a format that can be consumed by a Splunk metrics index. It can be used to write to a file using the file output, or for sending metrics to a HEC using the standard telegraf HTTP output. If you're using the HTTP output, this serializer knows how to batch the metrics so you don't end up with an HTTP POST per metric.
+
+Th data is output in a format that conforms to the specified Splunk HEC JSON format as found here: [Send metrics in JSON format](http://dev.splunk.com/view/event-collector/SP-CAAAFDN).
+
+An example event looks like:
+```javascript
+{
+  "time": 1529708430,
+  "event": "metric",
+  "host": "patas-mbp",
+  "fields": {
+    "_value": 0.6,
+    "cpu": "cpu0",
+    "dc": "mobile",
+    "metric_name": "cpu.usage_user",
+    "user": "ronnocol"
+  }
+}
+```
+In the above snippet, the following keys are dimensions:
+* cpu
+* dc
+* user
+
+## Using with the HTTP output
+
+To send this data to a Splunk HEC, you can use the HTTP output, there are some custom headers that you need to add
+to manage the HEC authorization, here's a sample config for an HTTP output:
+
+```toml
+[[outputs.http]]
+#   ## URL is the address to send metrics to
+   url = "https://localhost:8088/services/collector"
+#
+#   ## Timeout for HTTP message
+#   # timeout = "5s"
+#
+#   ## HTTP method, one of: "POST" or "PUT"
+#   # method = "POST"
+#
+#   ## HTTP Basic Auth credentials
+#   # username = "username"
+#   # password = "pa$$word"
+#
+#   ## Optional TLS Config
+#   # tls_ca = "/etc/telegraf/ca.pem"
+#   # tls_cert = "/etc/telegraf/cert.pem"
+#   # tls_key = "/etc/telegraf/key.pem"
+#   ## Use TLS but skip chain & host verification
+#   # insecure_skip_verify = false
+#
+#   ## Data format to output.
+#   ## Each data format has it's own unique set of configuration options, read
+#   ## more about them here:
+#   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+   data_format = "splunkmetric"
+#
+#   ## Additional HTTP headers
+    [outputs.http.headers]
+#   # Should be set manually to "application/json" for json data_format
+      Content-Type = "application/json"
+      Authorization = "Splunk xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      X-Splunk-Request-Channel = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+## Overrides
+You can override the default values for the HEC token you are using by adding additional tags to the config file.
+
+The following aspects of the token can be overriden with tags:
+* index
+* source
+
+You can either use `[global_tags]` or using a more advanced configuration as documented [here](https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md).
+ 
+Such as this example which overrides the index just on the cpu metric:
+```toml
+[[inputs.cpu]]
+  percpu = false
+  totalcpu = true
+  [inputs.cpu.tags]
+    index = "cpu_metrics"
+```
+

--- a/plugins/serializers/splunkmetric/README.md
+++ b/plugins/serializers/splunkmetric/README.md
@@ -1,8 +1,12 @@
 # Splunk Metrics serialzier
 
-This serializer formats and outputs the metric data in a format that can be consumed by a Splunk metrics index. It can be used to write to a file using the file output, or for sending metrics to a HEC using the standard telegraf HTTP output. If you're using the HTTP output, this serializer knows how to batch the metrics so you don't end up with an HTTP POST per metric.
+This serializer formats and outputs the metric data in a format that can be consumed by a Splunk metrics index.
+It can be used to write to a file using the file output, or for sending metrics to a HEC using the standard telegraf HTTP output.
 
-Th data is output in a format that conforms to the specified Splunk HEC JSON format as found here: [Send metrics in JSON format](http://dev.splunk.com/view/event-collector/SP-CAAAFDN).
+If you're using the HTTP output, this serializer knows how to batch the metrics so you don't end up with an HTTP POST per metric.
+
+Th data is output in a format that conforms to the specified Splunk HEC JSON format as found here:
+[Send metrics in JSON format](http://dev.splunk.com/view/event-collector/SP-CAAAFDN).
 
 An example event looks like:
 ```javascript

--- a/plugins/serializers/splunkmetric/README.md
+++ b/plugins/serializers/splunkmetric/README.md
@@ -56,6 +56,7 @@ to manage the HEC authorization, here's a sample config for an HTTP output:
 #   ## more about them here:
 #   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
    data_format = "splunkmetric"
+   hec_routing = true
 #
 #   ## Additional HTTP headers
     [outputs.http.headers]
@@ -83,3 +84,51 @@ Such as this example which overrides the index just on the cpu metric:
     index = "cpu_metrics"
 ```
 
+## Using with the File output
+
+You can use the file output when running telegraf on a machine with a Splunk forwarder.
+
+A sample event when `hec_routing` is false (or unset) looks like:
+```javascript
+{
+    "_value": 0.6,
+    "cpu": "cpu0",
+    "dc": "mobile",
+    "metric_name": "cpu.usage_user",
+    "user": "ronnocol",
+    "time": 1529708430
+}
+```
+Data formatted in this manner can be ingested with a simple `props.conf` file that
+looks like this:
+
+```ini
+[telegraf]
+category = Metrics
+description = Telegraf Metrics
+pulldown_type = 1
+DATETIME_CONFIG =
+NO_BINARY_CHECK = true
+SHOULD_LINEMERGE = true
+disabled = false
+INDEXED_EXTRACTIONS = json
+KV_MODE = none
+TIMESTAMP_FIELDS = time
+TIME_FORMAT = %s.%3N
+```
+
+An example configuration of a file based output is: 
+
+```toml
+# # Send telegraf metrics to file(s)
+[[outputs.file]]
+#   ## Files to write to, "stdout" is a specially handled file.
+   files = ["/tmp/metrics.out"]
+#
+#   ## Data format to output.
+#   ## Each data format has its own unique set of configuration options, read
+#   ## more about them here:
+#   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+   data_format = "splunkmetric"
+   hec_routing = false
+```

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -2,7 +2,7 @@ package splunkmetric
 
 import (
 	"encoding/json"
-	"errors"
+//	"errors"
 	"log"
 
 	"github.com/influxdata/telegraf"
@@ -23,7 +23,7 @@ func (s *serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 
 	m, err := s.createObject(metric)
 	if err != nil {
-		log.Printf("E! [serializer.splunkmetric] Dropping invalid metric")
+        log.Printf("E! [serializer.splunkmetric] Dropping invalid metric: %v [%v]", metric, m)
 		return []byte(""), err
 	}
 
@@ -37,7 +37,7 @@ func (s *serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	for _, metric := range metrics {
 		m, err := s.createObject(metric)
 		if err != nil {
-			log.Printf("E! [serializer.splunkmetric] Dropping invalid metric")
+            log.Printf("E! [serializer.splunkmetric] Dropping invalid metric: %v [%v]", metric, m)
 		} else {
 			serialized = append(serialized, m...)
 		}
@@ -69,8 +69,7 @@ func (s *serializer) createObject(metric telegraf.Metric) (metricJson []byte, er
 	for k, v := range metric.Fields() {
 
 		if !verifyValue(v) {
-			err = errors.New("can not parse value")
-			return []byte(""), err
+            log.Printf("E! Can not parse value: %v for key: %v",v,k)
 		}
 
 		obj := map[string]interface{}{}

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -2,7 +2,7 @@ package splunkmetric
 
 import (
 	"encoding/json"
-	//	"errors"
+	"fmt"
 	"log"
 
 	"github.com/influxdata/telegraf"
@@ -23,8 +23,8 @@ func (s *serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 
 	m, err := s.createObject(metric)
 	if err != nil {
-		log.Printf("E! [serializer.splunkmetric] Dropping invalid metric: %v [%v]", metric, m)
-		return []byte(""), err
+		log.Printf("D! [serializer.splunkmetric] Dropping invalid metric: %v [%v]", metric, m)
+		return nil, nil
 	}
 
 	return m, nil
@@ -37,7 +37,7 @@ func (s *serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	for _, metric := range metrics {
 		m, err := s.createObject(metric)
 		if err != nil {
-			log.Printf("E! [serializer.splunkmetric] Dropping invalid metric: %v [%v]", metric, m)
+			log.Printf("D! [serializer.splunkmetric] Dropping invalid metric: %v [%v]", metric, m)
 		} else {
 			serialized = append(serialized, m...)
 		}
@@ -69,8 +69,9 @@ func (s *serializer) createObject(metric telegraf.Metric) (metricJson []byte, er
 	for k, v := range metric.Fields() {
 
 		if !verifyValue(v) {
-			log.Printf("E! Can not parse value: %v for key: %v", v, k)
-			continue
+			log.Printf("D! Can not parse value: %v for key: %v", v, k)
+			err := fmt.Errorf("D! Can not parse value: %v for key: %v", v, k)
+			return nil, err
 		}
 
 		obj := map[string]interface{}{}

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -70,7 +70,7 @@ func (s *serializer) createObject(metric telegraf.Metric) (metricJson []byte, er
 
 		if !verifyValue(v) {
 			log.Printf("E! Can not parse value: %v for key: %v", v, k)
-            continue
+			continue
 		}
 
 		obj := map[string]interface{}{}

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -36,7 +36,7 @@ func (s *serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	for _, metric := range metrics {
 		m, err := s.createObject(metric)
 		if err != nil {
-		    return nil, fmt.Errorf("D! [serializer.splunkmetric] Dropping invalid metric: %s", metric.Name())
+			return nil, fmt.Errorf("D! [serializer.splunkmetric] Dropping invalid metric: %s", metric.Name())
 		} else if m != nil {
 			serialized = append(serialized, m...)
 		}
@@ -64,13 +64,13 @@ func (s *serializer) createObject(metric telegraf.Metric) (metricGroup []byte, e
 	}
 
 	dataGroup := HECTimeSeries{}
-    var metricJson []byte
+	var metricJson []byte
 
 	for _, field := range metric.FieldList() {
 
 		if !verifyValue(field.Value) {
 			log.Printf("D! Can not parse value: %v for key: %v", field.Value, field.Key)
-            continue
+			continue
 		}
 
 		obj := map[string]interface{}{}
@@ -107,7 +107,7 @@ func (s *serializer) createObject(metric telegraf.Metric) (metricGroup []byte, e
 			metricJson, err = json.Marshal(dataGroup.Fields)
 		}
 
-        metricGroup = append(metricGroup, metricJson...)
+		metricGroup = append(metricGroup, metricJson...)
 
 		if err != nil {
 			return nil, err

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -1,0 +1,135 @@
+package splunkmetric
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/influxdata/telegraf"
+)
+
+type serializer struct {
+	TimestampUnits time.Duration
+}
+
+func NewSerializer(timestampUnits time.Duration) (*serializer, error) {
+	s := &serializer{
+		TimestampUnits: truncateDuration(timestampUnits),
+	}
+	return s, nil
+}
+
+func (s *serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
+	var serialized string
+
+	m, err := s.createObject(metric)
+	if err == nil {
+		serialized = m + "\n"
+	}
+
+	return []byte(serialized), nil
+}
+
+func (s *serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
+
+	var serialized string
+
+	var objects []string
+
+	for _, metric := range metrics {
+		m, err := s.createObject(metric)
+		if err == nil {
+			objects = append(objects, m)
+		}
+	}
+
+	for _, m := range objects {
+		serialized = serialized + m + "\n"
+	}
+
+	return []byte(serialized), nil
+}
+
+func (s *serializer) createObject(metric telegraf.Metric) (metricString string, err error) {
+
+	/* Splunk supports one metric per line and has the following required names:
+	 ** metric_name: The name of the metric
+	 ** _value:      The value for the metric
+	 ** _time:       The timestamp for the metric
+	 ** All other index fields become deminsions.
+	 */
+	type HECTimeSeries struct {
+		Time   float64                `json:"time"`
+		Event  string                 `json:"event"`
+		Host   string                 `json:"host,omitempty"`
+		Index  string                 `json:"index,omitempty"`
+		Source string                 `json:"source,omitempty"`
+		Fields map[string]interface{} `json:"fields"`
+	}
+
+	dataGroup := HECTimeSeries{}
+
+	for k, v := range metric.Fields() {
+
+		if !verifyValue(v) {
+			err = errors.New("can not parse value")
+			return "", err
+		}
+
+		obj := map[string]interface{}{}
+		obj["metric_name"] = metric.Name() + "." + k
+		obj["_value"] = v
+
+		dataGroup.Event = "metric"
+		dataGroup.Time = float64(metric.Time().UnixNano() / int64(s.TimestampUnits))
+		dataGroup.Fields = obj
+
+		// Break tags out into key(n)=value(t) pairs
+		for n, t := range metric.Tags() {
+			if n == "host" {
+				dataGroup.Host = t
+			} else if n == "index" {
+				dataGroup.Index = t
+			} else if n == "source" {
+				dataGroup.Source = t
+			} else {
+				dataGroup.Fields[n] = t
+			}
+		}
+		dataGroup.Fields["metric_name"] = metric.Name() + "." + k
+		dataGroup.Fields["_value"] = v
+	}
+
+	metricJson, err := json.Marshal(dataGroup)
+
+	if err != nil {
+		return "", err
+	}
+
+	metricString = string(metricJson)
+	return metricString, nil
+}
+
+func verifyValue(v interface{}) bool {
+	switch v.(type) {
+	case string:
+		return false
+	}
+	return true
+}
+
+func truncateDuration(units time.Duration) time.Duration {
+	// Default precision is 1s
+	if units <= 0 {
+		return time.Second
+	}
+
+	// Search for the power of ten less than the duration
+	d := time.Nanosecond
+	for {
+		if d*10 > units {
+			return d
+		}
+		d = d * 10
+	}
+}

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -70,6 +70,7 @@ func (s *serializer) createObject(metric telegraf.Metric) (metricJson []byte, er
 
 		if !verifyValue(v) {
 			log.Printf("E! Can not parse value: %v for key: %v", v, k)
+            continue
 		}
 
 		obj := map[string]interface{}{}

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -2,7 +2,7 @@ package splunkmetric
 
 import (
 	"encoding/json"
-//	"errors"
+	//	"errors"
 	"log"
 
 	"github.com/influxdata/telegraf"
@@ -23,7 +23,7 @@ func (s *serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 
 	m, err := s.createObject(metric)
 	if err != nil {
-        log.Printf("E! [serializer.splunkmetric] Dropping invalid metric: %v [%v]", metric, m)
+		log.Printf("E! [serializer.splunkmetric] Dropping invalid metric: %v [%v]", metric, m)
 		return []byte(""), err
 	}
 
@@ -37,7 +37,7 @@ func (s *serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	for _, metric := range metrics {
 		m, err := s.createObject(metric)
 		if err != nil {
-            log.Printf("E! [serializer.splunkmetric] Dropping invalid metric: %v [%v]", metric, m)
+			log.Printf("E! [serializer.splunkmetric] Dropping invalid metric: %v [%v]", metric, m)
 		} else {
 			serialized = append(serialized, m...)
 		}
@@ -69,7 +69,7 @@ func (s *serializer) createObject(metric telegraf.Metric) (metricJson []byte, er
 	for k, v := range metric.Fields() {
 
 		if !verifyValue(v) {
-            log.Printf("E! Can not parse value: %v for key: %v",v,k)
+			log.Printf("E! Can not parse value: %v for key: %v", v, k)
 		}
 
 		obj := map[string]interface{}{}

--- a/plugins/serializers/splunkmetric/splunkmetric_test.go
+++ b/plugins/serializers/splunkmetric/splunkmetric_test.go
@@ -114,7 +114,7 @@ func TestSerializeMetricString(t *testing.T) {
 	buf, err = s.Serialize(m)
 	assert.NoError(t, err)
 
-	expS := `{"_value":5,"cpu":"cpu0","metric_name":"cpu.usage_idle","time":0}`
+	expS := ""
 	assert.Equal(t, string(expS), string(buf))
 	assert.NoError(t, err)
 }

--- a/plugins/serializers/splunkmetric/splunkmetric_test.go
+++ b/plugins/serializers/splunkmetric/splunkmetric_test.go
@@ -18,7 +18,8 @@ func MustMetric(v telegraf.Metric, err error) telegraf.Metric {
 }
 
 func TestSerializeMetricFloat(t *testing.T) {
-	now := time.Unix(0, 0)
+	// Test sub-second time
+	now := time.Unix(1529875740, 819000000)
 	tags := map[string]string{
 		"cpu": "cpu0",
 	}
@@ -28,11 +29,31 @@ func TestSerializeMetricFloat(t *testing.T) {
 	m, err := metric.New("cpu", tags, fields, now)
 	assert.NoError(t, err)
 
-	s, _ := NewSerializer(0)
+	s, _ := NewSerializer(false)
 	var buf []byte
 	buf, err = s.Serialize(m)
 	assert.NoError(t, err)
-	expS := `{"time":0,"event":"metric","fields":{"_value":91.5,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}` + "\n"
+	expS := `{"_value":91.5,"cpu":"cpu0","metric_name":"cpu.usage_idle","time":1529875740.819}`
+	assert.Equal(t, string(expS), string(buf))
+}
+
+func TestSerializeMetricFloatHec(t *testing.T) {
+	// Test sub-second time
+	now := time.Unix(1529875740, 819000000)
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": float64(91.5),
+	}
+	m, err := metric.New("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s, _ := NewSerializer(true)
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
+	expS := `{"time":1529875740.819,"event":"metric","fields":{"_value":91.5,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}`
 	assert.Equal(t, string(expS), string(buf))
 }
 
@@ -47,12 +68,32 @@ func TestSerializeMetricInt(t *testing.T) {
 	m, err := metric.New("cpu", tags, fields, now)
 	assert.NoError(t, err)
 
-	s, _ := NewSerializer(0)
+	s, _ := NewSerializer(false)
 	var buf []byte
 	buf, err = s.Serialize(m)
 	assert.NoError(t, err)
 
-	expS := `{"time":0,"event":"metric","fields":{"_value":90,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}` + "\n"
+	expS := `{"_value":90,"cpu":"cpu0","metric_name":"cpu.usage_idle","time":0}`
+	assert.Equal(t, string(expS), string(buf))
+}
+
+func TestSerializeMetricIntHec(t *testing.T) {
+	now := time.Unix(0, 0)
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": int64(90),
+	}
+	m, err := metric.New("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s, _ := NewSerializer(true)
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
+
+	expS := `{"time":0,"event":"metric","fields":{"_value":90,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}`
 	assert.Equal(t, string(expS), string(buf))
 }
 
@@ -67,13 +108,14 @@ func TestSerializeMetricString(t *testing.T) {
 	m, err := metric.New("cpu", tags, fields, now)
 	assert.NoError(t, err)
 
-	s, _ := NewSerializer(0)
-	var buf []byte
-	buf, err = s.Serialize(m)
-	assert.NoError(t, err)
+	s, _ := NewSerializer(false)
+	//var buf []byte
+	_, err = s.Serialize(m)
+	assert.Error(t, err)
 
-	expS := ""
-	assert.Equal(t, string(expS), string(buf))
+	//expS := ""
+	//	assert.Equal(t, string(expS), string(buf))
+	//assert.Error(t, err)
 }
 
 func TestSerializeBatch(t *testing.T) {
@@ -99,10 +141,41 @@ func TestSerializeBatch(t *testing.T) {
 	)
 
 	metrics := []telegraf.Metric{m, n}
-	s, _ := NewSerializer(0)
+	s, _ := NewSerializer(false)
 	buf, err := s.SerializeBatch(metrics)
 	assert.NoError(t, err)
 
-	expS := `{"time":0,"event":"metric","fields":{"_value":42,"metric_name":"cpu.value"}}` + "\n" + `{"time":0,"event":"metric","fields":{"_value":92,"metric_name":"cpu.value"}}` + "\n"
+	expS := `{"_value":42,"metric_name":"cpu.value","time":0}` + `{"_value":92,"metric_name":"cpu.value","time":0}`
+	assert.Equal(t, string(expS), string(buf))
+}
+
+func TestSerializeBatchHec(t *testing.T) {
+	m := MustMetric(
+		metric.New(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"value": 42.0,
+			},
+			time.Unix(0, 0),
+		),
+	)
+	n := MustMetric(
+		metric.New(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"value": 92.0,
+			},
+			time.Unix(0, 0),
+		),
+	)
+
+	metrics := []telegraf.Metric{m, n}
+	s, _ := NewSerializer(true)
+	buf, err := s.SerializeBatch(metrics)
+	assert.NoError(t, err)
+
+	expS := `{"time":0,"event":"metric","fields":{"_value":42,"metric_name":"cpu.value"}}` + `{"time":0,"event":"metric","fields":{"_value":92,"metric_name":"cpu.value"}}`
 	assert.Equal(t, string(expS), string(buf))
 }

--- a/plugins/serializers/splunkmetric/splunkmetric_test.go
+++ b/plugins/serializers/splunkmetric/splunkmetric_test.go
@@ -1,0 +1,108 @@
+package splunkmetric
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+)
+
+func MustMetric(v telegraf.Metric, err error) telegraf.Metric {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func TestSerializeMetricFloat(t *testing.T) {
+	now := time.Unix(0, 0)
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": float64(91.5),
+	}
+	m, err := metric.New("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s, _ := NewSerializer(0)
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
+	expS := `{"time":0,"event":"metric","fields":{"_value":91.5,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}` + "\n"
+	assert.Equal(t, string(expS), string(buf))
+}
+
+func TestSerializeMetricInt(t *testing.T) {
+	now := time.Unix(0, 0)
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": int64(90),
+	}
+	m, err := metric.New("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s, _ := NewSerializer(0)
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
+
+	expS := `{"time":0,"event":"metric","fields":{"_value":90,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}` + "\n"
+	assert.Equal(t, string(expS), string(buf))
+}
+
+func TestSerializeMetricString(t *testing.T) {
+	now := time.Now()
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": "foobar",
+	}
+	m, err := metric.New("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s, _ := NewSerializer(0)
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
+
+	expS := ""
+	assert.Equal(t, string(expS), string(buf))
+}
+
+func TestSerializeBatch(t *testing.T) {
+	m := MustMetric(
+		metric.New(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"value": 42.0,
+			},
+			time.Unix(0, 0),
+		),
+	)
+	n := MustMetric(
+		metric.New(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"value": 92.0,
+			},
+			time.Unix(0, 0),
+		),
+	)
+
+	metrics := []telegraf.Metric{m, n}
+	s, _ := NewSerializer(0)
+	buf, err := s.SerializeBatch(metrics)
+	assert.NoError(t, err)
+
+	expS := `{"time":0,"event":"metric","fields":{"_value":42,"metric_name":"cpu.value"}}` + "\n" + `{"time":0,"event":"metric","fields":{"_value":92,"metric_name":"cpu.value"}}` + "\n"
+	assert.Equal(t, string(expS), string(buf))
+}

--- a/plugins/serializers/splunkmetric/splunkmetric_test.go
+++ b/plugins/serializers/splunkmetric/splunkmetric_test.go
@@ -98,24 +98,25 @@ func TestSerializeMetricIntHec(t *testing.T) {
 }
 
 func TestSerializeMetricString(t *testing.T) {
-	now := time.Now()
+	now := time.Unix(0, 0)
 	tags := map[string]string{
 		"cpu": "cpu0",
 	}
 	fields := map[string]interface{}{
-		"usage_idle": "foobar",
+		"processorType": "ARMv7 Processor rev 4 (v7l)",
+		"usage_idle":    int64(5),
 	}
 	m, err := metric.New("cpu", tags, fields, now)
 	assert.NoError(t, err)
 
 	s, _ := NewSerializer(false)
-	//var buf []byte
-	_, err = s.Serialize(m)
-	assert.Error(t, err)
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
 
-	//expS := ""
-	//	assert.Equal(t, string(expS), string(buf))
-	//assert.Error(t, err)
+	expS := `{"_value":5,"cpu":"cpu0","metric_name":"cpu.usage_idle","time":0}`
+	assert.Equal(t, string(expS), string(buf))
+	assert.NoError(t, err)
 }
 
 func TestSerializeBatch(t *testing.T) {

--- a/plugins/serializers/splunkmetric/splunkmetric_test.go
+++ b/plugins/serializers/splunkmetric/splunkmetric_test.go
@@ -114,7 +114,7 @@ func TestSerializeMetricString(t *testing.T) {
 	buf, err = s.Serialize(m)
 	assert.NoError(t, err)
 
-	expS := ""
+	expS := `{"_value":5,"cpu":"cpu0","metric_name":"cpu.usage_idle","time":0}`
 	assert.Equal(t, string(expS), string(buf))
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This serializer properly formats the metrics data according to the Splunk metrics JSON specification, it can be used with any output that supports serializers, including file or HTTP. I decided that just formatting the data according to the Splunk spec was a better investment than managing the whole output pipeline. Now you can use telegraf without requiring a HEC (by using a file output), or you can use the well tested and maintained HTTP output and just set the extra headers required by the HEC.

Please see the docs in README.md

### Required for all PRs:

- [ x ] Signed [CLA](https://influxdata.com/community/cla/).
- [ x ] Associated README.md updated.
- [ x ] Has appropriate unit tests.