### PR TITLE
Add support for remaining file rotation options

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,12 +149,12 @@ type AgentConfig struct {
 	// Log file name, the empty string means to log to stderr.
 	Logfile string `toml:"logfile"`
 
-	// The logfile will be rotated when it becomes larger than the specified
-	// size.  When set to 0 no size based rotation is performed.
+	// The file will be rotated after the time interval specified.  When set
+	// to 0 no time based rotation is performed.
 	LogfileRotationInterval internal.Duration `toml:"logfile_rotation_interval"`
 
-	// Maximum number of rotated archives to keep, any older logs are deleted.
-	// If set to -1, no archives are removed.
+	// The logfile will be rotated when it becomes larger than the specified
+	// size.  When set to 0 no size based rotation is performed.
 	LogfileRotationMaxSize internal.Size `toml:"logfile_rotation_max_size"`
 
 	// Maximum number of rotated archives to keep, any older logs are deleted.

--- a/plugins/outputs/file/README.md
+++ b/plugins/outputs/file/README.md
@@ -1,15 +1,25 @@
-# file Output Plugin
+# File Output Plugin
 
 This plugin writes telegraf metrics to files
 
 ### Configuration
-```
+
+```toml
 [[outputs.file]]
   ## Files to write to, "stdout" is a specially handled file.
   files = ["stdout", "/tmp/metrics.out"]
 
-  ## If this is defined, files will be rotated by the time.Duration specified
-  # rotate_max_age = "1m"
+  ## The file will be rotated after the time interval specified.  When set
+  ## to 0 no time based rotation is performed.
+  # rotation_interval = "0h"
+
+  ## The logfile will be rotated when it becomes larger than the specified
+  ## size.  When set to 0 no size based rotation is performed.
+  # rotation_max_size = "0MB"
+
+  ## Maximum number of rotated archives to keep, any older logs are deleted.
+  ## If set to -1, no archives are removed.
+  # rotation_max_archives = 5
 
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/outputs/file/file.go
+++ b/plugins/outputs/file/file.go
@@ -4,21 +4,22 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/rotate"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
 type File struct {
-	Files        []string
-	RotateMaxAge string
+	Files               []string          `toml:"files"`
+	RotationInterval    internal.Duration `toml:"rotation_interval"`
+	RotationMaxSize     internal.Size     `toml:"rotation_max_size"`
+	RotationMaxArchives int               `toml:"rotation_max_archives"`
 
-	writer  io.Writer
-	closers []io.Closer
-
+	writer     io.Writer
+	closers    []io.Closer
 	serializer serializers.Serializer
 }
 
@@ -26,8 +27,17 @@ var sampleConfig = `
   ## Files to write to, "stdout" is a specially handled file.
   files = ["stdout", "/tmp/metrics.out"]
 
-  ## If this is defined, files will be rotated by the time.Duration specified
-  # rotate_max_age = "1m"
+  ## The file will be rotated after the time interval specified.  When set
+  ## to 0 no time based rotation is performed.
+  # rotation_interval = "0d"
+
+  ## The logfile will be rotated when it becomes larger than the specified
+  ## size.  When set to 0 no size based rotation is performed.
+  # rotation_max_size = "0MB"
+
+  ## Maximum number of rotated archives to keep, any older logs are deleted.
+  ## If set to -1, no archives are removed.
+  # rotation_max_archives = 5
 
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
@@ -51,23 +61,12 @@ func (f *File) Connect() error {
 		if file == "stdout" {
 			writers = append(writers, os.Stdout)
 		} else {
-			var of io.WriteCloser
-			var err error
-			if f.RotateMaxAge != "" {
-				maxAge, err := time.ParseDuration(f.RotateMaxAge)
-				if err != nil {
-					return err
-				}
-
-				// Only rotate by file age for now, keep no archives.
-				of, err = rotate.NewFileWriter(file, maxAge, 0, -1)
-			} else {
-				// Just open a normal file
-				of, err = rotate.NewFileWriter(file, 0, 0, -1)
-			}
+			of, err := rotate.NewFileWriter(
+				file, f.RotationInterval.Duration, f.RotationMaxSize.Size, f.RotationMaxArchives)
 			if err != nil {
 				return err
 			}
+
 			writers = append(writers, of)
 			f.closers = append(f.closers, of)
 		}
@@ -106,7 +105,7 @@ func (f *File) Write(metrics []telegraf.Metric) error {
 
 		_, err = f.writer.Write(b)
 		if err != nil {
-			writeErr = fmt.Errorf("E! failed to write message: %s, %s", b, err)
+			writeErr = fmt.Errorf("E! [outputs.file] failed to write message: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Added support for the reamining file rotations options available to the agent, and aligned the option naming.

related: #5547

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
