### PR TITLE
Sort alphabetically plugin lists

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -327,14 +328,24 @@ func main() {
 	// switch for flags which just do something and exit immediately
 	switch {
 	case *fOutputList:
-		fmt.Println("Available Output Plugins:")
+		fmt.Println("Available Output Plugins: ")
+		names := make([]string, 0, len(outputs.Outputs))
 		for k := range outputs.Outputs {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, k := range names {
 			fmt.Printf("  %s\n", k)
 		}
 		return
 	case *fInputList:
 		fmt.Println("Available Input Plugins:")
+		names := make([]string, 0, len(inputs.Inputs))
 		for k := range inputs.Inputs {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, k := range names {
 			fmt.Printf("  %s\n", k)
 		}
 		return


### PR DESCRIPTION
With tens of ouputs of plugins, and hundreds of input plugins, I struggled to easily read the needed plugin, so I though about sorting them alphabetically.
It can be useful to every user, instead of using grep to look for the needed plugin.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/) - signed
- [ ] Associated README.md updated - no relavant readme ( --help maybe?) 
- [ ] Has appropriate unit tests. - no test possible
