### PR TITLE
Fixed minor bug that caused error messages in vCenter log

### DIFF
--- a/plugins/inputs/vsphere/client.go
+++ b/plugins/inputs/vsphere/client.go
@@ -164,12 +164,10 @@ func (c *Client) close() {
 	// to close it multiple times.
 	c.closeGate.Do(func() {
 		ctx := context.Background()
-		if c.Views != nil {
-			c.Views.Destroy(ctx)
-
-		}
 		if c.Client != nil {
-			c.Client.Logout(ctx)
+			if err := c.Client.Logout(ctx); err != nil {
+				log.Printf("E! [input.vsphere]: Error during logout: %s", err)
+			}
 		}
 	})
 }


### PR DESCRIPTION
The plugin was calling an unsupported View.Destroy method which caused errors to be logged to the vCenter log. Removed the call, as any open views would be destroyed by the subsequent call to Logout anyway.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
