### PR TITLE
update telegraf supported environment variables

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -7,6 +7,11 @@ variables:
 ```
 docker run --name telegraf
         -v /:/hostfs:ro
+        -v /etc:/hostfs/etc:ro
+	-v /proc:/hostfs/proc:ro
+	-v /sys:/hostfs/sys:ro
+	-v /var:/hostfs/var:ro
+	-v /run:/hostfs/run:ro
 	-e HOST_ETC=/hostfs/etc
 	-e HOST_PROC=/hostfs/proc
 	-e HOST_SYS=/hostfs/sys

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,15 +6,16 @@ You will need to setup several volume mounts as well as some environment
 variables:
 ```
 docker run --name telegraf
-	-v /:/hostfs:ro
 	-v /etc:/hostfs/etc:ro
 	-v /proc:/hostfs/proc:ro
 	-v /sys:/hostfs/sys:ro
-	-v /var/run/utmp:/var/run/utmp:ro
+	-v /var:/hostfs/var:ro
+	-v /run:/hostfs/run:ro
 	-e HOST_ETC=/hostfs/etc
 	-e HOST_PROC=/hostfs/proc
 	-e HOST_SYS=/hostfs/sys
-	-e HOST_MOUNT_PREFIX=/hostfs
+	-e HOST_VAR=/hostfs/var
+	-e HOST_RUN=/hostfs/run
 	telegraf
 ```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,16 +6,13 @@ You will need to setup several volume mounts as well as some environment
 variables:
 ```
 docker run --name telegraf
-	-v /etc:/hostfs/etc:ro
-	-v /proc:/hostfs/proc:ro
-	-v /sys:/hostfs/sys:ro
-	-v /var:/hostfs/var:ro
-	-v /run:/hostfs/run:ro
+        -v /:/hostfs:ro
 	-e HOST_ETC=/hostfs/etc
 	-e HOST_PROC=/hostfs/proc
 	-e HOST_SYS=/hostfs/sys
 	-e HOST_VAR=/hostfs/var
 	-e HOST_RUN=/hostfs/run
+	-e HOST_MOUNT_PREFIX=/hostfs
 	telegraf
 ```
 


### PR DESCRIPTION
I found there are five environment variables(HostProc、HostSys、HostEtc、HostVar and HostRun) in gopsutil  which are used by telegraf referencing from https://github.com/shirou/gopsutil/blob/5335e3fd506df4cb63de0a8239c7461d23063be6/internal/common/common.go

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
