### PR TITLE
feat(inputs/docker): add better user-facing errors for API timeouts

### DIFF
--- a/plugins/inputs/docker/errors.go
+++ b/plugins/inputs/docker/errors.go
@@ -1,0 +1,11 @@
+package docker
+
+import "errors"
+
+var (
+	errInfoTimeout    = errors.New("timeout retrieving docker engine info")
+	errStatsTimeout   = errors.New("timeout retrieving container stats")
+	errInspectTimeout = errors.New("timeout retrieving container environment")
+	errListTimeout    = errors.New("timeout retrieving container list")
+	errServiceTimeout = errors.New("timeout retrieving swarm service list")
+)


### PR DESCRIPTION
Closes #2233 

Each client interaction with the Docker server may have a timeout.  Rather than return `context.DeadlineExceeded` as the error, this translates into a more clear error message.

I fixed up various linter problems as well as make the error messages more consistent.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
