### PR TITLE
csv: TrimLeadingSpace when TrimSpace is on

### DIFF
--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -45,6 +45,7 @@ func (p *Parser) compile(r *bytes.Reader) (*csv.Reader, error) {
 	if p.Comment != "" {
 		csvReader.Comment = []rune(p.Comment)[0]
 	}
+	csvReader.TrimLeadingSpace = p.TrimSpace
 	return csvReader, nil
 }
 

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -243,6 +243,30 @@ func TestTrimSpace(t *testing.T) {
 	require.Equal(t, expectedFields, metrics[0].Fields())
 }
 
+func TestTrimSpaceDelimetedBySpace(t *testing.T) {
+	p := Parser{
+		Delimiter:      " ",
+		HeaderRowCount: 1,
+		TrimSpace:      true,
+		TimeFunc:       DefaultTime,
+	}
+	testCSV := `   first   second   third   fourth
+abcdefgh        0       2    false
+  abcdef      3.3       4     true
+       f        0       2    false`
+
+	expectedFields := map[string]interface{}{
+		"first":  "abcdef",
+		"second": 3.3,
+		"third":  int64(4),
+		"fourth": true,
+	}
+
+	metrics, err := p.Parse([]byte(testCSV))
+	require.NoError(t, err)
+	require.Equal(t, expectedFields, metrics[1].Fields())
+}
+
 func TestSkipRows(t *testing.T) {
 	p := Parser{
 		HeaderRowCount:    1,


### PR DESCRIPTION
When TrimSpace is used and Delimeter is a space, it trips up the CSV reader otherwise.

Visual representation of now-supported format:
```
   first   second   third   fourth
abcdefgh        0       2    false
  abcdef      3.3       4     true
       f        0       2    false
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
