### PR TITLE
Fix filecount for paths with trailing slash

### DIFF
--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -1,6 +1,7 @@
 package filecount
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -156,6 +157,7 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	childSize := make(map[string]int64)
 
 	walkFn := func(path string, de *godirwalk.Dirent) error {
+		fmt.Println(path)
 		rel, err := filepath.Rel(basedir, path)
 		if err == nil && rel == "." {
 			return nil
@@ -267,11 +269,11 @@ func (fc *FileCount) onlyDirectories(directories []string) []string {
 func (fc *FileCount) getDirs() []string {
 	dirs := make([]string, len(fc.Directories))
 	for i, dir := range fc.Directories {
-		dirs[i] = dir
+		dirs[i] = filepath.Clean(dir)
 	}
 
 	if fc.Directory != "" {
-		dirs = append(dirs, fc.Directory)
+		dirs = append(dirs, filepath.Clean(fc.Directory))
 	}
 
 	return dirs

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -1,7 +1,6 @@
 package filecount
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -157,7 +156,6 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	childSize := make(map[string]int64)
 
 	walkFn := func(path string, de *godirwalk.Dirent) error {
-		fmt.Println(path)
 		rel, err := filepath.Rel(basedir, path)
 		if err == nil && rel == "." {
 			return nil


### PR DESCRIPTION
Paths returned during the walk have had filepath.Clean applied to them, so we need to create a glob that will match these cleaned paths.

closes #6329 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
