### PR TITLE
On host not available, set result_code accordingly

### DIFF
--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -31,6 +31,13 @@ apt-get install iputils-ping
   ## Interface or source address to send ping from (ping -I <INTERFACE/SRC_ADDR>)
   ## on Darwin and Freebsd only source address possible: (ping -S <SRC_ADDR>)
   # interface = ""
+
+  ## Specify the ping executable binary, default is "ping"
+  # binary = "ping"
+
+  ## Arguments for ping command
+  ## when arguments is not empty, other options (ping_interval, timeout, etc) will be ignored
+  # arguments = ["-c", "3"]
 ```
 
 ### Metrics:

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -133,6 +133,7 @@ func (p *Ping) pingToURL(u string, acc telegraf.Accumulator) {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			if ws, ok := exitError.Sys().(syscall.WaitStatus); ok {
 				status = ws.ExitStatus()
+				fields["result_code"] = status
 			}
 		}
 


### PR DESCRIPTION
Resolves #4772 
Since the original issue was added in 1.7.4 (PR 4550), does it need backported to the 1.7 line too?
