### PR TITLE
Don't require a telegraf.conf when config-directory specified

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -120,7 +120,7 @@ func runAgent(ctx context.Context,
 	c.OutputFilters = outputFilters
 	c.InputFilters = inputFilters
 	err := c.LoadConfig(*fConfig)
-	if err != nil {
+	if err != nil && *fConfigDirectory == "" {
 		return err
 	}
 


### PR DESCRIPTION
Resolves #5656 
Resolves #5571 

(Replaces #5573)