### PR TITLE
Update CI to Go 1.10.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults:
       - image: 'quay.io/influxdb/telegraf-ci:1.9.7'
   go-1_10: &go-1_10
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.10.3'
+      - image: 'quay.io/influxdb/telegraf-ci:1.10.4'
 
 version: 2
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,8 @@ plugin-%:
 
 .PHONY: ci-1.10
 ci-1.10:
-	docker build -t quay.io/influxdb/telegraf-ci:1.10.3 - < scripts/ci-1.10.docker
-	docker push quay.io/influxdb/telegraf-ci:1.10.3
+	docker build -t quay.io/influxdb/telegraf-ci:1.10.4 - < scripts/ci-1.10.docker
+	docker push quay.io/influxdb/telegraf-ci:1.10.4
 
 .PHONY: ci-1.9
 ci-1.9:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,11 @@ platform: x64
 
 install:
   - IF NOT EXIST "C:\Cache" mkdir C:\Cache
-  - IF NOT EXIST "C:\Cache\go1.10.3.msi" curl -o "C:\Cache\go1.10.3.msi" https://storage.googleapis.com/golang/go1.10.3.windows-amd64.msi
+  - IF NOT EXIST "C:\Cache\go1.10.4.msi" curl -o "C:\Cache\go1.10.4.msi" https://storage.googleapis.com/golang/go1.10.4.windows-amd64.msi
   - IF NOT EXIST "C:\Cache\gnuwin32-bin.zip" curl -o "C:\Cache\gnuwin32-bin.zip" https://dl.influxdata.com/telegraf/ci/make-3.81-bin.zip
   - IF NOT EXIST "C:\Cache\gnuwin32-dep.zip" curl -o "C:\Cache\gnuwin32-dep.zip" https://dl.influxdata.com/telegraf/ci/make-3.81-dep.zip
   - IF EXIST "C:\Go" rmdir /S /Q C:\Go
-  - msiexec.exe /i "C:\Cache\go1.10.3.msi" /quiet
+  - msiexec.exe /i "C:\Cache\go1.10.4.msi" /quiet
   - 7z x "C:\Cache\gnuwin32-bin.zip" -oC:\GnuWin32 -y
   - 7z x "C:\Cache\gnuwin32-dep.zip" -oC:\GnuWin32 -y
   - go get -d github.com/golang/dep

--- a/scripts/ci-1.10.docker
+++ b/scripts/ci-1.10.docker
@@ -1,4 +1,4 @@
-FROM golang:1.10.3
+FROM golang:1.10.4
 
 RUN chmod -R 755 "$GOPATH"
 


### PR DESCRIPTION
Updates CI image and config to latest Go 1.10.4 release.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
