### PR TITLE
Fibaro input: for battery operated devices, add battery level scraping

### DIFF
--- a/plugins/inputs/fibaro/README.md
+++ b/plugins/inputs/fibaro/README.md
@@ -30,6 +30,7 @@ Those values could be true (1) or false (0) for switches, percentage for dimmers
     - name (device name)
     - type (device type)
   - fields:
+    - batteryLevel (float, when available from device)
     - energy (float, when available from device)
     - power (float, when available from device)
     - value (float)
@@ -52,4 +53,5 @@ fibaro,deviceId=220,host=vm1,name=CO2\ (ppm),room=Salon,section=Pièces\ commune
 fibaro,deviceId=221,host=vm1,name=Humidité\ (%),room=Salon,section=Pièces\ communes,type=com.fibaro.humiditySensor value=61 1529996807000000000
 fibaro,deviceId=222,host=vm1,name=Pression\ (mb),room=Salon,section=Pièces\ communes,type=com.fibaro.multilevelSensor value=1013.7 1529996807000000000
 fibaro,deviceId=223,host=vm1,name=Bruit\ (db),room=Salon,section=Pièces\ communes,type=com.fibaro.multilevelSensor value=44 1529996807000000000
+fibaro,deviceId=248,host=vm1,name=Température,room=Garage,section=Extérieur,type=com.fibaro.temperatureSensor batteryLevel=85,value=10.8 1529996807000000000
 ```

--- a/plugins/inputs/fibaro/fibaro.go
+++ b/plugins/inputs/fibaro/fibaro.go
@@ -69,11 +69,12 @@ type Devices struct {
 	Type       string `json:"type"`
 	Enabled    bool   `json:"enabled"`
 	Properties struct {
-		Dead   interface{} `json:"dead"`
-		Energy interface{} `json:"energy"`
-		Power  interface{} `json:"power"`
-		Value  interface{} `json:"value"`
-		Value2 interface{} `json:"value2"`
+		BatteryLevel interface{} `json:"batteryLevel"`
+		Dead         interface{} `json:"dead"`
+		Energy       interface{} `json:"energy"`
+		Power        interface{} `json:"power"`
+		Value        interface{} `json:"value"`
+		Value2       interface{} `json:"value2"`
 	} `json:"properties"`
 }
 
@@ -173,6 +174,12 @@ func (f *Fibaro) Gather(acc telegraf.Accumulator) error {
 			"type":     device.Type,
 		}
 		fields := make(map[string]interface{})
+
+		if device.Properties.BatteryLevel != nil {
+			if fValue, err := strconv.ParseFloat(device.Properties.BatteryLevel.(string), 64); err == nil {
+				fields["batteryLevel"] = fValue
+			}
+		}
 
 		if device.Properties.Energy != nil {
 			if fValue, err := strconv.ParseFloat(device.Properties.Energy.(string), 64); err == nil {

--- a/plugins/inputs/fibaro/fibaro_test.go
+++ b/plugins/inputs/fibaro/fibaro_test.go
@@ -107,6 +107,7 @@ const devicesJSON = `
             "type": "com.fibaro.temperatureSensor",
             "enabled": true,
             "properties": {
+                "batteryLevel": "100",
                 "dead": "false",
                 "value": "22.80"
             },
@@ -196,7 +197,7 @@ func TestJSONSuccess(t *testing.T) {
 
 	// Ensure fields / values are correct - Device 4
 	tags = map[string]string{"deviceId": "4", "section": "Section 3", "room": "Room 4", "name": "Device 4", "type": "com.fibaro.temperatureSensor"}
-	fields = map[string]interface{}{"value": float64(22.8)}
+	fields = map[string]interface{}{"batteryLevel": float64(100), "value": float64(22.8)}
 	acc.AssertContainsTaggedFields(t, "fibaro", fields, tags)
 
 	// Ensure fields / values are correct - Device 5


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This simply adds battery level scraping for battery operated devices, in order to be able to alert when a battery runs out of juice.