### PR TITLE
Container Uptime in Docker Input Plugin

### DIFF
--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -278,6 +278,7 @@ status if configured.
     - exitcode (integer)
     - started_at (integer)
     - finished_at (integer)
+    - uptime_ns (integer)
 
 - docker_swarm
   - tags:

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -73,6 +73,7 @@ const (
 var (
 	sizeRegex       = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[bB]?$`)
 	containerStates = []string{"created", "restarting", "running", "removing", "paused", "exited", "dead"}
+	now             = time.Now
 )
 
 var sampleConfig = `

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -475,7 +475,7 @@ func (d *Docker) gatherContainer(
 		started, err := time.Parse(time.RFC3339, info.State.StartedAt)
 		if err == nil && !started.IsZero() {
 			statefields["started_at"] = started.UnixNano()
-			statefields["uptime_ns"] = int64(finished.Sub(started))
+			statefields["uptime_ns"] = finished.Sub(started).Nanoseconds()
 		}
 
 		acc.AddFields("docker_container_status", statefields, tags, time.Now())

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -3,10 +3,12 @@ package docker
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io/ioutil"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/influxdata/telegraf/testutil"
 
@@ -83,7 +85,7 @@ var baseClient = MockClient{
 		return containerStats(s), nil
 	},
 	ContainerInspectF: func(context.Context, string) (types.ContainerJSON, error) {
-		return containerInspect, nil
+		return containerInspect(), nil
 	},
 	ServiceListF: func(context.Context, types.ServiceListOptions) ([]swarm.Service, error) {
 		return ServiceList, nil
@@ -264,7 +266,7 @@ func TestDocker_WindowsMemoryContainerStats(t *testing.T) {
 					return containerStatsWindows(), nil
 				},
 				ContainerInspectF: func(ctx context.Context, containerID string) (types.ContainerJSON, error) {
-					return containerInspect, nil
+					return containerInspect(), nil
 				},
 				ServiceListF: func(context.Context, types.ServiceListOptions) ([]swarm.Service, error) {
 					return ServiceList, nil
@@ -534,6 +536,102 @@ func TestContainerNames(t *testing.T) {
 			}
 
 			require.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestContainerStatus(t *testing.T) {
+	type expectation struct {
+		// tags
+		Status string
+		// fields
+		OOMKilled  bool
+		Pid        int
+		ExitCode   int
+		StartedAt  time.Time
+		FinishedAt time.Time
+	}
+
+	var tests = []struct {
+		name    string
+		inspect types.ContainerJSON
+		expect  expectation
+	}{
+		{
+			name:    "finished_at is zero value",
+			inspect: containerInspect(),
+			expect: expectation{
+				Status:    "running",
+				OOMKilled: false,
+				Pid:       1234,
+				ExitCode:  0,
+				StartedAt: time.Date(2018, 6, 14, 5, 48, 53, 266176036, time.UTC),
+			},
+		},
+		{
+			name: "finished_at is non-zero value",
+			inspect: func() types.ContainerJSON {
+				i := containerInspect()
+				i.ContainerJSONBase.State.FinishedAt = "2018-06-14T05:53:53.266176036Z"
+				return i
+			}(),
+			expect: expectation{
+				Status:     "running",
+				OOMKilled:  false,
+				Pid:        1234,
+				ExitCode:   0,
+				StartedAt:  time.Date(2018, 6, 14, 5, 48, 53, 266176036, time.UTC),
+				FinishedAt: time.Date(2018, 6, 14, 5, 53, 53, 266176036, time.UTC),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var acc testutil.Accumulator
+
+			newClientFunc := func(string, *tls.Config) (Client, error) {
+				client := baseClient
+				client.ContainerListF = func(context.Context, types.ContainerListOptions) ([]types.Container, error) {
+					return containerList[:1], nil
+				}
+				client.ContainerInspectF = func(c context.Context, s string) (types.ContainerJSON, error) {
+					return tt.inspect, nil
+				}
+
+				return &client, nil
+			}
+
+			d := Docker{newClient: newClientFunc}
+
+			err := acc.GatherError(d.Gather)
+			require.NoError(t, err)
+
+			fields := map[string]interface{}{
+				"oomkilled":  tt.expect.OOMKilled,
+				"pid":        tt.expect.Pid,
+				"exitcode":   tt.expect.ExitCode,
+				"started_at": tt.expect.StartedAt.UnixNano(),
+			}
+
+			if finished := tt.expect.FinishedAt; !finished.IsZero() {
+				fields["finished_at"] = finished.UnixNano()
+			}
+
+			acc.AssertContainsTaggedFields(t,
+				"docker_container_status",
+				fields,
+				map[string]string{
+					"container_name":    "etcd",
+					"container_image":   "quay.io/coreos/etcd",
+					"container_version": "v2.2.2",
+					"engine_host":       "absol",
+					"label1":            "test_value_1",
+					"label2":            "test_value_2",
+					"server_version":    "17.09.0-ce",
+					"container_status":  tt.expect.Status,
+				})
+
+			fmt.Printf("%q\n", acc.Metrics)
 		})
 	}
 }

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -609,6 +609,7 @@ func TestContainerStatus(t *testing.T) {
 				d = Docker{newClient: newClientFunc}
 			)
 
+			// mock time
 			if tt.now != nil {
 				now = tt.now
 			}

--- a/plugins/inputs/docker/docker_testdata.go
+++ b/plugins/inputs/docker/docker_testdata.go
@@ -492,32 +492,34 @@ func containerStatsWindows() types.ContainerStats {
 	return stat
 }
 
-var containerInspect = types.ContainerJSON{
-	Config: &container.Config{
-		Env: []string{
-			"ENVVAR1=loremipsum",
-			"ENVVAR1FOO=loremipsum",
-			"ENVVAR2=dolorsitamet",
-			"ENVVAR3==ubuntu:10.04",
-			"ENVVAR4",
-			"ENVVAR5=",
-			"ENVVAR6= ",
-			"ENVVAR7=ENVVAR8=ENVVAR9",
-			"PATH=/bin:/sbin",
-		},
-	},
-	ContainerJSONBase: &types.ContainerJSONBase{
-		State: &types.ContainerState{
-			Health: &types.Health{
-				FailingStreak: 1,
-				Status:        "Unhealthy",
+func containerInspect() types.ContainerJSON {
+	return types.ContainerJSON{
+		Config: &container.Config{
+			Env: []string{
+				"ENVVAR1=loremipsum",
+				"ENVVAR1FOO=loremipsum",
+				"ENVVAR2=dolorsitamet",
+				"ENVVAR3==ubuntu:10.04",
+				"ENVVAR4",
+				"ENVVAR5=",
+				"ENVVAR6= ",
+				"ENVVAR7=ENVVAR8=ENVVAR9",
+				"PATH=/bin:/sbin",
 			},
-			Status:     "running",
-			OOMKilled:  false,
-			Pid:        1234,
-			ExitCode:   0,
-			StartedAt:  "2018-06-14T05:48:53.266176036Z",
-			FinishedAt: "0001-01-01T00:00:00Z",
 		},
-	},
+		ContainerJSONBase: &types.ContainerJSONBase{
+			State: &types.ContainerState{
+				Health: &types.Health{
+					FailingStreak: 1,
+					Status:        "Unhealthy",
+				},
+				Status:     "running",
+				OOMKilled:  false,
+				Pid:        1234,
+				ExitCode:   0,
+				StartedAt:  "2018-06-14T05:48:53.266176036Z",
+				FinishedAt: "0001-01-01T00:00:00Z",
+			},
+		},
+	}
 }


### PR DESCRIPTION
:wave:

This change introduces the `uptime_ns` field for the `docker_container_status` metric. This was a little low hanging fruit I thought I could take a stab at for a first contribution. As it was requested a long time ago, I imagine it might not even be desired anymore.

Resolves https://github.com/influxdata/telegraf/issues/3184

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
