### PR TITLE
Increase varnishstat time allotment.

### DIFF
--- a/plugins/inputs/varnish/varnish.go
+++ b/plugins/inputs/varnish/varnish.go
@@ -78,7 +78,7 @@ func varnishRunner(cmdName string, UseSudo bool, InstanceName string) (*bytes.Bu
 
 	var out bytes.Buffer
 	cmd.Stdout = &out
-	err := internal.RunTimeout(cmd, time.Millisecond*200)
+	err := internal.RunTimeout(cmd, time.Millisecond*500)
 	if err != nil {
 		return &out, fmt.Errorf("error running varnishstat: %s", err)
 	}


### PR DESCRIPTION
With a large amount of VCLs loaded, varnishstat can take slightly longer to run. This is not a complete fi, but should suffice in 98% of cases.

See https://github.com/varnishcache/varnish-cache/issues/2712#issuecomment-445864700 for some background.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
