### PR TITLE
Expose CrateDB on Host Port 6543

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     ports:
       - "4200:4200"
       - "4230:4230"
-      - "5432:5432"
+      - "6543:5432"
     command:
       - crate
       - -Cnetwork.host=0.0.0.0


### PR DESCRIPTION
This is what is configured in the connection string within cratedb_test.go

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
