### PR TITLE
Support multiple smart config definitions

### DIFF
--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -425,14 +425,14 @@ func parseInt(str string) int64 {
 }
 
 func init() {
-	m := Smart{}
-	path, _ := exec.LookPath("smartctl")
-	if len(path) > 0 {
-		m.Path = path
-	}
-	m.Nocheck = "standby"
-
 	inputs.Add("smart", func() telegraf.Input {
-		return &m
+		m := &Smart{}
+		path, _ := exec.LookPath("smartctl")
+		if len(path) > 0 {
+			m.Path = path
+		}
+		m.Nocheck = "standby"
+
+		return m
 	})
 }


### PR DESCRIPTION
Resolves #6309

Return a smart object per plugin rather than a shared object.

This has already been fixed for 1.12, hence the request to merge into `release-1.11`
