### PR TITLE
replaced subscription with topic in the pubsub output plugin

### DIFF
--- a/plugins/outputs/cloud_pubsub/README.md
+++ b/plugins/outputs/cloud_pubsub/README.md
@@ -12,11 +12,11 @@ generate it using `telegraf --usage pubsub`.
 ```toml
 [[inputs.pubsub]]
   ## Required. Name of Google Cloud Platform (GCP) Project that owns
-  ## the given PubSub subscription.
+  ## the given PubSub topic.
   project = "my-project"
 
-  ## Required. Name of PubSub subscription to ingest metrics from.
-  subscription = "my-subscription"
+  ## Required. Name of PubSub topic to publish metrics to.
+  topic = "my-topic"
 
   ## Required. Data format to consume.
   ## Each data format has its own unique set of configuration options.

--- a/plugins/outputs/cloud_pubsub/README.md
+++ b/plugins/outputs/cloud_pubsub/README.md
@@ -10,7 +10,7 @@ This section contains the default TOML to configure the plugin.  You can
 generate it using `telegraf --usage pubsub`.
 
 ```toml
-[[inputs.pubsub]]
+[[outputs.pubsub]]
   ## Required. Name of Google Cloud Platform (GCP) Project that owns
   ## the given PubSub topic.
   project = "my-project"

--- a/plugins/outputs/cloud_pubsub/README.md
+++ b/plugins/outputs/cloud_pubsub/README.md
@@ -7,10 +7,10 @@ as one of the supported [output data formats][].
 ### Configuration
 
 This section contains the default TOML to configure the plugin.  You can
-generate it using `telegraf --usage pubsub`.
+generate it using `telegraf --usage cloud_pubsub`.
 
 ```toml
-[[outputs.pubsub]]
+[[outputs.cloud_pubsub]]
   ## Required. Name of Google Cloud Platform (GCP) Project that owns
   ## the given PubSub topic.
   project = "my-project"

--- a/plugins/outputs/cloud_pubsub/pubsub.go
+++ b/plugins/outputs/cloud_pubsub/pubsub.go
@@ -16,11 +16,11 @@ import (
 
 const sampleConfig = `
   ## Required. Name of Google Cloud Platform (GCP) Project that owns
-  ## the given PubSub subscription.
+  ## the given PubSub topic.
   project = "my-project"
 
-  ## Required. Name of PubSub subscription to ingest metrics from.
-  subscription = "my-subscription"
+  ## Required. Name of PubSub topic to publish metrics to.
+  topic = "my-topic"
 
   ## Required. Data format to consume.
   ## Each data format has its own unique set of configuration options.


### PR DESCRIPTION
updated the default config (and the README) for the output plugin: the output plugin publishes to a topic, it does not subscribe to a subscription. This is probably a copy/paste error from the input plugin.
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [n/a ] Has appropriate unit tests.
