### PR TITLE
fix typo

### DIFF
--- a/plugins/inputs/jolokia2/examples/cassandra.conf
+++ b/plugins/inputs/jolokia2/examples/cassandra.conf
@@ -2,7 +2,7 @@
   urls = ["http://localhost:8778/jolokia"]
   name_prefix = "java_"
 
-  [[inputs.jolokia2_agent.metrics]]
+  [[inputs.jolokia2_agent.metric]]
     name  = "Memory"
     mbean = "java.lang:type=Memory"
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Typo in Cassandra example of `metrics` when it should be `metric`. Breaks reading from Cassandra with jolokia2.