### PR TITLE
Enhance error log when dns query isn't successful

### DIFF
--- a/plugins/inputs/dns_query/README.md
+++ b/plugins/inputs/dns_query/README.md
@@ -34,12 +34,40 @@ The DNS plugin gathers dns query times in miliseconds - like [Dig](https://en.wi
     - domain
     - record_type
     - result
+    - rcode
   - fields:
     - query_time_ms (float)
     - result_code (int, success = 0, timeout = 1, error = 2)
+    - rcode_value (int)
+
+
+### Rcode Descriptions
+|rcode_value|rcode|Description|
+|---|-----------|-----------------------------------|
+|0  | NoError   | No Error                          |
+|1  | FormErr   | Format Error                      |
+|2  | ServFail  | Server Failure                    |
+|3  | NXDomain  | Non-Existent Domain               |
+|4  | NotImp    | Not Implemented                   |
+|5  | Refused   | Query Refused                     |
+|6  | YXDomain  | Name Exists when it should not    |
+|7  | YXRRSet   | RR Set Exists when it should not  |
+|8  | NXRRSet   | RR Set that should exist does not |
+|9  | NotAuth   | Server Not Authoritative for zone |
+|10 | NotZone   | Name not contained in zone        |
+|16 | BADSIG    | TSIG Signature Failure            |
+|16 | BADVERS   | Bad OPT Version                   |
+|17 | BADKEY    | Key not recognized                |
+|18 | BADTIME   | Signature out of time window      |
+|19 | BADMODE   | Bad TKEY Mode                     |
+|20 | BADNAME   | Duplicate key name                |
+|21 | BADALG    | Algorithm not supported           |
+|22 | BADTRUNC  | Bad Truncation                    |
+|23 | BADCOOKIE | Bad/missing Server Cookie         |
+
 
 ### Example Output:
 
 ```
-dns_query,domain=mjasion.pl,record_type=A,server=8.8.8.8 query_time_ms=67.189842 1456082743585760680
+dns_query,domain=google.com,rcode=NOERROR,record_type=A,result=success,server=127.0.0.1 rcode_value=0i,result_code=0i,query_time_ms=0.13746 1550020750001000000
 ```

--- a/plugins/inputs/dns_query/dns_query.go
+++ b/plugins/inputs/dns_query/dns_query.go
@@ -150,7 +150,7 @@ func (d *DnsQuery) getDnsQueryTime(domain string, server string) (float64, error
 		return dnsQueryTime, err
 	}
 	if r.Rcode != dns.RcodeSuccess {
-		return dnsQueryTime, errors.New(fmt.Sprintf("Invalid answer name %s after %s query for %s\n", domain, d.RecordType, domain))
+		return dnsQueryTime, errors.New(fmt.Sprintf("Invalid answer (%s) from %s after %s query for %s", dns.RcodeToString[r.Rcode], server, d.RecordType, domain))
 	}
 	dnsQueryTime = float64(rtt.Nanoseconds()) / 1e6
 	return dnsQueryTime, nil

--- a/plugins/inputs/dns_query/dns_query.go
+++ b/plugins/inputs/dns_query/dns_query.go
@@ -85,7 +85,11 @@ func (d *DnsQuery) Gather(acc telegraf.Accumulator) error {
 					"record_type": d.RecordType,
 				}
 
-				dnsQueryTime, err := d.getDnsQueryTime(domain, server)
+				dnsQueryTime, rcode, err := d.getDnsQueryTime(domain, server)
+				if rcode >= 0 {
+					tags["rcode"] = dns.RcodeToString[rcode]
+					fields["rcode_value"] = rcode
+				}
 				if err == nil {
 					setResult(Success, fields, tags)
 					fields["query_time_ms"] = dnsQueryTime
@@ -130,7 +134,7 @@ func (d *DnsQuery) setDefaultValues() {
 	}
 }
 
-func (d *DnsQuery) getDnsQueryTime(domain string, server string) (float64, error) {
+func (d *DnsQuery) getDnsQueryTime(domain string, server string) (float64, int, error) {
 	dnsQueryTime := float64(0)
 
 	c := new(dns.Client)
@@ -140,20 +144,20 @@ func (d *DnsQuery) getDnsQueryTime(domain string, server string) (float64, error
 	m := new(dns.Msg)
 	recordType, err := d.parseRecordType()
 	if err != nil {
-		return dnsQueryTime, err
+		return dnsQueryTime, -1, err
 	}
 	m.SetQuestion(dns.Fqdn(domain), recordType)
 	m.RecursionDesired = true
 
 	r, rtt, err := c.Exchange(m, net.JoinHostPort(server, strconv.Itoa(d.Port)))
 	if err != nil {
-		return dnsQueryTime, err
+		return dnsQueryTime, -1, err
 	}
 	if r.Rcode != dns.RcodeSuccess {
-		return dnsQueryTime, errors.New(fmt.Sprintf("Invalid answer (%s) from %s after %s query for %s", dns.RcodeToString[r.Rcode], server, d.RecordType, domain))
+		return dnsQueryTime, r.Rcode, fmt.Errorf("Invalid answer (%s) from %s after %s query for %s", dns.RcodeToString[r.Rcode], server, d.RecordType, domain)
 	}
 	dnsQueryTime = float64(rtt.Nanoseconds()) / 1e6
-	return dnsQueryTime, nil
+	return dnsQueryTime, r.Rcode, nil
 }
 
 func (d *DnsQuery) parseRecordType() (uint16, error) {


### PR DESCRIPTION
Resolves #5276 

From what I see it's always been creating a metric with the result and result_code, but I've enhanced the logging to give more information:

```
2019-02-12T15:41:12Z E! [inputs.dns_query]: Error in plugin: Invalid answer (NXDOMAIN) from 127.0.0.1 after A query for definitelynotreal.com
dns_query,domain=definitelynotreal.com,record_type=A,result=error,server=127.0.0.1 result_code=2i 1549986072000000000
dns_query,domain=google.com,record_type=A,result=success,server=127.0.0.1 result_code=0i,query_time_ms=0.440704 1549986072000000000
```