### PR TITLE
 Add separate ping_native input plugin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -423,6 +423,14 @@
   revision = "25d852aebe32c875e9c044af3eef9c7dc6bc777f"
 
 [[projects]]
+  branch = "master"
+  digest = "1:6e331b87796a124ca648d7db9f720b8537ff526980d70ef108e95a275d751f23"
+  name = "github.com/glinton/ping"
+  packages = ["."]
+  pruneopts = ""
+  revision = "b1f885736f7f10060c0c638ff70334a4ef7ef552"
+
+[[projects]]
   digest = "1:858b7fe7b0f4bc7ef9953926828f2816ea52d01a88d72d1c45bc8c108f23c356"
   name = "github.com/go-ini/ini"
   packages = ["."]
@@ -1265,6 +1273,7 @@
     "http/httpguts",
     "http2",
     "http2/hpack",
+    "icmp",
     "idna",
     "internal/iana",
     "internal/socket",
@@ -1601,6 +1610,7 @@
     "github.com/ericchiang/k8s/apis/resource",
     "github.com/ericchiang/k8s/util/intstr",
     "github.com/ghodss/yaml",
+    "github.com/glinton/ping",
     "github.com/go-logfmt/logfmt",
     "github.com/go-redis/redis",
     "github.com/go-sql-driver/mysql",

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -109,6 +109,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/pgbouncer"
 	_ "github.com/influxdata/telegraf/plugins/inputs/phpfpm"
 	_ "github.com/influxdata/telegraf/plugins/inputs/ping"
+	_ "github.com/influxdata/telegraf/plugins/inputs/ping_native"
 	_ "github.com/influxdata/telegraf/plugins/inputs/postfix"
 	_ "github.com/influxdata/telegraf/plugins/inputs/postgresql"
 	_ "github.com/influxdata/telegraf/plugins/inputs/postgresql_extensible"

--- a/plugins/inputs/ping_native/README.md
+++ b/plugins/inputs/ping_native/README.md
@@ -2,7 +2,7 @@
 
 Sends a ping message and reports the results. This is done in pure go, eliminating the need to execute the system `ping` command.
 
-There is currently no support for TTL on windows, track progress https://github.com/golang/go/issues/7175 and https://github.com/golang/go/issues/7174
+There is currently no support for TTL on windows, track progress at https://github.com/golang/go/issues/7175 and https://github.com/golang/go/issues/7174
 
 
 ### Configuration:
@@ -33,7 +33,7 @@ There is currently no support for TTL on windows, track progress https://github.
 
 #### Permission Caveat (non Windows)
 
-Since this plugin listens on unprivileged raw sockets on linux and darwin, the system group of the user running telegraf must be allowed to create ICMP Echo sockets. [See man pages icmp(7) for `ping_group_range`](http://man7.org/linux/man-pages/man7/icmp.7.html) for linux and [man pages icmp(4) for ``](https://www.freebsd.org/cgi/man.cgi?query=icmp&apropos=0&sektion=0&manpath=Darwin+8.0.1%2Fppc&format=html) for darwin.
+Since this plugin listens on unprivileged raw sockets on Linux, the system group of the user running telegraf must be allowed to create ICMP Echo sockets. [See man pages icmp(7) for `ping_group_range`](http://man7.org/linux/man-pages/man7/icmp.7.html). On Linux hosts, run the following to give a group the proper permissions:
 
 ```
 sudo sysctl -w net.ipv4.ping_group_range="GROUPID   GROUPID"
@@ -43,7 +43,7 @@ sudo sysctl -w net.ipv4.ping_group_range="GROUPID   GROUPID"
 
 - ping
   - tags:
-    - ip
+    - source
   - fields:
     - packets_transmitted (integer)
     - packets_received (integer)
@@ -55,52 +55,14 @@ sudo sysctl -w net.ipv4.ping_group_range="GROUPID   GROUPID"
     - standard_deviation_ms (integer)
     - result_code (int, success = 0, no such host = 1, ping error = 2)
 
-##### reply_received vs packets_received
-<!-- todo: verify this -->
-
-On Windows systems, "Destination net unreachable" reply will increment `packets_received` but not `reply_received`.
-
 ### Example Output:
 
 **Windows:**
 ```
-ping,ip=127.0.0.1 average_response_ms=94.738085,maximum_response_ms=94.790376,minimum_response_ms=94.702181,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.037823 1560553382000000000
+ping,source=google.com average_response_ms=94.738085,maximum_response_ms=94.790376,minimum_response_ms=94.702181,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.037823 1560553382000000000
 ```
 
-**Linux:**
+**Other:**
 ```
-ping,ip=2600:: average_response_ms=94.738085,maximum_response_ms=94.790376,minimum_response_ms=94.702181,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.037823,ttl=52i 1560553382000000000
+ping,source=google.com average_response_ms=94.738085,maximum_response_ms=94.790376,minimum_response_ms=94.702181,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.037823,ttl=52i 1560553382000000000
 ```
-
-
-```toml
-[agent]
-  interval="5s"
-  flush_interval="1s"
-  omit_hostname=true
-
-[[outputs.file]]
-
-[[inputs.ping_native]]
-  count = 3
-  ping_interval = 1.0
-  timeout = 1.0
-  deadline = 10
-  interface= "2604:a880:1:20::352:7001"
-  ipv6=true
-  hosts = [
-    "google.com",
-    "2600::",
-    "2620:0:ccc::2",
-    "2620:0:ccd::2",
-  ]
-```
-
-<!-- ```
-root@ipv6-test:~# ./telegraf --config ./tel.conf --test
-2019-06-14T23:02:59Z I! Starting Telegraf 
-> ping,ip=2620:0:ccc::2 average_response_ms=1.857576,maximum_response_ms=2.098475,minimum_response_ms=1.724104,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.170672,ttl=61i 1560553382000000000
-> ping,ip=2620:0:ccd::2 average_response_ms=1.769044,maximum_response_ms=2.004256,minimum_response_ms=1.639915,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.166585,ttl=61i 1560553382000000000
-> ping,ip=2607:f8b0:4005:80b::200e average_response_ms=3.000772,maximum_response_ms=3.14064,minimum_response_ms=2.905394,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.10106,ttl=57i 1560553382000000000
-> ping,ip=2600:: average_response_ms=94.738085,maximum_response_ms=94.790376,minimum_response_ms=94.702181,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.037823,ttl=52i 1560553382000000000
-``` -->

--- a/plugins/inputs/ping_native/README.md
+++ b/plugins/inputs/ping_native/README.md
@@ -1,0 +1,106 @@
+# Ping Native Input Plugin
+
+Sends a ping message and reports the results. This is done in pure go, eliminating the need to execute the system `ping` command.
+
+There is currently no support for TTL on windows, track progress https://github.com/golang/go/issues/7175 and https://github.com/golang/go/issues/7174
+
+
+### Configuration:
+
+```toml
+[[inputs.ping_native]]
+  ## List of hosts to ping.
+  hosts = ["8.8.8.8"]
+
+  ## Number of pings to send per collection.
+  # count = 1
+
+  ## Interval, in s, at which to ping.
+  # ping_interval = 1.0
+
+  ## Per-ping timeout, in s (0 == no timeout).
+  # timeout = 1.0
+
+  ## Total-ping deadline, in s. Set to value equal to or lower than agent interval.
+  # deadline = 10
+
+  ## Interface or source address to send ping from.
+  # interface = ""
+
+	## Whether to ping ipv6 addresses.
+  # ipv6 = false
+```
+
+#### Permission Caveat (non Windows)
+
+Since this plugin listens on unprivileged raw sockets on linux and darwin, the system group of the user running telegraf must be allowed to create ICMP Echo sockets. [See man pages icmp(7) for `ping_group_range`](http://man7.org/linux/man-pages/man7/icmp.7.html) for linux and [man pages icmp(4) for ``](https://www.freebsd.org/cgi/man.cgi?query=icmp&apropos=0&sektion=0&manpath=Darwin+8.0.1%2Fppc&format=html) for darwin.
+
+```
+sudo sysctl -w net.ipv4.ping_group_range="GROUPID   GROUPID"
+```
+
+### Metrics:
+
+- ping
+  - tags:
+    - ip
+  - fields:
+    - packets_transmitted (integer)
+    - packets_received (integer)
+    - percent_packets_loss (float)
+    - ttl (integer, Not available on Windows)
+    - average_response_ms (integer)
+    - minimum_response_ms (integer)
+    - maximum_response_ms (integer)
+    - standard_deviation_ms (integer)
+    - result_code (int, success = 0, no such host = 1, ping error = 2)
+
+##### reply_received vs packets_received
+<!-- todo: verify this -->
+
+On Windows systems, "Destination net unreachable" reply will increment `packets_received` but not `reply_received`.
+
+### Example Output:
+
+**Windows:**
+```
+ping,ip=127.0.0.1 average_response_ms=94.738085,maximum_response_ms=94.790376,minimum_response_ms=94.702181,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.037823 1560553382000000000
+```
+
+**Linux:**
+```
+ping,ip=2600:: average_response_ms=94.738085,maximum_response_ms=94.790376,minimum_response_ms=94.702181,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.037823,ttl=52i 1560553382000000000
+```
+
+
+```toml
+[agent]
+  interval="5s"
+  flush_interval="1s"
+  omit_hostname=true
+
+[[outputs.file]]
+
+[[inputs.ping_native]]
+  count = 3
+  ping_interval = 1.0
+  timeout = 1.0
+  deadline = 10
+  interface= "2604:a880:1:20::352:7001"
+  ipv6=true
+  hosts = [
+    "google.com",
+    "2600::",
+    "2620:0:ccc::2",
+    "2620:0:ccd::2",
+  ]
+```
+
+<!-- ```
+root@ipv6-test:~# ./telegraf --config ./tel.conf --test
+2019-06-14T23:02:59Z I! Starting Telegraf 
+> ping,ip=2620:0:ccc::2 average_response_ms=1.857576,maximum_response_ms=2.098475,minimum_response_ms=1.724104,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.170672,ttl=61i 1560553382000000000
+> ping,ip=2620:0:ccd::2 average_response_ms=1.769044,maximum_response_ms=2.004256,minimum_response_ms=1.639915,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.166585,ttl=61i 1560553382000000000
+> ping,ip=2607:f8b0:4005:80b::200e average_response_ms=3.000772,maximum_response_ms=3.14064,minimum_response_ms=2.905394,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.10106,ttl=57i 1560553382000000000
+> ping,ip=2600:: average_response_ms=94.738085,maximum_response_ms=94.790376,minimum_response_ms=94.702181,packets_received=3i,packets_transmitted=3i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0.037823,ttl=52i 1560553382000000000
+``` -->

--- a/plugins/inputs/ping_native/dev/telegraf.conf
+++ b/plugins/inputs/ping_native/dev/telegraf.conf
@@ -1,0 +1,81 @@
+[agent]
+  interval="5s"
+  flush_interval="1s"
+  omit_hostname=true
+
+[[outputs.file]]
+
+[[inputs.ping_native]]
+  count = 3
+  ping_interval = 1.0
+  timeout = 1.0
+  deadline = 10
+  hosts = [
+    "8.8.8.8",
+    "8.8.4.4",
+    "9.9.9.9",
+    "149.112.112.112",
+    "208.67.222.222",
+    "208.67.220.220",
+    "1.1.1.1",
+    "1.0.0.1",
+    "185.228.168.9",
+    "185.228.169.9",
+    "64.6.64.6",
+    "64.6.65.6",
+    "198.101.242.72",
+    "23.253.163.53",
+    "176.103.130.130",
+    "176.103.130.131",
+    "209.244.0.3",
+    "209.244.0.4",
+    "84.200.69.80",
+    "84.200.70.40",
+    "8.26.56.26",
+    "8.20.247.20",
+    "81.218.119.11",
+    "209.88.198.133",
+    "195.46.39.39",
+    "195.46.39.40",
+    "172.98.193.42",
+    "208.76.50.50",
+    "216.146.35.35",
+    "216.146.36.36",
+    "45.33.97.5",
+    "37.235.1.177",
+    "77.88.8.8",
+    "77.88.8.1",
+    "91.239.100.100",
+    "89.233.43.71",
+    "99.192.182.100",
+    "99.192.182.101",
+    "74.82.42.42",
+    "109.69.8.51",
+    "45.77.165.194",
+  ]
+
+## hosts above are dns servers from:
+# Google
+# Quad9
+# OpenDNS Home
+# Cloudflare
+# CleanBrowsing
+# Verisign
+# Alternate DNS
+# AdGuard DNS
+# CenturyLink (Level3)
+# DNS.WATCH
+# Comodo Secure DNS
+# GreenTeamDNS
+# SafeDNS
+# OpenNIC
+# SmartViper
+# Dyn
+# FreeDNS
+# Yandex.DNS
+# UncensoredDNS
+# Neustar
+# Tenta
+# Hurricane Electric
+# puntCAT
+# Fourth Estate

--- a/plugins/inputs/ping_native/ping.go
+++ b/plugins/inputs/ping_native/ping.go
@@ -121,10 +121,15 @@ func (p *Ping) buildHostCache(acc telegraf.Accumulator) {
 			addr, err = net.ResolveIPAddr("ip4", host)
 		}
 
-		if p.IPV6 {
-			p.hosts["["+addr.String()+"]:0"] = host
-		} else {
-			p.hosts[addr.String()+":0"] = host
+		switch runtime.GOOS {
+		case "js", "nacl", "plan9", "windows":
+			p.hosts[addr.String()] = host
+		default:
+			if p.IPV6 {
+				p.hosts["["+addr.String()+"]:0"] = host
+			} else {
+				p.hosts[addr.String()+":0"] = host
+			}
 		}
 
 		if a, ok := addr.(*net.IPAddr); ok && runtime.GOOS == "darwin" || runtime.GOOS == "linux" {

--- a/plugins/inputs/ping_native/ping.go
+++ b/plugins/inputs/ping_native/ping.go
@@ -1,0 +1,247 @@
+package ping
+
+import (
+	"errors"
+	"net"
+	"runtime"
+	"time"
+
+	ping "github.com/glinton/go-ping"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+type Ping struct {
+	PingInterval float64  `toml:"ping_interval"` // Interval at which to ping (ping -i <INTERVAL>)
+	Count        int      `toml:"count"`         // Number of pings to send (ping -c <COUNT>)
+	Timeout      float64  `toml:"timeout"`       // Per-ping timeout, in seconds. 0 means no timeout (ping -W <TIMEOUT>)
+	Deadline     int      `toml:"deadline"`      // Ping deadline, in seconds. 0 means no deadline. (ping -w <DEADLINE>)
+	Interface    string   `toml:"interface"`     // Interface or source address to send ping from (ping -I/-S <INTERFACE/SRC_ADDR>)
+	Hosts        []string `toml:"hosts"`         // Hosts to ping
+	IPV6         bool     `toml:"ipv6"`          // Whether to ping ipv6 addresses
+
+	network    string                 // network is the network to listen on ("udp4", "udp6", "ip4:icmp", "ip6:ip6-icmp")
+	listenAddr string                 // listenAddr is the address associated with the interface defined.
+	hostCache  []net.Addr             // hosts to ping
+	rcvdCache  map[string]pingResults // cache of echo responses received
+}
+
+func (*Ping) Description() string {
+	return "Ping given host(s) and return statistics"
+}
+
+const sampleConfig = `
+  ## List of hosts to ping.
+  hosts = ["8.8.8.8"]
+
+  ## Number of pings to send per collection.
+  # count = 1
+
+  ## Interval, in s, at which to ping.
+  # ping_interval = 1.0
+
+  ## Per-ping timeout, in s (0 == no timeout).
+  # timeout = 1.0
+
+  ## Total-ping deadline, in s. Set to value equal to or lower than agent interval.
+  # deadline = 10
+
+  ## Interface or source address to send ping from.
+  # interface = ""
+
+	## Whether to ping ipv6 addresses.
+  # ipv6 = false
+`
+
+func (*Ping) SampleConfig() string {
+	return sampleConfig
+}
+
+func getAddr(iface string) string {
+	if addr := net.ParseIP(iface); addr != nil {
+		return addr.String()
+	}
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+
+	var ip net.IP
+	for i := range ifaces {
+		if ifaces[i].Name == iface {
+			addrs, err := ifaces[i].Addrs()
+			if err != nil {
+				return ""
+			}
+			if len(addrs) > 0 {
+				switch v := addrs[0].(type) {
+				case *net.IPNet:
+					ip = v.IP
+				case *net.IPAddr:
+					ip = v.IP
+				}
+				if len(ip) == 0 {
+					return ""
+				}
+				return ip.String()
+			}
+		}
+	}
+
+	return ""
+}
+
+func (p *Ping) buildHostCache(acc telegraf.Accumulator) {
+	if p.hostCache != nil {
+		return
+	}
+
+	p.network = "ip4:icmp"
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+		p.network = "udp4"
+		if p.IPV6 {
+			p.network = "udp6"
+		}
+	} else if p.IPV6 {
+		p.network = "ip6:ipv6-icmp"
+	}
+
+	p.hostCache = []net.Addr{}
+
+	for _, url := range p.Hosts {
+		var addr net.Addr
+		var err error
+		if p.IPV6 {
+			addr, err = net.ResolveIPAddr("ip6", url)
+		} else {
+			addr, err = net.ResolveIPAddr("ip4", url)
+		}
+
+		if a, ok := addr.(*net.IPAddr); ok && runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+			addr = &net.UDPAddr{IP: a.IP, Zone: a.Zone}
+		}
+
+		if err != nil {
+			acc.AddFields("ping", map[string]interface{}{"result_code": 1}, map[string]string{"url": url})
+			acc.AddError(err)
+			continue
+		}
+		if addr == nil {
+			continue
+		}
+		p.hostCache = append(p.hostCache, addr)
+	}
+}
+
+func (p *Ping) onRecv(pkt *ping.Packet) {
+	p.rcvdCache[pkt.IPAddr] = pingResults{ttl: pkt.TTL}
+}
+
+func (p *Ping) onFinish(acc telegraf.Accumulator) func(stats *ping.Statistics) {
+	return func(stats *ping.Statistics) {
+		min := float64(stats.MinRTT.Nanoseconds()) / float64(time.Millisecond)
+		avg := float64(stats.AvgRTT.Nanoseconds()) / float64(time.Millisecond)
+		max := float64(stats.MaxRTT.Nanoseconds()) / float64(time.Millisecond)
+		stddev := float64(stats.StdDevRTT.Nanoseconds()) / float64(time.Millisecond)
+
+		tags := map[string]string{"ip": stats.Addr}
+		fields := map[string]interface{}{
+			"result_code":         0,
+			"packets_transmitted": int(stats.PacketsSent),
+			"packets_received":    int(stats.PacketsRecv),
+			"percent_packet_loss": stats.PacketLoss,
+		}
+
+		if p.rcvdCache[stats.Addr].ttl > 0 {
+			fields["ttl"] = p.rcvdCache[stats.Addr].ttl
+		}
+		if min >= 0 {
+			fields["minimum_response_ms"] = min
+		}
+		if avg >= 0 {
+			fields["average_response_ms"] = avg
+		}
+		if max >= 0 {
+			fields["maximum_response_ms"] = max
+		}
+		if stddev >= 0 {
+			fields["standard_deviation_ms"] = stddev
+		}
+
+		acc.AddFields("ping", fields, tags)
+	}
+}
+
+// Gather gathers ping metrics via native ping implementation.
+func (p *Ping) Gather(acc telegraf.Accumulator) error {
+	if p.Interface != "" && p.listenAddr == "" {
+		p.listenAddr = getAddr(p.Interface)
+	}
+
+	p.buildHostCache(acc)
+	if len(p.hostCache) == 0 {
+		return errors.New("no valid hosts to ping")
+	}
+
+	conn, err := ping.Listen(p.network, p.listenAddr)
+	defer conn.Close()
+	if err != nil {
+		return err
+	}
+
+	if p.Count < 0 {
+		p.Count = 0
+	}
+
+	var size uint = 56
+	if p.IPV6 {
+		size = 128
+	}
+
+	pinger, err := ping.NewPinger(
+		conn,
+		ping.WithOnRecieve(p.onRecv),
+		ping.WithOnFinish(p.onFinish(acc)),
+		ping.WithSize(size),
+		ping.WithCount(uint(p.Count)),
+		ping.WithInterval(time.Nanosecond*time.Duration(p.PingInterval*1000000000)),
+		ping.WithTimeout(time.Nanosecond*time.Duration(p.Timeout*1000000000)),
+		ping.WithDeadline(time.Duration(p.Deadline)*time.Second),
+	)
+	if err != nil {
+		return err
+	}
+
+	if len(p.hostCache) == 1 {
+		pinger.Send(p.hostCache[0])
+	} else {
+		pinger.Send(p.hostCache[0], p.hostCache[1:]...)
+	}
+
+	return nil
+}
+
+type pingResults struct {
+	transmitted int
+	received    int
+	pktLoss     float64
+	ttl         int
+	min         float64
+	avg         float64
+	max         float64
+	stddev      float64
+}
+
+func init() {
+	inputs.Add("ping_native", func() telegraf.Input {
+		return &Ping{
+			PingInterval: 1.0,
+			Count:        1,
+			Timeout:      1.0,
+			Deadline:     10,
+			rcvdCache:    make(map[string]pingResults),
+		}
+	})
+}


### PR DESCRIPTION
This plugin provides ping capability without requiring a `ping` binary installed and should work with multiple languages as it isn't parsing output. It should also alleviate open-file issues when pinging multiple hosts.

This has been tested on Windows 10, macOS Sierra, and Ubuntu. IPv6 testing was on Ubuntu 18.04.