### PR TITLE
Log no metrics found at debug level in cloudwatch input

### DIFF
--- a/agent/accumulator.go
+++ b/agent/accumulator.go
@@ -111,7 +111,7 @@ func (ac *accumulator) AddError(err error) {
 		return
 	}
 	NErrors.Incr(1)
-	log.Printf("D! [%s] Error in plugin: %v", ac.maker.LogName(), err)
+	log.Printf("E! [%s] Error in plugin: %v", ac.maker.LogName(), err)
 }
 
 func (ac *accumulator) SetPrecision(precision time.Duration) {


### PR DESCRIPTION
Revert change to log all plugin errors at debug level, only report the "no metrics found" error from the cloudwatch plugin at debug level.

follow-up to #6630
closes #6666 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
