### PR TITLE
Docker log plugin

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -152,4 +152,5 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/zfs"
 	_ "github.com/influxdata/telegraf/plugins/inputs/zipkin"
 	_ "github.com/influxdata/telegraf/plugins/inputs/zookeeper"
+    _ "github.com/influxdata/telegraf/plugins/inputs/docker_logs"
 )

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -30,7 +30,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/dmcache"
 	_ "github.com/influxdata/telegraf/plugins/inputs/dns_query"
 	_ "github.com/influxdata/telegraf/plugins/inputs/docker"
-	_ "github.com/influxdata/telegraf/plugins/inputs/docker_logs"
+	_ "github.com/influxdata/telegraf/plugins/inputs/docker_log"
 	_ "github.com/influxdata/telegraf/plugins/inputs/dovecot"
 	_ "github.com/influxdata/telegraf/plugins/inputs/elasticsearch"
 	_ "github.com/influxdata/telegraf/plugins/inputs/exec"

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/dmcache"
 	_ "github.com/influxdata/telegraf/plugins/inputs/dns_query"
 	_ "github.com/influxdata/telegraf/plugins/inputs/docker"
+	_ "github.com/influxdata/telegraf/plugins/inputs/docker_logs"
 	_ "github.com/influxdata/telegraf/plugins/inputs/dovecot"
 	_ "github.com/influxdata/telegraf/plugins/inputs/elasticsearch"
 	_ "github.com/influxdata/telegraf/plugins/inputs/exec"
@@ -152,5 +153,4 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/zfs"
 	_ "github.com/influxdata/telegraf/plugins/inputs/zipkin"
 	_ "github.com/influxdata/telegraf/plugins/inputs/zookeeper"
-    _ "github.com/influxdata/telegraf/plugins/inputs/docker_logs"
 )

--- a/plugins/inputs/docker_log/README.md
+++ b/plugins/inputs/docker_log/README.md
@@ -16,11 +16,6 @@ to gather logs from the [Engine API](https://docs.docker.com/engine/api/v1.24/).
   ##   To use environment variables (ie, docker-machine), set endpoint = "ENV"
   endpoint = "unix:///var/run/docker.sock"
 
-  ## Only collect metrics for these containers. Values will be appended to
-  ## container_name_include.
-  ## Deprecated (1.4.0), use container_name_include
-  container_names = []
-
   ## Containers to include and exclude. Collect all if empty. Globs accepted.
   container_name_include = []
   container_name_exclude = []
@@ -56,11 +51,13 @@ When using the `"ENV"` endpoint, the connection is configured using the
 - docker_log
   - tags:
     - containerId
+    - containerName
   - fields:
     - log
 ### Example Output:
 
 ```
-docker_log,containerId=4325333a47ab42c78b8bf5cb01d5b0972321f857a4b9e116856b4f0459047077,host=prash-laptop log=" root@4325333a47ab:/# ls -l\r\n" 1530162134000000000
-docker_log,containerId=4325333a47ab42c78b8bf5cb01d5b0972321f857a4b9e116856b4f0459047077,host=prash-laptop log=" total 64\r\n drwxr-xr-x   2 root root 4096 May 26 00:45 bin\r\n drwxr-xr-x   2 root root 4096 Apr 24 08:34 boot\r\n drwxr-xr-x   5 root root  360 Jun 28 05:01 dev\r\n drwxr-xr-x   1 root root 4096 Jun 28 05:01 etc\r\n drwxr-xr-x   2 root root 4096 Apr 24 08:34 home\r\n drwxr-xr-x   8 root root 4096 May 26 00:44 lib\r\n drwxr-xr-x   2 root root 4096 May 26 00:44 lib64\r\n drwxr-xr-x   2 root root 4096 May 26 00:44 media\r\n drwxr-xr-x   2 root root 4096 May 26 00:44 mnt\r\n" 1530162134000000000
+docker_log,containerId=168c940a98b4317de15e336140bf6caae009c1ea948226d7fac84c839ccf6e6d,containerName=loving_leavitt,host=prash-laptop log=" root@168c940a98b4:/# ls\r\n" 1538210547000000000
+docker_log,containerId=168c940a98b4317de15e336140bf6caae009c1ea948226d7fac84c839ccf6e6d,containerName=loving_leavitt,host=prash-laptop log=" bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var\r\n" 1538210547000000000
+docker_log,containerId=168c940a98b4317de15e336140bf6caae009c1ea948226d7fac84c839ccf6e6d,containerName=loving_leavitt,host=prash-laptop log=" root@168c940a98b4:/# pwd\r\n /\r\n" 1538210552000000000
 ```

--- a/plugins/inputs/docker_log/README.md
+++ b/plugins/inputs/docker_log/README.md
@@ -5,7 +5,7 @@ docker containers.
 
 The docker plugin uses the [Official Docker Client](https://github.com/moby/moby/tree/master/client)
 to gather logs from the [Engine API](https://docs.docker.com/engine/api/v1.24/).
-Note: This plugin works only for containers with the `json-file` or `journald` logging driver.
+Note: This plugin works only for containers with the `local` or  `json-file` or `journald` logging driver.
 ### Configuration:
 
 ```toml
@@ -47,10 +47,11 @@ When using the `"ENV"` endpoint, the connection is configured using the
 
 - docker_log
   - tags:
-    - containerId
-    - containerName
+    - container_id
+    - container_name
+    - stream
   - fields:
-    - log
+    - message
 ### Example Output:
 
 ```

--- a/plugins/inputs/docker_log/README.md
+++ b/plugins/inputs/docker_log/README.md
@@ -5,7 +5,7 @@ docker containers.
 
 The docker plugin uses the [Official Docker Client](https://github.com/moby/moby/tree/master/client)
 to gather logs from the [Engine API](https://docs.docker.com/engine/api/v1.24/).
-
+Note: This plugin works only for containers with the `json-file` or `journald` logging driver.
 ### Configuration:
 
 ```toml

--- a/plugins/inputs/docker_log/README.md
+++ b/plugins/inputs/docker_log/README.md
@@ -43,9 +43,6 @@ Note: This plugin works only for containers with the `json-file` or `journald` l
 When using the `"ENV"` endpoint, the connection is configured using the
 [cli Docker environment variables](https://godoc.org/github.com/moby/moby/client#NewEnvClient).
 
-```
-
-
 ### Metrics:
 
 - docker_log
@@ -57,7 +54,6 @@ When using the `"ENV"` endpoint, the connection is configured using the
 ### Example Output:
 
 ```
-docker_log,containerId=168c940a98b4317de15e336140bf6caae009c1ea948226d7fac84c839ccf6e6d,containerName=loving_leavitt,host=prash-laptop log=" root@168c940a98b4:/# ls\r\n" 1538210547000000000
-docker_log,containerId=168c940a98b4317de15e336140bf6caae009c1ea948226d7fac84c839ccf6e6d,containerName=loving_leavitt,host=prash-laptop log=" bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var\r\n" 1538210547000000000
-docker_log,containerId=168c940a98b4317de15e336140bf6caae009c1ea948226d7fac84c839ccf6e6d,containerName=loving_leavitt,host=prash-laptop log=" root@168c940a98b4:/# pwd\r\n /\r\n" 1538210552000000000
+docker_log,com.docker.compose.config-hash=e19e13df8fd01ba2d7c1628158fca45cc91afbbe9661b2d30550547eb53a861e,com.docker.compose.container-number=1,com.docker.compose.oneoff=False,com.docker.compose.project=distribution,com.docker.compose.service=influxdb,com.docker.compose.version=1.21.2,containerId=fce475bbfa4c8380ff858d5d767f78622ca6de955b525477624c2b7896a5b8e4,containerName=aicon-influxdb,host=prash-laptop,logType=stderr log=" [httpd] 172.23.0.2 - aicon_admin [13/Apr/2019:08:35:53 +0000] \"POST /query?db=&q=SHOW+SUBSCRIPTIONS HTTP/1.1\" 200 232 \"-\" \"KapacitorInfluxDBClient\" 2661bc9c-5dc7-11e9-82f8-0242ac170007 1360\n" 1555144553541000000
+docker_log,com.docker.compose.config-hash=fd91b3b096c7ab346971c681b88fe1357c609dcc6850e4ea5b1287ad28a57e5d,com.docker.compose.container-number=1,com.docker.compose.oneoff=False,com.docker.compose.project=distribution,com.docker.compose.service=kapacitor,com.docker.compose.version=1.21.2,containerId=6514d1cf6d19e7ecfedf894941f0a2ea21b8aac5e6f48e64f19dbc9bb2805a25,containerName=aicon-kapacitor,host=prash-laptop,logType=stderr log=" ts=2019-04-13T08:36:00.019Z lvl=info msg=\"http request\" service=http host=172.23.0.7 username=- start=2019-04-13T08:36:00.013835165Z method=POST uri=/write?consistency=&db=_internal&precision=ns&rp=monitor protocol=HTTP/1.1 status=204 referer=- user-agent=InfluxDBClient request-id=2a3eb481-5dc7-11e9-825b-000000000000 duration=5.814404ms\n" 1555144560024000000
 ```

--- a/plugins/inputs/docker_log/README.md
+++ b/plugins/inputs/docker_log/README.md
@@ -1,0 +1,66 @@
+# Docker Log Input Plugin
+
+The docker log plugin uses the Docker Engine API to get logs on running
+docker containers.
+
+The docker plugin uses the [Official Docker Client](https://github.com/moby/moby/tree/master/client)
+to gather logs from the [Engine API](https://docs.docker.com/engine/api/v1.24/).
+
+### Configuration:
+
+```toml
+# Read metrics about docker containers
+[[inputs.docker_log]]
+  ## Docker Endpoint
+  ##   To use TCP, set endpoint = "tcp://[ip]:[port]"
+  ##   To use environment variables (ie, docker-machine), set endpoint = "ENV"
+  endpoint = "unix:///var/run/docker.sock"
+
+  ## Only collect metrics for these containers. Values will be appended to
+  ## container_name_include.
+  ## Deprecated (1.4.0), use container_name_include
+  container_names = []
+
+  ## Containers to include and exclude. Collect all if empty. Globs accepted.
+  container_name_include = []
+  container_name_exclude = []
+
+  ## Container states to include and exclude. Globs accepted.
+  ## When empty only containers in the "running" state will be captured.
+  # container_state_include = []
+  # container_state_exclude = []
+
+  ## docker labels to include and exclude as tags.  Globs accepted.
+  ## Note that an empty array for both will include all labels as tags
+  docker_label_include = []
+  docker_label_exclude = []
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+```
+
+#### Environment Configuration
+
+When using the `"ENV"` endpoint, the connection is configured using the
+[cli Docker environment variables](https://godoc.org/github.com/moby/moby/client#NewEnvClient).
+
+```
+
+
+### Metrics:
+
+- docker_log
+  - tags:
+    - containerId
+  - fields:
+    - log
+### Example Output:
+
+```
+docker_log,containerId=4325333a47ab42c78b8bf5cb01d5b0972321f857a4b9e116856b4f0459047077,host=prash-laptop log=" root@4325333a47ab:/# ls -l\r\n" 1530162134000000000
+docker_log,containerId=4325333a47ab42c78b8bf5cb01d5b0972321f857a4b9e116856b4f0459047077,host=prash-laptop log=" total 64\r\n drwxr-xr-x   2 root root 4096 May 26 00:45 bin\r\n drwxr-xr-x   2 root root 4096 Apr 24 08:34 boot\r\n drwxr-xr-x   5 root root  360 Jun 28 05:01 dev\r\n drwxr-xr-x   1 root root 4096 Jun 28 05:01 etc\r\n drwxr-xr-x   2 root root 4096 Apr 24 08:34 home\r\n drwxr-xr-x   8 root root 4096 May 26 00:44 lib\r\n drwxr-xr-x   2 root root 4096 May 26 00:44 lib64\r\n drwxr-xr-x   2 root root 4096 May 26 00:44 media\r\n drwxr-xr-x   2 root root 4096 May 26 00:44 mnt\r\n" 1530162134000000000
+```

--- a/plugins/inputs/docker_log/client.go
+++ b/plugins/inputs/docker_log/client.go
@@ -1,4 +1,4 @@
-package docker_logs
+package docker_log
 
 import (
 	"context"

--- a/plugins/inputs/docker_log/client.go
+++ b/plugins/inputs/docker_log/client.go
@@ -20,6 +20,7 @@ var (
 type Client interface {
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 	ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error)
+	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
 }
 
 func NewEnvClient() (Client, error) {
@@ -60,4 +61,7 @@ func (c *SocketClient) ContainerList(ctx context.Context, options types.Containe
 
 func (c *SocketClient) ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
 	return c.client.ContainerLogs(ctx, containerID, options)
+}
+func (c *SocketClient) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+	return c.client.ContainerInspect(ctx, containerID)
 }

--- a/plugins/inputs/docker_log/client.go
+++ b/plugins/inputs/docker_log/client.go
@@ -1,0 +1,61 @@
+package docker_logs
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/docker/docker/api/types"
+	docker "github.com/docker/docker/client"
+	"github.com/docker/go-connections/sockets"
+	"io"
+)
+/*This file is inherited from telegraf docker input plugin*/
+var (
+	version        = "1.24"
+	defaultHeaders = map[string]string{"User-Agent": "engine-api-cli-1.0"}
+)
+
+type Client interface {
+	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
+	ContainerLogs(ctx context.Context, containerID string,options types.ContainerLogsOptions) (io.ReadCloser, error)
+}
+
+func NewEnvClient() (Client, error) {
+	client, err := docker.NewEnvClient()
+	if err != nil {
+		return nil, err
+	}
+	return &SocketClient{client}, nil
+}
+
+func NewClient(host string, tlsConfig *tls.Config) (Client, error) {
+	proto, addr, _, err := docker.ParseHost(host)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+	sockets.ConfigureTransport(transport, proto, addr)
+	httpClient := &http.Client{Transport: transport}
+
+	client, err := docker.NewClient(host, version, httpClient, defaultHeaders)
+	if err != nil {
+		return nil, err
+	}
+	return &SocketClient{client}, nil
+}
+
+type SocketClient struct {
+	client *docker.Client
+}
+
+func (c *SocketClient) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+	return c.client.ContainerList(ctx, options)
+}
+
+func (c *SocketClient) ContainerLogs(ctx context.Context, containerID string,options types.ContainerLogsOptions) (io.ReadCloser, error) {
+	return c.client.ContainerLogs(ctx, containerID, options)
+}

--- a/plugins/inputs/docker_log/client.go
+++ b/plugins/inputs/docker_log/client.go
@@ -8,12 +8,11 @@ import (
 
 	"github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
-	"github.com/docker/go-connections/sockets"
 )
 
 /*This file is inherited from telegraf docker input plugin*/
 var (
-	version        = "1.24"
+	version        = "1.21"
 	defaultHeaders = map[string]string{"User-Agent": "engine-api-cli-1.0"}
 )
 
@@ -32,19 +31,16 @@ func NewEnvClient() (Client, error) {
 }
 
 func NewClient(host string, tlsConfig *tls.Config) (Client, error) {
-	url, err := docker.ParseHostURL(host)
-	if err != nil {
-		return nil, err
-	}
-
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
 	}
-	sockets.ConfigureTransport(transport, url.Scheme, url.Host)
 	httpClient := &http.Client{Transport: transport}
+	client, err := docker.NewClientWithOpts(
+		docker.WithHTTPHeaders(defaultHeaders),
+		docker.WithHTTPClient(httpClient),
+		docker.WithVersion(version),
+		docker.WithHost(host))
 
-	client, err := docker.NewClientWithOpts(docker.WithHost(host), docker.WithVersion(version),
-		docker.WithHTTPClient(httpClient), docker.WithHTTPHeaders(defaultHeaders))
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/docker_log/client.go
+++ b/plugins/inputs/docker_log/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/go-connections/sockets"
 	"io"
 )
+
 /*This file is inherited from telegraf docker input plugin*/
 var (
 	version        = "1.24"
@@ -18,7 +19,7 @@ var (
 
 type Client interface {
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
-	ContainerLogs(ctx context.Context, containerID string,options types.ContainerLogsOptions) (io.ReadCloser, error)
+	ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error)
 }
 
 func NewEnvClient() (Client, error) {
@@ -56,6 +57,6 @@ func (c *SocketClient) ContainerList(ctx context.Context, options types.Containe
 	return c.client.ContainerList(ctx, options)
 }
 
-func (c *SocketClient) ContainerLogs(ctx context.Context, containerID string,options types.ContainerLogsOptions) (io.ReadCloser, error) {
+func (c *SocketClient) ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
 	return c.client.ContainerLogs(ctx, containerID, options)
 }

--- a/plugins/inputs/docker_log/client.go
+++ b/plugins/inputs/docker_log/client.go
@@ -3,12 +3,12 @@ package docker_log
 import (
 	"context"
 	"crypto/tls"
+	"io"
 	"net/http"
 
 	"github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
 	"github.com/docker/go-connections/sockets"
-	"io"
 )
 
 /*This file is inherited from telegraf docker input plugin*/

--- a/plugins/inputs/docker_log/client.go
+++ b/plugins/inputs/docker_log/client.go
@@ -12,7 +12,7 @@ import (
 
 /*This file is inherited from telegraf docker input plugin*/
 var (
-	version        = "1.21"
+	version        = "1.24"
 	defaultHeaders = map[string]string{"User-Agent": "engine-api-cli-1.0"}
 )
 

--- a/plugins/inputs/docker_log/docker_logs.go
+++ b/plugins/inputs/docker_log/docker_logs.go
@@ -231,7 +231,7 @@ func (d *DockerLogs) getContainerLogs(
 			}
 			return err
 		}
-		if num > 0 && len(data) > 0 {
+		if num > 0 {
 			fields["log"] = data[:num]
 			acc.AddFields("docker_log", fields, tags)
 		}

--- a/plugins/inputs/docker_log/docker_logs.go
+++ b/plugins/inputs/docker_log/docker_logs.go
@@ -21,10 +21,10 @@ type DockerLogs struct {
 	Endpoint       string
 	ContainerNames []string // deprecated in 1.4; use container_name_include
 
-	Timeout      internal.Duration
+	Timeout internal.Duration
 
-	LabelInclude   []string `toml:"docker_label_include"`
-	LabelExclude   []string `toml:"docker_label_exclude"`
+	LabelInclude []string `toml:"docker_label_include"`
+	LabelExclude []string `toml:"docker_label_exclude"`
 
 	ContainerInclude []string `toml:"container_name_include"`
 	ContainerExclude []string `toml:"container_name_exclude"`

--- a/plugins/inputs/docker_log/docker_logs.go
+++ b/plugins/inputs/docker_log/docker_logs.go
@@ -1,0 +1,296 @@
+package docker_logs
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"time"
+	"sync"
+	"log"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/filter"
+	"github.com/influxdata/telegraf/internal"
+	tlsint "github.com/influxdata/telegraf/internal/tls"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+type DockerLogs struct {
+	Endpoint       string
+	ContainerNames []string // deprecated in 1.4; use container_name_include
+
+	Timeout        internal.Duration
+	LabelInclude   []string `toml:"docker_label_include"`
+	LabelExclude   []string `toml:"docker_label_exclude"`
+
+	ContainerInclude []string `toml:"container_name_include"`
+	ContainerExclude []string `toml:"container_name_exclude"`
+
+	ContainerStateInclude []string `toml:"container_state_include"`
+	ContainerStateExclude []string `toml:"container_state_exclude"`
+
+	tlsint.ClientConfig
+
+	newEnvClient func() (Client, error)
+	newClient    func(string, *tls.Config) (Client, error)
+
+	client          Client
+	filtersCreated  bool
+	labelFilter     filter.Filter
+	containerFilter filter.Filter
+	stateFilter     filter.Filter
+	opts	types.ContainerListOptions
+	wg sync.WaitGroup
+	mu sync.Mutex
+	containerList  map[string]io.ReadCloser
+}
+
+const (
+	defaultEndpoint = "unix:///var/run/docker.sock"
+	LOG_BYTES_MAX   = 1000
+)
+
+var (
+	containerStates = []string{"created", "restarting", "running", "removing", "paused", "exited", "dead"}
+)
+
+var sampleConfig = `
+  ## Docker Endpoint
+  ##   To use TCP, set endpoint = "tcp://[ip]:[port]"
+  ##   To use environment variables (ie, docker-machine), set endpoint = "ENV"
+  endpoint = "unix:///var/run/docker.sock"
+  ## Only collect metrics for these containers, collect all if empty
+  container_names = []
+  ## Containers to include and exclude. Globs accepted.
+  ## Note that an empty array for both will include all containers
+  container_name_include = []
+  container_name_exclude = []
+  ## Container states to include and exclude. Globs accepted.
+  ## When empty only containers in the "running" state will be captured.
+  # container_state_include = []
+  # container_state_exclude = []
+  ## docker labels to include and exclude as tags.  Globs accepted.
+  ## Note that an empty array for both will include all labels as tags
+  docker_label_include = []
+  docker_label_exclude = []
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+`
+
+func (d *DockerLogs) Description() string {
+	return "Plugin to get docker logs"
+}
+
+func (d *DockerLogs) SampleConfig() string {
+	return sampleConfig;
+}
+
+func (d *DockerLogs) Gather(acc telegraf.Accumulator) error {
+	/*Check to see if any new containers have been created since last time*/
+	d.containerListUpdate(acc)
+	return nil
+}
+/*Following few functions have been inherited from telegraf docker input plugin*/
+func (d *DockerLogs) createContainerFilters() error {
+	// Backwards compatibility for deprecated `container_names` parameter.
+	if len(d.ContainerNames) > 0 {
+		d.ContainerInclude = append(d.ContainerInclude, d.ContainerNames...)
+	}
+
+	filter, err := filter.NewIncludeExcludeFilter(d.ContainerInclude, d.ContainerExclude)
+	if err != nil {
+		return err
+	}
+	d.containerFilter = filter
+	return nil
+}
+
+func (d *DockerLogs) createLabelFilters() error {
+	filter, err := filter.NewIncludeExcludeFilter(d.LabelInclude, d.LabelExclude)
+	if err != nil {
+		return err
+	}
+	d.labelFilter = filter
+	return nil
+}
+
+func (d *DockerLogs) createContainerStateFilters() error {
+	if len(d.ContainerStateInclude) == 0 && len(d.ContainerStateExclude) == 0 {
+		d.ContainerStateInclude = []string{"running"}
+	}
+	filter, err := filter.NewIncludeExcludeFilter(d.ContainerStateInclude, d.ContainerStateExclude)
+	if err != nil {
+		return err
+	}
+	d.stateFilter = filter
+	return nil
+}
+
+func (d *DockerLogs) addToContainerList(containerId string,logReader io.ReadCloser) error {
+	d.containerList[containerId] = logReader;
+	return nil;
+}
+
+func (d *DockerLogs) removeFromContainerList(containerId string) error {
+	delete(d.containerList, containerId)
+	return nil;
+}
+
+func (d *DockerLogs) containerInContainerList(containerId string) bool {
+	if _, ok := d.containerList[containerId]; ok {
+		return true;
+	}
+	return false;
+}
+
+func (d *DockerLogs) stopAllReaders() error {
+	for _,container := range (d.containerList) {
+		container.Close()
+	}
+	return nil
+}
+
+func (d *DockerLogs) containerListUpdate(acc telegraf.Accumulator) error {
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout.Duration)
+	defer cancel()
+	if d.client == nil {
+		log.Println("ERR:Dock client is null");
+		return nil;
+	}
+	containers, err := d.client.ContainerList(ctx, d.opts)
+	if err != nil {
+		return err
+	}
+	for _, container := range containers {
+		if d.containerInContainerList(container.ID) {
+			continue;
+		}
+		d.wg.Add(1)
+		/*Start a new goroutine for every new container that has logs to collect*/
+		go func(c types.Container) {
+			defer d.wg.Done()
+			err := d.getContainerLogs(c, acc)
+			if err != nil {
+				d.removeFromContainerList(c.ID)
+				log.Println(err);
+				return;
+			}
+		}(container)
+	}
+	return nil
+}
+
+func (d *DockerLogs) getContainerLogs(
+	container types.Container,
+	acc telegraf.Accumulator,
+) error {
+	logOptions := types.ContainerLogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Timestamps: false,
+		Details:    true,
+		Follow:     true,
+		Tail:     "0",
+	}
+	logReader, err := d.client.ContainerLogs(context.Background(), container.ID, logOptions)
+	d.addToContainerList(container.ID,logReader)
+	if err != nil {
+		log.Printf("Error getting docker stats: %s", err.Error())
+		return err;
+	}
+	tags := map[string]string{
+		"containerId": container.ID,
+	}
+	fields := map[string]interface{}{}
+	data := make([]byte, LOG_BYTES_MAX)
+	for {
+		num, err := logReader.Read(data)
+		if err != nil {
+			if err == io.EOF {
+				fields["log"]=data[:num]
+				acc.AddFields("docker_log", fields, tags)
+			}
+			return err
+		}
+		if len(data) > 0 {
+			fields["log"]=data[:num]
+			acc.AddFields("docker_log", fields, tags)
+		}
+	}
+	return nil
+}
+func (d *DockerLogs) Start(acc telegraf.Accumulator) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var c Client
+	var err error
+	if d.Endpoint == "ENV" {
+		c, err = d.newEnvClient()
+	} else {
+		tlsConfig, err := d.ClientConfig.TLSConfig()
+		if err != nil {
+			return err
+		}
+
+		c, err = d.newClient(d.Endpoint, tlsConfig)
+	}
+	if err != nil {
+		return err
+	}
+	d.client = c
+	// Create label filters if not already created
+	if !d.filtersCreated {
+		err := d.createLabelFilters()
+		if err != nil {
+			return err
+		}
+		err = d.createContainerFilters()
+		if err != nil {
+			return err
+		}
+		err = d.createContainerStateFilters()
+		if err != nil {
+			return err
+		}
+		d.filtersCreated = true
+	}
+	filterArgs := filters.NewArgs()
+	for _, state := range containerStates {
+		if d.stateFilter.Match(state) {
+			filterArgs.Add("status", state)
+		}
+	}
+
+	// All container states were excluded
+	if filterArgs.Len() == 0 {
+		return nil
+	}
+
+	d.opts = types.ContainerListOptions{
+		Filters: filterArgs,
+	}
+	return nil
+}
+
+func (d *DockerLogs) Stop() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.stopAllReaders()
+	d.wg.Wait()
+}
+
+func init() {
+	inputs.Add("docker_logs", func() telegraf.Input { return &DockerLogs{
+			Timeout:        internal.Duration{Duration: time.Second * 5},
+			Endpoint:       defaultEndpoint,
+			newEnvClient:   NewEnvClient,
+			newClient:      NewClient,
+			filtersCreated: false,
+			containerList:  make(map[string]io.ReadCloser),
+	}})
+}

--- a/plugins/inputs/docker_log/docker_logs.go
+++ b/plugins/inputs/docker_log/docker_logs.go
@@ -1,4 +1,4 @@
-package docker_logs
+package docker_log
 
 import (
 	"context"
@@ -299,7 +299,7 @@ func (d *DockerLogs) Stop() {
 }
 
 func init() {
-	inputs.Add("docker_logs", func() telegraf.Input {
+	inputs.Add("docker_log", func() telegraf.Input {
 		return &DockerLogs{
 			Timeout:        internal.Duration{Duration: time.Second * 5},
 			Endpoint:       defaultEndpoint,

--- a/plugins/inputs/docker_log/docker_logs.go
+++ b/plugins/inputs/docker_log/docker_logs.go
@@ -205,7 +205,7 @@ func (d *DockerLogs) containerListUpdate(acc telegraf.Accumulator) error {
 			d.addToContainerList(c.ID, logReader)
 			err = d.tailContainerLogs(c, logReader, acc)
 			if err != nil {
-				acc.AddError(fmt.Errorf("%s : %s ", ERR_PREFIX, err.Error()))
+				acc.AddError(err)
 			}
 			d.removeFromContainerList(c.ID)
 			return

--- a/plugins/inputs/docker_log/docker_logs.go
+++ b/plugins/inputs/docker_log/docker_logs.go
@@ -382,7 +382,6 @@ func (d *DockerLogs) Start(acc telegraf.Accumulator) error {
 		c, err = d.newClient(d.Endpoint, tlsConfig)
 	}
 	if err != nil {
-		log.Printf("%s : %s", ERR_PREFIX, err.Error())
 		return err
 	}
 	d.client = c

--- a/plugins/inputs/docker_log/docker_logs.go
+++ b/plugins/inputs/docker_log/docker_logs.go
@@ -224,7 +224,6 @@ func (d *DockerLogs) getContainerLogs(
 			acc.AddFields("docker_log", fields, tags)
 		}
 	}
-	return nil
 }
 func (d *DockerLogs) Start(acc telegraf.Accumulator) error {
 	d.mu.Lock()


### PR DESCRIPTION
Resolves #1483 

This PR introduces a telegraf plugin to get docker logs . Sample output : 
`
docker_log,containerId=168c940a98b4317de15e336140bf6caae009c1ea948226d7fac84c839ccf6e6d,containerName=loving_leavitt,host=prash-laptop log=" root@168c940a98b4:/# ls\r\n" 1538210547000000000
docker_log,containerId=168c940a98b4317de15e336140bf6caae009c1ea948226d7fac84c839ccf6e6d,containerName=loving_leavitt,host=prash-laptop log=" bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var\r\n" 1538210547000000000
docker_log,containerId=168c940a98b4317de15e336140bf6caae009c1ea948226d7fac84c839ccf6e6d,containerName=loving_leavitt,host=prash-laptop log=" root@168c940a98b4:/# pwd\r\n /\r\n" 1538210552000000000
`
The plugin is a Telegraf service input plugin which creates a new goroutine for every running container and listens for the log stream using the docker engine APIs . Whenever it gets data from the stream it pushes it out with tags.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
