### PR TITLE
[tail/logparser] resume from last known offset when reloading

### DIFF
--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -183,7 +183,16 @@ func (l *LogParserPlugin) Start(acc telegraf.Accumulator) error {
 	l.wg.Add(1)
 	go l.parser()
 
-	return l.tailNewfiles(l.FromBeginning)
+	err = l.tailNewfiles(l.FromBeginning)
+
+	// clear offsets
+	l.offsets = make(map[string]int64)
+	// assumption that once Start is called, all parallel plugins have already been initialized
+	offsetsMutex.Lock()
+	offsets = make(map[string]int64)
+	offsetsMutex.Unlock()
+
+	return err
 }
 
 // check the globs against files on disk, and start tailing any new files.

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -102,7 +102,16 @@ func (t *Tail) Start(acc telegraf.Accumulator) error {
 	t.acc = acc
 	t.tailers = make(map[string]*tail.Tail)
 
-	return t.tailNewFiles(t.FromBeginning)
+	err := t.tailNewFiles(t.FromBeginning)
+
+	// clear offsets
+	t.offsets = make(map[string]int64)
+	// assumption that once Start is called, all parallel plugins have already been initialized
+	offsetsMutex.Lock()
+	offsets = make(map[string]int64)
+	offsetsMutex.Unlock()
+
+	return err
 }
 
 func (t *Tail) tailNewFiles(fromBeginning bool) error {

--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -108,7 +108,7 @@ func TestTailBadLine(t *testing.T) {
 	require.NoError(t, err)
 
 	acc.WaitError(1)
-	assert.Contains(t, acc.Errors[0].Error(), "E! Malformed log line")
+	assert.Contains(t, acc.Errors[0].Error(), "malformed log line")
 }
 
 func TestTailDosLineendings(t *testing.T) {


### PR DESCRIPTION
* Fixes #3522 - Not able to read rotated log file without missing lines
* ~Fixes #3573 - logparser/tail plugin stop after reload (removes unnecessary tailer.Cleanup() calls)~

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.



I did not write a unit test for this, but I did test externally:

### telegraf.conf
```toml
[agent]
  interval = "10s"
  round_interval = true
  metric_batch_size = 1000
  metric_buffer_limit = 10000
  collection_jitter = "0s"
  flush_interval = "600ms"
  flush_jitter = "0s"
  precision = ""
  debug = false
  quiet = false
  logfile = ""
  hostname = ""
  omit_hostname = true

[global_tags]

[[outputs.file]]
  files = ["stdout"]
  data_format = "influx"

[[inputs.tail]]
  files = ["/spare/local/tmp/mymetrics.out"]
  from_beginning = false
  watch_method = "notify"
  data_format = "influx"
```

### genmetrics.sh
```bash
#!/bin/bash
# Basic until loop
counter=1
until [ $counter -gt 150 ]; do
    if [ $counter -eq 75 ]; then
        pkill -HUP -f telegraf
    fi
    echo "weather temperature=$counter" >>/spare/local/tmp/mymetrics.out
    echo $counter
    ((counter++))
    sleep 0.000001
done
```

```shell
./telegraf --config telegraf.conf --debug >telegraf.out 2>&1 &
sleep 1
./genmetrics.sh
```


### telegraf.out
<details>

```
2019-07-05T18:32:31Z I! Starting Telegraf 
2019-07-05T18:32:31Z I! Loaded inputs: tail
2019-07-05T18:32:31Z I! Loaded aggregators: 
2019-07-05T18:32:31Z I! Loaded processors: 
2019-07-05T18:32:31Z I! Loaded outputs: file
2019-07-05T18:32:31Z I! Tags enabled: 
2019-07-05T18:32:31Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"", Flush Interval:600ms
2019-07-05T18:32:31Z D! [agent] Initializing plugins
2019-07-05T18:32:31Z D! [agent] Connecting outputs
2019-07-05T18:32:31Z D! [agent] Attempting connection to output: file
2019-07-05T18:32:31Z D! [agent] Successfully connected to output: file
2019-07-05T18:32:31Z D! [agent] Starting service inputs
2019-07-05T18:32:31Z D! [inputs.tail] tail added for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:32:32Z I! Reloading Telegraf config
2019-07-05T18:32:32Z D! [agent] Stopping service inputs
2019-07-05T18:32:32Z D! [inputs.tail] recording offset 654932 for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:32:32Z D! [inputs.tail] tail removed for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:32:32Z D! [agent] Input channel closed
2019-07-05T18:32:32Z I! [agent] Hang on, flushing any cached metrics before shutdown
weather,path=/spare/local/tmp/mymetrics.out temperature=74 1562351552340924952
weather,path=/spare/local/tmp/mymetrics.out temperature=73 1562351552340003403
weather,path=/spare/local/tmp/mymetrics.out temperature=72 1562351552339202150
weather,path=/spare/local/tmp/mymetrics.out temperature=71 1562351552338381728
weather,path=/spare/local/tmp/mymetrics.out temperature=70 1562351552337533974
weather,path=/spare/local/tmp/mymetrics.out temperature=69 1562351552336717410
weather,path=/spare/local/tmp/mymetrics.out temperature=68 1562351552335895593
weather,path=/spare/local/tmp/mymetrics.out temperature=67 1562351552335160793
weather,path=/spare/local/tmp/mymetrics.out temperature=66 1562351552334331626
weather,path=/spare/local/tmp/mymetrics.out temperature=65 1562351552333568666
weather,path=/spare/local/tmp/mymetrics.out temperature=64 1562351552332740482
weather,path=/spare/local/tmp/mymetrics.out temperature=63 1562351552331996492
weather,path=/spare/local/tmp/mymetrics.out temperature=62 1562351552331340280
weather,path=/spare/local/tmp/mymetrics.out temperature=61 1562351552330596475
weather,path=/spare/local/tmp/mymetrics.out temperature=60 1562351552329468030
weather,path=/spare/local/tmp/mymetrics.out temperature=59 1562351552328633814
weather,path=/spare/local/tmp/mymetrics.out temperature=58 1562351552327660473
weather,path=/spare/local/tmp/mymetrics.out temperature=57 1562351552326822230
weather,path=/spare/local/tmp/mymetrics.out temperature=56 1562351552325973569
weather,path=/spare/local/tmp/mymetrics.out temperature=55 1562351552325121223
weather,path=/spare/local/tmp/mymetrics.out temperature=54 1562351552324204146
weather,path=/spare/local/tmp/mymetrics.out temperature=53 1562351552323361807
weather,path=/spare/local/tmp/mymetrics.out temperature=52 1562351552322589302
weather,path=/spare/local/tmp/mymetrics.out temperature=51 1562351552321710515
weather,path=/spare/local/tmp/mymetrics.out temperature=50 1562351552321087960
weather,path=/spare/local/tmp/mymetrics.out temperature=49 1562351552320519706
weather,path=/spare/local/tmp/mymetrics.out temperature=48 1562351552319919279
weather,path=/spare/local/tmp/mymetrics.out temperature=47 1562351552319260746
weather,path=/spare/local/tmp/mymetrics.out temperature=46 1562351552318716222
weather,path=/spare/local/tmp/mymetrics.out temperature=45 1562351552318150177
weather,path=/spare/local/tmp/mymetrics.out temperature=44 1562351552317593941
weather,path=/spare/local/tmp/mymetrics.out temperature=43 1562351552316997121
weather,path=/spare/local/tmp/mymetrics.out temperature=42 1562351552316397219
weather,path=/spare/local/tmp/mymetrics.out temperature=41 1562351552315814089
weather,path=/spare/local/tmp/mymetrics.out temperature=40 1562351552315265961
weather,path=/spare/local/tmp/mymetrics.out temperature=39 1562351552314664686
weather,path=/spare/local/tmp/mymetrics.out temperature=38 1562351552314071988
weather,path=/spare/local/tmp/mymetrics.out temperature=37 1562351552313471155
weather,path=/spare/local/tmp/mymetrics.out temperature=36 1562351552312887387
weather,path=/spare/local/tmp/mymetrics.out temperature=35 1562351552312243124
weather,path=/spare/local/tmp/mymetrics.out temperature=34 1562351552311676612
weather,path=/spare/local/tmp/mymetrics.out temperature=33 1562351552311103039
weather,path=/spare/local/tmp/mymetrics.out temperature=32 1562351552310534773
weather,path=/spare/local/tmp/mymetrics.out temperature=31 1562351552309913603
weather,path=/spare/local/tmp/mymetrics.out temperature=30 1562351552309345873
weather,path=/spare/local/tmp/mymetrics.out temperature=29 1562351552308596519
weather,path=/spare/local/tmp/mymetrics.out temperature=28 1562351552307854758
weather,path=/spare/local/tmp/mymetrics.out temperature=27 1562351552307192509
weather,path=/spare/local/tmp/mymetrics.out temperature=26 1562351552306523741
weather,path=/spare/local/tmp/mymetrics.out temperature=25 1562351552305831292
weather,path=/spare/local/tmp/mymetrics.out temperature=24 1562351552305118370
weather,path=/spare/local/tmp/mymetrics.out temperature=23 1562351552304375280
weather,path=/spare/local/tmp/mymetrics.out temperature=22 1562351552303444550
weather,path=/spare/local/tmp/mymetrics.out temperature=21 1562351552302506687
weather,path=/spare/local/tmp/mymetrics.out temperature=20 1562351552301816843
weather,path=/spare/local/tmp/mymetrics.out temperature=19 1562351552301121072
weather,path=/spare/local/tmp/mymetrics.out temperature=18 1562351552300424980
weather,path=/spare/local/tmp/mymetrics.out temperature=17 1562351552299671968
weather,path=/spare/local/tmp/mymetrics.out temperature=16 1562351552298827364
weather,path=/spare/local/tmp/mymetrics.out temperature=15 1562351552297890531
weather,path=/spare/local/tmp/mymetrics.out temperature=14 1562351552296960859
weather,path=/spare/local/tmp/mymetrics.out temperature=13 1562351552295910185
weather,path=/spare/local/tmp/mymetrics.out temperature=12 1562351552294800252
weather,path=/spare/local/tmp/mymetrics.out temperature=11 1562351552293304000
weather,path=/spare/local/tmp/mymetrics.out temperature=10 1562351552292137278
weather,path=/spare/local/tmp/mymetrics.out temperature=9 1562351552290976073
weather,path=/spare/local/tmp/mymetrics.out temperature=8 1562351552289749897
weather,path=/spare/local/tmp/mymetrics.out temperature=7 1562351552288395695
weather,path=/spare/local/tmp/mymetrics.out temperature=6 1562351552286653210
weather,path=/spare/local/tmp/mymetrics.out temperature=5 1562351552285257469
weather,path=/spare/local/tmp/mymetrics.out temperature=4 1562351552283868176
weather,path=/spare/local/tmp/mymetrics.out temperature=3 1562351552282588488
weather,path=/spare/local/tmp/mymetrics.out temperature=2 1562351552281228500
weather,path=/spare/local/tmp/mymetrics.out temperature=1 1562351552278140912
2019-07-05T18:32:32Z D! [outputs.file] wrote batch of 74 metrics in 305.664µs
2019-07-05T18:32:32Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:32:32Z D! [agent] Closing outputs
2019-07-05T18:32:32Z D! [agent] Stopped Successfully
2019-07-05T18:32:32Z I! Starting Telegraf 
2019-07-05T18:32:32Z I! Loaded inputs: tail
2019-07-05T18:32:32Z I! Loaded aggregators: 
2019-07-05T18:32:32Z I! Loaded processors: 
2019-07-05T18:32:32Z I! Loaded outputs: file
2019-07-05T18:32:32Z I! Tags enabled: 
2019-07-05T18:32:32Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"", Flush Interval:600ms
2019-07-05T18:32:32Z D! [agent] Initializing plugins
2019-07-05T18:32:32Z D! [agent] Connecting outputs
2019-07-05T18:32:32Z D! [agent] Attempting connection to output: file
2019-07-05T18:32:32Z D! [agent] Successfully connected to output: file
2019-07-05T18:32:32Z D! [agent] Starting service inputs
2019-07-05T18:32:32Z D! [inputs.tail] using offset 654932 for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:32:32Z D! [inputs.tail] tail added for file: /spare/local/tmp/mymetrics.out
weather,path=/spare/local/tmp/mymetrics.out temperature=150 1562351552422145171
weather,path=/spare/local/tmp/mymetrics.out temperature=149 1562351552420619874
weather,path=/spare/local/tmp/mymetrics.out temperature=148 1562351552419125460
weather,path=/spare/local/tmp/mymetrics.out temperature=147 1562351552417534559
weather,path=/spare/local/tmp/mymetrics.out temperature=146 1562351552415971536
weather,path=/spare/local/tmp/mymetrics.out temperature=145 1562351552414680259
weather,path=/spare/local/tmp/mymetrics.out temperature=144 1562351552413397728
weather,path=/spare/local/tmp/mymetrics.out temperature=143 1562351552412154104
weather,path=/spare/local/tmp/mymetrics.out temperature=142 1562351552410946704
weather,path=/spare/local/tmp/mymetrics.out temperature=141 1562351552409648204
weather,path=/spare/local/tmp/mymetrics.out temperature=140 1562351552408387027
weather,path=/spare/local/tmp/mymetrics.out temperature=139 1562351552407069593
weather,path=/spare/local/tmp/mymetrics.out temperature=138 1562351552405679090
weather,path=/spare/local/tmp/mymetrics.out temperature=137 1562351552404348385
weather,path=/spare/local/tmp/mymetrics.out temperature=136 1562351552403265548
weather,path=/spare/local/tmp/mymetrics.out temperature=135 1562351552402080880
weather,path=/spare/local/tmp/mymetrics.out temperature=134 1562351552400932672
weather,path=/spare/local/tmp/mymetrics.out temperature=133 1562351552399705908
weather,path=/spare/local/tmp/mymetrics.out temperature=132 1562351552398593126
weather,path=/spare/local/tmp/mymetrics.out temperature=131 1562351552397408672
weather,path=/spare/local/tmp/mymetrics.out temperature=130 1562351552396249992
weather,path=/spare/local/tmp/mymetrics.out temperature=129 1562351552395013391
weather,path=/spare/local/tmp/mymetrics.out temperature=128 1562351552394069957
weather,path=/spare/local/tmp/mymetrics.out temperature=127 1562351552393058759
weather,path=/spare/local/tmp/mymetrics.out temperature=126 1562351552392074434
weather,path=/spare/local/tmp/mymetrics.out temperature=125 1562351552391249588
weather,path=/spare/local/tmp/mymetrics.out temperature=124 1562351552390382837
weather,path=/spare/local/tmp/mymetrics.out temperature=123 1562351552389504304
weather,path=/spare/local/tmp/mymetrics.out temperature=122 1562351552388632421
weather,path=/spare/local/tmp/mymetrics.out temperature=121 1562351552387500110
weather,path=/spare/local/tmp/mymetrics.out temperature=120 1562351552386621387
weather,path=/spare/local/tmp/mymetrics.out temperature=119 1562351552385753171
weather,path=/spare/local/tmp/mymetrics.out temperature=118 1562351552384863400
weather,path=/spare/local/tmp/mymetrics.out temperature=117 1562351552383935098
weather,path=/spare/local/tmp/mymetrics.out temperature=116 1562351552383111066
weather,path=/spare/local/tmp/mymetrics.out temperature=115 1562351552382291063
weather,path=/spare/local/tmp/mymetrics.out temperature=114 1562351552381401203
weather,path=/spare/local/tmp/mymetrics.out temperature=113 1562351552380547172
weather,path=/spare/local/tmp/mymetrics.out temperature=112 1562351552379587775
weather,path=/spare/local/tmp/mymetrics.out temperature=111 1562351552378753966
weather,path=/spare/local/tmp/mymetrics.out temperature=110 1562351552378059450
weather,path=/spare/local/tmp/mymetrics.out temperature=109 1562351552377419471
weather,path=/spare/local/tmp/mymetrics.out temperature=108 1562351552376803011
weather,path=/spare/local/tmp/mymetrics.out temperature=107 1562351552376211591
weather,path=/spare/local/tmp/mymetrics.out temperature=106 1562351552375610860
weather,path=/spare/local/tmp/mymetrics.out temperature=105 1562351552374985026
weather,path=/spare/local/tmp/mymetrics.out temperature=104 1562351552374368846
weather,path=/spare/local/tmp/mymetrics.out temperature=103 1562351552373724179
weather,path=/spare/local/tmp/mymetrics.out temperature=102 1562351552373076670
weather,path=/spare/local/tmp/mymetrics.out temperature=101 1562351552372347080
weather,path=/spare/local/tmp/mymetrics.out temperature=100 1562351552371694395
weather,path=/spare/local/tmp/mymetrics.out temperature=99 1562351552371079616
weather,path=/spare/local/tmp/mymetrics.out temperature=98 1562351552370431517
weather,path=/spare/local/tmp/mymetrics.out temperature=97 1562351552369802106
weather,path=/spare/local/tmp/mymetrics.out temperature=96 1562351552369172164
weather,path=/spare/local/tmp/mymetrics.out temperature=95 1562351552368457912
weather,path=/spare/local/tmp/mymetrics.out temperature=94 1562351552367756641
weather,path=/spare/local/tmp/mymetrics.out temperature=93 1562351552367146734
weather,path=/spare/local/tmp/mymetrics.out temperature=92 1562351552366545216
weather,path=/spare/local/tmp/mymetrics.out temperature=91 1562351552365913398
weather,path=/spare/local/tmp/mymetrics.out temperature=90 1562351552365319598
weather,path=/spare/local/tmp/mymetrics.out temperature=89 1562351552364731847
weather,path=/spare/local/tmp/mymetrics.out temperature=88 1562351552364107156
weather,path=/spare/local/tmp/mymetrics.out temperature=87 1562351552363486939
weather,path=/spare/local/tmp/mymetrics.out temperature=86 1562351552362768458
weather,path=/spare/local/tmp/mymetrics.out temperature=85 1562351552362200722
weather,path=/spare/local/tmp/mymetrics.out temperature=84 1562351552361648418
weather,path=/spare/local/tmp/mymetrics.out temperature=83 1562351552361108087
weather,path=/spare/local/tmp/mymetrics.out temperature=82 1562351552360564617
weather,path=/spare/local/tmp/mymetrics.out temperature=81 1562351552359936289
weather,path=/spare/local/tmp/mymetrics.out temperature=80 1562351552359342552
weather,path=/spare/local/tmp/mymetrics.out temperature=79 1562351552358724962
weather,path=/spare/local/tmp/mymetrics.out temperature=78 1562351552357983708
weather,path=/spare/local/tmp/mymetrics.out temperature=77 1562351552357374943
weather,path=/spare/local/tmp/mymetrics.out temperature=76 1562351552356863434
weather,path=/spare/local/tmp/mymetrics.out temperature=75 1562351552356853558
2019-07-05T18:32:33Z D! [outputs.file] wrote batch of 76 metrics in 258.019µs
2019-07-05T18:32:33Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:32:33Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:32:34Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:32:34Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:32:35Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:32:36Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:32:36Z D! [agent] Stopping service inputs
2019-07-05T18:32:36Z D! [inputs.tail] recording offset 656731 for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:32:36Z D! [inputs.tail] tail removed for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:32:36Z D! [agent] Input channel closed
2019-07-05T18:32:36Z I! [agent] Hang on, flushing any cached metrics before shutdown
2019-07-05T18:32:36Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:32:36Z D! [agent] Closing outputs
2019-07-05T18:32:36Z D! [agent] Stopped Successfully
```
</details>


### telegraf.out (vanilla)
stops reading log after SIGHUP
<details>

```
2019-07-05T18:35:14Z I! Starting Telegraf 
2019-07-05T18:35:14Z I! Loaded inputs: tail
2019-07-05T18:35:14Z I! Loaded aggregators: 
2019-07-05T18:35:14Z I! Loaded processors: 
2019-07-05T18:35:14Z I! Loaded outputs: file
2019-07-05T18:35:14Z I! Tags enabled: 
2019-07-05T18:35:14Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"", Flush Interval:600ms
2019-07-05T18:35:14Z D! [agent] Initializing plugins
2019-07-05T18:35:14Z D! [agent] Connecting outputs
2019-07-05T18:35:14Z D! [agent] Attempting connection to output: file
2019-07-05T18:35:14Z D! [agent] Successfully connected to output: file
2019-07-05T18:35:14Z D! [agent] Starting service inputs
2019-07-05T18:35:14Z D! [inputs.tail] tail added for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:35:15Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:35:15Z I! Reloading Telegraf config
2019-07-05T18:35:15Z D! [agent] Stopping service inputs
2019-07-05T18:35:15Z D! [inputs.tail] tail removed for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:35:15Z D! [agent] Input channel closed
2019-07-05T18:35:15Z I! [agent] Hang on, flushing any cached metrics before shutdown
weather,path=/spare/local/tmp/mymetrics.out temperature=75 1562351715578994565
weather,path=/spare/local/tmp/mymetrics.out temperature=74 1562351715557785350
weather,path=/spare/local/tmp/mymetrics.out temperature=73 1562351715556301979
weather,path=/spare/local/tmp/mymetrics.out temperature=72 1562351715555410226
weather,path=/spare/local/tmp/mymetrics.out temperature=71 1562351715550942729
weather,path=/spare/local/tmp/mymetrics.out temperature=70 1562351715545116817
weather,path=/spare/local/tmp/mymetrics.out temperature=69 1562351715528860811
weather,path=/spare/local/tmp/mymetrics.out temperature=68 1562351715523269159
weather,path=/spare/local/tmp/mymetrics.out temperature=67 1562351715521537351
weather,path=/spare/local/tmp/mymetrics.out temperature=66 1562351715518506390
weather,path=/spare/local/tmp/mymetrics.out temperature=65 1562351715517378515
weather,path=/spare/local/tmp/mymetrics.out temperature=64 1562351715514203772
weather,path=/spare/local/tmp/mymetrics.out temperature=63 1562351715513401022
weather,path=/spare/local/tmp/mymetrics.out temperature=62 1562351715511428400
weather,path=/spare/local/tmp/mymetrics.out temperature=61 1562351715509630884
weather,path=/spare/local/tmp/mymetrics.out temperature=60 1562351715508298893
weather,path=/spare/local/tmp/mymetrics.out temperature=59 1562351715507653841
weather,path=/spare/local/tmp/mymetrics.out temperature=58 1562351715506930706
weather,path=/spare/local/tmp/mymetrics.out temperature=57 1562351715504699530
weather,path=/spare/local/tmp/mymetrics.out temperature=56 1562351715500843277
weather,path=/spare/local/tmp/mymetrics.out temperature=55 1562351715499860272
weather,path=/spare/local/tmp/mymetrics.out temperature=54 1562351715496332278
weather,path=/spare/local/tmp/mymetrics.out temperature=53 1562351715494282781
weather,path=/spare/local/tmp/mymetrics.out temperature=52 1562351715488606533
weather,path=/spare/local/tmp/mymetrics.out temperature=51 1562351715470295349
weather,path=/spare/local/tmp/mymetrics.out temperature=50 1562351715469508652
weather,path=/spare/local/tmp/mymetrics.out temperature=49 1562351715468464406
weather,path=/spare/local/tmp/mymetrics.out temperature=48 1562351715467547014
weather,path=/spare/local/tmp/mymetrics.out temperature=47 1562351715466273745
weather,path=/spare/local/tmp/mymetrics.out temperature=46 1562351715465480160
weather,path=/spare/local/tmp/mymetrics.out temperature=45 1562351715455609733
weather,path=/spare/local/tmp/mymetrics.out temperature=44 1562351715447969788
weather,path=/spare/local/tmp/mymetrics.out temperature=43 1562351715447073027
weather,path=/spare/local/tmp/mymetrics.out temperature=42 1562351715446458303
weather,path=/spare/local/tmp/mymetrics.out temperature=41 1562351715445804445
weather,path=/spare/local/tmp/mymetrics.out temperature=40 1562351715444563747
weather,path=/spare/local/tmp/mymetrics.out temperature=39 1562351715442642762
weather,path=/spare/local/tmp/mymetrics.out temperature=38 1562351715441734122
weather,path=/spare/local/tmp/mymetrics.out temperature=37 1562351715434969209
weather,path=/spare/local/tmp/mymetrics.out temperature=36 1562351715428847852
weather,path=/spare/local/tmp/mymetrics.out temperature=35 1562351715426432009
weather,path=/spare/local/tmp/mymetrics.out temperature=34 1562351715423682674
weather,path=/spare/local/tmp/mymetrics.out temperature=33 1562351715421854907
weather,path=/spare/local/tmp/mymetrics.out temperature=32 1562351715420741047
weather,path=/spare/local/tmp/mymetrics.out temperature=31 1562351715420127423
weather,path=/spare/local/tmp/mymetrics.out temperature=30 1562351715418762033
weather,path=/spare/local/tmp/mymetrics.out temperature=29 1562351715417749786
weather,path=/spare/local/tmp/mymetrics.out temperature=28 1562351715416515982
weather,path=/spare/local/tmp/mymetrics.out temperature=27 1562351715413719834
weather,path=/spare/local/tmp/mymetrics.out temperature=26 1562351715412268667
weather,path=/spare/local/tmp/mymetrics.out temperature=25 1562351715410662089
weather,path=/spare/local/tmp/mymetrics.out temperature=24 1562351715408385927
weather,path=/spare/local/tmp/mymetrics.out temperature=23 1562351715407111139
weather,path=/spare/local/tmp/mymetrics.out temperature=22 1562351715405240281
weather,path=/spare/local/tmp/mymetrics.out temperature=21 1562351715404202948
weather,path=/spare/local/tmp/mymetrics.out temperature=20 1562351715395556429
weather,path=/spare/local/tmp/mymetrics.out temperature=19 1562351715384606087
weather,path=/spare/local/tmp/mymetrics.out temperature=18 1562351715373087511
weather,path=/spare/local/tmp/mymetrics.out temperature=17 1562351715370765814
weather,path=/spare/local/tmp/mymetrics.out temperature=16 1562351715361205160
weather,path=/spare/local/tmp/mymetrics.out temperature=15 1562351715352476674
weather,path=/spare/local/tmp/mymetrics.out temperature=14 1562351715351587201
weather,path=/spare/local/tmp/mymetrics.out temperature=13 1562351715349632772
weather,path=/spare/local/tmp/mymetrics.out temperature=12 1562351715348061036
weather,path=/spare/local/tmp/mymetrics.out temperature=11 1562351715341495527
weather,path=/spare/local/tmp/mymetrics.out temperature=10 1562351715335379408
weather,path=/spare/local/tmp/mymetrics.out temperature=9 1562351715334405589
weather,path=/spare/local/tmp/mymetrics.out temperature=8 1562351715333039662
weather,path=/spare/local/tmp/mymetrics.out temperature=7 1562351715328585961
weather,path=/spare/local/tmp/mymetrics.out temperature=6 1562351715319016183
weather,path=/spare/local/tmp/mymetrics.out temperature=5 1562351715309608666
weather,path=/spare/local/tmp/mymetrics.out temperature=4 1562351715298899790
weather,path=/spare/local/tmp/mymetrics.out temperature=3 1562351715297917955
weather,path=/spare/local/tmp/mymetrics.out temperature=2 1562351715297086914
weather,path=/spare/local/tmp/mymetrics.out temperature=1 1562351715295234691
2019-07-05T18:35:15Z D! [outputs.file] wrote batch of 75 metrics in 304.85µs
2019-07-05T18:35:15Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:35:15Z D! [agent] Closing outputs
2019-07-05T18:35:15Z D! [agent] Stopped Successfully
2019-07-05T18:35:15Z I! Starting Telegraf 
2019-07-05T18:35:15Z I! Loaded inputs: tail
2019-07-05T18:35:15Z I! Loaded aggregators: 
2019-07-05T18:35:15Z I! Loaded processors: 
2019-07-05T18:35:15Z I! Loaded outputs: file
2019-07-05T18:35:15Z I! Tags enabled: 
2019-07-05T18:35:15Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"", Flush Interval:600ms
2019-07-05T18:35:15Z D! [agent] Initializing plugins
2019-07-05T18:35:15Z D! [agent] Connecting outputs
2019-07-05T18:35:15Z D! [agent] Attempting connection to output: file
2019-07-05T18:35:15Z D! [agent] Successfully connected to output: file
2019-07-05T18:35:15Z D! [agent] Starting service inputs
2019-07-05T18:35:15Z D! [inputs.tail] tail added for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:35:16Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:35:16Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:35:17Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:35:17Z D! [agent] Stopping service inputs
2019-07-05T18:35:17Z D! [inputs.tail] tail removed for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:35:17Z D! [agent] Input channel closed
2019-07-05T18:35:17Z I! [agent] Hang on, flushing any cached metrics before shutdown
2019-07-05T18:35:17Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:35:17Z D! [agent] Closing outputs
2019-07-05T18:35:17Z D! [agent] Stopped Successfully
```
</details>

### telegraf.out (removing tailer.Close())
misses line that would have been `temperature=75`
<details>

```
2019-07-05T18:36:48Z I! Starting Telegraf 
2019-07-05T18:36:48Z I! Loaded inputs: tail
2019-07-05T18:36:48Z I! Loaded aggregators: 
2019-07-05T18:36:48Z I! Loaded processors: 
2019-07-05T18:36:48Z I! Loaded outputs: file
2019-07-05T18:36:48Z I! Tags enabled: 
2019-07-05T18:36:48Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"", Flush Interval:600ms
2019-07-05T18:36:48Z D! [agent] Initializing plugins
2019-07-05T18:36:48Z D! [agent] Connecting outputs
2019-07-05T18:36:48Z D! [agent] Attempting connection to output: file
2019-07-05T18:36:48Z D! [agent] Successfully connected to output: file
2019-07-05T18:36:48Z D! [agent] Starting service inputs
2019-07-05T18:36:48Z D! [inputs.tail] tail added for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:36:49Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:36:49Z I! Reloading Telegraf config
2019-07-05T18:36:49Z D! [agent] Stopping service inputs
2019-07-05T18:36:49Z D! [inputs.tail] tail removed for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:36:49Z D! [agent] Input channel closed
2019-07-05T18:36:49Z I! [agent] Hang on, flushing any cached metrics before shutdown
weather,path=/spare/local/tmp/mymetrics.out temperature=74 1562351809986517023
weather,path=/spare/local/tmp/mymetrics.out temperature=73 1562351809985921619
weather,path=/spare/local/tmp/mymetrics.out temperature=72 1562351809985278080
weather,path=/spare/local/tmp/mymetrics.out temperature=71 1562351809984654665
weather,path=/spare/local/tmp/mymetrics.out temperature=70 1562351809984028286
weather,path=/spare/local/tmp/mymetrics.out temperature=69 1562351809983363038
weather,path=/spare/local/tmp/mymetrics.out temperature=68 1562351809982788349
weather,path=/spare/local/tmp/mymetrics.out temperature=67 1562351809982157226
weather,path=/spare/local/tmp/mymetrics.out temperature=66 1562351809981525082
weather,path=/spare/local/tmp/mymetrics.out temperature=65 1562351809980951213
weather,path=/spare/local/tmp/mymetrics.out temperature=64 1562351809980362281
weather,path=/spare/local/tmp/mymetrics.out temperature=63 1562351809979802271
weather,path=/spare/local/tmp/mymetrics.out temperature=62 1562351809979220847
weather,path=/spare/local/tmp/mymetrics.out temperature=61 1562351809978631075
weather,path=/spare/local/tmp/mymetrics.out temperature=60 1562351809978054551
weather,path=/spare/local/tmp/mymetrics.out temperature=59 1562351809977412728
weather,path=/spare/local/tmp/mymetrics.out temperature=58 1562351809976798537
weather,path=/spare/local/tmp/mymetrics.out temperature=57 1562351809976006315
weather,path=/spare/local/tmp/mymetrics.out temperature=56 1562351809975401344
weather,path=/spare/local/tmp/mymetrics.out temperature=55 1562351809974829410
weather,path=/spare/local/tmp/mymetrics.out temperature=54 1562351809974242260
weather,path=/spare/local/tmp/mymetrics.out temperature=53 1562351809973669017
weather,path=/spare/local/tmp/mymetrics.out temperature=52 1562351809973019801
weather,path=/spare/local/tmp/mymetrics.out temperature=51 1562351809972455254
weather,path=/spare/local/tmp/mymetrics.out temperature=50 1562351809971909893
weather,path=/spare/local/tmp/mymetrics.out temperature=49 1562351809971342578
weather,path=/spare/local/tmp/mymetrics.out temperature=48 1562351809970807949
weather,path=/spare/local/tmp/mymetrics.out temperature=47 1562351809970265239
weather,path=/spare/local/tmp/mymetrics.out temperature=46 1562351809969738507
weather,path=/spare/local/tmp/mymetrics.out temperature=45 1562351809969209670
weather,path=/spare/local/tmp/mymetrics.out temperature=44 1562351809968619381
weather,path=/spare/local/tmp/mymetrics.out temperature=43 1562351809968046301
weather,path=/spare/local/tmp/mymetrics.out temperature=42 1562351809967379693
weather,path=/spare/local/tmp/mymetrics.out temperature=41 1562351809966834770
weather,path=/spare/local/tmp/mymetrics.out temperature=40 1562351809966278738
weather,path=/spare/local/tmp/mymetrics.out temperature=39 1562351809965744195
weather,path=/spare/local/tmp/mymetrics.out temperature=38 1562351809965177724
weather,path=/spare/local/tmp/mymetrics.out temperature=37 1562351809964662148
weather,path=/spare/local/tmp/mymetrics.out temperature=36 1562351809964068634
weather,path=/spare/local/tmp/mymetrics.out temperature=35 1562351809963517978
weather,path=/spare/local/tmp/mymetrics.out temperature=34 1562351809962982603
weather,path=/spare/local/tmp/mymetrics.out temperature=33 1562351809962361115
weather,path=/spare/local/tmp/mymetrics.out temperature=32 1562351809961632539
weather,path=/spare/local/tmp/mymetrics.out temperature=31 1562351809960894818
weather,path=/spare/local/tmp/mymetrics.out temperature=30 1562351809960134809
weather,path=/spare/local/tmp/mymetrics.out temperature=29 1562351809959391626
weather,path=/spare/local/tmp/mymetrics.out temperature=28 1562351809958657057
weather,path=/spare/local/tmp/mymetrics.out temperature=27 1562351809957937433
weather,path=/spare/local/tmp/mymetrics.out temperature=26 1562351809957148259
weather,path=/spare/local/tmp/mymetrics.out temperature=25 1562351809956459691
weather,path=/spare/local/tmp/mymetrics.out temperature=24 1562351809955770632
weather,path=/spare/local/tmp/mymetrics.out temperature=23 1562351809955097915
weather,path=/spare/local/tmp/mymetrics.out temperature=22 1562351809954398127
weather,path=/spare/local/tmp/mymetrics.out temperature=21 1562351809953696759
weather,path=/spare/local/tmp/mymetrics.out temperature=20 1562351809952981055
weather,path=/spare/local/tmp/mymetrics.out temperature=19 1562351809952280751
weather,path=/spare/local/tmp/mymetrics.out temperature=18 1562351809951562121
weather,path=/spare/local/tmp/mymetrics.out temperature=17 1562351809950879559
weather,path=/spare/local/tmp/mymetrics.out temperature=16 1562351809950167828
weather,path=/spare/local/tmp/mymetrics.out temperature=15 1562351809949473160
weather,path=/spare/local/tmp/mymetrics.out temperature=14 1562351809948753114
weather,path=/spare/local/tmp/mymetrics.out temperature=13 1562351809948010019
weather,path=/spare/local/tmp/mymetrics.out temperature=12 1562351809947299612
weather,path=/spare/local/tmp/mymetrics.out temperature=11 1562351809946630378
weather,path=/spare/local/tmp/mymetrics.out temperature=10 1562351809945952768
weather,path=/spare/local/tmp/mymetrics.out temperature=9 1562351809945205025
weather,path=/spare/local/tmp/mymetrics.out temperature=8 1562351809944294671
weather,path=/spare/local/tmp/mymetrics.out temperature=7 1562351809943354334
weather,path=/spare/local/tmp/mymetrics.out temperature=6 1562351809942403959
weather,path=/spare/local/tmp/mymetrics.out temperature=5 1562351809941436845
weather,path=/spare/local/tmp/mymetrics.out temperature=4 1562351809939985886
weather,path=/spare/local/tmp/mymetrics.out temperature=3 1562351809936885604
weather,path=/spare/local/tmp/mymetrics.out temperature=2 1562351809934729618
weather,path=/spare/local/tmp/mymetrics.out temperature=1 1562351809933028400
2019-07-05T18:36:49Z D! [outputs.file] wrote batch of 74 metrics in 437.066µs
2019-07-05T18:36:49Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:36:49Z D! [agent] Closing outputs
2019-07-05T18:36:49Z D! [agent] Stopped Successfully
2019-07-05T18:36:49Z I! Starting Telegraf 
2019-07-05T18:36:49Z I! Loaded inputs: tail
2019-07-05T18:36:49Z I! Loaded aggregators: 
2019-07-05T18:36:49Z I! Loaded processors: 
2019-07-05T18:36:49Z I! Loaded outputs: file
2019-07-05T18:36:49Z I! Tags enabled: 
2019-07-05T18:36:49Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"", Flush Interval:600ms
2019-07-05T18:36:49Z D! [agent] Initializing plugins
2019-07-05T18:36:49Z D! [agent] Connecting outputs
2019-07-05T18:36:49Z D! [agent] Attempting connection to output: file
2019-07-05T18:36:49Z D! [agent] Successfully connected to output: file
2019-07-05T18:36:49Z D! [agent] Starting service inputs
2019-07-05T18:36:49Z D! [inputs.tail] tail added for file: /spare/local/tmp/mymetrics.out
weather,path=/spare/local/tmp/mymetrics.out temperature=150 1562351810062940950
weather,path=/spare/local/tmp/mymetrics.out temperature=149 1562351810061840193
weather,path=/spare/local/tmp/mymetrics.out temperature=148 1562351810060935782
weather,path=/spare/local/tmp/mymetrics.out temperature=147 1562351810059873123
weather,path=/spare/local/tmp/mymetrics.out temperature=146 1562351810059049991
weather,path=/spare/local/tmp/mymetrics.out temperature=145 1562351810057971739
weather,path=/spare/local/tmp/mymetrics.out temperature=144 1562351810057135824
weather,path=/spare/local/tmp/mymetrics.out temperature=143 1562351810056123883
weather,path=/spare/local/tmp/mymetrics.out temperature=142 1562351810055286785
weather,path=/spare/local/tmp/mymetrics.out temperature=141 1562351810054164950
weather,path=/spare/local/tmp/mymetrics.out temperature=140 1562351810052955468
weather,path=/spare/local/tmp/mymetrics.out temperature=139 1562351810051959930
weather,path=/spare/local/tmp/mymetrics.out temperature=138 1562351810050865797
weather,path=/spare/local/tmp/mymetrics.out temperature=137 1562351810049279554
weather,path=/spare/local/tmp/mymetrics.out temperature=136 1562351810047661405
weather,path=/spare/local/tmp/mymetrics.out temperature=135 1562351810046548746
weather,path=/spare/local/tmp/mymetrics.out temperature=134 1562351810045416515
weather,path=/spare/local/tmp/mymetrics.out temperature=133 1562351810044132942
weather,path=/spare/local/tmp/mymetrics.out temperature=132 1562351810043141146
weather,path=/spare/local/tmp/mymetrics.out temperature=131 1562351810041994705
weather,path=/spare/local/tmp/mymetrics.out temperature=130 1562351810040942593
weather,path=/spare/local/tmp/mymetrics.out temperature=129 1562351810039734478
weather,path=/spare/local/tmp/mymetrics.out temperature=128 1562351810038792145
weather,path=/spare/local/tmp/mymetrics.out temperature=127 1562351810037837509
weather,path=/spare/local/tmp/mymetrics.out temperature=126 1562351810036853309
weather,path=/spare/local/tmp/mymetrics.out temperature=125 1562351810035811239
weather,path=/spare/local/tmp/mymetrics.out temperature=124 1562351810034830160
weather,path=/spare/local/tmp/mymetrics.out temperature=123 1562351810033766629
weather,path=/spare/local/tmp/mymetrics.out temperature=122 1562351810032737422
weather,path=/spare/local/tmp/mymetrics.out temperature=121 1562351810031811756
weather,path=/spare/local/tmp/mymetrics.out temperature=120 1562351810030961364
weather,path=/spare/local/tmp/mymetrics.out temperature=119 1562351810030036624
weather,path=/spare/local/tmp/mymetrics.out temperature=118 1562351810029157432
weather,path=/spare/local/tmp/mymetrics.out temperature=117 1562351810028233564
weather,path=/spare/local/tmp/mymetrics.out temperature=116 1562351810027269042
weather,path=/spare/local/tmp/mymetrics.out temperature=115 1562351810026387874
weather,path=/spare/local/tmp/mymetrics.out temperature=114 1562351810025480467
weather,path=/spare/local/tmp/mymetrics.out temperature=113 1562351810024577399
weather,path=/spare/local/tmp/mymetrics.out temperature=112 1562351810023576281
weather,path=/spare/local/tmp/mymetrics.out temperature=111 1562351810022775011
weather,path=/spare/local/tmp/mymetrics.out temperature=110 1562351810021963158
weather,path=/spare/local/tmp/mymetrics.out temperature=109 1562351810021154201
weather,path=/spare/local/tmp/mymetrics.out temperature=108 1562351810020119667
weather,path=/spare/local/tmp/mymetrics.out temperature=107 1562351810019321514
weather,path=/spare/local/tmp/mymetrics.out temperature=106 1562351810018538161
weather,path=/spare/local/tmp/mymetrics.out temperature=105 1562351810017677459
weather,path=/spare/local/tmp/mymetrics.out temperature=104 1562351810016794011
weather,path=/spare/local/tmp/mymetrics.out temperature=103 1562351810015941850
weather,path=/spare/local/tmp/mymetrics.out temperature=102 1562351810015179504
weather,path=/spare/local/tmp/mymetrics.out temperature=101 1562351810014374348
weather,path=/spare/local/tmp/mymetrics.out temperature=100 1562351810013480312
weather,path=/spare/local/tmp/mymetrics.out temperature=99 1562351810012650269
weather,path=/spare/local/tmp/mymetrics.out temperature=98 1562351810011988689
weather,path=/spare/local/tmp/mymetrics.out temperature=97 1562351810011464031
weather,path=/spare/local/tmp/mymetrics.out temperature=96 1562351810010924897
weather,path=/spare/local/tmp/mymetrics.out temperature=95 1562351810010419247
weather,path=/spare/local/tmp/mymetrics.out temperature=94 1562351810009902052
weather,path=/spare/local/tmp/mymetrics.out temperature=93 1562351810009347952
weather,path=/spare/local/tmp/mymetrics.out temperature=92 1562351810008820077
weather,path=/spare/local/tmp/mymetrics.out temperature=91 1562351810008057072
weather,path=/spare/local/tmp/mymetrics.out temperature=90 1562351810007497220
weather,path=/spare/local/tmp/mymetrics.out temperature=89 1562351810006949245
weather,path=/spare/local/tmp/mymetrics.out temperature=88 1562351810006340099
weather,path=/spare/local/tmp/mymetrics.out temperature=87 1562351810005781853
weather,path=/spare/local/tmp/mymetrics.out temperature=86 1562351810005179098
weather,path=/spare/local/tmp/mymetrics.out temperature=85 1562351810004546093
weather,path=/spare/local/tmp/mymetrics.out temperature=84 1562351810003352072
weather,path=/spare/local/tmp/mymetrics.out temperature=83 1562351810002802663
weather,path=/spare/local/tmp/mymetrics.out temperature=82 1562351810002227237
weather,path=/spare/local/tmp/mymetrics.out temperature=81 1562351810001626816
weather,path=/spare/local/tmp/mymetrics.out temperature=80 1562351810000993367
weather,path=/spare/local/tmp/mymetrics.out temperature=79 1562351810000472390
weather,path=/spare/local/tmp/mymetrics.out temperature=78 1562351809999946134
weather,path=/spare/local/tmp/mymetrics.out temperature=77 1562351809999400245
weather,path=/spare/local/tmp/mymetrics.out temperature=76 1562351809998866135
2019-07-05T18:36:51Z D! [outputs.file] wrote batch of 75 metrics in 425.768µs
2019-07-05T18:36:51Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:36:51Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:36:52Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:36:52Z D! [agent] Stopping service inputs
2019-07-05T18:36:52Z D! [inputs.tail] tail removed for file: /spare/local/tmp/mymetrics.out
2019-07-05T18:36:52Z D! [agent] Input channel closed
2019-07-05T18:36:52Z I! [agent] Hang on, flushing any cached metrics before shutdown
2019-07-05T18:36:52Z D! [outputs.file] buffer fullness: 0 / 10000 metrics. 
2019-07-05T18:36:52Z D! [agent] Closing outputs
2019-07-05T18:36:52Z D! [agent] Stopped Successfully
```
</details>