### PR TITLE
fix(package): make rpm verify pass after installation

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -18,6 +18,8 @@ import argparse
 
 # Packaging variables
 PACKAGE_NAME = "telegraf"
+USER = "telegraf"
+GROUP = "telegraf"
 INSTALL_ROOT_DIR = "/usr/bin"
 LOG_DIR = "/var/log/telegraf"
 SCRIPT_DIR = "/usr/lib/telegraf/scripts"
@@ -66,6 +68,7 @@ fpm_common_args = "-f -s dir --log error \
  --before-install {} \
  --after-remove {} \
  --before-remove {} \
+ --rpm-attr 755,{},{}:{} \
  --description \"{}\"".format(
     VENDOR,
     PACKAGE_URL,
@@ -77,6 +80,7 @@ fpm_common_args = "-f -s dir --log error \
     PREINST_SCRIPT,
     POSTREMOVE_SCRIPT,
     PREREMOVE_SCRIPT,
+    USER, GROUP, LOG_DIR,
     DESCRIPTION)
 
 targets = {

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -32,10 +32,6 @@ if ! id telegraf &>/dev/null; then
     useradd -r -M telegraf -s /bin/false -d /etc/telegraf -g telegraf
 fi
 
-test -d $LOG_DIR || mkdir -p $LOG_DIR
-chown -R -L telegraf:telegraf $LOG_DIR
-chmod 755 $LOG_DIR
-
 # Remove legacy symlink, if it exists
 if [[ -L /etc/init.d/telegraf ]]; then
     rm -f /etc/init.d/telegraf
@@ -72,6 +68,14 @@ if [[ -f /etc/redhat-release ]] || [[ -f /etc/SuSE-release ]]; then
     fi
 elif [[ -f /etc/debian_version ]]; then
     # Debian/Ubuntu logic
+
+    # Ownership for RH-based platforms is set in build.py via the `rmp-attr` option.
+    # We perform ownership change only for Debian-based systems.
+    # Moving these lines out of this if statement would make `rmp -V` fail after installation.
+    test -d $LOG_DIR || mkdir -p $LOG_DIR
+    chown -R -L telegraf:telegraf $LOG_DIR
+    chmod 755 $LOG_DIR
+
     if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
         install_systemd /lib/systemd/system/telegraf.service
         deb-systemd-invoke restart telegraf.service || echo "WARNING: systemd not running."


### PR DESCRIPTION
This change sets the ownership of directories on package generation with fpm instead that in post-install to make `rmp -i` pass.

For more details, see: https://github.com/influxdata/EAR/issues/716

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
