### PR TITLE
wavefront/serializer: improve performance by ~30%

### DIFF
--- a/plugins/serializers/wavefront/wavefront.go
+++ b/plugins/serializers/wavefront/wavefront.go
@@ -159,7 +159,7 @@ func formatMetricPoint(b *buffer, metricPoint *wavefront.MetricPoint, s *Wavefro
 	b.WriteString(`" `)
 	b.WriteFloat64(metricPoint.Value)
 	b.WriteChar(' ')
-	b.WriteUnit64(uint64(metricPoint.Timestamp))
+	b.WriteUint64(uint64(metricPoint.Timestamp))
 	b.WriteString(` source="`)
 	b.WriteString(metricPoint.Source)
 	b.WriteChar('"')
@@ -204,7 +204,7 @@ func (b *buffer) WriteChar(c byte) {
 	*b = append(*b, c)
 }
 
-func (b *buffer) WriteUnit64(val uint64) {
+func (b *buffer) WriteUint64(val uint64) {
 	*b = strconv.AppendUint(*b, val, 10)
 }
 

--- a/plugins/serializers/wavefront/wavefront.go
+++ b/plugins/serializers/wavefront/wavefront.go
@@ -192,10 +192,6 @@ func (b *buffer) Copy() []byte {
 	return p
 }
 
-func (b *buffer) Write(p []byte) {
-	*b = append(*b, p...)
-}
-
 func (b *buffer) WriteString(s string) {
 	*b = append(*b, s...)
 }

--- a/plugins/serializers/wavefront/wavefront.go
+++ b/plugins/serializers/wavefront/wavefront.go
@@ -2,10 +2,12 @@ package wavefront
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs/wavefront"
@@ -39,6 +41,12 @@ var tagValueReplacer = strings.NewReplacer("\"", "\\\"", "*", "-")
 
 var pathReplacer = strings.NewReplacer("_", ".")
 
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		return new(bytes.Buffer)
+	},
+}
+
 func NewSerializer(prefix string, useStrict bool, sourceOverride []string) (*WavefrontSerializer, error) {
 	s := &WavefrontSerializer{
 		Prefix:         prefix,
@@ -50,16 +58,17 @@ func NewSerializer(prefix string, useStrict bool, sourceOverride []string) (*Wav
 
 // Serialize : Serialize based on Wavefront format
 func (s *WavefrontSerializer) Serialize(m telegraf.Metric) ([]byte, error) {
-	out := []byte{}
-	metricSeparator := "."
+	const metricSeparator = "."
+	var out []byte
+	buf := pbFree.Get().(*buffer)
 
 	for fieldName, value := range m.Fields() {
 		var name string
 
 		if fieldName == "value" {
-			name = fmt.Sprintf("%s%s", s.Prefix, m.Name())
+			name = s.Prefix + m.Name()
 		} else {
-			name = fmt.Sprintf("%s%s%s%s", s.Prefix, m.Name(), metricSeparator, fieldName)
+			name = s.Prefix + m.Name() + metricSeparator + fieldName
 		}
 
 		if s.UseStrict {
@@ -70,80 +79,62 @@ func (s *WavefrontSerializer) Serialize(m telegraf.Metric) ([]byte, error) {
 
 		name = pathReplacer.Replace(name)
 
-		metric := &wavefront.MetricPoint{
-			Metric:    name,
-			Timestamp: m.Time().Unix(),
-		}
-
-		metricValue, buildError := buildValue(value, metric.Metric)
+		metricValue, buildError := buildValue(value, name)
 		if buildError != nil {
 			// bad value continue to next metric
 			continue
 		}
-		metric.Value = metricValue
-
 		source, tags := buildTags(m.Tags(), s)
-		metric.Source = source
-		metric.Tags = tags
-
-		out = append(out, formatMetricPoint(metric, s)...)
+		metric := wavefront.MetricPoint{
+			Metric:    name,
+			Timestamp: m.Time().Unix(),
+			Value:     metricValue,
+			Source:    source,
+			Tags:      tags,
+		}
+		out = append(out, formatMetricPoint(buf, &metric, s)...)
 	}
+
+	pbFree.Put(buf)
 	return out, nil
 }
 
 func (s *WavefrontSerializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
-	var batch bytes.Buffer
+	var batch []byte
 	for _, m := range metrics {
 		buf, err := s.Serialize(m)
 		if err != nil {
 			return nil, err
 		}
-		_, err = batch.Write(buf)
-		if err != nil {
-			return nil, err
+		batch = append(batch, buf...)
+	}
+	return batch, nil
+}
+
+func findSourceTag(mTags map[string]string, s *WavefrontSerializer) string {
+	if src, ok := mTags["source"]; ok {
+		delete(mTags, "source")
+		return src
+	}
+	for _, src := range s.SourceOverride {
+		if source, ok := mTags[src]; ok {
+			delete(mTags, src)
+			mTags["telegraf_host"] = mTags["host"]
+			return source
 		}
 	}
-	return batch.Bytes(), nil
+	return mTags["host"]
 }
 
 func buildTags(mTags map[string]string, s *WavefrontSerializer) (string, map[string]string) {
-
 	// Remove all empty tags.
 	for k, v := range mTags {
 		if v == "" {
 			delete(mTags, k)
 		}
 	}
-
-	var source string
-
-	if src, ok := mTags["source"]; ok {
-		source = src
-		delete(mTags, "source")
-	} else {
-		sourceTagFound := false
-		for _, src := range s.SourceOverride {
-			for k, v := range mTags {
-				if k == src {
-					source = v
-					mTags["telegraf_host"] = mTags["host"]
-					sourceTagFound = true
-					delete(mTags, k)
-					break
-				}
-			}
-			if sourceTagFound {
-				break
-			}
-		}
-
-		if !sourceTagFound {
-			source = mTags["host"]
-		}
-	}
-
+	source := findSourceTag(mTags, s)
 	delete(mTags, "host")
-
 	return tagValueReplacer.Replace(source), mTags
 }
 
@@ -156,14 +147,14 @@ func buildValue(v interface{}, name string) (float64, error) {
 			return 0, nil
 		}
 	case int64:
-		return float64(v.(int64)), nil
+		return float64(p), nil
 	case uint64:
-		return float64(v.(uint64)), nil
+		return float64(p), nil
 	case float64:
-		return v.(float64), nil
+		return p, nil
 	case string:
 		// return an error but don't log
-		return 0, fmt.Errorf("string type not supported")
+		return 0, errors.New("string type not supported")
 	default:
 		// return an error and log a debug message
 		err := fmt.Errorf("unexpected type: %T, with value: %v, for :%s", v, v, name)
@@ -172,31 +163,70 @@ func buildValue(v interface{}, name string) (float64, error) {
 	}
 }
 
-func formatMetricPoint(metricPoint *wavefront.MetricPoint, s *WavefrontSerializer) []byte {
-	var buffer bytes.Buffer
-	buffer.WriteString("\"")
-	buffer.WriteString(metricPoint.Metric)
-	buffer.WriteString("\" ")
-	buffer.WriteString(strconv.FormatFloat(metricPoint.Value, 'f', 6, 64))
-	buffer.WriteString(" ")
-	buffer.WriteString(strconv.FormatInt(metricPoint.Timestamp, 10))
-	buffer.WriteString(" source=\"")
-	buffer.WriteString(metricPoint.Source)
-	buffer.WriteString("\"")
+func formatMetricPoint(b *buffer, metricPoint *wavefront.MetricPoint, s *WavefrontSerializer) []byte {
+	b.Reset()
+
+	b.WriteChar('"')
+	b.WriteString(metricPoint.Metric)
+	b.WriteString(`" `)
+	b.WriteFloat64(metricPoint.Value)
+	b.WriteChar(' ')
+	b.WriteUnit64(uint64(metricPoint.Timestamp))
+	b.WriteString(` source="`)
+	b.WriteString(metricPoint.Source)
+	b.WriteChar('"')
 
 	for k, v := range metricPoint.Tags {
-		buffer.WriteString(" \"")
+		b.WriteString(` "`)
 		if s.UseStrict {
-			buffer.WriteString(strictSanitizedChars.Replace(k))
+			b.WriteString(strictSanitizedChars.Replace(k))
 		} else {
-			buffer.WriteString(sanitizedChars.Replace(k))
+			b.WriteString(sanitizedChars.Replace(k))
 		}
-		buffer.WriteString("\"=\"")
-		buffer.WriteString(tagValueReplacer.Replace(v))
-		buffer.WriteString("\"")
+		b.WriteString(`"="`)
+		b.WriteString(tagValueReplacer.Replace(v))
+		b.WriteChar('"')
 	}
 
-	buffer.WriteString("\n")
+	b.WriteChar('\n')
 
-	return buffer.Bytes()
+	return *b
+}
+
+// pbFree is the print buffer pool
+var pbFree = sync.Pool{
+	New: func() interface{} {
+		b := make(buffer, 0, 128)
+		return &b
+	},
+}
+
+// Use a fast and simple buffer for constructing statsd messages
+type buffer []byte
+
+func (b *buffer) Reset() { *b = (*b)[:0] }
+
+func (b *buffer) Write(p []byte) {
+	*b = append(*b, p...)
+}
+
+func (b *buffer) WriteString(s string) {
+	*b = append(*b, s...)
+}
+
+// This is named WriteChar instead of WriteByte because the 'stdmethods' check
+// of 'go vet' wants WriteByte to have the signature:
+//
+// 	func (b *buffer) WriteByte(c byte) error { ... }
+//
+func (b *buffer) WriteChar(c byte) {
+	*b = append(*b, c)
+}
+
+func (b *buffer) WriteUnit64(val uint64) {
+	*b = strconv.AppendUint(*b, val, 10)
+}
+
+func (b *buffer) WriteFloat64(val float64) {
+	*b = strconv.AppendFloat(*b, val, 'f', 6, 64)
 }

--- a/plugins/serializers/wavefront/wavefront.go
+++ b/plugins/serializers/wavefront/wavefront.go
@@ -181,7 +181,6 @@ func formatMetricPoint(b *buffer, metricPoint *wavefront.MetricPoint, s *Wavefro
 	return *b
 }
 
-// Use a fast and simple buffer for constructing statsd messages
 type buffer []byte
 
 func (b *buffer) Reset() { *b = (*b)[:0] }

--- a/plugins/serializers/wavefront/wavefront_test.go
+++ b/plugins/serializers/wavefront/wavefront_test.go
@@ -329,19 +329,6 @@ func BenchmarkSerialize(b *testing.B) {
 	}
 }
 
-func BenchmarkSerialize_Parallel(b *testing.B) {
-	var s WavefrontSerializer
-	metrics := benchmarkMetrics(b)
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		i := 0
-		for pb.Next() {
-			s.Serialize(metrics[i%len(metrics)])
-			i++
-		}
-	})
-}
-
 func BenchmarkSerializeBatch(b *testing.B) {
 	var s WavefrontSerializer
 	m := benchmarkMetrics(b)

--- a/plugins/serializers/wavefront/wavefront_test.go
+++ b/plugins/serializers/wavefront/wavefront_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/outputs/wavefront"
 	"github.com/stretchr/testify/assert"
@@ -132,7 +133,7 @@ func TestFormatMetricPoint(t *testing.T) {
 	s := WavefrontSerializer{}
 
 	for _, pt := range pointTests {
-		bout := formatMetricPoint(pt.ptIn, &s)
+		bout := formatMetricPoint(new(buffer), pt.ptIn, &s)
 		sout := string(bout[:])
 		if sout != pt.out {
 			t.Errorf("\nexpected\t%s\nreceived\t%s\n", pt.out, sout)
@@ -160,7 +161,7 @@ func TestUseStrict(t *testing.T) {
 	s := WavefrontSerializer{UseStrict: true}
 
 	for _, pt := range pointTests {
-		bout := formatMetricPoint(pt.ptIn, &s)
+		bout := formatMetricPoint(new(buffer), pt.ptIn, &s)
 		sout := string(bout[:])
 		if sout != pt.out {
 			t.Errorf("\nexpected\t%s\nreceived\t%s\n", pt.out, sout)
@@ -292,4 +293,61 @@ func TestSerializeMetricPrefix(t *testing.T) {
 
 	expS := []string{fmt.Sprintf("\"telegraf.cpu.usage.idle\" 91.000000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}
 	assert.Equal(t, expS, mS)
+}
+
+func benchmarkMetrics(b *testing.B) [4]telegraf.Metric {
+	b.Helper()
+	now := time.Now()
+	tags := map[string]string{
+		"cpu":  "cpu0",
+		"host": "realHost",
+	}
+	newMetric := func(v interface{}) telegraf.Metric {
+		fields := map[string]interface{}{
+			"usage_idle": v,
+		}
+		m, err := metric.New("cpu", tags, fields, now)
+		if err != nil {
+			b.Fatal(err)
+		}
+		return m
+	}
+	return [4]telegraf.Metric{
+		newMetric(91.5),
+		newMetric(91),
+		newMetric(true),
+		newMetric(false),
+	}
+}
+
+func BenchmarkSerialize(b *testing.B) {
+	var s WavefrontSerializer
+	metrics := benchmarkMetrics(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Serialize(metrics[i%len(metrics)])
+	}
+}
+
+func BenchmarkSerialize_Parallel(b *testing.B) {
+	var s WavefrontSerializer
+	metrics := benchmarkMetrics(b)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			s.Serialize(metrics[i%len(metrics)])
+			i++
+		}
+	})
+}
+
+func BenchmarkSerializeBatch(b *testing.B) {
+	var s WavefrontSerializer
+	m := benchmarkMetrics(b)
+	metrics := m[:]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.SerializeBatch(metrics)
+	}
 }


### PR DESCRIPTION
This PR improves the performance and memory consumption of the Wavefront serializer by roughly 30%.

```
benchmark                 old ns/op     new ns/op     delta
BenchmarkSerialize-16     1168          778           -33.39%

benchmark                 old allocs     new allocs     delta
BenchmarkSerialize-16     16             8              -50.00%

benchmark                 old bytes     new bytes     delta
BenchmarkSerialize-16     1116          800           -28.32%
```

### Required for all PRs:

- [ x ] Signed [CLA](https://influxdata.com/community/cla/).
- [ x ] Associated README.md updated.
- [ x ] Has appropriate unit tests.
