### PR TITLE
Only print final collection when runing --test

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -83,7 +83,8 @@ func reloadLoop(
 		ctx, cancel := context.WithCancel(context.Background())
 
 		signals := make(chan os.Signal)
-		signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM)
+		signal.Notify(signals, os.Interrupt, syscall.SIGHUP,
+			syscall.SIGTERM, syscall.SIGINT)
 		go func() {
 			select {
 			case sig := <-signals:
@@ -154,7 +155,7 @@ func runAgent(ctx context.Context,
 	)
 
 	if *fTest {
-		return ag.Test()
+		return ag.Test(ctx)
 	}
 
 	log.Printf("I! Starting Telegraf %s\n", version)


### PR DESCRIPTION
Resolves #3454

Currently, the cpu, mongodb, and procstat input plugins run twice so as to collect `cpu_usage`, this change will only print the second collection that includes it as a field.