### PR TITLE
Log warning when wireless plugin is used on unsupported platform

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -109,6 +109,11 @@ func runAgent(ctx context.Context,
 	inputFilters []string,
 	outputFilters []string,
 ) error {
+	// Setup default logging. This may need to change after reading the config
+	// file, but we can configure it to use our logger implementation now.
+	logger.SetupLogging(false, false, "")
+	log.Printf("I! Starting Telegraf %s", version)
+
 	// If no other options are specified, load the config file and run.
 	c := config.NewConfig()
 	c.OutputFilters = outputFilters
@@ -146,7 +151,7 @@ func runAgent(ctx context.Context,
 		return err
 	}
 
-	// Setup logging
+	// Setup logging as configured.
 	logger.SetupLogging(
 		ag.Config.Agent.Debug || *fDebug,
 		ag.Config.Agent.Quiet || *fQuiet,
@@ -157,7 +162,6 @@ func runAgent(ctx context.Context,
 		return ag.Test()
 	}
 
-	log.Printf("I! Starting Telegraf %s\n", version)
 	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))
 	log.Printf("I! Loaded aggregators: %s", strings.Join(c.AggregatorNames(), " "))
 	log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))

--- a/plugins/inputs/wireless/wireless.go
+++ b/plugins/inputs/wireless/wireless.go
@@ -1,3 +1,33 @@
-// +build !linux
-
 package wireless
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+// Wireless is used to store configuration values.
+type Wireless struct {
+	HostProc string `toml:"host_proc"`
+}
+
+var sampleConfig = `
+  ## Sets 'proc' directory path
+  ## If not specified, then default is /proc
+  # host_proc = "/proc"
+`
+
+// Description returns information about the plugin.
+func (w *Wireless) Description() string {
+	return "Monitor wifi signal strength and quality"
+}
+
+// SampleConfig displays configuration instructions.
+func (w *Wireless) SampleConfig() string {
+	return sampleConfig
+}
+
+func init() {
+	inputs.Add("wireless", func() telegraf.Input {
+		return &Wireless{}
+	})
+}

--- a/plugins/inputs/wireless/wireless_linux.go
+++ b/plugins/inputs/wireless/wireless_linux.go
@@ -40,27 +40,6 @@ type wirelessInterface struct {
 	Beacon    int64
 }
 
-// Wireless is used to store configuration values.
-type Wireless struct {
-	HostProc string `toml:"host_proc"`
-}
-
-var sampleConfig = `
-  ## Sets 'proc' directory path
-  ## If not specified, then default is /proc
-  # host_proc = "/proc"
-`
-
-// Description returns information about the plugin.
-func (w *Wireless) Description() string {
-	return "Monitor wifi signal strength and quality"
-}
-
-// SampleConfig displays configuration instructions.
-func (w *Wireless) SampleConfig() string {
-	return sampleConfig
-}
-
 // Gather collects the wireless information.
 func (w *Wireless) Gather(acc telegraf.Accumulator) error {
 	// load proc path, get default value if config value and env variable are empty

--- a/plugins/inputs/wireless/wireless_nonlinux.go
+++ b/plugins/inputs/wireless/wireless_nonlinux.go
@@ -1,0 +1,21 @@
+// +build !linux
+
+package wireless
+
+import (
+	"log"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+func (w *Wireless) Gather(acc telegraf.Accumulator) error {
+	return nil
+}
+
+func init() {
+	inputs.Add("wireless", func() telegraf.Input {
+		log.Print("W! [inputs.wireless] Current platform is not supported")
+		return &Wireless{}
+	})
+}


### PR DESCRIPTION
Log once on startup if the wireless plugin is not supported on the platform.


Pros
+ plugin is still a non-service plugin on all platforms
+ logging happens once
+ linux code doesn't need to worry about logging
+ plugin config still must be valid
+ fixes annoying timestamp format difference when Telegraf starts

Cons
- Tests can be ran only on linux
- Not crazy about the order of logging
- Telegraf still runs even if no plugins are supported
- Plugin still logged as loaded

Some of these issues can be resolved after config loading work.

Here is the logging output:
```
2018-11-13T23:32:39Z I! Starting Telegraf
2018-11-13T23:32:39Z I! Using config file: /home/dbn/.telegraf/telegraf.conf
2018-11-13T23:32:39Z W! [inputs.wireless] Current platform is not supported
2018-11-13T23:32:39Z I! Loaded inputs: inputs.wireless
2018-11-13T23:32:39Z I! Loaded aggregators:
2018-11-13T23:32:39Z I! Loaded processors:
2018-11-13T23:32:39Z I! Loaded outputs: file
2018-11-13T23:32:39Z I! Tags enabled:
2018-11-13T23:32:39Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"", Flush Interval:10s
```
closes #4982

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
