### PR TITLE
Set headers on influxdb_listener ping URL

### DIFF
--- a/plugins/inputs/influxdb_listener/influxdb_listener.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener.go
@@ -226,7 +226,9 @@ func (h *InfluxDBListener) handlePing() http.HandlerFunc {
 		verbose := req.URL.Query().Get("verbose")
 
 		// respond to ping requests
+		res.Header().Set("X-Influxdb-Version", "1.0")
 		if verbose != "" && verbose != "0" && verbose != "false" {
+			res.Header().Set("Content-Type", "application/json")
 			res.WriteHeader(http.StatusOK)
 			b, _ := json.Marshal(map[string]string{"version": "1.0"}) // based on header set above
 			res.Write(b)


### PR DESCRIPTION
Set x-influxdb-version and content-type headers on ping URL as expected by clients.

closes #7104 