### PR TITLE
Add BearerToken Defaults for Kubernetes Plugins

### DIFF
--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -41,6 +41,8 @@ avoid cardinality issues:
   # namespace = "default"
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
+  ## If both of these are empty, we'll use the default serviceaccount:
+  ## at: /run/secrets/kubernetes.io/serviceaccount/token
   # bearer_token = "/path/to/bearer/token"
   ## OR
   # bearer_token_string = "abc_123"
@@ -264,6 +266,7 @@ The persistentvolumeclaim "phase" is saved in the `phase` tag with a correlated 
 | lost      | 1                         |
 | pending   | 2                         |
 | unknown   | 3                         |
+
 
 ### Example Output:
 

--- a/plugins/inputs/kube_inventory/kube_state.go
+++ b/plugins/inputs/kube_inventory/kube_state.go
@@ -19,6 +19,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
+const (
+	defaultServiceAccountPath = "/run/secrets/kubernetes.io/serviceaccount/token"
+)
+
 // KubernetesInventory represents the config object for the plugin.
 type KubernetesInventory struct {
 	URL               string            `toml:"url"`
@@ -42,6 +46,8 @@ var sampleConfig = `
   # namespace = "default"
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
+  ## If both of these are empty, we'll use the default serviceaccount:
+  ## at: /run/secrets/kubernetes.io/serviceaccount/token
   # bearer_token = "/path/to/bearer/token"
   ## OR
   # bearer_token_string = "abc_123"
@@ -77,14 +83,32 @@ func (ki *KubernetesInventory) Description() string {
 	return "Read metrics from the Kubernetes api"
 }
 
-// Gather collects kubernetes metrics from a given URL.
-func (ki *KubernetesInventory) Gather(acc telegraf.Accumulator) (err error) {
-	if ki.client == nil {
-		if ki.client, err = ki.initClient(); err != nil {
-			return err
-		}
+func (ki *KubernetesInventory) Init() error {
+	// If neither are provided, use the default service account.
+	if ki.BearerToken == "" && ki.BearerTokenString == "" {
+		ki.BearerToken = defaultServiceAccountPath
 	}
 
+	if ki.BearerToken != "" {
+		token, err := ioutil.ReadFile(ki.BearerToken)
+		if err != nil {
+			return err
+		}
+		ki.BearerTokenString = strings.TrimSpace(string(token))
+	}
+
+	var err error
+	ki.client, err = newClient(ki.URL, ki.Namespace, ki.BearerTokenString, ki.ResponseTimeout.Duration, ki.ClientConfig)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Gather collects kubernetes metrics from a given URL.
+func (ki *KubernetesInventory) Gather(acc telegraf.Accumulator) (err error) {
 	resourceFilter, err := filter.NewIncludeExcludeFilter(ki.ResourceInclude, ki.ResourceExclude)
 	if err != nil {
 		return err
@@ -119,18 +143,6 @@ var availableCollectors = map[string]func(ctx context.Context, acc telegraf.Accu
 	"statefulsets":           collectStatefulSets,
 	"persistentvolumes":      collectPersistentVolumes,
 	"persistentvolumeclaims": collectPersistentVolumeClaims,
-}
-
-func (ki *KubernetesInventory) initClient() (*client, error) {
-	if ki.BearerToken != "" {
-		token, err := ioutil.ReadFile(ki.BearerToken)
-		if err != nil {
-			return nil, err
-		}
-		ki.BearerTokenString = strings.TrimSpace(string(token))
-	}
-
-	return newClient(ki.URL, ki.Namespace, ki.BearerTokenString, ki.ResponseTimeout.Duration, ki.ClientConfig)
 }
 
 func atoi(s string) int64 {

--- a/plugins/inputs/kubernetes/README.md
+++ b/plugins/inputs/kubernetes/README.md
@@ -38,6 +38,8 @@ avoid cardinality issues:
   url = "http://127.0.0.1:10255"
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
+  ## If both of these are empty, we'll use the default serviceaccount:
+  ## at: /run/secrets/kubernetes.io/serviceaccount/token
   # bearer_token = "/path/to/bearer/token"
   ## OR
   # bearer_token_string = "abc_123"

--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -36,6 +36,8 @@ var sampleConfig = `
   url = "http://127.0.0.1:10255"
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
+  ## If both of these are empty, we'll use the default serviceaccount:
+  ## at: /run/secrets/kubernetes.io/serviceaccount/token
   # bearer_token = "/path/to/bearer/token"
   ## OR
   # bearer_token_string = "abc_123"
@@ -52,7 +54,8 @@ var sampleConfig = `
 `
 
 const (
-	summaryEndpoint = `%s/stats/summary`
+	summaryEndpoint           = `%s/stats/summary`
+	defaultServiceAccountPath = "/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 func init() {
@@ -69,6 +72,23 @@ func (k *Kubernetes) SampleConfig() string {
 //Description returns the description of this plugin
 func (k *Kubernetes) Description() string {
 	return "Read metrics from the kubernetes kubelet api"
+}
+
+func (k *Kubernetes) Init() error {
+	// If neither are provided, use the default service account.
+	if k.BearerToken == "" && k.BearerTokenString == "" {
+		k.BearerToken = defaultServiceAccountPath
+	}
+
+	if k.BearerToken != "" {
+		token, err := ioutil.ReadFile(k.BearerToken)
+		if err != nil {
+			return err
+		}
+		k.BearerTokenString = strings.TrimSpace(string(token))
+	}
+
+	return nil
 }
 
 //Gather collects kubernetes metrics from a given URL
@@ -108,15 +128,7 @@ func (k *Kubernetes) gatherSummary(baseURL string, acc telegraf.Accumulator) err
 		}
 	}
 
-	if k.BearerToken != "" {
-		token, err := ioutil.ReadFile(k.BearerToken)
-		if err != nil {
-			return err
-		}
-		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
-	} else if k.BearerTokenString != "" {
-		req.Header.Set("Authorization", "Bearer "+k.BearerTokenString)
-	}
+	req.Header.Set("Authorization", "Bearer "+k.BearerTokenString)
 	req.Header.Add("Accept", "application/json")
 
 	resp, err = k.RoundTripper.RoundTrip(req)


### PR DESCRIPTION
Due to Kubernetes RBAC policies, it's extremely rare and unlikely that
anyone will run these plugins outside of the cluster. With that in-mind,
we should use as many defaults as possible to remove configuration.

All pods within Kubernetes have a ServiceAccount token mounted in to this
location, which shouldn't need to be repeated each time.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
