### PR TITLE
Add PowerDNS Recursor input plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ For documentation on the latest development code see the [documentation index][d
 * [postgresql_extensible](./plugins/inputs/postgresql_extensible)
 * [postgresql](./plugins/inputs/postgresql)
 * [powerdns](./plugins/inputs/powerdns)
+* [powerdns_recursor](./plugins/inputs/powerdns_recursor)
 * [processes](./plugins/inputs/processes)
 * [procstat](./plugins/inputs/procstat)
 * [prometheus](./plugins/inputs/prometheus) (can be used for [Caddy server](./plugins/inputs/prometheus/README.md#usage-for-caddy-http-server))

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -3346,6 +3346,20 @@
 #   unix_sockets = ["/var/run/pdns.controlsocket"]
 
 
+# # Read metrics from one or many PowerDNS recursors
+# [[inputs.powerdns_recursor]]
+#   ## An array of sockets to gather stats about.
+#   ## Specify a path to unix socket.
+#   ##
+#   ## If no servers are specified, then '/var/run/pdns_recursor.controlsocket' is used as the path.
+#   unix_sockets = ["/var/run/pdns_recursor.controlsocket"]
+#
+#   ## Socket for Receive
+#   # socket_dir = "/var/run/"
+#   ## Socket permissions
+#   # socket_mode = "0666"
+
+
 # # Monitor process cpu and memory usage
 # [[inputs.procstat]]
 #   ## PID file to monitor process

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -109,6 +109,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/postgresql"
 	_ "github.com/influxdata/telegraf/plugins/inputs/postgresql_extensible"
 	_ "github.com/influxdata/telegraf/plugins/inputs/powerdns"
+	_ "github.com/influxdata/telegraf/plugins/inputs/powerdns_recursor"
 	_ "github.com/influxdata/telegraf/plugins/inputs/processes"
 	_ "github.com/influxdata/telegraf/plugins/inputs/procstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/prometheus"

--- a/plugins/inputs/powerdns_recursor/README.md
+++ b/plugins/inputs/powerdns_recursor/README.md
@@ -1,0 +1,139 @@
+# PowerDNS Recursor Input Plugin
+
+The powerdns recursor plugin gathers metrics about PowerDNS Recursor using unix socket.
+
+### Configuration:
+
+```
+# Read metrics from one or many PowerDNS recursors
+[[inputs.powerdns_recursor]]
+  ## An array of sockets to gather stats about.
+  ## Specify a path to unix socket.
+  ##
+  ## If no servers are specified, then '/var/run/pdns_recursor.controlsocket' is used as the path.
+  unix_sockets = ["/var/run/pdns_recursor.controlsocket"]
+
+  ## Socket for Receive
+  # socket_dir = "/var/run/"
+  ## Socket permissions
+  # socket_mode = "0666"
+```
+
+### Measurements & Fields:
+
+- powerdns_recursor
+ - all-outqueries
+ - answers-slow
+ - answers0-1
+ - answers1-10
+ - answers10-100
+ - answers100-1000
+ - auth-zone-queries
+ - auth4-answers-slow
+ - auth4-answers0-1
+ - auth4-answers1-10
+ - auth4-answers10-100
+ - auth4-answers100-1000
+ - auth6-answers-slow
+ - auth6-answers0-1
+ - auth6-answers1-10
+ - auth6-answers10-100
+ - auth6-answers100-1000
+ - cache-entries
+ - cache-hits
+ - cache-misses
+ - case-mismatches
+ - chain-resends
+ - client-parse-errors
+ - concurrent-queries
+ - dlg-only-drops
+ - dnssec-queries
+ - dnssec-result-bogus
+ - dnssec-result-indeterminate
+ - dnssec-result-insecure
+ - dnssec-result-nta
+ - dnssec-result-secure
+ - dnssec-validations
+ - dont-outqueries
+ - ecs-queries
+ - ecs-responses
+ - edns-ping-matches
+ - edns-ping-mismatches
+ - failed-host-entries
+ - fd-usage
+ - ignored-packets
+ - ipv6-outqueries
+ - ipv6-questions
+ - malloc-bytes
+ - max-cache-entries
+ - max-mthread-stack
+ - max-packetcache-entries
+ - negcache-entries
+ - no-packet-error
+ - noedns-outqueries
+ - noerror-answers
+ - noping-outqueries
+ - nsset-invalidations
+ - nsspeeds-entries
+ - nxdomain-answers
+ - outgoing-timeouts
+ - outgoing4-timeouts
+ - outgoing6-timeouts
+ - over-capacity-drops
+ - packetcache-entries
+ - packetcache-hits
+ - packetcache-misses
+ - policy-drops
+ - policy-result-custom
+ - policy-result-drop
+ - policy-result-noaction
+ - policy-result-nodata
+ - policy-result-nxdomain
+ - policy-result-truncate
+ - qa-latency
+ - query-pipe-full-drops
+ - questions
+ - real-memory-usage
+ - resource-limits
+ - security-status
+ - server-parse-errors
+ - servfail-answers
+ - spoof-prevents
+ - sys-msec
+ - tcp-client-overflow
+ - tcp-clients
+ - tcp-outqueries
+ - tcp-questions
+ - throttle-entries
+ - throttled-out
+ - throttled-outqueries
+ - too-old-drops
+ - udp-in-errors
+ - udp-noport-errors
+ - udp-recvbuf-errors
+ - udp-sndbuf-errors
+ - unauthorized-tcp
+ - unauthorized-udp
+ - unexpected-packets
+ - unreachables
+ - uptime
+ - user-msec
+ - x-our-latency
+ - x-ourtime-slow
+ - x-ourtime0-1
+ - x-ourtime1-2
+ - x-ourtime16-32
+ - x-ourtime2-4
+ - x-ourtime4-8
+ - x-ourtime8-16
+
+### Tags:
+
+- tags: `server=socket`
+
+### Example Output:
+
+```
+$ ./telegraf --config telegraf.conf --input-filter powerdns_recursor --test
+> powerdns_recursor,server=/var/run/pdns_recursor.controlsocket all-outqueries=3631810i,answers-slow=36863i,answers0-1=179612i,answers1-10=1223305i,answers10-100=1252199i,answers100-1000=408357i,auth-zone-queries=4i,auth4-answers-slow=44758i,auth4-answers0-1=59721i,auth4-answers1-10=1766787i,auth4-answers10-100=1329638i,auth4-answers100-1000=430372i,auth6-answers-slow=0i,auth6-answers0-1=0i,auth6-answers1-10=0i,auth6-answers10-100=0i,auth6-answers100-1000=0i,cache-entries=296689i,cache-hits=150654i,cache-misses=2949682i,case-mismatches=0i,chain-resends=420004i,client-parse-errors=0i,concurrent-queries=0i,dlg-only-drops=0i,dnssec-queries=152970i,dnssec-result-bogus=0i,dnssec-result-indeterminate=0i,dnssec-result-insecure=0i,dnssec-result-nta=0i,dnssec-result-secure=47i,dnssec-validations=47i,dont-outqueries=62i,ecs-queries=0i,ecs-responses=0i,edns-ping-matches=0i,edns-ping-mismatches=0i,failed-host-entries=21i,fd-usage=32i,ignored-packets=0i,ipv6-outqueries=0i,ipv6-questions=0i,malloc-bytes=0i,max-cache-entries=1000000i,max-mthread-stack=33747i,max-packetcache-entries=500000i,negcache-entries=100019i,no-packet-error=0i,noedns-outqueries=73341i,noerror-answers=25453808i,noping-outqueries=0i,nsset-invalidations=2398i,nsspeeds-entries=3966i,nxdomain-answers=3341302i,outgoing-timeouts=44384i,outgoing4-timeouts=44384i,outgoing6-timeouts=0i,over-capacity-drops=0i,packetcache-entries=78258i,packetcache-hits=25999027i,packetcache-misses=3100179i,policy-drops=0i,policy-result-custom=0i,policy-result-drop=0i,policy-result-noaction=3100336i,policy-result-nodata=0i,policy-result-nxdomain=0i,policy-result-truncate=0i,qa-latency=6553i,query-pipe-full-drops=0i,questions=29099363i,real-memory-usage=280494080i,resource-limits=0i,security-status=1i,server-parse-errors=0i,servfail-answers=304253i,spoof-prevents=0i,sys-msec=1312600i,tcp-client-overflow=0i,tcp-clients=0i,tcp-outqueries=116i,tcp-questions=133i,throttle-entries=21i,throttled-out=13296i,throttled-outqueries=13296i,too-old-drops=2i,udp-in-errors=4i,udp-noport-errors=2918i,udp-recvbuf-errors=0i,udp-sndbuf-errors=0i,unauthorized-tcp=0i,unauthorized-udp=0i,unexpected-packets=0i,unreachables=1708i,uptime=167482i,user-msec=1282640i,x-our-latency=19i,x-ourtime-slow=642i,x-ourtime0-1=3095566i,x-ourtime1-2=3401i,x-ourtime16-32=201i,x-ourtime2-4=304i,x-ourtime4-8=198i,x-ourtime8-16=24i 1533903879000000000
+```

--- a/plugins/inputs/powerdns_recursor/powerdns_recursor.go
+++ b/plugins/inputs/powerdns_recursor/powerdns_recursor.go
@@ -1,0 +1,156 @@
+package powerdns_recursor
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+type PowerdnsRecursor struct {
+	UnixSockets []string
+
+	SocketDir  string `toml:"socket_dir"`
+	SocketMode uint32 `toml:"socket_mode"`
+}
+
+var defaultTimeout = 5 * time.Second
+
+var sampleConfig = `
+  ## An array of sockets to gather stats about.
+  ## Specify a path to unix socket.
+  unix_sockets = ["/var/run/pdns_recursor.controlsocket"]
+
+  ## Socket for Receive
+  #socket_dir = "/var/run/"
+  ## Socket permissions
+  #socket_mode = "0666"
+`
+
+func (p *PowerdnsRecursor) SampleConfig() string {
+	return sampleConfig
+}
+
+func (p *PowerdnsRecursor) Description() string {
+	return "Read metrics from one or many PowerDNS Recursor servers"
+}
+
+func (p *PowerdnsRecursor) Gather(acc telegraf.Accumulator) error {
+	if len(p.UnixSockets) == 0 {
+		return p.gatherServer("/var/run/pdns_recursor.controlsocket", acc)
+	}
+
+	for _, serverSocket := range p.UnixSockets {
+		if err := p.gatherServer(serverSocket, acc); err != nil {
+			acc.AddError(err)
+		}
+	}
+
+	return nil
+}
+
+func (p *PowerdnsRecursor) gatherServer(address string, acc telegraf.Accumulator) error {
+	randomNumber := rand.Int63()
+	recvSocket := filepath.Join("/", "var", "run", fmt.Sprintf("pdns_recursor_telegraf%d", randomNumber))
+	if p.SocketDir != "" {
+		recvSocket = filepath.Join(p.SocketDir, fmt.Sprintf("pdns_recursor_telegraf%d", randomNumber))
+	}
+
+	laddr, err := net.ResolveUnixAddr("unixgram", recvSocket)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(recvSocket)
+	raddr, err := net.ResolveUnixAddr("unixgram", address)
+	if err != nil {
+		return err
+	}
+	conn, err := net.DialUnix("unixgram", laddr, raddr)
+	if err != nil {
+		return err
+	}
+	perm := uint32(0666)
+	if p.SocketMode > 0 {
+		perm = p.SocketMode
+	}
+	if err := os.Chmod(recvSocket, os.FileMode(perm)); err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(defaultTimeout))
+
+	// Read and write buffer
+	rw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
+
+	// Send command
+	if _, err := fmt.Fprint(rw, "get-all\n"); err != nil {
+		return nil
+	}
+	if err := rw.Flush(); err != nil {
+		return err
+	}
+
+	// Read data
+	buf := make([]byte, 16384)
+	n, err := rw.Read(buf)
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return errors.New("no data received")
+	}
+
+	metrics := string(buf)
+
+	// Process data
+	fields := parseResponse(metrics)
+
+	// Add server socket as a tag
+	tags := map[string]string{"server": address}
+
+	acc.AddFields("powerdns_recursor", fields, tags)
+
+	conn.Close()
+
+	return nil
+}
+
+func parseResponse(metrics string) map[string]interface{} {
+	values := make(map[string]interface{})
+
+	s := strings.Split(metrics, "\n")
+
+	for _, metric := range s[:len(s)-1] {
+		m := strings.Split(metric, "\t")
+		if len(m) < 2 {
+			continue
+		}
+
+		i, err := strconv.ParseInt(m[1], 10, 64)
+		if err != nil {
+			log.Printf("E! [inputs.powerdns_recursor] Error parsing integer for metric [%s] %v",
+				metric, err)
+			continue
+		}
+		values[m[0]] = i
+	}
+
+	return values
+}
+
+func init() {
+	inputs.Add("powerdns_recursor", func() telegraf.Input {
+		return &PowerdnsRecursor{}
+	})
+}

--- a/plugins/inputs/powerdns_recursor/powerdns_recursor_test.go
+++ b/plugins/inputs/powerdns_recursor/powerdns_recursor_test.go
@@ -1,0 +1,543 @@
+package powerdns_recursor
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type statServer struct{}
+
+var metrics = "all-outqueries\t3591637\nanswers-slow\t36451\nanswers0-1\t177297\nanswers1-10\t1209328\n" +
+	"answers10-100\t1238786\nanswers100-1000\t402917\nauth-zone-queries\t4\nauth4-answers-slow\t44248\n" +
+	"auth4-answers0-1\t59169\nauth4-answers1-10\t1747403\nauth4-answers10-100\t1315621\n" +
+	"auth4-answers100-1000\t424683\nauth6-answers-slow\t0\nauth6-answers0-1\t0\nauth6-answers1-10\t0\n" +
+	"auth6-answers10-100\t0\nauth6-answers100-1000\t0\ncache-entries\t295917\ncache-hits\t148630\n" +
+	"cache-misses\t2916149\ncase-mismatches\t0\nchain-resends\t418602\nclient-parse-errors\t0\n" +
+	"concurrent-queries\t0\ndlg-only-drops\t0\ndnssec-queries\t151536\ndnssec-result-bogus\t0\n" +
+	"dnssec-result-indeterminate\t0\ndnssec-result-insecure\t0\ndnssec-result-nta\t0\n" +
+	"dnssec-result-secure\t46\ndnssec-validations\t46\ndont-outqueries\t62\necs-queries\t0\n" +
+	"ecs-responses\t0\nedns-ping-matches\t0\nedns-ping-mismatches\t0\nfailed-host-entries\t33\n" +
+	"fd-usage\t32\nignored-packets\t0\nipv6-outqueries\t0\nipv6-questions\t0\nmalloc-bytes\t0\n" +
+	"max-cache-entries\t1000000\nmax-mthread-stack\t33747\nmax-packetcache-entries\t500000\n" +
+	"negcache-entries\t100070\nno-packet-error\t0\nnoedns-outqueries\t72409\nnoerror-answers\t25155259\n" +
+	"noping-outqueries\t0\nnsset-invalidations\t2385\nnsspeeds-entries\t3571\nnxdomain-answers\t3307768\n" +
+	"outgoing-timeouts\t43876\noutgoing4-timeouts\t43876\noutgoing6-timeouts\t0\nover-capacity-drops\t0\n" +
+	"packetcache-entries\t80756\npacketcache-hits\t25698497\npacketcache-misses\t3064625\npolicy-drops\t0\n" +
+	"policy-result-custom\t0\npolicy-result-drop\t0\npolicy-result-noaction\t3064779\npolicy-result-nodata\t0\n" +
+	"policy-result-nxdomain\t0\npolicy-result-truncate\t0\nqa-latency\t6587\nquery-pipe-full-drops\t0\n" +
+	"questions\t28763276\nreal-memory-usage\t280465408\nresource-limits\t0\nsecurity-status\t1\n" +
+	"server-parse-errors\t0\nservfail-answers\t300249\nspoof-prevents\t0\nsys-msec\t1296588\n" +
+	"tcp-client-overflow\t0\ntcp-clients\t0\ntcp-outqueries\t116\ntcp-questions\t130\nthrottle-entries\t33\n" +
+	"throttled-out\t13187\nthrottled-outqueries\t13187\ntoo-old-drops\t2\nudp-in-errors\t4\n" +
+	"udp-noport-errors\t2908\nudp-recvbuf-errors\t0\nudp-sndbuf-errors\t0\nunauthorized-tcp\t0\n" +
+	"unauthorized-udp\t0\nunexpected-packets\t0\nunreachables\t1695\nuptime\t165725\nuser-msec\t1266384\n" +
+	"x-our-latency\t19\nx-ourtime-slow\t632\nx-ourtime0-1\t3060079\nx-ourtime1-2\t3351\nx-ourtime16-32\t197\n" +
+	"x-ourtime2-4\t302\nx-ourtime4-8\t194\nx-ourtime8-16\t24\n"
+
+// first metric has no "\t"
+var corruptMetrics = "all-outqueries3591637\nanswers-slow\t36451\nanswers0-1\t177297\nanswers1-10\t1209328\n" +
+	"answers10-100\t1238786\nanswers100-1000\t402917\nauth-zone-queries\t4\nauth4-answers-slow\t44248\n" +
+	"auth4-answers0-1\t59169\nauth4-answers1-10\t1747403\nauth4-answers10-100\t1315621\n" +
+	"auth4-answers100-1000\t424683\nauth6-answers-slow\t0\nauth6-answers0-1\t0\nauth6-answers1-10\t0\n" +
+	"auth6-answers10-100\t0\nauth6-answers100-1000\t0\ncache-entries\t295917\ncache-hits\t148630\n" +
+	"cache-misses\t2916149\ncase-mismatches\t0\nchain-resends\t418602\nclient-parse-errors\t0\n" +
+	"concurrent-queries\t0\ndlg-only-drops\t0\ndnssec-queries\t151536\ndnssec-result-bogus\t0\n" +
+	"dnssec-result-indeterminate\t0\ndnssec-result-insecure\t0\ndnssec-result-nta\t0\n" +
+	"dnssec-result-secure\t46\ndnssec-validations\t46\ndont-outqueries\t62\necs-queries\t0\n" +
+	"ecs-responses\t0\nedns-ping-matches\t0\nedns-ping-mismatches\t0\nfailed-host-entries\t33\n" +
+	"fd-usage\t32\nignored-packets\t0\nipv6-outqueries\t0\nipv6-questions\t0\nmalloc-bytes\t0\n" +
+	"max-cache-entries\t1000000\nmax-mthread-stack\t33747\nmax-packetcache-entries\t500000\n" +
+	"negcache-entries\t100070\nno-packet-error\t0\nnoedns-outqueries\t72409\nnoerror-answers\t25155259\n" +
+	"noping-outqueries\t0\nnsset-invalidations\t2385\nnsspeeds-entries\t3571\nnxdomain-answers\t3307768\n" +
+	"outgoing-timeouts\t43876\noutgoing4-timeouts\t43876\noutgoing6-timeouts\t0\nover-capacity-drops\t0\n" +
+	"packetcache-entries\t80756\npacketcache-hits\t25698497\npacketcache-misses\t3064625\npolicy-drops\t0\n" +
+	"policy-result-custom\t0\npolicy-result-drop\t0\npolicy-result-noaction\t3064779\npolicy-result-nodata\t0\n" +
+	"policy-result-nxdomain\t0\npolicy-result-truncate\t0\nqa-latency\t6587\nquery-pipe-full-drops\t0\n" +
+	"questions\t28763276\nreal-memory-usage\t280465408\nresource-limits\t0\nsecurity-status\t1\n" +
+	"server-parse-errors\t0\nservfail-answers\t300249\nspoof-prevents\t0\nsys-msec\t1296588\n" +
+	"tcp-client-overflow\t0\ntcp-clients\t0\ntcp-outqueries\t116\ntcp-questions\t130\nthrottle-entries\t33\n" +
+	"throttled-out\t13187\nthrottled-outqueries\t13187\ntoo-old-drops\t2\nudp-in-errors\t4\n" +
+	"udp-noport-errors\t2908\nudp-recvbuf-errors\t0\nudp-sndbuf-errors\t0\nunauthorized-tcp\t0\n" +
+	"unauthorized-udp\t0\nunexpected-packets\t0\nunreachables\t1695\nuptime\t165725\nuser-msec\t1266384\n" +
+	"x-our-latency\t19\nx-ourtime-slow\t632\nx-ourtime0-1\t3060079\nx-ourtime1-2\t3351\nx-ourtime16-32\t197\n" +
+	"x-ourtime2-4\t302\nx-ourtime4-8\t194\nx-ourtime8-16\t24\n"
+
+// integer overflow
+var intOverflowMetrics = "all-outqueries\t18446744073709550195\nanswers-slow\t36451\nanswers0-1\t177297\nanswers1-10\t1209328\n" +
+	"answers10-100\t1238786\nanswers100-1000\t402917\nauth-zone-queries\t4\nauth4-answers-slow\t44248\n" +
+	"auth4-answers0-1\t59169\nauth4-answers1-10\t1747403\nauth4-answers10-100\t1315621\n" +
+	"auth4-answers100-1000\t424683\nauth6-answers-slow\t0\nauth6-answers0-1\t0\nauth6-answers1-10\t0\n" +
+	"auth6-answers10-100\t0\nauth6-answers100-1000\t0\ncache-entries\t295917\ncache-hits\t148630\n" +
+	"cache-misses\t2916149\ncase-mismatches\t0\nchain-resends\t418602\nclient-parse-errors\t0\n" +
+	"concurrent-queries\t0\ndlg-only-drops\t0\ndnssec-queries\t151536\ndnssec-result-bogus\t0\n" +
+	"dnssec-result-indeterminate\t0\ndnssec-result-insecure\t0\ndnssec-result-nta\t0\n" +
+	"dnssec-result-secure\t46\ndnssec-validations\t46\ndont-outqueries\t62\necs-queries\t0\n" +
+	"ecs-responses\t0\nedns-ping-matches\t0\nedns-ping-mismatches\t0\nfailed-host-entries\t33\n" +
+	"fd-usage\t32\nignored-packets\t0\nipv6-outqueries\t0\nipv6-questions\t0\nmalloc-bytes\t0\n" +
+	"max-cache-entries\t1000000\nmax-mthread-stack\t33747\nmax-packetcache-entries\t500000\n" +
+	"negcache-entries\t100070\nno-packet-error\t0\nnoedns-outqueries\t72409\nnoerror-answers\t25155259\n" +
+	"noping-outqueries\t0\nnsset-invalidations\t2385\nnsspeeds-entries\t3571\nnxdomain-answers\t3307768\n" +
+	"outgoing-timeouts\t43876\noutgoing4-timeouts\t43876\noutgoing6-timeouts\t0\nover-capacity-drops\t0\n" +
+	"packetcache-entries\t80756\npacketcache-hits\t25698497\npacketcache-misses\t3064625\npolicy-drops\t0\n" +
+	"policy-result-custom\t0\npolicy-result-drop\t0\npolicy-result-noaction\t3064779\npolicy-result-nodata\t0\n" +
+	"policy-result-nxdomain\t0\npolicy-result-truncate\t0\nqa-latency\t6587\nquery-pipe-full-drops\t0\n" +
+	"questions\t28763276\nreal-memory-usage\t280465408\nresource-limits\t0\nsecurity-status\t1\n" +
+	"server-parse-errors\t0\nservfail-answers\t300249\nspoof-prevents\t0\nsys-msec\t1296588\n" +
+	"tcp-client-overflow\t0\ntcp-clients\t0\ntcp-outqueries\t116\ntcp-questions\t130\nthrottle-entries\t33\n" +
+	"throttled-out\t13187\nthrottled-outqueries\t13187\ntoo-old-drops\t2\nudp-in-errors\t4\n" +
+	"udp-noport-errors\t2908\nudp-recvbuf-errors\t0\nudp-sndbuf-errors\t0\nunauthorized-tcp\t0\n" +
+	"unauthorized-udp\t0\nunexpected-packets\t0\nunreachables\t1695\nuptime\t165725\nuser-msec\t1266384\n" +
+	"x-our-latency\t19\nx-ourtime-slow\t632\nx-ourtime0-1\t3060079\nx-ourtime1-2\t3351\nx-ourtime16-32\t197\n" +
+	"x-ourtime2-4\t302\nx-ourtime4-8\t194\nx-ourtime8-16\t24\n"
+
+func (s statServer) serverSocket(l *net.UnixConn) {
+
+	for {
+		go func(c *net.UnixConn) {
+			buf := make([]byte, 1024)
+			n, remote, _ := c.ReadFromUnix(buf)
+
+			data := buf[:n]
+			if string(data) == "get-all\n" {
+				c.WriteToUnix([]byte(metrics), remote)
+				c.Close()
+			}
+		}(l)
+	}
+}
+
+func TestPowerdnsRecursorGeneratesMetrics(t *testing.T) {
+	// We create a fake server to return test data
+	randomNumber := int64(5724354148158589552)
+	addr, err := net.ResolveUnixAddr("unixgram", fmt.Sprintf("/tmp/pdns%d.controlsocket", randomNumber))
+	if err != nil {
+		t.Fatal("Cannot parse unix socket")
+	}
+	socket, err := net.ListenUnixgram("unixgram", addr)
+	if err != nil {
+		t.Fatal("Cannot initialize server on port ")
+	}
+
+	defer socket.Close()
+
+	s := statServer{}
+	go s.serverSocket(socket)
+
+	p := &PowerdnsRecursor{
+		UnixSockets: []string{fmt.Sprintf("/tmp/pdns%d.controlsocket", randomNumber)},
+	}
+
+	var acc testutil.Accumulator
+
+	err = acc.GatherError(p.Gather)
+	require.NoError(t, err)
+
+	intMetrics := []string{"all-outqueries", "answers-slow", "answers0-1", "answers1-10",
+		"answers10-100", "answers100-1000", "auth-zone-queries", "auth4-answers-slow",
+		"auth4-answers0-1", "auth4-answers1-10", "auth4-answers10-100", "auth4-answers100-1000",
+		"auth6-answers-slow", "auth6-answers0-1", "auth6-answers1-10", "auth6-answers10-100",
+		"auth6-answers100-1000", "cache-entries", "cache-hits", "cache-misses", "case-mismatches",
+		"chain-resends", "client-parse-errors", "concurrent-queries", "dlg-only-drops", "dnssec-queries",
+		"dnssec-result-bogus", "dnssec-result-indeterminate", "dnssec-result-insecure", "dnssec-result-nta",
+		"dnssec-result-secure", "dnssec-validations", "dont-outqueries", "ecs-queries", "ecs-responses",
+		"edns-ping-matches", "edns-ping-mismatches", "failed-host-entries", "fd-usage", "ignored-packets",
+		"ipv6-outqueries", "ipv6-questions", "malloc-bytes", "max-cache-entries", "max-mthread-stack",
+		"max-packetcache-entries", "negcache-entries", "no-packet-error", "noedns-outqueries",
+		"noerror-answers", "noping-outqueries", "nsset-invalidations", "nsspeeds-entries",
+		"nxdomain-answers", "outgoing-timeouts", "outgoing4-timeouts", "outgoing6-timeouts",
+		"over-capacity-drops", "packetcache-entries", "packetcache-hits", "packetcache-misses",
+		"policy-drops", "policy-result-custom", "policy-result-drop", "policy-result-noaction",
+		"policy-result-nodata", "policy-result-nxdomain", "policy-result-truncate", "qa-latency",
+		"query-pipe-full-drops", "questions", "real-memory-usage", "resource-limits", "security-status",
+		"server-parse-errors", "servfail-answers", "spoof-prevents", "sys-msec", "tcp-client-overflow",
+		"tcp-clients", "tcp-outqueries", "tcp-questions", "throttle-entries", "throttled-out", "throttled-outqueries",
+		"too-old-drops", "udp-in-errors", "udp-noport-errors", "udp-recvbuf-errors", "udp-sndbuf-errors",
+		"unauthorized-tcp", "unauthorized-udp", "unexpected-packets", "unreachables", "uptime", "user-msec",
+		"x-our-latency", "x-ourtime-slow", "x-ourtime0-1", "x-ourtime1-2", "x-ourtime16-32",
+		"x-ourtime2-4", "x-ourtime4-8", "x-ourtime8-16"}
+
+	for _, metric := range intMetrics {
+		assert.True(t, acc.HasInt64Field("powerdns_recursor", metric), metric)
+	}
+}
+
+func TestPowerdnsRecursorParseMetrics(t *testing.T) {
+	values := parseResponse(metrics)
+
+	tests := []struct {
+		key   string
+		value int64
+	}{
+		{"all-outqueries", 3591637},
+		{"answers-slow", 36451},
+		{"answers0-1", 177297},
+		{"answers1-10", 1209328},
+		{"answers10-100", 1238786},
+		{"answers100-1000", 402917},
+		{"auth-zone-queries", 4},
+		{"auth4-answers-slow", 44248},
+		{"auth4-answers0-1", 59169},
+		{"auth4-answers1-10", 1747403},
+		{"auth4-answers10-100", 1315621},
+		{"auth4-answers100-1000", 424683},
+		{"auth6-answers-slow", 0},
+		{"auth6-answers0-1", 0},
+		{"auth6-answers1-10", 0},
+		{"auth6-answers10-100", 0},
+		{"auth6-answers100-1000", 0},
+		{"cache-entries", 295917},
+		{"cache-hits", 148630},
+		{"cache-misses", 2916149},
+		{"case-mismatches", 0},
+		{"chain-resends", 418602},
+		{"client-parse-errors", 0},
+		{"concurrent-queries", 0},
+		{"dlg-only-drops", 0},
+		{"dnssec-queries", 151536},
+		{"dnssec-result-bogus", 0},
+		{"dnssec-result-indeterminate", 0},
+		{"dnssec-result-insecure", 0},
+		{"dnssec-result-nta", 0},
+		{"dnssec-result-secure", 46},
+		{"dnssec-validations", 46},
+		{"dont-outqueries", 62},
+		{"ecs-queries", 0},
+		{"ecs-responses", 0},
+		{"edns-ping-matches", 0},
+		{"edns-ping-mismatches", 0},
+		{"failed-host-entries", 33},
+		{"fd-usage", 32},
+		{"ignored-packets", 0},
+		{"ipv6-outqueries", 0},
+		{"ipv6-questions", 0},
+		{"malloc-bytes", 0},
+		{"max-cache-entries", 1000000},
+		{"max-mthread-stack", 33747},
+		{"max-packetcache-entries", 500000},
+		{"negcache-entries", 100070},
+		{"no-packet-error", 0},
+		{"noedns-outqueries", 72409},
+		{"noerror-answers", 25155259},
+		{"noping-outqueries", 0},
+		{"nsset-invalidations", 2385},
+		{"nsspeeds-entries", 3571},
+		{"nxdomain-answers", 3307768},
+		{"outgoing-timeouts", 43876},
+		{"outgoing4-timeouts", 43876},
+		{"outgoing6-timeouts", 0},
+		{"over-capacity-drops", 0},
+		{"packetcache-entries", 80756},
+		{"packetcache-hits", 25698497},
+		{"packetcache-misses", 3064625},
+		{"policy-drops", 0},
+		{"policy-result-custom", 0},
+		{"policy-result-drop", 0},
+		{"policy-result-noaction", 3064779},
+		{"policy-result-nodata", 0},
+		{"policy-result-nxdomain", 0},
+		{"policy-result-truncate", 0},
+		{"qa-latency", 6587},
+		{"query-pipe-full-drops", 0},
+		{"questions", 28763276},
+		{"real-memory-usage", 280465408},
+		{"resource-limits", 0},
+		{"security-status", 1},
+		{"server-parse-errors", 0},
+		{"servfail-answers", 300249},
+		{"spoof-prevents", 0},
+		{"sys-msec", 1296588},
+		{"tcp-client-overflow", 0},
+		{"tcp-clients", 0},
+		{"tcp-outqueries", 116},
+		{"tcp-questions", 130},
+		{"throttle-entries", 33},
+		{"throttled-out", 13187},
+		{"throttled-outqueries", 13187},
+		{"too-old-drops", 2},
+		{"udp-in-errors", 4},
+		{"udp-noport-errors", 2908},
+		{"udp-recvbuf-errors", 0},
+		{"udp-sndbuf-errors", 0},
+		{"unauthorized-tcp", 0},
+		{"unauthorized-udp", 0},
+		{"unexpected-packets", 0},
+		{"unreachables", 1695},
+		{"uptime", 165725},
+		{"user-msec", 1266384},
+		{"x-our-latency", 19},
+		{"x-ourtime-slow", 632},
+		{"x-ourtime0-1", 3060079},
+		{"x-ourtime1-2", 3351},
+		{"x-ourtime16-32", 197},
+		{"x-ourtime2-4", 302},
+		{"x-ourtime4-8", 194},
+		{"x-ourtime8-16", 24},
+	}
+
+	for _, test := range tests {
+		value, ok := values[test.key]
+		if !ok {
+			t.Errorf("Did not find key for metric %s in values", test.key)
+			continue
+		}
+		if value != test.value {
+			t.Errorf("Metric: %s, Expected: %d, actual: %d",
+				test.key, test.value, value)
+		}
+	}
+}
+
+func TestPowerdnsRecursorParseCorruptMetrics(t *testing.T) {
+	values := parseResponse(corruptMetrics)
+
+	tests := []struct {
+		key   string
+		value int64
+	}{
+		{"answers-slow", 36451},
+		{"answers0-1", 177297},
+		{"answers1-10", 1209328},
+		{"answers10-100", 1238786},
+		{"answers100-1000", 402917},
+		{"auth-zone-queries", 4},
+		{"auth4-answers-slow", 44248},
+		{"auth4-answers0-1", 59169},
+		{"auth4-answers1-10", 1747403},
+		{"auth4-answers10-100", 1315621},
+		{"auth4-answers100-1000", 424683},
+		{"auth6-answers-slow", 0},
+		{"auth6-answers0-1", 0},
+		{"auth6-answers1-10", 0},
+		{"auth6-answers10-100", 0},
+		{"auth6-answers100-1000", 0},
+		{"cache-entries", 295917},
+		{"cache-hits", 148630},
+		{"cache-misses", 2916149},
+		{"case-mismatches", 0},
+		{"chain-resends", 418602},
+		{"client-parse-errors", 0},
+		{"concurrent-queries", 0},
+		{"dlg-only-drops", 0},
+		{"dnssec-queries", 151536},
+		{"dnssec-result-bogus", 0},
+		{"dnssec-result-indeterminate", 0},
+		{"dnssec-result-insecure", 0},
+		{"dnssec-result-nta", 0},
+		{"dnssec-result-secure", 46},
+		{"dnssec-validations", 46},
+		{"dont-outqueries", 62},
+		{"ecs-queries", 0},
+		{"ecs-responses", 0},
+		{"edns-ping-matches", 0},
+		{"edns-ping-mismatches", 0},
+		{"failed-host-entries", 33},
+		{"fd-usage", 32},
+		{"ignored-packets", 0},
+		{"ipv6-outqueries", 0},
+		{"ipv6-questions", 0},
+		{"malloc-bytes", 0},
+		{"max-cache-entries", 1000000},
+		{"max-mthread-stack", 33747},
+		{"max-packetcache-entries", 500000},
+		{"negcache-entries", 100070},
+		{"no-packet-error", 0},
+		{"noedns-outqueries", 72409},
+		{"noerror-answers", 25155259},
+		{"noping-outqueries", 0},
+		{"nsset-invalidations", 2385},
+		{"nsspeeds-entries", 3571},
+		{"nxdomain-answers", 3307768},
+		{"outgoing-timeouts", 43876},
+		{"outgoing4-timeouts", 43876},
+		{"outgoing6-timeouts", 0},
+		{"over-capacity-drops", 0},
+		{"packetcache-entries", 80756},
+		{"packetcache-hits", 25698497},
+		{"packetcache-misses", 3064625},
+		{"policy-drops", 0},
+		{"policy-result-custom", 0},
+		{"policy-result-drop", 0},
+		{"policy-result-noaction", 3064779},
+		{"policy-result-nodata", 0},
+		{"policy-result-nxdomain", 0},
+		{"policy-result-truncate", 0},
+		{"qa-latency", 6587},
+		{"query-pipe-full-drops", 0},
+		{"questions", 28763276},
+		{"real-memory-usage", 280465408},
+		{"resource-limits", 0},
+		{"security-status", 1},
+		{"server-parse-errors", 0},
+		{"servfail-answers", 300249},
+		{"spoof-prevents", 0},
+		{"sys-msec", 1296588},
+		{"tcp-client-overflow", 0},
+		{"tcp-clients", 0},
+		{"tcp-outqueries", 116},
+		{"tcp-questions", 130},
+		{"throttle-entries", 33},
+		{"throttled-out", 13187},
+		{"throttled-outqueries", 13187},
+		{"too-old-drops", 2},
+		{"udp-in-errors", 4},
+		{"udp-noport-errors", 2908},
+		{"udp-recvbuf-errors", 0},
+		{"udp-sndbuf-errors", 0},
+		{"unauthorized-tcp", 0},
+		{"unauthorized-udp", 0},
+		{"unexpected-packets", 0},
+		{"unreachables", 1695},
+		{"uptime", 165725},
+		{"user-msec", 1266384},
+		{"x-our-latency", 19},
+		{"x-ourtime-slow", 632},
+		{"x-ourtime0-1", 3060079},
+		{"x-ourtime1-2", 3351},
+		{"x-ourtime16-32", 197},
+		{"x-ourtime2-4", 302},
+		{"x-ourtime4-8", 194},
+		{"x-ourtime8-16", 24},
+	}
+
+	for _, test := range tests {
+		value, ok := values[test.key]
+		if !ok {
+			t.Errorf("Did not find key for metric %s in values", test.key)
+			continue
+		}
+		if value != test.value {
+			t.Errorf("Metric: %s, Expected: %d, actual: %d",
+				test.key, test.value, value)
+		}
+	}
+}
+
+func TestPowerdnsRecursorParseIntOverflowMetrics(t *testing.T) {
+	values := parseResponse(intOverflowMetrics)
+
+	tests := []struct {
+		key   string
+		value int64
+	}{
+		{"answers-slow", 36451},
+		{"answers0-1", 177297},
+		{"answers1-10", 1209328},
+		{"answers10-100", 1238786},
+		{"answers100-1000", 402917},
+		{"auth-zone-queries", 4},
+		{"auth4-answers-slow", 44248},
+		{"auth4-answers0-1", 59169},
+		{"auth4-answers1-10", 1747403},
+		{"auth4-answers10-100", 1315621},
+		{"auth4-answers100-1000", 424683},
+		{"auth6-answers-slow", 0},
+		{"auth6-answers0-1", 0},
+		{"auth6-answers1-10", 0},
+		{"auth6-answers10-100", 0},
+		{"auth6-answers100-1000", 0},
+		{"cache-entries", 295917},
+		{"cache-hits", 148630},
+		{"cache-misses", 2916149},
+		{"case-mismatches", 0},
+		{"chain-resends", 418602},
+		{"client-parse-errors", 0},
+		{"concurrent-queries", 0},
+		{"dlg-only-drops", 0},
+		{"dnssec-queries", 151536},
+		{"dnssec-result-bogus", 0},
+		{"dnssec-result-indeterminate", 0},
+		{"dnssec-result-insecure", 0},
+		{"dnssec-result-nta", 0},
+		{"dnssec-result-secure", 46},
+		{"dnssec-validations", 46},
+		{"dont-outqueries", 62},
+		{"ecs-queries", 0},
+		{"ecs-responses", 0},
+		{"edns-ping-matches", 0},
+		{"edns-ping-mismatches", 0},
+		{"failed-host-entries", 33},
+		{"fd-usage", 32},
+		{"ignored-packets", 0},
+		{"ipv6-outqueries", 0},
+		{"ipv6-questions", 0},
+		{"malloc-bytes", 0},
+		{"max-cache-entries", 1000000},
+		{"max-mthread-stack", 33747},
+		{"max-packetcache-entries", 500000},
+		{"negcache-entries", 100070},
+		{"no-packet-error", 0},
+		{"noedns-outqueries", 72409},
+		{"noerror-answers", 25155259},
+		{"noping-outqueries", 0},
+		{"nsset-invalidations", 2385},
+		{"nsspeeds-entries", 3571},
+		{"nxdomain-answers", 3307768},
+		{"outgoing-timeouts", 43876},
+		{"outgoing4-timeouts", 43876},
+		{"outgoing6-timeouts", 0},
+		{"over-capacity-drops", 0},
+		{"packetcache-entries", 80756},
+		{"packetcache-hits", 25698497},
+		{"packetcache-misses", 3064625},
+		{"policy-drops", 0},
+		{"policy-result-custom", 0},
+		{"policy-result-drop", 0},
+		{"policy-result-noaction", 3064779},
+		{"policy-result-nodata", 0},
+		{"policy-result-nxdomain", 0},
+		{"policy-result-truncate", 0},
+		{"qa-latency", 6587},
+		{"query-pipe-full-drops", 0},
+		{"questions", 28763276},
+		{"real-memory-usage", 280465408},
+		{"resource-limits", 0},
+		{"security-status", 1},
+		{"server-parse-errors", 0},
+		{"servfail-answers", 300249},
+		{"spoof-prevents", 0},
+		{"sys-msec", 1296588},
+		{"tcp-client-overflow", 0},
+		{"tcp-clients", 0},
+		{"tcp-outqueries", 116},
+		{"tcp-questions", 130},
+		{"throttle-entries", 33},
+		{"throttled-out", 13187},
+		{"throttled-outqueries", 13187},
+		{"too-old-drops", 2},
+		{"udp-in-errors", 4},
+		{"udp-noport-errors", 2908},
+		{"udp-recvbuf-errors", 0},
+		{"udp-sndbuf-errors", 0},
+		{"unauthorized-tcp", 0},
+		{"unauthorized-udp", 0},
+		{"unexpected-packets", 0},
+		{"unreachables", 1695},
+		{"uptime", 165725},
+		{"user-msec", 1266384},
+		{"x-our-latency", 19},
+		{"x-ourtime-slow", 632},
+		{"x-ourtime0-1", 3060079},
+		{"x-ourtime1-2", 3351},
+		{"x-ourtime16-32", 197},
+		{"x-ourtime2-4", 302},
+		{"x-ourtime4-8", 194},
+		{"x-ourtime8-16", 24},
+	}
+
+	for _, test := range tests {
+		value, ok := values[test.key]
+		if !ok {
+			t.Errorf("Did not find key for metric %s in values", test.key)
+			continue
+		}
+		if value != test.value {
+			t.Errorf("Metric: %s, Expected: %d, actual: %d",
+				test.key, test.value, value)
+		}
+	}
+}


### PR DESCRIPTION
Added a PowerDNS Recursor input plugin.

The PowerDNS plugin does not work for the recursor, as it as some differences.
Not only the command to get the stats is different, but also the socket type (datagram socket for the recursor).

As I also had to add some additional options, it looks better to me to have it in a separate plugin.

Please review the code if it can be merged. If things need to get changed, let me know!
I also get a strange error on make test ... so might need some assistance there!
