### PR TITLE
Move defered closing of connection

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -151,13 +151,14 @@ func (s *SQLServer) gatherServer(server string, query Query, acc telegraf.Accumu
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
+
 	// verify that a connection can be made before making a query
 	err = conn.Ping()
 	if err != nil {
 		// Handle error
 		return err
 	}
-	defer conn.Close()
 
 	// execute query
 	rows, err := conn.Query(query.Script)

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -153,13 +153,6 @@ func (s *SQLServer) gatherServer(server string, query Query, acc telegraf.Accumu
 	}
 	defer conn.Close()
 
-	// verify that a connection can be made before making a query
-	err = conn.Ping()
-	if err != nil {
-		// Handle error
-		return err
-	}
-
 	// execute query
 	rows, err := conn.Query(query.Script)
 	if err != nil {


### PR DESCRIPTION
Moved the  ```defer conn.Close()``` to before ```conn.Ping``` to ensure the connection is cleaned up if Ping fails.
Fixes https://github.com/influxdata/telegraf/issues/3485

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
