### PR TITLE
MySQL - Option for collecting global variables

### DIFF
--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -69,6 +69,9 @@ This plugin gathers the statistic data from MySQL server
   ## gather metrics from SHOW BINARY LOGS command output
   # gather_binary_logs = false
 
+  ## gather metrics from SHOW GLOBAL VARIABLES command output
+  # gather_global_variables = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.TABLE_IO_WAITS_SUMMARY_BY_TABLE
   # gather_table_io_waits = false
 

--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -70,7 +70,7 @@ This plugin gathers the statistic data from MySQL server
   # gather_binary_logs = false
 
   ## gather metrics from SHOW GLOBAL VARIABLES command output
-  # gather_global_variables = false
+  # gather_global_variables = true
 
   ## gather metrics from PERFORMANCE_SCHEMA.TABLE_IO_WAITS_SUMMARY_BY_TABLE
   # gather_table_io_waits = false

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -95,6 +95,9 @@ const sampleConfig = `
   ## gather metrics from SHOW BINARY LOGS command output
   # gather_binary_logs = false
 
+  ## gather metrics from PERFORMANCE_SCHEMA.GLOBAL_VARIABLES
+  # gather_global_variables = false
+
   ## gather metrics from PERFORMANCE_SCHEMA.TABLE_IO_WAITS_SUMMARY_BY_TABLE
   # gather_table_io_waits = false
 

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -96,7 +96,7 @@ const sampleConfig = `
   # gather_binary_logs = false
 
   ## gather metrics from PERFORMANCE_SCHEMA.GLOBAL_VARIABLES
-  # gather_global_variables = false
+  # gather_global_variables = true
 
   ## gather metrics from PERFORMANCE_SCHEMA.TABLE_IO_WAITS_SUMMARY_BY_TABLE
   # gather_table_io_waits = false
@@ -138,6 +138,7 @@ const (
 	defaultPerfEventsStatementsDigestTextLimit = 120
 	defaultPerfEventsStatementsLimit           = 250
 	defaultPerfEventsStatementsTimeLimit       = 86400
+	defaultGatherGlobalVars                    = true
 )
 
 func (m *Mysql) SampleConfig() string {
@@ -1773,6 +1774,7 @@ func init() {
 			PerfEventsStatementsDigestTextLimit: defaultPerfEventsStatementsDigestTextLimit,
 			PerfEventsStatementsLimit:           defaultPerfEventsStatementsLimit,
 			PerfEventsStatementsTimeLimit:       defaultPerfEventsStatementsTimeLimit,
+			GatherGlobalVars:                    defaultGatherGlobalVars,
 		}
 	})
 }

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -444,7 +444,7 @@ func (m *Mysql) gatherServer(serv string, acc telegraf.Accumulator) error {
 			}
 		}
 	}
-	
+
 	if m.GatherBinaryLogs {
 		err = m.gatherBinaryLogs(db, serv, acc)
 		if err != nil {


### PR DESCRIPTION
This PR addresses Issue #6789 

There should be a config value that allows for enabling/disabling collection of MySQL Global Variables.

- Readme: Added line for boolean config for collecting global vars
- mysql.go: added line to retrieve  config value
- mysql.go: added logic to either collect or not collect vars based on config

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
