### PR TITLE
Optimization for globpath (root elements for recursion)

### DIFF
--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -75,7 +75,7 @@ func (g *GlobPath) Match() map[string]os.FileInfo {
 }
 
 // find the root elements of the object path, the entry point for recursion
-// when you have a super-meta in your path (which are : 
+// when you have a super-meta in your path (which are :
 // glob(/your/expression/until/first/star/of/super-meta))
 // ie:
 //   /var/log/telegraf.conf -> /var/log/telegraf.conf

--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -16,7 +16,6 @@ type GlobPath struct {
 	hasMeta      bool
 	hasSuperMeta bool
 	g            glob.Glob
-	root         string
 }
 
 func Compile(path string) (*GlobPath, error) {
@@ -27,7 +26,7 @@ func Compile(path string) (*GlobPath, error) {
 	}
 
 	// if there are no glob meta characters in the path, don't bother compiling
-	// a glob object or finding the root directory. (see short-circuit in Match)
+	// a glob object
 	if !out.hasMeta || !out.hasSuperMeta {
 		return &out, nil
 	}
@@ -36,14 +35,12 @@ func Compile(path string) (*GlobPath, error) {
 	if out.g, err = glob.Compile(path, os.PathSeparator); err != nil {
 		return nil, err
 	}
-	// Get the root directory for this filepath
-	out.root = findRootDir(path)
 	return &out, nil
 }
 
 func (g *GlobPath) Match() map[string]os.FileInfo {
+	out := make(map[string]os.FileInfo)
 	if !g.hasMeta {
-		out := make(map[string]os.FileInfo)
 		info, err := os.Stat(g.path)
 		if err == nil {
 			out[g.path] = info
@@ -51,7 +48,6 @@ func (g *GlobPath) Match() map[string]os.FileInfo {
 		return out
 	}
 	if !g.hasSuperMeta {
-		out := make(map[string]os.FileInfo)
 		files, _ := filepath.Glob(g.path)
 		for _, file := range files {
 			info, err := os.Stat(file)
@@ -61,48 +57,37 @@ func (g *GlobPath) Match() map[string]os.FileInfo {
 		}
 		return out
 	}
-	return walkFilePath(g.root, g.g)
-}
-
-// walk the filepath from the given root and return a list of files that match
-// the given glob.
-func walkFilePath(root string, g glob.Glob) map[string]os.FileInfo {
-	matchedFiles := make(map[string]os.FileInfo)
+	roots, err := g.findRoots()
+	if err != nil {
+		return out
+	}
 	walkfn := func(path string, info os.FileInfo, _ error) error {
-		if g.Match(path) {
-			matchedFiles[path] = info
+		if g.g.Match(path) {
+			out[path] = info
 		}
 		return nil
-	}
-	filepath.Walk(root, walkfn)
-	return matchedFiles
-}
 
-// find the root dir of the given path (could include globs).
-// ie:
-//   /var/log/telegraf.conf -> /var/log
-//   /home/** ->               /home
-//   /home/*/** ->             /home
-//   /lib/share/*/*/**.txt ->  /lib/share
-func findRootDir(path string) string {
-	pathItems := strings.Split(path, sepStr)
-	out := sepStr
-	for i, item := range pathItems {
-		if i == len(pathItems)-1 {
-			break
-		}
-		if item == "" {
-			continue
-		}
-		if hasMeta(item) {
-			break
-		}
-		out += item + sepStr
 	}
-	if out != "/" {
-		out = strings.TrimSuffix(out, "/")
+	for _, root := range roots {
+		filepath.Walk(root, walkfn)
 	}
 	return out
+}
+
+// find the root elements of the object path, the entry point for recursion
+// when you have a super-meta in your path (which are : 
+// glob(/your/expression/until/first/star/of/super-meta))
+// ie:
+//   /var/log/telegraf.conf -> /var/log/telegraf.conf
+//   /home/** ->               filepath.Glob(/home/*)
+//   /home/*/** ->             filepath.Glob(/home/*/*)
+//   /lib/share/*/*/**.txt ->  filepath.Glob(/lib/share/*/*/*)
+func (g *GlobPath) findRoots() ([]string, error) {
+	if !g.hasSuperMeta {
+		return filepath.Glob(g.path)
+	}
+	rootGlob := g.path[:strings.Index(g.path, "**")+1]
+	return filepath.Glob(rootGlob)
 }
 
 // hasMeta reports whether path contains any magic glob characters.

--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -57,7 +57,7 @@ func (g *GlobPath) Match() map[string]os.FileInfo {
 		}
 		return out
 	}
-	roots, err := g.findRoots()
+	roots, err := findRoots(g.path)
 	if err != nil {
 		return out
 	}
@@ -82,11 +82,11 @@ func (g *GlobPath) Match() map[string]os.FileInfo {
 //   /home/** ->               filepath.Glob(/home/*)
 //   /home/*/** ->             filepath.Glob(/home/*/*)
 //   /lib/share/*/*/**.txt ->  filepath.Glob(/lib/share/*/*/*)
-func (g *GlobPath) findRoots() ([]string, error) {
-	if !g.hasSuperMeta {
-		return filepath.Glob(g.path)
+func findRoots(path string) ([]string, error) {
+	if strings.Index(path, "**") == -1 {
+		return filepath.Glob(path)
 	}
-	rootGlob := g.path[:strings.Index(g.path, "**")+1]
+	rootGlob := path[:strings.Index(path, "**")+1]
 	return filepath.Glob(rootGlob)
 }
 

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -39,22 +39,21 @@ func TestCompileAndMatch(t *testing.T) {
 	require.Len(t, matches, 0)
 }
 
-func TestFindRoots(t *testing.T) {
+func TestRootGlob(t *testing.T) {
 	dir := getTestdataDir()
 	tests := []struct {
 		input  string
-		output []string
+		output string
 	}{
-		{dir + "/**", []string{dir + "/test.conf", dir + "/nested1"}},
-		{dir + "/nested?/**", []string{dir + "/nested1/nested2"}},
-		{dir + "/lo*", []string{dir + "/log1.log", dir + "/log2.log"}},
+		{dir + "/**", dir + "/*"},
+		{dir + "/nested?/**", dir + "/nested?/*"},
+		{dir + "/ne**/nest*", dir + "/ne*"},
+		{dir + "/nested?/*", ""},
 	}
 
 	for _, test := range tests {
-		actual, _ := findRoots(test.input)
-		for _, output := range test.output {
-			require.Contains(t, actual, output)
-		}
+		actual, _ := Compile(test.input)
+		require.Equal(t, actual.rootGlob, test.output)
 	}
 }
 

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,15 +28,15 @@ func TestCompileAndMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	matches := g1.Match()
-	assert.Len(t, matches, 6)
+	require.Len(t, matches, 6)
 	matches = g2.Match()
-	assert.Len(t, matches, 2)
+	require.Len(t, matches, 2)
 	matches = g3.Match()
-	assert.Len(t, matches, 1)
+	require.Len(t, matches, 1)
 	matches = g4.Match()
-	assert.Len(t, matches, 0)
+	require.Len(t, matches, 0)
 	matches = g5.Match()
-	assert.Len(t, matches, 0)
+	require.Len(t, matches, 0)
 }
 
 func TestFindRoots(t *testing.T) {
@@ -54,7 +53,7 @@ func TestFindRoots(t *testing.T) {
 	for _, test := range tests {
 		actual, _ := findRoots(test.input)
 		for _, output := range test.output {
-			assert.Contains(t, actual, output)
+			require.Contains(t, actual, output)
 		}
 	}
 }
@@ -66,7 +65,7 @@ func TestFindNestedTextFile(t *testing.T) {
 	require.NoError(t, err)
 
 	matches := g1.Match()
-	assert.Len(t, matches, 1)
+	require.Len(t, matches, 1)
 }
 
 func getTestdataDir() string {

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -40,20 +40,22 @@ func TestCompileAndMatch(t *testing.T) {
 	assert.Len(t, matches, 0)
 }
 
-func TestFindRootDir(t *testing.T) {
+func TestFindRoots(t *testing.T) {
+	dir := getTestdataDir()
 	tests := []struct {
 		input  string
-		output string
+		output []string
 	}{
-		{"/var/log/telegraf.conf", "/var/log"},
-		{"/home/**", "/home"},
-		{"/home/*/**", "/home"},
-		{"/lib/share/*/*/**.txt", "/lib/share"},
+		{dir + "/**", []string{dir + "/test.conf", dir + "/nested1"}},
+		{dir + "/nested?/**", []string{dir + "/nested1/nested2"}},
+		{dir + "/lo*", []string{dir + "/log1.log", dir + "/log2.log"}},
 	}
 
 	for _, test := range tests {
-		actual := findRootDir(test.input)
-		assert.Equal(t, test.output, actual)
+		actual, _ := findRoots(test.input)
+		for _, output := range test.output {
+			assert.Contains(t, actual, output)
+		}
 	}
 }
 


### PR DESCRIPTION
When you have a super-meta in your expression (`**`), globpath was trying every files descendant of a root directory which was defined as « truncate path at the last / before the first star ». In cases such as `/path/**` or `/some/where/*/**`, it was OK.

But for path like `/some/*/path/*with/stars*/and/elements**` it was not optimal : it recursed through all directories under '/some', while it's only necessary to recurse through directories under `Glob("/some/*/path/*with/stars*/and/elements*")`.

This new version of globpath defines 'roots' (files and directories) as the filepath.Glob (« truncate between the 2 stars of the first `**` occurence »), and then calls filepath.Walk from these roots.

Simple tests (using 'time' on unix), where telegraf contains telegraf source code, and calling filestat agains these paths (md5=false) :

| | `telegraf/plugins/aggregators/**` | `telegraf/*lugins/aggregators/**`|
| -|-|-|
| master|real    0m0,093s|real    0m0,510s|
| optimized version|real    0m0,091s|real    0m0,088s|

(the differences between 0,088 and 0,093s are non significant I think).

I also tried using [godirwalk](https://github.com/karrick/godirwalk) as suggested by @danielnelson in #4778 but the improvement in performance was about 6% for recursing through telegraf source tree (with unsorted=true). Is it worth adding a dependency ?

And finally i moved from 'assert' to 'require' for some tests in globpath.go, as asked in [wiki/Review](https://github.com/influxdata/telegraf/wiki/Review), but i'm not sure if it's a good idea (I leave to you, maintainers, to decide, that's just 2219c2a commit to include or not).

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] (no need) Associated README.md updated.
- [x] Has appropriate unit tests.
