### PR TITLE
Fix lustre2 input plugin config parse regression

### DIFF
--- a/plugins/inputs/lustre2/lustre2.go
+++ b/plugins/inputs/lustre2/lustre2.go
@@ -25,8 +25,8 @@ type tags struct {
 // Lustre proc files can change between versions, so we want to future-proof
 // by letting people choose what to look at.
 type Lustre2 struct {
-	Ost_procfiles []string `toml:"ost_jobstat"`
-	Mds_procfiles []string `toml:"mds_jobstat"`
+	Ost_procfiles []string
+	Mds_procfiles []string
 
 	// allFields maps and OST name to the metric fields associated with that OST
 	allFields map[tags]map[string]interface{}

--- a/plugins/inputs/lustre2/lustre2.go
+++ b/plugins/inputs/lustre2/lustre2.go
@@ -25,8 +25,8 @@ type tags struct {
 // Lustre proc files can change between versions, so we want to future-proof
 // by letting people choose what to look at.
 type Lustre2 struct {
-	Ost_procfiles []string
-	Mds_procfiles []string
+	Ost_procfiles []string `toml:"ost_procfiles"`
+	Mds_procfiles []string `toml:"mds_procfiles"`
 
 	// allFields maps and OST name to the metric fields associated with that OST
 	allFields map[tags]map[string]interface{}

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -360,7 +360,7 @@ func TestLustre2CanParseConfiguration(t *testing.T) {
 
 	assert.Equal(t, Lustre2{
 		Ost_procfiles: []string{
-			"/proc/fs/lustre2/obdfilter/*/stats",
+			"/proc/fs/lustre/obdfilter/*/stats",
 			"/proc/fs/lustre/osd-ldiskfs/*/stats",
 		},
 		Mds_procfiles: []string{

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -329,4 +332,39 @@ func TestLustre2GeneratesJobstatsMetrics(t *testing.T) {
 
 	err = os.RemoveAll(os.TempDir() + "/telegraf")
 	require.NoError(t, err)
+}
+
+func TestLustre2CanParseConfiguration(t *testing.T) {
+	config := []byte(`
+[[inputs.lustre2]]
+   ost_procfiles = [
+     "/proc/fs/lustre/obdfilter/*/stats",
+     "/proc/fs/lustre/osd-ldiskfs/*/stats",
+   ]
+   mds_procfiles = [
+     "/proc/fs/lustre/mdt/*/md_stats",
+   ]`)
+
+	table, err := toml.Parse([]byte(config))
+	assert.NoError(t, err)
+
+	inputs, ok := table.Fields["inputs"]
+	require.True(t, ok)
+
+	lustre2, ok := inputs.(*ast.Table).Fields["lustre2"]
+	require.True(t, ok)
+
+	var plugin Lustre2
+
+	require.NoError(t, toml.UnmarshalTable(lustre2.([]*ast.Table)[0], &plugin))
+
+	assert.Equal(t, Lustre2{
+		Ost_procfiles: []string{
+			"/proc/fs/lustre2/obdfilter/*/stats",
+			"/proc/fs/lustre/osd-ldiskfs/*/stats",
+		},
+		Mds_procfiles: []string{
+			"/proc/fs/lustre/mdt/*/md_stats",
+		},
+	}, plugin)
 }

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -346,7 +346,7 @@ func TestLustre2CanParseConfiguration(t *testing.T) {
    ]`)
 
 	table, err := toml.Parse([]byte(config))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	inputs, ok := table.Fields["inputs"]
 	require.True(t, ok)


### PR DESCRIPTION
This closes https://github.com/influxdata/telegraf/issues/6107

PR contains a test definition to capture the regression scenario and an associated fix.

Oustanding question:

Was there a desire to parse these new `ost_jobstat` and `mds_jobstat` fields also? Do we need to support those field names as aliases?

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] ~Associated README.md updated.~
- [x] Has appropriate unit tests.
