### PR TITLE
fix(config): allow remote config with no auth

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -841,13 +841,14 @@ func loadConfig(config string) ([]byte, error) {
 }
 
 func fetchConfig(u *url.URL) ([]byte, error) {
-	v := os.Getenv("INFLUX_TOKEN")
-
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Authorization", "Token "+v)
+
+	if v, exists := os.LookupEnv("INFLUX_TOKEN"); exists {
+		req.Header.Add("Authorization", "Token "+v)
+	}
 	req.Header.Add("Accept", "application/toml")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Adding an `Authorization: Token <token>` header causes 404 errors with GitHub when using the raw content URI.

This fix only adds the header when the token is available, allowing for public configs to be loaded correctly.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.


You can test this with:

`telegraf --config https://raw.githubusercontent.com/influxdata/telegraf/master/etc/telegraf.conf`

To see the HTTP behaviour without Telegraf:

Returns 404:

`curl -X GET -H "Authorization: Token ABC" -H "Accept: application/toml" -I https://raw.githubusercontent.com/influxdata/telegraf/master/etc/telegraf.conf`

Returns 200

curl -X GET -H "Accept: application/toml" -I https://raw.githubusercontent.com/influxdata/telegraf/master/etc/telegraf.conf