### PR TITLE
Add support for ${} env vars in configuration file

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,10 +34,10 @@ configuration files.
 
 ### Environment Variables
 
-Environment variables can be used anywhere in the config file, simply prepend
-them with `$`.  Replacement occurs before file parsing.   For strings
-the variable must be within quotes, e.g., `"$STR_VAR"`, for numbers and booleans
-they should be unquoted, e.g., `$INT_VAR`, `$BOOL_VAR`.
+Environment variables can be used anywhere in the config file, simply surround
+them with `${}`.  Replacement occurs before file parsing.   For strings
+the variable must be within quotes, e.g., `"${STR_VAR}"`, for numbers and booleans
+they should be unquoted, e.g., `${INT_VAR}`, `${BOOL_VAR}`.
 
 When using the `.deb` or `.rpm` packages, you can define environment variables
 in the `/etc/default/telegraf` file.
@@ -55,14 +55,14 @@ INFLUX_PASSWORD="monkey123"
 `/etc/telegraf.conf`:
 ```toml
 [global_tags]
-  user = "$USER"
+  user = "${USER}"
 
 [[inputs.mem]]
 
 [[outputs.influxdb]]
-  urls = ["$INFLUX_URL"]
-  skip_database_creation = $INFLUX_SKIP_DATABASE_CREATION
-  password = "$INFLUX_PASSWORD"
+  urls = ["${INFLUX_URL}"]
+  skip_database_creation = ${INFLUX_SKIP_DATABASE_CREATION}
+  password = "${INFLUX_PASSWORD}"
 ```
 
 The above files will produce the following effective configuration file to be

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs/memcached"
 	"github.com/influxdata/telegraf/plugins/inputs/procstat"
 	"github.com/influxdata/telegraf/plugins/parsers"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +27,7 @@ func TestConfig_LoadSingleInputWithEnvVars(t *testing.T) {
 
 	filter := models.Filter{
 		NameDrop:  []string{"metricname2"},
-		NamePass:  []string{"metricname1"},
+		NamePass:  []string{"metricname1", "ip_192.168.1.1_name"},
 		FieldDrop: []string{"other", "stuff"},
 		FieldPass: []string{"some", "strings"},
 		TagDrop: []models.TagFilter{

--- a/internal/config/testdata/single_plugin_env_vars.toml
+++ b/internal/config/testdata/single_plugin_env_vars.toml
@@ -1,6 +1,6 @@
 [[inputs.memcached]]
   servers = ["$MY_TEST_SERVER"]
-  namepass = ["metricname1"]
+  namepass = ["metricname1", "ip_${MY_TEST_SERVER}_name"]
   namedrop = ["metricname2"]
   fieldpass = ["some", "strings"]
   fielddrop = ["other", "stuff"]


### PR DESCRIPTION
Both styles will work, but in the docs I'm only recommend the ${} syntax since it gives you one less thing to worry about.

closes #5646

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
