### PR TITLE
Replace colon chars in prometheus output labels with metric_version=1

### DIFF
--- a/plugins/outputs/prometheus_client/prometheus_client_v1_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v1_test.go
@@ -106,6 +106,34 @@ cpu_time_idle{host="example.org"} 42
 `),
 		},
 		{
+			name: "replace characters when using string as label",
+			output: &PrometheusClient{
+				Listen:            ":0",
+				MetricVersion:     1,
+				CollectorsExclude: []string{"gocollector", "process"},
+				Path:              "/metrics",
+				StringAsLabel:     true,
+				Log:               Logger,
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu_time_idle",
+					map[string]string{},
+					map[string]interface{}{
+						"host:name": "example.org",
+						"counter":   42.0,
+					},
+					time.Unix(0, 0),
+					telegraf.Counter,
+				),
+			},
+			expected: []byte(`
+# HELP cpu_time_idle Telegraf collected metric
+# TYPE cpu_time_idle counter
+cpu_time_idle{host_name="example.org"} 42
+`),
+		},
+		{
 			name: "prometheus gauge",
 			output: &PrometheusClient{
 				Listen:            ":0",

--- a/plugins/outputs/prometheus_client/v1/collector.go
+++ b/plugins/outputs/prometheus_client/v1/collector.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
+	serializer "github.com/influxdata/telegraf/plugins/serializers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -201,11 +202,11 @@ func (c *Collector) Add(metrics []telegraf.Metric) error {
 
 		labels := make(map[string]string)
 		for k, v := range tags {
-			tName := sanitize(k)
-			if !isValidTagName(tName) {
+			name, ok := serializer.SanitizeLabelName(k)
+			if !ok {
 				continue
 			}
-			labels[tName] = v
+			labels[name] = v
 		}
 
 		// Prometheus doesn't have a string value type, so convert string
@@ -214,11 +215,11 @@ func (c *Collector) Add(metrics []telegraf.Metric) error {
 			for fn, fv := range point.Fields() {
 				switch fv := fv.(type) {
 				case string:
-					tName := sanitize(fn)
-					if !isValidTagName(tName) {
+					name, ok := serializer.SanitizeLabelName(fn)
+					if !ok {
 						continue
 					}
-					labels[tName] = fv
+					labels[name] = fv
 				}
 			}
 		}

--- a/plugins/serializers/prometheus/prometheus_test.go
+++ b/plugins/serializers/prometheus/prometheus_test.go
@@ -553,6 +553,28 @@ cpu_time_idle{cpu="cpu0"} 42
 `),
 		},
 		{
+			name: "replace characters when using string as label",
+			config: FormatConfig{
+				StringHandling: StringAsLabel,
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"host:name": "example.org",
+						"time_idle": 42.0,
+					},
+					time.Unix(1574279268, 0),
+				),
+			},
+			expected: []byte(`
+# HELP cpu_time_idle Telegraf collected metric
+# TYPE cpu_time_idle untyped
+cpu_time_idle{host_name="example.org"} 42
+`),
+		},
+		{
 			name: "multiple fields grouping",
 			metrics: []telegraf.Metric{
 				testutil.MustMetric(


### PR DESCRIPTION
Replace `:` with `_` in label names when using `metric_version = 1`.  Version 2 already did this correctly.

closes #6757

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
