### PR TITLE
New aggregator: Firstlast

### DIFF
--- a/plugins/aggregators/all/all.go
+++ b/plugins/aggregators/all/all.go
@@ -2,6 +2,7 @@ package all
 
 import (
 	_ "github.com/influxdata/telegraf/plugins/aggregators/basicstats"
+	_ "github.com/influxdata/telegraf/plugins/aggregators/firstlast"
 	_ "github.com/influxdata/telegraf/plugins/aggregators/histogram"
 	_ "github.com/influxdata/telegraf/plugins/aggregators/minmax"
 	_ "github.com/influxdata/telegraf/plugins/aggregators/valuecounter"

--- a/plugins/aggregators/firstlast/README.md
+++ b/plugins/aggregators/firstlast/README.md
@@ -1,24 +1,33 @@
 # FirstLast Aggregator Plugin
 
-The firstlast aggregator emits the first and last metrics of a series.
+The firstlast aggregator emits the first and last metrics of a contiguous series.
+A contiguous series is defined as a series which receives updates within the time
+period in `series_timeout`. The contiguous series may be longer than the time interval
+defined by `period`.
 
-The first metric is resent with the `first_suffix` appended to the measurement name
-for all new series. The `warmup` parameter defines how long after Telegraf startup
-we wait until starting to send the first metrics. This can be used to avoid a flood
-of `first_` metrics if Telegraf is restarted.
+This is useful for getting the first and/or final values for data sources that produce
+discrete time series such as procstat, cgroup, kubernetes etc.
 
-The last metric is resent with the `last_suffix` appended. The `timeout` parameter defines
-how long a series is idle until sending the last metric.
+The first metric is emitted with the `_first` appended to field names for all new series
+that have appeared within the time interval defined by `period`
+
+The `warmup` parameter defines how long after Telegraf startup we wait until starting to
+send the first metrics. This can be used to avoid a flood of `_first` metrics if Telegraf
+is restarted.
+
+If a series has not been updated within the time defined in `series_timeout`, the last metric 
+is emttied with the `_last` appended.
 
 Assumptions for data to be aggregated properly:
- - The data should arrive in order
- - The data that arrives should not be older than "current time - `timeout`"
- - The metric should be contained in a single measurement line
 
-### Configuration:
+- The data should arrive in order
+- The data that arrives should not be older than "current time - `series_timeout`"
+- The metric should be contained in a single measurement line
+
+### Configuration
 
 ```toml
-# Keep the first and last series
+# Keep the first and/or last metrics of a contiguous series
 [[aggregators.firstlast]]
   ## General Aggregator Arguments:
   ## The period on which to flush & clear the aggregator.
@@ -26,36 +35,33 @@ Assumptions for data to be aggregated properly:
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.
   drop_original = false
-  ## The amount of time until a series is considered ended
-  timeout = "30s"
-  ## The amount of time before we start considering first series
-  warmup = "20s"
+  ## The time that a series is not updated until considering it ended
+  series_timeout = "30s"
+  ## The amount of time to wait after Telegraf startup until evaluating new series
+  warmup = "10s"
   ## Emit first entry of a series
   first = true
-  ## Suffix for the measurement names of first entries
-  first_suffix = "_first"
   ## Emit last entry of a series
   last = true
-  ## Suffix for the measurement names of last entries
-  last_suffix = "_last"
 ```
 
-### Measurements & Fields:
+### Measurements & Fields
 
-- measurement1_first
-- measurement1_last
+- measurement1
+  - field1_first
+  - field1_last
 
-### Tags:
+### Tags
 
 No tags are applied by this aggregator.
 
-### Example Output:
+### Example Output
 
 ```
-counter_first,host=bar i=1 1554281633101153300
-counter_first,host=foo i=1 1554281633099323601
-counter_last,host=bar i=3 1554281635115090133
-counter_last,host=foo i=3 1554281635112992012
+counter,host=bar i_first=1 1554281633101153300
+counter,host=foo i_first=1 1554281633099323601
+counter,host=bar i_last=3 1554281635115090133
+counter,host=foo i_last=3 1554281635112992012
 ```
 
 Original input:

--- a/plugins/aggregators/firstlast/README.md
+++ b/plugins/aggregators/firstlast/README.md
@@ -1,0 +1,69 @@
+# FirstLast Aggregator Plugin
+
+The firstlast aggregator emits the first and last metrics of a series.
+
+The first metric is resent with the `first_suffix` appended to the measurement name
+for all new series. The `warmup` parameter defines how long after Telegraf startup
+we wait until starting to send the first metrics. This can be used to avoid a flood
+of `first_` metrics if Telegraf is restarted.
+
+The last metric is resent with the `last_suffix` appended. The `timeout` parameter defines
+how long a series is idle until sending the last metric.
+
+Assumptions for data to be aggregated properly:
+ - The data should arrive in order
+ - The data that arrives should not be older than "current time - `timeout`"
+ - The metric should be contained in a single measurement line
+
+### Configuration:
+
+```toml
+# Keep the first and last series
+[[aggregators.firstlast]]
+  ## General Aggregator Arguments:
+  ## The period on which to flush & clear the aggregator.
+  period = "30s"
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+  ## The amount of time until a series is considered ended
+  timeout = "30s"
+  ## The amount of time before we start considering first series
+  warmup = "20s"
+  ## Emit first entry of a series
+  first = true
+  ## Suffix for the measurement names of first entries
+  first_suffix = "_first"
+  ## Emit last entry of a series
+  last = true
+  ## Suffix for the measurement names of last entries
+  last_suffix = "_last"
+```
+
+### Measurements & Fields:
+
+- measurement1_first
+- measurement1_last
+
+### Tags:
+
+No tags are applied by this aggregator.
+
+### Example Output:
+
+```
+counter_first,host=bar i=1 1554281633101153300
+counter_first,host=foo i=1 1554281633099323601
+counter_last,host=bar i=3 1554281635115090133
+counter_last,host=foo i=3 1554281635112992012
+```
+
+Original input:
+```
+counter,host=bar i=1 1554281633101153300
+counter,host=foo i=1 1554281633099323601
+counter,host=bar i=2 1554281634107980073
+counter,host=foo i=2 1554281634105931116
+counter,host=bar i=3 1554281635115090133
+counter,host=foo i=3 1554281635112992012
+```

--- a/plugins/aggregators/firstlast/firstlast.go
+++ b/plugins/aggregators/firstlast/firstlast.go
@@ -1,0 +1,102 @@
+package firstlast
+
+// FirstLast.go
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/aggregators"
+	"time"
+)
+
+type FirstLast struct {
+	LastTimeout internal.Duration `toml:"timeout"`
+	WarmupTime  internal.Duration `toml:"warmup"`
+	EnableFirst bool              `toml:"first"`
+	EnableLast  bool              `toml:"last"`
+	FirstSuffix string            `toml:"first_suffix"`
+	LastSuffix  string            `toml:"last_suffix"`
+
+	// caches for metric fields, names, and tags
+	startTime        time.Time
+	metricCache      map[uint64]telegraf.Metric
+	firstMetricCache map[uint64]telegraf.Metric
+}
+
+func NewFirstLast() telegraf.Aggregator {
+	return &FirstLast{
+		startTime:        time.Now(),
+		LastTimeout:      internal.Duration{Duration: 20 * time.Second},
+		WarmupTime:       internal.Duration{Duration: 10 * time.Second},
+		EnableFirst:      true,
+		EnableLast:       true,
+		FirstSuffix:      "_first",
+		LastSuffix:       "_last",
+		metricCache:      make(map[uint64]telegraf.Metric),
+		firstMetricCache: make(map[uint64]telegraf.Metric),
+	}
+}
+func (m *FirstLast) Reset() {
+
+}
+
+var sampleConfig = `
+  ## period is the flush & clear interval of the aggregator.
+  period = "30s"
+  ## If true drop_original will drop the original metrics and
+  ## only send aggregates.
+  drop_original = false
+  ## The amount of time until a series is considered ended
+  timeout = "30s"
+  ## The amount of time before we start issuing _first 
+  warmup = "10s"
+  ## Emit first entry of a series
+  first = true
+  ## Suffix for the measurement names of first entries
+  first_suffix = "_first"
+  ## Emit last entry of a series
+  last = true
+  ## Suffix for the measurement names of last entries
+  last_suffix = "_last"
+
+ `
+
+func (m *FirstLast) SampleConfig() string {
+	return sampleConfig
+}
+
+func (m *FirstLast) Description() string {
+	return "Get the first and/or last values of a series"
+}
+
+func (m *FirstLast) Add(in telegraf.Metric) {
+	id := in.HashID()
+	if _, ok := m.metricCache[id]; !ok {
+		m.firstMetricCache[id] = in
+	}
+	m.metricCache[id] = in
+}
+
+func (m *FirstLast) Push(acc telegraf.Accumulator) {
+	acc.SetPrecision(time.Nanosecond)
+	for id, metric := range m.firstMetricCache {
+		if time.Since(metric.Time()) > m.WarmupTime.Duration && m.EnableFirst {
+			acc.AddFields(metric.Name()+m.FirstSuffix, metric.Fields(), metric.Tags(), metric.Time())
+		}
+		delete(m.firstMetricCache, id)
+	}
+	for id, metric := range m.metricCache {
+		if time.Since(metric.Time()) > m.LastTimeout.Duration {
+			if m.EnableLast {
+				acc.AddFields(metric.Name()+m.LastSuffix, metric.Fields(), metric.Tags(), metric.Time())
+			}
+			delete(m.metricCache, id)
+		}
+	}
+}
+
+func init() {
+	aggregators.Add("firstlast", func() telegraf.Aggregator {
+		return NewFirstLast()
+	})
+}

--- a/plugins/aggregators/firstlast/firstlast_test.go
+++ b/plugins/aggregators/firstlast/firstlast_test.go
@@ -1,0 +1,103 @@
+package firstlast
+
+import (
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestFirstLastSimple(t *testing.T) {
+	acc := testutil.Accumulator{}
+	fl := NewFirstLast()
+
+	tags := map[string]string{"foo": "bar"}
+	m1, _ := metric.New("m1",
+		tags,
+		map[string]interface{}{"a": int64(1)},
+		time.Unix(1530939936, 0))
+	m2, _ := metric.New("m1",
+		tags,
+		map[string]interface{}{"a": int64(2)},
+		time.Unix(1530939937, 0))
+	m3, _ := metric.New("m1",
+		tags,
+		map[string]interface{}{"a": int64(3)},
+		time.Unix(1530939938, 0))
+	fl.Add(m1)
+	fl.Add(m2)
+	fl.Add(m3)
+	fl.Push(&acc)
+	assert.True(t, acc.HasPoint("m1_first", tags, "a", int64(1)))
+	assert.True(t, acc.HasPoint("m1_last", tags, "a", int64(3)))
+	assert.Equal(t, 2, int(acc.NMetrics()))
+}
+
+func TestFirstLastTwoTags(t *testing.T) {
+	acc := testutil.Accumulator{}
+	fl := NewFirstLast()
+
+	tags1 := map[string]string{"foo": "bar"}
+	tags2 := map[string]string{"foo": "baz"}
+
+	m1, _ := metric.New("m1",
+		tags1,
+		map[string]interface{}{"a": int64(1)},
+		time.Unix(1530939936, 0))
+	m2, _ := metric.New("m1",
+		tags2,
+		map[string]interface{}{"a": int64(2)},
+		time.Unix(1530939937, 0))
+	m3, _ := metric.New("m1",
+		tags1,
+		map[string]interface{}{"a": int64(3)},
+		time.Unix(1530939938, 0))
+	fl.Add(m1)
+	fl.Add(m2)
+	fl.Add(m3)
+	fl.Push(&acc)
+	assert.True(t, acc.HasPoint("m1_first", tags1, "a", int64(1)))
+	assert.True(t, acc.HasPoint("m1_last", tags1, "a", int64(3)))
+	assert.True(t, acc.HasPoint("m1_first", tags2, "a", int64(2)))
+	assert.True(t, acc.HasPoint("m1_last", tags2, "a", int64(2)))
+	assert.Equal(t, 4, int(acc.NMetrics()))
+}
+
+func TestFirstLastLongDifference(t *testing.T) {
+	acc := testutil.Accumulator{}
+	fl := NewFirstLast()
+
+	tags := map[string]string{"foo": "bar"}
+
+	// m1 and m2 are outside the timeout window. Should get a single _first and _last.
+	m1, _ := metric.New("m",
+		tags,
+		map[string]interface{}{"a": int64(1)},
+		time.Now().Add(time.Second*-300))
+	m2, _ := metric.New("m",
+		tags,
+		map[string]interface{}{"a": int64(2)},
+		time.Now().Add(time.Second*-290))
+	// Within the timeout window but outside warmup. We should get a "_first"
+	m3, _ := metric.New("m",
+		tags,
+		map[string]interface{}{"a": int64(3)},
+		time.Now().Add(time.Second*-45))
+	// Within the warmup window. Shouldn't do anything.
+	m4, _ := metric.New("m",
+		tags,
+		map[string]interface{}{"a": int64(3)},
+		time.Now().Add(time.Second*-15))
+	fl.Add(m1)
+	fl.Add(m2)
+	fl.Push(&acc)
+	fl.Add(m3)
+	fl.Push(&acc)
+	fl.Add(m4)
+
+	assert.True(t, acc.HasPoint("m_first", tags, "a", int64(1)))
+	assert.True(t, acc.HasPoint("m_last", tags, "a", int64(2)))
+	assert.True(t, acc.HasPoint("m_first", tags, "a", int64(3)))
+	assert.Equal(t, 3, int(acc.NMetrics()))
+}

--- a/plugins/aggregators/firstlast/firstlast_test.go
+++ b/plugins/aggregators/firstlast/firstlast_test.go
@@ -11,6 +11,7 @@ import (
 func TestFirstLastSimple(t *testing.T) {
 	acc := testutil.Accumulator{}
 	fl := NewFirstLast()
+	fl.startTime = (time.Unix(1530939906, 0))
 
 	tags := map[string]string{"foo": "bar"}
 	m1, _ := metric.New("m1",
@@ -29,14 +30,72 @@ func TestFirstLastSimple(t *testing.T) {
 	fl.Add(m2)
 	fl.Add(m3)
 	fl.Push(&acc)
-	assert.True(t, acc.HasPoint("m1_first", tags, "a", int64(1)))
-	assert.True(t, acc.HasPoint("m1_last", tags, "a", int64(3)))
+	assert.True(t, acc.HasPoint("m1", tags, "a_first", int64(1)))
+	assert.True(t, acc.HasPoint("m1", tags, "a_last", int64(3)))
 	assert.Equal(t, 2, int(acc.NMetrics()))
+}
+
+func TestFirstLastDisableLast(t *testing.T) {
+	acc := testutil.Accumulator{}
+	fl := NewFirstLast()
+	fl.EnableFirst = false
+	fl.startTime = (time.Unix(1530939906, 0))
+
+	tags := map[string]string{"foo": "bar"}
+	m1, _ := metric.New("m1",
+		tags,
+		map[string]interface{}{"a": int64(1)},
+		time.Unix(1530939936, 0))
+	m2, _ := metric.New("m1",
+		tags,
+		map[string]interface{}{"a": int64(2)},
+		time.Unix(1530939937, 0))
+	m3, _ := metric.New("m1",
+		tags,
+		map[string]interface{}{"a": int64(3)},
+		time.Unix(1530939938, 0))
+	fl.Add(m1)
+	fl.Add(m2)
+	fl.Add(m3)
+	fl.Push(&acc)
+	assert.False(t, acc.HasField("m1", "a_first"))
+	assert.True(t, acc.HasPoint("m1", tags, "a_last", int64(3)))
+	assert.Equal(t, 1, int(acc.NMetrics()))
+}
+
+func TestFirstLastDisableFirst(t *testing.T) {
+	acc := testutil.Accumulator{}
+	fl := NewFirstLast()
+	fl.EnableLast = false
+	fl.startTime = (time.Unix(1530939906, 0))
+
+	tags := map[string]string{"foo": "bar"}
+	m1, _ := metric.New("m1",
+		tags,
+		map[string]interface{}{"a": int64(1)},
+		time.Unix(1530939936, 0))
+	m2, _ := metric.New("m1",
+		tags,
+		map[string]interface{}{"a": int64(2)},
+		time.Unix(1530939937, 0))
+	m3, _ := metric.New("m1",
+		tags,
+		map[string]interface{}{"a": int64(3)},
+		time.Unix(1530939938, 0))
+	fl.Add(m1)
+	fl.Add(m2)
+	fl.Add(m3)
+	fl.Push(&acc)
+	assert.True(t, acc.HasPoint("m1", tags, "a_first", int64(1)))
+	assert.False(t, acc.HasField("m1", "a_last"))
+	assert.Equal(t, 1, int(acc.NMetrics()))
 }
 
 func TestFirstLastTwoTags(t *testing.T) {
 	acc := testutil.Accumulator{}
 	fl := NewFirstLast()
+
+	fl.startTime = (time.Unix(1530939906, 0))
 
 	tags1 := map[string]string{"foo": "bar"}
 	tags2 := map[string]string{"foo": "baz"}
@@ -57,47 +116,47 @@ func TestFirstLastTwoTags(t *testing.T) {
 	fl.Add(m2)
 	fl.Add(m3)
 	fl.Push(&acc)
-	assert.True(t, acc.HasPoint("m1_first", tags1, "a", int64(1)))
-	assert.True(t, acc.HasPoint("m1_last", tags1, "a", int64(3)))
-	assert.True(t, acc.HasPoint("m1_first", tags2, "a", int64(2)))
-	assert.True(t, acc.HasPoint("m1_last", tags2, "a", int64(2)))
+	assert.True(t, acc.HasPoint("m1", tags1, "a_first", int64(1)))
+	assert.True(t, acc.HasPoint("m1", tags1, "a_last", int64(3)))
+	assert.True(t, acc.HasPoint("m1", tags2, "a_first", int64(2)))
+	assert.True(t, acc.HasPoint("m1", tags2, "a_last", int64(2)))
 	assert.Equal(t, 4, int(acc.NMetrics()))
 }
 
 func TestFirstLastLongDifference(t *testing.T) {
 	acc := testutil.Accumulator{}
 	fl := NewFirstLast()
-
+	fl.startTime = time.Now().Add(time.Second * -500)
 	tags := map[string]string{"foo": "bar"}
 
-	// m1 and m2 are outside the timeout window. Should get a single _first and _last.
 	m1, _ := metric.New("m",
 		tags,
 		map[string]interface{}{"a": int64(1)},
-		time.Now().Add(time.Second*-300))
+		time.Now().Add(time.Second*-290))
 	m2, _ := metric.New("m",
 		tags,
 		map[string]interface{}{"a": int64(2)},
-		time.Now().Add(time.Second*-290))
-	// Within the timeout window but outside warmup. We should get a "_first"
+		time.Now().Add(time.Second*-275))
 	m3, _ := metric.New("m",
 		tags,
 		map[string]interface{}{"a": int64(3)},
-		time.Now().Add(time.Second*-45))
-	// Within the warmup window. Shouldn't do anything.
+		time.Now().Add(time.Second*-100))
 	m4, _ := metric.New("m",
 		tags,
-		map[string]interface{}{"a": int64(3)},
-		time.Now().Add(time.Second*-15))
+		map[string]interface{}{"a": int64(4)},
+		time.Now().Add(time.Second*-20))
 	fl.Add(m1)
 	fl.Add(m2)
 	fl.Push(&acc)
 	fl.Add(m3)
 	fl.Push(&acc)
 	fl.Add(m4)
+	fl.Push(&acc)
 
-	assert.True(t, acc.HasPoint("m_first", tags, "a", int64(1)))
-	assert.True(t, acc.HasPoint("m_last", tags, "a", int64(2)))
-	assert.True(t, acc.HasPoint("m_first", tags, "a", int64(3)))
-	assert.Equal(t, 3, int(acc.NMetrics()))
+	assert.True(t, acc.HasPoint("m", tags, "a_first", int64(1)))
+	assert.True(t, acc.HasPoint("m", tags, "a_last", int64(2)))
+	assert.True(t, acc.HasPoint("m", tags, "a_first", int64(3)))
+	assert.True(t, acc.HasPoint("m", tags, "a_last", int64(3)))
+	assert.True(t, acc.HasPoint("m", tags, "a_first", int64(4)))
+	assert.Equal(t, 5, int(acc.NMetrics()))
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

A new aggregator that can be used to emit first and last metrics of a discrete series (that sends metrics for a finite amount of time). For example if we want to get the first and final values of a counter associated with a network flow or process statistics from `procstat`. 

This was developed for a specific in-house use case but it might be useful to the community at-large. 