### PR TITLE
feat(inputs/statsd): Improve gather performance

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -51,9 +51,9 @@ func (a *Agent) Run(ctx context.Context) error {
 		return err
 	}
 
-	inputC := make(chan telegraf.Metric, 100)
-	procC := make(chan telegraf.Metric, 100)
-	outputC := make(chan telegraf.Metric, 100)
+	inputC := make(chan telegraf.Metric, a.Config.Agent.MetricBatchSize)
+	procC := make(chan telegraf.Metric, a.Config.Agent.MetricBatchSize)
+	outputC := make(chan telegraf.Metric, a.Config.Agent.MetricBatchSize)
 
 	startTime := time.Now()
 


### PR DESCRIPTION
Improve the gather performance to the statsd input processor by processing metric types in parallel.

Use Agent.MetricBatchSize to configure the processing channel buffer, which allows high throughput inputs to process entire batches.

Together these reduces the processing time of 50k metrics from over 1 second to ~100ms when not limited by the current influx metric serializer with a good selection of metric types.

Also:
* Add debug information about gather timings.

Helps: #7070

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
