### PR TITLE
Add tagdrop example for inputs.win_perf_counters

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -258,6 +258,21 @@ interpreted as part of the tagpass/tagdrop map.
     fstype = [ "ext4", "xfs" ]
     # Globs can also be used on the tag values
     path = [ "/opt", "/home*" ]
+    
+    
+[[inputs.win_perf_counters]]
+  [[inputs.win_perf_counters.object]]
+    ObjectName = "Network Interface"
+    Instances = ["*"]
+    Counters = [
+      "Bytes Received/sec",
+      "Bytes Sent/sec"
+    ]
+    Measurement = "win_net"
+  # Don't send metrics where the Windows interface name (instance) begins with isatap or Local
+  [inputs.win_perf_counters.tagdrop]
+    instance = ["isatap*", "Local*"]
+    
 ```
 
 #### Input Config: fieldpass and fielddrop


### PR DESCRIPTION
This example shows how to use tagdrop to filter based on windows network interface names. Related to this discussion: https://github.com/influxdata/telegraf/pull/5018#issuecomment-442243175

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
