### PR TITLE
Add memory_usage (percent) field to procstat input plugin

### DIFF
--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -21,6 +21,7 @@ type Process interface {
 	NumFDs() (int32, error)
 	NumThreads() (int32, error)
 	Percent(interval time.Duration) (float64, error)
+	MemoryPercent() (float32, error)
 	Times() (*cpu.TimesStat, error)
 	RlimitUsage(bool) ([]process.RlimitStat, error)
 	Username() (string, error)

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -245,6 +245,11 @@ func (p *Procstat) addMetric(proc Process, acc telegraf.Accumulator) {
 		fields[prefix+"memory_locked"] = mem.Locked
 	}
 
+	mem_perc, err := proc.MemoryPercent()
+	if err == nil {
+		fields[prefix+"memory_usage"] = mem_perc
+	}
+
 	rlims, err := proc.RlimitUsage(true)
 	if err == nil {
 		for _, rlim := range rlims {

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -148,6 +148,10 @@ func (p *testProc) Percent(interval time.Duration) (float64, error) {
 	return 0, nil
 }
 
+func (p *testProc) MemoryPercent() (float32, error) {
+	return 0, nil
+}
+
 func (p *testProc) Times() (*cpu.TimesStat, error) {
 	return &cpu.TimesStat{}, nil
 }


### PR DESCRIPTION
I needed it and [gopsutils](https://github.com/shirou/gopsutil/blob/master/process/process.go#L222-L241) already provides it.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
