### PR TITLE
Floats in statsd percentiles

### DIFF
--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -34,8 +34,9 @@
   ## Reset timings & histograms every interval (default=true)
   delete_timings = true
 
-  ## Percentiles to calculate for timing & histogram stats
-  percentiles = [90]
+  ## Percentiles to calculate for timing & histogram stats.
+  ## These always have to be passed as floating-point numbers.
+  percentiles = [90.0]
 
   ## separator to use between elements of a statsd metric
   metric_separator = "_"

--- a/plugins/inputs/statsd/running_stats.go
+++ b/plugins/inputs/statsd/running_stats.go
@@ -99,7 +99,7 @@ func (rs *RunningStats) Count() int64 {
 	return rs.n
 }
 
-func (rs *RunningStats) Percentile(n int) float64 {
+func (rs *RunningStats) Percentile(n float64) float64 {
 	if n > 100 {
 		n = 100
 	}
@@ -109,16 +109,16 @@ func (rs *RunningStats) Percentile(n int) float64 {
 		rs.sorted = true
 	}
 
-	i := int(float64(len(rs.perc)) * float64(n) / float64(100))
+	i := float64(len(rs.perc)) * n / float64(100)
 	return rs.perc[clamp(i, 0, len(rs.perc)-1)]
 }
 
-func clamp(i int, min int, max int) int {
-	if i < min {
+func clamp(i float64, min int, max int) int {
+	if i < float64(min) {
 		return min
 	}
-	if i > max {
+	if i > float64(max) {
 		return max
 	}
-	return i
+	return int(i)
 }

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -55,7 +55,7 @@ type Statsd struct {
 
 	// Percentiles specifies the percentiles that will be calculated for timing
 	// and histogram stats.
-	Percentiles     []int
+	Percentiles     []float64
 	PercentileLimit int
 
 	DeleteGauges   bool
@@ -206,7 +206,7 @@ const sampleConfig = `
   delete_timings = true
 
   ## Percentiles to calculate for timing & histogram stats
-  percentiles = [90]
+  percentiles = [90.0]
 
   ## separator to use between elements of a statsd metric
   metric_separator = "_"

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -411,7 +411,7 @@ func TestParse_Counters(t *testing.T) {
 // Tests low-level functionality of timings
 func TestParse_Timings(t *testing.T) {
 	s := NewTestStatsd()
-	s.Percentiles = []int{90}
+	s.Percentiles = []float64{90.0}
 	acc := &testutil.Accumulator{}
 
 	// Test that counters work
@@ -1156,7 +1156,7 @@ func TestParse_MeasurementsWithMultipleValues(t *testing.T) {
 func TestParse_Timings_MultipleFieldsWithTemplate(t *testing.T) {
 	s := NewTestStatsd()
 	s.Templates = []string{"measurement.field"}
-	s.Percentiles = []int{90}
+	s.Percentiles = []float64{90.0}
 	acc := &testutil.Accumulator{}
 
 	validLines := []string{
@@ -1207,7 +1207,7 @@ func TestParse_Timings_MultipleFieldsWithTemplate(t *testing.T) {
 func TestParse_Timings_MultipleFieldsWithoutTemplate(t *testing.T) {
 	s := NewTestStatsd()
 	s.Templates = []string{}
-	s.Percentiles = []int{90}
+	s.Percentiles = []float64{90.0}
 	acc := &testutil.Accumulator{}
 
 	validLines := []string{


### PR DESCRIPTION
### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This addresses #5527. Note that this will be a breaking change for those using the plugin with the percentile array configured with integer numbers. It will now fail in those cases and only work with floats.

The already-present Unit Tests were only slightly changed to accept the correct type. No new tests were added.
A signed CLA should be on its way.