### PR TITLE
 processor/strings: add support for `title` convertor

### DIFF
--- a/plugins/processors/strings/README.md
+++ b/plugins/processors/strings/README.md
@@ -5,6 +5,7 @@ The `strings` plugin maps certain go string functions onto measurement, tag, and
 Implemented functions are:
 - lowercase
 - uppercase
+- titlecase
 - trim
 - trim_left
 - trim_right
@@ -34,6 +35,10 @@ If you'd like to apply multiple processings to the same `tag_key` or `field_key`
   ## Convert a tag value to uppercase
   # [[processors.strings.uppercase]]
   #   tag = "method"
+
+  ## Convert a field value to titlecase
+  # [[processors.strings.titlecase]]
+  #   field = "status"
 
   ## Trim leading and trailing whitespace using the default cutset
   # [[processors.strings.trim]]

--- a/plugins/processors/strings/strings.go
+++ b/plugins/processors/strings/strings.go
@@ -13,6 +13,7 @@ import (
 type Strings struct {
 	Lowercase    []converter `toml:"lowercase"`
 	Uppercase    []converter `toml:"uppercase"`
+	Titlecase    []converter `toml:"titlecase"`
 	Trim         []converter `toml:"trim"`
 	TrimLeft     []converter `toml:"trim_left"`
 	TrimRight    []converter `toml:"trim_right"`
@@ -54,6 +55,10 @@ const sampleConfig = `
   # [[processors.strings.lowercase]]
   #   field = "uri_stem"
   #   dest = "uri_stem_normalised"
+
+  ## Convert a field value to titlecase
+  # [[processors.strings.titlecase]]
+  #   field = "status"
 
   ## Trim leading and trailing whitespace using the default cutset
   # [[processors.strings.trim]]
@@ -233,6 +238,10 @@ func (s *Strings) initOnce() {
 	}
 	for _, c := range s.Uppercase {
 		c.fn = strings.ToUpper
+		s.converters = append(s.converters, c)
+	}
+	for _, c := range s.Titlecase {
+		c.fn = strings.Title
 		s.converters = append(s.converters, c)
 	}
 	for _, c := range s.Trim {


### PR DESCRIPTION
- Title (https://golang.org/pkg/strings/#Title) function support all unicode letters.
- BUG: The rule Title uses for word boundaries does not handle Unicode punctuation properly, that should not effect much with use-case of Title rule in telegraf.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
