### PR TITLE
Include DEVLINKS in available diskio udev properties

### DIFF
--- a/plugins/inputs/diskio/README.md
+++ b/plugins/inputs/diskio/README.md
@@ -19,6 +19,9 @@ The diskio input plugin gathers metrics about disk traffic and timing.
   ## Currently only Linux is supported via udev properties. You can view
   ## available properties for a device by running:
   ## 'udevadm info -q property -n /dev/sda'
+  ## Note: Most, but not all, udev properties can be accessed this way. Properties
+  ## that are currently accessible include the "IS_*" series and the "DEVLINKS" 
+  ## property. For more info see https://github.com/influxdata/telegraf/issues/3663
   # device_tags = ["ID_FS_TYPE", "ID_FS_USAGE"]
   #
   ## Using the same metadata source as device_tags, you can also customize the

--- a/plugins/inputs/diskio/README.md
+++ b/plugins/inputs/diskio/README.md
@@ -20,8 +20,9 @@ The diskio input plugin gathers metrics about disk traffic and timing.
   ## available properties for a device by running:
   ## 'udevadm info -q property -n /dev/sda'
   ## Note: Most, but not all, udev properties can be accessed this way. Properties
-  ## that are currently accessible include the "IS_*" series and the "DEVLINKS" 
-  ## property. For more info see https://github.com/influxdata/telegraf/issues/3663
+  ## that are currently inaccessible include DEVTYPE, DEVNAME, and DEVPATH. 
+  ## DEVLINKS, however, can be used as a tag as of Telegraf 1.10
+  ## For more info see https://github.com/influxdata/telegraf/issues/3663
   # device_tags = ["ID_FS_TYPE", "ID_FS_USAGE"]
   #
   ## Using the same metadata source as device_tags, you can also customize the

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -51,33 +51,32 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	}
 	defer f.Close()
 
-	scnr := bufio.NewScanner(f)
-	var devlinks strings.Builder
-	for scnr.Scan() {
-		l := scnr.Text()
-		if len(l) < 4 {
-			continue
-		}
-		if l[:2] == "S:" {
-			if devlinks.Len() > 0 {
-				devlinks.WriteString(" " + l[2:])
-			} else {
-				devlinks.WriteString(l[2:])
-			}
-			continue
-		}
-		if l[:2] != "E:" {
-			continue
-		}
-		kv := strings.SplitN(l[2:], "=", 2)
-		if len(kv) < 2 {
-			continue
-		}
-		di[kv[0]] = kv[1]
-	}
-	if devlinks.Len() > 0 {
-		di["DEVLINKS"] = devlinks.String()
-	}
+        scnr := bufio.NewScanner(f)
+        var devlinks []string
+        for scnr.Scan() {
+                l := scnr.Text()
+                if len(l) < 4 {
+                        continue
+                }
+                if l[:2] == "S:" {
+                        devlinks = append(devlinks, l[2:])
+                        continue
+                }
+                if l[:2] != "E:" {
+                        continue
+                }
+                kv := strings.SplitN(l[2:], "=", 2)
+                if len(kv) < 2 {
+                        continue
+                }
+                di[kv[0]] = kv[1]
+        }
+
+        var devlink_str string
+        if len(devlinks) > 0 {
+                devlink_str = strings.Join(devlinks, " ")
+                di["DEVLINKS"] = devlink_str
+        }
 
 	return di, nil
 }

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -74,7 +74,6 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 		di[kv[0]] = kv[1]
 	}
 
-	var devlink_str string
 	if devlinks.Len() > 0 {
 		di["DEVLINKS"] = devlinks.String()
 	}

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -59,7 +59,8 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 			continue
 		}
 		if l[:2] == "S:" {
-			devlinks = append(devlinks, "/dev/" + l[2:])
+			devlinks = append(devlinks, "/dev/")
+			devlinks = append(devlinks, l[2:])
 			continue
 		}
 		if l[:2] != "E:" {

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -55,6 +55,9 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	var devlinks strings.Builder
 	for scnr.Scan() {
 		l := scnr.Text()
+		if len(l) < 4 {
+			continue
+		}
 		if l[:2] == "S:" {
 			if devlinks.Len() > 0 {
 				devlinks.WriteString(" " + l[2:])
@@ -63,7 +66,7 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 			}
 			continue
 		}
-		if len(l) < 4 || l[:2] != "E:" {
+		if l[:2] != "E:" {
 			continue
 		}
 		kv := strings.SplitN(l[2:], "=", 2)

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -75,7 +75,7 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	}
 
 	var devlink_str string
-	if len(devlinks) > 0 {
+	if devlinks.Len() > 0 {
 		di["DEVLINKS"] = devlinks.String()
 	}
 

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -56,7 +56,7 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	for scnr.Scan() {
 		l := scnr.Text()
 		if l[:2] == "S:" {
-		        if devlinks.Len > 0 {
+			if devlinks.Len > 0 {
 				devlinks.WriteString(" " + l[2:])
 			} else {
 				devlinks.WriteString(l[2:])

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -2,6 +2,7 @@ package diskio
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -52,15 +53,15 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	defer f.Close()
 
 	scnr := bufio.NewScanner(f)
-	var devlinks []string
+	var devlinks bytes.Buffer
 	for scnr.Scan() {
 		l := scnr.Text()
 		if len(l) < 4 {
 			continue
 		}
 		if l[:2] == "S:" {
-			devlinks = append(devlinks, "/dev/")
-			devlinks = append(devlinks, l[2:])
+			devlinks.WriteString("/dev/")
+			devlinks.WriteString(l[2:])
 			continue
 		}
 		if l[:2] != "E:" {
@@ -75,8 +76,7 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 
 	var devlink_str string
 	if len(devlinks) > 0 {
-		devlink_str = strings.Join(devlinks, " ")
-		di["DEVLINKS"] = devlink_str
+		di["DEVLINKS"] = devlinks.String()
 	}
 
 	return di, nil

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -51,32 +51,32 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	}
 	defer f.Close()
 
-        scnr := bufio.NewScanner(f)
-        var devlinks []string
-        for scnr.Scan() {
-                l := scnr.Text()
-                if len(l) < 4 {
-                        continue
-                }
-                if l[:2] == "S:" {
-                        devlinks = append(devlinks, l[2:])
-                        continue
-                }
-                if l[:2] != "E:" {
-                        continue
-                }
-                kv := strings.SplitN(l[2:], "=", 2)
-                if len(kv) < 2 {
-                        continue
-                }
-                di[kv[0]] = kv[1]
-        }
+	scnr := bufio.NewScanner(f)
+	var devlinks []string
+	for scnr.Scan() {
+		l := scnr.Text()
+		if len(l) < 4 {
+			continue
+		}
+		if l[:2] == "S:" {
+			devlinks = append(devlinks, l[2:])
+			continue
+		}
+		if l[:2] != "E:" {
+			continue
+		}
+		kv := strings.SplitN(l[2:], "=", 2)
+		if len(kv) < 2 {
+			continue
+		}
+		di[kv[0]] = kv[1]
+	}
 
-        var devlink_str string
-        if len(devlinks) > 0 {
-                devlink_str = strings.Join(devlinks, " ")
-                di["DEVLINKS"] = devlink_str
-        }
+	var devlink_str string
+	if len(devlinks) > 0 {
+		devlink_str = strings.Join(devlinks, " ")
+		di["DEVLINKS"] = devlink_str
+	}
 
 	return di, nil
 }

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -60,6 +60,9 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 			continue
 		}
 		if l[:2] == "S:" {
+			if devlinks.Len() > 0 {
+				devlinks.WriteString(" ")
+			}
 			devlinks.WriteString("/dev/")
 			devlinks.WriteString(l[2:])
 			continue

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -52,8 +52,17 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	defer f.Close()
 
 	scnr := bufio.NewScanner(f)
+	var devlinks strings.Builder
 	for scnr.Scan() {
 		l := scnr.Text()
+		if l[:2] == "S:" {
+		    if devlinks.Len > 0 {
+				devlinks.WriteString(" " + l[2:])
+			} else {
+				devlinks.WriteString(l[2:])
+			}
+			continue
+		}
 		if len(l) < 4 || l[:2] != "E:" {
 			continue
 		}
@@ -62,6 +71,9 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 			continue
 		}
 		di[kv[0]] = kv[1]
+	}
+	if devlinks.Len() > 0 {
+		di["DEVLINKS"] = devlinks.String()
 	}
 
 	return di, nil

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -59,7 +59,7 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 			continue
 		}
 		if l[:2] == "S:" {
-			devlinks = append(devlinks, l[2:])
+			devlinks = append(devlinks, "/dev" + l[2:])
 			continue
 		}
 		if l[:2] != "E:" {

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -56,7 +56,7 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	for scnr.Scan() {
 		l := scnr.Text()
 		if l[:2] == "S:" {
-			if devlinks.Len > 0 {
+			if devlinks.Len() > 0 {
 				devlinks.WriteString(" " + l[2:])
 			} else {
 				devlinks.WriteString(l[2:])

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -59,7 +59,7 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 			continue
 		}
 		if l[:2] == "S:" {
-			devlinks = append(devlinks, "/dev" + l[2:])
+			devlinks = append(devlinks, "/dev/" + l[2:])
 			continue
 		}
 		if l[:2] != "E:" {

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -56,7 +56,7 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	for scnr.Scan() {
 		l := scnr.Text()
 		if l[:2] == "S:" {
-		    if devlinks.Len > 0 {
+		        if devlinks.Len > 0 {
 				devlinks.WriteString(" " + l[2:])
 			} else {
 				devlinks.WriteString(l[2:])

--- a/plugins/inputs/diskio/diskio_linux_test.go
+++ b/plugins/inputs/diskio/diskio_linux_test.go
@@ -49,7 +49,7 @@ func TestDiskInfo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "myval1", di["MY_PARAM_1"])
 	assert.Equal(t, "myval2", di["MY_PARAM_2"])
-	assert.Equal(t, "foo/bar/devlink foo/bar/devlink1", di["DEVLINKS"])
+	assert.Equal(t, "/dev/foo/bar/devlink /dev/foo/bar/devlink1", di["DEVLINKS"])
 
 	// test that data is cached
 	err = clean()
@@ -59,7 +59,7 @@ func TestDiskInfo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "myval1", di["MY_PARAM_1"])
 	assert.Equal(t, "myval2", di["MY_PARAM_2"])
-	assert.Equal(t, "foo/bar/devlink foo/bar/devlink1", di["DEVLINKS"])
+	assert.Equal(t, "/dev/foo/bar/devlink /dev/foo/bar/devlink1", di["DEVLINKS"])
 
 	// unfortunately we can't adjust mtime on /dev/null to test cache invalidation
 }

--- a/plugins/inputs/diskio/diskio_linux_test.go
+++ b/plugins/inputs/diskio/diskio_linux_test.go
@@ -14,6 +14,7 @@ import (
 var nullDiskInfo = []byte(`
 E:MY_PARAM_1=myval1
 E:MY_PARAM_2=myval2
+S:foo/bar/devlink foo/bar/devlink1
 `)
 
 // setupNullDisk sets up fake udev info as if /dev/null were a disk.
@@ -47,6 +48,7 @@ func TestDiskInfo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "myval1", di["MY_PARAM_1"])
 	assert.Equal(t, "myval2", di["MY_PARAM_2"])
+	assert.Equal(t, "foo/bar/devlink foo/bar/devlink1", di["DEVLINKS"])
 
 	// test that data is cached
 	err = clean()
@@ -56,6 +58,7 @@ func TestDiskInfo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "myval1", di["MY_PARAM_1"])
 	assert.Equal(t, "myval2", di["MY_PARAM_2"])
+	assert.Equal(t, "foo/bar/devlink foo/bar/devlink1", di["DEVLINKS"])
 
 	// unfortunately we can't adjust mtime on /dev/null to test cache invalidation
 }

--- a/plugins/inputs/diskio/diskio_linux_test.go
+++ b/plugins/inputs/diskio/diskio_linux_test.go
@@ -14,7 +14,8 @@ import (
 var nullDiskInfo = []byte(`
 E:MY_PARAM_1=myval1
 E:MY_PARAM_2=myval2
-S:foo/bar/devlink foo/bar/devlink1
+S:foo/bar/devlink
+S:foo/bar/devlink1
 `)
 
 // setupNullDisk sets up fake udev info as if /dev/null were a disk.


### PR DESCRIPTION
Partial fix for https://github.com/influxdata/telegraf/issues/3663. The diskio plugin claims to grab udev properties when specified, but can't actually grab all of them due to the way it is written. One property it didn't grab is "DEVLINKS." Our company, Skytap, has a business need for using diskio to tag with DEVLINKS, and it was only a few lines of code to add that capability.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
