### PR TITLE
Mqtt consumer autoreconnect variable. Version upgrade

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
 
 [[constraint]]
   name = "github.com/eclipse/paho.mqtt.golang"
-  version = "1"
+  version = "1.2.0"
 
 [[constraint]]
   name = "github.com/go-sql-driver/mysql"

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -5310,6 +5310,10 @@
 #   ## waiting until the next flush_interval.
 #   # max_undelivered_messages = 1000
 #
+#   ## auto_reconnect sets whether the automatic reconnection
+#   ## logic should be used when the connection is lost.
+#   # auto_reconnect = true
+#
 #   ## Persistent session disables clearing of the client session on connection.
 #   ## In order for this option to work you must also set client_id to identity
 #   ## the client.  To receive messages that arrived while the client is offline,

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -44,6 +44,10 @@ and creates metrics using one of the supported [input data formats][].
   ## waiting until the next flush_interval.
   # max_undelivered_messages = 1000
 
+  ## auto_reconnect sets whether the automatic reconnection
+  ## logic should be used when the connection is lost.
+  # auto_reconnect = true
+
   ## Persistent session disables clearing of the client session on connection.
   ## In order for this option to work you must also set client_id to identity
   ## the client.  To receive messages that arrived while the client is offline,

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -50,6 +50,7 @@ type MQTTConsumer struct {
 	QoS                    int               `toml:"qos"`
 	ConnectionTimeout      internal.Duration `toml:"connection_timeout"`
 	MaxUndeliveredMessages int               `toml:"max_undelivered_messages"`
+	AutoReconnect          bool              `toml:"auto_reconnect"`
 
 	parser parsers.Parser
 

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -369,6 +369,7 @@ func (m *MQTTConsumer) createOpts() (*mqtt.ClientOptions, error) {
 	opts.SetCleanSession(!m.PersistentSession)
 	opts.SetConnectionLostHandler(m.onConnectionLost)
 	opts.SetOnConnectHandler(m.onConnect)
+	opts.SetConnectRetry(true)
 
 	return opts, nil
 }

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -114,8 +114,8 @@ var sampleConfig = `
   ## waiting until the next flush_interval.
   # max_undelivered_messages = 1000
 
-  # auto_reconnect sets whether the automatic reconnection
-  # logic should be used when the connection is lost. 
+  ## auto_reconnect sets whether the automatic reconnection
+  ## logic should be used when the connection is lost. 
   # auto_reconnect = true
 
   ## Persistent session disables clearing of the client session on connection.
@@ -362,7 +362,7 @@ func (m *MQTTConsumer) createOpts() (*mqtt.ClientOptions, error) {
 
 		opts.AddBroker(server)
 	}
-	opts.SetAutoReconnect(false)
+	opts.SetAutoReconnect(m.AutoReconnect)
 	opts.SetKeepAlive(time.Second * 60)
 	opts.SetCleanSession(!m.PersistentSession)
 	opts.SetConnectionLostHandler(m.onConnectionLost)

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -309,12 +309,6 @@ func (m *MQTTConsumer) Stop() {
 }
 
 func (m *MQTTConsumer) Gather(acc telegraf.Accumulator) error {
-	/*if m.state == Disconnected {
-		m.state = Connecting
-		m.Log.Debugf("Connecting %v", m.Servers)
-		m.connect()
-	}*/
-
 	return nil
 }
 

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -114,6 +114,10 @@ var sampleConfig = `
   ## waiting until the next flush_interval.
   # max_undelivered_messages = 1000
 
+  # auto_reconnect sets whether the automatic reconnection
+  # logic should be used when the connection is lost. 
+  # auto_reconnect = true
+
   ## Persistent session disables clearing of the client session on connection.
   ## In order for this option to work you must also set client_id to identity
   ## the client.  To receive messages that arrived while the client is offline,


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

* AutoReconnect field was added to MQTTConsumer struct to give the control to the end user.
* paho.mqtt.golang version is upgraded from 1 to 1.2