### PR TITLE
Add temp inputs plugin for collect temperature

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -113,6 +113,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/tail"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tcp_listener"
 	_ "github.com/influxdata/telegraf/plugins/inputs/teamspeak"
+	_ "github.com/influxdata/telegraf/plugins/inputs/temp"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tengine"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tomcat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/trig"

--- a/plugins/inputs/system/mock_PS.go
+++ b/plugins/inputs/system/mock_PS.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/host"
 
 	"github.com/shirou/gopsutil/load"
 	"github.com/shirou/gopsutil/mem"
@@ -95,6 +96,15 @@ func (m *MockPS) SwapStat() (*mem.SwapMemoryStat, error) {
 	ret := m.Called()
 
 	r0 := ret.Get(0).(*mem.SwapMemoryStat)
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+
+func (m *MockPS) Temperature() ([]host.TemperatureStat, error) {
+	ret := m.Called()
+
+	r0 := ret.Get(0).([]host.TemperatureStat)
 	r1 := ret.Error(1)
 
 	return r0, r1

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/host"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/shirou/gopsutil/net"
 )
@@ -23,6 +24,7 @@ type PS interface {
 	VMStat() (*mem.VirtualMemoryStat, error)
 	SwapStat() (*mem.SwapMemoryStat, error)
 	NetConnections() ([]net.ConnectionStat, error)
+	Temperature() ([]host.TemperatureStat, error)
 }
 
 type PSDiskDeps interface {
@@ -166,6 +168,10 @@ func (s *SystemPS) VMStat() (*mem.VirtualMemoryStat, error) {
 
 func (s *SystemPS) SwapStat() (*mem.SwapMemoryStat, error) {
 	return mem.SwapMemory()
+}
+
+func (s *SystemPS) Temperature() ([]host.TemperatureStat, error) {
+	return host.SensorsTemperatures()
 }
 
 func (s *SystemPSDisk) Partitions(all bool) ([]disk.PartitionStat, error) {

--- a/plugins/inputs/temp/README.md
+++ b/plugins/inputs/temp/README.md
@@ -1,0 +1,32 @@
+# Temp Input plugin
+
+This input plugin collect temperature.
+
+### Configuration:
+
+```
+[[inputs.temp]]
+```
+
+### Measurements & Fields:
+
+All fields are float64.
+
+- temp ( unit: °Celsius)
+
+### Tags:
+
+- All measurements have the following tags:
+    - host
+    - sensor
+
+### Example Output:
+
+```
+$ ./telegraf --config telegraf.conf --input-filter temp --test
+* Plugin: temp, Collection 1
+> temp,host=localhost,sensor=coretemp_physicalid0_crit temp=100 1531298763000000000
+> temp,host=localhost,sensor=coretemp_physicalid0_critalarm temp=0 1531298763000000000
+> temp,host=localhost,sensor=coretemp_physicalid0_input temp=100 1531298763000000000
+> temp,host=localhost,sensor=coretemp_physicalid0_max temp=100 1531298763000000000
+```

--- a/plugins/inputs/temp/temp.go
+++ b/plugins/inputs/temp/temp.go
@@ -1,0 +1,46 @@
+package temp
+
+import (
+	"fmt"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/inputs/system"
+)
+
+type Temperature struct {
+	ps system.PS
+}
+
+func (t *Temperature) Description() string {
+	return "Read metrics about temperature"
+}
+
+const sampleConfig = ""
+
+func (t *Temperature) SampleConfig() string {
+	return sampleConfig
+}
+
+func (t *Temperature) Gather(acc telegraf.Accumulator) error {
+	temps, err := t.ps.Temperature()
+	if err != nil {
+		return fmt.Errorf("error getting temperatures info: %s", err)
+	}
+	for _, temp := range temps {
+		tags := map[string]string{
+			"sensor": temp.SensorKey,
+		}
+		fields := map[string]interface{}{
+			"temp": temp.Temperature,
+		}
+		acc.AddFields("temp", fields, tags)
+	}
+	return nil
+}
+
+func init() {
+	inputs.Add("temp", func() telegraf.Input {
+		return &Temperature{ps: system.NewSystemPS()}
+	})
+}

--- a/plugins/inputs/temp/temp_test.go
+++ b/plugins/inputs/temp/temp_test.go
@@ -1,0 +1,38 @@
+package temp
+
+import (
+	"testing"
+
+	"github.com/shirou/gopsutil/host"
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/plugins/inputs/system"
+	"github.com/influxdata/telegraf/testutil"
+)
+
+func TestTemperature(t *testing.T) {
+	var mps system.MockPS
+	var err error
+	defer mps.AssertExpectations(t)
+	var acc testutil.Accumulator
+
+	ts := host.TemperatureStat{
+		SensorKey:   "coretemp_sensor1_crit",
+		Temperature: 60.5,
+	}
+
+	mps.On("Temperature").Return([]host.TemperatureStat{ts}, nil)
+
+	err = (&Temperature{ps: &mps}).Gather(&acc)
+	require.NoError(t, err)
+
+	expectedFields := map[string]interface{}{
+		"temp": float64(60.5),
+	}
+
+	expectedTags := map[string]string{
+		"sensor": "coretemp_sensor1_crit",
+	}
+	acc.AssertContainsTaggedFields(t, "temp", expectedFields, expectedTags)
+
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This `temp` inputs plugin implement #4400 . Use `gopsutil`  to collect virtual machine temperature.
