### PR TITLE
implementation for #6546 fibaro-plugin battery level

### DIFF
--- a/plugins/inputs/fibaro/README.md
+++ b/plugins/inputs/fibaro/README.md
@@ -34,6 +34,7 @@ Those values could be true (1) or false (0) for switches, percentage for dimmers
     - power (float, when available from device)
     - value (float)
     - value2 (float, when available from device)
+    - battery (float, when available from device)
 
 
 ### Example Output:
@@ -44,12 +45,12 @@ fibaro,deviceId=10,host=vm1,name=Escaliers,room=Dégagement,section=Pièces\ com
 fibaro,deviceId=13,host=vm1,name=Porte\ fenêtre,room=Salon,section=Pièces\ communes,type=com.fibaro.FGRM222 energy=4.33,power=0.7,value=99,value2=99 1529996807000000000
 fibaro,deviceId=21,host=vm1,name=LED\ îlot\ central,room=Cuisine,section=Cuisine,type=com.fibaro.binarySwitch value=0 1529996807000000000
 fibaro,deviceId=90,host=vm1,name=Détérioration,room=Entrée,section=Pièces\ communes,type=com.fibaro.heatDetector value=0 1529996807000000000
-fibaro,deviceId=163,host=vm1,name=Température,room=Cave,section=Cave,type=com.fibaro.temperatureSensor value=21.62 1529996807000000000
+fibaro,deviceId=163,host=vm1,name=Température,room=Cave,section=Cave,type=com.fibaro.temperatureSensor battery=88 value=21.62 1529996807000000000
 fibaro,deviceId=191,host=vm1,name=Présence,room=Garde-manger,section=Cuisine,type=com.fibaro.FGMS001 value=1 1529996807000000000
-fibaro,deviceId=193,host=vm1,name=Luminosité,room=Garde-manger,section=Cuisine,type=com.fibaro.lightSensor value=195 1529996807000000000
+fibaro,deviceId=193,host=vm1,name=Luminosité,room=Garde-manger,section=Cuisine,type=com.fibaro.lightSensor battery=45 value=195 1529996807000000000
 fibaro,deviceId=200,host=vm1,name=Etat,room=Garage,section=Extérieur,type=com.fibaro.doorSensor value=0 1529996807000000000
 fibaro,deviceId=220,host=vm1,name=CO2\ (ppm),room=Salon,section=Pièces\ communes,type=com.fibaro.multilevelSensor value=536 1529996807000000000
-fibaro,deviceId=221,host=vm1,name=Humidité\ (%),room=Salon,section=Pièces\ communes,type=com.fibaro.humiditySensor value=61 1529996807000000000
+fibaro,deviceId=221,host=vm1,name=Humidité\ (%),room=Salon,section=Pièces\ communes,type=com.fibaro.humiditySensor battery=78 value=61 1529996807000000000
 fibaro,deviceId=222,host=vm1,name=Pression\ (mb),room=Salon,section=Pièces\ communes,type=com.fibaro.multilevelSensor value=1013.7 1529996807000000000
 fibaro,deviceId=223,host=vm1,name=Bruit\ (db),room=Salon,section=Pièces\ communes,type=com.fibaro.multilevelSensor value=44 1529996807000000000
 ```

--- a/plugins/inputs/fibaro/fibaro.go
+++ b/plugins/inputs/fibaro/fibaro.go
@@ -69,11 +69,12 @@ type Devices struct {
 	Type       string `json:"type"`
 	Enabled    bool   `json:"enabled"`
 	Properties struct {
-		Dead   interface{} `json:"dead"`
-		Energy interface{} `json:"energy"`
-		Power  interface{} `json:"power"`
-		Value  interface{} `json:"value"`
-		Value2 interface{} `json:"value2"`
+		Dead    interface{} `json:"dead"`
+		Energy  interface{} `json:"energy"`
+		Power   interface{} `json:"power"`
+		Value   interface{} `json:"value"`
+		Value2  interface{} `json:"value2"`
+		Battery interface{} `json:"batteryLevel"`
 	} `json:"properties"`
 }
 
@@ -204,6 +205,12 @@ func (f *Fibaro) Gather(acc telegraf.Accumulator) error {
 		if device.Properties.Value2 != nil {
 			if fValue, err := strconv.ParseFloat(device.Properties.Value2.(string), 64); err == nil {
 				fields["value2"] = fValue
+			}
+		}
+
+		if device.Properties.Battery != nil {
+			if fValue, err := strconv.ParseFloat(device.Properties.Battery.(string), 64); err == nil {
+				fields["battery"] = fValue
 			}
 		}
 

--- a/plugins/inputs/fibaro/fibaro_test.go
+++ b/plugins/inputs/fibaro/fibaro_test.go
@@ -108,7 +108,8 @@ const devicesJSON = `
             "enabled": true,
             "properties": {
                 "dead": "false",
-                "value": "22.80"
+                "value": "22.80",
+                "batteryLevel": "88"
             },
             "sortOrder": 4
         },
@@ -196,7 +197,7 @@ func TestJSONSuccess(t *testing.T) {
 
 	// Ensure fields / values are correct - Device 4
 	tags = map[string]string{"deviceId": "4", "section": "Section 3", "room": "Room 4", "name": "Device 4", "type": "com.fibaro.temperatureSensor"}
-	fields = map[string]interface{}{"value": float64(22.8)}
+	fields = map[string]interface{}{"value": float64(22.8), "battery": float64(88)}
 	acc.AssertContainsTaggedFields(t, "fibaro", fields, tags)
 
 	// Ensure fields / values are correct - Device 5


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This commit provides an extension to the fibaro plugin to record in addition also the battery level of the devices as outlined in feature request #6546 