### PR TITLE
Adding Database IO Tempdb per Azure DB collection, Fixing PerfmonV2 collection for on-prem

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -359,24 +359,40 @@ BEGIN
 	SELECT
 		 ''sqlserver_database_io'' As [measurement]
 		,REPLACE(@@SERVERNAME,''\'','':'') AS [sql_instance]
-		,DB_NAME([vfs].[database_id]) AS [database_name]
+		,DB_NAME() as database_name
+		,vfs.database_id   -- /*needed as tempdb is different for each Azure SQL DB as grouping has to be by logical server + db_name + database_id*/
+		,vfs.file_id
 		,vfs.io_stall_read_ms AS read_latency_ms
 		,vfs.num_of_reads AS reads
 		,vfs.num_of_bytes_read AS read_bytes
 		,vfs.io_stall_write_ms AS write_latency_ms
 		,vfs.num_of_writes AS writes
 		,vfs.num_of_bytes_written AS write_bytes
-		,vfs.io_stall_queued_read_ms as rg_read_stall_ms
-		,ISNULL(b.name ,''RBPEX'') as logical_filename
-		,ISNULL(b.physical_name, ''RBPEX'') as physical_filename
+		,vfs.io_stall_queued_read_ms AS [rg_read_stall_ms]
+                ,vfs.io_stall_queued_write_ms AS [rg_write_stall_ms]
+		 ,CASE
+                        WHEN (vfs.database_id = 0) THEN ''RBPEX''
+                        ELSE b.logical_filename
+                  END as logical_filename
+                 ,CASE
+                        WHEN (vfs.database_id = 0) THEN ''RBPEX''
+                        ELSE b.physical_filename
+                  END as physical_filename
 		,CASE WHEN vfs.file_id = 2 THEN ''LOG'' ELSE ''DATA'' END AS file_type
 		,ISNULL(size,0)/128 AS current_size_mb
-		,ISNULL(FILEPROPERTY(b.name,''SpaceUsed'')/128,0) as space_used_mb
-		,vfs.io_stall_queued_read_ms AS [rg_read_stall_ms]
-		,vfs.io_stall_queued_write_ms AS [rg_write_stall_ms]
+		,ISNULL(FILEPROPERTY(b.logical_filename,''SpaceUsed'')/128,0) as space_used_mb
 	FROM [sys].[dm_io_virtual_file_stats](NULL,NULL) AS vfs
-	LEFT OUTER join sys.database_files b 
-		ON b.file_id = vfs.file_id
+	-- needed to get Tempdb file names  on Azure SQL DB so you can join appropriately. Without this had a bug where join was only on file_id
+        LEFT OUTER join
+        (
+             SELECT DB_ID() as database_id, file_id, logical_filename=name COLLATE SQL_Latin1_General_CP1_CI_AS
+                , physical_filename = physical_name COLLATE SQL_Latin1_General_CP1_CI_AS, size from  sys.database_files
+                where type <> 2
+             UNION ALL
+             SELECT 2 as database_id, file_id, logical_filename = name , physical_filename = physical_name, size
+                from  tempdb.sys.database_files
+         ) b ON b.database_id = vfs.database_id and b.file_id = vfs.file_id
+          where vfs.database_id IN (DB_ID(),0,2)
 	'
 	EXEC sp_executesql @SqlStatement
 
@@ -389,8 +405,8 @@ BEGIN
 		''sqlserver_database_io'' AS [measurement]
 		,REPLACE(@@SERVERNAME,''\'','':'') AS [sql_instance]
 		,DB_NAME(vfs.[database_id]) AS [database_name]
-		,COALESCE(mf.[physical_name],''RBPEX'') AS [physical_filename]	--RPBEX = Resilient Buffer Pool Extension
-		,COALESCE(mf.[name],''RBPEX'') AS [logical_filename]	--RPBEX = Resilient Buffer Pool Extension
+		,mf.[physical_name] AS [physical_filename]	
+		,mf.[name] AS [logical_filename]	
 		,mf.[type_desc] AS [file_type]
 		,IIF( RIGHT(vs.[volume_mount_point],1) = ''\''	/*Tag value cannot end with \ */
 			,LEFT(vs.[volume_mount_point],LEN(vs.[volume_mount_point])-1)

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -405,8 +405,8 @@ BEGIN
 		''sqlserver_database_io'' AS [measurement]
 		,REPLACE(@@SERVERNAME,''\'','':'') AS [sql_instance]
 		,DB_NAME(vfs.[database_id]) AS [database_name]
-		,mf.[physical_name] AS [physical_filename]	
-		,mf.[name] AS [logical_filename]	
+		,COALESCE(mf.[physical_name],''RBPEX'') AS [physical_filename]	--RPBEX = Resilient Buffer Pool Extension
+		,COALESCE(mf.[name],''RBPEX'') AS [logical_filename]	--RPBEX = Resilient Buffer Pool Extension	
 		,mf.[type_desc] AS [file_type]
 		,IIF( RIGHT(vs.[volume_mount_point],1) = ''\''	/*Tag value cannot end with \ */
 			,LEFT(vs.[volume_mount_point],LEN(vs.[volume_mount_point])-1)


### PR DESCRIPTION
### Required for all PRs:

- [X ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [] Has appropriate unit tests.

Datababase IO changes
Today on Azure SQL DB there was a bug where left outer join from virtual file stats and database_files was only on file_id. Tempdb was exposed on virtual file stats, but not in Database files. On Azure SQL DB have to use tempdb.sys.database_files. In addition each Azure SQL DB has its own tempdb so needed to add Database_id/File ID to be able to distinguish so that reporting can be done by Logical Server + Azure DB + database_id.  If you just looked at tempdb for a logical server would get multiple tempdb's belonging to different Azure SQL DB's as the logical server construct is just that a placeholder logical server not actual physical server.
Also corrected bug introduced earlier

PerfmonV2 Fix for [#7164](https://github.com/influxdata/telegraf/issues/7164)


