### PR TITLE
Use 1h or 3h rain values as appropriate

### DIFF
--- a/plugins/inputs/openweathermap/README.md
+++ b/plugins/inputs/openweathermap/README.md
@@ -56,7 +56,7 @@ condition ID, icon, and main is at [weather conditions][].
     - cloudiness (int, percent)
     - humidity (int, percent)
     - pressure (float, atmospheric pressure hPa)
-    - rain (float, rain volume for the last 3 hours in mm)
+    - rain (float, rain volume for the last 1-3 hours (depending on API response) in mm)
     - sunrise (int, nanoseconds since unix epoch)
     - sunset (int, nanoseconds since unix epoch)
     - temperature (float, degrees)

--- a/plugins/inputs/openweathermap/openweathermap.go
+++ b/plugins/inputs/openweathermap/openweathermap.go
@@ -179,6 +179,7 @@ type WeatherEntry struct {
 		Temp     float64 `json:"temp"`
 	} `json:"main"`
 	Rain struct {
+		Rain1 float64 `json:"1h"`
 		Rain3 float64 `json:"3h"`
 	} `json:"rain"`
 	Sys struct {
@@ -227,6 +228,13 @@ func gatherWeatherUrl(r io.Reader) (*Status, error) {
 	return status, nil
 }
 
+func gatherRain(e WeatherEntry) float64 {
+	if e.Rain.Rain1 > 0 {
+		return e.Rain.Rain1
+	}
+	return e.Rain.Rain3
+}
+
 func gatherWeather(acc telegraf.Accumulator, status *Status) {
 	for _, e := range status.List {
 		tm := time.Unix(e.Dt, 0)
@@ -235,7 +243,7 @@ func gatherWeather(acc telegraf.Accumulator, status *Status) {
 			"cloudiness":   e.Clouds.All,
 			"humidity":     e.Main.Humidity,
 			"pressure":     e.Main.Pressure,
-			"rain":         e.Rain.Rain3,
+			"rain":         gatherRain(e),
 			"sunrise":      time.Unix(e.Sys.Sunrise, 0).UnixNano(),
 			"sunset":       time.Unix(e.Sys.Sunset, 0).UnixNano(),
 			"temperature":  e.Main.Temp,
@@ -274,7 +282,7 @@ func gatherForecast(acc telegraf.Accumulator, status *Status) {
 			"cloudiness":   e.Clouds.All,
 			"humidity":     e.Main.Humidity,
 			"pressure":     e.Main.Pressure,
-			"rain":         e.Rain.Rain3,
+			"rain":         gatherRain(e),
 			"temperature":  e.Main.Temp,
 			"wind_degrees": e.Wind.Deg,
 			"wind_speed":   e.Wind.Speed,


### PR DESCRIPTION
The OpenWeatherMap API doesn't reliably return "3h" rain values,
so we examine the response for "1h" (preferred) or "3h" values as it
seems to depend on the particular weather station used which value will
be returned (see
https://openweathermap.desk.com/customer/en/portal/questions/17663899-rain-1h-3h-are-mutually-exclusive-?new=17663899).

Closes #6583

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
