### PR TITLE
Add Prometheus remote write output plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@
 - [#6241](https://github.com/influxdata/telegraf/pull/6241): Add configurable timeout setting to smart input.
 - [#6249](https://github.com/influxdata/telegraf/pull/6249): Add memory_usage field to procstat input plugin.
 - [#5971](https://github.com/influxdata/telegraf/pull/5971): Add support for custom attributes to vsphere input.
+- [#5926](https://github.com/influxdata/telegraf/pull/5926): Add cmdstat metrics to redis input.
+- [#6261](https://github.com/influxdata/telegraf/pull/6261): Add content_length metric to http_response input plugin.
+- [#6257](https://github.com/influxdata/telegraf/pull/6257): Add database_tag option to influxdb_listener to add database from query string.
 
 #### Bugfixes
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -501,7 +501,13 @@
 [[projects]]
   digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
   name = "github.com/gogo/protobuf"
-  packages = ["proto"]
+  packages = [
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+    "sortkeys",
+    "types",
+  ]
   pruneopts = ""
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
@@ -510,8 +516,12 @@
   digest = "1:f958a1c137db276e52f0b50efee41a1a389dcdded59a69711f3e872757dab34b"
   name = "github.com/golang/protobuf"
   packages = [
+    "jsonpb",
     "proto",
     "protoc-gen-go/descriptor",
+    "protoc-gen-go/generator",
+    "protoc-gen-go/generator/internal/remap",
+    "protoc-gen-go/plugin",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
@@ -593,6 +603,18 @@
   pruneopts = ""
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
+
+[[projects]]
+  digest = "1:dee8ec16fa714522c6cad579dfeeba3caf9644d93b8b452cd7138584402c81f7"
+  name = "github.com/grpc-ecosystem/grpc-gateway"
+  packages = [
+    "internal",
+    "runtime",
+    "utilities",
+  ]
+  pruneopts = ""
+  revision = "8fd5fd9d19ce68183a6b0934519dfe7fe6269612"
+  version = "v1.9.0"
 
 [[projects]]
   branch = "master"
@@ -1033,6 +1055,14 @@
   revision = "ae68e2d4c00fed4943b5f6698d504a5fe083da8a"
 
 [[projects]]
+  digest = "1:b9aa2275e8c025c1b7514b6bc3fb04c3fbfc922891979472eb7227b7110c40ae"
+  name = "github.com/prometheus/prometheus"
+  packages = ["prompb"]
+  pruneopts = ""
+  revision = "d20e84d0fb64aff2f62a977adc8cfb656da4e286"
+  version = "v2.10.0"
+
+[[projects]]
   branch = "master"
   digest = "1:15bcdc717654ef21128e8af3a63eec39a6d08a830e297f93d65163f87c8eb523"
   name = "github.com/rcrowley/go-metrics"
@@ -1446,6 +1476,7 @@
   packages = [
     "googleapis/api/annotations",
     "googleapis/api/distribution",
+    "googleapis/api/httpbody",
     "googleapis/api/label",
     "googleapis/api/metric",
     "googleapis/api/monitoredres",
@@ -1708,10 +1739,12 @@
     "github.com/go-redis/redis",
     "github.com/go-sql-driver/mysql",
     "github.com/gobwas/glob",
+    "github.com/gogo/protobuf/proto",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/ptypes/duration",
     "github.com/golang/protobuf/ptypes/empty",
     "github.com/golang/protobuf/ptypes/timestamp",
+    "github.com/golang/snappy",
     "github.com/google/go-cmp/cmp",
     "github.com/google/go-cmp/cmp/cmpopts",
     "github.com/google/go-github/github",
@@ -1748,6 +1781,7 @@
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/client_model/go",
     "github.com/prometheus/common/expfmt",
+    "github.com/prometheus/prometheus/prompb",
     "github.com/satori/go.uuid",
     "github.com/shirou/gopsutil/cpu",
     "github.com/shirou/gopsutil/disk",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,10 +47,6 @@
   version = "0.2.3"
 
 [[constraint]]
-  name = "github.com/golang/protobuf"
-  version = "1.1.0"
-
-[[constraint]]
   name = "github.com/google/go-cmp"
   version = "0.2.0"
 
@@ -221,10 +217,6 @@
   name = "gopkg.in/fsnotify.v1"
 
 [[constraint]]
-  branch = "master"
-  name = "google.golang.org/genproto"
-
-[[constraint]]
   name = "github.com/vmware/govmomi"
   version = "0.19.0"
 
@@ -292,3 +284,8 @@
 [[constraint]]
   branch = "master"
   name = "github.com/cisco-ie/nx-telemetry-proto"
+
+# Prometheus uses go modules so this transitive dependancy isn't pulled properly.
+[[override]]
+  name = "github.com/grpc-ecosystem/grpc-gateway"
+  version = "1.6.3"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,6 +47,10 @@
   version = "0.2.3"
 
 [[constraint]]
+  name = "github.com/golang/protobuf"
+  version = "1.1.0"
+
+[[constraint]]
   name = "github.com/google/go-cmp"
   version = "0.2.0"
 
@@ -215,6 +219,10 @@
 [[override]]
   source = "https://github.com/fsnotify/fsnotify/archive/v1.4.7.tar.gz"
   name = "gopkg.in/fsnotify.v1"
+
+[[constraint]]
+  branch = "master"
+  name = "google.golang.org/genproto"
 
 [[constraint]]
   name = "github.com/vmware/govmomi"

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1044,6 +1044,11 @@
 #   ## Export metric collection time.
 #   # export_timestamp = false
 
+# # Send metrics to systems that accept Prometheus Remote Write.
+# [[outputs.prometheus_remote_write]]
+#   url = "https://localhost/"
+#   # basic_username = "Foo"
+#   # basic_password = "Bar"
 
 # # Configuration for the Riemann server to send metrics to
 # [[outputs.riemann]]

--- a/plugins/inputs/prometheus/parser.go
+++ b/plugins/inputs/prometheus/parser.go
@@ -71,6 +71,7 @@ func Parse(buf []byte, header http.Header) ([]telegraf.Metric, error) {
 			} else if mf.GetType() == dto.MetricType_HISTOGRAM {
 				// histogram metric
 				fields = makeBuckets(m)
+				fields["+Inf"] = float64(m.GetHistogram().GetSampleCount())
 				fields["count"] = float64(m.GetHistogram().GetSampleCount())
 				fields["sum"] = float64(m.GetHistogram().GetSampleSum())
 

--- a/plugins/outputs/all/all.go
+++ b/plugins/outputs/all/all.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/outputs/nsq"
 	_ "github.com/influxdata/telegraf/plugins/outputs/opentsdb"
 	_ "github.com/influxdata/telegraf/plugins/outputs/prometheus_client"
+	_ "github.com/influxdata/telegraf/plugins/outputs/prometheus_remote_write"
 	_ "github.com/influxdata/telegraf/plugins/outputs/riemann"
 	_ "github.com/influxdata/telegraf/plugins/outputs/riemann_legacy"
 	_ "github.com/influxdata/telegraf/plugins/outputs/socket_writer"

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -346,7 +346,7 @@ func Sanitize(value string) string {
 	return InvalidNameCharRE.ReplaceAllString(value, "_")
 }
 
-func isValidTagName(tag string) bool {
+func IsValidTagName(tag string) bool {
 	return ValidNameCharRE.MatchString(tag)
 }
 
@@ -422,7 +422,7 @@ func (p *PrometheusClient) Write(metrics []telegraf.Metric) error {
 		labels := make(map[string]string)
 		for k, v := range tags {
 			tName := Sanitize(k)
-			if !isValidTagName(tName) {
+			if !IsValidTagName(tName) {
 				continue
 			}
 			labels[tName] = v
@@ -435,7 +435,7 @@ func (p *PrometheusClient) Write(metrics []telegraf.Metric) error {
 				switch fv := fv.(type) {
 				case string:
 					tName := Sanitize(fn)
-					if !isValidTagName(tName) {
+					if !IsValidTagName(tName) {
 						continue
 					}
 					labels[tName] = fv
@@ -484,7 +484,7 @@ func (p *PrometheusClient) Write(metrics []telegraf.Metric) error {
 			}
 			mname = Sanitize(point.Name())
 
-			if !isValidTagName(mname) {
+			if !IsValidTagName(mname) {
 				continue
 			}
 
@@ -530,7 +530,7 @@ func (p *PrometheusClient) Write(metrics []telegraf.Metric) error {
 			}
 			mname = Sanitize(point.Name())
 
-			if !isValidTagName(mname) {
+			if !IsValidTagName(mname) {
 				continue
 			}
 
@@ -578,7 +578,7 @@ func (p *PrometheusClient) Write(metrics []telegraf.Metric) error {
 						mname = Sanitize(fmt.Sprintf("%s_%s", point.Name(), fn))
 					}
 				}
-				if !isValidTagName(mname) {
+				if !IsValidTagName(mname) {
 					continue
 				}
 				p.addMetricFamily(point, sample, mname, sampleID)

--- a/plugins/outputs/prometheus_remote_write/README.md
+++ b/plugins/outputs/prometheus_remote_write/README.md
@@ -1,0 +1,19 @@
+# Prometheus Remote Write Output Plugin
+
+This plugin sends metrics to services which speak the [Prometheus Remote Write](https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage) format, such as [Cortex](https://github.com/cortexproject/cortex).  ***Note*** Prometheus does not accept writes in this format; it only sends them.
+
+## Configuration
+
+```toml
+# Send metrics on Prometheus
+[[outputs.prometheus_remote_write]]
+  ## URL to send Prometheus remote write requests to.
+  url = "http://localhost/push"
+
+  ## HTTP asic auth credentials (optional).
+  # basic_username = "username"
+  # basic_password = "pa55w0rd"
+```
+
+## TODO
+- Handle summaries and histograms.

--- a/plugins/outputs/prometheus_remote_write/README.md
+++ b/plugins/outputs/prometheus_remote_write/README.md
@@ -13,6 +13,9 @@ This plugin sends metrics to services which speak the [Prometheus Remote Write](
   ## HTTP asic auth credentials (optional).
   # basic_username = "username"
   # basic_password = "pa55w0rd"
+
+	## Optional Bearer token
+	# bearer_token = "bearer_token"
 ```
 
 ## TODO

--- a/plugins/outputs/prometheus_remote_write/README.md
+++ b/plugins/outputs/prometheus_remote_write/README.md
@@ -16,6 +16,9 @@ This plugin sends metrics to services which speak the [Prometheus Remote Write](
 
 	## Optional Bearer token
 	# bearer_token = "bearer_token"
+
+  ## Disable retry for 4XX http status codes
+  # retry_for_client_errors = false
 ```
 
 ## TODO

--- a/plugins/outputs/prometheus_remote_write/prometheus_remote_write.go
+++ b/plugins/outputs/prometheus_remote_write/prometheus_remote_write.go
@@ -116,7 +116,7 @@ func (p *PrometheusRemoteWrite) Write(metrics []telegraf.Metric) error {
 			if (metric.Type() == telegraf.Histogram || metric.Type() == telegraf.Summary) && (field.Key != "sum" && field.Key != "count") {
 				metricName = prometheus_client.Sanitize(metric.Name())
 			} else {
-				metricName = getSanitizedMetricName(metric.Name(), field.Key)
+				metricName = getSanitizedMetricName(metric.Name(), prometheus_client.Sanitize(field.Key))
 			}
 			labels := make([]prompb.Label, len(commonLabels), len(commonLabels)+1)
 			copy(labels, commonLabels)

--- a/plugins/outputs/prometheus_remote_write/prometheus_remote_write.go
+++ b/plugins/outputs/prometheus_remote_write/prometheus_remote_write.go
@@ -1,0 +1,172 @@
+package prometheus_remote_write
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/prompb"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/internal/tls"
+	"github.com/influxdata/telegraf/plugins/outputs"
+)
+
+func init() {
+	outputs.Add("prometheus_remote_write", func() telegraf.Output {
+		return &PrometheusRemoteWrite{}
+	})
+}
+
+var (
+	invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9_:]`)
+	validNameCharRE   = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*`)
+)
+
+type PrometheusRemoteWrite struct {
+	URL           string `toml:"url"`
+	BasicUsername string `toml:"basic_username"`
+	BasicPassword string `toml:"basic_password"`
+	tls.ClientConfig
+
+	client http.Client
+}
+
+var sampleConfig = `
+  ## URL to send Prometheus remote write requests to.
+  url = "http://localhost/push"
+
+  ## Optional HTTP asic auth credentials.
+  # basic_username = "username"
+  # basic_password = "pa55w0rd"
+
+  ## Optional TLS Config for use on HTTP connections.
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+`
+
+func (p *PrometheusRemoteWrite) Connect() error {
+	tlsConfig, err := p.ClientConfig.TLSConfig()
+	if err != nil {
+		return err
+	}
+
+	p.client = http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+	return nil
+}
+
+func (p *PrometheusRemoteWrite) Close() error {
+	return nil
+}
+
+func (p *PrometheusRemoteWrite) Description() string {
+	return "Configuration for the Prometheus remote write client to spawn"
+}
+
+func (p *PrometheusRemoteWrite) SampleConfig() string {
+	return sampleConfig
+}
+
+func (p *PrometheusRemoteWrite) Write(metrics []telegraf.Metric) error {
+	var req prompb.WriteRequest
+
+	for _, metric := range metrics {
+		tags := metric.TagList()
+		commonLabels := make([]prompb.Label, 0, len(tags))
+		for _, tag := range tags {
+			commonLabels = append(commonLabels, prompb.Label{
+				Name:  sanitize(tag.Key),
+				Value: tag.Value,
+			})
+		}
+
+		for _, field := range metric.FieldList() {
+			labels := make([]prompb.Label, len(commonLabels), len(commonLabels)+1)
+			copy(labels, commonLabels)
+			labels = append(labels, prompb.Label{
+				Name:  "__name__",
+				Value: metric.Name() + "_" + field.Key,
+			})
+			sort.Sort(byName(labels))
+
+			// Ignore histograms and summaries.
+			switch metric.Type() {
+			case telegraf.Histogram, telegraf.Summary:
+				continue
+			}
+
+			// Ignore string and bool fields.
+			var value float64
+			switch fv := field.Value.(type) {
+			case int64:
+				value = float64(fv)
+			case uint64:
+				value = float64(fv)
+			case float64:
+				value = fv
+			default:
+				continue
+			}
+
+			req.Timeseries = append(req.Timeseries, prompb.TimeSeries{
+				Labels: labels,
+				Samples: []prompb.Sample{{
+					Timestamp: metric.Time().UnixNano() / int64(time.Millisecond),
+					Value:     value,
+				}},
+			})
+		}
+	}
+
+	buf, err := proto.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	compressed := snappy.Encode(nil, buf)
+	httpReq, err := http.NewRequest("POST", p.URL, bytes.NewReader(compressed))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Add("Content-Encoding", "snappy")
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
+	httpReq.Header.Set("User-Agent", "Telegraf/"+internal.Version())
+	if p.BasicUsername != "" || p.BasicPassword != "" {
+		httpReq.SetBasicAuth(p.BasicUsername, p.BasicPassword)
+	}
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("server returned HTTP status %s (%d)", resp.Status, resp.StatusCode)
+	}
+	return nil
+}
+
+func sanitize(value string) string {
+	return invalidNameCharRE.ReplaceAllString(value, "_")
+}
+
+type byName []prompb.Label
+
+func (a byName) Len() int           { return len(a) }
+func (a byName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byName) Less(i, j int) bool { return a[i].Name < a[j].Name }

--- a/plugins/outputs/prometheus_remote_write/prometheus_remote_write.go
+++ b/plugins/outputs/prometheus_remote_write/prometheus_remote_write.go
@@ -180,7 +180,7 @@ func (p *PrometheusRemoteWrite) retryClientErrors(statusCode int) bool {
 		retryFlag = false
 	}
 	if retryFlag == false && (statusCode == http.StatusTooManyRequests || statusCode == http.StatusBadRequest) {
-		log.Printf("E! [outputs.prometheus_remote_write] dropped a batch of metrics.\n")
+		log.Printf("E! [outputs.prometheus_remote_write] dropped metrics because of bad request or rate limit.\n")
 		return false
 	}
 	return true

--- a/plugins/outputs/prometheus_remote_write/prometheus_remote_write.go
+++ b/plugins/outputs/prometheus_remote_write/prometheus_remote_write.go
@@ -31,6 +31,7 @@ var (
 
 type PrometheusRemoteWrite struct {
 	URL           string `toml:"url"`
+	BearerToken   string `toml:"bearer_token"`
 	BasicUsername string `toml:"basic_username"`
 	BasicPassword string `toml:"basic_password"`
 	tls.ClientConfig
@@ -52,6 +53,8 @@ var sampleConfig = `
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+	## Optional Bearer token
+  # bearer_token = "bearer_token"
 `
 
 func (p *PrometheusRemoteWrite) Connect() error {
@@ -145,6 +148,10 @@ func (p *PrometheusRemoteWrite) Write(metrics []telegraf.Metric) error {
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
 	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
 	httpReq.Header.Set("User-Agent", "Telegraf/"+internal.Version())
+	if p.BearerToken != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+p.BearerToken)
+	}
+
 	if p.BasicUsername != "" || p.BasicPassword != "" {
 		httpReq.SetBasicAuth(p.BasicUsername, p.BasicPassword)
 	}

--- a/plugins/outputs/prometheus_remote_write/prometheus_remote_write_test.go
+++ b/plugins/outputs/prometheus_remote_write/prometheus_remote_write_test.go
@@ -194,3 +194,57 @@ func TestWrite_WithStringFieldWithoutAnyNumericField(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteWithHistogram(t *testing.T) {
+	for i, tc := range []struct {
+		metrics  []telegraf.Metric
+		expected prompb.WriteRequest
+	}{
+		{
+			metrics:  []telegraf.Metric{},
+			expected: prompb.WriteRequest{},
+		},
+
+		{
+			metrics: []telegraf.Metric{
+				mustNew(t, "foo", map[string]string{"bar": "baz"},
+					map[string]interface{}{"99": 1.0}, time.Unix(0, 0), telegraf.Histogram),
+			},
+			expected: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{{
+					Labels: []prompb.Label{
+						{Name: "__name__", Value: "foo"},
+						{Name: "bar", Value: "baz"},
+						{Name: "le", Value: "99"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: 0, Value: 1.0},
+					},
+				}},
+			},
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var actual prompb.WriteRequest
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				buf, err := ioutil.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				buf, err = snappy.Decode(nil, buf)
+				require.NoError(t, err)
+
+				err = proto.Unmarshal(buf, &actual)
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			remote := PrometheusRemoteWrite{
+				URL: server.URL,
+			}
+			err := remote.Write(tc.metrics)
+			require.NoError(t, err)
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}

--- a/plugins/outputs/prometheus_remote_write/prometheus_remote_write_test.go
+++ b/plugins/outputs/prometheus_remote_write/prometheus_remote_write_test.go
@@ -1,0 +1,85 @@
+package prometheus_remote_write
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+)
+
+func mustNew(
+	t require.TestingT,
+	name string,
+	tags map[string]string,
+	fields map[string]interface{},
+	tm time.Time,
+	tp ...telegraf.ValueType,
+) telegraf.Metric {
+	m, err := metric.New(name, tags, fields, tm, tp...)
+	require.NoError(t, err)
+	return m
+}
+
+func TestWrite(t *testing.T) {
+	for i, tc := range []struct {
+		metrics  []telegraf.Metric
+		expected prompb.WriteRequest
+	}{
+		{
+			metrics:  []telegraf.Metric{},
+			expected: prompb.WriteRequest{},
+		},
+
+		{
+			metrics: []telegraf.Metric{
+				mustNew(t, "foo", map[string]string{"bar": "baz"},
+					map[string]interface{}{"blip": 0.0}, time.Unix(0, 0), telegraf.Counter),
+			},
+			expected: prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{{
+					Labels: []prompb.Label{
+						{Name: "__name__", Value: "foo_blip"},
+						{Name: "bar", Value: "baz"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: 0, Value: 0.0},
+					},
+				}},
+			},
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var actual prompb.WriteRequest
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				buf, err := ioutil.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				buf, err = snappy.Decode(nil, buf)
+				require.NoError(t, err)
+
+				err = proto.Unmarshal(buf, &actual)
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			remote := PrometheusRemoteWrite{
+				URL: server.URL,
+			}
+			err := remote.Write(tc.metrics)
+			require.NoError(t, err)
+			assert.Equal(t, actual, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
Add an output plugin that allows Telegraf to send metrics to systems which support Prometheus remote write format (such as Cortex and list of all remote writes are defined [here](https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage)).

This is PR contains the following changes:
1. Contains [this PR ](https://github.com/influxdata/telegraf/pull/5003) changes. (Seems like no one is actively working on this PR. I have added missing features and bug fixes as part of this PR)
2. Add bearer Token support for authentication apart from username and password based authentication.
3. Sanitize the metrics to follow Prometheus format i.e having an underscore in metrics.
4. Added sort functionality in metrics to handle timestamp out of order issue causing issues in remote write.
5. Add feature toggle in the config file for retry logic if data ingestion failed in remote write because of various reasons, like - rate limiting, metrics out of order due to partial write of metrics.


- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
