### PR TITLE
Fix off by one bug in snmp trap v1 generic trap field

### DIFF
--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -171,7 +171,7 @@ func makeTrapHandler(s *SnmpTrap) handler {
 			// translate a v1 trap to v2.
 			var trapOid string
 
-			if packet.GenericTrap > 0 && packet.GenericTrap < 6 {
+			if packet.GenericTrap >= 0 && packet.GenericTrap < 6 {
 				trapOid = "1.3.6.1.6.3.1.1.5." + strconv.Itoa(packet.GenericTrap+1)
 			} else if packet.GenericTrap == 6 {
 				trapOid = packet.Enterprise + ".0." + strconv.Itoa(packet.SpecificTrap)


### PR DESCRIPTION
- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

I tested this with a coldStart trap from net-snmp.  ColdStart is packet.GenericTrap == 0.