### PR TITLE
Allow for force gathering ES cluster stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,6 @@
 
 ### Features
 
-- [#4345](https://github.com/influxdata/telegraf/pull/4345): Allow to force gathering Elasticsearch cluster stats on non-master node.
 - [#4236](https://github.com/influxdata/telegraf/pull/4236): Add SSL/TLS support to redis input.
 - [#4160](https://github.com/influxdata/telegraf/pull/4160): Add tengine input plugin.
 - [#4262](https://github.com/influxdata/telegraf/pull/4262): Add power draw field to nvidia_smi plugin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 
 ### Features
 
+- [#4345](https://github.com/influxdata/telegraf/pull/4345): Allow to force gathering Elasticsearch cluster stats on non-master node.
 - [#4236](https://github.com/influxdata/telegraf/pull/4236): Add SSL/TLS support to redis input.
 - [#4160](https://github.com/influxdata/telegraf/pull/4160): Add tengine input plugin.
 - [#4262](https://github.com/influxdata/telegraf/pull/4262): Add power draw field to nvidia_smi plugin.

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1906,9 +1906,11 @@
 #   ##  - cluster
 #   # cluster_health_level = "indices"
 #
-#   ## Set cluster_stats to true when you want to also obtain cluster stats from the
-#   ## Master node.
+#   ## Set cluster_stats to true when you want to also obtain cluster stats.
 #   cluster_stats = false
+#
+#   ## Only gather cluster_stats from the master node. To work this require local = true
+#   cluster_stats_only_from_master = true
 #
 #   ## node_stats is a list of sub-stats that you want to have gathered. Valid options
 #   ## are "indices", "os", "process", "jvm", "thread_pool", "fs", "transport", "http",

--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -29,9 +29,11 @@ or [cluster-stats](https://www.elastic.co/guide/en/elasticsearch/reference/curre
   ##  - cluster
   # cluster_health_level = "indices"
 
-  ## Set cluster_stats to true when you want to also obtain cluster stats from the
-  ## Master node.
+  ## Set cluster_stats to true when you want to also obtain cluster stats.
   cluster_stats = false
+
+  ## Only gather cluster_stats from the master node. To work this require local = true
+  cluster_stats_only_from_master = true
 
   ## node_stats is a list of sub-stats that you want to have gathered. Valid options
   ## are "indices", "os", "process", "jvm", "thread_pool", "fs", "transport", "http",


### PR DESCRIPTION
Add option to gather Elasticsearch cluster stats from all node (default is old behavior, stats are only gathered from master).

Also documented the fact that gathering only from master node only works if local = true.
Slightly changed behavior when local=false and cluster_stats=true. Previous behavior was undetermined (it gather cluster stats only if the last node is the master node. The order was based on the order of a map which is probably not fixed). New behavior is the documented one: if local = false, we gather from all node.