### PR TITLE
[inputs.vsphere] Added custom attributes for all resource types

### DIFF
--- a/plugins/inputs/vsphere/finder.go
+++ b/plugins/inputs/vsphere/finder.go
@@ -233,12 +233,12 @@ func init() {
 	}
 
 	addFields = map[string][]string{
-		"HostSystem": {"parent"},
+		"HostSystem": {"parent", "summary.customValue", "customValue"},
 		"VirtualMachine": {"runtime.host", "config.guestId", "config.uuid", "runtime.powerState",
-			"summary.customValue", "guest.net", "guest.hostName"},
-		"Datastore":              {"parent", "info"},
-		"ClusterComputeResource": {"parent"},
-		"Datacenter":             {"parent"},
+			"summary.customValue", "guest.net", "guest.hostName", "customValue"},
+		"Datastore":              {"parent", "info", "customValue"},
+		"ClusterComputeResource": {"parent", "customValue" },
+		"Datacenter":             {"parent", "customValue"},
 	}
 
 	containers = map[string]interface{}{

--- a/plugins/inputs/vsphere/finder.go
+++ b/plugins/inputs/vsphere/finder.go
@@ -237,7 +237,7 @@ func init() {
 		"VirtualMachine": {"runtime.host", "config.guestId", "config.uuid", "runtime.powerState",
 			"summary.customValue", "guest.net", "guest.hostName", "customValue"},
 		"Datastore":              {"parent", "info", "customValue"},
-		"ClusterComputeResource": {"parent", "customValue" },
+		"ClusterComputeResource": {"parent", "customValue"},
 		"Datacenter":             {"parent", "customValue"},
 	}
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Fixes issue #6883. 

The original intention was that custom attribute should be collected for all resource types. However, only collection for VMs was working. This PR fixes that.

Maintainers: Is there a chance we can get this one into 1.13.1?