### PR TITLE
Add a Dockerfile that matches influxdata-docker to build images from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.11.0 as builder
+ENV DEP_VERSION 0.5.0
+RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 && chmod +x /usr/local/bin/dep
+WORKDIR /go/src/github.com/influxdata/telegraf
+COPY Gopkg.toml Gopkg.lock ./
+RUN dep ensure -vendor-only
+COPY . /go/src/github.com/influxdata/telegraf
+RUN go install ./cmd/...
+
+FROM buildpack-deps:stretch-curl
+COPY --from=builder /go/bin/* /usr/bin/
+COPY etc/telegraf.conf /etc/telegraf/telegraf.conf
+
+EXPOSE 8125/udp 8092/udp 8094
+
+COPY docker/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["telegraf"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,21 @@
+FROM golang:1.11.0 as builder
+ENV DEP_VERSION 0.5.0
+RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 && chmod +x /usr/local/bin/dep
+WORKDIR /go/src/github.com/influxdata/telegraf
+COPY Gopkg.toml Gopkg.lock ./
+RUN dep ensure -vendor-only
+COPY . /go/src/github.com/influxdata/telegraf
+RUN CGO_ENABLED=0 go install ./cmd/...
+
+FROM alpine:3.6
+RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \
+    update-ca-certificates
+COPY --from=builder /go/bin/* /usr/bin/
+COPY etc/telegraf.conf /etc/telegraf/telegraf.conf
+
+EXPOSE 8125/udp 8092/udp 8094
+
+COPY docker/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["telegraf"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- telegraf "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The images in influxdata-docker are meant to be built by downloading
official releases. Sometimes, it is useful to build directly from source
when you need an unofficial release. These images are meant to be used
then using multi-stage builds so that it can build from source and then
copy the results to images that match the official counterpart.