### PR TITLE
Clarify monitoring backend provenance

### DIFF
--- a/plugins/inputs/openldap/README.md
+++ b/plugins/inputs/openldap/README.md
@@ -4,7 +4,7 @@ This plugin gathers metrics from OpenLDAP's cn=Monitor backend.
 
 ### Configuration:
 
-To use this plugin you must enable the [monitoring](https://www.openldap.org/devel/admin/monitoringslapd.html) backend.
+To use this plugin you must enable the [slapd monitoring](https://www.openldap.org/devel/admin/monitoringslapd.html) backend.
 
 ```toml
 [[inputs.openldap]]


### PR DESCRIPTION
I think it's relevant to specify it's the OpenLDAP slapd _monitoring_ backend; I didn't hover over or click on the link and thought I needed a special telegraf monitoring backend.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
