### PR TITLE
Allow multiple certificates on same file for x509 input

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -2,6 +2,7 @@
 package x509_cert
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -98,7 +99,7 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 		}
 		var certs []*x509.Certificate
 		for {
-			block, rest := pem.Decode(content)
+			block, rest := pem.Decode(bytes.TrimSpace(content))
 			if block == nil {
 				return nil, fmt.Errorf("failed to parse certificate PEM")
 			}

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -140,7 +140,7 @@ func TestGatherLocal(t *testing.T) {
 		{name: "permission denied", mode: 0001, error: true},
 		{name: "not a certificate", mode: 0640, content: "test", error: true},
 		{name: "wrong certificate", mode: 0640, content: wrongCert, error: true},
-		{name: "correct certificate", mode: 0640, content: pki.ReadServerCert()},
+		{name: "correct certificate", mode: 0640, content: pki.ReadServerCert() + pki.ReadCACert()},
 	}
 
 	for _, test := range tests {

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -140,7 +140,15 @@ func TestGatherLocal(t *testing.T) {
 		{name: "permission denied", mode: 0001, error: true},
 		{name: "not a certificate", mode: 0640, content: "test", error: true},
 		{name: "wrong certificate", mode: 0640, content: wrongCert, error: true},
-		{name: "correct certificate", mode: 0640, content: pki.ReadServerCert() + pki.ReadCACert()},
+		{name: "correct certificate", mode: 0640, content: pki.ReadServerCert()},
+		{name: "correct certificate and extra trailing space", mode: 0640, content: pki.ReadServerCert() + " "},
+		{name: "correct certificate and extra leading space", mode: 0640, content: " " + pki.ReadServerCert()},
+		{name: "correct multiple certificates", mode: 0640, content: pki.ReadServerCert() + pki.ReadCACert()},
+		{name: "correct certificate and wrong certificate", mode: 0640, content: pki.ReadServerCert() + "\n" + wrongCert, error: true},
+		{name: "correct certificate and not a certificate", mode: 0640, content: pki.ReadServerCert() + "\ntest", error: true},
+		{name: "correct multiple certificates and extra trailing space", mode: 0640, content: pki.ReadServerCert() + pki.ReadServerCert() + " "},
+		{name: "correct multiple certificates and extra leading space", mode: 0640, content: " " + pki.ReadServerCert() + pki.ReadServerCert()},
+		{name: "correct multiple certificates and extra middle space", mode: 0640, content: pki.ReadServerCert() + " " + pki.ReadServerCert()},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Allow to load multiple certificates from the same file with the x509 input

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [] Associated README.md updated. (Not needed)
- [X] Has appropriate unit tests.
