### PR TITLE
Allow colons in metric names in prometheus_client output

### DIFF
--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9_:]`)
 	validNameCharRE   = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*`)
 )
 

--- a/plugins/outputs/prometheus_client/prometheus_client_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_test.go
@@ -186,15 +186,15 @@ func TestWrite_Sanitize(t *testing.T) {
 	client := NewClient()
 
 	p1, err := metric.New(
-		"foo.bar",
+		"foo.bar:colon",
 		map[string]string{"tag-with-dash": "localhost.local"},
-		map[string]interface{}{"field-with-dash": 42},
+		map[string]interface{}{"field-with-dash-and:colon": 42},
 		time.Now(),
 		telegraf.Counter)
 	err = client.Write([]telegraf.Metric{p1})
 	require.NoError(t, err)
 
-	fam, ok := client.fam["foo_bar_field_with_dash"]
+	fam, ok := client.fam["foo_bar:colon_field_with_dash_and:colon"]
 	require.True(t, ok)
 	require.Equal(t, map[string]int{"tag_with_dash": 1}, fam.LabelSet)
 


### PR DESCRIPTION
Signed-off-by: Robert Sullivan <rsullivan@pivotal.io>

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
