### PR TITLE
[processor] Compute field value(s) by a given formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ For documentation on the latest development code see the [documentation index][d
 
 * [clone](/plugins/processors/clone)
 * [converter](/plugins/processors/converter)
+* [compute](/plugins/processors/compute)
 * [date](/plugins/processors/date)
 * [dedup](/plugins/processors/dedup)
 * [enum](/plugins/processors/enum)

--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -2,6 +2,7 @@ package all
 
 import (
 	_ "github.com/influxdata/telegraf/plugins/processors/clone"
+	_ "github.com/influxdata/telegraf/plugins/processors/compute"
 	_ "github.com/influxdata/telegraf/plugins/processors/converter"
 	_ "github.com/influxdata/telegraf/plugins/processors/date"
 	_ "github.com/influxdata/telegraf/plugins/processors/dedup"

--- a/plugins/processors/compute/README.md
+++ b/plugins/processors/compute/README.md
@@ -1,0 +1,105 @@
+# Compute Processor
+
+The compute processor is used to calculate field values of metrics by
+specifying formulas for those target fields. These formulas can contain
+constants, arithmetic operation as well as variables referencing to existing
+field values.
+
+When referencing fields in the formulas that do not exist, a strategy can be
+provided to ignore or fill the missing values.
+
+### Configuration
+```toml
+  # Compute values for a metric using the given formula(s)
+  [[processors.compute]]
+  ## Strategy to handle missing variables in cases where a formula refers to
+  ## a non-existing field. Possible values are:
+  ##		 ignore  - ignore formula for metric and do not update field
+  ##     const   - target field will be replaced by the "constant" defined below
+  ##     default - target field will be set to "default" defined below
+  missing = "ignore"
+
+  ## Constant to be used in the "const" strategy for missing fields
+  # constant = 0
+
+  ## Default value to be used in the "default" strategy for missing fields
+  # default = 0
+
+  ## Table of computations
+  [processors.compute.fields]
+    value = "(a + 3) / 4.3"
+    x_sqr = "pow(a, 2)"
+    x_abs = "abs(value)"
+```
+
+### Supported operations
+- `+`, `-`, `/`, `*` basic arithmetic operations:
+- `%` modulo operation (integer only)
+- `abs(.)` absolute value function
+- `pow(x,y)` `x` raised to the power of `y`
+
+### Examples
+
+Compute `deltaT` from sensor values `T_in` and `T_out`, convert the `operating`
+time from seconds to hours and calcualte the `volumne` from a measured
+`diameter`:
+```toml
+
+[processors.compute]]
+  missing = "ignore"
+  [processors.compute.fields]
+    deltaT    = "T_out - T_in"
+    operation = "operation / 3600.0"
+    volume    = "4.0/3 * 3.1415 * pow(diameter, 3)"
+```
+
+```diff
+- chp,host=telegraf diameter=31.5,T_in=19.8000000000001,operation=19625,T_out=63.7 1584111710000000000
++ chp,host=telegraf diameter=31.5,T_out=63.7,T_in=19.8000000000001,operation=5.451388888888889,deltaT=43.899999999999906,volume=130920.44174999998 1584111710000000000
+```
+*Please note*:  The `operation` fields gets overwritten by the computation.
+
+Ignore all computations where the referenced `diameter` field is missing:
+```toml
+[processors.compute]]
+  missing = "ignore"
+  [processors.compute.fields]
+    operation = "operation / 3600.0"
+    volume    = "4.0/3 * 3.1415 * pow(diameter, 3)"
+```
+
+```diff
+- machine1,host=telegraf operation=19625 1584111710000000000
++ machine1,host=telegraf operation=5.451388888888889, 1584111710000000000
+```
+
+Fill all computations where the referenced `diameter` field is missing with a
+constant result:
+```toml
+[processors.compute]]
+  missing = "const"
+  constant = 42.0
+  [processors.compute.fields]
+    operation = "operation / 3600.0"
+    volume    = "4.0/3 * 3.1415 * pow(diameter, 3)"
+```
+
+```diff
+- machine1,host=telegraf operation=85786 1584111710000000000
++ machine1,host=telegraf operation=23.829444444444444,volume=42.0 1584111710000000000
+```
+
+Assume the missing `diameter` to be equal to the given `default` value during computation:
+```toml
+[processors.compute]]
+  missing = "default"
+  default = 3.0
+  [processors.compute.fields]
+    operation = "operation / 3600.0"
+    volume    = "4.0/3 * 3.1415 * pow(diameter, 3)"
+```
+
+```diff
+- machine1,host=telegraf operation=85786 1584111710000000000
++ machine1,host=telegraf operation=23.829444444444444,volume=113.094 1584111710000000000
+```

--- a/plugins/processors/compute/compute.go
+++ b/plugins/processors/compute/compute.go
@@ -1,0 +1,353 @@
+package compute
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+	"strings"
+
+	"go/ast"
+	"go/parser"
+	"go/token"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+var sampleConfig = `
+  ## Strategy to handle missing variables in cases where a formula refers to
+  ## a non-existing field. Possible values are:
+  ##		 ignore  - ignore formula for metric and do not update field
+  ##     const   - target field will be replaced by the "constant" defined below
+  ##     default - target field will be set to "default" defined below
+  missing = "ignore"
+
+  ## Constant to be used in the "const" strategy for missing fields
+  # constant = 0
+
+  ## Default value to be used in the "default" strategy for missing fields
+  # default = 0
+
+  ## Table of computations
+  [processors.compute.fields]
+    value = "(a + 3) / 4.3"
+    x_sqr = "pow(a, 2)"
+    x_abs = "abs(value)"
+`
+
+const (
+	_ = iota
+	ErrorBasicLiteral
+	ErrorBinaryExpression
+	ErrorFieldUnknown
+	ErrorFunctionArguments
+	ErrorFunctionTypeUnknown
+	ErrorFunctionUnknown
+	ErrorNodeTypeUnknown
+	ErrorUnaryExpression
+)
+
+type ComputeError struct {
+	Code byte
+	Text string
+}
+
+func (e *ComputeError) Error() string {
+	return e.Text
+}
+
+type Compute struct {
+	Missing  string            `toml:"missing"`
+	Constant interface{}       `toml:"constant"`
+	Default  interface{}       `toml:"default"`
+	Fields   map[string]string `toml:"fields"`
+
+	trees map[string]ast.Expr
+}
+
+func (c *Compute) SampleConfig() string {
+	return sampleConfig
+}
+
+func (c *Compute) Description() string {
+	return "Compute values for a metric using the given formula(s)"
+}
+
+func (c *Compute) Init() error {
+	// Check the given parameters
+	switch c.Missing {
+	case "ignore":
+		c.Constant = nil
+		c.Default = nil
+	case "const":
+		c.Default = nil
+
+		if c.Constant == nil {
+			c.Constant = int64(0)
+		}
+
+		switch c.Constant.(type) {
+		case int, int64, float64:
+		default:
+			return fmt.Errorf("wrong datatype for 'constant', has to be int or float")
+		}
+	case "default":
+		c.Constant = nil
+
+		if c.Default == nil {
+			c.Default = int64(0)
+		}
+		switch c.Default.(type) {
+		case int:
+			c.Default = int64(c.Default.(int))
+		case int64, float64:
+		default:
+			return fmt.Errorf("wrong datatype for 'default', has to be int64 or float64")
+		}
+	default:
+		return fmt.Errorf("unknown missing-value strategy '%s'", c.Missing)
+	}
+
+	// Parse all defined formulas into abstract-syntax-trees
+	c.trees = make(map[string]ast.Expr, len(c.Fields))
+	for name, expr := range c.Fields {
+		log.Printf("D! [processors.compute] parsing formula for field \"%s\"", name)
+		tree, err := parser.ParseExpr(expr)
+		if err != nil {
+			return fmt.Errorf("parsing of formula for field '%v' failed: %v", name, err)
+		}
+		c.trees[name] = tree
+	}
+
+	return nil
+}
+
+func (c *Compute) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
+	for _, metric := range metrics {
+		for name, tree := range c.trees {
+			log.Printf("D! [processors.compute] processing field '%s' for metric '%s'", name, metric.Name())
+			result, err := descend(tree, metric.Fields(), c.Default)
+			if err == nil {
+				metric.AddField(name, result)
+			} else if err.(*ComputeError).Code == ErrorFieldUnknown {
+				if c.Missing == "const" {
+					metric.AddField(name, c.Constant)
+				} else if c.Missing == "default" {
+					metric.AddField(name, c.Default)
+				}
+			}
+		}
+	}
+	return metrics
+}
+
+func handle_literal(kind token.Token, value string) (r interface{}, err error) {
+	switch kind {
+	case token.FLOAT:
+		r, err = strconv.ParseFloat(value, 64)
+	case token.INT:
+		r, err = strconv.ParseInt(value, 10, 64)
+	default:
+		r, err = math.NaN(), &ComputeError{ErrorBasicLiteral, fmt.Sprintf("unknown basic literal '%v' with value '%v'", kind, value)}
+	}
+
+	return r, err
+}
+
+func binary_expr_int(operation token.Token, x, y int64) (r int64, err error) {
+	switch operation {
+	case token.ADD:
+		r, err = x+y, nil
+	case token.SUB:
+		r, err = x-y, nil
+	case token.MUL:
+		r, err = x*y, nil
+	case token.QUO:
+		r, err = x/y, nil
+	case token.REM:
+		r, err = x%y, nil
+	default:
+		r, err = 0, &ComputeError{ErrorBinaryExpression, fmt.Sprintf("unknown binary integer operation '%v'", operation)}
+	}
+
+	return r, err
+}
+
+func binary_expr_float(operation token.Token, x, y float64) (r float64, err error) {
+	switch operation {
+	case token.ADD:
+		r, err = x+y, nil
+	case token.SUB:
+		r, err = x-y, nil
+	case token.MUL:
+		r, err = x*y, nil
+	case token.QUO:
+		r, err = x/y, nil
+	default:
+		r, err = math.NaN(), &ComputeError{ErrorBinaryExpression, fmt.Sprintf("unknown binary float operation '%v'", operation)}
+	}
+
+	return r, err
+}
+
+func handle_binary_expression(operation token.Token, x, y interface{}) (r interface{}, err error) {
+	_, x_int := x.(int64)
+	_, y_int := y.(int64)
+	if x_int && y_int {
+		r, err = binary_expr_int(operation, x.(int64), y.(int64))
+	} else {
+		// Handle mixed float int arguments
+		var fx, fy float64
+		if x_int {
+			fx = float64(x.(int64))
+		} else {
+			fx = x.(float64)
+		}
+		if y_int {
+			fy = float64(y.(int64))
+		} else {
+			fy = y.(float64)
+		}
+		r, err = binary_expr_float(operation, fx, fy)
+	}
+
+	return r, err
+}
+
+func unary_expr_int(operation token.Token, x int64) (r int64, err error) {
+	switch operation {
+	case token.ADD:
+		r, err = x, nil
+	case token.SUB:
+		r, err = -x, nil
+	default:
+		r, err = 0, &ComputeError{ErrorUnaryExpression, fmt.Sprintf("unknown unary int operation '%v'", operation)}
+	}
+
+	return r, err
+}
+
+func unary_expr_float(operation token.Token, x float64) (r float64, err error) {
+	switch operation {
+	case token.ADD:
+		r, err = x, nil
+	case token.SUB:
+		r, err = -x, nil
+	default:
+		r, err = math.NaN(), &ComputeError{ErrorUnaryExpression, fmt.Sprintf("unknown unary float operation '%v'", operation)}
+	}
+
+	return r, err
+}
+
+func handle_unary_expression(operation token.Token, x interface{}) (r interface{}, err error) {
+	_, x_int := x.(int64)
+	if x_int {
+		r, err = unary_expr_int(operation, x.(int64))
+	} else {
+		r, err = unary_expr_float(operation, x.(float64))
+	}
+
+	return r, err
+}
+
+func handle_function(fun string, args []interface{}) (r interface{}, err error) {
+	// NOTE: When adding a function, please also add a documentation in the
+	//       "Supported operations" section of the README!
+	switch strings.ToLower(fun) {
+	case "abs":
+		if len(args) != 1 {
+			return math.NaN(), &ComputeError{ErrorFunctionArguments, fmt.Sprintf("invalid number of arguments (%v) for function '%v'", len(args), fun)}
+		}
+		// Handle int/float arguments
+		if _, x_int := args[0].(int64); x_int {
+			x := args[0].(int64)
+			if x >= 0 {
+				r, err = x, nil
+			} else {
+				r, err = -x, nil
+			}
+		} else {
+			r, err = math.Abs(args[0].(float64)), nil
+		}
+	case "pow":
+		if len(args) != 2 {
+			return math.NaN(), &ComputeError{ErrorFunctionArguments, fmt.Sprintf("invalid number of arguments (%v) for function '%v'", len(args), fun)}
+		}
+		var x, y float64
+
+		// Convert arguments to float
+		if _, x_int := args[0].(int64); x_int {
+			x = float64(args[0].(int64))
+		} else {
+			x = args[0].(float64)
+		}
+
+		if _, y_int := args[1].(int64); y_int {
+			y = float64(args[1].(int64))
+		} else {
+			y = args[1].(float64)
+		}
+		r, err = math.Pow(x, y), nil
+	default:
+		r, err = math.NaN(), &ComputeError{ErrorFunctionUnknown, fmt.Sprintf("unknown function '%v'", fun)}
+	}
+
+	return r, err
+}
+
+func descend(n ast.Node, fields map[string]interface{}, default_value interface{}) (r interface{}, err error) {
+	switch d := n.(type) {
+	case *ast.BasicLit:
+		return handle_literal(d.Kind, d.Value)
+	case *ast.BinaryExpr:
+		x, err := descend(d.X, fields, default_value)
+		if err != nil {
+			return math.NaN(), err
+		}
+		y, err := descend(d.Y, fields, default_value)
+		if err != nil {
+			return math.NaN(), err
+		}
+		return handle_binary_expression(d.Op, x, y)
+	case *ast.UnaryExpr:
+		x, err := descend(d.X, fields, default_value)
+		if err != nil {
+			return math.NaN(), err
+		}
+		return handle_unary_expression(d.Op, x)
+	case *ast.Ident:
+		if _, ok := fields[d.Name]; !ok {
+			if default_value != nil {
+				return default_value, nil
+			}
+			return math.NaN(), &ComputeError{ErrorFieldUnknown, fmt.Sprintf("unknown field '%v'", d.Name)}
+		}
+		return fields[d.Name], nil
+	case *ast.ParenExpr:
+		r, err = descend(d.X, fields, default_value)
+	case *ast.CallExpr:
+		if fun, ok := d.Fun.(*ast.Ident); ok {
+			// Handle the arguments
+			args := make([]interface{}, len(d.Args))
+			for i, a := range d.Args {
+				x, err := descend(a, fields, default_value)
+				if err != nil {
+					return math.NaN(), err
+				}
+				args[i] = x
+			}
+			return handle_function(fun.Name, args)
+		} else {
+			return math.NaN(), &ComputeError{ErrorFunctionTypeUnknown, fmt.Sprintf("unknown function type '%v'", d.Fun)}
+		}
+	default:
+		return math.NaN(), &ComputeError{ErrorNodeTypeUnknown, fmt.Sprintf("unknown node type '%v'", d)}
+	}
+	return r, err
+}
+
+func init() {
+	processors.Add("compute", func() telegraf.Processor { return &Compute{} })
+}

--- a/plugins/processors/compute/compute_test.go
+++ b/plugins/processors/compute/compute_test.go
@@ -1,0 +1,446 @@
+package compute
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type testcase struct {
+	name     string
+	compute  *Compute
+	input    telegraf.Metric
+	expected telegraf.Metric
+}
+
+func TestComputeCorrectness(t *testing.T) {
+	tests := []testcase{
+		{
+			name: "constant arithmetic",
+			compute: &Compute{
+				Missing: "ignore",
+				Fields: map[string]string{
+					"x1": "3 + 1",
+					"x2": "3.1415 + 2.7182",
+					"x3": "23 - 42",
+					"x4": "23 - 42.42",
+					"x5": "1 / 3",
+					"x6": "12 / 3",
+					"x7": "1.0 / 3.0",
+					"x8": "12.345 * 2.1",
+					"x9": "12 * 3",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"x1": int64(3 + 1),
+					"x2": float64(3.1415 + 2.7182),
+					"x3": int64(23 - 42),
+					"x4": float64(23 - 42.42),
+					"x5": int64(1 / 3),
+					"x6": int64(12 / 3),
+					"x7": float64(1.0 / 3.0),
+					"x8": float64(12.345 * 2.1),
+					"x9": int64(12 * 3),
+				},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "operation order",
+			compute: &Compute{
+				Missing: "ignore",
+				Fields: map[string]string{
+					"x1": "(3 + 1) / 2",
+					"x2": "4.2 + 3.1 * 2.0",
+					"x3": "(2.1 + 1.2) / (0.5 - 8.0)",
+					"x4": "12.0/3.3 * 2.0 - 3.1415",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"x1": int64((3 + 1) / 2),
+					"x2": float64(4.2 + 3.1*2.0),
+					"x3": float64((2.1 + 1.2) / (0.5 - 8.0)),
+					"x4": float64(12.0/3.3*2.0 - 3.1415),
+				},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "field variables",
+			compute: &Compute{
+				Missing: "ignore",
+				Fields: map[string]string{
+					"x1": "a + b",
+					"x2": "2 * a",
+					"x3": "2.1 * a",
+					"x4": "a - c",
+					"x5": "b / d",
+					"x6": "2 * c",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+					"b": 2,
+					"c": 3.1415,
+					"d": 2.7182,
+				},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a":  1,
+					"b":  2,
+					"c":  3.1415,
+					"d":  2.7182,
+					"x1": int64(1 + 2),
+					"x2": int64(2 * 1),
+					"x3": float64(2.1 * 1),
+					"x4": float64(1 - 3.1415),
+					"x5": float64(2 / 2.7182),
+					"x6": float64(2 * 3.1415),
+				},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "functions",
+			compute: &Compute{
+				Missing: "ignore",
+				Fields: map[string]string{
+					"x1": "pow(a, 2)",
+					"x2": "pow(a, 2.0)",
+					"x3": "pow(b, 2)",
+					"x4": "pow(b, 2.0)",
+					"x5": "abs(-42)",
+					"x6": "abs(-42.23)",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 2,
+					"b": 3.1415,
+				},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a":  2,
+					"b":  3.1415,
+					"x1": float64(4.0),
+					"x2": float64(4.0),
+					"x3": float64(3.1415 * 3.1415),
+					"x4": float64(3.1415 * 3.1415),
+					"x5": int64(42),
+					"x6": float64(42.23),
+				},
+				time.Unix(0, 0),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup the processor
+			err := tt.compute.Init()
+			require.NoError(t, err)
+
+			// Do the processing
+			actual := tt.compute.Apply(tt.input)
+
+			// We expect only one metric
+			require.Len(t, actual, 1)
+
+			// Test with floating point precision in mind
+			testutil.RequireMetricEqual(t, tt.expected, actual[0], cmpopts.EquateApprox(0.0, 1e-6))
+		})
+	}
+}
+
+func TestComputeMissingStrategy(t *testing.T) {
+	tests := []testcase{
+		{
+			name: "ignore",
+			compute: &Compute{
+				Missing: "ignore",
+				Fields: map[string]string{
+					"x": "b + 1",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+				},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+				},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "constant (default)",
+			compute: &Compute{
+				Missing: "const",
+				Fields: map[string]string{
+					"x": "b + 1",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+				},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+					"x": 0,
+				},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "constant (integer)",
+			compute: &Compute{
+				Missing:  "const",
+				Constant: 42,
+				Fields: map[string]string{
+					"x": "b + 1",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+				},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+					"x": 42,
+				},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "constant (float)",
+			compute: &Compute{
+				Missing:  "const",
+				Constant: 42.1,
+				Fields: map[string]string{
+					"x": "b + 1",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+				},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+					"x": 42.1,
+				},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "default (default)",
+			compute: &Compute{
+				Missing: "default",
+				Fields: map[string]string{
+					"x": "b + 1",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+				},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+					"x": 1,
+				},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "default (integer)",
+			compute: &Compute{
+				Missing: "default",
+				Default: 42,
+				Fields: map[string]string{
+					"x": "b + 1",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+				},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+					"x": 43,
+				},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "default (float)",
+			compute: &Compute{
+				Missing: "default",
+				Default: 42.1,
+				Fields: map[string]string{
+					"x": "b + 1",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+				},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+					"x": 43.1,
+				},
+				time.Unix(0, 0),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup the processor
+			err := tt.compute.Init()
+			require.NoError(t, err)
+
+			// Do the processing
+			actual := tt.compute.Apply(tt.input)
+
+			// We expect only one metric
+			require.Len(t, actual, 1)
+
+			testutil.RequireMetricEqual(t, tt.expected, actual[0])
+		})
+	}
+}
+
+func TestComputeFieldCollision(t *testing.T) {
+	tests := []testcase{
+		{
+			name: "collision",
+			compute: &Compute{
+				Missing: "ignore",
+				Fields: map[string]string{
+					"x": "a + 1",
+				},
+			},
+			input: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+					"x": 25,
+				},
+				time.Unix(0, 0),
+			),
+			expected: testutil.MustMetric(
+				"test",
+				map[string]string{},
+				map[string]interface{}{
+					"a": 1,
+					"x": 2,
+				},
+				time.Unix(0, 0),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup the processor
+			err := tt.compute.Init()
+			require.NoError(t, err)
+
+			// Do the processing
+			actual := tt.compute.Apply(tt.input)
+
+			// We expect only one metric
+			require.Len(t, actual, 1)
+
+			testutil.RequireMetricEqual(t, tt.expected, actual[0])
+		})
+	}
+}
+
+func TestEmptyConfigInitError(t *testing.T) {
+	computer := &Compute{}
+	err := computer.Init()
+	require.Error(t, err)
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This PR adds a processor plugin that can compute the value of a given field using the given formula. To achieve this, the formula is parsed into an abstract-syntax-tree and is then interpreted by walking the tree in a depth-first way. When reaching a leaf-node the value is propagated upwards until the value for the root node is known.

Currently integer and float computation like simple arithmetic, few functions and usage of field values as variables are supported. However, these functions can be extended easily in code and there is a way to provide tag-variables and more sophisticated default values if there is demand.

This PR might also be better named "math"... You decide. Anyway it probably solves the problem described in #3709.