### PR TITLE
Docker Input Plugin Measure Thin Pool Minimum Free Space

### DIFF
--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -159,7 +159,7 @@ The above measurements for the devicemapper storage driver can now be found in t
     - metadata_space_available_bytes
     - thin_pool_minimum_free_space_bytes
 
-- docker_container_mem
++ docker_container_mem
   - tags:
     - engine_host
     - server_version
@@ -167,7 +167,7 @@ The above measurements for the devicemapper storage driver can now be found in t
     - container_name
     - container_status
     - container_version
-  - fields:
+  + fields:
     - total_pgmafault
     - cache
     - mapped_file
@@ -212,7 +212,7 @@ The above measurements for the devicemapper storage driver can now be found in t
     - container_status
     - container_version
     - cpu
-  - fields:
+  + fields:
     - throttling_periods
     - throttling_throttled_periods
     - throttling_throttled_time
@@ -223,7 +223,7 @@ The above measurements for the devicemapper storage driver can now be found in t
     - usage_percent
     - container_id
 
-- docker_container_net
++ docker_container_net
   - tags:
     - engine_host
     - server_version
@@ -232,7 +232,7 @@ The above measurements for the devicemapper storage driver can now be found in t
     - container_status
     - container_version
     - network
-  - fields:
+  + fields:
     - rx_dropped
     - rx_bytes
     - rx_errors

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -106,7 +106,7 @@ may prefer to exclude them:
     - unit
     - engine_host
     - server_version
-  - fields:
+  + fields:
     - n_used_file_descriptors
     - n_cpus
     - n_containers
@@ -122,12 +122,12 @@ may prefer to exclude them:
 The `docker_data` and `docker_metadata` measurements are available only for
 some storage drivers such as devicemapper.
 
-- docker_data (deprecated see: `docker_devicemapper`)
++ docker_data (deprecated see: `docker_devicemapper`)
   - tags:
     - unit
     - engine_host
     - server_version
-  - fields:
+  + fields:
     - available
     - total
     - used
@@ -137,7 +137,7 @@ some storage drivers such as devicemapper.
     - unit
     - engine_host
     - server_version
-  - fields:
+  + fields:
     - available
     - total
     - used
@@ -149,7 +149,7 @@ The above measurements for the devicemapper storage driver can now be found in t
     - engine_host
     - server_version
     - pool_name
-  - fields:
+  + fields:
     - pool_blocksize_bytes
     - data_space_used_bytes
     - data_space_total_bytes

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -117,12 +117,12 @@ may prefer to exclude them:
     - n_goroutines
     - n_listener_events
     - memory_total
-    - pool_blocksize (requires devicemapper storage driver)
+    - pool_blocksize (requires devicemapper storage driver) (deprecated see: `docker_devicemapper`)
 
 The `docker_data` and `docker_metadata` measurements are available only for
 some storage drivers such as devicemapper.
 
-- docker_data
+- docker_data (deprecated see: `docker_devicemapper`)
   - tags:
     - unit
     - engine_host
@@ -132,7 +132,7 @@ some storage drivers such as devicemapper.
     - total
     - used
 
-- docker_metadata
+- docker_metadata (deprecated see: `docker_devicemapper`)
   - tags:
     - unit
     - engine_host
@@ -141,6 +141,23 @@ some storage drivers such as devicemapper.
     - available
     - total
     - used
+
+The above measurements for the devicemapper storage driver can now be found in the new `docker_devicemapper` measurement
+
+- docker_devicemapper
+  - tags:
+    - engine_host
+    - server_version
+    - pool_name
+  - fields:
+    - pool_blocksize_bytes
+    - data_space_used_bytes
+    - data_space_total_bytes
+    - data_space_available_bytes
+    - metadata_space_used_bytes
+    - metadata_space_total_bytes
+    - metadata_space_available_bytes
+    - thin_pool_minimum_free_space_bytes
 
 - docker_container_mem
   - tags:

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -354,6 +354,7 @@ func (d *Docker) gatherInfo(acc telegraf.Accumulator) error {
 
 		switch name {
 		case "pool_blocksize",
+			"base_device_size",
 			"data_space_used",
 			"data_space_total",
 			"data_space_available",

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -343,6 +343,11 @@ func (d *Docker) gatherInfo(acc telegraf.Accumulator) error {
 				map[string]interface{}{"pool_blocksize": value},
 				tags,
 				now)
+		} else if name == "thin_pool_minimum_free_space" {
+			acc.AddFields("docker_thin_pool",
+				map[string]interface{}{"minimum_free_space": value},
+				tags,
+				now)
 		} else if strings.HasPrefix(name, "data_space_") {
 			// data space
 			fieldName := strings.TrimPrefix(name, "data_space_")

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -361,7 +361,7 @@ func (d *Docker) gatherInfo(acc telegraf.Accumulator) error {
 			"metadata_space_total",
 			"metadata_space_available",
 			"thin_pool_minimum_free_space":
-			deviceMapperFields[fmt.Sprintf("%s_bytes", name)] = value
+			deviceMapperFields[name+"_bytes"] = value
 		}
 
 		// Legacy devicemapper measurements

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -322,30 +322,53 @@ func (d *Docker) gatherInfo(acc telegraf.Accumulator) error {
 		"n_goroutines":            info.NGoroutines,
 		"n_listener_events":       info.NEventsListener,
 	}
+
 	// Add metrics
 	acc.AddFields("docker", fields, tags, now)
 	acc.AddFields("docker",
 		map[string]interface{}{"memory_total": info.MemTotal},
 		tags,
 		now)
+
 	// Get storage metrics
 	tags["unit"] = "bytes"
+
+	var (
+		// "docker_devicemapper" measurement fields
+		poolName           string
+		deviceMapperFields = map[string]interface{}{}
+	)
+
 	for _, rawData := range info.DriverStatus {
+		name := strings.ToLower(strings.Replace(rawData[0], " ", "_", -1))
+		if name == "pool_name" {
+			poolName = rawData[1]
+			continue
+		}
+
 		// Try to convert string to int (bytes)
 		value, err := parseSize(rawData[1])
 		if err != nil {
 			continue
 		}
-		name := strings.ToLower(strings.Replace(rawData[0], " ", "_", -1))
+
+		switch name {
+		case "pool_blocksize",
+			"data_space_used",
+			"data_space_total",
+			"data_space_available",
+			"metadata_space_used",
+			"metadata_space_total",
+			"metadata_space_available",
+			"thin_pool_minimum_free_space":
+			deviceMapperFields[fmt.Sprintf("%s_bytes", name)] = value
+		}
+
+		// Legacy devicemapper measurements
 		if name == "pool_blocksize" {
 			// pool blocksize
 			acc.AddFields("docker",
 				map[string]interface{}{"pool_blocksize": value},
-				tags,
-				now)
-		} else if name == "thin_pool_minimum_free_space" {
-			acc.AddFields("docker_thin_pool",
-				map[string]interface{}{"minimum_free_space": value},
 				tags,
 				now)
 		} else if strings.HasPrefix(name, "data_space_") {
@@ -358,12 +381,28 @@ func (d *Docker) gatherInfo(acc telegraf.Accumulator) error {
 			metadataFields[fieldName] = value
 		}
 	}
+
 	if len(dataFields) > 0 {
 		acc.AddFields("docker_data", dataFields, tags, now)
 	}
+
 	if len(metadataFields) > 0 {
 		acc.AddFields("docker_metadata", metadataFields, tags, now)
 	}
+
+	if len(deviceMapperFields) > 0 {
+		tags := map[string]string{
+			"engine_host":    d.engineHost,
+			"server_version": d.serverVersion,
+		}
+
+		if poolName != "" {
+			tags["pool_name"] = poolName
+		}
+
+		acc.AddFields("docker_devicemapper", deviceMapperFields, tags, now)
+	}
+
 	return nil
 }
 

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -754,14 +754,21 @@ func TestDockerGatherInfo(t *testing.T) {
 	)
 
 	acc.AssertContainsTaggedFields(t,
-		"docker_thin_pool",
+		"docker_devicemapper",
 		map[string]interface{}{
-			"minimum_free_space": int64(10740000000),
+			"pool_blocksize_bytes":               int64(65540),
+			"data_space_used_bytes":              int64(17300000000),
+			"data_space_total_bytes":             int64(107400000000),
+			"data_space_available_bytes":         int64(36530000000),
+			"metadata_space_used_bytes":          int64(20970000),
+			"metadata_space_total_bytes":         int64(2146999999),
+			"metadata_space_available_bytes":     int64(2126999999),
+			"thin_pool_minimum_free_space_bytes": int64(10740000000),
 		},
 		map[string]string{
 			"engine_host":    "absol",
 			"server_version": "17.09.0-ce",
-			"unit":           "bytes",
+			"pool_name":      "docker-8:1-1182287-pool",
 		},
 	)
 

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -756,6 +756,7 @@ func TestDockerGatherInfo(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"docker_devicemapper",
 		map[string]interface{}{
+			"base_device_size_bytes":             int64(107400000000),
 			"pool_blocksize_bytes":               int64(65540),
 			"data_space_used_bytes":              int64(17300000000),
 			"data_space_total_bytes":             int64(107400000000),

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -703,6 +703,29 @@ func TestDockerGatherInfo(t *testing.T) {
 	)
 
 	acc.AssertContainsTaggedFields(t,
+		"docker",
+		map[string]interface{}{
+			"memory_total": int64(3840757760),
+		},
+		map[string]string{
+			"engine_host":    "absol",
+			"server_version": "17.09.0-ce",
+		},
+	)
+
+	acc.AssertContainsTaggedFields(t,
+		"docker",
+		map[string]interface{}{
+			"pool_blocksize": int64(65540),
+		},
+		map[string]string{
+			"engine_host":    "absol",
+			"server_version": "17.09.0-ce",
+			"unit":           "bytes",
+		},
+	)
+
+	acc.AssertContainsTaggedFields(t,
 		"docker_data",
 		map[string]interface{}{
 			"used":      int64(17300000000),
@@ -710,11 +733,26 @@ func TestDockerGatherInfo(t *testing.T) {
 			"available": int64(36530000000),
 		},
 		map[string]string{
-			"unit":           "bytes",
 			"engine_host":    "absol",
 			"server_version": "17.09.0-ce",
+			"unit":           "bytes",
 		},
 	)
+
+	acc.AssertContainsTaggedFields(t,
+		"docker_metadata",
+		map[string]interface{}{
+			"used":      int64(20970000),
+			"total":     int64(2146999999),
+			"available": int64(2126999999),
+		},
+		map[string]string{
+			"engine_host":    "absol",
+			"server_version": "17.09.0-ce",
+			"unit":           "bytes",
+		},
+	)
+
 	acc.AssertContainsTaggedFields(t,
 		"docker_container_cpu",
 		map[string]interface{}{

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -754,6 +754,18 @@ func TestDockerGatherInfo(t *testing.T) {
 	)
 
 	acc.AssertContainsTaggedFields(t,
+		"docker_thinpool",
+		map[string]interface{}{
+			"minimum_free_space": int64(10740000000),
+		},
+		map[string]string{
+			"engine_host":    "absol",
+			"server_version": "17.09.0-ce",
+			"unit":           "bytes",
+		},
+	)
+
+	acc.AssertContainsTaggedFields(t,
 		"docker_container_cpu",
 		map[string]interface{}{
 			"usage_total":  uint64(1231652),

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -754,7 +754,7 @@ func TestDockerGatherInfo(t *testing.T) {
 	)
 
 	acc.AssertContainsTaggedFields(t,
-		"docker_thinpool",
+		"docker_thin_pool",
 		map[string]interface{}{
 			"minimum_free_space": int64(10740000000),
 		},

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -756,7 +756,7 @@ func TestDockerGatherInfo(t *testing.T) {
 	acc.AssertContainsTaggedFields(t,
 		"docker_devicemapper",
 		map[string]interface{}{
-			"base_device_size_bytes":             int64(107400000000),
+			"base_device_size_bytes":             int64(10740000000),
 			"pool_blocksize_bytes":               int64(65540),
 			"data_space_used_bytes":              int64(17300000000),
 			"data_space_total_bytes":             int64(107400000000),

--- a/plugins/inputs/docker/docker_testdata.go
+++ b/plugins/inputs/docker/docker_testdata.go
@@ -47,7 +47,7 @@ var info = types.Info{
 	HTTPSProxy:        "",
 	Labels:            []string{},
 	MemoryLimit:       false,
-	DriverStatus:      [][2]string{{"Pool Name", "docker-8:1-1182287-pool"}, {"Pool Blocksize", "65.54 kB"}, {"Backing Filesystem", "extfs"}, {"Data file", "/dev/loop0"}, {"Metadata file", "/dev/loop1"}, {"Data Space Used", "17.3 GB"}, {"Data Space Total", "107.4 GB"}, {"Data Space Available", "36.53 GB"}, {"Metadata Space Used", "20.97 MB"}, {"Metadata Space Total", "2.147 GB"}, {"Metadata Space Available", "2.127 GB"}, {"Udev Sync Supported", "true"}, {"Deferred Removal Enabled", "false"}, {"Data loop file", "/var/lib/docker/devicemapper/devicemapper/data"}, {"Metadata loop file", "/var/lib/docker/devicemapper/devicemapper/metadata"}, {"Library Version", "1.02.115 (2016-01-25)"}, {"Thin Pool Minimum Free Space", "10.74GB"}},
+	DriverStatus:      [][2]string{{"Pool Name", "docker-8:1-1182287-pool"}, {"Base Device Size", "10.74 GB"}, {"Pool Blocksize", "65.54 kB"}, {"Backing Filesystem", "extfs"}, {"Data file", "/dev/loop0"}, {"Metadata file", "/dev/loop1"}, {"Data Space Used", "17.3 GB"}, {"Data Space Total", "107.4 GB"}, {"Data Space Available", "36.53 GB"}, {"Metadata Space Used", "20.97 MB"}, {"Metadata Space Total", "2.147 GB"}, {"Metadata Space Available", "2.127 GB"}, {"Udev Sync Supported", "true"}, {"Deferred Removal Enabled", "false"}, {"Data loop file", "/var/lib/docker/devicemapper/devicemapper/data"}, {"Metadata loop file", "/var/lib/docker/devicemapper/devicemapper/metadata"}, {"Library Version", "1.02.115 (2016-01-25)"}, {"Thin Pool Minimum Free Space", "10.74GB"}},
 	NFd:               19,
 	HTTPProxy:         "",
 	Driver:            "devicemapper",

--- a/plugins/inputs/docker/docker_testdata.go
+++ b/plugins/inputs/docker/docker_testdata.go
@@ -47,7 +47,7 @@ var info = types.Info{
 	HTTPSProxy:        "",
 	Labels:            []string{},
 	MemoryLimit:       false,
-	DriverStatus:      [][2]string{{"Pool Name", "docker-8:1-1182287-pool"}, {"Pool Blocksize", "65.54 kB"}, {"Backing Filesystem", "extfs"}, {"Data file", "/dev/loop0"}, {"Metadata file", "/dev/loop1"}, {"Data Space Used", "17.3 GB"}, {"Data Space Total", "107.4 GB"}, {"Data Space Available", "36.53 GB"}, {"Metadata Space Used", "20.97 MB"}, {"Metadata Space Total", "2.147 GB"}, {"Metadata Space Available", "2.127 GB"}, {"Udev Sync Supported", "true"}, {"Deferred Removal Enabled", "false"}, {"Data loop file", "/var/lib/docker/devicemapper/devicemapper/data"}, {"Metadata loop file", "/var/lib/docker/devicemapper/devicemapper/metadata"}, {"Library Version", "1.02.115 (2016-01-25)"}},
+	DriverStatus:      [][2]string{{"Pool Name", "docker-8:1-1182287-pool"}, {"Pool Blocksize", "65.54 kB"}, {"Backing Filesystem", "extfs"}, {"Data file", "/dev/loop0"}, {"Metadata file", "/dev/loop1"}, {"Data Space Used", "17.3 GB"}, {"Data Space Total", "107.4 GB"}, {"Data Space Available", "36.53 GB"}, {"Metadata Space Used", "20.97 MB"}, {"Metadata Space Total", "2.147 GB"}, {"Metadata Space Available", "2.127 GB"}, {"Udev Sync Supported", "true"}, {"Deferred Removal Enabled", "false"}, {"Data loop file", "/var/lib/docker/devicemapper/devicemapper/data"}, {"Metadata loop file", "/var/lib/docker/devicemapper/devicemapper/metadata"}, {"Library Version", "1.02.115 (2016-01-25)"}, {"Thin Pool Minimum Free Space", "10.74GB"}},
 	NFd:               19,
 	HTTPProxy:         "",
 	Driver:            "devicemapper",


### PR DESCRIPTION
Closes https://github.com/influxdata/telegraf/issues/5758

This adds a new measurement `docker_thin_pool` with the field `minimum_free_space` measured in bytes.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
