### PR TITLE
Add topic_tag option to mqtt_consumer

### DIFF
--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -18,6 +18,10 @@ and creates metrics using one of the supported [input data formats][].
     "sensors/#",
   ]
 
+  ## The message topic will be stored in a tag specified by this value.  If set
+  ## to the empty string no topic tag will be created.
+  # topic_tag = "topic"
+
   ## QoS policy for messages
   ##   0 = at most once
   ##   1 = at least once


### PR DESCRIPTION
Add a new option `topic_tag` to the mqtt_consumer input.  When unset the default is `topic` in order to preserve backwards compatibility, when set to `""` no topic tag is added, otherwise the value is used for the topic tag.  This is the basic pattern I would like to use for all inputs with parsers and want to add metadata.

In 2.0 we should change the default to not add the topic tag.  We don't have a mechanism for changing the defaults yet, this is something that needs a plan.

closes: #6262

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
