### PR TITLE
Add carbon2 serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ For documentation on the latest development code see the [documentation index][d
 - [Graphite](/plugins/serializers/graphite)
 - [ServiceNow](/plugins/serializers/nowmetric)
 - [SplunkMetric](/plugins/serializers/splunkmetric)
+- [Carbon2](/plugins/serializers/carbon2)
 
 ## Processor Plugins
 

--- a/docs/DATA_FORMATS_OUTPUT.md
+++ b/docs/DATA_FORMATS_OUTPUT.md
@@ -8,6 +8,7 @@ plugins.
 1. [JSON](/plugins/serializers/json)
 1. [Graphite](/plugins/serializers/graphite)
 1. [SplunkMetric](/plugins/serializers/splunkmetric)
+1. [Carbon2](/plugins/serializers/carbon2)
 
 You will be able to identify the plugins with support by the presence of a
 `data_format` config option, for example, in the `file` output plugin:

--- a/plugins/serializers/carbon2/README.md
+++ b/plugins/serializers/carbon2/README.md
@@ -44,3 +44,6 @@ metric=weather field=wind location=us-midwest season=summer  100 1234567890
 
 ### Fields and Tags with spaces
 When a field key or tag key/value have spaces, spaces will be replaced with `_`.
+
+### Tags with empty values
+When a tag's value is empty, it will be replaced with `null`

--- a/plugins/serializers/carbon2/README.md
+++ b/plugins/serializers/carbon2/README.md
@@ -1,0 +1,45 @@
+# Carbon2
+
+The `carbon2` serializer translates the Telegraf metric format to the [Carbon2 format](http://metrics20.org/implementations/).
+
+### Configuration
+
+```toml
+[[outputs.file]]
+  ## Files to write to, "stdout" is a specially handled file.
+  files = ["stdout", "/tmp/metrics.out"]
+
+  ## Data format to output.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "carbon2"
+```
+
+#### example_option
+
+Standard form:
+```
+metric=name field=field_1 host=foo  30 1234567890
+metric=name field=field_2 host=foo  4 1234567890
+metric=name field=field_N host=foo  59 1234567890
+```
+
+### Metrics
+
+The serializer converts the metrics by creating `intrinsic_tags` using the combination of metric name and fields.  So, if one Telegraf metric has 4 fields, the `carbon2` output will be 4 separate metrics. There will be a `metric` tag that represents the name of the metric and a `field` tag to represent the field.
+
+### Example
+
+If we take the following InfluxDB Line Protocol:
+
+```
+weather,location=us-midwest,season=summer temperature=82,wind=100 1234567890
+```
+
+after serializing in Carbon2, the result would be:
+
+```
+metric=weather field=temperature location=us-midwest season=summer  82 1234567890
+metric=weather field=wind location=us-midwest season=summer  100 1234567890
+```

--- a/plugins/serializers/carbon2/README.md
+++ b/plugins/serializers/carbon2/README.md
@@ -41,3 +41,6 @@ after serializing in Carbon2, the result would be:
 metric=weather field=temperature location=us-midwest season=summer  82 1234567890
 metric=weather field=wind location=us-midwest season=summer  100 1234567890
 ```
+
+### Fields and Tags with spaces
+When a field key or tag key/value have spaces, spaces will be replaced with `_`.

--- a/plugins/serializers/carbon2/README.md
+++ b/plugins/serializers/carbon2/README.md
@@ -16,8 +16,6 @@ The `carbon2` serializer translates the Telegraf metric format to the [Carbon2 f
   data_format = "carbon2"
 ```
 
-#### example_option
-
 Standard form:
 ```
 metric=name field=field_1 host=foo  30 1234567890

--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -21,7 +21,7 @@ func (s *serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 }
 
 func (s *serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
-	var batch strings.Builder
+	var batch bytes.Buffer
 	for _, metric := range metrics {
 		batch.WriteString(s.createObject(metric))
 	}

--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -1,6 +1,7 @@
 package carbon2
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/influxdata/telegraf"
 	"strconv"
@@ -28,7 +29,7 @@ func (s *serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 }
 
 func (s *serializer) createObject(metric telegraf.Metric) string {
-	var m strings.Builder
+	var m bytes.Buffer
 	for fieldName, fieldValue := range metric.Fields() {
 		if isNumeric(fieldValue) {
 			m.WriteString("metric=")

--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -40,6 +40,9 @@ func (s *serializer) createObject(metric telegraf.Metric) string {
 			for k, v := range metric.Tags() {
 				m.WriteString(strings.Replace(k, " ", "_", -1))
 				m.WriteString("=")
+				if len(v) == 0 {
+					v = "null"
+				}
 				m.WriteString(strings.Replace(v, " ", "_", -1))
 				m.WriteString(" ")
 			}

--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -1,0 +1,62 @@
+package carbon2
+
+import (
+	"fmt"
+	"github.com/influxdata/telegraf"
+	"strconv"
+	"strings"
+)
+
+type serializer struct {
+}
+
+func NewSerializer() (*serializer, error) {
+	s := &serializer{}
+	return s, nil
+}
+
+func (s *serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
+	return []byte(s.createObject(metric)), nil
+}
+
+func (s *serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
+	var batch strings.Builder
+	for _, metric := range metrics {
+		batch.WriteString(s.createObject(metric))
+	}
+	return []byte(batch.String()), nil
+}
+
+func (s *serializer) createObject(metric telegraf.Metric) string {
+	var m strings.Builder
+	for fieldName, fieldValue := range metric.Fields() {
+		if isNumeric(fieldValue) {
+			m.WriteString("metric=")
+			m.WriteString(metric.Name())
+			m.WriteString(" field=")
+			m.WriteString(fieldName)
+			m.WriteString(" ")
+			for k, v := range metric.Tags() {
+				m.WriteString(k)
+				m.WriteString("=")
+				m.WriteString(v)
+				m.WriteString(" ")
+			}
+			m.WriteString(" ")
+			m.WriteString(fmt.Sprintf("%v", fieldValue))
+			m.WriteString(" ")
+			m.WriteString(strconv.FormatInt(metric.Time().Unix(), 10))
+			m.WriteString("\n")
+		}
+	}
+	return m.String()
+}
+
+func isNumeric(v interface{}) bool {
+	switch v.(type) {
+	case string:
+		return false
+	default:
+		return true
+	}
+}

--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -32,14 +32,14 @@ func (s *serializer) createObject(metric telegraf.Metric) string {
 	for fieldName, fieldValue := range metric.Fields() {
 		if isNumeric(fieldValue) {
 			m.WriteString("metric=")
-			m.WriteString(metric.Name())
+			m.WriteString(strings.Replace(metric.Name(), " ", "_", -1))
 			m.WriteString(" field=")
-			m.WriteString(fieldName)
+			m.WriteString(strings.Replace(fieldName, " ", "_", -1))
 			m.WriteString(" ")
 			for k, v := range metric.Tags() {
-				m.WriteString(k)
+				m.WriteString(strings.Replace(k, " ", "_", -1))
 				m.WriteString("=")
-				m.WriteString(v)
+				m.WriteString(strings.Replace(v, " ", "_", -1))
 				m.WriteString(" ")
 			}
 			m.WriteString(" ")

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -37,6 +37,25 @@ func TestSerializeMetricFloat(t *testing.T) {
 	assert.Equal(t, string(expS), string(buf))
 }
 
+func TestSerializeWithSpaces(t *testing.T) {
+	now := time.Now()
+	tags := map[string]string{
+		"cpu 0": "cpu 0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle 1": float64(91.5),
+	}
+	m, err := metric.New("cpu metric", tags, fields, now)
+	assert.NoError(t, err)
+
+	s, _ := NewSerializer()
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
+	expS := []byte(fmt.Sprintf(`metric=cpu_metric field=usage_idle_1 cpu_0=cpu_0  91.5 %d`, now.Unix()) + "\n")
+	assert.Equal(t, string(expS), string(buf))
+}
+
 func TestSerializeMetricInt(t *testing.T) {
 	now := time.Now()
 	tags := map[string]string{

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -37,6 +37,25 @@ func TestSerializeMetricFloat(t *testing.T) {
 	assert.Equal(t, string(expS), string(buf))
 }
 
+func TestSerializeMetricWithEmptyStringTag(t *testing.T) {
+	now := time.Now()
+	tags := map[string]string{
+		"cpu": "",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": float64(91.5),
+	}
+	m, err := metric.New("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s, _ := NewSerializer()
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
+	expS := []byte(fmt.Sprintf(`metric=cpu field=usage_idle cpu=null  91.5 %d`, now.Unix()) + "\n")
+	assert.Equal(t, string(expS), string(buf))
+}
+
 func TestSerializeWithSpaces(t *testing.T) {
 	now := time.Now()
 	tags := map[string]string{

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -1,0 +1,100 @@
+package carbon2
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+)
+
+func MustMetric(v telegraf.Metric, err error) telegraf.Metric {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func TestSerializeMetricFloat(t *testing.T) {
+	now := time.Now()
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": float64(91.5),
+	}
+	m, err := metric.New("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s, _ := NewSerializer()
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
+	expS := []byte(fmt.Sprintf(`metric=cpu field=usage_idle cpu=cpu0  91.5 %d`, now.Unix()) + "\n")
+	assert.Equal(t, string(expS), string(buf))
+}
+
+func TestSerializeMetricInt(t *testing.T) {
+	now := time.Now()
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": int64(90),
+	}
+	m, err := metric.New("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s, _ := NewSerializer()
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
+
+	expS := []byte(fmt.Sprintf(`metric=cpu field=usage_idle cpu=cpu0  90 %d`, now.Unix()) + "\n")
+	assert.Equal(t, string(expS), string(buf))
+}
+
+func TestSerializeMetricString(t *testing.T) {
+	now := time.Now()
+	tags := map[string]string{
+		"cpu": "cpu0",
+	}
+	fields := map[string]interface{}{
+		"usage_idle": "foobar",
+	}
+	m, err := metric.New("cpu", tags, fields, now)
+	assert.NoError(t, err)
+
+	s, _ := NewSerializer()
+	var buf []byte
+	buf, err = s.Serialize(m)
+	assert.NoError(t, err)
+
+	expS := []byte("")
+	assert.Equal(t, string(expS), string(buf))
+}
+
+func TestSerializeBatch(t *testing.T) {
+	m := MustMetric(
+		metric.New(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"value": 42,
+			},
+			time.Unix(0, 0),
+		),
+	)
+
+	metrics := []telegraf.Metric{m, m}
+	s, _ := NewSerializer()
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+	expS := []byte(`metric=cpu field=value  42 0
+metric=cpu field=value  42 0
+`)
+	assert.Equal(t, string(expS), string(buf))
+}

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 
+	"github.com/influxdata/telegraf/plugins/serializers/carbon2"
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/influxdata/telegraf/plugins/serializers/json"
@@ -82,6 +83,8 @@ func NewSerializer(config *Config) (Serializer, error) {
 		serializer, err = NewSplunkmetricSerializer(config.HecRouting)
 	case "nowmetric":
 		serializer, err = NewNowSerializer()
+	case "carbon2":
+		serializer, err = NewCarbon2Serializer()
 	default:
 		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
 	}
@@ -90,6 +93,10 @@ func NewSerializer(config *Config) (Serializer, error) {
 
 func NewJsonSerializer(timestampUnits time.Duration) (Serializer, error) {
 	return json.NewSerializer(timestampUnits)
+}
+
+func NewCarbon2Serializer() (Serializer, error) {
+	return carbon2.NewSerializer()
 }
 
 func NewSplunkmetricSerializer(splunkmetric_hec_routing bool) (Serializer, error) {


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This PR addresses issue #5344 by adding a Carbon2 serializer.  Carbon2 is a metrics format supported by multiple applications and vendors.  Implementing it as a serializer would allow it to integrate with the existing output plugin ecosystem as well as integrate with any additional vendors who want to add support for the Carbon2 format.
