### PR TITLE
Build the nats input on freebsd when cgo is enabled

### DIFF
--- a/plugins/inputs/nats/nats.go
+++ b/plugins/inputs/nats/nats.go
@@ -1,20 +1,18 @@
-// +build !freebsd
+// +build !freebsd freebsd,cgo
 
 package nats
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
 	"time"
 
-	"encoding/json"
-
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/inputs"
-
 	gnatsd "github.com/nats-io/gnatsd/server"
 )
 

--- a/plugins/inputs/nats/nats_freebsd.go
+++ b/plugins/inputs/nats/nats_freebsd.go
@@ -1,3 +1,3 @@
-// +build freebsd
+// +build freebsd,!cgo
 
 package nats

--- a/plugins/inputs/nats/nats_test.go
+++ b/plugins/inputs/nats/nats_test.go
@@ -1,4 +1,4 @@
-// +build !freebsd
+// +build !freebsd freebsd,cgo
 
 package nats
 


### PR DESCRIPTION
closes #6657

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
