### PR TITLE
Wavefront Parser: accept values with a negative exponent

### DIFF
--- a/plugins/parsers/wavefront/element.go
+++ b/plugins/parsers/wavefront/element.go
@@ -60,7 +60,7 @@ func (ep *ValueParser) parse(p *PointParser, pt *Point) error {
 		tok, lit = p.scan()
 	}
 
-	for tok != EOF && (tok == LETTER || tok == NUMBER || tok == DOT) {
+	for tok != EOF && (tok == LETTER || tok == NUMBER || tok == DOT || tok == MINUS_SIGN) {
 		p.writeBuf.WriteString(lit)
 		tok, lit = p.scan()
 	}

--- a/plugins/parsers/wavefront/parser_test.go
+++ b/plugins/parsers/wavefront/parser_test.go
@@ -63,6 +63,24 @@ func TestParse(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, parsedMetrics[0], testMetric)
 
+	parsedMetrics, err = parser.Parse([]byte("\"test.metric\" -1.1234 1530939936 \"source\"=\"mysource\" tag2=value2"))
+	assert.NoError(t, err)
+	testMetric, err = metric.New("test.metric", map[string]string{"source": "mysource", "tag2": "value2"}, map[string]interface{}{"value": -1.1234}, time.Unix(1530939936, 0))
+	assert.NoError(t, err)
+	assert.EqualValues(t, parsedMetrics[0], testMetric)
+
+	parsedMetrics, err = parser.Parse([]byte("\"test.metric\" 1.1234e04 1530939936 \"source\"=\"mysource\" tag2=value2"))
+	assert.NoError(t, err)
+	testMetric, err = metric.New("test.metric", map[string]string{"source": "mysource", "tag2": "value2"}, map[string]interface{}{"value": 1.1234e04}, time.Unix(1530939936, 0))
+	assert.NoError(t, err)
+	assert.EqualValues(t, parsedMetrics[0], testMetric)
+
+	parsedMetrics, err = parser.Parse([]byte("\"test.metric\" 1.1234e-04 1530939936 \"source\"=\"mysource\" tag2=value2"))
+	assert.NoError(t, err)
+	testMetric, err = metric.New("test.metric", map[string]string{"source": "mysource", "tag2": "value2"}, map[string]interface{}{"value": 1.1234e-04}, time.Unix(1530939936, 0))
+	assert.NoError(t, err)
+	assert.EqualValues(t, parsedMetrics[0], testMetric)
+
 	parsedMetrics, err = parser.Parse([]byte("test.metric		 1.1234      1530939936 	source=\"mysource\"    tag2=value2     "))
 	assert.NoError(t, err)
 	testMetric, err = metric.New("test.metric", map[string]string{"source": "mysource", "tag2": "value2"}, map[string]interface{}{"value": 1.1234}, time.Unix(1530939936, 0))
@@ -199,6 +217,9 @@ func TestParseInvalid(t *testing.T) {
 	assert.Error(t, err)
 
 	_, err = parser.Parse([]byte("test.metric 1 1530939936 tag1=val\\\"ue1"))
+	assert.Error(t, err)
+
+	_, err = parser.Parse([]byte("\"test.metric\" -1.12-34 1530939936 \"source\"=\"mysource\" tag2=value2"))
 	assert.Error(t, err)
 
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Values with negative exponents were being rejected. This patch allows values of the form `1.0E-05` to pass through.  Unit tests added accordingly.