### PR TITLE
[inputs.vsphere] Introduce use_int_samples to obtain backwards compatibility

### DIFF
--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -983,7 +983,7 @@ func (e *Endpoint) collectChunk(ctx context.Context, pqs []types.PerfQuerySpec, 
 					bucket.fields[fn] = float64(v) / 100.0
 				} else {
 					if e.Parent.UseIntSamples {
-						bucket.fields[fn] = int64(math.Round(v))
+						bucket.fields[fn] = int64(round(v))
 					} else {
 						bucket.fields[fn] = v
 					}
@@ -1088,7 +1088,7 @@ func cleanDiskTag(disk string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(disk, "<"), ">")
 }
 
-func Round(x float64) float64 {
+func round(x float64) float64 {
 	t := math.Trunc(x)
 	if math.Abs(x-t) >= 0.5 {
 		return t + math.Copysign(1, x)

--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"math/rand"
 	"net/url"
 	"regexp"
@@ -948,7 +949,7 @@ func (e *Endpoint) collectChunk(ctx context.Context, pqs []types.PerfQuerySpec, 
 			e.populateTags(&objectRef, resourceType, res, t, &v)
 
 			nValues := 0
-			alignedInfo, alignedValues := alignSamples(em.SampleInfo, v.Value, interval) // TODO: Estimate interval
+			alignedInfo, alignedValues := alignSamples(em.SampleInfo, v.Value, interval)
 
 			for idx, sample := range alignedInfo {
 				// According to the docs, SampleInfo and Value should have the same length, but we've seen corrupted
@@ -981,7 +982,11 @@ func (e *Endpoint) collectChunk(ctx context.Context, pqs []types.PerfQuerySpec, 
 				if info.UnitInfo.GetElementDescription().Key == "percent" {
 					bucket.fields[fn] = float64(v) / 100.0
 				} else {
-					bucket.fields[fn] = v
+					if e.Parent.UseIntSamples {
+						bucket.fields[fn] = int64(math.Round(v))
+					} else {
+						bucket.fields[fn] = v
+					}
 				}
 				count++
 

--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -1087,3 +1087,11 @@ func cleanDiskTag(disk string) string {
 	// Remove enclosing "<>"
 	return strings.TrimSuffix(strings.TrimPrefix(disk, "<"), ">")
 }
+
+func Round(x float64) float64 {
+	t := math.Trunc(x)
+	if math.Abs(x-t) >= 0.5 {
+		return t + math.Copysign(1, x)
+	}
+	return t
+}

--- a/plugins/inputs/vsphere/finder.go
+++ b/plugins/inputs/vsphere/finder.go
@@ -79,7 +79,6 @@ func (f *Finder) descend(ctx context.Context, root types.ManagedObjectReference,
 	}
 
 	m := view.NewManager(f.client.Client.Client)
-	defer m.Destroy(ctx)
 	v, err := m.CreateContainerView(ctx, root, ct, false)
 	if err != nil {
 		return err

--- a/plugins/inputs/vsphere/vsphere.go
+++ b/plugins/inputs/vsphere/vsphere.go
@@ -40,6 +40,7 @@ type VSphere struct {
 	DatastoreMetricExclude  []string
 	DatastoreInclude        []string
 	Separator               string
+	UseIntSamples           bool
 
 	MaxQueryObjects         int
 	MaxQueryMetrics         int
@@ -199,6 +200,12 @@ var sampleConfig = `
   ## timeout applies to any of the api request made to vcenter
   # timeout = "60s"
 
+  ## When set to true, all samples are sent as integers. This makes the output data types backwards compatible
+  ## with Telegraf 1.9 or lower. Normally all samples from vCenter, with the exception of percentages, are 
+  ## integer values, but under some conditions, some averaging takes place internally in the plugin. Setting this
+  ## flag to "false" will send values as floats to preserve the full precision when averaging takes place.
+  # use_int_samples = true
+
   ## Optional SSL Config
   # ssl_ca = "/path/to/cafile"
   # ssl_cert = "/path/to/certfile"
@@ -312,6 +319,7 @@ func init() {
 			DatastoreMetricExclude:  nil,
 			DatastoreInclude:        []string{"/*/datastore/**"},
 			Separator:               "_",
+			UseIntSamples:           true,
 
 			MaxQueryObjects:         256,
 			MaxQueryMetrics:         256,


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

TL;DR version:
In version 1.10, we changed the data type of all samples to floating point. This caused problems when sending data to existing InfluxDB databases. The ```use_int_samples``` forces the plugin to send int samples for everything except percentages.

Long version:
Under certain conditions, such as high load, vCenter can significantly delay sample delivery. When this happens, the plugin will see empty samples for the current time period. To solve this, we have to look back a certain number of sample periods to catch delayed data. Unfortunately, that data can come in at different time series granularity, so we apply a normalization process implemented in Endpoint.alignMetrics. This process consists of dividing the raw time series into buckets according to the desired sample period. If two or more samples end up in the same bucket, averaging occurs.

All vCenter metrics are integers, but when averaging occurs as described above, we need to use floating point math. Since the result of the normalization is a floating point vector, we changed the sample type to always be a float. Obviously, this was a mistake, since it breaks backwards compatibility.

The ```use_int_sample``` simply rounds output to the nearest integer and sends it as an integer type. Since the raw data was an integer, one could argue that this is just discarding false precision created in the averaging process. Either way, the rounding error should be negligible. 
