### PR TITLE
Add documentation regarding collecting invalid certs

### DIFF
--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -3,6 +3,8 @@
 This plugin provides information about X509 certificate accessible via local
 file or network connection.
 
+In order to always fetch cert information, it is suggested that you use `insecure_skip_verify = true` as telegraf fails to collect information on invalid certs without it.
+
 
 ### Configuration
 

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -52,6 +52,7 @@ func TestGatherRemote(t *testing.T) {
 		{name: "successful https", server: "https://example.org:443", timeout: 5},
 		{name: "successful file", server: "file://" + tmpfile.Name(), timeout: 5},
 		{name: "unsupported scheme", server: "foo://", timeout: 5, error: true},
+		{name: "expired certificate", server: "https://expired.badssl.com:443", timeout: 5},
 		{name: "no certificate", timeout: 5, unset: true, error: true},
 		{name: "closed connection", close: true, error: true},
 		{name: "no handshake", timeout: 5, noshake: true, error: true},


### PR DESCRIPTION
Resolves #6066

I wonder if a better solution would be to always enable `insecure_skip_verify`. The tests set it by default.