### PR TITLE
Added readable Database Names in SQL Managed Instance #6570

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -504,9 +504,7 @@ DECLARE @PCounters TABLE
     cntr_type INT,
     Primary Key(object_name, counter_name, instance_name)
 );
-
 DECLARE @SQL NVARCHAR(MAX)
-
 IF SERVERPROPERTY('EngineEdition') = 8
 SET @SQL = '
 SELECT  DISTINCT
@@ -532,7 +530,6 @@ SELECT  DISTINCT
         spi.cntr_type
 FROM    sys.dm_os_performance_counters AS spi
 '
-
 SET  @SQL = @SQL + '
 WHERE   (
             counter_name IN (
@@ -666,23 +663,23 @@ UNPIVOT (
 INSERT INTO @PCounters
 EXEC( @SQL )
 
-SELECT  'sqlserver_performance' AS [measurement],
-        REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
-        DB_NAME() as [database_name],
-        pc.object_name AS [object],
-        pc.counter_name AS [counter],
-        CASE pc.instance_name WHEN '_Total' THEN 'Total' ELSE ISNULL(pc.instance_name,'') END AS [instance],
-        CAST(CASE WHEN pc.cntr_type = 537003264 AND pc1.cntr_value > 0 THEN (pc.cntr_value * 1.0) / (pc1.cntr_value * 1.0) * 100 ELSE pc.cntr_value END AS float(10)) AS [value]
-FROM    @PCounters AS pc
-        LEFT OUTER JOIN @PCounters AS pc1
-            ON (
-                pc.counter_name = REPLACE(pc1.counter_name,' base','')
-                OR pc.counter_name = REPLACE(pc1.counter_name,' base',' (ms)')
-            )
-            AND pc.object_name = pc1.object_name
-            AND pc.instance_name = pc1.instance_name
-            AND pc1.counter_name LIKE '%base'
-WHERE   pc.counter_name NOT LIKE '% base'
+SELECT	'sqlserver_performance' AS [measurement],
+		REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+		DB_NAME() as [database_name],
+		pc.object_name AS [object],
+		pc.counter_name AS [counter],
+		CASE pc.instance_name WHEN '_Total' THEN 'Total' ELSE ISNULL(pc.instance_name,'') END AS [instance],
+		CAST(CASE WHEN pc.cntr_type = 537003264 AND pc1.cntr_value > 0 THEN (pc.cntr_value * 1.0) / (pc1.cntr_value * 1.0) * 100 ELSE pc.cntr_value END AS float(10)) AS [value]
+FROM	@PCounters AS pc
+		LEFT OUTER JOIN @PCounters AS pc1
+			ON (
+				pc.counter_name = REPLACE(pc1.counter_name,' base','')
+				OR pc.counter_name = REPLACE(pc1.counter_name,' base',' (ms)')
+			)
+			AND pc.object_name = pc1.object_name
+			AND pc.instance_name = pc1.instance_name
+			AND pc1.counter_name LIKE '%base'
+WHERE	pc.counter_name NOT LIKE '% base'
 OPTION(RECOMPILE);
 `
 

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -497,120 +497,145 @@ from sys.dm_os_schedulers
 const sqlPerformanceCountersV2 string = `SET DEADLOCK_PRIORITY -10;
 DECLARE @PCounters TABLE
 (
-	object_name nvarchar(128),
-	counter_name nvarchar(128),
-	instance_name nvarchar(128),
-	cntr_value bigint,
-	cntr_type INT,
-	Primary Key(object_name, counter_name, instance_name)
+    object_name nvarchar(128),
+    counter_name nvarchar(128),
+    instance_name nvarchar(128),
+    cntr_value bigint,
+    cntr_type INT,
+    Primary Key(object_name, counter_name, instance_name)
 );
-INSERT	INTO @PCounters
-SELECT	DISTINCT
-		RTrim(spi.object_name) object_name,
-		RTrim(spi.counter_name) counter_name,
-		RTrim(spi.instance_name) instance_name,
-		CAST(spi.cntr_value AS BIGINT) AS cntr_value,
-		spi.cntr_type
-FROM	sys.dm_os_performance_counters AS spi
-WHERE	(
-			counter_name IN (
-				'SQL Compilations/sec',
-				'SQL Re-Compilations/sec',
-				'User Connections',
-				'Batch Requests/sec',
-				'Logouts/sec',
-				'Logins/sec',
-				'Processes blocked',
-				'Latch Waits/sec',
-				'Full Scans/sec',
-				'Index Searches/sec',
-				'Page Splits/sec',
-				'Page Lookups/sec',
-				'Page Reads/sec',
-				'Page Writes/sec',
-				'Readahead Pages/sec',
-				'Lazy Writes/sec',
-				'Checkpoint Pages/sec',
-				'Page life expectancy',
-				'Log File(s) Size (KB)',
-				'Log File(s) Used Size (KB)',
-				'Data File(s) Size (KB)',
-				'Transactions/sec',
-				'Write Transactions/sec',
-				'Active Temp Tables',
-				'Temp Tables Creation Rate',
-				'Temp Tables For Destruction',
-				'Free Space in tempdb (KB)',
-				'Version Store Size (KB)',
-				'Memory Grants Pending',
-				'Memory Grants Outstanding',
-				'Free list stalls/sec',
-				'Buffer cache hit ratio',
-				'Buffer cache hit ratio base',
-				'Backup/Restore Throughput/sec',
-				'Total Server Memory (KB)',
-				'Target Server Memory (KB)',
-				'Log Flushes/sec',
-				'Log Flush Wait Time',
-				'Memory broker clerk size',
-				'Log Bytes Flushed/sec',
-				'Bytes Sent to Replica/sec',
-				'Log Send Queue',
-				'Bytes Sent to Transport/sec',
-				'Sends to Replica/sec',
-				'Bytes Sent to Transport/sec',
-				'Sends to Transport/sec',
-				'Bytes Received from Replica/sec',
-				'Receives from Replica/sec',
-				'Flow Control Time (ms/sec)',
-				'Flow Control/sec',
-				'Resent Messages/sec',
-				'Redone Bytes/sec',
-				'XTP Memory Used (KB)',
-				'Transaction Delay',
-				'Log Bytes Received/sec',
-				'Log Apply Pending Queue',
-				'Redone Bytes/sec',
-				'Recovery Queue',
-				'Log Apply Ready Queue',
-				'CPU usage %',
-				'CPU usage % base',
-				'Queued requests',
-				'Requests completed/sec',
-				'Blocked tasks',
-				'Active memory grant amount (KB)',
-				'Disk Read Bytes/sec',
-				'Disk Read IO Throttled/sec',
-				'Disk Read IO/sec',
-				'Disk Write Bytes/sec',
-				'Disk Write IO Throttled/sec',
-				'Disk Write IO/sec',
-				'Used memory (KB)',
-				'Forwarded Records/sec',
-				'Background Writer pages/sec',
-				'Percent Log Used',
-				'Log Send Queue KB',
-				'Redo Queue KB',
-				'Mirrored Write Transactions/sec',
-				'Group Commit Time',
-				'Group Commits/sec'
-			)
-		) OR (
-			object_name LIKE '%User Settable%'
-			OR object_name LIKE '%SQL Errors%'
-		) OR (
-			object_name LIKE 'SQLServer:Batch Resp Statistics%'
-		) OR (
-			instance_name IN ('_Total')
-			AND counter_name IN (
-				'Lock Timeouts/sec',
-				'Number of Deadlocks/sec',
-				'Lock Waits/sec',
-				'Latch Waits/sec'
-			)
-		)
 
 DECLARE @SQL NVARCHAR(MAX)
+
+IF SERVERPROPERTY('EngineEdition') = 8
+SET @SQL = '
+SELECT  DISTINCT
+        RTrim(spi.object_name) object_name,
+        RTrim(spi.counter_name) counter_name,
+		CASE WHEN d.name is null  or d.database_id <=4 THEN
+			RTrim(spi.instance_name)
+		ELSE
+			d.name
+		END instance_name,
+        CAST(spi.cntr_value AS BIGINT) AS cntr_value,
+        spi.cntr_type
+FROM    sys.dm_os_performance_counters AS spi
+LEFT JOIN sys.databases AS d on spi.instance_name=d.physical_database_name
+'
+ELSE
+SET @SQL = '
+SELECT  DISTINCT
+        RTrim(spi.object_name) object_name,
+        RTrim(spi.counter_name) counter_name,		
+		RTrim(spi.instance_name) instance_name,
+        CAST(spi.cntr_value AS BIGINT) AS cntr_value,
+        spi.cntr_type
+FROM    sys.dm_os_performance_counters AS spi
+'
+
+SET  @SQL = @SQL + '
+WHERE   (
+            counter_name IN (
+                ''SQL Compilations/sec'',
+                ''SQL Re-Compilations/sec'',
+                ''User Connections'',
+                ''Batch Requests/sec'',
+                ''Logouts/sec'',
+                ''Logins/sec'',
+                ''Processes blocked'',
+                ''Latch Waits/sec'',
+                ''Full Scans/sec'',
+                ''Index Searches/sec'',
+                ''Page Splits/sec'',
+                ''Page Lookups/sec'',
+                ''Page Reads/sec'',
+                ''Page Writes/sec'',
+                ''Readahead Pages/sec'',
+                ''Lazy Writes/sec'',
+                ''Checkpoint Pages/sec'',
+                ''Page life expectancy'',
+                ''Log File(s) Size (KB)'',
+                ''Log File(s) Used Size (KB)'',
+                ''Data File(s) Size (KB)'',
+                ''Transactions/sec'',
+                ''Write Transactions/sec'',
+                ''Active Temp Tables'',
+                ''Temp Tables Creation Rate'',
+                ''Temp Tables For Destruction'',
+                ''Free Space in tempdb (KB)'',
+                ''Version Store Size (KB)'',
+                ''Memory Grants Pending'',
+                ''Memory Grants Outstanding'',
+                ''Free list stalls/sec'',
+                ''Buffer cache hit ratio'',
+                ''Buffer cache hit ratio base'',
+                ''Backup/Restore Throughput/sec'',
+                ''Total Server Memory (KB)'',
+                ''Target Server Memory (KB)'',
+                ''Log Flushes/sec'',
+                ''Log Flush Wait Time'',
+                ''Memory broker clerk size'',
+                ''Log Bytes Flushed/sec'',
+                ''Bytes Sent to Replica/sec'',
+                ''Log Send Queue'',
+                ''Bytes Sent to Transport/sec'',
+                ''Sends to Replica/sec'',
+                ''Bytes Sent to Transport/sec'',
+                ''Sends to Transport/sec'',
+                ''Bytes Received from Replica/sec'',
+                ''Receives from Replica/sec'',
+                ''Flow Control Time (ms/sec)'',
+                ''Flow Control/sec'',
+                ''Resent Messages/sec'',
+                ''Redone Bytes/sec'',
+                ''XTP Memory Used (KB)'',
+                ''Transaction Delay'',
+                ''Log Bytes Received/sec'',
+                ''Log Apply Pending Queue'',
+                ''Redone Bytes/sec'',
+                ''Recovery Queue'',
+                ''Log Apply Ready Queue'',
+                ''CPU usage %'',
+                ''CPU usage % base'',
+                ''Queued requests'',
+                ''Requests completed/sec'',
+                ''Blocked tasks'',
+                ''Active memory grant amount (KB)'',
+                ''Disk Read Bytes/sec'',
+                ''Disk Read IO Throttled/sec'',
+                ''Disk Read IO/sec'',
+                ''Disk Write Bytes/sec'',
+                ''Disk Write IO Throttled/sec'',
+                ''Disk Write IO/sec'',
+                ''Used memory (KB)'',
+                ''Forwarded Records/sec'',
+                ''Background Writer pages/sec'',
+                ''Percent Log Used'',
+                ''Log Send Queue KB'',
+                ''Redo Queue KB'',
+                ''Mirrored Write Transactions/sec'',
+                ''Group Commit Time'',
+                ''Group Commits/sec''
+            )
+        ) OR (
+            object_name LIKE ''%User Settable%''
+            OR object_name LIKE ''%SQL Errors%''
+        ) OR (
+            object_name LIKE ''SQLServer:Batch Resp Statistics%''
+        ) OR (
+            instance_name IN (''_Total'')
+            AND counter_name IN (
+                ''Lock Timeouts/sec'',
+                ''Number of Deadlocks/sec'',
+                ''Lock Waits/sec'',
+                ''Latch Waits/sec''
+            )
+        )
+'
+
+INSERT  INTO @PCounters
+EXEC( @SQL )
+
 SET  @SQL = REPLACE('SELECT
 "SQLServer:Workload Group Stats" AS object,
 counter,
@@ -641,23 +666,23 @@ UNPIVOT (
 INSERT INTO @PCounters
 EXEC( @SQL )
 
-SELECT	'sqlserver_performance' AS [measurement],
-		REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
-		DB_NAME() as [database_name],
-		pc.object_name AS [object],
-		pc.counter_name AS [counter],
-		CASE pc.instance_name WHEN '_Total' THEN 'Total' ELSE ISNULL(pc.instance_name,'') END AS [instance],
-		CAST(CASE WHEN pc.cntr_type = 537003264 AND pc1.cntr_value > 0 THEN (pc.cntr_value * 1.0) / (pc1.cntr_value * 1.0) * 100 ELSE pc.cntr_value END AS float(10)) AS [value]
-FROM	@PCounters AS pc
-		LEFT OUTER JOIN @PCounters AS pc1
-			ON (
-				pc.counter_name = REPLACE(pc1.counter_name,' base','')
-				OR pc.counter_name = REPLACE(pc1.counter_name,' base',' (ms)')
-			)
-			AND pc.object_name = pc1.object_name
-			AND pc.instance_name = pc1.instance_name
-			AND pc1.counter_name LIKE '%base'
-WHERE	pc.counter_name NOT LIKE '% base'
+SELECT  'sqlserver_performance' AS [measurement],
+        REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+        DB_NAME() as [database_name],
+        pc.object_name AS [object],
+        pc.counter_name AS [counter],
+        CASE pc.instance_name WHEN '_Total' THEN 'Total' ELSE ISNULL(pc.instance_name,'') END AS [instance],
+        CAST(CASE WHEN pc.cntr_type = 537003264 AND pc1.cntr_value > 0 THEN (pc.cntr_value * 1.0) / (pc1.cntr_value * 1.0) * 100 ELSE pc.cntr_value END AS float(10)) AS [value]
+FROM    @PCounters AS pc
+        LEFT OUTER JOIN @PCounters AS pc1
+            ON (
+                pc.counter_name = REPLACE(pc1.counter_name,' base','')
+                OR pc.counter_name = REPLACE(pc1.counter_name,' base',' (ms)')
+            )
+            AND pc.object_name = pc1.object_name
+            AND pc.instance_name = pc1.instance_name
+            AND pc1.counter_name LIKE '%base'
+WHERE   pc.counter_name NOT LIKE '% base'
 OPTION(RECOMPILE);
 `
 


### PR DESCRIPTION
Added readable database names in SQL Managed Instance when pulling stats from sys.os_performance_counters. 

Using dynamic SQL as column physical_database_name does not exist in earlier versions of SQL Server, also only replaced user database names as replacing system database names was creating duplicate entries conflicting with primary key in table variable. 

Tested on SQL MI, SQL 2016 and SQL 2012. 

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
