### PR TITLE
Support Azure Sovereign Environments with EndpointOverride argument

### DIFF
--- a/plugins/outputs/azure_monitor/README.md
+++ b/plugins/outputs/azure_monitor/README.md
@@ -44,7 +44,7 @@ written as a dimension on each Azure Monitor metric.
   ## Optionally, if in Azure US Government, China, or other sovereign
   ## cloud environment, set the appropriate REST endpoint for receiving
   ## metrics. (Note: region may be  unused in this context)
-  # endpoint_override = "monitoring.core.usgovcloudapi.net"
+  # endpoint_url = "https://monitoring.core.usgovcloudapi.net"
 ```
 
 ### Setup

--- a/plugins/outputs/azure_monitor/README.md
+++ b/plugins/outputs/azure_monitor/README.md
@@ -40,6 +40,11 @@ written as a dimension on each Azure Monitor metric.
   ## The Azure Resource ID against which metric will be logged, e.g.
   ##   ex: resource_id = "/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.Compute/virtualMachines/<vm_name>"
   # resource_id = ""
+  
+  ## Optionally, if in Azure US Government, China, or other sovereign
+  ## cloud environment, set the appropriate REST endpoint for receiving
+  ## metrics. (Note: region may be  unused in this context)
+  # endpoint_override = "monitoring.core.usgovcloudapi.net"
 ```
 
 ### Setup

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -149,10 +149,10 @@ func (a *AzureMonitor) Connect() error {
 		return fmt.Errorf("no region configured or available via VM instance metadata")
 	}
 
-        if EndpointOverride == "" {
+        if endpointOverride == "" {
 	        a.url = fmt.Sprintf(urlTemplate, region, resourceID)
 	} else {
-	        a.url = fmt.Sprintf("https://%s%s/metrics", EndpointOverride, resourceID)
+	        a.url = fmt.Sprintf("https://%s%s/metrics", endpointOverride, resourceID)
 	}
 
 	log.Printf("D! Writing to Azure Monitor URL: %s", a.url)

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -128,7 +128,7 @@ func (a *AzureMonitor) Connect() error {
 	var region string
 	var resourceID string
 	var endpointOverride string
-	
+
 	if a.Region == "" || a.ResourceID == "" {
 		// Pull region and resource identifier
 		region, resourceID, err = vmInstanceMetadata(a.client)
@@ -143,7 +143,7 @@ func (a *AzureMonitor) Connect() error {
 		resourceID = a.ResourceID
 	}
 	if a.EndpointOverride != "" {
-	        endpointOverride = a.EndpointOverride
+		endpointOverride = a.EndpointOverride
 	}
 
 	if resourceID == "" {
@@ -152,10 +152,10 @@ func (a *AzureMonitor) Connect() error {
 		return fmt.Errorf("no region configured or available via VM instance metadata")
 	}
 
-        if endpointOverride == "" {
-	        a.url = fmt.Sprintf(urlTemplate, region, resourceID)
+	if endpointOverride == "" {
+		a.url = fmt.Sprintf(urlTemplate, region, resourceID)
 	} else {
-	        a.url = fmt.Sprintf(urlOverrideTemplate, endpointOverride, resourceID)
+		a.url = fmt.Sprintf(urlOverrideTemplate, endpointOverride, resourceID)
 	}
 
 	log.Printf("D! Writing to Azure Monitor URL: %s", a.url)

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -93,6 +93,11 @@ var sampleConfig = `
   ## The Azure Resource ID against which metric will be logged, e.g.
   ##   ex: resource_id = "/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.Compute/virtualMachines/<vm_name>"
   # resource_id = ""
+
+  ## Optionall, if in Azure US Government, China or other sovereign
+  ## cloud environment, set appropriate REST endpoint for receiving
+  ## metrics. (Note: region may be unused in this context)
+  # endpoint_url = "https://monitoring.core.usgovcloudapi.net"
 `
 
 // Description provides a description of the plugin

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -31,6 +31,7 @@ type AzureMonitor struct {
 	StringsAsDimensions bool   `toml:"strings_as_dimensions"`
 	Region              string
 	ResourceID          string `toml:"resource_id"`
+	EndpointOverride    string `toml:"endpoint_override"`
 
 	url    string
 	auth   autorest.Authorizer
@@ -138,13 +139,21 @@ func (a *AzureMonitor) Connect() error {
 	if a.ResourceID != "" {
 		resourceID = a.ResourceID
 	}
+	if a.EndpointOverride != "" {
+	        endpointOverride = a.EndpointOverride
+	}
 
 	if resourceID == "" {
 		return fmt.Errorf("no resource ID configured or available via VM instance metadata")
 	} else if region == "" {
 		return fmt.Errorf("no region configured or available via VM instance metadata")
 	}
-	a.url = fmt.Sprintf(urlTemplate, region, resourceID)
+
+        if EndpointOverride == "" {
+	        a.url = fmt.Sprintf(urlTemplate, region, resourceID)
+	} else {
+	        a.url = fmt.Sprintf("https://%s%s/metrics", EndpointOverride, resourceID)
+	}
 
 	log.Printf("D! Writing to Azure Monitor URL: %s", a.url)
 

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -127,6 +127,8 @@ func (a *AzureMonitor) Connect() error {
 	var err error
 	var region string
 	var resourceID string
+	var endpointOverride string
+	
 	if a.Region == "" || a.ResourceID == "" {
 		// Pull region and resource identifier
 		region, resourceID, err = vmInstanceMetadata(a.client)

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -31,7 +31,7 @@ type AzureMonitor struct {
 	StringsAsDimensions bool   `toml:"strings_as_dimensions"`
 	Region              string
 	ResourceID          string `toml:"resource_id"`
-	EndpointURL         string `toml:"endpoint_url"`
+	EndpointUrl         string `toml:"endpoint_url"`
 
 	url    string
 	auth   autorest.Authorizer

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -94,7 +94,7 @@ var sampleConfig = `
   ##   ex: resource_id = "/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.Compute/virtualMachines/<vm_name>"
   # resource_id = ""
 
-  ## Optionall, if in Azure US Government, China or other sovereign
+  ## Optionally, if in Azure US Government, China or other sovereign
   ## cloud environment, set appropriate REST endpoint for receiving
   ## metrics. (Note: region may be unused in this context)
   # endpoint_url = "https://monitoring.core.usgovcloudapi.net"

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -31,7 +31,7 @@ type AzureMonitor struct {
 	StringsAsDimensions bool   `toml:"strings_as_dimensions"`
 	Region              string
 	ResourceID          string `toml:"resource_id"`
-	EndpointOverride    string `toml:"endpoint_override"`
+	EndpointURL         string `toml:"endpoint_url"`
 
 	url    string
 	auth   autorest.Authorizer
@@ -66,7 +66,7 @@ const (
 	vmInstanceMetadataURL = "http://169.254.169.254/metadata/instance?api-version=2017-12-01"
 	resourceIDTemplate    = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s"
 	urlTemplate           = "https://%s.monitoring.azure.com%s/metrics"
-	urlOverrideTemplate   = "https://monitoring.%s%s/metrics"
+	urlOverrideTemplate   = "%s%s/metrics"
 	maxRequestBodySize    = 4000000
 )
 
@@ -127,7 +127,7 @@ func (a *AzureMonitor) Connect() error {
 	var err error
 	var region string
 	var resourceID string
-	var endpointOverride string
+	var endpointUrl string
 
 	if a.Region == "" || a.ResourceID == "" {
 		// Pull region and resource identifier
@@ -142,8 +142,8 @@ func (a *AzureMonitor) Connect() error {
 	if a.ResourceID != "" {
 		resourceID = a.ResourceID
 	}
-	if a.EndpointOverride != "" {
-		endpointOverride = a.EndpointOverride
+	if a.EndpointUrl != "" {
+		endpointUrl = a.EndpointUrl
 	}
 
 	if resourceID == "" {
@@ -152,10 +152,10 @@ func (a *AzureMonitor) Connect() error {
 		return fmt.Errorf("no region configured or available via VM instance metadata")
 	}
 
-	if endpointOverride == "" {
+	if endpointUrl == "" {
 		a.url = fmt.Sprintf(urlTemplate, region, resourceID)
 	} else {
-		a.url = fmt.Sprintf(urlOverrideTemplate, endpointOverride, resourceID)
+		a.url = fmt.Sprintf(urlOverrideTemplate, endpointUrl, resourceID)
 	}
 
 	log.Printf("D! Writing to Azure Monitor URL: %s", a.url)

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -66,6 +66,7 @@ const (
 	vmInstanceMetadataURL = "http://169.254.169.254/metadata/instance?api-version=2017-12-01"
 	resourceIDTemplate    = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s"
 	urlTemplate           = "https://%s.monitoring.azure.com%s/metrics"
+	urlOverrideTemplate   = "https://monitoring.%s%s/metrics"
 	maxRequestBodySize    = 4000000
 )
 
@@ -152,7 +153,7 @@ func (a *AzureMonitor) Connect() error {
         if endpointOverride == "" {
 	        a.url = fmt.Sprintf(urlTemplate, region, resourceID)
 	} else {
-	        a.url = fmt.Sprintf("https://%s%s/metrics", endpointOverride, resourceID)
+	        a.url = fmt.Sprintf(urlOverrideTemplate, endpointOverride, resourceID)
 	}
 
 	log.Printf("D! Writing to Azure Monitor URL: %s", a.url)


### PR DESCRIPTION
Azure sovereign cloud environments do not conform to the `<region>.monitoring.azure.com` endpoint address.  This proposed change looks to allow for an override of the endpoint URL so that metrics can be pushed to the appropriate URL and Azure Monitor.

Attempts to address #5452 and this is my first PR to this project.  Before I continue further, I'd like to get some insight/feedback on this approach and if it seems reasonable, will continue by building out the necessary unit tests (e.g. endpoint_override = "testymctesturl.testing")? 

Comments and insights appreciated (_also, I'm not a go programmer by any means, but wanted to contribute this_)

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [ ] Has appropriate unit tests.
