### PR TITLE
Add default url for http output

### DIFF
--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -9,7 +9,7 @@ data formats.  For data_formats that support batching, metrics are sent in batch
 # A plugin that can transmit metrics over HTTP
 [[outputs.http]]
   ## URL is the address to send metrics to
-  url = "http://127.0.0.1:8080/metric"
+  url = "http://127.0.0.1:8080/telegraf"
 
   ## Timeout for HTTP message
   # timeout = "5s"
@@ -40,12 +40,12 @@ data formats.  For data_formats that support batching, metrics are sent in batch
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   # data_format = "influx"
 
+  ## HTTP Content-Encoding for write request body, can be set to "gzip" to
+  ## compress body or "identity" to apply no encoding.
+  # content_encoding = "identity"
+
   ## Additional HTTP headers
   # [outputs.http.headers]
   #   # Should be set manually to "application/json" for json data_format
   #   Content-Type = "text/plain; charset=utf-8"
-
-  ## HTTP Content-Encoding for write request body, can be set to "gzip" to
-  ## compress body or "identity" to apply no encoding.
-  # content_encoding = "identity"
 ```

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -19,9 +19,13 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 )
 
+const (
+	defaultURL = "http://127.0.0.1:8080/telegraf"
+)
+
 var sampleConfig = `
   ## URL is the address to send metrics to
-  url = "http://127.0.0.1:8080/metric"
+  url = "http://127.0.0.1:8080/telegraf"
 
   ## Timeout for HTTP message
   # timeout = "5s"
@@ -52,14 +56,14 @@ var sampleConfig = `
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   # data_format = "influx"
 
+  ## HTTP Content-Encoding for write request body, can be set to "gzip" to
+  ## compress body or "identity" to apply no encoding.
+  # content_encoding = "identity"
+
   ## Additional HTTP headers
   # [outputs.http.headers]
   #   # Should be set manually to "application/json" for json data_format
   #   Content-Type = "text/plain; charset=utf-8"
-
-  ## HTTP Content-Encoding for write request body, can be set to "gzip" to
-  ## compress body or "identity" to apply no encoding.
-  # content_encoding = "identity"
 `
 
 const (
@@ -218,6 +222,7 @@ func init() {
 		return &HTTP{
 			Timeout: internal.Duration{Duration: defaultClientTimeout},
 			Method:  defaultMethod,
+			URL:     defaultURL,
 		}
 	})
 }


### PR DESCRIPTION
Default URL matches the http_listener_v2 input.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
