### PR TITLE
Accept any media type in the prometheus input

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -17,7 +17,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3`
+const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3,*/*;q=0.1`
 
 type Prometheus struct {
 	// An array of urls to scrape metrics from.


### PR DESCRIPTION
Add `*/*;q=0.1` to the accept header of the prometheus input.  This is for greater compatibility with the prometheus scaper:

https://github.com/prometheus/prometheus/blob/1fa5a75a3a066778de5a78305141ed0dcb791cc3/scrape/scrape.go#L518

closes #6523

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
