### PR TITLE
Allow stateful parsers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -980,17 +980,6 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 	}
 	input := creator()
 
-	// If the input has a SetParser function, then this means it can accept
-	// arbitrary types of input, so build the parser and set it.
-	switch t := input.(type) {
-	case parsers.ParserInput:
-		parser, err := buildParser(name, table)
-		if err != nil {
-			return err
-		}
-		t.SetParser(parser)
-	}
-
 	switch t := input.(type) {
 	case parsers.ParserFuncInput:
 		config, err := getParserConfig(name, table)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -151,7 +151,7 @@ func TestConfig_LoadDirectory(t *testing.T) {
 		DataFormat: "json",
 	})
 	assert.NoError(t, err)
-	ex.SetParser(p)
+	ex.SetParserFunc(func() parsers.Parser { return p })
 	ex.Command = "/usr/bin/myothercollector --foo=bar"
 	eConfig := &models.InputConfig{
 		Name:              "exec",

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -22,6 +22,8 @@ const (
 	defaultMaxUndeliveredMessages = 1000
 )
 
+var _ parsers.ParserFuncInput = (*AMQPConsumer)(nil)
+
 type empty struct{}
 type semaphore chan empty
 
@@ -172,8 +174,8 @@ func (a *AMQPConsumer) Description() string {
 	return "AMQP consumer plugin"
 }
 
-func (a *AMQPConsumer) SetParserFunc(fn func() parsers.Parser) {
-	a.parser = fn()
+func (a *AMQPConsumer) SetParserFunc(fn parsers.ParserFunc) {
+	a.parser, _ = fn()
 }
 
 // All gathering is done in the Start function

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -172,8 +172,8 @@ func (a *AMQPConsumer) Description() string {
 	return "AMQP consumer plugin"
 }
 
-func (a *AMQPConsumer) SetParser(parser parsers.Parser) {
-	a.parser = parser
+func (a *AMQPConsumer) SetParserFunc(fn func() parsers.Parser) {
+	a.parser = fn()
 }
 
 // All gathering is done in the Start function

--- a/plugins/inputs/cloud_pubsub/pubsub.go
+++ b/plugins/inputs/cloud_pubsub/pubsub.go
@@ -24,6 +24,8 @@ type semaphore chan empty
 const defaultMaxUndeliveredMessages = 1000
 const defaultRetryDelaySeconds = 5
 
+var _ parsers.ParserFuncInput = (*PubSub)(nil)
+
 type PubSub struct {
 	sync.Mutex
 
@@ -71,8 +73,8 @@ func (ps *PubSub) Gather(acc telegraf.Accumulator) error {
 }
 
 // SetParserFunc implements ParserFuncInput interface.
-func (ps *PubSub) SetParserFunc(fn func() parsers.Parser) {
-	ps.parser = fn()
+func (ps *PubSub) SetParserFunc(fn parsers.ParserFunc) {
+	ps.parser, _ = fn()
 }
 
 // Start initializes the plugin and processing messages from Google PubSub.

--- a/plugins/inputs/cloud_pubsub/pubsub.go
+++ b/plugins/inputs/cloud_pubsub/pubsub.go
@@ -5,16 +5,17 @@ import (
 	"fmt"
 	"sync"
 
-	"cloud.google.com/go/pubsub"
 	"encoding/base64"
+	"log"
+	"time"
+
+	"cloud.google.com/go/pubsub"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
-	"log"
-	"time"
 )
 
 type empty struct{}
@@ -69,9 +70,9 @@ func (ps *PubSub) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-// SetParser implements ParserInput interface.
-func (ps *PubSub) SetParser(parser parsers.Parser) {
-	ps.parser = parser
+// SetParserFunc implements ParserFuncInput interface.
+func (ps *PubSub) SetParserFunc(fn func() parsers.Parser) {
+	ps.parser = fn()
 }
 
 // Start initializes the plugin and processing messages from Google PubSub.

--- a/plugins/inputs/cloud_pubsub_push/pubsub_push.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push.go
@@ -25,6 +25,8 @@ import (
 const defaultMaxBodySize = 500 * 1024 * 1024
 const defaultMaxUndeliveredMessages = 1000
 
+var _ parsers.ParserFuncInput = (*PubSubPush)(nil)
+
 type PubSubPush struct {
 	ServiceAddress string
 	Token          string
@@ -125,8 +127,8 @@ func (p *PubSubPush) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (p *PubSubPush) SetParserFunc(fn func() parsers.Parser) {
-	p.Parser = fn()
+func (p *PubSubPush) SetParserFunc(fn parsers.ParserFunc) {
+	p.Parser, _ = fn()
 }
 
 // Start starts the http listener service.

--- a/plugins/inputs/cloud_pubsub_push/pubsub_push.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push.go
@@ -125,8 +125,8 @@ func (p *PubSubPush) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (p *PubSubPush) SetParser(parser parsers.Parser) {
-	p.Parser = parser
+func (p *PubSubPush) SetParserFunc(fn func() parsers.Parser) {
+	p.Parser = fn()
 }
 
 // Start starts the http listener service.

--- a/plugins/inputs/cloud_pubsub_push/pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push_test.go
@@ -139,7 +139,7 @@ func TestServeHTTP(t *testing.T) {
 			MetricName: "cloud_pubsub_push",
 			DataFormat: "influx",
 		})
-		pubPush.SetParserFunc(func() parsers.Parser { return p })
+		pubPush.SetParserFunc(func() (parsers.Parser, error) { return p, nil })
 
 		dst := make(chan telegraf.Metric, 1)
 		ro := models.NewRunningOutput("test", &testOutput{failWrite: test.fail}, &models.OutputConfig{}, 1, 1)

--- a/plugins/inputs/cloud_pubsub_push/pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push_test.go
@@ -139,7 +139,7 @@ func TestServeHTTP(t *testing.T) {
 			MetricName: "cloud_pubsub_push",
 			DataFormat: "influx",
 		})
-		pubPush.SetParser(p)
+		pubPush.SetParserFunc(func() parsers.Parser { return p })
 
 		dst := make(chan telegraf.Metric, 1)
 		ro := models.NewRunningOutput("test", &testOutput{failWrite: test.fail}, &models.OutputConfig{}, 1, 1)

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -20,6 +20,8 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers/nagios"
 )
 
+var _ parsers.ParserFuncInput = (*Exec)(nil)
+
 const sampleConfig = `
   ## Commands array
   commands = [
@@ -178,8 +180,8 @@ func (e *Exec) Description() string {
 	return "Read metrics from one or more commands that can output to stdout"
 }
 
-func (e *Exec) SetParserFunc(fn func() parsers.Parser) {
-	e.parser = fn()
+func (e *Exec) SetParserFunc(fn parsers.ParserFunc) {
+	e.parser, _ = fn()
 }
 
 func (e *Exec) Gather(acc telegraf.Accumulator) error {

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -178,8 +178,8 @@ func (e *Exec) Description() string {
 	return "Read metrics from one or more commands that can output to stdout"
 }
 
-func (e *Exec) SetParser(parser parsers.Parser) {
-	e.parser = parser
+func (e *Exec) SetParserFunc(fn func() parsers.Parser) {
+	e.parser = fn()
 }
 
 func (e *Exec) Gather(acc telegraf.Accumulator) error {

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -156,7 +156,7 @@ func TestExecCommandWithGlob(t *testing.T) {
 	parser, _ := parsers.NewValueParser("metric", "string", nil)
 	e := NewExec()
 	e.Commands = []string{"/bin/ech* metric_value"}
-	e.SetParserFunc(func() parsers.Parser { return parser })
+	e.SetParserFunc(func() (parsers.Parser, error) { return parser, nil })
 
 	var acc testutil.Accumulator
 	err := acc.GatherError(e.Gather)
@@ -172,7 +172,7 @@ func TestExecCommandWithoutGlob(t *testing.T) {
 	parser, _ := parsers.NewValueParser("metric", "string", nil)
 	e := NewExec()
 	e.Commands = []string{"/bin/echo metric_value"}
-	e.SetParserFunc(func() parsers.Parser { return parser })
+	e.SetParserFunc(func() (parsers.Parser, error) { return parser, nil })
 
 	var acc testutil.Accumulator
 	err := acc.GatherError(e.Gather)
@@ -188,7 +188,7 @@ func TestExecCommandWithoutGlobAndPath(t *testing.T) {
 	parser, _ := parsers.NewValueParser("metric", "string", nil)
 	e := NewExec()
 	e.Commands = []string{"echo metric_value"}
-	e.SetParserFunc(func() parsers.Parser { return parser })
+	e.SetParserFunc(func() (parsers.Parser, error) { return parser, nil })
 
 	var acc testutil.Accumulator
 	err := acc.GatherError(e.Gather)

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -156,7 +156,7 @@ func TestExecCommandWithGlob(t *testing.T) {
 	parser, _ := parsers.NewValueParser("metric", "string", nil)
 	e := NewExec()
 	e.Commands = []string{"/bin/ech* metric_value"}
-	e.SetParser(parser)
+	e.SetParserFunc(func() parsers.Parser { return parser })
 
 	var acc testutil.Accumulator
 	err := acc.GatherError(e.Gather)
@@ -172,7 +172,7 @@ func TestExecCommandWithoutGlob(t *testing.T) {
 	parser, _ := parsers.NewValueParser("metric", "string", nil)
 	e := NewExec()
 	e.Commands = []string{"/bin/echo metric_value"}
-	e.SetParser(parser)
+	e.SetParserFunc(func() parsers.Parser { return parser })
 
 	var acc testutil.Accumulator
 	err := acc.GatherError(e.Gather)
@@ -188,7 +188,7 @@ func TestExecCommandWithoutGlobAndPath(t *testing.T) {
 	parser, _ := parsers.NewValueParser("metric", "string", nil)
 	e := NewExec()
 	e.Commands = []string{"echo metric_value"}
-	e.SetParser(parser)
+	e.SetParserFunc(func() parsers.Parser { return parser })
 
 	var acc testutil.Accumulator
 	err := acc.GatherError(e.Gather)

--- a/plugins/inputs/file/file.go
+++ b/plugins/inputs/file/file.go
@@ -11,8 +11,8 @@ import (
 )
 
 type File struct {
-	Files  []string `toml:"files"`
-	parser parsers.Parser
+	Files      []string `toml:"files"`
+	parserFunc func() parsers.Parser
 
 	filenames []string
 }
@@ -60,8 +60,8 @@ func (f *File) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (f *File) SetParser(p parsers.Parser) {
-	f.parser = p
+func (f *File) SetParserFunc(fn func() parsers.Parser) {
+	f.parserFunc = fn
 }
 
 func (f *File) refreshFilePaths() error {
@@ -87,8 +87,8 @@ func (f *File) readMetric(filename string) ([]telegraf.Metric, error) {
 	if err != nil {
 		return nil, fmt.Errorf("E! Error file: %v could not be read, %s", filename, err)
 	}
-	return f.parser.Parse(fileContents)
 
+	return f.parserFunc().Parse(fileContents)
 }
 
 func init() {

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -33,8 +33,8 @@ func TestJSONParserCompile(t *testing.T) {
 	}
 	nParser, err := parsers.NewParser(&parserConfig)
 	assert.NoError(t, err)
-	r.parserFunc = func() parsers.Parser {
-		return nParser
+	r.parserFunc = func() (parsers.Parser, error) {
+		return nParser, nil
 	}
 
 	r.Gather(&acc)
@@ -55,7 +55,7 @@ func TestGrokParser(t *testing.T) {
 	}
 
 	nParser, err := parsers.NewParser(&parserConfig)
-	r.parserFunc = func() parsers.Parser { return nParser }
+	r.parserFunc = func() (parsers.Parser, error) { return nParser, nil }
 	assert.NoError(t, err)
 
 	err = r.Gather(&acc)

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -33,7 +33,9 @@ func TestJSONParserCompile(t *testing.T) {
 	}
 	nParser, err := parsers.NewParser(&parserConfig)
 	assert.NoError(t, err)
-	r.parser = nParser
+	r.parserFunc = func() parsers.Parser {
+		return nParser
+	}
 
 	r.Gather(&acc)
 	assert.Equal(t, map[string]string{"parent_ignored_child": "hi"}, acc.Metrics[0].Tags)
@@ -53,7 +55,7 @@ func TestGrokParser(t *testing.T) {
 	}
 
 	nParser, err := parsers.NewParser(&parserConfig)
-	r.parser = nParser
+	r.parserFunc = func() parsers.Parser { return nParser }
 	assert.NoError(t, err)
 
 	err = r.Gather(&acc)

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -16,6 +16,8 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers"
 )
 
+var _ parsers.ParserFuncInput = (*HTTP)(nil)
+
 type HTTP struct {
 	URLs            []string `toml:"urls"`
 	Method          string   `toml:"method"`
@@ -124,8 +126,8 @@ func (h *HTTP) Gather(acc telegraf.Accumulator) error {
 }
 
 // SetParserFunc takes the data_format from the config and finds the right parser for that format
-func (h *HTTP) SetParserFunc(fn func() parsers.Parser) {
-	h.parser = fn()
+func (h *HTTP) SetParserFunc(fn parsers.ParserFunc) {
+	h.parser, _ = fn()
 }
 
 // Gathers data from a particular URL

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -34,7 +34,7 @@ type HTTP struct {
 	client *http.Client
 
 	// The parser will automatically be set by Telegraf core code because
-	// this plugin implements the ParserInput interface (i.e. the SetParser method)
+	// this plugin implements the ParserInput interface (i.e. the SetParserFunc method)
 	parser parsers.Parser
 }
 
@@ -123,9 +123,9 @@ func (h *HTTP) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-// SetParser takes the data_format from the config and finds the right parser for that format
-func (h *HTTP) SetParser(parser parsers.Parser) {
-	h.parser = parser
+// SetParserFunc takes the data_format from the config and finds the right parser for that format
+func (h *HTTP) SetParserFunc(fn func() parsers.Parser) {
+	h.parser = fn()
 }
 
 // Gathers data from a particular URL

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -34,7 +34,7 @@ func TestHTTPwithJSONFormat(t *testing.T) {
 		DataFormat: "json",
 		MetricName: "metricName",
 	})
-	plugin.SetParserFunc(func() parsers.Parser { return p })
+	plugin.SetParserFunc(func() (parsers.Parser, error) { return p, nil })
 
 	var acc testutil.Accumulator
 	plugin.Init()
@@ -76,7 +76,7 @@ func TestHTTPHeaders(t *testing.T) {
 		DataFormat: "json",
 		MetricName: "metricName",
 	})
-	plugin.SetParserFunc(func() parsers.Parser { return p })
+	plugin.SetParserFunc(func() (parsers.Parser, error) { return p, nil })
 
 	var acc testutil.Accumulator
 	plugin.Init()
@@ -99,7 +99,7 @@ func TestInvalidStatusCode(t *testing.T) {
 		DataFormat: "json",
 		MetricName: metricName,
 	})
-	plugin.SetParserFunc(func() parsers.Parser { return p })
+	plugin.SetParserFunc(func() (parsers.Parser, error) { return p, nil })
 
 	var acc testutil.Accumulator
 	plugin.Init()
@@ -125,7 +125,7 @@ func TestMethod(t *testing.T) {
 		DataFormat: "json",
 		MetricName: "metricName",
 	})
-	plugin.SetParserFunc(func() parsers.Parser { return p })
+	plugin.SetParserFunc(func() (parsers.Parser, error) { return p, nil })
 
 	var acc testutil.Accumulator
 	plugin.Init()
@@ -219,7 +219,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 			p, err := parsers.NewParser(&parsers.Config{DataFormat: "influx"})
 			require.NoError(t, err)
 
-			tt.plugin.SetParserFunc(func() parsers.Parser { return p })
+			tt.plugin.SetParserFunc(func() (parsers.Parser, error) { return p, nil })
 
 			var acc testutil.Accumulator
 			tt.plugin.Init()

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -34,7 +34,7 @@ func TestHTTPwithJSONFormat(t *testing.T) {
 		DataFormat: "json",
 		MetricName: "metricName",
 	})
-	plugin.SetParser(p)
+	plugin.SetParserFunc(func() parsers.Parser { return p })
 
 	var acc testutil.Accumulator
 	plugin.Init()
@@ -76,7 +76,7 @@ func TestHTTPHeaders(t *testing.T) {
 		DataFormat: "json",
 		MetricName: "metricName",
 	})
-	plugin.SetParser(p)
+	plugin.SetParserFunc(func() parsers.Parser { return p })
 
 	var acc testutil.Accumulator
 	plugin.Init()
@@ -99,7 +99,7 @@ func TestInvalidStatusCode(t *testing.T) {
 		DataFormat: "json",
 		MetricName: metricName,
 	})
-	plugin.SetParser(p)
+	plugin.SetParserFunc(func() parsers.Parser { return p })
 
 	var acc testutil.Accumulator
 	plugin.Init()
@@ -125,7 +125,7 @@ func TestMethod(t *testing.T) {
 		DataFormat: "json",
 		MetricName: "metricName",
 	})
-	plugin.SetParser(p)
+	plugin.SetParserFunc(func() parsers.Parser { return p })
 
 	var acc testutil.Accumulator
 	plugin.Init()
@@ -216,10 +216,10 @@ func TestBodyAndContentEncoding(t *testing.T) {
 				tt.queryHandlerFunc(t, w, r)
 			})
 
-			parser, err := parsers.NewParser(&parsers.Config{DataFormat: "influx"})
+			p, err := parsers.NewParser(&parsers.Config{DataFormat: "influx"})
 			require.NoError(t, err)
 
-			tt.plugin.SetParser(parser)
+			tt.plugin.SetParserFunc(func() parsers.Parser { return p })
 
 			var acc testutil.Accumulator
 			tt.plugin.Init()

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -30,6 +30,8 @@ const (
 	query = "query"
 )
 
+var _ parsers.ParserFuncInput = (*HTTPListenerV2)(nil)
+
 // TimeFunc provides a timestamp for the metrics
 type TimeFunc func() time.Time
 
@@ -112,8 +114,8 @@ func (h *HTTPListenerV2) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (h *HTTPListenerV2) SetParserFunc(fn func() parsers.Parser) {
-	h.Parser = fn()
+func (h *HTTPListenerV2) SetParserFunc(fn parsers.ParserFunc) {
+	h.Parser, _ = fn()
 }
 
 // Start starts the http listener service.

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -112,8 +112,8 @@ func (h *HTTPListenerV2) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (h *HTTPListenerV2) SetParser(parser parsers.Parser) {
-	h.Parser = parser
+func (h *HTTPListenerV2) SetParserFunc(fn func() parsers.Parser) {
+	h.Parser = fn()
 }
 
 // Start starts the http listener service.

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -19,6 +19,8 @@ const (
 	defaultMaxUndeliveredMessages = 1000
 )
 
+var _ parsers.ParserFuncInput = (*Kafka)(nil)
+
 type empty struct{}
 type semaphore chan empty
 
@@ -118,8 +120,8 @@ func (k *Kafka) Description() string {
 	return "Read metrics from Kafka topic(s)"
 }
 
-func (k *Kafka) SetParserFunc(fn func() parsers.Parser) {
-	k.parser = fn()
+func (k *Kafka) SetParserFunc(fn parsers.ParserFunc) {
+	k.parser, _ = fn()
 }
 
 func (k *Kafka) Start(acc telegraf.Accumulator) error {

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -118,8 +118,8 @@ func (k *Kafka) Description() string {
 	return "Read metrics from Kafka topic(s)"
 }
 
-func (k *Kafka) SetParser(parser parsers.Parser) {
-	k.parser = parser
+func (k *Kafka) SetParserFunc(fn func() parsers.Parser) {
+	k.parser = fn()
 }
 
 func (k *Kafka) Start(acc telegraf.Accumulator) error {

--- a/plugins/inputs/kafka_consumer/kafka_consumer_integration_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_integration_test.go
@@ -41,7 +41,7 @@ func TestReadsMetricsFromKafka(t *testing.T) {
 		Offset:        "oldest",
 	}
 	p, _ := parsers.NewInfluxParser()
-	k.SetParserFunc(func() parsers.Parser { return p })
+	k.SetParserFunc(func() (parsers.Parser, error) { return p, nil })
 
 	// Verify that we can now gather the sent message
 	var acc testutil.Accumulator

--- a/plugins/inputs/kafka_consumer/kafka_consumer_integration_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_integration_test.go
@@ -41,7 +41,7 @@ func TestReadsMetricsFromKafka(t *testing.T) {
 		Offset:        "oldest",
 	}
 	p, _ := parsers.NewInfluxParser()
-	k.SetParser(p)
+	k.SetParserFunc(func() parsers.Parser { return p })
 
 	// Verify that we can now gather the sent message
 	var acc testutil.Accumulator

--- a/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy.go
+++ b/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy.go
@@ -14,6 +14,8 @@ import (
 	"github.com/wvanbergen/kafka/consumergroup"
 )
 
+var _ parsers.ParserFuncInput = (*Kafka)(nil)
+
 type Kafka struct {
 	ConsumerGroup   string
 	Topics          []string
@@ -77,8 +79,8 @@ func (k *Kafka) Description() string {
 	return "Read metrics from Kafka topic(s)"
 }
 
-func (k *Kafka) SetParserFunc(fn func() parsers.Parser) {
-	k.parser = fn()
+func (k *Kafka) SetParserFunc(fn parsers.ParserFunc) {
+	k.parser, _ = fn()
 }
 
 func (k *Kafka) Start(acc telegraf.Accumulator) error {

--- a/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy.go
+++ b/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy.go
@@ -77,8 +77,8 @@ func (k *Kafka) Description() string {
 	return "Read metrics from Kafka topic(s)"
 }
 
-func (k *Kafka) SetParser(parser parsers.Parser) {
-	k.parser = parser
+func (k *Kafka) SetParserFunc(fn func() parsers.Parser) {
+	k.parser = fn()
 }
 
 func (k *Kafka) Start(acc telegraf.Accumulator) error {

--- a/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go
+++ b/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go
@@ -44,7 +44,7 @@ func TestReadsMetricsFromKafka(t *testing.T) {
 		Offset:         "oldest",
 	}
 	p, _ := parsers.NewInfluxParser()
-	k.SetParserFunc(func() parsers.Parser { return p })
+	k.SetParserFunc(func() (parsers.Parser, error) { return p, nil })
 
 	// Verify that we can now gather the sent message
 	var acc testutil.Accumulator

--- a/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go
+++ b/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go
@@ -44,7 +44,7 @@ func TestReadsMetricsFromKafka(t *testing.T) {
 		Offset:         "oldest",
 	}
 	p, _ := parsers.NewInfluxParser()
-	k.SetParser(p)
+	k.SetParserFunc(func() parsers.Parser { return p })
 
 	// Verify that we can now gather the sent message
 	var acc testutil.Accumulator

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -20,6 +20,8 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers"
 )
 
+var _ parsers.ParserFuncInput = (*KinesisConsumer)(nil)
+
 type (
 	DynamoDB struct {
 		AppName   string `toml:"app_name"`
@@ -133,8 +135,8 @@ func (k *KinesisConsumer) Description() string {
 	return "Configuration for the AWS Kinesis input."
 }
 
-func (k *KinesisConsumer) SetParserFunc(fn func() parsers.Parser) {
-	k.parser = fn()
+func (k *KinesisConsumer) SetParserFunc(fn parsers.ParserFunc) {
+	k.parser, _ = fn()
 }
 
 func (k *KinesisConsumer) connect(ac telegraf.Accumulator) error {

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -133,8 +133,8 @@ func (k *KinesisConsumer) Description() string {
 	return "Configuration for the AWS Kinesis input."
 }
 
-func (k *KinesisConsumer) SetParser(parser parsers.Parser) {
-	k.parser = parser
+func (k *KinesisConsumer) SetParserFunc(fn func() parsers.Parser) {
+	k.parser = fn()
 }
 
 func (k *KinesisConsumer) connect(ac telegraf.Accumulator) error {

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -21,6 +21,8 @@ var (
 	defaultConnectionTimeout = internal.Duration{Duration: 30 * time.Second}
 
 	defaultMaxUndeliveredMessages = 1000
+
+	_ parsers.ParserFuncInput = (*MQTTConsumer)(nil)
 )
 
 type ConnectionState int
@@ -129,8 +131,8 @@ func (m *MQTTConsumer) Description() string {
 	return "Read metrics from MQTT topic(s)"
 }
 
-func (m *MQTTConsumer) SetParserFunc(fn func() parsers.Parser) {
-	m.parser = fn()
+func (m *MQTTConsumer) SetParserFunc(fn parsers.ParserFunc) {
+	m.parser, _ = fn()
 }
 
 func (m *MQTTConsumer) Start(acc telegraf.Accumulator) error {

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/eclipse/paho.mqtt.golang"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/tls"
@@ -129,8 +129,8 @@ func (m *MQTTConsumer) Description() string {
 	return "Read metrics from MQTT topic(s)"
 }
 
-func (m *MQTTConsumer) SetParser(parser parsers.Parser) {
-	m.parser = parser
+func (m *MQTTConsumer) SetParserFunc(fn func() parsers.Parser) {
+	m.parser = fn()
 }
 
 func (m *MQTTConsumer) Start(acc telegraf.Accumulator) error {

--- a/plugins/inputs/nats_consumer/nats_consumer.go
+++ b/plugins/inputs/nats_consumer/nats_consumer.go
@@ -14,6 +14,8 @@ import (
 
 var (
 	defaultMaxUndeliveredMessages = 1000
+
+	_ parsers.ParserFuncInput = (*natsConsumer)(nil)
 )
 
 type empty struct{}
@@ -98,8 +100,8 @@ func (n *natsConsumer) Description() string {
 	return "Read metrics from NATS subject(s)"
 }
 
-func (n *natsConsumer) SetParserFunc(fn func() parsers.Parser) {
-	n.parser = fn()
+func (n *natsConsumer) SetParserFunc(fn parsers.ParserFunc) {
+	n.parser, _ = fn()
 }
 
 func (n *natsConsumer) natsErrHandler(c *nats.Conn, s *nats.Subscription, e error) {

--- a/plugins/inputs/nats_consumer/nats_consumer.go
+++ b/plugins/inputs/nats_consumer/nats_consumer.go
@@ -98,8 +98,8 @@ func (n *natsConsumer) Description() string {
 	return "Read metrics from NATS subject(s)"
 }
 
-func (n *natsConsumer) SetParser(parser parsers.Parser) {
-	n.parser = parser
+func (n *natsConsumer) SetParserFunc(fn func() parsers.Parser) {
+	n.parser = fn()
 }
 
 func (n *natsConsumer) natsErrHandler(c *nats.Conn, s *nats.Subscription, e error) {

--- a/plugins/inputs/nsq_consumer/nsq_consumer.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer.go
@@ -15,6 +15,8 @@ const (
 	defaultMaxUndeliveredMessages = 1000
 )
 
+var _ parsers.ParserFuncInput = (*NSQConsumer)(nil)
+
 type empty struct{}
 type semaphore chan empty
 
@@ -74,8 +76,8 @@ var sampleConfig = `
 `
 
 // SetParserFunc takes the data_format from the config and finds the right parser for that format
-func (n *NSQConsumer) SetParserFunc(fn func() parsers.Parser) {
-	n.parser = fn()
+func (n *NSQConsumer) SetParserFunc(fn parsers.ParserFunc) {
+	n.parser, _ = fn()
 }
 
 // SampleConfig returns config values for generating a sample configuration file

--- a/plugins/inputs/nsq_consumer/nsq_consumer.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer.go
@@ -73,9 +73,9 @@ var sampleConfig = `
   data_format = "influx"
 `
 
-// SetParser takes the data_format from the config and finds the right parser for that format
-func (n *NSQConsumer) SetParser(parser parsers.Parser) {
-	n.parser = parser
+// SetParserFunc takes the data_format from the config and finds the right parser for that format
+func (n *NSQConsumer) SetParserFunc(fn func() parsers.Parser) {
+	n.parser = fn()
 }
 
 // SampleConfig returns config values for generating a sample configuration file

--- a/plugins/inputs/nsq_consumer/nsq_consumer_test.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer_test.go
@@ -45,7 +45,7 @@ func TestReadsMetricsFromNSQ(t *testing.T) {
 	}
 
 	p, _ := parsers.NewInfluxParser()
-	consumer.SetParserFunc(func() parsers.Parser { return p })
+	consumer.SetParserFunc(func() (parsers.Parser, error) { return p, nil })
 	var acc testutil.Accumulator
 	assert.Equal(t, 0, len(acc.Metrics), "There should not be any points")
 	if err := consumer.Start(&acc); err != nil {

--- a/plugins/inputs/nsq_consumer/nsq_consumer_test.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer_test.go
@@ -45,7 +45,7 @@ func TestReadsMetricsFromNSQ(t *testing.T) {
 	}
 
 	p, _ := parsers.NewInfluxParser()
-	consumer.SetParser(p)
+	consumer.SetParserFunc(func() parsers.Parser { return p })
 	var acc testutil.Accumulator
 	assert.Equal(t, 0, len(acc.Metrics), "There should not be any points")
 	if err := consumer.Start(&acc); err != nil {

--- a/plugins/inputs/socket_listener/socket_listener.go
+++ b/plugins/inputs/socket_listener/socket_listener.go
@@ -20,6 +20,8 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers"
 )
 
+var _ parsers.ParserFuncInput = (*streamSocketListener)(nil)
+
 type setReadBufferer interface {
 	SetReadBuffer(bytes int) error
 }
@@ -240,8 +242,8 @@ func (sl *SocketListener) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (sl *SocketListener) SetParserFunc(fn func() parsers.Parser) {
-	sl.Parser = fn()
+func (sl *SocketListener) SetParserFunc(fn parsers.ParserFunc) {
+	sl.Parser, _ = fn()
 }
 
 func (sl *SocketListener) Start(acc telegraf.Accumulator) error {

--- a/plugins/inputs/socket_listener/socket_listener.go
+++ b/plugins/inputs/socket_listener/socket_listener.go
@@ -240,8 +240,8 @@ func (sl *SocketListener) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (sl *SocketListener) SetParser(parser parsers.Parser) {
-	sl.Parser = parser
+func (sl *SocketListener) SetParserFunc(fn func() parsers.Parser) {
+	sl.Parser = fn()
 }
 
 func (sl *SocketListener) Start(acc telegraf.Accumulator) error {

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -23,6 +23,8 @@ const (
 var (
 	offsets      = make(map[string]int64)
 	offsetsMutex = new(sync.Mutex)
+
+	_ parsers.ParserFuncInput = (*Tail)(nil)
 )
 
 type Tail struct {

--- a/plugins/inputs/tcp_listener/tcp_listener.go
+++ b/plugins/inputs/tcp_listener/tcp_listener.go
@@ -14,6 +14,8 @@ import (
 	"github.com/influxdata/telegraf/selfstat"
 )
 
+var _ parsers.ParserFuncInput = (*TcpListener)(nil)
+
 type TcpListener struct {
 	ServiceAddress         string
 	AllowedPendingMessages int
@@ -77,8 +79,8 @@ func (t *TcpListener) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (t *TcpListener) SetParserFunc(fn func() parsers.Parser) {
-	t.parser = fn()
+func (t *TcpListener) SetParserFunc(fn parsers.ParserFunc) {
+	t.parser, _ = fn()
 }
 
 // Start starts the tcp listener service.

--- a/plugins/inputs/tcp_listener/tcp_listener.go
+++ b/plugins/inputs/tcp_listener/tcp_listener.go
@@ -77,8 +77,8 @@ func (t *TcpListener) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (t *TcpListener) SetParser(parser parsers.Parser) {
-	t.parser = parser
+func (t *TcpListener) SetParserFunc(fn func() parsers.Parser) {
+	t.parser = fn()
 }
 
 // Start starts the tcp listener service.

--- a/plugins/inputs/udp_listener/udp_listener.go
+++ b/plugins/inputs/udp_listener/udp_listener.go
@@ -13,6 +13,8 @@ import (
 	"github.com/influxdata/telegraf/selfstat"
 )
 
+var _ parsers.ParserFuncInput = (*UdpListener)(nil)
+
 // UdpListener main struct for the collector
 type UdpListener struct {
 	ServiceAddress string
@@ -86,8 +88,8 @@ func (u *UdpListener) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (u *UdpListener) SetParserFunc(fn func() parsers.Parser) {
-	u.parser = fn()
+func (u *UdpListener) SetParserFunc(fn parsers.ParserFunc) {
+	u.parser, _ = fn()
 }
 
 func (u *UdpListener) Start(acc telegraf.Accumulator) error {

--- a/plugins/inputs/udp_listener/udp_listener.go
+++ b/plugins/inputs/udp_listener/udp_listener.go
@@ -86,8 +86,8 @@ func (u *UdpListener) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (u *UdpListener) SetParser(parser parsers.Parser) {
-	u.parser = parser
+func (u *UdpListener) SetParserFunc(fn func() parsers.Parser) {
+	u.parser = fn()
 }
 
 func (u *UdpListener) Start(acc telegraf.Accumulator) error {

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -305,23 +305,37 @@ func TestParseStream(t *testing.T) {
 	}
 
 	csvHeader := "a,b,c"
-	csvBody := "1,2,3"
+	csvBody := `1,2,3
+4,5,6`
 
 	metrics, err := p.Parse([]byte(csvHeader))
 	require.NoError(t, err)
 	require.Len(t, metrics, 0)
-	metric, err := p.ParseLine(csvBody)
-	testutil.RequireMetricEqual(t,
-		testutil.MustMetric(
-			"csv",
-			map[string]string{},
-			map[string]interface{}{
-				"a": int64(1),
-				"b": int64(2),
-				"c": int64(3),
-			},
-			DefaultTime(),
-		), metric)
+
+	metrics, err = p.Parse([]byte(csvBody))
+	testutil.RequireMetricsEqual(t,
+		[]telegraf.Metric{
+			testutil.MustMetric(
+				"csv",
+				map[string]string{},
+				map[string]interface{}{
+					"a": int64(1),
+					"b": int64(2),
+					"c": int64(3),
+				},
+				DefaultTime(),
+			),
+			testutil.MustMetric(
+				"csv",
+				map[string]string{},
+				map[string]interface{}{
+					"a": int64(4),
+					"b": int64(5),
+					"c": int64(6),
+				},
+				DefaultTime(),
+			),
+		}, metrics)
 }
 
 func TestTimestampUnixFloatPrecision(t *testing.T) {

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -21,13 +21,6 @@ import (
 
 type ParserFunc func() (Parser, error)
 
-// ParserInput is an interface for input plugins that are able to parse
-// arbitrary data formats.
-type ParserInput interface {
-	// SetParser sets the parser function for the interface
-	SetParser(parser Parser)
-}
-
 // ParserFuncInput is an interface for input plugins that are able to parse
 // arbitrary data formats.
 type ParserFuncInput interface {

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -326,6 +326,8 @@ func (a *Accumulator) AssertContainsTaggedFields(
 	fields map[string]interface{},
 	tags map[string]string,
 ) {
+	t.Helper()
+
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -337,7 +339,7 @@ func (a *Accumulator) AssertContainsTaggedFields(
 			return
 		}
 	}
-	msg := fmt.Sprintf("unknown measurement %s with tags %v", measurement, tags)
+	msg := fmt.Sprintf("measurement %s with tags %v not found", measurement, tags)
 	assert.Fail(t, msg)
 }
 
@@ -347,6 +349,8 @@ func (a *Accumulator) AssertDoesNotContainsTaggedFields(
 	fields map[string]interface{},
 	tags map[string]string,
 ) {
+	t.Helper()
+
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -369,6 +373,8 @@ func (a *Accumulator) AssertContainsFields(
 	measurement string,
 	fields map[string]interface{},
 ) {
+	t.Helper()
+
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -407,6 +413,8 @@ func (a *Accumulator) HasPoint(
 }
 
 func (a *Accumulator) AssertDoesNotContainMeasurement(t *testing.T, measurement string) {
+	t.Helper()
+
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {


### PR DESCRIPTION
closes: https://github.com/influxdata/telegraf/issues/6138

This is a work in progress.

It updates the `tail` plugin to only use the `parser.Parse` function instead of `parser.ParseLine`. This is a standard we would like to obvserve in all plugins going forward. Deprecating the ParseLine method. As per discussion in the above issue.

This brings with it other changes in the form of:

- `plugin.SetParserFunc` to be standard in place of `plugin.SetParser` allowing plugins to acknowledge when new parses are required. In the event that a parse may be stateful (e.g. csv).
- Update to `file` input plugin to call parser func per new file to be read. Rather than use same parser for each file.

TODO:

- [ ] better understand implications of stateful parsers for other parser consumers (other than just `file` and `tail`).

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
