### PR TITLE
Fixed ping plugin under bsd variants. 

### DIFF
--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -206,7 +206,7 @@ func (p *Ping) args(url string, system string) []string {
 		case "darwin":
 			args = append(args, "-W", strconv.FormatFloat(p.Timeout*1000, 'f', -1, 64))
 		case "freebsd", "netbsd", "openbsd":
-			args = append(args, "-w", strconv.FormatFloat(p.Timeout*1000, 'f', -1, 64))
+			args = append(args, "-W", strconv.FormatFloat(p.Timeout*1000, 'f', -1, 64))
 		case "linux":
 			args = append(args, "-W", strconv.FormatFloat(p.Timeout, 'f', -1, 64))
 		default:


### PR DESCRIPTION
Under version `Telegraf 1.9.0` the ping plugin throws the following error under FreeBSD 11.2:

```
2018-12-05T13:42:50Z E! [inputs.ping]: Error in plugin: host 1.1.1.1: ping: illegal option -- w
usage: ping [-AaDdfnoQqRrv] [-c count] [-G sweepmaxsize] [-g sweepminsize]
            [-h sweepincrsize] [-i wait] [-l preload] [-M mask | time] [-m ttl]
            [-P policy] [-p pattern] [-S src_addr] [-s packetsize] [-t timeout]
            [-W waittime] [-z tos] host
       ping [-AaDdfLnoQqRrv] [-c count] [-I iface] [-i wait] [-l preload]
            [-M mask | time] [-m ttl] [-P policy] [-p pattern] [-S src_addr]
            [-s packetsize] [-T ttl] [-t timeout] [-W waittime]
            [-z tos] mcast-group, exit status 64
```

This fixes that and changes the flag to `-W` which was probably intended in that use-case.

### Required for all PRs
- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
