### PR TITLE
Regex: don't emit empty tags and fields when pattern doesn't match and result_key specified

### DIFF
--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -67,7 +67,9 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	for _, metric := range in {
 		for _, converter := range r.Tags {
 			if value, ok := metric.GetTag(converter.Key); ok {
-				metric.AddTag(r.convert(converter, value))
+				if key, newValue := r.convert(converter, value); newValue != "" {
+					metric.AddTag(key, newValue)
+				}
 			}
 		}
 
@@ -75,7 +77,9 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 			if value, ok := metric.GetField(converter.Key); ok {
 				switch value := value.(type) {
 				case string:
-					metric.AddField(r.convert(converter, value))
+					if key, newValue := r.convert(converter, value); newValue != "" {
+						metric.AddField(key, newValue)
+					}
 				}
 			}
 		}

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -222,7 +222,7 @@ func TestNoMatches(t *testing.T) {
 			},
 		},
 		{
-			message: "Should emit empty string when result_key given but regex doesn't match",
+			message: "Should not emit new tag/field when result_key given but regex doesn't match",
 			converter: converter{
 				Key:         "request",
 				Pattern:     "not_match",
@@ -230,8 +230,7 @@ func TestNoMatches(t *testing.T) {
 				ResultKey:   "new_field",
 			},
 			expectedFields: map[string]interface{}{
-				"request":   "/users/42/",
-				"new_field": "",
+				"request": "/users/42/",
 			},
 		},
 	}


### PR DESCRIPTION
Fixed behavior when pattern doesn't match:
a) if no `result_key` specified => plugin doesn't alter existing tag/field
b) if `result_key` specified => plugin doesn't create tag/field with `result_key` name (resolves #4374)

### Test `telegraf.conf`

```toml
[agent]
  interval="1s"
  flush_interval="1s"

[[inputs.exec]]
  timeout = "1s"
  data_format = "influx"
  commands = [
    "echo 'deal,computer_name=hosta message=\"stuff\" 1530654676316265790'",
    "echo 'deal,computer_name=hostb message=\"stuff\" 1530654676316265790'",
  ]

[[processors.regex]]
  [[processors.regex.tags]]
    key = "computer_name"
    pattern = "^(.*?)a$"
    replacement = "${1}"
    result_key = "server_name"
  [[processors.regex.tags]]
    key = "computer_name"
    pattern = "^(.*?)b$"
    replacement = "${1}"
    result_key = "server_name"

[[outputs.file]]
  files = ["stdout"]
```

### Output
```
deal,computer_name=hostb,host=44px-notebook.local,server_name=host message="stuff" 1530654676000000000
deal,computer_name=hosta,host=44px-notebook.local,server_name=host message="stuff" 1530654676000000000
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
