### PR TITLE
[outputs.signalfx] Add output plugin for SignalFX

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1703,6 +1703,7 @@
     "github.com/shirou/gopsutil/mem",
     "github.com/shirou/gopsutil/net",
     "github.com/shirou/gopsutil/process",
+    "github.com/signalfx/golib/datapoint",
     "github.com/signalfx/golib/sfxclient",
     "github.com/soniah/gosnmp",
     "github.com/streadway/amqp",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1056,6 +1056,40 @@
   revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
+  branch = "master"
+  digest = "1:ec0b4406ee4d860a33d6cf6748ec4c4546f6890e7c90d8fcf541e1ac7d9add91"
+  name = "github.com/signalfx/com_signalfx_metrics_protobuf"
+  packages = ["."]
+  pruneopts = ""
+  revision = "93e507b42f43f458a109ca278d1542a26a0b87fc"
+
+[[projects]]
+  branch = "master"
+  digest = "1:970b1463f5a08bf6790ad497c47ffe87ca75d37f0dd76bd7cd24b1318900a93e"
+  name = "github.com/signalfx/gohistogram"
+  packages = ["."]
+  pruneopts = ""
+  revision = "1ccfd2ff508314074672f4450a917011a2060408"
+
+[[projects]]
+  digest = "1:3d52a2ff8fabf5cb15a88e8451a524af87f203c80ad8a33209fd52e15eaa4997"
+  name = "github.com/signalfx/golib"
+  packages = [
+    "datapoint",
+    "errors",
+    "event",
+    "eventcounter",
+    "log",
+    "sfxclient",
+    "timekeeper",
+    "trace",
+    "trace/format",
+  ]
+  pruneopts = ""
+  revision = "271e7b77c46c2cb201be901a302cb181a9d1645a"
+  version = "v2.0.0"
+
+[[projects]]
   digest = "1:8cf46b6c18a91068d446e26b67512cf16f1540b45d90b28b9533706a127f0ca6"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -1513,6 +1547,14 @@
   version = "v2.5.1"
 
 [[projects]]
+  digest = "1:df89444601379b2e1ee82bf8e6b72af9901cbeed4b469fa380a519c89c339310"
+  name = "gopkg.in/logfmt.v0"
+  packages = ["."]
+  pruneopts = ""
+  revision = "07c9b44f60d7ffdfb7d8efe1ad539965737836dc"
+  version = "v0.4.0"
+
+[[projects]]
   branch = "v2"
   digest = "1:f54ba71a035aac92ced3e902d2bff3734a15d1891daff73ec0f90ef236750139"
   name = "gopkg.in/mgo.v2"
@@ -1537,6 +1579,14 @@
   pruneopts = ""
   revision = "52741dc2ce53629cbe1e673869040d886cba2cd5"
   version = "v5.0.70"
+
+[[projects]]
+  digest = "1:a01080d20c45c031c13f3828c56e58f4f51d926a482ad10cc0316225097eb7ea"
+  name = "gopkg.in/stack.v1"
+  packages = ["."]
+  pruneopts = ""
+  revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
+  version = "v1.8.0"
 
 [[projects]]
   branch = "v1"
@@ -1653,6 +1703,7 @@
     "github.com/shirou/gopsutil/mem",
     "github.com/shirou/gopsutil/net",
     "github.com/shirou/gopsutil/process",
+    "github.com/signalfx/golib/sfxclient",
     "github.com/soniah/gosnmp",
     "github.com/streadway/amqp",
     "github.com/stretchr/testify/assert",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -298,5 +298,6 @@
   name = "github.com/cisco-ie/nx-telemetry-proto"
 
 [[constraint]]
+  branch = "master"
   name = "github.com/signalfx/golib"
-  version = "2.0.0"
+  # version = "2.0.0" TODO: bump this to 2.3.5 or later once available

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -296,3 +296,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/cisco-ie/nx-telemetry-proto"
+
+[[constraint]]
+  name = "github.com/signalfx/golib"
+  version = "2.0.0"

--- a/plugins/outputs/all/all.go
+++ b/plugins/outputs/all/all.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/outputs/prometheus_client"
 	_ "github.com/influxdata/telegraf/plugins/outputs/riemann"
 	_ "github.com/influxdata/telegraf/plugins/outputs/riemann_legacy"
+	_ "github.com/influxdata/telegraf/plugins/outputs/signalfx"
 	_ "github.com/influxdata/telegraf/plugins/outputs/socket_writer"
 	_ "github.com/influxdata/telegraf/plugins/outputs/stackdriver"
 	_ "github.com/influxdata/telegraf/plugins/outputs/syslog"

--- a/plugins/outputs/signalfx/README.md
+++ b/plugins/outputs/signalfx/README.md
@@ -4,8 +4,7 @@ This plugin transmits metrics back to the SignalFX ingest servers.
 
 ## Configuration
 ```toml
+# A plugin that can transmit metrics to SignalFX
 [[outputs.signalfx]]
-    ## SignalFx API Token
-    APIToken = "your_api_token" # required.
-
+  api_token = xxx
 ```

--- a/plugins/outputs/signalfx/README.md
+++ b/plugins/outputs/signalfx/README.md
@@ -1,0 +1,11 @@
+# SignalFx Output Plugin
+
+This plugin transmits metrics back to the SignalFX ingest servers.
+
+## Configuration
+```toml
+[[outputs.signalfx]]
+    ## SignalFx API Token
+    APIToken = "your_api_token" # required.
+
+```

--- a/plugins/outputs/signalfx/signalfx.go
+++ b/plugins/outputs/signalfx/signalfx.go
@@ -1,0 +1,109 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/outputs"
+	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/sfxclient"
+)
+
+var sampleConfig = `
+  api_token = xxx
+`
+
+// SignalFX knows how to send metrics to the signalfx cloud
+type SignalFX struct {
+	APIToken string `toml:"api_token"`
+
+	sink *sfxclient.HTTPSink
+}
+
+// Connect initializes the connection to the signalfx cloud
+func (s *SignalFX) Connect() error {
+	s.sink = sfxclient.NewHTTPSink()
+	s.sink.AuthToken = s.APIToken
+
+	return nil
+}
+
+// Close - NOOP since the `sink` does not expose a way to close the connection
+func (s *SignalFX) Close() error {
+	return nil
+}
+
+// Description returns a string describing this plugins functionality
+func (s *SignalFX) Description() string {
+	return "A plugin that can transmit metrics to SignalFX"
+}
+
+// SampleConfig returns the sample configuration for this plugin
+func (s *SignalFX) SampleConfig() string {
+	return sampleConfig
+}
+
+// Write sends the metrics to the signalfx server
+func (s *SignalFX) Write(metrics []telegraf.Metric) error {
+	d := []*datapoint.Datapoint{}
+	for _, m := range metrics {
+		d = append(d, telegrafMetricToSignalFXDatapoints(m)...)
+	}
+	if len(d) <= 0 {
+		return nil
+	}
+	err := s.sink.AddDatapoints(context.TODO(), d)
+	if err != nil {
+		log.Println("E! Failed to add datapoints to signalfx sink:", err)
+		return err
+	}
+	return nil
+}
+
+func telegrafMetricToSignalFXDatapoints(m telegraf.Metric) []*datapoint.Datapoint {
+	fields := m.FieldList()
+	datapoints := make([]*datapoint.Datapoint, 0, len(fields))
+
+	sfxType := telegrafTypeToSignalFXType(m.Type())
+	sfxTime := m.Time()
+
+	for _, field := range fields {
+		sfxName := m.Name()
+		if field.Key != "value" {
+			sfxName = fmt.Sprintf("%s.%s", sfxName, field.Key)
+		}
+
+		sfxValue, err := datapoint.CastMetricValue(field.Value)
+		if err != nil {
+			// Intentionally emitting a debug level msg (not error) since
+			// plugins can often be naughty and emit fields that are strings
+			// (i.e. not numeric/chartable). E.g. system.uptime_format
+			log.Println("D! Failed to cast value for", field.Key)
+			continue
+		}
+		d := datapoint.New(sfxName, m.Tags(), sfxValue, sfxType, sfxTime)
+		datapoints = append(datapoints, d)
+	}
+	return datapoints
+}
+
+func telegrafTypeToSignalFXType(t telegraf.ValueType) datapoint.MetricType {
+	switch t {
+	case telegraf.Counter:
+		return datapoint.Counter
+	case telegraf.Gauge:
+		return datapoint.Gauge
+	default:
+		// All other telegraf types are sent as gauges (since they do not map
+		// on to any of the SignalFX types)
+		return datapoint.Gauge
+	}
+}
+
+func init() {
+	outputs.Add("signalfx", func() telegraf.Output {
+		return &SignalFX{}
+	})
+}

--- a/plugins/outputs/signalfx/signalfx_test.go
+++ b/plugins/outputs/signalfx/signalfx_test.go
@@ -1,0 +1,65 @@
+package http
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/signalfx/golib/datapoint"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/require"
+)
+
+func getMetric() telegraf.Metric {
+	m, err := metric.New(
+		"cpu",
+		map[string]string{
+			"tagKey": "tagValue",
+		},
+		map[string]interface{}{
+			"time_user":       43.0,
+			"time_system":     44.0,
+			"time_idle":       45.0,
+			"time_nice":       46.0,
+			"time_iowait":     47.0,
+			"time_irq":        48.0,
+			"time_softirq":    49.0,
+			"time_steal":      50.0,
+			"time_guest":      51.0,
+			"time_guest_nice": 52.0,
+		},
+		time.Unix(0, 0),
+	)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+func TestTelegrafTypeToSignalFXDatapoint(t *testing.T) {
+	m := getMetric()
+	d := telegrafMetricToSignalFXDatapoints(m)
+	require.Len(t, d, 10, "len mismatch")
+
+	for _, datapoint := range d {
+		nameParts := strings.Split(datapoint.Metric, ".")
+		require.True(t, (nameParts[0] == m.Name()))
+		require.True(t, m.HasField(nameParts[1]))
+	}
+}
+
+func TestTelegrafTypeToSignalFXType(t *testing.T) {
+	tests := map[telegraf.ValueType]datapoint.MetricType{
+		telegraf.Histogram: datapoint.Gauge,
+		telegraf.Summary:   datapoint.Gauge,
+		telegraf.Gauge:     datapoint.Gauge,
+		telegraf.Counter:   datapoint.Counter,
+		telegraf.Untyped:   datapoint.Gauge,
+	}
+
+	for arg, expected := range tests {
+		require.Equal(t, telegrafTypeToSignalFXType(arg), expected)
+	}
+}


### PR DESCRIPTION
This output plugin converts the `telegraf.Metrics` into signalfx
`datapoint`s and then transmits them to the ingest servers using
signalfx golang client lib.

As of this commit, the client lib is allowed to pick sane defaults
and none of its fields are overridable via telegraf config. This
can be changed in the future if needed.

The unit tests only test for conversion of `telegraf.Metric`s to
the `datapoint` structs. All code that executes after that is
assumed to be tested in the signalfx client lib itself (and not
worth writing end-to-end tests for).

TODO: datapoints are flushed back to the signalfx server in the
batch size that is passed into the `Write` method of this plugin.
However we could allow this batch size to be configurable via
some plugin config knobs if desired.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.