### PR TITLE
Fix #5156: Allowing using non-english counter names

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -63,8 +63,6 @@ Example:
 
 #### PreVistaSupport
 
-_Deprecated. Necessary features on Windows Vista and newer are checked dynamically_
-
 Bool, if set to `true`, the plugin will use the localized PerfCounter interface that has been present since before Vista for backwards compatability.
 
 It is recommended NOT to use this on OSes starting with Vista and newer because it requires more configuration to use this than the newer interface present since Vista.

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -139,8 +139,7 @@ var sampleConfig = `
 `
 
 type Win_PerfCounters struct {
-	PrintValid bool
-	//deprecated: determined dynamically
+	PrintValid              bool
 	PreVistaSupport         bool
 	UsePerfCounterTime      bool
 	Object                  []perfobject
@@ -247,7 +246,7 @@ func (m *Win_PerfCounters) SampleConfig() string {
 func (m *Win_PerfCounters) AddItem(counterPath string, objectName string, instance string, counterName string, measurement string, includeTotal bool) error {
 	var err error
 	var counterHandle PDH_HCOUNTER
-	if !m.query.IsVistaOrNewer() {
+	if m.PreVistaSupport || !m.query.IsVistaOrNewer() {
 		counterHandle, err = m.query.AddCounterToQuery(counterPath)
 		if err != nil {
 			return err


### PR DESCRIPTION
`PreVistaSupport` param forces  using PhAddCounter which allows localized counter names

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
