### PR TITLE
add queue_durability property to amqp_consumer input

### DIFF
--- a/plugins/inputs/amqp_consumer/README.md
+++ b/plugins/inputs/amqp_consumer/README.md
@@ -46,6 +46,10 @@ The following defaults are known to work with RabbitMQ:
 
   ## AMQP queue name
   queue = "telegraf"
+  
+  ## AMQP queue durability.
+  queue_durability = true
+  
   ## Binding Key
   binding_key = "#"
 

--- a/plugins/inputs/amqp_consumer/README.md
+++ b/plugins/inputs/amqp_consumer/README.md
@@ -47,8 +47,8 @@ The following defaults are known to work with RabbitMQ:
   ## AMQP queue name
   queue = "telegraf"
   
-  ## AMQP queue durability.
-  queue_durability = true
+  ## AMQP queue durability can be "transient" or "durable".
+  queue_durability = "durable"
   
   ## Binding Key
   binding_key = "#"

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -32,6 +32,7 @@ type AMQPConsumer struct {
 	// Queue Name
 	Queue           string `toml:"queue"`
 	QueueDurability string `toml:"queue_durability"`
+
 	// Binding Key
 	BindingKey string `toml:"binding_key"`
 
@@ -64,6 +65,8 @@ const (
 
 	DefaultExchangeType       = "topic"
 	DefaultExchangeDurability = "durable"
+
+	DefaultQueueDurability = "durable"
 
 	DefaultPrefetchCount = 50
 )
@@ -392,6 +395,7 @@ func init() {
 			AuthMethod:         DefaultAuthMethod,
 			ExchangeType:       DefaultExchangeType,
 			ExchangeDurability: DefaultExchangeDurability,
+			QueueDurability:    DefaultQueueDurability,
 			PrefetchCount:      DefaultPrefetchCount,
 		}
 	})

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -30,7 +30,8 @@ type AMQPConsumer struct {
 	ExchangeArguments  map[string]string `toml:"exchange_arguments"`
 
 	// Queue Name
-	Queue string
+	Queue           string `toml:"queue"`
+	QueueDurability bool   `toml:"queue_durability"`
 	// Binding Key
 	BindingKey string `toml:"binding_key"`
 
@@ -98,10 +99,13 @@ func (a *AMQPConsumer) SampleConfig() string {
   # exchange_arguments = { }
   # exchange_arguments = {"hash_propery" = "timestamp"}
 
-  ## AMQP queue name
+  ## AMQP queue name.
   queue = "telegraf"
 
-  ## Binding Key
+  ## AMQP queue durability.
+  queue_durability = true
+
+  ## Binding Key.
   binding_key = "#"
 
   ## Maximum number of messages server should give to the worker.
@@ -261,12 +265,12 @@ func (a *AMQPConsumer) connect(amqpConf *amqp.Config) (<-chan amqp.Delivery, err
 	}
 
 	q, err := ch.QueueDeclare(
-		a.Queue, // queue
-		true,    // durable
-		false,   // delete when unused
-		false,   // exclusive
-		false,   // no-wait
-		nil,     // arguments
+		a.Queue,           // queue
+		a.QueueDurability, // durable
+		false,             // delete when unused
+		false,             // exclusive
+		false,             // no-wait
+		nil,               // arguments
 	)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to declare a queue: %s", err)


### PR DESCRIPTION
### Required for all PRs:

- [+] Signed [CLA](https://influxdata.com/community/cla/).
- [+] Associated README.md updated.
- [-] Has appropriate unit tests.

Added a Queue Durability property to amqp_consumer input plugin.

The amqp_consumer input plugin always creates at RabbitMQ server a queue with durable 'true',
that meas RabbitMQ is saving messages to disk in the queue util they are consumed. Sometimes it is needed to avoid impact of disk I/O and set the queue 'not durable'. It is easy to do in plugin configuration file.

Please review the code if it can be merged. 