### PR TITLE
Fix 'nil' file created by Makefile on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifeq ($(OS), Windows_NT)
-	VERSION := $(shell git describe --exact-match --tags 2>nil)
+	VERSION := $(shell git describe --exact-match --tags 2>nul)
 	HOME := $(HOMEPATH)
 	CGO_ENABLED ?= 0
 	export CGO_ENABLED


### PR DESCRIPTION
The /dev/null device on Windows is a virtual file named "nul" not "nil".
This fix works under both cmd.exe and Powershell.

### Required for all PRs:

- [ X] Signed [CLA](https://influxdata.com/community/cla/).
Not applicable:
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
