### PR TITLE
Sql server - ring buffer cpu v2

### DIFF
--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -65,6 +65,7 @@ GO
   ## - Schedulers
   ## - SqlRequests
   ## - VolumeSpace
+  ## - Cpu
   ## Version 1:
   ## - PerformanceCounters
   ## - WaitStatsCategorized
@@ -81,13 +82,13 @@ GO
   # include_query = []
 
   ## A list of queries to explicitly ignore.
-  exclude_query = [ 'Schedulers' , 'SqlRequests']
+  exclude_query = [ 'Schedulers' , 'SqlRequests' ]
 ```
 
 ### Metrics:
 To provide backwards compatibility, this plugin support two versions of metrics queries.
 
-**Note**: Version 2 queries are not backwards compatible with the old queries. Any dashboards or queries based on the old query format will not work with the new format. The version 2 queries are written in such a way as to only gather SQL specific metrics (no overall CPU related metrics) and they only report raw metrics, no math has been done to calculate deltas. To graph this data you must calculate deltas in your dashboarding software.
+**Note**: Version 2 queries are not backwards compatible with the old queries. Any dashboards or queries based on the old query format will not work with the new format. The version 2 queries only report raw metrics, no math has been done to calculate deltas. To graph this data you must calculate deltas in your dashboarding software.
 
 #### Version 1 (deprecated in 1.6):
 The original metrics queries provide:
@@ -124,6 +125,7 @@ The new (version 2) metrics provide:
   dm_exec_sessions that gives you running requests as well as wait types and
   blocking sessions.
 - *VolumeSpace* - uses sys.dm_os_volume_stats to get total, used and occupied space on every disk that contains a data or log file. (Note that even if enabled it won't get any data from Azure SQL Database or SQL Managed Instance). It is pointless to run this with high frequency (ie: every 10s), but it won't cause any problem.
+- *Cpu* - uses the buffer ring (sys.dm_os_ring_buffers) to get CPU data, the table is updated once per minute. (Note that even if enabled it won't get any data from Azure SQL Database or SQL Managed Instance).
 
   In order to allow tracking on a per statement basis this query produces a
   unique tag for each query.  Depending on the database workload, this may

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -1596,17 +1596,7 @@ IF SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 
 const sqlServerCpuV2 string = `
 /*The ring buffer has a new value every minute*/
-DECLARE
-	 @EngineEdition AS int
-
-SELECT 
-	 @EngineEdition = y.[EngineEdition]
-FROM (
-	SELECT
-		CAST(SERVERPROPERTY('EngineEdition') AS int) as [EngineEdition]
-) as y
-
-IF @EngineEdition NOT IN (5,8) /*No azure DB and managed instance*/
+IF SERVERPROPERTY('EngineEdition') NOT IN (5,8) /*No azure DB and managed instance*/
 BEGIN
 SELECT 
 	 'sqlserver_cpu' AS [measurement]

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -16,13 +16,13 @@ func TestSqlServer_QueriesInclusionExclusion(t *testing.T) {
 	cases := []map[string]interface{}{
 		{
 			"IncludeQuery": []string{},
-			"ExcludeQuery": []string{"WaitStatsCategorized", "DatabaseIO", "ServerProperties", "MemoryClerk", "Schedulers", "VolumeSpace"},
+			"ExcludeQuery": []string{"WaitStatsCategorized", "DatabaseIO", "ServerProperties", "MemoryClerk", "Schedulers", "VolumeSpace", "Cpu"},
 			"queries":      []string{"PerformanceCounters", "SqlRequests"},
 			"queriesTotal": 2,
 		},
 		{
 			"IncludeQuery": []string{"PerformanceCounters", "SqlRequests"},
-			"ExcludeQuery": []string{"SqlRequests", "WaitStatsCategorized", "DatabaseIO", "VolumeSpace"},
+			"ExcludeQuery": []string{"SqlRequests", "WaitStatsCategorized", "DatabaseIO", "VolumeSpace", "Cpu"},
 			"queries":      []string{"PerformanceCounters"},
 			"queriesTotal": 1,
 		},


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Closes #7269

This PR adds a new measurement called "sqlserver_cpu" with the following structure:
| measurement | sql_instance | sqlserver_process_cpu | system_idle_cpu | other_process_cpu |
| ------ | ------ | ------ | ------ | ------ |
| sqlserver_cpu | QDLP03:SQL2019 | 0 | 95 | 5 |

It reads the CPU data from the ring buffer, therefore it allows to get CPU data from any version of SQL Server (including express and standard).
In the source, the data are updated once every minute.

As of now, it works only on the On-prem version of SQL Server (from SQL 2008 to 2019) but I'm looking to make it work also on Azure SQL DB and managed Instance. (maybe using sys.dm_db_resource_stats or sys.server_resource_stats)
