### PR TITLE
Add owned directories to rpm package

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -647,7 +647,7 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                             package_build_root,
                             current_location)
                         if package_type == "rpm":
-                            fpm_command += "--depends coreutils --depends shadow-utils --rpm-posttrans {}".format(POSTINST_SCRIPT)
+                            fpm_command += "--directories /var/log/telegraf --directories /etc/telegraf --depends coreutils --depends shadow-utils --rpm-posttrans {}".format(POSTINST_SCRIPT)
                         out = run(fpm_command, shell=True)
                         matches = re.search(':path=>"(.*)"', out)
                         outfile = None


### PR DESCRIPTION
With this change the `/etc/telegraf`, `/etc/telegraf/telegraf.d`, and `/var/log/telegraf` directories will be removed with the package.  

Following standard rpm behavior the directories are not removed if they contain new files. As before, if the `/etc/telegraf/telegraf.conf` file has been modified it will be renamed and saved as `/etc/telegraf/telegraf.conf.rpmsave`.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
