### PR TITLE
Use Systemd for Amazon Linux 2

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -88,7 +88,10 @@ elif [[ -f /etc/debian_version ]]; then
     fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
-    if [[ $ID = "amzn" ]]; then
+    if [[ "$NAME" = "Amazon Linux" ]]; then
+        # Amazon Linux 2+ logic
+        install_systemd /usr/lib/systemd/system/telegraf.service
+    elif [[ "$NAME" = "Amazon Linux AMI" ]]; then
         # Amazon Linux logic
         install_init
         # Run update-rc.d or fallback to chkconfig if not available

--- a/scripts/post-remove.sh
+++ b/scripts/post-remove.sh
@@ -48,11 +48,15 @@ elif [[ -f /etc/debian_version ]]; then
     fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
-    if [[ $ID = "amzn" ]]; then
-        # Amazon Linux logic
-        if [[ "$1" = "0" ]]; then
-            # InfluxDB is no longer installed, remove from init system
-            rm -f /etc/default/telegraf
+    if [[ "$ID" = "amzn" ]] && [[ "$1" = "0" ]]; then
+        # InfluxDB is no longer installed, remove from init system
+        rm -f /etc/default/telegraf
+
+        if [[ "$NAME" = "Amazon Linux" ]]; then
+            # Amazon Linux 2+ logic
+            disable_systemd /usr/lib/systemd/system/telegraf.service
+        elif [[ "$NAME" = "Amazon Linux AMI" ]]; then
+            # Amazon Linux logic
             disable_chkconfig
         fi
     fi


### PR DESCRIPTION
Amazon Linux 2 uses systemd. This PR adds support for Amazon Linux 2 in the Telegraf `post-install.sh` and `post-remove.sh` scripts.

closes #5117

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
