### PR TITLE
Fixes for two pgbouncer issues. 

### DIFF
--- a/plugins/inputs/pgbouncer/pgbouncer.go
+++ b/plugins/inputs/pgbouncer/pgbouncer.go
@@ -2,6 +2,7 @@ package pgbouncer
 
 import (
 	"bytes"
+	"strconv"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
@@ -70,10 +71,16 @@ func (p *PgBouncer) Gather(acc telegraf.Accumulator) error {
 		for col, val := range columnMap {
 			_, ignore := ignoredColumns[col]
 			if !ignore {
-				fields[col] = *val
+				// these values are returned by pgbouncer as strings, which we need to convert.
+				fields[col], _ = strconv.ParseUint((*val).(string), 10, 64)
 			}
 		}
 		acc.AddFields("pgbouncer", fields, tags)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return err
 	}
 
 	query = `SHOW POOLS`

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -122,6 +122,13 @@ func (p *Service) Start(telegraf.Accumulator) (err error) {
 						Name:  "int8OID",
 						OID:   pgtype.Int8OID,
 					})
+					// Newer versions of pgbouncer need this defined. See the discussion here:
+					// https://github.com/jackc/pgx/issues/649
+					info.RegisterDataType(pgtype.DataType{
+						Value: &pgtype.OIDValue{},
+						Name:  "numericOID",
+						OID:   pgtype.NumericOID,
+					})
 
 					return info, nil
 				},


### PR DESCRIPTION
The pgbouncer input plugin was not checking for errors from the 'SHOW POOLS' query. For at least newer versions of pgbouncer, this query was failing, silently, causing none of those values to be recorded. The second issue was the cause of that query failing. For whatever reason, we need to register pgtype.NumericOID because pgbouncer is now sending data with that. See https://github.com/jackc/pgx/issues/649 for a discussion about this.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
