### PR TITLE
Update github.com/kardianos/service to 1.0.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -760,20 +760,12 @@
   revision = "c2b33e84"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2c5ad58492804c40bdaf5d92039b0cde8b5becd2b7feeb37d7d1cc36a8aa8dbe"
-  name = "github.com/kardianos/osext"
-  packages = ["."]
-  pruneopts = ""
-  revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
-
-[[projects]]
-  branch = "master"
-  digest = "1:fed90fa725d3b1bac0a760de64426834dfef4546474cf182f2ec94285afa74a8"
+  digest = "1:b498ceccf0d2efa0af877b1dda20d3742ef9ff7475123e8e922016f0b737069b"
   name = "github.com/kardianos/service"
   packages = ["."]
   pruneopts = ""
-  revision = "615a14ed75099c9eaac6949e22ac2341bf9d3197"
+  revision = "56787a3ea05e9b262708192e7ce3b500aba73561"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:3e160bec100719bb664ce5192b42e82e66b290397da4c0845aed5ce3cfce60cb"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,7 @@
 
 [[constraint]]
   name = "github.com/kardianos/service"
-  branch = "master"
+  version = "1.0.0"
 
 [[constraint]]
   name = "github.com/kballard/go-shellquote"


### PR DESCRIPTION
This fixes a step that happens during static initialization where the library detects the init system.  Since we use this library only for Windows service and event log support, I would separately like to split the library out of the build for other platforms.

closes #6846 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
