### PR TITLE
Skip lines with missing refid and other fields

### DIFF
--- a/plugins/inputs/ntpq/ntpq.go
+++ b/plugins/inputs/ntpq/ntpq.go
@@ -75,6 +75,7 @@ func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
 	}
 
 	lineCounter := 0
+	numColumns := 0
 	scanner := bufio.NewScanner(bytes.NewReader(out))
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -96,6 +97,7 @@ func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
 
 		// If lineCounter == 0, then this is the header line
 		if lineCounter == 0 {
+			numColumns = len(fields)
 			for i, field := range fields {
 				// Check if field is a tag:
 				if tagKey, ok := tagHeaders[field]; ok {
@@ -116,6 +118,10 @@ func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
 				}
 			}
 		} else {
+			if len(fields) != numColumns {
+				continue
+			}
+
 			mFields := make(map[string]interface{})
 
 			// Get tags from output

--- a/plugins/inputs/ntpq/ntpq_test.go
+++ b/plugins/inputs/ntpq/ntpq_test.go
@@ -3,10 +3,12 @@ package ntpq
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSingleNTPQ(t *testing.T) {
@@ -28,35 +30,6 @@ func TestSingleNTPQ(t *testing.T) {
 		"delay":  float64(51.016),
 		"offset": float64(233.010),
 		"jitter": float64(17.462),
-	}
-	tags := map[string]string{
-		"remote":       "uschi5-ntp-002.",
-		"state_prefix": "*",
-		"refid":        "10.177.80.46",
-		"stratum":      "2",
-		"type":         "u",
-	}
-	acc.AssertContainsTaggedFields(t, "ntpq", fields, tags)
-}
-
-func TestMissingJitterField(t *testing.T) {
-	tt := tester{
-		ret: []byte(missingJitterField),
-		err: nil,
-	}
-	n := &NTPQ{
-		runQ: tt.runqTest,
-	}
-
-	acc := testutil.Accumulator{}
-	assert.NoError(t, acc.GatherError(n.Gather))
-
-	fields := map[string]interface{}{
-		"when":   int64(101),
-		"poll":   int64(256),
-		"reach":  int64(37),
-		"delay":  float64(51.016),
-		"offset": float64(233.010),
 	}
 	tags := map[string]string{
 		"remote":       "uschi5-ntp-002.",
@@ -428,6 +401,59 @@ func TestFailedNTPQ(t *testing.T) {
 	assert.Error(t, acc.GatherError(n.Gather))
 }
 
+func TestNoRefID(t *testing.T) {
+	now := time.Now()
+	expected := []telegraf.Metric{
+		testutil.MustMetric("ntpq",
+			map[string]string{
+				"refid":   "10.177.80.37",
+				"remote":  "83.137.98.96",
+				"stratum": "2",
+				"type":    "u",
+			},
+			map[string]interface{}{
+				"delay":  float64(54.033),
+				"jitter": float64(449514),
+				"offset": float64(243.426),
+				"poll":   int64(1024),
+				"reach":  int64(377),
+				"when":   int64(740),
+			},
+			now),
+		testutil.MustMetric("ntpq",
+			map[string]string{
+				"refid":   "10.177.80.37",
+				"remote":  "131.188.3.221",
+				"stratum": "2",
+				"type":    "u",
+			},
+			map[string]interface{}{
+				"delay":  float64(111.820),
+				"jitter": float64(449528),
+				"offset": float64(261.921),
+				"poll":   int64(1024),
+				"reach":  int64(377),
+				"when":   int64(783),
+			},
+			now),
+	}
+
+	tt := tester{
+		ret: []byte(noRefID),
+		err: nil,
+	}
+	n := &NTPQ{
+		runQ: tt.runqTest,
+	}
+
+	acc := testutil.Accumulator{
+		TimeFunc: func() time.Time { return now },
+	}
+
+	require.NoError(t, acc.GatherError(n.Gather))
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
+}
+
 type tester struct {
 	ret []byte
 	err error
@@ -472,11 +498,6 @@ func resetVars() {
 var singleNTPQ = `     remote           refid      st t when poll reach   delay   offset  jitter
 ==============================================================================
 *uschi5-ntp-002. 10.177.80.46     2 u  101  256   37   51.016  233.010  17.462
-`
-
-var missingJitterField = `     remote           refid      st t when poll reach   delay   offset  jitter
-==============================================================================
-*uschi5-ntp-002. 10.177.80.46     2 u  101  256   37   51.016  233.010
 `
 
 var badHeaderNTPQ = `remote      refid   foobar t when poll reach   delay   offset  jitter
@@ -527,6 +548,7 @@ var multiNTPQ = `     remote           refid      st t when poll reach   delay  
  5.9.29.107      10.177.80.37     2 u  703 1024  377  205.704  160.406 449602.
  91.189.94.4     10.177.80.37     2 u  673 1024  377  143.047  274.726 449445.
 `
+
 var multiParserNTPQ = `     remote           refid      st t when poll reach   delay   offset  jitter
 ==============================================================================
 *SHM(0)          .PPS.                          1 u   60  64   377    0.000    0.045   1.012
@@ -534,4 +556,11 @@ var multiParserNTPQ = `     remote           refid      st t when poll reach   d
 +37.58.57.238 (domain) 192.53.103.103   2 u   10 1024  377    1.748    0.373   0.101
 +37.58.57.238 ( 192.53.103.103			2 u   10 1024  377    1.748    0.373   0.101
 -SHM(1)          .GPS.                          1 u   121 128  377    0.000   10.105   2.012
+`
+
+var noRefID = `     remote           refid      st t when poll reach   delay   offset  jitter
+==============================================================================
+ 83.137.98.96    10.177.80.37     2 u  740 1024  377   54.033  243.426 449514.
+ 91.189.94.4                      2 u  673 1024  377  143.047  274.726 449445.
+ 131.188.3.221   10.177.80.37     2 u  783 1024  377  111.820  261.921 449528.
 `

--- a/plugins/inputs/ntpq/ntpq_test.go
+++ b/plugins/inputs/ntpq/ntpq_test.go
@@ -401,6 +401,9 @@ func TestFailedNTPQ(t *testing.T) {
 	assert.Error(t, acc.GatherError(n.Gather))
 }
 
+// It is possible for the output of ntqp to be missing the refid column.  This
+// is believed to be http://bugs.ntp.org/show_bug.cgi?id=3484 which is fixed
+// in ntp-4.2.8p12 (included first in Debian Buster).
 func TestNoRefID(t *testing.T) {
 	now := time.Now()
 	expected := []telegraf.Metric{


### PR DESCRIPTION
Fix for report of lines with missing refid:
```
+10.0.0.1 16 u 1048 1024 376 15.384 -0.538 0.943
```

I believe this is the actual cause of #1634 based on the error message, which is why I'm removing the test case created for that issue.  The panic from that issue would also no longer occur due to other changes to the plugin since then.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
