### PR TITLE
graphite: reduce the memory used by GraphiteParser.Parse() by ~80%

### DIFF
--- a/plugins/parsers/graphite/parser.go
+++ b/plugins/parsers/graphite/parser.go
@@ -72,7 +72,7 @@ func (p *GraphiteParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	for {
 		n := bytes.IndexByte(buf, '\n')
 		var line []byte
-		if n != -1 {
+		if n >= 0 {
 			line = bytes.TrimSpace(buf[:n:n])
 		} else {
 			line = bytes.TrimSpace(buf) // last line
@@ -85,7 +85,7 @@ func (p *GraphiteParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 				errs = append(errs, err.Error())
 			}
 		}
-		if n == -1 {
+		if n < 0 {
 			break
 		}
 		buf = buf[n+1:]


### PR DESCRIPTION
The commit reduces the amount of memory used by `GraphiteParser.Parse()` by 80% and increases performance by 30%.  Honestly, this would be more efficient if we stepped through `buf` line-by-line but this improvement is good enough to justify a PR.

```
benchmark             old ns/op     new ns/op     delta
BenchmarkParse-16     1825          1235          -32.33%

benchmark             old allocs     new allocs     delta
BenchmarkParse-16     24             20             -16.67%

benchmark             old bytes     new bytes     delta
BenchmarkParse-16     5200          896           -82.77%
```

### Required for all PRs:

- [ x ] Signed [CLA](https://influxdata.com/community/cla/).
- [ x ] Associated README.md updated.
- [ x ] Has appropriate unit tests.

Also, this codebase and in particular anything on the statsd path spends quite a bit of time and memory splitting strings.  Fixing this would lead to some pretty easy perf wins.