### PR TITLE
Fix doc-link

### DIFF
--- a/plugins/inputs/zookeeper/README.md
+++ b/plugins/inputs/zookeeper/README.md
@@ -1,7 +1,7 @@
 ## Zookeeper Input Plugin
 
 The zookeeper plugin collects variables outputted from the 'mntr' command
-[Zookeeper Admin](https://zookeeper.apache.org/doc/trunk/zookeeperAdmin.html).
+[Zookeeper Admin](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html).
 
 ### Configuration
 


### PR DESCRIPTION
They dont seem to use "trunk" anymore, changed to "current"

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
