### PR TITLE
Exit after running --test without requiring --console

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -342,7 +342,7 @@ func main() {
 		log.Println("Telegraf version already configured to: " + internal.Version())
 	}
 
-	if runtime.GOOS == "windows" && !(*fRunAsConsole) {
+	if runtime.GOOS == "windows" && windowsRunAsService() {
 		svcConfig := &service.Config{
 			Name:        *fServiceName,
 			DisplayName: "Telegraf Data Collector Service",
@@ -391,4 +391,17 @@ func main() {
 			processorFilters,
 		)
 	}
+}
+
+// Return true if Telegraf should create a Windows service.
+func windowsRunAsService() bool {
+	if *fService != "" {
+		return true
+	}
+
+	if *fRunAsConsole {
+		return false
+	}
+
+	return !service.Interactive()
 }


### PR DESCRIPTION
If neither --console or --service is added to the command line, run as a service only in a non-interactive shell.  This is always a little scary to change, but currently Telegraf refuses to exit when running --test unless you also specify --console.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
