### PR TITLE
Add an exec daemon plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ For documentation on the latest development code see the [documentation index][d
 * [elasticsearch](./plugins/inputs/elasticsearch)
 * [ethtool](./plugins/inputs/ethtool)
 * [exec](./plugins/inputs/exec) (generic executable plugin, support JSON, influx, graphite and nagios)
+* [execd](./plugins/inputs/execd)
 * [fail2ban](./plugins/inputs/fail2ban)
 * [fibaro](./plugins/inputs/fibaro)
 * [file](./plugins/inputs/file)

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/elasticsearch"
 	_ "github.com/influxdata/telegraf/plugins/inputs/ethtool"
 	_ "github.com/influxdata/telegraf/plugins/inputs/exec"
+	_ "github.com/influxdata/telegraf/plugins/inputs/execd"
 	_ "github.com/influxdata/telegraf/plugins/inputs/fail2ban"
 	_ "github.com/influxdata/telegraf/plugins/inputs/fibaro"
 	_ "github.com/influxdata/telegraf/plugins/inputs/file"

--- a/plugins/inputs/execd/README.md
+++ b/plugins/inputs/execd/README.md
@@ -10,7 +10,7 @@ Program output on standard error is mirrored to the telegraf log.
 
 ```toml
   ## Program to run as daemon
-  command = "telegraf-smartctl"
+  command = ["telegraf-smartctl", "-d", "/dev/sda"]
 
   ## Define how the process is signaled on each collection interval.
 
@@ -47,7 +47,7 @@ done
 
 ```toml
 [[inputs.execd]]
-  command = "plugins/inputs/execd/examples/count.sh"
+  command = ["plugins/inputs/execd/examples/count.sh"]
   signal = "STDIN"
 ```
 
@@ -81,7 +81,7 @@ func main() {
 
 ```toml
 [[inputs.execd]]
-  command = "plugins/inputs/execd/examples/count.go.exe"
+  command = ["plugins/inputs/execd/examples/count.go.exe"]
   signal = "SIGHUP"
 ```
 
@@ -103,6 +103,6 @@ end
 
 ```toml
 [[inputs.execd]]
-  command = "plugins/inputs/execd/examples/count.rb"
+  command = ["plugins/inputs/execd/examples/count.rb"]
   signal = "none"
 ```

--- a/plugins/inputs/execd/README.md
+++ b/plugins/inputs/execd/README.md
@@ -1,0 +1,108 @@
+# Execd Input Plugin
+
+The `execd` plugin runs an external program as a daemon. The programs must output metrics in any one of the accepted [Input Data Formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md) on its standard output.
+
+The `signal` can be configured to send a signal the running daemon on each collection interval.
+
+Program output on standard error is mirrored to the telegraf log.
+
+### Configuration:
+
+```toml
+  ## Program to run as daemon
+  command = "telegraf-smartctl"
+
+  ## Define how the process is signaled on each collection interval.
+
+  ## Valid values are:
+  ##   "none"    : Do not signal anything.
+  ##              The process must output metrics by itself.
+  ##   "STDIN"   : Send a newline on STDIN.
+  ##   "SIGHUP"  : Send a HUP signal. Not available on Windows.
+  ##   "SIGUSR1" : Send a USR1 signal. Not available on Windows.
+  ##   "SIGUSR2" : Send a USR2 signal. Not available on Windows.
+  signal = "none"
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"
+```
+
+### Example
+
+##### Daemon written in bash using STDIN signaling
+
+```bash
+#!/bin/bash
+
+counter=0
+
+while IFS= read -r LINE; do
+    echo "counter_bash count=${counter}"
+    let counter=counter+1
+done
+```
+
+```toml
+[[inputs.execd]]
+  command = "plugins/inputs/execd/examples/count.sh"
+  signal = "STDIN"
+```
+
+##### Go daemon using SIGHUP
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+    "os/signal"
+    "syscall"
+)
+
+func main() {
+    c := make(chan os.Signal, 1)
+    signal.Notify(c, syscall.SIGHUP)
+
+    counter := 0
+
+    for {
+        <-c
+
+        fmt.Printf("counter_go count=%d\n", counter)
+        counter++
+    }
+}
+
+```
+
+```toml
+[[inputs.execd]]
+  command = "plugins/inputs/execd/examples/count.go.exe"
+  signal = "SIGHUP"
+```
+
+##### Ruby daemon running standalone
+
+```ruby
+#!/usr/bin/env ruby
+
+counter = 0
+
+loop do
+  puts "counter_ruby count=#{counter}"
+  STDOUT.flush
+
+  counter += 1
+  sleep 1
+end
+```
+
+```toml
+[[inputs.execd]]
+  command = "plugins/inputs/execd/examples/count.rb"
+  signal = "none"
+```

--- a/plugins/inputs/execd/README.md
+++ b/plugins/inputs/execd/README.md
@@ -23,6 +23,9 @@ Program output on standard error is mirrored to the telegraf log.
   ##   "SIGUSR2" : Send a USR2 signal. Not available on Windows.
   signal = "none"
 
+  ## Delay before the process is restarted after an unexpected termination
+  restart_delay = "10s"
+
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/inputs/execd/examples/count.go
+++ b/plugins/inputs/execd/examples/count.go
@@ -1,0 +1,24 @@
+package main
+
+// Example using HUP signaling
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGHUP)
+
+	counter := 0
+
+	for {
+		<-c
+
+		fmt.Printf("counter_go count=%d\n", counter)
+		counter++
+	}
+}

--- a/plugins/inputs/execd/examples/count.rb
+++ b/plugins/inputs/execd/examples/count.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+## Example in Ruby not using any signaling
+
+counter = 0
+
+loop do
+  puts "counter_ruby count=#{counter}"
+  STDOUT.flush
+  counter += 1
+
+  sleep 1
+end

--- a/plugins/inputs/execd/examples/count.sh
+++ b/plugins/inputs/execd/examples/count.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## Example in bash using STDIN signaling
+
+counter=0
+
+while read; do
+    echo "counter_bash count=${counter}"
+    let counter=counter+1
+done
+
+(>&2 echo "terminate")

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -158,7 +158,7 @@ func (e *Execd) cmdReadOut(out io.Reader) {
 		}
 
 		for _, metric := range metrics {
-			e.acc.AddFields(metric.Name(), metric.Fields(), metric.Tags(), metric.Time())
+			e.acc.AddMetric(metric)
 		}
 	}
 

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -159,7 +159,7 @@ func (e *Execd) cmdReadErr(out io.Reader, wg *sync.WaitGroup) {
 	scanner := bufio.NewScanner(out)
 
 	for scanner.Scan() {
-		log.Printf("E! [inputs.execd] stderr output: %s", scanner.Text())
+		log.Printf("E! [inputs.execd] stderr output: %q", scanner.Text())
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -1,0 +1,176 @@
+package execd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/kballard/go-shellquote"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/parsers"
+)
+
+const sampleConfig = `
+  ## Program to run as daemon
+  command = "telegraf-smartctl"
+
+  ## Define how the process is signaled on each collection interval.
+
+  ## Valid values are:
+  ##   "none"   : Do not signal anything.
+  ##              The process must output metrics by itself.
+  ##   "STDIN"  : Send a newline on STDIN.
+  ##   "SIGHUP" : Send a HUP signal. Not available on Windows.
+  signal = "none"
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"
+`
+
+type Execd struct {
+	Command string
+	Signal  string
+
+	acc    telegraf.Accumulator
+	cmd    *exec.Cmd
+	parser parsers.Parser
+	stdin  io.WriteCloser
+}
+
+func (e *Execd) SampleConfig() string {
+	return sampleConfig
+}
+
+func (e *Execd) Description() string {
+	return "Run executable as long-running input plugin"
+}
+
+func (e *Execd) SetParser(parser parsers.Parser) {
+	e.parser = parser
+}
+
+func (e *Execd) Start(acc telegraf.Accumulator) error {
+	e.acc = acc
+
+	args, err := shellquote.Split(e.Command)
+	if err != nil || len(args) == 0 {
+		return fmt.Errorf("execd: unable to parse command: %s", err)
+	}
+
+	go e.cmdRun(args)
+
+	return nil
+}
+
+func (e *Execd) Stop() {
+	if e.cmd == nil || e.cmd.Process == nil {
+		return
+	}
+
+	if err := e.cmd.Process.Kill(); err != nil {
+		log.Printf("E! FATAL error killing process: %s", err)
+	}
+}
+
+func (e *Execd) cmdRun(args []string) error {
+	var wg sync.WaitGroup
+
+	if len(args) > 1 {
+		e.cmd = exec.Command(args[0], args[1:]...)
+	} else {
+		e.cmd = exec.Command(args[0])
+	}
+
+	stdin, err := e.cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("execd: error opening stdin pipe: %s", err)
+	}
+
+	e.stdin = stdin
+
+	stdout, err := e.cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("execd: error opening stdout pipe: %s", err)
+	}
+
+	stderr, err := e.cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("execd: error opening stderr pipe: %s", err)
+	}
+
+	log.Printf("D! execd start program: %s", e.Command)
+
+	err = e.cmd.Start()
+	if err != nil {
+		return fmt.Errorf("execd error starting program: %s", err)
+	}
+
+	wg.Add(2)
+
+	go e.cmdReadOut(stdout, &wg)
+	go e.cmdReadErr(stderr, &wg)
+
+	wg.Wait()
+	e.cmd.Wait()
+
+	log.Printf("E! execd: %s terminated. Restart in one second...", e.Command)
+
+	go func() {
+		<-time.After(time.Second)
+		e.cmdRun(args)
+	}()
+
+	return nil
+}
+
+func (e *Execd) cmdReadOut(out io.Reader, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	scanner := bufio.NewScanner(out)
+
+	for scanner.Scan() {
+		metrics, err := e.parser.Parse(scanner.Bytes())
+		if err != nil {
+			e.acc.AddError(fmt.Errorf("parse error: %s", err.Error()))
+		}
+
+		for _, metric := range metrics {
+			e.acc.AddFields(metric.Name(), metric.Fields(), metric.Tags(), metric.Time())
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		e.acc.AddError(fmt.Errorf("Error reading stdout: %s", err.Error()))
+	}
+}
+
+func (e *Execd) cmdReadErr(out io.Reader, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	scanner := bufio.NewScanner(out)
+
+	for scanner.Scan() {
+		log.Printf("E! execd stderr output: %s", scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		e.acc.AddError(fmt.Errorf("Error reading stderr: %s", err.Error()))
+	}
+}
+
+func init() {
+	inputs.Add("execd", func() telegraf.Input {
+		return &Execd{
+			Signal: "none",
+		}
+	})
+}

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -63,7 +63,7 @@ func (e *Execd) Start(acc telegraf.Accumulator) error {
 
 	args, err := shellquote.Split(e.Command)
 	if err != nil || len(args) == 0 {
-		return fmt.Errorf("execd: unable to parse command: %s", err)
+		return fmt.Errorf("unable to parse command: %s", err)
 	}
 
 	go e.cmdRun(args)
@@ -92,26 +92,26 @@ func (e *Execd) cmdRun(args []string) error {
 
 	stdin, err := e.cmd.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("execd: error opening stdin pipe: %s", err)
+		return fmt.Errorf("error opening stdin pipe: %s", err)
 	}
 
 	e.stdin = stdin
 
 	stdout, err := e.cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("execd: error opening stdout pipe: %s", err)
+		return fmt.Errorf("error opening stdout pipe: %s", err)
 	}
 
 	stderr, err := e.cmd.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("execd: error opening stderr pipe: %s", err)
+		return fmt.Errorf("error opening stderr pipe: %s", err)
 	}
 
 	log.Printf("D! execd start program: %s", e.Command)
 
 	err = e.cmd.Start()
 	if err != nil {
-		return fmt.Errorf("execd error starting program: %s", err)
+		return fmt.Errorf("error starting program: %s", err)
 	}
 
 	wg.Add(2)

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -61,9 +61,9 @@ func (e *Execd) Start(acc telegraf.Accumulator) error {
 	e.acc = acc
 
 	if len(e.Command) == 0 {
-		return fmt.Errorf("E! [input.execd] FATAL no command specified")
 	} else {
 		go e.cmdRun()
+		return fmt.Errorf("E! [inputs.execd] FATAL no command specified")
 	}
 
 	return nil
@@ -92,26 +92,26 @@ func (e *Execd) cmdRun() error {
 
 	stdin, err := e.cmd.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("error opening stdin pipe: %s", err)
+		return fmt.Errorf("E! [inputs.execd] Error opening stdin pipe: %s", err)
 	}
 
 	e.stdin = stdin
 
 	stdout, err := e.cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("error opening stdout pipe: %s", err)
+		return fmt.Errorf("E! [inputs.execd] Error opening stdout pipe: %s", err)
 	}
 
 	stderr, err := e.cmd.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("error opening stderr pipe: %s", err)
+		return fmt.Errorf("E! [inputs.execd] Error opening stderr pipe: %s", err)
 	}
 
-	log.Printf("D! [inputs.execd] Start program: %s", e.Command)
+	log.Printf("D! [inputs.execd] Starting process: %s", e.Command)
 
 	err = e.cmd.Start()
 	if err != nil {
-		return fmt.Errorf("error starting program: %s", err)
+		return fmt.Errorf("E! [inputs.execd] Error starting process: %s", err)
 	}
 
 	wg.Add(2)
@@ -149,7 +149,7 @@ func (e *Execd) cmdReadOut(out io.Reader) {
 	for scanner.Scan() {
 		metrics, err := e.parser.Parse(scanner.Bytes())
 		if err != nil {
-			e.acc.AddError(fmt.Errorf("parse error: %s", err.Error()))
+			e.acc.AddError(fmt.Errorf("E! [inputs.execd] Parse error: %s", err))
 		}
 
 		for _, metric := range metrics {
@@ -158,7 +158,7 @@ func (e *Execd) cmdReadOut(out io.Reader) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		e.acc.AddError(fmt.Errorf("Error reading stdout: %s", err.Error()))
+		e.acc.AddError(fmt.Errorf("E! [inputs.execd] Error reading stdout: %s", err))
 	}
 }
 
@@ -166,11 +166,11 @@ func (e *Execd) cmdReadErr(out io.Reader) {
 	scanner := bufio.NewScanner(out)
 
 	for scanner.Scan() {
-		log.Printf("E! [inputs.execd] stderr output: %q", scanner.Text())
+		log.Printf("E! [inputs.execd] stderr: %q", scanner.Text())
 	}
 
 	if err := scanner.Err(); err != nil {
-		e.acc.AddError(fmt.Errorf("Error reading stderr: %s", err.Error()))
+		e.acc.AddError(fmt.Errorf("E! [inputs.execd] Error reading stderr: %s", err))
 	}
 }
 

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -119,8 +119,15 @@ func (e *Execd) cmdRun(args []string) error {
 
 	wg.Add(2)
 
-	go e.cmdReadOut(stdout, &wg)
-	go e.cmdReadErr(stderr, &wg)
+	go func() {
+		e.cmdReadOut(stdout)
+		wg.Done()
+	}()
+
+	go func() {
+		e.cmdReadErr(stderr)
+		wg.Done()
+	}()
 
 	wg.Wait()
 	e.cmd.Wait()
@@ -139,9 +146,7 @@ func (e *Execd) cmdRun(args []string) error {
 	return nil
 }
 
-func (e *Execd) cmdReadOut(out io.Reader, wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (e *Execd) cmdReadOut(out io.Reader) {
 	scanner := bufio.NewScanner(out)
 
 	for scanner.Scan() {
@@ -160,9 +165,7 @@ func (e *Execd) cmdReadOut(out io.Reader, wg *sync.WaitGroup) {
 	}
 }
 
-func (e *Execd) cmdReadErr(out io.Reader, wg *sync.WaitGroup) {
-	defer wg.Done()
-
+func (e *Execd) cmdReadErr(out io.Reader) {
 	scanner := bufio.NewScanner(out)
 
 	for scanner.Scan() {

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -77,7 +77,7 @@ func (e *Execd) Stop() {
 	}
 
 	if err := e.cmd.Process.Kill(); err != nil {
-		log.Printf("E! FATAL error killing process: %s", err)
+		log.Printf("E! [inputs.execd] FATAL error killing process: %s", err)
 	}
 }
 
@@ -107,7 +107,7 @@ func (e *Execd) cmdRun(args []string) error {
 		return fmt.Errorf("error opening stderr pipe: %s", err)
 	}
 
-	log.Printf("D! execd start program: %s", e.Command)
+	log.Printf("D! [inputs.execd] Start program: %s", e.Command)
 
 	err = e.cmd.Start()
 	if err != nil {
@@ -122,7 +122,7 @@ func (e *Execd) cmdRun(args []string) error {
 	wg.Wait()
 	e.cmd.Wait()
 
-	log.Printf("E! execd: %s terminated. Restart in one second...", e.Command)
+	log.Printf("E! [inputs.execd] %s terminated. Restart in one second...", e.Command)
 
 	go func() {
 		<-time.After(time.Second)
@@ -159,7 +159,7 @@ func (e *Execd) cmdReadErr(out io.Reader, wg *sync.WaitGroup) {
 	scanner := bufio.NewScanner(out)
 
 	for scanner.Scan() {
-		log.Printf("E! execd stderr output: %s", scanner.Text())
+		log.Printf("E! [inputs.execd] stderr output: %s", scanner.Text())
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/plugins/inputs/execd/execd_unix.go
+++ b/plugins/inputs/execd/execd_unix.go
@@ -1,0 +1,33 @@
+// +build !windows
+
+package execd
+
+import (
+	"fmt"
+	"io"
+	"syscall"
+
+	"github.com/influxdata/telegraf"
+)
+
+func (e *Execd) Gather(acc telegraf.Accumulator) error {
+	if e.cmd == nil || e.cmd.Process == nil {
+		return nil
+	}
+
+	switch e.Signal {
+	case "SIGHUP":
+		e.cmd.Process.Signal(syscall.SIGHUP)
+	case "SIGUSR1":
+		e.cmd.Process.Signal(syscall.SIGUSR1)
+	case "SIGUSR2":
+		e.cmd.Process.Signal(syscall.SIGUSR2)
+	case "STDIN":
+		io.WriteString(e.stdin, "\n")
+	case "none":
+	default:
+		return fmt.Errorf("execd: invalid signal: %s", e.Signal)
+	}
+
+	return nil
+}

--- a/plugins/inputs/execd/execd_unix.go
+++ b/plugins/inputs/execd/execd_unix.go
@@ -26,7 +26,7 @@ func (e *Execd) Gather(acc telegraf.Accumulator) error {
 		io.WriteString(e.stdin, "\n")
 	case "none":
 	default:
-		return fmt.Errorf("execd: invalid signal: %s", e.Signal)
+		return fmt.Errorf("invalid signal: %s", e.Signal)
 	}
 
 	return nil

--- a/plugins/inputs/execd/execd_win.go
+++ b/plugins/inputs/execd/execd_win.go
@@ -19,7 +19,7 @@ func (e *Execd) Gather(acc telegraf.Accumulator) error {
 		io.WriteString(e.stdin, "\n")
 	case "none":
 	default:
-		return fmt.Errorf("execd: invalid signal: %s", e.Signal)
+		return fmt.Errorf("invalid signal: %s", e.Signal)
 	}
 
 	return nil

--- a/plugins/inputs/execd/execd_win.go
+++ b/plugins/inputs/execd/execd_win.go
@@ -1,0 +1,26 @@
+// +build windows
+
+package execd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/influxdata/telegraf"
+)
+
+func (e *Execd) Gather(acc telegraf.Accumulator) error {
+	if e.cmd == nil || e.cmd.Process == nil {
+		return nil
+	}
+
+	switch e.Signal {
+	case "STDIN":
+		io.WriteString(e.stdin, "\n")
+	case "none":
+	default:
+		return fmt.Errorf("execd: invalid signal: %s", e.Signal)
+	}
+
+	return nil
+}


### PR DESCRIPTION
The execd input plugin spawns a long running process and parses its output to gather metrics. The process can be signaled in different ways on each interval.

This can be used to avoid spawning processes on each interval as with the exec plugin or with external programs that report metrics by themselves e.g. in irregular intervals (events). Processes are restarted after termination with a one second pause.

The overhead is minimal for both sides as only `stdout`, `stderr`, and `stdin` or signals are used. Some example daemons in bash, go, and ruby are included.

---

This is my first time writing Go at all. Feel free to comment or change things. I only have this running on linux, but cross compilation to windows works. I have no idea how to unit test this unfortunately.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
