### PR TITLE
Expose kafka client id

### DIFF
--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -16,13 +16,14 @@ and use the old zookeeper connection method.
 [[inputs.kafka_consumer]]
   ## topic(s) to consume
   topics = ["telegraf"]
-  ## kafka client id
-  client_id = "my_client"
   brokers = ["localhost:9092"]
   ## the name of the consumer group
   consumer_group = "telegraf_metrics_consumers"
   ## Offset (must be either "oldest" or "newest")
   offset = "oldest"
+
+  ## Optional client id
+  # client_id = "my_client"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -16,6 +16,8 @@ and use the old zookeeper connection method.
 [[inputs.kafka_consumer]]
   ## topic(s) to consume
   topics = ["telegraf"]
+  ## kafka client id
+  client_id = "my_client"
   brokers = ["localhost:9092"]
   ## the name of the consumer group
   consumer_group = "telegraf_metrics_consumers"

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -17,7 +17,7 @@ import (
 
 type Kafka struct {
 	ConsumerGroup string
-	ClientId      string `toml:"client_id"`
+	ClientID      string `toml:"client_id"`
 	Topics        []string
 	Brokers       []string
 	MaxMessageLen int
@@ -62,7 +62,7 @@ var sampleConfig = `
   topics = ["telegraf"]
   
   ## Optional Client id
-  # client_id = "my_client"
+  # client_id = "Telegraf"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
@@ -118,8 +118,10 @@ func (k *Kafka) Start(acc telegraf.Accumulator) error {
 		return err
 	}
 
-	if k.ClientId != "" {
-		config.ClientID = k.ClientId
+	if k.ClientID != "" {
+		config.ClientID = k.ClientID
+	} else {
+		config.ClientID = "Telegraf"
 	}
 
 	if tlsConfig != nil {

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -60,8 +60,9 @@ var sampleConfig = `
   brokers = ["localhost:9092"]
   ## topic(s) to consume
   topics = ["telegraf"]
-  ## kafka client id
-  client_id = "my_client"
+  
+  ## Optional Client id
+  # client_id = "my_client"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -17,6 +17,7 @@ import (
 
 type Kafka struct {
 	ConsumerGroup string
+	ClientId      string `toml:"client_id"`
 	Topics        []string
 	Brokers       []string
 	MaxMessageLen int
@@ -59,6 +60,8 @@ var sampleConfig = `
   brokers = ["localhost:9092"]
   ## topic(s) to consume
   topics = ["telegraf"]
+  ## kafka client id
+  client_id = "my_client"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
@@ -112,6 +115,10 @@ func (k *Kafka) Start(acc telegraf.Accumulator) error {
 	tlsConfig, err := k.ClientConfig.TLSConfig()
 	if err != nil {
 		return err
+	}
+
+	if k.ClientId != "" {
+		config.ClientID = k.ClientId
 	}
 
 	if tlsConfig != nil {

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -9,6 +9,8 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
   brokers = ["localhost:9092"]
   ## Kafka topic for producer messages
   topic = "telegraf"
+  ## Kafka client id
+  ClientId string `toml:"client_id"`
 
   ## Optional topic suffix configuration.
   ## If the section is omitted, no suffix is used.

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -9,8 +9,9 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
   brokers = ["localhost:9092"]
   ## Kafka topic for producer messages
   topic = "telegraf"
-  ## kafka client id
-  client_id = "my_client"
+
+  ## Optional client id
+  # client_id = "my_client"
 
   ## Optional topic suffix configuration.
   ## If the section is omitted, no suffix is used.

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -9,8 +9,8 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
   brokers = ["localhost:9092"]
   ## Kafka topic for producer messages
   topic = "telegraf"
-  ## Kafka client id
-  ClientId string `toml:"client_id"`
+  ## kafka client id
+  client_id = "my_client"
 
   ## Optional topic suffix configuration.
   ## If the section is omitted, no suffix is used.

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -25,6 +25,8 @@ type (
 		Brokers []string
 		// Kafka topic
 		Topic string
+		// Kafka client id
+		ClientId string `toml:"client_id"`
 		// Kafka topic suffix option
 		TopicSuffix TopicSuffix `toml:"topic_suffix"`
 		// Routing Key Tag
@@ -68,6 +70,8 @@ var sampleConfig = `
   brokers = ["localhost:9092"]
   ## Kafka topic for producer messages
   topic = "telegraf"
+  ## Kafka client id
+  client_id = "my_client"
 
   ## Optional topic suffix configuration.
   ## If the section is omitted, no suffix is used.
@@ -185,6 +189,10 @@ func (k *Kafka) Connect() error {
 		return err
 	}
 	config := sarama.NewConfig()
+
+	if k.ClientId != "" {
+		config.ClientID = k.ClientId
+	}
 
 	config.Producer.RequiredAcks = sarama.RequiredAcks(k.RequiredAcks)
 	config.Producer.Compression = sarama.CompressionCodec(k.CompressionCodec)

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -70,8 +70,9 @@ var sampleConfig = `
   brokers = ["localhost:9092"]
   ## Kafka topic for producer messages
   topic = "telegraf"
-  ## Kafka client id
-  client_id = "my_client"
+  
+  ## Optional Client id
+  # client_id = "my_client"
 
   ## Optional topic suffix configuration.
   ## If the section is omitted, no suffix is used.

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -26,7 +26,7 @@ type (
 		// Kafka topic
 		Topic string
 		// Kafka client id
-		ClientId string `toml:"client_id"`
+		ClientID string `toml:"client_id"`
 		// Kafka topic suffix option
 		TopicSuffix TopicSuffix `toml:"topic_suffix"`
 		// Routing Key Tag
@@ -72,7 +72,7 @@ var sampleConfig = `
   topic = "telegraf"
   
   ## Optional Client id
-  # client_id = "my_client"
+  # client_id = "Telegraf"
 
   ## Optional topic suffix configuration.
   ## If the section is omitted, no suffix is used.
@@ -191,8 +191,10 @@ func (k *Kafka) Connect() error {
 	}
 	config := sarama.NewConfig()
 
-	if k.ClientId != "" {
-		config.ClientID = k.ClientId
+	if k.ClientID != "" {
+		config.ClientID = k.ClientID
+	} else {
+		config.ClientID = "Telegraf"
 	}
 
 	config.Producer.RequiredAcks = sarama.RequiredAcks(k.RequiredAcks)


### PR DESCRIPTION
The team running the Kafka I was using required that I set the client id for reads and writes.  For reference, the default client id is "sarama"

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

I ran "make lint" and "make test", the latter showed failures for unrelated files. (outputs/socket_writer, outputs/influxdb, inputs/syslog, inputs/socket_listener, inputs/ping, inputs/http_response, inputs/fluentd)
