### PR TITLE
Fix issue #6278

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -235,6 +235,9 @@ func (a *Agent) Test(ctx context.Context, waitDuration time.Duration) error {
 		a.stopServiceInputs()
 	}
 
+	if NErrors.Get() > 0 {
+		return fmt.Errorf("One or more input plugins had an error")
+	}
 	return nil
 }
 


### PR DESCRIPTION
A couple notes:

1. I added a separate `--test-status` option to `telegraf` to implement this. I did this to maintain backwards compatibility in case anyone is depending on the current behavior of always returning 0.

2. The exec plugin was always returning no error. I fixed this plugin since we are using it. It is possible other plugins are also not correctly returning any errors.

closes: #6278

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
