### PR TITLE
Set windows docker client version to lowest supported

### DIFF
--- a/plugins/inputs/docker/client.go
+++ b/plugins/inputs/docker/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	"runtime"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
@@ -34,6 +35,9 @@ func NewEnvClient() (Client, error) {
 }
 
 func NewClient(host string, tlsConfig *tls.Config) (Client, error) {
+	if runtime.GOOS == "windows" {
+		version = "1.24"
+	}
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
 	}


### PR DESCRIPTION
As pointed out in #4666, the lowest docker version windows supports is `1.24`. `NegotiateAPIVersion` isn't an option because it only downgrades the client to the server version, since the client in telegraf is set lower than docker will ever report, it does nothing.

Ideally we'd quit supporting EOL docker versions that require older docker clients and go back to using `1.24` for all distributions. Would revert change made in #4434 to support deprecated versions of docker :flushed:.