### PR TITLE
Set headers correctly on influxdb_listener

### DIFF
--- a/plugins/inputs/influxdb_listener/http_listener.go
+++ b/plugins/inputs/influxdb_listener/http_listener.go
@@ -244,7 +244,9 @@ func (h *HTTPListener) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		verbose := req.URL.Query().Get("verbose")
 
 		// respond to ping requests
+		res.Header().Set("X-Influxdb-Version", "1.0")
 		if verbose != "" && verbose != "0" && verbose != "false" {
+			res.Header().Set("Content-Type", "application/json")
 			res.WriteHeader(http.StatusOK)
 			b, _ := json.Marshal(map[string]string{"version": "1.0"}) // based on header set above
 			res.Write(b)


### PR DESCRIPTION
The ping endpoint in influx returns the version in a HTTP header (eg X-Influxdb-Version: 1.0).  The presence of this header is checked by Springboot influxdb ping() implementation (at quite possibly other clients).  This PR adds this header to ping responses and additionally sets the Content-Type correctly when used with the verbose parameter.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
