### PR TITLE
Emit sarama library log messages at debug level

### DIFF
--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/Shopify/sarama"
@@ -62,6 +61,26 @@ type (
 		Separator string   `toml:"separator"`
 	}
 )
+
+// DebugLogger logs messages from sarama at the debug level.
+type DebugLogger struct {
+}
+
+func (*DebugLogger) Print(v ...interface{}) {
+	args := make([]interface{}, 0, len(v)+1)
+	args = append(args, "D! [sarama] ")
+	log.Print(v...)
+}
+
+func (*DebugLogger) Printf(format string, v ...interface{}) {
+	log.Printf("D! [sarama] "+format, v...)
+}
+
+func (*DebugLogger) Println(v ...interface{}) {
+	args := make([]interface{}, 0, len(v)+1)
+	args = append(args, "D! [sarama] ")
+	log.Println(args...)
+}
 
 var sampleConfig = `
   ## URLs of kafka brokers
@@ -206,7 +225,6 @@ func (k *Kafka) Connect() error {
 		return err
 	}
 	config := sarama.NewConfig()
-	sarama.Logger = log.New(os.Stderr, "[Sarama] ", log.LstdFlags)
 
 	if k.Version != "" {
 		version, err := sarama.ParseKafkaVersion(k.Version)
@@ -329,6 +347,7 @@ func (k *Kafka) Write(metrics []telegraf.Metric) error {
 }
 
 func init() {
+	sarama.Logger = &DebugLogger{}
 	outputs.Add("kafka", func() telegraf.Output {
 		return &Kafka{
 			MaxRetry:     3,

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/Shopify/sarama"
@@ -205,6 +206,7 @@ func (k *Kafka) Connect() error {
 		return err
 	}
 	config := sarama.NewConfig()
+	sarama.Logger = log.New(os.Stderr, "[Sarama] ", log.LstdFlags)
 
 	if k.Version != "" {
 		version, err := sarama.ParseKafkaVersion(k.Version)


### PR DESCRIPTION
This is a little messier than I would like, we can't be specific about if these messages come from the input or the output as sarama has only a single global logger.

related: #6072

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
