### PR TITLE
[outputs/stackdriver] Allow to group metrics to bypass MetricDescriptor quota (500)

### DIFF
--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -24,6 +24,9 @@ Additional resource labels can be configured by `resource_labels`. By default th
   ## Custom resource type
   # resource_type = "generic_node"
 
+  ## Compact by type
+  # group_metrics = false
+
   ## Additonal resource labels
   # [outputs.stackdriver.resource_labels]
   #   node_id = "$HOSTNAME"


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

Hello, I propose to add capabilities to group metric by tag to allow to bypass Stackdriver quota. 
MetricDescriptor is limited to 500, so this PR allow to switch to register metrics like Stackdriver Agent and organize metrics by tags. 
Initial logic is preserve.

I don't write unit tests by I tested on my GCP environment.
