### PR TITLE
Add IPSIpAddress syntax to ipaddr conversion in snmp plugin

### DIFF
--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -1010,7 +1010,7 @@ func snmpTranslateCall(oid string) (mibName string, oidNum string, oidText strin
 			switch tc {
 			case "MacAddress", "PhysAddress":
 				conversion = "hwaddr"
-			case "InetAddressIPv4", "InetAddressIPv6", "InetAddress":
+			case "InetAddressIPv4", "InetAddressIPv6", "InetAddress", "IPSIpAddress":
 				conversion = "ipaddr"
 			}
 		} else if strings.HasPrefix(line, "::= { ") {


### PR DESCRIPTION
As used in Cisco VPN's, eg: http://oidref.com/1.3.6.1.4.1.9.9.171.1.3.2.1.4

The relevant fields are of course garbled without this.

### Required for all PRs:

- [ X ] Signed [CLA](https://influxdata.com/community/cla/).
- [ U ] Associated README.md updated.
- [ U ] Has appropriate unit tests.
