### PR TITLE
Fix internal metrics for output split into multiple lines

### DIFF
--- a/internal/models/buffer.go
+++ b/internal/models/buffer.go
@@ -33,6 +33,11 @@ type Buffer struct {
 
 // NewBuffer returns a new empty Buffer with the given capacity.
 func NewBuffer(name string, alias string, capacity int) *Buffer {
+	tags := map[string]string{"output": name}
+	if alias != "" {
+		tags["alias"] = alias
+	}
+
 	b := &Buffer{
 		buf:   make([]telegraf.Metric, capacity),
 		first: 0,
@@ -43,27 +48,27 @@ func NewBuffer(name string, alias string, capacity int) *Buffer {
 		MetricsAdded: selfstat.Register(
 			"write",
 			"metrics_added",
-			map[string]string{"output": name, "alias": alias},
+			tags,
 		),
 		MetricsWritten: selfstat.Register(
 			"write",
 			"metrics_written",
-			map[string]string{"output": name, "alias": alias},
+			tags,
 		),
 		MetricsDropped: selfstat.Register(
 			"write",
 			"metrics_dropped",
-			map[string]string{"output": name, "alias": alias},
+			tags,
 		),
 		BufferSize: selfstat.Register(
 			"write",
 			"buffer_size",
-			map[string]string{"output": name, "alias": alias},
+			tags,
 		),
 		BufferLimit: selfstat.Register(
 			"write",
 			"buffer_limit",
-			map[string]string{"output": name, "alias": alias},
+			tags,
 		),
 	}
 	b.BufferSize.Set(int64(0))


### PR DESCRIPTION
Fix a issue where the internal metrics were split over two lines unnecessarily due to the alias tag being set to the empty string.

1.13.4
```
> internal_write,host=loaner,output=kafka,version=unknown errors=0i,metrics_filtered=0i,write_time_ns=0i 1583447470000000000
> internal_write,host=loaner,output=kafka,version=unknown buffer_limit=10000000i,buffer_size=0i,metrics_added=0i,metrics_dropped=0i,metrics_written=0i 1583447470000000000
```

With change
```
internal_write,host=loaner,output=file,version=unknown buffer_limit=10000000i,buffer_size=0i,errors=0i,metrics_added=0i,metrics_dropped=0i,metrics_filtered=0i,metrics_written=0i,write_time_ns=0i 1583447704000000000
```


### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
