### PR TITLE
aggregators: allow historical data in aggregators

### DIFF
--- a/docs/AGGREGATORS.md
+++ b/docs/AGGREGATORS.md
@@ -50,6 +50,8 @@ var sampleConfig = `
   ## If true drop_original will drop the original metrics and
   ## only send aggregates.
   drop_original = false
+  ## If true, metrics that fall outside the period won't be ignored.
+  # allow_historical = false
 `
 
 func (m *Min) Init() error {

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1493,6 +1493,8 @@
 #   ## If true, the original metric will be dropped by the
 #   ## aggregator and will not get sent to the output plugins.
 #   drop_original = false
+#   ## If true, metrics that fall outside the period won't be ignored.
+#   allow_historical = false
 #
 #   ## Configures which basic stats to push as fields
 #   # stats = ["count", "min", "max", "mean", "stdev", "s2", "sum"]
@@ -1505,6 +1507,8 @@
 #   ## If true, the original metric will be dropped by the
 #   ## aggregator and will not get sent to the output plugins.
 #   drop_original = false
+#   ## If true, metrics that fall outside the period won't be ignored.
+#   allow_historical = false
 #
 #   ## The time that a series is not updated until considering it final.
 #   series_timeout = "5m"
@@ -1518,6 +1522,9 @@
 #   ## If true, the original metric will be dropped by the
 #   ## aggregator and will not get sent to the output plugins.
 #   drop_original = false
+#
+#   ## If true, metrics that fall outside the period won't be ignored.
+#   allow_historical = false
 #
 #   ## If true, the histogram will be reset on flush instead
 #   ## of accumulating the results.
@@ -1548,6 +1555,8 @@
 #   ## If true, the original metric will be dropped by the
 #   ## aggregator and will not get sent to the output plugins.
 #   drop_original = false
+#   ## If true, metrics that fall outside the period won't be ignored.
+#   allow_historical = false
 
 
 # # Count the occurrence of values in fields.
@@ -1558,6 +1567,8 @@
 #   ## If true, the original metric will be dropped by the
 #   ## aggregator and will not get sent to the output plugins.
 #   drop_original = false
+#   ## If true, metrics that fall outside the period won't be ignored.
+#   allow_historical = false
 #   ## The fields for which the values will be counted
 #   fields = []
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1065,6 +1065,18 @@ func buildAggregator(name string, tbl *ast.Table) (*models.AggregatorConfig, err
 		}
 	}
 
+	if node, ok := tbl.Fields["allow_historical"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if b, ok := kv.Value.(*ast.Boolean); ok {
+				var err error
+				conf.AllowHistorical, err = strconv.ParseBool(b.Value)
+				if err != nil {
+					log.Printf("Error parsing boolean value for %s: %s\n", name, err)
+				}
+			}
+		}
+	}
+
 	if node, ok := tbl.Fields["name_prefix"]; ok {
 		if kv, ok := node.(*ast.KeyValue); ok {
 			if str, ok := kv.Value.(*ast.String); ok {
@@ -1101,6 +1113,7 @@ func buildAggregator(name string, tbl *ast.Table) (*models.AggregatorConfig, err
 	delete(tbl.Fields, "period")
 	delete(tbl.Fields, "delay")
 	delete(tbl.Fields, "drop_original")
+	delete(tbl.Fields, "allow_historical")
 	delete(tbl.Fields, "name_prefix")
 	delete(tbl.Fields, "name_suffix")
 	delete(tbl.Fields, "name_override")

--- a/plugins/aggregators/basicstats/basicstats.go
+++ b/plugins/aggregators/basicstats/basicstats.go
@@ -52,6 +52,8 @@ var sampleConfig = `
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.
   drop_original = false
+  ## If true, metrics that fall outside the period won't be ignored.
+  # allow_historical = false
 
   ## Configures which basic stats to push as fields
   # stats = ["count", "min", "max", "mean", "stdev", "s2", "sum"]

--- a/plugins/aggregators/final/final.go
+++ b/plugins/aggregators/final/final.go
@@ -14,6 +14,8 @@ var sampleConfig = `
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.
   drop_original = false
+  ## If true, metrics that fall outside the period won't be ignored.
+  # allow_historical = false
 
   ## The time that a series is not updated until considering it final.
   series_timeout = "5m"

--- a/plugins/aggregators/histogram/histogram.go
+++ b/plugins/aggregators/histogram/histogram.go
@@ -73,6 +73,9 @@ var sampleConfig = `
   ## aggregator and will not get sent to the output plugins.
   drop_original = false
 
+  ## If true, metrics that fall outside the period won't be ignored.
+  # allow_historical = false
+
   ## If true, the histogram will be reset on flush instead
   ## of accumulating the results.
   reset = false

--- a/plugins/aggregators/minmax/minmax.go
+++ b/plugins/aggregators/minmax/minmax.go
@@ -33,6 +33,8 @@ var sampleConfig = `
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.
   drop_original = false
+  ## If true, metrics that fall outside the period won't be ignored.
+  # allow_historical = false
 `
 
 func (m *MinMax) SampleConfig() string {

--- a/plugins/aggregators/valuecounter/valuecounter.go
+++ b/plugins/aggregators/valuecounter/valuecounter.go
@@ -36,6 +36,8 @@ var sampleConfig = `
   drop_original = false
   ## The fields for which the values will be counted
   fields = []
+  ## If true, metrics that fall outside the period won't be ignored.
+  # allow_historical = false
 `
 
 // SampleConfig generates a sample config for the ValueCounter plugin


### PR DESCRIPTION
Addresses https://github.com/influxdata/telegraf/issues/1992

This PR adds a boolean config to aggregator plugins, `allow_historical`, which overrides the default behavior of ignoring metrics outside the period of the plugin. This override is useful when aggregating old logs or metrics that are delayed beyond the period window.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
