### PR TITLE
Add more counter for "memory manager" object.

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -450,6 +450,12 @@ WHERE	(
 			'Buffer cache hit ratio',
 			'Buffer cache hit ratio base',
 			'Backup/Restore Throughput/sec',
+			'Connection_Memory_(KB)',
+                        'Database_Cache_Memory_(KB)',
+                        'Lock_Memory_(KB)',
+                        'Optimizer_Memory_(KB)',
+                        'SQL_Cache_Memory_(KB)',
+                        'Log_Pool_Memory_(KB)',
 			'Total Server Memory (KB)',
 			'Target Server Memory (KB)'
 		)

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -464,6 +464,9 @@ WHERE	(
 			AND counter_name IN (
 				'Log Flushes/sec',
 				'Log Flush Wait Time',
+				'Log Pool Requests/sec',                                                                                                           
+                                'Log Pool Cache Misses/sec',                                                                                                       
+                                'Log Pool Disk Reads/sec'    
 				'Lock Timeouts/sec',
 				'Number of Deadlocks/sec',
 				'Lock Waits/sec',


### PR DESCRIPTION
Add follow counter for sql server memory monitoring.
	                'Connection_Memory_(KB)',
                        'Database_Cache_Memory_(KB)',
                        'Lock_Memory_(KB)',
                        'Optimizer_Memory_(KB)',
                        'SQL_Cache_Memory_(KB)',
                        'Log_Pool_Memory_(KB)',

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
