### PR TITLE
Use valid measurement names in csv parser

### DIFF
--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -204,7 +204,7 @@ outer:
 
 	// will default to plugin name
 	measurementName := p.MetricName
-	if recordFields[p.MeasurementColumn] != nil {
+	if recordFields[p.MeasurementColumn] != nil && recordFields[p.MeasurementColumn] != "" {
 		measurementName = fmt.Sprintf("%v", recordFields[p.MeasurementColumn])
 	}
 


### PR DESCRIPTION
If an empty column is present in parsed csv data, a `recordFields` is
set to the key of "". If no `MeasurementColumn` is defined, this empty
value was being used as the measurement name. By only setting the
measurementName if the value is not empty, we avoid this error.

Since an empty column is a valid column, skip values must account for
them.

Resolves #5530 