### PR TITLE
Fix incorrect results in ping plugin

### DIFF
--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -293,10 +293,12 @@ func (p *Ping) pingToURLNative(destination string, acc telegraf.Accumulator) {
 					if strings.Contains(err.Error(), "not permitted") {
 						sent.sent = false
 					}
+					sents <- sent
 					return
 				}
 
 				resps <- resp
+				sents <- sent
 			}(i + 1)
 		}
 	}

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -355,4 +355,5 @@ func TestPingGatherNative(t *testing.T) {
 
 	assert.NoError(t, acc.GatherError(p.Gather))
 	assert.True(t, acc.HasPoint("ping", map[string]string{"url": "localhost"}, "packets_transmitted", 5))
+	assert.True(t, acc.HasPoint("ping", map[string]string{"url": "localhost"}, "packets_received", 5))
 }


### PR DESCRIPTION
In the last change, sending to a channel was overlooked, causing all
ping errors and packet sent count to be ignored.

Resolves #6576 