### PR TITLE
Support multiple templates for graphite serializers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1891,6 +1891,18 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 		}
 	}
 
+	if node, ok := tbl.Fields["templates"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if ary, ok := kv.Value.(*ast.Array); ok {
+				for _, elem := range ary.Value {
+					if str, ok := elem.(*ast.String); ok {
+						c.Templates = append(c.Templates, str.Value)
+					}
+				}
+			}
+		}
+	}
+
 	if node, ok := tbl.Fields["influx_max_line_bytes"]; ok {
 		if kv, ok := node.(*ast.KeyValue); ok {
 			if integer, ok := kv.Value.(*ast.Integer); ok {
@@ -2046,6 +2058,7 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 	delete(tbl.Fields, "data_format")
 	delete(tbl.Fields, "prefix")
 	delete(tbl.Fields, "template")
+	delete(tbl.Fields, "templates")
 	delete(tbl.Fields, "json_timestamp_units")
 	delete(tbl.Fields, "splunkmetric_hec_routing")
 	delete(tbl.Fields, "splunkmetric_multimetric")

--- a/plugins/outputs/graphite/README.md
+++ b/plugins/outputs/graphite/README.md
@@ -21,6 +21,16 @@ see the [Graphite Data Format](../../../docs/DATA_FORMATS_OUTPUT.md)
   ## see https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   template = "host.tags.measurement.field"
 
+  ## Graphite templates patterns
+  ## 1. Template for cpu
+  ## 2. Template for disk*
+  ## 3. Default template
+  # templates = [
+  #  "cpu tags.measurement.host.field",
+  #  "disk* measurement.field",
+  #  "host.measurement.tags.field"
+  #]
+
   ## Enable Graphite tags support
   # graphite_tag_support = false
 

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -41,6 +41,16 @@ var sampleConfig = `
   ## Enable Graphite tags support
   # graphite_tag_support = false
 
+  ## Graphite templates patterns
+  ## 1. Template for cpu
+  ## 2. Template for disk*
+  ## 3. Default template
+  # templates = [
+  #  "cpu tags.measurement.host.field",
+  #  "disk* measurement.field",
+  #  "host.measurement.tags.field"
+  #]
+
   ## timeout in seconds for the write connection to graphite
   timeout = 2
 

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -18,11 +18,12 @@ import (
 type Graphite struct {
 	GraphiteTagSupport bool
 	// URL is only for backwards compatibility
-	Servers  []string
-	Prefix   string
-	Template string
-	Timeout  int
-	conns    []net.Conn
+	Servers   []string
+	Prefix    string
+	Template  string
+	Templates []string
+	Timeout   int
+	conns     []net.Conn
 	tlsint.ClientConfig
 }
 
@@ -134,7 +135,7 @@ func checkEOF(conn net.Conn) {
 func (g *Graphite) Write(metrics []telegraf.Metric) error {
 	// Prepare data
 	var batch []byte
-	s, err := serializers.NewGraphiteSerializer(g.Prefix, g.Template, g.GraphiteTagSupport)
+	s, err := serializers.NewGraphiteSerializer(g.Prefix, g.Template, g.GraphiteTagSupport, g.Templates)
 	if err != nil {
 		return err
 	}

--- a/plugins/outputs/graphite/graphite_test.go
+++ b/plugins/outputs/graphite/graphite_test.go
@@ -98,6 +98,70 @@ func TestGraphiteOK(t *testing.T) {
 	g.Close()
 }
 
+func TestGraphiteOKWithMultipleTemplates(t *testing.T) {
+	var wg sync.WaitGroup
+	// Start TCP server
+	wg.Add(1)
+	t.Log("Starting server")
+	TCPServer1WithMultipleTemplates(t, &wg)
+
+	// Init plugin
+	g := Graphite{
+		Prefix:   "my.prefix",
+		Template: "measurement.host.tags.field",
+		Templates: []string{
+			"my_* host.measurement.tags.field",
+			"measurement.tags.host.field",
+		},
+	}
+
+	// Init metrics
+	m1, _ := metric.New(
+		"mymeasurement",
+		map[string]string{"host": "192.168.0.1", "mytag": "valuetag"},
+		map[string]interface{}{"myfield": float64(3.14)},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+	m2, _ := metric.New(
+		"mymeasurement",
+		map[string]string{"host": "192.168.0.1", "mytag": "valuetag"},
+		map[string]interface{}{"value": float64(3.14)},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+	m3, _ := metric.New(
+		"my_measurement",
+		map[string]string{"host": "192.168.0.1", "mytag": "valuetag"},
+		map[string]interface{}{"value": float64(3.14)},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+
+	// Prepare point list
+	metrics := []telegraf.Metric{m1}
+	metrics2 := []telegraf.Metric{m2, m3}
+	err1 := g.Connect()
+	require.NoError(t, err1)
+	// Send Data
+	t.Log("Send first data")
+	err2 := g.Write(metrics)
+	require.NoError(t, err2)
+
+	// Waiting TCPserver, should reconnect and resend
+	wg.Wait()
+	t.Log("Finished Waiting for first data")
+	var wg2 sync.WaitGroup
+	// Start TCP server
+	wg2.Add(1)
+	TCPServer2WithMultipleTemplates(t, &wg2)
+	//Write but expect an error, but reconnect
+	err3 := g.Write(metrics2)
+	t.Log("Finished writing second data, it should have reconnected automatically")
+
+	require.NoError(t, err3)
+	t.Log("Finished writing third data")
+	wg2.Wait()
+	g.Close()
+}
+
 func TestGraphiteOkWithTags(t *testing.T) {
 	var wg sync.WaitGroup
 	// Start TCP server
@@ -183,6 +247,36 @@ func TCPServer2(t *testing.T, wg *sync.WaitGroup) {
 		assert.Equal(t, "my.prefix.192_168_0_1.mymeasurement 3.14 1289430000", data2)
 		data3, _ := tp.ReadLine()
 		assert.Equal(t, "my.prefix.192_168_0_1.my_measurement 3.14 1289430000", data3)
+		conn2.Close()
+		tcpServer.Close()
+	}()
+}
+
+func TCPServer1WithMultipleTemplates(t *testing.T, wg *sync.WaitGroup) {
+	tcpServer, _ := net.Listen("tcp", "127.0.0.1:2003")
+	go func() {
+		defer wg.Done()
+		conn, _ := (tcpServer).Accept()
+		reader := bufio.NewReader(conn)
+		tp := textproto.NewReader(reader)
+		data1, _ := tp.ReadLine()
+		assert.Equal(t, "my.prefix.mymeasurement.valuetag.192_168_0_1.myfield 3.14 1289430000", data1)
+		conn.Close()
+		tcpServer.Close()
+	}()
+}
+
+func TCPServer2WithMultipleTemplates(t *testing.T, wg *sync.WaitGroup) {
+	tcpServer, _ := net.Listen("tcp", "127.0.0.1:2003")
+	go func() {
+		defer wg.Done()
+		conn2, _ := (tcpServer).Accept()
+		reader := bufio.NewReader(conn2)
+		tp := textproto.NewReader(reader)
+		data2, _ := tp.ReadLine()
+		assert.Equal(t, "my.prefix.mymeasurement.valuetag.192_168_0_1 3.14 1289430000", data2)
+		data3, _ := tp.ReadLine()
+		assert.Equal(t, "my.prefix.192_168_0_1.my_measurement.valuetag 3.14 1289430000", data3)
 		conn2.Close()
 		tcpServer.Close()
 	}()

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -27,6 +27,7 @@ type Instrumental struct {
 	Prefix     string
 	DataFormat string
 	Template   string
+	Templates  []string
 	Timeout    internal.Duration
 	Debug      bool
 
@@ -85,7 +86,7 @@ func (i *Instrumental) Write(metrics []telegraf.Metric) error {
 		}
 	}
 
-	s, err := serializers.NewGraphiteSerializer(i.Prefix, i.Template, false)
+	s, err := serializers.NewGraphiteSerializer(i.Prefix, i.Template, false, i.Templates)
 	if err != nil {
 		return err
 	}

--- a/plugins/serializers/graphite/README.md
+++ b/plugins/serializers/graphite/README.md
@@ -22,6 +22,16 @@ method is used, otherwise the [Template Pattern](templates) is used.
   prefix = "telegraf"
   ## Graphite template pattern
   template = "host.tags.measurement.field"
+  
+  ## Graphite templates patterns
+  ## 1. Template for cpu
+  ## 2. Template for disk*
+  ## 3. Default template
+  # templates = [
+  #  "cpu tags.measurement.host.field",
+  #  "disk* measurement.field",
+  #  "host.measurement.tags.field"
+  #]
 
   ## Support Graphite tags, recommended to enable when using Graphite 1.1 or later.
   # graphite_tag_support = false

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -66,7 +66,8 @@ type Config struct {
 
 	// Template for converting telegraf metrics into Graphite
 	// only supports Graphite
-	Template string `toml:"template"`
+	Template  string   `toml:"template"`
+	Templates []string `toml:"templates"`
 
 	// Timestamp units to use for JSON formatted output
 	TimestampUnits time.Duration `toml:"timestamp_units"`
@@ -104,7 +105,7 @@ func NewSerializer(config *Config) (Serializer, error) {
 	case "influx":
 		serializer, err = NewInfluxSerializerConfig(config)
 	case "graphite":
-		serializer, err = NewGraphiteSerializer(config.Prefix, config.Template, config.GraphiteTagSupport)
+		serializer, err = NewGraphiteSerializer(config.Prefix, config.Template, config.GraphiteTagSupport, config.Templates)
 	case "json":
 		serializer, err = NewJsonSerializer(config.TimestampUnits)
 	case "splunkmetric":
@@ -188,10 +189,21 @@ func NewInfluxSerializer() (Serializer, error) {
 	return influx.NewSerializer(), nil
 }
 
-func NewGraphiteSerializer(prefix, template string, tag_support bool) (Serializer, error) {
+func NewGraphiteSerializer(prefix, template string, tag_support bool, templates []string) (Serializer, error) {
+	graphiteTemplates, defaultTemplate, err := graphite.InitGraphiteTemplates(templates)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if defaultTemplate != "" {
+		template = defaultTemplate
+	}
+
 	return &graphite.GraphiteSerializer{
 		Prefix:     prefix,
 		Template:   template,
 		TagSupport: tag_support,
+		Templates:  graphiteTemplates,
 	}, nil
 }

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -66,9 +66,9 @@ type Config struct {
 
 	// Template for converting telegraf metrics into Graphite
 	// only supports Graphite
-	Template  string   `toml:"template"`
+	Template string `toml:"template"`
 
-	// Same Template, but multiple
+	// Templates same Template, but multiple
 	Templates []string `toml:"templates"`
 
 	// Timestamp units to use for JSON formatted output

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -67,6 +67,8 @@ type Config struct {
 	// Template for converting telegraf metrics into Graphite
 	// only supports Graphite
 	Template  string   `toml:"template"`
+
+	// Same Template, but multiple
 	Templates []string `toml:"templates"`
 
 	// Timestamp units to use for JSON formatted output


### PR DESCRIPTION
### Current behavior:

```
[[outputs.graphite]]
  ...
  template = "host.tags.measurement.field"
```

### Desired behavior:

```
[[outputs.graphite]]
    ...
    templates = [
     "cpu tags.measurement.host.field",
     "disk* measurement.field",
     "host.measurement.tags.field"
   ]

```

closes #7135

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
