### PR TITLE
Convert check state to an integer

### DIFF
--- a/plugins/inputs/icinga2/icinga2.go
+++ b/plugins/inputs/icinga2/icinga2.go
@@ -38,10 +38,10 @@ type Object struct {
 }
 
 type Attribute struct {
-	CheckCommand string `json:"check_command"`
-	DisplayName  string `json:"display_name"`
-	Name         string `json:"name"`
-	State        int    `json:"state"`
+	CheckCommand string  `json:"check_command"`
+	DisplayName  string  `json:"display_name"`
+	Name         string  `json:"name"`
+	State        float64 `json:"state"`
 }
 
 var levels = []string{"ok", "warning", "critical", "unknown"}
@@ -51,7 +51,7 @@ type ObjectType string
 var sampleConfig = `
   ## Required Icinga2 server address (default: "https://localhost:5665")
   # server = "https://localhost:5665"
-  
+
   ## Required Icinga2 object type ("services" or "hosts, default "services")
   # object_type = "services"
 
@@ -88,12 +88,14 @@ func (i *Icinga2) GatherStatus(acc telegraf.Accumulator, checks []Object) {
 			log.Fatal(err)
 		}
 
+		state := int64(check.Attrs.State)
+
 		fields["name"] = check.Attrs.Name
-		fields["state_code"] = check.Attrs.State
+		fields["state_code"] = state
 
 		tags["display_name"] = check.Attrs.DisplayName
 		tags["check_command"] = check.Attrs.CheckCommand
-		tags["state"] = levels[check.Attrs.State]
+		tags["state"] = levels[state]
 		tags["source"] = url.Hostname()
 		tags["scheme"] = url.Scheme
 		tags["port"] = url.Port()

--- a/plugins/inputs/icinga2/icinga2_test.go
+++ b/plugins/inputs/icinga2/icinga2_test.go
@@ -3,89 +3,112 @@ package icinga2
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestGatherServicesStatus(t *testing.T) {
-
-	s := `{"results":[
-    {
-      "attrs": {
-        "check_command": "check-bgp-juniper-netconf",
-        "display_name": "eq-par.dc2.fr",
-        "name": "ef017af8-c684-4f3f-bb20-0dfe9fcd3dbe",
-        "state": 0
-      },
-      "joins": {},
-      "meta": {},
-      "name": "eq-par.dc2.fr!ef017af8-c684-4f3f-bb20-0dfe9fcd3dbe",
-      "type": "Service"
-    }
-  ]}`
+	s := `{
+    "results": [
+        {
+            "attrs": {
+                "check_command": "check-bgp-juniper-netconf",
+                "display_name": "eq-par.dc2.fr",
+                "name": "ef017af8-c684-4f3f-bb20-0dfe9fcd3dbe",
+                "state": 0
+            },
+            "joins": {},
+            "meta": {},
+            "name": "eq-par.dc2.fr!ef017af8-c684-4f3f-bb20-0dfe9fcd3dbe",
+            "type": "Service"
+        }
+    ]
+}
+`
 
 	checks := Result{}
 	json.Unmarshal([]byte(s), &checks)
-	fields := map[string]interface{}{
-		"name":       "ef017af8-c684-4f3f-bb20-0dfe9fcd3dbe",
-		"state_code": 0,
-	}
-	tags := map[string]string{
-		"display_name":  "eq-par.dc2.fr",
-		"check_command": "check-bgp-juniper-netconf",
-		"state":         "ok",
-		"source":        "localhost",
-		"port":          "5665",
-		"scheme":        "https",
-	}
-
-	var acc testutil.Accumulator
 
 	icinga2 := new(Icinga2)
 	icinga2.ObjectType = "services"
 	icinga2.Server = "https://localhost:5665"
+
+	var acc testutil.Accumulator
 	icinga2.GatherStatus(&acc, checks.Results)
-	acc.AssertContainsTaggedFields(t, "icinga2_services", fields, tags)
+
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"icinga2_services",
+			map[string]string{
+				"display_name":  "eq-par.dc2.fr",
+				"check_command": "check-bgp-juniper-netconf",
+				"state":         "ok",
+				"source":        "localhost",
+				"port":          "5665",
+				"scheme":        "https",
+			},
+			map[string]interface{}{
+				"name":       "ef017af8-c684-4f3f-bb20-0dfe9fcd3dbe",
+				"state_code": 0,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestGatherHostsStatus(t *testing.T) {
-
-	s := `{"results":[
-    {
-      "attrs": {
-				"name": "webserver",
-        "address": "192.168.1.1",
-        "check_command": "ping",
-        "display_name": "apache",
-        "state": 2
-      },
-      "joins": {},
-      "meta": {},
-      "name": "webserver",
-      "type": "Host"
-    }
-  ]}`
+	s := `{
+    "results": [
+        {
+            "attrs": {
+                "address": "192.168.1.1",
+                "check_command": "ping",
+                "display_name": "apache",
+                "name": "webserver",
+                "state": 2.0
+            },
+            "joins": {},
+            "meta": {},
+            "name": "webserver",
+            "type": "Host"
+        }
+    ]
+}
+`
 
 	checks := Result{}
 	json.Unmarshal([]byte(s), &checks)
-	fields := map[string]interface{}{
-		"name":       "webserver",
-		"state_code": 2,
-	}
-	tags := map[string]string{
-		"display_name":  "apache",
-		"check_command": "ping",
-		"state":         "critical",
-		"source":        "localhost",
-		"port":          "5665",
-		"scheme":        "https",
-	}
 
 	var acc testutil.Accumulator
 
 	icinga2 := new(Icinga2)
 	icinga2.ObjectType = "hosts"
 	icinga2.Server = "https://localhost:5665"
+
 	icinga2.GatherStatus(&acc, checks.Results)
-	acc.AssertContainsTaggedFields(t, "icinga2_hosts", fields, tags)
+
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"icinga2_hosts",
+			map[string]string{
+				"display_name":  "apache",
+				"check_command": "ping",
+				"state":         "critical",
+				"source":        "localhost",
+				"port":          "5665",
+				"scheme":        "https",
+			},
+			map[string]interface{}{
+				"name":       "webserver",
+				"state_code": 2,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }


### PR DESCRIPTION
Parse state into a float64 and then convert to and int later, to support numbers with a decimal component in the response body.  It is unknown if icinga ever returns a number without a decimal but this will work in either case.

closes #6331

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
