### PR TITLE
Fix known mysql type conversion issues

### DIFF
--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -566,7 +566,7 @@ func (m *Mysql) gatherGlobalVariables(db *sql.DB, serv string, acc telegraf.Accu
 
 		value, err := m.parseGlobalVariables(key, val)
 		if err != nil {
-			m.Log.Debugf("Error parsing global variables: %v", err)
+			m.Log.Debugf("Error parsing global variable %q: %v", key, err)
 		} else {
 			fields[key] = value
 		}

--- a/plugins/inputs/mysql/v2/convert.go
+++ b/plugins/inputs/mysql/v2/convert.go
@@ -79,6 +79,10 @@ var GlobalVariableConversions = map[string]ConversionFunc{
 }
 
 func ConvertGlobalStatus(key string, value sql.RawBytes) (interface{}, error) {
+	if bytes.Equal(value, []byte("")) {
+		return nil, nil
+	}
+
 	if conv, ok := GlobalStatusConversions[key]; ok {
 		return conv(value)
 	}
@@ -87,6 +91,10 @@ func ConvertGlobalStatus(key string, value sql.RawBytes) (interface{}, error) {
 }
 
 func ConvertGlobalVariables(key string, value sql.RawBytes) (interface{}, error) {
+	if bytes.Equal(value, []byte("")) {
+		return nil, nil
+	}
+
 	if conv, ok := GlobalVariableConversions[key]; ok {
 		return conv(value)
 	}

--- a/plugins/inputs/mysql/v2/convert.go
+++ b/plugins/inputs/mysql/v2/convert.go
@@ -46,14 +46,6 @@ func ParseGTIDMode(value sql.RawBytes) (interface{}, error) {
 	}
 }
 
-var GlobalStatusConversions = map[string]ConversionFunc{
-	"ssl_ctx_verify_depth": ParseInt,
-}
-
-var GlobalVariableConversions = map[string]ConversionFunc{
-	"gtid_mode": ParseGTIDMode,
-}
-
 func ParseValue(value sql.RawBytes) (interface{}, error) {
 	if bytes.EqualFold(value, []byte("YES")) || bytes.Compare(value, []byte("ON")) == 0 {
 		return 1, nil
@@ -75,6 +67,15 @@ func ParseValue(value sql.RawBytes) (interface{}, error) {
 	}
 
 	return nil, fmt.Errorf("unconvertible value: %q", string(value))
+}
+
+var GlobalStatusConversions = map[string]ConversionFunc{
+	"ssl_ctx_verify_depth": ParseInt,
+	"ssl_verify_depth":     ParseInt,
+}
+
+var GlobalVariableConversions = map[string]ConversionFunc{
+	"gtid_mode": ParseGTIDMode,
 }
 
 func ConvertGlobalStatus(key string, value sql.RawBytes) (interface{}, error) {

--- a/plugins/inputs/mysql/v2/convert.go
+++ b/plugins/inputs/mysql/v2/convert.go
@@ -1,0 +1,94 @@
+package v2
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"strconv"
+)
+
+type ConversionFunc func(value sql.RawBytes) (interface{}, error)
+
+func ParseInt(value sql.RawBytes) (interface{}, error) {
+	v, err := strconv.ParseInt(string(value), 10, 64)
+
+	// Ignore ErrRange.  When this error is set the returned value is "the
+	// maximum magnitude integer of the appropriate bitSize and sign."
+	if err, ok := err.(*strconv.NumError); ok && err.Err == strconv.ErrRange {
+		return v, nil
+	}
+
+	return v, err
+}
+
+func ParseBoolAsInteger(value sql.RawBytes) (interface{}, error) {
+	if bytes.EqualFold(value, []byte("YES")) || bytes.EqualFold(value, []byte("ON")) {
+		return int64(1), nil
+	}
+
+	return int64(0), nil
+}
+
+func ParseGTIDMode(value sql.RawBytes) (interface{}, error) {
+	// https://dev.mysql.com/doc/refman/8.0/en/replication-mode-change-online-concepts.html
+	v := string(value)
+	switch v {
+	case "OFF":
+		return int64(0), nil
+	case "ON":
+		return int64(1), nil
+	case "OFF_PERMISSIVE":
+		return int64(0), nil
+	case "ON_PERMISSIVE":
+		return int64(1), nil
+	default:
+		return nil, fmt.Errorf("unrecognized gtid_mode: %q", v)
+	}
+}
+
+var GlobalStatusConversions = map[string]ConversionFunc{
+	"ssl_ctx_verify_depth": ParseInt,
+}
+
+var GlobalVariableConversions = map[string]ConversionFunc{
+	"gtid_mode": ParseGTIDMode,
+}
+
+func ParseValue(value sql.RawBytes) (interface{}, error) {
+	if bytes.EqualFold(value, []byte("YES")) || bytes.Compare(value, []byte("ON")) == 0 {
+		return 1, nil
+	}
+
+	if bytes.EqualFold(value, []byte("NO")) || bytes.Compare(value, []byte("OFF")) == 0 {
+		return 0, nil
+	}
+
+	if val, err := strconv.ParseInt(string(value), 10, 64); err == nil {
+		return val, nil
+	}
+	if val, err := strconv.ParseFloat(string(value), 64); err == nil {
+		return val, nil
+	}
+
+	if len(string(value)) > 0 {
+		return string(value), nil
+	}
+
+	return nil, fmt.Errorf("unconvertible value: %q", string(value))
+}
+
+func ConvertGlobalStatus(key string, value sql.RawBytes) (interface{}, error) {
+	if conv, ok := GlobalStatusConversions[key]; ok {
+		return conv(value)
+	}
+
+	return ParseValue(value)
+}
+
+func ConvertGlobalVariables(key string, value sql.RawBytes) (interface{}, error) {
+	if conv, ok := GlobalVariableConversions[key]; ok {
+		return conv(value)
+	}
+
+	return ParseValue(value)
+}

--- a/plugins/inputs/mysql/v2/convert_test.go
+++ b/plugins/inputs/mysql/v2/convert_test.go
@@ -1,0 +1,72 @@
+package v2
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertGlobalStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		value       sql.RawBytes
+		expected    interface{}
+		expectedErr error
+	}{
+		{
+			name:        "default",
+			key:         "ssl_ctx_verify_depth",
+			value:       []byte("0"),
+			expected:    int64(0),
+			expectedErr: nil,
+		},
+		{
+			name:        "overflow int64",
+			key:         "ssl_ctx_verify_depth",
+			value:       []byte("18446744073709551615"),
+			expected:    int64(9223372036854775807),
+			expectedErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ConvertGlobalStatus(tt.key, tt.value)
+			require.Equal(t, tt.expectedErr, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestCovertGlobalVariables(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		value       sql.RawBytes
+		expected    interface{}
+		expectedErr error
+	}{
+		{
+			name:        "boolean type mysql<=5.6",
+			key:         "gtid_mode",
+			value:       []byte("ON"),
+			expected:    int64(1),
+			expectedErr: nil,
+		},
+		{
+			name:        "enum type mysql>=5.7",
+			key:         "gtid_mode",
+			value:       []byte("ON_PERMISSIVE"),
+			expected:    int64(1),
+			expectedErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ConvertGlobalVariables(tt.key, tt.value)
+			require.Equal(t, tt.expectedErr, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/plugins/inputs/mysql/v2/convert_test.go
+++ b/plugins/inputs/mysql/v2/convert_test.go
@@ -29,6 +29,13 @@ func TestConvertGlobalStatus(t *testing.T) {
 			expected:    int64(9223372036854775807),
 			expectedErr: nil,
 		},
+		{
+			name:        "defined variable but unset",
+			key:         "ssl_ctx_verify_depth",
+			value:       []byte(""),
+			expected:    nil,
+			expectedErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -59,6 +66,13 @@ func TestCovertGlobalVariables(t *testing.T) {
 			key:         "gtid_mode",
 			value:       []byte("ON_PERMISSIVE"),
 			expected:    int64(1),
+			expectedErr: nil,
+		},
+		{
+			name:        "defined variable but unset",
+			key:         "ssl_ctx_verify_depth",
+			value:       []byte(""),
+			expected:    nil,
 			expectedErr: nil,
 		},
 	}


### PR DESCRIPTION
Add the ability to have per field conversion functions for the global status and global variables queries.  These queries both return tables of the form:
```
+----------------+---------------+------+-----+---------+-------+
| Field          | Type          | Null | Key | Default | Extra |
+----------------+---------------+------+-----+---------+-------+
| VARIABLE_NAME  | varchar(64)   | NO   |     |         |       |
| VARIABLE_VALUE | varchar(2048) | NO   |     |         |       |
+----------------+---------------+------+-----+---------+-------+
```

closes #5529
closes #6646

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
