### PR TITLE
Smart Input Plugin Extra Attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@
 /telegraf.exe
 /telegraf.gz
 /vendor
-*.swp
-*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /telegraf.exe
 /telegraf.gz
 /vendor
+*.swp
+*.swo

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -48,6 +48,8 @@ var (
 	nvmePowerCycleAttr = regexp.MustCompile("^Power Cycles:\\s+(.*)$")
 	// Power On Hours: 6,038
 	nvmePowerOnAttr = regexp.MustCompile("^Power On Hours:\\s+(.*)$")
+	// Media and Data Integrity Errors: 0
+	nvmeIntegrityErrAttr = regexp.MustCompile("^Media and Data Integrity Errors:\\s+(.*)$")
 
 	// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
 	//   1 Raw_Read_Error_Rate     -O-RC-   200   200   000    -    0
@@ -330,6 +332,18 @@ func gatherDisk(acc telegraf.Accumulator, usesudo, collectAttributes bool, smart
 					tags["id"] = "9"
 					tags["name"] = "Power_On_Hours"
 					i, err := strconv.ParseInt(strings.Replace(powerOn[1], ",", "", -1), 10, 64)
+					if err != nil {
+						continue
+					}
+					fields["raw_value"] = i
+
+					acc.AddFields("smart_attribute", fields, tags)
+					continue
+				}
+
+				if errors := nvmeIntegrityErrAttr.FindStringSubmatch(line); len(errors) > 1 {
+					tags["name"] = "Media_and_Data_Integrity_Errors"
+					i, err := strconv.ParseInt(strings.Replace(errors[1], ",", "", -1), 10, 64)
 					if err != nil {
 						continue
 					}

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -18,20 +18,6 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-const (
-	// NVME Critical Warnings as per https://nvmexpress.org
-	// critical warning spare threshold
-	criticalWarningST uint8 = 1 << iota
-	// critical warning temperature above or under threshold
-	criticalWarningTAUT
-	// critical warning reliability degraded
-	criticalWarningRD
-	// critical warning read only
-	criticalWarningRO
-	// critical warning volatile backup memory failed
-	criticalWarningVMBF
-)
-
 var (
 	// Device Model:     APPLE SSD SM256E
 	// Product:              HUH721212AL5204
@@ -65,14 +51,6 @@ var (
 		"190": "temp_c",
 		"194": "temp_c",
 		"199": "udma_crc_errors",
-	}
-
-	nvmeCriticalWarnings = map[uint8]string{
-		criticalWarningST:   "Critical_Warning_Spare_Treshold",
-		criticalWarningTAUT: "Critical_Warning_Temperature_Above_or_Under_Threshold",
-		criticalWarningRD:   "Critical_Warning_Reliability_Degraded",
-		criticalWarningRO:   "Critical_Warning_Read_Only",
-		criticalWarningVMBF: "Critical_Warning_Volative_Memory_Backup_Failed",
 	}
 
 	sasNvmeAttributes = map[string]struct {
@@ -111,6 +89,19 @@ var (
 		},
 		"Error Information Log Entries": {
 			Name: "Error_Information_Log_Entries",
+		},
+		"Critical Warning": {
+			Name: "Critical_Warning",
+			Parse: func(fields, _ map[string]interface{}, str string) error {
+				var value int64
+				if _, err := fmt.Sscanf(str, "0x%x", &value); err != nil {
+					return err
+				}
+
+				fields["raw_value"] = value
+
+				return nil
+			},
 		},
 		"Available Spare": {
 			Name: "Available_Spare",
@@ -358,23 +349,6 @@ func gatherDisk(acc telegraf.Accumulator, usesudo, collectAttributes bool, smart
 		} else {
 			if collectAttributes {
 				if matches := sasNvmeAttr.FindStringSubmatch(line); len(matches) > 2 {
-					if matches[1] == "Critical Warning" {
-						var flags uint8
-						if _, err := fmt.Sscanf(matches[2], "0x%x", &flags); err != nil {
-							continue
-						}
-
-						for flag, name := range nvmeCriticalWarnings {
-							tags["name"] = name
-
-							acc.AddFields("smart_attribute", map[string]interface{}{
-								"raw_value": flags&flag > 0,
-							}, tags)
-						}
-
-						continue
-					}
-
 					if attr, ok := sasNvmeAttributes[matches[1]]; ok {
 						tags["name"] = attr.Name
 						if attr.ID != "" {

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -405,7 +405,7 @@ func parseInt(str string) int64 {
 	return 0
 }
 
-func parseCommaSeperatedInt(fields, deviceFields map[string]interface{}, str string) error {
+func parseCommaSeperatedInt(fields, _ map[string]interface{}, str string) error {
 	i, err := strconv.ParseInt(strings.Replace(str, ",", "", -1), 10, 64)
 	if err != nil {
 		return err

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -37,7 +37,7 @@ var (
 	smartOverallHealth = regexp.MustCompile("^(SMART overall-health self-assessment test result|SMART Health Status):\\s+(\\w+).*$")
 
 	// sasNvmeAttr is a SAS or NVME SMART attribute
-	sasNvmeAttr = regexp.MustCompile(`^([^:]*):\s+(.*)$`)
+	sasNvmeAttr = regexp.MustCompile(`^([^:]+):\s+(.+)$`)
 
 	// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
 	//   1 Raw_Read_Error_Rate     -O-RC-   200   200   000    -    0
@@ -93,11 +93,7 @@ var (
 		"Available Spare": {
 			Name: "Available_Spare",
 			Parse: func(fields, deviceFields map[string]interface{}, str string) error {
-				if str[len(str)-1] == '%' {
-					str = str[:len(str)-1]
-				}
-
-				return parseCommaSeperatedInt(fields, deviceFields, str)
+				return parseCommaSeperatedInt(fields, deviceFields, strings.TrimSuffix(str, "%"))
 			},
 		},
 	}

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -509,6 +509,17 @@ func TestGatherNvme(t *testing.T) {
 		testutil.MustMetric("smart_attribute",
 			map[string]string{
 				"device":    ".",
+				"name":      "Available_Spare",
+				"serial_no": "D704940282?",
+			},
+			map[string]interface{}{
+				"raw_value": 100,
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
 				"id":        "194",
 				"name":      "Temperature_Celsius",
 				"serial_no": "D704940282?",

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -487,6 +487,17 @@ func TestGatherNvme(t *testing.T) {
 		testutil.MustMetric("smart_attribute",
 			map[string]string{
 				"device":    ".",
+				"name":      "Media_and_Data_Integrity_Errors",
+				"serial_no": "D704940282?",
+			},
+			map[string]interface{}{
+				"raw_value": 0,
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
 				"id":        "194",
 				"name":      "Temperature_Celsius",
 				"serial_no": "D704940282?",

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -532,55 +532,11 @@ func TestGatherNvme(t *testing.T) {
 		testutil.MustMetric("smart_attribute",
 			map[string]string{
 				"device":    ".",
-				"name":      "Critical_Warning_Spare_Treshold",
+				"name":      "Critical_Warning",
 				"serial_no": "D704940282?",
 			},
 			map[string]interface{}{
-				"raw_value": true,
-			},
-			time.Now(),
-		),
-		testutil.MustMetric("smart_attribute",
-			map[string]string{
-				"device":    ".",
-				"name":      "Critical_Warning_Temperature_Above_or_Under_Threshold",
-				"serial_no": "D704940282?",
-			},
-			map[string]interface{}{
-				"raw_value": false,
-			},
-			time.Now(),
-		),
-		testutil.MustMetric("smart_attribute",
-			map[string]string{
-				"device":    ".",
-				"name":      "Critical_Warning_Reliability_Degraded",
-				"serial_no": "D704940282?",
-			},
-			map[string]interface{}{
-				"raw_value": false,
-			},
-			time.Now(),
-		),
-		testutil.MustMetric("smart_attribute",
-			map[string]string{
-				"device":    ".",
-				"name":      "Critical_Warning_Read_Only",
-				"serial_no": "D704940282?",
-			},
-			map[string]interface{}{
-				"raw_value": true,
-			},
-			time.Now(),
-		),
-		testutil.MustMetric("smart_attribute",
-			map[string]string{
-				"device":    ".",
-				"name":      "Critical_Warning_Volative_Memory_Backup_Failed",
-				"serial_no": "D704940282?",
-			},
-			map[string]interface{}{
-				"raw_value": false,
+				"raw_value": int64(9),
 			},
 			time.Now(),
 		),

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -498,6 +498,17 @@ func TestGatherNvme(t *testing.T) {
 		testutil.MustMetric("smart_attribute",
 			map[string]string{
 				"device":    ".",
+				"name":      "Error_Information_Log_Entries",
+				"serial_no": "D704940282?",
+			},
+			map[string]interface{}{
+				"raw_value": 119699,
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
 				"id":        "194",
 				"name":      "Temperature_Celsius",
 				"serial_no": "D704940282?",

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -529,6 +529,61 @@ func TestGatherNvme(t *testing.T) {
 			},
 			time.Now(),
 		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Critical_Warning_Spare_Treshold",
+				"serial_no": "D704940282?",
+			},
+			map[string]interface{}{
+				"raw_value": true,
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Critical_Warning_Temperature_Above_or_Under_Threshold",
+				"serial_no": "D704940282?",
+			},
+			map[string]interface{}{
+				"raw_value": false,
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Critical_Warning_Reliability_Degraded",
+				"serial_no": "D704940282?",
+			},
+			map[string]interface{}{
+				"raw_value": false,
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Critical_Warning_Read_Only",
+				"serial_no": "D704940282?",
+			},
+			map[string]interface{}{
+				"raw_value": true,
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Critical_Warning_Volative_Memory_Backup_Failed",
+				"serial_no": "D704940282?",
+			},
+			map[string]interface{}{
+				"raw_value": false,
+			},
+			time.Now(),
+		),
 	}
 
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(),
@@ -967,7 +1022,7 @@ Local Time is: Fri Jun 15 11:41:35 2018 UTC
 SMART overall-health self-assessment test result: PASSED
 
 SMART/Health Information (NVMe Log 0x02, NSID 0xffffffff)
-Critical Warning: 0x00
+Critical Warning: 0x09
 Temperature: 38 Celsius
 Available Spare: 100%
 Available Spare Threshold: 10%


### PR DESCRIPTION
This PR attempts to deliver most of https://github.com/influxdata/telegraf/issues/6041

Currently this PR supports:
- [x] Media and Data Integrity Errors (count)
- [x] Error Information Log Entries (count)
- [x] Available Spare (percentage)
- [x] Critical Warning (integer bit set)

Outstanding Questions:

1. Documentation for smart attributes seem to be a little elusive to me. Can anyone point me in the direction of the attributes id's for all the above attributes. Perhaps you know @coccobill1 ?

2. `Critical Warning` appears to be a bit flag printed as a hex value. I have struggled to find decent documentation around the meaning of all these attributes. Maybe someone can point me in the best direction of better docs. I have this https://www.intel.com/content/dam/support/us/en/documents/solid-state-drives/Intel_SSD_Smart_Attrib_for_PCIe.pdf for example.

Given we know the definitive meaning (and that there is one) for what each flag means, do we have any suggestions on how to communicate that best to telegraf? cc @danielnelson 

What I mean is, for example, would we want to communicate each flags as individual distinct fields. Each field with a boolean value (on or off)?

e.g. The reading `0x01` given the first bit in the byte represents `available spare is below threshold` (as I have currently taken from the shared intel doc above) would lead to a field like `Critical_Warning_Available_Spare_Below_Threshold` with a `raw_value=1`?

3. I couldn't find any decent examples of the extra fields to build a sensible test from or have a clear idea on the format of the value in the output. So I haven't taken them on yet. These are:

- Reallocated Sector Count
- Wear Leveling Count
- Uncorrectable Errors Count

I could implement them all as just counts and fabricate a test and hope they exist as described here if people are happy with this.

I could be completely missing the point here 😂 so any advice welcomed.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated. (there currently doesn't seem to exist any documentation at this fidelity)
- [x] Has appropriate unit tests.
