### PR TITLE
Run ServiceInputs during test mode; add --test-wait option

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -136,7 +136,7 @@ func (a *Agent) Run(ctx context.Context) error {
 }
 
 // Test runs the inputs once and prints the output to stdout in line protocol.
-func (a *Agent) Test(ctx context.Context) error {
+func (a *Agent) Test(ctx context.Context, waitDuration time.Duration) error {
 	var wg sync.WaitGroup
 	metricC := make(chan telegraf.Metric)
 	nulC := make(chan telegraf.Metric)
@@ -156,8 +156,8 @@ func (a *Agent) Test(ctx context.Context) error {
 			octets, err := s.Serialize(metric)
 			if err == nil {
 				fmt.Print("> ", string(octets))
-
 			}
+			metric.Reject()
 		}
 	}()
 
@@ -168,41 +168,56 @@ func (a *Agent) Test(ctx context.Context) error {
 		}
 	}()
 
+	hasServiceInputs := false
+	for _, input := range a.Config.Inputs {
+		if _, ok := input.Input.(telegraf.ServiceInput); ok {
+			hasServiceInputs = true
+			break
+		}
+	}
+
+	if hasServiceInputs {
+		log.Printf("D! [agent] Starting service inputs")
+		a.startServiceInputs(ctx, metricC)
+	}
+
 	for _, input := range a.Config.Inputs {
 		select {
 		case <-ctx.Done():
 			return nil
 		default:
-			if _, ok := input.Input.(telegraf.ServiceInput); ok {
-				log.Printf("W!: [agent] skipping plugin [[%s]]: service inputs not supported in --test mode",
-					input.Name())
-				continue
+			break
+		}
+
+		acc := NewAccumulator(input, metricC)
+		acc.SetPrecision(a.Precision())
+
+		// Special instructions for some inputs. cpu, for example, needs to be
+		// run twice in order to return cpu usage percentages.
+		switch input.Name() {
+		case "inputs.cpu", "inputs.mongodb", "inputs.procstat":
+			nulAcc := NewAccumulator(input, nulC)
+			nulAcc.SetPrecision(a.Precision())
+			if err := input.Input.Gather(nulAcc); err != nil {
+				acc.AddError(err)
 			}
 
-			acc := NewAccumulator(input, metricC)
-			acc.SetPrecision(a.Precision())
-			input.SetDefaultTags(a.Config.Tags)
-
-			// Special instructions for some inputs. cpu, for example, needs to be
-			// run twice in order to return cpu usage percentages.
-			switch input.Name() {
-			case "inputs.cpu", "inputs.mongodb", "inputs.procstat":
-				nulAcc := NewAccumulator(input, nulC)
-				nulAcc.SetPrecision(a.Precision())
-				if err := input.Input.Gather(nulAcc); err != nil {
-					return err
-				}
-
-				time.Sleep(500 * time.Millisecond)
-				if err := input.Input.Gather(acc); err != nil {
-					return err
-				}
-			default:
-				if err := input.Input.Gather(acc); err != nil {
-					return err
-				}
+			time.Sleep(500 * time.Millisecond)
+			if err := input.Input.Gather(acc); err != nil {
+				acc.AddError(err)
+			}
+		default:
+			if err := input.Input.Gather(acc); err != nil {
+				acc.AddError(err)
 			}
 		}
+	}
+
+	if hasServiceInputs {
+		log.Printf("D! [agent] Waiting for service inputs")
+		internal.SleepContext(ctx, waitDuration)
+		log.Printf("D! [agent] Stopping service inputs")
+		a.stopServiceInputs()
 	}
 
 	return nil

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -178,7 +178,10 @@ func (a *Agent) Test(ctx context.Context, waitDuration time.Duration) error {
 
 	if hasServiceInputs {
 		log.Printf("D! [agent] Starting service inputs")
-		a.startServiceInputs(ctx, metricC)
+		err := a.startServiceInputs(ctx, metricC)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, input := range a.Config.Inputs {

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/influxdata/telegraf/agent"
 	"github.com/influxdata/telegraf/internal"
@@ -33,7 +34,8 @@ var pprofAddr = flag.String("pprof-addr", "",
 	"pprof address to listen on, not activate pprof if empty")
 var fQuiet = flag.Bool("quiet", false,
 	"run in quiet mode")
-var fTest = flag.Bool("test", false, "gather metrics, print them out, and exit")
+var fTest = flag.Bool("test", false, "enable test mode: gather metrics, print them out, and exit")
+var fTestWait = flag.Int("test-wait", 0, "wait up to this many seconds for service inputs to complete in test mode")
 var fConfig = flag.String("config", "", "configuration file to load")
 var fConfigDirectory = flag.String("config-directory", "",
 	"directory containing additional *.conf files")
@@ -167,8 +169,9 @@ func runAgent(ctx context.Context,
 
 	logger.SetupLogging(logConfig)
 
-	if *fTest {
-		return ag.Test(ctx)
+	if *fTest || *fTestWait != 0 {
+		testWaitDuration := time.Duration(*fTestWait) * time.Second
+		return ag.Test(ctx, testWaitDuration)
 	}
 
 	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -31,6 +31,8 @@ The commands & flags are:
   --sample-config                print out full sample configuration
   --test                         gather metrics, print them out, and exit;
                                  processors, aggregators, and outputs are not run
+  --test-wait                    wait up to this many seconds for service
+                                 inputs to complete in test mode
   --usage <plugin>               print usage for a plugin, ie, 'telegraf --usage mysql'
   --version                      display the version and exit
 

--- a/internal/usage_windows.go
+++ b/internal/usage_windows.go
@@ -31,6 +31,8 @@ The commands & flags are:
                                  'processors', 'aggregators' and 'inputs'
   --test                         gather metrics, print them out, and exit;
                                  processors, aggregators, and outputs are not run
+  --test-wait                    wait up to this many seconds for service
+                                 inputs to complete in test mode
   --usage <plugin>               print usage for a plugin, ie, 'telegraf --usage mysql'
   --version                      display the version and exit
 


### PR DESCRIPTION
Some plugins use the Start/Stop functions for setup/teardown but are still polling based inputs at heart.  With this change you won't have to choose to between having `--test` support and using these functions.

I Added a new option, `--test-wait`, which is the number of seconds to pause after running Gather.  The default is 0 and so Telegraf exits immediately.  This can be set higher to, for example, run socket_listener for a few minutes.

Call flow is:
- Start
- Gather
- Wait
- Stop

This pull request does have some important limitations.  The Gather function is only called once instead of on an interval.  Service inputs that use the Gather function, such as statsd, may not behave normally.  In the statsd case it will not emit any metrics.

When using `--test` with a queue consumer, messages will be consumed but when supported they will mark the message as undelivered.  This should result in the message being redelivered in amqp or kafka, but for queues that don't support rejecting messages then the message will be lost.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
