### PR TITLE
Corrected application insights example config

### DIFF
--- a/plugins/outputs/application_insights/README.md
+++ b/plugins/outputs/application_insights/README.md
@@ -12,7 +12,7 @@ This plugin writes telegraf metrics to [Azure Application Insights](https://azur
   # timeout = "5s"
 
   ## Enable additional diagnostic logging.
-  # enable_diagnosic_logging = false
+  # enable_diagnostic_logging = false
 
   ## Context Tag Sources add Application Insights context tags to a tag value.
   ##
@@ -37,7 +37,7 @@ foo,host=a first=42,second=43 1525293034000000000
 
 In the special case of a single field named `value`, a single telemetry record is created named using only the measurement name
 
-**Example:** Create a telemetry record `foo`:
+**Example:** Create a telemetry record `bar`:
 ```
 bar,host=a value=42 1525293034000000000
 ```

--- a/plugins/outputs/application_insights/application_insights.go
+++ b/plugins/outputs/application_insights/application_insights.go
@@ -48,7 +48,7 @@ var (
   # timeout = "5s"
 
   ## Enable additional diagnostic logging.
-  # enable_diagnosic_logging = false
+  # enable_diagnostic_logging = false
 
   ## Context Tag Sources add Application Insights context tags to a tag value.
   ##


### PR DESCRIPTION
Found small miss spelling from application insights example config.

### Required for all PRs:
- [X ] Signed [CLA](https://influxdata.com/community/cla/).
- [X ] Associated README.md updated.
- [  ] Has appropriate unit tests.

/cc @karolz-ms