### PR TITLE
Support obtaining all builds within the max_build_age in jenkins input

### DIFF
--- a/plugins/inputs/jenkins/client.go
+++ b/plugins/inputs/jenkins/client.go
@@ -48,7 +48,7 @@ func (c *client) init() error {
 		}
 	}
 	// first api fetch
-	if err := c.doGet(context.Background(), jobPath, new(jobResponse)); err != nil {
+	if err := c.doGet(context.Background(), jsonSuffix, new(jobResponse)); err != nil {
 		return err
 	}
 	return nil
@@ -132,21 +132,18 @@ func createGetRequest(url string, username, password string, sessionCookie *http
 	return req, nil
 }
 
-func (c *client) getJobs(ctx context.Context, jr *jobRequest) (js *jobResponse, err error) {
-	js = new(jobResponse)
-	url := jobPath
-	if jr != nil {
-		url = jr.URL()
-	}
+func (c *client) getJobs(ctx context.Context) (js *jobsResponse, err error) {
+	js = new(jobsResponse)
+	url := jsonSuffix
 	err = c.doGet(ctx, url, js)
 	return js, err
 }
 
-func (c *client) getBuild(ctx context.Context, jr jobRequest, number int64) (b *buildResponse, err error) {
-	b = new(buildResponse)
-	url := jr.buildURL(number)
-	err = c.doGet(ctx, url, b)
-	return b, err
+func (c *client) getJob(ctx context.Context, jr *jobRequest) (js *jobResponse, err error) {
+	js = new(jobResponse)
+	url := jr.url()
+	err = c.doGet(ctx, url, js)
+	return js, err
 }
 
 func (c *client) getAllNodes(ctx context.Context) (nodeResp *nodeResponse, err error) {

--- a/plugins/inputs/jenkins/jenkins.go
+++ b/plugins/inputs/jenkins/jenkins.go
@@ -318,7 +318,7 @@ func (j *Jenkins) getJobDetail(jr jobRequest, acc telegraf.Accumulator) error {
 
 			// If the build is before the cutoff, skip recording its metrics
 			cutoff := time.Now().Add(-1 * j.MaxBuildAge.Duration)
-		
+
 			if b.GetTimestamp().Before(cutoff) {
 				j.Log.Debugf("The following build is too old to record: %s, build %v", jr.name, b.Number)
 				return
@@ -374,7 +374,7 @@ type innerJob struct {
 }
 
 type jobsResponse struct {
-	Jobs      []innerJob `json:"jobs"`
+	Jobs []innerJob `json:"jobs"`
 }
 
 type jobBuild struct {
@@ -386,9 +386,9 @@ type jobBuild struct {
 }
 
 type jobResponse struct {
-	Builds    []jobBuild `json:"builds"`
-	Jobs      []innerJob `json:"jobs"`
-	Name      string     `json:"name"`
+	Builds []jobBuild `json:"builds"`
+	Jobs   []innerJob `json:"jobs"`
+	Name   string     `json:"name"`
 }
 
 func (b *jobBuild) GetTimestamp() time.Time {
@@ -397,7 +397,7 @@ func (b *jobBuild) GetTimestamp() time.Time {
 
 const (
 	jsonSuffix = "/api/json"
-	nodePath = "/computer/api/json"
+	nodePath   = "/computer/api/json"
 )
 
 type jobRequest struct {

--- a/plugins/inputs/jenkins/jenkins_test.go
+++ b/plugins/inputs/jenkins/jenkins_test.go
@@ -393,7 +393,7 @@ func TestGatherJobs(t *testing.T) {
 					"/job/job1/api/json": &jobResponse{
 						Builds: []jobBuild{
 							{
-								Number: 1,
+								Number:   1,
 								Building: true,
 							},
 						},
@@ -413,15 +413,15 @@ func TestGatherJobs(t *testing.T) {
 					"/job/job1/api/json": &jobResponse{
 						Builds: []jobBuild{
 							{
-								Number: 3,
-								Building: false,
+								Number:    3,
+								Building:  false,
 								Result:    "SUCCESS",
 								Duration:  500,
 								Timestamp: 100,
 							},
 							{
-								Number: 4,
-								Building: false,
+								Number:    4,
+								Building:  false,
 								Result:    "SUCCESS",
 								Duration:  25558,
 								Timestamp: (time.Now().Unix() - int64(time.Minute.Seconds())) * 1000,
@@ -458,8 +458,8 @@ func TestGatherJobs(t *testing.T) {
 					"/job/job1/api/json": &jobResponse{
 						Builds: []jobBuild{
 							{
-								Number: 3,
-								Building: false,
+								Number:    3,
+								Building:  false,
 								Result:    "SUCCESS",
 								Duration:  25558,
 								Timestamp: (time.Now().Unix() - int64(time.Minute.Seconds())) * 1000,
@@ -469,7 +469,7 @@ func TestGatherJobs(t *testing.T) {
 					"/job/job2/api/json": &jobResponse{
 						Builds: []jobBuild{
 							{
-								Number: 1,
+								Number:    1,
 								Building:  false,
 								Result:    "FAILURE",
 								Duration:  1558,
@@ -531,7 +531,7 @@ func TestGatherJobs(t *testing.T) {
 					"/job/apps/job/chronograf/api/json": &jobResponse{
 						Builds: []jobBuild{
 							{
-								Number: 1,
+								Number:    1,
 								Building:  false,
 								Result:    "FAILURE",
 								Duration:  1558,
@@ -549,7 +549,7 @@ func TestGatherJobs(t *testing.T) {
 					"/job/apps/job/k8s-cloud/job/PR-100/api/json": &jobResponse{
 						Builds: []jobBuild{
 							{
-								Number: 1,
+								Number:    1,
 								Building:  false,
 								Result:    "SUCCESS",
 								Duration:  91558,
@@ -560,7 +560,7 @@ func TestGatherJobs(t *testing.T) {
 					"/job/apps/job/k8s-cloud/job/PR-101/api/json": &jobResponse{
 						Builds: []jobBuild{
 							{
-								Number: 4,
+								Number:    4,
 								Building:  false,
 								Result:    "SUCCESS",
 								Duration:  76558,


### PR DESCRIPTION
This fixes #6966 

This changes the job query to include a depth parameter so the build
information for the job is obtained in the same result as the job
details. I also limit the size of the body to only the fields we're
interested in using the tree parameter.

Before the change, we would get metrics of 20 nodes and 100 builds in
23.56 seconds on average. After this change, we get metrics of 20 nodes
and 2006 builds in 7.76 seconds on average.

We were able to get a 3x decrease in time while increasing the number
of metrics by over 16x.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [NA] Associated README.md updated.
- [x] Has appropriate unit tests.
