### PR TITLE
Fix InfluxDB UDP line splitting (#5438)

### DIFF
--- a/plugins/serializers/influx/influx.go
+++ b/plugins/serializers/influx/influx.go
@@ -240,6 +240,7 @@ func (s *Serializer) writeMetric(w io.Writer, m telegraf.Metric) error {
 				return err
 			}
 
+			pairsLen = 0
 			firstField = true
 			bytesNeeded = len(s.header) + len(s.pair) + len(s.footer)
 

--- a/plugins/serializers/influx/influx_test.go
+++ b/plugins/serializers/influx/influx_test.go
@@ -277,7 +277,7 @@ var tests = []struct {
 	},
 	{
 		name:     "split_fields_overflow",
-		maxBytes: 36,
+		maxBytes: 43,
 		input: MustMetric(
 			metric.New(
 				"cpu",
@@ -285,11 +285,13 @@ var tests = []struct {
 				map[string]interface{}{
 					"abc": 123,
 					"def": 456,
+					"ghi": 789,
+					"jkl": 123,
 				},
 				time.Unix(1519194109, 42),
 			),
 		),
-		output: []byte("cpu abc=123i 1519194109000000042\ncpu def=456i 1519194109000000042\n"),
+		output: []byte("cpu abc=123i,def=456i 1519194109000000042\ncpu ghi=789i,jkl=123i 1519194109000000042\n"),
 	},
 	{
 		name: "name newline",

--- a/plugins/serializers/influx/influx_test.go
+++ b/plugins/serializers/influx/influx_test.go
@@ -276,6 +276,22 @@ var tests = []struct {
 		output: []byte("cpu abc=123i 1519194109000000042\ncpu def=456i 1519194109000000042\n"),
 	},
 	{
+		name:     "split_fields_overflow",
+		maxBytes: 36,
+		input: MustMetric(
+			metric.New(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{
+					"abc": 123,
+					"def": 456,
+				},
+				time.Unix(1519194109, 42),
+			),
+		),
+		output: []byte("cpu abc=123i 1519194109000000042\ncpu def=456i 1519194109000000042\n"),
+	},
+	{
 		name: "name newline",
 		input: MustMetric(
 			metric.New(


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.

Fixes #5438 

- Set MaxLineBytes correctly
- Split the data to utilize as much of the datagram as possible (even with MaxLineBytes set correctly each metric that did not fit into the first datagram was split up separately)
- Split the byte slice from serializer to separate UDP datagrams if there are multiple lines