### PR TITLE
Optimization : globpath using godirwalk

### DIFF
--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -41,32 +41,23 @@ func Compile(path string) (*GlobPath, error) {
 }
 
 // Match returns all files matching the expression
-func (g *GlobPath) Match() map[string]os.FileInfo {
-	out := make(map[string]os.FileInfo)
+// If it's a static path, returns path
+func (g *GlobPath) Match() []string {
 	if !g.hasMeta {
-		info, err := os.Stat(g.path)
-		if err == nil {
-			out[g.path] = info
-		}
-		return out
+		return []string{g.path}
 	}
 	if !g.HasSuperMeta {
 		files, _ := filepath.Glob(g.path)
-		for _, file := range files {
-			info, err := os.Stat(file)
-			if err == nil {
-				out[file] = info
-			}
-		}
-		return out
+		return files
 	}
 	roots, err := filepath.Glob(g.rootGlob)
 	if err != nil {
-		return out
+		return []string{}
 	}
-	walkfn := func(path string, info os.FileInfo, _ error) error {
+	out := []string{}
+	walkfn := func(path string, _ os.FileInfo, _ error) error {
 		if g.g.Match(path) {
-			out[path] = info
+			out = append(out, path)
 		}
 		return nil
 

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -1,7 +1,6 @@
 package globpath
 
 import (
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -34,7 +33,7 @@ func TestCompileAndMatch(t *testing.T) {
 	matches = g3.Match()
 	require.Len(t, matches, 1)
 	matches = g4.Match()
-	require.Len(t, matches, 0)
+	require.Len(t, matches, 1)
 	matches = g5.Match()
 	require.Len(t, matches, 0)
 }
@@ -75,10 +74,10 @@ func getTestdataDir() string {
 func TestMatch_ErrPermission(t *testing.T) {
 	tests := []struct {
 		input    string
-		expected map[string]os.FileInfo
+		expected []string
 	}{
-		{"/root/foo", map[string]os.FileInfo{}},
-		{"/root/f*", map[string]os.FileInfo{}},
+		{"/root/foo", []string{"/root/foo"}},
+		{"/root/f*", []string(nil)},
 	}
 
 	for _, test := range tests {

--- a/plugins/inputs/file/file.go
+++ b/plugins/inputs/file/file.go
@@ -75,10 +75,7 @@ func (f *File) refreshFilePaths() error {
 		if len(files) <= 0 {
 			return fmt.Errorf("could not find file: %v", file)
 		}
-
-		for k := range files {
-			allFiles = append(allFiles, k)
-		}
+		allFiles = append(allFiles, files...)
 	}
 
 	f.filenames = allFiles

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -73,12 +73,16 @@ func (f *FileStat) Gather(acc telegraf.Accumulator) error {
 			continue
 		}
 
-		for fileName, fileInfo := range files {
+		for _, fileName := range files {
 			tags := map[string]string{
 				"file": fileName,
 			}
 			fields := map[string]interface{}{
 				"exists": int64(1),
+			}
+			fileInfo, err := os.Stat(fileName)
+			if os.IsNotExist(err) {
+				fields["exists"] = int64(0)
 			}
 
 			if fileInfo == nil {

--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -182,7 +182,7 @@ func (l *LogParserPlugin) tailNewfiles(fromBeginning bool) error {
 		}
 		files := g.Match()
 
-		for file := range files {
+		for _, file := range files {
 			if _, ok := l.tailers[file]; ok {
 				// we're already tailing this file
 				continue

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -111,7 +111,7 @@ func (t *Tail) tailNewFiles(fromBeginning bool) error {
 		if err != nil {
 			t.acc.AddError(fmt.Errorf("E! Error Glob %s failed to compile, %s", filepath, err))
 		}
-		for file := range g.Match() {
+		for _, file := range g.Match() {
 			if _, ok := t.tailers[file]; ok {
 				// we're already tailing this file
 				continue


### PR DESCRIPTION
Hello,

### What it does

This PR adds 2 simple optimizations to globpath internal library :
- returns file names rather than fileInfo (-> prevents us stat-ing found files, as fileInfo is most of the times discarded by the caller)
- replaces filepath.walk with godirwalk library. The latter is more efficient (less `stat` calls).

### Not sorting results anymore

I used `unsorted : true` option of godirwalk. It changes the order of recursion (the option name is quite explicit), and thus the order of the results provided by telegraf plugins. As there is no contract about the order of results with telegraf users, i don't consider this move as a breaking change. But this (small) optimization could be reverted if you disagree with that point.

### Results

While it is an optimization on the paper, results are not striking. Simple `time` results with and without the optimization, run on path relative to telegraf source tree :

| **plugin** | **path** | **master** | **optimization**
|--------|----|---|------------- |
|file|/**.csv|0,346s|0,203s|
|filestat (no md5) | /**.go|0,539s|0,463s|
|filestat (no md5) | /** |0,775s|0,816s|

I don't know why in the last case the 'optimized' code performs less than the non-optimized one. Maybe because filestat `stat`s every results, so the first optimization doesn't apply.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [pointless] Associated README.md updated.
- [x] Has appropriate unit tests.
