### PR TITLE
Add options for basic auth to haproxy input

### DIFF
--- a/plugins/inputs/haproxy/haproxy.go
+++ b/plugins/inputs/haproxy/haproxy.go
@@ -173,7 +173,7 @@ func (g *haproxy) gatherServer(addr string, acc telegraf.Accumulator) error {
 		addr = u.String()
 	}
 
-	if g.Username != "" {
+	if g.Username != "" || g.Password != "" {
 		req.SetBasicAuth(g.Username, g.Password)
 	}
 

--- a/plugins/inputs/haproxy/haproxy.go
+++ b/plugins/inputs/haproxy/haproxy.go
@@ -23,6 +23,8 @@ import (
 type haproxy struct {
 	Servers        []string
 	KeepFieldNames bool
+	Username       string
+	Password       string
 	tls.ClientConfig
 
 	client *http.Client
@@ -36,6 +38,10 @@ var sampleConfig = `
 
   ## If no servers are specified, then default to 127.0.0.1:1936/haproxy?stats
   servers = ["http://myhaproxy.com:1936/haproxy?stats"]
+
+  ## Credentials for basic HTTP authentication
+  # username = "admin"
+  # password = "admin"
 
   ## You can also use local socket with standard wildcard globbing.
   ## Server address not starting with 'http' will be treated as a possible
@@ -163,6 +169,12 @@ func (g *haproxy) gatherServer(addr string, acc telegraf.Accumulator) error {
 	if u.User != nil {
 		p, _ := u.User.Password()
 		req.SetBasicAuth(u.User.Username(), p)
+		u.User = &url.Userinfo{}
+		addr = u.String()
+	}
+
+	if g.Username != "" {
+		req.SetBasicAuth(g.Username, g.Password)
 	}
 
 	res, err := g.client.Do(req)


### PR DESCRIPTION
Resolves #4509 

Formerly users who enabled auth on their haproxy servers were required to set the username/password in the url. Now it is added separately. Older config styles (`https://user:pass@host/haproxy?stats`) won't break and won't print login info in logs on bad connections.