### PR TITLE
Add content_length metric to http_response input plugin (#6037)

### DIFF
--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -61,6 +61,7 @@ This input plugin checks HTTP/HTTPS connections.
     - result ([see below](#result--result_code))
   - fields:
     - response_time (float, seconds)
+    - content_length (int, response body length)
     - response_string_match (int, 0 = mismatch / body read error, 1 = match)
     - http_response_code (int, response status code)
 	- result_type (string, deprecated in 1.6: use `result` tag and `result_code` field)
@@ -85,5 +86,5 @@ This tag is used to expose network and plugin errors. HTTP errors are considered
 ### Example Output:
 
 ```
-http_response,method=GET,server=http://www.github.com,status_code=200,result=success http_response_code=200i,response_time=6.223266528,result_type="success",result_code=0i 1459419354977857955
+http_response,method=GET,result=success,server=http://github.com,status_code=200 content_length=87878i,http_response_code=200i,response_time=0.937655534,result_code=0i,result_type="success" 1565839598000000000
 ```


### PR DESCRIPTION
Added content_length metric to http_responce input plugin according to feature request #6037 

closes #6037

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
