### PR TITLE
Update README: add link to Telegraf playground to try it in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Telegraf is plugin-driven and has the concept of 4 distinct plugin types:
 New plugins are designed to be easy to contribute, we'll eagerly accept pull
 requests and will manage the set of plugins that Telegraf supports.
 
+## Try in Browser :rocket:
+
+You can try Telegraf right in your browser in the [Telegraf playground](https://rootnroll.com/d/telegraf/).
+
 ## Contributing
 
 There are many ways to contribute:


### PR DESCRIPTION
Add **Try in Browser** section in README with the link to the [Telegraf playground](https://rootnroll.com/d/telegraf/) to try it out right in the browser.

https://rootnroll.com is a standalone service for running cli playgrounds.

Source files used to create the Poetry playground: https://github.com/rootnroll/library/tree/master/telegraf/
Automated build of the docker image: https://hub.docker.com/r/rootnroll/demo-telegraf/

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
