### PR TITLE
inputs.ping Wrong ping flag on BSD

### DIFF
--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -234,7 +234,7 @@ func (p *Ping) args(url string, system string) []string {
 		case "darwin":
 			args = append(args, "-I", p.Interface)
 		case "freebsd", "netbsd", "openbsd":
-			args = append(args, "-s", p.Interface)
+			args = append(args, "-S", p.Interface)
 		case "linux":
 			args = append(args, "-I", p.Interface)
 		default:


### PR DESCRIPTION
-s is packet size, -S is source.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
