### PR TITLE
systemd-timings: add systemd boot and unit timing input plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible // indirect
 	github.com/cisco-ie/nx-telemetry-proto v0.0.0-20190531143454-82441e232cf6
 	github.com/cockroachdb/apd v1.1.0 // indirect
+	github.com/coreos/go-systemd/v22 v22.0.0
 	github.com/couchbase/go-couchbase v0.0.0-20180501122049-16db1f1fe037
 	github.com/couchbase/gomemcached v0.0.0-20180502221210-0da75df14530 // indirect
 	github.com/couchbase/goutils v0.0.0-20180530154633-e865a1461c8a // indirect

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
+github.com/coreos/go-systemd/v22 v22.0.0 h1:XJIw/+VlJ+87J+doOxznsAWIdmWuViOVhkQamW5YV28=
+github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/couchbase/go-couchbase v0.0.0-20180501122049-16db1f1fe037 h1:Dbz60fpCq04vRxVVVJLbQuL0G7pRt0Gyo2BkozFc4SQ=
 github.com/couchbase/go-couchbase v0.0.0-20180501122049-16db1f1fe037/go.mod h1:TWI8EKQMs5u5jLKW/tsb9VwauIrMIxQG1r5fMsswK5U=
 github.com/couchbase/gomemcached v0.0.0-20180502221210-0da75df14530 h1:F8nmbiuX+gCz9xvWMi6Ak8HQntB4ATFXP46gaxifbp4=
@@ -223,6 +225,8 @@ github.com/goburrow/serial v0.1.0 h1:v2T1SQa/dlUqQiYIT8+Cu7YolfqAi3K96UmhwYyuSrA
 github.com/goburrow/serial v0.1.0/go.mod h1:sAiqG0nRVswsm1C97xsttiYCzSLBmUZ/VSlVLZJ8haA=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
+github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v2.1.0+incompatible h1:8oEj3gioPmmDAOLQUZdnW+h4FZu9aSE/SQIas1E9pzA=
 github.com/gofrs/uuid v2.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -156,6 +156,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/syslog"
 	_ "github.com/influxdata/telegraf/plugins/inputs/sysstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/system"
+	_ "github.com/influxdata/telegraf/plugins/inputs/systemd_timings"
 	_ "github.com/influxdata/telegraf/plugins/inputs/systemd_units"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tail"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tcp_listener"

--- a/plugins/inputs/systemd_timings/README.md
+++ b/plugins/inputs/systemd_timings/README.md
@@ -1,0 +1,51 @@
+# systemd_timings Input Plugin
+
+The systemd_timings plugin collects timestamps relating to the systemd based
+boot process.  All values are accessed via systemd APIs which are exposed
+on D-Bus. For more information on the systemd D-Bus API see:
+
+   * https://www.freedesktop.org/wiki/Software/systemd/dbus/
+
+## System Wide Boot Timestamps
+
+The values produced here indicate timestamps of various system wide boot tasks:
+
+   * FirmwareTimestampMonotonic
+   * LoaderTimestampMonotonic
+   * InitRDTimestampMonotonic
+   * UserspaceTimestampMonotonic
+   * FinishTimestampMonotonic
+   * SecurityStartTimestampMonotonic
+   * SecurityFinishTimestampMonotonic
+   * GeneratorsStartTimestampMonotonic
+   * GeneratorsFinishTimestampMonotonic
+   * UnitsLoadStartTimestampMonotonic
+   * UnitsLoadFinishTimestampMonotonic
+   * InitRDSecurityStartTimestampMonotonic
+   * InitRDSecurityFinishTimestampMonotonic
+   * InitRDGeneratorsStartTimestampMonotonic
+   * InitRDGeneratorsFinishTimestampMonotonic
+   * InitRDUnitsLoadStartTimestampMonotonic
+   * InitRDUnitsLoadFinishTimestampMonotonic
+
+All values are of type uint64 and are measured in microseconds.  These
+timestamps are sent any time telegraf is started.
+
+## Unit Activation/Deactivation Timestamps
+
+For each unit in the system the following timestamps are produced:
+
+   * Activating
+   * Activated
+   * Deactivating
+   * Deactivated
+   * Time
+
+The "Time" timestamp is the delta between Activated and Activating OR between
+Deactivated and Deactivating depending on which set of timestamps is non zero.
+This corresponds to the amount of time that it took a unit to start or to stop.
+
+All values are of type uint64 and are measured in microseconds since userspace
+start.  These timestamps are sent for all units on telegraf startup, if a unit
+is restarted or stopped whilst telegraf is running then the new versions of the
+timestamps are sent.

--- a/plugins/inputs/systemd_timings/systemd_timings_linux.go
+++ b/plugins/inputs/systemd_timings/systemd_timings_linux.go
@@ -1,0 +1,354 @@
+package systemd_timings
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+// SystemdTimings is a telegraf plugin to gather systemd boot timing metrics.
+type SystemdTimings struct {
+}
+
+// Measurement name.
+const measurement = "systemd_timings"
+
+// Record if we've already posted the system wide boot timestamps.
+var postedBootTimestamps = false
+
+// Map of a system wide boot metrics to their timestamps in microseconds, see:
+// https://www.freedesktop.org/wiki/Software/systemd/dbus/ for more details.
+var managerProps = map[string]string{
+	"FirmwareTimestampMonotonic":               "",
+	"LoaderTimestampMonotonic":                 "",
+	"InitRDTimestampMonotonic":                 "",
+	"UserspaceTimestampMonotonic":              "",
+	"FinishTimestampMonotonic":                 "",
+	"SecurityStartTimestampMonotonic":          "",
+	"SecurityFinishTimestampMonotonic":         "",
+	"GeneratorsStartTimestampMonotonic":        "",
+	"GeneratorsFinishTimestampMonotonic":       "",
+	"UnitsLoadStartTimestampMonotonic":         "",
+	"UnitsLoadFinishTimestampMonotonic":        "",
+	"InitRDSecurityStartTimestampMonotonic":    "",
+	"InitRDSecurityFinishTimestampMonotonic":   "",
+	"InitRDGeneratorsStartTimestampMonotonic":  "",
+	"InitRDGeneratorsFinishTimestampMonotonic": "",
+	"InitRDUnitsLoadStartTimestampMonotonic":   "",
+	"InitRDUnitsLoadFinishTimestampMonotonic":  "",
+}
+
+// Group unit timestamps.
+type unitTimestamps struct {
+	Activating   uint64
+	Activated    uint64
+	Deactivating uint64
+	Deactivated  uint64
+}
+
+// Keep track of the units previous timestamps, we only push if they have
+// have changed against the previous set.
+var allUnitTimestamps = map[string]*unitTimestamps{}
+
+// stripType removes the dbus type from the string str to return only the value.
+// See https://www.alteeve.com/w/List_of_DBus_data_types for dbus type
+// information.
+func stripType(str string) string {
+	return strings.Split(str, " ")[1]
+}
+
+// getManagerProp retrieves the property value with name propName.
+func getManagerProp(dbusConn *dbus.Conn, propName string) (string, error) {
+	prop, err := dbusConn.GetManagerProperty(propName)
+	if err != nil {
+		return "", err
+	}
+
+	return stripType(prop), nil
+}
+
+// bootIsFinished returns true if systemd has completed all unit initialization.
+func bootIsFinished() bool {
+	// Connect to the systemd dbus.
+	dbusConn, err := dbus.NewSystemConnection()
+	if err != nil {
+		return false
+	}
+
+	defer dbusConn.Close()
+
+	// Read the "FinishTimestampMonotonic" manager property, this will be
+	// non-zero if the system has finished initialization.
+	progressStr, err := getManagerProp(dbusConn, "FinishTimestampMonotonic")
+	if err != nil {
+		return false
+	}
+
+	// Convert to an int for comparison.
+	progressVal, err := strconv.ParseInt(progressStr, 10, 32)
+	if err != nil {
+		return false
+	}
+
+	return progressVal != 0
+}
+
+// postAllManagerProps reads all systemd manager properties and sends them to
+// telegraf.
+func postAllManagerProps(dbusConn *dbus.Conn, acc telegraf.Accumulator) error {
+
+	// Read all properties and send non zero values to telegraf.
+	for name := range managerProps {
+		propVal, err := getManagerProp(dbusConn, name)
+		if err != nil {
+			continue
+		} else {
+			// Save since we might need the value later when computing per unit
+			// time deltas.
+			managerProps[name] = propVal
+			if propVal == "" || propVal == "0" {
+				// Skip zero valued properties, these indicate unset properties
+				// in systemd.
+				continue
+			}
+
+			value, err := strconv.ParseUint(propVal, 10, 64)
+			if err != nil {
+				acc.AddError(err)
+				continue
+			}
+
+			// Build field and tag maps.
+			tags := map[string]string{"SystemTimestamp": name}
+
+			fields := map[string]interface{}{"SystemTimestampValue": value}
+
+			// Send to telegraf.
+			acc.AddFields(measurement, fields, tags)
+		}
+	}
+
+	return nil
+}
+
+// query dbus to access unit startup timing data, all time measurements here
+// are measured in microseconds.
+func getUnitTimingData(dbusConn *dbus.Conn,
+	unitName string,
+	userSpaceStart uint64) (uint64, uint64, uint64, uint64, uint64, error) {
+
+	// Retrieve all timing properties for this unit.
+	activatingProp, err := dbusConn.GetUnitProperty(unitName,
+		"InactiveExitTimestampMonotonic")
+	if err != nil {
+		return 0, 0, 0, 0, 0, err
+	}
+
+	activatedProp, err := dbusConn.GetUnitProperty(unitName,
+		"ActiveEnterTimestampMonotonic")
+	if err != nil {
+		return 0, 0, 0, 0, 0, err
+	}
+
+	deactivatingProp, err := dbusConn.GetUnitProperty(unitName,
+		"ActiveExitTimestampMonotonic")
+	if err != nil {
+		return 0, 0, 0, 0, 0, err
+	}
+
+	deactivatedProp, err := dbusConn.GetUnitProperty(unitName,
+		"InactiveEnterTimestampMonotonic")
+	if err != nil {
+		return 0, 0, 0, 0, 0, err
+	}
+
+	// Convert all to uint64 types and subtract the user space start time
+	// stamp to give us relative startup times.
+	activating, err := strconv.ParseUint(
+		stripType(activatingProp.Value.String()), 10, 64)
+	if err != nil {
+		return 0, 0, 0, 0, 0, err
+	}
+
+	activated, err := strconv.ParseUint(
+		stripType(activatedProp.Value.String()), 10, 64)
+	if err != nil {
+		return 0, 0, 0, 0, 0, err
+	}
+
+	deactivating, err := strconv.ParseUint(
+		stripType(deactivatingProp.Value.String()), 10, 64)
+	if err != nil {
+		return 0, 0, 0, 0, 0, err
+	}
+
+	deactivated, err := strconv.ParseUint(
+		stripType(deactivatedProp.Value.String()), 10, 64)
+	if err != nil {
+		return 0, 0, 0, 0, 0, err
+	}
+
+	if activating > 0 {
+		activating -= userSpaceStart
+	}
+
+	if activated > 0 {
+		activated -= userSpaceStart
+	}
+
+	if deactivating > 0 {
+		deactivating -= userSpaceStart
+	}
+
+	if deactivated > 0 {
+		deactivated -= userSpaceStart
+	}
+
+	runtime := uint64(0)
+	if activated >= activating {
+		runtime = activated - activating
+	} else if deactivated >= activating {
+		runtime = deactivated - activating
+	}
+
+	// Return the timing data for this unit, converted to seconds.
+	return activating, activated, deactivating, deactivated, runtime, nil
+}
+
+// postAllUnitTimingData
+func postAllUnitTimingData(dbusConn *dbus.Conn, acc telegraf.Accumulator) error {
+	statusList, err := dbusConn.ListUnits()
+	if err != nil {
+		acc.AddError(err)
+		return err
+	}
+
+	// Get the user space start timestamp so we can subtract it from all
+	// unit timestamps to give us a relative offset from user space start.
+	userTs, found := managerProps["UserspaceTimestampMonotonic"]
+	if !found {
+		return fmt.Errorf(`UserspaceTimestampMonotonic not found, cannot
+						  compute unit timestamps`)
+	}
+
+	// Convert UserspaceTimestampMonotonic to a uint64
+	userStartTs, err := strconv.ParseUint(userTs, 10, 64)
+	if err != nil {
+		acc.AddError(err)
+		return err
+	}
+
+	// For each unit query timing data, don't stop on failure.
+	for _, unitStatus := range statusList {
+		activating, activated, deactivating, deactivated, runtime, err :=
+			getUnitTimingData(dbusConn, unitStatus.Name, userStartTs)
+		if err != nil {
+			acc.AddError(err)
+		} else {
+			if runtime == 0 {
+				// Don't post results for services which were never started
+				// or stopped.
+				continue
+			}
+
+			// Only post these to telegraf if they are different that the
+			// last time they were posted.  This ensures that only restarted
+			// or manually stopped services would have new metrics posted.
+			entry, exists := allUnitTimestamps[unitStatus.Name]
+			if exists {
+				if entry.Activating == activating &&
+					entry.Activated == activated &&
+					entry.Deactivating == deactivating &&
+					entry.Deactivated == deactivated {
+					// No change since the last time we collected, so don't
+					// post to telegraf.
+					continue
+				}
+			} else {
+				entry = new(unitTimestamps)
+			}
+
+			entry.Activating = activating
+			entry.Activated = activated
+			entry.Deactivating = deactivating
+			entry.Deactivated = deactivated
+			allUnitTimestamps[unitStatus.Name] = entry
+
+			// These are per unit wide timestamps, so tag them as such.
+			tags := map[string]string{"UnitName": unitStatus.Name}
+
+			// Construct fields map.
+			fields := map[string]interface{}{
+				"ActivatingTimestamp":   activating,
+				"ActivatedTimestamp":    activated,
+				"DeactivatingTimestamp": deactivating,
+				"DeactivatedTimestamp":  deactivated,
+				"RunDuration":           runtime,
+			}
+
+			// Send to telegraf.
+			acc.AddFields(measurement, fields, tags)
+		}
+	}
+
+	return nil
+}
+
+// Description returns a short description of the plugin
+func (s *SystemdTimings) Description() string {
+	return "Gather systemd boot and unit timing data"
+}
+
+// SampleConfig returns sample configuration options.
+func (s *SystemdTimings) SampleConfig() string {
+	return ""
+}
+
+// Gather reads timestamp metrics from systemd via dbus and sends them to
+// telegraf.
+func (s *SystemdTimings) Gather(acc telegraf.Accumulator) error {
+	if !bootIsFinished() {
+		// We are not ready to collect yet, telegraf will call us later to try
+		// again.
+		return nil
+	}
+
+	// Connect to the systemd dbus.
+	dbusConn, err := dbus.NewSystemConnection()
+	if err != nil {
+		return err
+	}
+
+	defer dbusConn.Close()
+
+	// Only read system wide "manager" properties once per telegraf lifetime.
+	if postedBootTimestamps == false {
+		err = postAllManagerProps(dbusConn, acc)
+		if err != nil {
+			acc.AddError(err)
+			return err
+		}
+
+		postedBootTimestamps = true
+	}
+
+	// Read all unit timing data, this will only post metrics which have changed
+	// value.
+	err = postAllUnitTimingData(dbusConn, acc)
+	if err != nil {
+		acc.AddError(err)
+		return err
+	}
+
+	return nil
+}
+
+func init() {
+	inputs.Add("systemd_timings", func() telegraf.Input {
+		return &SystemdTimings{}
+	})
+}

--- a/plugins/inputs/systemd_timings/systemd_timings_linux_test.go
+++ b/plugins/inputs/systemd_timings/systemd_timings_linux_test.go
@@ -1,0 +1,54 @@
+package systemd_timings
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+)
+
+func TestSystemdTiming(t *testing.T) {
+	t.Run("systemdTimingsTestAll", func(t *testing.T) {
+		systemdTimings := &SystemdTimings{}
+		acc := new(testutil.Accumulator)
+		err := acc.GatherError(systemdTimings.Gather)
+		if err != nil {
+			t.Errorf("Error calling Gather: '%#v'", err)
+		}
+		for _, metric := range acc.Metrics {
+			if !reflect.DeepEqual(metric.Measurement, measurement) {
+				t.Errorf("expected measurement '%#v' got '%#v'\n",
+					measurement, metric.Measurement)
+			}
+
+			unitName, isUnit := metric.Tags["UnitName"]
+			tsName, isGlobal := metric.Tags["SystemTimestamp"]
+			if !isUnit && !isGlobal {
+				t.Errorf("no valid metric tags found, expected either "+
+					"UnitName or SystemTimestamp, got: %v\n", metric.Tags)
+			}
+
+			if isGlobal {
+				value, ok := metric.Fields["SystemTimestampValue"].(uint64)
+				if ok {
+					if value <= 0 {
+						t.Errorf("expected positive timestamp for %s, "+
+							"got: %d\n", tsName, value)
+					}
+				} else {
+					t.Errorf("failed to convert %s to an integer\n", tsName)
+				}
+			} else if isUnit {
+				value, ok := metric.Fields["RunDuration"].(uint64)
+				if ok {
+					if value <= 0 {
+						t.Errorf("expected positive timestamp for %s, "+
+							"got: %d\n", unitName, value)
+					}
+				} else {
+					t.Errorf("failed to convert %s to an integer\n", unitName)
+				}
+			}
+		}
+	})
+}

--- a/plugins/inputs/systemd_timings/systemd_timings_notlinux.go
+++ b/plugins/inputs/systemd_timings/systemd_timings_notlinux.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package systemd_timings


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.

This input plugin collects systemd boot and unit related timestamps. Timestamps are accessed via systemd exposed APIs on D-Bus.  There are 2 classes of timestamps collected:

- System wide: These are timestamps pertaining to the overall boot process.
- Per unit: These timestamps indicate the time taken to start or stop a unit.

System wide timestamps are collected and sent once after telegraf is started.  Per unit timestamps are sent whenever telegraf is started and also later if a unit is started or stopped.  All timestamps are at a microsecond resolution.

For more information see README.md.

closes #7010