### PR TITLE
Stackdriver output: Set startTime to timestamp - 1

### DIFF
--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -11,6 +11,8 @@ Metrics are grouped by the `namespace` variable and metric key - eg: `custom.goo
 
 Additional resource labels can be configured by `resource_labels`. By default the required `project_id` label is always set to the `project` variable.
 
+For cumulative metric [intervals](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TimeInterval), the start time is by default set to the start time of the telegraf process. To get periodic intervals, the `cumulative_interval_seconds` parameter can be set to define the number of seconds between each interval.
+
 ### Configuration
 
 ```toml
@@ -24,7 +26,10 @@ Additional resource labels can be configured by `resource_labels`. By default th
   ## Custom resource type
   # resource_type = "generic_node"
 
-  ## Additonal resource labels
+  ## Number of seconds between reseting cumulative startTime
+  # cumulative_interval_seconds = 60
+
+  ## Additional resource labels
   # [outputs.stackdriver.resource_labels]
   #   node_id = "$HOSTNAME"
   #   namespace = "myapp"

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -61,6 +61,9 @@ var sampleConfig = `
   ## Custom resource type
   # resource_type = "generic_node"
 
+  ## Number of seconds between cumulative intervals
+  # cumulative_interval_seconds = 60
+
   ## Additonal resource labels
   # [outputs.stackdriver.resource_labels]
   #   node_id = "$HOSTNAME"

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -166,7 +166,7 @@ func (s *Stackdriver) Write(metrics []telegraf.Metric) error {
 
 			var startTime, endTime int64 = defaultStartTime, m.Time().Unix()
 			var endTimeNanos int32 = 0
-			if s.CumulativeIntervalSeconds > 0 {
+			if s.CumulativeIntervalSeconds > 0 && metricKind == metricpb.MetricDescriptor_CUMULATIVE {
 				startTime = m.Time().Unix() + (m.Time().Unix() % s.CumulativeIntervalSeconds)
 				if endTime == startTime {
 					endTimeNanos = 1000
@@ -264,7 +264,6 @@ func getStackdriverTimeInterval(
 		return &monitoringpb.TimeInterval{
 			EndTime: &googlepb.Timestamp{
 				Seconds: end,
-				Nanos:   endNanos,
 			},
 		}, nil
 	case metricpb.MetricDescriptor_CUMULATIVE:


### PR DESCRIPTION
Our cumulative Stackdriver metrics complete broke overnight this weekend. Instead of as previously resulting in one-minute intervals, we now have single timeSeries values extending from `T - 2*52 weeks` to `T`.

My guess is that Google has changed the supported timewindow for writing cumulative time series from very short to 104 weeks (~2 years).

I am not 100% certain if the approach here (startTime = timestamp - 1 second), but it looks like it's resolving the problem for us after running it for a bit.


### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
