### PR TITLE
Improve stability of appveyor builds

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1202,6 +1202,7 @@
   ]
   pruneopts = ""
   revision = "a2144134853fc9a27a7b1e3eb4f19f1a76df13c9"
+  source = "https://github.com/golang/crypto.git"
 
 [[projects]]
   branch = "master"
@@ -1230,6 +1231,7 @@
   ]
   pruneopts = ""
   revision = "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1"
+  source = "https://github.com/golang/net.git"
 
 [[projects]]
   branch = "master"
@@ -1245,6 +1247,7 @@
   ]
   pruneopts = ""
   revision = "d2e6202438beef2727060aa7cabdd924d92ebfd9"
+  source = "https://github.com/golang/oauth2.git"
 
 [[projects]]
   branch = "master"
@@ -1256,6 +1259,7 @@
   ]
   pruneopts = ""
   revision = "42b317875d0fa942474b76e1b46a6060d720ae6e"
+  source = "https://github.com/golang/sync.git"
 
 [[projects]]
   branch = "master"
@@ -1272,6 +1276,7 @@
   ]
   pruneopts = ""
   revision = "7c4c994c65f702f41ed7d6620a2cb34107576a77"
+  source = "https://github.com/golang/sys.git"
 
 [[projects]]
   digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
@@ -1307,6 +1312,7 @@
   pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
+  source = "https://github.com/golang/text.git"
 
 [[projects]]
   branch = "master"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ version: "{build}"
 
 cache:
  - C:\Cache
+ - C:\gopath\pkg\dep\sources -> Gopkg.lock
 
 clone_folder: C:\gopath\src\github.com\influxdata\telegraf
 


### PR DESCRIPTION
Most of the errors I am seeing on Appveyor are caused by not being able to clone the golang.org/x repos.  The hosting for these repos does not appear to be very reliable, so this switches to the github.com mirrors.

Also cache the dep/sources directory unless the Gopkg.lock changes.

Might pull this over to release-1.10 if we continue to have problems there.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
