### PR TITLE
refactor(execd): avoid printing nil error

### DIFF
--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -107,7 +107,11 @@ func (e *Execd) cmdLoop(ctx context.Context) {
 			internal.WaitTimeout(e.cmd, 200*time.Millisecond)
 			return
 		case err := <-done:
-			log.Printf("E! [inputs.execd] Process %s terminated: %s", e.Command, err)
+			var reason string
+			if err != nil {
+				reason = fmt.Sprintf(": %s", err)
+			}
+			log.Printf("E! [inputs.execd] Process %s terminated%s", e.Command, reason)
 		}
 
 		log.Printf("E! [inputs.execd] Restarting in %s...", e.RestartDelay.Duration)


### PR DESCRIPTION
Recently I started playing with the `execd` input. I have a program that doesn't run in its own loop, but instead executes a job, emits some Influx line protocol, and then terminates gracefully.

This is running fine in Telegraf, but I noticed some messy output where a `nil` error was being formatted into a string.

```
2020-04-28T16:17:12Z E! [inputs.execd] Restarting in 10s...
2020-04-28T16:17:23Z E! [inputs.execd] Process [my_program arg1 arrg2] terminated: %!s(<nil>)
2020-04-28T16:17:23Z E! [inputs.execd] Restarting in 10s...
2020-04-28T16:17:33Z E! [inputs.execd] Process [my_program arg1 arrg2] terminated: %!s(<nil>)
2020-04-28T16:17:33Z E! [inputs.execd] Restarting in 10s...
2020-04-28T16:17:44Z E! [inputs.execd] Process [my_program arg1 arrg2] terminated: %!s(<nil>)
2020-04-28T16:17:44Z E! [inputs.execd] Restarting in 10s...
2020-04-28T16:17:54Z E! [inputs.execd] Process [my_program arg1 arrg2] terminated: %!s(<nil>)
2020-04-28T16:17:54Z E! [inputs.execd] Restarting in 10s...
2020-04-28T16:18:05Z E! [inputs.execd] Process [my_program arg1 arrg2] terminated: %!s(<nil>)
2020-04-28T16:18:05Z E! [inputs.execd] Restarting in 10s...
```

This PR tidies things up a bit by only emitting `: some error` if there was a non-nil error returned from the process.

New output no error:

```
2020-04-28T16:19:57Z I! Starting Telegraf
2020-04-28T16:19:57Z I! Loaded inputs: system cpu mem processes net swap execd disk diskio
2020-04-28T16:19:57Z I! Loaded aggregators:
2020-04-28T16:19:57Z I! Loaded processors:
2020-04-28T16:19:57Z I! Loaded outputs: influxdb_v2 influxdb_v2
2020-04-28T16:19:57Z I! Tags enabled: host=Alameda
2020-04-28T16:19:57Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"Alameda", Flush Interval:10s
2020-04-28T16:19:57Z E! [inputs.execd] Process [wiggle https://www.wiggle.co.uk/wahoo-kickr-smart-turbo-trainer-4 //span[contains(text(), 'Out of stock')] xpath,retailer=wiggle,item=kickr2018] terminated
2020-04-28T16:19:57Z E! [inputs.execd] Restarting in 10s...
2020-04-28T16:20:08Z E! [inputs.execd] Process [wiggle https://www.wiggle.co.uk/wahoo-kickr-smart-turbo-trainer-4 //span[contains(text(), 'Out of stock')] xpath,retailer=wiggle,item=kickr2018] terminated
2020-04-28T16:20:08Z E! [inputs.execd] Restarting in 10s...
2020-04-28T16:20:19Z E! [inputs.execd] Process [wiggle https://www.wiggle.co.uk/wahoo-kickr-smart-turbo-trainer-4 //span[contains(text(), 'Out of stock')] xpath,retailer=wiggle,item=kickr2018] terminated
2020-04-28T16:20:19Z E! [inputs.execd] Restarting in 10s...
^C2020-04-28T16:20:25Z I! [agent] Hang on, flushing any cached metrics before shutdown