### PR TITLE
Allow regexp processor to mix different tags

### DIFF
--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -2,6 +2,8 @@
 
 The `regex` plugin transforms tag and field values with regex pattern. If `result_key` parameter is present, it can produce new tags and fields from existing ones.
 
+For tags transforms, if `append` is set to `true`, it will append the transformation to the existing tag value, instead of overwriting it.
+
 ### Configuration:
 
 ```toml

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -18,6 +18,7 @@ type converter struct {
 	Pattern     string
 	Replacement string
 	ResultKey   string
+	Append      bool
 }
 
 const sampleConfig = `
@@ -68,6 +69,11 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 		for _, converter := range r.Tags {
 			if value, ok := metric.GetTag(converter.Key); ok {
 				if key, newValue := r.convert(converter, value); newValue != "" {
+					if converter.Append {
+						if v, ok := metric.GetTag(key); ok {
+							newValue = v + newValue
+						}
+					}
 					metric.AddTag(key, newValue)
 				}
 			}

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -109,6 +109,20 @@ func TestTagConversions(t *testing.T) {
 			},
 		},
 		{
+			message: "Should append to existing tag",
+			converter: converter{
+				Key:         "verb",
+				Pattern:     "^(.*)$",
+				Replacement: " (${1})",
+				ResultKey:   "resp_code",
+				Append:      true,
+			},
+			expectedTags: map[string]string{
+				"verb":      "GET",
+				"resp_code": "200 (GET)",
+			},
+		},
+		{
 			message: "Should add new tag",
 			converter: converter{
 				Key:         "resp_code",


### PR DESCRIPTION
This change allows to mix values from different tags.
When regexp is used to transform a tag, if value `append` is set to
`true` and we the `result_key` tag already exists, replacement value
will be appended to the end of the current tag value.

Example use case, set `host` tag with the values of tags `clustername` and `dcname`:
Input:
```
vsphere_cluster_vmop,clustername=somecluster,dcname=mydc,host=xxxx numPoweron_latest=27i 1557967800000000000
```

Processor config:
```
[[processors.regex]]
  [[processors.regex.tags]]
    key = "clustername"
    pattern = "^(.*)"
    replacement = "${1}"
    result_key = "host"
  [[processors.regex.tags]]
    key = "dcname"
    pattern = "^(.*)"
    replacement = "_${1}"
    result_key = "host"
    append = true
```

Output:
```
vsphere_cluster_vmop,clustername=somecluster,dcname=mydc,host=somecluster_mydc numPoweron_latest=27i 1557967800000000000
```

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
