### PR TITLE
Lock buffer when adding metrics

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -40,18 +40,18 @@ func (b *Buffer) Len() int {
 
 // Add adds metrics to the buffer.
 func (b *Buffer) Add(metrics ...telegraf.Metric) {
+	b.mu.Lock()
 	for i, _ := range metrics {
 		MetricsWritten.Incr(1)
 		select {
 		case b.buf <- metrics[i]:
 		default:
-			b.mu.Lock()
 			MetricsDropped.Incr(1)
 			<-b.buf
 			b.buf <- metrics[i]
-			b.mu.Unlock()
 		}
 	}
+	b.mu.Unlock()
 }
 
 // Batch returns a batch of metrics of size batchSize.


### PR DESCRIPTION
This function is not thread-safe but is currently used by multiple goroutines in RunningOutput

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
