### PR TITLE
Implement HTTP Output Compression

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -223,7 +223,9 @@ func CompressWithGzip(data io.Reader) (io.Reader, error) {
 	go func() {
 		_, err = io.Copy(gzipWriter, data)
 		gzipWriter.Close()
-		pipeWriter.Close()
+		// subsequent reads from the read half of the pipe will
+		// return no bytes and the error err, or EOF if err is nil.
+		pipeWriter.CloseWithError(err)
 	}()
 
 	return pipeReader, err

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -1,6 +1,9 @@
 package internal
 
 import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
 	"os/exec"
 	"testing"
 	"time"
@@ -161,4 +164,21 @@ func TestDuration(t *testing.T) {
 	d = Duration{}
 	d.UnmarshalTOML([]byte(`1.5`))
 	assert.Equal(t, time.Second, d.Duration)
+}
+
+func TestCompressWithGzip(t *testing.T) {
+	testData := "the quick brown fox jumps over the lazy dog"
+	inputBuffer := bytes.NewBuffer([]byte(testData))
+
+	outputBuffer, err := CompressWithGzip(inputBuffer)
+	assert.NoError(t, err)
+
+	gzipReader, err := gzip.NewReader(outputBuffer)
+	assert.NoError(t, err)
+	defer gzipReader.Close()
+
+	output, err := ioutil.ReadAll(gzipReader)
+	assert.NoError(t, err)
+
+	assert.Equal(t, testData, string(output))
 }

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -44,4 +44,8 @@ data formats.  For data_formats that support batching, metrics are sent in batch
   # [outputs.http.headers]
   #   # Should be set manually to "application/json" for json data_format
   #   Content-Type = "text/plain; charset=utf-8"
+
+  ## HTTP Content-Encoding for write request body, can be set to "gzip" to
+  ## compress body or "identity" to apply no encoding.
+  # content_encoding = "identity"
 ```

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -170,11 +169,10 @@ func (h *HTTP) Write(metrics []telegraf.Metric) error {
 
 func (h *HTTP) write(reqBody []byte) error {
 	var reqBodyBuffer io.Reader = bytes.NewBuffer(reqBody)
+
 	var err error
-
 	if h.ContentEncoding == "gzip" {
-		reqBodyBuffer, err = compressWithGzip(reqBodyBuffer)
-
+		reqBodyBuffer, err = internal.CompressWithGzip(reqBodyBuffer)
 		if err != nil {
 			return err
 		}
@@ -209,20 +207,6 @@ func (h *HTTP) write(reqBody []byte) error {
 	}
 
 	return nil
-}
-
-func compressWithGzip(data io.Reader) (io.Reader, error) {
-	pr, pw := io.Pipe()
-	gw := gzip.NewWriter(pw)
-	var err error
-
-	go func() {
-		_, err = io.Copy(gw, data)
-		gw.Close()
-		pw.Close()
-	}()
-
-	return pr, err
 }
 
 func init() {

--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -1,7 +1,6 @@
 package influxdb
 
 import (
-	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 )
 
@@ -360,7 +360,7 @@ func (c *httpClient) makeQueryRequest(query string) (*http.Request, error) {
 func (c *httpClient) makeWriteRequest(body io.Reader) (*http.Request, error) {
 	var err error
 	if c.ContentEncoding == "gzip" {
-		body, err = compressWithGzip(body)
+		body, err = internal.CompressWithGzip(body)
 		if err != nil {
 			return nil, err
 		}
@@ -379,20 +379,6 @@ func (c *httpClient) makeWriteRequest(body io.Reader) (*http.Request, error) {
 	}
 
 	return req, nil
-}
-
-func compressWithGzip(data io.Reader) (io.Reader, error) {
-	pr, pw := io.Pipe()
-	gw := gzip.NewWriter(pw)
-	var err error
-
-	go func() {
-		_, err = io.Copy(gw, data)
-		gw.Close()
-		pw.Close()
-	}()
-
-	return pr, err
 }
 
 func (c *httpClient) addHeaders(req *http.Request) {


### PR DESCRIPTION
Fixes #4472.

TODO:
- [x] Should there be some refactoring done to avoid duplicating `compressWithGzip` here, since it's already present [in influxdb](https://github.com/influxdata/telegraf/blob/6bf5643351c86aa09ae4819816ec783b8a4e1c2f/plugins/outputs/influxdb/http.go#L384) and [in influxdb_v2](https://github.com/influxdata/telegraf/blob/6bf5643351c86aa09ae4819816ec783b8a4e1c2f/plugins/outputs/influxdb_v2/http.go#L261)?
- [x] Would you be interested in caching gzip writers similar to [here](https://github.com/Nitro/lazyraster/blob/318cb9c229e728d756299e34bb06386d88082c08/http.go#L463-L490) for better performance?
- [x] Do you really want to support "deflate" compression besides "gzip"?
- [x] If "br" stands for "brotli", it's not supported natively yet: https://github.com/google/brotli/issues/182 Do you want to bring in a 3rd party package for this if support for it is required?

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
