### PR TITLE
Add dev telegraf.conf for input pluigns

### DIFF
--- a/plugins/inputs/docker/dev/telegraf.conf
+++ b/plugins/inputs/docker/dev/telegraf.conf
@@ -1,0 +1,13 @@
+[agent]
+  interval="1s"
+  flush_interval="1s"
+
+[[inputs.docker]]
+  endpoint = "unix:///var/run/docker.sock"
+  timeout = "5s"
+  perdevice = true
+  total = false
+  container_names = []
+
+[[outputs.file]]
+  files = ["stdout"]

--- a/plugins/inputs/exec/dev/telegraf.conf
+++ b/plugins/inputs/exec/dev/telegraf.conf
@@ -1,0 +1,26 @@
+[agent]
+  interval="1s"
+  flush_interval="1s"
+
+[[inputs.exec]]
+  timeout = "1s"
+  data_format = "influx"
+  commands = [
+    "echo 'deal,computer_name=hosta message=\"stuff\" 1530654676316265790'",
+    "echo 'deal,computer_name=hostb message=\"stuff\" 1530654676316265790'",
+  ]
+
+[[processors.regex]]
+  [[processors.regex.tags]]
+    key = "computer_name"
+    pattern = "^(.*?)a$"
+    replacement = "${1}"
+    result_key = "server_name"
+  [[processors.regex.tags]]
+    key = "computer_name"
+    pattern = "^(.*?)b$"
+    replacement = "${1}"
+    result_key = "server_name"
+
+[[outputs.file]]
+  files = ["stdout"]

--- a/plugins/inputs/procstat/dev/telegraf.conf
+++ b/plugins/inputs/procstat/dev/telegraf.conf
@@ -1,0 +1,9 @@
+[agent]
+  interval="1s"
+  flush_interval="1s"
+
+[[inputs.procstat]]
+  exe = "telegraf"
+
+[[outputs.file]]
+  files = ["stdout"]


### PR DESCRIPTION
Add at least a `dev/telegraf.conf` file for input plugins:
 - [x] docker
 - [x] exec
 - [x] procstat
 - [ ] syslog
 - [ ] wireless

Refers to #4367