### PR TITLE
Add support for freebsd/arm64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,8 +103,7 @@ require (
 	github.com/safchain/ethtool v0.0.0-20200128171343-ef7e7c9c2763
 	github.com/samuel/go-zookeeper v0.0.0-20180130194729-c4fab1ac1bec // indirect
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b // indirect
-	github.com/shirou/gopsutil v2.19.11+incompatible
-	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
+	github.com/shirou/gopsutil v2.20.1+incompatible
 	github.com/shopspring/decimal v0.0.0-20200105231215-408a2507e114 // indirect
 	github.com/sirupsen/logrus v1.2.0
 	github.com/soniah/gosnmp v1.22.0
@@ -121,9 +120,9 @@ require (
 	github.com/wvanbergen/kafka v0.0.0-20171203153745-e2edea948ddf
 	github.com/wvanbergen/kazoo-go v0.0.0-20180202103751-f72d8611297a // indirect
 	github.com/yuin/gopher-lua v0.0.0-20180630135845-46796da1b0b4 // indirect
-	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
-	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456
+	golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4
 	gonum.org/v1/gonum v0.6.2 // indirect
 	google.golang.org/api v0.3.1
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107

--- a/go.sum
+++ b/go.sum
@@ -387,10 +387,8 @@ github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybL
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/shirou/gopsutil v2.19.11+incompatible h1:lJHR0foqAjI4exXqWsU3DbH7bX1xvdhGdnXTIARA9W4=
-github.com/shirou/gopsutil v2.19.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
-github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
+github.com/shirou/gopsutil v2.20.1+incompatible h1:oIq9Cq4i84Hk8uQAUOG3eNdI/29hBawGrD5YRl6JRDY=
+github.com/shirou/gopsutil v2.20.1+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shopspring/decimal v0.0.0-20200105231215-408a2507e114 h1:Pm6R878vxWWWR+Sa3ppsLce/Zq+JNTs6aVvRu13jv9A=
 github.com/shopspring/decimal v0.0.0-20200105231215-408a2507e114/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
@@ -473,6 +471,8 @@ golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -495,6 +495,8 @@ golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
+golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5FJfjTceCKIp96+biqP4To=


### PR DESCRIPTION
### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
```
# Update sys, net and gopsutil to fix build failure on FreeBSD/aarch64:
github.com/influxdata/telegraf/vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/cmsghdr.go:9:10: undefined: cmsghdr
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/cmsghdr.go:10:10: undefined: cmsghdr
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/cmsghdr.go:11:10: undefined: cmsghdr
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/cmsghdr_bsd.go:9:10: undefined: cmsghdr
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/iovec_64bit.go:12:10: undefined: iovec
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/msghdr_bsd.go:11:10: undefined: msghdr
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/msghdr_bsd.go:11:28: undefined: iovec
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/msghdr_bsd.go:26:10: undefined: msghdr
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/msghdr_bsd.go:33:10: undefined: msghdr
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/msghdr_bsd.go:37:10: undefined: msghdr
vendor/github.com/miekg/dns/vendor/golang.org/x/net/internal/socket/msghdr_bsd.go:37:10: too many errors

# github.com/influxdata/telegraf/vendor/golang.org/x/sys/unix
vendor/golang.org/x/sys/unix/ztypes_freebsd_arm64.go:400:12: undefined: uint128

# github.com/influxdata/telegraf/vendor/github.com/shirou/gopsutil/disk
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:26:36: undefined: MNT_WAIT
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:31:15: undefined: Statfs
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:32:28: undefined: MNT_WAIT
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:38:17: undefined: MNT_RDONLY
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:41:17: undefined: MNT_SYNCHRONOUS
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:44:17: undefined: MNT_NOEXEC
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:154:9: undefined: Bintime
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:163:22: undefined: Statfs
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:167:54: undefined: Statfs
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:182:32: undefined: Devstat
vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go:44:17: too many errors
```