### PR TITLE
Add a better default error description

### DIFF
--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -193,11 +193,7 @@ func (c *httpClient) Write(ctx context.Context, metrics []telegraf.Metric) error
 	err = json.NewDecoder(resp.Body).Decode(writeResp)
 	desc := writeResp.Error()
 	if err != nil {
-		if err != io.EOF {
-			desc = err.Error()
-		} else {
-			desc = resp.Status
-		}
+		desc = resp.Status
 	}
 
 	switch resp.StatusCode {

--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -193,7 +193,11 @@ func (c *httpClient) Write(ctx context.Context, metrics []telegraf.Metric) error
 	err = json.NewDecoder(resp.Body).Decode(writeResp)
 	desc := writeResp.Error()
 	if err != nil {
-		desc = err.Error()
+		if err != io.EOF {
+			desc = err.Error()
+		} else {
+			desc = resp.Status
+		}
 	}
 
 	switch resp.StatusCode {


### PR DESCRIPTION
Resolves #4947 

Now, instead of `EOF` the description will contain the response status:

`E! [outputs.influxdb_v2] Failed to write metric: 403 Forbidden`