### PR TITLE
[aggregators/histogram] Add option to reset buckets on flush

### DIFF
--- a/plugins/aggregators/histogram/README.md
+++ b/plugins/aggregators/histogram/README.md
@@ -7,8 +7,9 @@ Values added to a bucket are also added to the larger buckets in the
 distribution.  This creates a [cumulative histogram](https://en.wikipedia.org/wiki/Histogram#/media/File:Cumulative_vs_normal_histogram.svg).
 
 Like other Telegraf aggregators, the metric is emitted every `period` seconds.
-Bucket counts however are not reset between periods and will be non-strictly
-increasing while Telegraf is running.
+By default bucket counts are not reset between periods and will be non-strictly
+increasing while Telegraf is running. This behavior can be changed by setting the
+`reset` parameter to true.
 
 #### Design
 
@@ -33,6 +34,10 @@ of the algorithm which is implemented in the Prometheus
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.
   drop_original = false
+
+  ## If true, the histogram will be reset on flush instead
+  ## of accumulating the results.
+  reset = false
 
   ## Example config that aggregates all fields of the metric.
   # [[aggregators.histogram.config]]

--- a/plugins/aggregators/histogram/histogram.go
+++ b/plugins/aggregators/histogram/histogram.go
@@ -73,6 +73,10 @@ var sampleConfig = `
   ## aggregator and will not get sent to the output plugins.
   drop_original = false
 
+  ## If true, the histogram will be reset on flush instead
+  ## of accumulating the results.
+  reset = false
+
   ## Example config that aggregates all fields of the metric.
   # [[aggregators.histogram.config]]
   #   ## The set of buckets.

--- a/plugins/aggregators/histogram/histogram.go
+++ b/plugins/aggregators/histogram/histogram.go
@@ -16,7 +16,8 @@ const bucketInf = "+Inf"
 
 // HistogramAggregator is aggregator with histogram configs and particular histograms for defined metrics
 type HistogramAggregator struct {
-	Configs []config `toml:"config"`
+	Configs      []config `toml:"config"`
+	ResetBuckets bool     `toml:"reset"`
 
 	buckets bucketsByMetrics
 	cache   map[uint64]metricHistogramCollection
@@ -203,7 +204,11 @@ func (h *HistogramAggregator) groupField(
 
 // Reset does nothing, because we need to collect counts for a long time, otherwise if config parameter 'reset' has
 // small value, we will get a histogram with a small amount of the distribution.
-func (h *HistogramAggregator) Reset() {}
+func (h *HistogramAggregator) Reset() {
+	if h.ResetBuckets {
+		h.resetCache()
+	}
+}
 
 // resetCache resets cached counts(hits) in the buckets
 func (h *HistogramAggregator) resetCache() {

--- a/plugins/aggregators/histogram/histogram.go
+++ b/plugins/aggregators/histogram/histogram.go
@@ -202,11 +202,14 @@ func (h *HistogramAggregator) groupField(
 	)
 }
 
-// Reset does nothing, because we need to collect counts for a long time, otherwise if config parameter 'reset' has
-// small value, we will get a histogram with a small amount of the distribution.
+// Reset does nothing by default, because we need to collect counts for a long time,
+// otherwise if config parameter 'reset' has small value, we will get a histogram
+// with a small amount of the distribution. However in some use cases a reset is useful.
+
 func (h *HistogramAggregator) Reset() {
 	if h.ResetBuckets {
 		h.resetCache()
+		h.buckets = make(bucketsByMetrics)
 	}
 }
 

--- a/plugins/aggregators/histogram/histogram.go
+++ b/plugins/aggregators/histogram/histogram.go
@@ -206,10 +206,9 @@ func (h *HistogramAggregator) groupField(
 	)
 }
 
-// Reset does nothing by default, because we need to collect counts for a long time,
-// otherwise if config parameter 'reset' has small value, we will get a histogram
+// Reset does nothing by default, because we typically need to collect counts for a long time.
+// Otherwise if config parameter 'reset' has 'true' value, we will get a histogram
 // with a small amount of the distribution. However in some use cases a reset is useful.
-
 func (h *HistogramAggregator) Reset() {
 	if h.ResetBuckets {
 		h.resetCache()


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

For some use cases it is desireable for the histogram buckets to be reset between operations. 

A good example is collecting data from processes using the PID as a tag where the cardinality may become very high and series can become "stale". With the current implementation, series for already dead processes will still continue to be reported on. 

This functionality could be further improved by adding a reset interval and per-subconfig reset options but I expect that for most use cases just having everything reset on flush is a simple and effective solution. 

@vlamug It would be good to hear your thoughts on this