### PR TITLE
Add telegraf and go version to the internal input plugin

### DIFF
--- a/plugins/inputs/internal/README.md
+++ b/plugins/inputs/internal/README.md
@@ -12,9 +12,17 @@ plugin.
 [[inputs.internal]]
   ## If true, collect telegraf memory stats.
   # collect_memstats = true
+  ## If true, send telegraf version
+  # send_version = true
 ```
 
 ### Measurements & Fields:
+
+Telegraf version and Go version used to compile it.
+
+- internal_version
+    - telegraf
+    - go
 
 memstats are taken from the Go runtime: https://golang.org/pkg/runtime/#MemStats
 
@@ -76,6 +84,7 @@ to each particular plugin.
 ### Example Output:
 
 ```
+internal_version,host=tyrion go="1.12.7",telegraf="1.12.0" 1480682800000000000
 internal_memstats,host=tyrion alloc_bytes=4457408i,sys_bytes=10590456i,pointer_lookups=7i,mallocs=17642i,frees=7473i,heap_sys_bytes=6848512i,heap_idle_bytes=1368064i,heap_in_use_bytes=5480448i,heap_released_bytes=0i,total_alloc_bytes=6875560i,heap_alloc_bytes=4457408i,heap_objects_bytes=10169i,num_gc=2i 1480682800000000000
 internal_agent,host=tyrion metrics_written=18i,metrics_dropped=0i,metrics_gathered=19i,gather_errors=0i 1480682800000000000
 internal_write,output=file,host=tyrion buffer_limit=10000i,write_time_ns=636609i,metrics_added=18i,metrics_written=18i,buffer_size=0i 1480682800000000000

--- a/plugins/inputs/internal/README.md
+++ b/plugins/inputs/internal/README.md
@@ -12,17 +12,9 @@ plugin.
 [[inputs.internal]]
   ## If true, collect telegraf memory stats.
   # collect_memstats = true
-  ## If true, send telegraf version
-  # send_version = true
 ```
 
 ### Measurements & Fields:
-
-Telegraf version and Go version used to compile it.
-
-- internal_version
-    - telegraf
-    - go
 
 memstats are taken from the Go runtime: https://golang.org/pkg/runtime/#MemStats
 
@@ -50,14 +42,16 @@ agent stats collect aggregate stats on all telegraf plugins.
     - metrics_written
 
 internal_gather stats collect aggregate stats on all input plugins
-that are of the same input type. They are tagged with `input=<plugin_name>`.
+that are of the same input type. They are tagged with `input=<plugin_name>`
+`version=<telegraf_version>` and `go_version=<go_build_version>`.
 
 - internal_gather
     - gather_time_ns
     - metrics_gathered
 
 internal_write stats collect aggregate stats on all output plugins
-that are of the same input type. They are tagged with `output=<plugin_name>`.
+that are of the same input type. They are tagged with `output=<plugin_name>`
+and `version=<telegraf_version>`.
 
 
 - internal_write
@@ -71,7 +65,7 @@ that are of the same input type. They are tagged with `output=<plugin_name>`.
 
 internal_<plugin_name> are metrics which are defined on a per-plugin basis, and
 usually contain tags which differentiate each instance of a particular type of
-plugin.
+plugin and `version=<telegraf_version>`.
 
 - internal_<plugin_name>
     - individual plugin-specific fields, such as requests counts.
@@ -79,16 +73,16 @@ plugin.
 ### Tags:
 
 All measurements for specific plugins are tagged with information relevant
-to each particular plugin.
+to each particular plugin and with `version=<telegraf_version>`.
+
 
 ### Example Output:
 
 ```
-internal_version,host=tyrion go="1.12.7",telegraf="1.12.0" 1480682800000000000
 internal_memstats,host=tyrion alloc_bytes=4457408i,sys_bytes=10590456i,pointer_lookups=7i,mallocs=17642i,frees=7473i,heap_sys_bytes=6848512i,heap_idle_bytes=1368064i,heap_in_use_bytes=5480448i,heap_released_bytes=0i,total_alloc_bytes=6875560i,heap_alloc_bytes=4457408i,heap_objects_bytes=10169i,num_gc=2i 1480682800000000000
-internal_agent,host=tyrion metrics_written=18i,metrics_dropped=0i,metrics_gathered=19i,gather_errors=0i 1480682800000000000
-internal_write,output=file,host=tyrion buffer_limit=10000i,write_time_ns=636609i,metrics_added=18i,metrics_written=18i,buffer_size=0i 1480682800000000000
-internal_gather,input=internal,host=tyrion metrics_gathered=19i,gather_time_ns=442114i 1480682800000000000
-internal_gather,input=http_listener,host=tyrion metrics_gathered=0i,gather_time_ns=167285i 1480682800000000000
-internal_http_listener,address=:8186,host=tyrion queries_received=0i,writes_received=0i,requests_received=0i,buffers_created=0i,requests_served=0i,pings_received=0i,bytes_received=0i,not_founds_served=0i,pings_served=0i,queries_served=0i,writes_served=0i 1480682800000000000
+internal_agent,host=tyrion,go_version=1.12.7,version=1.99.0 metrics_written=18i,metrics_dropped=0i,metrics_gathered=19i,gather_errors=0i 1480682800000000000
+internal_write,output=file,host=tyrion,version=1.99.0 buffer_limit=10000i,write_time_ns=636609i,metrics_added=18i,metrics_written=18i,buffer_size=0i 1480682800000000000
+internal_gather,input=internal,host=tyrion,version=1.99.0 metrics_gathered=19i,gather_time_ns=442114i 1480682800000000000
+internal_gather,input=http_listener,host=tyrion,version=1.99.0 metrics_gathered=0i,gather_time_ns=167285i 1480682800000000000
+internal_http_listener,address=:8186,host=tyrion,version=1.99.0 queries_received=0i,writes_received=0i,requests_received=0i,buffers_created=0i,requests_served=0i,pings_received=0i,bytes_received=0i,not_founds_served=0i,pings_served=0i,queries_served=0i,writes_served=0i 1480682800000000000
 ```

--- a/plugins/inputs/internal/internal_test.go
+++ b/plugins/inputs/internal/internal_test.go
@@ -26,7 +26,8 @@ func TestSelfPlugin(t *testing.T) {
 			"test": int64(3),
 		},
 		map[string]string{
-			"test": "foo",
+			"test":    "foo",
+			"version": "",
 		},
 	)
 	acc.ClearMetrics()
@@ -39,7 +40,8 @@ func TestSelfPlugin(t *testing.T) {
 			"test": int64(101),
 		},
 		map[string]string{
-			"test": "foo",
+			"test":    "foo",
+			"version": "",
 		},
 	)
 	acc.ClearMetrics()
@@ -56,7 +58,8 @@ func TestSelfPlugin(t *testing.T) {
 			"test_ns": int64(150),
 		},
 		map[string]string{
-			"test": "foo",
+			"test":    "foo",
+			"version": "",
 		},
 	)
 }


### PR DESCRIPTION
Collecting telegraf version is useful to find outdated agents and match
behavioural changes with version changes.

closes #5958

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
