### PR TITLE
Add warning log for detecting invalid summary or histogram

### DIFF
--- a/plugins/serializers/prometheus/collection.go
+++ b/plugins/serializers/prometheus/collection.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"hash/fnv"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -441,6 +442,7 @@ func (c *Collection) GetProto() []*dto.MetricFamily {
 				}
 
 				if len(buckets) == 0 {
+					log.Println("W! prometheus histogram requires a bucket label")
 					continue
 				}
 
@@ -459,6 +461,7 @@ func (c *Collection) GetProto() []*dto.MetricFamily {
 				}
 
 				if len(quantiles) == 0 {
+					log.Println("W! prometheus summary requires a quantile label")
 					continue
 				}
 


### PR DESCRIPTION
**Background**
Spring boot supports the Prometheus registry to expose JVM metric, custom metric and etc. But this metric haven't quantile label about summary type without percentile option. This means Telegraf drops the summary metric noiselessly. Prometheus beginner loses the chance to dig root cause.
It is not collected by the following code:
https://github.com/influxdata/telegraf/blob/master/plugins/serializers/prometheus/collection.go#L461

**Request**
I want to give some hint to protect losing metric. So I add the logging in Prometheus serializer.

**Suggestion**
I think the Prometheus serializer provides an option to avoid invalid summary and histogram. But I have some concern about why must accept the invalid data format. So this is just my idea. I want to listen to your advice.

For example) 
_option_
accept_invalid_prometheus_format = true

_behavior_
accepts invalid Prometheus format like omit bucket and quantile.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
