### PR TITLE
Add support for sending HTTP Basic Auth in influxdb input

### DIFF
--- a/plugins/inputs/influxdb/README.md
+++ b/plugins/inputs/influxdb/README.md
@@ -20,6 +20,10 @@ InfluxDB-formatted endpoints. See below for more information.
     "http://localhost:8086/debug/vars"
   ]
 
+  ## Username and password to send using HTTP Basic Authentication.
+  # username = ""
+  # password = ""
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"

--- a/plugins/inputs/influxdb/influxdb_test.go
+++ b/plugins/inputs/influxdb/influxdb_test.go
@@ -1,6 +1,7 @@
 package influxdb_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -176,6 +177,31 @@ func TestErrorHandling404(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.Error(t, acc.GatherError(plugin.Gather))
+}
+
+func TestErrorResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error": "unable to parse authentication credentials"}`))
+	}))
+	defer ts.Close()
+
+	plugin := &influxdb.InfluxDB{
+		URLs: []string{ts.URL},
+	}
+
+	var acc testutil.Accumulator
+	err := plugin.Gather(&acc)
+	require.NoError(t, err)
+
+	expected := []error{
+		&influxdb.APIError{
+			StatusCode:  http.StatusUnauthorized,
+			Reason:      fmt.Sprintf("%d %s", http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized)),
+			Description: "unable to parse authentication credentials",
+		},
+	}
+	require.Equal(t, expected, acc.Errors)
 }
 
 const basicJSON = `


### PR DESCRIPTION
closes #6588

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
