### PR TITLE
plugins/filestat: Create option to disable logging of missing files

### DIFF
--- a/plugins/inputs/filestat/README.md
+++ b/plugins/inputs/filestat/README.md
@@ -14,6 +14,9 @@ The filestat plugin gathers metrics about file existence, size, and other stats.
 
   ## If true, read the entire file and calculate an md5 checksum.
   md5 = false
+
+  ## If true, don't log an error if the file is missing.
+  NoLogFileMissing = false
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -25,11 +25,15 @@ const sampleConfig = `
 
   ## If true, read the entire file and calculate an md5 checksum.
   md5 = false
+  
+  ## If true, don't log an error if the file is missing.
+  NoLogFileMissing = false
 `
 
 type FileStat struct {
-	Md5   bool
-	Files []string
+	Md5              bool
+	NoLogFileMissing bool
+	Files            []string
 
 	Log telegraf.Logger
 
@@ -88,8 +92,10 @@ func (f *FileStat) Gather(acc telegraf.Accumulator) error {
 			}
 
 			if fileInfo == nil {
-				f.Log.Errorf("Unable to get info for file %q, possible permissions issue",
-					fileName)
+				if f.NoLogFileMissing == false {
+					f.Log.Errorf("Unable to get info for file %q, possible permissions issue",
+						fileName)
+				}
 			} else {
 				fields["size_bytes"] = fileInfo.Size()
 				fields["modification_time"] = fileInfo.ModTime().UnixNano()


### PR DESCRIPTION
Create configuration option NoLogFileMissing to prevent log spam when
the file is missing. For example, when using telegraf to check for
/var/run/reboot-needed (which is only present when the reboot is needed)
the agent will log the following each time the file is checked, and missing:

2020-01-25T15:23:20Z E! [inputs.filestat] Unable to get info for file "/var/run/reboot-required", possible permissions issue

This will allow us to disable this log alert.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
