### PR TITLE
logsfs available bytes fix

### DIFF
--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -208,7 +208,7 @@ func buildPodMetrics(summaryMetrics *SummaryMetrics, acc telegraf.Accumulator) {
 			fields["rootfs_available_bytes"] = container.RootFS.AvailableBytes
 			fields["rootfs_capacity_bytes"] = container.RootFS.CapacityBytes
 			fields["rootfs_used_bytes"] = container.RootFS.UsedBytes
-			fields["logsfs_avaialble_bytes"] = container.LogsFS.AvailableBytes
+			fields["logsfs_available_bytes"] = container.LogsFS.AvailableBytes
 			fields["logsfs_capacity_bytes"] = container.LogsFS.CapacityBytes
 			fields["logsfs_used_bytes"] = container.LogsFS.UsedBytes
 			acc.AddFields("kubernetes_pod_container", fields, tags)

--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -156,7 +156,7 @@ func buildSystemContainerMetrics(summaryMetrics *SummaryMetrics, acc telegraf.Ac
 		fields["memory_major_page_faults"] = container.Memory.MajorPageFaults
 		fields["rootfs_available_bytes"] = container.RootFS.AvailableBytes
 		fields["rootfs_capacity_bytes"] = container.RootFS.CapacityBytes
-		fields["logsfs_avaialble_bytes"] = container.LogsFS.AvailableBytes
+		fields["logsfs_available_bytes"] = container.LogsFS.AvailableBytes
 		fields["logsfs_capacity_bytes"] = container.LogsFS.CapacityBytes
 		acc.AddFields("kubernetes_system_container", fields, tags)
 	}

--- a/plugins/inputs/kubernetes/kubernetes_test.go
+++ b/plugins/inputs/kubernetes/kubernetes_test.go
@@ -35,7 +35,7 @@ func TestKubernetesStats(t *testing.T) {
 		"memory_major_page_faults":   int64(13),
 		"rootfs_available_bytes":     int64(84379979776),
 		"rootfs_capacity_bytes":      int64(105553100800),
-		"logsfs_avaialble_bytes":     int64(84379979776),
+		"logsfs_available_bytes":     int64(84379979776),
 		"logsfs_capacity_bytes":      int64(105553100800),
 	}
 	tags := map[string]string{

--- a/plugins/inputs/kubernetes/kubernetes_test.go
+++ b/plugins/inputs/kubernetes/kubernetes_test.go
@@ -80,7 +80,7 @@ func TestKubernetesStats(t *testing.T) {
 		"rootfs_available_bytes":     int64(84379979776),
 		"rootfs_capacity_bytes":      int64(105553100800),
 		"rootfs_used_bytes":          int64(57344),
-		"logsfs_avaialble_bytes":     int64(84379979776),
+		"logsfs_available_bytes":     int64(84379979776),
 		"logsfs_capacity_bytes":      int64(105553100800),
 		"logsfs_used_bytes":          int64(24576),
 	}
@@ -103,7 +103,7 @@ func TestKubernetesStats(t *testing.T) {
 		"rootfs_available_bytes":     int64(0),
 		"rootfs_capacity_bytes":      int64(0),
 		"rootfs_used_bytes":          int64(0),
-		"logsfs_avaialble_bytes":     int64(0),
+		"logsfs_available_bytes":     int64(0),
 		"logsfs_capacity_bytes":      int64(0),
 		"logsfs_used_bytes":          int64(0),
 	}


### PR DESCRIPTION
Fixed misspelled field name `logsfs_available_bytes`
