### PR TITLE
Add process' user as a tag

### DIFF
--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -21,6 +21,7 @@ type Process interface {
 	Percent(interval time.Duration) (float64, error)
 	Times() (*cpu.TimesStat, error)
 	RlimitUsage(bool) ([]process.RlimitStat, error)
+	Username() (string, error)
 }
 
 type PIDFinder interface {
@@ -56,6 +57,10 @@ func (p *Proc) Tags() map[string]string {
 
 func (p *Proc) PID() PID {
 	return PID(p.Process.Pid)
+}
+
+func (p *Proc) Username() (string, error) {
+	return p.Process.Username()
 }
 
 func (p *Proc) Percent(interval time.Duration) (float64, error) {

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -128,6 +128,14 @@ func (p *Procstat) addMetrics(proc Process, acc telegraf.Accumulator) {
 		}
 	}
 
+	//If user tag is not already set, set to actual name
+	if _, ok := proc.Tags()["user"]; !ok {
+		user, err := proc.Username()
+		if err == nil {
+			proc.Tags()["user"] = user
+		}
+	}
+
 	//If pid is not present as a tag, include it as a field.
 	if _, pidInTags := proc.Tags()["pid"]; !pidInTags {
 		fields["pid"] = int32(proc.PID())

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -104,6 +104,10 @@ func (p *testProc) PID() PID {
 	return p.pid
 }
 
+func (p *testProc) Username() (string, error) {
+	return "testuser", nil
+}
+
 func (p *testProc) Tags() map[string]string {
 	return p.tags
 }


### PR DESCRIPTION
This adds the username of the user running a process as a tag to the `procstat` plugin.

Resolves #4378 
