### PR TITLE
Allow non local udp connections in net_response

### DIFF
--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -141,9 +141,8 @@ func (n *NetResponse) UDPGather() (tags map[string]string, fields map[string]int
 	start := time.Now()
 	// Resolving
 	udpAddr, err := net.ResolveUDPAddr("udp", n.Address)
-	LocalAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
 	// Connecting
-	conn, err := net.DialUDP("udp", LocalAddr, udpAddr)
+	conn, err := net.DialUDP("udp", nil, udpAddr)
 	// Handle error
 	if err != nil {
 		setResult(ConnectionFailed, fields, tags, n.Expect)


### PR DESCRIPTION
Previously, `net_response` was limiting udp connections to localhost as the return address was always `127.0.0.1`