### PR TITLE
Kinesis input compressed metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1580,6 +1580,7 @@
     "github.com/golang/protobuf/ptypes/duration",
     "github.com/golang/protobuf/ptypes/empty",
     "github.com/golang/protobuf/ptypes/timestamp",
+    "github.com/golang/snappy",
     "github.com/google/go-cmp/cmp",
     "github.com/google/go-github/github",
     "github.com/gorilla/mux",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -288,3 +288,7 @@
 [[constraint]]
   name = "github.com/google/go-github"
   version = "24.0.1"
+  
+[[constraint]]
+  name = "github.com/golang/snappy"
+  revision = "2a8bb927dd31d8daada140a5d09578521ce5c36a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -288,7 +288,6 @@
 [[constraint]]
   name = "github.com/google/go-github"
   version = "24.0.1"
-  
 [[constraint]]
+  branch = "master"
   name = "github.com/golang/snappy"
-  revision = "2a8bb927dd31d8daada140a5d09578521ce5c36a"

--- a/plugins/inputs/kinesis_consumer/README.md
+++ b/plugins/inputs/kinesis_consumer/README.md
@@ -85,6 +85,16 @@ Partition key: namespace
 Sort key: shard_id
 ```
 
+#### Compressed metrics
+
+Kinesis cares very little about what is in the payloads of the records. Therefore you can store compressed metrics like that of the Kinesis output plugin.
+You will need to tell telegraf what is in the records before hand.
+Currently supported compression formats: `["gzip", "snappy"]`
+
+```toml
+compressed_metrics = true
+compression_type = gzip
+```
 
 [kinesis]: https://aws.amazon.com/kinesis/
 [input data formats]: /docs/DATA_FORMATS_INPUT.md

--- a/plugins/inputs/kinesis_consumer/README.md
+++ b/plugins/inputs/kinesis_consumer/README.md
@@ -60,27 +60,31 @@ and creates metrics using one of the supported [input data formats][].
     ## unique name for this consumer
     app_name = "default"
     table_name = "default"
+  
+  ## Configuration for compressed metrics
+  ## compression_type can be equal to either "gzip", "snappy" or the
+  ## default of none
+  compression_type = "none"
 ```
 
 
 #### Required AWS IAM permissions
 
-Kinesis:
- - DescribeStream
- - GetRecords
- - GetShardIterator
+- Kinesis
+  - DescribeStream
+  - GetRecords
+  - GetShardIterator
 
-DynamoDB:
- - GetItem
- - PutItem
-
+- DynamoDB
+  - GetItem
+  - PutItem
 
 #### DynamoDB Checkpoint
 
 The DynamoDB checkpoint stores the last processed record in a DynamoDB. To leverage
-this functionality, create a table with the folowing string type keys:
+this functionality, create a table with the following string type keys:
 
-```
+```none
 Partition key: namespace
 Sort key: shard_id
 ```
@@ -88,12 +92,11 @@ Sort key: shard_id
 #### Compressed metrics
 
 Kinesis cares very little about what is in the payloads of the records. Therefore you can store compressed metrics like that of the Kinesis output plugin.
-You will need to tell telegraf what is in the records before hand.
-Currently supported compression formats: `["gzip", "snappy"]`
+You will need to tell telegraf, what is in the records before hand.
+Currently supported compression formats: `["gzip", "snappy", "none"]`
 
 ```toml
-compressed_metrics = true
-compression_type = gzip
+compression_type = "gzip"
 ```
 
 [kinesis]: https://aws.amazon.com/kinesis/

--- a/plugins/inputs/kinesis_consumer/decompressrecords.go
+++ b/plugins/inputs/kinesis_consumer/decompressrecords.go
@@ -1,0 +1,33 @@
+package kinesis_consumer
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/golang/snappy"
+)
+
+func decompressGZip(recordSlug []byte) ([]byte, error) {
+	buffer := bytes.NewBuffer(recordSlug)
+	decompressionReader, err := gzip.NewReader(buffer)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create reader for gzip. Error: %s", err)
+	}
+	defer decompressionReader.Close()
+	b, err := ioutil.ReadAll(decompressionReader)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read from gzip reader. Error:s %s", err)
+	}
+	return b, nil
+}
+
+func decompressSnappy(recordSlug []byte) ([]byte, error) {
+	b, err := snappy.Decode(nil, recordSlug)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to decode snappy data. Error: %s", err)
+	}
+
+	return b, nil
+}

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
@@ -18,12 +18,15 @@ func TestDecompression(t *testing.T) {
 			name:  "gzip",
 			input: []byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 42, 73, 45, 46, 73, 73, 44, 73, 52, 52, 50, 54, 81, 84, 58, 180, 88, 133, 176, 0, 32, 0, 0, 255, 255, 54, 208, 10, 134, 51, 0, 0, 0},
 		},
+		{
+			name:  "none",
+			input: expectedOutput,
+		},
 	}
 
 	for _, test := range tests {
 		k := KinesisConsumer{
-			CompressedMetrics: true,
-			CompressionType:   test.name,
+			Compression: test.name,
 		}
 
 		output, err := k.decompress(test.input)

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
@@ -1,0 +1,41 @@
+package kinesis_consumer
+
+import "testing"
+
+func TestDecompression(t *testing.T) {
+	// All compression should result in the same output
+	expectedOutput := []byte(`testdata1234!"£$testdata1234!"£$testdata1234!"£$`)
+
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "snappy",
+			input: []byte{51, 64, 116, 101, 115, 116, 100, 97, 116, 97, 49, 50, 51, 52, 33, 34, 194, 163, 36, 134, 17, 0},
+		},
+		{
+			name:  "gzip",
+			input: []byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 42, 73, 45, 46, 73, 73, 44, 73, 52, 52, 50, 54, 81, 84, 58, 180, 88, 133, 176, 0, 32, 0, 0, 255, 255, 54, 208, 10, 134, 51, 0, 0, 0},
+		},
+	}
+
+	for _, test := range tests {
+		k := KinesisConsumer{
+			CompressedMetrics: true,
+			CompressionType:   test.name,
+		}
+
+		output, err := k.decompress(test.input)
+		if err != nil {
+			// Snappy can't actually fail but we put it in here to follow convention.
+			t.Logf("Decompression of %s data failed. Error: %s", test.name, err)
+			t.Fail()
+		}
+
+		if string(output) != string(expectedOutput) {
+			t.Logf("%s produced a different result than expected.", test.name)
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

###############################################

This code change is a supplement to PR #5588

With this you can now download the compressed metrics using the Telegraf Kinesis Input plugin.