### PR TITLE
Fix GNMI TypedValue to scalar value conversion and update supported platforms

### DIFF
--- a/plugins/inputs/cisco_telemetry_gnmi/README.md
+++ b/plugins/inputs/cisco_telemetry_gnmi/README.md
@@ -1,9 +1,8 @@
 # Cisco GNMI Telemetry
 
-Cisco GNMI Telemetry is an input plugin that consumes telemetry data similar to the [GNMI specification](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md).
-This GRPC-based protocol can utilize TLS for authentication and encryption.
+Cisco GNMI Telemetry is an input plugin that consumes telemetry data based on the [GNMI](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md) Subscribe method. TLS is supported for authentication and encryption.
 
-This plugin has been developed to support GNMI telemetry as produced by Cisco IOS XR (64-bit) version 6.5.1 and later.
+It has been optimized to support GNMI telemetry as produced by Cisco IOS XR (64-bit) version 6.5.1, Cisco NX-OS 9.3 and Cisco IOS XE 16.12 and later.
 
 
 ### Configuration

--- a/plugins/inputs/cisco_telemetry_gnmi/cisco_telemetry_gnmi.go
+++ b/plugins/inputs/cisco_telemetry_gnmi/cisco_telemetry_gnmi.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"path"
 	"strings"
@@ -332,7 +333,7 @@ func (c *CiscoTelemetryGNMI) handleTelemetryField(update *gnmi.Update, tags map[
 	case *gnmi.TypedValue_BytesVal:
 		value = val.BytesVal
 	case *gnmi.TypedValue_DecimalVal:
-		value = val.DecimalVal
+		value = float64(val.DecimalVal.Digits) / math.Pow(10, float64(val.DecimalVal.Precision))
 	case *gnmi.TypedValue_FloatVal:
 		value = val.FloatVal
 	case *gnmi.TypedValue_IntVal:


### PR DESCRIPTION
This uses the GNMI library native ToScalar function to convert GNMI TypedValues to scalar Go values.
Also adds an updated note on tested device platforms.


Fixes #7167 