### PR TITLE
unbound: expose unbound-control config file option

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -4590,6 +4590,9 @@
 #   ## The default location of the unbound-control binary can be overridden with:
 #   # binary = "/usr/sbin/unbound-control"
 #
+#   ## The default location of the unbound config file can be overridden with:
+#   # config_file = "/etc/unbound/unbound.conf"
+#
 #   ## The default timeout of 1s can be overriden with:
 #   # timeout = "1s"
 #

--- a/plugins/inputs/unbound/README.md
+++ b/plugins/inputs/unbound/README.md
@@ -18,6 +18,9 @@ a validating, recursive, and caching DNS resolver.
   ## The default location of the unbound-control binary can be overridden with:
   # binary = "/usr/sbin/unbound-control"
 
+  ## The default location of the unbound config file can be overridden with:
+  # config_file = "/etc/unbound/unbound.conf"
+
   ## The default timeout of 1s can be overriden with:
   # timeout = "1s"
 

--- a/plugins/inputs/unbound/unbound.go
+++ b/plugins/inputs/unbound/unbound.go
@@ -17,7 +17,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-type runner func(cmdName string, Timeout internal.Duration, UseSudo bool, Server string, ThreadAsTag bool) (*bytes.Buffer, error)
+type runner func(cmdName string, Timeout internal.Duration, UseSudo bool, Server string, ThreadAsTag bool, ConfigFile string) (*bytes.Buffer, error)
 
 // Unbound is used to store configuration values
 type Unbound struct {
@@ -26,6 +26,7 @@ type Unbound struct {
 	UseSudo     bool
 	Server      string
 	ThreadAsTag bool
+	ConfigFile  string
 
 	filter filter.Filter
 	run    runner
@@ -44,6 +45,9 @@ var sampleConfig = `
 
   ## The default location of the unbound-control binary can be overridden with:
   # binary = "/usr/sbin/unbound-control"
+
+  ## The default location of the unbound config file can be overridden with:
+  # config_file = "/etc/unbound/unbound.conf"
 
   ## The default timeout of 1s can be overriden with:
   # timeout = "1s"
@@ -67,7 +71,7 @@ func (s *Unbound) SampleConfig() string {
 }
 
 // Shell out to unbound_stat and return the output
-func unboundRunner(cmdName string, Timeout internal.Duration, UseSudo bool, Server string, ThreadAsTag bool) (*bytes.Buffer, error) {
+func unboundRunner(cmdName string, Timeout internal.Duration, UseSudo bool, Server string, ThreadAsTag bool, ConfigFile string) (*bytes.Buffer, error) {
 	cmdArgs := []string{"stats_noreset"}
 
 	if Server != "" {
@@ -94,6 +98,10 @@ func unboundRunner(cmdName string, Timeout internal.Duration, UseSudo bool, Serv
 		}
 
 		cmdArgs = append([]string{"-s", server}, cmdArgs...)
+	}
+
+	if ConfigFile != "" {
+		cmdArgs = append([]string{"-c", ConfigFile}, cmdArgs...)
 	}
 
 	cmd := exec.Command(cmdName, cmdArgs...)
@@ -125,7 +133,7 @@ func (s *Unbound) Gather(acc telegraf.Accumulator) error {
 		return err
 	}
 
-	out, err := s.run(s.Binary, s.Timeout, s.UseSudo, s.Server, s.ThreadAsTag)
+	out, err := s.run(s.Binary, s.Timeout, s.UseSudo, s.Server, s.ThreadAsTag, s.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("error gathering metrics: %s", err)
 	}
@@ -207,6 +215,7 @@ func init() {
 			UseSudo:     false,
 			Server:      "",
 			ThreadAsTag: false,
+			ConfigFile:  "",
 		}
 	})
 }

--- a/plugins/inputs/unbound/unbound_test.go
+++ b/plugins/inputs/unbound/unbound_test.go
@@ -12,8 +12,8 @@ import (
 
 var TestTimeout = internal.Duration{Duration: time.Second}
 
-func UnboundControl(output string, Timeout internal.Duration, useSudo bool, Server string, ThreadAsTag bool) func(string, internal.Duration, bool, string, bool) (*bytes.Buffer, error) {
-	return func(string, internal.Duration, bool, string, bool) (*bytes.Buffer, error) {
+func UnboundControl(output string, Timeout internal.Duration, useSudo bool, Server string, ThreadAsTag bool, ConfigFile string) func(string, internal.Duration, bool, string, bool, string) (*bytes.Buffer, error) {
+	return func(string, internal.Duration, bool, string, bool, string) (*bytes.Buffer, error) {
 		return bytes.NewBuffer([]byte(output)), nil
 	}
 }
@@ -21,7 +21,7 @@ func UnboundControl(output string, Timeout internal.Duration, useSudo bool, Serv
 func TestParseFullOutput(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Unbound{
-		run: UnboundControl(fullOutput, TestTimeout, true, "", false),
+		run: UnboundControl(fullOutput, TestTimeout, true, "", false, ""),
 	}
 	err := v.Gather(acc)
 
@@ -38,7 +38,7 @@ func TestParseFullOutput(t *testing.T) {
 func TestParseFullOutputThreadAsTag(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Unbound{
-		run:         UnboundControl(fullOutput, TestTimeout, true, "", true),
+		run:         UnboundControl(fullOutput, TestTimeout, true, "", true, ""),
 		ThreadAsTag: true,
 	}
 	err := v.Gather(acc)


### PR DESCRIPTION
This PR exposes the [-c cfgfile option of unbound-control](https://linux.die.net/man/8/unbound-control) allowing Telegraf users to monitor non-default unbound setups.
Unbounds default location `/etc/unbound/unbound.conf` is set as Telegraf default.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
