### PR TITLE
Get the number of logcal CPUs dynamically

### DIFF
--- a/plugins/inputs/system/README.md
+++ b/plugins/inputs/system/README.md
@@ -3,6 +3,8 @@
 The system plugin gathers general stats on system load, uptime,
 and number of users logged in. It is similar to the unix `uptime` command.
 
+Number of CPUs is obtained from the /proc/cpuinfo file.
+
 ### Configuration:
 
 ```toml

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
 	"github.com/shirou/gopsutil/load"
 )
@@ -35,11 +35,16 @@ func (_ *SystemStats) Gather(acc telegraf.Accumulator) error {
 		return err
 	}
 
+	numCPUs, err := cpu.Counts(true)
+	if err != nil {
+		return err
+	}
+
 	fields := map[string]interface{}{
 		"load1":  loadavg.Load1,
 		"load5":  loadavg.Load5,
 		"load15": loadavg.Load15,
-		"n_cpus": runtime.NumCPU(),
+		"n_cpus": numCPUs,
 	}
 
 	users, err := host.Users()


### PR DESCRIPTION
runtime.NumCPU() return the number of logical CPUs at the startup of the
process, https://golang.org/pkg/runtime/#NumCPU.
gopsutil return the current number of CPUs, giving the correct number
when CPU hot un/plug are being done.

closes #5451

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [ ] Has appropriate unit tests.
