### PR TITLE
Remove dead link from logparser sampleconfig and fix syntax

### DIFF
--- a/plugins/inputs/logparser/README.md
+++ b/plugins/inputs/logparser/README.md
@@ -7,6 +7,7 @@ regex patterns.
 ### Configuration:
 
 ```toml
+# Stream and parse log file(s).
 [[inputs.logparser]]
   ## Log files to parse.
   ## These accept standard unix glob matching rules, but with the addition of
@@ -25,7 +26,6 @@ regex patterns.
   # watch_method = "inotify"
 
   ## Parse logstash-style "grok" patterns:
-  ##   Telegraf built-in parsing patterns: https://goo.gl/dkay10
   [inputs.logparser.grok]
     ## This is a list of patterns to check the given log file(s) for.
     ## Note that adding patterns here increases processing time. The most
@@ -54,7 +54,7 @@ regex patterns.
     ##   1. Local             -- interpret based on machine localtime
     ##   2. "Canada/Eastern"  -- Unix TZ values like those found in https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     ##   3. UTC               -- or blank/unspecified, will return timestamp in UTC
-    timezone = "Canada/Eastern"
+    # timezone = "Canada/Eastern"
 ```
 
 ### Grok Parser

--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -88,6 +88,7 @@ const sampleConfig = `
 
     ## Custom patterns can also be defined here. Put one pattern per line.
     custom_patterns = '''
+    '''
 
     ## Timezone allows you to provide an override for timestamps that
     ## don't already include an offset
@@ -98,8 +99,7 @@ const sampleConfig = `
     ##   1. Local             -- interpret based on machine localtime
     ##   2. "Canada/Eastern"  -- Unix TZ values like those found in https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     ##   3. UTC               -- or blank/unspecified, will return timestamp in UTC
-    timezone = "Canada/Eastern"
-    '''
+    # timezone = "Canada/Eastern"
 `
 
 // SampleConfig returns the sample configuration for the plugin


### PR DESCRIPTION
closes #4882 

Regenerated README config from plugin, noticed an error in the custom_patterns multiline string and fixed.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
