### PR TITLE
Load external .so plugins, fixes #1717

### DIFF
--- a/internal/usage.go
+++ b/internal/usage.go
@@ -16,6 +16,9 @@ The commands & flags are:
   --aggregator-filter <filter>   filter the aggregators to enable, separator is :
   --config <file>                configuration file to load
   --config-directory <directory> directory containing additional *.conf files
+  --plugin-directory             directory containing *.so files, this directory will be
+                                 searched recursively. Any Plugin found will be loaded
+                                 and namespaced.
   --debug                        turn on debug logging
   --input-filter <filter>        filter the inputs to enable, separator is :
   --input-list                   print available input plugins.


### PR DESCRIPTION
Original patch written by sparrc, brought up to date by timidger.
Original from 92d8a2e5ea2846a34ba8c90a67606b9708aa5eb0 message follows:

support for the Go 1.8 shared object feature of loading external
plugins.

this support relies on the developer defining a `Plugin` symbol in their
.so file that is a telegraf plugin interface.

So instead of the plugin developer "Adding" their own plugin to the
telegraf registry, telegraf loads the .so, looks up the Plugin symbol,
and then adds it if it finds it.

The name of the plugin is determined by telegraf, and is namespaced
based on the filename and path.

see #1717

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

Since this adding a new capability to inject plugins I wasn't sure where to document this or how to test this. So looking for feed back on how to do those things :smile: 