### PR TITLE
iptables input plugin: Extract target as a tag for each rule

### DIFF
--- a/plugins/inputs/iptables/iptables.go
+++ b/plugins/inputs/iptables/iptables.go
@@ -102,8 +102,8 @@ const measurement = "iptables"
 
 var errParse = errors.New("Cannot parse iptables list information")
 var chainNameRe = regexp.MustCompile(`^Chain\s+(\S+)`)
-var fieldsHeaderRe = regexp.MustCompile(`^\s*pkts\s+bytes\s+`)
-var valuesRe = regexp.MustCompile(`^\s*(\d+)\s+(\d+)\s+.*?/\*\s*(.+?)\s*\*/\s*`)
+var fieldsHeaderRe = regexp.MustCompile(`^\s*pkts\s+bytes\s+target`)
+var valuesRe = regexp.MustCompile(`^\s*(\d+)\s+(\d+)\s+(\w+).*?/\*\s*(.+?)\s*\*/\s*`)
 
 func (ipt *Iptables) parseAndGather(data string, acc telegraf.Accumulator) error {
 	lines := strings.Split(data, "\n")
@@ -119,15 +119,16 @@ func (ipt *Iptables) parseAndGather(data string, acc telegraf.Accumulator) error
 	}
 	for _, line := range lines[2:] {
 		matches := valuesRe.FindStringSubmatch(line)
-		if len(matches) != 4 {
+		if len(matches) != 5 {
 			continue
 		}
 
 		pkts := matches[1]
 		bytes := matches[2]
-		comment := matches[3]
+		target := matches[3]
+		comment := matches[4]
 
-		tags := map[string]string{"table": ipt.Table, "chain": mchain[1], "ruleid": comment}
+		tags := map[string]string{"table": ipt.Table, "chain": mchain[1], "target": target, "ruleid": comment}
 		fields := make(map[string]interface{})
 
 		var err error

--- a/plugins/inputs/iptables/iptables_test.go
+++ b/plugins/inputs/iptables/iptables_test.go
@@ -42,7 +42,7 @@ func TestIptables_Gather(t *testing.T) {
 		                pkts      bytes target     prot opt in     out     source               destination
 		                57     4520 RETURN     tcp  --  *      *       0.0.0.0/0            0.0.0.0/0   /* foobar */
 		                `},
-			tags: []map[string]string{{"table": "filter", "chain": "INPUT", "ruleid": "foobar"}},
+			tags: []map[string]string{{"table": "filter", "chain": "INPUT", "target": "RETURN", "ruleid": "foobar"}},
 			fields: [][]map[string]interface{}{
 				{map[string]interface{}{"pkts": uint64(57), "bytes": uint64(4520)}},
 			},
@@ -98,9 +98,9 @@ func TestIptables_Gather(t *testing.T) {
 		                `,
 			},
 			tags: []map[string]string{
-				{"table": "filter", "chain": "INPUT", "ruleid": "foo"},
-				{"table": "filter", "chain": "FORWARD", "ruleid": "bar"},
-				{"table": "filter", "chain": "FORWARD", "ruleid": "foobar"},
+				{"table": "filter", "chain": "INPUT", "target": "RETURN", "ruleid": "foo"},
+				{"table": "filter", "chain": "FORWARD", "target": "RETURN", "ruleid": "bar"},
+				{"table": "filter", "chain": "FORWARD", "target": "RETURN", "ruleid": "foobar"},
 			},
 			fields: [][]map[string]interface{}{
 				{map[string]interface{}{"pkts": uint64(200), "bytes": uint64(4520)}},
@@ -118,7 +118,7 @@ func TestIptables_Gather(t *testing.T) {
                         100     4520 RETURN     tcp  --  *      *       0.0.0.0/0            0.0.0.0/0    tcp dpt:80
 		                `},
 			tags: []map[string]string{
-				{"table": "filter", "chain": "INPUT", "ruleid": "foobar"},
+				{"table": "filter", "chain": "INPUT", "target": "RETURN", "ruleid": "foobar"},
 			},
 			fields: [][]map[string]interface{}{
 				{map[string]interface{}{"pkts": uint64(57), "bytes": uint64(4520)}},
@@ -134,8 +134,8 @@ func TestIptables_Gather(t *testing.T) {
 						0 0 CLASSIFY all -- * * 1.3.5.7 0.0.0.0/0 /* test2 */ CLASSIFY set 1:4
 						`},
 			tags: []map[string]string{
-				{"table": "mangle", "chain": "SHAPER", "ruleid": "test"},
-				{"table": "mangle", "chain": "SHAPER", "ruleid": "test2"},
+				{"table": "mangle", "chain": "SHAPER", "target": "ACCEPT", "ruleid": "test"},
+				{"table": "mangle", "chain": "SHAPER", "target": "CLASSIFY", "ruleid": "test2"},
 			},
 			fields: [][]map[string]interface{}{
 				{map[string]interface{}{"pkts": uint64(0), "bytes": uint64(0)}},
@@ -163,7 +163,7 @@ func TestIptables_Gather(t *testing.T) {
 						 123   456        all  --  eth0 *   0.0.0.0/0 0.0.0.0/0   /* all_recv */
 		               `},
 			tags: []map[string]string{
-				{"table": "all_recv", "chain": "accountfwd", "ruleid": "all_recv"},
+				{"table": "all_recv", "chain": "accountfwd", "target": "all", "ruleid": "all_recv"},
 			},
 			fields: [][]map[string]interface{}{
 				{map[string]interface{}{"pkts": uint64(123), "bytes": uint64(456)}},


### PR DESCRIPTION
This is very handy to find all rules going to a certain target, for
example DROP.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
