### PR TITLE
Check if a process is running using it's name

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -287,11 +287,19 @@ func (p *Procstat) updateProcesses(pids []PID, tags map[string]string, prevInfo 
 	for _, pid := range pids {
 		info, ok := prevInfo[pid]
 		if ok {
+			// Assumption: if a process has no name, it probably does not exist
+			if name, _ := info.Name(); name == "" {
+				continue
+			}
 			procs[pid] = info
 		} else {
 			proc, err := p.createProcess(pid)
 			if err != nil {
 				// No problem; process may have ended after we found it
+				continue
+			}
+			// Assumption: if a process has no name, it probably does not exist
+			if name, _ := proc.Name(); name == "" {
 				continue
 			}
 			procs[pid] = proc


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

This PR relates to #5746. When you provide a `pid_file` that exists, has a (int32) number in it of a non-existing process, it will report the process as running right from the start of the agent:
```
> procstat_lookup,host=Kita.local,pid_finder=pgrep,pidfile=/tmp/process.pid,result=success pid_count=1i,result_code=0i,running=1i 1556141065000000000
```

A process is marked running if the [procs map has at least one item](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/procstat/procstat.go#L137):
```golang
"running":     len(procs),
```
This map is build/filled by [updateProcesses](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/procstat/procstat.go#L284):
```golang
info, ok := prevInfo[pid]
if ok {
  procs[pid] = info
}
...
proc, err := p.createProcess(pid)
if err != nil {
  // No problem; process may have ended after we found it
  continue
}
procs[pid] = proc
```
Because the PID is specified by a `pid_file` we have a valid `PID` (`int32`). This results in a valid `Process` from `p.createProcess(pid)`, regardless whether the process exists or not. This `Process` is inserted into the `procs` map resulting in a map that has 1 or more entries. So if you provide a `pid_file` that has a number in it, `procstat` will _always_ return `running=1i`.

In this PR I assume processes without name are rare and the chance that you want to monitor a process with no name is even rarer, a process without (or empty) name is seen as not running.