### PR TITLE
inputs.ecs: add v3 metadata support.

### DIFF
--- a/plugins/inputs/ecs/README.md
+++ b/plugins/inputs/ecs/README.md
@@ -1,8 +1,8 @@
 # Amazon ECS Input Plugin
 
-Amazon ECS, Fargate compatible, input plugin which uses the [Amazon ECS v2 metadata and
-stats API][task-metadata-endpoint-v2] endpoints to gather stats on running
-containers in a Task.
+Amazon ECS, Fargate compatible, input plugin which uses the Amazon ECS metadata and
+stats [v2][task-metadata-endpoint-v2] or [v3][task-metadata-endpoint-v3] API endpoints
+to gather stats on running containers in a Task.
 
 The telegraf container must be run in the same Task as the workload it is
 inspecting.
@@ -14,13 +14,86 @@ formats.
 The amazon-ecs-agent (though it _is_ a container running on the host) is not
 present in the metadata/stats endpoints.
 
-### Configuration
+### Configuration (v2 Endpoint)
 
 ```toml
 # Read metrics about ECS containers
 [[inputs.ecs]]
-  ## ECS metadata url
+  ## ECS metadata url. Auto-set if empty.
   # endpoint_url = "http://169.254.170.2"
+
+  ## ECS metadata version (2, 3)
+  ## Ignored if endpoint_url is empty and auto-set according to the
+  ## detected metadata availability.
+  # metadata_version = 2
+
+  ## Containers to include and exclude. Globs accepted.
+  ## Note that an empty array for both will include all containers
+  # container_name_include = []
+  # container_name_exclude = []
+
+  ## Container states to include and exclude. Globs accepted.
+  ## When empty only containers in the "RUNNING" state will be captured.
+  ## Possible values are "NONE", "PULLED", "CREATED", "RUNNING",
+  ## "RESOURCES_PROVISIONED", "STOPPED".
+  # container_status_include = []
+  # container_status_exclude = []
+
+  ## ecs labels to include and exclude as tags.  Globs accepted.
+  ## Note that an empty array for both will include all labels as tags
+  ecs_label_include = [ "com.amazonaws.ecs.*" ]
+  ecs_label_exclude = []
+
+  ## Timeout for queries.
+  # timeout = "5s"
+```
+
+### Configuration (v3 Endpoint)
+
+```toml
+# Read metrics about ECS containers
+[[inputs.ecs]]
+  ## ECS metadata url. Auto-set if empty.
+  endpoint_url = "${ECS_CONTAINER_METADATA_URI}"
+
+  ## ECS metadata version (2, 3)
+  ## Ignored if endpoint_url is empty and auto-set according to the
+  ## detected metadata availability.
+  metadata_version = 3
+
+  ## Containers to include and exclude. Globs accepted.
+  ## Note that an empty array for both will include all containers
+  # container_name_include = []
+  # container_name_exclude = []
+
+  ## Container states to include and exclude. Globs accepted.
+  ## When empty only containers in the "RUNNING" state will be captured.
+  ## Possible values are "NONE", "PULLED", "CREATED", "RUNNING",
+  ## "RESOURCES_PROVISIONED", "STOPPED".
+  # container_status_include = []
+  # container_status_exclude = []
+
+  ## ecs labels to include and exclude as tags.  Globs accepted.
+  ## Note that an empty array for both will include all labels as tags
+  ecs_label_include = [ "com.amazonaws.ecs.*" ]
+  ecs_label_exclude = []
+
+  ## Timeout for queries.
+  # timeout = "5s"
+```
+
+### Configuration (auto-detect)
+
+```toml
+# Read metrics about ECS containers
+[[inputs.ecs]]
+  ## ECS metadata url. Auto-set if empty.
+  endpoint_url = ""
+
+  ## ECS metadata version (2, 3)
+  ## Ignored if endpoint_url is empty and auto-set according to the
+  ## detected metadata availability.
+  # metadata_version = 2
 
   ## Containers to include and exclude. Globs accepted.
   ## Note that an empty array for both will include all containers
@@ -210,3 +283,4 @@ ecs_container_meta,cluster=test,com.amazonaws.ecs.cluster=test,com.amazonaws.ecs
 
 [docker-input]: /plugins/inputs/docker/README.md
 [task-metadata-endpoint-v2]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html
+[task-metadata-endpoint-v3] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html

--- a/plugins/inputs/ecs/README.md
+++ b/plugins/inputs/ecs/README.md
@@ -14,18 +14,15 @@ formats.
 The amazon-ecs-agent (though it _is_ a container running on the host) is not
 present in the metadata/stats endpoints.
 
-### Configuration (v2 Endpoint)
+### Configuration
 
 ```toml
 # Read metrics about ECS containers
 [[inputs.ecs]]
-  ## ECS metadata url. Auto-set if empty.
-  # endpoint_url = "http://169.254.170.2"
-
-  ## ECS metadata version (2, 3)
-  ## Ignored if endpoint_url is empty and auto-set according to the
-  ## detected metadata availability.
-  # metadata_version = 2
+  ## ECS metadata url.
+  ## Metadata v2 API is used if set explicitly. Otherwise,
+  ## v3 metadata endpoint API is used if available.
+  # endpoint_url = ""
 
   ## Containers to include and exclude. Globs accepted.
   ## Note that an empty array for both will include all containers
@@ -48,52 +45,15 @@ present in the metadata/stats endpoints.
   # timeout = "5s"
 ```
 
-### Configuration (v3 Endpoint)
+### Configuration (enforce v2 metadata)
 
 ```toml
 # Read metrics about ECS containers
 [[inputs.ecs]]
-  ## ECS metadata url. Auto-set if empty.
-  endpoint_url = "${ECS_CONTAINER_METADATA_URI}"
-
-  ## ECS metadata version (2, 3)
-  ## Ignored if endpoint_url is empty and auto-set according to the
-  ## detected metadata availability.
-  metadata_version = 3
-
-  ## Containers to include and exclude. Globs accepted.
-  ## Note that an empty array for both will include all containers
-  # container_name_include = []
-  # container_name_exclude = []
-
-  ## Container states to include and exclude. Globs accepted.
-  ## When empty only containers in the "RUNNING" state will be captured.
-  ## Possible values are "NONE", "PULLED", "CREATED", "RUNNING",
-  ## "RESOURCES_PROVISIONED", "STOPPED".
-  # container_status_include = []
-  # container_status_exclude = []
-
-  ## ecs labels to include and exclude as tags.  Globs accepted.
-  ## Note that an empty array for both will include all labels as tags
-  ecs_label_include = [ "com.amazonaws.ecs.*" ]
-  ecs_label_exclude = []
-
-  ## Timeout for queries.
-  # timeout = "5s"
-```
-
-### Configuration (auto-detect)
-
-```toml
-# Read metrics about ECS containers
-[[inputs.ecs]]
-  ## ECS metadata url. Auto-set if empty.
-  endpoint_url = ""
-
-  ## ECS metadata version (2, 3)
-  ## Ignored if endpoint_url is empty and auto-set according to the
-  ## detected metadata availability.
-  # metadata_version = 2
+  ## ECS metadata url.
+  ## Metadata v2 API is used if set explicitly. Otherwise,
+  ## v3 metadata endpoint API is used if available.
+  endpoint_url = "http://169.254.170.2"
 
   ## Containers to include and exclude. Globs accepted.
   ## Note that an empty array for both will include all containers

--- a/plugins/inputs/ecs/client_test.go
+++ b/plugins/inputs/ecs/client_test.go
@@ -238,3 +238,13 @@ func TestEcsClient_ContainerStats(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMetadataPath(t *testing.T) {
+	assert.Equal(t, "/v2/metadata", getMetadataPath(2))
+	assert.Equal(t, "/task", getMetadataPath(3))
+}
+
+func TestGetMetaStatsPath(t *testing.T) {
+	assert.Equal(t, "/v2/stats", getMetaStatsPath(2))
+	assert.Equal(t, "/task/stats", getMetaStatsPath(3))
+}

--- a/plugins/inputs/ecs/ecs_test.go
+++ b/plugins/inputs/ecs/ecs_test.go
@@ -769,7 +769,7 @@ var validMeta = Task{
 	PullStoppedAt: metaPullStop,
 }
 
-func TestInitEndpoint(t *testing.T) {
+func TestResolveEndpoint(t *testing.T) {
 	tests := []struct {
 		name   string
 		given  Ecs
@@ -778,38 +778,27 @@ func TestInitEndpoint(t *testing.T) {
 		afterF func()
 	}{
 		{
-			name: "defaults are preserved",
+			name: "Endpoint is explicitly set => use v2 metadata",
 			given: Ecs{
-				EndpointURL:     v2Endpoint,
-				MetadataVersion: 2,
+				EndpointURL: "192.162.0.1/custom_endpoint",
 			},
 			exp: Ecs{
-				EndpointURL:     v2Endpoint,
-				MetadataVersion: 2,
+				EndpointURL:     "192.162.0.1/custom_endpoint",
+				metadataVersion: 2,
 			},
 		},
 		{
-			name: "overrides version to 2 if not explicitly set to 3",
-			given: Ecs{
-				EndpointURL: v2Endpoint,
-			},
-			exp: Ecs{
-				EndpointURL:     v2Endpoint,
-				MetadataVersion: 2,
-			},
-		},
-		{
-			name: "EndpointURL not set. No ECS_CONTAINER_METADATA_URI.",
+			name: "Endpoint is not set, ECS_CONTAINER_METADATA_URI is not set => use v2 metadata",
 			given: Ecs{
 				EndpointURL: "",
 			},
 			exp: Ecs{
 				EndpointURL:     v2Endpoint,
-				MetadataVersion: 2,
+				metadataVersion: 2,
 			},
 		},
 		{
-			name: "EndpointURL not set. ECS_CONTAINER_METADATA_URI is set",
+			name: "Endpoint is not set, ECS_CONTAINER_METADATA_URI is set => use v3 metadata",
 			preF: func() {
 				os.Setenv("ECS_CONTAINER_METADATA_URI", "v3-endpoint.local")
 			},
@@ -821,7 +810,7 @@ func TestInitEndpoint(t *testing.T) {
 			},
 			exp: Ecs{
 				EndpointURL:     "v3-endpoint.local",
-				MetadataVersion: 3,
+				metadataVersion: 3,
 			},
 		},
 	}
@@ -835,7 +824,7 @@ func TestInitEndpoint(t *testing.T) {
 			}
 
 			act := tt.given
-			initEndpoint(&act)
+			resolveEndpoint(&act)
 			assert.Equal(t, tt.exp, act)
 		})
 	}


### PR DESCRIPTION
Justification: v2 `metadata and Docker stats are available to tasks that use the awsvpc network mode ...` only [v2]. v3 metadata is available regardless of the network mode and provides the same statistics as the v2 metadata.

[v2] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
