### PR TITLE
Recommend Installing TICK Stack with Helm Stable Charts

### DIFF
--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -280,4 +280,3 @@ kubernetes_statefulset,namespace=default,statefulset_name=etcd replicas_updated=
 [series cardinality]: https://docs.influxdata.com/influxdb/latest/query_language/spec/#show-cardinality
 [influx-docs]: https://docs.influxdata.com/influxdb/latest/
 [k8s-telegraf]: https://www.influxdata.com/blog/monitoring-kubernetes-architecture/
-[tick-charts]: https://github.com/influxdata/tick-charts

--- a/plugins/inputs/kubernetes/README.md
+++ b/plugins/inputs/kubernetes/README.md
@@ -48,7 +48,12 @@ avoid cardinality issues:
 ### DaemonSet
 
 For recommendations on running Telegraf as a DaemonSet see [Monitoring Kubernetes
-Architecture][k8s-telegraf] or view the [Helm charts][tick-charts].
+Architecture][k8s-telegraf] or view the Helm charts:
+
+- [Telegraf][]
+- [InfluxDB][]
+- [Chronograf][]
+- [Kapacitor][]
 
 ### Metrics
 
@@ -136,4 +141,7 @@ kubernetes_system_container
 [series cardinality]: https://docs.influxdata.com/influxdb/latest/query_language/spec/#show-cardinality
 [influx-docs]: https://docs.influxdata.com/influxdb/latest/
 [k8s-telegraf]: https://www.influxdata.com/blog/monitoring-kubernetes-architecture/
-[tick-charts]: https://github.com/influxdata/tick-charts
+[Telegraf]: https://github.com/helm/charts/tree/master/stable/telegraf
+[InfluxDB]: https://github.com/helm/charts/tree/master/stable/influxdb
+[Chronograf]: https://github.com/helm/charts/tree/master/stable/chronograf
+[Kapacitor]: https://github.com/helm/charts/tree/master/stable/kapacitor


### PR DESCRIPTION
Our [tick-charts](https://github.com/influxdata/tick-charts) repository is not maintained. It has been decided that we should adopt the upstream Helm Stable repositories and support them as much as we can.

[Internal Issue](https://github.com/influxdata/devrel-team/issues/30)

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
