### PR TITLE
Add disk host to fields

### DIFF
--- a/plugins/inputs/hddtemp/go-hddtemp/hddtemp.go
+++ b/plugins/inputs/hddtemp/go-hddtemp/hddtemp.go
@@ -14,6 +14,7 @@ type Disk struct {
 	Temperature int32
 	Unit        string
 	Status      string
+	DiskHost    string
 }
 
 type hddtemp struct {
@@ -61,6 +62,7 @@ func (h *hddtemp) Fetch(address string) ([]Disk, error) {
 			Temperature: int32(temperature),
 			Unit:        fields[offset+4],
 			Status:      status,
+			DiskHost:    address,
 		})
 	}
 


### PR DESCRIPTION
Allow for easier monitoring of large disk deployments by allowing tag filtering based on originating host.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
