### PR TITLE
Change the Exec output to use BatchSerialize()

### DIFF
--- a/plugins/outputs/exec/exec.go
+++ b/plugins/outputs/exec/exec.go
@@ -67,13 +67,11 @@ func (e *Exec) SampleConfig() string {
 // Write writes the metrics to the configured command.
 func (e *Exec) Write(metrics []telegraf.Metric) error {
 	var buffer bytes.Buffer
-	for _, metric := range metrics {
-		value, err := e.serializer.Serialize(metric)
-		if err != nil {
-			return err
-		}
-		buffer.Write(value)
+	serializedMetrics, err := e.serializer.SerializeBatch(metrics)
+	if err != nil {
+		return err
 	}
+	buffer.Write(serializedMetrics)
 
 	if buffer.Len() <= 0 {
 		return nil


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Solves #6445

When the exec output serialises the metrics it does it one by one and writes it to the buffer. Error checking is done on the serialising but not the writing into the buffer. So there is no reason to not use the batch serialiser.

When developing against the output exec I expected the output to follow the rules of the data format that I specified. For my use case I am using JSON and expected a list of metrics but was unfortunately greeted with a multiple lines of single metrics, making it extremely difficult to render the metrics again.

Sample of bad output:

```json
{"fields":{"bytes_recv":0,"bytes_sent":0,"drop_in":0,"drop_out":0,"err_in":0,"err_out":0,"packets_recv":0,"packets_sent":0},"name":"net","tags":{"host":"pickle","interface":"br-0ac7079a5349"},"timestamp":1569418417000}
{"fields":{"bytes_recv":526400,"bytes_sent":1924156,"drop_in":0,"drop_out":0,"err_in":0,"err_out":0,"packets_recv":5289,"packets_sent":13564},"name":"net","tags":{"host":"pickle","interface":"docker0"},"timestamp":1569418417000}
{"fields":{"bytes_recv":0,"bytes_sent":0,"drop_in":0,"drop_out":0,"err_in":0,"err_out":0,"packets_recv":0,"packets_sent":0},"name":"net","tags":{"host":"pickle","interface":"br-349b964a2f38"},"timestamp":1569418417000}
```

This PR removes the looping over the metrics and rather just use the batch serialise function.
