### PR TITLE
[inputs/modbus] Implement retry when slave is busy

### DIFF
--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -20,6 +20,11 @@ The Modbus plugin collects Discrete Inputs, Coils, Input Registers and Holding R
  ## Timeout for each request
  timeout = "1s"
 
+ ## Maximum number of retries and the time to wait between retries
+ ## when a slave-device is busy
+ #busy_retries = 0
+ #busy_retries_wait = "100ms"
+
  # TCP - connect via Modbus/TCP
  controller = "tcp://localhost:502"
 
@@ -53,7 +58,7 @@ The Modbus plugin collects Discrete Inputs, Coils, Input Registers and Holding R
 
  ## Analog Variables, Input Registers and Holding Registers
  ## measurement - the (optional) measurement name, defaults to "modbus"
- ## name       - the variable name 
+ ## name       - the variable name
  ## byte_order - the ordering of bytes
  ##  |---AB, ABCD   - Big Endian
  ##  |---BA, DCBA   - Little Endian

--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -21,7 +21,10 @@ The Modbus plugin collects Discrete Inputs, Coils, Input Registers and Holding R
  timeout = "1s"
 
  ## Maximum number of retries and the time to wait between retries
- ## when a slave-device is busy
+ ## when a slave-device is busy.
+ ## NOTE: Please make sure that the overall retry time (#retries * wait time)
+ ##       is always smaller than the query interval as otherwise you will get
+ ##       an "did not complete within its interval" warning.
  #busy_retries = 0
  #busy_retries_wait = "100ms"
 

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -174,10 +174,6 @@ func (m *Modbus) Init() error {
 		return fmt.Errorf("retries cannot be negative")
 	}
 
-	if m.Retries > 0 && m.RetriesWaitTime.Duration < 0 {
-		return fmt.Errorf("wait time between retries cannot be negative")
-	}
-
 	err := m.InitRegister(m.DiscreteInputs, cDiscreteInputs)
 	if err != nil {
 		return err

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -674,7 +674,6 @@ func (m *Modbus) Gather(acc telegraf.Accumulator) error {
 				return err
 			}
 		}
-		log.Printf("D! [inputs.modbus] sleeping %d millisecond(s)...", m.RetriesWaitTime.Duration.Milliseconds())
 		time.Sleep(m.RetriesWaitTime.Duration)
 	}
 

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -88,7 +88,10 @@ const sampleConfig = `
  timeout = "1s"
 
  ## Maximum number of retries and the time to wait between retries
- ## when a slave-device is busy
+ ## when a slave-device is busy.
+ ## NOTE: Please make sure that the overall retry time (#retries * wait time)
+ ##       is always smaller than the query interval as otherwise you will get
+ ##       an "did not complete within its interval" warning.
  #busy_retries = 0
  #busy_retries_wait = "100ms"
 

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -665,6 +665,7 @@ func (m *Modbus) Gather(acc telegraf.Accumulator) error {
 			mberr, ok := err.(*mb.ModbusError)
 			if ok && mberr.ExceptionCode == mb.ExceptionCodeServerDeviceBusy && retry < m.Retries {
 				log.Printf("I! [inputs.modbus] device busy! Retrying %d more time(s)...", m.Retries-retry)
+				time.Sleep(m.RetriesWaitTime.Duration)
 				continue
 			}
 			disconnect(m)
@@ -673,7 +674,6 @@ func (m *Modbus) Gather(acc telegraf.Accumulator) error {
 		}
 		// Reading was successful, leave the retry loop
 		break
-		time.Sleep(m.RetriesWaitTime.Duration)
 	}
 
 	grouper := metric.NewSeriesGrouper()

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -3,6 +3,7 @@ package modbus
 import (
 	"encoding/binary"
 	"fmt"
+	"log"
 	"math"
 	"net"
 	"net/url"
@@ -27,6 +28,8 @@ type Modbus struct {
 	StopBits         int               `toml:"stop_bits"`
 	SlaveID          int               `toml:"slave_id"`
 	Timeout          internal.Duration `toml:"timeout"`
+	Retries          int               `toml:"busy_retries"`
+	RetriesWaitTime  internal.Duration `toml:"busy_retries_wait"`
 	DiscreteInputs   []fieldContainer  `toml:"discrete_inputs"`
 	Coils            []fieldContainer  `toml:"coils"`
 	HoldingRegisters []fieldContainer  `toml:"holding_registers"`
@@ -83,6 +86,11 @@ const sampleConfig = `
 
  ## Timeout for each request
  timeout = "1s"
+
+ ## Maximum number of retries and the time to wait between retries
+ ## when a slave-device is busy
+ #busy_retries = 0
+ #busy_retries_wait = "100ms"
 
  # TCP - connect via Modbus/TCP
  controller = "tcp://localhost:502"
@@ -157,6 +165,14 @@ func (m *Modbus) Init() error {
 	//check device name
 	if m.Name == "" {
 		return fmt.Errorf("device name is empty")
+	}
+
+	if m.Retries < 0 {
+		return fmt.Errorf("retries cannot be negative")
+	}
+
+	if m.Retries > 0 && m.RetriesWaitTime.Duration < 0 {
+		return fmt.Errorf("wait time between retries cannot be negative")
 	}
 
 	err := m.InitRegister(m.DiscreteInputs, cDiscreteInputs)
@@ -642,11 +658,24 @@ func (m *Modbus) Gather(acc telegraf.Accumulator) error {
 	}
 
 	timestamp := time.Now()
-	err := m.getFields()
-	if err != nil {
-		disconnect(m)
-		m.isConnected = false
-		return err
+	for retry := 0; retry <= m.Retries; retry += 1 {
+		timestamp = time.Now()
+		err := m.getFields()
+		if err == nil {
+			// Reading was successful, leave the retry loop
+			break
+		} else {
+			mberr, ok := err.(*mb.ModbusError)
+			if ok && mberr.ExceptionCode == mb.ExceptionCodeServerDeviceBusy && retry < m.Retries {
+				log.Printf("I! [inputs.modbus] device busy! Retrying %d more time(s)...", m.Retries-retry)
+			} else {
+				disconnect(m)
+				m.isConnected = false
+				return err
+			}
+		}
+		log.Printf("D! [inputs.modbus] sleeping %d millisecond(s)...", m.RetriesWaitTime.Duration.Milliseconds())
+		time.Sleep(m.RetriesWaitTime.Duration)
 	}
 
 	grouper := metric.NewSeriesGrouper()


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Currently, when the slave device is busy, e.g. because it already serves a request of another client, we get an error and the measurement is lost for the gathering interval. This potentially leads to many lost measurements for very busy devices.

With this PR you can specify the number of retry attempts (and a wait time) to be performed if the device is busy. This achives a higher probability to get a measurement on busy devices for each query interval.