### PR TITLE
Show default settings in mysql sample config

### DIFF
--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -21,10 +21,9 @@ This plugin gathers the statistic data from MySQL server
 ### Configuration
 
 ```toml
-# Read metrics from one or many mysql servers
 [[inputs.mysql]]
   ## specify servers via a url matching:
-  ##  [username[:password]@][protocol[(address)]]/[?tls=[true|false|skip-verify]]
+  ##  [username[:password]@][protocol[(address)]]/[?tls=[true|false|skip-verify|custom]]
   ##  see https://github.com/go-sql-driver/mysql#dsn-data-source-name
   ##  e.g.
   ##    servers = ["user:passwd@tcp(127.0.0.1:3306)/?tls=false"]
@@ -32,60 +31,77 @@ This plugin gathers the statistic data from MySQL server
   #
   ## If no servers are specified, then localhost is used as the host.
   servers = ["tcp(127.0.0.1:3306)/"]
-  ## the limits for metrics form perf_events_statements
-  perf_events_statements_digest_text_limit  = 120
-  perf_events_statements_limit              = 250
-  perf_events_statements_time_limit         = 86400
-  #
-  ## if the list is empty, then metrics are gathered from all database tables
-  table_schema_databases                    = []
-  #
+
+  ## Selects the metric output format.
+  ##
+  ## This option exists to maintain backwards compatibility, if you have
+  ## existing metrics do not set or change this value until you are ready to
+  ## migrate to the new format.
+  ##
+  ## If you do not have existing metrics from this plugin set to the latest
+  ## version.
+  ##
+  ## Telegraf >=1.6: metric_version = 2
+  ##           <1.6: metric_version = 1 (or unset)
+  metric_version = 2
+
+  ## if the list is empty, then metrics are gathered from all databasee tables
+  # table_schema_databases = []
+
   ## gather metrics from INFORMATION_SCHEMA.TABLES for databases provided above list
-  gather_table_schema                       = false
-  #
+  # gather_table_schema = false
+
   ## gather thread state counts from INFORMATION_SCHEMA.PROCESSLIST
-  gather_process_list                       = true
-  #
-  ## gather thread state counts from INFORMATION_SCHEMA.USER_STATISTICS
-  gather_user_statistics                    = true
-  #
+  # gather_process_list = false
+
+  ## gather user statistics from INFORMATION_SCHEMA.USER_STATISTICS
+  # gather_user_statistics = false
+
   ## gather auto_increment columns and max values from information schema
-  gather_info_schema_auto_inc               = true
-  #
+  # gather_info_schema_auto_inc = false
+
   ## gather metrics from INFORMATION_SCHEMA.INNODB_METRICS
-  gather_innodb_metrics                     = true
-  #
+  # gather_innodb_metrics = false
+
   ## gather metrics from SHOW SLAVE STATUS command output
-  gather_slave_status                       = true
-  #
+  # gather_slave_status = false
+
   ## gather metrics from SHOW BINARY LOGS command output
-  gather_binary_logs                        = false
-  #
+  # gather_binary_logs = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.TABLE_IO_WAITS_SUMMARY_BY_TABLE
-  gather_table_io_waits                     = false
-  #
+  # gather_table_io_waits = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.TABLE_LOCK_WAITS
-  gather_table_lock_waits                   = false
-  #
+  # gather_table_lock_waits = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.TABLE_IO_WAITS_SUMMARY_BY_INDEX_USAGE
-  gather_index_io_waits                     = false
-  #
+  # gather_index_io_waits = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.EVENT_WAITS
-  gather_event_waits                        = false
-  #
+  # gather_event_waits = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.FILE_SUMMARY_BY_EVENT_NAME
-  gather_file_events_stats                  = false
-  #
+  # gather_file_events_stats = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.EVENTS_STATEMENTS_SUMMARY_BY_DIGEST
-  gather_perf_events_statements             = false
-  #
+  # gather_perf_events_statements = false
+
+  ## the limits for metrics form perf_events_statements
+  # perf_events_statements_digest_text_limit = 120
+  # perf_events_statements_limit = 250
+  # perf_events_statements_time_limit = 86400
+
   ## Some queries we may want to run less often (such as SHOW GLOBAL VARIABLES)
-  interval_slow                             = "30m"
+  ##   example: interval_slow = "30m"
+  # interval_slow = ""
 
   ## Optional TLS Config (will be used if tls=custom parameter specified in server uri)
-  tls_ca = "/etc/telegraf/ca.pem"
-  tls_cert = "/etc/telegraf/cert.pem"
-  tls_key = "/etc/telegraf/key.pem"
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
 ```
 
 #### Metric Version

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -9,12 +9,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/inputs/mysql/v1"
-
-	"github.com/go-sql-driver/mysql"
 )
 
 type Mysql struct {
@@ -68,55 +67,56 @@ const sampleConfig = `
   ##           <1.6: metric_version = 1 (or unset)
   metric_version = 2
 
-  ## the limits for metrics form perf_events_statements
-  perf_events_statements_digest_text_limit  = 120
-  perf_events_statements_limit              = 250
-  perf_events_statements_time_limit         = 86400
-  #
   ## if the list is empty, then metrics are gathered from all databasee tables
-  table_schema_databases                    = []
-  #
+  # table_schema_databases = []
+
   ## gather metrics from INFORMATION_SCHEMA.TABLES for databases provided above list
-  gather_table_schema                       = false
-  #
+  # gather_table_schema = false
+
   ## gather thread state counts from INFORMATION_SCHEMA.PROCESSLIST
-  gather_process_list                       = true
-  #
+  # gather_process_list = false
+
   ## gather user statistics from INFORMATION_SCHEMA.USER_STATISTICS
-  gather_user_statistics                    = true
-  #
+  # gather_user_statistics = false
+
   ## gather auto_increment columns and max values from information schema
-  gather_info_schema_auto_inc               = true
-  #
+  # gather_info_schema_auto_inc = false
+
   ## gather metrics from INFORMATION_SCHEMA.INNODB_METRICS
-  gather_innodb_metrics                     = true
-  #
+  # gather_innodb_metrics = false
+
   ## gather metrics from SHOW SLAVE STATUS command output
-  gather_slave_status                       = true
-  #
+  # gather_slave_status = false
+
   ## gather metrics from SHOW BINARY LOGS command output
-  gather_binary_logs                        = false
-  #
+  # gather_binary_logs = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.TABLE_IO_WAITS_SUMMARY_BY_TABLE
-  gather_table_io_waits                     = false
-  #
+  # gather_table_io_waits = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.TABLE_LOCK_WAITS
-  gather_table_lock_waits                   = false
-  #
+  # gather_table_lock_waits = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.TABLE_IO_WAITS_SUMMARY_BY_INDEX_USAGE
-  gather_index_io_waits                     = false
-  #
+  # gather_index_io_waits = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.EVENT_WAITS
-  gather_event_waits                        = false
-  #
+  # gather_event_waits = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.FILE_SUMMARY_BY_EVENT_NAME
-  gather_file_events_stats                  = false
-  #
+  # gather_file_events_stats = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.EVENTS_STATEMENTS_SUMMARY_BY_DIGEST
-  gather_perf_events_statements             = false
-  #
+  # gather_perf_events_statements = false
+
+  ## the limits for metrics form perf_events_statements
+  # perf_events_statements_digest_text_limit = 120
+  # perf_events_statements_limit = 250
+  # perf_events_statements_time_limit = 86400
+
   ## Some queries we may want to run less often (such as SHOW GLOBAL VARIABLES)
-  interval_slow                   = "30m"
+  ##   example: interval_slow = "30m"
+  # interval_slow = ""
 
   ## Optional TLS Config (will be used if tls=custom parameter specified in server uri)
   # tls_ca = "/etc/telegraf/ca.pem"
@@ -126,7 +126,12 @@ const sampleConfig = `
   # insecure_skip_verify = false
 `
 
-const defaultTimeout = time.Second * time.Duration(5)
+const (
+	defaultTimeout                             = 5 * time.Second
+	defaultPerfEventsStatementsDigestTextLimit = 120
+	defaultPerfEventsStatementsLimit           = 250
+	defaultPerfEventsStatementsTimeLimit       = 86400
+)
 
 func (m *Mysql) SampleConfig() string {
 	return sampleConfig
@@ -1734,6 +1739,10 @@ func getDSNTag(dsn string) string {
 
 func init() {
 	inputs.Add("mysql", func() telegraf.Input {
-		return &Mysql{}
+		return &Mysql{
+			PerfEventsStatementsDigestTextLimit: defaultPerfEventsStatementsDigestTextLimit,
+			PerfEventsStatementsLimit:           defaultPerfEventsStatementsLimit,
+			PerfEventsStatementsTimeLimit:       defaultPerfEventsStatementsTimeLimit,
+		}
 	})
 }


### PR DESCRIPTION
The sample config now shows the default values.  I added new defaults for the perf events since the existing defaults were not usable and the plugin required them to be set.
```
  # perf_events_statements_digest_text_limit = 120
  # perf_events_statements_limit = 250
  # perf_events_statements_time_limit = 86400
```

closes #6444 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
