### PR TITLE
Add base64decode operation to string processor

### DIFF
--- a/plugins/processors/strings/README.md
+++ b/plugins/processors/strings/README.md
@@ -68,6 +68,10 @@ If you'd like to apply multiple processings to the same `tag_key` or `field_key`
   # [[processors.strings.left]]
   #   field = "message"
   #   width = 10
+
+  ## Decode a base64 encoded string
+  # [[processors.strings.base64decode]]
+  #   field = "message"
 ```
 
 #### Trim, TrimLeft, TrimRight

--- a/plugins/processors/strings/README.md
+++ b/plugins/processors/strings/README.md
@@ -12,6 +12,7 @@ Implemented functions are:
 - trim_suffix
 - replace
 - left
+- base64decode
 
 Please note that in this implementation these are processed in the order that they appear above.
 
@@ -69,7 +70,7 @@ If you'd like to apply multiple processings to the same `tag_key` or `field_key`
   #   field = "message"
   #   width = 10
 
-  ## Decode a base64 encoded string
+  ## Decode a base64 encoded utf-8 string
   # [[processors.strings.base64decode]]
   #   field = "message"
 ```

--- a/plugins/processors/strings/strings.go
+++ b/plugins/processors/strings/strings.go
@@ -1,23 +1,26 @@
 package strings
 
 import (
+	"encoding/base64"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/processors"
 )
 
 type Strings struct {
-	Lowercase  []converter `toml:"lowercase"`
-	Uppercase  []converter `toml:"uppercase"`
-	Trim       []converter `toml:"trim"`
-	TrimLeft   []converter `toml:"trim_left"`
-	TrimRight  []converter `toml:"trim_right"`
-	TrimPrefix []converter `toml:"trim_prefix"`
-	TrimSuffix []converter `toml:"trim_suffix"`
-	Replace    []converter `toml:"replace"`
-	Left       []converter `toml:"left"`
+	Lowercase    []converter `toml:"lowercase"`
+	Uppercase    []converter `toml:"uppercase"`
+	Trim         []converter `toml:"trim"`
+	TrimLeft     []converter `toml:"trim_left"`
+	TrimRight    []converter `toml:"trim_right"`
+	TrimPrefix   []converter `toml:"trim_prefix"`
+	TrimSuffix   []converter `toml:"trim_suffix"`
+	Replace      []converter `toml:"replace"`
+	Left         []converter `toml:"left"`
+	Base64Decode []converter `toml:"base64decode"`
 
 	converters []converter
 	init       bool
@@ -86,6 +89,10 @@ const sampleConfig = `
   # [[processors.strings.left]]
   #   field = "message"
   #   width = 10
+
+  ## Decode a base64 encoded utf-8 string
+  # [[processors.strings.base64decode]]
+  #   field = "message"
 `
 
 func (s *Strings) SampleConfig() string {
@@ -285,6 +292,20 @@ func (s *Strings) initOnce() {
 			} else {
 				return s[:c.Width]
 			}
+		}
+		s.converters = append(s.converters, c)
+	}
+	for _, c := range s.Base64Decode {
+		c := c
+		c.fn = func(s string) string {
+			data, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return s
+			}
+			if utf8.Valid(data) {
+				return string(data)
+			}
+			return s
 		}
 		s.converters = append(s.converters, c)
 	}


### PR DESCRIPTION
This is an updated version of #4698.  It adds support for the "standard base64 encoding" and not the "alternate base64 encoding" aka url encoded base64.  If the string is not base64 encoded or does not contain encoded utf-8 data, the unmodified string is passed through without warning, consistent with the other operations of the plugin.

closes #4697

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
