### PR TITLE
Adding new Input-Plugin for Atlassian Jira statistics over JQL

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -54,6 +54,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/iptables"
 	_ "github.com/influxdata/telegraf/plugins/inputs/ipvs"
 	_ "github.com/influxdata/telegraf/plugins/inputs/jenkins"
+	_ "github.com/influxdata/telegraf/plugins/inputs/jira"
 	_ "github.com/influxdata/telegraf/plugins/inputs/jolokia"
 	_ "github.com/influxdata/telegraf/plugins/inputs/jolokia2"
 	_ "github.com/influxdata/telegraf/plugins/inputs/jti_openconfig_telemetry"

--- a/plugins/inputs/jira/README.md
+++ b/plugins/inputs/jira/README.md
@@ -20,6 +20,19 @@ You can generate it using `telegraf --usage jira`.
   # Create tags based on these fields values
   tag_fields = ["custom_field_666"]
 
+
+# Define here the preffered authentication values
+# You should prefere the API-Token and leave username and password clear
+[[inputs.jira.authentication]]
+  # Username amd Password for BasicAuth - this may be deprecated in your Jira-Installation
+  username = MyUser
+  password = MyPass
+
+  # If you're using the new API-Token, fill in these values
+  email = myjira@example.com
+  token = my-generated-api-token
+
+
 # ${DATE} will be replaced with the current date on every request
 # Define as much JQLs as you need and give them each a name for having statistics on the count of issues
 [[inputs.jira.jql]]
@@ -34,6 +47,14 @@ You can generate it using `telegraf --usage jira`.
   name = "total"
   jql = "Team in (DevTeam, TestingTeam) AND issuetype = Bug AND status was in (\"Ready for develope\", Development, QA) on ${DATE}"
 ```
+
+### Authentication:
+
+Atlassian announced that [BasicAuth will be deprecated](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-basic-auth-and-cookie-based-auth/). Therefore you should not use this anymore.
+
+For BasicAuth you can use the `username` and `password` fields in the `inputs.jira.authentication` section. Just enter the plain values there.
+If you're using the API-Token, what is also a Basic-Authentication in the background, use the `email` and `token` fields.
+
 
 ### Metrics:
 

--- a/plugins/inputs/jira/README.md
+++ b/plugins/inputs/jira/README.md
@@ -1,0 +1,86 @@
+# Atlassian Jira Input Plugin
+---
+
+The Jira plugin gathers metrics of Atlassian Jira using [rest/api/latest](https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/) endpoint.
+
+### Configuration:
+
+This section contains the default TOML to configure the Jira-Plugin.
+You can generate it using `telegraf --usage jira`.
+
+```toml
+# Works with multiple Atlassian Jira instances
+[[inputs.jira]]
+  # Multiple Hosts from which to read ticket stats
+  hosts = ["http://jira:8080/"]
+
+  # Give here all fields to be selected. Each field will be counted grouped by the hosts, tags and JQLs below
+  fields = ["priority", "custom_field_1234"]
+
+  # Create tags based on these fields values
+  tag_fields = ["custom_field_666"]
+
+# ${DATE} will be replaced with the current date on every request
+# Define as much JQLs as you need and give them each a name for having statistics on the count of issues
+[[inputs.jira.jql]]
+  name = "new"
+  jql = "Team in (DevTeam, TestingTeam) AND issuetype = Bug AND status changed to \"Ready for develope\" on ${DATE}"
+
+[[inputs.jira.jql]]
+  name = "closed"
+  jql = "Team in (DevTeam, TestingTeam) AND issuetype = Bug AND status changed to (Closed, Resolved) on ${DATE} AND status was QA on ${DATE}"
+
+[[inputs.jira.jql]]
+  name = "total"
+  jql = "Team in (DevTeam, TestingTeam) AND issuetype = Bug AND status was in (\"Ready for develope\", Development, QA) on ${DATE}"
+```
+
+### Metrics:
+
+The JQL-Filter-Names are the base for the field names. Based on the example Configuration it's `new, closed, total`. Each of these values is used as Prefix for each `fields` Field. Based on the `Value` of the response of the group, the fieldname is finally built: `JQL_FIELD_VALUE`.
+
+Let's describe it more simple:
+
+- Given is a JQL-Filter with the name `new` which is selecting all new Issues from today.
+- Given is a JQL-Filter with the name `closed` which is selecting all today closed Issues.
+- Given are the Fields `fields = [ "priority", "custom_field_1234" ]`
+- Given are the Tagfields `tag_fields = [ "custom_field_666" ]`
+
+The two given Filters are the base for the field names: `new_` and `closed_`.
+Each field is then appended to the base fieldname: `new_priority_`, `closed_priority_` and `new_custom_field_1234_`, `closed_custom_field_1234_`
+After the values of the fields are taken. In Priority we have values for `high`, `medium` and `low`. The customfield is for the customer, lets say it has `Company`, `ACME`.
+These values are taken and appended ot the fields as well: `new_priority_high`, `new_priority_medium`, `new_priority_low`, `closed_priority_high`, `closed_priority_medium`, `closed_priority_low`.
+And for the customfield as well: `new_custom_field_1234_Company`, `new_custom_field_1234_Company`, `closed_custom_field_1234_ACME`, `closed_custom_field_1234_ACME`
+
+The Tagfields are used to first group the issues based on the value of the fields. Let's assume in the `custom_field_666` we have which Dev-Team is responsible for the bug: `DevTeam`, `ConfigTeam`.
+Each issue is then first checked if it's for the `DevTeam` or the `ConfigTeam` and grouped by this value. This results in a clean output which has only the amount of issues for which the teams are responsible for and which are interreting for them.
+
+In this Example where we have the Customer in the `custom_field_1234` field, it could be better to use that field also as a tag. Then we would have the data grouped by the team and customer.
+
+For more Information about how to filter query issues from Atlassian Jira, see their (Jira Server REST APIs)[https://developer.atlassian.com/server/jira/platform/rest-apis/].
+
+
+### Example output:
+
+Based on the example Configuration.
+
+**Tags:**
+
+* server
+* custom_field_666
+
+**Output Fields:**
+
+* new_priority_critical
+* new_priority_high
+* new_priority_low
+* closed_priority_critical
+* closed_priority_high
+* closed_priority_low
+
+**Output**
+
+```
+jira,server=https://jira:8080/,custom_field_666=DevTeam new_priority_low=55,new_priority_high=10,new_priority_critical=1,closed_priority_low=55,closed_priority_high=10,closed_priority_critical=1,total_priority_low=55,total_priority_high=10,total_priority_critical=1 1536707179000000000
+jira,server=https://jira:8080/,custom_field_666=ConfigTeam new_priority_low=55,new_priority_high=10,new_priority_critical=1,closed_priority_low=55,closed_priority_high=10,closed_priority_critical=1,total_priority_low=55,total_priority_high=10,total_priority_critical=1 1536707179000000000
+```

--- a/plugins/inputs/jira/dev/docker-compose.yml
+++ b/plugins/inputs/jira/dev/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  jira:
+    image: nginx
+    ports:
+      - "8080:80"
+    expose:
+      - "8080"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+      - ./:/usr/share/nginx/html
+  telegraf:
+    image: glinton/scratch
+    depends_on:
+      - jira
+    volumes:
+      - ./telegraf.conf:/telegraf.conf
+      - ../../../../telegraf:/telegraf
+    entrypoint:
+      - /telegraf
+      - --config
+      - /telegraf.conf

--- a/plugins/inputs/jira/dev/nginx.conf
+++ b/plugins/inputs/jira/dev/nginx.conf
@@ -1,0 +1,14 @@
+
+http {
+	server {
+		error_page 405 =200 $uri;
+		
+		location / {
+			root /usr/share/nginx/html;
+			types {}
+			default_type application/json;
+		}
+	}
+}
+
+events {}

--- a/plugins/inputs/jira/dev/rest/api/latest/search
+++ b/plugins/inputs/jira/dev/rest/api/latest/search
@@ -1,0 +1,128 @@
+{
+  "expand": "schema,names",
+  "startAt": 0,
+  "maxResults": 5,
+  "total": 13544,
+  "issues": [
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "90375",
+      "self": "https://jira.local/rest/api/latest/issue/90375",
+      "key": "PROJECT-20001622",
+      "fields": {
+        "priority": {
+          "self": "https://jira.local/rest/api/2/priority/6",
+          "iconUrl": "https://jira.local/images/icons/priorities/critical.svg",
+          "name": "Express",
+          "id": "6"
+        },
+        "custom_field_1234": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "Customer",
+          "id": "10583"
+        },
+        "customfield_10510": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "DevTeam",
+          "id": "10583"
+        }
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "89394",
+      "self": "https://jira.local/rest/api/latest/issue/89394",
+      "key": "PROJECT-20001551",
+      "fields": {
+        "priority": {
+          "self": "https://jira.local/rest/api/2/priority/1",
+          "iconUrl": "https://jira.local/images/icons/priorities/major.svg",
+          "name": "High",
+          "id": "1"
+        },
+        "custom_field_1234": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "Customer",
+          "id": "10583"
+        },
+        "customfield_10510": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "DevTeam",
+          "id": "10583"
+        }
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "88845",
+      "self": "https://jira.local/rest/api/latest/issue/88845",
+      "key": "PROJECT-20001492",
+      "fields": {
+        "priority": {
+          "self": "https://jira.local/rest/api/2/priority/6",
+          "iconUrl": "https://jira.local/images/icons/priorities/critical.svg",
+          "name": "Express",
+          "id": "6"
+        },
+        "custom_field_1234": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "ACME",
+          "id": "10583"
+        },
+        "customfield_10510": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "TestingTeam",
+          "id": "10583"
+        }
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "88541",
+      "self": "https://jira.local/rest/api/latest/issue/88541",
+      "key": "PROJECT-20001460",
+      "fields": {
+        "priority": {
+          "self": "https://jira.local/rest/api/2/priority/1",
+          "iconUrl": "https://jira.local/images/icons/priorities/major.svg",
+          "name": "Normal",
+          "id": "1"
+        },
+        "custom_field_1234": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "ACME",
+          "id": "10583"
+        },
+        "customfield_10510": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "TestingTeam",
+          "id": "10583"
+        }
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "88410",
+      "self": "https://jira.local/rest/api/latest/issue/88410",
+      "key": "PROJECT-20001448",
+      "fields": {
+        "priority": {
+          "self": "https://jira.local/rest/api/2/priority/1",
+          "iconUrl": "https://jira.local/images/icons/priorities/major.svg",
+          "name": "Normal",
+          "id": "1"
+        },
+        "custom_field_1234": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "ACME",
+          "id": "10583"
+        },
+        "customfield_10510": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "DevTeam",
+          "id": "10583"
+        }
+      }
+    }
+  ]
+} 

--- a/plugins/inputs/jira/dev/telegraf.conf
+++ b/plugins/inputs/jira/dev/telegraf.conf
@@ -9,6 +9,17 @@
   # Create tags based on these fields values
   tag_fields = ["customfield_10510"]
 
+# Define here the preffered authentication values
+# You should prefere the API-Token and leave username and password clear
+[[inputs.jira.authentication]]
+  # Username amd Password for BasicAuth - this may be deprecated in your Jira-Installation
+  username = MyUser
+  password = MyPass
+
+  # If you're using the new API-Token, fill in these values
+  email = myjira@example.com
+  token = my-generated-api-token
+
 # ${DATE} will be replaced with the current date on every request
 # Define as much JQLs as you need and give them each a name for having statistics on the count of issues
 [[inputs.jira.jql]]

--- a/plugins/inputs/jira/dev/telegraf.conf
+++ b/plugins/inputs/jira/dev/telegraf.conf
@@ -1,0 +1,27 @@
+# Works with multiple Atlassian Jira instances
+[[inputs.jira]]
+  # Multiple Hosts from which to read ticket stats
+  hosts = ["http://jira/"]
+
+  # Give here all fields to be selected. Each field will be counted grouped by the hosts, tags and JQLs below
+  fields = ["priority", "custom_field_1234"]
+
+  # Create tags based on these fields values
+  tag_fields = ["customfield_10510"]
+
+# ${DATE} will be replaced with the current date on every request
+# Define as much JQLs as you need and give them each a name for having statistics on the count of issues
+[[inputs.jira.jql]]
+  name = "new"
+  jql = "Team in (DevTeam, TestingTeam) AND issuetype = Bug AND status changed to \"Ready for develope\" on ${DATE}"
+
+[[inputs.jira.jql]]
+  name = "closed"
+  jql = "Team in (DevTeam, TestingTeam) AND issuetype = Bug AND status changed to (Closed, Resolved) on ${DATE} AND status was QA on ${DATE}"
+
+[[inputs.jira.jql]]
+  name = "total"
+  jql = "Team in (DevTeam, TestingTeam) AND issuetype = Bug AND status was in (\"Ready for develope\", Development, QA) on ${DATE}"
+
+[[outputs.file]]
+  files = ["stdout"]

--- a/plugins/inputs/jira/jira.go
+++ b/plugins/inputs/jira/jira.go
@@ -1,0 +1,211 @@
+package jira
+
+import (
+	"fmt"
+	"sync"
+	"time"
+	"bytes"
+	"regexp"
+	"strings"
+	"strconv"
+	"net/http"
+	"encoding/json"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+type (
+	Jira struct {
+		Servers  []string  `toml:"hosts"`
+		Fields   []string  `toml:"fields"`
+		Tags     []string  `toml:"tag_fields"`
+		Jql      []Jql     `toml:"jql"`
+		client *http.Client
+	}
+	Jql struct {
+		Key    string  `toml:"name"`
+		Value  string  `toml:"jql"`
+	}
+)
+
+type (
+	field struct {
+		Id          int64   `json:"id"`
+		Field       string  `json:"_"`
+		Name        string  `json:"name"`
+		Value       string  `json:"value"`
+	}
+	
+	issues struct {
+		Id          string        `json:"id"`
+		Uri         string        `json:"self"`
+		Key         string        `json:"key"`
+		Fields  map[string]field  `json:"fields"`
+	}
+	
+	Stats struct {
+		StartAt       int64   `json:"startAt"`
+		MaxResults    int64   `json:"maxResults"`
+		Total         int64   `json:"total"`
+		Issues      []issues  `json:"issues"`
+	}
+)
+
+func (j *Jira) Description() string {
+	return "Jira ticket statistics"
+}
+
+func (j *Jira) SampleConfig() string {
+	return `
+# Works with multiple Atlassian Jira instances
+[[inputs.jira]]
+  # Multiple Hosts from which to read ticket stats
+  hosts = ["http://jira:8080/"]
+
+  # Give here all fields to be selected. Each field will be counted grouped by the hosts, tags and JQLs below
+  fields = ["priority", "custom_field_1234"]
+
+  # Create tags based on these fields values
+  tag_fields = ["customfield_666"]
+
+# ${DATE} will be replaced with the current date on every request
+# Define as much JQLs as you need and give them each a name for having statistics on the count of issues
+[[inputs.jira.jql]]
+  name = "new"
+  jql = "Team in (DevTeam, TestingTeam) AND issuetype = Bug AND status changed to \"Ready for develope\" on ${DATE}"
+
+[[inputs.jira.jql]]
+  name = "closed"
+  jql = "Team in (DevTeam, TestingTeam) AND issuetype = Bug AND status changed to (Closed, Resolved) on ${DATE} AND status was QA on ${DATE}"
+
+[[inputs.jira.jql]]
+  name = "total"
+  jql = "Team in (DevTeam, TestingTeam) AND issuetype = Bug AND status was in (\"Ready for develope\", Development, QA) on ${DATE}"
+`
+}
+
+func (j *Jira) Gather(accumulator telegraf.Accumulator) error {
+	var wg sync.WaitGroup
+	for _, h := range j.Servers {
+		wg.Add(1)
+		go func(host string) {
+			defer wg.Done()
+			if err := j.fetchAndProcess(accumulator, host); err != nil {
+				accumulator.AddError(fmt.Errorf("[host=%s]: %s", host, err))
+			}
+		}(h)
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (j *Jira) fetchAndProcess(accumulator telegraf.Accumulator, host string) error {
+	if j.client == nil {
+		j.client = &http.Client{
+			Transport: &http.Transport{
+				ResponseHeaderTimeout: time.Duration(3 * time.Second),
+			},
+			Timeout: time.Duration(4 * time.Second),
+		}
+	}
+	
+	time := time.Now()
+	cache := make(map[string]map[string]int64)
+	uri := host + "/rest/api/latest/search"
+	
+	for _, jql := range j.Jql {
+		name := jql.Key
+		filter := strings.Replace(jql.Value, "${DATE}", strconv.Itoa(time.Year()) + "-" + strconv.Itoa(int(time.Month())) + "-" + strconv.Itoa(time.Day()), -1)
+
+		var post = []byte(`{"jql": "` + strings.Replace(filter, `"`, `\"`, -1) + `",
+    "startAt": 0,
+    "maxResults": 9999,
+    "fields": ["` + strings.Join(append(j.Fields, j.Tags...)[:], `","`) + `"]
+  }`)
+		response, error := j.client.Post(uri, "application/json", bytes.NewBuffer(post))
+		if error != nil {
+			return error
+		}
+		defer response.Body.Close()
+
+		if response.StatusCode != 200 {
+			return fmt.Errorf("Failed to get stats from jira: HTTP responded %d", response.StatusCode)
+		}
+		
+		stats := Stats{}
+		decoder := json.NewDecoder(response.Body)
+		decoder.Decode(&stats)
+		
+		for _, issue := range stats.Issues {
+			tags := j.getTagValues(issue.Fields)
+			if _, ok := cache[tags]; !ok {
+				cache[tags] = make(map[string]int64)
+			}
+			
+			var fieldName string;
+			for _, fn := range j.Fields {
+				if field, ok := issue.Fields[fn]; ok {
+					fieldName = name + "_" + fn
+					if len(field.Name) > 0 {
+						fieldName += "_" + field.Name
+					} else if len(field.Value) > 0 {
+						fieldName += "_" + field.Value
+					}
+					cache[tags][fieldName] += 1
+				}
+			}
+		}
+	}
+
+	for tag, values := range cache {
+		tags := map[string]string{
+			"server": host,
+		}
+		
+		for _, part := range strings.Split(tag, ",") {
+			var p = strings.Split(part, "=")
+			if len(p) == 2 {
+				tags[p[0]] = p[1]
+			}
+		}
+		
+		fields := map[string]interface{}{}
+		for n, v := range values {
+			fields[n] = v
+		}
+		accumulator.AddFields("jira", fields, tags, time.UTC())
+	}
+	return nil
+}
+
+func (j *Jira) getTagValues(fields map[string]field) string {
+	re := regexp.MustCompile("[\\s,.]+")
+	var tags []string
+	for _, tag := range j.Tags {
+		if field, ok := fields[tag]; ok {
+			var value string
+			if len(field.Value) > 0 {
+				value = field.Value
+			} else if len(field.Name) > 0 {
+				value = field.Name
+			}
+			tags = append(tags, tag + "=" + re.ReplaceAllString(value, ""))
+		}
+	}
+	return strings.Join(tags[:], ",")
+}
+
+func init() {
+	inputs.Add("jira", func() telegraf.Input {
+		return &Jira{
+			client: &http.Client{
+				Transport: &http.Transport{
+					ResponseHeaderTimeout: time.Duration(3 * time.Second),
+				},
+				Timeout: time.Duration(4 * time.Second),
+			},
+		}
+	})
+}

--- a/plugins/inputs/jira/jira_test.go
+++ b/plugins/inputs/jira/jira_test.go
@@ -1,0 +1,138 @@
+package jira_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/influxdata/telegraf/plugins/inputs/jira"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasic(t *testing.T) {
+	js := `
+{
+  "expand": "schema,names",
+  "startAt": 0,
+  "maxResults": 5,
+  "total": 13544,
+  "issues": [
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "90375",
+      "self": "https://jira.local/rest/api/latest/issue/90375",
+      "key": "PROJECT-20001622",
+      "fields": {
+        "priority": {
+          "self": "https://jira.local/rest/api/2/priority/6",
+          "iconUrl": "https://jira.local/images/icons/priorities/critical.svg",
+          "name": "Express",
+          "id": "6"
+        },
+        "customfield_10510": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "DevTeam",
+          "id": "10583"
+        }
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "89394",
+      "self": "https://jira.local/rest/api/latest/issue/89394",
+      "key": "PROJECT-20001551",
+      "fields": {
+        "priority": {
+          "self": "https://jira.local/rest/api/2/priority/1",
+          "iconUrl": "https://jira.local/images/icons/priorities/major.svg",
+          "name": "High",
+          "id": "1"
+        },
+        "customfield_10510": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "DevTeam",
+          "id": "10583"
+        }
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "88845",
+      "self": "https://jira.local/rest/api/latest/issue/88845",
+      "key": "PROJECT-20001492",
+      "fields": {
+        "priority": {
+          "self": "https://jira.local/rest/api/2/priority/6",
+          "iconUrl": "https://jira.local/images/icons/priorities/critical.svg",
+          "name": "Express",
+          "id": "6"
+        },
+        "customfield_10510": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "TestingTeam",
+          "id": "10583"
+        }
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "88541",
+      "self": "https://jira.local/rest/api/latest/issue/88541",
+      "key": "PROJECT-20001460",
+      "fields": {
+        "priority": {
+          "self": "https://jira.local/rest/api/2/priority/1",
+          "iconUrl": "https://jira.local/images/icons/priorities/major.svg",
+          "name": "Normal",
+          "id": "1"
+        },
+        "customfield_10510": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "TestingTeam",
+          "id": "10583"
+        }
+      }
+    },
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "88410",
+      "self": "https://jira.local/rest/api/latest/issue/88410",
+      "key": "PROJECT-20001448",
+      "fields": {
+        "priority": {
+          "self": "https://jira.local/rest/api/2/priority/1",
+          "iconUrl": "https://jira.local/images/icons/priorities/major.svg",
+          "name": "Normal",
+          "id": "1"
+        },
+        "customfield_10510": {
+          "self": "https://jira.local/rest/api/2/customFieldOption/10583",
+          "value": "DevTeam",
+          "id": "10583"
+        }
+      }
+    }
+  ]
+}
+`
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/latest/search" {
+			_, _ = w.Write([]byte(js))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer fakeServer.Close()
+
+	plugin := &jira.Jira{
+		Servers:  []string{fakeServer.URL},
+		Fields:   []string{"priority"},
+		Tags:     []string{"customfield_10510"},
+		Jql:      []jira.Jql{{Key:"new", Value:"Jql"},{Key:"total", Value:"Jql"}},
+	}
+
+	var acc testutil.Accumulator
+	acc.SetDebug(true)
+	require.NoError(t, acc.GatherError(plugin.Gather))
+}

--- a/plugins/inputs/jira/jira_test.go
+++ b/plugins/inputs/jira/jira_test.go
@@ -126,10 +126,10 @@ func TestBasic(t *testing.T) {
 	defer fakeServer.Close()
 
 	plugin := &jira.Jira{
-		Servers:  []string{fakeServer.URL},
-		Fields:   []string{"priority"},
-		Tags:     []string{"customfield_10510"},
-		Jql:      []jira.Jql{{Key:"new", Value:"Jql"},{Key:"total", Value:"Jql"}},
+		Servers: []string{fakeServer.URL},
+		Fields:  []string{"priority"},
+		Tags:    []string{"customfield_10510"},
+		Jql:     []jira.Jql{{Key: "new", Value: "Jql"}, {Key: "total", Value: "Jql"}},
 	}
 
 	var acc testutil.Accumulator


### PR DESCRIPTION
I am not that familiar with go, hope it conforms your needs.

This plugin is able to fetch statistics based on JQL from Atlassian Jira. For example to measure the amount of new, resolved and rejected Bugs or whatever.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
