### PR TITLE
Add http path configuration for OpenTSDB plugin

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -723,6 +723,10 @@
 #   ## Not used with telnet API.
 #   httpBatchSize = 50
 #
+#   ## URI Path for Http requests to OpenTSDB.
+#   ## Used in cases where OpenTSDB is located behind a reverse proxy.
+#   httpPath = "/api/put"
+#
 #   ## Debug true - Prints OpenTSDB communication
 #   debug = false
 #

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -22,6 +22,7 @@ var (
 		`%`, "-",
 		"#", "-",
 		"$", "-")
+	defaultHttpPath  = "/api/put"
 	defaultSeperator = "_"
 )
 
@@ -266,6 +267,7 @@ func sanitize(value string) string {
 func init() {
 	outputs.Add("opentsdb", func() telegraf.Output {
 		return &OpenTSDB{
+			HttpPath:  defaultHttpPath,
 			Separator: defaultSeperator,
 		}
 	})

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -32,6 +32,7 @@ type OpenTSDB struct {
 	Port int
 
 	HttpBatchSize int
+	HttpPath      string
 
 	Debug bool
 
@@ -53,6 +54,10 @@ var sampleConfig = `
   ## Number of data points to send to OpenTSDB in Http requests.
   ## Not used with telnet API.
   httpBatchSize = 50
+
+  ## URI Path for Http requests to OpenTSDB.
+  ## Used in cases where OpenTSDB is located behind a reverse proxy.
+  httpPath = "/api/put"
 
   ## Debug true - Prints OpenTSDB communication
   debug = false
@@ -121,6 +126,7 @@ func (o *OpenTSDB) WriteHttp(metrics []telegraf.Metric, u *url.URL) error {
 		Scheme:    u.Scheme,
 		User:      u.User,
 		BatchSize: o.HttpBatchSize,
+		Path:      o.HttpPath,
 		Debug:     o.Debug,
 	}
 

--- a/plugins/outputs/opentsdb/opentsdb_http.go
+++ b/plugins/outputs/opentsdb/opentsdb_http.go
@@ -26,6 +26,7 @@ type openTSDBHttp struct {
 	Scheme    string
 	User      *url.Userinfo
 	BatchSize int
+	Path      string
 	Debug     bool
 
 	metricCounter int
@@ -123,7 +124,7 @@ func (o *openTSDBHttp) flush() error {
 		Scheme: o.Scheme,
 		User:   o.User,
 		Host:   fmt.Sprintf("%s:%d", o.Host, o.Port),
-		Path:   "/api/put",
+		Path:   o.Path,
 	}
 
 	if o.Debug {

--- a/plugins/outputs/opentsdb/opentsdb_test.go
+++ b/plugins/outputs/opentsdb/opentsdb_test.go
@@ -156,6 +156,7 @@ func BenchmarkHttpSend(b *testing.B) {
 		Port:          port,
 		Prefix:        "",
 		HttpBatchSize: BatchSize,
+		HttpPath:      "/api/put",
 	}
 
 	b.ResetTimer()


### PR DESCRIPTION
This PR updates the OpenTSDB to allow for the path to be configured when using the HTTP client. Currently there is no way for telegraf to send data to OpenTSDB servers behind a reverse proxy with non default routes.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
