### PR TITLE
Fix pid_count with systemd_unit in procstat_lookup

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -398,7 +398,7 @@ func (p *Procstat) systemdUnitPIDs() ([]PID, error) {
 		if !bytes.Equal(kv[0], []byte("MainPID")) {
 			continue
 		}
-		if len(kv[1]) == 0 {
+		if len(kv[1]) == 0 || bytes.Equal(kv[1], []byte("0")){
 			return nil, nil
 		}
 		pid, err := strconv.Atoi(string(kv[1]))

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -398,7 +398,7 @@ func (p *Procstat) systemdUnitPIDs() ([]PID, error) {
 		if !bytes.Equal(kv[0], []byte("MainPID")) {
 			continue
 		}
-		if len(kv[1]) == 0 || bytes.Equal(kv[1], []byte("0")){
+		if len(kv[1]) == 0 || bytes.Equal(kv[1], []byte("0")) {
 			return nil, nil
 		}
 		pid, err := strconv.Atoi(string(kv[1]))


### PR DESCRIPTION
Attempt at fixing #5300. Not sure if using an OR statement or writing a separate if was a better practice. Since both check for valid PIDs I used an OR statement.
Also I tested this on golang and know almost nothing of GO, so there might be better ways to write this.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
