### PR TITLE
Update tail and logparser plugins to use a different tail library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -404,6 +404,14 @@
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   branch = "master"
   digest = "1:ec95c1c49fbec27ab5383b9c47fae5c2fe1d97ac5b41d36d78e17588a44e9f3f"
   name = "github.com/ghodss/yaml"
@@ -638,20 +646,6 @@
   pruneopts = ""
   revision = "0cd00a9f0a5e5607d5ef9a294c260f77a74e3b5a"
   version = "v2.0.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:bc3eb5ddfd59781ea1183f2b3d1eb105a1495d421f09b2ccd360c7fced0b612d"
-  name = "github.com/influxdata/tail"
-  packages = [
-    ".",
-    "ratelimiter",
-    "util",
-    "watch",
-    "winfile",
-  ]
-  pruneopts = ""
-  revision = "c43482518d410361b6c383d7aebce33d0471d7bc"
 
 [[projects]]
   branch = "telegraf"
@@ -1006,6 +1000,19 @@
   pruneopts = ""
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
+
+[[projects]]
+  digest = "1:a1225914e8139b1304e9358394e0c6d0ce49ca9e60367331de2ffedebbbd841c"
+  name = "github.com/sgtsquiggs/tail"
+  packages = [
+    "logger",
+    "logline",
+    "tailer",
+    "watcher",
+  ]
+  pruneopts = ""
+  revision = "03e9ae54be6ec1c0540d94cc7d82e0240d4fa22f"
+  version = "v1.0.3"
 
 [[projects]]
   digest = "1:d77a85cf43b70ae61fa2543d402d782b40dca0f5f41413839b5f916782b0fab9"
@@ -1615,6 +1622,10 @@
     "github.com/prometheus/client_model/go",
     "github.com/prometheus/common/expfmt",
     "github.com/satori/go.uuid",
+    "github.com/sgtsquiggs/tail/logger",
+    "github.com/sgtsquiggs/tail/logline",
+    "github.com/sgtsquiggs/tail/tailer",
+    "github.com/sgtsquiggs/tail/watcher",
     "github.com/shirou/gopsutil/cpu",
     "github.com/shirou/gopsutil/disk",
     "github.com/shirou/gopsutil/host",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -917,12 +917,12 @@
   version = "v2.0.3"
 
 [[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = ""
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
@@ -1455,15 +1455,6 @@
   version = "v2.0.0"
 
 [[projects]]
-  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
-  name = "gopkg.in/fsnotify.v1"
-  packages = ["."]
-  pruneopts = ""
-  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
-  source = "https://github.com/fsnotify/fsnotify/archive/v1.4.7.tar.gz"
-  version = "v1.4.7"
-
-[[projects]]
   digest = "1:960720207d3d0992995f4576e1366fd9e9b1483473b07fb7243144f75f5b1546"
   name = "gopkg.in/gorethink/gorethink.v3"
   packages = [
@@ -1517,14 +1508,6 @@
   pruneopts = ""
   revision = "52741dc2ce53629cbe1e673869040d886cba2cd5"
   version = "v5.0.70"
-
-[[projects]]
-  branch = "v1"
-  digest = "1:a96d16bd088460f2e0685d46c39bcf1208ba46e0a977be2df49864ec7da447dd"
-  name = "gopkg.in/tomb.v1"
-  packages = ["."]
-  pruneopts = ""
-  revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
   digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
@@ -1597,7 +1580,6 @@
     "github.com/influxdata/go-syslog/nontransparent",
     "github.com/influxdata/go-syslog/octetcounting",
     "github.com/influxdata/go-syslog/rfc5424",
-    "github.com/influxdata/tail",
     "github.com/influxdata/toml",
     "github.com/influxdata/toml/ast",
     "github.com/influxdata/wlog",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,8 +75,8 @@
   version = "2.0.0"
 
 [[constraint]]
-  name = "github.com/influxdata/tail"
-  branch = "master"
+  name = "github.com/sgtsquiggs/tail"
+  version = "1.0.3"
 
 [[constraint]]
   name = "github.com/influxdata/toml"

--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -3,12 +3,19 @@
 package logparser
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"sync"
+	"time"
 
-	"github.com/influxdata/tail"
+	taillog "github.com/sgtsquiggs/tail/logger"
+	"github.com/sgtsquiggs/tail/logline"
+	"github.com/sgtsquiggs/tail/tailer"
+	"github.com/sgtsquiggs/tail/watcher"
+
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/globpath"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
@@ -16,7 +23,8 @@ import (
 )
 
 const (
-	defaultWatchMethod = "inotify"
+	defaultPollInterval = time.Millisecond * 250
+	defaultWatchMethod  = "inotify"
 )
 
 // LogParser in the primary interface for the plugin
@@ -40,10 +48,12 @@ type LogParserPlugin struct {
 	Files         []string
 	FromBeginning bool
 	WatchMethod   string
+	PollInterval  internal.Duration
 
-	tailers map[string]*tail.Tail
-	lines   chan logEntry
-	done    chan struct{}
+	watcher watcher.Watcher
+	tailer  *tailer.Tailer
+	lines   chan *logline.LogLine
+	files   map[string]bool
 	wg      sync.WaitGroup
 	acc     telegraf.Accumulator
 
@@ -69,6 +79,9 @@ const sampleConfig = `
 
   ## Method used to watch for file updates.  Can be either "inotify" or "poll".
   # watch_method = "inotify"
+
+  ## Poll interval. Used when watch_method is set to "poll".
+  # poll_interval = "250ms"
 
   ## Parse logstash-style "grok" patterns:
   [inputs.logparser.grok]
@@ -122,7 +135,7 @@ func (l *LogParserPlugin) Gather(acc telegraf.Accumulator) error {
 	defer l.Unlock()
 
 	// always start from the beginning of files that appear while we're running
-	return l.tailNewfiles(true)
+	return l.tailNewFiles(true)
 }
 
 // Start kicks off collection of stats for the plugin
@@ -131,9 +144,32 @@ func (l *LogParserPlugin) Start(acc telegraf.Accumulator) error {
 	defer l.Unlock()
 
 	l.acc = acc
-	l.lines = make(chan logEntry, 1000)
-	l.done = make(chan struct{})
-	l.tailers = make(map[string]*tail.Tail)
+	l.lines = make(chan *logline.LogLine)
+	l.files = make(map[string]bool)
+
+	var poll bool
+	if l.WatchMethod == "poll" {
+		poll = true
+	}
+
+	var err error
+	l.watcher, err = watcher.NewLogWatcher(l.PollInterval.Duration, !poll, watcher.Logger(taillog.DiscardingLogger))
+	if err != nil {
+		defer close(l.lines)
+		return err
+	}
+
+	opts := []tailer.Option{tailer.Logger(taillog.DiscardingLogger)}
+	if l.FromBeginning {
+		opts = append(opts, tailer.OneShot)
+	}
+
+	l.tailer, err = tailer.New(l.lines, l.watcher, opts...)
+	if err != nil {
+		defer l.watcher.Close()
+		defer close(l.lines)
+		return err
+	}
 
 	mName := "logparser"
 	if l.GrokConfig.MeasurementName != "" {
@@ -152,56 +188,33 @@ func (l *LogParserPlugin) Start(acc telegraf.Accumulator) error {
 		DataFormat:             "grok",
 	}
 
-	var err error
 	l.GrokParser, err = parsers.NewParser(config)
 	if err != nil {
 		return err
 	}
 
 	l.wg.Add(1)
-	go l.parser()
+	go l.parse()
 
-	return l.tailNewfiles(l.FromBeginning)
+	return l.tailNewFiles(l.FromBeginning)
 }
 
 // check the globs against files on disk, and start tailing any new files.
 // Assumes l's lock is held!
-func (l *LogParserPlugin) tailNewfiles(fromBeginning bool) error {
-	var seek tail.SeekInfo
-	if !fromBeginning {
-		seek.Whence = 2
-		seek.Offset = 0
-	}
+func (l *LogParserPlugin) tailNewFiles(fromBeginning bool) error {
 
-	var poll bool
-	if l.WatchMethod == "poll" {
-		poll = true
-	}
-
-	// Create a "tailer" for each file
 	for _, filepath := range l.Files {
 		g, err := globpath.Compile(filepath)
 		if err != nil {
-			log.Printf("E! Error Glob %s failed to compile, %s", filepath, err)
-			continue
+			l.acc.AddError(fmt.Errorf("E! Error Glob %s failed to compile, %s", filepath, err))
 		}
-		files := g.Match()
-
-		for _, file := range files {
-			if _, ok := l.tailers[file]; ok {
+		for _, file := range g.Match() {
+			if _, ok := l.files[file]; ok {
 				// we're already tailing this file
 				continue
 			}
 
-			tailer, err := tail.TailFile(file,
-				tail.Config{
-					ReOpen:    true,
-					Follow:    true,
-					Location:  &seek,
-					MustExist: true,
-					Poll:      poll,
-					Logger:    tail.DiscardingLogger,
-				})
+			err := l.tailer.TailPath(file)
 			if err != nil {
 				l.acc.AddError(err)
 				continue
@@ -210,73 +223,38 @@ func (l *LogParserPlugin) tailNewfiles(fromBeginning bool) error {
 			log.Printf("D! [inputs.logparser] tail added for file: %v", file)
 
 			// create a goroutine for each "tailer"
-			l.wg.Add(1)
-			go l.receiver(tailer)
-			l.tailers[file] = tailer
+			l.files[file] = true
 		}
 	}
 
 	return nil
 }
 
-// receiver is launched as a goroutine to continuously watch a tailed logfile
-// for changes and send any log lines down the l.lines channel.
-func (l *LogParserPlugin) receiver(tailer *tail.Tail) {
-	defer l.wg.Done()
-
-	var line *tail.Line
-	for line = range tailer.Lines {
-
-		if line.Err != nil {
-			log.Printf("E! Error tailing file %s, Error: %s\n",
-				tailer.Filename, line.Err)
-			continue
-		}
-
-		// Fix up files with Windows line endings.
-		text := strings.TrimRight(line.Text, "\r")
-
-		entry := logEntry{
-			path: tailer.Filename,
-			line: text,
-		}
-
-		select {
-		case <-l.done:
-		case l.lines <- entry:
-		}
-	}
-}
-
 // parse is launched as a goroutine to watch the l.lines channel.
 // when a line is available, parse parses it and adds the metric(s) to the
 // accumulator.
-func (l *LogParserPlugin) parser() {
+func (l *LogParserPlugin) parse() {
 	defer l.wg.Done()
 
 	var m telegraf.Metric
 	var err error
-	var entry logEntry
-	for {
-		select {
-		case <-l.done:
-			return
-		case entry = <-l.lines:
-			if entry.line == "" || entry.line == "\n" {
-				continue
-			}
+	for line := range l.lines {
+		// Fix up files with Windows line endings.
+		line.Line = strings.TrimRight(line.Line, "\r")
+		if line.Line == "" || line.Line == "\n" {
+			continue
 		}
-		m, err = l.GrokParser.ParseLine(entry.line)
+
+		m, err = l.GrokParser.ParseLine(line.Line)
 		if err == nil {
 			if m != nil {
 				tags := m.Tags()
-				tags["path"] = entry.path
+				tags["path"] = line.Filename
 				l.acc.AddFields(m.Name(), m.Fields(), tags, m.Time())
 			}
 		} else {
 			log.Println("E! Error parsing log line: " + err.Error())
 		}
-
 	}
 }
 
@@ -285,25 +263,23 @@ func (l *LogParserPlugin) Stop() {
 	l.Lock()
 	defer l.Unlock()
 
-	for _, t := range l.tailers {
-		err := t.Stop()
-
-		//message for a stopped tailer
-		log.Printf("D! tail dropped for file: %v", t.Filename)
-
-		if err != nil {
-			log.Printf("E! Error stopping tail on file %s\n", t.Filename)
+	err := l.tailer.Close()
+	if err != nil {
+		l.acc.AddError(fmt.Errorf("E! Error closing tailer, Error: %s\n", err))
+	} else {
+		for file := range l.files {
+			log.Printf("D! [inputs.logparser] tail removed for file: %v", file)
 		}
-		t.Cleanup()
 	}
-	close(l.done)
+
 	l.wg.Wait()
 }
 
 func init() {
 	inputs.Add("logparser", func() telegraf.Input {
 		return &LogParserPlugin{
-			WatchMethod: defaultWatchMethod,
+			WatchMethod:  defaultWatchMethod,
+			PollInterval: internal.Duration{Duration: defaultPollInterval},
 		}
 	})
 }

--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -1,4 +1,5 @@
 // +build !solaris
+// +build go1.10
 
 package logparser
 

--- a/plugins/inputs/logparser/logparser_go1.9.go
+++ b/plugins/inputs/logparser/logparser_go1.9.go
@@ -1,0 +1,1 @@
+package logparser

--- a/plugins/inputs/logparser/logparser_solaris.go
+++ b/plugins/inputs/logparser/logparser_solaris.go
@@ -1,3 +1,4 @@
 // +build solaris
+// +build go1.10
 
 package logparser

--- a/plugins/inputs/logparser/logparser_test.go
+++ b/plugins/inputs/logparser/logparser_test.go
@@ -1,3 +1,5 @@
+// +build go1.10
+
 package logparser
 
 import (

--- a/plugins/inputs/tail/README.md
+++ b/plugins/inputs/tail/README.md
@@ -1,6 +1,10 @@
-# Tail Input Plugin
+# Tail2 Input Plugin
 
 The tail plugin "tails" a logfile and parses each log message.
+
+It is a port of the old tail plugin using https://gitlab.tower-research.com/SEFO/tail.
+It is a port of the tail plugin using https://github.com/sgtsquiggs/tail instead 
+of https://github.com/influxdata/tail.
 
 By default, the tail plugin acts like the following unix tail command:
 
@@ -36,8 +40,6 @@ The plugin expects messages in one of the
   files = ["/var/mymetrics.out"]
   ## Read file from beginning.
   from_beginning = false
-  ## Whether file is a named pipe
-  pipe = false
 
   ## Method used to watch for file updates.  Can be either "inotify" or "poll".
   # watch_method = "inotify"

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -1,4 +1,5 @@
 // +build !solaris
+// +build go1.10
 
 package tail
 

--- a/plugins/inputs/tail/tail_go1.9.go
+++ b/plugins/inputs/tail/tail_go1.9.go
@@ -1,0 +1,1 @@
+package tail

--- a/plugins/inputs/tail/tail_solaris.go
+++ b/plugins/inputs/tail/tail_solaris.go
@@ -1,5 +1,6 @@
 // Skipping plugin on Solaris due to fsnotify support
 //
 // +build solaris
+// +build go1.10
 
 package tail

--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -1,3 +1,5 @@
+// +build go1.10
+
 package tail
 
 import (


### PR DESCRIPTION
This new tail plugin fixes the current `tail` plugin problem where it stops reading new lines after telegraf reloads configuration (via SIGHUP). This is documented in ticket #3573 for `logparser` but also affects `tail` since they both use the same underlying log tailing engine.

More presenting this as an idea rather than a real pull request. Ideally both `tail` and `logparser` use the same underlying engine and that engine works after a SIGHUP :smile: 


`tail2` is a copy of `tail` with the change:
* [github.com/influxdata/tail](https://github.com/influxdata/tail) -> [github.com/sgtsquiggs/tail](https://github.com/sgtsquiggs/tail)

github.com/sgtsquiggs/tail is a fork of [github.com/google/mtail](https://github.com/google/mtail) modified to act as a library without unnecessary dependencies


I welcome feedback! Thank you!


### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
