### PR TITLE
Fix dash to underscore replacement when handling embedded tags in Cisco MDT

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -76,7 +76,7 @@ func (c *CiscoTelemetryMDT) Start(acc telegraf.Accumulator) error {
 	// Fill extra tags
 	c.extraTags = make(map[string]map[string]struct{})
 	for _, tag := range c.EmbeddedTags {
-		dir := path.Dir(tag)
+		dir := strings.Replace(path.Dir(tag), "-", "_", -1)
 		if _, hasKey := c.extraTags[dir]; !hasKey {
 			c.extraTags[dir] = make(map[string]struct{})
 		}
@@ -400,7 +400,7 @@ func (c *CiscoTelemetryMDT) parseContentField(grouper *metric.SeriesGrouper, fie
 		name = prefix + "/" + name
 	}
 
-	extraTags := c.extraTags[path+"/"+name]
+	extraTags := c.extraTags[strings.Replace(path, "-", "_", -1)+"/"+name]
 
 	if value := decodeValue(field); value != nil {
 		// Do alias lookup, to shorten measurement names
@@ -423,7 +423,7 @@ func (c *CiscoTelemetryMDT) parseContentField(grouper *metric.SeriesGrouper, fie
 	if len(extraTags) > 0 {
 		for _, subfield := range field.Fields {
 			if _, isExtraTag := extraTags[subfield.Name]; isExtraTag {
-				tags[name+"/"+subfield.Name] = decodeTag(subfield)
+				tags[name+"/"+strings.Replace(subfield.Name, "-", "_", -1)] = decodeTag(subfield)
 			}
 		}
 	}


### PR DESCRIPTION
Currently configuring embedded_tags for cisco_telemetry_mdt input
requires an unusual mix of - and _, i.e. one needs to specify e.g.
Cisco-IOS-XR-wdsysmon-fd-oper:system-monitoring/cpu-utilization/process_cpu/process-id
for it to work correctly. Additionally, tags created might still contain
dashes against convention.

This fix creates correctly formatted tags with underscores instead of
dashes and unifies the configuration parameter to expect either dashes
or underscores, so old configurations are still valid.
