### PR TITLE
Fix open error handling in file output

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -129,10 +129,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	wg.Wait()
 
 	log.Printf("D! [agent] Closing outputs")
-	err = a.closeOutputs()
-	if err != nil {
-		return err
-	}
+	a.closeOutputs()
 
 	log.Printf("D! [agent] Stopped Successfully")
 	return nil
@@ -587,12 +584,10 @@ func (a *Agent) connectOutputs(ctx context.Context) error {
 }
 
 // closeOutputs closes all outputs.
-func (a *Agent) closeOutputs() error {
-	var err error
+func (a *Agent) closeOutputs() {
 	for _, output := range a.Config.Outputs {
-		err = output.Output.Close()
+		output.Close()
 	}
-	return err
 }
 
 // startServiceInputs starts all service inputs.

--- a/internal/models/running_output.go
+++ b/internal/models/running_output.go
@@ -180,6 +180,13 @@ func (ro *RunningOutput) WriteBatch() error {
 	return nil
 }
 
+func (ro *RunningOutput) Close() {
+	err := ro.Output.Close()
+	if err != nil {
+		log.Printf("E! [outputs.%s] Error closing output: %v", ro.Name, err)
+	}
+}
+
 func (ro *RunningOutput) write(metrics []telegraf.Metric) error {
 	start := time.Now()
 	err := ro.Output.Write(metrics)

--- a/plugins/outputs/file/file.go
+++ b/plugins/outputs/file/file.go
@@ -43,17 +43,11 @@ func (f *File) Connect() error {
 		if file == "stdout" {
 			f.writers = append(f.writers, os.Stdout)
 		} else {
-			var of *os.File
-			var err error
-			if _, err := os.Stat(file); os.IsNotExist(err) {
-				of, err = os.Create(file)
-			} else {
-				of, err = os.OpenFile(file, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
-			}
-
+			of, err := os.OpenFile(file, os.O_CREATE|os.O_APPEND|os.O_WRONLY, os.ModeAppend|0644)
 			if err != nil {
 				return err
 			}
+
 			f.writers = append(f.writers, of)
 			f.closers = append(f.closers, of)
 		}
@@ -62,16 +56,14 @@ func (f *File) Connect() error {
 }
 
 func (f *File) Close() error {
-	var errS string
+	var err error
 	for _, c := range f.closers {
-		if err := c.Close(); err != nil {
-			errS += err.Error() + "\n"
+		errClose := c.Close()
+		if errClose != nil {
+			err = errClose
 		}
 	}
-	if errS != "" {
-		return fmt.Errorf(errS)
-	}
-	return nil
+	return err
 }
 
 func (f *File) SampleConfig() string {


### PR DESCRIPTION
- Always use OpenFile, this way the file is always opened in append mode.
- Fix err handling, err was incorrectly shadowed
- Changed agent so that close errors are reported per plugin (eg `[outputs.file]`)

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
