### PR TITLE
Issue #3911: Expose telegraf agent version in internal module

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -326,8 +326,13 @@ func main() {
 		return
 	}
 
+	shortVersion := version
+	if shortVersion == "" {
+		shortVersion = "unknown"
+	}
+
 	// Configure version
-	if err := internal.SetVersion(formatFullVersion()); err != nil {
+	if err := internal.SetVersion(shortVersion); err != nil {
 		log.Println("Telegraf version already configured to: " + internal.Version())
 	}
 

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -326,6 +326,11 @@ func main() {
 		return
 	}
 
+	// Configure version
+	if err := internal.SetVersion(formatFullVersion()); err != nil {
+		log.Println("Telegraf version already configured to: " + internal.Version())
+	}
+
 	if runtime.GOOS == "windows" && !(*fRunAsConsole) {
 		svcConfig := &service.Config{
 			Name:        *fServiceName,

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -24,11 +24,30 @@ var (
 	TimeoutErr = errors.New("Command timed out.")
 
 	NotImplementedError = errors.New("not implemented yet")
+
+	VersionAlreadySetError = errors.New("version has already been set")
 )
+
+// Set via the main module
+var version string
 
 // Duration just wraps time.Duration
 type Duration struct {
 	Duration time.Duration
+}
+
+// SetVersion sets the telegraf agent version
+func SetVersion(v string) error {
+	if version != "" {
+		return VersionAlreadySetError
+	}
+	version = v
+	return nil
+}
+
+// Version returns the telegraf agent version
+func Version() string {
+	return version
 }
 
 // UnmarshalTOML parses the duration from the TOML config file

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -182,3 +182,15 @@ func TestCompressWithGzip(t *testing.T) {
 
 	assert.Equal(t, testData, string(output))
 }
+
+func TestVersionAlreadySet(t *testing.T) {
+	err := SetVersion("foo")
+	assert.Nil(t, err)
+
+	err = SetVersion("bar")
+
+	assert.NotNil(t, err)
+	assert.IsType(t, VersionAlreadySetError, err)
+
+	assert.Equal(t, "foo", Version())
+}


### PR DESCRIPTION
### Required for all PRs:

- [ Y] Signed [CLA](https://influxdata.com/community/cla/).
- [ NA] Associated README.md updated.
- [ Y] Has appropriate unit tests.

@danielnelson This PR exposes the agent version in the _internal_ module per our conversation in #3911 

I decided to separate this in to two PRs, one to expose the version and then one to use it, in case there is back and forth on how the version is initially exposed.