### PR TITLE
plugins/inputs/procstat: add memory_pss on Linux

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -148,7 +148,7 @@
 
 [[constraint]]
   name = "github.com/shirou/gopsutil"
-  version = "2.18.05"
+  version = "2.18.07"
 
 [[constraint]]
   name = "github.com/Shopify/sarama"

--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -92,6 +92,7 @@ implemented as a WMI query.  The pattern allows fuzzy matching using only
     - involuntary_context_switches (int)
     - memory_data (int)
     - memory_locked (int)
+    - memory_pss (int)
     - memory_rss (int)
     - memory_stack (int)
     - memory_swap (int)

--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -4,25 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/process"
 )
-
-type Process interface {
-	PID() PID
-	Tags() map[string]string
-
-	IOCounters() (*process.IOCountersStat, error)
-	MemoryInfo() (*process.MemoryInfoStat, error)
-	Name() (string, error)
-	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)
-	NumFDs() (int32, error)
-	NumThreads() (int32, error)
-	Percent(interval time.Duration) (float64, error)
-	Times() (*cpu.TimesStat, error)
-	RlimitUsage(bool) ([]process.RlimitStat, error)
-	Username() (string, error)
-}
 
 type PIDFinder interface {
 	PidFile(path string) ([]PID, error)

--- a/plugins/inputs/procstat/process_darwin.go
+++ b/plugins/inputs/procstat/process_darwin.go
@@ -1,0 +1,24 @@
+package procstat
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/process"
+)
+
+type Process interface {
+	PID() PID
+	Tags() map[string]string
+
+	IOCounters() (*process.IOCountersStat, error)
+	MemoryInfo() (*process.MemoryInfoStat, error)
+	Name() (string, error)
+	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)
+	NumFDs() (int32, error)
+	NumThreads() (int32, error)
+	Percent(interval time.Duration) (float64, error)
+	Times() (*cpu.TimesStat, error)
+	RlimitUsage(bool) ([]process.RlimitStat, error)
+	Username() (string, error)
+}

--- a/plugins/inputs/procstat/process_freebsd.go
+++ b/plugins/inputs/procstat/process_freebsd.go
@@ -1,0 +1,24 @@
+package procstat
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/process"
+)
+
+type Process interface {
+	PID() PID
+	Tags() map[string]string
+
+	IOCounters() (*process.IOCountersStat, error)
+	MemoryInfo() (*process.MemoryInfoStat, error)
+	Name() (string, error)
+	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)
+	NumFDs() (int32, error)
+	NumThreads() (int32, error)
+	Percent(interval time.Duration) (float64, error)
+	Times() (*cpu.TimesStat, error)
+	RlimitUsage(bool) ([]process.RlimitStat, error)
+	Username() (string, error)
+}

--- a/plugins/inputs/procstat/process_linux.go
+++ b/plugins/inputs/procstat/process_linux.go
@@ -1,0 +1,25 @@
+package procstat
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/process"
+)
+
+type Process interface {
+	PID() PID
+	Tags() map[string]string
+
+	IOCounters() (*process.IOCountersStat, error)
+	MemoryInfo() (*process.MemoryInfoStat, error)
+	MemoryMaps(bool) (*[]process.MemoryMapsStat, error)
+	Name() (string, error)
+	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)
+	NumFDs() (int32, error)
+	NumThreads() (int32, error)
+	Percent(interval time.Duration) (float64, error)
+	Times() (*cpu.TimesStat, error)
+	RlimitUsage(bool) ([]process.RlimitStat, error)
+	Username() (string, error)
+}

--- a/plugins/inputs/procstat/process_windows.go
+++ b/plugins/inputs/procstat/process_windows.go
@@ -1,0 +1,24 @@
+package procstat
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/process"
+)
+
+type Process interface {
+	PID() PID
+	Tags() map[string]string
+
+	IOCounters() (*process.IOCountersStat, error)
+	MemoryInfo() (*process.MemoryInfoStat, error)
+	Name() (string, error)
+	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)
+	NumFDs() (int32, error)
+	NumThreads() (int32, error)
+	Percent(interval time.Duration) (float64, error)
+	Times() (*cpu.TimesStat, error)
+	RlimitUsage(bool) ([]process.RlimitStat, error)
+	Username() (string, error)
+}

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -115,7 +115,7 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 func (p *Procstat) addMetrics(proc Process, acc telegraf.Accumulator) {
 	var prefix string
 	if p.Prefix != "" {
-		p.Prefix += "_"
+		prefix = p.Prefix + "_"
 	}
 
 	//If process_name tag is not already set, set to actual name

--- a/plugins/inputs/procstat/procstat_darwin.go
+++ b/plugins/inputs/procstat/procstat_darwin.go
@@ -1,0 +1,9 @@
+package procstat
+
+// Add Linux metrics into fields map
+func (p *Procstat) getOSMetrics(proc Process, prefix string) map[string]interface{} {
+
+	fields := map[string]interface{}{}
+
+	return fields
+}

--- a/plugins/inputs/procstat/procstat_darwin.go
+++ b/plugins/inputs/procstat/procstat_darwin.go
@@ -1,6 +1,6 @@
 package procstat
 
-// Add Linux metrics into fields map
+// Add Darwin-specific metrics into fields map
 func (p *Procstat) getOSMetrics(proc Process, prefix string) map[string]interface{} {
 
 	fields := map[string]interface{}{}

--- a/plugins/inputs/procstat/procstat_freebsd.go
+++ b/plugins/inputs/procstat/procstat_freebsd.go
@@ -1,6 +1,6 @@
 package procstat
 
-// Add Windows-specific metrics into fields map
+// Add FreeBSD-specific metrics into fields map
 func (p *Procstat) getOSMetrics(proc Process, prefix string) map[string]interface{} {
 
 	fields := map[string]interface{}{}

--- a/plugins/inputs/procstat/procstat_linux.go
+++ b/plugins/inputs/procstat/procstat_linux.go
@@ -1,0 +1,19 @@
+package procstat
+
+// Add Linux-specific metrics into fields map
+func (p *Procstat) getOSMetrics(proc Process, prefix string) map[string]interface{} {
+
+	fields := map[string]interface{}{}
+
+	mmaps, err := proc.MemoryMaps(false)
+	if err == nil {
+		memory_pss := 0
+		for _, mmap := range *mmaps {
+			// pss is returned in kbytes
+			memory_pss += int(mmap.Pss * 1024)
+		}
+		fields[prefix+"memory_pss"] = memory_pss
+	}
+
+	return fields
+}

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -120,6 +120,10 @@ func (p *testProc) MemoryInfo() (*process.MemoryInfoStat, error) {
 	return &process.MemoryInfoStat{}, nil
 }
 
+func (p *testProc) MemoryMaps() (*process.MemoryMapsStat, error) {
+	return &process.MemoryMapsStat{}, nil
+}
+
 func (p *testProc) Name() (string, error) {
 	return "test_proc", nil
 }

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -120,8 +120,8 @@ func (p *testProc) MemoryInfo() (*process.MemoryInfoStat, error) {
 	return &process.MemoryInfoStat{}, nil
 }
 
-func (p *testProc) MemoryMaps() (*process.MemoryMapsStat, error) {
-	return &process.MemoryMapsStat{}, nil
+func (p *testProc) MemoryMaps(bool) (*[]process.MemoryMapsStat, error) {
+	return &[]process.MemoryMapsStat{}, nil
 }
 
 func (p *testProc) Name() (string, error) {

--- a/plugins/inputs/procstat/procstat_windows.go
+++ b/plugins/inputs/procstat/procstat_windows.go
@@ -1,0 +1,9 @@
+package procstat
+
+// Add Linux metrics into fields map
+func (p *Procstat) getOSMetrics(proc Process, prefix string) map[string]interface{} {
+
+	fields := map[string]interface{}{}
+
+	return fields
+}


### PR DESCRIPTION
### Background
PSS (proportional set size) is a great metric for measuring memory consumption of multi-process applications. Whereas RSS includes the total amount of memory used by shared libraries, PSS will only show a proportional amount divided by all processes using this library.
Thus, RSS of a multi-process application is the sum of the PSS metrics of all its processes.

### MR Content
- refactor procstat to support OS-specific metrics
- add pss as a Linux-specific metric to procstat
- update `procstat/README.md` correspondingly
- bump `gopsutil` version in `Gopkg.toml`

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
