### PR TITLE
Dockerstate

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ configuration options.
 * [dmcache](./plugins/inputs/dmcache)
 * [dns query time](./plugins/inputs/dns_query)
 * [docker](./plugins/inputs/docker)
+* [dockerstate](./plugins/inputs/dockerstate)
 * [dovecot](./plugins/inputs/dovecot)
 * [elasticsearch](./plugins/inputs/elasticsearch)
 * [exec](./plugins/inputs/exec) (generic executable plugin, support JSON, influx, graphite and nagios)

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/dmcache"
 	_ "github.com/influxdata/telegraf/plugins/inputs/dns_query"
 	_ "github.com/influxdata/telegraf/plugins/inputs/docker"
+	_ "github.com/influxdata/telegraf/plugins/inputs/dockerstate"
 	_ "github.com/influxdata/telegraf/plugins/inputs/dovecot"
 	_ "github.com/influxdata/telegraf/plugins/inputs/elasticsearch"
 	_ "github.com/influxdata/telegraf/plugins/inputs/exec"

--- a/plugins/inputs/dockerstate/dev/docker-compose.yml
+++ b/plugins/inputs/dockerstate/dev/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  telegraf:
+      image: glinton/scratch
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - ./telegraf.conf:/telegraf.conf
+        - ../../../../telegraf:/telegraf
+      entrypoint:
+        - /telegraf
+        - --config
+        - /telegraf.conf

--- a/plugins/inputs/dockerstate/dev/telegraf.conf
+++ b/plugins/inputs/dockerstate/dev/telegraf.conf
@@ -1,0 +1,8 @@
+[agent]
+  interval="1s"
+  flush_interval="1s"
+
+[[inputs.dockerstate]]
+
+[[outputs.file]]
+  files = ["stdout"]

--- a/plugins/inputs/dockerstate/dockerstate.go
+++ b/plugins/inputs/dockerstate/dockerstate.go
@@ -1,0 +1,84 @@
+package dockerstate
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/influxdata/telegraf"
+    "github.com/influxdata/telegraf/plugins/inputs"
+	"net"
+	"net/http"
+	"strings"
+)
+
+type Stats struct {
+	Fields	map[string]interface{}
+	Socket	string
+}
+
+var DefaultSocket = "/var/run/docker.sock"
+
+func (s *Stats) Description() string {
+	return "Basic Up/Down stats for docker containers"
+}
+
+func (s *Stats) SampleConfig() string {
+	return `
+  [inputs.docker_state]
+	socket = /var/run/docker.sock
+`
+}
+
+func (s *Stats) Gather(acc telegraf.Accumulator) error {
+	c := http.Client{Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial("unix", s.Socket)
+				},
+			},
+		 }
+	var resp *http.Response
+	var err error
+	resp, err = c.Get("http://unix/containers/json?all=1&limit")
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	var containerobj interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&containerobj); err != nil {
+		panic(err)
+	}
+	containers := containerobj.([]interface{})
+	for _, v := range containers {
+		v := v.(map[string]interface{})
+		var state int
+		if v["State"].(string) == "running" {
+			state = 1
+		} else {
+			state = 0
+		}
+		container := strings.Split(v["Image"].(string), ":")
+		container_ver := "latest"
+		if len(container) > 1 {
+			container_ver = container[1]
+		}
+		tags := map[string]string{
+			"container": container[0],
+			"version": container_ver,
+			"status": v["Status"].(string),
+		}
+		fields := map[string]interface{}{
+			"state": state,
+			"created": v["Created"],
+		}
+		acc.AddGauge("dockerstate", fields, tags)
+	}
+	return nil
+}
+
+func init() {
+	inputs.Add("dockerstate", func() telegraf.Input {
+		return &Stats{
+			Fields: make(map[string]interface{}),
+			Socket: DefaultSocket,
+		}
+	})
+}

--- a/plugins/inputs/dockerstate/dockerstate.go
+++ b/plugins/inputs/dockerstate/dockerstate.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/influxdata/telegraf"
-    "github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/inputs"
 	"net"
 	"net/http"
 	"strings"
 )
 
 type Stats struct {
-	Fields	map[string]interface{}
-	Socket	string
+	Fields map[string]interface{}
+	Socket string
 }
 
 var DefaultSocket = "/var/run/docker.sock"
@@ -30,11 +30,11 @@ func (s *Stats) SampleConfig() string {
 
 func (s *Stats) Gather(acc telegraf.Accumulator) error {
 	c := http.Client{Transport: &http.Transport{
-				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial("unix", s.Socket)
-				},
-			},
-		 }
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("unix", s.Socket)
+		},
+	},
+	}
 	var resp *http.Response
 	var err error
 	resp, err = c.Get("http://unix/containers/json?all=1&limit")
@@ -62,11 +62,11 @@ func (s *Stats) Gather(acc telegraf.Accumulator) error {
 		}
 		tags := map[string]string{
 			"container": container[0],
-			"version": container_ver,
-			"status": v["Status"].(string),
+			"version":   container_ver,
+			"status":    v["Status"].(string),
 		}
 		fields := map[string]interface{}{
-			"state": state,
+			"state":   state,
 			"created": v["Created"],
 		}
 		acc.AddGauge("dockerstate", fields, tags)


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This plugin collects very _basic_ stats about each docker container running (and stopped) on a system. It is far less verbose than the current `docker` input plugin. If you are collecting docker stats for 100s of hosts, this might be more useful.