### PR TITLE
Add means for config to 'work' (not cause an exit) cross platform

### DIFF
--- a/plugins/inputs/invalid_plugin.go
+++ b/plugins/inputs/invalid_plugin.go
@@ -1,0 +1,39 @@
+package inputs
+
+import (
+	"log"
+
+	"github.com/influxdata/telegraf"
+)
+
+// InvalidPlugin is used when a plugin may be invalid for a
+// platform or other reason.
+type InvalidPlugin struct {
+	InvalidReason string
+	OrigDesc      string
+	OrigSampleCfg string
+}
+
+// Description should be inherited from the parent plugin.
+func (i *InvalidPlugin) Description() string {
+	return i.OrigDesc
+}
+
+// SampleConfig should be inherited from the parent plugin.
+func (i *InvalidPlugin) SampleConfig() string {
+	return i.OrigSampleCfg
+}
+
+// Gather does nothing, as the plugin is invalid.
+func (i *InvalidPlugin) Gather(_a0 telegraf.Accumulator) error {
+	return nil
+}
+
+// Start prints the reason the plugin was not valid.
+func (i *InvalidPlugin) Start(telegraf.Accumulator) error {
+	log.Printf("E! %s", i.InvalidReason)
+	return nil
+}
+
+// Stop does nothing, as the plugin is invalid.
+func (i *InvalidPlugin) Stop() { return }

--- a/plugins/inputs/processes/processes_windows.go
+++ b/plugins/inputs/processes/processes_windows.go
@@ -1,3 +1,18 @@
 // +build windows
 
 package processes
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+func init() {
+	inputs.Add("processes", func() telegraf.Input {
+		return &inputs.InvalidPlugin{
+			InvalidReason: "Process input plugin not supported on windows",
+			OrigDesc:      "Get the number of processes and group them by status",
+			OrigSampleCfg: "",
+		}
+	})
+}


### PR DESCRIPTION
Potential solution for #2652 

This adds a generic service input plugin that will print a custom error message on `Start()`, allowing a shared config to not prevent telegraf from starting up.