### PR TITLE
More metrics for SQL Server plugin

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -598,6 +598,9 @@ WHERE	(
 			object_name LIKE '%User Settable%'
 			OR object_name LIKE '%SQL Errors%'
 		) OR (
+			object_name LIKE 'SQLServer:Batch Resp Statistics%'
+			AND instance_name LIKE 'CPU%'
+		) OR (
 			instance_name IN ('_Total')
 			AND counter_name IN (
 				'Lock Timeouts/sec',

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -592,7 +592,10 @@ WHERE	(
 				'Background Writer pages/sec',
 				'Percent Log Used',
 				'Log Send Queue KB',
-				'Redo Queue KB'
+				'Redo Queue KB',
+				'Mirrored Write Transactions/sec',
+				'Group Commit Time',
+				'Group Commits/sec'
 			)
 		) OR (
 			object_name LIKE '%User Settable%'

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -602,7 +602,6 @@ WHERE	(
 			OR object_name LIKE '%SQL Errors%'
 		) OR (
 			object_name LIKE 'SQLServer:Batch Resp Statistics%'
-			AND instance_name LIKE 'CPU%'
 		) OR (
 			instance_name IN ('_Total')
 			AND counter_name IN (


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This change will add some previously removed "Batch Response Statistics" back, and also add a few more metrics around Availability Group performance.