### PR TITLE
Extract end-entity certificate data only

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -143,11 +143,10 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 			"source": location,
 		}
 
-		for _, cert := range certs {
-			fields := getFields(cert, now)
+		// Only extract data from the end-entity certificate (first in the chain)
+		fields := getFields(certs[0], now)
 
-			acc.AddFields("x509_cert", fields, tags)
-		}
+		acc.AddFields("x509_cert", fields, tags)
 	}
 
 	return nil


### PR DESCRIPTION
The previous code was iterating over each certificate in the chain and over-writing the "fields" variable with each subsequent certificate. This had the effect of only extracting the data from the last certificate in the chain (typically the issuing authority certificate), when actually the user is likely expecting the first (the end-entity certificate).

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.