### PR TITLE
Containers can now be identified by the container ID

### DIFF
--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -26,6 +26,9 @@ to gather stats from the [Engine API](https://docs.docker.com/engine/api/v1.24/)
   ## Deprecated (1.4.0), use container_name_include
   container_names = []
 
+  ## Set the host tag for the metrics to the container ID hostname, eg first 12 chars
+  container_id_as_hostname = false
+
   ## Containers to include and exclude. Collect all if empty. Globs accepted.
   container_name_include = []
   container_name_exclude = []
@@ -92,6 +95,17 @@ lines to the telegraf container definition in a docker compose file:
 volumes:
   - /var/run/docker.sock:/var/run/docker.sock
 ```
+
+#### host tag
+
+Selecting the containers measurements can be tricky if you have many containers with the same name.
+To alleviate this issue you can set the below value to true
+
+```toml
+container_id_as_hostname = true
+```
+
+This will cause all measurements to have the `host` tag be set to the first 12 characters of the container id. The first 12 characters is the common hostname for containers that have no hostname set, as defined by docker.
 
 #### Kubernetes Labels
 

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -99,7 +99,7 @@ volumes:
 #### source tag
 
 Selecting the containers measurements can be tricky if you have many containers with the same name.
-To alleviate this issue you can set the below value to true
+To alleviate this issue you can set the below value to `true`
 
 ```toml
 source_tag = true

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -26,8 +26,8 @@ to gather stats from the [Engine API](https://docs.docker.com/engine/api/v1.24/)
   ## Deprecated (1.4.0), use container_name_include
   container_names = []
 
-  ## Set the host tag for the metrics to the container ID hostname, eg first 12 chars
-  container_id_as_hostname = false
+  ## Set the source tag for the metrics to the container ID hostname, eg first 12 chars
+  source_tag = false
 
   ## Containers to include and exclude. Collect all if empty. Globs accepted.
   container_name_include = []
@@ -96,16 +96,16 @@ volumes:
   - /var/run/docker.sock:/var/run/docker.sock
 ```
 
-#### host tag
+#### source tag
 
 Selecting the containers measurements can be tricky if you have many containers with the same name.
 To alleviate this issue you can set the below value to true
 
 ```toml
-container_id_as_hostname = true
+source_tag = true
 ```
 
-This will cause all measurements to have the `host` tag be set to the first 12 characters of the container id. The first 12 characters is the common hostname for containers that have no hostname set, as defined by docker.
+This will cause all measurements to have the `source` tag be set to the first 12 characters of the container id. The first 12 characters is the common hostname for containers that have no explicit hostname set, as defined by docker.
 
 #### Kubernetes Labels
 

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -44,7 +44,7 @@ type Docker struct {
 	ContainerStateInclude []string `toml:"container_state_include"`
 	ContainerStateExclude []string `toml:"container_state_exclude"`
 
-	ContainerIDAsHostname bool `toml:"container_id_as_hostname"`
+	IncludeSourceTag bool `toml:"source_tag"`
 
 	Log telegraf.Logger
 
@@ -92,8 +92,8 @@ var sampleConfig = `
   ## Only collect metrics for these containers, collect all if empty
   container_names = []
 
-  ## Set the host tag for the metrics to the container ID hostname, eg first 12 chars
-  container_id_as_hostname = false
+  ## Set the source tag for the metrics to the container ID hostname, eg first 12 chars
+  source_tag = false
 
   ## Containers to include and exclude. Globs accepted.
   ## Note that an empty array for both will include all containers
@@ -455,8 +455,8 @@ func (d *Docker) gatherContainer(
 		"container_version": imageVersion,
 	}
 
-	if d.ContainerIDAsHostname {
-		tags["host"] = hostnameFromID(container.ID)
+	if d.IncludeSourceTag {
+		tags["source"] = hostnameFromID(container.ID)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout.Duration)

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -92,7 +92,7 @@ var sampleConfig = `
   ## Only collect metrics for these containers, collect all if empty
   container_names = []
 
-  ## Set the hostname for the metric to the container ID
+  ## Set the host tag for the metrics to the container ID hostname, eg first 12 chars
   container_id_as_hostname = false
 
   ## Containers to include and exclude. Globs accepted.

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -629,8 +629,9 @@ func TestContainerStatus(t *testing.T) {
 					return &client, nil
 				}
 				d = Docker{
-					Log:       testutil.Logger{},
-					newClient: newClientFunc,
+					Log:                   testutil.Logger{},
+					newClient:             newClientFunc,
+					ContainerIDAsHostname: true,
 				}
 			)
 
@@ -673,6 +674,7 @@ func TestContainerStatus(t *testing.T) {
 					"label2":            "test_value_2",
 					"server_version":    "17.09.0-ce",
 					"container_status":  tt.expect.Status,
+					"host":              "e2173b9478a6",
 				})
 		})
 	}
@@ -1016,4 +1018,38 @@ func TestContainerName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHostnameFromID(t *testing.T) {
+	tests := []struct {
+		name   string
+		id     string
+		expect string
+	}{
+		{
+			name:   "Real ID",
+			id:     "565e3a55f5843cfdd4aa5659a1a75e4e78d47f73c3c483f782fe4a26fc8caa07",
+			expect: "565e3a55f584",
+		},
+		{
+			name:   "Short ID",
+			id:     "shortid123",
+			expect: "shortid123",
+		},
+		{
+			name:   "No ID",
+			id:     "",
+			expect: "shortid123",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := hostnameFromID(test.id)
+			if test.expect != output {
+				t.Logf("Container ID for hostname is wrong. Want: %s, Got: %s", output, test.expect)
+			}
+		})
+	}
+
 }

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -629,9 +629,9 @@ func TestContainerStatus(t *testing.T) {
 					return &client, nil
 				}
 				d = Docker{
-					Log:                   testutil.Logger{},
-					newClient:             newClientFunc,
-					ContainerIDAsHostname: true,
+					Log:              testutil.Logger{},
+					newClient:        newClientFunc,
+					IncludeSourceTag: true,
 				}
 			)
 
@@ -674,7 +674,7 @@ func TestContainerStatus(t *testing.T) {
 					"label2":            "test_value_2",
 					"server_version":    "17.09.0-ce",
 					"container_status":  tt.expect.Status,
-					"host":              "e2173b9478a6",
+					"source":            "e2173b9478a6",
 				})
 		})
 	}

--- a/plugins/inputs/docker_log/README.md
+++ b/plugins/inputs/docker_log/README.md
@@ -43,6 +43,9 @@ The docker plugin uses the [Official Docker Client][] to gather logs from the
   # docker_label_include = []
   # docker_label_exclude = []
 
+  ## Set the source tag for the metrics to the container ID hostname, eg first 12 chars
+  source_tag = false
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
@@ -58,6 +61,17 @@ When using the `"ENV"` endpoint, the connection is configured using the
 
 [env]: https://godoc.org/github.com/moby/moby/client#NewEnvClient
 
+### source tag
+
+Selecting the containers can be tricky if you have many containers with the same name.
+To alleviate this issue you can set the below value to `true`
+
+```toml
+source_tag = true
+```
+
+This will cause all data points to have the `source` tag be set to the first 12 characters of the container id. The first 12 characters is the common hostname for containers that have no explicit hostname set, as defined by docker.
+
 ### Metrics
 
 - docker_log
@@ -66,6 +80,7 @@ When using the `"ENV"` endpoint, the connection is configured using the
     - container_version
     - container_name
     - stream (stdout, stderr, or tty)
+    - source
   - fields:
     - container_id
     - message

--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -49,6 +49,9 @@ var sampleConfig = `
   # docker_label_include = []
   # docker_label_exclude = []
 
+  ## Set the source tag for the metrics to the container ID hostname, eg first 12 chars
+  source_tag = false
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
@@ -82,6 +85,7 @@ type DockerLogs struct {
 	ContainerExclude      []string          `toml:"container_name_exclude"`
 	ContainerStateInclude []string          `toml:"container_state_include"`
 	ContainerStateExclude []string          `toml:"container_state_exclude"`
+	IncludeSourceTag      bool              `toml:"source_tag"`
 
 	tlsint.ClientConfig
 
@@ -256,6 +260,10 @@ func (d *DockerLogs) tailContainerLogs(
 		"container_name":    containerName,
 		"container_image":   imageName,
 		"container_version": imageVersion,
+	}
+
+	if d.IncludeSourceTag {
+		tags["source"] = hostnameFromID(container.ID)
 	}
 
 	// Add matching container labels as tags
@@ -434,4 +442,11 @@ func init() {
 			containerList: make(map[string]context.CancelFunc),
 		}
 	})
+}
+
+func hostnameFromID(id string) string {
+	if len(id) > 12 {
+		return id[0:12]
+	}
+	return id
 }

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -98,6 +98,7 @@ func Test(t *testing.T) {
 						"container_image":   "influxdata/telegraf",
 						"container_version": "1.11.0",
 						"stream":            "tty",
+						"source":            "deadbeef",
 					},
 					map[string]interface{}{
 						"container_id": "deadbeef",
@@ -141,6 +142,7 @@ func Test(t *testing.T) {
 						"container_image":   "influxdata/telegraf",
 						"container_version": "1.11.0",
 						"stream":            "stdout",
+						"source":            "deadbeef",
 					},
 					map[string]interface{}{
 						"container_id": "deadbeef",
@@ -155,9 +157,10 @@ func Test(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var acc testutil.Accumulator
 			plugin := &DockerLogs{
-				Timeout:       internal.Duration{Duration: time.Second * 5},
-				newClient:     func(string, *tls.Config) (Client, error) { return tt.client, nil },
-				containerList: make(map[string]context.CancelFunc),
+				Timeout:          internal.Duration{Duration: time.Second * 5},
+				newClient:        func(string, *tls.Config) (Client, error) { return tt.client, nil },
+				containerList:    make(map[string]context.CancelFunc),
+				IncludeSourceTag: true,
 			}
 
 			err := plugin.Init()


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Solves #6472

I'm not 100% sure of the config value name `container_id_as_hostname`, I'm happy to take some guidance on this.

This PR allows the user to set a config value to tag all measurements gathered by this plugin with the container_id, stripped down to the common hostname value.
It sets this in the `host` tag which telegraf expects to be set and will set itself if its not already set. This allows for backwards comparability with the current behaviour.
