### PR TITLE
feature-7338 Retry failed remote HTTP Config on startup

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -41,6 +41,7 @@ var fTestWait = flag.Int("test-wait", 0, "wait up to this many seconds for servi
 var fConfig = flag.String("config", "", "configuration file to load")
 var fConfigDirectory = flag.String("config-directory", "",
 	"directory containing additional *.conf files")
+var fConfigHttpRetry = flag.Int("config-http-retry", 600, "retry interval for failed http config requests")
 var fVersion = flag.Bool("version", false, "display the version and exit")
 var fSampleConfig = flag.Bool("sample-config", false,
 	"print out full sample configuration")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -16,6 +16,7 @@ The commands & flags are:
   --aggregator-filter <filter>   filter the aggregators to enable, separator is :
   --config <file>                configuration file to load
   --config-directory <directory> directory containing additional *.conf files
+  --config-http-retry <secs>     retry a failed remote http config request
   --plugin-directory             directory containing *.so files, this directory will be
                                  searched recursively. Any Plugin found will be loaded
                                  and namespaced.

--- a/internal/usage_windows.go
+++ b/internal/usage_windows.go
@@ -16,6 +16,7 @@ The commands & flags are:
   --aggregator-filter <filter>   filter the aggregators to enable, separator is :
   --config <file>                configuration file to load
   --config-directory <directory> directory containing additional *.conf files
+  --config-http-retry <secs>     retry a failed remote http config request
   --debug                        turn on debug logging
   --input-filter <filter>        filter the inputs to enable, separator is :
   --input-list                   print available input plugins.


### PR DESCRIPTION
### Required for all PRs:

- [Y] Signed [CLA](https://influxdata.com/community/cla/).
- [Y] Associated README.md updated.
- [Y] Has appropriate unit tests.

Retry remote HTTP config pull on agent startup to prevent agent stopping if HTTP endpoint is down
https://github.com/influxdata/telegraf/issues/7338 