### PR TITLE
Signal telegraf process until it exits

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -134,6 +134,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		return err
 	}
 
+	log.Printf("D! [agent] Stopped Successfully")
 	return nil
 }
 


### PR DESCRIPTION
It often takes Telegraf a while to do a clean shutdown, as it attempts to write the metric buffer before stopping, which led to a few issues.

This line signals the process and returns success if signaled, this almost always works and so the pidfile is removed.  If Telegraf has not shutdown this will remove the pidfile before Telegraf can do so.  Since the script then exits stop it is possible that Telegraf will be restarted before the running Telegraf exits.  The new pidfile will then be removed by the closing Telegraf, which means any future attempts to stop Telegraf will not be able to find the process to signal it.
```
killproc -p $pidfile SIGTERM && /bin/rm -rf $pidfile
```

With this change the pidfile is removed only if Telegraf exits.  The script will wait for Telegraf to exit, you can always ctrl-c out if you get impatient.

If the user sends a SIGKILL to Telegraf or it crashes, and the pidfile is orphaned, it will be required to remove it manually after insuring there are no running Telegraf processes.

closes #4610

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
