### PR TITLE
[inputs/diskio] Fix how major and minor identifiers of block devices are read.

### DIFF
--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -35,8 +35,8 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 		return ic.values, nil
 	}
 
-	major := unix.Major(stat.Rdev)
-	minor := unix.Minor(stat.Rdev)
+	major := unix.Major(uint64(stat.Rdev))
+	minor := unix.Minor(uint64(stat.Rdev))
 	udevDataPath := fmt.Sprintf("%s/b%d:%d", udevPath, major, minor)
 
 	di := map[string]string{}

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -36,7 +36,7 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	}
 
 	major := stat.Rdev >> 8 & 0xff
-	minor := stat.Rdev & 0xff
+	minor := (stat.Rdev & 0xff) | (stat.Rdev>>12)&^0xff
 	udevDataPath := fmt.Sprintf("%s/b%d:%d", udevPath, major, minor)
 
 	di := map[string]string{}

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -35,8 +35,8 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 		return ic.values, nil
 	}
 
-	major := stat.Rdev >> 8 & 0xff
-	minor := (stat.Rdev & 0xff) | (stat.Rdev>>12)&^0xff
+	major := unix.Major(stat.Rdev)
+	minor := unix.Minor(stat.Rdev)
 	udevDataPath := fmt.Sprintf("%s/b%d:%d", udevPath, major, minor)
 
 	di := map[string]string{}


### PR DESCRIPTION
The current implementation assure that the major and the minor are
coded on one byte. But they are not:

```
brw-rw----  1 root disk    252, 290 Feb 25 11:36 dm-290
```

290 as minor in this example is over 1 byte.

So after wondering why all my devices iops weren't correctly stored,
I found out that several points were added for some disks. For `dm-290`
it was overriding `252:34`, instead of getting udev stats for `252:290`.

The solution is here:
https://sites.uclouvain.be/SystInfo/usr/include/sys/sysmacros.h.html

The implementation is directly taken from this, fixing my bug.