### PR TITLE
Keep leading whitespace for messages in syslog input

### DIFF
--- a/plugins/inputs/syslog/README.md
+++ b/plugins/inputs/syslog/README.md
@@ -33,9 +33,9 @@ Syslog messages should be formatted according to
   ## Only applies to stream sockets (e.g. TCP).
   # max_connections = 1024
 
-  ## Read timeout (default = 500ms).
+  ## Read timeout is the maximum time allowed for reading a single message (default = 5s).
   ## 0 means unlimited.
-  # read_timeout = 500ms
+  # read_timeout = "5s"
 
   ## Whether to parse in best effort mode or not (default = false).
   ## By default best effort parsing is off.

--- a/plugins/inputs/syslog/rfc5426_test.go
+++ b/plugins/inputs/syslog/rfc5426_test.go
@@ -202,6 +202,38 @@ func getTestCasesForRFC5426() []testCase5426 {
 			},
 			werr: true,
 		},
+		{
+			name: "trim message",
+			data: []byte("<1>1 - - - - - - \tA\n"),
+			wantBestEffort: &testutil.Metric{
+				Measurement: "syslog",
+				Fields: map[string]interface{}{
+					"version":       uint16(1),
+					"message":       "\tA",
+					"facility_code": 0,
+					"severity_code": 1,
+				},
+				Tags: map[string]string{
+					"severity": "alert",
+					"facility": "kern",
+				},
+				Time: defaultTime,
+			},
+			wantStrict: &testutil.Metric{
+				Measurement: "syslog",
+				Fields: map[string]interface{}{
+					"version":       uint16(1),
+					"message":       "\tA",
+					"facility_code": 0,
+					"severity_code": 1,
+				},
+				Tags: map[string]string{
+					"severity": "alert",
+					"facility": "kern",
+				},
+				Time: defaultTime,
+			},
+		},
 	}
 
 	return testCases

--- a/plugins/inputs/syslog/syslog.go
+++ b/plugins/inputs/syslog/syslog.go
@@ -71,9 +71,9 @@ var sampleConfig = `
   ## Only applies to stream sockets (e.g. TCP).
   # max_connections = 1024
 
-  ## Read timeout (default = 500ms).
+  ## Read timeout is the maximum time allowed for reading a single message (default = 5s).
   ## 0 means unlimited.
-  # read_timeout = 500ms
+  # read_timeout = "5s"
 
   ## Whether to parse in best effort mode or not (default = false).
   ## By default best effort parsing is off.

--- a/plugins/inputs/syslog/syslog.go
+++ b/plugins/inputs/syslog/syslog.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/influxdata/go-syslog/rfc5424"
 	"github.com/influxdata/go-syslog/rfc5425"
@@ -365,7 +366,9 @@ func fields(msg rfc5424.SyslogMessage, s *Syslog) map[string]interface{} {
 	}
 
 	if msg.Message() != nil {
-		flds["message"] = strings.TrimSpace(*msg.Message())
+		flds["message"] = strings.TrimRightFunc(*msg.Message(), func(r rune) bool {
+			return unicode.IsSpace(r)
+		})
 	}
 
 	if msg.StructuredData() != nil {


### PR DESCRIPTION
Preserve leading whitespace commonly used for indention when logging stack traces.

Also fixed the documentation for the default read timeout.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
