### PR TITLE
Graylog Input X-Requested-By added.

### DIFF
--- a/plugins/inputs/graylog/graylog.go
+++ b/plugins/inputs/graylog/graylog.go
@@ -235,6 +235,9 @@ func (h *GrayLog) sendRequest(serverURL string) (string, float64, error) {
 	if err != nil {
 		return "", -1, fmt.Errorf("Invalid server URL \"%s\"", serverURL)
 	}
+	// Add X-Requested-By header
+	headers["X-Requested-By"] = requestURL.Hostname()
+
 	if strings.Contains(requestURL.String(), "multiple") {
 		m := &Messagebody{Metrics: h.Metrics}
 		http_body, err := json.Marshal(m)


### PR DESCRIPTION
X-Requested-By is needed by Graylog in order to respond API requests. It adds URL's hostname as requested-by parameter.

### Required for all PRs:

- [ x ] Signed [CLA](https://influxdata.com/community/cla/).
- [ x ] Associated README.md updated.
- [ x ] Has appropriate unit tests.

Resolves #5010