### PR TITLE
templating: fix templateSpecs.Less()

### DIFF
--- a/internal/templating/template.go
+++ b/internal/templating/template.go
@@ -124,21 +124,16 @@ type templateSpecs []templateSpec
 // Less reports whether the element with
 // index j should sort before the element with index k.
 func (e templateSpecs) Less(j, k int) bool {
-	if len(e[j].filter) == 0 && len(e[k].filter) == 0 {
-		jlength := len(strings.Split(e[j].template, e[j].separator))
-		klength := len(strings.Split(e[k].template, e[k].separator))
-		return jlength < klength
-	}
-	if len(e[j].filter) == 0 {
+	jlen := len(e[j].filter)
+	klen := len(e[k].filter)
+	if jlen == 0 && klen != 0 {
 		return true
 	}
-	if len(e[k].filter) == 0 {
+	if klen == 0 && jlen != 0 {
 		return false
 	}
-
-	jlength := len(strings.Split(e[j].template, e[j].separator))
-	klength := len(strings.Split(e[k].template, e[k].separator))
-	return jlength < klength
+	return strings.Count(e[j].template, e[j].separator) <
+		strings.Count(e[k].template, e[k].separator)
 }
 
 // Swap swaps the elements with indexes i and j.

--- a/internal/templating/template_test.go
+++ b/internal/templating/template_test.go
@@ -1,0 +1,14 @@
+package templating
+
+import "testing"
+
+func BenchmarkTemplateLess(b *testing.B) {
+	a := templateSpec{
+		template:  "aa|bb|cc|dd|ee|ff",
+		separator: "|",
+	}
+	specs := templateSpecs{a, a}
+	for i := 0; i < b.N; i++ {
+		specs.Less(0, 1)
+	}
+}


### PR DESCRIPTION
Using the length of the slice returned by strings.Split() to count the number of separators in a string is incredibly wasteful and makes for expensive sort operations.  This commit fixes that.

```sh
$ benchcmp base.txt new.txt
benchmark                    old ns/op     new ns/op     delta
BenchmarkTemplateLess-16     180           12.5          -93.06%

benchmark                    old allocs     new allocs     delta
BenchmarkTemplateLess-16     2              0              -100.00%

benchmark                    old bytes     new bytes     delta
BenchmarkTemplateLess-16     192           0             -100.00%
```

### Required for all PRs:

- [ x ] Signed [CLA](https://influxdata.com/community/cla/).
- [ x ] Associated README.md updated.
N/A
- [ x ] Has appropriate unit tests.
A benchmark was added to identify regressions.
