### PR TITLE
Change log level of buffer too small error

### DIFF
--- a/plugins/inputs/influxdb_listener/http_listener.go
+++ b/plugins/inputs/influxdb_listener/http_listener.go
@@ -326,7 +326,7 @@ func (h *HTTPListener) serveWrite(res http.ResponseWriter, req *http.Request) {
 		i := bytes.LastIndexByte(buf, '\n')
 		if i == -1 {
 			// drop any line longer than the max buffer size
-			log.Printf("D! http_listener received a single line longer than the maximum of %d bytes",
+			log.Printf("E! http_listener received a single line longer than the maximum of %d bytes",
 				len(buf))
 			hangingBytes = true
 			return400 = true

--- a/plugins/inputs/influxdb_listener/http_listener.go
+++ b/plugins/inputs/influxdb_listener/http_listener.go
@@ -72,6 +72,8 @@ type HTTPListener struct {
 	NotFoundsServed selfstat.Stat
 	BuffersCreated  selfstat.Stat
 	AuthFailures    selfstat.Stat
+
+	longLines selfstat.Stat
 }
 
 const sampleConfig = `
@@ -138,6 +140,7 @@ func (h *HTTPListener) Start(acc telegraf.Accumulator) error {
 	h.NotFoundsServed = selfstat.Register("http_listener", "not_founds_served", tags)
 	h.BuffersCreated = selfstat.Register("http_listener", "buffers_created", tags)
 	h.AuthFailures = selfstat.Register("http_listener", "auth_failures", tags)
+	h.longLines = selfstat.Register("http_listener", "long_lines", tags)
 
 	if h.MaxBodySize.Size == 0 {
 		h.MaxBodySize.Size = DEFAULT_MAX_BODY_SIZE
@@ -325,8 +328,9 @@ func (h *HTTPListener) serveWrite(res http.ResponseWriter, req *http.Request) {
 		// final newline, then push the rest of the bytes into the next buffer.
 		i := bytes.LastIndexByte(buf, '\n')
 		if i == -1 {
+			h.longLines.Incr(1)
 			// drop any line longer than the max buffer size
-			log.Printf("E! http_listener received a single line longer than the maximum of %d bytes",
+			log.Printf("D! http_listener received a single line longer than the maximum of %d bytes",
 				len(buf))
 			hangingBytes = true
 			return400 = true


### PR DESCRIPTION
Provides the ability to sort/search for errors that relate to the input being oversized.