### PR TITLE
Revert field name case in interrupts input

### DIFF
--- a/plugins/inputs/interrupts/interrupts.go
+++ b/plugins/inputs/interrupts/interrupts.go
@@ -102,7 +102,7 @@ func gatherTagsFields(irq IRQ) (map[string]string, map[string]interface{}) {
 	tags := map[string]string{"irq": irq.ID, "type": irq.Type, "device": irq.Device}
 	fields := map[string]interface{}{"total": irq.Total}
 	for i := 0; i < len(irq.Cpus); i++ {
-		cpu := fmt.Sprintf("cpu%d", i)
+		cpu := fmt.Sprintf("CPU%d", i)
 		fields[cpu] = irq.Cpus[i]
 	}
 	return tags, fields

--- a/plugins/inputs/interrupts/interrupts_test.go
+++ b/plugins/inputs/interrupts/interrupts_test.go
@@ -23,7 +23,7 @@ func expectCpuAsFields(m *testutil.Accumulator, t *testing.T, measurement string
 	fields := map[string]interface{}{}
 	total := int64(0)
 	for idx, count := range irq.Cpus {
-		fields[fmt.Sprintf("cpu%d", idx)] = count
+		fields[fmt.Sprintf("CPU%d", idx)] = count
 		total += count
 	}
 	fields["total"] = total


### PR DESCRIPTION
Resolves #5836

Should we also change the case of the newly added cpu as tag to uppercase to match?