### PR TITLE
Use new higher limit for cloudwatch GetMetricData

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -212,7 +212,7 @@ func (c *CloudWatch) Gather(acc telegraf.Accumulator) error {
 	results := []*cloudwatch.MetricDataResult{}
 
 	// 100 is the maximum number of metric data queries a `GetMetricData` request can contain.
-	batchSize := 100
+	batchSize := 500
 	var batches [][]*cloudwatch.MetricDataQuery
 
 	for batchSize < len(queries) {


### PR DESCRIPTION
closes #7322

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
