### PR TITLE
Added source and port tags in jenkins_job metrics

### DIFF
--- a/plugins/inputs/jenkins/README.md
+++ b/plugins/inputs/jenkins/README.md
@@ -60,14 +60,15 @@ This plugin does not require a plugin on jenkins and it makes use of Jenkins API
     - node_name
     - status ("online", "offline")
     - source
+    - port
   - fields:
-    - disk_available
-    - temp_available
-    - memory_available
-    - memory_total
-    - swap_available
-    - swap_total
-    - response_time
+    - disk_available (Bytes)
+    - temp_available (Bytes)
+    - memory_available (Bytes)
+    - memory_total (Bytes)
+    - swap_available (Bytes)
+    - swap_total (Bytes)
+    - response_time (ms)
     - num_executors
 
 - jenkins_job
@@ -76,8 +77,9 @@ This plugin does not require a plugin on jenkins and it makes use of Jenkins API
     - parents
     - result
     - source
+    - port
   - fields:
-    - duration
+    - duration (ms)
     - result_code (0 = SUCCESS, 1 = FAILURE, 2 = NOT_BUILD, 3 = UNSTABLE, 4 = ABORTED)
 
 ### Sample Queries:
@@ -94,7 +96,8 @@ SELECT mean("duration") AS "mean_duration" FROM "jenkins_job" WHERE time > now()
 
 ```
 $ ./telegraf --config telegraf.conf --input-filter jenkins --test
-jenkins_node,arch=Linux\ (amd64),disk_path=/var/jenkins_home,temp_path=/tmp,host=myhost,node_name=master swap_total=4294963200,memory_available=586711040,memory_total=6089498624,status=online,response_time=1000i,disk_available=152392036352,temp_available=152392036352,swap_available=3503263744 1516031535000000000
-jenkins_job,host=myhost,name=JOB1,parents=apps/br1,result=SUCCESS duration=2831i,result_code=0i 1516026630000000000
-jenkins_job,host=myhost,name=JOB2,parents=apps/br2,result=SUCCESS duration=2285i,result_code=0i 1516027230000000000
+jenkins_node,arch=Linux\ (amd64),disk_path=/var/jenkins_home,temp_path=/tmp,host=myhost,node_name=master,source=my-jenkins-instance,port=8080 swap_total=4294963200,memory_available=586711040,memory_total=6089498624,status=online,response_time=1000i,disk_available=152392036352,temp_available=152392036352,swap_available=3503263744,num_executors=2i 1516031535000000000
+jenkins_job,host=myhost,name=JOB1,parents=apps/br1,result=SUCCESS,source=my-jenkins-instance,port=8080 duration=2831i,result_code=0i 1516026630000000000
+jenkins_job,host=myhost,name=JOB2,parents=apps/br2,result=SUCCESS,source=my-jenkins-instance,port=8080 duration=2285i,result_code=0i 1516027230000000000
 ```
+

--- a/plugins/inputs/jenkins/jenkins.go
+++ b/plugins/inputs/jenkins/jenkins.go
@@ -170,10 +170,10 @@ func (j *Jenkins) initialize(client *http.Client) error {
 // Function to get source and port tags
 func (j *Jenkins) getInitialTags() (map[string]string, error) {
 	tags := map[string]string{}
-	u, err := url.Parse(j.URL)	
+	u, err := url.Parse(j.URL)
 	if err != nil {
 		return tags, err
-		}
+	}
 	tags["source"] = u.Hostname()
 	tags["port"] = u.Port()
 	return tags, nil
@@ -234,12 +234,12 @@ func (j *Jenkins) gatherNodesData(acc telegraf.Accumulator) {
 		acc.AddError(err)
 		return
 	}
-	// Get source and port tags 
+	// Get source and port tags
 	tags, err := j.getInitialTags()
-        if err != nil {
+	if err != nil {
 		acc.AddError(err)
-                return
-        }
+		return
+	}
 	// get node data
 	for _, node := range nodeResp.Computers {
 		err = j.gatherNodeData(tags, node, acc)

--- a/plugins/inputs/jenkins/jenkins_test.go
+++ b/plugins/inputs/jenkins/jenkins_test.go
@@ -1,3 +1,4 @@
+// Test Suite
 package jenkins
 
 import (


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/). - Done
- [x] Associated README.md updated. -  Done
- [x] Has appropriate unit tests. - Done

-> Earlier "url.Parse" function was called "N Nodes" and "J Jobs" times which is now reduced to just  2 calls by creating separate function for URL parsing and source, port split.
-> Added missing source and port tags in jenkins_job metrics
