### PR TITLE
Add Start() function to DockerLogs input plugin

### DIFF
--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -68,6 +68,8 @@ const (
 
 var (
 	containerStates = []string{"created", "restarting", "running", "removing", "paused", "exited", "dead"}
+	// ensure *DockerLogs implements telegaf.ServiceInput
+	_ telegraf.ServiceInput = (*DockerLogs)(nil)
 )
 
 type DockerLogs struct {
@@ -378,6 +380,12 @@ func tailMultiplexed(
 	src.Close()
 	wg.Wait()
 	return err
+}
+
+// Start is a noop which is required for a *DockerLogs to implement
+// the telegraf.ServiceInput interface
+func (d *DockerLogs) Start(telegraf.Accumulator) error {
+	return nil
 }
 
 func (d *DockerLogs) Stop() {


### PR DESCRIPTION
Closes: https://github.com/influxdata/telegraf/issues/6146

This is required in order for the docker_logs input plugin to be treated as a service input. Rather than just a regular input. This ensures that Stop is called and that the input channel within the accumulator is not closed before all the logs calls have exited and have stopped sending on the it.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
