### PR TITLE
Fix Statsd input panic when processing DataDog events

### DIFF
--- a/plugins/inputs/statsd/datadog_test.go
+++ b/plugins/inputs/statsd/datadog_test.go
@@ -74,7 +74,8 @@ func TestEventGather(t *testing.T) {
 	}
 	acc := &testutil.Accumulator{}
 	s := NewTestStatsd()
-	s.acc = acc
+	require.NoError(t, s.Start(acc))
+	defer s.Stop()
 
 	for i := range tests {
 		t.Run(tests[i].name, func(t *testing.T) {
@@ -379,11 +380,13 @@ func TestEvents(t *testing.T) {
 			},
 		},
 	}
+	s := NewTestStatsd()
+	acc := &testutil.Accumulator{}
+	require.NoError(t, s.Start(acc))
+	defer s.Stop()
 	for i := range tests {
 		t.Run(tests[i].name, func(t *testing.T) {
-			s := NewTestStatsd()
-			acc := &testutil.Accumulator{}
-			s.acc = acc
+			acc.ClearMetrics()
 			err := s.parseEventMessage(tests[i].args.now, tests[i].args.message, tests[i].args.hostname)
 			require.Nil(t, err)
 			m := acc.Metrics[0]
@@ -406,7 +409,10 @@ func TestEvents(t *testing.T) {
 func TestEventError(t *testing.T) {
 	now := time.Now()
 	s := NewTestStatsd()
-	s.acc = &testutil.Accumulator{}
+	acc := &testutil.Accumulator{}
+	require.NoError(t, s.Start(acc))
+	defer s.Stop()
+
 	// missing length header
 	err := s.parseEventMessage(now, "_e:title|text", "default-hostname")
 	require.Error(t, err)

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -309,11 +309,14 @@ func (s *Statsd) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (s *Statsd) Start(_ telegraf.Accumulator) error {
+func (s *Statsd) Start(ac telegraf.Accumulator) error {
 	if s.ParseDataDogTags {
 		s.DataDogExtensions = true
 		log.Printf("W! [inputs.statsd] The parse_data_dog_tags option is deprecated, use datadog_extensions instead.")
 	}
+
+	s.acc = ac
+
 	// Make data structures
 	s.gauges = make(map[string]cachedgauge)
 	s.counters = make(map[string]cachedcounter)


### PR DESCRIPTION
Fixes the folllowing panic that is caused by sending a Datadog event to the StatsD input

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1747ff7]

goroutine 12 [running]:
github.com/influxdata/telegraf/plugins/inputs/statsd.(*Statsd).parseEventMessage(0xc0001b8380, 0xbf434fd5f15bd546, 0xd7be3d60, 0x4554680, 0xc000286380, 0x3a, 0xc00
04b8060, 0x9, 0x1, 0x0)
        /go/src/github.com/influxdata/telegraf/plugins/inputs/statsd/datadog.go:136 +0x10a7
github.com/influxdata/telegraf/plugins/inputs/statsd.(*Statsd).parser(0xc0001b8380, 0x2695778, 0xc0001b8408)
        /go/src/github.com/influxdata/telegraf/plugins/inputs/statsd/statsd.go:502 +0x2fd
github.com/influxdata/telegraf/plugins/inputs/statsd.(*Statsd).Start.func4(0xc0001b8380)
        /go/src/github.com/influxdata/telegraf/plugins/inputs/statsd/statsd.go:401 +0x5a
created by github.com/influxdata/telegraf/plugins/inputs/statsd.(*Statsd).Start
        /go/src/github.com/influxdata/telegraf/plugins/inputs/statsd/statsd.go:399 +0x9a7
```

The PR adds the initialization of the accumulator used by the `parseEventMessage` function

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] ~Associated README.md updated.~
- [x] Has appropriate unit tests.
