### PR TITLE
Remove 'inputs.' prefix when logging loaded inputs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,7 +160,7 @@ func (c *Config) InputNames() []string {
 func (c *Config) AggregatorNames() []string {
 	var name []string
 	for _, aggregator := range c.Aggregators {
-		name = append(name, aggregator.Name())
+		name = append(name, aggregator.Config.Name)
 	}
 	return name
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,7 +151,7 @@ type AgentConfig struct {
 func (c *Config) InputNames() []string {
 	var name []string
 	for _, input := range c.Inputs {
-		name = append(name, input.Name())
+		name = append(name, input.Config.Name)
 	}
 	return name
 }


### PR DESCRIPTION
Resolves #5475