### PR TITLE
Add support for interface field in http_response input plugin

### DIFF
--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -46,6 +46,9 @@ This input plugin checks HTTP/HTTPS connections.
   ## HTTP Request Headers (all values must be strings)
   # [inputs.http_response.headers]
   #   Host = "github.com"
+
+  ## Interface to use when dialing an address
+  # interface = "eth0"
 ```
 
 ### Metrics:

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -160,8 +160,8 @@ func localAddress(interfaceName string) (net.Addr, error) {
 
 	for _, addr := range addrs {
 		if naddr, ok := addr.(*net.IPNet); ok {
-			// leaving port set to zero to let kernel decide
-			return &net.TCPAddr{naddr.IP, 0, ""}, nil
+			// leaving port set to zero to let kernel pick
+			return &net.TCPAddr{IP: naddr.IP}, nil
 		}
 	}
 

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -31,6 +31,7 @@ type HTTPResponse struct {
 	Headers             map[string]string
 	FollowRedirects     bool
 	ResponseStringMatch string
+	Interface           string
 	tls.ClientConfig
 
 	compiledStringMatch *regexp.Regexp
@@ -82,6 +83,9 @@ var sampleConfig = `
   ## HTTP Request Headers (all values must be strings)
   # [inputs.http_response.headers]
   #   Host = "github.com"
+
+  ## Interface to use when dialing an address
+  # interface = "eth0"
 `
 
 // SampleConfig returns the plugin SampleConfig
@@ -108,16 +112,27 @@ func getProxyFunc(http_proxy string) func(*http.Request) (*url.URL, error) {
 	}
 }
 
-// CreateHttpClient creates an http client which will timeout at the specified
+// createHttpClient creates an http client which will timeout at the specified
 // timeout period and can follow redirects if specified
 func (h *HTTPResponse) createHttpClient() (*http.Client, error) {
 	tlsCfg, err := h.ClientConfig.TLSConfig()
 	if err != nil {
 		return nil, err
 	}
+
+	dialer := &net.Dialer{}
+
+	if h.Interface != "" {
+		dialer.LocalAddr, err = localAddress(h.Interface)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	client := &http.Client{
 		Transport: &http.Transport{
 			Proxy:             getProxyFunc(h.HTTPProxy),
+			DialContext:       dialer.DialContext,
 			DisableKeepAlives: true,
 			TLSClientConfig:   tlsCfg,
 		},
@@ -130,6 +145,27 @@ func (h *HTTPResponse) createHttpClient() (*http.Client, error) {
 		}
 	}
 	return client, nil
+}
+
+func localAddress(interfaceName string) (net.Addr, error) {
+	i, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs, err := i.Addrs()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, addr := range addrs {
+		if naddr, ok := addr.(*net.IPNet); ok {
+			// leaving port set to zero to let kernel decide
+			return &net.TCPAddr{naddr.IP, 0, ""}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot create local address for interface %q", interfaceName)
 }
 
 func setResult(result_string string, fields map[string]interface{}, tags map[string]string) {

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -217,7 +217,7 @@ func findInterface() (net.Interface, error) {
 
 	for _, i := range potential {
 		// ignore interfaces which are down or not used for broadcast
-		if (i.Flags&net.FlagUp == 0) || (i.Flags&net.FlagBroadcast == 0) {
+		if (i.Flags&net.FlagUp == 0) || (i.Flags&net.FlagLoopback == 0) {
 			continue
 		}
 
@@ -239,9 +239,7 @@ func TestInterface(t *testing.T) {
 	defer ts.Close()
 
 	intf, err := findInterface()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	h := &HTTPResponse{
 		Address:         ts.URL + "/good",

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -216,7 +216,7 @@ func findInterface() (net.Interface, error) {
 	potential, _ := net.Interfaces()
 
 	for _, i := range potential {
-		// ignore interfaces which are down or not used for broadcast
+		// we are only interest in loopback interfaces which are up
 		if (i.Flags&net.FlagUp == 0) || (i.Flags&net.FlagLoopback == 0) {
 			continue
 		}
@@ -227,7 +227,7 @@ func findInterface() (net.Interface, error) {
 		}
 	}
 
-	return net.Interface{}, errors.New("cannot find suitable interface")
+	return net.Interface{}, errors.New("cannot find suitable loopback interface")
 }
 
 func TestInterface(t *testing.T) {


### PR DESCRIPTION
This is an attempt to implement the `interface` field in the `http_response` input plugin.

The `interface` field can be populated with an interface name such as `eth0`. A local address associated with the network interface will be derived and used for dialing.

Resolves: https://github.com/influxdata/telegraf/issues/5856

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
