### PR TITLE
Fix deadlock when Telegraf is aligning aggregators

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -378,7 +378,10 @@ func (a *Agent) runAggregators(
 	for _, agg := range a.Config.Aggregators {
 		wg.Add(1)
 		go func(agg *models.RunningAggregator) {
-			defer wg.Done()
+			defer func() {
+				wg.Done()
+				close(aggregations)
+			}()
 
 			if a.Config.Agent.RoundInterval {
 				// Aggregators are aligned to the agent interval regardless of
@@ -394,7 +397,6 @@ func (a *Agent) runAggregators(
 			acc := NewAccumulator(agg, aggregations)
 			acc.SetPrecision(precision, interval)
 			a.push(ctx, agg, acc)
-			close(aggregations)
 		}(agg)
 	}
 


### PR DESCRIPTION
If a Telegraf is asked to stop (SIGTERM, SIGINT) while it is aligning an
aggregator, ``internal.SleepContext`` will fail and the goroutine will
return without closing the ``aggregations`` channel getting stuck
forever in ``for metric := range aggregations``

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

Sample config file to test the problem:
```
[global_tags]
[agent]
  interval = "60s"
  debug = true

[[aggregators.basicstats]]
  period = "1800s"

[[inputs.mem]]

[[outputs.file]]
  files = [ "stdout" ]
```

Run telegraf:
```
telegraf -config telegraf.conf
```

Kill it before 60s:
```
pkill telegraf
```

It won't finish.

Here [telegraf.log](https://github.com/influxdata/telegraf/files/2988434/telegraf.log) is the log of the execution mixed with the ``kill -ABRT`` used to check the status of goroutines.

``goroutine 58 (agent.runAggregators)`` is the problematic one. It is stuck so it is not closing the channel used by the outputs.

``goroutine 59 (agent.runOutputs)`` is waiting till the aggregator close the input channel.

``goroutine 60 (agent.flush)``: this one should be stopped by runOutputs

 `` goroutine 36 (ticker)`` is going to stop when agent.flushOnce finishes. Meanwhile is keeping one goroutine running so Go could not detect a deadlock.

``goroutine 51 (opencensus)`` is strange. I have not configured nothing related with opencensus. Looking at the code, that lib have a [init() function](https://github.com/census-instrumentation/opencensus-go/blob/master/stats/view/worker.go#L27) that starts its own goroutine with a time Ticker. At first glance do not look like a good pattern to start a goroutine in the init() function, in fact using the init() looks like is not a [good pattern](https://github.com/leighmcculloch/gochecknoinits).
Removing this import does not solve the not-detected-deadlock problem.
Maybe could be a good idea to check for no init() functions in the vendor libs, but maybe too much.
