### PR TITLE
Fix burrow_group.offset calculation for Burrow plugin

### DIFF
--- a/plugins/inputs/burrow/README.md
+++ b/plugins/inputs/burrow/README.md
@@ -50,7 +50,7 @@ Supported Burrow version: `1.x`
   # insecure_skip_verify = false
 ```
 
-### Partition Status mappings
+### Group/Partition Status mappings
 
 * `OK` = 1
 * `NOT_FOUND` = 2
@@ -66,9 +66,11 @@ Supported Burrow version: `1.x`
 * `burrow_group` (one event per each consumer group)
   - status (string, see Partition Status mappings)
   - status_code (int, `1..6`, see Partition status mappings)
-  - parition_count (int, `number of partitions`)
+  - partition_count (int, `number of partitions`)
+  - offset (int64, `total offset of all partitions`)
   - total_lag (int64, `totallag`)
   - lag (int64, `maxlag.current_lag || 0`)
+  - timestamp (int64, `end.timestamp`)
 
 * `burrow_partition` (one event per each topic partition)
   - status (string, see Partition Status mappings)

--- a/plugins/inputs/burrow/burrow.go
+++ b/plugins/inputs/burrow/burrow.go
@@ -397,13 +397,11 @@ func (b *burrow) genGroupStatusMetrics(r *apiResponse, cluster, group string, ac
 		partitionCount = len(r.Status.Partitions)
 	}
 
-	// get max timestamp and offset from partitions list
+	// get max timestamp and total offset from partitions list
 	offset := int64(0)
 	timestamp := int64(0)
 	for _, partition := range r.Status.Partitions {
-		if partition.End.Offset > offset {
-			offset = partition.End.Offset
-		}
+		offset += partition.End.Offset
 		if partition.End.Timestamp > timestamp {
 			timestamp = partition.End.Timestamp
 		}

--- a/plugins/inputs/burrow/burrow_test.go
+++ b/plugins/inputs/burrow/burrow_test.go
@@ -160,7 +160,7 @@ func TestBurrowGroup(t *testing.T) {
 			"partition_count": 3,
 			"total_lag":       int64(0),
 			"lag":             int64(0),
-			"offset":          int64(431323195),
+			"offset":          int64(431323195 + 431322962 + 428636563),
 			"timestamp":       int64(1515609490008),
 		},
 	}


### PR DESCRIPTION
The value returned in `burrow_group.offset` field was the highest offset of any partition, rather than the sum of all partition offsets.  Note that the partition offset is still available from the `burrow_partition` metric if needed, this PR just fixes the `burrow_group` calculation to provide a better indication of total offset for the group.

### Required for all PRs:

- [*] Signed [CLA](https://influxdata.com/community/cla/).
- [*] Associated README.md updated.
- [*] Has appropriate unit tests.
