### PR TITLE
Fix templating patterns wildcard matching

### DIFF
--- a/internal/templating/engine_test.go
+++ b/internal/templating/engine_test.go
@@ -3,6 +3,7 @@ package templating
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,4 +20,47 @@ func TestEngineAlternateSeparator(t *testing.T) {
 		"origin": "host01",
 	}, tags)
 	require.Equal(t, "", field)
+}
+
+func TestEngineWithWildcardTemplate(t *testing.T) {
+	var (
+		defaultTmpl, err = NewDefaultTemplateWithPattern("measurement*")
+		templates        = []string{
+			"taskmanagerTask.alarm-detector.Assign.alarmDefinitionId metricsType.process.nodeId.x.alarmDefinitionId.measurement.field rule=1",
+			"taskmanagerTask.*.*.*.*                                 metricsType.process.nodeId.measurement rule=2",
+		}
+
+		lineOne = "taskmanagerTask.alarm-detector.Assign.alarmDefinitionId.timeout_errors.duration.p75"
+		lineTwo = "taskmanagerTask.alarm-detector.Assign.numRecordsInPerSecond.m5_rate"
+	)
+	require.NoError(t, err)
+
+	engine, err := NewEngine(".", defaultTmpl, templates)
+	require.NoError(t, err)
+
+	measurement, tags, field, err := engine.Apply(lineOne)
+	require.NoError(t, err)
+
+	assert.Equal(t, "duration", measurement)
+	assert.Equal(t, "p75", field)
+	assert.Equal(t, map[string]string{
+		"metricsType":       "taskmanagerTask",
+		"process":           "alarm-detector",
+		"nodeId":            "Assign",
+		"x":                 "alarmDefinitionId",
+		"alarmDefinitionId": "timeout_errors",
+		"rule":              "1",
+	}, tags)
+
+	measurement, tags, field, err = engine.Apply(lineTwo)
+	require.NoError(t, err)
+
+	assert.Equal(t, "numRecordsInPerSecond", measurement)
+	assert.Equal(t, "", field)
+	assert.Equal(t, map[string]string{
+		"metricsType": "taskmanagerTask",
+		"process":     "alarm-detector",
+		"nodeId":      "Assign",
+		"rule":        "2",
+	}, tags)
 }

--- a/internal/templating/node.go
+++ b/internal/templating/node.go
@@ -65,8 +65,10 @@ func (n *node) recursiveSearch(lineParts []string) *Template {
 		length      = len(n.children)
 	)
 
-	// search children excluding wildcard match has been
-	// artifically sorted to the end of the children set
+	// exclude last child from search if it is a wildcard. sort.Search expects
+	// a lexicographically sorted set of children and we have artificially sorted
+	// wildcards to the end of the child set
+	// wildcards will be searched seperately if no exact match is found
 	if hasWildcard = n.children[length-1].value == "*"; hasWildcard {
 		length--
 	}
@@ -84,9 +86,9 @@ func (n *node) recursiveSearch(lineParts []string) *Template {
 		}
 	}
 
-	// if last child is a wildcard
+	// given no template is found and the last child is a wildcard
 	if hasWildcard {
-		// descend the wildcard node
+		// also search the wildcard child node
 		return n.children[length].recursiveSearch(lineParts[1:])
 	}
 


### PR DESCRIPTION
Closes: https://github.com/influxdata/telegraf/issues/5894

This fixes an issue within templating rules used by line formats like the graphite format. The templating rules do not exhaustively explore all matches. The moment a match is found at any level, if the search fails to match the filters children it will bail out and return a nil template (which gets replace by teh caller with a default template).

Instead the template should return to the previous successful match and check to see if a wildcard exists which can also be explored.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
