### PR TITLE
added result_code field

### DIFF
--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -1,7 +1,7 @@
 # Procstat Input Plugin
 
 The procstat plugin can be used to monitor the system resource usage of one or more processes.
-The procstat_lookup metric displays the query information, 
+The procstat_lookup metric displays the query information,
 specifically the number of PIDs returned on a search
 
 Processes can be selected for monitoring using one of several methods:
@@ -134,6 +134,7 @@ implemented as a WMI query.  The pattern allows fuzzy matching using only
     - voluntary_context_switches (int)
     - write_bytes (int, *telegraf* may need to be ran as **root**)
     - write_count (int, *telegraf* may need to be ran as **root**)
+    - result_code (int, success = 0, not_running = 1, error_getting_process = 2)
 - procstat_lookup
   - tags:
     - exe (string)

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -86,6 +86,14 @@ func (_ *Procstat) Description() string {
 }
 
 func (p *Procstat) Gather(acc telegraf.Accumulator) error {
+	var prefix string
+	if p.Prefix != "" {
+		prefix = p.Prefix + "_"
+	}
+
+	tags := map[string]string{"exe": p.Exe, "pidfile": p.PidFile, "pattern": p.Pattern, "user": p.User}
+	fields := map[string]interface{}{}
+
 	if p.createPIDFinder == nil {
 		switch p.PidFinder {
 		case "native":
@@ -105,6 +113,11 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 	if err != nil {
 		acc.AddError(fmt.Errorf("E! Error: procstat getting process, exe: [%s] pidfile: [%s] pattern: [%s] user: [%s] %s",
 			p.Exe, p.PidFile, p.Pattern, p.User, err.Error()))
+		fields[prefix+"result_code"] = 2
+		acc.AddFields("procstat", fields, tags)
+	} else if len(procs) == 0 {
+		fields[prefix+"result_code"] = 1
+		acc.AddFields("procstat", fields, tags)
 	}
 	p.procs = procs
 
@@ -123,6 +136,7 @@ func (p *Procstat) addMetrics(proc Process, acc telegraf.Accumulator) {
 	}
 
 	fields := map[string]interface{}{}
+	fields[prefix+"result_code"] = 0
 
 	//If process_name tag is not already set, set to actual name
 	if _, nameInTags := proc.Tags()["process_name"]; !nameInTags {

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -384,5 +384,5 @@ func TestProcstatLookupMetric(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(p.Gather)
 	require.NoError(t, err)
-	require.Equal(t, len(p.procs)+1, len(acc.Metrics))
+	require.Equal(t, len(p.procs)+2, len(acc.Metrics))
 }


### PR DESCRIPTION
Hello,
added the result_code field to the procstate input plugin, similar to the http_response and net_response plugins.
result_code (int, success = 0, not_running = 1, error_getting_process = 2)
Please consider the request.