### PR TITLE
Improve testutil AssertDoesNotContainsTaggedFields

### DIFF
--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -340,9 +340,10 @@ func (a *Accumulator) AssertDoesNotContainsTaggedFields(
 			continue
 		}
 
-		if p.Measurement == measurement {
-			assert.Equal(t, fields, p.Fields)
-			msg := fmt.Sprintf("found measurement %s with tags %v which should not be there", measurement, tags)
+		if p.Measurement == measurement && reflect.DeepEqual(fields, p.Fields) {
+			msg := fmt.Sprintf(
+				"found measurement %s with tagged fields (tags %v) which should not be there",
+				measurement, tags)
 			assert.Fail(t, msg)
 		}
 	}


### PR DESCRIPTION
Improved the testutil accumulator's `AssertDoesNotContainsTaggedFields` method to allow testing for specific fields that don't have a set of tags (tags that may exist in the same measurement under different fields). Otherwise such a test within the same measurement type isn't possible (checking that the same set of tags exists on some fields but not others).

I think the method as is would have been more accurately named `AssertDoesNotContainsTags` since it is mainly testing for tags. If it's better to instead create a `AssertDoesNotContainsTags` method with the original logic, and `AssertDoesNotContainsTaggedFields` with the changes below, I am happy to make that change!

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
