### PR TITLE
Set skip rows and columns in csv parser

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1591,7 +1591,7 @@ func getParserConfig(name string, tbl *ast.Table) (*parsers.Config, error) {
 				if err != nil {
 					return nil, err
 				}
-				c.CSVHeaderRowCount = int(v)
+				c.CSVSkipRows = int(v)
 			}
 		}
 	}
@@ -1603,7 +1603,7 @@ func getParserConfig(name string, tbl *ast.Table) (*parsers.Config, error) {
 				if err != nil {
 					return nil, err
 				}
-				c.CSVHeaderRowCount = int(v)
+				c.CSVSkipColumns = int(v)
 			}
 		}
 	}


### PR DESCRIPTION
Resolves #5334

Turns out `skip_rows` and `skip_columns` were never getting set in the csv parser.

Tested with:
```toml
[[inputs.exec]]
  timeout = "1s"
  command = "echo -en 'version=13.0\ndate,instance,Incoming Requests,Outgoing Requests,Incoming Answers 2xxx,Outgoing Answers 2xxx,Incoming Answers UTD,Outgoing Answers UTD,Incoming Answers Redirect,Outgoing Answers Redirect,Incoming Answers Other,Outgoing Answers Other,Retransmit Requests,Rejected Requests Filtering,Rejected Requests In-gress Filtering,Rejected Requests Other,Timeout Requests,Discarded Answers\n2018-01-23-12:04,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1\n'"
  data_format = "csv"
  csv_skip_rows = 1
  csv_header_row_count = 1
  csv_delimiter = ","
  csv_trim_space = true
  csv_tag_columns = ["instance"]
  csv_timestamp_column = "date"
  csv_timestamp_format = "2006-01-02-15:04"
```