### PR TITLE
Adding plex webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v1.13 [unreleased]
 
+#### Release Notes
+
+- Official packages are built with Go 1.13.1.
+
 #### New Inputs
 
 - [azure_storage_queue](/plugins/inputs/azure_storage_queue/README.md) - Contributed by @mjiderhamn

--- a/plugins/inputs/webhooks/README.md
+++ b/plugins/inputs/webhooks/README.md
@@ -37,6 +37,9 @@ $ sudo service telegraf start
   [inputs.webhooks.papertrail]
     path = "/papertrail"
 
+  [inputs.webhooks.plex]
+    path = "/plex"
+
   [inputs.webhooks.particle]
     path = "/particle"
 ```
@@ -49,6 +52,7 @@ $ sudo service telegraf start
 - [Mandrill](mandrill/)
 - [Rollbar](rollbar/)
 - [Papertrail](papertrail/)
+- [Plex](plex/)
 - [Particle](particle/)
 
 

--- a/plugins/inputs/webhooks/plex/README.md
+++ b/plugins/inputs/webhooks/plex/README.md
@@ -18,7 +18,6 @@ The tag values and field values show the place on the incoming JSON object where
 * 'is_user_webhook' = `event.user` bool
 * 'is_owner_webhook' = `event.owner` bool
 * 'user_id' = `event.Account.id` string
-* 'user_thumb' = `event.Account.thumb` string
 * 'user_name' = `event.Account.title` string
 * 'server_title' = `event.Server.title` string
 * 'server_uuid' = `event.Server.uuid` string
@@ -33,17 +32,12 @@ The tag values and field values show the place on the incoming JSON object where
 * 'grandparent_title' = `event.Metadata.grandparentTitle` string
 * 'parent_title' = `event.Metadata.parentTitle` string
 * 'parent_index' = `event.Metadata.parentIndex` string
-* 'parent_thumb' = `event.Metadata.parentThumb` string
-* 'grandparent_thumb' = `event.Metadata.grandparentThumb` string
-* 'grandparent_art' = `event.Metadata.grandparentArt` string
 
 **Fields:**		
 * 'rating_count' = `event.Metadata.ratingCount` int
 * 'added_at' = `event.Metadata.addedAt` int
 * 'updated_at' = `event.Metadata.updatedAt` int
 * 'summary' = `event.Metadata.summary` string
-* 'thumb' = `event.Metadata.thumb` string
-* 'art' = `event.Metadata.art` string
 * 'title' = `event.Metadata.title` string
 * 'index' = `event.Metadata.index` int
 * 'library_selection_id' = `event.Metadata.librarySectionID` int

--- a/plugins/inputs/webhooks/plex/README.md
+++ b/plugins/inputs/webhooks/plex/README.md
@@ -1,0 +1,51 @@
+# plex webhooks
+
+You should configure Plex's Webhooks to point at the `webhooks` service. To do this, follow the instructions in the [Plex webhooks support documentation](https://support.plex.tv/articles/115002267687-webhooks/). Webhooks are a premium feature and require an active Plex Pass Subscription for the Plex Media Server account.
+
+## Events
+
+The titles of the following sections are links to the full payloads and details for each event. The body contains what information from the event is persisted. The format is as follows:
+```
+# TAGS
+* 'tagKey' = `tagValue` type
+# FIELDS
+* 'fieldKey' = `fieldValue` type
+```
+The tag values and field values show the place on the incoming JSON object where the data is sourced from.
+
+**Tags:**
+* 'event' = `event.event` string
+* 'is_user_webhook' = `event.user` bool
+* 'is_owner_webhook' = `event.owner` bool
+* 'user_id' = `event.Account.id` string
+* 'user_thumb' = `event.Account.thumb` string
+* 'user_name' = `event.Account.title` string
+* 'server_title' = `event.Server.title` string
+* 'server_uuid' = `event.Server.uuid` string
+* 'is_player_local' = `event.Player.local` bool
+* 'player_public_ip' = `event.Player.publicAddress` string
+* 'player_title' = `event.Player.title` string
+* 'player_uuid' = `event.Player.uuid` string
+* 'library_selection_type' = `event.Metadata.librarySectionType` string
+* 'media_type' = `event.Metadata.type` string
+* 'grandparent_key' = `event.Metadata.grandparentKey` string
+* 'parent_key' = `event.Metadata.parentKey` string
+* 'grandparent_title' = `event.Metadata.grandparentTitle` string
+* 'parent_title' = `event.Metadata.parentTitle` string
+* 'parent_index' = `event.Metadata.parentIndex` string
+* 'parent_thumb' = `event.Metadata.parentThumb` string
+* 'grandparent_thumb' = `event.Metadata.grandparentThumb` string
+* 'grandparent_art' = `event.Metadata.grandparentArt` string
+
+**Fields:**		
+* 'rating_count' = `event.Metadata.ratingCount` int
+* 'added_at' = `event.Metadata.addedAt` int
+* 'updated_at' = `event.Metadata.updatedAt` int
+* 'summary' = `event.Metadata.summary` string
+* 'thumb' = `event.Metadata.thumb` string
+* 'art' = `event.Metadata.art` string
+* 'title' = `event.Metadata.title` string
+* 'index' = `event.Metadata.index` int
+* 'library_selection_id' = `event.Metadata.librarySectionID` int
+* 'guid' = `event.Metadata.guid` string
+

--- a/plugins/inputs/webhooks/plex/plex_webhooks.go
+++ b/plugins/inputs/webhooks/plex/plex_webhooks.go
@@ -1,0 +1,50 @@
+package plex
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/influxdata/telegraf"
+)
+
+type PlexWebhook struct {
+	Path string
+	acc  telegraf.Accumulator
+}
+
+func (p *PlexWebhook) Register(router *mux.Router, acc telegraf.Accumulator) {
+	router.HandleFunc(p.Path, p.eventHandler).Methods("POST")
+	log.Printf("I! Started the webhooks_plex on %s\n", p.Path)
+	p.acc = acc
+}
+
+func (p *PlexWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	e, err := generateEvent(data, &PlexWebhookEvent{})
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if e != nil {
+		newMetric := e.NewMetric()
+		p.acc.AddFields("github_webhooks", newMetric.Fields(), newMetric.Tags(), newMetric.Time())
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func generateEvent(data []byte, event Event) (Event, error) {
+	err := json.Unmarshal(data, event)
+	if err != nil {
+		return nil, err
+	}
+	return event, nil
+}

--- a/plugins/inputs/webhooks/plex/plex_webhooks_mock_json.go
+++ b/plugins/inputs/webhooks/plex/plex_webhooks_mock_json.go
@@ -1,0 +1,50 @@
+package plex
+
+func PlexWebhookEventJSON() string {
+	return `{  
+    "event": "media.play",
+    "user": true,
+    "owner": true,
+    "Account": {
+       "id": 1,
+       "thumb": "https://plex.tv/users/1022b120ffbaa/avatar?c=1465525047",
+       "title": "elan"
+    },
+    "Server": {
+       "title": "Office",
+       "uuid": "54664a3d8acc39983675640ec9ce00b70af9cc36"
+    },
+    "Player": {
+       "local": true,
+       "publicAddress": "200.200.200.200",
+       "title": "Plex Web (Safari)",
+       "uuid": "r6yfkdnfggbh2bdnvkffwbms"
+    },
+    "Metadata": {
+       "librarySectionType": "artist",
+       "ratingKey": "1936545",
+       "key": "/library/metadata/1936545",
+       "parentRatingKey": "1936544",
+       "grandparentRatingKey": "1936543",
+       "guid": "com.plexapp.agents.plexmusic://gracenote/track/7572499-91016293BE6BF7F1AB2F848F736E74E5/7572500-3CBAE310D4F3E66C285E104A1458B272?lang=en",
+       "librarySectionID": 1224,
+       "type": "track",
+       "title": "Love The One You're With",
+       "grandparentKey": "/library/metadata/1936543",
+       "parentKey": "/library/metadata/1936544",
+       "grandparentTitle": "Stephen Stills",
+       "parentTitle": "Stephen Stills",
+       "summary": "",
+       "index": 1,
+       "parentIndex": 1,
+       "ratingCount": 6794,
+       "thumb": "/library/metadata/1936544/thumb/1432897518",
+       "art": "/library/metadata/1936543/art/1485951497",
+       "parentThumb": "/library/metadata/1936544/thumb/1432897518",
+       "grandparentThumb": "/library/metadata/1936543/thumb/1485951497",
+       "grandparentArt": "/library/metadata/1936543/art/1485951497",
+       "addedAt": 1000396126,
+       "updatedAt": 1432897518
+    }
+ }`
+}

--- a/plugins/inputs/webhooks/plex/plex_webhooks_models.go
+++ b/plugins/inputs/webhooks/plex/plex_webhooks_models.go
@@ -1,0 +1,115 @@
+package plex
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+)
+
+const meas = "plex_webhooks"
+
+type Event interface {
+	NewMetric() telegraf.Metric
+}
+
+type PlexWebhookEvent struct {
+	Event    string   `json:"event"`
+	User     bool     `json:"user"`
+	Owner    bool     `json:"owner"`
+	Account  Account  `json:"Account"`
+	Server   Server   `json:"Server"`
+	Player   Player   `json:"Player"`
+	Metadata Metadata `json:"Metadata"`
+}
+
+type Account struct {
+	ID    int    `json:"id"`
+	Thumb string `json:"thumb"`
+	Title string `json:"title"`
+}
+
+type Server struct {
+	Title string `json:"title"`
+	UUID  string `json:"uuid"`
+}
+
+type Player struct {
+	Local         bool   `json:"local"`
+	PublicAddress string `json:"PublicAddress"`
+	Title         string `json:"title"`
+	UUID          string `json:"uuid"`
+}
+
+type Metadata struct {
+	LibrarySectionType   string `json:"librarySectionType"`
+	RatingKey            string `json:"ratingKey"`
+	Key                  string `json:"key"`
+	ParentRatingKey      string `json:"parentRatingKey"`
+	GrandparentRatingKey string `json:"grandparentRatingKey"`
+	GUID                 string `json:"guid"`
+	LibrarySectionID     int    `json:"librarySectionID"`
+	MediaType            string `json:"type"`
+	Title                string `json:"title"`
+	GrandparentKey       string `json:"grandparentKey"`
+	ParentKey            string `json:"parentKey"`
+	GrandparentTitle     string `json:"grandparentTitle"`
+	ParentTitle          string `json:"parentTitle"`
+	Summary              string `json:"summary"`
+	Index                int    `json:"index"`
+	ParentIndex          int    `json:"parentIndex"`
+	RatingCount          int    `json:"ratingCount"`
+	Thumb                string `json:"thumb"`
+	Art                  string `json:"art"`
+	ParentThumb          string `json:"parentThumb"`
+	GrandparentThumb     string `json:"grandparentThumb"`
+	GrandparentArt       string `json:"grandparentArt"`
+	AddedAt              int    `json:"addedAt"`
+	UpdatedAt            int    `json:"updatedAt"`
+}
+
+func (s PlexWebhookEvent) NewMetric() telegraf.Metric {
+	t := map[string]string{
+		"event":                  s.Event,
+		"is_user_webhook":        fmt.Sprintf("%v", s.User),
+		"is_owner_webhook":       fmt.Sprintf("%v", s.Owner),
+		"user_id":                fmt.Sprintf("%v", s.Account.ID),
+		"user_thumb":             s.Account.Thumb,
+		"user_name":              s.Account.Title,
+		"server_title":           s.Server.Title,
+		"server_uuid":            s.Server.UUID,
+		"is_player_local":        fmt.Sprintf("%v", s.Player.Local),
+		"player_public_ip":       s.Player.PublicAddress,
+		"player_title":           s.Player.Title,
+		"player_uuid":            s.Player.UUID,
+		"library_selection_type": s.Metadata.LibrarySectionType,
+		"media_type":             s.Metadata.MediaType,
+		"grandparent_key":        s.Metadata.GrandparentKey,
+		"parent_key":             s.Metadata.ParentKey,
+		"grandparent_title":      s.Metadata.GrandparentTitle,
+		"parent_title":           s.Metadata.ParentTitle,
+		"parent_index":           fmt.Sprintf("%v", s.Metadata.ParentIndex),
+		"parent_thumb":           s.Metadata.ParentThumb,
+		"grandparent_thumb":      s.Metadata.GrandparentThumb,
+		"grandparent_art":        s.Metadata.GrandparentArt,
+	}
+	f := map[string]interface{}{
+		"rating_count":         s.Metadata.RatingCount,
+		"added_at":             s.Metadata.AddedAt,
+		"updated_at":           s.Metadata.UpdatedAt,
+		"summary":              s.Metadata.Summary,
+		"thumb":                s.Metadata.Thumb,
+		"art":                  s.Metadata.Art,
+		"title":                s.Metadata.Title,
+		"index":                s.Metadata.Index,
+		"library_selection_id": s.Metadata.LibrarySectionID,
+		"guid":                 s.Metadata.GUID,
+	}
+	m, err := metric.New(meas, t, f, time.Now())
+	if err != nil {
+		log.Fatalf("Failed to create %v event", s)
+	}
+	return m
+}

--- a/plugins/inputs/webhooks/plex/plex_webhooks_models.go
+++ b/plugins/inputs/webhooks/plex/plex_webhooks_models.go
@@ -76,7 +76,6 @@ func (s PlexWebhookEvent) NewMetric() telegraf.Metric {
 		"is_user_webhook":        fmt.Sprintf("%v", s.User),
 		"is_owner_webhook":       fmt.Sprintf("%v", s.Owner),
 		"user_id":                fmt.Sprintf("%v", s.Account.ID),
-		"user_thumb":             s.Account.Thumb,
 		"user_name":              s.Account.Title,
 		"server_title":           s.Server.Title,
 		"server_uuid":            s.Server.UUID,
@@ -91,17 +90,12 @@ func (s PlexWebhookEvent) NewMetric() telegraf.Metric {
 		"grandparent_title":      s.Metadata.GrandparentTitle,
 		"parent_title":           s.Metadata.ParentTitle,
 		"parent_index":           fmt.Sprintf("%v", s.Metadata.ParentIndex),
-		"parent_thumb":           s.Metadata.ParentThumb,
-		"grandparent_thumb":      s.Metadata.GrandparentThumb,
-		"grandparent_art":        s.Metadata.GrandparentArt,
 	}
 	f := map[string]interface{}{
 		"rating_count":         s.Metadata.RatingCount,
 		"added_at":             s.Metadata.AddedAt,
 		"updated_at":           s.Metadata.UpdatedAt,
 		"summary":              s.Metadata.Summary,
-		"thumb":                s.Metadata.Thumb,
-		"art":                  s.Metadata.Art,
 		"title":                s.Metadata.Title,
 		"index":                s.Metadata.Index,
 		"library_selection_id": s.Metadata.LibrarySectionID,
@@ -109,7 +103,7 @@ func (s PlexWebhookEvent) NewMetric() telegraf.Metric {
 	}
 	m, err := metric.New(meas, t, f, time.Now())
 	if err != nil {
-		log.Fatalf("Failed to create %v event", s)
+		log.Fatalf("Failed to create %v event", s.Event)
 	}
 	return m
 }

--- a/plugins/inputs/webhooks/plex/plex_webhooks_test.go
+++ b/plugins/inputs/webhooks/plex/plex_webhooks_test.go
@@ -1,0 +1,25 @@
+package plex
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+)
+
+func PlexWebhookRequest(jsonString string, t *testing.T) {
+	var acc testutil.Accumulator
+	gh := &PlexWebhook{Path: "/plex", acc: &acc}
+	req, _ := http.NewRequest("POST", "/plex", strings.NewReader(jsonString))
+	w := httptest.NewRecorder()
+	gh.eventHandler(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("POST returned HTTP status code %v.\nExpected %v", w.Code, http.StatusOK)
+	}
+}
+
+func TestPlexEvent(t *testing.T) {
+	PlexWebhookRequest(PlexWebhookEventJSON(), t)
+}

--- a/plugins/inputs/webhooks/plex/plex_webhooks_test.go
+++ b/plugins/inputs/webhooks/plex/plex_webhooks_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 func PlexWebhookRequest(jsonString string, t *testing.T) {
@@ -23,9 +24,7 @@ func PlexWebhookRequest(jsonString string, t *testing.T) {
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	w := httptest.NewRecorder()
 	p.eventHandler(w, req)
-	if w.Code != http.StatusOK {
-		t.Errorf("POST returned HTTP status code %v.\nExpected %v", w.Code, http.StatusOK)
-	}
+	require.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestPlexEvent(t *testing.T) {

--- a/plugins/inputs/webhooks/plex/plex_webhooks_test.go
+++ b/plugins/inputs/webhooks/plex/plex_webhooks_test.go
@@ -1,6 +1,9 @@
 package plex
 
 import (
+	"bytes"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,10 +14,15 @@ import (
 
 func PlexWebhookRequest(jsonString string, t *testing.T) {
 	var acc testutil.Accumulator
-	gh := &PlexWebhook{Path: "/plex", acc: &acc}
-	req, _ := http.NewRequest("POST", "/plex", strings.NewReader(jsonString))
+	p := &PlexWebhook{Path: "/plex", acc: &acc}
+	values := map[string]io.Reader{
+		"payload": strings.NewReader(jsonString),
+	}
+	writer, b, _ := BuildFormData(values)
+	req, _ := http.NewRequest("POST", "/plex", &b)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
 	w := httptest.NewRecorder()
-	gh.eventHandler(w, req)
+	p.eventHandler(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("POST returned HTTP status code %v.\nExpected %v", w.Code, http.StatusOK)
 	}
@@ -22,4 +30,27 @@ func PlexWebhookRequest(jsonString string, t *testing.T) {
 
 func TestPlexEvent(t *testing.T) {
 	PlexWebhookRequest(PlexWebhookEventJSON(), t)
+}
+
+func BuildFormData(values map[string]io.Reader) (w *multipart.Writer, b bytes.Buffer, err error) {
+	// Prepare a form that you will submit to that URL.
+	w = multipart.NewWriter(&b)
+	for key, r := range values {
+		var fw io.Writer
+		if x, ok := r.(io.Closer); ok {
+			defer x.Close()
+		}
+		// Add other fields
+		fw, err = w.CreateFormField(key)
+		if err != nil {
+			return nil, b, err
+		}
+		_, err = io.Copy(fw, r)
+		if err != nil {
+			return nil, b, err
+		}
+
+	}
+	w.Close()
+	return w, b, nil
 }

--- a/plugins/inputs/webhooks/webhooks.go
+++ b/plugins/inputs/webhooks/webhooks.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/mandrill"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/papertrail"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/particle"
+	"github.com/influxdata/telegraf/plugins/inputs/webhooks/plex"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/rollbar"
 )
 
@@ -35,6 +36,7 @@ type Webhooks struct {
 	Mandrill   *mandrill.MandrillWebhook
 	Rollbar    *rollbar.RollbarWebhook
 	Papertrail *papertrail.PapertrailWebhook
+	Plex       *plex.PlexWebhook
 	Particle   *particle.ParticleWebhook
 
 	srv *http.Server
@@ -63,7 +65,10 @@ func (wb *Webhooks) SampleConfig() string {
     path = "/rollbar"
 
   [inputs.webhooks.papertrail]
-    path = "/papertrail"
+	path = "/papertrail"
+  
+  [inputs.webhooks.plex]
+    path = "/plex"
 
   [inputs.webhooks.particle]
     path = "/particle"


### PR DESCRIPTION
This adds the ability for Telegraf to parse Plex Webhooks: https://support.plex.tv/articles/115002267687-webhooks/

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
