### PR TITLE
Allow using name_* modificators for output plugins

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -269,6 +269,9 @@ Parameters that can be used with any output plugin:
 - **metric_buffer_limit**: The maximum number of unsent metrics to buffer.
   Use this setting to override the agent `metric_buffer_limit` on a per plugin
   basis.
+- **name_override**: Override the original name of the measurement.
+- **name_prefix**: Specifies a prefix to attach to the measurement name.
+- **name_suffix**: Specifies a suffix to attach to the measurement name.
 
 The [metric filtering][] parameters can be used to limit what metrics are
 emitted from the output plugin.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2138,11 +2138,38 @@ func buildOutput(name string, tbl *ast.Table) (*models.OutputConfig, error) {
 		}
 	}
 
+	if node, ok := tbl.Fields["name_override"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if str, ok := kv.Value.(*ast.String); ok {
+				oc.NameOverride = str.Value
+			}
+		}
+	}
+
+	if node, ok := tbl.Fields["name_suffix"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if str, ok := kv.Value.(*ast.String); ok {
+				oc.NameSuffix = str.Value
+			}
+		}
+	}
+
+	if node, ok := tbl.Fields["name_prefix"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if str, ok := kv.Value.(*ast.String); ok {
+				oc.NamePrefix = str.Value
+			}
+		}
+	}
+
 	delete(tbl.Fields, "flush_interval")
 	delete(tbl.Fields, "flush_jitter")
 	delete(tbl.Fields, "metric_buffer_limit")
 	delete(tbl.Fields, "metric_batch_size")
 	delete(tbl.Fields, "alias")
+	delete(tbl.Fields, "name_override")
+	delete(tbl.Fields, "name_suffix")
+	delete(tbl.Fields, "name_prefix")
 
 	return oc, nil
 }

--- a/internal/models/running_output.go
+++ b/internal/models/running_output.go
@@ -27,6 +27,10 @@ type OutputConfig struct {
 	FlushJitter       *time.Duration
 	MetricBufferLimit int
 	MetricBatchSize   int
+
+	NameOverride      string
+	NamePrefix        string
+	NameSuffix        string
 }
 
 // RunningOutput contains the output configuration
@@ -146,6 +150,18 @@ func (ro *RunningOutput) AddMetric(metric telegraf.Metric) {
 		output.Add(metric)
 		ro.aggMutex.Unlock()
 		return
+	}
+
+	if len(ro.Config.NameOverride) > 0 {
+		metric.SetName(ro.Config.NameOverride)
+	}
+
+	if len(ro.Config.NamePrefix) > 0 {
+		metric.AddPrefix(ro.Config.NamePrefix)
+	}
+
+	if len(ro.Config.NameSuffix) > 0 {
+		metric.AddSuffix(ro.Config.NameSuffix)
 	}
 
 	dropped := ro.buffer.Add(metric)

--- a/internal/models/running_output.go
+++ b/internal/models/running_output.go
@@ -28,9 +28,9 @@ type OutputConfig struct {
 	MetricBufferLimit int
 	MetricBatchSize   int
 
-	NameOverride      string
-	NamePrefix        string
-	NameSuffix        string
+	NameOverride string
+	NamePrefix   string
+	NameSuffix   string
 }
 
 // RunningOutput contains the output configuration

--- a/internal/models/running_output_test.go
+++ b/internal/models/running_output_test.go
@@ -218,6 +218,60 @@ func TestRunningOutput_TagIncludeMatch(t *testing.T) {
 	assert.Len(t, m.Metrics()[0].Tags(), 1)
 }
 
+// Test that measurement name overriding correctly
+func TestRunningOutput_NameOverride(t *testing.T) {
+	conf := &OutputConfig{
+		NameOverride: "new_metric_name",
+	}
+
+	m := &mockOutput{}
+	ro := NewRunningOutput("test", m, conf, 1000, 10000)
+
+	ro.AddMetric(testutil.TestMetric(101, "metric1"))
+	assert.Len(t, m.Metrics(), 0)
+
+	err := ro.Write()
+	assert.NoError(t, err)
+	assert.Len(t, m.Metrics(), 1)
+	assert.Equal(t, "new_metric_name", m.Metrics()[0].Name())
+}
+
+// Test that measurement name prefix is added correctly
+func TestRunningOutput_NamePrefix(t *testing.T) {
+	conf := &OutputConfig{
+		NamePrefix: "prefix_",
+	}
+
+	m := &mockOutput{}
+	ro := NewRunningOutput("test", m, conf, 1000, 10000)
+
+	ro.AddMetric(testutil.TestMetric(101, "metric1"))
+	assert.Len(t, m.Metrics(), 0)
+
+	err := ro.Write()
+	assert.NoError(t, err)
+	assert.Len(t, m.Metrics(), 1)
+	assert.Equal(t, "prefix_metric1", m.Metrics()[0].Name())
+}
+
+// Test that measurement name suffix is added correctly
+func TestRunningOutput_NameSuffix(t *testing.T) {
+	conf := &OutputConfig{
+		NameSuffix: "_suffix",
+	}
+
+	m := &mockOutput{}
+	ro := NewRunningOutput("test", m, conf, 1000, 10000)
+
+	ro.AddMetric(testutil.TestMetric(101, "metric1"))
+	assert.Len(t, m.Metrics(), 0)
+
+	err := ro.Write()
+	assert.NoError(t, err)
+	assert.Len(t, m.Metrics(), 1)
+	assert.Equal(t, "metric1_suffix", m.Metrics()[0].Name())
+}
+
 // Test that we can write metrics with simple default setup.
 func TestRunningOutputDefault(t *testing.T) {
 	conf := &OutputConfig{


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This PR adds the ability to apply name_* modifiers to measurement names in output plugins. It closes the issue #7033.