### PR TITLE
Stackdriver output config resourcetype labels

### DIFF
--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -7,6 +7,8 @@ Requires `project` to specify where Stackdriver metrics will be delivered to.
 
 Metrics are grouped by the `namespace` variable and metric key - eg: `custom.googleapis.com/telegraf/system/load5`
 
+[Resource type](https://cloud.google.com/monitoring/api/resources) is configured by the `resource_type` variable (default `global`).
+
 ### Configuration
 
 ```toml

--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -9,6 +9,8 @@ Metrics are grouped by the `namespace` variable and metric key - eg: `custom.goo
 
 [Resource type](https://cloud.google.com/monitoring/api/resources) is configured by the `resource_type` variable (default `global`).
 
+Additional resource labels can be configured by `resource_labels`. By default the required `project_id` label is always set to the `project` variable.
+
 ### Configuration
 
 ```toml
@@ -18,6 +20,15 @@ Metrics are grouped by the `namespace` variable and metric key - eg: `custom.goo
 
   # The namespace for the metric descriptor
   namespace = "telegraf"
+
+  # Custom resource type
+  resource_type = "generic_node"
+
+# Additonal resource labels
+[outputs.stackdriver.resource_labels]
+  node_id = "$HOSTNAME"
+  namespace = "myapp"
+  location = "eu-north0"
 ```
 
 ### Restrictions

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -19,8 +19,9 @@ import (
 
 // Stackdriver is the Google Stackdriver config info.
 type Stackdriver struct {
-	Project   string
-	Namespace string
+	Project      string
+	Namespace    string
+	ResourceType string `toml:"resource_type"`
 
 	client *monitoring.MetricClient
 }
@@ -62,6 +63,10 @@ func (s *Stackdriver) Connect() error {
 
 	if s.Namespace == "" {
 		return fmt.Errorf("Namespace is a required field for stackdriver output")
+	}
+
+	if s.ResourceType == "" {
+		s.ResourceType = "global"
 	}
 
 	if s.client == nil {
@@ -137,7 +142,7 @@ func (s *Stackdriver) Write(metrics []telegraf.Metric) error {
 					},
 					MetricKind: metricKind,
 					Resource: &monitoredrespb.MonitoredResource{
-						Type: "global",
+						Type: s.ResourceType,
 						Labels: map[string]string{
 							"project_id": s.Project,
 						},

--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -97,6 +97,36 @@ func TestWrite(t *testing.T) {
 	require.NoError(t, err)
 	err = s.Write(testutil.MockMetrics())
 	require.NoError(t, err)
+
+	request := mockMetric.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
+	require.Equal(t, request.TimeSeries[0].Resource.Type, "global")
+}
+
+func TestWriteResourceType(t *testing.T) {
+	expectedResponse := &emptypb.Empty{}
+	mockMetric.err = nil
+	mockMetric.reqs = nil
+	mockMetric.resps = append(mockMetric.resps[:0], expectedResponse)
+
+	c, err := monitoring.NewMetricClient(context.Background(), clientOpt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Stackdriver{
+		Project:      fmt.Sprintf("projects/%s", "[PROJECT]"),
+		Namespace:    "test",
+		ResourceType: "foo",
+		client:       c,
+	}
+
+	err = s.Connect()
+	require.NoError(t, err)
+	err = s.Write(testutil.MockMetrics())
+	require.NoError(t, err)
+
+	request := mockMetric.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
+	require.Equal(t, request.TimeSeries[0].Resource.Type, "foo")
 }
 
 func TestWriteAscendingTime(t *testing.T) {

--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -100,9 +100,10 @@ func TestWrite(t *testing.T) {
 
 	request := mockMetric.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
 	require.Equal(t, request.TimeSeries[0].Resource.Type, "global")
+	require.Equal(t, request.TimeSeries[0].Resource.Labels["project_id"], "projects/[PROJECT]")
 }
 
-func TestWriteResourceType(t *testing.T) {
+func TestWriteResourceTypeAndLabels(t *testing.T) {
 	expectedResponse := &emptypb.Empty{}
 	mockMetric.err = nil
 	mockMetric.reqs = nil
@@ -117,7 +118,10 @@ func TestWriteResourceType(t *testing.T) {
 		Project:      fmt.Sprintf("projects/%s", "[PROJECT]"),
 		Namespace:    "test",
 		ResourceType: "foo",
-		client:       c,
+		ResourceLabels: map[string]string{
+			"mylabel": "myvalue",
+		},
+		client: c,
 	}
 
 	err = s.Connect()
@@ -127,6 +131,8 @@ func TestWriteResourceType(t *testing.T) {
 
 	request := mockMetric.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
 	require.Equal(t, request.TimeSeries[0].Resource.Type, "foo")
+	require.Equal(t, request.TimeSeries[0].Resource.Labels["project_id"], "projects/[PROJECT]")
+	require.Equal(t, request.TimeSeries[0].Resource.Labels["mylabel"], "myvalue")
 }
 
 func TestWriteAscendingTime(t *testing.T) {


### PR DESCRIPTION
This is a follow-up on #5389 and depends on it. Adds functionality to customize resource labels for Stackdriver metrics. Resource types apart from `global` have required labels, so this is necessary to make #5389 useful.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
