### PR TITLE
inheritance of environment variables for the exec plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Release Notes
 
+- With the addition of the standalone `grok` input data format, the
+  `logparser` input plugin has been deprecated in favor of using the `tail`
+  input plugin combined with `data_format="grok"` .
+
 ### New Inputs
 
 - [file](./plugins/inputs/file/README.md) - Contributed by @maxunt

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -97,6 +98,7 @@ func (c CommandRunner) Run(
 	}
 
 	cmd := exec.Command(split_cmd[0], split_cmd[1:]...)
+	cmd.Env = os.Environ()
 
 	var (
 		out    bytes.Buffer


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

I think it would be very useful for the processes spawned by the exec plugin to to ihnerit the environment variables. It is very common to use them to pass informations about the state of the application and/or the environment itself. It is the used way in Kubernetes and Mesos/Marathon for example.