### PR TITLE
Remove shared package level vars from sqlserver and mysql input plugins

### DIFF
--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -39,9 +39,9 @@ type Mysql struct {
 	IntervalSlow                        string   `toml:"interval_slow"`
 	MetricVersion                       int      `toml:"metric_version"`
 	tls.ClientConfig
-	lastT                               time.Time
-	initDone                            bool
-	scanIntervalSlow                    uint32
+	lastT            time.Time
+	initDone         bool
+	scanIntervalSlow uint32
 }
 
 const sampleConfig = `
@@ -136,7 +136,7 @@ func (m *Mysql) Description() string {
 	return "Read metrics from one or many mysql servers"
 }
 
-const	localhost        = ""
+const localhost = ""
 
 func (m *Mysql) InitMysql() {
 	if len(m.IntervalSlow) > 0 {

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -182,7 +182,7 @@ func (m *Mysql) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-// These are const but can't be labelled as such because golang doesn't allow const maps
+// These are const but can't be declared as such because golang doesn't allow const maps
 var (
 	// status counter
 	generalThreadStates = map[string]uint32{

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -137,8 +137,6 @@ func (m *Mysql) Description() string {
 }
 
 const	localhost        = ""
-var (
-)
 
 func (m *Mysql) InitMysql() {
 	if len(m.IntervalSlow) > 0 {

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -39,9 +39,12 @@ type Mysql struct {
 	IntervalSlow                        string   `toml:"interval_slow"`
 	MetricVersion                       int      `toml:"metric_version"`
 	tls.ClientConfig
+	lastT                               time.Time
+	initDone                            bool
+	scanIntervalSlow                    uint32
 }
 
-var sampleConfig = `
+const sampleConfig = `
   ## specify servers via a url matching:
   ##  [username[:password]@][protocol[(address)]]/[?tls=[true|false|skip-verify|custom]]
   ##  see https://github.com/go-sql-driver/mysql#dsn-data-source-name
@@ -123,7 +126,7 @@ var sampleConfig = `
   # insecure_skip_verify = false
 `
 
-var defaultTimeout = time.Second * time.Duration(5)
+const defaultTimeout = time.Second * time.Duration(5)
 
 func (m *Mysql) SampleConfig() string {
 	return sampleConfig
@@ -133,21 +136,18 @@ func (m *Mysql) Description() string {
 	return "Read metrics from one or many mysql servers"
 }
 
+const	localhost        = ""
 var (
-	localhost        = ""
-	lastT            time.Time
-	initDone         = false
-	scanIntervalSlow uint32
 )
 
 func (m *Mysql) InitMysql() {
 	if len(m.IntervalSlow) > 0 {
 		interval, err := time.ParseDuration(m.IntervalSlow)
 		if err == nil && interval.Seconds() >= 1.0 {
-			scanIntervalSlow = uint32(interval.Seconds())
+			m.scanIntervalSlow = uint32(interval.Seconds())
 		}
 	}
-	initDone = true
+	m.initDone = true
 }
 
 func (m *Mysql) Gather(acc telegraf.Accumulator) error {
@@ -156,7 +156,7 @@ func (m *Mysql) Gather(acc telegraf.Accumulator) error {
 		return m.gatherServer(localhost, acc)
 	}
 	// Initialise additional query intervals
-	if !initDone {
+	if !m.initDone {
 		m.InitMysql()
 	}
 
@@ -184,6 +184,7 @@ func (m *Mysql) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
+// These are const but can't be labelled as such because golang doesn't allow const maps
 var (
 	// status counter
 	generalThreadStates = map[string]uint32{
@@ -426,12 +427,12 @@ func (m *Mysql) gatherServer(serv string, acc telegraf.Accumulator) error {
 
 	// Global Variables may be gathered less often
 	if len(m.IntervalSlow) > 0 {
-		if uint32(time.Since(lastT).Seconds()) >= scanIntervalSlow {
+		if uint32(time.Since(m.lastT).Seconds()) >= m.scanIntervalSlow {
 			err = m.gatherGlobalVariables(db, serv, acc)
 			if err != nil {
 				return err
 			}
-			lastT = time.Now()
+			m.lastT = time.Now()
 		}
 	}
 

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
@@ -15,7 +16,7 @@ func TestMysqlDefaultsToLocal(t *testing.T) {
 	}
 
 	m := &Mysql{
-		Servers: []string{"root@tcp(127.0.0.1:3306)/?tls=false"},
+		Servers: []string{fmt.Sprintf("root@tcp(127.0.0.1:3306)/?tls=false")},
 	}
 
 	var acc testutil.Accumulator
@@ -29,9 +30,9 @@ func TestMysqlMultipleInstances(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-
+	testServer := "root@tcp(127.0.0.1:3306)/?tls=false"
 	m := &Mysql{
-		Servers: []string{"root@tcp(127.0.0.1:3306)/?tls=false"},
+		Servers: []string{testServer},
 		IntervalSlow: "30s",
 	}
 
@@ -43,7 +44,7 @@ func TestMysqlMultipleInstances(t *testing.T) {
 	assert.True(t, acc.HasMeasurement("mysql_variables"))
 
 	m2 := &Mysql{
-		Servers: []string{"root@tcp(127.0.0.1:3306)/?tls=false"},
+		Servers: []string{testServer},
 	}
 	err = m2.Gather(&acc2)
 	require.NoError(t, err)
@@ -64,6 +65,7 @@ func TestMysqlMultipleInits(t *testing.T) {
 	assert.False(t, m2.initDone)
 	assert.Equal(t, m.scanIntervalSlow, uint32(30))
 	assert.Equal(t, m2.scanIntervalSlow, uint32(0))
+
 	m2.InitMysql()
 	assert.True(t, m.initDone)
 	assert.True(t, m2.initDone)

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -16,7 +16,7 @@ func TestMysqlDefaultsToLocal(t *testing.T) {
 	}
 
 	m := &Mysql{
-		Servers: []string{fmt.Sprintf("root@tcp(127.0.0.1:3306)/?tls=false")},
+		Servers: []string{fmt.Sprintf("root@tcp(%s:3306)/", testutil.GetLocalHost())},
 	}
 
 	var acc testutil.Accumulator

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -27,6 +27,8 @@ func TestMysqlDefaultsToLocal(t *testing.T) {
 }
 
 func TestMysqlMultipleInstances(t *testing.T) {
+	// Invoke Gather() from two separate configurations and
+	//  confirm they don't interfere with each other
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -16,7 +16,7 @@ func TestMysqlDefaultsToLocal(t *testing.T) {
 	}
 
 	m := &Mysql{
-		Servers: []string{fmt.Sprintf("root@tcp(%s:3306)/", testutil.GetLocalHost())},
+		Servers: []string{fmt.Sprintf("root@tcp(127.0.0.1:3306)/?tls=false")},
 	}
 
 	var acc testutil.Accumulator
@@ -34,7 +34,7 @@ func TestMysqlMultipleInstances(t *testing.T) {
 	}
 	testServer := "root@tcp(127.0.0.1:3306)/?tls=false"
 	m := &Mysql{
-		Servers: []string{testServer},
+		Servers:      []string{testServer},
 		IntervalSlow: "30s",
 	}
 
@@ -59,8 +59,7 @@ func TestMysqlMultipleInits(t *testing.T) {
 	m := &Mysql{
 		IntervalSlow: "30s",
 	}
-	m2 := &Mysql{
-	}
+	m2 := &Mysql{}
 
 	m.InitMysql()
 	assert.True(t, m.initDone)

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -12,11 +12,11 @@ import (
 
 // SQLServer struct
 type SQLServer struct {
-	Servers      []string `toml:"servers"`
-	QueryVersion int      `toml:"query_version"`
-	AzureDB      bool     `toml:"azuredb"`
-	ExcludeQuery []string `toml:"exclude_query"`
-	queries MapQuery
+	Servers       []string `toml:"servers"`
+	QueryVersion  int      `toml:"query_version"`
+	AzureDB       bool     `toml:"azuredb"`
+	ExcludeQuery  []string `toml:"exclude_query"`
+	queries       MapQuery
 	isInitialized bool
 }
 

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"sync"
 	"time"
-	"fmt"
 
 	_ "github.com/denisenkom/go-mssqldb" // go-mssqldb initialization
 	"github.com/influxdata/telegraf"
@@ -101,8 +100,6 @@ func initQueries(s *SQLServer) {
 		queries["WaitStatsCategorized"] = Query{Script: sqlWaitStatsCategorizedV2, ResultByRow: false}
 		queries["DatabaseIO"] = Query{Script: sqlDatabaseIOV2, ResultByRow: false}
 		queries["ServerProperties"] = Query{Script: sqlServerPropertiesV2, ResultByRow: false}
-		time.Sleep(1 * time.Millisecond)
-		fmt.Println("gbj2")
 		queries["MemoryClerk"] = Query{Script: sqlMemoryClerkV2, ResultByRow: false}
 		queries["Schedulers"] = Query{Script: sqlServerSchedulersV2, ResultByRow: false}
 		queries["SqlRequests"] = Query{Script: sqlServerRequestsV2, ResultByRow: false}
@@ -236,7 +233,7 @@ func (s *SQLServer) accRow(query Query, acc telegraf.Accumulator, row scanner) e
 
 func init() {
 	inputs.Add("sqlserver", func() telegraf.Input {
-		return &SQLServer{isInitialized: false}
+		return &SQLServer{}
 	})
 }
 

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -12,11 +12,11 @@ import (
 
 // SQLServer struct
 type SQLServer struct {
-	Servers       []string `toml:"servers"`
-	QueryVersion  int      `toml:"query_version"`
-	AzureDB       bool     `toml:"azuredb"`
-	ExcludeQuery  []string `toml:"exclude_query"`
-	queries       MapQuery
+	Servers      []string `toml:"servers"`
+	QueryVersion int      `toml:"query_version"`
+	AzureDB      bool     `toml:"azuredb"`
+	ExcludeQuery []string `toml:"exclude_query"`
+	queries      MapQuery
 	isInitialized bool
 }
 

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -12,11 +12,11 @@ import (
 
 // SQLServer struct
 type SQLServer struct {
-	Servers      []string `toml:"servers"`
-	QueryVersion int      `toml:"query_version"`
-	AzureDB      bool     `toml:"azuredb"`
-	ExcludeQuery []string `toml:"exclude_query"`
-	queries      MapQuery
+	Servers       []string `toml:"servers"`
+	QueryVersion  int      `toml:"query_version"`
+	AzureDB       bool     `toml:"azuredb"`
+	ExcludeQuery  []string `toml:"exclude_query"`
+	queries       MapQuery
 	isInitialized bool
 }
 

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -31,9 +31,9 @@ type Query struct {
 // MapQuery type
 type MapQuery map[string]Query
 
-var defaultServer = "Server=.;app name=telegraf;log=1;"
+const defaultServer = "Server=.;app name=telegraf;log=1;"
 
-var sampleConfig = `
+const sampleConfig = `
   ## Specify instances to monitor with a list of connection strings.
   ## All connection parameters are optional.
   ## By default, the host is localhost, listening on default port, TCP 1433.

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -83,6 +83,8 @@ func TestSqlServer_ParseMetrics(t *testing.T) {
 }
 
 func TestSqlServer_MultipleInstance(t *testing.T) {
+	// Invoke Gather() from two separate configurations and
+	//  confirm they don't interfere with each other
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -114,6 +114,28 @@ func TestSqlServer_MultipleInstance(t *testing.T) {
 	assert.False(t, acc2.HasMeasurement("Log size (bytes)"))
 }
 
+func TestSqlServer_MultipleInit(t *testing.T) {
+
+	s := &SQLServer{
+	}
+	s2 := &SQLServer{
+		ExcludeQuery: []string{"DatabaseSize"},
+	}
+
+	initQueries(s)
+	_, ok := s.queries["DatabaseSize"]
+	assert.True(t,ok)
+	assert.Equal(t, s.isInitialized, true)
+	assert.Equal(t, s2.isInitialized, false)
+
+	initQueries(s2)
+	_, ok = s2.queries["DatabaseSize"]
+	assert.False(t,ok)
+	assert.Equal(t, s.isInitialized, true)
+	assert.Equal(t, s2.isInitialized, true)
+}
+
+
 const mockPerformanceMetrics = `measurement;servername;type;Point In Time Recovery;Available physical memory (bytes);Average pending disk IO;Average runnable tasks;Average tasks;Buffer pool rate (bytes/sec);Connection memory per connection (bytes);Memory grant pending;Page File Usage (%);Page lookup per batch request;Page split per batch request;Readahead per page read;Signal wait (%);Sql compilation per batch request;Sql recompilation per batch request;Total target memory ratio
 Performance metrics;WIN8-DEV;Performance metrics;0;6353158144;0;0;7;2773;415061;0;25;229371;130;10;18;188;52;14`
 

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -86,13 +86,13 @@ func TestSqlServer_MultipleInstance(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-
+	testServer := "Server=127.0.0.1;Port=1433;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"
 	s := &SQLServer{
-		Servers: []string{"Server=127.0.0.1;Port=1433;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"},
+		Servers: []string{testServer},
 		ExcludeQuery: []string{"MemoryClerk"},
 	}
 	s2 := &SQLServer{
-		Servers: []string{"Server=127.0.0.1;Port=1433;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"},
+		Servers: []string{testServer},
 		ExcludeQuery: []string{"DatabaseSize"},
 	}
 
@@ -107,9 +107,11 @@ func TestSqlServer_MultipleInstance(t *testing.T) {
 	assert.Equal(t, s.isInitialized, true)
 	assert.Equal(t, s2.isInitialized, true)
 
+	// acc includes size metrics, and excludes memory metrics
 	assert.False(t, acc.HasMeasurement("Memory breakdown (%)"))
 	assert.True(t, acc.HasMeasurement("Log size (bytes)"))
 
+	// acc2 includes memory metrics, and excludes size metrics
 	assert.True(t, acc2.HasMeasurement("Memory breakdown (%)"))
 	assert.False(t, acc2.HasMeasurement("Log size (bytes)"))
 }
@@ -124,12 +126,14 @@ func TestSqlServer_MultipleInit(t *testing.T) {
 
 	initQueries(s)
 	_, ok := s.queries["DatabaseSize"]
+	// acc includes size metrics
 	assert.True(t,ok)
 	assert.Equal(t, s.isInitialized, true)
 	assert.Equal(t, s2.isInitialized, false)
 
 	initQueries(s2)
 	_, ok = s2.queries["DatabaseSize"]
+	// acc2 excludes size metrics
 	assert.False(t,ok)
 	assert.Equal(t, s.isInitialized, true)
 	assert.Equal(t, s2.isInitialized, true)

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -101,8 +101,13 @@ func TestSqlServer_MultipleInstance(t *testing.T) {
 	var acc, acc2 testutil.Accumulator
 	err := s.Gather(&acc)
 	require.NoError(t, err)
+	assert.Equal(t, s.isInitialized, true)
+	assert.Equal(t, s2.isInitialized, false)
+
 	err = s2.Gather(&acc2)
 	require.NoError(t, err)
+	assert.Equal(t, s.isInitialized, true)
+	assert.Equal(t, s2.isInitialized, true)
 
 	assert.False(t, acc.HasMeasurement("Memory breakdown (%)"))
 	assert.True(t, acc.HasMeasurement("Log size (bytes)"))

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -90,11 +90,11 @@ func TestSqlServer_MultipleInstance(t *testing.T) {
 	}
 	testServer := "Server=127.0.0.1;Port=1433;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"
 	s := &SQLServer{
-		Servers: []string{testServer},
+		Servers:      []string{testServer},
 		ExcludeQuery: []string{"MemoryClerk"},
 	}
 	s2 := &SQLServer{
-		Servers: []string{testServer},
+		Servers:      []string{testServer},
 		ExcludeQuery: []string{"DatabaseSize"},
 	}
 
@@ -120,8 +120,7 @@ func TestSqlServer_MultipleInstance(t *testing.T) {
 
 func TestSqlServer_MultipleInit(t *testing.T) {
 
-	s := &SQLServer{
-	}
+	s := &SQLServer{}
 	s2 := &SQLServer{
 		ExcludeQuery: []string{"DatabaseSize"},
 	}
@@ -129,18 +128,17 @@ func TestSqlServer_MultipleInit(t *testing.T) {
 	initQueries(s)
 	_, ok := s.queries["DatabaseSize"]
 	// acc includes size metrics
-	assert.True(t,ok)
+	assert.True(t, ok)
 	assert.Equal(t, s.isInitialized, true)
 	assert.Equal(t, s2.isInitialized, false)
 
 	initQueries(s2)
 	_, ok = s2.queries["DatabaseSize"]
 	// acc2 excludes size metrics
-	assert.False(t,ok)
+	assert.False(t, ok)
 	assert.Equal(t, s.isInitialized, true)
 	assert.Equal(t, s2.isInitialized, true)
 }
-
 
 const mockPerformanceMetrics = `measurement;servername;type;Point In Time Recovery;Available physical memory (bytes);Average pending disk IO;Average runnable tasks;Average tasks;Buffer pool rate (bytes/sec);Connection memory per connection (bytes);Memory grant pending;Page File Usage (%);Page lookup per batch request;Page split per batch request;Readahead per page read;Signal wait (%);Sql compilation per batch request;Sql recompilation per batch request;Total target memory ratio
 Performance metrics;WIN8-DEV;Performance metrics;0;6353158144;0;0;7;2773;415061;0;25;229371;130;10;18;188;52;14`

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -90,12 +90,10 @@ func TestSqlServer_MultipleInstance(t *testing.T) {
 	s := &SQLServer{
 		Servers: []string{"Server=127.0.0.1;Port=1433;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"},
 		ExcludeQuery: []string{"MemoryClerk"},
-		isInitialized: false,
 	}
 	s2 := &SQLServer{
 		Servers: []string{"Server=127.0.0.1;Port=1433;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"},
 		ExcludeQuery: []string{"DatabaseSize"},
-		isInitialized: false,
 	}
 
 	var acc, acc2 testutil.Accumulator


### PR DESCRIPTION
### Required for all PRs:

- [x ] Signed [CLA](https://influxdata.com/community/cla/).
- [ x] Associated README.md updated.
- [ x] Has appropriate unit tests.


The current implementations of mysql and sqlserver input plugins don't support running multiple times with different configurations because they use shared package level vars

I've just revised the package level var's to either declare them as const's or move them into the instance struct.  Also added tests, both integration and unit, that correspond to those changes.

