### PR TITLE
Add networks, subscribers, and watchers to github input

### DIFF
--- a/plugins/inputs/github/README.md
+++ b/plugins/inputs/github/README.md
@@ -28,10 +28,13 @@ alternative method for collecting repository information.
     - language - The primary language of the repository
     - license - The license set for the repository
   - fields:
-    - stars (int)
     - forks (int)
     - open_issues (int)
+    - networks (int)
     - size (int)
+    - subscribers (int)
+    - stars (int)
+    - watchers (int)
 
 When the [internal][] input is enabled:
 
@@ -46,7 +49,7 @@ When the [internal][] input is enabled:
 ### Example Output
 
 ```
-github,full_name=influxdata/telegraf,name=telegraf,owner=influxdata,language=Go,license=MIT\ License stars=6401i,forks=2421i,open_issues=722i,size=22611i 1552651811000000000
+github_repository,language=Go,license=MIT\ License,name=telegraf,owner=influxdata forks=2679i,networks=2679i,open_issues=794i,size=23263i,stars=7091i,subscribers=316i,watchers=7091i 1563901372000000000
 internal_github,access_token=Unauthenticated rate_limit_remaining=59i,rate_limit_limit=60i,rate_limit_blocks=0i 1552653551000000000
 ```
 

--- a/plugins/inputs/github/github.go
+++ b/plugins/inputs/github/github.go
@@ -168,6 +168,9 @@ func getTags(repositoryInfo *github.Repository) map[string]string {
 func getFields(repositoryInfo *github.Repository) map[string]interface{} {
 	return map[string]interface{}{
 		"stars":       repositoryInfo.GetStargazersCount(),
+		"subscribers": repositoryInfo.GetSubscribersCount(),
+		"watchers":    repositoryInfo.GetWatchersCount(),
+		"networks":    repositoryInfo.GetNetworkCount(),
 		"forks":       repositoryInfo.GetForksCount(),
 		"open_issues": repositoryInfo.GetOpenIssuesCount(),
 		"size":        repositoryInfo.GetSize(),

--- a/plugins/inputs/github/github_test.go
+++ b/plugins/inputs/github/github_test.go
@@ -98,12 +98,17 @@ func TestGetFields(t *testing.T) {
 	forks := 2
 	openIssues := 3
 	size := 4
+	subscribers := 5
+	watchers := 6
 
 	repository := gh.Repository{
-		StargazersCount: &stars,
-		ForksCount:      &forks,
-		OpenIssuesCount: &openIssues,
-		Size:            &size,
+		StargazersCount:  &stars,
+		ForksCount:       &forks,
+		OpenIssuesCount:  &openIssues,
+		Size:             &size,
+		NetworkCount:     &forks,
+		SubscribersCount: &subscribers,
+		WatchersCount:    &watchers,
 	}
 
 	getFieldsReturn := getFields(&repository)
@@ -112,8 +117,11 @@ func TestGetFields(t *testing.T) {
 
 	correctFieldReturn["stars"] = 1
 	correctFieldReturn["forks"] = 2
+	correctFieldReturn["networks"] = 2
 	correctFieldReturn["open_issues"] = 3
 	correctFieldReturn["size"] = 4
+	correctFieldReturn["subscribers"] = 5
+	correctFieldReturn["watchers"] = 6
 
 	require.Equal(t, true, reflect.DeepEqual(getFieldsReturn, correctFieldReturn))
 }


### PR DESCRIPTION
This adds networks, subscribers, and watchers as fields.

According to [github's api docs](https://developer.github.com/v3/repos/#list-organization-repositories), forks_count is indeed different than network_count.