### PR TITLE
Allow multiple tag replaces in the string processor

### DIFF
--- a/plugins/processors/strings/strings.go
+++ b/plugins/processors/strings/strings.go
@@ -91,13 +91,15 @@ func (c *converter) convertTag(metric telegraf.Metric) {
 	var tags map[string]string
 	if c.Tag == "*" {
 		tags = metric.Tags()
-	} else {
-		tags = make(map[string]string)
-		tv, ok := metric.GetTag(c.Tag)
+	}
+
+	tags = make(map[string]string)
+	for _, tag := range []string{c.Tag, c.Dest} {
+		tv, ok := metric.GetTag(tag)
 		if !ok {
-			return
+			continue
 		}
-		tags[c.Tag] = tv
+		tags[tag] = tv
 	}
 
 	for key, value := range tags {

--- a/plugins/processors/strings/strings.go
+++ b/plugins/processors/strings/strings.go
@@ -115,13 +115,15 @@ func (c *converter) convertField(metric telegraf.Metric) {
 	var fields map[string]interface{}
 	if c.Field == "*" {
 		fields = metric.Fields()
-	} else {
-		fields = make(map[string]interface{})
-		fv, ok := metric.GetField(c.Field)
+	}
+
+	fields = make(map[string]interface{})
+	for _, field := range []string{c.Field, c.Dest} {
+		fv, ok := metric.GetField(field)
 		if !ok {
-			return
+			continue
 		}
-		fields[c.Field] = fv
+		fields[field] = fv
 	}
 
 	for key, value := range fields {

--- a/plugins/processors/strings/strings_test.go
+++ b/plugins/processors/strings/strings_test.go
@@ -438,6 +438,90 @@ func TestMultipleConversions(t *testing.T) {
 	assert.Equal(t, expectedTags, processed[0].Tags())
 }
 
+func TestMultipleEnumLikeConversionsTags(t *testing.T) {
+	plugin := &Strings{
+		Replace: []converter{
+			{
+				Tag:  "foo",
+				Old:  "a",
+				New:  "x",
+				Dest: "bar",
+			},
+			{
+				Tag:  "foo",
+				Old:  "b",
+				New:  "y",
+				Dest: "bar",
+			},
+		},
+	}
+
+	m, _ := metric.New("IIS_log",
+		map[string]string{
+			"foo": "a",
+		},
+		map[string]interface{}{
+			"request": "/replace/it",
+		},
+		time.Now(),
+	)
+
+	processed := plugin.Apply(m)
+
+	expectedFields := map[string]interface{}{
+		"request": "/replace/it",
+	}
+	expectedTags := map[string]string{
+		"foo": "a",
+		"bar": "x",
+	}
+
+	assert.Equal(t, expectedFields, processed[0].Fields())
+	assert.Equal(t, expectedTags, processed[0].Tags())
+}
+
+func TestMultipleEnumLikeConversionsFields(t *testing.T) {
+	plugin := &Strings{
+		Replace: []converter{
+			{
+				Field: "request",
+				Old:   "/replace/it",
+				New:   "/user",
+				Dest:  "req",
+			},
+			{
+				Field: "request",
+				Old:   "/replace/this",
+				New:   "/admin",
+				Dest:  "req",
+			},
+		},
+	}
+
+	m, _ := metric.New("IIS_log",
+		map[string]string{
+			"foo": "a",
+		},
+		map[string]interface{}{
+			"request": "/replace/it",
+		},
+		time.Now(),
+	)
+
+	processed := plugin.Apply(m)
+
+	expectedFields := map[string]interface{}{
+		"request": "/replace/it",
+		"req":     "/user",
+	}
+	expectedTags := map[string]string{
+		"foo": "a",
+	}
+
+	assert.Equal(t, expectedFields, processed[0].Fields())
+	assert.Equal(t, expectedTags, processed[0].Tags())
+}
+
 func TestReadmeExample(t *testing.T) {
 	plugin := &Strings{
 		Lowercase: []converter{


### PR DESCRIPTION
Resolves #5843

With the following config file, it is easy to reproduce the initial reported bug:
```toml
[[outputs.file]]

[[inputs.exec]]
  command = "echo -en 'testmessage,SenderId=IPC_123456_01 message=\"sweet nothings\" 1530654676316265790\ntestmessage,SenderId=IPC_812345_01 message=\"sweet nothings\" 1530654676316265790'"
  data_format = "influx"

  [[processors.strings]]  
    [[processors.strings.replace]]
      tag = "SenderId"
      old = "IPC_123456_01"
      new = "SITE01"
      dest = "site_id"  
      
    [[processors.strings.replace]]
      tag = "SenderId"
      old = "IPC_812345_01"
      new = "SITE02"
      dest = "site_id" 
```

Difference between 1.10.3 and this commit
```diff
testmessage,SenderId=IPC_812345_01,site_id=SITE02 message="sweet nothings" 1530654676000000000
< testmessage,SenderId=IPC_123456_01,site_id=IPC_123456_01 message="sweet nothings" 1530654676000000000
> testmessage,SenderId=IPC_123456_01,site_id=SITE01 message="sweet nothings" 1530654676000000000
```
