### PR TITLE
plugins/parsers/json: Use same timestamp for all objects in arrays

### DIFF
--- a/plugins/parsers/json/parser_test.go
+++ b/plugins/parsers/json/parser_test.go
@@ -794,6 +794,18 @@ func TestTimeErrors(t *testing.T) {
 	require.Equal(t, fmt.Errorf("JSON time key could not be found"), err)
 }
 
+func TestShareTimestamp(t *testing.T) {
+	parser, err := New(&Config{
+		MetricName: "json_test",
+	})
+	require.NoError(t, err)
+
+	metrics, err := parser.Parse([]byte(validJSONArrayMultiple))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(metrics))
+	require.Equal(t, true, metrics[0].Time() == metrics[1].Time())
+}
+
 func TestNameKey(t *testing.T) {
 	testString := `{
 		"a": 5,


### PR DESCRIPTION
I am new to this, so please let me know if this is not appropriate.

My data is sent as a single JSON packet but the resulting measurements generated from the JSON array all had different timestamps.  This made it difficult to work with the data.  Because all objects in the JSON array arrive at the same time they should have the same timestamp.  With the same timestamp the data has the correlation that it should.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated. (no changes needed)
- [X] Has appropriate unit tests.
