### PR TITLE
Rework mqtt_consumer connect/reconnect

### DIFF
--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -12,24 +12,17 @@ import (
 )
 
 const (
-	testMsg         = "cpu_load_short,host=server01 value=23422.0 1422568543702900257\n"
-	testMsgNeg      = "cpu_load_short,host=server01 value=-23422.0 1422568543702900257\n"
-	testMsgGraphite = "cpu.load.short.graphite 23422 1454780029"
-	testMsgJSON     = "{\"a\": 5, \"b\": {\"c\": 6}}\n"
-	invalidMsg      = "cpu_load_short,host=server01 1422568543702900257\n"
+	testMsg    = "cpu_load_short,host=server01 value=23422.0 1422568543702900257\n"
+	invalidMsg = "cpu_load_short,host=server01 1422568543702900257\n"
 )
 
-func newTestMQTTConsumer() (*MQTTConsumer, chan mqtt.Message) {
-	in := make(chan mqtt.Message, 100)
+func newTestMQTTConsumer() *MQTTConsumer {
 	n := &MQTTConsumer{
-		Topics:    []string{"telegraf"},
-		Servers:   []string{"localhost:1883"},
-		in:        in,
-		done:      make(chan struct{}),
-		connected: true,
+		Topics:  []string{"telegraf"},
+		Servers: []string{"localhost:1883"},
 	}
 
-	return n, in
+	return n
 }
 
 // Test that default client has random ID
@@ -79,31 +72,12 @@ func TestPersistentClientIDFail(t *testing.T) {
 }
 
 func TestRunParser(t *testing.T) {
-	n, in := newTestMQTTConsumer()
+	n := newTestMQTTConsumer()
 	acc := testutil.Accumulator{}
 	n.acc = &acc
-	defer close(n.done)
-
 	n.parser, _ = parsers.NewInfluxParser()
-	go n.receiver()
-	in <- mqttMsg(testMsgNeg)
-	acc.Wait(1)
 
-	if a := acc.NFields(); a != 1 {
-		t.Errorf("got %v, expected %v", a, 1)
-	}
-}
-
-func TestRunParserNegativeNumber(t *testing.T) {
-	n, in := newTestMQTTConsumer()
-	acc := testutil.Accumulator{}
-	n.acc = &acc
-	defer close(n.done)
-
-	n.parser, _ = parsers.NewInfluxParser()
-	go n.receiver()
-	in <- mqttMsg(testMsg)
-	acc.Wait(1)
+	n.recvMessage(nil, mqttMsg(testMsg))
 
 	if a := acc.NFields(); a != 1 {
 		t.Errorf("got %v, expected %v", a, 1)
@@ -112,82 +86,30 @@ func TestRunParserNegativeNumber(t *testing.T) {
 
 // Test that the parser ignores invalid messages
 func TestRunParserInvalidMsg(t *testing.T) {
-	n, in := newTestMQTTConsumer()
+	n := newTestMQTTConsumer()
 	acc := testutil.Accumulator{}
 	n.acc = &acc
-	defer close(n.done)
-
 	n.parser, _ = parsers.NewInfluxParser()
-	go n.receiver()
-	in <- mqttMsg(invalidMsg)
-	acc.WaitError(1)
+
+	n.recvMessage(nil, mqttMsg(invalidMsg))
 
 	if a := acc.NFields(); a != 0 {
 		t.Errorf("got %v, expected %v", a, 0)
 	}
-	assert.Contains(t, acc.Errors[0].Error(), "MQTT Parse Error")
+	assert.Len(t, acc.Errors, 1)
 }
 
 // Test that the parser parses line format messages into metrics
 func TestRunParserAndGather(t *testing.T) {
-	n, in := newTestMQTTConsumer()
+	n := newTestMQTTConsumer()
 	acc := testutil.Accumulator{}
 	n.acc = &acc
-
-	defer close(n.done)
-
 	n.parser, _ = parsers.NewInfluxParser()
-	go n.receiver()
-	in <- mqttMsg(testMsg)
-	acc.Wait(1)
 
-	n.Gather(&acc)
+	n.recvMessage(nil, mqttMsg(testMsg))
 
 	acc.AssertContainsFields(t, "cpu_load_short",
 		map[string]interface{}{"value": float64(23422)})
-}
-
-// Test that the parser parses graphite format messages into metrics
-func TestRunParserAndGatherGraphite(t *testing.T) {
-	n, in := newTestMQTTConsumer()
-	acc := testutil.Accumulator{}
-	n.acc = &acc
-	defer close(n.done)
-
-	n.parser, _ = parsers.NewGraphiteParser("_", []string{}, nil)
-	go n.receiver()
-	in <- mqttMsg(testMsgGraphite)
-
-	n.Gather(&acc)
-	acc.Wait(1)
-
-	acc.AssertContainsFields(t, "cpu_load_short_graphite",
-		map[string]interface{}{"value": float64(23422)})
-}
-
-// Test that the parser parses json format messages into metrics
-func TestRunParserAndGatherJSON(t *testing.T) {
-	n, in := newTestMQTTConsumer()
-	acc := testutil.Accumulator{}
-	n.acc = &acc
-	defer close(n.done)
-
-	n.parser, _ = parsers.NewParser(&parsers.Config{
-		DataFormat: "json",
-		MetricName: "nats_json_test",
-	})
-	go n.receiver()
-	in <- mqttMsg(testMsgJSON)
-
-	n.Gather(&acc)
-
-	acc.Wait(1)
-
-	acc.AssertContainsFields(t, "nats_json_test",
-		map[string]interface{}{
-			"a":   float64(5),
-			"b_c": float64(6),
-		})
 }
 
 func mqttMsg(val string) mqtt.Message {


### PR DESCRIPTION
Reworks the connection lifetime for the mqtt_consumer plugin.  For now I have this marked for 1.9.0 but if we can get some help testing we can consider it for 1.8.x.

closes #4594 
closes #4580
closes #4731

Based on #4814 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
