### PR TITLE
Add certificate verification status to x509_cert input

### DIFF
--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -19,9 +19,6 @@ file or network connection.
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
-
-  ## Use TLS but skip chain & host verification
-  # insecure_skip_verify = false
 ```
 
 
@@ -35,7 +32,10 @@ file or network connection.
     - country
     - province
     - locality
+    - validation
   - fields:
+    - validation (int)
+    - validation_error (string)
     - expiry (int, seconds)
     - age (int, seconds)
     - startdate (int, seconds)
@@ -45,6 +45,8 @@ file or network connection.
 ### Example output
 
 ```
-x509_cert,host=myhost,source=https://example.org age=1753627i,expiry=5503972i,startdate=1516092060i,enddate=1523349660i 1517845687000000000
-x509_cert,host=myhost,source=/etc/ssl/certs/ssl-cert-snakeoil.pem age=7522207i,expiry=308002732i,startdate=1510323480i,enddate=1825848420i 1517845687000000000
+x509_cert,common_name=ubuntu,source=/etc/ssl/certs/ssl-cert-snakeoil.pem,validation=success age=7693222i,enddate=1871249033i,expiry=307666777i,startdate=1555889033i,validation=0i 1563582256000000000
+x509_cert,common_name=www.example.org,country=US,locality=Los\ Angeles,organization=Internet\ Corporation\ for\ Assigned\ Names\ and\ Numbers,organizational_unit=Technology,province=California,source=https://example.org:443,validation=fail age=20219055i,enddate=1606910400i,expiry=43328144i,startdate=1543363200i,validation=1i,validation_error="x509: certificate signed by unknown authority" 1563582256000000000
+x509_cert,common_name=DigiCert\ SHA2\ Secure\ Server\ CA,country=US,organization=DigiCert\ Inc,source=https://example.org:443,validation=success age=200838255i,enddate=1678276800i,expiry=114694544i,startdate=1362744000i,validation=0i 1563582256000000000
+x509_cert,common_name=DigiCert\ Global\ Root\ CA,country=US,organization=DigiCert\ Inc,organizational_unit=www.digicert.com,source=https://example.org:443,validation=success age=400465455i,enddate=1952035200i,expiry=388452944i,startdate=1163116800i,validation=0i 1563582256000000000
 ```

--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -32,10 +32,10 @@ file or network connection.
     - country
     - province
     - locality
-    - validation
+    - verification
   - fields:
-    - validation (int)
-    - validation_error (string)
+    - verification_code (int)
+    - verification_error (string)
     - expiry (int, seconds)
     - age (int, seconds)
     - startdate (int, seconds)
@@ -45,8 +45,8 @@ file or network connection.
 ### Example output
 
 ```
-x509_cert,common_name=ubuntu,source=/etc/ssl/certs/ssl-cert-snakeoil.pem,validation=success age=7693222i,enddate=1871249033i,expiry=307666777i,startdate=1555889033i,validation=0i 1563582256000000000
-x509_cert,common_name=www.example.org,country=US,locality=Los\ Angeles,organization=Internet\ Corporation\ for\ Assigned\ Names\ and\ Numbers,organizational_unit=Technology,province=California,source=https://example.org:443,validation=fail age=20219055i,enddate=1606910400i,expiry=43328144i,startdate=1543363200i,validation=1i,validation_error="x509: certificate signed by unknown authority" 1563582256000000000
-x509_cert,common_name=DigiCert\ SHA2\ Secure\ Server\ CA,country=US,organization=DigiCert\ Inc,source=https://example.org:443,validation=success age=200838255i,enddate=1678276800i,expiry=114694544i,startdate=1362744000i,validation=0i 1563582256000000000
-x509_cert,common_name=DigiCert\ Global\ Root\ CA,country=US,organization=DigiCert\ Inc,organizational_unit=www.digicert.com,source=https://example.org:443,validation=success age=400465455i,enddate=1952035200i,expiry=388452944i,startdate=1163116800i,validation=0i 1563582256000000000
+x509_cert,common_name=ubuntu,source=/etc/ssl/certs/ssl-cert-snakeoil.pem,verification=valid age=7693222i,enddate=1871249033i,expiry=307666777i,startdate=1555889033i,verification_code=0i 1563582256000000000
+x509_cert,common_name=www.example.org,country=US,locality=Los\ Angeles,organization=Internet\ Corporation\ for\ Assigned\ Names\ and\ Numbers,organizational_unit=Technology,province=California,source=https://example.org:443,verification=invalid age=20219055i,enddate=1606910400i,expiry=43328144i,startdate=1543363200i,verification_code=1i,verification_error="x509: certificate signed by unknown authority" 1563582256000000000
+x509_cert,common_name=DigiCert\ SHA2\ Secure\ Server\ CA,country=US,organization=DigiCert\ Inc,source=https://example.org:443,verification=valid age=200838255i,enddate=1678276800i,expiry=114694544i,startdate=1362744000i,verification_code=0i 1563582256000000000
+x509_cert,common_name=DigiCert\ Global\ Root\ CA,country=US,organization=DigiCert\ Inc,organizational_unit=www.digicert.com,source=https://example.org:443,verification=valid age=400465455i,enddate=1952035200i,expiry=388452944i,startdate=1163116800i,verification_code=0i 1563582256000000000
 ```

--- a/plugins/inputs/x509_cert/dev/telegraf.conf
+++ b/plugins/inputs/x509_cert/dev/telegraf.conf
@@ -1,5 +1,4 @@
 [[inputs.x509_cert]]
-    sources = ["https://www.influxdata.com:443"]
+  sources = ["https://expired.badssl.com:443", "https://wrong.host.badssl.com:443"]
 
 [[outputs.file]]
-  files = ["stdout"]

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -187,11 +187,11 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 			_, err = cert.Verify(opts)
 			if err == nil {
 				tags["verification"] = "valid"
-				fields["verification"] = 0
+				fields["verification_code"] = 0
 			} else {
 				tags["verification"] = "invalid"
-				fields["verification"] = 1
-				fields["validation_error"] = err.Error()
+				fields["verification_code"] = 1
+				fields["verification_error"] = err.Error()
 			}
 
 			acc.AddFields("x509_cert", fields, tags)

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -110,6 +110,7 @@ func TestGatherRemote(t *testing.T) {
 				Sources: []string{test.server},
 				Timeout: internal.Duration{Duration: test.timeout},
 			}
+			sc.Init()
 
 			sc.InsecureSkipVerify = true
 			testErr := false
@@ -169,6 +170,7 @@ func TestGatherLocal(t *testing.T) {
 			sc := X509Cert{
 				Sources: []string{f.Name()},
 			}
+			sc.Init()
 
 			error := false
 
@@ -218,6 +220,7 @@ func TestGatherChain(t *testing.T) {
 			sc := X509Cert{
 				Sources: []string{f.Name()},
 			}
+			sc.Init()
 
 			error := false
 
@@ -237,6 +240,7 @@ func TestGatherChain(t *testing.T) {
 
 func TestStrings(t *testing.T) {
 	sc := X509Cert{}
+	sc.Init()
 
 	tests := []struct {
 		name     string
@@ -265,6 +269,7 @@ func TestGatherCert(t *testing.T) {
 	m := &X509Cert{
 		Sources: []string{"https://www.influxdata.com:443"},
 	}
+	m.Init()
 
 	var acc testutil.Accumulator
 	err := m.Gather(&acc)


### PR DESCRIPTION
Resolves #4877 

This always sets `insecure_skip_verify` as it verifies the cert once it's been collected/parsed.

To verify a self-signed cert (remote endpoint or file), set the `tls_ca` to the self-signing ca, or the self-signed cert itself for validation to be successful.

Alternate to #6139