### PR TITLE
Fix duplicate TrackingIDs returned

### DIFF
--- a/metric/tracking.go
+++ b/metric/tracking.go
@@ -34,8 +34,7 @@ var (
 )
 
 func newTrackingID() telegraf.TrackingID {
-	atomic.AddUint64(&lastID, 1)
-	return telegraf.TrackingID(lastID)
+	return telegraf.TrackingID(atomic.AddUint64(&lastID, 1))
 }
 
 func debugFinalizer(d *trackingData) {


### PR DESCRIPTION
There is a small chance the newTrackingID() function in tracking.go
will return the same id to multiple simultaneous callers.
The function must return the value returned by atomic.AddUint64()
to be safe.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
