### PR TITLE
stop Wavefront parser rejecting delta metrics

### DIFF
--- a/plugins/parsers/wavefront/element.go
+++ b/plugins/parsers/wavefront/element.go
@@ -37,7 +37,10 @@ type LiteralParser struct {
 func (ep *NameParser) parse(p *PointParser, pt *Point) error {
 	//Valid characters are: a-z, A-Z, 0-9, hyphen ("-"), underscore ("_"), dot (".").
 	// Forward slash ("/") and comma (",") are allowed if metricName is enclosed in double quotes.
+	// Delta (U+2206) is allowed as the first characeter of the
+	// metricName
 	name, err := parseLiteral(p)
+
 	if err != nil {
 		return err
 	}
@@ -225,6 +228,9 @@ func parseLiteral(p *PointParser) (string, error) {
 	for tok != EOF && tok > literal_beg && tok < literal_end {
 		p.writeBuf.WriteString(lit)
 		tok, lit = p.scan()
+		if tok == DELTA {
+			return "", errors.New("found delta inside metric name")
+		}
 	}
 	if tok == QUOTES {
 		return "", errors.New("found quote inside unquoted literal")

--- a/plugins/parsers/wavefront/parser_test.go
+++ b/plugins/parsers/wavefront/parser_test.go
@@ -19,6 +19,28 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, parsedMetrics[0].Name(), testMetric.Name())
 	assert.Equal(t, parsedMetrics[0].Fields(), testMetric.Fields())
 
+	parsedMetrics, err = parser.Parse([]byte("∆dev.rack.request 1 1543271541 source=tornado-www site=\"sysdef-0.0.8\" page=\"/post/2014-10-22-solaris-upnp-linn-minidlna\""))
+	assert.NoError(t, err)
+	testMetric, err = metric.New("∆dev.rack.request 1 1543271541 source=tornado-www site=\"sysdef-0.0.8\" page=\"/post/2014-10-22-solaris-upnp-linn-minidlna\"", map[string]string{},
+		map[string]interface{}{"value": 1.}, time.Unix(1530939936, 0))
+	assert.NoError(t, err)
+	assert.EqualValues(t, parsedMetrics[0], testMetric)
+	parsedMetrics, err = parser.Parse([]byte("\u2206test.delta 1 1530939936"))
+	assert.NoError(t, err)
+	testMetric, err = metric.New("\u2206test.delta", map[string]string{},
+		map[string]interface{}{"value": 1.}, time.Unix(1530939936, 0))
+	assert.NoError(t, err)
+	assert.EqualValues(t, parsedMetrics[0], testMetric)
+
+	parsedMetrics, err = parser.Parse([]byte("\u0394test.delta 1 1530939936"))
+	assert.NoError(t, err)
+	testMetric, err = metric.New("\u0394test.delta", map[string]string{},
+		map[string]interface{}{"value": 1.}, time.Unix(1530939936, 0))
+	assert.NoError(t, err)
+	assert.EqualValues(t, parsedMetrics[0], testMetric)
+
+	parsedMetrics, err = parser.Parse([]byte("test.metric 1 1530939936"))
+
 	parsedMetrics, err = parser.Parse([]byte("test.metric 1 1530939936"))
 	assert.NoError(t, err)
 	testMetric, err = metric.New("test.metric", map[string]string{}, map[string]interface{}{"value": 1.}, time.Unix(1530939936, 0))
@@ -164,6 +186,9 @@ func TestParseInvalid(t *testing.T) {
 	assert.Error(t, err)
 
 	_, err = parser.Parse([]byte("test.metric 1 string"))
+	assert.Error(t, err)
+
+	_, err = parser.Parse([]byte("test.\u2206delta 1"))
 	assert.Error(t, err)
 
 	_, err = parser.Parse([]byte("test.metric 1 1530939936 tag_no_pair"))

--- a/plugins/parsers/wavefront/parser_test.go
+++ b/plugins/parsers/wavefront/parser_test.go
@@ -19,12 +19,6 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, parsedMetrics[0].Name(), testMetric.Name())
 	assert.Equal(t, parsedMetrics[0].Fields(), testMetric.Fields())
 
-	parsedMetrics, err = parser.Parse([]byte("∆dev.rack.request 1 1543271541 source=tornado-www site=\"sysdef-0.0.8\" page=\"/post/2014-10-22-solaris-upnp-linn-minidlna\""))
-	assert.NoError(t, err)
-	testMetric, err = metric.New("∆dev.rack.request 1 1543271541 source=tornado-www site=\"sysdef-0.0.8\" page=\"/post/2014-10-22-solaris-upnp-linn-minidlna\"", map[string]string{},
-		map[string]interface{}{"value": 1.}, time.Unix(1530939936, 0))
-	assert.NoError(t, err)
-	assert.EqualValues(t, parsedMetrics[0], testMetric)
 	parsedMetrics, err = parser.Parse([]byte("\u2206test.delta 1 1530939936"))
 	assert.NoError(t, err)
 	testMetric, err = metric.New("\u2206test.delta", map[string]string{},
@@ -39,7 +33,11 @@ func TestParse(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, parsedMetrics[0], testMetric)
 
-	parsedMetrics, err = parser.Parse([]byte("test.metric 1 1530939936"))
+	parsedMetrics, err = parser.Parse([]byte("\u0394test.delta 1.234 1530939936 source=\"mysource\" tag2=value2"))
+	assert.NoError(t, err)
+	testMetric, err = metric.New("\u0394test.delta", map[string]string{"source": "mysource", "tag2": "value2"}, map[string]interface{}{"value": 1.234}, time.Unix(1530939936, 0))
+	assert.NoError(t, err)
+	assert.EqualValues(t, parsedMetrics[0], testMetric)
 
 	parsedMetrics, err = parser.Parse([]byte("test.metric 1 1530939936"))
 	assert.NoError(t, err)

--- a/plugins/parsers/wavefront/scanner.go
+++ b/plugins/parsers/wavefront/scanner.go
@@ -40,6 +40,8 @@ func (s *PointScanner) Scan() (Token, string) {
 		return LETTER, string(ch)
 	} else if isNumber(ch) {
 		return NUMBER, string(ch)
+	} else if isDelta(ch) {
+		return DELTA, string(ch)
 	}
 
 	// Otherwise read the individual character.

--- a/plugins/parsers/wavefront/token.go
+++ b/plugins/parsers/wavefront/token.go
@@ -18,6 +18,7 @@ const (
 	SLASH
 	BACKSLASH
 	COMMA
+	DELTA
 	literal_end
 
 	// Misc characters
@@ -36,6 +37,10 @@ func isLetter(ch rune) bool {
 
 func isNumber(ch rune) bool {
 	return ch >= '0' && ch <= '9'
+}
+
+func isDelta(ch rune) bool {
+	return ch == '\u2206' || ch == '\u0394'
 }
 
 var eof = rune(0)


### PR DESCRIPTION
In response to issue #5114 .

With this patch, Telegraf accepts and forwards delta metrics correctly using a Wavefront format listener.