### PR TITLE
Use require in cisco mdt tests to avoid follow on errors

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -12,18 +12,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/influxdata/telegraf/metric"
-
 	dialout "github.com/cisco-ie/nx-telemetry-proto/mdt_dialout"
 	telemetry "github.com/cisco-ie/nx-telemetry-proto/telemetry_bis"
 	"github.com/golang/protobuf/proto"
 	"github.com/influxdata/telegraf"
 	internaltls "github.com/influxdata/telegraf/internal/tls"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
-	// Register GRPC gzip decoder to support compressed telemetry
+	"google.golang.org/grpc/credentials" // Register GRPC gzip decoder to support compressed telemetry
 	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/peer"
 )
@@ -494,6 +491,10 @@ func (c *CiscoTelemetryMDT) parseContentField(grouper *metric.SeriesGrouper, fie
 		}
 	}
 	delete(tags, prefix)
+}
+
+func (c *CiscoTelemetryMDT) Address() net.Addr {
+	return c.listener.Addr()
 }
 
 // Stop listener and cleanup


### PR DESCRIPTION
This intermittent error appears to be an error calling net.Listen, with a follow on error later in the test causing the panic.  It is unknown why the Listen call failed.

To address, change tests to listen on an available port instead of a hardcoded port to avoid conflicts, and use require to stop the test after the first error.

```
--- FAIL: TestTCPDialoutOverflow (0.00s)
    cisco_telemetry_mdt_test.go:390: 
        	Error Trace:	cisco_telemetry_mdt_test.go:390
        	Error:      	Expected nil, but got: &net.OpError{Op:"listen", Net:"tcp", Source:net.Addr(nil), Addr:(*net.TCPAddr)(0xc00014db30), Err:(*os.SyscallError)(0xc00000fba0)}
        	Test:       	TestTCPDialoutOverflow
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x51fd30]

goroutine 10 [running]:
testing.tRunner.func1(0xc00018a600)
	/usr/local/go/src/testing/testing.go:830 +0x392
panic(0x8fe820, 0xdce320)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
encoding/binary.Write(0x0, 0x0, 0xa4c500, 0xdfbb50, 0x9507e0, 0xc000029de0, 0xf, 0x0)
	/usr/local/go/src/encoding/binary/binary.go:355 +0x1430
github.com/influxdata/telegraf/plugins/inputs/cisco_telemetry_mdt.TestTCPDialoutOverflow(0xc00018a600)
	/go/src/github.com/influxdata/telegraf/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go:401 +0x2b4
testing.tRunner(0xc00018a600, 0x9b6c18)
	/usr/local/go/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:916 +0x35a
FAIL	github.com/influxdata/telegraf/plugins/inputs/cisco_telemetry_mdt	0.014s
```

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
