### PR TITLE
#4699 Improve how the datadog plugin uses Metric.Fields and Metric.Tags

### DIFF
--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"sort"
 	"strings"
 
 	"github.com/influxdata/telegraf"
@@ -76,10 +75,9 @@ func (d *Datadog) Write(metrics []telegraf.Metric) error {
 
 	for _, m := range metrics {
 		if dogMs, err := buildMetrics(m); err == nil {
-			tagMap := m.Tags()
-			metricTags := buildTags(tagMap)
-			host, _ := tagMap["host"]
-			
+			metricTags := buildTags(m.TagList())
+			host, _ := m.GetTag("host")
+
 			for fieldName, dogM := range dogMs {
 				// name of the datadog measurement
 				var dname string
@@ -160,14 +158,13 @@ func buildMetrics(m telegraf.Metric) (map[string]Point, error) {
 	return ms, nil
 }
 
-func buildTags(mTags map[string]string) []string {
-	tags := make([]string, len(mTags))
+func buildTags(tagList []*telegraf.Tag) []string {
+	tags := make([]string, len(tagList))
 	index := 0
-	for k, v := range mTags {
-		tags[index] = fmt.Sprintf("%s:%s", k, v)
+	for _, tag := range tagList {
+		tags[index] = fmt.Sprintf("%s:%s", tag.Key, tag.Value)
 		index += 1
 	}
-	sort.Strings(tags)
 	return tags
 }
 

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -74,19 +74,33 @@ func TestAuthenticatedUrl(t *testing.T) {
 
 func TestBuildTags(t *testing.T) {
 	var tagtests = []struct {
-		ptIn    map[string]string
+		ptIn    []*telegraf.Tag
 		outTags []string
 	}{
 		{
-			map[string]string{"one": "two", "three": "four"},
+			[]*telegraf.Tag{
+				&telegraf.Tag{
+					Key:   "one",
+					Value: "two",
+				},
+				&telegraf.Tag{
+					Key:   "three",
+					Value: "four",
+				},
+			},
 			[]string{"one:two", "three:four"},
 		},
 		{
-			map[string]string{"aaa": "bbb"},
+			[]*telegraf.Tag{
+				&telegraf.Tag{
+					Key:   "aaa",
+					Value: "bbb",
+				},
+			},
 			[]string{"aaa:bbb"},
 		},
 		{
-			map[string]string{},
+			[]*telegraf.Tag{},
 			[]string{},
 		},
 	}


### PR DESCRIPTION
### Required for all PRs:

- [Y ] Signed [CLA](https://influxdata.com/community/cla/).
- [ NA] Associated README.md updated.
- [ NA] Has appropriate unit tests.

@danielnelson This PR addresses the feedback in #4699.  I replaced the use of `Metric.Fields` with `Metric.FieldList` and reduced how often `Metric.Tags` is called (it didn't look like using `TagList` made sense)

Since the changes were internal, I left the existing tests as is.