### PR TITLE
Allow win_perf_counter input plugin to have no instances present. Fixes #7281

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -81,12 +81,12 @@ Supported on Windows Vista/Windows Server 2008 and newer
 Example:
 `UsePerfCounterTime=true`
 
-#### IgnoreMissingData
+#### IgnoreMissingInstance
 
-Bool, if set to `true`, the plugin will not report errors when counter is not providing any data.
+Bool, if set to `true`, the plugin will not report errors when counter has no instances.
 Useful when working with performance counters that have instances only when certain conditions are met, e.g. `\RemoteFX Network(*)\`.
 Example:
-`IgnoreMissingData=true`
+`IgnoreMissingInstance=true`
 
 ### Object
 
@@ -399,7 +399,7 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
 ### RemoteFX monitoring
 ```
 [[inputs.win_perf_counters]]
-  IgnoreMissingData = true
+  IgnoreMissingInstance = true
 
   [[inputs.win_perf_counters.object]]
     ObjectName = "RemoteFX Network"

--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -81,6 +81,13 @@ Supported on Windows Vista/Windows Server 2008 and newer
 Example:
 `UsePerfCounterTime=true`
 
+#### IgnoreMissingData
+
+Bool, if set to `true`, the plugin will not report errors when counter is not providing any data.
+Useful when working with performance counters that have instances only when certain conditions are met, e.g. `\RemoteFX Network(*)\`.
+Example:
+`IgnoreMissingData=true`
+
 ### Object
 
 See Entry below.
@@ -387,6 +394,62 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
     Instances = ["w3wp"]
     Measurement = "win_dotnet_security"
     #IncludeTotal=false #Set to true to include _Total instance when querying for all (*).
+```
+
+### RemoteFX monitoring
+```
+[[inputs.win_perf_counters]]
+  IgnoreMissingData = true
+
+  [[inputs.win_perf_counters.object]]
+    ObjectName = "RemoteFX Network"
+    Instances = ["*"]
+    Counters = [
+      "Total Received Bytes",
+      "Total Sent Bytes",
+      "Current UDP Bandwidth",
+      "Current UDP RTT",
+      "Base UDP RTT",
+      "FEC Rate",
+      "Retransmission Rate",
+      "Loss Rate",
+      "Sent Rate P3",
+      "Sent Rate P2",
+      "Sent Rate P1",
+      "Sent Rate P0",
+      "UDP Packets Sent/sec",
+      "UDP Sent Rate",
+      "TCP Sent Rate",
+      "Total Sent Rate",
+      "UDP Packets Received/sec",
+      "UDP Received Rate",
+      "TCP Received Rate",
+      "Total Received Rate",
+      "Current TCP Bandwidth",
+      "Current TCP RTT",
+      "Base TCP RTT",
+    ]
+    Measurement = "remotefx.network"
+    # Set to true to include _Total instance when querying for all (*).
+    IncludeTotal = false
+
+  [[inputs.win_perf_counters.object]]
+    ObjectName = "RemoteFX Graphics"
+    Instances = ["*"]
+    Counters = [
+      "Source Frames/Second",
+      "Average Encoding Time",
+      "Frame Quality",
+      "Frames Skipped/Second - Insufficient Server Resources",
+      "Frames Skipped/Second - Insufficient Network Resources",
+      "Frames Skipped/Second - Insufficient Client Resources",
+      "Output Frames/Second",
+      "Graphics Compression ratio",
+      "Input Frames/Second",
+    ]
+    Measurement = "remotefx.graphics"
+    # Set to true to include _Total instance when querying for all (*).
+    IncludeTotal = false
 ```
 
 ## Troubleshooting

--- a/plugins/inputs/win_perf_counters/performance_query.go
+++ b/plugins/inputs/win_perf_counters/performance_query.go
@@ -42,10 +42,6 @@ func (m *PdhError) Error() string {
 }
 
 func NewPdhError(code uint32) error {
-	// PDH_NO_DATA ignored....
-	if code == 0x800007D5 {
-		return nil
-	}
 	return &PdhError{
 		ErrorCode: code,
 		errorText: PdhFormatError(code),

--- a/plugins/inputs/win_perf_counters/performance_query.go
+++ b/plugins/inputs/win_perf_counters/performance_query.go
@@ -42,6 +42,10 @@ func (m *PdhError) Error() string {
 }
 
 func NewPdhError(code uint32) error {
+	// PDH_NO_DATA ignored....
+	if code == 0x800007D5 {
+		return nil
+	}
 	return &PdhError{
 		ErrorCode: code,
 		errorText: PdhFormatError(code),

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -359,7 +359,6 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 		}
 		//some counters need two data samples before computing a value
 		if err = m.query.CollectData(); err != nil {
-			m.Log.Errorf("No data? Error: %s\n", err.Error())
 			return err
 		}
 		m.lastRefreshed = time.Now()

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -151,7 +151,7 @@ type Win_PerfCounters struct {
 	lastRefreshed time.Time
 	counters      []*counter
 	query         PerformanceQuery
-	IgnoreMissingData bool
+	IgnoreMissingInstance bool
 }
 
 type perfobject struct {
@@ -360,7 +360,7 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 		}
 		//some counters need two data samples before computing a value
 		if err = m.query.CollectData(); err != nil {
-			if pdhErr, ok := err.(*PdhError); ok && (pdhErr.ErrorCode == PDH_NO_DATA) && m.IgnoreMissingData {
+			if pdhErr, ok := err.(*PdhError); ok && (pdhErr.ErrorCode == PDH_NO_DATA) && m.IgnoreMissingInstance {
 				return nil
 			} else {
 				return err

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -145,13 +145,13 @@ type Win_PerfCounters struct {
 	Object                  []perfobject
 	CountersRefreshInterval internal.Duration
 	UseWildcardsExpansion   bool
+	IgnoreMissingInstance   bool
 
 	Log telegraf.Logger
 
 	lastRefreshed time.Time
 	counters      []*counter
 	query         PerformanceQuery
-	IgnoreMissingInstance bool
 }
 
 type perfobject struct {

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -359,6 +359,7 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 		}
 		//some counters need two data samples before computing a value
 		if err = m.query.CollectData(); err != nil {
+			m.Log.Errorf("No data? Error: %s\n", err.Error())
 			return err
 		}
 		m.lastRefreshed = time.Now()

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -151,6 +151,7 @@ type Win_PerfCounters struct {
 	lastRefreshed time.Time
 	counters      []*counter
 	query         PerformanceQuery
+	IgnoreMissingData bool
 }
 
 type perfobject struct {
@@ -359,7 +360,11 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 		}
 		//some counters need two data samples before computing a value
 		if err = m.query.CollectData(); err != nil {
-			return err
+			if pdhErr, ok := err.(*PdhError); ok && (pdhErr.ErrorCode == PDH_NO_DATA) && m.IgnoreMissingData {
+				return nil
+			} else {
+				return err
+			}
 		}
 		m.lastRefreshed = time.Now()
 


### PR DESCRIPTION
This pull request is my attempt to fix issue #7281 with plugin-wide configuration option.
I've tested that on the live system, but I couldn't create relevant unit tests - it looks to me that similar condition (PDH_NO_DATA) is handled, but in the different place.

I decided to share this PR as-is with assumption that someone more knowledgeable could help with writing tests. Also creating PR early could help fix the code quality (first time writing anything in go...).

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
