### PR TITLE
Adjust Postfix docs to have proper setfacl command

### DIFF
--- a/plugins/inputs/postfix/README.md
+++ b/plugins/inputs/postfix/README.md
@@ -29,7 +29,7 @@ $ sudo chmod g+r /var/spool/postfix/maildrop
 
 Posix ACL:
 ```sh
-$ sudo setfacl -Rdm u:telegraf:rX /var/spool/postfix/{active,hold,incoming,deferred,maildrop}
+$ sudo setfacl -Rdm g:telegraf:rX /var/spool/postfix/{active,hold,incoming,deferred,maildrop}
 ```
 
 ### Measurements & Fields:


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.

When you did set the u:telegraf:rX acl, the telegraf user has only r-x permissions on the maildrop folder.
Now when the telegraf user wants to send an email, it calls postdrop (which has root:postdrop and 2555/-r-xr-sr-x permissions).

This means that postdrop accesses the maildrop folder with telegraf:postdrop user:group.
Now the user acl is matched, and write access is denied. So telegraf user cannot send any email!

The workaround is to set g:telegraf:rX permissions.
Now when postdrop sends an email, it will match the unix permissions for the postdrop group (which is -wx), and mail will work.
When telegraf postfix plugin accesses the folders, it uses telegraf:telegraf, and matches the g:telegraf:rX permission acl :)

So both things work!
