### PR TITLE
Log once and stop collecting services that don't exist in win_services input

### DIFF
--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -109,6 +109,16 @@ func (m *WinServices) SampleConfig() string {
 	return sampleConfig
 }
 
+func stopSvcCollect(svcs []string, svc string) []string {
+	for i := range svcs {
+		if svcs[i] == svc {
+			svcs[i] = svcs[len(svcs)-1]
+			return svcs[:len(svcs)-1]
+		}
+	}
+	return svcs
+}
+
 func (m *WinServices) Gather(acc telegraf.Accumulator) error {
 	scmgr, err := m.mgrProvider.Connect()
 	if err != nil {
@@ -129,6 +139,7 @@ func (m *WinServices) Gather(acc telegraf.Accumulator) error {
 			} else {
 				acc.AddError(err)
 			}
+			m.ServiceNames = stopSvcCollect(m.ServiceNames, srvName)
 			continue
 		}
 


### PR DESCRIPTION
Addresses #5964 rather harshly. If the service is later installed, Telegraf will not begin to collect stats for it until it re-reads the config (via a reload or restart).
We could store the original `ServiceNames` list and increment a counter each `Gather` then retry the original list after `x` number of gathers if this is desired.