### PR TITLE
Fix string to int64 conversion for SNMP input

### DIFF
--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -804,9 +804,9 @@ func fieldConvert(conv string, v interface{}) (interface{}, error) {
 		case uint64:
 			v = int64(vt)
 		case []byte:
-			v, _ = strconv.Atoi(string(vt))
+			v, _ = strconv.ParseInt(string(vt), 10, 64)
 		case string:
-			v, _ = strconv.Atoi(vt)
+			v, _ = strconv.ParseInt(vt, 10, 64)
 		}
 		return v, nil
 	}

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -694,6 +694,8 @@ func TestFieldConvert(t *testing.T) {
 		{uint64(123), "float(3)", float64(0.123)},
 		{"123", "int", int64(123)},
 		{[]byte("123"), "int", int64(123)},
+		{"123123123123", "int", int64(123123123123)},
+		{[]byte("123123123123"), "int", int64(123123123123)},
 		{float32(12.3), "int", int64(12)},
 		{float64(12.3), "int", int64(12)},
 		{int(123), "int", int64(123)},


### PR DESCRIPTION
`strconv.Atoi` produces a 32 bit and truncates larger inputs. Switch this to `strconv.ParseInt` to get an int64, matching the other conversions. Add a unit test. No changes to README.md needed.

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
