### PR TITLE
Override github.com/satori/go.uuid revision for transitive deps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -81,7 +81,6 @@
   version = "v13.3.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:298712a3ee36b59c3ca91f4183bd75d174d5eaa8b4aed5072831f126e2e752f6"
   name = "github.com/Microsoft/ApplicationInsights-Go"
   packages = [
@@ -90,6 +89,7 @@
   ]
   pruneopts = ""
   revision = "d2df5d440eda5372f24fcac03839a64d6cb5f7e5"
+  version = "v0.4.2"
 
 [[projects]]
   digest = "1:45ec6eb579713a01991ad07f538fed3b576ee55f5ce9f248320152a9270d9258"
@@ -1103,12 +1103,11 @@
   revision = "c4fab1ac1bec58281ad0667dc3f0907a9476ac47"
 
 [[projects]]
-  digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
+  digest = "1:47081c00d00c1dfc9a530c2556e78be391a5c24db1043efe6d406af882a169a1"
   name = "github.com/satori/go.uuid"
   packages = ["."]
   pruneopts = ""
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
+  revision = "b2ce2384e17bbe0c6d34077efa39dbab3e09123b"
 
 [[projects]]
   digest = "1:9024df427b3c8a80a0c4b34e535e5e1ae922c7174e3242b6c7f30ffb3b9f715e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -100,7 +100,7 @@
 
 [[constraint]]
   name = "github.com/Microsoft/ApplicationInsights-Go"
-  branch = "master"
+  version = "0.4.2"
 
 [[constraint]]
   name = "github.com/miekg/dns"
@@ -304,3 +304,7 @@
 [[constraint]]
   name = "github.com/safchain/ethtool"
   revision = "42ed695e3de80b9d695f280295fd7994639f209d"
+
+[[override]]
+  name = "github.com/satori/go.uuid"
+  revision = "b2ce2384e17bbe0c6d34077efa39dbab3e09123b"


### PR DESCRIPTION
This change is being made to reduce confusion around if Telegraf is affected by https://github.com/satori/go.uuid/issues/73.  Neither Telegraf 1.12 or 1.13 are affected by this issue, I have not investigated earlier versions.

Telegraf dropped this library as a direct dependency in 1.13, moving to gofrs.  In Telegraf 1.12, we do use the affected library, but only for random partitioning in the kinesis and kafka outputs where randomness is not a security issue.

This library still exists as a transitive dependency for the Microsoft Application Insights output plugin.  However, they have worked around this bug in their library and we have had the fix since Telegraf 1.8: https://github.com/microsoft/ApplicationInsights-Go/blob/master/appinsights/uuid.go#L14-L21

At first glance it may also appear that the pgx package uses this library, but we are not using the portion of code that includes it.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
