### PR TITLE
Add hostname to TLS config for SNI support

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -80,6 +80,7 @@ func (c *X509Cert) getCert(location string, timeout time.Duration) ([]*x509.Cert
 		}
 		defer ipConn.Close()
 
+		tlsCfg.ServerName = u.Host
 		conn := tls.Client(ipConn, tlsCfg)
 		defer conn.Close()
 


### PR DESCRIPTION
x509_cert plugin was creating TLS connection without specifying a
server name for handshake. If there are multiple certificates on the
same host, the first one is received, resulting insecure host warning.

ServerName in tls.Config turns Server Name Indication (SNI) on for the
handshake, which allows virtual hosts on the same server.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
