### PR TITLE
Marklogic Input Plugin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1234,14 +1234,6 @@
   revision = "f72d8611297a7cf105da904c04198ad701a60101"
 
 [[projects]]
-  digest = "1:08f54f35f83370bac9bf1043df718d05ca270f48f5faa5bd8e233b5e69a550f0"
-  name = "github.com/xinsnake/go-http-digest-auth-client"
-  packages = ["."]
-  pruneopts = ""
-  revision = "9da83de55d71220f00cbffb736dba373e6e683b1"
-  version = "v0.4.0"
-
-[[projects]]
   branch = "master"
   digest = "1:c5918689b7e187382cc1066bf0260de54ba9d1b323105f46ed2551d2fb4a17c7"
   name = "github.com/yuin/gopher-lua"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1234,6 +1234,14 @@
   revision = "f72d8611297a7cf105da904c04198ad701a60101"
 
 [[projects]]
+  digest = "1:08f54f35f83370bac9bf1043df718d05ca270f48f5faa5bd8e233b5e69a550f0"
+  name = "github.com/xinsnake/go-http-digest-auth-client"
+  packages = ["."]
+  pruneopts = ""
+  revision = "9da83de55d71220f00cbffb736dba373e6e683b1"
+  version = "v0.4.0"
+
+[[projects]]
   branch = "master"
   digest = "1:c5918689b7e187382cc1066bf0260de54ba9d1b323105f46ed2551d2fb4a17c7"
   name = "github.com/yuin/gopher-lua"
@@ -1780,6 +1788,7 @@
     "github.com/vmware/govmomi/vim25/types",
     "github.com/wavefronthq/wavefront-sdk-go/senders",
     "github.com/wvanbergen/kafka/consumergroup",
+    "github.com/xinsnake/go-http-digest-auth-client",
     "golang.org/x/net/context",
     "golang.org/x/net/html/charset",
     "golang.org/x/oauth2",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1780,7 +1780,6 @@
     "github.com/vmware/govmomi/vim25/types",
     "github.com/wavefronthq/wavefront-sdk-go/senders",
     "github.com/wvanbergen/kafka/consumergroup",
-    "github.com/xinsnake/go-http-digest-auth-client",
     "golang.org/x/net/context",
     "golang.org/x/net/html/charset",
     "golang.org/x/oauth2",

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -79,6 +79,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/logparser"
 	_ "github.com/influxdata/telegraf/plugins/inputs/lustre2"
 	_ "github.com/influxdata/telegraf/plugins/inputs/mailchimp"
+	_ "github.com/influxdata/telegraf/plugins/inputs/marklogic"
 	_ "github.com/influxdata/telegraf/plugins/inputs/mcrouter"
 	_ "github.com/influxdata/telegraf/plugins/inputs/mem"
 	_ "github.com/influxdata/telegraf/plugins/inputs/memcached"

--- a/plugins/inputs/marklogic/README.md
+++ b/plugins/inputs/marklogic/README.md
@@ -1,6 +1,6 @@
 # MarkLogic Plugin
 
-The MarkLogic Telegraf plugin gathers status metrics from one or more host in the MarkLogic Cluster.
+The MarkLogic Telegraf plugin gathers status metrics from one or more host in a MarkLogic Cluster.
 
 ### Configuration:
 

--- a/plugins/inputs/marklogic/README.md
+++ b/plugins/inputs/marklogic/README.md
@@ -1,6 +1,6 @@
 # MarkLogic Plugin
 
-The MarkLogic Telegraf plugin gathers status metrics from one or more host in a MarkLogic Cluster.
+The MarkLogic Telegraf plugin gathers health status metrics from one or more host.
 
 ### Configuration:
 
@@ -9,12 +9,12 @@ The MarkLogic Telegraf plugin gathers status metrics from one or more host in a 
   ## Base URL of the MarkLogic HTTP Server.
   url = "http://localhost:8002"
 
-  ## List of specific hostnames in a cluster to retrieve information. At least (1) required.
+  ## List of specific hostnames to retrieve information. At least (1) required.
   # hosts = ["hostname1", "hostname2"]
 
   ## Using HTTP Digest Authentication. Management API requires 'manage-user' role privileges
   # username = "myuser"
-  # password = "p@ssw0rd"
+  # password = "mypassword"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/marklogic/README.md
+++ b/plugins/inputs/marklogic/README.md
@@ -1,0 +1,50 @@
+# Marklogic Plugin
+
+The Marklogic Telegraf plugin gathers status metrics from one or more host in the Marklogic cluster.
+
+### Configuration:
+
+```toml
+# Description
+[[inputs.marklogic]]
+
+## List URLs of Marklogic hosts using Management API endpoint.
+# hosts = ["http://localhost:8002/manage/v2/hosts/${hostname}?view=status&format=json"]
+
+# Using HTTP Digest Authentication.
+# digest_username = "telegraf"
+# digest_password = "p@ssw0rd"
+```
+
+### Measurements & Fields:
+
+Marklogic provides one measurement named "marklogic", with the following fields:
+
+- online
+- total_cpu_stat_user
+- total_cpu_stat_system
+- memory_process_size
+- memory_process_rss
+- memory_system_total
+- memory_system_free
+- num_cores
+- total_load
+- data_dir_space
+- query_read_bytes
+- query_read_load
+- http_server_receive_bytes
+- http_server_send_bytes
+
+### Tags:
+
+All measurements have the following tags:
+
+- ml_hostname (the hostname of the server address, ex. `ml1.local`)
+- id (the host node unique id ex. `2592913110757471141`)
+
+### Example Output:
+
+```
+$ ./telegraf --config telegraf.conf --input-filter marklogic --test
+> marklogic,host=Craigs-MacBook-Pro-2.local,id=2592913110757471141,ml_hostname=ml1.local data_dir_space=29212i,http_server_receive_bytes=0,http_server_send_bytes=0,memory_process_rss=273i,memory_process_size=702i,memory_system_free=3417i,memory_system_total=3947i,num_cores=4i,online=true,query_read_bytes=3545624i,query_read_load=0i,total_cpu_stat_system=0.63408100605011,total_cpu_stat_user=0.302343010902405,total_load=0.0847966074943543 1564731542000000000
+```

--- a/plugins/inputs/marklogic/README.md
+++ b/plugins/inputs/marklogic/README.md
@@ -12,7 +12,7 @@ The MarkLogic Telegraf plugin gathers health status metrics from one or more hos
   ## List of specific hostnames to retrieve information. At least (1) required.
   # hosts = ["hostname1", "hostname2"]
 
-  ## Using HTTP Digest Authentication. Management API requires 'manage-user' role privileges
+  ## Using HTTP Basic Authentication. Management API requires 'manage-user' role privileges
   # username = "myuser"
   # password = "mypassword"
 
@@ -44,17 +44,21 @@ The MarkLogic Telegraf plugin gathers health status metrics from one or more hos
     - memory_process_rss
     - memory_system_total
     - memory_system_free
+    - memory_process_swap_size
     - memory_size
     - host_size
+    - log_device_space
     - data_dir_space
     - query_read_bytes
     - query_read_load
+    - merge_read_bytes
+    - merge_write_load
     - http_server_receive_bytes
     - http_server_send_bytes
 
 ### Example Output:
 
 ```
-$> marklogic,host=localhost,id=17879472307902936940,source=ml1.local data_dir_space=28394i,host_size=0i,http_server_receive_bytes=0i,http_server_send_bytes=0i,memory_process_rss=187i,memory_process_size=622i,memory_size=4096i,memory_system_free=3772i,memory_system_total=3947i,ncores=4i,ncpus=1i,online=true,query_read_bytes=0i,query_read_load=0i,total_cpu_stat_idle=97.9717025756836,total_cpu_stat_iowait=0.0168676991015673,total_cpu_stat_system=0.695792019367218,total_cpu_stat_user=1.29881000518799,total_load=0,total_rate=33.8406105041504 1566024482000000000
+$> marklogic,host=localhost,id=2592913110757471141,source=ml1.local total_cpu_stat_iowait=0.0125649003311992,memory_process_swap_size=0i,host_size=380i,data_dir_space=28216i,query_read_load=0i,ncpus=1i,log_device_space=28216i,query_read_bytes=13947332i,merge_write_load=0i,http_server_receive_bytes=225893i,online=true,ncores=4i,total_cpu_stat_user=0.150778993964195,total_cpu_stat_system=0.598927974700928,total_cpu_stat_idle=99.2210006713867,memory_system_total=3947i,memory_system_free=2669i,memory_size=4096i,total_rate=14.7697010040283,http_server_send_bytes=0i,memory_process_size=903i,memory_process_rss=486i,merge_read_load=0i,total_load=0.00502600101754069 1566373000000000000
 
 ```

--- a/plugins/inputs/marklogic/README.md
+++ b/plugins/inputs/marklogic/README.md
@@ -17,7 +17,7 @@ The MarkLogic Telegraf plugin gathers status metrics from one or more host in th
   # password = "p@ssw0rd"
 ```
 
-### Measurements & Fields:
+### Measurement & Fields:
 
 MarkLogic provides one measurement named "marklogic", with the following fields:
 

--- a/plugins/inputs/marklogic/README.md
+++ b/plugins/inputs/marklogic/README.md
@@ -1,34 +1,41 @@
-# Marklogic Plugin
+# MarkLogic Plugin
 
-The Marklogic Telegraf plugin gathers status metrics from one or more host in the Marklogic cluster.
+The MarkLogic Telegraf plugin gathers status metrics from one or more host in the MarkLogic Cluster.
 
 ### Configuration:
 
 ```toml
-# Description
 [[inputs.marklogic]]
+  ## Base URL of MarkLogic host for Management API endpoint.
+  url = "http://localhost:8002"
 
-## List URLs of Marklogic hosts using Management API endpoint.
-# hosts = ["http://localhost:8002/manage/v2/hosts/${hostname}?view=status&format=json"]
+  ## List of specific hostnames in a cluster to retrieve information. At least (1) required.
+  # hosts = ["hostname1", "hostname2"]
 
-# Using HTTP Digest Authentication.
-# digest_username = "telegraf"
-# digest_password = "p@ssw0rd"
+  ## Using HTTP Digest Authentication. This requires 'manage-user' role privileges
+  # username = "telegraf"
+  # password = "p@ssw0rd"
 ```
 
 ### Measurements & Fields:
 
-Marklogic provides one measurement named "marklogic", with the following fields:
+MarkLogic provides one measurement named "marklogic", with the following fields:
 
 - online
+- total_load
+- total_rate
+- ncpus
+- ncores
 - total_cpu_stat_user
 - total_cpu_stat_system
+- total_cpu_stat_idle
+- total_cpu_stat_iowait
 - memory_process_size
 - memory_process_rss
 - memory_system_total
 - memory_system_free
-- num_cores
-- total_load
+- memory_size
+- host_size
 - data_dir_space
 - query_read_bytes
 - query_read_load
@@ -39,12 +46,12 @@ Marklogic provides one measurement named "marklogic", with the following fields:
 
 All measurements have the following tags:
 
-- ml_hostname (the hostname of the server address, ex. `ml1.local`)
+- name (the hostname of the server address, ex. `ml1.local`)
 - id (the host node unique id ex. `2592913110757471141`)
 
 ### Example Output:
 
 ```
-$ ./telegraf --config telegraf.conf --input-filter marklogic --test
-> marklogic,host=Craigs-MacBook-Pro-2.local,id=2592913110757471141,ml_hostname=ml1.local data_dir_space=29212i,http_server_receive_bytes=0,http_server_send_bytes=0,memory_process_rss=273i,memory_process_size=702i,memory_system_free=3417i,memory_system_total=3947i,num_cores=4i,online=true,query_read_bytes=3545624i,query_read_load=0i,total_cpu_stat_system=0.63408100605011,total_cpu_stat_user=0.302343010902405,total_load=0.0847966074943543 1564731542000000000
+$> marklogic,host=localhost,id=17879472307902936940,name=ml2.local data_dir_space=28398i,host_size=0i,http_server_receive_bytes=8059i,http_server_send_bytes=0i,memory_process_rss=303i,memory_process_size=728i,memory_size=4096i,memory_system_free=3664i,memory_system_total=3947i,ncores=4i,ncpus=1i,online=true,query_read_bytes=0i,query_read_load=0i,total_cpu_stat_idle=99.1915969848633,total_cpu_stat_iowait=0.0167552996426821,total_cpu_stat_system=0.523603975772858,total_cpu_stat_user=0.251329988241196,total_load=0,total_rate=16.1815872192383 1565067570000000000
+
 ```

--- a/plugins/inputs/marklogic/README.md
+++ b/plugins/inputs/marklogic/README.md
@@ -6,52 +6,55 @@ The MarkLogic Telegraf plugin gathers status metrics from one or more host in a 
 
 ```toml
 [[inputs.marklogic]]
-  ## Base URL of MarkLogic host for Management API endpoint.
+  ## Base URL of the MarkLogic HTTP Server.
   url = "http://localhost:8002"
 
   ## List of specific hostnames in a cluster to retrieve information. At least (1) required.
   # hosts = ["hostname1", "hostname2"]
 
-  ## Using HTTP Digest Authentication. This requires 'manage-user' role privileges
-  # username = "telegraf"
+  ## Using HTTP Digest Authentication. Management API requires 'manage-user' role privileges
+  # username = "myuser"
   # password = "p@ssw0rd"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
 ```
 
-### Measurement & Fields:
+### Metrics
 
-MarkLogic provides one measurement named "marklogic", with the following fields:
-
-- online
-- total_load
-- total_rate
-- ncpus
-- ncores
-- total_cpu_stat_user
-- total_cpu_stat_system
-- total_cpu_stat_idle
-- total_cpu_stat_iowait
-- memory_process_size
-- memory_process_rss
-- memory_system_total
-- memory_system_free
-- memory_size
-- host_size
-- data_dir_space
-- query_read_bytes
-- query_read_load
-- http_server_receive_bytes
-- http_server_send_bytes
-
-### Tags:
-
-All measurements have the following tags:
-
-- name (the hostname of the server address, ex. `ml1.local`)
-- id (the host node unique id ex. `2592913110757471141`)
+- marklogic
+  - tags:
+    - source (the hostname of the server address, ex. `ml1.local`)
+    - id (the host node unique id ex. `2592913110757471141`)
+  - fields:
+    - online
+    - total_load
+    - total_rate
+    - ncpus
+    - ncores
+    - total_cpu_stat_user
+    - total_cpu_stat_system
+    - total_cpu_stat_idle
+    - total_cpu_stat_iowait
+    - memory_process_size
+    - memory_process_rss
+    - memory_system_total
+    - memory_system_free
+    - memory_size
+    - host_size
+    - data_dir_space
+    - query_read_bytes
+    - query_read_load
+    - http_server_receive_bytes
+    - http_server_send_bytes
 
 ### Example Output:
 
 ```
-$> marklogic,host=localhost,id=17879472307902936940,name=ml2.local data_dir_space=28398i,host_size=0i,http_server_receive_bytes=8059i,http_server_send_bytes=0i,memory_process_rss=303i,memory_process_size=728i,memory_size=4096i,memory_system_free=3664i,memory_system_total=3947i,ncores=4i,ncpus=1i,online=true,query_read_bytes=0i,query_read_load=0i,total_cpu_stat_idle=99.1915969848633,total_cpu_stat_iowait=0.0167552996426821,total_cpu_stat_system=0.523603975772858,total_cpu_stat_user=0.251329988241196,total_load=0,total_rate=16.1815872192383 1565067570000000000
+$> marklogic,host=localhost,id=17879472307902936940,source=ml1.local data_dir_space=28394i,host_size=0i,http_server_receive_bytes=0i,http_server_send_bytes=0i,memory_process_rss=187i,memory_process_size=622i,memory_size=4096i,memory_system_free=3772i,memory_system_total=3947i,ncores=4i,ncpus=1i,online=true,query_read_bytes=0i,query_read_load=0i,total_cpu_stat_idle=97.9717025756836,total_cpu_stat_iowait=0.0168676991015673,total_cpu_stat_system=0.695792019367218,total_cpu_stat_user=1.29881000518799,total_load=0,total_rate=33.8406105041504 1566024482000000000
 
 ```

--- a/plugins/inputs/marklogic/marklogic.go
+++ b/plugins/inputs/marklogic/marklogic.go
@@ -1,0 +1,235 @@
+package marklogic
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	dac "github.com/go-http-digest-auth-client"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+type Marklogic struct {
+
+	Hosts         []string `toml:"hosts"`
+	DigestUsername string   `toml:"digest_username"`
+	DigestPassword string   `toml:"digest_password"`
+
+	// HTTP client & request
+	client *http.Client
+}
+
+// NewMarklogic return a new instance of Marklogic with a default http client
+func NewMarklogic() *Marklogic {
+	tr := &http.Transport{ResponseHeaderTimeout: time.Duration(3 * time.Second)}
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   time.Duration(4 * time.Second),
+	}
+	return &Marklogic{client: client}
+}
+
+type MLHosts struct {
+	HostStatus struct {
+		ID                  string `json:"id"`
+		Name                string `json:"name"`
+		Version             string `json:"version"`
+		EffectiveVersion    int    `json:"effective-version"`
+		HostMode            string `json:"host-mode"`
+		HostModeDescription string `json:"host-mode-description"`
+		Meta                struct {
+			URI         string    `json:"uri"`
+			CurrentTime time.Time `json:"current-time"`
+			ElapsedTime struct {
+				Units string  `json:"units"`
+				Value float64 `json:"value"`
+			} `json:"elapsed-time"`
+		} `json:"meta"`
+		StatusProperties struct {
+			Online struct {
+				Units string `json:"units"`
+				Value bool   `json:"value"`
+			} `json:"online"`
+			LoadProperties struct {
+				TotalLoad struct {
+					Units string  `json:"units"`
+					Value float64 `json:"value"`
+				} `json:"total-load"`
+			} `json:"load-properties"`
+			StatusDetail struct {
+				HostMode          struct {
+					Units string `json:"units"`
+					Value string `json:"value"`
+				} `json:"host-mode"`
+				Cpus struct {
+					Units string `json:"units"`
+					Value int    `json:"value"`
+				} `json:"cpus"`
+				Cores struct {
+					Units string `json:"units"`
+					Value int    `json:"value"`
+				} `json:"cores"`
+				CoreThreads struct {
+					Units string `json:"units"`
+					Value int    `json:"value"`
+				} `json:"core-threads"`
+				TotalCPUStatUser      float64 `json:"total-cpu-stat-user"`
+				TotalCPUStatNice      float64  `json:"total-cpu-stat-nice"`
+				TotalCPUStatSystem    float64 `json:"total-cpu-stat-system"`
+				TotalCPUStatIdle      float64 `json:"total-cpu-stat-idle"`
+				TotalCPUStatGuest     float64  `json:"total-cpu-stat-guest"`
+				MemoryProcessSize     struct {
+					Units string `json:"units"`
+					Value float64 `json:"value"`
+				} `json:"memory-process-size"`
+				MemoryProcessRss struct {
+					Units string `json:"units"`
+					Value float64    `json:"value"`
+				} `json:"memory-process-rss"`
+				MemorySystemTotal struct {
+					Units string `json:"units"`
+					Value float64    `json:"value"`
+				} `json:"memory-system-total"`
+				MemorySystemFree struct {
+					Units string `json:"units"`
+					Value float64    `json:"value"`
+				} `json:"memory-system-free"`
+				DataDirSpace struct {
+					Units string `json:"units"`
+					Value float64    `json:"value"`
+				} `json:"data-dir-space"`
+				QueryReadBytes struct {
+					Units string `json:"units"`
+					Value float64    `json:"value"`
+				} `json:"query-read-bytes"`
+				QueryReadLoad struct {
+					Units string `json:"units"`
+					Value float64    `json:"value"`
+				} `json:"query-read-load"`
+				HTTPServerReceiveBytes struct {
+					Units string `json:"units"`
+					Value float64    `json:"value"`
+				} `json:"http-server-receive-bytes"`
+				HTTPServerSendBytes struct {
+					Units string `json:"units"`
+					Value float64    `json:"value"`
+				} `json:"http-server-send-bytes"`
+			} `json:"status-detail"`
+		} `json:"status-properties"`
+	} `json:"host-status"`
+}
+
+func (c *Marklogic) Description() string {
+	return "Gathers host health status data from a Marklogic Cluster"
+}
+
+var sampleConfig = `
+  ## List URLs of Marklogic hosts using Management API endpoint.
+  # hosts = ["http://localhost:8002/manage/v2/hosts/${hostname}?view=status&format=json"]
+
+	# Using HTTP Digest Authentication.
+	# digest_username = "telegraf"
+	# digest_password = "p@ssw0rd"
+`
+
+func (c *Marklogic) SampleConfig() string {
+	return sampleConfig
+}
+
+// Gather read stats from all hosts configured in cluster.
+func (c *Marklogic) Gather(accumulator telegraf.Accumulator) error {
+	var wg sync.WaitGroup
+
+	if len(c.Hosts) == 0 {
+		c.Hosts = []string{"http://localhost:8002/manage/v2/hosts/ml1.local?view=status&format=json"}
+	}
+
+	// Range over all ML servers, gathering stats. Returns early in case of any error.
+	for _, u := range c.Hosts {
+		wg.Add(1)
+		go func(host string) {
+			defer wg.Done()
+			if err := c.fetchAndInsertData(accumulator, host); err != nil {
+				accumulator.AddError(fmt.Errorf("[host=%s]: %s", host, err))
+			}
+		}(u)
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+func (c *Marklogic) fetchAndInsertData(acc telegraf.Accumulator, host string) error {
+	if c.client == nil {
+		c.client = &http.Client{
+			Transport: &http.Transport{
+				ResponseHeaderTimeout: time.Duration(3 * time.Second),
+			},
+			Timeout: time.Duration(4 * time.Second),
+		}
+	}
+
+t := dac.NewTransport(c.DigestUsername, c.DigestPassword)
+req, err := http.NewRequest("GET", host, nil)
+if err != nil {
+	return err
+}
+
+	response, err := t.RoundTrip(req)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		return fmt.Errorf("Failed to get status from Marklogic Management API: HTTP responded %d", response.StatusCode)
+	}
+
+	// Decode the response JSON into a new lights struct
+	stats := &MLHosts{}
+	if err := json.NewDecoder(response.Body).Decode(stats); err != nil {
+		return fmt.Errorf("Unable to decode MLHosts{} object from Management API response: %s", err)
+	}
+
+	// Build a map of tags
+	tags := map[string]string{
+    //"server":   hs.Host,
+		"ml_hostname":  stats.HostStatus.Name,
+		"id":  stats.HostStatus.ID,
+
+	}
+
+	// Build a map of field values
+	fields := map[string]interface{}{
+
+		"online":                             stats.HostStatus.StatusProperties.Online.Value,
+    "total_cpu_stat_user":                stats.HostStatus.StatusProperties.StatusDetail.TotalCPUStatUser,
+		"total_cpu_stat_system":              stats.HostStatus.StatusProperties.StatusDetail.TotalCPUStatSystem,
+		"memory_process_size":                stats.HostStatus.StatusProperties.StatusDetail.MemoryProcessSize.Value,
+		"memory_process_rss":                 stats.HostStatus.StatusProperties.StatusDetail.MemoryProcessRss.Value,
+		"memory_system_total":                stats.HostStatus.StatusProperties.StatusDetail.MemorySystemTotal.Value,
+		"memory_system_free":                 stats.HostStatus.StatusProperties.StatusDetail.MemorySystemFree.Value,
+		"num_cores":                          stats.HostStatus.StatusProperties.StatusDetail.Cores.Value,
+		"total_load":                         stats.HostStatus.StatusProperties.LoadProperties.TotalLoad.Value,
+		"data_dir_space":                     stats.HostStatus.StatusProperties.StatusDetail.DataDirSpace.Value,
+		"query_read_bytes":                   stats.HostStatus.StatusProperties.StatusDetail.QueryReadBytes.Value,
+		"query_read_load":                    stats.HostStatus.StatusProperties.StatusDetail.QueryReadLoad.Value,
+		"http_server_receive_bytes":          stats.HostStatus.StatusProperties.StatusDetail.HTTPServerReceiveBytes.Value,
+	  "http_server_send_bytes":             stats.HostStatus.StatusProperties.StatusDetail.HTTPServerSendBytes.Value,
+	}
+
+	// Accumulate the tags and values
+	acc.AddFields("marklogic", fields, tags)
+
+	return nil
+}
+
+func init() {
+	inputs.Add("marklogic", func() telegraf.Input {
+		return NewMarklogic()
+	})
+}

--- a/plugins/inputs/marklogic/marklogic.go
+++ b/plugins/inputs/marklogic/marklogic.go
@@ -165,8 +165,8 @@ func (c *Marklogic) fetchAndInsertData(acc telegraf.Accumulator, url string) err
 
 	// Build a map of tags
 	tags := map[string]string{
-		"name": ml.HostStatus.Name,
-		"id":   ml.HostStatus.ID,
+		"source": ml.HostStatus.Name,
+		"id":     ml.HostStatus.ID,
 	}
 
 	// Build a map of field values

--- a/plugins/inputs/marklogic/marklogic.go
+++ b/plugins/inputs/marklogic/marklogic.go
@@ -61,21 +61,21 @@ type MlHost struct {
 				TotalRate MlPointFloat `json:"total-rate"`
 			} `json:"rate-properties"`
 			StatusDetail struct {
-				Cpus                   MlPointInt   `json:"cpus"`
-				Cores                  MlPointInt   `json:"cores"`
-				TotalCPUStatUser       float64      `json:"total-cpu-stat-user"`
-				TotalCPUStatSystem     float64      `json:"total-cpu-stat-system"`
-				TotalCPUStatIdle       float64      `json:"total-cpu-stat-idle"`
-				TotalCPUStatIowait     float64      `json:"total-cpu-stat-iowait"`
-				MemoryProcessSize      MlPointInt   `json:"memory-process-size"`
-				MemoryProcessRss       MlPointInt   `json:"memory-process-rss"`
-				MemorySystemTotal      MlPointInt   `json:"memory-system-total"`
-				MemorySystemFree       MlPointInt   `json:"memory-system-free"`
-				MemorySize             MlPointInt   `json:"memory-size"`
-				HostSize               MlPointInt   `json:"host-size"`
-				DataDirSpace           MlPointInt   `json:"data-dir-space"`
-				QueryReadBytes         MlPointInt   `json:"query-read-bytes"`
-				QueryReadLoad          MlPointInt   `json:"query-read-load"`
+				Cpus                   MlPointInt `json:"cpus"`
+				Cores                  MlPointInt `json:"cores"`
+				TotalCPUStatUser       float64    `json:"total-cpu-stat-user"`
+				TotalCPUStatSystem     float64    `json:"total-cpu-stat-system"`
+				TotalCPUStatIdle       float64    `json:"total-cpu-stat-idle"`
+				TotalCPUStatIowait     float64    `json:"total-cpu-stat-iowait"`
+				MemoryProcessSize      MlPointInt `json:"memory-process-size"`
+				MemoryProcessRss       MlPointInt `json:"memory-process-rss"`
+				MemorySystemTotal      MlPointInt `json:"memory-system-total"`
+				MemorySystemFree       MlPointInt `json:"memory-system-free"`
+				MemorySize             MlPointInt `json:"memory-size"`
+				HostSize               MlPointInt `json:"host-size"`
+				DataDirSpace           MlPointInt `json:"data-dir-space"`
+				QueryReadBytes         MlPointInt `json:"query-read-bytes"`
+				QueryReadLoad          MlPointInt `json:"query-read-load"`
 				HTTPServerReceiveBytes MlPointInt `json:"http-server-receive-bytes"`
 				HTTPServerSendBytes    MlPointInt `json:"http-server-send-bytes"`
 			} `json:"status-detail"`
@@ -133,10 +133,8 @@ func (c *Marklogic) Gather(accumulator telegraf.Accumulator) error {
 func (c *Marklogic) fetchAndInsertData(acc telegraf.Accumulator, url string) error {
 	if c.client == nil {
 		c.client = &http.Client{
-			Transport: &http.Transport{
-				ResponseHeaderTimeout: time.Duration(3 * time.Second),
-			},
-			Timeout: time.Duration(4 * time.Second),
+			Transport: &http.Transport{},
+			Timeout:   time.Duration(5 * time.Second),
 		}
 	}
 

--- a/plugins/inputs/marklogic/marklogic.go
+++ b/plugins/inputs/marklogic/marklogic.go
@@ -7,14 +7,13 @@ import (
 	"sync"
 	"time"
 
-	dac "github.com/go-http-digest-auth-client"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	dac "github.com/xinsnake/go-http-digest-auth-client"
 )
 
 type Marklogic struct {
-
-	Hosts         []string `toml:"hosts"`
+	Hosts          []string `toml:"hosts"`
 	DigestUsername string   `toml:"digest_username"`
 	DigestPassword string   `toml:"digest_password"`
 
@@ -60,7 +59,7 @@ type MLHosts struct {
 				} `json:"total-load"`
 			} `json:"load-properties"`
 			StatusDetail struct {
-				HostMode          struct {
+				HostMode struct {
 					Units string `json:"units"`
 					Value string `json:"value"`
 				} `json:"host-mode"`
@@ -76,46 +75,46 @@ type MLHosts struct {
 					Units string `json:"units"`
 					Value int    `json:"value"`
 				} `json:"core-threads"`
-				TotalCPUStatUser      float64 `json:"total-cpu-stat-user"`
-				TotalCPUStatNice      float64  `json:"total-cpu-stat-nice"`
-				TotalCPUStatSystem    float64 `json:"total-cpu-stat-system"`
-				TotalCPUStatIdle      float64 `json:"total-cpu-stat-idle"`
-				TotalCPUStatGuest     float64  `json:"total-cpu-stat-guest"`
-				MemoryProcessSize     struct {
+				TotalCPUStatUser   float64 `json:"total-cpu-stat-user"`
+				TotalCPUStatNice   float64 `json:"total-cpu-stat-nice"`
+				TotalCPUStatSystem float64 `json:"total-cpu-stat-system"`
+				TotalCPUStatIdle   float64 `json:"total-cpu-stat-idle"`
+				TotalCPUStatGuest  float64 `json:"total-cpu-stat-guest"`
+				MemoryProcessSize  struct {
 					Units string `json:"units"`
-					Value float64 `json:"value"`
+					Value int    `json:"value"`
 				} `json:"memory-process-size"`
 				MemoryProcessRss struct {
 					Units string `json:"units"`
-					Value float64    `json:"value"`
+					Value int    `json:"value"`
 				} `json:"memory-process-rss"`
 				MemorySystemTotal struct {
 					Units string `json:"units"`
-					Value float64    `json:"value"`
+					Value int    `json:"value"`
 				} `json:"memory-system-total"`
 				MemorySystemFree struct {
 					Units string `json:"units"`
-					Value float64    `json:"value"`
+					Value int    `json:"value"`
 				} `json:"memory-system-free"`
 				DataDirSpace struct {
 					Units string `json:"units"`
-					Value float64    `json:"value"`
+					Value int    `json:"value"`
 				} `json:"data-dir-space"`
 				QueryReadBytes struct {
 					Units string `json:"units"`
-					Value float64    `json:"value"`
+					Value int    `json:"value"`
 				} `json:"query-read-bytes"`
 				QueryReadLoad struct {
 					Units string `json:"units"`
-					Value float64    `json:"value"`
+					Value int    `json:"value"`
 				} `json:"query-read-load"`
 				HTTPServerReceiveBytes struct {
-					Units string `json:"units"`
-					Value float64    `json:"value"`
+					Units string  `json:"units"`
+					Value float64 `json:"value"`
 				} `json:"http-server-receive-bytes"`
 				HTTPServerSendBytes struct {
-					Units string `json:"units"`
-					Value float64    `json:"value"`
+					Units string  `json:"units"`
+					Value float64 `json:"value"`
 				} `json:"http-server-send-bytes"`
 			} `json:"status-detail"`
 		} `json:"status-properties"`
@@ -173,11 +172,11 @@ func (c *Marklogic) fetchAndInsertData(acc telegraf.Accumulator, host string) er
 		}
 	}
 
-t := dac.NewTransport(c.DigestUsername, c.DigestPassword)
-req, err := http.NewRequest("GET", host, nil)
-if err != nil {
-	return err
-}
+	t := dac.NewTransport(c.DigestUsername, c.DigestPassword)
+	req, err := http.NewRequest("GET", host, nil)
+	if err != nil {
+		return err
+	}
 
 	response, err := t.RoundTrip(req)
 	if err != nil {
@@ -197,29 +196,28 @@ if err != nil {
 
 	// Build a map of tags
 	tags := map[string]string{
-    //"server":   hs.Host,
-		"ml_hostname":  stats.HostStatus.Name,
-		"id":  stats.HostStatus.ID,
-
+		//"server":   hs.Host,
+		"ml_hostname": stats.HostStatus.Name,
+		"id":          stats.HostStatus.ID,
 	}
 
 	// Build a map of field values
 	fields := map[string]interface{}{
 
-		"online":                             stats.HostStatus.StatusProperties.Online.Value,
-    "total_cpu_stat_user":                stats.HostStatus.StatusProperties.StatusDetail.TotalCPUStatUser,
-		"total_cpu_stat_system":              stats.HostStatus.StatusProperties.StatusDetail.TotalCPUStatSystem,
-		"memory_process_size":                stats.HostStatus.StatusProperties.StatusDetail.MemoryProcessSize.Value,
-		"memory_process_rss":                 stats.HostStatus.StatusProperties.StatusDetail.MemoryProcessRss.Value,
-		"memory_system_total":                stats.HostStatus.StatusProperties.StatusDetail.MemorySystemTotal.Value,
-		"memory_system_free":                 stats.HostStatus.StatusProperties.StatusDetail.MemorySystemFree.Value,
-		"num_cores":                          stats.HostStatus.StatusProperties.StatusDetail.Cores.Value,
-		"total_load":                         stats.HostStatus.StatusProperties.LoadProperties.TotalLoad.Value,
-		"data_dir_space":                     stats.HostStatus.StatusProperties.StatusDetail.DataDirSpace.Value,
-		"query_read_bytes":                   stats.HostStatus.StatusProperties.StatusDetail.QueryReadBytes.Value,
-		"query_read_load":                    stats.HostStatus.StatusProperties.StatusDetail.QueryReadLoad.Value,
-		"http_server_receive_bytes":          stats.HostStatus.StatusProperties.StatusDetail.HTTPServerReceiveBytes.Value,
-	  "http_server_send_bytes":             stats.HostStatus.StatusProperties.StatusDetail.HTTPServerSendBytes.Value,
+		"online":                    stats.HostStatus.StatusProperties.Online.Value,
+		"total_cpu_stat_user":       stats.HostStatus.StatusProperties.StatusDetail.TotalCPUStatUser,
+		"total_cpu_stat_system":     stats.HostStatus.StatusProperties.StatusDetail.TotalCPUStatSystem,
+		"memory_process_size":       stats.HostStatus.StatusProperties.StatusDetail.MemoryProcessSize.Value,
+		"memory_process_rss":        stats.HostStatus.StatusProperties.StatusDetail.MemoryProcessRss.Value,
+		"memory_system_total":       stats.HostStatus.StatusProperties.StatusDetail.MemorySystemTotal.Value,
+		"memory_system_free":        stats.HostStatus.StatusProperties.StatusDetail.MemorySystemFree.Value,
+		"num_cores":                 stats.HostStatus.StatusProperties.StatusDetail.Cores.Value,
+		"total_load":                stats.HostStatus.StatusProperties.LoadProperties.TotalLoad.Value,
+		"data_dir_space":            stats.HostStatus.StatusProperties.StatusDetail.DataDirSpace.Value,
+		"query_read_bytes":          stats.HostStatus.StatusProperties.StatusDetail.QueryReadBytes.Value,
+		"query_read_load":           stats.HostStatus.StatusProperties.StatusDetail.QueryReadLoad.Value,
+		"http_server_receive_bytes": stats.HostStatus.StatusProperties.StatusDetail.HTTPServerReceiveBytes.Value,
+		"http_server_send_bytes":    stats.HostStatus.StatusProperties.StatusDetail.HTTPServerSendBytes.Value,
 	}
 
 	// Accumulate the tags and values

--- a/plugins/inputs/marklogic/marklogic.go
+++ b/plugins/inputs/marklogic/marklogic.go
@@ -83,7 +83,7 @@ var sampleConfig = `
   ## Base URL of the MarkLogic HTTP Server.
   url = "http://localhost:8002"
 
-  ## List of specific hostnames in a cluster to retrieve information. At least (1) required.
+  ## List of specific hostnames to retrieve information. At least (1) required.
   # hosts = ["hostname1", "hostname2"]
 
   ## Using HTTP Digest Authentication. Management API requires 'manage-user' role privileges

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -20,7 +20,7 @@ func TestMarklogic(t *testing.T) {
 	defer ts.Close()
 
 	// Parse the URL of the test server, used to verify the expected host
-  _, err := url.Parse(ts.URL)
+	_, err := url.Parse(ts.URL)
 	require.NoError(t, err)
 
 	// Create a new Marklogic instance with our given test server
@@ -37,29 +37,27 @@ func TestMarklogic(t *testing.T) {
 	// Expect the correct values for all known keys
 	expectFields := map[string]interface{}{
 
-		"online":                   bool(true),
-    "total_cpu_stat_user":      float64(0.276381999254227 ),
-		"total_cpu_stat_system":    float64(0.636515974998474),
-		"memory_process_size":      float64(1234),
-		"memory_process_rss":       float64(815),
-		"memory_system_total":      float64(3947),
-		"memory_system_free":       float64(2761),
-		"num_cores":                int(4),
-		"total_load":               float64(0.00429263804107904),
-		"data_dir_space":           float64(34968),
-		"query_read_bytes":         float64(11492428),
-		"query_read_load":           float64(0),
+		"online":                    bool(true),
+		"total_cpu_stat_user":       float64(0.276381999254227),
+		"total_cpu_stat_system":     float64(0.636515974998474),
+		"memory_process_size":       int(1234),
+		"memory_process_rss":        int(815),
+		"memory_system_total":       int(3947),
+		"memory_system_free":        int(2761),
+		"num_cores":                 int(4),
+		"total_load":                float64(0.00429263804107904),
+		"data_dir_space":            int(34968),
+		"query_read_bytes":          int(11492428),
+		"query_read_load":           int(0),
 		"http_server_receive_bytes": float64(285915),
 		"http_server_send_bytes":    float64(0),
-
 	}
 	// Expect the correct values for all tags
 	expectTags := map[string]string{
-		"ml_hostname":  string("ml1.local"),
-		"id":   string("2592913110757471141"),
+		"ml_hostname": string("ml1.local"),
+		"id":          string("2592913110757471141"),
 	}
 
-  //fmt.Println(acc.Metrics)
 	acc.AssertContainsTaggedFields(t, "marklogic", expectFields, expectTags)
 
 }

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -60,7 +60,7 @@ func TestMarklogic(t *testing.T) {
 	}
 	// Expect the correct values for all tags
 	expectTags := map[string]string{
-		"name": "ml1.local",
+		"source": "ml1.local",
 		"id":   "2592913110757471141",
 	}
 

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -24,13 +24,19 @@ func TestMarklogic(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new Marklogic instance with our given test server
+
 	ml := &Marklogic{
 		Hosts: []string{"example1"},
 		URL:   string(ts.URL),
+		//Sources: []string{"http://localhost:8002/manage/v2/hosts/hostname1?view=status&format=json"},
 	}
 
 	// Create a test accumulator
 	acc := &testutil.Accumulator{}
+
+	// Init() call to parse all source URL's
+	err = ml.Init()
+	require.NoError(t, err)
 
 	// Gather data from the test server
 	err = ml.Gather(acc)
@@ -51,11 +57,15 @@ func TestMarklogic(t *testing.T) {
 		"memory_process_rss":        815,
 		"memory_system_total":       3947,
 		"memory_system_free":        2761,
+		"memory_process_swap_size":  0,
 		"memory_size":               4096,
 		"host_size":                 64,
+		"log_device_space":          34968,
 		"data_dir_space":            34968,
 		"query_read_bytes":          11492428,
 		"query_read_load":           0,
+		"merge_read_load":           0,
+		"merge_write_load":          0,
 		"http_server_receive_bytes": 285915,
 		"http_server_send_bytes":    0,
 	}

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -24,15 +24,16 @@ func TestMarklogic(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new Marklogic instance with our given test server
-	Marklogic := NewMarklogic()
-	Marklogic.Hosts = []string{"example1"}
-	Marklogic.URL = string(ts.URL)
+	ml := &Marklogic{
+		Hosts: []string{"example1"},
+		URL:   string(ts.URL),
+	}
 
 	// Create a test accumulator
 	acc := &testutil.Accumulator{}
 
 	// Gather data from the test server
-	err = Marklogic.Gather(acc)
+	err = ml.Gather(acc)
 	require.NoError(t, err)
 
 	// Expect the correct values for all known keys

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -1,0 +1,1267 @@
+package marklogic
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarklogic(t *testing.T) {
+	// Create a test server with the const response JSON
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, response)
+	}))
+	defer ts.Close()
+
+	// Parse the URL of the test server, used to verify the expected host
+  _, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	// Create a new Marklogic instance with our given test server
+	Marklogic := NewMarklogic()
+	Marklogic.Hosts = []string{ts.URL}
+
+	// Create a test accumulator
+	acc := &testutil.Accumulator{}
+
+	// Gather data from the test server
+	err = Marklogic.Gather(acc)
+	require.NoError(t, err)
+
+	// Expect the correct values for all known keys
+	expectFields := map[string]interface{}{
+
+		"online":                   bool(true),
+    "total_cpu_stat_user":      float64(0.276381999254227 ),
+		"total_cpu_stat_system":    float64(0.636515974998474),
+		"memory_process_size":      float64(1234),
+		"memory_process_rss":       float64(815),
+		"memory_system_total":      float64(3947),
+		"memory_system_free":       float64(2761),
+		"num_cores":                int(4),
+		"total_load":               float64(0.00429263804107904),
+		"data_dir_space":           float64(34968),
+		"query_read_bytes":         float64(11492428),
+		"query_read_load":           float64(0),
+		"http_server_receive_bytes": float64(285915),
+		"http_server_send_bytes":    float64(0),
+
+	}
+	// Expect the correct values for all tags
+	expectTags := map[string]string{
+		"ml_hostname":  string("ml1.local"),
+		"id":   string("2592913110757471141"),
+	}
+
+  //fmt.Println(acc.Metrics)
+	acc.AssertContainsTaggedFields(t, "marklogic", expectFields, expectTags)
+
+}
+
+var response = `
+{
+  "host-status": {
+    "id": "2592913110757471141",
+    "name": "ml1.local",
+    "version": "10.0-1",
+    "effective-version": 10000100,
+    "host-mode": "normal",
+    "host-mode-description": "",
+    "meta": {
+      "uri": "/manage/LATEST/hosts/ml1.local?view=status",
+      "current-time": "2019-07-28T22:32:19.056203Z",
+      "elapsed-time": {
+        "units": "sec",
+        "value": 0.013035
+      }
+    },
+    "relations": {
+      "relation-group": [
+        {
+          "uriref": "/manage/LATEST/forests?view=status&host-id=ml1.local",
+          "typeref": "forests",
+          "relation": [
+            {
+              "uriref": "/manage/LATEST/forests/App-Services",
+              "idref": "8573569457346659714",
+              "nameref": "App-Services"
+            },
+            {
+              "uriref": "/manage/LATEST/forests/Documents",
+              "idref": "17189472171231792168",
+              "nameref": "Documents"
+            },
+            {
+              "uriref": "/manage/LATEST/forests/Extensions",
+              "idref": "1510244530748962553",
+              "nameref": "Extensions"
+            },
+            {
+              "uriref": "/manage/LATEST/forests/Fab",
+              "idref": "16221965829238302106",
+              "nameref": "Fab"
+            },
+            {
+              "uriref": "/manage/LATEST/forests/Last-Login",
+              "idref": "1093671762706318022",
+              "nameref": "Last-Login"
+            },
+            {
+              "uriref": "/manage/LATEST/forests/Meters",
+              "idref": "1573439446779995954",
+              "nameref": "Meters"
+            },
+            {
+              "uriref": "/manage/LATEST/forests/Modules",
+              "idref": "18320951141685848719",
+              "nameref": "Modules"
+            },
+            {
+              "uriref": "/manage/LATEST/forests/Schemas",
+              "idref": "18206720449696085936",
+              "nameref": "Schemas"
+            },
+            {
+              "uriref": "/manage/LATEST/forests/Security",
+              "idref": "9348728036360382939",
+              "nameref": "Security"
+            },
+            {
+              "uriref": "/manage/LATEST/forests/Triggers",
+              "idref": "10142793547905338229",
+              "nameref": "Triggers"
+            }
+          ]
+        },
+        {
+          "typeref": "groups",
+          "relation": [
+            {
+              "uriref": "/manage/LATEST/groups/Default?view=status",
+              "idref": "16808579782544283978",
+              "nameref": "Default"
+            }
+          ]
+        }
+      ]
+    },
+    "status-properties": {
+      "online": {
+        "units": "bool",
+        "value": true
+      },
+      "secure": {
+        "units": "bool",
+        "value": false
+      },
+      "cache-properties": {
+        "cache-detail": {
+          "compressed-tree-cache-partition": [
+            {
+              "partition-size": 64,
+              "partition-table": 3.40000009536743,
+              "partition-used": 29.7000007629395,
+              "partition-free": 70.1999969482422,
+              "partition-overhead": 0.100000001490116
+            }
+          ],
+          "expanded-tree-cache-partition": [
+            {
+              "partition-size": 128,
+              "partition-table": 6.19999980926514,
+              "partition-busy": 0,
+              "partition-used": 87.3000030517578,
+              "partition-free": 12.3999996185303,
+              "partition-overhead": 0.300000011920929
+            }
+          ],
+          "triple-cache-partition": [
+            {
+              "partition-size": 64,
+              "partition-busy": 0,
+              "partition-used": 0,
+              "partition-free": 100
+            }
+          ],
+          "triple-value-cache-partition": [
+            {
+              "partition-size": 128,
+              "partition-busy": 0,
+              "partition-used": 0,
+              "partition-free": 100,
+              "value-count": 0,
+              "value-bytes-total": 0,
+              "value-bytes-average": 0
+            }
+          ]
+        }
+      },
+      "load-properties": {
+        "total-load": {
+          "units": "sec/sec",
+          "value": 0.00429263804107904
+        },
+        "load-detail": {
+          "query-read-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "journal-write-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "save-write-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "merge-read-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "merge-write-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "backup-read-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "backup-write-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "restore-read-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "restore-write-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "large-read-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "large-write-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "external-binary-read-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "xdqp-client-receive-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "xdqp-client-send-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "xdqp-server-receive-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "xdqp-server-send-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "foreign-xdqp-client-receive-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "foreign-xdqp-client-send-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "foreign-xdqp-server-receive-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "foreign-xdqp-server-send-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "read-lock-wait-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "read-lock-hold-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "write-lock-wait-load": {
+            "units": "sec/sec",
+            "value": 0
+          },
+          "write-lock-hold-load": {
+            "units": "sec/sec",
+            "value": 0.00429263804107904
+          },
+          "deadlock-wait-load": {
+            "units": "sec/sec",
+            "value": 0
+          }
+        }
+      },
+      "rate-properties": {
+        "total-rate": {
+          "units": "MB/sec",
+          "value": 15.6527042388916
+        },
+        "rate-detail": {
+          "memory-system-pagein-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "memory-system-pageout-rate": {
+            "units": "MB/sec",
+            "value": 15.6420001983643
+          },
+          "memory-system-swapin-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "memory-system-swapout-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "query-read-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "journal-write-rate": {
+            "units": "MB/sec",
+            "value": 0.00372338597662747
+          },
+          "save-write-rate": {
+            "units": "MB/sec",
+            "value": 0.0024786819703877
+          },
+          "merge-read-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "merge-write-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "backup-read-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "backup-write-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "restore-read-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "restore-write-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "large-read-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "large-write-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "external-binary-read-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "xdqp-client-receive-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "xdqp-client-send-rate": {
+            "units": "MB/sec",
+            "value": 0.00293614692054689
+          },
+          "xdqp-server-receive-rate": {
+            "units": "MB/sec",
+            "value": 0.00156576896551996
+          },
+          "xdqp-server-send-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "foreign-xdqp-client-receive-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "foreign-xdqp-client-send-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "foreign-xdqp-server-receive-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "foreign-xdqp-server-send-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "read-lock-rate": {
+            "units": "MB/sec",
+            "value": 0
+          },
+          "write-lock-rate": {
+            "units": "MB/sec",
+            "value": 0.251882910728455
+          },
+          "deadlock-rate": {
+            "units": "MB/sec",
+            "value": 0
+          }
+        }
+      },
+      "status-detail": {
+        "bind-port": 7999,
+        "connect-port": 7999,
+        "ssl-fips-enabled": {
+          "units": "bool",
+          "value": true
+        },
+        "foreign-bind-port": 7998,
+        "foreign-connect-port": 7998,
+        "background-io-limit": {
+          "units": "quantity",
+          "value": 0
+        },
+        "metering-enabled": {
+          "units": "bool",
+          "value": true
+        },
+        "meters-database": {
+          "units": "quantity",
+          "value": "11952918530142281790"
+        },
+        "performance-metering-enabled": {
+          "units": "bool",
+          "value": true
+        },
+        "performance-metering-period": {
+          "units": "second",
+          "value": 60
+        },
+        "performance-metering-retain-raw": {
+          "units": "day",
+          "value": 7
+        },
+        "performance-metering-retain-hourly": {
+          "units": "day",
+          "value": 30
+        },
+        "performance-metering-retain-daily": {
+          "units": "day",
+          "value": 90
+        },
+        "last-startup": {
+          "units": "datetime",
+          "value": "2019-07-26T17:23:36.412644Z"
+        },
+        "version": "10.0-1",
+        "effective-version": {
+          "units": "quantity",
+          "value": 10000100
+        },
+        "software-version": {
+          "units": "quantity",
+          "value": 10000100
+        },
+        "os-version": "Linux 4.9.125-linuxkit (CentOS Linux release 7.6.1810 (Core) ) on Docker",
+        "converters-version": "10.0-1",
+        "host-mode": {
+          "units": "enum",
+          "value": "normal"
+        },
+        "architecture": "x86_64",
+        "platform": "linux",
+        "license-key": "B585-FDCF-618B-FB5F-C38E-285F-DCF6-F7B6-C13E-6275-93BC-50E4-0738-32C5-1EC0-7783-4C52-E417-B838-C54E-7CCE-4D00",
+        "licensee": "Craig Hobbs - Development",
+        "license-key-expires": {
+          "units": "datetime",
+          "value": "2020-01-23T00:00:00Z"
+        },
+        "license-key-cpus": {
+          "units": "quantity",
+          "value": 0
+        },
+        "license-key-cores": {
+          "units": "quantity",
+          "value": 0
+        },
+        "license-key-size": {
+          "units": "MB",
+          "value": 0
+        },
+        "license-key-option": [
+          {
+            "units": "enum",
+            "value": "conversion"
+          },
+          {
+            "units": "enum",
+            "value": "failover"
+          },
+          {
+            "units": "enum",
+            "value": "alerting"
+          },
+          {
+            "units": "enum",
+            "value": "geospatial"
+          },
+          {
+            "units": "enum",
+            "value": "flexible replication"
+          },
+          {
+            "units": "enum",
+            "value": "tiered storage"
+          },
+          {
+            "units": "enum",
+            "value": "semantics"
+          },
+          {
+            "units": "enum",
+            "value": "French"
+          },
+          {
+            "units": "enum",
+            "value": "Italian"
+          },
+          {
+            "units": "enum",
+            "value": "German"
+          },
+          {
+            "units": "enum",
+            "value": "Spanish"
+          },
+          {
+            "units": "enum",
+            "value": "Traditional Chinese"
+          },
+          {
+            "units": "enum",
+            "value": "Simplified Chinese"
+          },
+          {
+            "units": "enum",
+            "value": "Arabic"
+          },
+          {
+            "units": "enum",
+            "value": "Russian"
+          },
+          {
+            "units": "enum",
+            "value": "Dutch"
+          },
+          {
+            "units": "enum",
+            "value": "Korean"
+          },
+          {
+            "units": "enum",
+            "value": "Persian"
+          },
+          {
+            "units": "enum",
+            "value": "Japanese"
+          },
+          {
+            "units": "enum",
+            "value": "Portuguese"
+          },
+          {
+            "units": "enum",
+            "value": "English"
+          }
+        ],
+        "edition": {
+          "units": "enum",
+          "value": "Enterprise Edition"
+        },
+        "environment": {
+          "units": "enum",
+          "value": "developer"
+        },
+        "cpus": {
+          "units": "quantity",
+          "value": 1
+        },
+        "cores": {
+          "units": "quantity",
+          "value": 4
+        },
+        "core-threads": {
+          "units": "quantity",
+          "value": 4
+        },
+        "total-cpu-stat-user": 0.276381999254227,
+        "total-cpu-stat-nice": 0,
+        "total-cpu-stat-system": 0.636515974998474,
+        "total-cpu-stat-idle": 99.0578002929688,
+        "total-cpu-stat-iowait": 0.0125628001987934,
+        "total-cpu-stat-irq": 0,
+        "total-cpu-stat-softirq": 0.0167504008859396,
+        "total-cpu-stat-steal": 0,
+        "total-cpu-stat-guest": 0,
+        "total-cpu-stat-guest-nice": 0,
+        "memory-process-size": {
+          "units": "fraction",
+          "value": 1234
+        },
+        "memory-process-rss": {
+          "units": "fraction",
+          "value": 815
+        },
+        "memory-process-anon": {
+          "units": "fraction",
+          "value": 743
+        },
+        "memory-process-rss-hwm": {
+          "units": "fraction",
+          "value": 1072
+        },
+        "memory-process-swap-size": {
+          "units": "fraction",
+          "value": 0
+        },
+        "memory-process-huge-pages-size": {
+          "units": "fraction",
+          "value": 0
+        },
+        "memory-system-total": {
+          "units": "fraction",
+          "value": 3947
+        },
+        "memory-system-free": {
+          "units": "fraction",
+          "value": 2761
+        },
+        "memory-system-pagein-rate": {
+          "units": "fraction",
+          "value": 0
+        },
+        "memory-system-pageout-rate": {
+          "units": "fraction",
+          "value": 15.6420001983643
+        },
+        "memory-system-swapin-rate": {
+          "units": "fraction",
+          "value": 0
+        },
+        "memory-system-swapout-rate": {
+          "units": "fraction",
+          "value": 0
+        },
+        "memory-size": {
+          "units": "quantity",
+          "value": 4096
+        },
+        "memory-file-size": {
+          "units": "quantity",
+          "value": 5
+        },
+        "memory-forest-size": {
+          "units": "quantity",
+          "value": 849
+        },
+        "memory-unclosed-size": {
+          "units": "quantity",
+          "value": 0
+        },
+        "memory-cache-size": {
+          "units": "quantity",
+          "value": 320
+        },
+        "memory-registry-size": {
+          "units": "quantity",
+          "value": 1
+        },
+        "memory-join-size": {
+          "units": "quantity",
+          "value": 0
+        },
+        "host-size": {
+          "units": "MB",
+          "value": 64
+        },
+        "host-large-data-size": {
+          "units": "MB",
+          "value": 0
+        },
+        "log-device-space": {
+          "units": "MB",
+          "value": 34968
+        },
+        "data-dir-space": {
+          "units": "MB",
+          "value": 34968
+        },
+        "query-read-bytes": {
+          "units": "bytes",
+          "value": 11492428
+        },
+        "query-read-time": {
+          "units": "time",
+          "value": "PT0.141471S"
+        },
+        "query-read-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "query-read-load": {
+          "units": "",
+          "value": 0
+        },
+        "journal-write-bytes": {
+          "units": "bytes",
+          "value": 285717868
+        },
+        "journal-write-time": {
+          "units": "time",
+          "value": "PT17.300832S"
+        },
+        "journal-write-rate": {
+          "units": "MB/sec",
+          "value": 0.00372338597662747
+        },
+        "journal-write-load": {
+          "units": "",
+          "value": 0
+        },
+        "save-write-bytes": {
+          "units": "bytes",
+          "value": 95818597
+        },
+        "save-write-time": {
+          "units": "time",
+          "value": "PT2.972855S"
+        },
+        "save-write-rate": {
+          "units": "MB/sec",
+          "value": 0.0024786819703877
+        },
+        "save-write-load": {
+          "units": "",
+          "value": 0
+        },
+        "merge-read-bytes": {
+          "units": "bytes",
+          "value": 55374848
+        },
+        "merge-read-time": {
+          "units": "time",
+          "value": "PT0.535705S"
+        },
+        "merge-read-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "merge-read-load": {
+          "units": "",
+          "value": 0
+        },
+        "merge-write-bytes": {
+          "units": "bytes",
+          "value": 146451731
+        },
+        "merge-write-time": {
+          "units": "time",
+          "value": "PT5.392288S"
+        },
+        "merge-write-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "merge-write-load": {
+          "units": "",
+          "value": 0
+        },
+        "backup-read-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "backup-read-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "backup-read-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "backup-read-load": {
+          "units": "",
+          "value": 0
+        },
+        "backup-write-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "backup-write-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "backup-write-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "backup-write-load": {
+          "units": "",
+          "value": 0
+        },
+        "restore-read-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "restore-read-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "restore-read-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "restore-read-load": {
+          "units": "",
+          "value": 0
+        },
+        "restore-write-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "restore-write-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "restore-write-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "restore-write-load": {
+          "units": "",
+          "value": 0
+        },
+        "large-read-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "large-read-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "large-read-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "large-read-load": {
+          "units": "",
+          "value": 0
+        },
+        "large-write-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "large-write-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "large-write-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "large-write-load": {
+          "units": "",
+          "value": 0
+        },
+        "external-binary-read-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "external-binary-read-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "external-binary-read-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "external-binary-read-load": {
+          "units": "",
+          "value": 0
+        },
+        "webDAV-server-receive-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "webDAV-server-receive-time": {
+          "units": "sec",
+          "value": "PT0S"
+        },
+        "webDAV-server-receive-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "webDAV-server-receive-load": {
+          "units": "",
+          "value": 0
+        },
+        "webDAV-server-send-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "webDAV-server-send-time": {
+          "units": "sec",
+          "value": "PT0S"
+        },
+        "webDAV-server-send-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "webDAV-server-send-load": {
+          "units": "",
+          "value": 0
+        },
+        "http-server-receive-bytes": {
+          "units": "bytes",
+          "value": 285915
+        },
+        "http-server-receive-time": {
+          "units": "sec",
+          "value": "PT0.02028S"
+        },
+        "http-server-receive-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "http-server-receive-load": {
+          "units": "",
+          "value": 0
+        },
+        "http-server-send-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "http-server-send-time": {
+          "units": "sec",
+          "value": "PT0S"
+        },
+        "http-server-send-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "http-server-send-load": {
+          "units": "",
+          "value": 0
+        },
+        "xdbc-server-receive-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "xdbc-server-receive-time": {
+          "units": "sec",
+          "value": "PT0S"
+        },
+        "xdbc-server-receive-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "xdbc-server-receive-load": {
+          "units": "",
+          "value": 0
+        },
+        "xdbc-server-send-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "xdbc-server-send-time": {
+          "units": "sec",
+          "value": "PT0S"
+        },
+        "xdbc-server-send-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "xdbc-server-send-load": {
+          "units": "",
+          "value": 0
+        },
+        "odbc-server-receive-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "odbc-server-receive-time": {
+          "units": "sec",
+          "value": "PT0S"
+        },
+        "odbc-server-receive-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "odbc-server-receive-load": {
+          "units": "",
+          "value": 0
+        },
+        "odbc-server-send-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "odbc-server-send-time": {
+          "units": "sec",
+          "value": "PT0S"
+        },
+        "odbc-server-send-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "odbc-server-send-load": {
+          "units": "",
+          "value": 0
+        },
+        "xdqp-client-receive-bytes": {
+          "units": "bytes",
+          "value": 3020032
+        },
+        "xdqp-client-receive-time": {
+          "units": "time",
+          "value": "PT0.046612S"
+        },
+        "xdqp-client-receive-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "xdqp-client-receive-load": {
+          "units": "",
+          "value": 0
+        },
+        "xdqp-client-send-bytes": {
+          "units": "bytes",
+          "value": 163513952
+        },
+        "xdqp-client-send-time": {
+          "units": "time",
+          "value": "PT22.700289S"
+        },
+        "xdqp-client-send-rate": {
+          "units": "MB/sec",
+          "value": 0.00293614692054689
+        },
+        "xdqp-client-send-load": {
+          "units": "",
+          "value": 0
+        },
+        "xdqp-server-receive-bytes": {
+          "units": "bytes",
+          "value": 131973888
+        },
+        "xdqp-server-receive-time": {
+          "units": "time",
+          "value": "PT3.474521S"
+        },
+        "xdqp-server-receive-rate": {
+          "units": "MB/sec",
+          "value": 0.00156576896551996
+        },
+        "xdqp-server-receive-load": {
+          "units": "",
+          "value": 0
+        },
+        "xdqp-server-send-bytes": {
+          "units": "bytes",
+          "value": 10035300
+        },
+        "xdqp-server-send-time": {
+          "units": "time",
+          "value": "PT4.275597S"
+        },
+        "xdqp-server-send-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "xdqp-server-send-load": {
+          "units": "",
+          "value": 0
+        },
+        "xdqp-server-request-time": {
+          "units": "milliseconds",
+          "value": 0.743777990341187
+        },
+        "xdqp-server-request-rate": {
+          "units": "requests/sec",
+          "value": 0.371862411499023
+        },
+        "foreign-xdqp-client-receive-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "foreign-xdqp-client-receive-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "foreign-xdqp-client-receive-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "foreign-xdqp-client-receive-load": {
+          "units": "",
+          "value": 0
+        },
+        "foreign-xdqp-client-send-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "foreign-xdqp-client-send-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "foreign-xdqp-client-send-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "foreign-xdqp-client-send-load": {
+          "units": "",
+          "value": 0
+        },
+        "foreign-xdqp-server-receive-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "foreign-xdqp-server-receive-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "foreign-xdqp-server-receive-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "foreign-xdqp-server-receive-load": {
+          "units": "",
+          "value": 0
+        },
+        "foreign-xdqp-server-send-bytes": {
+          "units": "bytes",
+          "value": 0
+        },
+        "foreign-xdqp-server-send-time": {
+          "units": "time",
+          "value": "PT0S"
+        },
+        "foreign-xdqp-server-send-rate": {
+          "units": "MB/sec",
+          "value": 0
+        },
+        "foreign-xdqp-server-send-load": {
+          "units": "",
+          "value": 0
+        },
+        "read-lock-count": {
+          "units": "locks",
+          "value": 104
+        },
+        "read-lock-wait-time": {
+          "units": "seconds",
+          "value": "PT0.001464S"
+        },
+        "read-lock-hold-time": {
+          "units": "seconds",
+          "value": "PT3.022913S"
+        },
+        "read-lock-rate": {
+          "units": "locks/sec",
+          "value": 0
+        },
+        "read-lock-wait-load": {
+          "units": "",
+          "value": 0
+        },
+        "read-lock-hold-load": {
+          "units": "",
+          "value": 0
+        },
+        "write-lock-count": {
+          "units": "locks",
+          "value": 15911
+        },
+        "write-lock-wait-time": {
+          "units": "seconds",
+          "value": "PT0.317098S"
+        },
+        "write-lock-hold-time": {
+          "units": "seconds",
+          "value": "PT11M46.9923759S"
+        },
+        "write-lock-rate": {
+          "units": "locks/sec",
+          "value": 0.251882910728455
+        },
+        "write-lock-wait-load": {
+          "units": "",
+          "value": 0
+        },
+        "write-lock-hold-load": {
+          "units": "",
+          "value": 0.00429263804107904
+        },
+        "deadlock-count": {
+          "units": "locks",
+          "value": 0
+        },
+        "deadlock-wait-time": {
+          "units": "seconds",
+          "value": "PT0S"
+        },
+        "deadlock-rate": {
+          "units": "locks/sec",
+          "value": 0
+        },
+        "deadlock-wait-load": {
+          "units": "",
+          "value": 0
+        },
+        "external-kms-request-rate": {
+          "units": "requests/sec",
+          "value": 0
+        },
+        "external-kms-request-time": {
+          "units": "milliseconds",
+          "value": 0
+        },
+        "keystore-status": "normal",
+        "ldap-request-rate": {
+          "units": "requests/sec",
+          "value": 0
+        },
+        "ldap-request-time": {
+          "units": "milliseconds",
+          "value": 0
+        }
+      }
+    },
+    "related-views": {
+      "related-view": [
+        {
+          "view-type": "item",
+          "view-name": "default",
+          "view-uri": "/manage/LATEST/hosts/ml1.local"
+        }
+      ]
+    }
+  }
+}
+`

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -25,7 +25,8 @@ func TestMarklogic(t *testing.T) {
 
 	// Create a new Marklogic instance with our given test server
 	Marklogic := NewMarklogic()
-	Marklogic.Hosts = []string{ts.URL}
+	Marklogic.Hosts = []string{"example1"}
+	Marklogic.URL = string(ts.URL)
 
 	// Create a test accumulator
 	acc := &testutil.Accumulator{}
@@ -36,26 +37,31 @@ func TestMarklogic(t *testing.T) {
 
 	// Expect the correct values for all known keys
 	expectFields := map[string]interface{}{
-
-		"online":                    bool(true),
-		"total_cpu_stat_user":       float64(0.276381999254227),
-		"total_cpu_stat_system":     float64(0.636515974998474),
-		"memory_process_size":       int(1234),
-		"memory_process_rss":        int(815),
-		"memory_system_total":       int(3947),
-		"memory_system_free":        int(2761),
-		"num_cores":                 int(4),
-		"total_load":                float64(0.00429263804107904),
-		"data_dir_space":            int(34968),
-		"query_read_bytes":          int(11492428),
-		"query_read_load":           int(0),
-		"http_server_receive_bytes": float64(285915),
-		"http_server_send_bytes":    float64(0),
+		"online":                    true,
+		"total_load":                0.00429263804107904,
+		"ncpus":                     1,
+		"ncores":                    4,
+		"total_rate":                15.6527042388916,
+		"total_cpu_stat_user":       0.276381999254227,
+		"total_cpu_stat_system":     0.636515974998474,
+		"total_cpu_stat_idle":       99.0578002929688,
+		"total_cpu_stat_iowait":     0.0125628001987934,
+		"memory_process_size":       1234,
+		"memory_process_rss":        815,
+		"memory_system_total":       3947,
+		"memory_system_free":        2761,
+		"memory_size":               4096,
+		"host_size":                 64,
+		"data_dir_space":            34968,
+		"query_read_bytes":          11492428,
+		"query_read_load":           0,
+		"http_server_receive_bytes": 285915,
+		"http_server_send_bytes":    0,
 	}
 	// Expect the correct values for all tags
 	expectTags := map[string]string{
-		"ml_hostname": string("ml1.local"),
-		"id":          string("2592913110757471141"),
+		"name": "ml1.local",
+		"id":   "2592913110757471141",
 	}
 
 	acc.AssertContainsTaggedFields(t, "marklogic", expectFields, expectTags)
@@ -72,7 +78,7 @@ var response = `
     "host-mode": "normal",
     "host-mode-description": "",
     "meta": {
-      "uri": "/manage/LATEST/hosts/ml1.local?view=status",
+      "uri": "/manage/v2/hosts/ml1.local?view=status",
       "current-time": "2019-07-28T22:32:19.056203Z",
       "elapsed-time": {
         "units": "sec",
@@ -82,56 +88,56 @@ var response = `
     "relations": {
       "relation-group": [
         {
-          "uriref": "/manage/LATEST/forests?view=status&host-id=ml1.local",
+          "uriref": "/manage/v2/forests?view=status&host-id=ml1.local",
           "typeref": "forests",
           "relation": [
             {
-              "uriref": "/manage/LATEST/forests/App-Services",
+              "uriref": "/manage/v2/forests/App-Services",
               "idref": "8573569457346659714",
               "nameref": "App-Services"
             },
             {
-              "uriref": "/manage/LATEST/forests/Documents",
+              "uriref": "/manage/v2/forests/Documents",
               "idref": "17189472171231792168",
               "nameref": "Documents"
             },
             {
-              "uriref": "/manage/LATEST/forests/Extensions",
+              "uriref": "/manage/v2/forests/Extensions",
               "idref": "1510244530748962553",
               "nameref": "Extensions"
             },
             {
-              "uriref": "/manage/LATEST/forests/Fab",
+              "uriref": "/manage/v2/forests/Fab",
               "idref": "16221965829238302106",
               "nameref": "Fab"
             },
             {
-              "uriref": "/manage/LATEST/forests/Last-Login",
+              "uriref": "/manage/v2/forests/Last-Login",
               "idref": "1093671762706318022",
               "nameref": "Last-Login"
             },
             {
-              "uriref": "/manage/LATEST/forests/Meters",
+              "uriref": "/manage/v2/forests/Meters",
               "idref": "1573439446779995954",
               "nameref": "Meters"
             },
             {
-              "uriref": "/manage/LATEST/forests/Modules",
+              "uriref": "/manage/v2/forests/Modules",
               "idref": "18320951141685848719",
               "nameref": "Modules"
             },
             {
-              "uriref": "/manage/LATEST/forests/Schemas",
+              "uriref": "/manage/v2/forests/Schemas",
               "idref": "18206720449696085936",
               "nameref": "Schemas"
             },
             {
-              "uriref": "/manage/LATEST/forests/Security",
+              "uriref": "/manage/v2/forests/Security",
               "idref": "9348728036360382939",
               "nameref": "Security"
             },
             {
-              "uriref": "/manage/LATEST/forests/Triggers",
+              "uriref": "/manage/v2/forests/Triggers",
               "idref": "10142793547905338229",
               "nameref": "Triggers"
             }
@@ -141,7 +147,7 @@ var response = `
           "typeref": "groups",
           "relation": [
             {
-              "uriref": "/manage/LATEST/groups/Default?view=status",
+              "uriref": "/manage/v2/groups/Default?view=status",
               "idref": "16808579782544283978",
               "nameref": "Default"
             }
@@ -478,7 +484,7 @@ var response = `
           "units": "quantity",
           "value": 10000100
         },
-        "os-version": "Linux 4.9.125-linuxkit (CentOS Linux release 7.6.1810 (Core) ) on Docker",
+        "os-version": "NA",
         "converters-version": "10.0-1",
         "host-mode": {
           "units": "enum",
@@ -486,11 +492,11 @@ var response = `
         },
         "architecture": "x86_64",
         "platform": "linux",
-        "license-key": "B585-FDCF-618B-FB5F-C38E-285F-DCF6-F7B6-C13E-6275-93BC-50E4-0738-32C5-1EC0-7783-4C52-E417-B838-C54E-7CCE-4D00",
-        "licensee": "Craig Hobbs - Development",
+        "license-key": "000-000-000-000-000-000-000",
+        "licensee": "NA",
         "license-key-expires": {
           "units": "datetime",
-          "value": "2020-01-23T00:00:00Z"
+          "value": "2999-01-23T00:00:00Z"
         },
         "license-key-cpus": {
           "units": "quantity",
@@ -1256,7 +1262,7 @@ var response = `
         {
           "view-type": "item",
           "view-name": "default",
-          "view-uri": "/manage/LATEST/hosts/ml1.local"
+          "view-uri": "/manage/v2/hosts/example"
         }
       ]
     }

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -61,7 +61,7 @@ func TestMarklogic(t *testing.T) {
 	// Expect the correct values for all tags
 	expectTags := map[string]string{
 		"source": "ml1.local",
-		"id":   "2592913110757471141",
+		"id":     "2592913110757471141",
 	}
 
 	acc.AssertContainsTaggedFields(t, "marklogic", expectFields, expectTags)


### PR DESCRIPTION
### Required for all PRs:

- [] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This is a new input plugin for monitoring the Marklogic Databases using their Management API. The plugin requires the "Digest Authentication" as that is the default method for MarklogicDB.

[TAGS]
"ml_hostname"
"id"
[FIELDS]
"online"                          
"total_cpu_stat_user"               
"total_cpu_stat_system"           
"memory_process_size"             
"memory_process_rss"
"memory_system_total"
"memory_system_free":                 
"num_cores"
"total_load"                        
"data_dir_space"
"query_read_bytes"
"query_read_load"                    
"http_server_receive_bytes"
"http_server_send_bytes":             

Go-Libraray for Digest Auth Support:
xinsnake/go-http-digest-auth-client

Marklogic Documentation
-https://docs.marklogic.com/guide/monitoring/monitoringAPI
-https://docs.marklogic.com/REST/GET/manage/v2/hosts/[id-or-name]@view=status