### PR TITLE
Add docs for how to handle errors in check-deps script

### DIFF
--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -48,8 +48,19 @@ for dep in $(LC_ALL=C sort -u "${tmpdir}/golist"); do
 	dep="${dep%%/v[0-9]}"
 	dep="${dep%%/v[0-9][0-9]}"
 
-	echo "${dep}" >> "${tmpdir}/actual"
+	echo "${dep}" >> "${tmpdir}/HEAD"
 done
 
-grep '^-' docs/LICENSE_OF_DEPENDENCIES.md | grep -v github.com/DataDog/datadog-agent | cut -f 2 -d' ' > "${tmpdir}/expected"
-diff -U0 "${tmpdir}/expected" "${tmpdir}/actual"
+grep '^-' docs/LICENSE_OF_DEPENDENCIES.md | grep -v github.com/DataDog/datadog-agent | cut -f 2 -d' ' > "${tmpdir}/LICENSE_OF_DEPENDENCIES.md"
+
+diff -U0 "${tmpdir}/LICENSE_OF_DEPENDENCIES.md" "${tmpdir}/HEAD" ||
+cat - <<EOF
+
+
+The docs/LICENSE_OF_DEPENDENCIES.md file does not contain the expected entries.
+
+Lines prefixed with '+' should be added to LICENSE_OF_DEPENDENCIES.md and '-'
+lines should be removed.
+
+Include a link to the appropriate licenses for any additions.
+EOF


### PR DESCRIPTION
This scripts output was confusing, this change adds some directions for how to handle errors.

Example output:

```
$ ./scripts/check-deps.sh
--- /tmp/tmp.NnRf7xH9bB/LICENSE_OF_DEPENDENCIES.md      2020-03-27 11:45:01.273020284 -0700
+++ /tmp/tmp.NnRf7xH9bB/HEAD    2020-03-27 11:45:01.272020301 -0700
@@ -67 +66,0 @@
-github.com/gorilla/context

The docs/LICENSE_OF_DEPENDENCIES.md file does not contain the expected entries.

Lines prefixed with '+' should be added to LICENSE_OF_DEPENDENCIES.md and '-'
lines should be removed.

Include a link to the appropriate licenses for any additions.
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
