### PR TITLE
Build with Go 1.13.3 and 1.12.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ defaults:
       GOFLAGS: -p=8
   go-1_12: &go-1_12
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.12.10'
+      - image: 'quay.io/influxdb/telegraf-ci:1.12.12'
   go-1_13: &go-1_13
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.13.1'
+      - image: 'quay.io/influxdb/telegraf-ci:1.13.3'
 
 version: 2
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -131,10 +131,10 @@ plugin-%:
 
 .PHONY: ci-1.13
 ci-1.13:
-	docker build -t quay.io/influxdb/telegraf-ci:1.13.1 - < scripts/ci-1.13.docker
-	docker push quay.io/influxdb/telegraf-ci:1.13.1
+	docker build -t quay.io/influxdb/telegraf-ci:1.13.3 - < scripts/ci-1.13.docker
+	docker push quay.io/influxdb/telegraf-ci:1.13.3
 
 .PHONY: ci-1.12
 ci-1.12:
-	docker build -t quay.io/influxdb/telegraf-ci:1.12.10 - < scripts/ci-1.12.docker
-	docker push quay.io/influxdb/telegraf-ci:1.12.10
+	docker build -t quay.io/influxdb/telegraf-ci:1.12.12 - < scripts/ci-1.12.docker
+	docker push quay.io/influxdb/telegraf-ci:1.12.12

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,11 @@ platform: x64
 
 install:
   - IF NOT EXIST "C:\Cache" mkdir C:\Cache
-  - IF NOT EXIST "C:\Cache\go1.13.1.msi" curl -o "C:\Cache\go1.13.1.msi" https://storage.googleapis.com/golang/go1.13.1.windows-amd64.msi
+  - IF NOT EXIST "C:\Cache\go1.13.3.msi" curl -o "C:\Cache\go1.13.3.msi" https://storage.googleapis.com/golang/go1.13.3.windows-amd64.msi
   - IF NOT EXIST "C:\Cache\gnuwin32-bin.zip" curl -o "C:\Cache\gnuwin32-bin.zip" https://dl.influxdata.com/telegraf/ci/make-3.81-bin.zip
   - IF NOT EXIST "C:\Cache\gnuwin32-dep.zip" curl -o "C:\Cache\gnuwin32-dep.zip" https://dl.influxdata.com/telegraf/ci/make-3.81-dep.zip
   - IF EXIST "C:\Go" rmdir /S /Q C:\Go
-  - msiexec.exe /i "C:\Cache\go1.13.1.msi" /quiet
+  - msiexec.exe /i "C:\Cache\go1.13.3.msi" /quiet
   - 7z x "C:\Cache\gnuwin32-bin.zip" -oC:\GnuWin32 -y
   - 7z x "C:\Cache\gnuwin32-dep.zip" -oC:\GnuWin32 -y
   - go get -d github.com/golang/dep

--- a/scripts/ci-1.12.docker
+++ b/scripts/ci-1.12.docker
@@ -1,4 +1,4 @@
-FROM golang:1.12.10
+FROM golang:1.12.12
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/ci-1.13.docker
+++ b/scripts/ci-1.13.docker
@@ -1,4 +1,4 @@
-FROM golang:1.13.1
+FROM golang:1.13.3
 
 RUN chmod -R 755 "$GOPATH"
 


### PR DESCRIPTION
Note: Telegraf 1.12.4 will be with 1.12.12.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
