### PR TITLE
Fix input plugin MongoDB server connection info

### DIFF
--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -599,6 +599,11 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 		Faults:    -1,
 	}
 
+	// set connection info
+	returnVal.CurrentC = newStat.Connections.Current
+	returnVal.AvailableC = newStat.Connections.Available
+	returnVal.TotalCreatedC = newStat.Connections.TotalCreated
+
 	// set the storage engine appropriately
 	if newStat.StorageEngine != nil && newStat.StorageEngine["name"] != "" {
 		returnVal.StorageEngine = newStat.StorageEngine["name"]


### PR DESCRIPTION
The MongoDB plugin currently showing the connection information, example:
```
./telegraf --config telegraf.conf --test
2018-11-27T20:32:59Z I! Starting Telegraf
> mongodb,host=muraritele-01-154333202752 commands_per_sec=8i,connections_available=0i,connections_current=0i,deletes_per_sec=0i,flushes_per_sec=0i,getmores_per_sec=0i,inserts_per_sec=0i,queries_per_sec=2i,resident_megabytes=49i,updates_per_sec=0i,vsize_megabytes=307i 1543350780000000000
> mongodb_db_stats,db_name=admin,host=muraritele-01-154333202752 avg_obj_size=310.7,collections=3i,data_size=3107i,index_size=81920i,indexes=4i,num_extents=0i,objects=10i,ok=1i,storage_size=65536i,type="db_stat" 1543350780000000000
> mongodb_db_stats,db_name=local,host=muraritele-01-154333202752 avg_obj_size=1826.3333333333333,collections=1i,data_size=5479i,index_size=36864i,indexes=1i,num_extents=0i,objects=3i,ok=1i,storage_size=36864i,type="db_stat" 1543350780000000000
> mongodb_db_stats,db_name=murari_telegraf,host=muraritele-01-154333202752 avg_obj_size=0,collections=1i,data_size=0i,index_size=4096i,indexes=1i,num_extents=0i,objects=0i,ok=1i,storage_size=4096i,type="db_stat" 1543350780000000000
```

This PR fix #4664 
```
./telegraf --config telegraf.conf --test
2018-11-27T20:39:44Z I! Starting Telegraf
> mongodb,host=muraritele-01-154333202752 commands_per_sec=8i,connections_available=26197i,connections_current=7i,deletes_per_sec=0i,flushes_per_sec=0i,getmores_per_sec=0i,inserts_per_sec=0i,queries_per_sec=2i,resident_megabytes=49i,updates_per_sec=0i,vsize_megabytes=311i 1543351185000000000
> mongodb_db_stats,db_name=admin,host=muraritele-01-154333202752 avg_obj_size=310.7,collections=3i,data_size=3107i,index_size=81920i,indexes=4i,num_extents=0i,objects=10i,ok=1i,storage_size=65536i,type="db_stat" 1543351185000000000
> mongodb_db_stats,db_name=local,host=muraritele-01-154333202752 avg_obj_size=1826.3333333333333,collections=1i,data_size=5479i,index_size=36864i,indexes=1i,num_extents=0i,objects=3i,ok=1i,storage_size=36864i,type="db_stat" 1543351185000000000
> mongodb_db_stats,db_name=murari_telegraf,host=muraritele-01-154333202752 avg_obj_size=0,collections=1i,data_size=0i,index_size=4096i,indexes=1i,num_extents=0i,objects=0i,ok=1i,storage_size=4096i,type="db_stat" 1543351185000000000
```

As u can see, the `connections_current`, `connections_available` and `connections_total_created` are right after this fix.

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
