### PR TITLE
Fix nagios parser to parse all perfdata and report info message.

### DIFF
--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/kballard/go-shellquote"
@@ -66,26 +65,6 @@ type Runner interface {
 
 type CommandRunner struct{}
 
-func AddNagiosState(exitCode error, acc telegraf.Accumulator) error {
-	nagiosState := 0
-	if exitCode != nil {
-		exiterr, ok := exitCode.(*exec.ExitError)
-		if ok {
-			status, ok := exiterr.Sys().(syscall.WaitStatus)
-			if ok {
-				nagiosState = status.ExitStatus()
-			} else {
-				return fmt.Errorf("exec: unable to get nagios plugin exit code")
-			}
-		} else {
-			return fmt.Errorf("exec: unable to get nagios plugin exit code")
-		}
-	}
-	fields := map[string]interface{}{"state": nagiosState}
-	acc.AddFields("nagios_state", fields, nil)
-	return nil
-}
-
 func (c CommandRunner) Run(
 	e *Exec,
 	command string,
@@ -105,43 +84,46 @@ func (c CommandRunner) Run(
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 
-	if err := internal.RunTimeout(cmd, e.Timeout.Duration); err != nil {
-		switch e.parser.(type) {
-		case *nagios.NagiosParser:
-			AddNagiosState(err, acc)
-		default:
-			var errMessage = ""
-			if stderr.Len() > 0 {
-				stderr = removeCarriageReturns(stderr)
-				// Limit the number of bytes.
-				didTruncate := false
-				if stderr.Len() > MaxStderrBytes {
-					stderr.Truncate(MaxStderrBytes)
+	_, isNagiosParser := e.parser.(*nagios.NagiosParser)
+
+	err = internal.RunTimeout(cmd, e.Timeout.Duration)
+	nagiosErr := err
+	if err != nil && !isNagiosParser {
+		var errMessage = ""
+		if stderr.Len() > 0 {
+			stderr = removeCarriageReturns(stderr)
+			// Limit the number of bytes.
+			didTruncate := false
+			if stderr.Len() > MaxStderrBytes {
+				stderr.Truncate(MaxStderrBytes)
+				didTruncate = true
+			}
+			if i := bytes.IndexByte(stderr.Bytes(), '\n'); i > 0 {
+				// Only show truncation if the newline wasn't the last character.
+				if i < stderr.Len()-1 {
 					didTruncate = true
 				}
-				if i := bytes.IndexByte(stderr.Bytes(), '\n'); i > 0 {
-					// Only show truncation if the newline wasn't the last character.
-					if i < stderr.Len()-1 {
-						didTruncate = true
-					}
-					stderr.Truncate(i)
-				}
-				if didTruncate {
-					stderr.WriteString("...")
-				}
-
-				errMessage = fmt.Sprintf(": %s", stderr.String())
+				stderr.Truncate(i)
 			}
-			return nil, fmt.Errorf("exec: %s for command '%s'%s", err, command, errMessage)
+			if didTruncate {
+				stderr.WriteString("...")
+			}
+
+			errMessage = fmt.Sprintf(": %s", stderr.String())
 		}
-	} else {
-		switch e.parser.(type) {
-		case *nagios.NagiosParser:
-			AddNagiosState(nil, acc)
-		}
+		return nil, fmt.Errorf("exec: %s for command '%s'%s", err, command, errMessage)
 	}
 
 	out = removeCarriageReturns(out)
+
+	if isNagiosParser {
+		exitCode, err := nagios.GetExitCode(nagiosErr)
+		if err != nil {
+			return nil, fmt.Errorf("exec: get exit code: %s", err)
+		}
+		nagios.AppendExitCode(&out, exitCode)
+	}
+
 	return out.Bytes(), nil
 }
 

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -60,19 +61,18 @@ func NewExec() *Exec {
 }
 
 type Runner interface {
-	Run(*Exec, string, telegraf.Accumulator) ([]byte, error)
+	Run(string, time.Duration) ([]byte, []byte, error)
 }
 
 type CommandRunner struct{}
 
 func (c CommandRunner) Run(
-	e *Exec,
 	command string,
-	acc telegraf.Accumulator,
-) ([]byte, error) {
+	timeout time.Duration,
+) ([]byte, []byte, error) {
 	split_cmd, err := shellquote.Split(command)
 	if err != nil || len(split_cmd) == 0 {
-		return nil, fmt.Errorf("exec: unable to parse command, %s", err)
+		return nil, nil, fmt.Errorf("exec: unable to parse command, %s", err)
 	}
 
 	cmd := exec.Command(split_cmd[0], split_cmd[1:]...)
@@ -84,47 +84,35 @@ func (c CommandRunner) Run(
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 
-	_, isNagiosParser := e.parser.(*nagios.NagiosParser)
-
-	err = internal.RunTimeout(cmd, e.Timeout.Duration)
-	nagiosErr := err
-	if err != nil && !isNagiosParser {
-		var errMessage = ""
-		if stderr.Len() > 0 {
-			stderr = removeCarriageReturns(stderr)
-			// Limit the number of bytes.
-			didTruncate := false
-			if stderr.Len() > MaxStderrBytes {
-				stderr.Truncate(MaxStderrBytes)
-				didTruncate = true
-			}
-			if i := bytes.IndexByte(stderr.Bytes(), '\n'); i > 0 {
-				// Only show truncation if the newline wasn't the last character.
-				if i < stderr.Len()-1 {
-					didTruncate = true
-				}
-				stderr.Truncate(i)
-			}
-			if didTruncate {
-				stderr.WriteString("...")
-			}
-
-			errMessage = fmt.Sprintf(": %s", stderr.String())
-		}
-		return nil, fmt.Errorf("exec: %s for command '%s'%s", err, command, errMessage)
-	}
+	runErr := internal.RunTimeout(cmd, timeout)
 
 	out = removeCarriageReturns(out)
-
-	if isNagiosParser {
-		exitCode, err := nagios.GetExitCode(nagiosErr)
-		if err != nil {
-			return nil, fmt.Errorf("exec: get exit code: %s", err)
-		}
-		nagios.AppendExitCode(&out, exitCode)
+	if stderr.Len() > 0 {
+		stderr = removeCarriageReturns(stderr)
+		stderr = truncate(stderr)
 	}
 
-	return out.Bytes(), nil
+	return out.Bytes(), stderr.Bytes(), runErr
+}
+
+func truncate(buf bytes.Buffer) bytes.Buffer {
+	// Limit the number of bytes.
+	didTruncate := false
+	if buf.Len() > MaxStderrBytes {
+		buf.Truncate(MaxStderrBytes)
+		didTruncate = true
+	}
+	if i := bytes.IndexByte(buf.Bytes(), '\n'); i > 0 {
+		// Only show truncation if the newline wasn't the last character.
+		if i < buf.Len()-1 {
+			didTruncate = true
+		}
+		buf.Truncate(i)
+	}
+	if didTruncate {
+		buf.WriteString("...")
+	}
+	return buf
 }
 
 // removeCarriageReturns removes all carriage returns from the input if the
@@ -155,9 +143,11 @@ func removeCarriageReturns(b bytes.Buffer) bytes.Buffer {
 
 func (e *Exec) ProcessCommand(command string, acc telegraf.Accumulator, wg *sync.WaitGroup) {
 	defer wg.Done()
+	_, isNagios := e.parser.(*nagios.NagiosParser)
 
-	out, err := e.runner.Run(e, command, acc)
-	if err != nil {
+	out, errbuf, runErr := e.runner.Run(command, e.Timeout.Duration)
+	if !isNagios && runErr != nil {
+		err := fmt.Errorf("exec: %s for command '%s': %s", runErr, command, string(errbuf))
 		acc.AddError(err)
 		return
 	}
@@ -165,10 +155,18 @@ func (e *Exec) ProcessCommand(command string, acc telegraf.Accumulator, wg *sync
 	metrics, err := e.parser.Parse(out)
 	if err != nil {
 		acc.AddError(err)
-	} else {
-		for _, metric := range metrics {
-			acc.AddFields(metric.Name(), metric.Fields(), metric.Tags(), metric.Time())
+		return
+	}
+
+	if isNagios {
+		metrics, err = nagios.TryAddState(runErr, metrics)
+		if err != nil {
+			log.Printf("E! [inputs.exec] failed to add nagios state: %s", err)
 		}
+	}
+
+	for _, m := range metrics {
+		acc.AddMetric(m)
 	}
 }
 

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
+	"time"
 
-	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/parsers"
 
 	"github.com/influxdata/telegraf/testutil"
@@ -74,22 +74,21 @@ var crTests = []CarriageReturnTest{
 }
 
 type runnerMock struct {
-	out []byte
-	err error
+	out    []byte
+	errout []byte
+	err    error
 }
 
-func newRunnerMock(out []byte, err error) Runner {
+func newRunnerMock(out []byte, errout []byte, err error) Runner {
 	return &runnerMock{
-		out: out,
-		err: err,
+		out:    out,
+		errout: errout,
+		err:    err,
 	}
 }
 
-func (r runnerMock) Run(e *Exec, command string, acc telegraf.Accumulator) ([]byte, error) {
-	if r.err != nil {
-		return nil, r.err
-	}
-	return r.out, nil
+func (r runnerMock) Run(command string, _ time.Duration) ([]byte, []byte, error) {
+	return r.out, r.errout, r.err
 }
 
 func TestExec(t *testing.T) {
@@ -98,7 +97,7 @@ func TestExec(t *testing.T) {
 		MetricName: "exec",
 	})
 	e := &Exec{
-		runner:   newRunnerMock([]byte(validJson), nil),
+		runner:   newRunnerMock([]byte(validJson), nil, nil),
 		Commands: []string{"testcommand arg1"},
 		parser:   parser,
 	}
@@ -127,7 +126,7 @@ func TestExecMalformed(t *testing.T) {
 		MetricName: "exec",
 	})
 	e := &Exec{
-		runner:   newRunnerMock([]byte(malformedJson), nil),
+		runner:   newRunnerMock([]byte(malformedJson), nil, nil),
 		Commands: []string{"badcommand arg1"},
 		parser:   parser,
 	}
@@ -143,7 +142,7 @@ func TestCommandError(t *testing.T) {
 		MetricName: "exec",
 	})
 	e := &Exec{
-		runner:   newRunnerMock(nil, fmt.Errorf("exit status code 1")),
+		runner:   newRunnerMock(nil, nil, fmt.Errorf("exit status code 1")),
 		Commands: []string{"badcommand"},
 		parser:   parser,
 	}
@@ -199,6 +198,66 @@ func TestExecCommandWithoutGlobAndPath(t *testing.T) {
 		"value": "metric_value",
 	}
 	acc.AssertContainsFields(t, "metric", fields)
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name string
+		bufF func() *bytes.Buffer
+		expF func() *bytes.Buffer
+	}{
+		{
+			name: "should not truncate",
+			bufF: func() *bytes.Buffer {
+				var b bytes.Buffer
+				b.WriteString("hello world")
+				return &b
+			},
+			expF: func() *bytes.Buffer {
+				var b bytes.Buffer
+				b.WriteString("hello world")
+				return &b
+			},
+		},
+		{
+			name: "should truncate up to the new line",
+			bufF: func() *bytes.Buffer {
+				var b bytes.Buffer
+				b.WriteString("hello world\nand all the people")
+				return &b
+			},
+			expF: func() *bytes.Buffer {
+				var b bytes.Buffer
+				b.WriteString("hello world...")
+				return &b
+			},
+		},
+		{
+			name: "should truncate to the MaxStderrBytes",
+			bufF: func() *bytes.Buffer {
+				var b bytes.Buffer
+				for i := 0; i < 2*MaxStderrBytes; i++ {
+					b.WriteByte('b')
+				}
+				return &b
+			},
+			expF: func() *bytes.Buffer {
+				var b bytes.Buffer
+				for i := 0; i < MaxStderrBytes; i++ {
+					b.WriteByte('b')
+				}
+				b.WriteString("...")
+				return &b
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := truncate(*tt.bufF())
+			require.Equal(t, tt.expF().Bytes(), res.Bytes())
+		})
+	}
 }
 
 func TestRemoveCarriageReturns(t *testing.T) {

--- a/plugins/parsers/nagios/parser.go
+++ b/plugins/parsers/nagios/parser.go
@@ -129,7 +129,7 @@ func (p *NagiosParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		if bytes.Contains(s.Bytes(), []byte{'|'}) {
 			parts := bytes.Split(s.Bytes(), []byte{'|'})
 			if longmsg.Len() != 0 {
-				longmsg.WriteByte(' ')
+				longmsg.WriteByte('\n')
 			}
 			longmsg.Write(bytes.TrimSpace(parts[0]))
 
@@ -141,7 +141,7 @@ func (p *NagiosParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 			break
 		}
 		if longmsg.Len() != 0 {
-			longmsg.WriteByte(' ')
+			longmsg.WriteByte('\n')
 		}
 		longmsg.Write(bytes.TrimSpace((s.Bytes())))
 	}
@@ -161,11 +161,11 @@ func (p *NagiosParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 
 	// Create nagios state.
 	fields := map[string]interface{}{
-		"state": state,
-		"msg":   msg.String(),
+		"state":          state,
+		"service_output": msg.String(),
 	}
 	if longmsg.Len() != 0 {
-		fields["longmsg"] = longmsg.String()
+		fields["long_service_output"] = longmsg.String()
 	}
 
 	m, err := metric.New("nagios_state", nil, fields, ts)

--- a/plugins/parsers/nagios/parser.go
+++ b/plugins/parsers/nagios/parser.go
@@ -129,7 +129,7 @@ func (p *NagiosParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		if bytes.Contains(s.Bytes(), []byte{'|'}) {
 			parts := bytes.Split(s.Bytes(), []byte{'|'})
 			if longmsg.Len() != 0 {
-				longmsg.WriteByte('\n')
+				longmsg.WriteByte(' ')
 			}
 			longmsg.Write(bytes.TrimSpace(parts[0]))
 
@@ -141,7 +141,7 @@ func (p *NagiosParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 			break
 		}
 		if longmsg.Len() != 0 {
-			longmsg.WriteByte('\n')
+			longmsg.WriteByte(' ')
 		}
 		longmsg.Write(bytes.TrimSpace((s.Bytes())))
 	}

--- a/plugins/parsers/nagios/parser.go
+++ b/plugins/parsers/nagios/parser.go
@@ -100,8 +100,8 @@ func (p *NagiosParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 
 	s := bufio.NewScanner(bytes.NewReader(buf))
 
-	var msg strings.Builder
-	var longmsg strings.Builder
+	var msg bytes.Buffer
+	var longmsg bytes.Buffer
 
 	metrics := make([]telegraf.Metric, 0)
 

--- a/plugins/parsers/nagios/parser_test.go
+++ b/plugins/parsers/nagios/parser_test.go
@@ -151,9 +151,9 @@ with three lines
 				}, metrics[1].Fields())
 
 				assertNagiosState(t, metrics[2], map[string]interface{}{
-					"state":   int64(0),
-					"msg":     "PING OK - Packet loss = 0%, RTA = 0.30 ms",
-					"longmsg": "This is a long output with three lines",
+					"state":               int64(0),
+					"service_output":      "PING OK - Packet loss = 0%, RTA = 0.30 ms",
+					"long_service_output": "This is a long output\nwith three lines",
 				})
 			},
 		},
@@ -175,8 +175,8 @@ with three lines
 				}, metrics[0].Fields())
 
 				assertNagiosState(t, metrics[1], map[string]interface{}{
-					"state": int64(0),
-					"msg":   "TCP OK - 0.008 second response time on port 80",
+					"state":          int64(0),
+					"service_output": "TCP OK - 0.008 second response time on port 80",
 				})
 			},
 		},
@@ -195,8 +195,8 @@ with three lines
 				}, metrics[0].Fields())
 
 				assertNagiosState(t, metrics[1], map[string]interface{}{
-					"state": int64(0),
-					"msg":   "TCP OK - 0.008 second response time on port 80",
+					"state":          int64(0),
+					"service_output": "TCP OK - 0.008 second response time on port 80",
 				})
 			},
 		},
@@ -246,8 +246,8 @@ with three lines
 				}, metrics[2].Fields())
 
 				assertNagiosState(t, metrics[3], map[string]interface{}{
-					"state": int64(0),
-					"msg":   "OK: Load average: 0.00, 0.01, 0.05",
+					"state":          int64(0),
+					"service_output": "OK: Load average: 0.00, 0.01, 0.05",
 				})
 			},
 		},
@@ -259,8 +259,8 @@ with three lines
 				require.Len(t, metrics, 1)
 
 				assertNagiosState(t, metrics[0], map[string]interface{}{
-					"state": int64(0),
-					"msg":   "PING OK - Packet loss = 0%, RTA = 0.30 ms",
+					"state":          int64(0),
+					"service_output": "PING OK - Packet loss = 0%, RTA = 0.30 ms",
 				})
 			},
 		},
@@ -272,8 +272,8 @@ with three lines
 				require.Len(t, metrics, 1)
 
 				assertNagiosState(t, metrics[0], map[string]interface{}{
-					"state": int64(0),
-					"msg":   "PING OK - Packet loss = 0%, RTA = 0.30 ms",
+					"state":          int64(0),
+					"service_output": "PING OK - Packet loss = 0%, RTA = 0.30 ms",
 				})
 			},
 		},
@@ -351,9 +351,9 @@ with three lines
 				}, metrics[3].Fields())
 
 				assertNagiosState(t, metrics[4], map[string]interface{}{
-					"state":   int64(0),
-					"msg":     "DISK OK - free space: / 3326 MB (56%);",
-					"longmsg": "/ 15272 MB (77%); /boot 68 MB (69%); /home 69357 MB (27%); /var/log 819 MB (84%);",
+					"state":               int64(0),
+					"service_output":      "DISK OK - free space: / 3326 MB (56%);",
+					"long_service_output": "/ 15272 MB (77%);\n/boot 68 MB (69%);\n/home 69357 MB (27%);\n/var/log 819 MB (84%);",
 				})
 			},
 		},

--- a/plugins/parsers/nagios/parser_test.go
+++ b/plugins/parsers/nagios/parser_test.go
@@ -1,112 +1,377 @@
 package nagios
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
 )
 
-const validOutput1 = `PING OK - Packet loss = 0%, RTA = 0.30 ms|rta=0.298000ms;4000.000000;6000.000000;0.000000 pl=0%;80;90;0;100
-This is a long output
-with three lines
-`
-const validOutput2 = "TCP OK - 0.008 second response time on port 80|time=0.008457s;;;0.000000;10.000000"
-const validOutput3 = "TCP OK - 0.008 second response time on port 80|time=0.008457"
-const validOutput4 = "OK: Load average: 0.00, 0.01, 0.05 | 'load1'=0.00;~:4;@0:6;0; 'load5'=0.01;3;0:5;0; 'load15'=0.05;0:2;0:4;0;"
-const invalidOutput3 = "PING OK - Packet loss = 0%, RTA = 0.30 ms"
-const invalidOutput4 = "PING OK - Packet loss = 0%, RTA = 0.30 ms| =3;;;; dgasdg =;;;; sff=;;;;"
-
-func TestParseValidOutput(t *testing.T) {
-	parser := NagiosParser{
-		MetricName: "nagios_test",
+func TestAppendExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		exitCode int
+		exp      []byte
+	}{
+		{
+			name:     "exit 0",
+			exitCode: 0,
+			exp:      []byte{0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:     "exit 123",
+			exitCode: 123,
+			exp:      []byte{0, 123, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:     "exit -1",
+			exitCode: -1,
+			exp:      []byte{0, 255, 255, 255, 255, 255, 255, 255, 255},
+		},
 	}
 
-	// Output1
-	metrics, err := parser.Parse([]byte(validOutput1))
-	require.NoError(t, err)
-	require.Len(t, metrics, 2)
-	// rta
-	assert.Equal(t, "rta", metrics[0].Tags()["perfdata"])
-	assert.Equal(t, map[string]interface{}{
-		"value":       float64(0.298),
-		"warning_lt":  float64(0),
-		"warning_gt":  float64(4000),
-		"critical_lt": float64(0),
-		"critical_gt": float64(6000),
-		"min":         float64(0),
-	}, metrics[0].Fields())
-	assert.Equal(t, map[string]string{"unit": "ms", "perfdata": "rta"}, metrics[0].Tags())
-	// pl
-	assert.Equal(t, "pl", metrics[1].Tags()["perfdata"])
-	assert.Equal(t, map[string]interface{}{
-		"value":       float64(0),
-		"warning_lt":  float64(0),
-		"warning_gt":  float64(80),
-		"critical_lt": float64(0),
-		"critical_gt": float64(90),
-		"min":         float64(0),
-		"max":         float64(100),
-	}, metrics[1].Fields())
-	assert.Equal(t, map[string]string{"unit": "%", "perfdata": "pl"}, metrics[1].Tags())
-
-	// Output2
-	metrics, err = parser.Parse([]byte(validOutput2))
-	require.NoError(t, err)
-	require.Len(t, metrics, 1)
-	// time
-	assert.Equal(t, "time", metrics[0].Tags()["perfdata"])
-	assert.Equal(t, map[string]interface{}{
-		"value": float64(0.008457),
-		"min":   float64(0),
-		"max":   float64(10),
-	}, metrics[0].Fields())
-	assert.Equal(t, map[string]string{"unit": "s", "perfdata": "time"}, metrics[0].Tags())
-
-	// Output3
-	metrics, err = parser.Parse([]byte(validOutput3))
-	require.NoError(t, err)
-	require.Len(t, metrics, 1)
-	// time
-	assert.Equal(t, "time", metrics[0].Tags()["perfdata"])
-	assert.Equal(t, map[string]interface{}{
-		"value": float64(0.008457),
-	}, metrics[0].Fields())
-	assert.Equal(t, map[string]string{"perfdata": "time"}, metrics[0].Tags())
-
-	// Output4
-	metrics, err = parser.Parse([]byte(validOutput4))
-	require.NoError(t, err)
-	require.Len(t, metrics, 3)
-	// load
-	// const validOutput4 = "OK: Load average: 0.00, 0.01, 0.05 | 'load1'=0.00;0:4;0:6;0; 'load5'=0.01;0:3;0:5;0; 'load15'=0.05;0:2;0:4;0;"
-	assert.Equal(t, map[string]interface{}{
-		"value":       float64(0.00),
-		"warning_lt":  MinFloat64,
-		"warning_gt":  float64(4),
-		"critical_le": float64(0),
-		"critical_ge": float64(6),
-		"min":         float64(0),
-	}, metrics[0].Fields())
-
-	assert.Equal(t, map[string]string{"perfdata": "load1"}, metrics[0].Tags())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			AppendExitCode(&buf, tt.exitCode)
+			require.Equal(t, tt.exp, buf.Bytes())
+		})
+	}
 }
 
-func TestParseInvalidOutput(t *testing.T) {
+func TestExtractExitCode(t *testing.T) {
+	tests := []struct {
+		name   string
+		buf    []byte
+		expBuf []byte
+		exp    int
+	}{
+		{
+			name:   "code 0",
+			buf:    []byte{0, 0, 0, 0, 0, 0, 0, 0, 0},
+			expBuf: []byte{},
+			exp:    0,
+		},
+		{
+			name:   "code 123",
+			buf:    []byte{0, 123, 0, 0, 0, 0, 0, 0, 0},
+			expBuf: []byte{},
+			exp:    123,
+		},
+		{
+			name:   "code -1",
+			buf:    []byte{0, 255, 255, 255, 255, 255, 255, 255, 255},
+			expBuf: []byte{},
+			exp:    -1,
+		},
+		{
+			name:   "expect default due to short input",
+			buf:    []byte{0, 255, 255, 255, 255, 255, 255, 255},
+			expBuf: []byte{0, 255, 255, 255, 255, 255, 255, 255},
+			exp:    defaultExitCode,
+		},
+		{
+			name:   "expect default due to unsatisfied encoding",
+			buf:    []byte{0, 1, 255, 255, 255, 255, 255, 255, 255, 255},
+			expBuf: []byte{0, 1, 255, 255, 255, 255, 255, 255, 255, 255},
+			exp:    defaultExitCode,
+		},
+		{
+			name:   "expect encoded exit code trimmed",
+			buf:    []byte{1, 0, 123, 0, 0, 0, 0, 0, 0, 0},
+			expBuf: []byte{1},
+			exp:    123,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf, ec := ExtractExitCode(tt.buf)
+			require.Equal(t, tt.expBuf, buf)
+			require.Equal(t, tt.exp, ec)
+		})
+	}
+}
+
+func assertNagiosState(t *testing.T, m telegraf.Metric, f map[string]interface{}) {
+	assert.Equal(t, map[string]string{}, m.Tags())
+	assert.Equal(t, f, m.Fields())
+}
+
+func TestParse(t *testing.T) {
 	parser := NagiosParser{
 		MetricName: "nagios_test",
 	}
 
-	// invalidOutput3
-	metrics, err := parser.Parse([]byte(invalidOutput3))
-	require.NoError(t, err)
-	require.Len(t, metrics, 0)
+	tests := []struct {
+		name    string
+		input   string
+		inputF  func(string) []byte
+		assertF func(*testing.T, []telegraf.Metric, error)
+	}{
+		{
+			name: "valid output 1",
+			input: `PING OK - Packet loss = 0%, RTA = 0.30 ms|rta=0.298000ms;4000.000000;6000.000000;0.000000 pl=0%;80;90;0;100
+This is a long output
+with three lines
+`,
+			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+				require.NoError(t, err)
+				require.Len(t, metrics, 3)
+				// rta
+				assert.Equal(t, map[string]string{
+					"unit":     "ms",
+					"perfdata": "rta",
+				}, metrics[0].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value":       float64(0.298),
+					"warning_lt":  float64(0),
+					"warning_gt":  float64(4000),
+					"critical_lt": float64(0),
+					"critical_gt": float64(6000),
+					"min":         float64(0),
+				}, metrics[0].Fields())
 
-	// invalidOutput4
-	metrics, err = parser.Parse([]byte(invalidOutput4))
-	require.NoError(t, err)
-	require.Len(t, metrics, 0)
+				// pl
+				assert.Equal(t, map[string]string{
+					"unit":     "%",
+					"perfdata": "pl",
+				}, metrics[1].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value":       float64(0),
+					"warning_lt":  float64(0),
+					"warning_gt":  float64(80),
+					"critical_lt": float64(0),
+					"critical_gt": float64(90),
+					"min":         float64(0),
+					"max":         float64(100),
+				}, metrics[1].Fields())
 
+				assertNagiosState(t, metrics[2], map[string]interface{}{
+					"state":   int64(0),
+					"msg":     "PING OK - Packet loss = 0%, RTA = 0.30 ms",
+					"longmsg": "This is a long output\nwith three lines",
+				})
+			},
+		},
+		{
+			name:  "valid output 2",
+			input: "TCP OK - 0.008 second response time on port 80|time=0.008457s;;;0.000000;10.000000",
+			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+				require.NoError(t, err)
+				require.Len(t, metrics, 2)
+				// time
+				assert.Equal(t, map[string]string{
+					"unit":     "s",
+					"perfdata": "time",
+				}, metrics[0].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value": float64(0.008457),
+					"min":   float64(0),
+					"max":   float64(10),
+				}, metrics[0].Fields())
+
+				assertNagiosState(t, metrics[1], map[string]interface{}{
+					"state": int64(0),
+					"msg":   "TCP OK - 0.008 second response time on port 80",
+				})
+			},
+		},
+		{
+			name:  "valid output 3",
+			input: "TCP OK - 0.008 second response time on port 80|time=0.008457",
+			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+				require.NoError(t, err)
+				require.Len(t, metrics, 2)
+				// time
+				assert.Equal(t, map[string]string{
+					"perfdata": "time",
+				}, metrics[0].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value": float64(0.008457),
+				}, metrics[0].Fields())
+
+				assertNagiosState(t, metrics[1], map[string]interface{}{
+					"state": int64(0),
+					"msg":   "TCP OK - 0.008 second response time on port 80",
+				})
+			},
+		},
+		{
+			name:  "valid output 4",
+			input: "OK: Load average: 0.00, 0.01, 0.05 | 'load1'=0.00;~:4;@0:6;0; 'load5'=0.01;3;0:5;0; 'load15'=0.05;0:2;0:4;0;",
+			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+				require.NoError(t, err)
+				require.Len(t, metrics, 4)
+				// load1
+				assert.Equal(t, map[string]string{
+					"perfdata": "load1",
+				}, metrics[0].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value":       float64(0.00),
+					"warning_lt":  MinFloat64,
+					"warning_gt":  float64(4),
+					"critical_le": float64(0),
+					"critical_ge": float64(6),
+					"min":         float64(0),
+				}, metrics[0].Fields())
+
+				// load5
+				assert.Equal(t, map[string]string{
+					"perfdata": "load5",
+				}, metrics[1].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value":       float64(0.01),
+					"warning_gt":  float64(3),
+					"warning_lt":  float64(0),
+					"critical_lt": float64(0),
+					"critical_gt": float64(5),
+					"min":         float64(0),
+				}, metrics[1].Fields())
+
+				// load15
+				assert.Equal(t, map[string]string{
+					"perfdata": "load15",
+				}, metrics[2].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value":       float64(0.05),
+					"warning_lt":  float64(0),
+					"warning_gt":  float64(2),
+					"critical_lt": float64(0),
+					"critical_gt": float64(4),
+					"min":         float64(0),
+				}, metrics[2].Fields())
+
+				assertNagiosState(t, metrics[3], map[string]interface{}{
+					"state": int64(0),
+					"msg":   "OK: Load average: 0.00, 0.01, 0.05",
+				})
+			},
+		},
+		{
+			name:  "no perf data",
+			input: "PING OK - Packet loss = 0%, RTA = 0.30 ms",
+			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+				require.NoError(t, err)
+				require.Len(t, metrics, 1)
+
+				assertNagiosState(t, metrics[0], map[string]interface{}{
+					"state": int64(0),
+					"msg":   "PING OK - Packet loss = 0%, RTA = 0.30 ms",
+				})
+			},
+		},
+		{
+			name:  "malformed perf data",
+			input: "PING OK - Packet loss = 0%, RTA = 0.30 ms| =3;;;; dgasdg =;;;; sff=;;;;",
+			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+				require.NoError(t, err)
+				require.Len(t, metrics, 1)
+
+				assertNagiosState(t, metrics[0], map[string]interface{}{
+					"state": int64(0),
+					"msg":   "PING OK - Packet loss = 0%, RTA = 0.30 ms",
+				})
+			},
+		},
+		{
+			name: "from https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/pluginapi.html",
+			input: `DISK OK - free space: / 3326 MB (56%); | /=2643MB;5948;5958;0;5968
+/ 15272 MB (77%);
+/boot 68 MB (69%);
+/home 69357 MB (27%);
+/var/log 819 MB (84%); | /boot=68MB;88;93;0;98
+/home=69357MB;253404;253409;0;253414
+/var/log=818MB;970;975;0;980
+`,
+			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+				require.NoError(t, err)
+				require.Len(t, metrics, 5)
+				// /=2643MB;5948;5958;0;5968
+				assert.Equal(t, map[string]string{
+					"unit":     "MB",
+					"perfdata": "/",
+				}, metrics[0].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value":       float64(2643),
+					"warning_lt":  float64(0),
+					"warning_gt":  float64(5948),
+					"critical_lt": float64(0),
+					"critical_gt": float64(5958),
+					"min":         float64(0),
+					"max":         float64(5968),
+				}, metrics[0].Fields())
+
+				// /boot=68MB;88;93;0;98
+				assert.Equal(t, map[string]string{
+					"unit":     "MB",
+					"perfdata": "/boot",
+				}, metrics[1].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value":       float64(68),
+					"warning_lt":  float64(0),
+					"warning_gt":  float64(88),
+					"critical_lt": float64(0),
+					"critical_gt": float64(93),
+					"min":         float64(0),
+					"max":         float64(98),
+				}, metrics[1].Fields())
+
+				// /home=69357MB;253404;253409;0;253414
+				assert.Equal(t, map[string]string{
+					"unit":     "MB",
+					"perfdata": "/home",
+				}, metrics[2].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value":       float64(69357),
+					"warning_lt":  float64(0),
+					"warning_gt":  float64(253404),
+					"critical_lt": float64(0),
+					"critical_gt": float64(253409),
+					"min":         float64(0),
+					"max":         float64(253414),
+				}, metrics[2].Fields())
+
+				// /var/log=818MB;970;975;0;980
+				assert.Equal(t, map[string]string{
+					"unit":     "MB",
+					"perfdata": "/var/log",
+				}, metrics[3].Tags())
+				assert.Equal(t, map[string]interface{}{
+					"value":       float64(818),
+					"warning_lt":  float64(0),
+					"warning_gt":  float64(970),
+					"critical_lt": float64(0),
+					"critical_gt": float64(975),
+					"min":         float64(0),
+					"max":         float64(980),
+				}, metrics[3].Fields())
+
+				assertNagiosState(t, metrics[4], map[string]interface{}{
+					"state":   int64(0),
+					"msg":     "DISK OK - free space: / 3326 MB (56%);",
+					"longmsg": "/ 15272 MB (77%);\n/boot 68 MB (69%);\n/home 69357 MB (27%);\n/var/log 819 MB (84%);",
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var in []byte
+			if tt.inputF != nil {
+				in = tt.inputF(tt.input)
+			} else {
+				in = []byte(tt.input)
+			}
+
+			metrics, err := parser.Parse(in)
+			tt.assertF(t, metrics, err)
+		})
+	}
 }
 
 func TestParseThreshold(t *testing.T) {

--- a/plugins/parsers/nagios/parser_test.go
+++ b/plugins/parsers/nagios/parser_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestGetExitCode(t *testing.T) {
@@ -93,6 +94,16 @@ func (b *metricBuilder) b() telegraf.Metric {
 	return m
 }
 
+// assertEqual asserts two slices to be equal. Note, that the order
+// of the entries matters.
+func assertEqual(t *testing.T, exp, actual []telegraf.Metric) {
+	require.Equal(t, len(exp), len(actual))
+	for i := 0; i < len(exp); i++ {
+		ok := testutil.MetricEqual(exp[i], actual[i])
+		require.True(t, ok)
+	}
+}
+
 func TestTryAddState(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -123,7 +134,7 @@ func TestTryAddState(t *testing.T) {
 						f("service_output", "OK: system working").
 						f("state", 0).b(),
 				}
-				require.Equal(t, exp, metrics)
+				assertEqual(t, exp, metrics)
 				require.NoError(t, err)
 			},
 		},
@@ -146,7 +157,7 @@ func TestTryAddState(t *testing.T) {
 						n("nagios_state").
 						f("state", 0).b(),
 				}
-				require.Equal(t, exp, metrics)
+				assertEqual(t, exp, metrics)
 				require.NoError(t, err)
 			},
 		},
@@ -185,7 +196,7 @@ func TestTryAddState(t *testing.T) {
 				}
 				expErr := "exec: get exit code: expected *exec.ExitError"
 
-				require.Equal(t, exp, metrics)
+				assertEqual(t, exp, metrics)
 				require.Equal(t, expErr, err.Error())
 			},
 		},

--- a/plugins/parsers/nagios/parser_test.go
+++ b/plugins/parsers/nagios/parser_test.go
@@ -153,7 +153,7 @@ with three lines
 				assertNagiosState(t, metrics[2], map[string]interface{}{
 					"state":   int64(0),
 					"msg":     "PING OK - Packet loss = 0%, RTA = 0.30 ms",
-					"longmsg": "This is a long output\nwith three lines",
+					"longmsg": "This is a long output with three lines",
 				})
 			},
 		},
@@ -353,7 +353,7 @@ with three lines
 				assertNagiosState(t, metrics[4], map[string]interface{}{
 					"state":   int64(0),
 					"msg":     "DISK OK - free space: / 3326 MB (56%);",
-					"longmsg": "/ 15272 MB (77%);\n/boot 68 MB (69%);\n/home 69357 MB (27%);\n/var/log 819 MB (84%);",
+					"longmsg": "/ 15272 MB (77%); /boot 68 MB (69%); /home 69357 MB (27%); /var/log 819 MB (84%);",
 				})
 			},
 		},


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] ~Associated README.md updated.~ Not needed.
- [x] Has appropriate unit tests.

Example Nagios check output:
```
DISK OK - free space: / 3326 MB (56%); | /=2643MB;5948;5958;0;5968
/ 15272 MB (77%);
/boot 68 MB (69%);
/home 69357 MB (27%);
/var/log 819 MB (84%); | /boot=68MB;88;93;0;98
/home=69357MB;253404;253409;0;253414
/var/log=818MB;970;975;0;980
```

Old behavior:
```
nagios_state,host=localhost state=0i 1552677172000000000
nagios,host=localhost,perfdata=/,unit=MB critical_gt=5958,critical_lt=0,max=5968,min=0,value=2643,warning_gt=5948,warning_lt=0 1552677172000000000
nagios,host=localhost,perfdata=/boot,unit=MB critical_gt=93,critical_lt=0,max=98,min=0,value=68,warning_gt=88,warning_lt=0 1552677172000000000
```

**New** behavior:
```
nagios,host=localhost,perfdata=/,unit=MB critical_gt=5958,critical_lt=0,max=5968,min=0,value=2643,warning_gt=5948,warning_lt=0 1552939211000000000
nagios,host=localhost,perfdata=/boot,unit=MB critical_gt=93,critical_lt=0,max=98,min=0,value=68,warning_gt=88,warning_lt=0 1552939211000000000
nagios,host=localhost,perfdata=/home,unit=MB critical_gt=253409,critical_lt=0,max=253414,min=0,value=69357,warning_gt=253404,warning_lt=0 1552939211000000000
nagios,host=localhost,perfdata=/var/log,unit=MB critical_gt=975,critical_lt=0,max=980,min=0,value=818,warning_gt=970,warning_lt=0 1552939211000000000
nagios_state,host=localhost longmsg="/ 15272 MB (77%); /boot 68 MB (69%); /home 69357 MB (27%); /var/log 819 MB (84%);",msg="DISK OK - free space: / 3326 MB (56%);",state=0i 1552939211000000000
```

Changes:
- Lines for `perfdata` in `{/home, /var/log}` added.
- Info message and long info message are reported for the nagios_state.

Fixes #5591.