### PR TITLE
Openweathermap doesnt use /data/2.5/group, /data/2.5/weather is used …

### DIFF
--- a/plugins/inputs/openweathermap/openweathermap.go
+++ b/plugins/inputs/openweathermap/openweathermap.go
@@ -111,7 +111,7 @@ func (n *OpenWeatherMap) Gather(acc telegraf.Accumulator) error {
 				}
 				cities := strings.Join(strs, ",")
 
-				addr := n.formatURL("/data/2.5/group", cities)
+				addr := n.formatURL("/data/2.5/weather", cities)
 				wg.Add(1)
 				go func() {
 					defer wg.Done()


### PR DESCRIPTION
Here is a link to the docs where the correct api endpoint is specfied:

https://openweathermap.org/current

### Required for all PRs:

- [y] Signed [CLA](https://influxdata.com/community/cla/).
- [na] Associated README.md updated.
- [na] Has appropriate unit tests.
