### PR TITLE
Non-systemd udev path + adjusted unit test

### DIFF
--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -44,6 +44,12 @@ func (s *DiskIO) diskInfo(devName string) (map[string]string, error) {
 		major := unix.Major(uint64(stat.Rdev))
 		minor := unix.Minor(uint64(stat.Rdev))
 		udevDataPath = fmt.Sprintf("/run/udev/data/b%d:%d", major, minor)
+
+		f, err := os.Open(udevDataPath)
+		defer f.Close()
+		if err != nil {
+			udevDataPath = fmt.Sprintf("/dev/.udev/db/block:%s", devName)
+		}
 	}
 
 	di := map[string]string{}


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.

Now only probing 2 paths at most.

This is a rewrite with lessons learned by writing #5180 .
Closes #3900