### PR TITLE
Fixes #5883 Omits power_failed and power_restored when the Apex provides invalid timestamps. Eg: "none"

### DIFF
--- a/plugins/inputs/neptune_apex/README.md
+++ b/plugins/inputs/neptune_apex/README.md
@@ -59,8 +59,8 @@ programming. These tags are clearly marked in the list below and should be consi
     - amp (float, Ampere) is the amount of current flowing through the 120V outlet.
     - watt (float, Watt) represents the amount of energy flowing through the 120V outlet.
     - xstatus (string) indicates the xstatus of an outlet. Found on wireless Vortech devices.
-    - power_failed (int64, Unix epoch in ns) when the controller last lost power.
-    - power_restored (int64, Unix epoch in ns) when the controller last powered on.
+    - power_failed (int64, Unix epoch in ns) when the controller last lost power. Omitted if the apex reports it as "none"
+    - power_restored (int64, Unix epoch in ns) when the controller last powered on. Omitted if the apex reports it as "none"
     - serial (string, serial number)
    - time:
      - The time used for the metric is parsed from the status.xml page. This helps when cross-referencing events with

--- a/plugins/inputs/neptune_apex/neptune_apex.go
+++ b/plugins/inputs/neptune_apex/neptune_apex.go
@@ -110,27 +110,21 @@ func (n *NeptuneApex) parseXML(acc telegraf.Accumulator, data []byte) error {
 			err, data)
 	}
 
+	mainFields := map[string]interface{}{
+		"serial": r.Serial,
+	}
 	var reportTime time.Time
-	var powerFailed, powerRestored int64
+
 	if reportTime, err = parseTime(r.Date, r.Timezone); err != nil {
 		return err
 	}
-	if val, err := parseTime(r.PowerFailed, r.Timezone); err != nil {
-		return err
-	} else {
-		powerFailed = val.UnixNano()
+	if val, err := parseTime(r.PowerFailed, r.Timezone); err == nil {
+		mainFields["power_failed"] = val.UnixNano()
 	}
-	if val, err := parseTime(r.PowerRestored, r.Timezone); err != nil {
-		return err
-	} else {
-		powerRestored = val.UnixNano()
+	if val, err := parseTime(r.PowerRestored, r.Timezone); err == nil {
+		mainFields["power_restored"] = val.UnixNano()
 	}
 
-	mainFields := map[string]interface{}{
-		"serial":         r.Serial,
-		"power_failed":   powerFailed,
-		"power_restored": powerRestored,
-	}
 	acc.AddFields(Measurement, mainFields,
 		map[string]string{
 			"source":   r.Hostname,

--- a/plugins/inputs/neptune_apex/neptune_apex_test.go
+++ b/plugins/inputs/neptune_apex/neptune_apex_test.go
@@ -226,7 +226,22 @@ func TestParseXML(t *testing.T) {
 				`<status><date>12/22/2018 21:55:37</date>
 				<timezone>-8.0</timezone><power><failed>a</failed>
 				<restored>12/22/2018 22:55:37</restored></power></status>`),
-			wantErr: true,
+			wantMetrics: []*testutil.Metric{
+				{
+					Measurement: Measurement,
+					Time:        goodTime,
+					Tags: map[string]string{
+						"source":   "",
+						"type":     "controller",
+						"hardware": "",
+						"software": "",
+					},
+					Fields: map[string]interface{}{
+						"serial":         "",
+						"power_restored": int64(1545548137000000000),
+					},
+				},
+			},
 		},
 		{
 			name: "Power restored time failure",
@@ -234,7 +249,22 @@ func TestParseXML(t *testing.T) {
 				`<status><date>12/22/2018 21:55:37</date>
 				<timezone>-8.0</timezone><power><restored>a</restored>
 				<failed>12/22/2018 22:55:37</failed></power></status>`),
-			wantErr: true,
+			wantMetrics: []*testutil.Metric{
+				{
+					Measurement: Measurement,
+					Time:        goodTime,
+					Tags: map[string]string{
+						"source":   "",
+						"type":     "controller",
+						"hardware": "",
+						"software": "",
+					},
+					Fields: map[string]interface{}{
+						"serial":       "",
+						"power_failed": int64(1545548137000000000),
+					},
+				},
+			},
 		},
 		{
 			name: "Power failed failure",


### PR DESCRIPTION
closes #5883

### Required for all PRs:

- [✓ ] Signed [CLA](https://influxdata.com/community/cla/).
- [✓ ] Associated README.md updated.
- [✓ ] Has appropriate unit tests.
