### PR TITLE
Preserve metric type when using filters in output plugins

### DIFF
--- a/internal/models/running_output.go
+++ b/internal/models/running_output.go
@@ -105,12 +105,13 @@ func (ro *RunningOutput) AddMetric(m telegraf.Metric) {
 		tags := m.Tags()
 		fields := m.Fields()
 		t := m.Time()
+		tp := m.Type()
 		if ok := ro.Config.Filter.Apply(name, fields, tags); !ok {
 			ro.MetricsFiltered.Incr(1)
 			return
 		}
 		// error is not possible if creating from another metric, so ignore.
-		m, _ = metric.New(name, tags, fields, t)
+		m, _ = metric.New(name, tags, fields, t, tp)
 	}
 
 	ro.metrics.Add(m)


### PR DESCRIPTION
Resolves #4501

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

### Steps to reproduce:

Using telegraf 1.7.2 with the following config to export kube-scheduler metrics:
```
[[outputs.prometheus_client]]
  listen = "0.0.0.0:9273"
  expiration_interval = "60s"
  [outputs.prometheus_client.tagpass]
    _OUTPUT = ["prometheus"]

[[inputs.prometheus]]
  urls = ["http://127.0.0.1:10251/metrics"]
  [inputs.prometheus.tags]
    _OUTPUT = "prometheus"
```

Histograms in http://127.0.0.1:9273/metrics look like:
```
...
# HELP scheduler_scheduling_algorithm_latency_microseconds_16000 Telegraf collected metric
# TYPE scheduler_scheduling_algorithm_latency_microseconds_16000 untyped
scheduler_scheduling_algorithm_latency_microseconds_16000{_OUTPUT="prometheus",host="xxx",url="http://127.0.0.1:10251/metrics"} 0
# HELP scheduler_scheduling_algorithm_latency_microseconds_1_024e_06 Telegraf collected metric
# TYPE scheduler_scheduling_algorithm_latency_microseconds_1_024e_06 untyped
scheduler_scheduling_algorithm_latency_microseconds_1_024e_06{_OUTPUT="prometheus",host="xxx",url="http://127.0.0.1:10251/metrics"} 0
...
```

With the tagpass filter removed from `outputs.prometheus_client`, the output preserved the metric type:
```
...
# HELP scheduler_scheduling_algorithm_latency_microseconds Telegraf collected metric
# TYPE scheduler_scheduling_algorithm_latency_microseconds histogram
...
scheduler_scheduling_algorithm_latency_microseconds_bucket{_OUTPUT="prometheus",host="xxx",url="http://127.0.0.1:10251/metrics",le="16000"} 0
scheduler_scheduling_algorithm_latency_microseconds_bucket{_OUTPUT="prometheus",host="xxx",url="http://127.0.0.1:10251/metrics",le="1.024e+06"} 0
...
```

### Fix

The fix is simple, just pass the metric type when recreating the filtered metric in `RunningOutput`.
I tried to add a test for it but it seems `testutil.TestMetric` needs to updated to support metric type first, which seems too big to be included in this commit.