### PR TITLE
Allow only a config directory to be used

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -24,35 +24,35 @@ func TestAgent_OmitHostname(t *testing.T) {
 func TestAgent_LoadPlugin(t *testing.T) {
 	c := config.NewConfig()
 	c.InputFilters = []string{"mysql"}
-	err := c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err := c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ := NewAgent(c)
 	assert.Equal(t, 1, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"foo"}
-	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ = NewAgent(c)
 	assert.Equal(t, 0, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"mysql", "foo"}
-	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ = NewAgent(c)
 	assert.Equal(t, 1, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"mysql", "redis"}
-	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ = NewAgent(c)
 	assert.Equal(t, 2, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"mysql", "foo", "redis", "bar"}
-	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ = NewAgent(c)
 	assert.Equal(t, 2, len(a.Config.Inputs))
@@ -61,42 +61,42 @@ func TestAgent_LoadPlugin(t *testing.T) {
 func TestAgent_LoadOutput(t *testing.T) {
 	c := config.NewConfig()
 	c.OutputFilters = []string{"influxdb"}
-	err := c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err := c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ := NewAgent(c)
 	assert.Equal(t, 2, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"kafka"}
-	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ = NewAgent(c)
 	assert.Equal(t, 1, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{}
-	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ = NewAgent(c)
 	assert.Equal(t, 3, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"foo"}
-	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ = NewAgent(c)
 	assert.Equal(t, 0, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"influxdb", "foo"}
-	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ = NewAgent(c)
 	assert.Equal(t, 2, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"influxdb", "kafka"}
-	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(c.Outputs))
 	a, _ = NewAgent(c)
@@ -104,7 +104,7 @@ func TestAgent_LoadOutput(t *testing.T) {
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"influxdb", "foo", "kafka", "bar"}
-	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
+	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml", false)
 	assert.NoError(t, err)
 	a, _ = NewAgent(c)
 	assert.Equal(t, 3, len(a.Config.Outputs))

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -119,7 +119,7 @@ func runAgent(ctx context.Context,
 	c := config.NewConfig()
 	c.OutputFilters = outputFilters
 	c.InputFilters = inputFilters
-	err := c.LoadConfig(*fConfig)
+	err := c.LoadConfig(*fConfig, *fConfigDirectory != "")
 	if err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -550,7 +550,7 @@ func (c *Config) LoadDirectory(path string) error {
 		if len(name) < 6 || name[len(name)-5:] != ".conf" {
 			return nil
 		}
-		err := c.LoadConfig(thispath)
+		err := c.LoadConfig(thispath, false)
 		if err != nil {
 			return err
 		}
@@ -584,10 +584,13 @@ func getDefaultConfigPath() (string, error) {
 }
 
 // LoadConfig loads the given config file and applies it to c
-func (c *Config) LoadConfig(path string) error {
+func (c *Config) LoadConfig(path string, dirPath bool) error {
 	var err error
 	if path == "" {
 		if path, err = getDefaultConfigPath(); err != nil {
+			if dirPath {
+				return nil
+			}
 			return err
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,7 +21,7 @@ func TestConfig_LoadSingleInputWithEnvVars(t *testing.T) {
 	assert.NoError(t, err)
 	err = os.Setenv("TEST_INTERVAL", "10s")
 	assert.NoError(t, err)
-	c.LoadConfig("./testdata/single_plugin_env_vars.toml")
+	c.LoadConfig("./testdata/single_plugin_env_vars.toml", false)
 
 	memcached := inputs.Inputs["memcached"]().(*memcached.Memcached)
 	memcached.Servers = []string{"192.168.1.1"}
@@ -60,7 +60,7 @@ func TestConfig_LoadSingleInputWithEnvVars(t *testing.T) {
 
 func TestConfig_LoadSingleInput(t *testing.T) {
 	c := NewConfig()
-	c.LoadConfig("./testdata/single_plugin.toml")
+	c.LoadConfig("./testdata/single_plugin.toml", false)
 
 	memcached := inputs.Inputs["memcached"]().(*memcached.Memcached)
 	memcached.Servers = []string{"localhost"}
@@ -99,7 +99,7 @@ func TestConfig_LoadSingleInput(t *testing.T) {
 
 func TestConfig_LoadDirectory(t *testing.T) {
 	c := NewConfig()
-	err := c.LoadConfig("./testdata/single_plugin.toml")
+	err := c.LoadConfig("./testdata/single_plugin.toml", false)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
No longer require a config file to be specified/found if only a config
directory is used.

Resolves #5571