### PR TITLE
Move capacity check for stackdriver output plugin

### DIFF
--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -199,7 +199,7 @@ func (s *Stackdriver) Write(metrics []telegraf.Metric) error {
 	for len(buckets) != 0 {
 		// can send up to 200 time series to stackdriver
 		timeSeries := make([]*monitoringpb.TimeSeries, 0, 200)
-		for i := 0; i < len(keys); i++ {
+		for i := 0; i < len(keys) && len(timeSeries) < cap(timeSeries); i++ {
 			k := keys[i]
 			s := buckets[k]
 			timeSeries = append(timeSeries, s[0])
@@ -212,10 +212,6 @@ func (s *Stackdriver) Write(metrics []telegraf.Metric) error {
 
 			s = s[1:]
 			buckets[k] = s
-
-			if len(timeSeries) == cap(timeSeries) {
-				break
-			}
 		}
 
 		// Prepare time series request.


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

@danielnelson Apologies for the succession of incomplete fixes - the current `master` can encounter off-by-one-errors writing > 200 timeseries per request because the loop was broken too late. This adrdesses that - has been running the past 3 days with decent loads without any issues. Good news is compared to before the bucket-batching we are seeing over an order of magnitude of reduction in requests.
