### PR TITLE
Mirror influxdb api for large payloads in influx_listener input

### DIFF
--- a/plugins/inputs/influxdb_listener/http_listener_test.go
+++ b/plugins/inputs/influxdb_listener/http_listener_test.go
@@ -185,7 +185,7 @@ func TestWriteHTTP(t *testing.T) {
 	resp, err = http.Post(createURL(listener, "http", "/write", "db=mydb"), "", bytes.NewBuffer([]byte(hugeMetric)))
 	require.NoError(t, err)
 	resp.Body.Close()
-	require.EqualValues(t, 400, resp.StatusCode)
+	require.EqualValues(t, 413, resp.StatusCode)
 
 	acc.Wait(3)
 	acc.AssertContainsTaggedFields(t, "cpu_load_short",


### PR DESCRIPTION
Addresses comments in #2280

An attempt was made to add a `content-length` header to the influxdb output, but it was decided that would cost more than it was worth (read the body to count bytes, then allocate a new reader to use in the request)