### PR TITLE
Fix Converter Processor Example

### DIFF
--- a/plugins/processors/converter/README.md
+++ b/plugins/processors/converter/README.md
@@ -48,7 +48,7 @@ will overwrite one another.
 
   [processors.converter.fields]
     integer = ["scboard_*"]
-    tag = ["ParseServerConfigGeneration"]
+    tag = ["ParentServerConfigGeneration"]
 ```
 
 ```diff


### PR DESCRIPTION
Rename "ParseServerConfigGeneration" in example config to match "ParentServerConfigGeneration" as used in example diff.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
