### PR TITLE
name the parsers so we can include details about what failed

### DIFF
--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -2,7 +2,6 @@ package amqp_consumer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/influxdata/telegraf/internal/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/pkg/errors"
 	"github.com/streadway/amqp"
 )
 
@@ -500,7 +500,7 @@ func (a *AMQPConsumer) onMessage(acc telegraf.TrackingAccumulator, d amqp.Delive
 	metrics, err := a.parser.Parse(body)
 	if err != nil {
 		onError()
-		return err
+		return errors.Wrapf(err, "%s parser error", a.parser.Name())
 	}
 
 	id := acc.AddTrackingMetricGroup(metrics)

--- a/plugins/inputs/cloud_pubsub/pubsub.go
+++ b/plugins/inputs/cloud_pubsub/pubsub.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
@@ -188,7 +189,7 @@ func (ps *PubSub) onMessage(ctx context.Context, msg message) error {
 	metrics, err := ps.parser.Parse(data)
 	if err != nil {
 		msg.Ack()
-		return err
+		return errors.Wrapf(err, "%s parser error", ps.parser.Name())
 	}
 
 	if len(metrics) == 0 {

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/parsers/nagios"
 	"github.com/kballard/go-shellquote"
+	"github.com/pkg/errors"
 )
 
 const sampleConfig = `
@@ -153,7 +154,7 @@ func (e *Exec) ProcessCommand(command string, acc telegraf.Accumulator, wg *sync
 
 	metrics, err := e.parser.Parse(out)
 	if err != nil {
-		acc.AddError(err)
+		acc.AddError(errors.Wrapf(err, "%s parser error", e.parser.Name()))
 		return
 	}
 

--- a/plugins/inputs/file/file.go
+++ b/plugins/inputs/file/file.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/telegraf/internal/globpath"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/pkg/errors"
 )
 
 type File struct {
@@ -96,8 +97,8 @@ func (f *File) readMetric(filename string) ([]telegraf.Metric, error) {
 	if err != nil {
 		return nil, fmt.Errorf("E! Error file: %v could not be read, %s", filename, err)
 	}
-	return f.parser.Parse(fileContents)
-
+	metric, err := f.parser.Parse(fileContents)
+	return metric, errors.Wrapf(err, "%s parser error", f.parser.Name())
 }
 
 func init() {

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/telegraf/internal/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/pkg/errors"
 )
 
 type HTTP struct {
@@ -204,7 +205,7 @@ func (h *HTTP) gatherURL(
 
 	metrics, err := h.parser.Parse(b)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "%s parser error", h.parser.Name())
 	}
 
 	for _, metric := range metrics {

--- a/plugins/inputs/httpjson/httpjson.go
+++ b/plugins/inputs/httpjson/httpjson.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/telegraf/internal/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -193,7 +194,7 @@ func (h *HttpJson) gatherServer(
 
 	metrics, err := parser.Parse([]byte(resp))
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "%s parser error", parser.Name())
 	}
 
 	for _, metric := range metrics {

--- a/plugins/inputs/influxdb_listener/http_listener.go
+++ b/plugins/inputs/influxdb_listener/http_listener.go
@@ -19,6 +19,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/selfstat"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -377,7 +378,7 @@ func (h *HTTPListener) parse(b []byte, t time.Time, precision, db string) error 
 	h.handler.SetTimeFunc(func() time.Time { return t })
 	metrics, err := h.parser.Parse(b)
 	if err != nil {
-		return fmt.Errorf("unable to parse: %s", err.Error())
+		return errors.Wrapf(err, "unable to parse: %s parser error", h.parser.Name())
 	}
 
 	for _, m := range metrics {

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/kafka"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/pkg/errors"
 )
 
 const sampleConfig = `
@@ -392,7 +393,7 @@ func (h *ConsumerGroupHandler) Handle(session sarama.ConsumerGroupSession, msg *
 	metrics, err := h.parser.Parse(msg.Value)
 	if err != nil {
 		h.release()
-		return err
+		return errors.Wrapf(err, "%s parser error", h.parser.Name())
 	}
 
 	if len(h.TopicTag) > 0 {

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	consumer "github.com/harlow/kinesis-consumer"
 	"github.com/harlow/kinesis-consumer/checkpoint/ddb"
+	"github.com/pkg/errors"
 
 	"github.com/influxdata/telegraf"
 	internalaws "github.com/influxdata/telegraf/internal/config/aws"
@@ -241,7 +242,7 @@ func (k *KinesisConsumer) Start(ac telegraf.Accumulator) error {
 func (k *KinesisConsumer) onMessage(acc telegraf.TrackingAccumulator, r *consumer.Record) error {
 	metrics, err := k.parser.Parse(r.Data)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "%s parser error", k.parser.Name())
 	}
 
 	k.recordsTex.Lock()

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -2,17 +2,17 @@ package mqtt_consumer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/eclipse/paho.mqtt.golang"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -276,7 +276,7 @@ func (m *MQTTConsumer) recvMessage(c mqtt.Client, msg mqtt.Message) {
 func (m *MQTTConsumer) onMessage(acc telegraf.TrackingAccumulator, msg mqtt.Message) error {
 	metrics, err := m.parser.Parse(msg.Payload())
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "%s parser error", m.parser.Name())
 	}
 
 	if m.topicTag != "" {

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eclipse/paho.mqtt.golang"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/testutil"
@@ -48,6 +48,10 @@ type FakeParser struct {
 
 // FakeParser satisfies parsers.Parser
 var _ parsers.Parser = &FakeParser{}
+
+func (p *FakeParser) Name() string {
+	return "FakeParser"
+}
 
 func (p *FakeParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	panic("not implemented")

--- a/plugins/inputs/nats_consumer/nats_consumer.go
+++ b/plugins/inputs/nats_consumer/nats_consumer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/nats-io/nats.go"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -234,7 +235,7 @@ func (n *natsConsumer) receiver(ctx context.Context) {
 			case msg := <-n.in:
 				metrics, err := n.parser.Parse(msg.Data)
 				if err != nil {
-					n.Log.Errorf("Subject: %s, error: %s", msg.Subject, err.Error())
+					n.Log.Error(errors.Wrapf(err, "Subject: %s, error: %s parser error", msg.Subject, n.parser.Name()))
 					<-sem
 					continue
 				}

--- a/plugins/inputs/nsq_consumer/nsq_consumer.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	nsq "github.com/nsqio/go-nsq"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -107,7 +108,7 @@ func (n *NSQConsumer) Start(ac telegraf.Accumulator) error {
 	n.consumer.AddHandler(nsq.HandlerFunc(func(message *nsq.Message) error {
 		metrics, err := n.parser.Parse(message.Body)
 		if err != nil {
-			acc.AddError(err)
+			acc.AddError(errors.Wrapf(err, "%s parser error", n.parser.Name()))
 			// Remove the message from the queue
 			message.Finish()
 			return nil

--- a/plugins/parsers/collectd/parser.go
+++ b/plugins/parsers/collectd/parser.go
@@ -31,6 +31,10 @@ func (p *CollectdParser) SetParseOpts(popts *network.ParseOpts) {
 	p.popts = *popts
 }
 
+func (p *CollectdParser) Name() string {
+	return "CollectdParser"
+}
+
 func NewCollectdParser(
 	authFile string,
 	securityLevel string,

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -31,6 +31,10 @@ type Parser struct {
 	TimeFunc          func() time.Time
 }
 
+func (p *Parser) Name() string {
+	return "CSV parser - " + p.MetricName
+}
+
 func (p *Parser) SetTimeFunc(fn metric.TimeFunc) {
 	p.TimeFunc = fn
 }

--- a/plugins/parsers/dropwizard/parser.go
+++ b/plugins/parsers/dropwizard/parser.go
@@ -65,6 +65,10 @@ func NewParser() *parser {
 	return parser
 }
 
+func (p *parser) Name() string {
+	return "Dropwizard parser"
+}
+
 // Parse parses the input bytes to an array of metrics
 func (p *parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 

--- a/plugins/parsers/form_urlencoded/parser.go
+++ b/plugins/parsers/form_urlencoded/parser.go
@@ -24,6 +24,10 @@ type Parser struct {
 	AllowedKeys []string
 }
 
+func (p *Parser) Name() string {
+	return "form_urlencoded parser - " + p.MetricName
+}
+
 // Parse converts a slice of bytes in "application/x-www-form-urlencoded" format into metrics
 func (p Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	buf = bytes.TrimSpace(buf)

--- a/plugins/parsers/graphite/parser.go
+++ b/plugins/parsers/graphite/parser.go
@@ -28,6 +28,10 @@ type GraphiteParser struct {
 	templateEngine *templating.Engine
 }
 
+func (p *GraphiteParser) Name() string {
+	return "GraphiteParser"
+}
+
 func (p *GraphiteParser) SetDefaultTags(tags map[string]string) {
 	p.DefaultTags = tags
 }

--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -126,6 +126,10 @@ type Parser struct {
 	tsModder *tsModder
 }
 
+func (p *Parser) Name() string {
+	return "grok parser"
+}
+
 // Compile is a bound method to Parser which will process the options for our parser
 func (p *Parser) Compile() error {
 	p.typeMap = make(map[string]map[string]string)

--- a/plugins/parsers/influx/parser.go
+++ b/plugins/parsers/influx/parser.go
@@ -46,6 +46,10 @@ type Parser struct {
 	handler *MetricHandler
 }
 
+func (p *Parser) Name() string {
+	return "Influx Parser"
+}
+
 // NewParser returns a Parser than accepts line protocol
 func NewParser(handler *MetricHandler) *Parser {
 	return &Parser{

--- a/plugins/parsers/json/parser.go
+++ b/plugins/parsers/json/parser.go
@@ -67,6 +67,10 @@ func New(config *Config) (*Parser, error) {
 	}, nil
 }
 
+func (p *Parser) Name() string {
+	return "JSON parser - " + p.metricName
+}
+
 func (p *Parser) parseArray(data []interface{}) ([]telegraf.Metric, error) {
 	results := make([]telegraf.Metric, 0)
 

--- a/plugins/parsers/logfmt/parser.go
+++ b/plugins/parsers/logfmt/parser.go
@@ -31,6 +31,10 @@ func NewParser(metricName string, defaultTags map[string]string) *Parser {
 	}
 }
 
+func (p *Parser) Name() string {
+	return "logfmt.Parser - " + p.MetricName
+}
+
 // Parse converts a slice of bytes in logfmt format to metrics.
 func (p *Parser) Parse(b []byte) ([]telegraf.Metric, error) {
 	reader := bytes.NewReader(b)

--- a/plugins/parsers/nagios/parser.go
+++ b/plugins/parsers/nagios/parser.go
@@ -78,6 +78,10 @@ type NagiosParser struct {
 	DefaultTags map[string]string
 }
 
+func (p *NagiosParser) Name() string {
+	return "NagiosParser - " + p.MetricName
+}
+
 // Got from Alignak
 // https://github.com/Alignak-monitoring/alignak/blob/develop/alignak/misc/perfdata.py
 var (

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -37,6 +37,9 @@ type ParserFuncInput interface {
 
 // Parser is an interface defining functions that a parser plugin must satisfy.
 type Parser interface {
+	// Name is a name identifying the type of parser and optionally the metric it's configured for
+	Name() string
+
 	// Parse takes a byte buffer separated by newlines
 	// ie, `cpu.usage.idle 90\ncpu.usage.busy 10`
 	// and parses it into telegraf metrics

--- a/plugins/parsers/value/parser.go
+++ b/plugins/parsers/value/parser.go
@@ -17,6 +17,10 @@ type ValueParser struct {
 	DefaultTags map[string]string
 }
 
+func (v *ValueParser) Name() string {
+	return "ValueParser - " + v.MetricName
+}
+
 func (v *ValueParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	vStr := string(bytes.TrimSpace(bytes.Trim(buf, "\x00")))
 

--- a/plugins/parsers/wavefront/parser.go
+++ b/plugins/parsers/wavefront/parser.go
@@ -68,6 +68,10 @@ func NewPointParser(parent *WavefrontParser) *PointParser {
 	return &PointParser{Elements: elements, parent: parent}
 }
 
+func (p *WavefrontParser) Name() string {
+	return "WavefrontParser"
+}
+
 func (p *WavefrontParser) ParseLine(line string) (telegraf.Metric, error) {
 	buf := []byte(line)
 


### PR DESCRIPTION
parser errors are a little opaque as to why the parser failed, for example: 

`[inputs.kafka_consumer] Error in plugin: metric parse error: expected tag at 1:74: "{"@timestamp":"2020-02 20T16:09:18.329Z","@metadata":`

This change modifies the parser errors to include context about which parser is processing the text. With this change, the above error would have been:

`[inputs.kafka_consumer] Error in plugin: Influx Parser parser error: metric parse error: expected tag at 1:74: "{"@timestamp":"2020-02 20T16:09:18.329Z","@metadata":`

Which would have been obvious that it was a configuration error: you can't parse json with the influx line parser.