### PR TITLE
Remove string trimming from grok parser

### DIFF
--- a/plugins/parsers/grok/influx_patterns.go
+++ b/plugins/parsers/grok/influx_patterns.go
@@ -69,7 +69,7 @@ COMMON_LOG_FORMAT %{CLIENT:client_ip} %{NOTSPACE:ident} %{NOTSPACE:auth} \[%{HTT
 # Combined log format is the same as the common log format but with the addition
 # of two quoted strings at the end for "referrer" and "agent"
 #   See Examples at http://httpd.apache.org/docs/current/mod/mod_log_config.html
-COMBINED_LOG_FORMAT %{COMMON_LOG_FORMAT} %{QS:referrer} %{QS:agent}
+COMBINED_LOG_FORMAT %{COMMON_LOG_FORMAT} "%{DATA:referrer}" "%{DATA:agent}"
 
 # HTTPD log formats
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:loglevel:tag}\] (?:\[client %{IPORHOST:clientip}\] ){0,1}%{GREEDYDATA:errormsg}

--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -271,7 +271,7 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 		case TAG:
 			tags[k] = v
 		case STRING:
-			fields[k] = strings.Trim(v, `"`)
+			fields[k] = v
 		case EPOCH:
 			parts := strings.SplitN(v, ".", 2)
 			if len(parts) == 0 {

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -1047,3 +1047,24 @@ func TestEmptyYearInTimestamp(t *testing.T) {
 	require.NotNil(t, m)
 	require.Equal(t, time.Now().Year(), m.Time().Year())
 }
+
+func TestTrimRegression(t *testing.T) {
+	// https://github.com/influxdata/telegraf/issues/4998
+	p := &Parser{
+		Patterns: []string{`%{GREEDYDATA:message:string}`},
+	}
+	require.NoError(t, p.Compile())
+
+	actual, err := p.ParseLine(`level=info msg="ok"`)
+	require.NoError(t, err)
+
+	expected := testutil.MustMetric(
+		"",
+		map[string]string{},
+		map[string]interface{}{
+			"message": `level=info msg="ok"`,
+		},
+		actual.Time(),
+	)
+	require.Equal(t, expected, actual)
+}


### PR DESCRIPTION
This change is not backwards compatible, the workaround for old patterns relying on this trimming is:
`%{QS} -> "%{DATA}"`

closes #4998 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
