### PR TITLE
Speed up getting interfaces stats

### DIFF
--- a/plugins/inputs/net/net.go
+++ b/plugins/inputs/net/net.go
@@ -54,6 +54,15 @@ func (s *NetIOStats) Gather(acc telegraf.Accumulator) error {
 		}
 	}
 
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return fmt.Errorf("error getting list of interfaces: %s", err)
+	}
+	interfacesByName := map[string]net.Interface{}
+	for _, iface := range interfaces {
+		interfacesByName[iface.Name] = iface
+	}
+
 	for _, io := range netio {
 		if len(s.Interfaces) != 0 {
 			var found bool
@@ -66,8 +75,8 @@ func (s *NetIOStats) Gather(acc telegraf.Accumulator) error {
 				continue
 			}
 		} else if !s.skipChecks {
-			iface, err := net.InterfaceByName(io.Name)
-			if err != nil {
+			iface, ok := interfacesByName[io.Name]
+			if !ok {
 				continue
 			}
 


### PR DESCRIPTION
On nodes where there are hundreds of interfaces net plugin can take a very long time to finish.

On my test env for 700 interfaces it takes over 6 seconds to gather stats. With this patch it takes only 0.1 second.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
