### PR TITLE
[input.vsphere] Fixed race condition in discovery

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -248,7 +248,7 @@
 
 [[constraint]]
   name = "github.com/wavefronthq/wavefront-sdk-go"
-  version = "v0.9.0"
+  version = "v0.9.1"
 
 [[constraint]]
   name = "github.com/karrick/godirwalk"


### PR DESCRIPTION
- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

## Race condition
Under certain circumstances, the timestamp for the last collection could be overwritten by stale data when running a resource discovery. 

Please merge this one before cutting a new release, as this is a regression introduced in #5113. My apologies for breaking things...

## Updated wavefront-sdk-go dependency
Uses 0.9.1, which eliminates annoying (but benign) "short write" messages in the log.

