### PR TITLE
Install and configure CLAsee

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     name: "Check CLA"
     steps:
-      - uses: actions/checkout@v1
       - name: "Lookup PR Author"
         uses: influxdata/clasee@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  cla-checker:
+    runs-on: ubuntu-latest
+    name: "Check CLA"
+    steps:
+      - uses: actions/checkout@v1
+      - name: "Lookup PR Author"
+        uses: influxdata/clasee@v1
+        with:
+          spreadsheet: "1jnRZYSw83oa6hcEBb1lxK6nNvXrWnOzPT8Bz9iR4Q8s"
+          range: "Form Responses!E:E"
+        env:
+          CLASEE_SECRET: ${{ secrets.CLASEE_SECRET }}


### PR DESCRIPTION
This installs and configures a github action which looks up our CLA spreadsheet using the PR authors github username. It ensures the username is present. If it is not, it fails the action. 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/). **if I have done my job right I shouldn't have to look this up**
- [x] Associated README.md updated.
- [x] ~Has appropriate unit tests.~
