### PR TITLE
Add `fieldvaluepass` and `fieldvaluedrop` to select by field value

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -382,6 +382,15 @@ a pattern in this list are emitted.
 The inverse of `namepass`.  If a match is found the metric is discarded. This
 is tested on metrics after they have passed the `namepass` test.
 
+- **fieldvaluepass**:
+A table mapping field keys to arrays of glob pattern strings.  Only metrics
+that contain a field key in the table and a field value matching one of its
+patterns is emitted.
+
+- **fieldvaluedrop**:
+The inverse of `fieldvaluepass`.  If a match is found the metric is discarded. This
+is tested on metrics after they have passed the `fieldvaluepass` test.
+
 - **tagpass**:
 A table mapping tag keys to arrays of glob pattern strings.  Only metrics
 that contain a tag key in the table and a tag value matching one of its
@@ -418,6 +427,26 @@ will be discarded from the metric.  Any tag can be filtered including global
 tags and the agent `host` tag.
 
 ##### Filtering Examples
+
+Using fieldvaluepass and fieldvaluedrop:
+```toml
+[[inputs.tail]]
+  # Only collect lines related to deletions
+  [inputs.tail.fieldvaluepass]
+    message = [ "*delete*" ]
+  # But exclude lines containing /tmp
+  [inputs.tail.fieldvaluedrop]
+    message = [ "*/tmp*" ]
+
+[[inputs.socket_listener]]
+  [inputs.socket_listener.tagpass]
+    # fieldvaluepass conditions are OR, not AND.
+    # If the (target is space or land) OR (the comment is culture or code)
+    # then the metric passes
+    target = [ "space", "land" ]
+    # Globs can also be used on the field values
+    comment = [ "culture", "code*" ]
+```
 
 Using tagpass and tagdrop:
 ```toml

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1087,6 +1087,42 @@ func buildFilter(tbl *ast.Table) (models.Filter, error) {
 		}
 	}
 
+	if node, ok := tbl.Fields["fieldvaluepass"]; ok {
+		if subtbl, ok := node.(*ast.Table); ok {
+			for name, val := range subtbl.Fields {
+				if kv, ok := val.(*ast.KeyValue); ok {
+					fieldfilter := &models.FieldFilter{Name: name}
+					if ary, ok := kv.Value.(*ast.Array); ok {
+						for _, elem := range ary.Value {
+							if str, ok := elem.(*ast.String); ok {
+								fieldfilter.Filter = append(fieldfilter.Filter, str.Value)
+							}
+						}
+					}
+					f.FieldValuePass = append(f.FieldValuePass, *fieldfilter)
+				}
+			}
+		}
+	}
+
+	if node, ok := tbl.Fields["fieldvaluedrop"]; ok {
+		if subtbl, ok := node.(*ast.Table); ok {
+			for name, val := range subtbl.Fields {
+				if kv, ok := val.(*ast.KeyValue); ok {
+					fieldfilter := &models.FieldFilter{Name: name}
+					if ary, ok := kv.Value.(*ast.Array); ok {
+						for _, elem := range ary.Value {
+							if str, ok := elem.(*ast.String); ok {
+								fieldfilter.Filter = append(fieldfilter.Filter, str.Value)
+							}
+						}
+					}
+					f.FieldValueDrop = append(f.FieldValueDrop, *fieldfilter)
+				}
+			}
+		}
+	}
+
 	fields := []string{"pass", "fieldpass"}
 	for _, field := range fields {
 		if node, ok := tbl.Fields[field]; ok {
@@ -1182,6 +1218,8 @@ func buildFilter(tbl *ast.Table) (models.Filter, error) {
 
 	delete(tbl.Fields, "namedrop")
 	delete(tbl.Fields, "namepass")
+	delete(tbl.Fields, "fieldvaluedrop")
+	delete(tbl.Fields, "fieldvaluepass")
 	delete(tbl.Fields, "fielddrop")
 	delete(tbl.Fields, "fieldpass")
 	delete(tbl.Fields, "drop")


### PR DESCRIPTION
Resolves #3904.

Implements a field value filter as is currently implemented for tags.

The new filter names are `fieldvaluepass` and `fieldvaluedrop`. They work the same as `tagpass` and `tagdrop`, but for fields.

This implementation is limited. It treats all non-string field values as strings via `fmt.Sprintf("%v", value)`.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
