### PR TITLE
Keep input timestamp for prometheus metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -892,15 +892,16 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"
+  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
+    "prometheus/internal",
     "prometheus/promhttp",
   ]
   pruneopts = ""
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -132,7 +132,7 @@
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  version = "0.8.0"
+  version = "0.9.2"
 
 [[constraint]]
   name = "github.com/prometheus/client_model"

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -35,4 +35,7 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
   ## If set, enable TLS with the given certificate.
   # tls_cert = "/etc/ssl/telegraf.crt"
   # tls_key = "/etc/ssl/telegraf.key"
+
+  ## Export metric collection time.
+  # export_timestamp = true
 ```

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -37,5 +37,5 @@ This plugin starts a [Prometheus](https://prometheus.io/) Client, it exposes all
   # tls_key = "/etc/ssl/telegraf.key"
 
   ## Export metric collection time.
-  # export_timestamp = true
+  # export_timestamp = false
 ```

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -107,7 +107,7 @@ var sampleConfig = `
   # tls_key = "/etc/ssl/telegraf.key"
 
   ## Export metric collection time.
-  # export_timestamp = true
+  # export_timestamp = false
 `
 
 func (p *PrometheusClient) auth(h http.Handler) http.Handler {


### PR DESCRIPTION
This change passes the metrics collection time to prometheus.
Prior to this change, prometheus can see one sample as two different samples, which generates dips/spikes on the charts.

For example:
- prometheus scrape interval = 7 sec;
- collection interval = 5 sec;
- expression: `irate(system_uptime[30s])`
![image](https://user-images.githubusercontent.com/2458138/51210169-25c92600-1923-11e9-9c39-aa99cf3f9284.png)
