### PR TITLE
Improve syslog connection handling

### DIFF
--- a/plugins/inputs/syslog/syslog.go
+++ b/plugins/inputs/syslog/syslog.go
@@ -314,7 +314,7 @@ func (s *Syslog) handle(conn net.Conn, acc telegraf.Accumulator) {
 				return
 			}
 			// other error, log and return
-			s.store(rfc5425.Result{Error: fmt.Errorf("failed reading from syslog client - %s", err.Error())}, acc)
+			acc.AddError(fmt.Errorf("failed reading from syslog client - %s", err.Error()))
 			return
 		}
 		// handle client disconnect

--- a/plugins/inputs/syslog/syslog.go
+++ b/plugins/inputs/syslog/syslog.go
@@ -395,7 +395,7 @@ func fields(msg rfc5424.SyslogMessage, s *Syslog) map[string]interface{} {
 	}
 
 	if msg.Message() != nil {
-		flds["message"] = *msg.Message()
+		flds["message"] = strings.TrimSpace(*msg.Message())
 	}
 
 	if msg.StructuredData() != nil {

--- a/plugins/inputs/syslog/syslog.go
+++ b/plugins/inputs/syslog/syslog.go
@@ -19,7 +19,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-const defaultReadTimeout = time.Millisecond * 500
+const defaultReadTimeout = time.Second * 5
 const ipMaxPacketSize = 64 * 1024
 
 // Syslog is a syslog plugin


### PR DESCRIPTION
This change reads from a syslog client in a separate step from the log parsing. This allows fewer errors in telegraf's logs about exceeding read timeouts. This should also limit the amount of reconnecting syslog clients must do when streaming logs to telegraf.

Previously, the syslog plugin would immediately start reading from a connection and if data was not immediately provided (or a connection was made and closed), `found EOF, expecting a MSGLEN` would be printed to telgraf's log.

By reading the data on the connection in a separate step, we are able to handle connection issues separately from parsing issues, thus resulting in less of them. This will also allow for syslog client connections to stay alive longer.

Resolves #4335

