### PR TITLE
Adding the x509_cert plugin into the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [file](./plugins/inputs/file/README.md) - Contributed by @maxunt
 - [tengine](./plugins/inputs/tengine/README.md) - Contributed by @ertaoxu
+- [x509_cert](./plugins/inputs/x509_cert/README.md) - Contributed by @jtyr
 
 ### New Processors
 


### PR DESCRIPTION
### Required for all PRs:

Just adding the `x509_cert` into the changelog.

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
