### PR TITLE
Check if SNMP6 directory exists (#5403)

### DIFF
--- a/plugins/inputs/nstat/README.md
+++ b/plugins/inputs/nstat/README.md
@@ -36,6 +36,8 @@ The sample config file
   # dump_zeros			= 	true
 ```
 
+In case that `proc_net_snmp6` path doesn't exist (e.g. IPv6 is not enabled) no error would be raised.
+
 ### Measurements & Fields
 
 - nstat

--- a/plugins/inputs/nstat/nstat.go
+++ b/plugins/inputs/nstat/nstat.go
@@ -84,15 +84,14 @@ func (ns *Nstat) Gather(acc telegraf.Accumulator) error {
 	}
 
 	// collect SNMP6 data, if SNMP6 directory exists (IPv6 enabled)
-	if _, err := os.Stat(ns.ProcNetSNMP6); err == nil {
-		snmp6, err := ioutil.ReadFile(ns.ProcNetSNMP6)
-		if err != nil {
-			return err
-		}
+	snmp6, err := ioutil.ReadFile(ns.ProcNetSNMP6)
+	if err == nil {
 		err = ns.gatherSNMP6(snmp6, acc)
 		if err != nil {
 			return err
 		}
+	} else if !os.IsNotExist(err) {
+		return err
 	}
 	return nil
 }

--- a/plugins/inputs/nstat/nstat.go
+++ b/plugins/inputs/nstat/nstat.go
@@ -83,14 +83,16 @@ func (ns *Nstat) Gather(acc telegraf.Accumulator) error {
 		return err
 	}
 
-	// collect SNMP6 data
-	snmp6, err := ioutil.ReadFile(ns.ProcNetSNMP6)
-	if err != nil {
-		return err
-	}
-	err = ns.gatherSNMP6(snmp6, acc)
-	if err != nil {
-		return err
+	// collect SNMP6 data, if SNMP6 directory exists (IPv6 enabled)
+	if _, err := os.Stat(ns.ProcNetSNMP6); err == nil {
+		snmp6, err := ioutil.ReadFile(ns.ProcNetSNMP6)
+		if err != nil {
+			return err
+		}
+		err = ns.gatherSNMP6(snmp6, acc)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Silently ignore missing `/proc/stat/snmp6` directory

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests. 

Resolves #5403