### PR TITLE
Continue with batch if a metric is unserializable in InfluxDB UDP output

### DIFF
--- a/plugins/outputs/influxdb/udp_test.go
+++ b/plugins/outputs/influxdb/udp_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"net/url"
 	"sync"
@@ -13,7 +14,6 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/outputs/influxdb"
-	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,19 +63,6 @@ type MockDialer struct {
 
 func (d *MockDialer) DialContext(ctx context.Context, network string, address string) (influxdb.Conn, error) {
 	return d.DialContextF(network, address)
-}
-
-type MockSerializer struct {
-	SerializeF      func(metric telegraf.Metric) ([]byte, error)
-	SerializeBatchF func(metrics []telegraf.Metric) ([]byte, error)
-}
-
-func (s *MockSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
-	return s.SerializeF(metric)
-}
-
-func (s *MockSerializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
-	return s.SerializeBatchF(metrics)
 }
 
 func TestUDP_NewUDPClientNoURL(t *testing.T) {
@@ -177,28 +164,69 @@ func TestUDP_WriteError(t *testing.T) {
 	require.True(t, closed)
 }
 
-func TestUDP_SerializeError(t *testing.T) {
-	config := &influxdb.UDPConfig{
-		URL: getURL(),
-		Dialer: &MockDialer{
-			DialContextF: func(network, address string) (influxdb.Conn, error) {
-				conn := &MockConn{}
-				return conn, nil
+func TestUDP_ErrorLogging(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *influxdb.UDPConfig
+		metrics     []telegraf.Metric
+		logContains string
+	}{
+		{
+			name: "logs need more space",
+			config: &influxdb.UDPConfig{
+				MaxPayloadSize: 1,
+				URL:            getURL(),
+				Dialer: &MockDialer{
+					DialContextF: func(network, address string) (influxdb.Conn, error) {
+						conn := &MockConn{}
+						return conn, nil
+					},
+				},
 			},
+			metrics:     []telegraf.Metric{getMetric()},
+			logContains: `could not serialize metric: "cpu": need more space`,
 		},
-		Serializer: &MockSerializer{
-			SerializeF: func(metric telegraf.Metric) ([]byte, error) {
-				return nil, influx.ErrNeedMoreSpace
+		{
+			name: "logs series name",
+			config: &influxdb.UDPConfig{
+				URL: getURL(),
+				Dialer: &MockDialer{
+					DialContextF: func(network, address string) (influxdb.Conn, error) {
+						conn := &MockConn{}
+						return conn, nil
+					},
+				},
 			},
+			metrics: []telegraf.Metric{
+				func() telegraf.Metric {
+					metric, _ := metric.New(
+						"cpu",
+						map[string]string{
+							"host": "example.org",
+						},
+						map[string]interface{}{},
+						time.Unix(0, 0),
+					)
+					return metric
+				}(),
+			},
+			logContains: `could not serialize metric: "cpu,host=example.org": no serializable fields`,
 		},
 	}
-	client, err := influxdb.NewUDPClient(config)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b bytes.Buffer
+			log.SetOutput(&b)
 
-	ctx := context.Background()
-	err = client.Write(ctx, []telegraf.Metric{getMetric()})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), influx.ErrNeedMoreSpace.Error())
+			client, err := influxdb.NewUDPClient(tt.config)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			err = client.Write(ctx, tt.metrics)
+			require.NoError(t, err)
+			require.Contains(t, b.String(), tt.logContains)
+		})
+	}
 }
 
 func TestUDP_WriteWithRealConn(t *testing.T) {

--- a/plugins/serializers/influx/influx_test.go
+++ b/plugins/serializers/influx/influx_test.go
@@ -23,7 +23,7 @@ var tests = []struct {
 	typeSupport FieldTypeSupport
 	input       telegraf.Metric
 	output      []byte
-	err         error
+	errReason   string
 }{
 	{
 		name: "minimal",
@@ -98,7 +98,7 @@ var tests = []struct {
 				time.Unix(0, 0),
 			),
 		),
-		err: ErrNoFields,
+		errReason: NoFields,
 	},
 	{
 		name: "float Inf",
@@ -333,8 +333,8 @@ var tests = []struct {
 				time.Unix(1519194109, 42),
 			),
 		),
-		output: nil,
-		err:    ErrNeedMoreSpace,
+		output:    nil,
+		errReason: NeedMoreSpace,
 	},
 	{
 		name: "no fields",
@@ -346,7 +346,7 @@ var tests = []struct {
 				time.Unix(0, 0),
 			),
 		),
-		err: ErrNoFields,
+		errReason: NoFields,
 	},
 	{
 		name: "procstat",
@@ -427,7 +427,10 @@ func TestSerializer(t *testing.T) {
 			serializer.SetFieldSortOrder(SortFields)
 			serializer.SetFieldTypeSupport(tt.typeSupport)
 			output, err := serializer.Serialize(tt.input)
-			require.Equal(t, tt.err, err)
+			if tt.errReason != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errReason)
+			}
 			require.Equal(t, string(tt.output), string(output))
 		})
 	}

--- a/plugins/serializers/influx/reader.go
+++ b/plugins/serializers/influx/reader.go
@@ -2,7 +2,6 @@ package influx
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"log"
 
@@ -54,17 +53,11 @@ func (r *reader) Read(p []byte) (int, error) {
 		r.offset += 1
 		if err != nil {
 			r.buf.Reset()
-			switch err.(type) {
-			case *MetricError:
-				// Since we are serializing an array of metrics, don't fail
+			if err != nil {
+				// Since we are serializing multiple metrics, don't fail the
 				// the entire batch just because of one unserializable metric.
-				log.Printf(
-					"D! [serializers.influx] could not serialize metric %q: %v; discarding metric",
-					metric.Name(), err)
+				log.Printf("E! [serializers.influx] could not serialize metric: %v; discarding metric", err)
 				continue
-			default:
-				fmt.Println(err)
-				return 0, err
 			}
 		}
 		break


### PR DESCRIPTION
Additionally display the series, measurement_name + tagset, if a serialization error occurs.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
