### PR TITLE
Smart Input Plugin: support for metrics from Error Counter Log

### DIFF
--- a/plugins/inputs/smart/README.md
+++ b/plugins/inputs/smart/README.md
@@ -3,7 +3,11 @@
 Get metrics using the command line utility `smartctl` for S.M.A.R.T. (Self-Monitoring, Analysis and Reporting Technology) storage devices. SMART is a monitoring system included in computer hard disk drives (HDDs) and solid-state drives (SSDs)[1] that detects and reports on various indicators of drive reliability, with the intent of enabling the anticipation of hardware failures.
 See smartmontools (https://www.smartmontools.org/).
 
-SMART information is separated between different measurements: `smart_device` is used for general information, while `smart_attribute` stores the detailed attribute information if `attributes = true` is enabled in the plugin configuration.
+SMART information is separated between different measurements:
+
+- `smart_device` - used for general information
+- `smart_attribute` - stores the detailed attribute information if `attributes = true` is enabled in the plugin configuration
+- `smart_error_counter_log` - stores metrics from Error Counter Log if `error_counter_log = true` is enabled in the plugin configuration
 
 If no devices are specified, the plugin will scan for SMART devices via the following command:
 
@@ -15,6 +19,12 @@ Metrics will be reported from the following `smartctl` command:
 
 ```
 smartctl --info --attributes --health --tolerance=verypermissive -n <nocheck> --format=brief <device>
+```
+
+Additionaly following option will be added if `error_counter_log` set to `true`:
+
+```
+--log error
 ```
 
 This plugin supports _smartmontools_ version 5.41 and above, but v. 5.41 and v. 5.42
@@ -51,6 +61,10 @@ smartctl -s on <device>
   ## Gather all returned S.M.A.R.T. attribute metrics and the detailed
   ## information from each drive into the `smart_attribute` measurement.
   # attributes = false
+
+  ## Gather all returned S.M.A.R.T. error counter log metrics
+  ## for each drive into the 'smart_error_counter_log' measurement.
+  # error_counter_log = false
 
   ## Optionally specify devices to exclude from reporting.
   # excludes = [ "/dev/pass6" ]
@@ -123,6 +137,25 @@ Defaults!SMARTCTL !logfile, !syslog, !pam_session
     - value
     - worst
 
+- smart_error_counter_log:
+  - tags:
+    - capacity
+    - device
+    - enabled
+    - model
+    - serial_no
+    - wwn
+    - page_name
+
+  - fields:
+    - errors_corrected_by_eccfast
+    - errors_corrected_by_eccdelayed
+    - errors_corrected_by_rereads_rewrites
+    - total_errors_corrected
+    - correction_algorithm_invocations
+    - gigabytes_processed
+    - total_uncorrected_errors
+
 #### Flags
 
 The interpretation of the tag `flags` is:
@@ -132,6 +165,13 @@ The interpretation of the tag `flags` is:
  - `S` speed/performance
  - `O` updated online
  - `P` prefailure warning
+
+### Page Name
+
+Possible valus for tag `page_name` in measurement `smart_error_counter_log`:
+- read
+- write
+- verify 
 
 #### Exit Status
 

--- a/plugins/inputs/smart/README.md
+++ b/plugins/inputs/smart/README.md
@@ -14,7 +14,7 @@ smartctl --scan
 Metrics will be reported from the following `smartctl` command:
 
 ```
-smartctl --info --attributes --health -n <nocheck> --format=brief <device>
+smartctl --info --attributes --health --tolerance=verypermissive -n <nocheck> --format=brief <device>
 ```
 
 This plugin supports _smartmontools_ version 5.41 and above, but v. 5.41 and v. 5.42

--- a/plugins/inputs/smart/README.md
+++ b/plugins/inputs/smart/README.md
@@ -168,7 +168,7 @@ The interpretation of the tag `flags` is:
 
 ### Page Name
 
-Possible valus for tag `page_name` in measurement `smart_error_counter_log`:
+Possible values for tag `page_name` in measurement `smart_error_counter_log`:
 - read
 - write
 - verify 

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -394,7 +394,7 @@ func (m *Smart) gatherDisk(acc telegraf.Accumulator, device string, wg *sync.Wai
 
 		if m.ErrorCounterLog {
 			ecl := errorCounterLog.FindStringSubmatch(line)
-			if len(ecl) > 1 {
+			if len(ecl) == 9 {
 				eclTags := map[string]string{}
 				eclFields := make(map[string]interface{})
 

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -112,13 +112,15 @@ var (
 )
 
 type Smart struct {
-	Path       string
-	Nocheck    string
-	Attributes bool
-	Excludes   []string
-	Devices    []string
-	UseSudo    bool
-	Timeout    internal.Duration
+	Path            string            `toml:"path"`
+	Nocheck         string            `toml:"nocheck"`
+	Attributes      bool              `toml:"attributes"`
+	ErrorCounterLog bool              `toml:"error_counter_log"`
+	Excludes        []string          `toml:"excludes"`
+	Devices         []string          `toml:"devices"`
+	UseSudo         bool              `toml:"use_sudo"`
+	Timeout         internal.Duration `toml:"timeout"`
+	Log             telegraf.Logger
 }
 
 var sampleConfig = `
@@ -142,6 +144,10 @@ var sampleConfig = `
   ## Gather all returned S.M.A.R.T. attribute metrics and the detailed
   ## information from each drive into the 'smart_attribute' measurement.
   # attributes = false
+
+  ## Gather all returned S.M.A.R.T. error counter log metrics
+  ## for each drive into the 'smart_error_counter_log' measurement.
+  # error_counter_log = false
 
   ## Optionally specify devices to exclude from reporting.
   # excludes = [ "/dev/pass6" ]

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -268,6 +268,9 @@ func (m *Smart) gatherDisk(acc telegraf.Accumulator, device string, wg *sync.Wai
 	defer wg.Done()
 	// smartctl 5.41 & 5.42 have are broken regarding handling of --nocheck/-n
 	args := []string{"--info", "--health", "--attributes", "--tolerance=verypermissive", "-n", m.Nocheck, "--format=brief"}
+	if m.ErrorCounterLog {
+		args = append(args, "--log", "error")
+	}
 	args = append(args, strings.Split(device, " ")...)
 	out, e := runCmd(m.Timeout, m.UseSudo, m.Path, args...)
 	outStr := string(out)

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -44,6 +44,15 @@ var (
 	// 192 Power-Off_Retract_Count -O--C-   097   097   000    -    14716
 	attribute = regexp.MustCompile("^\\s*([0-9]+)\\s(\\S+)\\s+([-P][-O][-S][-R][-C][-K])\\s+([0-9]+)\\s+([0-9]+)\\s+([0-9-]+)\\s+([-\\w]+)\\s+([\\w\\+\\.]+).*$")
 
+	// 	Error counter log:
+	// 	Errors Corrected by           Total   Correction     Gigabytes    Total
+	// 		ECC          rereads/    errors   algorithm      processed    uncorrected
+	// 	fast | delayed   rewrites  corrected  invocations   [10^9 bytes]  errors
+	// read:          0        0         0         0          0       4797.541           0
+	// write:         0        0         0         0          0       8932.303           0
+	// verify:        0        0         0         0          0          5.713           0
+	errorCounterLog = regexp.MustCompile(`^(read|write|verify):\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+([\d\.]+)\s+(\d+)\s*$`)
+
 	deviceFieldIds = map[string]string{
 		"1":   "read_error_rate",
 		"7":   "seek_error_rate",

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -380,7 +380,6 @@ func TestExcludedDev(t *testing.T) {
 
 func TestGatherSATAInfo(t *testing.T) {
 	s := NewSmart()
-	s.Timeout = internal.Duration{Duration: time.Second * 30}
 	s.UseSudo = true
 	s.Attributes = true
 	s.Path = "smartctl"
@@ -403,7 +402,6 @@ func TestGatherSATAInfo(t *testing.T) {
 
 func TestGatherSATAInfo65(t *testing.T) {
 	s := NewSmart()
-	s.Timeout = internal.Duration{Duration: time.Second * 30}
 	s.UseSudo = true
 	s.Attributes = true
 	s.Path = "smartctl"
@@ -426,7 +424,6 @@ func TestGatherSATAInfo65(t *testing.T) {
 
 func TestGatherHgstSAS(t *testing.T) {
 	s := NewSmart()
-	s.Timeout = internal.Duration{Duration: time.Second * 30}
 	s.UseSudo = true
 	s.Attributes = true
 	s.Path = "smartctl"
@@ -449,7 +446,6 @@ func TestGatherHgstSAS(t *testing.T) {
 
 func TestGatherHtSAS(t *testing.T) {
 	s := NewSmart()
-	s.Timeout = internal.Duration{Duration: time.Second * 30}
 	s.UseSudo = true
 	s.Attributes = true
 	s.Path = "smartctl"
@@ -520,7 +516,6 @@ func TestGatherHtSAS(t *testing.T) {
 
 func TestGatherSSD(t *testing.T) {
 	s := NewSmart()
-	s.Timeout = internal.Duration{Duration: time.Second * 30}
 	s.UseSudo = true
 	s.Attributes = true
 	s.Path = "smartctl"
@@ -543,7 +538,6 @@ func TestGatherSSD(t *testing.T) {
 
 func TestGatherSSDRaid(t *testing.T) {
 	s := NewSmart()
-	s.Timeout = internal.Duration{Duration: time.Second * 30}
 	s.UseSudo = true
 	s.Attributes = true
 	s.Path = "smartctl"
@@ -566,7 +560,6 @@ func TestGatherSSDRaid(t *testing.T) {
 
 func TestGatherNvme(t *testing.T) {
 	s := NewSmart()
-	s.Timeout = internal.Duration{Duration: time.Second * 30}
 	s.UseSudo = true
 	s.Attributes = true
 	s.Path = "smartctl"
@@ -693,7 +686,6 @@ func TestGatherNvme(t *testing.T) {
 
 func TestGatherHgstSASErrorCounterLog(t *testing.T) {
 	s := NewSmart()
-	s.Timeout = internal.Duration{Duration: time.Second * 30}
 	s.UseSudo = true
 	s.Attributes = true
 	s.Path = "smartctl"

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -1141,4 +1141,57 @@ Error Information Log Entries: 119,699
 Warning Comp. Temperature Time: 0
 Critical Comp. Temperature Time: 0
 `
+
+	// smartctl.exe --info --health --attributes --tolerance=verypermissive -n "standby"  --format=brief --log error [DEVICE]
+	hgstSASErrorCounterLog = `smartctl 7.0 2018-12-30 r4883 [x86_64-w64-mingw32-2016] (sf-7.0-1)
+Copyright (C) 2002-18, Bruce Allen, Christian Franke, www.smartmontools.org
+
+=== START OF INFORMATION SECTION ===
+Vendor:               HGST
+Product:              HUSMM1616ASS204
+Revision:             C2D0
+Compliance:           SPC-4
+User Capacity:        1,600,321,314,816 bytes [1.60 TB]
+Logical block size:   512 bytes
+Physical block size:  4096 bytes
+LU is resource provisioned, LBPRZ=1
+Rotation Rate:        Solid State Device
+Form Factor:          2.5 inches
+Logical Unit id:      0x5000cca050b1e1a0
+Serial number:        0SX4XZ5A
+Device type:          disk
+Transport protocol:   SAS (SPL-3)
+Local Time is:        Sun Oct 27 12:54:55 2019 CEST
+SMART support is:     Available - device has SMART capability.
+SMART support is:     Enabled
+Temperature Warning:  Enabled
+
+=== START OF READ SMART DATA SECTION ===
+SMART Health Status: OK
+
+Percentage used endurance indicator: 0%
+Current Drive Temperature:     25 C
+Drive Trip Temperature:        70 C
+
+Manufactured in week 32 of year 2016
+Specified cycle count over device lifetime:  0
+Accumulated start-stop cycles:  0
+Specified load-unload count over device lifetime:  0
+Accumulated load-unload cycles:  0
+defect list format 6 unknown
+Elements in grown defect list: 0
+
+Vendor (Seagate Cache) information
+	Blocks sent to initiator = 6228039079838468
+
+Error counter log:
+			Errors Corrected by           Total   Correction     Gigabytes    Total
+				ECC          rereads/    errors   algorithm      processed    uncorrected
+			fast | delayed   rewrites  corrected  invocations   [10^9 bytes]  errors
+read:          0        0         0         0          0       5621.586           0
+write:         0        0         0         0          0      12135.220           0
+verify:        0        0         0         0          0          5.713           0
+
+Non-medium error count:        0
+`
 )

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -691,6 +691,30 @@ func TestGatherNvme(t *testing.T) {
 		testutil.SortMetrics(), testutil.IgnoreTime())
 }
 
+func TestGatherHgstSASErrorCounterLog(t *testing.T) {
+	s := NewSmart()
+	s.Timeout = internal.Duration{Duration: time.Second * 30}
+	s.UseSudo = true
+	s.Attributes = true
+	s.Path = "smartctl"
+	s.Nocheck = ""
+	s.ErrorCounterLog = true
+
+	runCmd = func(timeout internal.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+		return []byte(hgstSASErrorCounterLog), nil
+	}
+
+	var (
+		acc = &testutil.Accumulator{}
+		wg  = &sync.WaitGroup{}
+	)
+
+	wg.Add(1)
+	s.gatherDisk(acc, "", wg)
+	assert.Equal(t, 27, acc.NFields(), "Wrong number of fields gathered")
+	assert.Equal(t, uint64(7), acc.NMetrics(), "Wrong number of metrics gathered")
+}
+
 // smartctl output
 var (
 	// smartctl --scan

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -379,6 +379,13 @@ func TestExcludedDev(t *testing.T) {
 }
 
 func TestGatherSATAInfo(t *testing.T) {
+	s := NewSmart()
+	s.Timeout = internal.Duration{Duration: time.Second * 30}
+	s.UseSudo = true
+	s.Attributes = true
+	s.Path = "smartctl"
+	s.Nocheck = ""
+
 	runCmd = func(timeout internal.Duration, sudo bool, command string, args ...string) ([]byte, error) {
 		return []byte(hgstSATAInfoData), nil
 	}
@@ -389,12 +396,19 @@ func TestGatherSATAInfo(t *testing.T) {
 	)
 
 	wg.Add(1)
-	gatherDisk(acc, internal.Duration{Duration: time.Second * 30}, true, true, "", "", "", wg)
+	s.gatherDisk(acc, "", wg)
 	assert.Equal(t, 101, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(20), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
 func TestGatherSATAInfo65(t *testing.T) {
+	s := NewSmart()
+	s.Timeout = internal.Duration{Duration: time.Second * 30}
+	s.UseSudo = true
+	s.Attributes = true
+	s.Path = "smartctl"
+	s.Nocheck = ""
+
 	runCmd = func(timeout internal.Duration, sudo bool, command string, args ...string) ([]byte, error) {
 		return []byte(hgstSATAInfoData65), nil
 	}
@@ -405,12 +419,19 @@ func TestGatherSATAInfo65(t *testing.T) {
 	)
 
 	wg.Add(1)
-	gatherDisk(acc, internal.Duration{Duration: time.Second * 30}, true, true, "", "", "", wg)
+	s.gatherDisk(acc, "", wg)
 	assert.Equal(t, 91, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(18), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
 func TestGatherHgstSAS(t *testing.T) {
+	s := NewSmart()
+	s.Timeout = internal.Duration{Duration: time.Second * 30}
+	s.UseSudo = true
+	s.Attributes = true
+	s.Path = "smartctl"
+	s.Nocheck = ""
+
 	runCmd = func(timeout internal.Duration, sudo bool, command string, args ...string) ([]byte, error) {
 		return []byte(hgstSASInfoData), nil
 	}
@@ -421,12 +442,19 @@ func TestGatherHgstSAS(t *testing.T) {
 	)
 
 	wg.Add(1)
-	gatherDisk(acc, internal.Duration{Duration: time.Second * 30}, true, true, "", "", "", wg)
+	s.gatherDisk(acc, "", wg)
 	assert.Equal(t, 6, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(4), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
 func TestGatherHtSAS(t *testing.T) {
+	s := NewSmart()
+	s.Timeout = internal.Duration{Duration: time.Second * 30}
+	s.UseSudo = true
+	s.Attributes = true
+	s.Path = "smartctl"
+	s.Nocheck = ""
+
 	runCmd = func(timeout internal.Duration, sudo bool, command string, args ...string) ([]byte, error) {
 		return []byte(htSASInfoData), nil
 	}
@@ -437,7 +465,7 @@ func TestGatherHtSAS(t *testing.T) {
 	)
 
 	wg.Add(1)
-	gatherDisk(acc, internal.Duration{Duration: time.Second * 30}, true, true, "", "", "", wg)
+	s.gatherDisk(acc, "", wg)
 
 	expected := []telegraf.Metric{
 		testutil.MustMetric(
@@ -491,6 +519,13 @@ func TestGatherHtSAS(t *testing.T) {
 }
 
 func TestGatherSSD(t *testing.T) {
+	s := NewSmart()
+	s.Timeout = internal.Duration{Duration: time.Second * 30}
+	s.UseSudo = true
+	s.Attributes = true
+	s.Path = "smartctl"
+	s.Nocheck = ""
+
 	runCmd = func(timeout internal.Duration, sudo bool, command string, args ...string) ([]byte, error) {
 		return []byte(ssdInfoData), nil
 	}
@@ -501,12 +536,19 @@ func TestGatherSSD(t *testing.T) {
 	)
 
 	wg.Add(1)
-	gatherDisk(acc, internal.Duration{Duration: time.Second * 30}, true, true, "", "", "", wg)
+	s.gatherDisk(acc, "", wg)
 	assert.Equal(t, 105, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(26), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
 func TestGatherSSDRaid(t *testing.T) {
+	s := NewSmart()
+	s.Timeout = internal.Duration{Duration: time.Second * 30}
+	s.UseSudo = true
+	s.Attributes = true
+	s.Path = "smartctl"
+	s.Nocheck = ""
+
 	runCmd = func(timeout internal.Duration, sudo bool, command string, args ...string) ([]byte, error) {
 		return []byte(ssdRaidInfoData), nil
 	}
@@ -517,12 +559,19 @@ func TestGatherSSDRaid(t *testing.T) {
 	)
 
 	wg.Add(1)
-	gatherDisk(acc, internal.Duration{Duration: time.Second * 30}, true, true, "", "", "", wg)
+	s.gatherDisk(acc, "", wg)
 	assert.Equal(t, 74, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(15), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
 func TestGatherNvme(t *testing.T) {
+	s := NewSmart()
+	s.Timeout = internal.Duration{Duration: time.Second * 30}
+	s.UseSudo = true
+	s.Attributes = true
+	s.Path = "smartctl"
+	s.Nocheck = ""
+
 	runCmd = func(timeout internal.Duration, sudo bool, command string, args ...string) ([]byte, error) {
 		return []byte(nvmeInfoData), nil
 	}
@@ -533,7 +582,7 @@ func TestGatherNvme(t *testing.T) {
 	)
 
 	wg.Add(1)
-	gatherDisk(acc, internal.Duration{Duration: time.Second * 30}, true, true, "", "", "", wg)
+	s.gatherDisk(acc, "", wg)
 
 	expected := []telegraf.Metric{
 		testutil.MustMetric("smart_device",


### PR DESCRIPTION
Additional measurement `smart_error_counter_log` which includes data parsed from smartctl "Error Counter Log".

* smart_error_counter_log
    * tags
        * capacity
        * device
        * enabled
        * model
        * serial_no
        * wwn
        * page_name - read, write, verify

    * fields
        * errors_corrected_by_eccfast
        * errors_corrected_by_eccdelayed
        * errors_corrected_by_rereads_rewrites
        * total_errors_corrected
        * correction_algorithm_invocations
        * gigabytes_processed
        * total_uncorrected_errors

For devices attached using scsi protocol (including SAS drives) smartctl prints error counter log if it is supported.


Discussed in #6461
 
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
