### PR TITLE
Set socket permissions for unix domain sockets

### DIFF
--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -25,8 +25,12 @@ This is a sample configuration for the plugin.
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
 
-  ## File mode for unix sockets
-  # file_mode = "777"
+  ## Change the file mode bits on unix sockets.  These permissions may not be
+  ## repected by some platforms, to safely restrict write permissions it is best
+  ## to place the socket into a directory that has previously been created
+  ## with the desired permissions.
+  ##   ex: socket_mode = "777"
+  # socket_mode = ""
 
   ## Maximum number of concurrent connections.
   ## Only applies to stream sockets (e.g. TCP).

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -26,7 +26,7 @@ This is a sample configuration for the plugin.
   # service_address = "unixgram:///tmp/telegraf.sock"
 
   ## Change the file mode bits on unix sockets.  These permissions may not be
-  ## repected by some platforms, to safely restrict write permissions it is best
+  ## respected by some platforms, to safely restrict write permissions it is best
   ## to place the socket into a directory that has previously been created
   ## with the desired permissions.
   ##   ex: socket_mode = "777"

--- a/plugins/inputs/socket_listener/socket_listener.go
+++ b/plugins/inputs/socket_listener/socket_listener.go
@@ -193,7 +193,7 @@ func (sl *SocketListener) SampleConfig() string {
   # service_address = "unixgram:///tmp/telegraf.sock"
 
   ## Change the file mode bits on unix sockets.  These permissions may not be
-  ## repected by some platforms, to safely restrict write permissions it is best
+  ## respected by some platforms, to safely restrict write permissions it is best
   ## to place the socket into a directory that has previously been created
   ## with the desired permissions.
   ##   ex: socket_mode = "777"


### PR DESCRIPTION
Continuation of the work on #3996.

Renamed the option to socket_mode to match the name in pdns_recursor and only set the mode if set in the configuration file so by default we honor the umask.

closes #3239

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
