### PR TITLE
Skip logging when logfile is unset

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"errors"
-
 	"io"
 	"log"
 	"os"
@@ -112,7 +111,6 @@ func (t *telegrafLogCreator) CreateLogger(config LogConfig) (io.Writer, error) {
 				writer = defaultWriter
 			}
 		} else {
-			log.Print("E! Empty logfile, using stderr")
 			writer = defaultWriter
 		}
 	case LogTargetStderr, "":


### PR DESCRIPTION
Having `logfile` unset is not an error, and is in fact the default value.  This is a unreleased log message that was added in #4291

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
