### PR TITLE
Add readme note about docker socket permissions

### DIFF
--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -66,6 +66,31 @@ to gather stats from the [Engine API](https://docs.docker.com/engine/api/v1.24/)
 When using the `"ENV"` endpoint, the connection is configured using the
 [cli Docker environment variables](https://godoc.org/github.com/moby/moby/client#NewEnvClient).
 
+#### Security
+
+Giving telegraf access to the Docker daemon expands the [attack surface](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface) that could result in an attacker gaining root access to a machine. This is especially relevant if the telegraf configuration can be changed by untrusted users.
+
+#### Docker Daemon Permissions
+
+Typically, telegraf must be given permission to access the docker daemon unix
+socket when using the default endpoint. This can be done by adding the
+`telegraf` unix user (created when installing a Telegraf package) to the
+`docker` unix group with the following command:
+
+```
+sudo usermod -aG docker telegraf
+```
+
+If telegraf is run within a container, the unix socket will need to be exposed
+within the telegraf container. This can be done in the docker CLI by add the
+option `-v /var/run/docker.sock:/var/run/docker.sock` or adding the following
+lines to the telegraf container definition in a docker compose file:
+
+```
+volumes:
+  - /var/run/docker.sock:/var/run/docker.sock
+```
+
 #### Kubernetes Labels
 
 Kubernetes may add many labels to your containers, if they are not needed you
@@ -73,7 +98,6 @@ may prefer to exclude them:
 ```
   docker_label_exclude = ["annotation.kubernetes*"]
 ```
-
 
 ### Metrics:
 


### PR DESCRIPTION
This updates the docker input plugin readme with a section about setting permissions for telegraf to access the docker daemon socket. This should address some of the confusion about why the docker input plugin does not work out of the box ([as seen here](https://github.com/influxdata/telegraf/issues/1074#issuecomment-213040280)).

There should probably be a note about security considerations with the current method. That could be a link to [this page](https://docs.docker.com/install/linux/linux-postinstall/#use-a-different-storage-engine) or [this page](https://docs.docker.com/engine/security/https/) on the Docker docs.

A better solution would be showing a way to give telegraf read-only permissions to the socket. Any suggestions on the "right" way to do that would be appreciated.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
