### PR TITLE
Log access denied opening a service at debug level

### DIFF
--- a/plugins/inputs/win_services/README.md
+++ b/plugins/inputs/win_services/README.md
@@ -25,7 +25,7 @@ The `state` field can have the following values:
 - 3 - stop pending
 - 4 - running
 - 5 - continue pending
-- 6 - pause pending 
+- 6 - pause pending
 - 7 - paused
 
 The `startup_mode` field can have the following values:
@@ -33,7 +33,7 @@ The `startup_mode` field can have the following values:
 - 1 - system start
 - 2 - auto start
 - 3 - demand start
-- 4 - disabled   
+- 4 - disabled
 
 ### Tags:
 
@@ -50,7 +50,7 @@ The `startup_mode` field can have the following values:
 ### TICK Scripts
 
 A sample TICK script for a notification about a not running service.
-It sends a notification whenever any service changes its state to be not _running_ and when it changes that state back to _running_. 
+It sends a notification whenever any service changes its state to be not _running_ and when it changes that state back to _running_.
 The notification is sent via an HTTP POST call.
 
 ```

--- a/plugins/inputs/win_services/README.md
+++ b/plugins/inputs/win_services/README.md
@@ -1,7 +1,9 @@
-# Telegraf Plugin: win_services
-Input plugin to report Windows services info.
+# Windows Services Input Plugin
 
-It requires that Telegraf must be running under the administrator privileges.
+Reports information about Windows service status.
+
+Monitoring some services may require running Telegraf with administrator privileges.
+
 ### Configuration:
 
 ```toml
@@ -43,9 +45,8 @@ The `startup_mode` field can have the following values:
 
 ### Example Output:
 ```
-* Plugin: inputs.win_services, Collection 1
-> win_services,host=WIN2008R2H401,display_name=Server,service_name=LanmanServer state=4i,startup_mode=2i 1500040669000000000
-> win_services,display_name=Remote\ Desktop\ Services,service_name=TermService,host=WIN2008R2H401 state=1i,startup_mode=3i 1500040669000000000
+win_services,host=WIN2008R2H401,display_name=Server,service_name=LanmanServer state=4i,startup_mode=2i 1500040669000000000
+win_services,display_name=Remote\ Desktop\ Services,service_name=TermService,host=WIN2008R2H401 state=1i,startup_mode=3i 1500040669000000000
 ```
 ### TICK Scripts
 

--- a/plugins/inputs/win_services/win_services_integration_test.go
+++ b/plugins/inputs/win_services/win_services_integration_test.go
@@ -4,11 +4,10 @@
 package win_services
 
 import (
-	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/windows/svc/mgr"
 	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 var InvalidServices = []string{"XYZ1@", "ZYZ@", "SDF_@#"}
@@ -18,57 +17,30 @@ func TestList(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	services, err := listServices(&MgProvider{}, KnownServices)
+	provider := &MgProvider{}
+	scmgr, err := provider.Connect()
 	require.NoError(t, err)
-	assert.Len(t, services, 2, "Different number of services")
-	assert.Equal(t, services[0].ServiceName, KnownServices[0])
-	assert.Nil(t, services[0].Error)
-	assert.Equal(t, services[1].ServiceName, KnownServices[1])
-	assert.Nil(t, services[1].Error)
+	defer scmgr.Disconnect()
+
+	services, err := listServices(scmgr, KnownServices)
+	require.NoError(t, err)
+	require.Len(t, services, 2, "Different number of services")
+	require.Equal(t, services[0], KnownServices[0])
+	require.Equal(t, services[1], KnownServices[1])
 }
 
 func TestEmptyList(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	services, err := listServices(&MgProvider{}, []string{})
+	provider := &MgProvider{}
+	scmgr, err := provider.Connect()
 	require.NoError(t, err)
-	assert.Condition(t, func() bool { return len(services) > 20 }, "Too few service")
-}
+	defer scmgr.Disconnect()
 
-func TestListEr(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-	services, err := listServices(&MgProvider{}, InvalidServices)
+	services, err := listServices(scmgr, []string{})
 	require.NoError(t, err)
-	assert.Len(t, services, 3, "Different number of services")
-	for i := 0; i < 3; i++ {
-		assert.Equal(t, services[i].ServiceName, InvalidServices[i])
-		assert.NotNil(t, services[i].Error)
-	}
-}
-
-func TestGather(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-	ws := &WinServices{KnownServices, &MgProvider{}}
-	assert.Len(t, ws.ServiceNames, 2, "Different number of services")
-	var acc testutil.Accumulator
-	require.NoError(t, ws.Gather(&acc))
-	assert.Len(t, acc.Errors, 0, "There should be no errors after gather")
-
-	for i := 0; i < 2; i++ {
-		fields := make(map[string]interface{})
-		tags := make(map[string]string)
-		si := getServiceInfo(KnownServices[i])
-		fields["state"] = int(si.State)
-		fields["startup_mode"] = int(si.StartUpMode)
-		tags["service_name"] = si.ServiceName
-		tags["display_name"] = si.DisplayName
-		acc.AssertContainsTaggedFields(t, "win_services", fields, tags)
-	}
+	require.Condition(t, func() bool { return len(services) > 20 }, "Too few service")
 }
 
 func TestGatherErrors(t *testing.T) {
@@ -76,40 +48,8 @@ func TestGatherErrors(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 	ws := &WinServices{InvalidServices, &MgProvider{}}
-	assert.Len(t, ws.ServiceNames, 3, "Different number of services")
+	require.Len(t, ws.ServiceNames, 3, "Different number of services")
 	var acc testutil.Accumulator
 	require.NoError(t, ws.Gather(&acc))
-	assert.Len(t, acc.Errors, 3, "There should be 3 errors after gather")
-}
-
-func getServiceInfo(srvName string) *ServiceInfo {
-
-	scmgr, err := mgr.Connect()
-	if err != nil {
-		return nil
-	}
-	defer scmgr.Disconnect()
-
-	srv, err := scmgr.OpenService(srvName)
-	if err != nil {
-		return nil
-	}
-	var si ServiceInfo
-	si.ServiceName = srvName
-	srvStatus, err := srv.Query()
-	if err == nil {
-		si.State = int(srvStatus.State)
-	} else {
-		si.Error = err
-	}
-
-	srvCfg, err := srv.Config()
-	if err == nil {
-		si.DisplayName = srvCfg.DisplayName
-		si.StartUpMode = int(srvCfg.StartType)
-	} else {
-		si.Error = err
-	}
-	srv.Close()
-	return &si
+	require.Len(t, acc.Errors, 3, "There should be 3 errors after gather")
 }


### PR DESCRIPTION
This is a mitigation for #4522, reduce the log level to debug when a service cannot be opened due to permissions issues.  This allows Telegraf to be ran with reduce privileges without spamming the log.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
