### PR TITLE
plugins/inputs/http_response: add ability to set source address on HTTP connections

### DIFF
--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -32,6 +32,9 @@ This input plugin checks HTTP/HTTPS connections.
   # response_string_match = "ok"
   # response_string_match = "\".*_status\".?:.?\"up\""
 
+  ## Optional source address used on connections (useful when a host has multiple IP addresses)
+  # source_address = "a.b.c.d"
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"


### PR DESCRIPTION
Allow the source address to optionally be set on outbound HTTP(S) connections.  This is useful when you need connections to come from a specific address on a host with multiple IP addresses.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
