### PR TITLE
feat(scripts): add darwin (macOS) builds to the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ version.
 ### Nightly Builds
 
 These builds are generated from the master branch:
+- [telegraf-nightly_darwin_amd64.tar.gz](https://dl.influxdata.com/telegraf/nightlies/telegraf-nightly_darwin_amd64.tar.gz)
 - [telegraf_nightly_amd64.deb](https://dl.influxdata.com/telegraf/nightlies/telegraf_nightly_amd64.deb)
 - [telegraf_nightly_arm64.deb](https://dl.influxdata.com/telegraf/nightlies/telegraf_nightly_arm64.deb)
 - [telegraf-nightly.arm64.rpm](https://dl.influxdata.com/telegraf/nightlies/telegraf-nightly.arm64.rpm)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -88,12 +88,14 @@ targets = {
 }
 
 supported_builds = {
+    'darwin': [ "amd64" ],
     "windows": [ "amd64", "i386" ],
     "linux": [ "amd64", "i386", "armhf", "armel", "arm64", "static_amd64", "s390x", "mipsel", "mips"],
     "freebsd": [ "amd64", "i386" ]
 }
 
 supported_packages = {
+    "darwin": [ "tar" ],
     "linux": [ "deb", "rpm", "tar" ],
     "windows": [ "zip" ],
     "freebsd": [ "tar" ]


### PR DESCRIPTION
Closes #4801

This will build a darwin tar.gz package for macOS.  This allows people an easy way to download
releases from github directly.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
