### PR TITLE
Added a timestamp processor. This adds the metric time as a unix nano…

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ For documentation on the latest development code see the [documentation index][d
 * [regex](./plugins/processors/regex)
 * [rename](./plugins/processors/rename)
 * [strings](./plugins/processors/strings)
+* [timestamp](./plugins/processors/timestamp)
 * [topk](./plugins/processors/topk)
 * [unpivot](./plugins/processors/unpivot)
 

--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/processors/regex"
 	_ "github.com/influxdata/telegraf/plugins/processors/rename"
 	_ "github.com/influxdata/telegraf/plugins/processors/strings"
+	_ "github.com/influxdata/telegraf/plugins/processors/timestamp"
 	_ "github.com/influxdata/telegraf/plugins/processors/topk"
 	_ "github.com/influxdata/telegraf/plugins/processors/unpivot"
 )

--- a/plugins/processors/timestamp/README.md
+++ b/plugins/processors/timestamp/README.md
@@ -1,0 +1,20 @@
+# Timestamp Processor Plugin
+
+Use the `timestamp` processor to add a unix nano timestamp to the metric.
+
+This can be used to mimic logs from syslog that you'd want to display in Chronograf.
+
+### Configuration
+
+```toml
+[[processors.timestamp]]
+  ## New tag to create
+  field_key = "timestamp"
+```
+
+### Example
+
+```diff
+- syslog,appname=myapp,facility=user,hostname=test,severity=notice message="notice msg",severity_code=5i,version=1i,facility_code=1i 1564997347582799644
++ syslog,appname=myapp,facility=user,hostname=test,severity=notice message="notice msg",severity_code=5i,version=1i,facility_code=1i,timestamp=1564997347582799644i 1564997347582799644
+```

--- a/plugins/processors/timestamp/timestamp.go
+++ b/plugins/processors/timestamp/timestamp.go
@@ -1,0 +1,37 @@
+package timestamp
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+const sampleConfig = `
+  ## New tag to create
+  field_key = "timestamp"
+`
+
+type Timestamp struct {
+	FieldKey string `toml:"tag_key"`
+}
+
+func (d *Timestamp) SampleConfig() string {
+	return sampleConfig
+}
+
+func (d *Timestamp) Description() string {
+	return "Add unix nano timestamp to metrics."
+}
+
+func (d *Timestamp) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	for _, point := range in {
+		point.AddField(d.FieldKey, point.Time().UnixNano())
+	}
+
+	return in
+}
+
+func init() {
+	processors.Add("timestamp", func() telegraf.Processor {
+		return &Timestamp{}
+	})
+}

--- a/plugins/processors/timestamp/timestamp_test.go
+++ b/plugins/processors/timestamp/timestamp_test.go
@@ -1,0 +1,25 @@
+package timestamp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimestampTag(t *testing.T) {
+	sut := Timestamp{
+		FieldKey: "timestamp",
+	}
+
+	currentTime := time.Now()
+
+	met, _ := metric.New("foo", nil, nil, currentTime)
+
+	sut.Apply(met)
+
+	timestamp, _ := met.GetField("timestamp")
+
+	assert.Equal(t, timestamp, currentTime.UnixNano())
+}


### PR DESCRIPTION
This processor adds a unix ns timestamp to metrics.

I needed this to create custom syslog entries and have them presented in Chronograf.

It's very, very simple. But I cannot figure out another way to do this - ideally better log support in the stack would be ideal.

Alternatively a more generic plugin that can add timestamps based on a date field could be written. The "date" processor only allows output in formatted dates which do not include unix time.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
