### PR TITLE
sched_monitor input plugin

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -131,6 +131,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/rethinkdb"
 	_ "github.com/influxdata/telegraf/plugins/inputs/riak"
 	_ "github.com/influxdata/telegraf/plugins/inputs/salesforce"
+	_ "github.com/influxdata/telegraf/plugins/inputs/sched_monitor"
 	_ "github.com/influxdata/telegraf/plugins/inputs/sensors"
 	_ "github.com/influxdata/telegraf/plugins/inputs/smart"
 	_ "github.com/influxdata/telegraf/plugins/inputs/snmp"

--- a/plugins/inputs/sched_monitor/README.md
+++ b/plugins/inputs/sched_monitor/README.md
@@ -1,0 +1,23 @@
+# Scheduling monitor Input Plugin
+The `sched_monitor` plugin gathers scheduling metrics such as cpu time, and voluntary/involuntary context switches for configured CPUs.
+It is recommended to use for tracking performance issues driven by scheduling pressure or general compute resource distribution efficiency.
+Using it to collect data from a noisy, general purpose CPU may create large volumes of data. This plugin is ideal for tracing scheduling dynamics
+on an isolated CPU.
+As this plugin's functionality relies on the 'proc' subsystem, it only works on Linux
+
+#### Configuration
+```toml
+[[inputs.sched_monitor]]
+  ## CPUs to monitor
+  cpu_list = 
+  ## Filter operating system threads
+  exclude_kernel = false
+```
+
+### Metrics
+sched_monitor,cmd=irq/68-nvidia,cpu=0,host=qdlt-pc cpu_time=773715i,ctx_swtch=8i,invl_ctx_swtch=0i 1571432791000000000
+sched_monitor,cmd=kworker/0:1,cpu=0,host=qdlt-pc cpu_time=36815i,ctx_swtch=6i,invl_ctx_swtch=0i 1571432791000000000
+sched_monitor,cmd=jbd2/nvme0n1p2,cpu=0,host=qdlt-pc cpu_time=84029i,ctx_swtch=3i,invl_ctx_swtch=1i 1571432791000000000
+sched_monitor,cmd=kworker/0:1H,cpu=0,host=qdlt-pc cpu_time=12548i,ctx_swtch=2i,invl_ctx_swtch=0i 1571432791000000000
+sched_monitor,cmd=Chrome_IOThread,cpu=0,host=qdlt-pc cpu_time=92369i,ctx_swtch=1i,invl_ctx_swtch=0i 1571432791000000000
+

--- a/plugins/inputs/sched_monitor/sched_monitor.go
+++ b/plugins/inputs/sched_monitor/sched_monitor.go
@@ -1,0 +1,254 @@
+package sched_monitor
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+const (
+	globTaskPath = "/proc/[0-9]*/task/*"
+	taskStatFmt  = "/proc/%d/task/%d/stat"
+	taskSchedFmt = "/proc/%d/task/%d/sched"
+
+	sampleConfig = `
+	  ## A list of cpus to collect data from. heT format of this list is:
+	  ## <cpu number>,...,<cpu number> 
+	  ## or: 
+	  ## <cpu number>-<cpu number> (must be a positive range in ascending order)
+	  ## or a mixture:
+	  ## <cpu number>,...,<cpu number>-<cpu number>
+	  ## For example:
+	  ## cpu_list = "1,3,5-8,12"
+	  ##
+	  ## The default is empty list
+	  # cpu_list = 
+
+	  ## To filter out kernel threads set the following to true (the default is false):
+	  # exclude_kernel = false
+	`
+)
+
+var (
+	taskPathExpr  = regexp.MustCompile(`/proc/(?P<pid>\d+)/task/(?P<tid>\d+)`)
+	tasks         = map[int]taskInfo{}
+	currentTids   = map[int]bool{}
+	monitoredCPUS = map[int]bool{}
+	initialized   = false
+)
+
+type SchedMonitor struct {
+	CPUList       string `toml:"cpu_list"`
+	ExcludeKernel bool   `toml:"exclude_kernel"`
+}
+
+type taskInfo struct {
+	name           string
+	pid            int
+	tid            int
+	cpuTimeNanos   int64
+	voluntaryCtx   int64
+	involuntaryCtx int64
+}
+
+func (s *SchedMonitor) Gather(acc telegraf.Accumulator) error {
+	if !initialized {
+		initializeState(s.CPUList, s.ExcludeKernel)
+	}
+
+	collectData(s.ExcludeKernel, acc)
+	return nil
+}
+
+func (s *SchedMonitor) Description() string {
+	return "This plugin collects per-thread scheduling statistics (cpu time, voluntary/involuntary context switches) for configured CPUs"
+}
+
+func (s *SchedMonitor) SampleConfig() string {
+	return sampleConfig
+}
+
+// iterates over all threads running on the host and collects their sched stats
+func collectData(excludeKernel bool, acc telegraf.Accumulator) {
+	iterateTasks(excludeKernel, func(pid int, tid int, cmd string, cpu int, cpuTime int64, ctxSwitch int64, invlCtxSwitch int64) {
+		if task, found := tasks[tid]; found {
+			if cpuTime == task.cpuTimeNanos {
+				return // task hasn't been scheduled since the last check; nothing to report
+			}
+
+			// report deltas
+			fields := map[string]interface{}{
+				"cpu_time":       cpuTime - task.cpuTimeNanos,
+				"ctx_swtch":      ctxSwitch - task.voluntaryCtx,
+				"invl_ctx_swtch": invlCtxSwitch - task.involuntaryCtx,
+			}
+
+			tags := map[string]string{
+				"cmd": cmd,
+				"cpu": strconv.Itoa(cpu),
+			}
+
+			acc.AddFields("sched_monitor", fields, tags)
+
+			// update task stats
+			task.cpuTimeNanos = cpuTime
+			task.voluntaryCtx = ctxSwitch
+			task.involuntaryCtx = invlCtxSwitch
+		}
+	})
+
+	// remove dead tasks
+	for tid := range tasks {
+		if _, found := currentTids[tid]; !found {
+			delete(tasks, tid)
+		}
+	}
+
+}
+
+func initializeState(cpuList string, excludeKernel bool) {
+	parseCPUList(cpuList)
+	initialSnapshot(excludeKernel)
+
+	initialized = true
+}
+
+// parses string cpu list and collects initial snapshot of sched stats for all threads
+func initialSnapshot(excludeKernel bool) {
+	iterateTasks(excludeKernel, func(pid int, tid int, cmd string, cpu int, cpuTime int64, ctxSwitch int64, invlCtxSwitch int64) {
+		tasks[tid] = taskInfo{
+			name:           cmd,
+			pid:            pid,
+			tid:            tid,
+			cpuTimeNanos:   cpuTime,
+			voluntaryCtx:   ctxSwitch,
+			involuntaryCtx: invlCtxSwitch,
+		}
+	})
+}
+
+// iterates over all threads and executes a processing function for each one
+func iterateTasks(excludeKernel bool, process func(int, int, string, int, int64, int64, int64)) {
+	taskPaths, _ := filepath.Glob(globTaskPath)
+
+	for _, taskPath := range taskPaths {
+		pid, tid := decodeTaskPath(taskPath)
+		currentTids[tid] = true
+
+		cpu := lastUsedCPU(pid, tid)
+		if cpu < 0 {
+			continue
+		}
+
+		if _, found := monitoredCPUS[cpu]; found {
+			schedFile := openSchedFile(pid, tid)
+			cmd, cpuTime, ctxSwitch, invlCtxSwitch := parseSchedStats(schedFile)
+			if (excludeKernel && isKernelTask(cmd)) || cmd == "" {
+				continue
+			}
+
+			process(pid, tid, cmd, cpu, cpuTime, ctxSwitch, invlCtxSwitch)
+		}
+	}
+}
+
+func openSchedFile(pid int, tid int) io.Reader {
+	schedFile, _ := os.Open(fmt.Sprintf(taskSchedFmt, pid, tid))
+	defer schedFile.Close()
+
+	return schedFile
+}
+
+func isKernelTask(cmd string) bool {
+	return strings.HasPrefix(cmd, "[") && strings.HasSuffix(cmd, "]")
+}
+
+func parseCPUList(cpuList string) {
+	tokens := strings.Split(cpuList, ",")
+
+	for _, s := range tokens {
+		if strings.Contains(s, "-") {
+			fromTo := strings.Split(s, "-")
+			fromCPU, _ := strconv.Atoi(fromTo[0])
+			toCPU, _ := strconv.Atoi(fromTo[1])
+			for i := fromCPU; i <= toCPU; i++ {
+				monitoredCPUS[i] = true
+			}
+		} else {
+			cpu, _ := strconv.Atoi(s)
+			monitoredCPUS[cpu] = true
+		}
+	}
+}
+
+func decodeTaskPath(taskPath string) (int, int) {
+	match := taskPathExpr.FindStringSubmatch(taskPath)
+	pid, _ := strconv.Atoi(match[1])
+	tid, _ := strconv.Atoi(match[2])
+
+	return pid, tid
+}
+
+// parses sched file for a given thread
+func parseSchedStats(file io.Reader) (cmd string, cpuTime int64, ctxSwich int64, invlCtxSwitch int64) {
+	scanner := bufio.NewScanner(file)
+	if scanner.Scan() {
+		cmd = strings.Fields(scanner.Text())[0]
+	}
+
+	for scanner.Scan() {
+		fields := strings.Split(scanner.Text(), ":")
+		if len(fields) != 2 {
+			continue
+		}
+
+		metric := strings.TrimSpace(fields[0])
+		strValue := strings.TrimSpace(fields[1])
+
+		if strings.Contains(metric, "sum_exec_runtime") {
+			value, _ := strconv.ParseFloat(strValue, 64)
+			cpuTime = int64(value * 1_000_000)
+			continue
+		} else if strings.Contains(metric, "nr_voluntary") {
+			value, _ := strconv.ParseInt(strValue, 10, 64)
+			ctxSwich = value
+			continue
+		} else if strings.Contains(metric, "nr_involuntary") {
+			value, _ := strconv.ParseInt(strValue, 10, 64)
+			invlCtxSwitch = value
+			break
+		}
+	}
+
+	return
+}
+
+func lastUsedCPU(pid int, tid int) int {
+	f, _ := os.Open(fmt.Sprintf(taskStatFmt, pid, tid))
+	defer f.Close()
+
+	buf, _ := ioutil.ReadAll(f)
+	if len(buf) == 0 {
+		return -1
+	}
+
+	columns := strings.Split(string(buf), " ")
+	cpu, _ := strconv.Atoi(columns[38])
+
+	return cpu
+}
+
+func init() {
+	inputs.Add("sched_monitor", func() telegraf.Input {
+		return &SchedMonitor{}
+	})
+}

--- a/plugins/inputs/sched_monitor/sched_monitor.go
+++ b/plugins/inputs/sched_monitor/sched_monitor.go
@@ -216,7 +216,7 @@ func parseSchedStats(file io.Reader) (cmd string, cpuTime int64, ctxSwich int64,
 
 		if strings.Contains(metric, "sum_exec_runtime") {
 			value, _ := strconv.ParseFloat(strValue, 64)
-			cpuTime = int64(value * 1_000_000)
+			cpuTime = int64(value * 1000000)
 			continue
 		} else if strings.Contains(metric, "nr_voluntary") {
 			value, _ := strconv.ParseInt(strValue, 10, 64)

--- a/plugins/inputs/sched_monitor/sched_monitor_test.go
+++ b/plugins/inputs/sched_monitor/sched_monitor_test.go
@@ -1,0 +1,49 @@
+package sched_monitor
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const sampleSchedFile = `migration (10, #threads: 1)
+-------------------------------------------------------------------
+se.exec_start                                :      43042098.108342
+se.vruntime                                  :             0.000000
+se.sum_exec_runtime                          :            87.654321
+se.nr_migrations                             :                    0
+nr_switches                                  :                   42
+nr_voluntary_switches                        :                   32
+nr_involuntary_switches                      :                   10
+se.load.weight                               :              1048576
+se.runnable_weight                           :              1048576
+`
+
+func TestParseSchedStats(t *testing.T) {
+	f := bytes.NewBufferString(sampleSchedFile)
+	cmd, cpuTime, ctxSwtch, invCtxSwtch := parseSchedStats(f)
+
+	require.Equal(t, "migration", cmd)
+	require.Equal(t, int64(87654321), cpuTime)
+	require.Equal(t, int64(32), ctxSwtch)
+	require.Equal(t, int64(10), invCtxSwtch)
+}
+
+func TestDecodeTaskPath(t *testing.T) {
+	pid, tid := decodeTaskPath("/proc/123/task/456")
+
+	require.Equal(t, 123, pid)
+	require.Equal(t, 456, tid)
+}
+
+func TestParseCpuList(t *testing.T) {
+	parseCPUList("1,2,5-8,10,12-15")
+
+	expected := map[int]bool{1: true, 2: true, 5: true, 6: true, 7: true, 8: true, 10: true, 12: true, 13: true, 14: true, 15: true}
+	require.Equal(t, expected, monitoredCPUS)
+}
+
+func TestIsKernelTask(t *testing.T) {
+	require.True(t, isKernelTask("[migration]"))
+}


### PR DESCRIPTION
This is a (thread) scheduling monitoring input plugin. It tracks basic scheduling metrics such as cpu time and voluntary/involuntary context switching per thread per cpu and reports changes.
This kind of input plugin can be very useful in tracking scheduling dynamics on critical CPUs and investigating CPU time distribution.
People who run specialised workloads on isolated CPUs may find this tool invaluable (this is the original premise of the plugin).
The data collected should not be considered the ultimate source of truth due to occurrence of ABA problem but no method of tracking scheduling dynamics can be precise without hooking into the system scheduler itself.
Nevertheless the data provided by the plugin, especially for isolated CPUs can be very useful in discovering potential issues with resource allocation as well as investigating ongoing issues.

Below is an example Grafana dashboard utilizing the plugin:
![image](https://user-images.githubusercontent.com/1662063/67425828-b75f7580-f5d0-11e9-95b3-29fa97209105.png)

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

