### PR TITLE
Deprecate uptime_format field in system input

### DIFF
--- a/plugins/inputs/system/README.md
+++ b/plugins/inputs/system/README.md
@@ -25,7 +25,7 @@ the `telegraf` user to be added to the `utmp` group on some systems.
 	- n_users (integer)
 	- n_cpus (integer)
 	- uptime (integer, seconds)
-	- uptime_format (string)
+	- uptime_format (string, deprecated in 1.10, use `uptime` field)
 
 ### Example Output:
 

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -9,11 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shirou/gopsutil/host"
-	"github.com/shirou/gopsutil/load"
-
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/load"
 )
 
 type SystemStats struct{}
@@ -22,7 +21,12 @@ func (_ *SystemStats) Description() string {
 	return "Read metrics about system load & uptime"
 }
 
-func (_ *SystemStats) SampleConfig() string { return "" }
+func (_ *SystemStats) SampleConfig() string {
+	return `
+  ## Uncomment to remove deprecated metrics.
+  # fielddrop = ["uptime_format"]
+`
+}
 
 func (_ *SystemStats) Gather(acc telegraf.Accumulator) error {
 	loadavg, err := load.Avg()


### PR DESCRIPTION
closes: #5606

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
