### PR TITLE
updated version of telegraf(1.7+) that supports OpenHardwareMonitor!

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ For documentation on the latest development code see the [documentation index][d
 * [openweathermap](./plugins/inputs/openweathermap)
 * [pf](./plugins/inputs/pf)
 * [pgbouncer](./plugins/inputs/pgbouncer)
+* [open_hardware_monitor](./plugins/inputs/open_hardware_monitor)
 * [phpfpm](./plugins/inputs/phpfpm)
 * [phusion passenger](./plugins/inputs/passenger)
 * [ping](./plugins/inputs/ping)

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -116,6 +116,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/nstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/ntpq"
 	_ "github.com/influxdata/telegraf/plugins/inputs/nvidia_smi"
+	_ "github.com/influxdata/telegraf/plugins/inputs/open_hardware_monitor"
 	_ "github.com/influxdata/telegraf/plugins/inputs/openldap"
 	_ "github.com/influxdata/telegraf/plugins/inputs/openntpd"
 	_ "github.com/influxdata/telegraf/plugins/inputs/opensmtpd"

--- a/plugins/inputs/open_hardware_monitor/README.md
+++ b/plugins/inputs/open_hardware_monitor/README.md
@@ -1,0 +1,95 @@
+# OpenHardwareMonitor Input Plugin
+
+This input plugin will gather sensors data provide by [Open hardware Monitor](http://openhardwaremonitor.org) application via Windows Management Instrumentation interface (WMI) 
+
+### Configuration:
+
+```
+# # Get sensors data from Open Hardware Monitor via WMI
+# [[inputs.open_hardware_monitor]]
+	## Sensors to query ( if not given then all is queried )
+	SensorsType = ["Temperature", "Fan", "Voltage"] # optional
+	
+	## Which hardware should be available
+	Parent = ["intelcpu_0"]  # optional
+```
+
+### Measurements & Fields:
+
+- All sensors provided by OpenHardwareMonitor or specify subset defined in the SensorsType configuration. 
+
+### Tags:
+
+- All measurements have the following tags:
+	
+	- name
+	- parent
+
+### Example Output:
+
+```
+* Plugin: open_hardware_monitor, Collection 1
+ohm,host=Test-PC,name=Temperature_#2,parent=lpc_nct6779d Temperature=34 1469698553000000000
+ohm,host=Test-PC,name=VTT,parent=lpc_nct6779d Voltage=1.056 1469698553000000000
+ohm,host=Test-PC,name=Voltage_#14,parent=lpc_nct6779d Voltage=1 1469698553000000000
+ohm,host=Test-PC,name=3VCC,parent=lpc_nct6779d Voltage=3.4240003 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#3,parent=intelcpu_0 Temperature=41 1469698553000000000
+ohm,host=Test-PC,name=Fan_Control_#4,parent=lpc_nct6779d Control=100 1469698553000000000
+ohm,host=Test-PC,name=GPU_Shader,parent=nvidiagpu_0 Clock=270 1469698553000000000
+ohm,host=Test-PC,name=Bus_Speed,parent=intelcpu_0 Clock=99.99993 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#2,parent=intelcpu_0 Clock=1599.9989 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#2,parent=intelcpu_0 Load=0 1469698553000000000
+ohm,host=Test-PC,name=GPU_Fan,parent=nvidiagpu_0 Control=33 1469698553000000000
+ohm,host=Test-PC,name=Available_Memory,parent=ram Data=13.124931 1469698553000000000
+ohm,host=Test-PC,name=3VSB,parent=lpc_nct6779d Voltage=3.4080002 1469698553000000000
+ohm,host=Test-PC,name=Voltage_#12,parent=lpc_nct6779d Voltage=0.24800001 1469698553000000000
+ohm,host=Test-PC,name=Voltage_#2,parent=lpc_nct6779d Voltage=1 1469698553000000000
+ohm,host=Test-PC,name=Fan_Control_#1,parent=lpc_nct6779d Control=74.117645 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core,parent=lpc_nct6779d Temperature=46 1469698553000000000
+ohm,host=Test-PC,name=Voltage_#6,parent=lpc_nct6779d Voltage=2.0400002 1469698553000000000
+ohm,host=Test-PC,name=GPU_Core,parent=nvidiagpu_0 Clock=135 1469698553000000000
+ohm,host=Test-PC,name=CPU_Cores,parent=intelcpu_0 Power=4.77574 1469698553000000000
+ohm,host=Test-PC,name=CPU_Package,parent=intelcpu_0 Temperature=45 1469698553000000000
+ohm,host=Test-PC,name=GPU_Memory_Controller,parent=nvidiagpu_0 Load=5 1469698553000000000
+ohm,host=Test-PC,name=Memory,parent=ram Load=45.18159 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#4,parent=intelcpu_0 Clock=2999.998 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#4,parent=intelcpu_0 Load=3.125 1469698553000000000
+ohm,host=Test-PC,name=GPU_Core,parent=nvidiagpu_0 Temperature=37 1469698553000000000
+ohm,host=Test-PC,name=Temperature_#6,parent=lpc_nct6779d Temperature=-7 1469698553000000000
+ohm,host=Test-PC,name=Fan_#4,parent=lpc_nct6779d Fan=672 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#1,parent=intelcpu_0 Temperature=44 1469698553000000000
+ohm,host=Test-PC,name=Temperature_#4,parent=lpc_nct6779d Temperature=-25 1469698553000000000
+ohm,host=Test-PC,name=Temperature_#5,parent=lpc_nct6779d Temperature=90 1469698553000000000
+ohm,host=Test-PC,name=Fan_#2,parent=lpc_nct6779d Fan=1355 1469698553000000000
+ohm,host=Test-PC,name=Voltage_#11,parent=lpc_nct6779d Voltage=1.8240001 1469698553000000000
+ohm,host=Test-PC,name=Temperature_#3,parent=lpc_nct6779d Temperature=32 1469698553000000000
+ohm,host=Test-PC,name=GPU_Video_Engine,parent=nvidiagpu_0 Load=0 1469698553000000000
+ohm,host=Test-PC,name=VBAT,parent=lpc_nct6779d Voltage=3.3600001 1469698553000000000
+ohm,host=Test-PC,name=Used_Space,parent=hdd_1 Load=36.86175 1469698553000000000
+ohm,host=Test-PC,name=Voltage_#13,parent=lpc_nct6779d Voltage=1.016 1469698553000000000
+ohm,host=Test-PC,name=AVCC,parent=lpc_nct6779d Voltage=3.4240003 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#2,parent=intelcpu_0 Temperature=41 1469698553000000000
+ohm,host=Test-PC,name=Fan_Control_#3,parent=lpc_nct6779d Control=100 1469698553000000000
+ohm,host=Test-PC,name=GPU_Memory,parent=nvidiagpu_0 Clock=405.00003 1469698553000000000
+ohm,host=Test-PC,name=CPU_Graphics,parent=intelcpu_0 Power=0 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#1,parent=intelcpu_0 Clock=1599.9989 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#1,parent=intelcpu_0 Load=3.125 1469698553000000000
+ohm,host=Test-PC,name=CPU_Total,parent=intelcpu_0 Load=2.734375 1469698553000000000
+ohm,host=Test-PC,name=Used_Memory,parent=ram Data=10.817631 1469698553000000000
+ohm,host=Test-PC,name=Voltage_#7,parent=lpc_nct6779d Voltage=1.5680001 1469698553000000000
+ohm,host=Test-PC,name=Used_Space,parent=hdd_0 Load=48.958797 1469698553000000000
+ohm,host=Test-PC,name=Temperature_#1,parent=lpc_nct6779d Temperature=39 1469698553000000000
+ohm,host=Test-PC,name=CPU_VCore,parent=lpc_nct6779d Voltage=0.87200004 1469698553000000000
+ohm,host=Test-PC,name=Voltage_#15,parent=lpc_nct6779d Voltage=0.216 1469698553000000000
+ohm,host=Test-PC,name=Voltage_#5,parent=lpc_nct6779d Voltage=1.016 1469698553000000000
+ohm,host=Test-PC,name=GPU,parent=nvidiagpu_0 Fan=1480 1469698553000000000
+ohm,host=Test-PC,name=CPU_Package,parent=intelcpu_0 Power=10.8843355 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#4,parent=intelcpu_0 Temperature=32 1469698553000000000
+ohm,host=Test-PC,name=Fan_Control_#5,parent=lpc_nct6779d Control=100 1469698553000000000
+ohm,host=Test-PC,name=GPU_Core,parent=nvidiagpu_0 Load=0 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#3,parent=intelcpu_0 Clock=2999.998 1469698553000000000
+ohm,host=Test-PC,name=CPU_Core_#3,parent=intelcpu_0 Load=4.6875 1469698553000000000
+ohm,host=Test-PC,name=GPU_Memory,parent=nvidiagpu_0 Load=8.956909 1469698553000000000
+ohm,host=Test-PC,name=Fan_#1,parent=lpc_nct6779d Fan=1078 1469698553000000000
+ohm,host=Test-PC,name=Fan_Control_#2,parent=lpc_nct6779d Control=45.882355 1469698553000000000
+ohm,host=Test-PC,name=Fan_#3,parent=lpc_nct6779d Fan=1000 1469698553000000000

--- a/plugins/inputs/open_hardware_monitor/open_hardware_monitor.go
+++ b/plugins/inputs/open_hardware_monitor/open_hardware_monitor.go
@@ -1,0 +1,114 @@
+// +build windows
+
+package open_hardware_monitor
+
+import (
+	"fmt"
+	"github.com/StackExchange/wmi"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"strings"
+)
+
+type OpenHardwareMonitorConfig struct {
+	SensorsType []string
+	Parent      []string
+}
+
+type OpenHardwareMonitorData struct {
+	Name       string
+	SensorType string
+	Parent     string
+	Value      float32
+}
+
+func (p *OpenHardwareMonitorConfig) Description() string {
+	return "Get sensors data from Open Hardware Monitor via WMI"
+}
+
+const sampleConfig = `
+	## Sensors to query ( if not given then all is queried )
+	SensorsType = ["Temperature", "Fan", "Voltage"] # optional
+	
+	## Which hardware should be available
+	Parent = ["_intelcpu_0"]  # optional
+`
+
+func (p *OpenHardwareMonitorConfig) SampleConfig() string {
+	return sampleConfig
+}
+
+func (p *OpenHardwareMonitorConfig) CreateQuery() (string, error) {
+	query := "SELECT * FROM SENSOR"
+	if len(p.SensorsType) != 0 {
+		query += " WHERE "
+		var sensors []string
+		for _, sensor := range p.SensorsType {
+			sensors = append(sensors, fmt.Sprint("SensorType='", sensor, "'"))
+		}
+		query += strings.Join(sensors, " OR ")
+	}
+	return query, nil
+}
+
+func (p *OpenHardwareMonitorConfig) QueryData(query string) ([]OpenHardwareMonitorData, error) {
+	var dst []OpenHardwareMonitorData
+	err := wmi.QueryNamespace(query, &dst, "root/OpenHardwareMonitor")
+
+	// Replace all spaces
+	replace := map[string]string{
+		" ": "_",
+		"/": "_",
+	}
+	for i := range dst {
+		for key, value := range replace {
+			dst[i].Name = strings.Replace(strings.Trim(dst[i].Name, key), key, value, -1)
+			dst[i].SensorType = strings.Replace(strings.Trim(dst[i].SensorType, key), key, value, -1)
+			dst[i].Parent = strings.Replace(strings.Trim(dst[i].Parent, key), key, value, -1)
+		}
+	}
+
+	return dst, err
+}
+
+func contains(s []string, e string) bool {
+	if len(s) == 0 {
+		return true
+	}
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *OpenHardwareMonitorConfig) Gather(acc telegraf.Accumulator) error {
+	var dst []OpenHardwareMonitorData
+	query, err := p.CreateQuery()
+	if err == nil {
+		dst, err = p.QueryData(query)
+		if err != nil {
+			acc.AddError(err)
+		}
+		for _, sensorData := range dst {
+			if contains(p.Parent, sensorData.Parent) {
+				tags := map[string]string{
+					"name":   sensorData.Name,
+					"parent": sensorData.Parent,
+				}
+				fields := map[string]interface{}{sensorData.SensorType: sensorData.Value}
+				acc.AddFields("ohm", fields, tags)
+			}
+		}
+	} else {
+		acc.AddError(err)
+	}
+	return nil
+}
+
+func init() {
+	inputs.Add("open_hardware_monitor", func() telegraf.Input {
+		return &OpenHardwareMonitorConfig{}
+	})
+}

--- a/plugins/inputs/open_hardware_monitor/open_hardware_monitor_notwindows.go
+++ b/plugins/inputs/open_hardware_monitor/open_hardware_monitor_notwindows.go
@@ -1,0 +1,3 @@
+// +build !windows
+
+package open_hardware_monitor

--- a/plugins/inputs/open_hardware_monitor/open_hardware_monitor_test.go
+++ b/plugins/inputs/open_hardware_monitor/open_hardware_monitor_test.go
@@ -1,0 +1,28 @@
+// +build windows
+
+package open_hardware_monitor
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCreateQueryWithSensors(t *testing.T) {
+	//var acc testutil.Accumulator
+	p := OpenHardwareMonitorConfig{
+		SensorsType: []string{"Temperature", "Voltage"},
+	}
+
+	query, _ := p.CreateQuery()
+
+	assert.Equal(t, "SELECT * FROM SENSOR WHERE SensorType='Temperature' OR SensorType='Voltage'", query)
+}
+
+func TestCreateQueryEmpty(t *testing.T) {
+	//var acc testutil.Accumulator
+	var p OpenHardwareMonitorConfig
+
+	query, _ := p.CreateQuery()
+
+	assert.Equal(t, "SELECT * FROM SENSOR", query)
+}


### PR DESCRIPTION
Please precompile an updated version of telegraf(1.7+) that supports OpenHardwareMonitor! I only run windows, and DEP doesn't have windows installers. I also have never had to use GO before. 
Thanks,