### PR TITLE
Remove leading slash from rcon commands

### DIFF
--- a/plugins/inputs/minecraft/client.go
+++ b/plugins/inputs/minecraft/client.go
@@ -84,7 +84,7 @@ func (c *client) Players() ([]string, error) {
 		}
 	}
 
-	resp, err := c.conn.Execute("/scoreboard players list")
+	resp, err := c.conn.Execute("scoreboard players list")
 	if err != nil {
 		c.conn = nil
 		return nil, err
@@ -107,7 +107,7 @@ func (c *client) Scores(player string) ([]Score, error) {
 		}
 	}
 
-	resp, err := c.conn.Execute("/scoreboard players list " + player)
+	resp, err := c.conn.Execute("scoreboard players list " + player)
 	if err != nil {
 		c.conn = nil
 		return nil, err

--- a/plugins/inputs/minecraft/client_test.go
+++ b/plugins/inputs/minecraft/client_test.go
@@ -31,63 +31,63 @@ func TestClient_Player(t *testing.T) {
 		{
 			name: "minecraft 1.12 no players",
 			commands: map[string]string{
-				"/scoreboard players list": "There are no tracked players on the scoreboard",
+				"scoreboard players list": "There are no tracked players on the scoreboard",
 			},
 			expected: []string{},
 		},
 		{
 			name: "minecraft 1.12 single player",
 			commands: map[string]string{
-				"/scoreboard players list": "Showing 1 tracked players on the scoreboard:Etho",
+				"scoreboard players list": "Showing 1 tracked players on the scoreboard:Etho",
 			},
 			expected: []string{"Etho"},
 		},
 		{
 			name: "minecraft 1.12 two players",
 			commands: map[string]string{
-				"/scoreboard players list": "Showing 2 tracked players on the scoreboard:Etho and torham",
+				"scoreboard players list": "Showing 2 tracked players on the scoreboard:Etho and torham",
 			},
 			expected: []string{"Etho", "torham"},
 		},
 		{
 			name: "minecraft 1.12 three players",
 			commands: map[string]string{
-				"/scoreboard players list": "Showing 3 tracked players on the scoreboard:Etho, notch and torham",
+				"scoreboard players list": "Showing 3 tracked players on the scoreboard:Etho, notch and torham",
 			},
 			expected: []string{"Etho", "notch", "torham"},
 		},
 		{
 			name: "minecraft 1.12 players space in username",
 			commands: map[string]string{
-				"/scoreboard players list": "Showing 4 tracked players on the scoreboard:with space, Etho, notch and torham",
+				"scoreboard players list": "Showing 4 tracked players on the scoreboard:with space, Etho, notch and torham",
 			},
 			expected: []string{"with space", "Etho", "notch", "torham"},
 		},
 		{
 			name: "minecraft 1.12 players and in username",
 			commands: map[string]string{
-				"/scoreboard players list": "Showing 5 tracked players on the scoreboard:left and right, with space,Etho, notch and torham",
+				"scoreboard players list": "Showing 5 tracked players on the scoreboard:left and right, with space,Etho, notch and torham",
 			},
 			expected: []string{"left and right", "with space", "Etho", "notch", "torham"},
 		},
 		{
 			name: "minecraft 1.13 no players",
 			commands: map[string]string{
-				"/scoreboard players list": "There are no tracked entities",
+				"scoreboard players list": "There are no tracked entities",
 			},
 			expected: []string{},
 		},
 		{
 			name: "minecraft 1.13 single player",
 			commands: map[string]string{
-				"/scoreboard players list": "There are 1 tracked entities: torham",
+				"scoreboard players list": "There are 1 tracked entities: torham",
 			},
 			expected: []string{"torham"},
 		},
 		{
 			name: "minecraft 1.13 multiple player",
 			commands: map[string]string{
-				"/scoreboard players list": "There are 3 tracked entities: Etho, notch, torham",
+				"scoreboard players list": "There are 3 tracked entities: Etho, notch, torham",
 			},
 			expected: []string{"Etho", "notch", "torham"},
 		},
@@ -120,7 +120,7 @@ func TestClient_Scores(t *testing.T) {
 			name:   "minecraft 1.12 player with no scores",
 			player: "Etho",
 			commands: map[string]string{
-				"/scoreboard players list Etho": "Player Etho has no scores recorded",
+				"scoreboard players list Etho": "Player Etho has no scores recorded",
 			},
 			expected: []Score{},
 		},
@@ -128,7 +128,7 @@ func TestClient_Scores(t *testing.T) {
 			name:   "minecraft 1.12 player with one score",
 			player: "Etho",
 			commands: map[string]string{
-				"/scoreboard players list Etho": "Showing 1 tracked objective(s) for Etho:- jump: 2 (jump)",
+				"scoreboard players list Etho": "Showing 1 tracked objective(s) for Etho:- jump: 2 (jump)",
 			},
 			expected: []Score{
 				{Name: "jump", Value: 2},
@@ -138,7 +138,7 @@ func TestClient_Scores(t *testing.T) {
 			name:   "minecraft 1.12 player with many scores",
 			player: "Etho",
 			commands: map[string]string{
-				"/scoreboard players list Etho": "Showing 3 tracked objective(s) for Etho:- hopper: 2 (hopper)- dropper: 2 (dropper)- redstone: 1 (redstone)",
+				"scoreboard players list Etho": "Showing 3 tracked objective(s) for Etho:- hopper: 2 (hopper)- dropper: 2 (dropper)- redstone: 1 (redstone)",
 			},
 			expected: []Score{
 				{Name: "hopper", Value: 2},
@@ -150,7 +150,7 @@ func TestClient_Scores(t *testing.T) {
 			name:   "minecraft 1.13 player with no scores",
 			player: "Etho",
 			commands: map[string]string{
-				"/scoreboard players list Etho": "Etho has no scores to show",
+				"scoreboard players list Etho": "Etho has no scores to show",
 			},
 			expected: []Score{},
 		},
@@ -158,7 +158,7 @@ func TestClient_Scores(t *testing.T) {
 			name:   "minecraft 1.13 player with one score",
 			player: "Etho",
 			commands: map[string]string{
-				"/scoreboard players list Etho": "Etho has 1 scores:[jumps]: 1",
+				"scoreboard players list Etho": "Etho has 1 scores:[jumps]: 1",
 			},
 			expected: []Score{
 				{Name: "jumps", Value: 1},
@@ -168,7 +168,7 @@ func TestClient_Scores(t *testing.T) {
 			name:   "minecraft 1.13 player with many scores",
 			player: "Etho",
 			commands: map[string]string{
-				"/scoreboard players list Etho": "Etho has 3 scores:[hopper]: 2[dropper]: 2[redstone]: 1",
+				"scoreboard players list Etho": "Etho has 3 scores:[hopper]: 2[dropper]: 2[redstone]: 1",
 			},
 			expected: []Score{
 				{Name: "hopper", Value: 2},


### PR DESCRIPTION
This is required when using the Spigot Minecraft server and compatible
with the vanilla server.

closes #6287

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
