### PR TITLE
Config fields for prometheus serializer missing at serializer config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1988,6 +1988,42 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 		}
 	}
 
+	if node, ok := tbl.Fields["prometheus_export_timestamp"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if b, ok := kv.Value.(*ast.Boolean); ok {
+				var err error
+				c.PrometheusExportTimestamp, err = b.Boolean()
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	if node, ok := tbl.Fields["prometheus_sort_metrics"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if b, ok := kv.Value.(*ast.Boolean); ok {
+				var err error
+				c.PrometheusSortMetrics, err = b.Boolean()
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	if node, ok := tbl.Fields["prometheus_string_as_label"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if b, ok := kv.Value.(*ast.Boolean); ok {
+				var err error
+				c.PrometheusStringAsLabel, err = b.Boolean()
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
 	delete(tbl.Fields, "influx_max_line_bytes")
 	delete(tbl.Fields, "influx_sort_fields")
 	delete(tbl.Fields, "influx_uint_support")
@@ -2000,6 +2036,9 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 	delete(tbl.Fields, "splunkmetric_multimetric")
 	delete(tbl.Fields, "wavefront_source_override")
 	delete(tbl.Fields, "wavefront_use_strict")
+	delete(tbl.Fields, "prometheus_export_timestamp")
+	delete(tbl.Fields, "prometheus_sort_metrics")
+	delete(tbl.Fields, "prometheus_string_as_label")
 	return serializers.NewSerializer(c)
 }
 


### PR DESCRIPTION
New 1.13 prometheus serializer includes configuration fields that are not included in the serializer configs.  Adding these parameters enable telegraf to prometheus http push gateway to work.

closes #6823

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [n/a] Associated README.md updated.
- [n/a] Has appropriate unit tests.
