### PR TITLE
Remove tail cleanup call to avoid double decrement

### DIFF
--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -294,7 +294,6 @@ func (l *LogParserPlugin) Stop() {
 		if err != nil {
 			log.Printf("E! Error stopping tail on file %s\n", t.Filename)
 		}
-		t.Cleanup()
 	}
 	close(l.done)
 	l.wg.Wait()

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/influxdata/tail"
-
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/globpath"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -213,9 +212,6 @@ func (t *Tail) Stop() {
 		}
 	}
 
-	for _, tailer := range t.tailers {
-		tailer.Cleanup()
-	}
 	t.wg.Wait()
 }
 


### PR DESCRIPTION
This is discussed further on https://github.com/influxdata/tail/pull/6.  In short, over time the Cleanup call has been broken and shouldn't be used since it decrements the reference count unconditionally.

closes: #3573

https://github.com/hpcloud/tail/issues/153

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
