### PR TITLE
add flag to remove uptime and n_users

### DIFF
--- a/plugins/inputs/system/README.md
+++ b/plugins/inputs/system/README.md
@@ -8,8 +8,12 @@ and number of users logged in. It is similar to the unix `uptime` command.
 ```toml
 # Read metrics about system load & uptime
 [[inputs.system]]
-  # no configuration
+  ## Uncomment the following line to disable uptime collection
+  # skip_uptime = true
+  ## Uncomment the following line to disable uptime collection
+  # skip_users = true
 ```
+
 #### Permissions:
 
 The `n_users` field requires read access to `/var/run/utmp`, and may require


### PR DESCRIPTION
This PR allows setting of flags to turn them off for those who wish.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests. 

https://github.com/influxdata/telegraf/issues/5398
https://github.com/influxdata/telegraf/issues/5283
https://github.com/influxdata/telegraf/issues/3837
more...

Flags set to true

```
system,host=some-clever-name load1=2.18,load5=3.31,load15=3.45,n_cpus=8i 1555475800000000000
```

Flags set to false (still the default)
```
system,host=some-clever-name uptime_format=" 0:34" 1555475750000000000
system,host=some-clever-name uptime=2095i 1555475750000000000
system,host=some-clever-name load1=2.36,load5=3.5,load15=3.52,n_cpus=8i,n_users=1i 1555475750000000000
```