### PR TITLE
Update write path to match updated v2 API

### DIFF
--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -267,9 +267,9 @@ func makeWriteURL(loc url.URL, org, bucket string) (string, error) {
 	case "unix":
 		loc.Scheme = "http"
 		loc.Host = "127.0.0.1"
-		loc.Path = "v2/write"
+		loc.Path = "/api/v2/write"
 	case "http", "https":
-		loc.Path = path.Join(loc.Path, "v2/write")
+		loc.Path = path.Join(loc.Path, "/api/v2/write")
 	default:
 		return "", fmt.Errorf("unsupported scheme: %q", loc.Scheme)
 	}

--- a/plugins/outputs/influxdb_v2/http_internal_test.go
+++ b/plugins/outputs/influxdb_v2/http_internal_test.go
@@ -21,11 +21,11 @@ func TestMakeWriteURL(t *testing.T) {
 	}{
 		{
 			url: genURL("http://localhost:9999"),
-			act: "http://localhost:9999/v2/write?bucket=telegraf&org=influx",
+			act: "http://localhost:9999/api/v2/write?bucket=telegraf&org=influx",
 		},
 		{
 			url: genURL("unix://var/run/influxd.sock"),
-			act: "http://127.0.0.1/v2/write?bucket=telegraf&org=influx",
+			act: "http://127.0.0.1/api/v2/write?bucket=telegraf&org=influx",
 		},
 		{
 			err: true,


### PR DESCRIPTION
Updating write url to match changes made in influxdata/platform commit [1a2f606](https://github.com/influxdata/platform/commit/1a2f606533672fa94be5ade1b8a22f862c2fdf52) (Convert everything to /api/v2)