### PR TITLE
Handle per-plugin flush jitter, fixes #6569

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -503,6 +503,12 @@ func (a *Agent) runOutputs(
 			interval = output.Config.FlushInterval
 		}
 
+		jitter := jitter
+		// Overwrite agent flush_jitter if this plugin has its own.
+		if output.Config.FlushJitter != nil {
+			jitter = *output.Config.FlushJitter
+		}
+
 		wg.Add(1)
 		go func(output *models.RunningOutput) {
 			defer wg.Done()

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -127,9 +127,11 @@ The agent table configures Telegraf and the defaults used across all plugins.
   flush_interval + flush_jitter.
 
 - **flush_jitter**:
-  Jitter the flush [interval][] by a random amount. This is primarily to avoid
-  large write spikes for users running a large number of telegraf instances.
-  ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s.
+  Default flush jitter for all outputs. This jitters the flush [interval][]
+  by a random amount. This is primarily to avoid large write spikes for users
+  running a large number of telegraf instances. ie, a jitter of 5s and interval
+  10s means flushes will happen every 10-15s.
+
 
 - **precision**:
   Collected metrics are rounded to the precision specified as an [interval][].
@@ -260,6 +262,8 @@ Parameters that can be used with any output plugin:
 - **alias**: Name an instance of a plugin.
 - **flush_interval**: The maximum time between flushes.  Use this setting to
   override the agent `flush_interval` on a per plugin basis.
+- **flush_jitter**: The amount of time to jitter the flush interval.  Use this
+  setting to override the agent `flush_jitter` on a per plugin basis.
 - **metric_batch_size**: The maximum number of metrics to send at once.  Use
   this setting to override the agent `metric_batch_size` on a per plugin basis.
 - **metric_buffer_limit**: The maximum number of unsent metrics to buffer.
@@ -275,6 +279,7 @@ Override flush parameters for a single output:
 ```toml
 [agent]
   flush_interval = "10s"
+  flush_jitter = "5s"
   metric_batch_size = 1000
 
 [[outputs.influxdb]]
@@ -284,6 +289,7 @@ Override flush parameters for a single output:
 [[outputs.file]]
   files = [ "stdout" ]
   flush_interval = "1s"
+  flush_jitter = "1s"
   metric_batch_size = 10
 ```
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2026,6 +2026,19 @@ func buildOutput(name string, tbl *ast.Table) (*models.OutputConfig, error) {
 		}
 	}
 
+	if node, ok := tbl.Fields["flush_jitter"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if str, ok := kv.Value.(*ast.String); ok {
+				dur, err := time.ParseDuration(str.Value)
+				if err != nil {
+					return nil, err
+				}
+				oc.FlushJitter = new(time.Duration)
+				*oc.FlushJitter = dur
+			}
+		}
+	}
+
 	if node, ok := tbl.Fields["metric_buffer_limit"]; ok {
 		if kv, ok := node.(*ast.KeyValue); ok {
 			if integer, ok := kv.Value.(*ast.Integer); ok {
@@ -2059,6 +2072,7 @@ func buildOutput(name string, tbl *ast.Table) (*models.OutputConfig, error) {
 	}
 
 	delete(tbl.Fields, "flush_interval")
+	delete(tbl.Fields, "flush_jitter")
 	delete(tbl.Fields, "metric_buffer_limit")
 	delete(tbl.Fields, "metric_batch_size")
 	delete(tbl.Fields, "alias")

--- a/internal/models/running_output.go
+++ b/internal/models/running_output.go
@@ -24,6 +24,7 @@ type OutputConfig struct {
 	Filter Filter
 
 	FlushInterval     time.Duration
+	FlushJitter       *time.Duration
 	MetricBufferLimit int
 	MetricBatchSize   int
 }


### PR DESCRIPTION
This supports setting unique flush intervals per output plugin.

See [#6569](https://github.com/influxdata/telegraf/issues/6569)

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
