### PR TITLE
Use nanosecond precision in docker_log input

### DIFF
--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -203,6 +203,7 @@ func (d *DockerLogs) matchedContainerName(names []string) string {
 
 func (d *DockerLogs) Gather(acc telegraf.Accumulator) error {
 	ctx := context.Background()
+	acc.SetPrecision(time.Nanosecond)
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout.Duration)
 	defer cancel()


### PR DESCRIPTION
closes #6652

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
