### PR TITLE
Return error if NewRequest fails

### DIFF
--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -127,6 +127,9 @@ func (h *HTTP) Write(metrics []telegraf.Metric) error {
 
 func (h *HTTP) write(reqBody []byte) error {
 	req, err := http.NewRequest(h.Method, h.URL, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return err
+	}
 
 	req.Header.Set("Content-Type", defaultContentType)
 	for k, v := range h.Headers {


### PR DESCRIPTION
Telegraf will panic if the `http` output's `url` was an incorrect/unparseable [format](https://golang.org/pkg/net/url/#URL). This returns the error, allowing the user to know and correct the url.

Resolves #4389 
