### PR TITLE
plugins/filestat: Skip missing files

### DIFF
--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -35,11 +35,18 @@ type FileStat struct {
 
 	// maps full file paths to globmatch obj
 	globs map[string]*globpath.GlobPath
+
+	// files that were missing - we only log the first time it's not found.
+	missingFiles map[string]bool
+	// files that had an error in Stat - we only log the first error.
+	filesWithErrors map[string]bool
 }
 
 func NewFileStat() *FileStat {
 	return &FileStat{
-		globs: make(map[string]*globpath.GlobPath),
+		globs:           make(map[string]*globpath.GlobPath),
+		missingFiles:    make(map[string]bool),
+		filesWithErrors: make(map[string]bool),
 	}
 }
 
@@ -86,13 +93,22 @@ func (f *FileStat) Gather(acc telegraf.Accumulator) error {
 			if os.IsNotExist(err) {
 				fields["exists"] = int64(0)
 				acc.AddFields("filestat", fields, tags)
+				if !f.missingFiles[fileName] {
+					f.Log.Warnf("File %q not found", fileName)
+					f.missingFiles[fileName] = true
+				}
 				continue
 			}
+			f.missingFiles[fileName] = false
 
 			if fileInfo == nil {
-				f.Log.Errorf("Unable to get info for file %q: %v",
-					fileName)
+				if !f.filesWithErrors[fileName] {
+					f.filesWithErrors[fileName] = true
+					f.Log.Errorf("Unable to get info for file %q: %v",
+						fileName, err)
+				}
 			} else {
+				f.filesWithErrors[fileName] = false
 				fields["size_bytes"] = fileInfo.Size()
 				fields["modification_time"] = fileInfo.ModTime().UnixNano()
 			}

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -85,10 +85,12 @@ func (f *FileStat) Gather(acc telegraf.Accumulator) error {
 			fileInfo, err := os.Stat(fileName)
 			if os.IsNotExist(err) {
 				fields["exists"] = int64(0)
+				acc.AddFields("filestat", fields, tags)
+				continue
 			}
 
 			if fileInfo == nil {
-				f.Log.Errorf("Unable to get info for file %q, possible permissions issue",
+				f.Log.Errorf("Unable to get info for file %q: %v",
 					fileName)
 			} else {
 				fields["size_bytes"] = fileInfo.Size()

--- a/plugins/inputs/filestat/filestat_test.go
+++ b/plugins/inputs/filestat/filestat_test.go
@@ -76,6 +76,23 @@ func TestGatherExplicitFiles(t *testing.T) {
 	require.True(t, acc.HasPoint("filestat", tags3, "exists", int64(0)))
 }
 
+func TestNonExistentFile(t *testing.T) {
+	fs := NewFileStat()
+	fs.Log = testutil.Logger{}
+	fs.Md5 = true
+	fs.Files = []string{
+		"/non/existant/file",
+	}
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fs.Gather))
+
+	acc.AssertContainsFields(t, "filestat", map[string]interface{}{"exists": int64(0)})
+	assert.False(t, acc.HasField("filestat", "error"))
+	assert.False(t, acc.HasField("filestat", "md5_sum"))
+	assert.False(t, acc.HasField("filestat", "size_bytes"))
+	assert.False(t, acc.HasField("filestat", "modification_time"))
+}
+
 func TestGatherGlob(t *testing.T) {
 	dir := getTestdataDir()
 	fs := NewFileStat()


### PR DESCRIPTION
This PR attempts to fix #7315, the same problem as #6940, but without adding a config flag.

Previously, the filestat plugin would check for a file's existence, and then try to compute all sorts of things for the missing file, which failed and resulted in a log message about possible permission errors.

Now, the plugin just skips the file if it exists. If an error is encountered probing an existing file, the plugin now logs that error, too, instead of hazarding a guess at permission problems.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated. (no update needed)
- [x] Has appropriate unit tests: Added a test.
