### PR TITLE
don't try to reach STS if role_arn is not specified

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -210,17 +210,19 @@ func (c *CloudWatch) Connect() error {
 	}
 	configProvider := credentialConfig.Credentials()
 
-	stsService := sts.New(configProvider)
+	if c.RoleARN != "" {
+		stsService := sts.New(configProvider)
 
-	params := &sts.GetCallerIdentityInput{}
+		params := &sts.GetCallerIdentityInput{}
 
-	_, err := stsService.GetCallerIdentity(params)
+		_, err := stsService.GetCallerIdentity(params)
 
-	if err != nil {
-		log.Printf("E! cloudwatch: Cannot use credentials to connect to AWS : %+v \n", err.Error())
-		return err
+		if err != nil {
+			log.Printf("E! cloudwatch: Cannot use credentials to connect to AWS : %+v \n", err.Error())
+			return err
+		}
 	}
-
+	
 	c.svc = cloudwatch.New(configProvider)
 
 	return nil

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -222,7 +222,7 @@ func (c *CloudWatch) Connect() error {
 			return err
 		}
 	}
-	
+
 	c.svc = cloudwatch.New(configProvider)
 
 	return nil


### PR DESCRIPTION
When telegraf is running inside a VPC, STS (AWS Simple Token Service) may not be reachable. This makes the cloudwatch output plugin fail before it even tries other methods of getting its authentication tokens.

Since the documentation already states that STS is only tried if role_arn is specified, this patch skips STS entirely if the role_arn is blank.
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

Since the change I'm making here simply makes the existing README.md true, there was no need to modify it.

I didn't add a unit test; I don't know enough about go yet to know how to mock out the sts module and the existing tests don't have a good example to copy. Assuming that's required for this change, I can learn that...