### PR TITLE
Add support for time precision when using influxdb as output

### DIFF
--- a/plugins/outputs/influxdb/README.md
+++ b/plugins/outputs/influxdb/README.md
@@ -72,6 +72,10 @@ The InfluxDB output plugin writes metrics to the [InfluxDB v1.x] HTTP or UDP ser
   ## integer values.  Enabling this option will result in field type errors if
   ## existing data has been written.
   # influx_uint_support = false
+
+  ## When writing data to InfluxDB, time precision that should be used (s, ms, us, ns)
+  ## defaults to "ns"
+  # time_precision = ""
 ```
 
 [InfluxDB v1.x]: https://github.com/influxdata/influxdb

--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -97,6 +97,7 @@ type HTTPConfig struct {
 	RetentionPolicy      string
 	Consistency          string
 	SkipDatabaseCreation bool
+	TimePrecision        string
 
 	InfluxUintSupport bool `toml:"influx_uint_support"`
 	Serializer        *influx.Serializer
@@ -272,7 +273,7 @@ func (c *httpClient) Write(ctx context.Context, metrics []telegraf.Metric) error
 }
 
 func (c *httpClient) writeBatch(ctx context.Context, db string, metrics []telegraf.Metric) error {
-	url, err := makeWriteURL(c.config.URL, db, c.config.RetentionPolicy, c.config.Consistency)
+	url, err := makeWriteURL(c.config.URL, db, c.config.RetentionPolicy, c.config.Consistency, c.config.TimePrecision)
 	if err != nil {
 		return err
 	}
@@ -407,7 +408,7 @@ func (c *httpClient) addHeaders(req *http.Request) {
 	}
 }
 
-func makeWriteURL(loc *url.URL, db, rp, consistency string) (string, error) {
+func makeWriteURL(loc *url.URL, db, rp, consistency, timePrecision string) (string, error) {
 	params := url.Values{}
 	params.Set("db", db)
 
@@ -417,6 +418,10 @@ func makeWriteURL(loc *url.URL, db, rp, consistency string) (string, error) {
 
 	if consistency != "one" && consistency != "" {
 		params.Set("consistency", consistency)
+	}
+
+	if timePrecision != "" {
+		params.Set("precision", timePrecision)
 	}
 
 	u := *loc

--- a/plugins/outputs/influxdb/http_test.go
+++ b/plugins/outputs/influxdb/http_test.go
@@ -359,6 +359,18 @@ func TestHTTP_Write(t *testing.T) {
 			},
 		},
 		{
+			name: "send time precision",
+			config: influxdb.HTTPConfig{
+				URL:           u,
+				Database:      "telegraf",
+				TimePrecision: "ms",
+			},
+			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "ms", r.FormValue("precision"))
+				w.WriteHeader(http.StatusNoContent)
+			},
+		},
+		{
 			name: "hinted handoff not empty no log no error",
 			config: influxdb.HTTPConfig{
 				URL:      u,

--- a/plugins/outputs/influxdb_v2/README.md
+++ b/plugins/outputs/influxdb_v2/README.md
@@ -52,6 +52,10 @@ The InfluxDB output plugin writes metrics to the [InfluxDB v2.x] HTTP service.
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## When writing data to InfluxDB, time precision that should be used (s, ms, us, ns)
+  ## defaults to "ns"
+  # time_precision = ""
 ```
 
 [InfluxDB v2.x]: https://github.com/influxdata/influxdb

--- a/plugins/outputs/influxdb_v2/http_internal_test.go
+++ b/plugins/outputs/influxdb_v2/http_internal_test.go
@@ -20,11 +20,11 @@ func TestMakeWriteURL(t *testing.T) {
 	}{
 		{
 			url: genURL("http://localhost:9999"),
-			act: "http://localhost:9999/api/v2/write?bucket=telegraf&org=influx",
+			act: "http://localhost:9999/api/v2/write?bucket=telegraf&org=influx&precision=ms",
 		},
 		{
 			url: genURL("unix://var/run/influxd.sock"),
-			act: "http://127.0.0.1/api/v2/write?bucket=telegraf&org=influx",
+			act: "http://127.0.0.1/api/v2/write?bucket=telegraf&org=influx&precision=ms",
 		},
 		{
 			err: true,
@@ -33,7 +33,7 @@ func TestMakeWriteURL(t *testing.T) {
 	}
 
 	for i := range tests {
-		rURL, err := makeWriteURL(*tests[i].url, "influx", "telegraf")
+		rURL, err := makeWriteURL(*tests[i].url, "influx", "telegraf", "ms")
 		if !tests[i].err {
 			require.NoError(t, err)
 		} else {

--- a/plugins/outputs/influxdb_v2/influxdb.go
+++ b/plugins/outputs/influxdb_v2/influxdb.go
@@ -89,6 +89,7 @@ type InfluxDB struct {
 	ContentEncoding string            `toml:"content_encoding"`
 	UintSupport     bool              `toml:"influx_uint_support"`
 	tls.ClientConfig
+	TimePrecision string `toml:"time_precision"`
 
 	clients    []Client
 	serializer *influx.Serializer
@@ -104,6 +105,10 @@ func (i *InfluxDB) Connect() error {
 	i.serializer = influx.NewSerializer()
 	if i.UintSupport {
 		i.serializer.SetFieldTypeSupport(influx.UintSupport)
+	}
+
+	if i.TimePrecision != "" {
+		i.serializer.SetTimeFormat(i.TimePrecision)
 	}
 
 	for _, u := range i.URLs {

--- a/plugins/serializers/influx/influx_test.go
+++ b/plugins/serializers/influx/influx_test.go
@@ -24,6 +24,7 @@ var tests = []struct {
 	input       telegraf.Metric
 	output      []byte
 	errReason   string
+	timeFormat  string
 }{
 	{
 		name: "minimal",
@@ -244,6 +245,21 @@ var tests = []struct {
 		output: []byte("cpu value=42 1519194109000000042\n"),
 	},
 	{
+		name:       "timestamp in milliseconds",
+		timeFormat: "ms",
+		input: MustMetric(
+			metric.New(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{
+					"value": 42.0,
+				},
+				time.Unix(1519194109, 42),
+			),
+		),
+		output: []byte("cpu value=42 1519194109000\n"),
+	},
+	{
 		name:     "split fields exact",
 		maxBytes: 33,
 		input: MustMetric(
@@ -444,6 +460,7 @@ func TestSerializer(t *testing.T) {
 			serializer.SetMaxLineBytes(tt.maxBytes)
 			serializer.SetFieldSortOrder(SortFields)
 			serializer.SetFieldTypeSupport(tt.typeSupport)
+			serializer.SetTimeFormat(tt.timeFormat)
 			output, err := serializer.Serialize(tt.input)
 			if tt.errReason != "" {
 				require.Error(t, err)


### PR DESCRIPTION
This allows to set the time precision (s, ms, us, ns) when sending metrics to InfluxDB. Previously, only ns was possible.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
