### PR TITLE
Fix powerdns_recursor socket_mode option

### DIFF
--- a/plugins/inputs/powerdns/README.md
+++ b/plugins/inputs/powerdns/README.md
@@ -14,6 +14,16 @@ The powerdns plugin gathers metrics about PowerDNS using unix socket.
   unix_sockets = ["/var/run/pdns.controlsocket"]
 ```
 
+#### Permissions
+
+Telegraf will need read access to the powerdns control socket.
+
+On many systems this can be accomplished by adding the `telegraf` user to the
+`pdns` group:
+```
+usermod telegraf -a -G pdns
+```
+
 ### Measurements & Fields:
 
 - powerdns

--- a/plugins/inputs/powerdns_recursor/powerdns_recursor_test.go
+++ b/plugins/inputs/powerdns_recursor/powerdns_recursor_test.go
@@ -139,7 +139,10 @@ func TestPowerdnsRecursorGeneratesMetrics(t *testing.T) {
 	p := &PowerdnsRecursor{
 		UnixSockets: []string{controlSocket},
 		SocketDir:   "/tmp",
+		SocketMode:  "0666",
 	}
+	err = p.Init()
+	require.NoError(t, err)
 
 	var acc testutil.Accumulator
 


### PR DESCRIPTION
closes: #6564

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
