### PR TITLE
Stop claiming plugin contributions are eagerly accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Telegraf is plugin-driven and has the concept of 4 distinct plugin types:
 3. [Aggregator Plugins](#aggregator-plugins) create aggregate metrics (e.g. mean, min, max, quantiles, etc.)
 4. [Output Plugins](#output-plugins) write metrics to various destinations
 
-New plugins are designed to be easy to contribute, we'll eagerly accept pull
+New plugins are designed to be easy to contribute, we'll ~~eagerly~~ accept pull
 requests and will manage the set of plugins that Telegraf supports.
 
 ## Try in Browser :rocket:


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [-] Has appropriate unit tests.

The `README.md` claims that plugin contributions via pull requests are "eagerly" accepted. As subjective as "eagerly" may be interpreted, the claim seems less than honest considering the age of many of the open pull requests. (While I subjectively think mine is way over due for "eagerly", it isn't even old in comparison.)

To avoid leading companies to make tooling decision based on less than accurate information, I suggest this claim is removed.