### PR TITLE
Open log file in append mode.

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -50,16 +50,10 @@ func SetupLogging(debug, quiet bool, logfile string) {
 
 	var oFile *os.File
 	if logfile != "" {
-		if _, err := os.Stat(logfile); os.IsNotExist(err) {
-			if oFile, err = os.Create(logfile); err != nil {
-				log.Printf("E! Unable to create %s (%s), using stderr", logfile, err)
-				oFile = os.Stderr
-			}
-		} else {
-			if oFile, err = os.OpenFile(logfile, os.O_APPEND|os.O_WRONLY, os.ModeAppend); err != nil {
-				log.Printf("E! Unable to append to %s (%s), using stderr", logfile, err)
-				oFile = os.Stderr
-			}
+		var err error
+		if oFile, err = os.OpenFile(logfile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, os.ModeAppend|0644); err != nil {
+			log.Printf("E! Unable to open %s (%s), using stderr", logfile, err)
+			oFile = os.Stderr
 		}
 	} else {
 		oFile = os.Stderr

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -64,6 +64,29 @@ func TestAddDefaultLogLevel(t *testing.T) {
 	assert.Equal(t, f[19:], []byte("Z I! TEST\n"))
 }
 
+func TestWriteToTruncatedFile(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+	defer func() { os.Remove(tmpfile.Name()) }()
+
+	SetupLogging(true, false, tmpfile.Name())
+	log.Printf("TEST")
+
+	f, err := ioutil.ReadFile(tmpfile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, f[19:], []byte("Z I! TEST\n"))
+
+	tmpf, err := os.OpenFile(tmpfile.Name(), os.O_TRUNC, 0644)
+	assert.NoError(t, err)
+	assert.NoError(t, tmpf.Close())
+
+	log.Printf("SHOULD BE FIRST")
+
+	f, err = ioutil.ReadFile(tmpfile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, f[19:], []byte("Z I! SHOULD BE FIRST\n"))
+}
+
 func BenchmarkTelegrafLogWrite(b *testing.B) {
 	var msg = []byte("test")
 	var buf bytes.Buffer


### PR DESCRIPTION
Problem:
When log file didn't exist the agent used to create a file without `O_APPEND` mode. This led to the file growing indefinitely, because the writes ignored the truncated file (by the current `logrotate` settings) and did not update the fd offset.

When you write to the offset bigger than the current file size, the file is expanded by the OS (at least Linux), the gap is filled with `\0`.

Note:
This behavior doesn't apply when the log file has already been created before Telegraf starts. The file opened in the proper append mode then.

Fix:
Always open in `O_APPEND` mode.

### Required for all PRs:

- [ x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] ~Associated README.md updated.~ Not needed
- [ x] Has appropriate unit tests.
