### PR TITLE
Use operation subtables in enum and rename processors

### DIFF
--- a/plugins/processors/enum/README.md
+++ b/plugins/processors/enum/README.md
@@ -13,13 +13,13 @@ source field is overwritten.
 
 ```toml
 [[processors.enum]]
-  [[processors.enum.fields]]
+  [[processors.enum.mapping]]
     ## Name of the field to map
-    source = "name"
+    field = "status"
 
     ## Destination field to be used for the mapped value.  By default the source
     ## field is used, overwriting the original value.
-    # destination = "mapped"
+    # dest = "status_code"
 
     ## Default value to be used for all values not contained in the mapping
     ## table.  When unset, the unmodified value for the field will be used if no
@@ -27,7 +27,15 @@ source field is overwritten.
     # default = 0
 
     ## Table of mappings
-    [processors.enum.fields.value_mappings]
-      value1 = 1
-      value2 = 2
+    [processors.enum.mapping.value_mappings]
+      green = 1
+      amber = 2
+      red = 3
+```
+
+### Example:
+
+```diff
+- xyzzy status="green" 1502489900000000000
++ xyzzy status="green",status_code=1i 1502489900000000000
 ```

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -49,7 +49,7 @@ func TestRetainsMetric(t *testing.T) {
 }
 
 func TestMapsSingleStringValue(t *testing.T) {
-	mapper := EnumMapper{Fields: []Mapping{{Source: "string_value", ValueMappings: map[string]interface{}{"test": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", ValueMappings: map[string]interface{}{"test": int64(1)}}}}
 
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
@@ -57,7 +57,7 @@ func TestMapsSingleStringValue(t *testing.T) {
 }
 
 func TestNoFailureOnMappingsOnNonStringValuedFields(t *testing.T) {
-	mapper := EnumMapper{Fields: []Mapping{{Source: "int_value", ValueMappings: map[string]interface{}{"13i": int64(7)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{Field: "int_value", ValueMappings: map[string]interface{}{"13i": int64(7)}}}}
 
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
@@ -65,7 +65,7 @@ func TestNoFailureOnMappingsOnNonStringValuedFields(t *testing.T) {
 }
 
 func TestMapSingleBoolValue(t *testing.T) {
-	mapper := EnumMapper{Fields: []Mapping{{Source: "true_value", ValueMappings: map[string]interface{}{"true": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{Field: "true_value", ValueMappings: map[string]interface{}{"true": int64(1)}}}}
 
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
@@ -73,7 +73,7 @@ func TestMapSingleBoolValue(t *testing.T) {
 }
 
 func TestMapsToDefaultValueOnUnknownSourceValue(t *testing.T) {
-	mapper := EnumMapper{Fields: []Mapping{{Source: "string_value", Default: int64(42), ValueMappings: map[string]interface{}{"other": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Default: int64(42), ValueMappings: map[string]interface{}{"other": int64(1)}}}}
 
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
@@ -81,7 +81,7 @@ func TestMapsToDefaultValueOnUnknownSourceValue(t *testing.T) {
 }
 
 func TestDoNotMapToDefaultValueKnownSourceValue(t *testing.T) {
-	mapper := EnumMapper{Fields: []Mapping{{Source: "string_value", Default: int64(42), ValueMappings: map[string]interface{}{"test": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Default: int64(42), ValueMappings: map[string]interface{}{"test": int64(1)}}}}
 
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
@@ -89,7 +89,7 @@ func TestDoNotMapToDefaultValueKnownSourceValue(t *testing.T) {
 }
 
 func TestNoMappingWithoutDefaultOrDefinedMappingValue(t *testing.T) {
-	mapper := EnumMapper{Fields: []Mapping{{Source: "string_value", ValueMappings: map[string]interface{}{"other": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", ValueMappings: map[string]interface{}{"other": int64(1)}}}}
 
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
@@ -97,7 +97,7 @@ func TestNoMappingWithoutDefaultOrDefinedMappingValue(t *testing.T) {
 }
 
 func TestWritesToDestination(t *testing.T) {
-	mapper := EnumMapper{Fields: []Mapping{{Source: "string_value", Destination: "string_code", ValueMappings: map[string]interface{}{"test": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Dest: "string_code", ValueMappings: map[string]interface{}{"test": int64(1)}}}}
 
 	fields := calculateProcessedValues(mapper, createTestMetric())
 

--- a/plugins/processors/rename/README.md
+++ b/plugins/processors/rename/README.md
@@ -5,28 +5,23 @@ The `rename` processor renames measurements, fields, and tags.
 ### Configuration:
 
 ```toml
-## Measurement, tag, and field renamings are stored in separate sub-tables.
-## Specify one sub-table per rename operation.
 [[processors.rename]]
-[[processors.rename.measurement]]
-  ## measurement to change
-  from = "network_interface_throughput"
-  to = "throughput"
+  ## Specify one sub-table per rename operation.
+  [[processors.rename.replace]]
+    measurement = "network_interface_throughput"
+    dest = "throughput"
 
-[[processors.rename.tag]]
-  ## tag to change
-  from = "hostname"
-  to = "host"
+  [[processors.rename.replace]]
+    tag = "hostname"
+    dest = "host"
 
-[[processors.rename.field]]
-  ## field to change
-  from = "lower"
-  to = "min"
+  [[processors.rename.replace]]
+    field = "lower"
+    dest = "min"
 
-[[processors.rename.field]]
-  ## field to change
-  from = "upper"
-  to = "max"
+  [[processors.rename.replace]]
+    field = "upper"
+    dest = "max"
 ```
 
 ### Tags:
@@ -36,6 +31,6 @@ No tags are applied by this processor, though it can alter them by renaming.
 ### Example processing:
 
 ```diff
-- network_interface_throughput,hostname=backend.example.com,units=kbps lower=10i,upper=1000i,mean=500i 1502489900000000000
-+ throughput,host=backend.example.com,units=kbps min=10i,max=1000i,mean=500i 1502489900000000000
+- network_interface_throughput,hostname=backend.example.com lower=10i,upper=1000i,mean=500i 1502489900000000000
++ throughput,host=backend.example.com min=10i,max=1000i,mean=500i 1502489900000000000
 ```

--- a/plugins/processors/rename/rename_test.go
+++ b/plugins/processors/rename/rename_test.go
@@ -21,10 +21,11 @@ func newMetric(name string, tags map[string]string, fields map[string]interface{
 }
 
 func TestMeasurementRename(t *testing.T) {
-	r := Rename{}
-	r.Measurement = []renamer{
-		{From: "foo", To: "bar"},
-		{From: "baz", To: "quux"},
+	r := Rename{
+		Replaces: []Replace{
+			{Measurement: "foo", Dest: "bar"},
+			{Measurement: "baz", Dest: "quux"},
+		},
 	}
 	m1 := newMetric("foo", nil, nil)
 	m2 := newMetric("bar", nil, nil)
@@ -36,9 +37,10 @@ func TestMeasurementRename(t *testing.T) {
 }
 
 func TestTagRename(t *testing.T) {
-	r := Rename{}
-	r.Tag = []renamer{
-		{From: "hostname", To: "host"},
+	r := Rename{
+		Replaces: []Replace{
+			{Tag: "hostname", Dest: "host"},
+		},
 	}
 	m := newMetric("foo", map[string]string{"hostname": "localhost", "region": "east-1"}, nil)
 	results := r.Apply(m)
@@ -47,9 +49,10 @@ func TestTagRename(t *testing.T) {
 }
 
 func TestFieldRename(t *testing.T) {
-	r := Rename{}
-	r.Field = []renamer{
-		{From: "time_msec", To: "time"},
+	r := Rename{
+		Replaces: []Replace{
+			{Field: "time_msec", Dest: "time"},
+		},
 	}
 	m := newMetric("foo", nil, map[string]interface{}{"time_msec": int64(1250), "snakes": true})
 	results := r.Apply(m)


### PR DESCRIPTION
Based on #4616, this pull request switches the enum and rename to use the operation style subtables.

The primary reason for this is free up the `field`/`fields` options and make the various processors configs a bit more uniform.  There is no change in functionality.

cc @goldibex @KarstenSchnitter

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
