### PR TITLE
Add support for fetching config over https

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"log"
 	"math"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -589,7 +591,12 @@ func (c *Config) LoadConfig(path string) error {
 			return err
 		}
 	}
-	tbl, err := parseFile(path)
+	data, err := loadConfig(path)
+	if err != nil {
+		return fmt.Errorf("Error loading %s, %s", path, err)
+	}
+
+	tbl, err := parseConfig(data)
 	if err != nil {
 		return fmt.Errorf("Error parsing %s, %s", path, err)
 	}
@@ -736,15 +743,35 @@ func escapeEnv(value string) string {
 	return envVarEscaper.Replace(value)
 }
 
-// parseFile loads a TOML configuration from a provided path and
-// returns the AST produced from the TOML parser. When loading the file, it
-// will find environment variables and replace them.
-func parseFile(fpath string) (*ast.Table, error) {
-	contents, err := ioutil.ReadFile(fpath)
+func loadConfig(config string) ([]byte, error) {
+	u, err := url.Parse(config)
 	if err != nil {
 		return nil, err
 	}
-	// ugh windows why
+
+	switch u.Scheme {
+	case "https": // http not permitted
+		return fetchConfig(u)
+	default:
+		// If it isn't a http scheme, try it as a file.
+	}
+	return ioutil.ReadFile(config)
+
+}
+
+func fetchConfig(u *url.URL) ([]byte, error) {
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return ioutil.ReadAll(resp.Body)
+}
+
+// parseFile loads a TOML configuration from a provided path and
+// returns the AST produced from the TOML parser. When loading the file, it
+// will find environment variables and replace them.
+func parseConfig(contents []byte) (*ast.Table, error) {
 	contents = trimBOM(contents)
 
 	env_vars := envVarRe.FindAll(contents, -1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -753,14 +753,21 @@ func loadConfig(config string) ([]byte, error) {
 	case "https": // http not permitted
 		return fetchConfig(u)
 	default:
-		// If it isn't a http scheme, try it as a file.
+		// If it isn't a https scheme, try it as a file.
 	}
 	return ioutil.ReadFile(config)
 
 }
 
 func fetchConfig(u *url.URL) ([]byte, error) {
-	resp, err := http.Get(u.String())
+	v := os.Getenv("INFLUX_TOKEN")
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", "Token "+v)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -767,6 +767,7 @@ func fetchConfig(u *url.URL) ([]byte, error) {
 		return nil, err
 	}
 	req.Header.Add("Authorization", "Token "+v)
+	req.Header.Add("Accept", "application/toml")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -768,7 +768,7 @@ func fetchConfig(u *url.URL) ([]byte, error) {
 	return ioutil.ReadAll(resp.Body)
 }
 
-// parseFile loads a TOML configuration from a provided path and
+// parseConfig loads a TOML configuration from a provided path and
 // returns the AST produced from the TOML parser. When loading the file, it
 // will find environment variables and replace them.
 func parseConfig(contents []byte) (*ast.Table, error) {


### PR DESCRIPTION
closes #4489

Only permits HTTPS with a valid certificate.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
