### PR TITLE
Fix links and add config to webhook readme

### DIFF
--- a/plugins/inputs/webhooks/README.md
+++ b/plugins/inputs/webhooks/README.md
@@ -13,7 +13,36 @@ $ cp config.conf.new /etc/telegraf/telegraf.conf
 $ sudo service telegraf start
 ```
 
-## Available webhooks
+
+### Configuration:
+
+```toml
+[[inputs.webhooks]]
+  ## Address and port to host Webhook listener on
+  service_address = ":1619"
+
+  [inputs.webhooks.filestack]
+    path = "/filestack"
+
+  [inputs.webhooks.github]
+    path = "/github"
+    # secret = ""
+
+  [inputs.webhooks.mandrill]
+    path = "/mandrill"
+
+  [inputs.webhooks.rollbar]
+    path = "/rollbar"
+
+  [inputs.webhooks.papertrail]
+    path = "/papertrail"
+
+  [inputs.webhooks.particle]
+    path = "/particle"
+```
+
+
+### Available webhooks
 
 - [Filestack](filestack/)
 - [Github](github/)
@@ -23,7 +52,7 @@ $ sudo service telegraf start
 - [Particle](particle/)
 
 
-## Adding new webhooks plugin
+### Adding new webhooks plugin
 
 1. Add your webhook plugin inside the `webhooks` folder
 1. Your plugin must implement the `Webhook` interface

--- a/plugins/inputs/webhooks/filestack/README.md
+++ b/plugins/inputs/webhooks/filestack/README.md
@@ -1,6 +1,6 @@
 # Filestack webhook
 
-You should configure your Filestack's Webhooks to point at the `webhooks` service. To do this go to `filestack.com/`, select your app and click `Credentials > Webhooks`. In the resulting page, set the `URL` to `http://<my_ip>:1619/filestack`, and click on `Add`.
+You should configure your Filestack's Webhooks to point at the `webhooks` service. To do this go to [filestack.com](https://www.filestack.com/), select your app and click `Credentials > Webhooks`. In the resulting page, set the `URL` to `http://<my_ip>:1619/filestack`, and click on `Add`.
 
 ## Events
 

--- a/plugins/inputs/webhooks/mandrill/README.md
+++ b/plugins/inputs/webhooks/mandrill/README.md
@@ -1,6 +1,6 @@
 # mandrill webhook
 
-You should configure your Mandrill's Webhooks to point at the `webhooks` service. To do this go to `mandrillapp.com/` and click `Settings > Webhooks`. In the resulting page, click on `Add a Webhook`, select all events, and set the `URL` to `http://<my_ip>:1619/mandrill`, and click on `Create Webhook`.
+You should configure your Mandrill's Webhooks to point at the `webhooks` service. To do this go to [mandrillapp.com](https://mandrillapp.com) and click `Settings > Webhooks`. In the resulting page, click on `Add a Webhook`, select all events, and set the `URL` to `http://<my_ip>:1619/mandrill`, and click on `Create Webhook`.
 
 ## Events
 

--- a/plugins/inputs/webhooks/particle/README.md
+++ b/plugins/inputs/webhooks/particle/README.md
@@ -1,7 +1,7 @@
 # particle webhooks
 
 
-You should configure your Particle.io's Webhooks to point at the `webhooks` service. To do this go to `(https://console.particle.io/)[https://console.particle.io]` and click `Integrations > New Integration > Webhook`. In the resulting page set `URL` to `http://<my_ip>:1619/particle`, and  under `Advanced Settings` click on `JSON` and add:
+You should configure your Particle.io's Webhooks to point at the `webhooks` service. To do this go to [https://console.particle.io](https://console.particle.io/) and click `Integrations > New Integration > Webhook`. In the resulting page set `URL` to `http://<my_ip>:1619/particle`, and  under `Advanced Settings` click on `JSON` and add:
 
 ```
 {

--- a/plugins/inputs/webhooks/rollbar/README.md
+++ b/plugins/inputs/webhooks/rollbar/README.md
@@ -1,6 +1,6 @@
 # rollbar webhooks
 
-You should configure your Rollbar's Webhooks to point at the `webhooks` service. To do this go to `rollbar.com/` and click `Settings > Notifications > Webhook`. In the resulting page set `URL` to `http://<my_ip>:1619/rollbar`, and click on `Enable Webhook Integration`.
+You should configure your Rollbar's Webhooks to point at the `webhooks` service. To do this go to [rollbar.com](https://rollbar.com/) and click `Settings > Notifications > Webhook`. In the resulting page set `URL` to `http://<my_ip>:1619/rollbar`, and click on `Enable Webhook Integration`.
 
 ## Events
 

--- a/plugins/inputs/webhooks/webhooks.go
+++ b/plugins/inputs/webhooks/webhooks.go
@@ -67,7 +67,7 @@ func (wb *Webhooks) SampleConfig() string {
 
   [inputs.webhooks.particle]
     path = "/particle"
- `
+`
 }
 
 func (wb *Webhooks) Description() string {


### PR DESCRIPTION
Add configuration example and links to supported webhook sites.

It appears the individual webhook readmes were all based off of the same example. I don't quite believe that every supported webhook has the same methods of adding a webhook endpoint.