### PR TITLE
add User-Agent header on fetchConfig

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -860,7 +860,7 @@ func fetchConfig(u *url.URL) ([]byte, error) {
 		req.Header.Add("Authorization", "Token "+v)
 	}
 	req.Header.Add("Accept", "application/toml")
-	req.Header.Set("User-Agent", "Telegraf/"+internal.Version()+" ("+runtime.GOOS+" "+runtime.GOARCH+")")
+	req.Header.Set("User-Agent", internal.ProductToken()+" ("+runtime.GOOS+" "+runtime.GOARCH+")")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -860,6 +860,7 @@ func fetchConfig(u *url.URL) ([]byte, error) {
 		req.Header.Add("Authorization", "Token "+v)
 	}
 	req.Header.Add("Accept", "application/toml")
+	req.Header.Set("User-Agent", "Telegraf/"+internal.Version()+" ("+runtime.GOOS+" "+runtime.GOARCH+")")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
include OS and ARCH

needed on server side for:
identify the operating system to generate certain configurations
identify the telegraf version to check plugin is available

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
