### PR TITLE
Log mongodb oplog auth errors at debug level

### DIFF
--- a/plugins/inputs/mongodb/mongodb_server.go
+++ b/plugins/inputs/mongodb/mongodb_server.go
@@ -214,7 +214,7 @@ func (s *Server) gatherData(acc telegraf.Accumulator, gatherDbStats bool, gather
 	if replSetStatus != nil {
 		oplogStats, err = s.gatherOplogStats()
 		if err != nil {
-			return err
+			s.authLog(fmt.Errorf("Unable to get oplog stats: %v", err))
 		}
 	}
 


### PR DESCRIPTION
Restore debug logging of authentication errors when reading the oplog first added in #4869.

closes #6684

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
