### PR TITLE
Require goplugin build flag to enable go plugin support

### DIFF
--- a/internal/goplugin/noplugin.go
+++ b/internal/goplugin/noplugin.go
@@ -1,0 +1,9 @@
+// +build !goplugin
+
+package goplugin
+
+import "errors"
+
+func LoadExternalPlugins(rootDir string) error {
+	return errors.New("go plugin support is not enabled")
+}

--- a/internal/goplugin/plugin.go
+++ b/internal/goplugin/plugin.go
@@ -1,0 +1,42 @@
+// +build goplugin
+
+package goplugin
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"plugin"
+	"strings"
+)
+
+// loadExternalPlugins loads external plugins from shared libraries (.so, .dll, etc.)
+// in the specified directory.
+func LoadExternalPlugins(rootDir string) error {
+	return filepath.Walk(rootDir, func(pth string, info os.FileInfo, err error) error {
+		// Stop if there was an error.
+		if err != nil {
+			return err
+		}
+
+		// Ignore directories.
+		if info.IsDir() {
+			return nil
+		}
+
+		// Ignore files that aren't shared libraries.
+		ext := strings.ToLower(path.Ext(pth))
+		if ext != ".so" && ext != ".dll" {
+			return nil
+		}
+
+		// Load plugin.
+		_, err = plugin.Open(pth)
+		if err != nil {
+			return fmt.Errorf("error loading %s: %s", pth, err)
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
It has come to my attention that the Go plugin support added in #6024 had an unexpected and hefty cost in terms of binary size, to the tune of about 19MB.

Despite this feature been released in 1.12, I propose we add a build flag and disable it on official Telegraf builds.  Based on my testing of this feature, it is quite difficult to get plugins working without building the plugin and Telegraf together on the same host, and the extra binary size is just too much for a feature that will be rarely used.

To build with Go plugin support add `-tags goplugin` to the build command:
```
go build -tags goplugin -ldflags "-w -s -X main.commit=9e3f918d -X main.branch=HEAD" ./cmd/telegraf
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
