### PR TITLE
Added missing HTTP basic auth credentials for stats endpoint

### DIFF
--- a/plugins/inputs/haproxy/README.md
+++ b/plugins/inputs/haproxy/README.md
@@ -15,6 +15,10 @@ or [HTTP statistics page](https://cbonte.github.io/haproxy-dconv/1.9/management.
   ## Make sure you specify the complete path to the stats endpoint
   ## including the protocol, ie http://10.10.3.33:1936/haproxy?stats
 
+  ## Credentials for basic HTTP authentication
+  # username = "admin"
+  # password = "admin"
+
   ## If no servers are specified, then default to 127.0.0.1:1936/haproxy?stats
   servers = ["http://myhaproxy.com:1936/haproxy?stats"]
 


### PR DESCRIPTION
Added missing HTTP basic auth credentials for HAProxy stats endpoint in README.md for HAProxy input plugin

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x ] Associated README.md updated.
- [ ] Has appropriate unit tests. Doc update not applicable
