### PR TITLE
Fix aggregator metric drop

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -364,6 +364,8 @@ func (a *Agent) runAggregators(
 
 			if !dropOriginal {
 				dst <- metric
+			} else {
+				metric.Drop()
 			}
 		}
 		cancel()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - KAFKA_ADVERTISED_HOST_NAME=localhost
       - KAFKA_ADVERTISED_PORT=9092
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_CREATE_TOPICS="test:1:1"
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
       - JAVA_OPTS="-Xms256m -Xmx256m"
     ports:
       - "9092:9092"
@@ -38,7 +38,7 @@ services:
       - "3306:3306"
   memcached:
     image: memcached
-    ports: 
+    ports:
       - "11211:11211"
   pgbouncer:
     image: mbed/pgbouncer


### PR DESCRIPTION
Aggregators' `drop_original = true` doesn't work well with `*_consumer` inputs' `max_undelivered_messages`. (mentioned by me at https://github.com/influxdata/telegraf/issues/5595#issuecomment-476546850)

`*_consumer` inputs are using `AddTrackingMetricGroup` to find out whether metrics get delivered (either `Accept` or `Drop`, `Reject` won't count). However, when `drop_original = true`, metrics are dropped without calling `metric.Drop()`. As a result, inputs lost track of metrics, consider dropped metrics undelivered, and `max_undelivered_messages` is reached rather quickly. Eventually, `*_consumer` inputs stop consuming new messages.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
