### PR TITLE
Improve AWS Kinesis IAM Security

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -137,7 +137,7 @@
   revision = "f2867c24984aa53edec54a138c03db934221bdea"
 
 [[projects]]
-  digest = "1:65a05bde9b02f645c73afa61c9f6af92d94d726c81a268f45cc70218bd58de65"
+  digest = "1:996727880e06dcf037f712c4d046e241d1b1b01844636fefb0fbaa480cfd230e"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -173,8 +173,8 @@
     "service/sts",
   ]
   pruneopts = ""
-  revision = "8cf662a972fa7fba8f2c1ec57648cf840e2bb401"
-  version = "v1.14.30"
+  revision = "bf8067ceb6e7f51e150c218972dccfeeed892b85"
+  version = "v1.15.54"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,7 +16,7 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.14.8"
+  version = "1.15.54"
 
 [[constraint]]
   name = "github.com/bsm/sarama-cluster"


### PR DESCRIPTION
Updates the plugin's stream discovery to use DescribeStreamSummary[1]
in favor of ListStreams[2]. The API switch has the following benefits.

* **Faster Startup** - Previously, the configured stream had to be compared
against all available streams (possibly paginating the results) to check
its existence. Now it just calls a single API.

* **Improved Security** - Previously, the AWS IAM credentials had to have
read access to list all available streams. Now the AWS IAM credentials
can restrict operations to a specific Kinesis stream ARN.

* **Improve API Limits** - Per the AWS documentation, DescribeStreamSummary[1]
has a limit of 20 transactions per second while ListStreams[2] has a limit
of 5 transaction per second.

[1] https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeStreamSummary.html
[2] https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListStreams.html

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
