### PR TITLE
Add ip restriction for the prometheus_client output

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -747,6 +747,9 @@
 #   #basic_username = "Foo"
 #   #basic_password = "Bar"
 #
+#   ## IP Ranges which are allowed to access metrics
+#   #ip_range = ["192.168.0.0/24", "192.168.1.0/30"]
+#
 #   ## Interval to expire metrics and not deliver to prometheus, 0 == no expiration
 #   # expiration_interval = "60s"
 #

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -18,6 +18,9 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
   basic_username = "Foo"
   basic_password = "Bar"
 
+  # IP Ranges which are allowed to access metrics
+  ip_range = ["192.168.0.0/24", "192.168.1.0/30"]
+
   # Path to publish the metrics on, defaults to /metrics
   path = "/metrics"   
 


### PR DESCRIPTION
Sometimes you want to protect the exported /metrics path from the prometheus_client.
It was already possible to secure it with a password.

This patch adds the option to allow only defined CIDR ranges to access the /metrics.