### PR TITLE
Add retain flag to mqtt output to let brokers/servers cache measurements

### DIFF
--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -32,10 +32,14 @@ This plugin writes to a [MQTT Broker](http://http://mqtt.org/) acting as a mqtt 
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
-
+  
   ## When true, metrics will be sent in one MQTT message per flush.  Otherwise,
   ## metrics are written one metric per MQTT message.
   # batch = false
+  
+  ## When true, metric will have RETAIN flag set, making broker cache entries until someone
+  ## actually reads it
+  # retain = flase
 
   ## Data format to output.
   # data_format = "influx"
@@ -56,4 +60,5 @@ This plugin writes to a [MQTT Broker](http://http://mqtt.org/) acting as a mqtt 
 * `tls_cert`: TLS CERT
 * `tls_key`: TLS key
 * `insecure_skip_verify`: Use TLS but skip chain & host verification (default: false)
+* `retain`: Set `retain` flag when publishing, instructing server to cache metric until someone reads it (default: false)
 * `data_format`: [About Telegraf data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md)

--- a/plugins/outputs/mqtt/mqtt.go
+++ b/plugins/outputs/mqtt/mqtt.go
@@ -49,6 +49,10 @@ var sampleConfig = `
   ## When true, metrics will be sent in one MQTT message per flush.  Otherwise,
   ## metrics are written one metric per MQTT message.
   # batch = false
+  
+  ## When true, metric will have RETAIN flag set, making broker cache entries until someone
+  ## actually reads it
+  # retain = flase
 
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
@@ -68,6 +72,7 @@ type MQTT struct {
 	ClientID    string `toml:"client_id"`
 	tls.ClientConfig
 	BatchMessage bool `toml:"batch"`
+	Retain       bool
 
 	client paho.Client
 	opts   *paho.ClientOptions
@@ -174,7 +179,7 @@ func (m *MQTT) Write(metrics []telegraf.Metric) error {
 }
 
 func (m *MQTT) publish(topic string, body []byte) error {
-	token := m.client.Publish(topic, byte(m.QoS), false, body)
+	token := m.client.Publish(topic, byte(m.QoS), m.Retain, body)
 	token.WaitTimeout(m.Timeout.Duration)
 	if token.Error() != nil {
 		return token.Error()


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

----

Not unit-testable. Behavior confirmed to be correct in-house on the following configuration:
* FreeBSD 11-STABLE
* Mosquitto 1.5.3
* `mosquitto.conf`:
```txt
persistence true
autosave_interval 5
autosave_on_changes true
log_dest syslog
log_type warning
persistence_location /data/mosquitto/
persistent_client_expiration 1w

bind_address 127.0.0.1
port 1300
```
* `telegraf.conf`:
```toml
[global_tags]
[agent]
  interval = "60s"
  round_interval = true
  metric_batch_size = 100
  metric_buffer_limit = 10000
  collection_jitter = "500ms"
  flush_interval = "10s"
  flush_jitter = "10s"
  precision = ""
  quiet = true
  hostname = ""
  omit_hostname = false
[[outputs.mqtt]]
  servers = ["localhost:1300"]
  client_id = "telegraf-out"
  qos = 2
  batch = true
  retain = true
  topic_prefix = "telegraf"
[[inputs.cpu]]
[[inputs.disk]]
  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "fdescfs", "procfs"]
[[inputs.diskio]]
  devices = ["ada*", "da*"]
[[inputs.kernel]]
[[inputs.mem]]
[[inputs.processes]]
[[inputs.swap]]
[[inputs.system]]
[[inputs.net]]
[[inputs.syslog]]
  server = "udp4://localhost:6514"
  keep_alive_period = "1m"
  best_effort = true
```

Broker caches results until they are drained by:
```sh
mosquitto_sub -p 1300 -v -t 'telegraf/#' -q 2
```
