### PR TITLE
Allow globs in FPM unix socket paths

### DIFF
--- a/plugins/inputs/phpfpm/README.md
+++ b/plugins/inputs/phpfpm/README.md
@@ -19,6 +19,8 @@ Get phpfpm stats using either HTTP status page or fpm socket.
   ##       "/var/run/php5-fpm.sock"
   ##      or using a custom fpm status path:
   ##       "/var/run/php5-fpm.sock:fpm-custom-status-path"
+  ##      glob patterns are also supported:
+  ##       "/var/run/php*.sock"
   ##
   ##   - fcgi: the URL must start with fcgi:// or cgi://, and port must be present, ie:
   ##       "fcgi://10.0.0.12:9000/status"

--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -298,7 +298,7 @@ func globUnixSocket(url string) ([]string, error) {
 	pattern, status := unixSocketPaths(url)
 	paths, err := filepath.Glob(pattern)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "couldn't read the file path pattern %q", pattern)
 	}
 
 	addrs := make([]string, 0, len(paths))

--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -299,18 +299,13 @@ func globUnixSocket(url string) ([]string, error) {
 	}
 	paths := glob.Match()
 	if len(paths) == 0 {
-		return nil, nil
-	}
-
-	// globpath.Match() returns the given argument when it's a static path,
-	// i.e., not a glob pattern. In that case, ensure it exists.
-	if len(paths) == 1 && paths[0] == pattern {
 		if _, err := os.Stat(paths[0]); err != nil {
 			if os.IsNotExist(err) {
 				return nil, fmt.Errorf("Socket doesn't exist  '%s': %s", pattern, err)
 			}
 			return nil, err
 		}
+		return nil, nil
 	}
 
 	addrs := make([]string, 0, len(paths))

--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -298,7 +298,7 @@ func globUnixSocket(url string) ([]string, error) {
 	pattern, status := unixSocketPaths(url)
 	glob, err := globpath.Compile(pattern)
 	if err != nil {
-		return nil, fmt.Errorf("couldn not compile glob %q: %v", pattern, err)
+		return nil, fmt.Errorf("could not compile glob %q: %v", pattern, err)
 	}
 	paths := glob.Match()
 	addrs := make([]string, 0, len(paths))

--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -8,16 +8,15 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/internal/globpath"
 	"github.com/influxdata/telegraf/internal/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -297,11 +296,11 @@ func expandUrls(urls []string) ([]string, error) {
 
 func globUnixSocket(url string) ([]string, error) {
 	pattern, status := unixSocketPaths(url)
-	paths, err := filepath.Glob(pattern)
+	glob, err := globpath.Compile(pattern)
 	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't read the file path pattern %q", pattern)
+		return nil, fmt.Errorf("couldn not compile glob %q: %v", pattern, err)
 	}
-
+	paths := glob.Match()
 	addrs := make([]string, 0, len(paths))
 
 	if len(paths) == 0 {

--- a/plugins/inputs/phpfpm/phpfpm_test.go
+++ b/plugins/inputs/phpfpm/phpfpm_test.go
@@ -292,7 +292,7 @@ func TestPhpFpmGeneratesMetrics_Throw_Error_When_Socket_Path_Is_Invalid(t *testi
 
 	err := acc.GatherError(r.Gather)
 	require.Error(t, err)
-	assert.Equal(t, `Socket doesn't exist  '/tmp/invalid.sock': stat /tmp/invalid.sock: no such file or directory`, err.Error())
+	assert.Equal(t, `dial unix /tmp/invalid.sock: connect: no such file or directory`, err.Error())
 
 }
 

--- a/plugins/inputs/phpfpm/phpfpm_test.go
+++ b/plugins/inputs/phpfpm/phpfpm_test.go
@@ -148,6 +148,71 @@ func TestPhpFpmGeneratesMetrics_From_Socket(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "phpfpm", fields, tags)
 }
 
+func TestPhpFpmGeneratesMetrics_From_Multiple_Sockets_With_Glob(t *testing.T) {
+	// Create a socket in /tmp because we always have write permission and if the
+	// removing of socket fail when system restart /tmp is clear so
+	// we don't have junk files around
+	var randomNumber int64
+	binary.Read(rand.Reader, binary.LittleEndian, &randomNumber)
+	socket1 := fmt.Sprintf("/tmp/test-fpm%d.sock", randomNumber)
+	tcp1, err := net.Listen("unix", socket1)
+	if err != nil {
+		t.Fatal("Cannot initialize server on port ")
+	}
+	defer tcp1.Close()
+
+	binary.Read(rand.Reader, binary.LittleEndian, &randomNumber)
+	socket2 := fmt.Sprintf("/tmp/test-fpm%d.sock", randomNumber)
+	tcp2, err := net.Listen("unix", socket2)
+	if err != nil {
+		t.Fatal("Cannot initialize server on port ")
+	}
+	defer tcp2.Close()
+
+	s := statServer{}
+	go fcgi.Serve(tcp1, s)
+	go fcgi.Serve(tcp2, s)
+
+	r := &phpfpm{
+		Urls: []string{"/tmp/test-fpm[\\-0-9]*.sock"},
+	}
+
+	var acc1, acc2 testutil.Accumulator
+
+	err = acc1.GatherError(r.Gather)
+	require.NoError(t, err)
+
+	err = acc2.GatherError(r.Gather)
+	require.NoError(t, err)
+
+	tags1 := map[string]string{
+		"pool": "www",
+		"url":  socket1,
+	}
+
+	tags2 := map[string]string{
+		"pool": "www",
+		"url":  socket2,
+	}
+
+	fields := map[string]interface{}{
+		"start_since":          int64(1991),
+		"accepted_conn":        int64(3),
+		"listen_queue":         int64(1),
+		"max_listen_queue":     int64(0),
+		"listen_queue_len":     int64(0),
+		"idle_processes":       int64(1),
+		"active_processes":     int64(1),
+		"total_processes":      int64(2),
+		"max_active_processes": int64(1),
+		"max_children_reached": int64(2),
+		"slow_requests":        int64(1),
+	}
+
+	acc1.AssertContainsTaggedFields(t, "phpfpm", fields, tags1)
+	acc2.AssertContainsTaggedFields(t, "phpfpm", fields, tags2)
+}
+
 func TestPhpFpmGeneratesMetrics_From_Socket_Custom_Status_Path(t *testing.T) {
 	// Create a socket in /tmp because we always have write permission. If the
 	// removing of socket fail we won't have junk files around. Cuz when system


### PR DESCRIPTION
This PR allows glob patterns to be used in the `unixsocket` configuration. This is useful in environments where FPM pools are managed dynamically, so that the configuration file doesn't have to be edited every time a pool is created or deleted.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
