### PR TITLE
Add kafka SASL version control to kafka_consumer

### DIFF
--- a/plugins/common/kafka/sasl.go
+++ b/plugins/common/kafka/sasl.go
@@ -1,0 +1,25 @@
+package kafka
+
+import (
+	"errors"
+
+	"github.com/Shopify/sarama"
+)
+
+func SASLVersion(kafkaVersion sarama.KafkaVersion, saslVersion *int) (int16, error) {
+	if saslVersion == nil {
+		if kafkaVersion.IsAtLeast(sarama.V1_0_0_0) {
+			return sarama.SASLHandshakeV1, nil
+		}
+		return sarama.SASLHandshakeV0, nil
+	}
+
+	switch *saslVersion {
+	case 0:
+		return sarama.SASLHandshakeV0, nil
+	case 1:
+		return sarama.SASLHandshakeV1, nil
+	default:
+		return 0, errors.New("invalid SASL version")
+	}
+}

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -34,9 +34,13 @@ and use the old zookeeper connection method.
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
-  ## Optional SASL Config
+  ## SASL authentication credentials.  These settings should typically be used
+  ## with TLS encryption enabled using the "enable_tls" option.
   # sasl_username = "kafka"
   # sasl_password = "secret"
+
+  ## SASL protocol version.  When connecting to Azure EventHub set to 0.
+  # sasl_version = 1
 
   ## Name of the consumer group.
   # consumer_group = "telegraf_metrics_consumers"

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -2,6 +2,7 @@ package kafka_consumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -95,6 +96,7 @@ type KafkaConsumer struct {
 	Version                string   `toml:"version"`
 	SASLPassword           string   `toml:"sasl_password"`
 	SASLUsername           string   `toml:"sasl_username"`
+	SASLVersion            *int     `toml:"sasl_version"`
 
 	tls.ClientConfig
 
@@ -172,6 +174,12 @@ func (k *KafkaConsumer) Init() error {
 		config.Net.SASL.User = k.SASLUsername
 		config.Net.SASL.Password = k.SASLPassword
 		config.Net.SASL.Enable = true
+
+		version, err := SASLVersion(config.Version, k.SASLVersion)
+		if err != nil {
+			return err
+		}
+		config.Net.SASL.Version = version
 	}
 
 	if k.ClientID != "" {
@@ -206,6 +214,24 @@ func (k *KafkaConsumer) Init() error {
 
 	k.config = config
 	return nil
+}
+
+func SASLVersion(kafkaVersion sarama.KafkaVersion, saslVersion *int) (int16, error) {
+	if saslVersion == nil {
+		if kafkaVersion.IsAtLeast(sarama.V1_0_0_0) {
+			return sarama.SASLHandshakeV1, nil
+		}
+		return sarama.SASLHandshakeV0, nil
+	}
+
+	switch *saslVersion {
+	case 0:
+		return sarama.SASLHandshakeV0, nil
+	case 1:
+		return sarama.SASLHandshakeV1, nil
+	default:
+		return 0, errors.New("invalid SASL version")
+	}
 }
 
 func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {

--- a/plugins/inputs/zookeeper/README.md
+++ b/plugins/inputs/zookeeper/README.md
@@ -19,7 +19,7 @@ The zookeeper plugin collects variables outputted from the 'mntr' command
   # timeout = "5s"
 
   ## Optional TLS Config
-  # enable_ssl = true
+  # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -96,6 +96,9 @@ This plugin writes to a [Kafka Broker](http://kafka.apache.org/07/quickstart.htm
   # sasl_username = "kafka"
   # sasl_password = "secret"
 
+  ## SASL protocol version.  When connecting to Azure EventHub set to 0.
+  # sasl_version = 1
+
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/influxdata/telegraf"
 	tlsint "github.com/influxdata/telegraf/internal/tls"
+	"github.com/influxdata/telegraf/plugins/common/kafka"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
@@ -43,12 +44,12 @@ type (
 		// TLS certificate authority
 		CA string
 
+		EnableTLS bool `toml:"enable_tls"`
 		tlsint.ClientConfig
 
-		// SASL Username
 		SASLUsername string `toml:"sasl_username"`
-		// SASL Password
 		SASLPassword string `toml:"sasl_password"`
+		SASLVersion  *int   `toml:"sasl_version"`
 
 		Log telegraf.Logger `toml:"-"`
 
@@ -170,6 +171,7 @@ var sampleConfig = `
   # max_message_bytes = 1000000
 
   ## Optional TLS Config
+  # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
@@ -179,6 +181,9 @@ var sampleConfig = `
   ## Optional SASL Config
   # sasl_username = "kafka"
   # sasl_password = "secret"
+
+  ## SASL protocol version.  When connecting to Azure EventHub set to 0.
+  # sasl_version = 1
 
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
@@ -258,6 +263,10 @@ func (k *Kafka) Connect() error {
 		k.TLSKey = k.Key
 	}
 
+	if k.EnableTLS {
+		config.Net.TLS.Enable = true
+	}
+
 	tlsConfig, err := k.ClientConfig.TLSConfig()
 	if err != nil {
 		return err
@@ -265,6 +274,8 @@ func (k *Kafka) Connect() error {
 
 	if tlsConfig != nil {
 		config.Net.TLS.Config = tlsConfig
+
+		// TLS is forced on if a custom tls.Config is set.
 		config.Net.TLS.Enable = true
 	}
 
@@ -272,6 +283,12 @@ func (k *Kafka) Connect() error {
 		config.Net.SASL.User = k.SASLUsername
 		config.Net.SASL.Password = k.SASLPassword
 		config.Net.SASL.Enable = true
+
+		version, err := kafka.SASLVersion(config.Version, k.SASLVersion)
+		if err != nil {
+			return err
+		}
+		config.Net.SASL.Version = version
 	}
 
 	producer, err := sarama.NewSyncProducer(k.Brokers, config)


### PR DESCRIPTION
Add manual control of SASL version for testing.  Before merging this support should also be added to the output.

related #6342

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
