### PR TITLE
Fixed issue 4783 (Non-realtime samples missing)

### DIFF
--- a/plugins/inputs/vsphere/client.go
+++ b/plugins/inputs/vsphere/client.go
@@ -173,10 +173,11 @@ func (c *Client) close() {
 	})
 }
 
+// GetServerTime returns the time at the vCenter server
 func (c *Client) GetServerTime(ctx context.Context) (time.Time, error) {
-	if t, err := methods.GetCurrentTime(ctx, c.Client); err != nil {
+	t, err := methods.GetCurrentTime(ctx, c.Client)
+	if err != nil {
 		return time.Time{}, err
-	} else {
-		return *t, nil
 	}
+	return *t, nil
 }

--- a/plugins/inputs/vsphere/client.go
+++ b/plugins/inputs/vsphere/client.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/performance"
@@ -170,4 +171,12 @@ func (c *Client) close() {
 			}
 		}
 	})
+}
+
+func (c *Client) GetServerTime(ctx context.Context) (time.Time, error) {
+	if t, err := methods.GetCurrentTime(ctx, c.Client); err != nil {
+		return time.Time{}, err
+	} else {
+		return *t, nil
+	}
 }


### PR DESCRIPTION
### Required for all PRs:

- [ x ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

closes #4783 
When collecting non-realtime metrics, there's a risk of getting null metrics or incorrect metrics if the clock on the collector node is ahead of vCenter by just a very modest amount. 

Fixed it by getting "current time" from the vCenter server instead of the local clock.
