### PR TITLE
Stackdriver sort order

### DIFF
--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -22,3 +22,15 @@ Metrics are grouped by the `namespace` variable and metric key - eg: `custom.goo
 
 Stackdriver does not support string values in custom metrics, any string
 fields will not be written.
+
+The Stackdriver API does not allow writing points which are out of order,
+older than 24 hours, or more with resolution greater than than one per point
+minute.  Since Telegraf writes the newest points first and moves backwards
+through the metric buffer, it may not be possible to write historical data
+after an interruption.
+
+Points collected with greater than 1 minute precision may need to be
+aggregated before then can be written.  Consider using the [basicstats][]
+aggregator to do this.
+
+[basicstats]: /plugins/aggregators/basicstats/README.md

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -76,7 +76,9 @@ func (s *Stackdriver) Connect() error {
 	return nil
 }
 
-// sorted returns a copy of the metrics in time ascending order
+// Sorted returns a copy of the metrics in time ascending order.  A copy is
+// made to avoid modifying the input metric slice since doing so is not
+// allowed.
 func sorted(metrics []telegraf.Metric) []telegraf.Metric {
 	batch := make([]telegraf.Metric, 0, len(metrics))
 	for i := len(metrics) - 1; i >= 0; i-- {

--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -186,6 +186,10 @@ func TestWriteIgnoredErrors(t *testing.T) {
 			err:  errors.New(errStringPointsOutOfOrder),
 		},
 		{
+			name: "points too frequent",
+			err:  errors.New(errStringPointsTooFrequent),
+		},
+		{
 			name:        "other errors reported",
 			err:         errors.New("test"),
 			expectedErr: true,

--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -2,16 +2,19 @@ package stackdriver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3"
 	"github.com/golang/protobuf/proto"
 	emptypb "github.com/golang/protobuf/ptypes/empty"
+	googlepb "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
@@ -94,6 +97,126 @@ func TestWrite(t *testing.T) {
 	require.NoError(t, err)
 	err = s.Write(testutil.MockMetrics())
 	require.NoError(t, err)
+}
+
+func TestWriteAscendingTime(t *testing.T) {
+	expectedResponse := &emptypb.Empty{}
+	mockMetric.err = nil
+	mockMetric.reqs = nil
+	mockMetric.resps = append(mockMetric.resps[:0], expectedResponse)
+
+	c, err := monitoring.NewMetricClient(context.Background(), clientOpt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Stackdriver{
+		Project:   fmt.Sprintf("projects/%s", "[PROJECT]"),
+		Namespace: "test",
+		client:    c,
+	}
+
+	// Metrics in descending order of timestamp
+	metrics := []telegraf.Metric{
+		testutil.MustMetric("cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"value": 42,
+			},
+			time.Unix(2, 0),
+		),
+		testutil.MustMetric("cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"value": 43,
+			},
+			time.Unix(1, 0),
+		),
+	}
+
+	err = s.Connect()
+	require.NoError(t, err)
+	err = s.Write(metrics)
+	require.NoError(t, err)
+
+	require.Len(t, mockMetric.reqs, 2)
+	request := mockMetric.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
+	require.Len(t, request.TimeSeries, 1)
+	ts := request.TimeSeries[0]
+	require.Len(t, ts.Points, 1)
+	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+		EndTime: &googlepb.Timestamp{
+			Seconds: 1,
+		},
+	})
+	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
+		Value: &monitoringpb.TypedValue_Int64Value{
+			Int64Value: int64(43),
+		},
+	})
+
+	request = mockMetric.reqs[1].(*monitoringpb.CreateTimeSeriesRequest)
+	require.Len(t, request.TimeSeries, 1)
+	ts = request.TimeSeries[0]
+	require.Len(t, ts.Points, 1)
+	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+		EndTime: &googlepb.Timestamp{
+			Seconds: 2,
+		},
+	})
+	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
+		Value: &monitoringpb.TypedValue_Int64Value{
+			Int64Value: int64(42),
+		},
+	})
+}
+
+func TestWriteIgnoredErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		expectedErr bool
+	}{
+		{
+			name: "points too old",
+			err:  errors.New(errStringPointsTooOld),
+		},
+		{
+			name: "points out of order",
+			err:  errors.New(errStringPointsOutOfOrder),
+		},
+		{
+			name:        "other errors reported",
+			err:         errors.New("test"),
+			expectedErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMetric.err = tt.err
+			mockMetric.reqs = nil
+
+			c, err := monitoring.NewMetricClient(context.Background(), clientOpt)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s := &Stackdriver{
+				Project:   fmt.Sprintf("projects/%s", "[PROJECT]"),
+				Namespace: "test",
+				client:    c,
+			}
+
+			err = s.Connect()
+			require.NoError(t, err)
+			err = s.Write(testutil.MockMetrics())
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestGetStackdriverLabels(t *testing.T) {


### PR DESCRIPTION
This change attempts to mitigate #5364 by sorting the batch, but doesn't solve the issue.  Remaining issues are documented in the README and some errors are ignored, resulting in some points being dropped, but attempting to keep the output from becoming stuck.

related #5364

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
