### PR TITLE
No longer requires dep to be in $GOPATH/bin

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -160,8 +160,7 @@ def go_get(branch, update=False, no_uncommitted=False):
         logging.error("There are uncommitted changes in the current directory.")
         return False
     logging.info("Retrieving dependencies with `dep`...")
-    run("{}/bin/dep ensure -v -vendor-only".format(os.environ.get("GOPATH",
-        os.path.expanduser("~/go"))))
+    run("dep ensure -v -vendor-only")
     return True
 
 def run_tests(race, parallel, timeout, no_vet):


### PR DESCRIPTION
The Makefile already requires dep to be in the $PATH, which should
include $GOPATH/bin. This change helps in case dep was not compiled
from source but maybe installed from distro packages.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
