### PR TITLE
Issue #6347: Allow ignoring global tags on an input

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -194,6 +194,8 @@ Parameters that can be used with any input plugin:
 - **name_prefix**: Specifies a prefix to attach to the measurement name.
 - **name_suffix**: Specifies a suffix to attach to the measurement name.
 - **tags**: A map of tags to apply to a specific input's measurements.
+- **ignored_default_tags**: An array of global tag names that will not be
+  applied by this input
 
 The [metric filtering][] parameters can be used to limit what metrics are
 emitted from the input plugin.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1363,6 +1363,18 @@ func buildInput(name string, tbl *ast.Table) (*models.InputConfig, error) {
 		}
 	}
 
+	if node, ok := tbl.Fields["ignored_default_tags"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if ary, ok := kv.Value.(*ast.Array); ok {
+				for _, elem := range ary.Value {
+					if str, ok := elem.(*ast.String); ok {
+						cp.IgnoredDefaultTags = append(cp.IgnoredDefaultTags, str.Value)
+					}
+				}
+			}
+		}
+	}
+
 	cp.Tags = make(map[string]string)
 	if node, ok := tbl.Fields["tags"]; ok {
 		if subtbl, ok := node.(*ast.Table); ok {
@@ -1378,6 +1390,7 @@ func buildInput(name string, tbl *ast.Table) (*models.InputConfig, error) {
 	delete(tbl.Fields, "alias")
 	delete(tbl.Fields, "interval")
 	delete(tbl.Fields, "tags")
+	delete(tbl.Fields, "ignored_default_tags")
 	var err error
 	cp.Filter, err = buildFilter(tbl)
 	if err != nil {

--- a/internal/config/testdata/single_plugin_global_tags.toml
+++ b/internal/config/testdata/single_plugin_global_tags.toml
@@ -1,0 +1,5 @@
+[global_tags]
+test_accepted = "accepted"
+test_ignored = "ignored"
+[[inputs.memcached]]
+  ignored_default_tags = ["test_ignored"]

--- a/internal/models/running_input.go
+++ b/internal/models/running_input.go
@@ -52,11 +52,12 @@ type InputConfig struct {
 	Alias    string
 	Interval time.Duration
 
-	NameOverride      string
-	MeasurementPrefix string
-	MeasurementSuffix string
-	Tags              map[string]string
-	Filter            Filter
+	NameOverride       string
+	MeasurementPrefix  string
+	MeasurementSuffix  string
+	IgnoredDefaultTags []string
+	Tags               map[string]string
+	Filter             Filter
 }
 
 func (r *RunningInput) metricFiltered(metric telegraf.Metric) {
@@ -111,5 +112,12 @@ func (r *RunningInput) Gather(acc telegraf.Accumulator) error {
 }
 
 func (r *RunningInput) SetDefaultTags(tags map[string]string) {
-	r.defaultTags = tags
+	tempMap := make(map[string]string, len(tags))
+	for k, v := range tags {
+		tempMap[k] = v
+	}
+	for _, ignored := range r.Config.IgnoredDefaultTags {
+		delete(tempMap, ignored)
+	}
+	r.defaultTags = tempMap
 }

--- a/internal/models/running_input_test.go
+++ b/internal/models/running_input_test.go
@@ -175,6 +175,38 @@ func TestMakeMetricWithDaemonTags(t *testing.T) {
 	require.Equal(t, expected, m)
 }
 
+func TestMakeMetricWithIgnoredDaemonTags(t *testing.T) {
+	now := time.Now()
+	ri := NewRunningInput(&testInput{}, &InputConfig{
+		Name:               "TestRunningInput",
+		IgnoredDefaultTags: []string{"baz"},
+	})
+	ri.SetDefaultTags(map[string]string{
+		"foo": "bar",
+		"baz": "qux",
+	})
+
+	m := testutil.MustMetric("RITest",
+		map[string]string{},
+		map[string]interface{}{
+			"value": int64(101),
+		},
+		now,
+		telegraf.Untyped)
+	m = ri.MakeMetric(m)
+	expected, err := metric.New("RITest",
+		map[string]string{
+			"foo": "bar",
+		},
+		map[string]interface{}{
+			"value": 101,
+		},
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, expected, m)
+}
+
 func TestMakeMetricNameOverride(t *testing.T) {
 	now := time.Now()
 	ri := NewRunningInput(&testInput{}, &InputConfig{


### PR DESCRIPTION
This PR addresses issue #6347

When setting up multi-layer telegraf system, we often find ourselves in a situation where we expect global tags to be applied on all but one plugin. An example of such situation is a proxy-telegraf where we need to apply the "hostname" for all the internal and hardware plugins but we need it excluded from the http_listener input. If the measurement comes via HTTP without the "host" tag, we want to honor that. On top of that the capability to "tagexclude" doesn't work in this case as we expect some metrics to come in with the "host" present and we want to retain it.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
