### PR TITLE
Allow jobs with dashes in the name by changing job marker.

### DIFF
--- a/plugins/inputs/lustre2/lustre2.go
+++ b/plugins/inputs/lustre2/lustre2.go
@@ -377,7 +377,7 @@ func (l *Lustre2) GetLustreProcStats(fileglob string, wantedFields []*mapping, a
 		if err != nil {
 			return err
 		}
-		jobs := strings.Split(string(wholeFile), "-")
+		jobs := strings.Split(string(wholeFile), "- ")
 		for _, job := range jobs {
 			lines := strings.Split(string(job), "\n")
 			jobid := ""

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -39,7 +39,7 @@ cache_miss                11653333250 samples [pages] 1 1 11653333250
 `
 
 const obdfilterJobStatsContents = `job_stats:
-- job_id:          testjob1
+- job_id:          cluster-testjob1
   snapshot_time:   1461772761
   read_bytes:      { samples:           1, unit: bytes, min:    4096, max:    4096, sum:            4096 }
   write_bytes:     { samples:          25, unit: bytes, min: 1048576, max: 1048576, sum:        26214400 }
@@ -89,7 +89,7 @@ crossdir_rename           369571 samples [reqs]
 `
 
 const mdtJobStatsContents = `job_stats:
-- job_id:          testjob1
+- job_id:          cluster-testjob1
   snapshot_time:   1461772761
   open:            { samples:           5, unit:  reqs }
   close:           { samples:           4, unit:  reqs }
@@ -204,7 +204,7 @@ func TestLustre2GeneratesJobstatsMetrics(t *testing.T) {
 
 	tempdir := os.TempDir() + "/telegraf/proc/fs/lustre/"
 	ost_name := "OST0001"
-	job_names := []string{"testjob1", "testjob2"}
+	job_names := []string{"cluster-testjob1", "testjob2"}
 
 	mdtdir := tempdir + "/mdt/"
 	err := os.MkdirAll(mdtdir+"/"+ost_name, 0755)


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [X] Has appropriate unit tests.

Seems like a bugfix, so not sure what would need to be changed in the README.md

Currently, jobs with a dash in the jobid aren't captured correctly.
