### PR TITLE
Allow influxdb_listener to keep the database name from the query string if supplied

### DIFF
--- a/plugins/inputs/influxdb_listener/README.md
+++ b/plugins/inputs/influxdb_listener/README.md
@@ -46,6 +46,16 @@ submits data to InfluxDB determines the destination database.
   tls_cert = "/etc/telegraf/cert.pem"
   tls_key = "/etc/telegraf/key.pem"
 
+  ## If the write has a database on it then it should be kept
+  ## for metrics further on. The database will be added as a tag.
+  ## This tag can be used in downstream outputs.
+  keep_database = true
+
+  ## Optional tag name used to store the database if you want to change it to something custom. 
+  ## If not set it will be "database"
+  ## Only used if keep_database is set to true.
+  # database_tag = database
+
   ## Optional username and password to accept for HTTP basic authentication.
   ## You probably want to make sure you have TLS configured above for this.
   # basic_username = "foobar"

--- a/plugins/inputs/influxdb_listener/README.md
+++ b/plugins/inputs/influxdb_listener/README.md
@@ -50,6 +50,8 @@ submits data to InfluxDB determines the destination database.
   ## If the write has a database in the query string then it will be kept in this tag name.
   ## This tag can be used in downstream outputs.
   ## The default value of nothing means it will be off and the database will not be recorded.
+  ## If you have a tag that is the same as the one specified below, and supply a database,
+  ## the tag will be overwritten with the database supplied.
   # database_tag = ""
 
   ## Optional username and password to accept for HTTP basic authentication.

--- a/plugins/inputs/influxdb_listener/README.md
+++ b/plugins/inputs/influxdb_listener/README.md
@@ -46,7 +46,7 @@ submits data to InfluxDB determines the destination database.
   tls_cert = "/etc/telegraf/cert.pem"
   tls_key = "/etc/telegraf/key.pem"
 
-  ## Optional tag name used to store the database.
+  ## Optional tag name used to store the database name.
   ## If the write has a database in the query string then it will be kept in this tag name.
   ## This tag can be used in downstream outputs.
   ## The default value of nothing means it will be off and the database will not be recorded.

--- a/plugins/inputs/influxdb_listener/README.md
+++ b/plugins/inputs/influxdb_listener/README.md
@@ -46,15 +46,11 @@ submits data to InfluxDB determines the destination database.
   tls_cert = "/etc/telegraf/cert.pem"
   tls_key = "/etc/telegraf/key.pem"
 
-  ## If the write has a database on it then it should be kept
-  ## for metrics further on. The database will be added as a tag.
+  ## Optional tag name used to store the database.
+  ## If the write has a database in the query string then it will be kept in this tag name.
   ## This tag can be used in downstream outputs.
-  keep_database = true
-
-  ## Optional tag name used to store the database if you want to change it to something custom. 
-  ## If not set it will be "database"
-  ## Only used if keep_database is set to true.
-  # database_tag = database
+  ## The default value of nothing means it will be off and the database will not be recorded.
+  # database_tag = ""
 
   ## Optional username and password to accept for HTTP basic authentication.
   ## You probably want to make sure you have TLS configured above for this.

--- a/plugins/inputs/influxdb_listener/http_listener.go
+++ b/plugins/inputs/influxdb_listener/http_listener.go
@@ -380,7 +380,7 @@ func (h *HTTPListener) parse(b []byte, t time.Time, precision, db string) error 
 	}
 
 	for _, m := range metrics {
-		// Do we need to keep the database name in the query string
+		// Do we need to keep the database name in the query string.
 		// If a tag has been supplied to put the db in and we actually got a db query,
 		// then we write it in. This overwrites the database tag if one was sent.
 		// This makes it behave like the influx endpoint.

--- a/plugins/inputs/influxdb_listener/http_listener.go
+++ b/plugins/inputs/influxdb_listener/http_listener.go
@@ -381,14 +381,11 @@ func (h *HTTPListener) parse(b []byte, t time.Time, precision, db string) error 
 
 	for _, m := range metrics {
 		// Do we need to keep the database name in the query string
-		if h.DatabaseTag != "" {
-			// Did we get a database argument. If we didn't get it. We can't set it.
-			if db != "" {
-				// Is there already a database set. If not use the database in the query string.
-				if _, ok := m.Tags()[h.DatabaseTag]; !ok {
-					m.AddTag(h.DatabaseTag, db)
-				}
-			}
+		// If a tag has been supplied to put the db in and we actually got a db query,
+		// then we write it in. This overwrites the database tag if one was sent.
+		// This makes it behave like the influx endpoint.
+		if h.DatabaseTag != "" && db != "" {
+			m.AddTag(h.DatabaseTag, db)
 		}
 		h.acc.AddFields(m.Name(), m.Fields(), m.Tags(), m.Time())
 	}

--- a/plugins/inputs/influxdb_listener/http_listener_test.go
+++ b/plugins/inputs/influxdb_listener/http_listener_test.go
@@ -46,7 +46,6 @@ func newTestHTTPListener() *HTTPListener {
 	listener := &HTTPListener{
 		ServiceAddress: "localhost:0",
 		TimeFunc:       time.Now,
-		DatabaseTag:    DefaultDatabaseTag,
 	}
 	return listener
 }
@@ -149,7 +148,7 @@ func TestWriteHTTPBasicAuth(t *testing.T) {
 
 func TestWriteHTTPKeepDatabase(t *testing.T) {
 	listener := newTestHTTPListener()
-	listener.KeepDatabase = true
+	listener.DatabaseTag = "database"
 
 	acc := &testutil.Accumulator{}
 	require.NoError(t, listener.Start(acc))


### PR DESCRIPTION
Updating to allow the users to keep the database that gets sent in the query string. See issue #6253

Adding a test for the code change
Adding new configuration to the README.
Adding toml tags to make it like the rest of the plugins.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
