### PR TITLE
Fix docs for metric buffer limit to reflect current behavior

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -112,10 +112,7 @@ The agent table configures Telegraf and the defaults used across all plugins.
   This controls the size of writes that Telegraf sends to output plugins.
 
 - **metric_buffer_limit**:
-  For failed writes, telegraf will cache metric_buffer_limit metrics for each
-  output, and will flush this buffer on a successful write. Oldest metrics
-  are dropped first when this buffer fills.
-  This buffer only fills when writes fail to output plugin(s).
+  Maximum number of unwritten metrics per output.
 
 - **collection_jitter**:
   Collection jitter is used to jitter the collection by a random [interval][].

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -9,9 +9,9 @@
 # Use 'telegraf -config telegraf.conf -test' to see what metrics a config
 # file would generate.
 #
-# Environment variables can be used anywhere in this config file, simply prepend
-# them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
-# for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)
+# Environment variables can be used anywhere in this config file, simply surround
+# them with ${}. For strings the variable must be within quotes (ie, "${STR_VAR}"),
+# for numbers and booleans they should be plain (ie, ${INT_VAR}, ${BOOL_VAR})
 
 
 # Global tags can be specified here in key="value" format.
@@ -35,10 +35,7 @@
   ## This controls the size of writes that Telegraf sends to output plugins.
   metric_batch_size = 1000
 
-  ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
-  ## output, and will flush this buffer on a successful write. Oldest metrics
-  ## are dropped first when this buffer fills.
-  ## This buffer only fills when writes fail to output plugin(s).
+  ## Maximum number of unwritten metrics per output.
   metric_buffer_limit = 10000
 
   ## Collection jitter is used to jitter the collection by a random amount.
@@ -1092,6 +1089,10 @@
 #   ## When true will convert all _ (underscore) characters in final metric name. default is true
 #   #convert_paths = true
 #
+#   ## Use Strict rules to sanitize metric and tag names from invalid characters
+#   ## When enabled forward slash (/) and comma (,) will be accpeted
+#   #use_strict = false
+#
 #   ## Use Regex to sanitize metric and tag names from invalid characters
 #   ## Regex is more thorough, but significantly slower. default is false
 #   #use_regex = false
@@ -1352,6 +1353,10 @@
 #   ## aggregator and will not get sent to the output plugins.
 #   drop_original = false
 #
+#   ## If true, the histogram will be reset on flush instead
+#   ## of accumulating the results.
+#   reset = false
+#
 #   ## Example config that aggregates all fields of the metric.
 #   # [[aggregators.histogram.config]]
 #   #   ## The set of buckets.
@@ -1469,7 +1474,8 @@
 
 # Read metrics about system load & uptime
 [[inputs.system]]
-  # no configuration
+  ## Uncomment to remove deprecated metrics.
+  # fielddrop = ["uptime_format"]
 
 
 # # Gather ActiveMQ metrics
@@ -1584,6 +1590,15 @@
 #   ## List of tubes to gather stats about.
 #   ## If no tubes specified then data gathered for each tube on server reported by list-tubes command
 #   tubes = ["notifications"]
+
+
+# # Read BIND nameserver XML statistics
+# [[inputs.bind]]
+#   ## An array of BIND XML statistics URI to gather stats.
+#   ## Default is "http://localhost:8053/xml/v3".
+#   # urls = ["http://localhost:8053/xml/v3"]
+#   # gather_memory_contexts = false
+#   # gather_views = false
 
 
 # # Collect bond interface status, slaves statuses and failures count
@@ -2149,6 +2164,18 @@
 # 	  "monitor_agent",
 # 	  "dummy",
 #   ]
+
+
+# # Gather repository information from GitHub hosted repositories.
+# [[inputs.github]]
+#   ## List of repositories to monitor.
+#   repositories = ["influxdata/telegraf"]
+#
+#   ## Github API access token.  Unauthenticated requests are limited to 60 per hour.
+#   # access_token = ""
+#
+#   ## Timeout for HTTP requests.
+#   # http_timeout = "5s"
 
 
 # # Read flattened metrics from one or more GrayLog HTTP endpoints
@@ -3260,9 +3287,19 @@
 #   ##       "fcgi://10.0.0.12:9000/status"
 #   ##       "cgi://10.0.10.12:9001/status"
 #   ##
-#   ## Example of multiple gathering from local socket and remove host
+#   ## Example of multiple gathering from local socket and remote host
 #   ## urls = ["http://192.168.1.20/status", "/tmp/fpm.sock"]
 #   urls = ["http://localhost/status"]
+#
+#   ## Duration allowed to complete HTTP requests.
+#   # timeout = "5s"
+#
+#   ## Optional TLS Config
+#   # tls_ca = "/etc/telegraf/ca.pem"
+#   # tls_cert = "/etc/telegraf/cert.pem"
+#   # tls_key = "/etc/telegraf/key.pem"
+#   ## Use TLS but skip chain & host verification
+#   # insecure_skip_verify = false
 
 
 # # Ping given url(s) and return statistics
@@ -3333,6 +3370,9 @@
 #
 #   ## Field name prefix
 #   # prefix = ""
+#
+#   ## When true add the full cmdline as a tag.
+#   # cmdline_tag = false
 #
 #   ## Add PID as a tag instead of a field; useful to differentiate between
 #   ## processes whose tags are otherwise the same.  Can create a large number
@@ -4853,6 +4893,9 @@
 #   ## - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
 #   ## - prometheus.io/port: If port is not 9102 use this annotation
 #   # monitor_kubernetes_pods = true
+#   ## Restricts Kubernetes monitoring to a single namespace
+#   ##   ex: monitor_kubernetes_pods_namespace = "default"
+#   # monitor_kubernetes_pods_namespace = ""
 #
 #   ## Use bearer token for authorization. ('bearer_token' takes priority)
 #   # bearer_token = "/path/to/bearer/token"

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -35,10 +35,7 @@
   ## This controls the size of writes that Telegraf sends to output plugins.
   metric_batch_size = 1000
 
-  ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
-  ## output, and will flush this buffer on a successful write. Oldest metrics
-  ## are dropped first when this buffer fills.
-  ## This buffer only fills when writes fail to output plugin(s).
+  ## Maximum number of unwritten metrics per output.
   metric_buffer_limit = 10000
 
   ## Collection jitter is used to jitter the collection by a random amount.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,10 +234,7 @@ var header = `# Telegraf Configuration
   ## This controls the size of writes that Telegraf sends to output plugins.
   metric_batch_size = 1000
 
-  ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
-  ## output, and will flush this buffer on a successful write. Oldest metrics
-  ## are dropped first when this buffer fills.
-  ## This buffer only fills when writes fail to output plugin(s).
+  ## Maximum number of unwritten metrics per output.
   metric_buffer_limit = 10000
 
   ## Collection jitter is used to jitter the collection by a random amount.

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -25,83 +25,19 @@ import (
 )
 
 var configHeader = `
-# Telegraf Configuration
-#
-# Telegraf is entirely plugin driven. All metrics are gathered from the
-# declared inputs, and sent to the declared outputs.
-#
-# Plugins must be declared in here to be active.
-# To deactivate a plugin, comment out the name and any variables.
-#
-# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
-# file would generate.
-#
-# Environment variables can be used anywhere in this config file, simply prepend
-# them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
-# for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)
-
-
-# Global tags can be specified here in key="value" format.
-[global_tags]
-  # dc = "us-east-1" # will tag all metrics with dc=us-east-1
-  # rack = "1a"
-  ## Environment variables can be used as tags, and throughout the config file
-  # user = "$USER"
-
-
-# Configuration for telegraf agent
 [agent]
-  ## Default data collection interval for all inputs
   interval = "10s"
-  ## Rounds collection interval to 'interval'
-  ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
   round_interval = true
-
-  ## Telegraf will send metrics to outputs in batches of at most
-  ## metric_batch_size metrics.
-  ## This controls the size of writes that Telegraf sends to output plugins.
   metric_batch_size = 1000
-
-  ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
-  ## output, and will flush this buffer on a successful write. Oldest metrics
-  ## are dropped first when this buffer fills.
-  ## This buffer only fills when writes fail to output plugin(s).
   metric_buffer_limit = 10000
-
-  ## Collection jitter is used to jitter the collection by a random amount.
-  ## Each plugin will sleep for a random time within jitter before collecting.
-  ## This can be used to avoid many plugins querying things like sysfs at the
-  ## same time, which can have a measurable effect on the system.
   collection_jitter = "0s"
-
-  ## Default flushing interval for all outputs. You shouldn't set this below
-  ## interval. Maximum flush_interval will be flush_interval + flush_jitter
   flush_interval = "10s"
-  ## Jitter the flush interval by a random amount. This is primarily to avoid
-  ## large write spikes for users running a large number of telegraf instances.
-  ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
   flush_jitter = "0s"
-
-  ## By default or when set to "0s", precision will be set to the same
-  ## timestamp order as the collection interval, with the maximum being 1s.
-  ##   ie, when interval = "10s", precision will be "1s"
-  ##       when interval = "250ms", precision will be "1ms"
-  ## Precision will NOT be used for service inputs. It is up to each individual
-  ## service input to set the timestamp at the appropriate precision.
-  ## Valid time units are "ns", "us" (or "µs"), "ms", "s".
   precision = ""
-
-  ## Logging configuration:
-  ## Run telegraf with debug log messages.
   debug = false
-  ## Run telegraf in quiet mode (error log messages only).
   quiet = false
-  ## Specify the log file name. The empty string means to log to stderr.
   logfile = ""
-
-  ## Override default hostname, if empty use os.Hostname()
   hostname = ""
-  ## If set to true, do no set the "host" tag in the telegraf agent.
   omit_hostname = false
 `
 


### PR DESCRIPTION
This corrects an out of date description of how the metric buffers work.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
