### PR TITLE
Removing auth from /ping route

### DIFF
--- a/plugins/inputs/influxdb_listener/http_listener.go
+++ b/plugins/inputs/influxdb_listener/http_listener.go
@@ -229,9 +229,7 @@ func (h *HTTPListener) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		h.PingsRecv.Incr(1)
 		defer h.PingsServed.Incr(1)
 		// respond to ping requests
-		h.AuthenticateIfSet(func(res http.ResponseWriter, req *http.Request) {
-			res.WriteHeader(http.StatusNoContent)
-		}, res, req)
+		res.WriteHeader(http.StatusNoContent)
 	default:
 		defer h.NotFoundsServed.Incr(1)
 		// Don't know how to respond to calls to other endpoints


### PR DESCRIPTION
Adding ability to disable authentication on ping route.  Load balancers like AWS's ALBs don't support basic auth.

### Required for all PRs:

- [ X] Signed [CLA](https://influxdata.com/community/cla/).
- [ X] Associated README.md updated.
- [ X] Has appropriate unit tests.
