### PR TITLE
Add a nameable file tag to file input plugin

### DIFF
--- a/plugins/inputs/file/README.md
+++ b/plugins/inputs/file/README.md
@@ -7,6 +7,7 @@ Files will always be read in their entirety, if you wish to tail/follow a file
 use the [tail input plugin](/plugins/inputs/tail) instead.
 
 ### Configuration:
+
 ```toml
 [[inputs.file]]
   ## Files to parse each interval.
@@ -22,4 +23,8 @@ use the [tail input plugin](/plugins/inputs/tail) instead.
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
+
+  ## Name a tag containing the name of the file the data was parsed from.  Leave empty
+  ## to disable.
+  # file_tag = "filename"
 ```

--- a/plugins/inputs/file/README.md
+++ b/plugins/inputs/file/README.md
@@ -26,5 +26,5 @@ use the [tail input plugin](/plugins/inputs/tail) instead.
 
   ## Name a tag containing the name of the file the data was parsed from.  Leave empty
   ## to disable.
-  # file_tag = "filename"
+  # file_tag = ""
 ```

--- a/plugins/inputs/file/file.go
+++ b/plugins/inputs/file/file.go
@@ -3,6 +3,7 @@ package file
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/globpath"
@@ -12,6 +13,7 @@ import (
 
 type File struct {
 	Files  []string `toml:"files"`
+	File   string   `toml:"file_tag"`
 	parser parsers.Parser
 
 	filenames []string
@@ -31,6 +33,10 @@ const sampleConfig = `
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
+  
+  ## Name a tag containing the name of the file the data was parsed from.  Leave empty 
+  ## to disable.
+  # file_tag = "filename"
 `
 
 // SampleConfig returns the default configuration of the Input
@@ -54,6 +60,9 @@ func (f *File) Gather(acc telegraf.Accumulator) error {
 		}
 
 		for _, m := range metrics {
+			if f.File != "" {
+				m.AddTag(f.File, filepath.Base(k))
+			}
 			acc.AddFields(m.Name(), m.Fields(), m.Tags(), m.Time())
 		}
 	}

--- a/plugins/inputs/file/file.go
+++ b/plugins/inputs/file/file.go
@@ -12,9 +12,9 @@ import (
 )
 
 type File struct {
-	Files  []string `toml:"files"`
-	File   string   `toml:"file_tag"`
-	parser parsers.Parser
+	Files   []string `toml:"files"`
+	FileTag string   `toml:"file_tag"`
+	parser  parsers.Parser
 
 	filenames []string
 }
@@ -36,7 +36,7 @@ const sampleConfig = `
   
   ## Name a tag containing the name of the file the data was parsed from.  Leave empty 
   ## to disable.
-  # file_tag = "filename"
+  # file_tag = ""
 `
 
 // SampleConfig returns the default configuration of the Input
@@ -60,8 +60,8 @@ func (f *File) Gather(acc telegraf.Accumulator) error {
 		}
 
 		for _, m := range metrics {
-			if f.File != "" {
-				m.AddTag(f.File, filepath.Base(k))
+			if f.FileTag != "" {
+				m.AddTag(f.FileTag, filepath.Base(k))
 			}
 			acc.AddFields(m.Name(), m.Fields(), m.Tags(), m.Time())
 		}

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -27,8 +27,8 @@ func TestFileTag(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 	r := File{
-		Files: []string{filepath.Join(wd, "dev/testfiles/json_a.log")},
-		File:  "filename",
+		Files:   []string{filepath.Join(wd, "dev/testfiles/json_a.log")},
+		FileTag: "filename",
 	}
 
 	parserConfig := parsers.Config{
@@ -43,7 +43,7 @@ func TestFileTag(t *testing.T) {
 
 	for _, m := range acc.Metrics {
 		for key, value := range m.Tags {
-			assert.Equal(t, r.File, key)
+			assert.Equal(t, r.FileTag, key)
 			assert.Equal(t, filepath.Base(r.Files[0]), value)
 		}
 	}

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -21,6 +21,34 @@ func TestRefreshFilePaths(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(r.filenames))
 }
+
+func TestFileTag(t *testing.T) {
+	acc := testutil.Accumulator{}
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	r := File{
+		Files: []string{filepath.Join(wd, "dev/testfiles/json_a.log")},
+		File:  "filename",
+	}
+
+	parserConfig := parsers.Config{
+		DataFormat: "json",
+	}
+	nParser, err := parsers.NewParser(&parserConfig)
+	assert.NoError(t, err)
+	r.parser = nParser
+
+	err = r.Gather(&acc)
+	require.NoError(t, err)
+
+	for _, m := range acc.Metrics {
+		for key, value := range m.Tags {
+			assert.Equal(t, r.File, key)
+			assert.Equal(t, filepath.Base(r.Files[0]), value)
+		}
+	}
+}
+
 func TestJSONParserCompile(t *testing.T) {
 	var acc testutil.Accumulator
 	wd, _ := os.Getwd()


### PR DESCRIPTION
This PR adds the ability to create and name a tag containing the filename of the file parsed using the file input plugin.  Leaving this option blank will cause the tag not to be generated.

Resolves #6644.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
