### PR TITLE
Add certificate subject as a tag

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -4,6 +4,7 @@ package x509_cert
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -130,6 +131,31 @@ func getFields(cert *x509.Certificate, now time.Time) map[string]interface{} {
 	return fields
 }
 
+func getTags(subject pkix.Name, location string) map[string]string {
+	tags := map[string]string{
+		"source":      location,
+		"common_name": subject.CommonName,
+	}
+
+	if len(subject.Organization) > 0 {
+		tags["organization"] = subject.Organization[0]
+	}
+	if len(subject.OrganizationalUnit) > 0 {
+		tags["organizational_unit"] = subject.OrganizationalUnit[0]
+	}
+	if len(subject.Country) > 0 {
+		tags["country"] = subject.Country[0]
+	}
+	if len(subject.Province) > 0 {
+		tags["province"] = subject.Province[0]
+	}
+	if len(subject.Locality) > 0 {
+		tags["locality"] = subject.Locality[0]
+	}
+
+	return tags
+}
+
 // Gather adds metrics into the accumulator.
 func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 	now := time.Now()
@@ -140,12 +166,9 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 			return fmt.Errorf("cannot get SSL cert '%s': %s", location, err.Error())
 		}
 
-		tags := map[string]string{
-			"source": location,
-		}
-
 		for _, cert := range certs {
 			fields := getFields(cert, now)
+			tags := getTags(cert.Subject, location)
 
 			acc.AddFields("x509_cert", fields, tags)
 		}

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -182,6 +182,56 @@ func TestGatherLocal(t *testing.T) {
 	}
 }
 
+func TestGatherChain(t *testing.T) {
+	cert := fmt.Sprintf("%s\n%s", pki.ReadServerCert(), pki.ReadCACert())
+
+	tests := []struct {
+		name    string
+		content string
+		error   bool
+	}{
+		{name: "chain certificate", content: cert},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f, err := ioutil.TempFile("", "x509_cert")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = f.Write([]byte(test.content))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = f.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			defer os.Remove(f.Name())
+
+			sc := X509Cert{
+				Sources: []string{f.Name()},
+			}
+
+			error := false
+
+			acc := testutil.Accumulator{}
+			err = sc.Gather(&acc)
+			if err != nil {
+				error = true
+			}
+
+			if error != test.error {
+				t.Errorf("%s", err)
+			}
+		})
+	}
+
+}
+
 func TestStrings(t *testing.T) {
 	sc := X509Cert{}
 


### PR DESCRIPTION
If there is a certificate chain in input source, all certificates are
returned with the same source tag. Subject of the certificate is added
to use all certs in the chain as an input.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
