### PR TITLE
issue#6992 - Add support for MDB database information

### DIFF
--- a/plugins/inputs/openldap/openldap.go
+++ b/plugins/inputs/openldap/openldap.go
@@ -56,6 +56,12 @@ var attrTranslate = map[string]string{
 	"monitoredInfo":      "",
 	"monitorOpInitiated": "_initiated",
 	"monitorOpCompleted": "_completed",
+	"olmMDBPagesMax":     "_mdb_pages_max",
+	"olmMDBPagesUsed":    "_mdb_pages_used",
+	"olmMDBPagesFree":    "_mdb_pages_free",
+	"olmMDBReadersMax":   "_mdb_readers_max",
+	"olmMDBReadersUsed":  "_mdb_readers_used",
+	"olmMDBEntries":      "_mdb_entries",
 }
 
 func (o *Openldap) SampleConfig() string {


### PR DESCRIPTION
Update the OpenLDAP plugin to be able to utilize the new information about the database state available in OpenLDAP 2.4.49 and later

### Required for all PRs:

- [X ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
