### PR TITLE
SQL Server - Fix - Perf Counter missing RTRIM

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -629,9 +629,9 @@ SET @SQL = N'SELECT	DISTINCT
  			WHEN RTRIM(object_name) LIKE ''%:Availability Replica''
 				AND TRY_CONVERT(uniqueidentifier, spi.instance_name) IS NOT NULL -- for cloud only
 			THEN d.name + RTRIM(SUBSTRING(spi.instance_name, 37, LEN(spi.instance_name)))
-                       ELSE spi.instance_name
+                       ELSE RTRIM(spi.instance_name)
                 END AS instance_name,'
-		ELSE 'spi.instance_name as instance_name, '
+		ELSE 'RTRIM(spi.instance_name) as instance_name, '
 		END
 		+
 		'CAST(spi.cntr_value AS BIGINT) AS cntr_value,


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

closes #7241

added the missing RTRIM on the column that becomes the tag "instance" in the perf counters query