### PR TITLE
Improve passthrough in prometheus output and input plugins

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -968,6 +968,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "024194b983d91b9500fe97e0aa0ddb5fe725030cb51ddfb034e386cae1098370"
+  inputs-digest = "6694ba5b3f987292a075a845c2a2188020c491eb03c2b5eae4f733166f6fe654"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -109,10 +109,6 @@
   branch = "master"
 
 [[constraint]]
-  name = "github.com/matttproud/golang_protobuf_extensions"
-  version = "1.0.1"
-
-[[constraint]]
   name = "github.com/Microsoft/ApplicationInsights-Go"
   branch = "master"
 

--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -52,7 +52,6 @@ following works:
 - github.com/kardianos/service [ZLIB](https://github.com/kardianos/service/blob/master/LICENSE) (License not named but matches word for word with ZLib)
 - github.com/kballard/go-shellquote [MIT](https://github.com/kballard/go-shellquote/blob/master/LICENSE)
 - github.com/lib/pq [MIT](https://github.com/lib/pq/blob/master/LICENSE.md)
-- github.com/matttproud/golang_protobuf_extensions [APACHE](https://github.com/matttproud/golang_protobuf_extensions/blob/master/LICENSE)
 - github.com/Microsoft/ApplicationInsights-Go [APACHE](https://github.com/Microsoft/ApplicationInsights-Go/blob/master/LICENSE)
 - github.com/Microsoft/go-winio [MIT](https://github.com/Microsoft/go-winio/blob/master/LICENSE)
 - github.com/miekg/dns [BSD](https://github.com/miekg/dns/blob/master/LICENSE)

--- a/plugins/inputs/prometheus/parser.go
+++ b/plugins/inputs/prometheus/parser.go
@@ -4,19 +4,16 @@ package prometheus
 // https://github.com/prometheus/prom2json/blob/master/main.go
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
 	"math"
-	"mime"
 	"net/http"
 	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 
-	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )
@@ -25,58 +22,57 @@ import (
 // metrics
 func Parse(buf []byte, header http.Header) ([]telegraf.Metric, error) {
 	var metrics []telegraf.Metric
-	var parser expfmt.TextParser
 	// parse even if the buffer begins with a newline
 	buf = bytes.TrimPrefix(buf, []byte("\n"))
 	// Read raw data
-	buffer := bytes.NewBuffer(buf)
-	reader := bufio.NewReader(buffer)
+	reader := bytes.NewReader(buf)
 
-	mediatype, params, err := mime.ParseMediaType(header.Get("Content-Type"))
-	// Prepare output
-	metricFamilies := make(map[string]*dto.MetricFamily)
-
-	if err == nil && mediatype == "application/vnd.google.protobuf" &&
-		params["encoding"] == "delimited" &&
-		params["proto"] == "io.prometheus.client.MetricFamily" {
-		for {
-			mf := &dto.MetricFamily{}
-			if _, ierr := pbutil.ReadDelimited(reader, mf); ierr != nil {
-				if ierr == io.EOF {
-					break
-				}
-				return nil, fmt.Errorf("reading metric family protocol buffer failed: %s", ierr)
-			}
-			metricFamilies[mf.GetName()] = mf
-		}
-	} else {
-		metricFamilies, err = parser.TextToMetricFamilies(reader)
-		if err != nil {
-			return nil, fmt.Errorf("reading text format failed: %s", err)
-		}
-	}
+	format := expfmt.ResponseFormat(header)
+	decoder := expfmt.NewDecoder(reader, format)
 
 	// read metrics
-	for metricName, mf := range metricFamilies {
-		for _, m := range mf.Metric {
+	family := &dto.MetricFamily{}
+	for {
+		err := decoder.Decode(family)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("decoding prometheus exposition format failed: %s", err)
+		}
+
+		for _, m := range family.Metric {
 			// reading tags
 			tags := makeLabels(m)
+			tags["prometheus_type"] = family.GetType().String()
+			tags["prometheus_help"] = family.GetHelp()
 			// reading fields
 			fields := make(map[string]interface{})
-			if mf.GetType() == dto.MetricType_SUMMARY {
+			switch family.GetType() {
+			case dto.MetricType_SUMMARY:
 				// summary metric
-				fields = makeQuantiles(m)
+				fields = makeQuantiles(m.GetSummary())
 				fields["count"] = float64(m.GetSummary().GetSampleCount())
 				fields["sum"] = float64(m.GetSummary().GetSampleSum())
-			} else if mf.GetType() == dto.MetricType_HISTOGRAM {
+			case dto.MetricType_HISTOGRAM:
 				// histogram metric
-				fields = makeBuckets(m)
+				fields = makeBuckets(m.GetHistogram())
 				fields["count"] = float64(m.GetHistogram().GetSampleCount())
 				fields["sum"] = float64(m.GetHistogram().GetSampleSum())
-
-			} else {
-				// standard metric
-				fields = getNameAndValue(m)
+			case dto.MetricType_COUNTER:
+				// counter metric
+				// counter is allways at least 0
+				fields["counter"] = float64(m.GetCounter().GetValue())
+			case dto.MetricType_GAUGE:
+				// gauge metric
+				// gauge can be unset, returning NaN
+				if !math.IsNaN(m.GetGauge().GetValue()) {
+					fields["gauge"] = float64(m.GetGauge().GetValue())
+				}
+			default:
+				// untyped metric
+				if !math.IsNaN(m.GetUntyped().GetValue()) {
+					fields["value"] = float64(m.GetUntyped().GetValue())
+				}
 			}
 			// converting to telegraf metric
 			if len(fields) > 0 {
@@ -86,7 +82,7 @@ func Parse(buf []byte, header http.Header) ([]telegraf.Metric, error) {
 				} else {
 					t = time.Now()
 				}
-				metric, err := metric.New(metricName, tags, fields, t, valueType(mf.GetType()))
+				metric, err := metric.New(family.GetName(), tags, fields, t, valueType(family.GetType()))
 				if err == nil {
 					metrics = append(metrics, metric)
 				}
@@ -94,7 +90,7 @@ func Parse(buf []byte, header http.Header) ([]telegraf.Metric, error) {
 		}
 	}
 
-	return metrics, err
+	return metrics, nil
 }
 
 func valueType(mt dto.MetricType) telegraf.ValueType {
@@ -113,9 +109,10 @@ func valueType(mt dto.MetricType) telegraf.ValueType {
 }
 
 // Get Quantiles from summary metric
-func makeQuantiles(m *dto.Metric) map[string]interface{} {
+func makeQuantiles(s *dto.Summary) map[string]interface{} {
 	fields := make(map[string]interface{})
-	for _, q := range m.GetSummary().Quantile {
+	for _, q := range s.Quantile {
+		// with no events to process summary returns NaN
 		if !math.IsNaN(q.GetValue()) {
 			fields[fmt.Sprint(q.GetQuantile())] = float64(q.GetValue())
 		}
@@ -124,9 +121,9 @@ func makeQuantiles(m *dto.Metric) map[string]interface{} {
 }
 
 // Get Buckets  from histogram metric
-func makeBuckets(m *dto.Metric) map[string]interface{} {
+func makeBuckets(h *dto.Histogram) map[string]interface{} {
 	fields := make(map[string]interface{})
-	for _, b := range m.GetHistogram().Bucket {
+	for _, b := range h.Bucket {
 		fields[fmt.Sprint(b.GetUpperBound())] = float64(b.GetCumulativeCount())
 	}
 	return fields
@@ -139,23 +136,4 @@ func makeLabels(m *dto.Metric) map[string]string {
 		result[lp.GetName()] = lp.GetValue()
 	}
 	return result
-}
-
-// Get name and value from metric
-func getNameAndValue(m *dto.Metric) map[string]interface{} {
-	fields := make(map[string]interface{})
-	if m.Gauge != nil {
-		if !math.IsNaN(m.GetGauge().GetValue()) {
-			fields["gauge"] = float64(m.GetGauge().GetValue())
-		}
-	} else if m.Counter != nil {
-		if !math.IsNaN(m.GetCounter().GetValue()) {
-			fields["counter"] = float64(m.GetCounter().GetValue())
-		}
-	} else if m.Untyped != nil {
-		if !math.IsNaN(m.GetUntyped().GetValue()) {
-			fields["value"] = float64(m.GetUntyped().GetValue())
-		}
-	}
-	return fields
 }

--- a/plugins/inputs/prometheus/parser_test.go
+++ b/plugins/inputs/prometheus/parser_test.go
@@ -116,6 +116,8 @@ func TestParseValidPrometheus(t *testing.T) {
 		"cadvisorVersion":  "",
 		"dockerVersion":    "1.8.2",
 		"kernelVersion":    "3.10.0-229.20.1.el7.x86_64",
+		"prometheus_help":  "A metric with a constant '1' value labeled by kernel version, OS version, docker version, cadvisor version & cadvisor revision.",
+		"prometheus_type":  "GAUGE",
 	}, metrics[0].Tags())
 
 	// Counter value
@@ -126,7 +128,10 @@ func TestParseValidPrometheus(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{
 		"counter": float64(0),
 	}, metrics[0].Fields())
-	assert.Equal(t, map[string]string{}, metrics[0].Tags())
+	assert.Equal(t, map[string]string{
+		"prometheus_help": "Counter of failed Token() requests to the alternate token source",
+		"prometheus_type": "COUNTER",
+	}, metrics[0].Tags())
 
 	// Summary data
 	//SetDefaultTags(map[string]string{})
@@ -141,7 +146,11 @@ func TestParseValidPrometheus(t *testing.T) {
 		"count": 9.0,
 		"sum":   1.8909097205e+07,
 	}, metrics[0].Fields())
-	assert.Equal(t, map[string]string{"handler": "prometheus"}, metrics[0].Tags())
+	assert.Equal(t, map[string]string{
+		"handler":         "prometheus",
+		"prometheus_help": "The HTTP request latencies in microseconds.",
+		"prometheus_type": "SUMMARY",
+	}, metrics[0].Tags())
 
 	// histogram data
 	metrics, err = Parse([]byte(validUniqueHistogram), http.Header{})
@@ -161,7 +170,11 @@ func TestParseValidPrometheus(t *testing.T) {
 		"1e+06":  2005.0,
 	}, metrics[0].Fields())
 	assert.Equal(t,
-		map[string]string{"verb": "POST", "resource": "bindings"},
-		metrics[0].Tags())
+		map[string]string{
+			"verb":            "POST",
+			"resource":        "bindings",
+			"prometheus_help": "Response latency distribution in microseconds for each verb, resource and client.",
+			"prometheus_type": "HISTOGRAM",
+		}, metrics[0].Tags())
 
 }

--- a/plugins/outputs/prometheus_client/prometheus_client_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_test.go
@@ -45,7 +45,7 @@ func TestWrite_Basic(t *testing.T) {
 
 	fam, ok := client.fam["foo"]
 	require.True(t, ok)
-	require.Equal(t, telegraf.Untyped, fam.TelegrafValueType)
+	require.Equal(t, telegraf.Untyped, fam.ValueType)
 	require.Equal(t, map[string]int{}, fam.LabelSet)
 
 	sample, ok := fam.Samples[CreateSampleID(pt1.Tags())]
@@ -177,7 +177,7 @@ func TestWrite_Counters(t *testing.T) {
 
 			fam, ok := client.fam[tt.metricName]
 			require.True(t, ok)
-			require.Equal(t, tt.valueType, fam.TelegrafValueType)
+			require.Equal(t, tt.valueType, fam.ValueType)
 		})
 	}
 }
@@ -275,7 +275,7 @@ func TestWrite_Gauge(t *testing.T) {
 
 			fam, ok := client.fam[tt.metricName]
 			require.True(t, ok)
-			require.Equal(t, tt.valueType, fam.TelegrafValueType)
+			require.Equal(t, tt.valueType, fam.ValueType)
 
 		})
 	}
@@ -426,7 +426,7 @@ func TestWrite_Tags(t *testing.T) {
 
 	fam, ok := client.fam["foo"]
 	require.True(t, ok)
-	require.Equal(t, telegraf.Untyped, fam.TelegrafValueType)
+	require.Equal(t, telegraf.Untyped, fam.ValueType)
 
 	require.Equal(t, map[string]int{"host": 1}, fam.LabelSet)
 


### PR DESCRIPTION
Prometheus metrics will get mangled when passed to another telegraf instance using any of the serializers due to the loss of type. This is makes the histogram and summary metrics unusable in prometheus.

This change will store prometheus help and type as metric tags in prometheus input and restore them in prometheus output.

Let me know what you think about this change. My go knowledge is mostly superficial as my main focus is system administration, I will wellcome a code review.