### PR TITLE
Add squid proxy input

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -128,6 +128,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/socket_listener"
 	_ "github.com/influxdata/telegraf/plugins/inputs/solr"
 	_ "github.com/influxdata/telegraf/plugins/inputs/sqlserver"
+	_ "github.com/influxdata/telegraf/plugins/inputs/squid"
 	_ "github.com/influxdata/telegraf/plugins/inputs/stackdriver"
 	_ "github.com/influxdata/telegraf/plugins/inputs/statsd"
 	_ "github.com/influxdata/telegraf/plugins/inputs/swap"

--- a/plugins/inputs/squid/README.md
+++ b/plugins/inputs/squid/README.md
@@ -1,0 +1,104 @@
+# Squid Input Plugin
+
+This plugin gathers metrics from a Squid web proxy cache server (http://www.squid-cache.org/).
+
+### Configuration:
+
+To use this plugin you must [configure the manager api to allow access](https://wiki.squid-cache.org/Features/CacheManager) from the system on which telegraf is running
+
+```toml
+# Squid web proxy cache plugin
+[[inputs.squid]]
+  ## url of the squid proxy manager counters page
+  url = http://localhost:3128/squid-internal-mgr/counters
+  ## Maximum time to receive response.
+  response_timeout = "5s"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+```
+
+### Metrics
+
+Metrics currently gathered come from `/squid-internal-mgr/counters`, and are all 64-bit counters.
+
+- squid
+  - tags:
+    - source (url used)      
+  - fields:
+    - aborted_requests
+    - cd_kbytes_recv
+    - cd_kbytes_sent
+    - cd_local_memory
+    - cd_memory
+    - cd_msgs_recv
+    - cd_msgs_sent
+    - cd_times_used
+    - client_http_errors
+    - client_http_hit_kbytes_out
+    - client_http_hits
+    - client_http_kbytes_in
+    - client_http_kbytes_out
+    - client_http_requests
+    - cpu_time
+    - icp_kbytes_recv
+    - icp_kbytes_sent
+    - icp_pkts_recv
+    - icp_pkts_sent
+    - icp_q_kbytes_recv
+    - icp_q_kbytes_sent
+    - icp_queries_recv
+    - icp_queries_sent
+    - icp_query_timeouts
+    - icp_r_kbytes_recv
+    - icp_r_kbytes_sent
+    - icp_replies_queued
+    - icp_replies_recv
+    - icp_replies_sent
+    - icp_times_used
+    - page_faults
+    - select_loops
+    - server_all_errors
+    - server_all_kbytes_in
+    - server_all_kbytes_out
+    - server_all_requests
+    - server_ftp_kbytes_in
+    - server_ftp_kbytes_out
+    - server_ftp_requests
+    - server_http_errors
+    - server_http_kbytes_in
+    - server_http_kbytes_out
+    - server_http_requests
+    - server_other_errors
+    - server_other_kbytes_in
+    - server_other_kbytes_out
+    - server_other_requests
+    - swap_files_cleaned
+    - swap_ins
+    - swap_outs
+    - unlink_requests
+    - wall_time
+
+### Example Output:
+
+```
+squid,host=d3541b1c1112,source=http://squid:3128/squid-internal-mgr/counters wall_time=0.884082,server_http_kbytes_in=0,server_other_kbytes_out=0,icp_kbytes_sent=0,icp_q_kbytes_recv=0,icp_r_kbytes_recv=0,cd_times_used=0,server_all_errors=0,server_other_requests=0,unlink_requests=0,swap_files_cleaned=0,cpu_time=0.056241,server_all_kbytes_out=0,server_http_requests=0,icp_replies_sent=0,icp_replies_queued=0,client_http_hit_kbytes_out=0,cd_msgs_recv=0,cd_kbytes_recv=0,server_other_errors=0,icp_r_kbytes_sent=0,icp_times_used=0,cd_memory=0,client_http_requests=0,client_http_kbytes_in=0,server_http_errors=0,server_ftp_kbytes_in=0,page_faults=0,client_http_errors=0,icp_pkts_sent=0,icp_queries_sent=0,icp_query_timeouts=0,aborted_requests=0,swap_outs=0,swap_ins=0,icp_queries_recv=0,server_ftp_kbytes_out=0,icp_pkts_recv=0,icp_kbytes_recv=0,cd_msgs_sent=0,cd_local_memory=0,client_http_kbytes_out=0,server_all_kbytes_in=0,cd_kbytes_sent=0,server_http_kbytes_out=0,select_loops=2,client_http_hits=0,server_other_kbytes_in=0,server_ftp_requests=0,server_ftp_errors=0,server_all_requests=0,icp_replies_recv=0,icp_q_kbytes_sent=0 1565150341000000000
+```
+
+### Development
+
+Run short tests:
+```
+go test -short
+```
+
+Run full integration tests:
+```
+cd plugins/inputs/squid
+docker-compose -f dev/docker-compose.yml up squid
+go test
+```

--- a/plugins/inputs/squid/dev/docker-compose.yml
+++ b/plugins/inputs/squid/dev/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+  squid:
+    image: b4tman/squid:latest
+    restart: always
+    volumes:
+      - ./squid.conf:/etc/squid/squid.conf:ro
+    ports:
+      - "3128:3128"
+  telegraf:
+    image: glinton/scratch
+    depends_on:
+      - squid
+    volumes:
+      - ./telegraf.conf:/telegraf.conf:ro
+      - ../../../../telegraf:/telegraf:ro
+    entrypoint:
+      - /telegraf
+      - --config
+      - /telegraf.conf

--- a/plugins/inputs/squid/dev/squid.conf
+++ b/plugins/inputs/squid/dev/squid.conf
@@ -1,0 +1,33 @@
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow all manager
+http_access allow localnet
+http_access allow localhost
+http_access deny all
+http_port 3128
+coredump_dir /var/cache/squid
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320
+include /etc/squid/conf.d/*.conf

--- a/plugins/inputs/squid/dev/telegraf.conf
+++ b/plugins/inputs/squid/dev/telegraf.conf
@@ -1,0 +1,12 @@
+[agent]
+  interval = "1s"
+  flush_interval = "1s"
+  quiet = false
+  debug = true
+
+[[inputs.squid]]
+  url = "http://squid:3128/squid-internal-mgr/counters"
+
+[[outputs.file]]
+  files = ["stdout"]
+  data_format = "influx"

--- a/plugins/inputs/squid/squid.go
+++ b/plugins/inputs/squid/squid.go
@@ -1,0 +1,142 @@
+package squid
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/internal/tls"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Squid struct {
+	Url             string
+	ResponseTimeout internal.Duration
+	tls.ClientConfig
+
+	client *http.Client
+}
+
+const sampleConfig string = `
+  ## url of the squid proxy manager counters page
+  url = http://localhost:3128/squid-internal-mgr/counters
+  ## Maximum time to receive response.
+  response_timeout = "5s"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+`
+
+func (s *Squid) SampleConfig() string {
+	return sampleConfig
+}
+
+func (o *Squid) Description() string {
+	return "Squid web proxy cache plugin"
+}
+
+// return an initialized Squid
+func NewSquid() *Squid {
+	return &Squid{
+		Url:             "http://localhost:3128/squid-internal-mgr/counters",
+		ResponseTimeout: internal.Duration{Duration: time.Second * 5},
+	}
+}
+
+// Gather metrics
+func (s *Squid) Gather(acc telegraf.Accumulator) error {
+	if s.client == nil {
+		tlsCfg, err := s.ClientConfig.TLSConfig()
+		if err != nil {
+			return err
+		}
+		s.client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsCfg,
+			},
+			Timeout: s.ResponseTimeout.Duration,
+		}
+	}
+
+	acc.AddError(s.gatherCounters(s.Url, acc))
+
+	return nil
+}
+
+// gather counters
+func (s *Squid) gatherCounters(url string, acc telegraf.Accumulator) error {
+	resp, err := s.client.Get(url)
+	if err != nil {
+		return fmt.Errorf("unable to GET \"%s\": %s", url, err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("non-OK status code returned from \"%s\": %d", url, resp.StatusCode)
+	}
+
+	fields := parseBody(resp.Body)
+	if err != nil {
+		return fmt.Errorf("unable to parse body from \"%s\": %s", url, err)
+	}
+
+	tags := map[string]string{
+		"source": s.Url,
+	}
+
+	acc.AddFields("squid", fields, tags)
+
+	return nil
+}
+
+// parseBody accepts a response body as an io.Reader and uses bufio.NewScanner
+// to walk the body. It returns the metric fields expected format is "this.key
+// = 0.000\n"
+func parseBody(body io.Reader) map[string]interface{} {
+	fields := map[string]interface{}{}
+	sc := bufio.NewScanner(body)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.Contains(line, "=") {
+			parts := strings.SplitN(line, "=", 2)
+			// skip if this line isn't long enough
+			if len(parts) != 2 {
+				continue
+			}
+
+			// skip sample_time
+			if parts[0] == "sample_time" {
+				continue
+			}
+
+			key := strings.TrimSpace(parts[0])
+			key = strings.Replace(key, ".", "_", -1)
+			valueStr := strings.TrimSpace(parts[1])
+
+			// src/mgr/CountersAction.h defines these all as double,
+			// so turn them into 64-bit floats
+			value, err := strconv.ParseFloat(valueStr, 64)
+			if err != nil {
+				continue
+			}
+
+			// store this field
+			fields[key] = value
+		}
+	}
+	return fields
+}
+
+func init() {
+	inputs.Add("squid", func() telegraf.Input { return NewSquid() })
+}

--- a/plugins/inputs/squid/squid_test.go
+++ b/plugins/inputs/squid/squid_test.go
@@ -1,0 +1,114 @@
+package squid
+
+import (
+	"fmt"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+	"time"
+)
+
+const sampleBody = `
+sample_time = 1549933585.137495 (Tue, 12 Feb 2019 01:06:25 GMT)
+client_http.requests = 37
+client_http.hits = 0
+client_http.errors = 3
+client_http.kbytes_in = 5
+client_http.kbytes_out = 207
+client_http.hit_kbytes_out = 0
+server.all.requests = 4
+server.all.errors = 0
+server.all.kbytes_in = 98
+server.all.kbytes_out = 1
+server.http.requests = 1
+server.http.errors = 0
+server.http.kbytes_in = 0
+server.http.kbytes_out = 0
+server.ftp.requests = 0
+server.ftp.errors = 0
+server.ftp.kbytes_in = 0
+server.ftp.kbytes_out = 0
+server.other.requests = 3
+server.other.errors = 0
+server.other.kbytes_in = 98
+server.other.kbytes_out = 1
+icp.pkts_sent = 0
+icp.pkts_recv = 0
+icp.queries_sent = 0
+icp.replies_sent = 0
+icp.queries_recv = 0
+icp.replies_recv = 0
+icp.query_timeouts = 0
+icp.replies_queued = 0
+icp.kbytes_sent = 0
+icp.kbytes_recv = 0
+icp.q_kbytes_sent = 0
+icp.r_kbytes_sent = 0
+icp.q_kbytes_recv = 0
+icp.r_kbytes_recv = 0
+icp.times_used = 0
+cd.times_used = 0
+cd.msgs_sent = 0
+cd.msgs_recv = 0
+cd.memory = 0
+cd.local_memory = 0
+cd.kbytes_sent = 0
+cd.kbytes_recv = 0
+unlink.requests = 0
+page_faults = 0
+select_loops = 5102
+cpu_time = 0.291445
+wall_time = 49.503122
+swap.outs = 0
+swap.ins = 0
+swap.files_cleaned = 0
+aborted_requests = 0`
+
+func TestGatherTimeout(t *testing.T) {
+	var acc testutil.Accumulator
+
+	// dummy config to a url that should timeout
+	s := &Squid{
+		Url:             "http://localhost:1021/squid-internal-mgr/counters",
+		ResponseTimeout: internal.Duration{Duration: time.Millisecond * 100},
+	}
+
+	// this should return an error
+	err := s.Gather(&acc)
+
+	require.NoError(t, err)        // test that we did not return an error
+	assert.Zero(t, acc.NFields())  // test that we didn't return any fields
+	assert.NotEmpty(t, acc.Errors) // test that the accumulator has errors
+}
+
+func TestGatherFull(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	s := &Squid{
+		Url:             fmt.Sprintf("http://%s:3128/squid-internal-mgr/counters", testutil.GetLocalHost()),
+		ResponseTimeout: internal.Duration{Duration: time.Second * 5},
+	}
+
+	var acc testutil.Accumulator
+	err := s.Gather(&acc)
+
+	require.NoError(t, err)
+	assert.Empty(t, acc.Errors, "accumulator had no errors")
+	assert.True(t, acc.HasMeasurement("squid"), "Has a measurement called 'squid'")
+	assert.Equal(t, s.Url, acc.TagValue("squid", "source"), "Has a tag value for squid equal to localhost")
+	assert.True(t, acc.HasFloatField("squid", "client_http_requests"), "Has a float field called client_http.requests")
+}
+
+func TestParseBody(t *testing.T) {
+	body := strings.NewReader(sampleBody)
+	fields := parseBody(body)
+
+	assert.Empty(t, fields["sample_time"], "ommitted sample_time field")
+	assert.Equal(t, float64(37), fields["client_http_requests"], "Has field called 'client_http.requests'")
+	assert.Equal(t, float64(49.503122), fields["wall_time"], "Has field called 'wall_time'")
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This is pretty straightforward. I structured it based loosely on `apache` so it would be trivial to add support for polling multiple hosts/ports and/or additional manager endpoints if there's a desire from the community. The `counters` endpoint seems to have most of the more interesting metrics for Squid.