### PR TITLE
support expiration of stale metrics and hide unchanged metrics

### DIFF
--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -3,14 +3,14 @@
 ### Configuration
 
 ```toml
-# Statsd Server
+# Statsd UDP/TCP Server
 [[inputs.statsd]]
-  ## Protocol, must be "tcp", "udp4", "udp6" or "udp" (default=udp)
+  ## Protocol, must be "tcp", "udp", "udp4" or "udp6" (default=udp)
   protocol = "udp"
 
   ## MaxTCPConnection - applicable when protocol is set to tcp (default=250)
   max_tcp_connections = 250
-  
+
   ## Enable TCP keep alive probes (default=false)
   tcp_keep_alive = false
 
@@ -33,6 +33,9 @@
   delete_sets = true
   ## Reset timings & histograms every interval (default=true)
   delete_timings = true
+
+  ## Interval to expire metrics and not be collected, 0 == no expiration (default=1h)
+  expiration_interval = "24h"
 
   ## Percentiles to calculate for timing & histogram stats
   percentiles = [90]
@@ -172,6 +175,7 @@ to allow. Used when protocol is set to tcp.
 - **delete_counters** boolean: Delete counters on every collection interval
 - **delete_sets** boolean: Delete set counters on every collection interval
 - **delete_timings** boolean: Delete timings on every collection interval
+- **expiration_interval** Duration: Expire unchanged old metrics on every collection internal
 - **percentiles** []int: Percentiles to calculate for timing & histogram stats
 - **allowed_pending_messages** integer: Number of messages allowed to queue up
 waiting to be processed. When this fills, messages will be dropped and logged.

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -36,10 +36,10 @@ func NewTestStatsd() *Statsd {
 	// Make data structures
 	s.done = make(chan struct{})
 	s.in = make(chan *bytes.Buffer, s.AllowedPendingMessages)
-	s.gauges = make(map[string]cachedgauge)
-	s.counters = make(map[string]cachedcounter)
-	s.sets = make(map[string]cachedset)
-	s.timings = make(map[string]cachedtimings)
+	s.gauges = make(map[string]*cachedgauge)
+	s.counters = make(map[string]*cachedcounter)
+	s.sets = make(map[string]*cachedset)
+	s.timings = make(map[string]*cachedtimings)
 
 	s.MetricSeparator = "_"
 
@@ -503,7 +503,7 @@ func TestParse_InvalidSampleRate(t *testing.T) {
 	counter_validations := []struct {
 		name  string
 		value int64
-		cache map[string]cachedcounter
+		cache map[string]*cachedcounter
 	}{
 		{
 			"invalid_sample_rate",
@@ -920,20 +920,20 @@ func TestParse_DataDogTags(t *testing.T) {
 
 func tagsForItem(m interface{}) map[string]string {
 	switch m.(type) {
-	case map[string]cachedcounter:
-		for _, v := range m.(map[string]cachedcounter) {
+	case map[string]*cachedcounter:
+		for _, v := range m.(map[string]*cachedcounter) {
 			return v.tags
 		}
-	case map[string]cachedgauge:
-		for _, v := range m.(map[string]cachedgauge) {
+	case map[string]*cachedgauge:
+		for _, v := range m.(map[string]*cachedgauge) {
 			return v.tags
 		}
-	case map[string]cachedset:
-		for _, v := range m.(map[string]cachedset) {
+	case map[string]*cachedset:
+		for _, v := range m.(map[string]*cachedset) {
 			return v.tags
 		}
-	case map[string]cachedtimings:
-		for _, v := range m.(map[string]cachedtimings) {
+	case map[string]*cachedtimings:
+		for _, v := range m.(map[string]*cachedtimings) {
 			return v.tags
 		}
 	}
@@ -1508,7 +1508,7 @@ func TestParseKeyValue(t *testing.T) {
 func test_validate_set(
 	name string,
 	value int64,
-	cache map[string]cachedset,
+	cache map[string]*cachedset,
 	field ...string,
 ) error {
 	var f string
@@ -1517,7 +1517,7 @@ func test_validate_set(
 	} else {
 		f = "value"
 	}
-	var metric cachedset
+	var metric *cachedset
 	var found bool
 	for _, v := range cache {
 		if v.name == name {
@@ -1540,7 +1540,7 @@ func test_validate_set(
 func test_validate_counter(
 	name string,
 	valueExpected int64,
-	cache map[string]cachedcounter,
+	cache map[string]*cachedcounter,
 	field ...string,
 ) error {
 	var f string
@@ -1572,7 +1572,7 @@ func test_validate_counter(
 func test_validate_gauge(
 	name string,
 	valueExpected float64,
-	cache map[string]cachedgauge,
+	cache map[string]*cachedgauge,
 	field ...string,
 ) error {
 	var f string


### PR DESCRIPTION
In pull mode such as Prometheus, if the source is down, its metrics
are still kept in Telegraf's cache when delete_{gauges,counters,sets,timings}
are false, then Prometheus pull those stale metrics again and again. This
patch hides metrics unchanged since last gather and deletes too old ones.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
