### PR TITLE
Build packages with Go 1.13.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ defaults:
       GOFLAGS: -p=8
   go-1_12: &go-1_12
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.12.12'
+      - image: 'quay.io/influxdb/telegraf-ci:1.12.14'
   go-1_13: &go-1_13
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.13.3'
+      - image: 'quay.io/influxdb/telegraf-ci:1.13.5'
 
 version: 2
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Release Notes
 
-- Official packages built with Go 1.13.3.
+- Official packages built with Go 1.13.5.
 - The `prometheus` input and `prometheus_client` output have a new mapping to
   and from Telegraf metrics, which can be enabled by setting `metric_version = 2`.
   The original mapping is deprecated.  When both plugins have the same setting,

--- a/Makefile
+++ b/Makefile
@@ -131,10 +131,10 @@ plugin-%:
 
 .PHONY: ci-1.13
 ci-1.13:
-	docker build -t quay.io/influxdb/telegraf-ci:1.13.3 - < scripts/ci-1.13.docker
-	docker push quay.io/influxdb/telegraf-ci:1.13.3
+	docker build -t quay.io/influxdb/telegraf-ci:1.13.5 - < scripts/ci-1.13.docker
+	docker push quay.io/influxdb/telegraf-ci:1.13.5
 
 .PHONY: ci-1.12
 ci-1.12:
-	docker build -t quay.io/influxdb/telegraf-ci:1.12.12 - < scripts/ci-1.12.docker
-	docker push quay.io/influxdb/telegraf-ci:1.12.12
+	docker build -t quay.io/influxdb/telegraf-ci:1.12.14 - < scripts/ci-1.12.docker
+	docker push quay.io/influxdb/telegraf-ci:1.12.14

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,11 @@ platform: x64
 
 install:
   - IF NOT EXIST "C:\Cache" mkdir C:\Cache
-  - IF NOT EXIST "C:\Cache\go1.13.3.msi" curl -o "C:\Cache\go1.13.3.msi" https://storage.googleapis.com/golang/go1.13.3.windows-amd64.msi
+  - IF NOT EXIST "C:\Cache\go1.13.5.msi" curl -o "C:\Cache\go1.13.5.msi" https://storage.googleapis.com/golang/go1.13.5.windows-amd64.msi
   - IF NOT EXIST "C:\Cache\gnuwin32-bin.zip" curl -o "C:\Cache\gnuwin32-bin.zip" https://dl.influxdata.com/telegraf/ci/make-3.81-bin.zip
   - IF NOT EXIST "C:\Cache\gnuwin32-dep.zip" curl -o "C:\Cache\gnuwin32-dep.zip" https://dl.influxdata.com/telegraf/ci/make-3.81-dep.zip
   - IF EXIST "C:\Go" rmdir /S /Q C:\Go
-  - msiexec.exe /i "C:\Cache\go1.13.3.msi" /quiet
+  - msiexec.exe /i "C:\Cache\go1.13.5.msi" /quiet
   - 7z x "C:\Cache\gnuwin32-bin.zip" -oC:\GnuWin32 -y
   - 7z x "C:\Cache\gnuwin32-dep.zip" -oC:\GnuWin32 -y
   - go get -d github.com/golang/dep

--- a/scripts/ci-1.12.docker
+++ b/scripts/ci-1.12.docker
@@ -1,4 +1,4 @@
-FROM golang:1.12.12
+FROM golang:1.12.14
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/ci-1.13.docker
+++ b/scripts/ci-1.13.docker
@@ -1,4 +1,4 @@
-FROM golang:1.13.3
+FROM golang:1.13.5
 
 RUN chmod -R 755 "$GOPATH"
 


### PR DESCRIPTION
Fix issue on Darwin where binary fails to run with "developer cannot be verified" error.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
