### PR TITLE
Add optional namespace restriction to prometheus input plugin

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -24,8 +24,9 @@ in Prometheus format.
   ## - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
   ## - prometheus.io/port: If port is not 9102 use this annotation
   # monitor_kubernetes_pods = true
-  ## Only monitor one namespace
-  # monitor_kubernetes_pods_namespace = "test-namespace"
+  ## Restricts Kubernetes monitoring to a single namespace
+  ##   ex: monitor_kubernetes_pods_namespace = "default"
+  # monitor_kubernetes_pods_namespace = ""
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   # bearer_token = "/path/to/bearer/token"

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -24,6 +24,8 @@ in Prometheus format.
   ## - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
   ## - prometheus.io/port: If port is not 9102 use this annotation
   # monitor_kubernetes_pods = true
+  ## Only monitor one namespace
+  # monitor_kubernetes_pods_namespace = "test-namespace"
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   # bearer_token = "/path/to/bearer/token"
@@ -63,6 +65,8 @@ Currently the following annotation are supported:
 * `prometheus.io/scheme` If the metrics endpoint is secured then you will need to set this to `https` & most likely set the tls config. (default 'http')
 * `prometheus.io/path` Override the path for the metrics endpoint on the service. (default '/metrics')
 * `prometheus.io/port` Used to override the port. (default 9102)
+
+Using the `monitor_kubernetes_pods_namespace` option allows you to limit which pods you are scraping.
 
 #### Bearer Token
 

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -83,7 +83,7 @@ func (p *Prometheus) start(ctx context.Context) error {
 // directed to do so by K8s.
 func (p *Prometheus) watch(ctx context.Context, client *k8s.Client) error {
 	pod := &corev1.Pod{}
-	watcher, err := client.Watch(ctx, "", &corev1.Pod{})
+	watcher, err := client.Watch(ctx, p.PodNamespace, &corev1.Pod{})
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -66,8 +66,9 @@ var sampleConfig = `
   ## - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
   ## - prometheus.io/port: If port is not 9102 use this annotation
   # monitor_kubernetes_pods = true
-  ## Only monitor one namespace
-  # monitor_kubernetes_pods_namespace = "test-namespace"
+  ## Restricts Kubernetes monitoring to a single namespace
+  ##   ex: monitor_kubernetes_pods_namespace = "default"
+  # monitor_kubernetes_pods_namespace = ""
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   # bearer_token = "/path/to/bearer/token"

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -41,7 +41,8 @@ type Prometheus struct {
 	client *http.Client
 
 	// Should we scrape Kubernetes services for prometheus annotations
-	MonitorPods    bool `toml:"monitor_kubernetes_pods"`
+	MonitorPods    bool   `toml:"monitor_kubernetes_pods"`
+	PodNamespace   string `toml:"monitor_kubernetes_pods_namespace"`
 	lock           sync.Mutex
 	kubernetesPods map[string]URLAndAddress
 	cancel         context.CancelFunc
@@ -65,6 +66,8 @@ var sampleConfig = `
   ## - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
   ## - prometheus.io/port: If port is not 9102 use this annotation
   # monitor_kubernetes_pods = true
+  ## Only monitor one namespace
+  # monitor_kubernetes_pods_namespace = "test-namespace"
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   # bearer_token = "/path/to/bearer/token"


### PR DESCRIPTION
Allow prometheus to operate as a namespaced pod with namespace level permissions. This addresses https://github.com/influxdata/telegraf/issues/5306

### Required for all PRs:

- [√] Signed [CLA](https://influxdata.com/community/cla/).
- [√] Associated README.md updated.
- [√] Has appropriate unit tests.
