### PR TITLE
Deliver empty metric tracking group immediately

### DIFF
--- a/agent/accumulator_test.go
+++ b/agent/accumulator_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -124,6 +123,21 @@ func TestSetPrecision(t *testing.T) {
 
 			close(metrics)
 		})
+	}
+}
+
+func TestAddTrackingMetricGroupEmpty(t *testing.T) {
+	ch := make(chan telegraf.Metric, 10)
+	metrics := []telegraf.Metric{}
+	acc := NewAccumulator(&TestMetricMaker{}, ch).WithTracking(1)
+
+	id := acc.AddTrackingMetricGroup(metrics)
+
+	select {
+	case tracking := <-acc.Delivered():
+		require.Equal(t, tracking.ID(), id)
+	default:
+		t.Fatal("empty group should be delivered immediately")
 	}
 }
 


### PR DESCRIPTION
If an empty array of tracking metrics is added to the accumulator, just mark it as immediately delivered and send delivery notification.  This avoids potential errors and avoids the input needing to check for empty groups.

closes #5170

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
