### PR TITLE
redis input: fix percentage value parsing

### DIFF
--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -253,8 +253,11 @@ func gatherInfoOutput(
 
 		val := strings.TrimSpace(parts[1])
 
+		// Some percentage values have a "%" suffix that we need to get rid of before int/float conversion
+		num_val := strings.TrimSuffix(val, "%")
+
 		// Try parsing as int
-		if ival, err := strconv.ParseInt(val, 10, 64); err == nil {
+		if ival, err := strconv.ParseInt(num_val, 10, 64); err == nil {
 			switch name {
 			case "keyspace_hits":
 				keyspace_hits = ival
@@ -269,7 +272,7 @@ func gatherInfoOutput(
 		}
 
 		// Try parsing as a float
-		if fval, err := strconv.ParseFloat(val, 64); err == nil {
+		if fval, err := strconv.ParseFloat(num_val, 64); err == nil {
 			fields[metric] = fval
 			continue
 		}

--- a/plugins/inputs/redis/redis_test.go
+++ b/plugins/inputs/redis/redis_test.go
@@ -49,6 +49,8 @@ func TestRedis_ParseMetrics(t *testing.T) {
 		"used_memory_rss":                int64(811008),
 		"used_memory_peak":               int64(1003936),
 		"used_memory_lua":                int64(33792),
+		"used_memory_peak_perc":          float64(93.58),
+		"used_memory_dataset_perc":       float64(20.27),
 		"mem_fragmentation_ratio":        float64(0.81),
 		"loading":                        int64(0),
 		"rdb_changes_since_last_save":    int64(0),
@@ -152,6 +154,8 @@ used_memory_peak_human:980.41K
 used_memory_lua:33792
 mem_fragmentation_ratio:0.81
 mem_allocator:libc
+used_memory_peak_perc:93.58%
+used_memory_dataset_perc:20.27%
 
 # Persistence
 loading:0


### PR DESCRIPTION
Percentage values would get interpreted incorrectly as tags because they
did not pass the int/float conversion.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
