### PR TITLE
Clarify platform support for temp input

### DIFF
--- a/plugins/inputs/temp/README.md
+++ b/plugins/inputs/temp/README.md
@@ -1,6 +1,9 @@
 # Temp Input plugin
 
-This input plugin collect temperature.
+The temp input plugin gather metrics on system temperature.  This plugin is
+meant to be multi platform and uses platform specific collection methods.
+
+Currently supports Linux and Windows.
 
 ### Configuration:
 
@@ -8,25 +11,19 @@ This input plugin collect temperature.
 [[inputs.temp]]
 ```
 
-### Measurements & Fields:
+### Metrics:
 
-All fields are float64.
-
-- temp ( unit: °Celsius)
-
-### Tags:
-
-- All measurements have the following tags:
-    - host
+- temp
+  - tags:
     - sensor
+  - fields:
+    - temp (float, celcius)
 
 ### Example Output:
 
 ```
-$ ./telegraf --config telegraf.conf --input-filter temp --test
-* Plugin: temp, Collection 1
-> temp,host=localhost,sensor=coretemp_physicalid0_crit temp=100 1531298763000000000
-> temp,host=localhost,sensor=coretemp_physicalid0_critalarm temp=0 1531298763000000000
-> temp,host=localhost,sensor=coretemp_physicalid0_input temp=100 1531298763000000000
-> temp,host=localhost,sensor=coretemp_physicalid0_max temp=100 1531298763000000000
+temp,sensor=coretemp_physicalid0_crit temp=100 1531298763000000000
+temp,sensor=coretemp_physicalid0_critalarm temp=0 1531298763000000000
+temp,sensor=coretemp_physicalid0_input temp=100 1531298763000000000
+temp,sensor=coretemp_physicalid0_max temp=100 1531298763000000000
 ```

--- a/plugins/inputs/temp/temp.go
+++ b/plugins/inputs/temp/temp.go
@@ -2,6 +2,7 @@ package temp
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -25,6 +26,9 @@ func (t *Temperature) SampleConfig() string {
 func (t *Temperature) Gather(acc telegraf.Accumulator) error {
 	temps, err := t.ps.Temperature()
 	if err != nil {
+		if strings.Contains(err.Error(), "not implemented yet") {
+			return fmt.Errorf("plugin is not supported on this platform: %v", err)
+		}
 		return fmt.Errorf("error getting temperatures info: %s", err)
 	}
 	for _, temp := range temps {


### PR DESCRIPTION
This plugin notably does not yet support FreeBSD or Darwin.  Mention the current platform support and provide a more specific error message if a "not implemented error" is returned from gopsutil.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
