### PR TITLE
[inputs.vsphere] Deprecated force_discovery_on_init flag

### DIFF
--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -286,20 +286,8 @@ func (e *Endpoint) init(ctx context.Context) error {
 	}
 
 	if e.Parent.ObjectDiscoveryInterval.Duration > 0 {
-
-		// Run an initial discovery. If force_discovery_on_init isn't set, we kick it off as a
-		// goroutine without waiting for it. This will probably cause us to report an empty
-		// dataset on the first collection, but it solves the issue of the first collection timing out.
-		if e.Parent.ForceDiscoverOnInit {
-			e.Parent.Log.Debug("Running initial discovery and waiting for it to finish")
-			e.initalDiscovery(ctx)
-		} else {
-			// Otherwise, just run it in the background. We'll probably have an incomplete first metric
-			// collection this way.
-			go func() {
-				e.initalDiscovery(ctx)
-			}()
-		}
+		e.Parent.Log.Debug("Running initial discovery")
+		e.initalDiscovery(ctx)
 	}
 	e.initialized = true
 	return nil

--- a/plugins/inputs/vsphere/vsphere.go
+++ b/plugins/inputs/vsphere/vsphere.go
@@ -195,11 +195,6 @@ var sampleConfig = `
   # collect_concurrency = 1
   # discover_concurrency = 1
 
-  ## whether or not to force discovery of new objects on initial gather call before collecting metrics
-  ## when true for large environments this may cause errors for time elapsed while collecting metrics
-  ## when false (default) the first collection cycle may result in no or limited metrics while objects are discovered
-  # force_discover_on_init = false
-
   ## the interval before (re)discovering objects subject to metrics collection (default: 300s)
   # object_discovery_interval = "300s"
 
@@ -247,6 +242,11 @@ func (v *VSphere) Start(acc telegraf.Accumulator) error {
 	v.Log.Info("Starting plugin")
 	ctx, cancel := context.WithCancel(context.Background())
 	v.cancel = cancel
+
+	// Check for deprecated settings
+	if !v.ForceDiscoverOnInit {
+		v.Log.Warn("The 'force_discover_on_init' configuration parameter has been deprecated. Setting it to 'false' has no effect")
+	}
 
 	// Create endpoints, one for each vCenter we're monitoring
 	v.endpoints = make([]*Endpoint, len(v.Vcenters))
@@ -344,7 +344,7 @@ func init() {
 			MaxQueryMetrics:         256,
 			CollectConcurrency:      1,
 			DiscoverConcurrency:     1,
-			ForceDiscoverOnInit:     false,
+			ForceDiscoverOnInit:     true,
 			ObjectDiscoveryInterval: internal.Duration{Duration: time.Second * 300},
 			Timeout:                 internal.Duration{Duration: time.Second * 60},
 		}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

The ```force_discovery_on_init``` flag was causing problems and setting it to false no longer has any desirable effects due to the way discovery is implemented.

The flag is now deprecated and setting it to ```false``` will print a warning and will be ignored.

closes #6860