### PR TITLE
Omit retained messages for mqtt_consumer plugin

### DIFF
--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -51,6 +51,15 @@ and creates metrics using one of the supported [input data formats][].
   ## publishing.
   # persistent_session = false
 
+  ## Omit retained messages.
+  ## If this value is set to true, retained messages are not sent to the output
+  ## plug-ins. This prevents duplicate messages from being saved when Telegraf is
+  ## restarted. However, this also prevents the last state from being received when
+  ## Telegraf is first started. This only affects messages that were sent by the
+  ## broker as retained messages. Messages received during an active subscription
+  ## are still processed as usual, regardless if the retained flag is set or not.
+  # omit_retained = false
+
   ## If unset, a random client ID will be generated.
   # client_id = ""
 


### PR DESCRIPTION
Solves an issue when dealing with retained messages.
Without this option being set to true, retained messages are stored twice into a database, when Telegraf is restarted. If you don't want this behaviour, set the new option to true. Messages received by the broker as retained are omitted (and thus not stored twice).

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
