### PR TITLE
Remove timeout deadline for udp syslog input.

### DIFF
--- a/plugins/inputs/syslog/syslog.go
+++ b/plugins/inputs/syslog/syslog.go
@@ -213,10 +213,6 @@ func (s *Syslog) listenPacket(acc telegraf.Accumulator) {
 			break
 		}
 
-		if s.ReadTimeout != nil && s.ReadTimeout.Duration > 0 {
-			s.udpListener.SetReadDeadline(time.Now().Add(s.ReadTimeout.Duration))
-		}
-
 		message, err := p.Parse(b[:n], &s.BestEffort)
 		if message != nil {
 			acc.AddFields("syslog", fields(*message, s), tags(*message), s.time())


### PR DESCRIPTION
On UDP sockets we shouldn't use the timeout due to the connection-less nature of the socket.

related: #4593

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
