### PR TITLE
Fix segfault in x509_cert

### DIFF
--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -10,7 +10,7 @@ file or network connection.
 # Reads metrics from a SSL certificate
 [[inputs.x509_cert]]
   ## List certificate sources
-  sources = ["/etc/ssl/certs/ssl-cert-snakeoil.pem", "https://example.org"]
+  sources = ["/etc/ssl/certs/ssl-cert-snakeoil.pem", "https://example.org:443"]
 
   ## Timeout for SSL connection
   # timeout = "5s"

--- a/plugins/inputs/x509_cert/dev/telegraf.conf
+++ b/plugins/inputs/x509_cert/dev/telegraf.conf
@@ -1,0 +1,5 @@
+[[inputs.x509_cert]]
+    sources = ["https://www.influxdata.com:443"]
+
+[[outputs.file]]
+  files = ["stdout"]

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -80,7 +80,10 @@ func (c *X509Cert) getCert(location string, timeout time.Duration) ([]*x509.Cert
 		}
 		defer ipConn.Close()
 
-		tlsCfg.ServerName = u.Host
+		if tlsCfg == nil {
+			tlsCfg = &tls.Config{}
+		}
+		tlsCfg.ServerName = u.Hostname()
 		conn := tls.Client(ipConn, tlsCfg)
 		defer conn.Close()
 

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -202,4 +204,20 @@ func TestStrings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGatherCert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	m := &X509Cert{
+		Sources: []string{"https://www.influxdata.com:443"},
+	}
+
+	var acc testutil.Accumulator
+	err := m.Gather(&acc)
+	require.NoError(t, err)
+
+	assert.True(t, acc.HasMeasurement("x509_cert"))
 }


### PR DESCRIPTION
- When no tls params are in config, tlsCfg will be nil
- fix setting hostname in tlsCfg it will contain the port number and never correctly match server certs
- Add a test that shows that it now works
- Fix readme as port number is required in soruces

Its currently possible to workaround the crash by adding `insecure_skip_verify = true` to the conf

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
