### PR TITLE
kafka_consumer: expose partition assignment strategy configuration (#6687)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -100,12 +100,12 @@
   version = "v0.4.9"
 
 [[projects]]
-  digest = "1:322bf7f4bb312294fc551f6e2c82d02f2ab8f94920f4163b3deeb07a8141ac79"
+  digest = "1:33f56caa9ab45fedc63d3d1d3e342d9f9d00726071f22c67d06b0cd26d49a55e"
   name = "github.com/Shopify/sarama"
   packages = ["."]
   pruneopts = ""
-  revision = "b12709e6ca29240128c89fe0b30b6a76be42b457"
-  source = "https://github.com/influxdata/sarama.git"
+  revision = ""
+  version = "v1.24.1"
 
 [[projects]]
   digest = "1:f82b8ac36058904227087141017bb82f4b0fc58272990a4cdae3e2d6d222644e"
@@ -790,6 +790,20 @@
   packages = ["."]
   pruneopts = ""
   revision = "95032a82bc518f77982ea72343cc1ade730072f0"
+
+[[projects]]
+  digest = "1:4ceab6231efd01210f2b8b6ab360d480d49c0f44df63841ca0465920a387495d"
+  name = "github.com/klauspost/compress"
+  packages = [
+    "fse",
+    "huff0",
+    "snappy",
+    "zstd",
+    "zstd/internal/xxhash",
+  ]
+  pruneopts = ""
+  revision = "4e96aec082898e4dad17d8aca1a7e2d01362ff6c"
+  version = "v1.9.2"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -148,8 +148,7 @@
 
 [[constraint]]
   name = "github.com/Shopify/sarama"
-  revision = "b12709e6ca29240128c89fe0b30b6a76be42b457"
-  source = "https://github.com/influxdata/sarama.git"
+  version = "1.24.0"
 
 [[constraint]]
   name = "github.com/soniah/gosnmp"

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -5116,6 +5116,9 @@
 #   ## Initial offset position; one of "oldest" or "newest".
 #   # offset = "oldest"
 #
+#   ## Consumer group partition assignment strategy; one of "range", "roundrobin" or "sticky".
+#   # balance_strategy = "range"
+#
 #   ## Maximum length of a message to consume, in bytes (default 0/unlimited);
 #   ## larger messages are dropped
 #   max_message_len = 1000000

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -44,6 +44,9 @@ and use the old zookeeper connection method.
   ## Initial offset position; one of "oldest" or "newest".
   # offset = "oldest"
 
+  ## Consumer group partition assignment strategy; one of "range", "roundrobin" or "sticky".
+  # balance_strategy = "range"
+
   ## Maximum length of a message to consume, in bytes (default 0/unlimited);
   ## larger messages are dropped
   max_message_len = 1000000


### PR DESCRIPTION
Exposed the balance strategy configuration as in https://github.com/Shopify/sarama/blob/master/balance_strategy.go.

Fixes #6687.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
