### PR TITLE
feat: RunOnce / Serverless Telegraf

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -18,13 +18,15 @@ import (
 
 // Agent runs a set of plugins.
 type Agent struct {
-	Config *config.Config
+	Config  *config.Config
+	RunOnce bool
 }
 
 // NewAgent returns an Agent for the given Config.
-func NewAgent(config *config.Config) (*Agent, error) {
+func NewAgent(config *config.Config, runOnce bool) (*Agent, error) {
 	a := &Agent{
-		Config: config,
+		Config:  config,
+		RunOnce: runOnce,
 	}
 	return a, nil
 }
@@ -58,10 +60,12 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	startTime := time.Now()
 
-	log.Printf("D! [agent] Starting service inputs")
-	err = a.startServiceInputs(ctx, inputC)
-	if err != nil {
-		return err
+	if !a.RunOnce {
+		log.Printf("D! [agent] Starting service inputs")
+		err = a.startServiceInputs(ctx, inputC)
+		if err != nil {
+			return err
+		}
 	}
 
 	var wg sync.WaitGroup
@@ -78,8 +82,10 @@ func (a *Agent) Run(ctx context.Context) error {
 			log.Printf("E! [agent] Error running inputs: %v", err)
 		}
 
-		log.Printf("D! [agent] Stopping service inputs")
-		a.stopServiceInputs()
+		if !a.RunOnce {
+			log.Printf("D! [agent] Stopping service inputs")
+			a.stopServiceInputs()
+		}
 
 		close(dst)
 		log.Printf("D! [agent] Input channel closed")
@@ -272,12 +278,17 @@ func (a *Agent) runInputs(
 		go func(input *models.RunningInput) {
 			defer wg.Done()
 
-			if a.Config.Agent.RoundInterval {
+			if !a.RunOnce && a.Config.Agent.RoundInterval {
 				err := internal.SleepContext(
 					ctx, internal.AlignDuration(startTime, interval))
 				if err != nil {
 					return
 				}
+			}
+
+			if a.RunOnce {
+				a.gatherOnce(acc, input, interval)
+				return
 			}
 
 			a.gatherOnInterval(ctx, acc, input, interval, jitter)
@@ -517,6 +528,15 @@ func (a *Agent) runOutputs(
 		wg.Add(1)
 		go func(output *models.RunningOutput) {
 			defer wg.Done()
+
+			if !a.RunOnce && !a.Config.Agent.RoundInterval {
+				err := internal.SleepContext(
+					ctx, internal.AlignDuration(startTime, interval))
+				if err != nil {
+					return
+				}
+			}
+
 			a.flushLoop(ctx, startTime, output, interval, jitter)
 		}(output)
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -14,7 +14,7 @@ import (
 func TestAgent_OmitHostname(t *testing.T) {
 	c := config.NewConfig()
 	c.Agent.OmitHostname = true
-	_, err := NewAgent(c, false)
+	_, err := NewAgent(c)
 	assert.NoError(t, err)
 	assert.NotContains(t, c.Tags, "host")
 }
@@ -24,35 +24,35 @@ func TestAgent_LoadPlugin(t *testing.T) {
 	c.InputFilters = []string{"mysql"}
 	err := c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ := NewAgent(c, false)
+	a, _ := NewAgent(c)
 	assert.Equal(t, 1, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"foo"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c, false)
+	a, _ = NewAgent(c)
 	assert.Equal(t, 0, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"mysql", "foo"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c, false)
+	a, _ = NewAgent(c)
 	assert.Equal(t, 1, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"mysql", "redis"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c, false)
+	a, _ = NewAgent(c)
 	assert.Equal(t, 2, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"mysql", "foo", "redis", "bar"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c, false)
+	a, _ = NewAgent(c)
 	assert.Equal(t, 2, len(a.Config.Inputs))
 }
 
@@ -61,35 +61,35 @@ func TestAgent_LoadOutput(t *testing.T) {
 	c.OutputFilters = []string{"influxdb"}
 	err := c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ := NewAgent(c, false)
+	a, _ := NewAgent(c)
 	assert.Equal(t, 2, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"kafka"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c, false)
+	a, _ = NewAgent(c)
 	assert.Equal(t, 1, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c, false)
+	a, _ = NewAgent(c)
 	assert.Equal(t, 3, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"foo"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c, false)
+	a, _ = NewAgent(c)
 	assert.Equal(t, 0, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"influxdb", "foo"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c, false)
+	a, _ = NewAgent(c)
 	assert.Equal(t, 2, len(a.Config.Outputs))
 
 	c = config.NewConfig()
@@ -97,14 +97,14 @@ func TestAgent_LoadOutput(t *testing.T) {
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(c.Outputs))
-	a, _ = NewAgent(c, false)
+	a, _ = NewAgent(c)
 	assert.Equal(t, 3, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"influxdb", "foo", "kafka", "bar"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c, false)
+	a, _ = NewAgent(c)
 	assert.Equal(t, 3, len(a.Config.Outputs))
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -14,7 +14,7 @@ import (
 func TestAgent_OmitHostname(t *testing.T) {
 	c := config.NewConfig()
 	c.Agent.OmitHostname = true
-	_, err := NewAgent(c)
+	_, err := NewAgent(c, false)
 	assert.NoError(t, err)
 	assert.NotContains(t, c.Tags, "host")
 }
@@ -24,35 +24,35 @@ func TestAgent_LoadPlugin(t *testing.T) {
 	c.InputFilters = []string{"mysql"}
 	err := c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ := NewAgent(c)
+	a, _ := NewAgent(c, false)
 	assert.Equal(t, 1, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"foo"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c)
+	a, _ = NewAgent(c, false)
 	assert.Equal(t, 0, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"mysql", "foo"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c)
+	a, _ = NewAgent(c, false)
 	assert.Equal(t, 1, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"mysql", "redis"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c)
+	a, _ = NewAgent(c, false)
 	assert.Equal(t, 2, len(a.Config.Inputs))
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"mysql", "foo", "redis", "bar"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c)
+	a, _ = NewAgent(c, false)
 	assert.Equal(t, 2, len(a.Config.Inputs))
 }
 
@@ -61,35 +61,35 @@ func TestAgent_LoadOutput(t *testing.T) {
 	c.OutputFilters = []string{"influxdb"}
 	err := c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ := NewAgent(c)
+	a, _ := NewAgent(c, false)
 	assert.Equal(t, 2, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"kafka"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c)
+	a, _ = NewAgent(c, false)
 	assert.Equal(t, 1, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c)
+	a, _ = NewAgent(c, false)
 	assert.Equal(t, 3, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"foo"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c)
+	a, _ = NewAgent(c, false)
 	assert.Equal(t, 0, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"influxdb", "foo"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c)
+	a, _ = NewAgent(c, false)
 	assert.Equal(t, 2, len(a.Config.Outputs))
 
 	c = config.NewConfig()
@@ -97,14 +97,14 @@ func TestAgent_LoadOutput(t *testing.T) {
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(c.Outputs))
-	a, _ = NewAgent(c)
+	a, _ = NewAgent(c, false)
 	assert.Equal(t, 3, len(a.Config.Outputs))
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"influxdb", "foo", "kafka", "bar"}
 	err = c.LoadConfig("../internal/config/testdata/telegraf-agent.toml")
 	assert.NoError(t, err)
-	a, _ = NewAgent(c)
+	a, _ = NewAgent(c, false)
 	assert.Equal(t, 3, len(a.Config.Outputs))
 }
 

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -67,6 +67,7 @@ var fServiceDisplayName = flag.String("service-display-name", "Telegraf Data Col
 var fRunAsConsole = flag.Bool("console", false, "run as console application (windows only)")
 var fPlugins = flag.String("plugin-directory", "",
 	"path to directory containing external plugins")
+var fRunOnce = flag.Bool("run-once", false, "collect metrics from inputs once and exit")
 
 var (
 	version string
@@ -151,7 +152,7 @@ func runAgent(ctx context.Context,
 			c.Agent.Interval.Duration)
 	}
 
-	ag, err := agent.NewAgent(c)
+	ag, err := agent.NewAgent(c, *fRunOnce)
 	if err != nil {
 		return err
 	}

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -152,7 +152,13 @@ func runAgent(ctx context.Context,
 			c.Agent.Interval.Duration)
 	}
 
-	ag, err := agent.NewAgent(c, *fRunOnce)
+	// Command-line argument takes precedence over configuration file
+	if *fRunOnce {
+		c.Agent.RunOnce = true
+
+	}
+
+	ag, err := agent.NewAgent(c)
 	if err != nil {
 		return err
 	}
@@ -197,6 +203,10 @@ func runAgent(ctx context.Context,
 				}
 			}()
 		}
+	}
+
+	if ag.Config.Agent.RunOnce {
+		return ag.RunOnce(ctx)
 	}
 
 	return ag.Run(ctx)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,7 @@ func NewConfig() *Config {
 			FlushInterval:              internal.Duration{Duration: 10 * time.Second},
 			LogTarget:                  "file",
 			LogfileRotationMaxArchives: 5,
+			RunOnce:                    false,
 		},
 
 		Tags:          make(map[string]string),
@@ -167,6 +168,9 @@ type AgentConfig struct {
 	// Maximum number of rotated archives to keep, any older logs are deleted.
 	// If set to -1, no archives are removed.
 	LogfileRotationMaxArchives int `toml:"logfile_rotation_max_archives"`
+
+	// Run the collection once, then exit
+	RunOnce bool `toml:"run_once"`
 
 	Hostname     string
 	OmitHostname bool


### PR DESCRIPTION
Follow-up to #6537

I can reduce some of the duplication between `Run` and `RunOnce`, but I don't want to put too much time into this unless it's closer to what was expected.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
