### PR TITLE
Ensure metrics generated are correct in ping plugin using "native"

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -438,12 +438,12 @@
   revision = "25d852aebe32c875e9c044af3eef9c7dc6bc777f"
 
 [[projects]]
-  digest = "1:c6f371f2b02c751a83be83139a12a5467e55393feda16d4f8dfa95adfc4efede"
+  digest = "1:1c43ffc41749039318c291a397bde76f8eb0d92836e685f57fab3bcb8b977a4e"
   name = "github.com/glinton/ping"
   packages = ["."]
   pruneopts = ""
-  revision = "1983bc2fd5de3ea00aa5457bbc8774300e889db9"
-  version = "v0.1.1"
+  revision = "f160bc1281bab2b841d5851990494fef6e63d92f"
+  version = "v0.1.2"
 
 [[projects]]
   digest = "1:df89444601379b2e1ee82bf8e6b72af9901cbeed4b469fa380a519c89c339310"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -438,12 +438,12 @@
   revision = "25d852aebe32c875e9c044af3eef9c7dc6bc777f"
 
 [[projects]]
-  digest = "1:1c43ffc41749039318c291a397bde76f8eb0d92836e685f57fab3bcb8b977a4e"
+  digest = "1:7a9dc29b3fbc9a6440d98fcff422a2ce1a613975697ea560e3610084234f91ec"
   name = "github.com/glinton/ping"
   packages = ["."]
   pruneopts = ""
-  revision = "f160bc1281bab2b841d5851990494fef6e63d92f"
-  version = "v0.1.2"
+  revision = "d3c0ecf4df108179eccdff2176f4ff569c3aab37"
+  version = "v0.1.3"
 
 [[projects]]
   digest = "1:df89444601379b2e1ee82bf8e6b72af9901cbeed4b469fa380a519c89c339310"

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -261,8 +261,6 @@ func (p *Ping) pingToURLNative(destination string, acc telegraf.Accumulator) {
 					Seq: seq,
 				})
 				if err != nil {
-					acc.AddFields("ping", map[string]interface{}{"result_code": 2}, map[string]string{"url": destination})
-					acc.AddError(err)
 					return
 				}
 


### PR DESCRIPTION
There was a bug when using raw socket mode with `method = "native"` on the ping input plugin where responses would be processed for the wrong host. This has been rectified upstream and the library updated in telegraf.
Better matching in `result_code` has also been implemented in telegraf between `exec` and `native` methods.

Resolves #6521 