### PR TITLE
Add filtering to stackdriver labels

### DIFF
--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -21,6 +21,13 @@ Additional resource labels can be configured by `resource_labels`. By default th
   ## The namespace for the metric descriptor
   namespace = "telegraf"
 
+  ## Preferred labels:
+  ## Stackdriver custom metrics are limited to 10 labels total;
+  ## if there are >10 tags associated with the input data, we
+  ## will attempt to preserve these tags while staying under
+	## the stackdriver quota.
+  # preferred_labels = "foo,bar,baz"
+
   ## Custom resource type
   # resource_type = "generic_node"
 

--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -434,3 +434,37 @@ func TestGetStackdriverLabels(t *testing.T) {
 	labels := getStackdriverLabels(tags)
 	require.Equal(t, QuotaLabelsPerMetricDescriptor, len(labels))
 }
+
+func TestTrimStackdriverLabels(t *testing.T) {
+	preferredLabels = make(map[string]string)
+	preferredLabels["project"] = ""
+	preferredLabels["test"] = ""
+	preferredLabels["host"] = ""
+	preferredLabels["device"] = ""
+	preferredLabels["reserve"] = ""
+
+	tags := []*telegraf.Tag{
+		{Key: "project", Value: "bar"},
+		{Key: "discuss", Value: "revolutionary"},
+		{Key: "marble", Value: "discount"},
+		{Key: "applied", Value: "falsify"},
+		{Key: "test", Value: "foo"},
+		{Key: "porter", Value: "discount"},
+		{Key: "play", Value: "tiger"},
+		{Key: "fireplace", Value: "display"},
+		{Key: "host", Value: "this"},
+		{Key: "name", Value: "bat"},
+		{Key: "device", Value: "local"},
+		{Key: "reserve", Value: "publication"},
+		{Key: "xpfqacltlmpguimhtjlou2qlmf9uqqwk3teajwlwqkoxtsppbnjksaxvzc1aa973pho9m96gfnl5op8ku7sv93rexyx42qe3zty12ityv", Value: "keyquota"},
+		{Key: "valuequota", Value: "icym5wcpejnhljcvy2vwk15svmhrtueoppwlvix61vlbaeedufn1g6u4jgwjoekwew9s2dboxtgrkiyuircnl8h1lbzntt9gzcf60qunhxurhiz0g2bynzy1v6eyn4ravndeiiugobsrsj2bfaguahg4gxn7nx4irwfknunhkk6jdlldevawj8levebjajcrcbeugewd14fa8o34ycfwx2ymalyeqxhfqrsksxnii2deqq6cghrzi6qzwmittkzdtye3imoygqmjjshiskvnzz1e4ipd9c6wfor5jsygn1kvcg6jm4clnsl1fnxotbei9xp4swrkjpgursmfmkyvxcgq9hoy435nwnolo3ipnvdlhk6pmlzpdjn6gqi3v9gv7jn5ro2p1t5ufxzfsvqq1fyrgoi7gvmttil1banh3cftkph1dcoaqfhl7y0wkvhwwvrmslmmxp1wedyn8bacd7akmjgfwdvcmrymbzvmrzfvq1gs1xnmmg8rsfxci2h6r1ralo3splf4f3bdg4c7cy0yy9qbxzxhcmdpwekwc7tdjs8uj6wmofm2aor4hum8nwyfwwlxy3yvsnbjy32oucsrmhcnu6l2i8laujkrhvsr9fcix5jflygznlydbqw5uhw1rg1g5wiihqumwmqgggemzoaivm3ut41vjaff4uqtqyuhuwblmuiphfkd7si49vgeeswzg7tpuw0oxmkesgibkcjtev2h9ouxzjs3eb71jffhdacyiuyhuxwvm5bnrjewbm4x2kmhgbirz3eoj7ijgplggdkx5vixufg65ont8zi1jabsuxx0vsqgprunwkugqkxg2r7iy6fmgs4lob4dlseinowkst6gp6x1ejreauyzjz7atzm3hbmr5rbynuqp4lxrnhhcbuoun69mavvaaki0bdz5ybmbbbz5qdv0odtpjo2aezat5uosjuhzbvic05jlyclikynjgfhencdkz3qcqzbzhnsynj1zdke0sk4zfpvfyryzsxv9pu0qm"},
+	}
+
+	labels := getStackdriverLabels(tags)
+	require.Equal(t, QuotaLabelsPerMetricDescriptor, len(labels))
+	require.Equal(t, labels["project"], "bar")
+	require.Equal(t, labels["test"], "foo")
+	require.Equal(t, labels["host"], "this")
+	require.Equal(t, labels["device"], "local")
+	require.Equal(t, labels["reserve"], "publication")
+}


### PR DESCRIPTION
# Add filtering to stackdriver labels

Stackdriver has a hard quota of no more than 10 labels per external metric.

Previously, if an input metric contained over 10 tags, we would remove them sequentially to stay under the limit, regardless of which tags were present.

This PR adds the ability to specify a list of tag names (as a comma-separated string) which the stackdriver plugin will preferentially and consistently add to the list of stackdriver labels for the metric.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
