### PR TITLE
Fixed #4764 (Panic when error during call to GetAvailableMetrics)

### DIFF
--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -661,7 +661,7 @@ func (e *Endpoint) collectResource(ctx context.Context, resourceType string, acc
 	err := make(multiError, 0)
 	wp.Drain(ctx, func(ctx context.Context, in interface{}) bool {
 		if in != nil {
-			mux.Unlock()
+			mux.Lock()
 			defer mux.Unlock()
 			err = append(err, in.(error))
 			return false


### PR DESCRIPTION
This is a fix for #4764 

If a network error is encountered while querying for metric metadata, it is possible to get a panic due to a typo in endpoint.go (Unlock instead of Lock). 

https://github.com/influxdata/telegraf/blob/af0ef55c0281af67fe2db52d8c700fa8f636010e/plugins/inputs/vsphere/endpoint.go#L660-666

### Required for all PRs:

- [ X] Signed [CLA](https://influxdata.com/community/cla/).
- [ X] Associated README.md updated.
- [ X] Has appropriate unit tests.
