### PR TITLE
Log rotation

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -114,7 +114,7 @@ func runAgent(ctx context.Context,
 ) error {
 	// Setup default logging. This may need to change after reading the config
 	// file, but we can configure it to use our logger implementation now.
-	logger.SetupLogging(false, false, "", internal.Duration{Duration: 0}, internal.Size{Size: int64(0)}, 0)
+	logger.SetupLogging(logger.LogConfig{})
 	log.Printf("I! Starting Telegraf %s", version)
 
 	// If no other options are specified, load the config file and run.
@@ -155,13 +155,16 @@ func runAgent(ctx context.Context,
 	}
 
 	// Setup logging as configured.
-	logger.SetupLogging(
-		ag.Config.Agent.Debug || *fDebug,
-		ag.Config.Agent.Quiet || *fQuiet,
-		ag.Config.Agent.Logfile,
-		ag.Config.Agent.LogfileRotationInterval,
-		ag.Config.Agent.LogfileRotationMaxSize,
-		ag.Config.Agent.LogfileRotationMaxArchives)
+	logConfig := logger.LogConfig{
+		Debug:               ag.Config.Agent.Debug || *fDebug,
+		Quiet:               ag.Config.Agent.Quiet || *fQuiet,
+		Logfile:             ag.Config.Agent.Logfile,
+		RotationInterval:    ag.Config.Agent.LogfileRotationInterval,
+		RotationMaxSize:     ag.Config.Agent.LogfileRotationMaxSize,
+		RotationMaxArchives: ag.Config.Agent.LogfileRotationMaxArchives,
+	}
+
+	logger.SetupLogging(logConfig)
 
 	if *fTest {
 		return ag.Test(ctx)

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -114,7 +114,7 @@ func runAgent(ctx context.Context,
 ) error {
 	// Setup default logging. This may need to change after reading the config
 	// file, but we can configure it to use our logger implementation now.
-	logger.SetupLogging(false, false, "")
+	logger.SetupLogging(false, false, "", internal.Duration{Duration: 0}, internal.Size{Size: int64(0)}, 0)
 	log.Printf("I! Starting Telegraf %s", version)
 
 	// If no other options are specified, load the config file and run.
@@ -159,7 +159,9 @@ func runAgent(ctx context.Context,
 		ag.Config.Agent.Debug || *fDebug,
 		ag.Config.Agent.Quiet || *fQuiet,
 		ag.Config.Agent.Logfile,
-	)
+		ag.Config.Agent.LogfileRotationInterval,
+		ag.Config.Agent.LogfileRotationMaxSize,
+		ag.Config.Agent.LogfileRotationMaxArchives)
 
 	if *fTest {
 		return ag.Test(ctx)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -147,7 +147,7 @@ The agent table configures Telegraf and the defaults used across all plugins.
   The log file max [size][]. Log files will be rotated when they exceed this size. Default is 0 => no rotation based on file size.
 - **logfile_rotation_max_archives**:
   Maximum number of archives (rotated) files to keep. Older log files are deleted first.
-  This setting is only applicable if MaxAge and/or MaxSize settings have been specified (otherwise there is no rotation)
+  This setting is only applicable if `logfile_rotation_interval` and/or `logfile_rotation_max_size` settings have been specified (otherwise there is no rotation)
   Default is 0 => all rotated files are deleted. Use -1 to keep all archives.
 
 - **hostname**:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -141,6 +141,14 @@ The agent table configures Telegraf and the defaults used across all plugins.
   Run telegraf in quiet mode (error log messages only).
 - **logfile**:
   Specify the log file name. The empty string means to log to stderr.
+- **logfile_rotation_interval**:
+  Log file rotation time [interval][], e.g. "1d" means logs will rotated every day. Default is 0 => no rotation based on time.
+- **logfile_rotation_max_size**:
+  The log file max [size][]. Log files will be rotated when they exceed this size. Default is 0 => no rotation based on file size.
+- **logfile_rotation_max_archives**:
+  Maximum number of archives (rotated) files to keep. Older log files are deleted first.
+  This setting is only applicable if MaxAge and/or MaxSize settings have been specified (otherwise there is no rotation)
+  Default is 0 => all rotated files are deleted. Use -1 to keep all archives.
 
 - **hostname**:
   Override default hostname, if empty use os.Hostname()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,15 @@ type AgentConfig struct {
 	// Logfile specifies the file to send logs to
 	Logfile string
 
+	// The log file rotation interval
+	LogfileRotationInterval internal.Duration
+
+	// The log file max size. Logs will rotated when they exceed this size.
+	LogfileRotationMaxSize internal.Size
+
+	// The max number of log archives to keep
+	LogfileRotationMaxArchives int
+
 	// Quiet is the option for running in quiet mode
 	Quiet        bool
 	Hostname     string
@@ -273,6 +282,17 @@ var agentConfig = `
   quiet = false
   ## Specify the log file name. The empty string means to log to stderr.
   logfile = ""
+  ## Rotation settings, only applicable when log file name is specified.
+  ## Log file rotation time interval, e.g. "1d" means logs will rotated every day. Default is 0 => no rotation based on time.
+  # logfile_rotation_interval = "1d"
+  ## The log file max size. Log files will be rotated when they exceed this size. Default is 0 => no rotation based on file size.
+  # logfile_rotation_max_size = "10 MB"
+  ## Maximum number of archives (rotated) files to keep. Older log files are deleted first.
+  ## This setting is only applicable if MaxAge and/or MaxSize settings have been specified (otherwise there is no rotation)
+  ## Default is 0 => all rotated files are deleted. 
+  ## Use -1 to keep all archives.
+  ## Analogous to logrotate "rotate" setting http://man7.org/linux/man-pages/man8/logrotate.8.html
+  # logfile_rotation_max_archives = 0
 
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -288,7 +288,7 @@ var agentConfig = `
   ## The log file max size. Log files will be rotated when they exceed this size. Default is 0 => no rotation based on file size.
   # logfile_rotation_max_size = "10 MB"
   ## Maximum number of archives (rotated) files to keep. Older log files are deleted first.
-  ## This setting is only applicable if MaxAge and/or MaxSize settings have been specified (otherwise there is no rotation)
+  ## This setting is only applicable if logfile_rotation_interval and/or logfile_rotation_max_size settings have been specified (otherwise there is no rotation)
   ## Default is 0 => all rotated files are deleted. 
   ## Use -1 to keep all archives.
   ## Analogous to logrotate "rotate" setting http://man7.org/linux/man-pages/man8/logrotate.8.html

--- a/internal/rotate/file_writer.go
+++ b/internal/rotate/file_writer.go
@@ -1,0 +1,176 @@
+package rotate
+
+// Rotating things
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FilePerm defines the permissions that Writer will use for all
+// the files it creates.
+const (
+	FilePerm   = os.FileMode(0644)
+	DateFormat = "2006-01-02"
+)
+
+// FileWriter implements the io.Writer interface and writes to the
+// filename specified.
+// Will rotate at the specified interval and/or when the current file size exceeds maxSizeInBytes
+// At rotation time, current file is renamed and a new file is created.
+// If the number of archives exceeds maxArchives, older files are deleted.
+type FileWriter struct {
+	filename                 string
+	filenameRotationTemplate string
+	current                  *os.File
+	interval                 time.Duration
+	maxSizeInBytes           int64
+	maxArchives              int
+	expireTime               time.Time
+	bytesWritten             int64
+	sync.Mutex
+}
+
+// NewFileWriter creates a new file writer.
+func NewFileWriter(filename string, interval time.Duration, maxSizeInBytes int64, maxArchives int) (io.WriteCloser, error) {
+	if interval == 0 && maxSizeInBytes <= 0 {
+		// No rotation needed so a basic io.Writer will do the trick
+		return openFile(filename)
+	}
+
+	w := &FileWriter{filename: filename, interval: interval, maxSizeInBytes: maxSizeInBytes,
+		maxArchives: maxArchives, filenameRotationTemplate: getFilenameRotationTemplate(filename)}
+
+	if err := w.openCurrent(true); err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+func openFile(filename string) (*os.File, error) {
+	return os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_APPEND, FilePerm)
+}
+
+func getFilenameRotationTemplate(filename string) string {
+	// Extract the file extension
+	fileExt := filepath.Ext(filename)
+	// Remove the file extension from the filename (if any)
+	filenameWithoutExtension := strings.TrimSuffix(filename, fileExt)
+	return filenameWithoutExtension + "-%s-%s" + fileExt
+}
+
+// Write writes p to the current file, then checks to see if
+// rotation is necessary.
+func (w *FileWriter) Write(p []byte) (n int, err error) {
+	w.Lock()
+	defer w.Unlock()
+	if n, err = w.current.Write(p); err != nil {
+		return 0, err
+	}
+	w.bytesWritten += int64(n)
+
+	if err = w.rotateIfNeeded(); err != nil {
+		return 0, err
+	}
+
+	return n, nil
+}
+
+// Close closes the current file.  Writer is unusable after this
+// is called.
+func (w *FileWriter) Close() (err error) {
+	w.Lock()
+	defer w.Unlock()
+
+	// Rotate before closing
+	if err = w.rotate(false); err != nil {
+		return err
+	}
+
+	if err = w.current.Close(); err != nil {
+		return err
+	}
+	w.current = nil
+	return nil
+}
+
+func (w *FileWriter) openCurrent(firstRun bool) (err error) {
+	w.current, err = openFile(w.filename)
+	w.expireTime = time.Now().Add(w.interval)
+	w.bytesWritten = 0
+
+	if err != nil {
+		return err
+	}
+	if !firstRun {
+		return nil
+	}
+
+	// Goal here is to rotate old pre-existing files. For that we use fileInfo.ModTime, instead of time.Now(), only when the FileWriter is created (firstRun)
+	// Example: telegraf is restarted every 23 hours and the rotation interval is set to 24 hours. With time.now() as a reference we'd never rotate the file.
+	// It's only necessary to use modtime when the filewriter is created, otherwise we assume that we've been continuously running, so time.now is fine.
+	if fileInfo, err := w.current.Stat(); err == nil {
+		w.expireTime = fileInfo.ModTime().Add(w.interval)
+	}
+	return nil
+}
+
+func (w *FileWriter) rotateIfNeeded() error {
+	if (w.interval > 0 && time.Now().After(w.expireTime)) ||
+		(w.maxSizeInBytes > 0 && w.bytesWritten >= w.maxSizeInBytes) {
+		return w.rotate(true)
+	}
+	return nil
+}
+
+func (w *FileWriter) rotate(createNewFile bool) (err error) {
+	if err = w.current.Close(); err != nil {
+		return err
+	}
+	now := time.Now()
+	// Use year-month-date for readability, unix time to make archive names unique
+	rotatedFilename := fmt.Sprintf(w.filenameRotationTemplate, now.Format(DateFormat), strconv.FormatInt(now.UnixNano(), 10))
+	if err = os.Rename(w.filename, rotatedFilename); err != nil {
+		return err
+	}
+
+	if err = w.purgeArchivesIfNeeded(); err != nil {
+		return err
+	}
+
+	if createNewFile {
+		return w.openCurrent(false)
+	}
+	return nil
+}
+
+func (w *FileWriter) purgeArchivesIfNeeded() (err error) {
+	if w.maxArchives == -1 {
+		//Skip archiving
+		return nil
+	}
+
+	var matches []string
+	if matches, err = filepath.Glob(fmt.Sprintf(w.filenameRotationTemplate, "*", "*")); err != nil {
+		return err
+	}
+
+	//if there are more archives than the configured maximum, then purge older files
+	if len(matches) > w.maxArchives {
+		//sort files alphanumerically to delete older files first
+		sort.Strings(matches)
+		for _, filename := range matches[:len(matches)-w.maxArchives] {
+			if err = os.Remove(filename); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/rotate/file_writer_test.go
+++ b/internal/rotate/file_writer_test.go
@@ -1,0 +1,110 @@
+package rotate
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileWriter_NoRotation(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "RotationNo")
+	require.NoError(t, err)
+	writer, err := NewFileWriter(filepath.Join(tempDir, "test"), 0, 0, 0)
+	require.NoError(t, err)
+	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
+
+	_, err = writer.Write([]byte("Hello World"))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("Hello World 2"))
+	require.NoError(t, err)
+	files, _ := ioutil.ReadDir(tempDir)
+	assert.Equal(t, 1, len(files))
+}
+
+func TestFileWriter_TimeRotation(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "RotationTime")
+	require.NoError(t, err)
+	interval, _ := time.ParseDuration("1s")
+	writer, err := NewFileWriter(filepath.Join(tempDir, "test"), interval, 0, -1)
+	require.NoError(t, err)
+	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
+
+	_, err = writer.Write([]byte("Hello World"))
+	require.NoError(t, err)
+	time.Sleep(1 * time.Second)
+	_, err = writer.Write([]byte("Hello World 2"))
+	require.NoError(t, err)
+	files, _ := ioutil.ReadDir(tempDir)
+	assert.Equal(t, 2, len(files))
+}
+
+func TestFileWriter_SizeRotation(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "RotationSize")
+	require.NoError(t, err)
+	maxSize := int64(9)
+	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, -1)
+	require.NoError(t, err)
+	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
+
+	_, err = writer.Write([]byte("Hello World"))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("World 2"))
+	require.NoError(t, err)
+	files, _ := ioutil.ReadDir(tempDir)
+	assert.Equal(t, 2, len(files))
+}
+
+func TestFileWriter_deleteArchives(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "RotationDeleteArchives")
+	require.NoError(t, err)
+	maxSize := int64(5)
+	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, 2)
+	require.NoError(t, err)
+	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
+
+	_, err = writer.Write([]byte("First file"))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("Second file"))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("Third file"))
+	require.NoError(t, err)
+
+	files, _ := ioutil.ReadDir(tempDir)
+	assert.Equal(t, 3, len(files))
+
+	for _, tempFile := range files {
+		var bytes []byte
+		var err error
+		path := filepath.Join(tempDir, tempFile.Name())
+		if bytes, err = ioutil.ReadFile(path); err != nil {
+			t.Error(err.Error())
+			return
+		}
+		contents := string(bytes)
+
+		if contents != "" && contents != "Second file" && contents != "Third file" {
+			t.Error("Should have deleted the eldest log file")
+			return
+		}
+	}
+}
+
+func TestFileWriter_CloseRotates(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "RotationClose")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	maxSize := int64(9)
+	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, -1)
+	require.NoError(t, err)
+
+	writer.Close()
+
+	files, _ := ioutil.ReadDir(tempDir)
+	assert.Equal(t, 1, len(files))
+	assert.Regexp(t, "^test-[^\\.]+\\.log$", files[0].Name())
+}

--- a/internal/rotate/file_writer_test.go
+++ b/internal/rotate/file_writer_test.go
@@ -59,7 +59,7 @@ func TestFileWriter_SizeRotation(t *testing.T) {
 	assert.Equal(t, 2, len(files))
 }
 
-func TestFileWriter_deleteArchives(t *testing.T) {
+func TestFileWriter_DeleteArchives(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "RotationDeleteArchives")
 	require.NoError(t, err)
 	maxSize := int64(5)
@@ -69,8 +69,13 @@ func TestFileWriter_deleteArchives(t *testing.T) {
 
 	_, err = writer.Write([]byte("First file"))
 	require.NoError(t, err)
+	// File names include the date with second precision
+	// So, to force rotation with different file names
+	// we need to wait
+	time.Sleep(1 * time.Second)
 	_, err = writer.Write([]byte("Second file"))
 	require.NoError(t, err)
+	time.Sleep(1 * time.Second)
 	_, err = writer.Write([]byte("Third file"))
 	require.NoError(t, err)
 
@@ -106,5 +111,5 @@ func TestFileWriter_CloseRotates(t *testing.T) {
 
 	files, _ := ioutil.ReadDir(tempDir)
 	assert.Equal(t, 1, len(files))
-	assert.Regexp(t, "^test-[^\\.]+\\.log$", files[0].Name())
+	assert.Regexp(t, "^test\\.[^\\.]+\\.log$", files[0].Name())
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,12 +1,15 @@
 package logger
 
 import (
+	"errors"
 	"io"
 	"log"
 	"os"
 	"regexp"
 	"time"
 
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/internal/rotate"
 	"github.com/influxdata/wlog"
 )
 
@@ -33,13 +36,29 @@ func (t *telegrafLog) Write(b []byte) (n int, err error) {
 	return t.writer.Write(line)
 }
 
+func (t *telegrafLog) Close() error {
+	closer, isCloser := t.writer.(io.Closer)
+	if !isCloser {
+		return errors.New("the underlying writer cannot be closed")
+	}
+	return closer.Close()
+}
+
 // SetupLogging configures the logging output.
-//   debug   will set the log level to DEBUG
-//   quiet   will set the log level to ERROR
-//   logfile will direct the logging output to a file. Empty string is
-//           interpreted as stderr. If there is an error opening the file the
-//           logger will fallback to stderr.
-func SetupLogging(debug, quiet bool, logfile string) {
+//   debug                  will set the log level to DEBUG
+//   quiet                  will set the log level to ERROR
+//   logfile                will direct the logging output to a file. Empty string is
+//                          interpreted as stderr. If there is an error opening the file the
+//                          logger will fallback to stderr.
+//   logRotationInterval    will rotate when current file at the specified time interval.
+//   logRotationMaxSize     will rotate when current file size exceeds this parameter.
+//   logRotationMaxArchives maximum rotated files to keep (older ones will be deleted)
+func SetupLogging(debug, quiet bool, logfile string, logRotationInterval internal.Duration, logRotationMaxSize internal.Size, logRotationMaxArchives int) {
+	setupLoggingAndReturnWriter(debug, quiet, logfile, logRotationInterval, logRotationMaxSize, logRotationMaxArchives)
+}
+
+func setupLoggingAndReturnWriter(debug, quiet bool, logfile string, logRotationInterval internal.Duration, logRotationMaxSize internal.Size,
+	logRotationMaxArchives int) io.Writer {
 	log.SetFlags(0)
 	if debug {
 		wlog.SetLevel(wlog.DEBUG)
@@ -48,16 +67,18 @@ func SetupLogging(debug, quiet bool, logfile string) {
 		wlog.SetLevel(wlog.ERROR)
 	}
 
-	var oFile *os.File
+	var writer io.Writer
 	if logfile != "" {
 		var err error
-		if oFile, err = os.OpenFile(logfile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, os.ModeAppend|0644); err != nil {
+		if writer, err = rotate.NewFileWriter(logfile, logRotationInterval.Duration, logRotationMaxSize.Size, logRotationMaxArchives); err != nil {
 			log.Printf("E! Unable to open %s (%s), using stderr", logfile, err)
-			oFile = os.Stderr
+			writer = os.Stderr
 		}
 	} else {
-		oFile = os.Stderr
+		writer = os.Stderr
 	}
 
-	log.SetOutput(newTelegrafWriter(oFile))
+	telegrafLog := newTelegrafWriter(writer)
+	log.SetOutput(telegrafLog)
+	return telegrafLog
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -66,10 +66,10 @@ func (t *telegrafLog) Close() error {
 
 // SetupLogging configures the logging output.
 func SetupLogging(config LogConfig) {
-	setupLoggingAndReturnWriter(config)
+	newLogWriter(config)
 }
 
-func setupLoggingAndReturnWriter(config LogConfig) io.Writer {
+func newLogWriter(config LogConfig) io.Writer {
 	log.SetFlags(0)
 	if config.Debug {
 		wlog.SetLevel(wlog.DEBUG)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -101,7 +101,7 @@ func TestWriteToFileInRotation(t *testing.T) {
 	require.NoError(t, err)
 	config := createBasicLogConfig(filepath.Join(tempDir, "test.log"))
 	config.RotationMaxSize = internal.Size{Size: int64(30)}
-	writer := setupLoggingAndReturnWriter(config)
+	writer := newLogWriter(config)
 	// Close the writer here, otherwise the temp folder cannot be deleted because the current log file is in use.
 	closer, isCloser := writer.(io.Closer)
 	assert.True(t, isCloser)


### PR DESCRIPTION
Concerns #3393

I took the code from #5547 as a basis and did the following:
- created a reusable rotation-aware file writer
- added additional rotation features (maxsize, maxarchives)
- wrote unit tests. 

This PR uses the new file writer for logging purposes only, but it can be easily plugged in the output file plugin.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
