### PR TITLE
Fix diskio utilization and queue length issue.

### DIFF
--- a/plugins/inputs/system/DISKIO_README.md
+++ b/plugins/inputs/system/DISKIO_README.md
@@ -107,13 +107,13 @@ requests that are in the queue but not yet issued to the device driver.
 
 #### Calculate percent IO utilization per disk and host:
 ```
-SELECT derivative(last("io_time"),1ms) FROM "diskio" WHERE time > now() - 30m GROUP BY "host","name",time(60s)
+SELECT non_negative_derivative(last("io_time"),1ms) FROM "diskio" WHERE time > now() - 30m GROUP BY "host","name",time(60s)
 ```
 
 #### Calculate average queue depth:
 `iops_in_progress` will give you an instantaneous value. This will give you the average between polling intervals.
 ```
-SELECT derivative(last("weighted_io_time",1ms)) from "diskio" WHERE time > now() - 30m GROUP BY "host","name",time(60s)
+SELECT non_negative_derivative(last("weighted_io_time",1ms)) from "diskio" WHERE time > now() - 30m GROUP BY "host","name",time(60s)
 ```
 
 ### Example Output:


### PR DESCRIPTION
diskio utilization and queue length should be positive, not negative.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
