### PR TITLE
Skip collection stats when disabled

### DIFF
--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -13,8 +13,10 @@
 
   ## When true, collect per database stats
   # gather_perdb_stats = false
+
   ## When true, collect per collection stats
   # gather_col_stats = false
+
   ## List of db where collections stats are collected
   ## If empty, all db are concerned
   # col_stats_dbs = ["local"]

--- a/plugins/inputs/mongodb/mongodb.go
+++ b/plugins/inputs/mongodb/mongodb.go
@@ -42,8 +42,10 @@ var sampleConfig = `
 
   ## When true, collect per database stats
   # gather_perdb_stats = false
+
   ## When true, collect per collection stats
   # gather_col_stats = false
+
   ## List of db where collections stats are collected
   ## If empty, all db are concerned
   # col_stats_dbs = ["local"]
@@ -177,7 +179,8 @@ func (m *MongoDB) gatherServer(server *Server, acc telegraf.Accumulator) error {
 func init() {
 	inputs.Add("mongodb", func() telegraf.Input {
 		return &MongoDB{
-			mongos: make(map[string]*Server),
+			ColStatsDbs: []string{"local"},
+			mongos:      make(map[string]*Server),
 		}
 	})
 }

--- a/plugins/inputs/mongodb/mongodb_server.go
+++ b/plugins/inputs/mongodb/mongodb_server.go
@@ -227,9 +227,13 @@ func (s *Server) gatherData(acc telegraf.Accumulator, gatherDbStats bool, gather
 			authLogLevel(err), err)
 	}
 
-	collectionStats, err := s.gatherCollectionStats(colStatsDbs)
-	if err != nil {
-		return err
+	var collectionStats *ColStats
+	if gatherColStats {
+		stats, err := s.gatherCollectionStats(colStatsDbs)
+		if err != nil {
+			return err
+		}
+		collectionStats = stats
 	}
 
 	dbStats := &DbStats{}

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -961,24 +961,25 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 		}
 	}
 
-	newColStats := *newMongo.ColStats
-	for _, col := range newColStats.Collections {
-		colStatsData := col.ColStatsData
-		// mongos doesn't have the db key, so setting the db name
-		if colStatsData.Collection == "" {
-			colStatsData.Collection = col.Name
+	if newMongo.ColStats != nil {
+		for _, col := range newMongo.ColStats.Collections {
+			colStatsData := col.ColStatsData
+			// mongos doesn't have the db key, so setting the db name
+			if colStatsData.Collection == "" {
+				colStatsData.Collection = col.Name
+			}
+			colStatLine := &ColStatLine{
+				Name:           colStatsData.Collection,
+				DbName:         col.DbName,
+				Count:          colStatsData.Count,
+				Size:           colStatsData.Size,
+				AvgObjSize:     colStatsData.AvgObjSize,
+				StorageSize:    colStatsData.StorageSize,
+				TotalIndexSize: colStatsData.TotalIndexSize,
+				Ok:             colStatsData.Ok,
+			}
+			returnVal.ColStatsLines = append(returnVal.ColStatsLines, *colStatLine)
 		}
-		colStatLine := &ColStatLine{
-			Name:           colStatsData.Collection,
-			DbName:         col.DbName,
-			Count:          colStatsData.Count,
-			Size:           colStatsData.Size,
-			AvgObjSize:     colStatsData.AvgObjSize,
-			StorageSize:    colStatsData.StorageSize,
-			TotalIndexSize: colStatsData.TotalIndexSize,
-			Ok:             colStatsData.Ok,
-		}
-		returnVal.ColStatsLines = append(returnVal.ColStatsLines, *colStatLine)
 	}
 
 	// Set shard stats


### PR DESCRIPTION
In addition to fixing the `gather_col_stats` option, this sets the default list of collection stat databases to the documented value.  This avoids errors reading the collections in the admin database that the documented role does not have permission to read.

closes #6362

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
