### PR TITLE
Ignore tracking for metrics added to aggregator

### DIFF
--- a/metric/metric.go
+++ b/metric/metric.go
@@ -62,6 +62,28 @@ func New(
 	return m, nil
 }
 
+// FromMetric returns a deep copy of the metric with any tracking information
+// removed.
+func FromMetric(other telegraf.Metric) telegraf.Metric {
+	m := &metric{
+		name:      other.Name(),
+		tags:      make([]*telegraf.Tag, len(other.TagList())),
+		fields:    make([]*telegraf.Field, len(other.FieldList())),
+		tm:        other.Time(),
+		tp:        other.Type(),
+		aggregate: other.IsAggregate(),
+	}
+
+	for i, tag := range other.TagList() {
+		m.tags[i] = &telegraf.Tag{Key: tag.Key, Value: tag.Value}
+	}
+
+	for i, field := range other.FieldList() {
+		m.fields[i] = &telegraf.Field{Key: field.Key, Value: field.Value}
+	}
+	return m
+}
+
 func (m *metric) String() string {
 	return fmt.Sprintf("%s %v %v %d", m.name, m.Tags(), m.Fields(), m.tm.UnixNano())
 }


### PR DESCRIPTION
When passing a metric into an aggregator remove the tracking info and don't count it towards the metric refcount.

While it would be possible to track the metric in the aggregator, there are a few issues:
- The throughput would be limited to `max_undelivered / aggregator period`, since nothing would be delivered until the aggregator period ends.
- If the metric was not delivered, it is unlikely it can be aggregated again anyway, since we do not support aggregating metrics with timestamps in the past.  Reprocessing the metric would produce only the original metric, so its not helpful to hold off on marking it delivered.

closes #5325

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
