### PR TITLE
[inputs/filecount] Add sizes to filecount

### DIFF
--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -10,6 +10,9 @@ Counts files in directories that match certain criteria.
   ## Directory to gather stats about.
   directory = "/var/cache/apt/archives"
 
+  ## Also compute total size of matched elements. Defaults to false.
+  count_size = false
+
   ## Only count files that match the name pattern. Defaults to "*".
   name = "*.deb"
 
@@ -34,6 +37,7 @@ Counts files in directories that match certain criteria.
 
 - filecount
     - count (int)
+    - size (int, in Bytes)
 
 ### Tags:
 
@@ -44,6 +48,6 @@ Counts files in directories that match certain criteria.
 
 ```
 $ telegraf --config /etc/telegraf/telegraf.conf --input-filter filecount --test
-> filecount,directory=/var/cache/apt,host=czernobog count=7i 1530034445000000000
-> filecount,directory=/tmp,host=czernobog count=17i 1530034445000000000
+> filecount,directory=/var/cache/apt,host=czernobog count=7i,size=7438336i 1530034445000000000
+> filecount,directory=/tmp,host=czernobog count=17i,size=28934786i 1530034445000000000
 ```

--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -22,10 +22,12 @@ Counts files in directories that match certain criteria.
   ## Only count regular files. Defaults to true.
   regular_only = true
 
-  ## Only count files that are at least this size in bytes. If size is
-  ## a negative number, only count files that are smaller than the
-  ## absolute value of size. Defaults to 0.
-  size = 0
+  ## Only count files that are at least this size. If size is a 
+  ## negative number, only count files that are smaller than the
+  ## absolute value of size. Defaults to "0B".
+  ## For available units, see :
+  ## https://godoc.org/github.com/alecthomas/units#pkg-constants
+  size = "0B"
 
   ## Only count files that have not been touched for at least this
   ## duration. If mtime is negative, only count files that have been
@@ -36,8 +38,8 @@ Counts files in directories that match certain criteria.
   recursive_print = false
 
   ## Only output directories whose sub elements weighs more than this
-  ## size in bytes. Defaults to 0.
-  recursive_print_size = 0
+  ## size. Defaults to "0B".
+  recursive_print_size = "0B"
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -5,7 +5,7 @@ Counts files in directories that match certain criteria.
 ### Configuration:
 
 ```toml
-# Count files in a directory
+# Count files in a directory and compute their size
 [[inputs.filecount]]
   ## Directory to gather stats about.
   directory = "/var/cache/apt/archives"
@@ -31,6 +31,13 @@ Counts files in directories that match certain criteria.
   ## duration. If mtime is negative, only count files that have been
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
+
+  ## Output stats for every subdirectory. Defaults to false.
+  recursive_print = false
+
+  ## Only output directories whose sub elements weighs more than this
+  ## size in bytes. Defaults to 0.
+  recursive_print_size = 0
 ```
 
 ### Measurements & Fields:
@@ -42,7 +49,7 @@ Counts files in directories that match certain criteria.
 ### Tags:
 
 - All measurements have the following tags:
-    - directory (the directory path, as specified in the config)
+    - directory (the directory path)
 
 ### Example Output:
 

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -46,12 +46,12 @@ func TestRegularOnlyFilter(t *testing.T) {
 
 func TestSizeFilter(t *testing.T) {
 	fc := getNoFilterFileCount()
-	fc.Size = -100
+	fc.Size = "-100B"
 	matches := []string{"foo", "bar", "baz",
 		"subdir/quux", "subdir/quuz"}
 	require.True(t, fileCountEquals(fc, len(matches), 0))
 
-	fc.Size = 100
+	fc.Size = "100B"
 	matches = []string{"qux", "subdir/qux"}
 	require.True(t, fileCountEquals(fc, len(matches), 892))
 }
@@ -95,10 +95,10 @@ func getNoFilterFileCount() FileCount {
 		Name:               "*",
 		Recursive:          true,
 		RegularOnly:        false,
-		Size:               0,
+		Size:               "0B",
 		MTime:              internal.Duration{Duration: 0},
 		RecursivePrint:     false,
-		RecursivePrintSize: 0,
+		RecursivePrintSize: "0B",
 		fileFilters:        nil,
 	}
 }

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -76,16 +76,30 @@ func TestMTimeFilter(t *testing.T) {
 	require.True(t, fileCountEquals(fc, len(matches), 0))
 }
 
+func TestRecursivePrint(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.RecursivePrint = true;
+
+	acc := testutil.Accumulator{}
+	acc.GatherError(fc.Gather)
+	tags := map[string]string{"directory": getTestdataDir() + string(os.PathSeparator) + "subdir"}
+
+	require.True(t, acc.HasPoint("filecount", tags, "count", int64(3)))
+	require.True(t, acc.HasPoint("filecount", tags, "size", int64(446)))
+}
+
 func getNoFilterFileCount() FileCount {
 	return FileCount{
-		Directory:   getTestdataDir(),
-		CountSize:   true,
-		Name:        "*",
-		Recursive:   true,
-		RegularOnly: false,
-		Size:        0,
-		MTime:       internal.Duration{Duration: 0},
-		fileFilters: nil,
+		Directory:          getTestdataDir(),
+		CountSize:          true,
+		Name:               "*",
+		Recursive:          true,
+		RegularOnly:        false,
+		Size:               0,
+		MTime:              internal.Duration{Duration: 0},
+		RecursivePrint:     false,
+		RecursivePrintSize: 0,
+		fileFilters:        nil,
 	}
 }
 

--- a/plugins/inputs/filecount/testdata/subdir/qux
+++ b/plugins/inputs/filecount/testdata/subdir/qux
@@ -1,0 +1,7 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in
+reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
# What this PR changes

It alters filecount input plugin, by adding configuration options :
- count_size : also output the total size of matched elements (subfiles/directories of 'directory'). This was [asked in influx community forums](https://community.influxdata.com/t/collect-folder-size-with-telegraf/3059).
- recursive_print : print gathered statistics (count/size) also for subdirectories
- recursive_print_size : minimum size of subdirectory to output it

It modifies the option "size" which was the minimum size in Bytes of files to take into account for counting : it is now a string with units (KiB, MiB...), parsed by [units](https://godoc.org/github.com/alecthomas/units) plugin (side note : this package was listed in dependencies but i haven't found where it were used). This breaks existing configurations which made use of this option, and is introduces by the last commit.

Internally, it uses the more specific 'addGauge' method where 'addFields' was used.

### Required for all PRs:

- [ X ] Signed [CLA](https://influxdata.com/community/cla/).
- [ X ] Associated README.md updated.
- [ X ] Has appropriate unit tests.
