### PR TITLE
Support StatisticValues in cloudwatch output plugin (#4318)

### DIFF
--- a/plugins/outputs/cloudwatch/README.md
+++ b/plugins/outputs/cloudwatch/README.md
@@ -36,3 +36,12 @@ Examples include but are not limited to:
 ### namespace
 
 The namespace used for AWS CloudWatch metrics.
+
+### enable_statistic_values
+
+If you have a large amount of metrics, you should consider to send 
+statistic values instead of raw metrics. This would not only improve
+performance but also save AWS API cost. Use `basicstats` aggregator to 
+calculate those required statistic fields (count, min, max, and sum).
+[See Cloudwatch StatisticSet](https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatch/#StatisticSet).
+This plugin would try to parse those statistic fields and send to Cloudwatch.

--- a/plugins/outputs/cloudwatch/README.md
+++ b/plugins/outputs/cloudwatch/README.md
@@ -37,11 +37,12 @@ Examples include but are not limited to:
 
 The namespace used for AWS CloudWatch metrics.
 
-### enable_statistic_values
+### write_statistics
 
-If you have a large amount of metrics, you should consider to send 
-statistic values instead of raw metrics. This would not only improve
-performance but also save AWS API cost. Use `basicstats` aggregator to 
-calculate those required statistic fields (count, min, max, and sum).
-[See Cloudwatch StatisticSet](https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatch/#StatisticSet).
-This plugin would try to parse those statistic fields and send to Cloudwatch.
+If you have a large amount of metrics, you should consider to send statistic 
+values instead of raw metrics which could not only improve performance but 
+also save AWS API cost. If enable this flag, this plugin would parse the required 
+[CloudWatch statistic fields](https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatch/#StatisticSet) 
+(count, min, max, and sum) and send them to CloudWatch. You could use `basicstats` 
+aggregator to calculate those fields. If not all statistic fields are available, 
+all fields would still be sent as raw metrics.

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -28,7 +28,7 @@ type CloudWatch struct {
 	Namespace string `toml:"namespace"` // CloudWatch Metrics Namespace
 	svc       *cloudwatch.CloudWatch
 
-	EnableStatisticValues bool `toml:"enable_statistic_values"`
+	WriteStatistics bool `toml:"write_statistics"`
 }
 
 type statisticSet struct {
@@ -61,13 +61,13 @@ var sampleConfig = `
   ## Namespace for the CloudWatch MetricDatums
   namespace = "InfluxData/Telegraf"
 
-  ## If you have a large amount of metrics, you should consider to send 
-  ## statistic values instead of raw metrics. This would not only improve
-  ## performance but also save AWS API cost. Use basicstats aggregator to
-  ## calculate required statistic fields (count, min, max, and sum) and 
-  ## enable this flag. This plugin would try to parse those fields and 
-  ## send statistic values to Cloudwatch.
-  # enable_statistic_values = false
+  ## If you have a large amount of metrics, you should consider to send statistic 
+  ## values instead of raw metrics which could not only improve performance but 
+  ## also save AWS API cost. If enable this flag, this plugin would parse the required 
+  ## CloudWatch statistic fields (count, min, max, and sum) and send them to CloudWatch. 
+  ## You could use basicstats aggregator to calculate those fields. If not all statistic 
+  ## fields are available, all fields would still be sent as raw metrics. 
+  # write_statistics = false
 `
 
 func (c *CloudWatch) SampleConfig() string {
@@ -114,7 +114,7 @@ func (c *CloudWatch) Write(metrics []telegraf.Metric) error {
 
 	var datums []*cloudwatch.MetricDatum
 	for _, m := range metrics {
-		d := BuildMetricDatum(m)
+		d := BuildMetricDatum(c.WriteStatistics, m)
 		datums = append(datums, d...)
 	}
 

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -400,16 +400,16 @@ func getStatisticType(name string) (sType statisticType, fieldName string) {
 	switch {
 	case strings.HasSuffix(name, "_max"):
 		sType = statisticTypeMax
-		fieldName = name[:len(name)-len("_max")]
+		fieldName = strings.TrimSuffix(name, "_max")
 	case strings.HasSuffix(name, "_min"):
 		sType = statisticTypeMin
-		fieldName = name[:len(name)-len("_min")]
+		fieldName = strings.TrimSuffix(name, "_min")
 	case strings.HasSuffix(name, "_sum"):
 		sType = statisticTypeSum
-		fieldName = name[:len(name)-len("_sum")]
+		fieldName = strings.TrimSuffix(name, "_sum")
 	case strings.HasSuffix(name, "_count"):
 		sType = statisticTypeCount
-		fieldName = name[:len(name)-len("_count")]
+		fieldName = strings.TrimSuffix(name, "_count")
 	default:
 		sType = statisticTypeNone
 		fieldName = name

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -91,14 +91,28 @@ func TestBuildMetricDatums(t *testing.T) {
 	datums := BuildMetricDatum(true, statisticMetric)
 	assert.Equal(1, len(datums), fmt.Sprintf("Valid point should create a Datum {value: %v}", statisticMetric))
 
-	multipleFieldsMetric, _ := metric.New(
+	multiFieldsMetric, _ := metric.New(
 		"test1",
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{"valueA": float64(10), "valueB": float64(0), "valueC": float64(100), "valueD": float64(20)},
 		time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-	datums = BuildMetricDatum(true, multipleFieldsMetric)
-	assert.Equal(4, len(datums), fmt.Sprintf("Each field should create a Datum {value: %v}", multipleFieldsMetric))
+	datums = BuildMetricDatum(true, multiFieldsMetric)
+	assert.Equal(4, len(datums), fmt.Sprintf("Each field should create a Datum {value: %v}", multiFieldsMetric))
+
+	multiStatisticMetric, _ := metric.New(
+		"test1",
+		map[string]string{"tag1": "value1"},
+		map[string]interface{}{
+			"valueA_max": float64(10), "valueA_min": float64(0), "valueA_sum": float64(100), "valueA_count": float64(20),
+			"valueB_max": float64(10), "valueB_min": float64(0), "valueB_sum": float64(100), "valueB_count": float64(20),
+			"valueC_max": float64(10), "valueC_min": float64(0), "valueC_sum": float64(100),
+			"valueD": float64(10), "valueE": float64(0),
+		},
+		time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+	datums = BuildMetricDatum(true, multiStatisticMetric)
+	assert.Equal(7, len(datums), fmt.Sprintf("Valid point should create a Datum {value: %v}", multiStatisticMetric))
 }
 
 func TestPartitionDatums(t *testing.T) {


### PR DESCRIPTION
Fix #4318 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Add `enable_statistic_values` flag. If true, this plugin would try to parse required statistic fields and send StatisticSet to Cloudwatch.