### PR TITLE
Fix ping skips remaining hosts after dns lookup error

### DIFF
--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -125,7 +125,7 @@ func (p *Ping) Gather(acc telegraf.Accumulator) error {
 	for _, host := range p.Urls {
 		_, err := net.LookupHost(host)
 		if err != nil {
-			acc.AddFields("ping", map[string]interface{}{"result_code": 1}, map[string]string{"ip": host})
+			acc.AddFields("ping", map[string]interface{}{"result_code": 1}, map[string]string{"url": host})
 			acc.AddError(err)
 			continue
 		}

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -122,27 +122,25 @@ func (p *Ping) Gather(acc telegraf.Accumulator) error {
 		p.listenAddr = getAddr(p.Interface)
 	}
 
-	for _, ip := range p.Urls {
-		_, err := net.LookupHost(ip)
+	for _, host := range p.Urls {
+		_, err := net.LookupHost(host)
 		if err != nil {
-			acc.AddFields("ping", map[string]interface{}{"result_code": 1}, map[string]string{"ip": ip})
+			acc.AddFields("ping", map[string]interface{}{"result_code": 1}, map[string]string{"ip": host})
 			acc.AddError(err)
-			return nil
+			continue
 		}
 
-		if p.Method == "native" {
-			p.wg.Add(1)
-			go func(ip string) {
-				defer p.wg.Done()
-				p.pingToURLNative(ip, acc)
-			}(ip)
-		} else {
-			p.wg.Add(1)
-			go func(ip string) {
-				defer p.wg.Done()
-				p.pingToURL(ip, acc)
-			}(ip)
-		}
+		p.wg.Add(1)
+		go func(host string) {
+			defer p.wg.Done()
+
+			switch p.Method {
+			case "native":
+				p.pingToURLNative(host, acc)
+			default:
+				p.pingToURL(host, acc)
+			}
+		}(host)
 	}
 
 	p.wg.Wait()


### PR DESCRIPTION
Continue after error.  Also fix tag name regression `url` -> `ip`. 
Compare against 1.11:

https://github.com/influxdata/telegraf/blob/747b136466cfe31084ef0ec5fc24ffb2aabba8c9/plugins/inputs/ping/ping.go#L111-L120

closes #6690

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
