### PR TITLE
Use fieldsCopy in testutil.Accumulator AddFields

### DIFF
--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -73,6 +73,10 @@ func (a *Accumulator) AddFields(
 		return
 	}
 
+	if len(fields) == 0 {
+		return
+	}
+
 	tagsCopy := map[string]string{}
 	for k, v := range tags {
 		tagsCopy[k] = v
@@ -81,10 +85,6 @@ func (a *Accumulator) AddFields(
 	fieldsCopy := map[string]interface{}{}
 	for k, v := range fields {
 		fieldsCopy[k] = v
-	}
-
-	if len(fields) == 0 {
-		return
 	}
 
 	var t time.Time

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -104,7 +104,7 @@ func (a *Accumulator) AddFields(
 
 	p := &Metric{
 		Measurement: measurement,
-		Fields:      fields,
+		Fields:      fieldsCopy,
 		Tags:        tagsCopy,
 		Time:        t,
 	}


### PR DESCRIPTION
Simple fix in the `testutil.Accumulator` `AddFields` method - `fieldsCopy` should be used instead of `fields` which can be mutated outside of the method. Also made a change to return earlier to avoid an extra iteration of `tags`.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
