### PR TITLE
Don't start telegraf when stale pidfile found

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -120,13 +120,13 @@ confdir=/etc/telegraf/telegraf.d
 case $1 in
     start)
         # Checked the PID file exists and check the actual status of process
-        if [ -e $pidfile ]; then
-            pidofproc -p $pidfile $daemon > /dev/null 2>&1 && status="0" || status="$?"
-            # If the status is SUCCESS then don't need to start again.
-            if [ "x$status" = "x0" ]; then
-                log_failure_msg "$name process is running"
-                exit 0 # Exit
-            fi
+        if [ -e "$pidfile" ]; then
+            if pidofproc -p $pidfile $daemon > /dev/null; then
+				log_failure_msg "$name process is running"
+			else
+				log_failure_msg "$name pidfile has no corresponding process; ensure $name is stopped and remove $pidfile"
+			fi
+			exit 0
         fi
 
         # Bump the file limits, before launching the daemon. These will carry over to
@@ -150,8 +150,7 @@ case $1 in
     stop)
         # Stop the daemon.
         if [ -e $pidfile ]; then
-            pidofproc -p $pidfile $daemon > /dev/null 2>&1 && status="0" || status="$?"
-            if [ "$status" = 0 ]; then
+            if pidofproc -p $pidfile $daemon > /dev/null; then
                 # periodically signal until process exists
                 while true; do
                         if ! pidofproc -p $pidfile $daemon > /dev/null; then
@@ -172,8 +171,7 @@ case $1 in
     reload)
         # Reload the daemon.
         if [ -e $pidfile ]; then
-            pidofproc -p $pidfile $daemon > /dev/null 2>&1 && status="0" || status="$?"
-            if [ "$status" = 0 ]; then
+            if pidofproc -p $pidfile $daemon > /dev/null; then
                 if killproc -p $pidfile SIGHUP; then
                     log_success_msg "$name process was reloaded"
                 else


### PR DESCRIPTION
In the case that a stale pidfile is found, refuse to start until it has been dealt with by the system administrator.

closes #5730

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
