### PR TITLE
Use actual database name in db creation failed log

### DIFF
--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -278,7 +278,7 @@ func (i *InfluxDB) httpClient(ctx context.Context, url *url.URL, proxy *url.URL)
 		err = c.CreateDatabase(ctx, c.Database())
 		if err != nil {
 			i.Log.Warnf("When writing to [%s]: database %q creation failed: %v",
-				c.URL(), i.Database, err)
+				c.URL(), c.Database(), err)
 		}
 	}
 


### PR DESCRIPTION
Use the effective database name instead of the name from the configuration file.  These are only different when using the default "telegraf" database.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
