### PR TITLE
Prevent new tag from being overwritten

### DIFF
--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -34,7 +34,7 @@ const sampleConfig = `
   #   key = "request"
   #   ## All the power of the Go regular expressions available here
   #   ## For example, named subgroups
-  #   pattern = "^/api(?P<method>/[\\w/]+)\\S*" 
+  #   pattern = "^/api(?P<method>/[\\w/]+)\\S*"
   #   replacement = "${method}"
   #   ## If result_key is present, a new field will be created
   #   ## instead of changing existing field
@@ -67,7 +67,10 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	for _, metric := range in {
 		for _, converter := range r.Tags {
 			if value, ok := metric.GetTag(converter.Key); ok {
-				metric.AddTag(r.convert(converter, value))
+				k, v := r.convert(converter, value)
+				if k != "" && v != "" {
+					metric.AddTag(k, v)
+				}
 			}
 		}
 
@@ -75,7 +78,10 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 			if value, ok := metric.GetField(converter.Key); ok {
 				switch value := value.(type) {
 				case string:
-					metric.AddField(r.convert(converter, value))
+					k, v := r.convert(converter, value)
+					if k != "" && v != "" {
+						metric.AddField(r.convert(converter, value))
+					}
 				}
 			}
 		}

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -68,7 +68,7 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 		for _, converter := range r.Tags {
 			if value, ok := metric.GetTag(converter.Key); ok {
 				k, v := r.convert(converter, value)
-				if k != "" && v != "" {
+				if k != "" {
 					metric.AddTag(k, v)
 				}
 			}
@@ -78,8 +78,8 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 			if value, ok := metric.GetField(converter.Key); ok {
 				switch value := value.(type) {
 				case string:
-					k, v := r.convert(converter, value)
-					if k != "" && v != "" {
+					k, _ := r.convert(converter, value)
+					if k != "" {
 						metric.AddField(r.convert(converter, value))
 					}
 				}

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -222,7 +222,7 @@ func TestNoMatches(t *testing.T) {
 			},
 		},
 		{
-			message: "Should emit empty string when result_key given but regex doesn't match",
+			message: "Shouldn't emit empty string when result_key given but regex doesn't match",
 			converter: converter{
 				Key:         "request",
 				Pattern:     "not_match",
@@ -230,8 +230,7 @@ func TestNoMatches(t *testing.T) {
 				ResultKey:   "new_field",
 			},
 			expectedFields: map[string]interface{}{
-				"request":   "/users/42/",
-				"new_field": "",
+				"request": "/users/42/",
 			},
 		},
 	}

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -222,7 +222,7 @@ func TestNoMatches(t *testing.T) {
 			},
 		},
 		{
-			message: "Shouldn't emit empty string when result_key given but regex doesn't match",
+			message: "Should emit empty string when result_key given but regex doesn't match",
 			converter: converter{
 				Key:         "request",
 				Pattern:     "not_match",
@@ -230,7 +230,8 @@ func TestNoMatches(t *testing.T) {
 				ResultKey:   "new_field",
 			},
 			expectedFields: map[string]interface{}{
-				"request": "/users/42/",
+				"request":   "/users/42/",
+				"new_field": "",
 			},
 		},
 	}


### PR DESCRIPTION
This prevents tags from being overwritten by other regex processors.

Resolves #4374
