### PR TITLE
Remove init checks for valid label and field selectors

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -163,8 +163,6 @@ following works:
 - gopkg.in/olivere/elastic.v5 [MIT License](https://github.com/olivere/elastic/blob/v5.0.76/LICENSE)
 - gopkg.in/tomb.v1 [BSD 3-Clause Clear License](https://github.com/go-tomb/tomb/blob/v1/LICENSE)
 - gopkg.in/yaml.v2 [Apache License 2.0](https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE)
-- k8s.io/apimachinery [Apache License 2.0](https://github.com/kubernetes/apimachinery/blob/master/LICENSE)
-- k8s.io/klog [Apache License 2.0](https://github.com/kubernetes/klog/blob/master/LICENSE)
 
 ## telegraf used and modified code from these projects
 - github.com/DataDog/datadog-agent [Apache License 2.0](https://github.com/DataDog/datadog-agent/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,7 @@ require (
 	gopkg.in/olivere/elastic.v5 v5.0.70
 	gopkg.in/yaml.v2 v2.2.4
 	gotest.tools v2.2.0+incompatible // indirect
-	k8s.io/apimachinery v0.17.1
+	k8s.io/apimachinery v0.17.1 // indirect
 )
 
 // replaced due to https://github.com/satori/go.uuid/issues/73

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -15,8 +15,6 @@ import (
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3,*/*;q=0.1`
@@ -136,20 +134,6 @@ func (p *Prometheus) Description() string {
 func (p *Prometheus) Init() error {
 	if p.MetricVersion != 2 {
 		p.Log.Warnf("Use of deprecated configuration: 'metric_version = 1'; please update to 'metric_version = 2'")
-	}
-
-	if len(p.KubernetesLabelSelector) > 0 {
-		_, err := labels.Parse(p.KubernetesLabelSelector)
-		if err != nil {
-			return fmt.Errorf("label selector validation failed %q: %v", p.KubernetesLabelSelector, err)
-		}
-	}
-
-	if len(p.KubernetesFieldSelector) > 0 {
-		_, err := fields.ParseSelector(p.KubernetesFieldSelector)
-		if err != nil {
-			return fmt.Errorf("field selector validation failed %s: %v", p.KubernetesFieldSelector, err)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
Importing these libraries starts a goroutine at init time.  The removal of the checks will push a startup time error to a runtime error.

```
goroutine 8 [chan receive]:
k8s.io/klog.(*loggingT).flushDaemon(0x454f3c0)
        /home/dbn/src/influx/pkg/mod/k8s.io/klog@v1.0.0/klog.go:1010 +0x8b
created by k8s.io/klog.init.0
        /home/dbn/src/influx/pkg/mod/k8s.io/klog@v1.0.0/klog.go:411 +0xd6
```

related #6969

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
