### PR TITLE
Add cookie support to input and output HTTP plugins

### DIFF
--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -1,15 +1,24 @@
 package http_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
 	plugin "github.com/influxdata/telegraf/plugins/inputs/http"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+const simpleJSON = `
+{
+    "a": 1.2
+}
+`
 
 func TestHTTPwithJSONFormat(t *testing.T) {
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -144,8 +153,87 @@ func TestParserNotSet(t *testing.T) {
 	require.Error(t, acc.GatherError(plugin.Gather))
 }
 
-const simpleJSON = `
-{
-    "a": 1.2
+func TestCookieJar(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	u, err := url.Parse(fmt.Sprintf("http://%s", ts.Listener.Addr().String()))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                string
+		plugin              *plugin.HTTP
+		cookieName          string
+		cookieValue         string
+		expiration          time.Time
+		expectedCookieCount int
+	}{
+		{
+			name: "cookie is set",
+			plugin: &plugin.HTTP{
+				URLs: []string{u.String()},
+			},
+			cookieName:          "Amaretti",
+			cookieValue:         "Italy",
+			expiration:          time.Now().Add(1 * time.Second),
+			expectedCookieCount: 1,
+		},
+		{
+			name: "expired cookie is not set",
+			plugin: &plugin.HTTP{
+				URLs: []string{u.String()},
+			},
+			cookieName:          "Macaron",
+			cookieValue:         "France",
+			expiration:          time.Now().Add(-1 * time.Second),
+			expectedCookieCount: 0,
+		},
+	}
+
+	parser, _ := parsers.NewParser(&parsers.Config{
+		DataFormat: "json",
+		MetricName: "metricName",
+	})
+	var acc testutil.Accumulator
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			firstReq := true
+			ts.Config.Handler = http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					// Set a cookie when receiving the first request
+					if firstReq {
+						http.SetCookie(w, &http.Cookie{
+							Name:    tt.cookieName,
+							Value:   tt.cookieValue,
+							Expires: tt.expiration,
+						})
+						firstReq = false
+						return
+					}
+
+					// Check that subsequent requests contain the cookie set above
+					cookies := r.Cookies()
+					require.Len(t, cookies, tt.expectedCookieCount)
+
+					if tt.expectedCookieCount > 0 {
+						require.Equal(
+							t,
+							fmt.Sprintf("%s=%s", tt.cookieName, tt.cookieValue),
+							cookies[0].String(),
+						)
+					}
+				},
+			)
+
+			tt.plugin.SetParser(parser)
+
+			// Send two requests to the mock server and check that the
+			// cookies are propagated properly during the second request.
+			for i := 0; i < 2; i++ {
+				err = acc.GatherError(tt.plugin.Gather)
+				require.NoError(t, err)
+			}
+		})
+	}
 }
-`


### PR DESCRIPTION
I believe this fixes #4813.

Note: It would be great to test these changes against a real REST API environment which uses this authentication mechanism. Not sure how to get access to one (cc @Touchedegris).

Questions:
- [ ] The test code is mostly duplicated for both plugins, so I'm considering to hide parts of it under `testutil`. WDYT?
- [ ] Is there any place in the docs where this new feature needs to be mentioned?

### Required for all PRs:
- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
