### PR TITLE
Update influxdb_listener to allow partial writes

### DIFF
--- a/plugins/inputs/influxdb_listener/http_listener.go
+++ b/plugins/inputs/influxdb_listener/http_listener.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -318,6 +319,10 @@ func (h *HTTPListener) serveWrite(res http.ResponseWriter, req *http.Request) {
 			err = h.parse(buf[:n+bufStart], now, precision)
 			if err != nil {
 				log.Println("D! "+err.Error(), bufStart+n)
+				if strings.HasPrefix(err.Error(), "partial write:") {
+					partialWrite(res, err.Error())
+					return
+				}
 				return400 = true
 			}
 			if return400 {
@@ -365,13 +370,17 @@ func (h *HTTPListener) parse(b []byte, t time.Time, precision string) error {
 
 	h.handler.SetTimePrecision(getPrecisionMultiplier(precision))
 	h.handler.SetTimeFunc(func() time.Time { return t })
-	metrics, err := h.parser.Parse(b)
-	if err != nil {
-		return fmt.Errorf("unable to parse: %s", err.Error())
-	}
+	metrics, err := h.parser.EagerParse(b)
 
 	for _, m := range metrics {
 		h.acc.AddFields(m.Name(), m.Fields(), m.Tags(), m.Time())
+	}
+
+	if err != nil {
+		if len(metrics) > 0 {
+			return fmt.Errorf("partial write: unable to parse: %s", err.Error())
+		}
+		return fmt.Errorf("unable to parse: %s", err.Error())
 	}
 
 	return nil
@@ -391,6 +400,14 @@ func badRequest(res http.ResponseWriter, errString string) {
 	if errString == "" {
 		errString = "http: bad request"
 	}
+	res.Header().Set("X-Influxdb-Error", errString)
+	res.WriteHeader(http.StatusBadRequest)
+	res.Write([]byte(fmt.Sprintf(`{"error":%q}`, errString)))
+}
+
+func partialWrite(res http.ResponseWriter, errString string) {
+	res.Header().Set("Content-Type", "application/json")
+	res.Header().Set("X-Influxdb-Version", "1.0")
 	res.Header().Set("X-Influxdb-Error", errString)
 	res.WriteHeader(http.StatusBadRequest)
 	res.Write([]byte(fmt.Sprintf(`{"error":%q}`, errString)))


### PR DESCRIPTION
Resolves #6124 

Previously, if a batch contained an invalid metric, the batch failed. This change allows for valid metrics to be processed and a "partial write" error to be sent to the client.