### PR TITLE
add database name in azure Managed instance. query version 2 is worki…

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -508,10 +508,11 @@ INSERT	INTO @PCounters
 SELECT	DISTINCT
 		RTrim(spi.object_name) object_name,
 		RTrim(spi.counter_name) counter_name,
-		RTrim(spi.instance_name) instance_name,
+		RTrim(isnull(d.name,spi.instance_name) instance_name,
 		CAST(spi.cntr_value AS BIGINT) AS cntr_value,
 		spi.cntr_type
-FROM	sys.dm_os_performance_counters AS spi
+FROM	sys.dm_os_performance_counters AS spi 
+LEFT OUTER JOIN sys.databases AS d ON spi.instance_name = d.physical_database_name
 WHERE	(
 			counter_name IN (
 				'SQL Compilations/sec',


### PR DESCRIPTION
…ng Vm sqlserver instacnes but not in Manged instances, it returned Guid.

INSERT	INTO @PCounters
SELECT	DISTINCT
		RTrim(spi.object_name) object_name,
		RTrim(spi.counter_name) counter_name,
		RTrim(isnull(d.name,spi.instance_name) instance_name,
		CAST(spi.cntr_value AS BIGINT) AS cntr_value,
		spi.cntr_type
FROM	sys.dm_os_performance_counters AS spi 
LEFT OUTER JOIN sys.databases AS d ON spi.instance_name = d.physical_database_name

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
