### PR TITLE
Add result type to regex processor

### DIFF
--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -26,6 +26,9 @@ The `regex` plugin transforms tag and field values with regex pattern. If `resul
     ## If result_key is present, a new field will be created
     ## instead of changing existing field
     result_key = "method"
+    ## If result_type is also present, result_key will be used to create
+    ## a field or tag instead of the existing type
+    result_type = "tag"
 
   # Multiple conversions may be applied for one field sequentially
   # Let's extract one more value

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -4,10 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
 )
 
 func newM1() telegraf.Metric {


### PR DESCRIPTION
I really needed the ability to add/update a tag based on field content; the easiest path seemed to be modifying the regex processor. Perhaps someone else will need this functionality as well?



### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
