### PR TITLE
Add running field to procstat_lookup

### DIFF
--- a/agent/accumulator.go
+++ b/agent/accumulator.go
@@ -82,6 +82,7 @@ func (ac *accumulator) AddHistogram(
 }
 
 func (ac *accumulator) AddMetric(m telegraf.Metric) {
+	m.SetTime(m.Time().Round(ac.precision))
 	if m := ac.maker.MakeMetric(m); m != nil {
 		ac.metrics <- m
 	}

--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -147,6 +147,7 @@ implemented as a WMI query.  The pattern allows fuzzy matching using only
     - win_service (string)
   - fields:
     - pid_count (int)
+    - running (int)
 *NOTE: Resource limit > 2147483647 will be reported as 2147483647.*
 
 ### Example Output:

--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -136,18 +136,21 @@ implemented as a WMI query.  The pattern allows fuzzy matching using only
     - write_count (int, *telegraf* may need to be ran as **root**)
 - procstat_lookup
   - tags:
-    - exe (string)
-    - pid_finder (string)
-    - pid_file (string)
-    - pattern (string)
-    - prefix (string)
-    - user (string)
-    - systemd_unit (string)
-    - cgroup (string)
-    - win_service (string)
+    - exe
+    - pid_finder
+    - pid_file
+    - pattern
+    - prefix
+    - user
+    - systemd_unit
+    - cgroup
+    - win_service
+    - result
   - fields:
     - pid_count (int)
     - running (int)
+    - result_code (int, success = 0, lookup_error = 1)
+
 *NOTE: Resource limit > 2147483647 will be reported as 2147483647.*
 
 ### Example Output:

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -93,6 +93,7 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 		case "pgrep":
 			p.createPIDFinder = NewPgrep
 		default:
+			p.PidFinder = "pgrep"
 			p.createPIDFinder = defaultPIDFinder
 		}
 
@@ -101,7 +102,12 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 		p.createProcess = defaultProcess
 	}
 
-	procs, err := p.updateProcesses(acc, p.procs)
+	pids, tags, err := p.findPids(acc)
+	if err != nil {
+		return err
+	}
+
+	procs, err := p.updateProcesses(pids, tags, p.procs)
 	if err != nil {
 		acc.AddError(fmt.Errorf("E! Error: procstat getting process, exe: [%s] pidfile: [%s] pattern: [%s] user: [%s] %s",
 			p.Exe, p.PidFile, p.Pattern, p.User, err.Error()))
@@ -109,14 +115,21 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 	p.procs = procs
 
 	for _, proc := range p.procs {
-		p.addMetrics(proc, acc)
+		p.addMetric(proc, acc)
 	}
+
+	fields := map[string]interface{}{
+		"pid_count": len(pids),
+		"running":   len(procs),
+	}
+	tags["pid_finder"] = p.PidFinder
+	acc.AddFields("procstat_lookup", fields, tags)
 
 	return nil
 }
 
 // Add metrics a single Process
-func (p *Procstat) addMetrics(proc Process, acc telegraf.Accumulator) {
+func (p *Procstat) addMetric(proc Process, acc telegraf.Accumulator) {
 	var prefix string
 	if p.Prefix != "" {
 		prefix = p.Prefix + "_"
@@ -242,12 +255,7 @@ func (p *Procstat) addMetrics(proc Process, acc telegraf.Accumulator) {
 }
 
 // Update monitored Processes
-func (p *Procstat) updateProcesses(acc telegraf.Accumulator, prevInfo map[PID]Process) (map[PID]Process, error) {
-	pids, tags, err := p.findPids(acc)
-	if err != nil {
-		return nil, err
-	}
-
+func (p *Procstat) updateProcesses(pids []PID, tags map[string]string, prevInfo map[PID]Process) (map[PID]Process, error) {
 	procs := make(map[PID]Process, len(prevInfo))
 
 	for _, pid := range pids {
@@ -327,18 +335,7 @@ func (p *Procstat) findPids(acc telegraf.Accumulator) ([]PID, map[string]string,
 		err = fmt.Errorf("Either exe, pid_file, user, pattern, systemd_unit, cgroup, or win_service must be specified")
 	}
 
-	rTags := make(map[string]string)
-	for k, v := range tags {
-		rTags[k] = v
-	}
-
-	//adds a metric with info on the pgrep query
-	fields := make(map[string]interface{})
-	tags["pid_finder"] = p.PidFinder
-	fields["pid_count"] = len(pids)
-	acc.AddFields("procstat_lookup", fields, tags)
-
-	return pids, rTags, err
+	return pids, tags, err
 }
 
 // execCommand is so tests can mock out exec.Command usage.

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -109,8 +109,10 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 			"running":     0,
 			"result_code": 1,
 		}
-		tags["pid_finder"] = p.PidFinder
-		tags["result"] = "lookup_error"
+		tags := map[string]string{
+			"pid_finder": p.PidFinder,
+			"result":     "lookup_error",
+		}
 		acc.AddFields("procstat_lookup", fields, tags)
 		return err
 	}

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -104,6 +104,14 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 
 	pids, tags, err := p.findPids(acc)
 	if err != nil {
+		fields := map[string]interface{}{
+			"pid_count":   0,
+			"running":     0,
+			"result_code": 1,
+		}
+		tags["pid_finder"] = p.PidFinder
+		tags["result"] = "lookup_error"
+		acc.AddFields("procstat_lookup", fields, tags)
 		return err
 	}
 
@@ -119,10 +127,12 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 	}
 
 	fields := map[string]interface{}{
-		"pid_count": len(pids),
-		"running":   len(procs),
+		"pid_count":   len(pids),
+		"running":     len(procs),
+		"result_code": 0,
 	}
 	tags["pid_finder"] = p.PidFinder
+	tags["result"] = "success"
 	acc.AddFields("procstat_lookup", fields, tags)
 
 	return nil


### PR DESCRIPTION
This field indicates the number of processes that were actually found, as opposed to pid_count which tells you how many pids were found and may not be what you are after with some query methods.

closes #5043 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
