### PR TITLE
Changed to wavefront-sdk-go 0.9.1

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -248,7 +248,7 @@
 
 [[constraint]]
   name = "github.com/wavefronthq/wavefront-sdk-go"
-  version = "v0.9.0"
+  version = "v0.9.1"
 
 [[constraint]]
   name = "github.com/karrick/godirwalk"


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This gets rid of some error messages in the log caused by a (benign) race condition in the sdk.
