### PR TITLE
String or Binary data will be truncated

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -393,7 +393,7 @@ const sqlServerPropertiesV2 = `DECLARE @sys_info TABLE (
 	server_memory BIGINT,
 	sku NVARCHAR(64),
 	engine_edition SMALLINT,
-	hardware_type VARCHAR(15),
+	hardware_type VARCHAR(16),
 	total_storage_mb BIGINT,
 	available_storage_mb BIGINT,
 	uptime INT


### PR DESCRIPTION
Physical machine is 16 characters long rather than 15 characters.  Changed definition of @sys_info table. Also, worth noting for future a Virtual Box VM in Linux shows up as a Physical Machine.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
