### PR TITLE
Add input plugin for IPVS

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -130,6 +130,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:e9e3028d555759b840afa38b3667f634495197c4859685f2fd3f251b086f7bda"
+  name = "github.com/amoghe/libipvs"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ec9c6c9b088817d9fc7099cb36b0a84ff5abbf3e"
+
+[[projects]]
+  branch = "master"
   digest = "1:0828d8c0f95689f832cf348fe23827feb7640cd698d612ef59e2f9d041f54c68"
   name = "github.com/apache/thrift"
   packages = ["lib/go/thrift"]
@@ -530,6 +538,14 @@
   pruneopts = ""
   revision = "d6574a5bb1226678d7010325fb6c985db20ee458"
   version = "v0.8.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:3c591e075048f334a5a1cd94be61360bd9bd2cc5cf832620e1367f04df8d473c"
+  name = "github.com/hkwi/nlgo"
+  packages = ["."]
+  pruneopts = ""
+  revision = "dbae43f4fc47bf868bca3cc3c1ea2954c2059842"
 
 [[projects]]
   digest = "1:a39ef049cdeee03a57b132e7d60e32711b9d949c78458da78e702d9864c54369"
@@ -1312,6 +1328,7 @@
     "github.com/StackExchange/wmi",
     "github.com/aerospike/aerospike-client-go",
     "github.com/amir/raidman",
+    "github.com/amoghe/libipvs",
     "github.com/apache/thrift/lib/go/thrift",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/client",

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -50,6 +50,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/ipmi_sensor"
 	_ "github.com/influxdata/telegraf/plugins/inputs/ipset"
 	_ "github.com/influxdata/telegraf/plugins/inputs/iptables"
+	_ "github.com/influxdata/telegraf/plugins/inputs/ipvs"
 	_ "github.com/influxdata/telegraf/plugins/inputs/jolokia"
 	_ "github.com/influxdata/telegraf/plugins/inputs/jolokia2"
 	_ "github.com/influxdata/telegraf/plugins/inputs/jti_openconfig_telemetry"

--- a/plugins/inputs/ipvs/ipvs.go
+++ b/plugins/inputs/ipvs/ipvs.go
@@ -1,0 +1,85 @@
+// +build linux
+
+package ipvs
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/amoghe/libipvs"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+// IPVS holds the state for this input plugin
+type IPVS struct {
+	handle     libipvs.IPVSHandle
+	handleOpen bool
+}
+
+// Description returns a description string
+func (i *IPVS) Description() string {
+	return "Read IPVS stats"
+}
+
+// SampleConfig returns a sample configuration for this input plugin
+func (i *IPVS) SampleConfig() string {
+	return `
+  ## This plugin takes no configuration, it collects data on all the servers
+  ## (virtual and real) discovered on the system it is running on.
+  ## In the future we may add a way to monitor only a subset of the servers.
+`
+}
+
+// Gather gathers the stats
+func (i *IPVS) Gather(acc telegraf.Accumulator) error {
+
+	// helper: given a Service, return tags that identify it
+	serviceTags := func(s *libipvs.Service) map[string]string {
+		if s.FWMark > 0 {
+			return map[string]string{
+				"fwmark": strconv.Itoa(int(s.FWMark)),
+			}
+		}
+		return map[string]string{
+			"protocol": s.Protocol.String(),
+			"address":  s.Address.String(),
+			"port":     strconv.Itoa(int(s.Port)),
+		}
+	}
+
+	if i.handleOpen == false {
+		h, err := libipvs.New()
+		if err != nil {
+			return errors.New("Unable to open IPVS handle")
+		}
+		i.handle = h
+		i.handleOpen = true
+	}
+
+	services, err := i.handle.ListServices()
+	if err != nil {
+		i.handle.Close()
+		i.handleOpen = false // trigger a reopen on next call to gather
+		return errors.New("Failed to list IPVS services")
+	}
+	for _, s := range services {
+		fields := map[string]interface{}{
+			"connections": s.Stats.Connections,
+			"pkts_in":     s.Stats.PacketsIn,
+			"pkts_out":    s.Stats.PacketsOut,
+			"bytes_in":    s.Stats.BytesIn,
+			"bytes_out":   s.Stats.BytesOut,
+			"pps_in":      s.Stats.PPSIn,
+			"pps_out":     s.Stats.PPSOut,
+			"cps":         s.Stats.CPS,
+		}
+		acc.AddGauge("ipvs.virtual_server", fields, serviceTags(s))
+	}
+
+	return nil
+}
+
+func init() {
+	inputs.Add("ipvs", func() telegraf.Input { return &IPVS{} })
+}

--- a/plugins/inputs/ipvs/ipvs_notlinux.go
+++ b/plugins/inputs/ipvs/ipvs_notlinux.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package ipvs


### PR DESCRIPTION
This is a first pass at adding an IPVS input plugin. It is quite
rudimentary and has the following limitations:
1. does not support filtering, reports *all* the stats it sees
2. only reports virtual server stats (not real servers)

Both of these limitations will be addressed in subsequent commits.

NOTE: currently relies on github.com/amoghe/libipvs , however we
should change this to use github.com/viswananda/netlink since that
is well maintained (needs support for IPVS to be added to it).

### Required for all PRs:

- [X ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
