### PR TITLE
Set version to unknown if not set

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -58,21 +58,10 @@ var fService = flag.String("service", "",
 var fRunAsConsole = flag.Bool("console", false, "run as console application (windows only)")
 
 var (
-	nextVersion = "1.8.0"
-	version     string
-	commit      string
-	branch      string
+	version string
+	commit  string
+	branch  string
 )
-
-func init() {
-	// If commit or branch are not set, make that clear.
-	if commit == "" {
-		commit = "unknown"
-	}
-	if branch == "" {
-		branch = "unknown"
-	}
-}
 
 var stop chan struct{}
 
@@ -165,7 +154,7 @@ func reloadLoop(
 			}
 		}()
 
-		log.Printf("I! Starting Telegraf %s\n", displayVersion())
+		log.Printf("I! Starting Telegraf %s\n", version)
 		log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))
 		log.Printf("I! Loaded aggregators: %s", strings.Join(c.AggregatorNames(), " "))
 		log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))
@@ -225,11 +214,27 @@ func (p *program) Stop(s service.Service) error {
 	return nil
 }
 
-func displayVersion() string {
-	if version == "" {
-		return fmt.Sprintf("v%s~%s", nextVersion, commit)
+func formatFullVersion() string {
+	var parts = []string{"Telegraf"}
+
+	if version != "" {
+		parts = append(parts, version)
+	} else {
+		parts = append(parts, "unknown")
 	}
-	return "v" + version
+
+	if branch != "" || commit != "" {
+		if branch == "" {
+			branch = "unknown"
+		}
+		if commit == "" {
+			commit = "unknown"
+		}
+		git := fmt.Sprintf("(git: %s %s)", branch, commit)
+		parts = append(parts, git)
+	}
+
+	return strings.Join(parts, " ")
 }
 
 func main() {
@@ -273,7 +278,7 @@ func main() {
 	if len(args) > 0 {
 		switch args[0] {
 		case "version":
-			fmt.Printf("Telegraf %s (git: %s %s)\n", displayVersion(), branch, commit)
+			fmt.Println(formatFullVersion())
 			return
 		case "config":
 			config.PrintSampleConfig(
@@ -301,7 +306,7 @@ func main() {
 		}
 		return
 	case *fVersion:
-		fmt.Printf("Telegraf %s (git: %s %s)\n", displayVersion(), branch, commit)
+		fmt.Println(formatFullVersion())
 		return
 	case *fSampleConfig:
 		config.PrintSampleConfig(


### PR DESCRIPTION
Prevents setting the branch version to the last major release, and as a bonus we no longer need to set this variable on release:
```
$ go build -ldflags "-X main.version=1.8.0 -X main.commit=fa08656a -X main.branch=default-version" ./cmd/telegraf
$ ./telegraf version
Telegraf 1.8.0 (git: default-version fa08656a)
```
```
$ go build -ldflags " -X main.commit=fa08656a -X main.branch=default-version" ./cmd/telegraf
$ ./telegraf version
Telegraf unknown (git: default-version fa08656a)
```
```
$ go build ./cmd/telegraf
$ ./telegraf version
Telegraf unknown
```

closes #4516 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
