### PR TITLE
Apply ping deadline to dns lookup

### DIFF
--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -3,7 +3,9 @@
 package ping
 
 import (
+	"context"
 	"errors"
+	"net"
 	"reflect"
 	"sort"
 	"testing"
@@ -340,6 +342,12 @@ func TestPingBinary(t *testing.T) {
 	acc.GatherError(p.Gather)
 }
 
+func mockHostResolver(ctx context.Context, ipv6 bool, host string) (*net.IPAddr, error) {
+	ipaddr := net.IPAddr{}
+	ipaddr.IP = net.IPv4(127, 0, 0, 1)
+	return &ipaddr, nil
+}
+
 // Test that Gather function works using native ping
 func TestPingGatherNative(t *testing.T) {
 	if testing.Short() {
@@ -348,12 +356,35 @@ func TestPingGatherNative(t *testing.T) {
 
 	var acc testutil.Accumulator
 	p := Ping{
-		Urls:   []string{"localhost", "127.0.0.2"},
-		Method: "native",
-		Count:  5,
+		Urls:        []string{"localhost", "127.0.0.2"},
+		Method:      "native",
+		Count:       5,
+		resolveHost: mockHostResolver,
 	}
 
 	assert.NoError(t, acc.GatherError(p.Gather))
 	assert.True(t, acc.HasPoint("ping", map[string]string{"url": "localhost"}, "packets_transmitted", 5))
 	assert.True(t, acc.HasPoint("ping", map[string]string{"url": "localhost"}, "packets_received", 5))
+}
+
+func mockHostResolverError(ctx context.Context, ipv6 bool, host string) (*net.IPAddr, error) {
+	return nil, errors.New("myMock error")
+}
+
+// Test failed DNS resolutions
+func TestDNSLookupError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test due to permission requirements.")
+	}
+
+	var acc testutil.Accumulator
+	p := Ping{
+		Urls:        []string{"localhost"},
+		Method:      "native",
+		IPv6:        false,
+		resolveHost: mockHostResolverError,
+	}
+
+	acc.GatherError(p.Gather)
+	assert.True(t, len(acc.Errors) > 0)
 }


### PR DESCRIPTION
This includes dns lookup in ping deadline. The deadline context is used for performing dns lookups, thus a ping collection will fail if the dealine times out during a lookup

Fixes #5059

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
