### PR TITLE
Allow CR and FF inside of string fields and fix parser panic

### DIFF
--- a/plugins/parsers/influx/machine.go
+++ b/plugins/parsers/influx/machine.go
@@ -30,14 +30,14 @@ var (
 
 
 //line plugins/parsers/influx/machine.go:33
-const LineProtocol_start int = 270
-const LineProtocol_first_final int = 270
+const LineProtocol_start int = 269
+const LineProtocol_first_final int = 269
 const LineProtocol_error int = 0
 
-const LineProtocol_en_main int = 270
-const LineProtocol_en_discard_line int = 258
-const LineProtocol_en_align int = 740
-const LineProtocol_en_series int = 261
+const LineProtocol_en_main int = 269
+const LineProtocol_en_discard_line int = 257
+const LineProtocol_en_align int = 739
+const LineProtocol_en_series int = 260
 
 
 //line plugins/parsers/influx/machine.go.rl:321
@@ -173,8 +173,8 @@ func (m *machine) exec() error {
 
 _again:
 	switch ( m.cs) {
-	case 270:
-		goto st270
+	case 269:
+		goto st269
 	case 1:
 		goto st1
 	case 2:
@@ -189,14 +189,14 @@ _again:
 		goto st5
 	case 6:
 		goto st6
-	case 7:
-		goto st7
+	case 270:
+		goto st270
 	case 271:
 		goto st271
 	case 272:
 		goto st272
-	case 273:
-		goto st273
+	case 7:
+		goto st7
 	case 8:
 		goto st8
 	case 9:
@@ -245,24 +245,24 @@ _again:
 		goto st30
 	case 31:
 		goto st31
-	case 32:
-		goto st32
+	case 273:
+		goto st273
 	case 274:
 		goto st274
-	case 275:
-		goto st275
+	case 32:
+		goto st32
 	case 33:
 		goto st33
-	case 34:
-		goto st34
+	case 275:
+		goto st275
 	case 276:
 		goto st276
 	case 277:
 		goto st277
+	case 34:
+		goto st34
 	case 278:
 		goto st278
-	case 35:
-		goto st35
 	case 279:
 		goto st279
 	case 280:
@@ -297,18 +297,18 @@ _again:
 		goto st294
 	case 295:
 		goto st295
-	case 296:
-		goto st296
+	case 35:
+		goto st35
 	case 36:
 		goto st36
-	case 37:
-		goto st37
+	case 296:
+		goto st296
 	case 297:
 		goto st297
 	case 298:
 		goto st298
-	case 299:
-		goto st299
+	case 37:
+		goto st37
 	case 38:
 		goto st38
 	case 39:
@@ -317,18 +317,18 @@ _again:
 		goto st40
 	case 41:
 		goto st41
-	case 42:
-		goto st42
+	case 299:
+		goto st299
 	case 300:
 		goto st300
 	case 301:
 		goto st301
 	case 302:
 		goto st302
+	case 42:
+		goto st42
 	case 303:
 		goto st303
-	case 43:
-		goto st43
 	case 304:
 		goto st304
 	case 305:
@@ -371,8 +371,8 @@ _again:
 		goto st323
 	case 324:
 		goto st324
-	case 325:
-		goto st325
+	case 43:
+		goto st43
 	case 44:
 		goto st44
 	case 45:
@@ -391,14 +391,14 @@ _again:
 		goto st51
 	case 52:
 		goto st52
-	case 53:
-		goto st53
+	case 325:
+		goto st325
 	case 326:
 		goto st326
 	case 327:
 		goto st327
-	case 328:
-		goto st328
+	case 53:
+		goto st53
 	case 54:
 		goto st54
 	case 55:
@@ -409,14 +409,14 @@ _again:
 		goto st57
 	case 58:
 		goto st58
-	case 59:
-		goto st59
+	case 328:
+		goto st328
 	case 329:
 		goto st329
+	case 59:
+		goto st59
 	case 330:
 		goto st330
-	case 60:
-		goto st60
 	case 331:
 		goto st331
 	case 332:
@@ -455,18 +455,18 @@ _again:
 		goto st348
 	case 349:
 		goto st349
+	case 60:
+		goto st60
 	case 350:
 		goto st350
-	case 61:
-		goto st61
 	case 351:
 		goto st351
 	case 352:
 		goto st352
+	case 61:
+		goto st61
 	case 353:
 		goto st353
-	case 62:
-		goto st62
 	case 354:
 		goto st354
 	case 355:
@@ -505,8 +505,8 @@ _again:
 		goto st371
 	case 372:
 		goto st372
-	case 373:
-		goto st373
+	case 62:
+		goto st62
 	case 63:
 		goto st63
 	case 64:
@@ -515,10 +515,10 @@ _again:
 		goto st65
 	case 66:
 		goto st66
+	case 373:
+		goto st373
 	case 67:
 		goto st67
-	case 374:
-		goto st374
 	case 68:
 		goto st68
 	case 69:
@@ -527,18 +527,20 @@ _again:
 		goto st70
 	case 71:
 		goto st71
-	case 72:
-		goto st72
+	case 374:
+		goto st374
 	case 375:
 		goto st375
 	case 376:
 		goto st376
-	case 377:
-		goto st377
+	case 72:
+		goto st72
 	case 73:
 		goto st73
 	case 74:
 		goto st74
+	case 377:
+		goto st377
 	case 378:
 		goto st378
 	case 379:
@@ -547,8 +549,6 @@ _again:
 		goto st75
 	case 380:
 		goto st380
-	case 76:
-		goto st76
 	case 381:
 		goto st381
 	case 382:
@@ -587,8 +587,8 @@ _again:
 		goto st398
 	case 399:
 		goto st399
-	case 400:
-		goto st400
+	case 76:
+		goto st76
 	case 77:
 		goto st77
 	case 78:
@@ -615,52 +615,52 @@ _again:
 		goto st88
 	case 89:
 		goto st89
-	case 90:
-		goto st90
+	case 400:
+		goto st400
 	case 401:
 		goto st401
 	case 402:
 		goto st402
 	case 403:
 		goto st403
-	case 404:
-		goto st404
+	case 90:
+		goto st90
 	case 91:
 		goto st91
 	case 92:
 		goto st92
 	case 93:
 		goto st93
-	case 94:
-		goto st94
+	case 404:
+		goto st404
 	case 405:
 		goto st405
-	case 406:
-		goto st406
+	case 94:
+		goto st94
 	case 95:
 		goto st95
+	case 406:
+		goto st406
 	case 96:
 		goto st96
-	case 407:
-		goto st407
 	case 97:
 		goto st97
-	case 98:
-		goto st98
+	case 407:
+		goto st407
 	case 408:
 		goto st408
+	case 98:
+		goto st98
 	case 409:
 		goto st409
-	case 99:
-		goto st99
 	case 410:
 		goto st410
-	case 411:
-		goto st411
+	case 99:
+		goto st99
 	case 100:
 		goto st100
-	case 101:
-		goto st101
+	case 411:
+		goto st411
 	case 412:
 		goto st412
 	case 413:
@@ -695,28 +695,28 @@ _again:
 		goto st427
 	case 428:
 		goto st428
+	case 101:
+		goto st101
 	case 429:
 		goto st429
-	case 102:
-		goto st102
 	case 430:
 		goto st430
 	case 431:
 		goto st431
-	case 432:
-		goto st432
+	case 102:
+		goto st102
 	case 103:
 		goto st103
-	case 104:
-		goto st104
+	case 432:
+		goto st432
 	case 433:
 		goto st433
 	case 434:
 		goto st434
+	case 104:
+		goto st104
 	case 435:
 		goto st435
-	case 105:
-		goto st105
 	case 436:
 		goto st436
 	case 437:
@@ -755,10 +755,10 @@ _again:
 		goto st453
 	case 454:
 		goto st454
+	case 105:
+		goto st105
 	case 455:
 		goto st455
-	case 106:
-		goto st106
 	case 456:
 		goto st456
 	case 457:
@@ -801,8 +801,8 @@ _again:
 		goto st475
 	case 476:
 		goto st476
-	case 477:
-		goto st477
+	case 106:
+		goto st106
 	case 107:
 		goto st107
 	case 108:
@@ -811,18 +811,18 @@ _again:
 		goto st109
 	case 110:
 		goto st110
+	case 477:
+		goto st477
 	case 111:
 		goto st111
 	case 478:
 		goto st478
-	case 112:
-		goto st112
 	case 479:
 		goto st479
+	case 112:
+		goto st112
 	case 480:
 		goto st480
-	case 113:
-		goto st113
 	case 481:
 		goto st481
 	case 482:
@@ -839,48 +839,48 @@ _again:
 		goto st487
 	case 488:
 		goto st488
-	case 489:
-		goto st489
+	case 113:
+		goto st113
 	case 114:
 		goto st114
 	case 115:
 		goto st115
+	case 489:
+		goto st489
 	case 116:
 		goto st116
-	case 490:
-		goto st490
 	case 117:
 		goto st117
 	case 118:
 		goto st118
+	case 490:
+		goto st490
 	case 119:
 		goto st119
-	case 491:
-		goto st491
 	case 120:
 		goto st120
-	case 121:
-		goto st121
+	case 491:
+		goto st491
 	case 492:
 		goto st492
-	case 493:
-		goto st493
+	case 121:
+		goto st121
 	case 122:
 		goto st122
 	case 123:
 		goto st123
 	case 124:
 		goto st124
-	case 125:
-		goto st125
+	case 493:
+		goto st493
 	case 494:
 		goto st494
 	case 495:
 		goto st495
+	case 125:
+		goto st125
 	case 496:
 		goto st496
-	case 126:
-		goto st126
 	case 497:
 		goto st497
 	case 498:
@@ -919,12 +919,12 @@ _again:
 		goto st514
 	case 515:
 		goto st515
-	case 516:
-		goto st516
+	case 126:
+		goto st126
 	case 127:
 		goto st127
-	case 128:
-		goto st128
+	case 516:
+		goto st516
 	case 517:
 		goto st517
 	case 518:
@@ -941,48 +941,48 @@ _again:
 		goto st523
 	case 524:
 		goto st524
-	case 525:
-		goto st525
+	case 128:
+		goto st128
 	case 129:
 		goto st129
 	case 130:
 		goto st130
+	case 525:
+		goto st525
 	case 131:
 		goto st131
-	case 526:
-		goto st526
 	case 132:
 		goto st132
 	case 133:
 		goto st133
+	case 526:
+		goto st526
 	case 134:
 		goto st134
-	case 527:
-		goto st527
 	case 135:
 		goto st135
-	case 136:
-		goto st136
+	case 527:
+		goto st527
 	case 528:
 		goto st528
-	case 529:
-		goto st529
+	case 136:
+		goto st136
 	case 137:
 		goto st137
 	case 138:
 		goto st138
-	case 139:
-		goto st139
+	case 529:
+		goto st529
 	case 530:
 		goto st530
+	case 139:
+		goto st139
 	case 531:
 		goto st531
 	case 140:
 		goto st140
 	case 532:
 		goto st532
-	case 141:
-		goto st141
 	case 533:
 		goto st533
 	case 534:
@@ -997,28 +997,28 @@ _again:
 		goto st538
 	case 539:
 		goto st539
-	case 540:
-		goto st540
+	case 141:
+		goto st141
 	case 142:
 		goto st142
 	case 143:
 		goto st143
+	case 540:
+		goto st540
 	case 144:
 		goto st144
-	case 541:
-		goto st541
 	case 145:
 		goto st145
 	case 146:
 		goto st146
+	case 541:
+		goto st541
 	case 147:
 		goto st147
-	case 542:
-		goto st542
 	case 148:
 		goto st148
-	case 149:
-		goto st149
+	case 542:
+		goto st542
 	case 543:
 		goto st543
 	case 544:
@@ -1057,26 +1057,26 @@ _again:
 		goto st560
 	case 561:
 		goto st561
-	case 562:
-		goto st562
+	case 149:
+		goto st149
 	case 150:
 		goto st150
-	case 151:
-		goto st151
+	case 562:
+		goto st562
 	case 563:
 		goto st563
 	case 564:
 		goto st564
+	case 151:
+		goto st151
 	case 565:
 		goto st565
-	case 152:
-		goto st152
 	case 566:
 		goto st566
+	case 152:
+		goto st152
 	case 567:
 		goto st567
-	case 153:
-		goto st153
 	case 568:
 		goto st568
 	case 569:
@@ -1111,16 +1111,16 @@ _again:
 		goto st583
 	case 584:
 		goto st584
-	case 585:
-		goto st585
+	case 153:
+		goto st153
 	case 154:
 		goto st154
+	case 585:
+		goto st585
 	case 155:
 		goto st155
 	case 586:
 		goto st586
-	case 156:
-		goto st156
 	case 587:
 		goto st587
 	case 588:
@@ -1135,32 +1135,32 @@ _again:
 		goto st592
 	case 593:
 		goto st593
-	case 594:
-		goto st594
+	case 156:
+		goto st156
 	case 157:
 		goto st157
 	case 158:
 		goto st158
+	case 594:
+		goto st594
 	case 159:
 		goto st159
-	case 595:
-		goto st595
 	case 160:
 		goto st160
 	case 161:
 		goto st161
+	case 595:
+		goto st595
 	case 162:
 		goto st162
-	case 596:
-		goto st596
 	case 163:
 		goto st163
-	case 164:
-		goto st164
+	case 596:
+		goto st596
 	case 597:
 		goto st597
-	case 598:
-		goto st598
+	case 164:
+		goto st164
 	case 165:
 		goto st165
 	case 166:
@@ -1171,8 +1171,8 @@ _again:
 		goto st168
 	case 169:
 		goto st169
-	case 170:
-		goto st170
+	case 598:
+		goto st598
 	case 599:
 		goto st599
 	case 600:
@@ -1209,28 +1209,28 @@ _again:
 		goto st615
 	case 616:
 		goto st616
-	case 617:
-		goto st617
+	case 170:
+		goto st170
 	case 171:
 		goto st171
 	case 172:
 		goto st172
-	case 173:
-		goto st173
+	case 617:
+		goto st617
 	case 618:
 		goto st618
 	case 619:
 		goto st619
+	case 173:
+		goto st173
 	case 620:
 		goto st620
-	case 174:
-		goto st174
 	case 621:
 		goto st621
+	case 174:
+		goto st174
 	case 622:
 		goto st622
-	case 175:
-		goto st175
 	case 623:
 		goto st623
 	case 624:
@@ -1239,76 +1239,76 @@ _again:
 		goto st625
 	case 626:
 		goto st626
-	case 627:
-		goto st627
+	case 175:
+		goto st175
 	case 176:
 		goto st176
 	case 177:
 		goto st177
+	case 627:
+		goto st627
 	case 178:
 		goto st178
-	case 628:
-		goto st628
 	case 179:
 		goto st179
 	case 180:
 		goto st180
+	case 628:
+		goto st628
 	case 181:
 		goto st181
-	case 629:
-		goto st629
 	case 182:
 		goto st182
-	case 183:
-		goto st183
+	case 629:
+		goto st629
 	case 630:
 		goto st630
+	case 183:
+		goto st183
 	case 631:
 		goto st631
-	case 184:
-		goto st184
 	case 632:
 		goto st632
 	case 633:
 		goto st633
-	case 634:
-		goto st634
+	case 184:
+		goto st184
 	case 185:
 		goto st185
 	case 186:
 		goto st186
+	case 634:
+		goto st634
 	case 187:
 		goto st187
-	case 635:
-		goto st635
 	case 188:
 		goto st188
 	case 189:
 		goto st189
+	case 635:
+		goto st635
 	case 190:
 		goto st190
-	case 636:
-		goto st636
 	case 191:
 		goto st191
-	case 192:
-		goto st192
+	case 636:
+		goto st636
 	case 637:
 		goto st637
-	case 638:
-		goto st638
+	case 192:
+		goto st192
 	case 193:
 		goto st193
 	case 194:
 		goto st194
+	case 638:
+		goto st638
 	case 195:
 		goto st195
-	case 639:
-		goto st639
 	case 196:
 		goto st196
-	case 197:
-		goto st197
+	case 639:
+		goto st639
 	case 640:
 		goto st640
 	case 641:
@@ -1323,38 +1323,38 @@ _again:
 		goto st645
 	case 646:
 		goto st646
-	case 647:
-		goto st647
+	case 197:
+		goto st197
 	case 198:
 		goto st198
 	case 199:
 		goto st199
+	case 647:
+		goto st647
 	case 200:
 		goto st200
-	case 648:
-		goto st648
 	case 201:
 		goto st201
 	case 202:
 		goto st202
+	case 648:
+		goto st648
 	case 203:
 		goto st203
-	case 649:
-		goto st649
 	case 204:
 		goto st204
-	case 205:
-		goto st205
+	case 649:
+		goto st649
 	case 650:
 		goto st650
-	case 651:
-		goto st651
+	case 205:
+		goto st205
 	case 206:
 		goto st206
 	case 207:
 		goto st207
-	case 208:
-		goto st208
+	case 651:
+		goto st651
 	case 652:
 		goto st652
 	case 653:
@@ -1391,8 +1391,8 @@ _again:
 		goto st668
 	case 669:
 		goto st669
-	case 670:
-		goto st670
+	case 208:
+		goto st208
 	case 209:
 		goto st209
 	case 210:
@@ -1401,14 +1401,14 @@ _again:
 		goto st211
 	case 212:
 		goto st212
+	case 670:
+		goto st670
 	case 213:
 		goto st213
-	case 671:
-		goto st671
 	case 214:
 		goto st214
-	case 215:
-		goto st215
+	case 671:
+		goto st671
 	case 672:
 		goto st672
 	case 673:
@@ -1425,44 +1425,44 @@ _again:
 		goto st678
 	case 679:
 		goto st679
-	case 680:
-		goto st680
+	case 215:
+		goto st215
 	case 216:
 		goto st216
 	case 217:
 		goto st217
+	case 680:
+		goto st680
 	case 218:
 		goto st218
-	case 681:
-		goto st681
 	case 219:
 		goto st219
 	case 220:
 		goto st220
+	case 681:
+		goto st681
 	case 221:
 		goto st221
-	case 682:
-		goto st682
 	case 222:
 		goto st222
-	case 223:
-		goto st223
+	case 682:
+		goto st682
 	case 683:
 		goto st683
-	case 684:
-		goto st684
+	case 223:
+		goto st223
 	case 224:
 		goto st224
 	case 225:
 		goto st225
+	case 684:
+		goto st684
 	case 226:
 		goto st226
-	case 685:
-		goto st685
 	case 227:
 		goto st227
-	case 228:
-		goto st228
+	case 685:
+		goto st685
 	case 686:
 		goto st686
 	case 687:
@@ -1477,20 +1477,20 @@ _again:
 		goto st691
 	case 692:
 		goto st692
-	case 693:
-		goto st693
+	case 228:
+		goto st228
 	case 229:
 		goto st229
 	case 230:
 		goto st230
+	case 693:
+		goto st693
 	case 231:
 		goto st231
-	case 694:
-		goto st694
 	case 232:
 		goto st232
-	case 233:
-		goto st233
+	case 694:
+		goto st694
 	case 695:
 		goto st695
 	case 696:
@@ -1505,38 +1505,38 @@ _again:
 		goto st700
 	case 701:
 		goto st701
-	case 702:
-		goto st702
+	case 233:
+		goto st233
 	case 234:
 		goto st234
 	case 235:
 		goto st235
+	case 702:
+		goto st702
 	case 236:
 		goto st236
-	case 703:
-		goto st703
 	case 237:
 		goto st237
 	case 238:
 		goto st238
+	case 703:
+		goto st703
 	case 239:
 		goto st239
-	case 704:
-		goto st704
 	case 240:
 		goto st240
-	case 241:
-		goto st241
+	case 704:
+		goto st704
 	case 705:
 		goto st705
-	case 706:
-		goto st706
+	case 241:
+		goto st241
 	case 242:
 		goto st242
 	case 243:
 		goto st243
-	case 244:
-		goto st244
+	case 706:
+		goto st706
 	case 707:
 		goto st707
 	case 708:
@@ -1573,18 +1573,18 @@ _again:
 		goto st723
 	case 724:
 		goto st724
-	case 725:
-		goto st725
+	case 244:
+		goto st244
 	case 245:
 		goto st245
+	case 725:
+		goto st725
 	case 246:
 		goto st246
-	case 726:
-		goto st726
 	case 247:
 		goto st247
-	case 248:
-		goto st248
+	case 726:
+		goto st726
 	case 727:
 		goto st727
 	case 728:
@@ -1599,70 +1599,68 @@ _again:
 		goto st732
 	case 733:
 		goto st733
-	case 734:
-		goto st734
+	case 248:
+		goto st248
 	case 249:
 		goto st249
 	case 250:
 		goto st250
+	case 734:
+		goto st734
 	case 251:
 		goto st251
-	case 735:
-		goto st735
 	case 252:
 		goto st252
 	case 253:
 		goto st253
+	case 735:
+		goto st735
 	case 254:
 		goto st254
-	case 736:
-		goto st736
 	case 255:
 		goto st255
-	case 256:
-		goto st256
+	case 736:
+		goto st736
 	case 737:
 		goto st737
-	case 738:
-		goto st738
+	case 256:
+		goto st256
 	case 257:
 		goto st257
-	case 258:
-		goto st258
-	case 739:
-		goto st739
-	case 261:
-		goto st261
+	case 738:
+		goto st738
+	case 260:
+		goto st260
+	case 740:
+		goto st740
 	case 741:
 		goto st741
-	case 742:
-		goto st742
+	case 261:
+		goto st261
 	case 262:
 		goto st262
 	case 263:
 		goto st263
 	case 264:
 		goto st264
+	case 742:
+		goto st742
 	case 265:
 		goto st265
 	case 743:
 		goto st743
 	case 266:
 		goto st266
-	case 744:
-		goto st744
 	case 267:
 		goto st267
 	case 268:
 		goto st268
-	case 269:
-		goto st269
-	case 740:
-		goto st740
+	case 739:
+		goto st739
+	case 258:
+		goto st258
 	case 259:
 		goto st259
-	case 260:
-		goto st260
 	}
 
 	if ( m.p)++; ( m.p) == ( m.pe) {
@@ -1670,8 +1668,8 @@ _again:
 	}
 _resume:
 	switch ( m.cs) {
-	case 270:
-		goto st_case_270
+	case 269:
+		goto st_case_269
 	case 1:
 		goto st_case_1
 	case 2:
@@ -1686,14 +1684,14 @@ _resume:
 		goto st_case_5
 	case 6:
 		goto st_case_6
-	case 7:
-		goto st_case_7
+	case 270:
+		goto st_case_270
 	case 271:
 		goto st_case_271
 	case 272:
 		goto st_case_272
-	case 273:
-		goto st_case_273
+	case 7:
+		goto st_case_7
 	case 8:
 		goto st_case_8
 	case 9:
@@ -1742,24 +1740,24 @@ _resume:
 		goto st_case_30
 	case 31:
 		goto st_case_31
-	case 32:
-		goto st_case_32
+	case 273:
+		goto st_case_273
 	case 274:
 		goto st_case_274
-	case 275:
-		goto st_case_275
+	case 32:
+		goto st_case_32
 	case 33:
 		goto st_case_33
-	case 34:
-		goto st_case_34
+	case 275:
+		goto st_case_275
 	case 276:
 		goto st_case_276
 	case 277:
 		goto st_case_277
+	case 34:
+		goto st_case_34
 	case 278:
 		goto st_case_278
-	case 35:
-		goto st_case_35
 	case 279:
 		goto st_case_279
 	case 280:
@@ -1794,18 +1792,18 @@ _resume:
 		goto st_case_294
 	case 295:
 		goto st_case_295
-	case 296:
-		goto st_case_296
+	case 35:
+		goto st_case_35
 	case 36:
 		goto st_case_36
-	case 37:
-		goto st_case_37
+	case 296:
+		goto st_case_296
 	case 297:
 		goto st_case_297
 	case 298:
 		goto st_case_298
-	case 299:
-		goto st_case_299
+	case 37:
+		goto st_case_37
 	case 38:
 		goto st_case_38
 	case 39:
@@ -1814,18 +1812,18 @@ _resume:
 		goto st_case_40
 	case 41:
 		goto st_case_41
-	case 42:
-		goto st_case_42
+	case 299:
+		goto st_case_299
 	case 300:
 		goto st_case_300
 	case 301:
 		goto st_case_301
 	case 302:
 		goto st_case_302
+	case 42:
+		goto st_case_42
 	case 303:
 		goto st_case_303
-	case 43:
-		goto st_case_43
 	case 304:
 		goto st_case_304
 	case 305:
@@ -1868,8 +1866,8 @@ _resume:
 		goto st_case_323
 	case 324:
 		goto st_case_324
-	case 325:
-		goto st_case_325
+	case 43:
+		goto st_case_43
 	case 44:
 		goto st_case_44
 	case 45:
@@ -1888,14 +1886,14 @@ _resume:
 		goto st_case_51
 	case 52:
 		goto st_case_52
-	case 53:
-		goto st_case_53
+	case 325:
+		goto st_case_325
 	case 326:
 		goto st_case_326
 	case 327:
 		goto st_case_327
-	case 328:
-		goto st_case_328
+	case 53:
+		goto st_case_53
 	case 54:
 		goto st_case_54
 	case 55:
@@ -1906,14 +1904,14 @@ _resume:
 		goto st_case_57
 	case 58:
 		goto st_case_58
-	case 59:
-		goto st_case_59
+	case 328:
+		goto st_case_328
 	case 329:
 		goto st_case_329
+	case 59:
+		goto st_case_59
 	case 330:
 		goto st_case_330
-	case 60:
-		goto st_case_60
 	case 331:
 		goto st_case_331
 	case 332:
@@ -1952,18 +1950,18 @@ _resume:
 		goto st_case_348
 	case 349:
 		goto st_case_349
+	case 60:
+		goto st_case_60
 	case 350:
 		goto st_case_350
-	case 61:
-		goto st_case_61
 	case 351:
 		goto st_case_351
 	case 352:
 		goto st_case_352
+	case 61:
+		goto st_case_61
 	case 353:
 		goto st_case_353
-	case 62:
-		goto st_case_62
 	case 354:
 		goto st_case_354
 	case 355:
@@ -2002,8 +2000,8 @@ _resume:
 		goto st_case_371
 	case 372:
 		goto st_case_372
-	case 373:
-		goto st_case_373
+	case 62:
+		goto st_case_62
 	case 63:
 		goto st_case_63
 	case 64:
@@ -2012,10 +2010,10 @@ _resume:
 		goto st_case_65
 	case 66:
 		goto st_case_66
+	case 373:
+		goto st_case_373
 	case 67:
 		goto st_case_67
-	case 374:
-		goto st_case_374
 	case 68:
 		goto st_case_68
 	case 69:
@@ -2024,18 +2022,20 @@ _resume:
 		goto st_case_70
 	case 71:
 		goto st_case_71
-	case 72:
-		goto st_case_72
+	case 374:
+		goto st_case_374
 	case 375:
 		goto st_case_375
 	case 376:
 		goto st_case_376
-	case 377:
-		goto st_case_377
+	case 72:
+		goto st_case_72
 	case 73:
 		goto st_case_73
 	case 74:
 		goto st_case_74
+	case 377:
+		goto st_case_377
 	case 378:
 		goto st_case_378
 	case 379:
@@ -2044,8 +2044,6 @@ _resume:
 		goto st_case_75
 	case 380:
 		goto st_case_380
-	case 76:
-		goto st_case_76
 	case 381:
 		goto st_case_381
 	case 382:
@@ -2084,8 +2082,8 @@ _resume:
 		goto st_case_398
 	case 399:
 		goto st_case_399
-	case 400:
-		goto st_case_400
+	case 76:
+		goto st_case_76
 	case 77:
 		goto st_case_77
 	case 78:
@@ -2112,52 +2110,52 @@ _resume:
 		goto st_case_88
 	case 89:
 		goto st_case_89
-	case 90:
-		goto st_case_90
+	case 400:
+		goto st_case_400
 	case 401:
 		goto st_case_401
 	case 402:
 		goto st_case_402
 	case 403:
 		goto st_case_403
-	case 404:
-		goto st_case_404
+	case 90:
+		goto st_case_90
 	case 91:
 		goto st_case_91
 	case 92:
 		goto st_case_92
 	case 93:
 		goto st_case_93
-	case 94:
-		goto st_case_94
+	case 404:
+		goto st_case_404
 	case 405:
 		goto st_case_405
-	case 406:
-		goto st_case_406
+	case 94:
+		goto st_case_94
 	case 95:
 		goto st_case_95
+	case 406:
+		goto st_case_406
 	case 96:
 		goto st_case_96
-	case 407:
-		goto st_case_407
 	case 97:
 		goto st_case_97
-	case 98:
-		goto st_case_98
+	case 407:
+		goto st_case_407
 	case 408:
 		goto st_case_408
+	case 98:
+		goto st_case_98
 	case 409:
 		goto st_case_409
-	case 99:
-		goto st_case_99
 	case 410:
 		goto st_case_410
-	case 411:
-		goto st_case_411
+	case 99:
+		goto st_case_99
 	case 100:
 		goto st_case_100
-	case 101:
-		goto st_case_101
+	case 411:
+		goto st_case_411
 	case 412:
 		goto st_case_412
 	case 413:
@@ -2192,28 +2190,28 @@ _resume:
 		goto st_case_427
 	case 428:
 		goto st_case_428
+	case 101:
+		goto st_case_101
 	case 429:
 		goto st_case_429
-	case 102:
-		goto st_case_102
 	case 430:
 		goto st_case_430
 	case 431:
 		goto st_case_431
-	case 432:
-		goto st_case_432
+	case 102:
+		goto st_case_102
 	case 103:
 		goto st_case_103
-	case 104:
-		goto st_case_104
+	case 432:
+		goto st_case_432
 	case 433:
 		goto st_case_433
 	case 434:
 		goto st_case_434
+	case 104:
+		goto st_case_104
 	case 435:
 		goto st_case_435
-	case 105:
-		goto st_case_105
 	case 436:
 		goto st_case_436
 	case 437:
@@ -2252,10 +2250,10 @@ _resume:
 		goto st_case_453
 	case 454:
 		goto st_case_454
+	case 105:
+		goto st_case_105
 	case 455:
 		goto st_case_455
-	case 106:
-		goto st_case_106
 	case 456:
 		goto st_case_456
 	case 457:
@@ -2298,8 +2296,8 @@ _resume:
 		goto st_case_475
 	case 476:
 		goto st_case_476
-	case 477:
-		goto st_case_477
+	case 106:
+		goto st_case_106
 	case 107:
 		goto st_case_107
 	case 108:
@@ -2308,18 +2306,18 @@ _resume:
 		goto st_case_109
 	case 110:
 		goto st_case_110
+	case 477:
+		goto st_case_477
 	case 111:
 		goto st_case_111
 	case 478:
 		goto st_case_478
-	case 112:
-		goto st_case_112
 	case 479:
 		goto st_case_479
+	case 112:
+		goto st_case_112
 	case 480:
 		goto st_case_480
-	case 113:
-		goto st_case_113
 	case 481:
 		goto st_case_481
 	case 482:
@@ -2336,48 +2334,48 @@ _resume:
 		goto st_case_487
 	case 488:
 		goto st_case_488
-	case 489:
-		goto st_case_489
+	case 113:
+		goto st_case_113
 	case 114:
 		goto st_case_114
 	case 115:
 		goto st_case_115
+	case 489:
+		goto st_case_489
 	case 116:
 		goto st_case_116
-	case 490:
-		goto st_case_490
 	case 117:
 		goto st_case_117
 	case 118:
 		goto st_case_118
+	case 490:
+		goto st_case_490
 	case 119:
 		goto st_case_119
-	case 491:
-		goto st_case_491
 	case 120:
 		goto st_case_120
-	case 121:
-		goto st_case_121
+	case 491:
+		goto st_case_491
 	case 492:
 		goto st_case_492
-	case 493:
-		goto st_case_493
+	case 121:
+		goto st_case_121
 	case 122:
 		goto st_case_122
 	case 123:
 		goto st_case_123
 	case 124:
 		goto st_case_124
-	case 125:
-		goto st_case_125
+	case 493:
+		goto st_case_493
 	case 494:
 		goto st_case_494
 	case 495:
 		goto st_case_495
+	case 125:
+		goto st_case_125
 	case 496:
 		goto st_case_496
-	case 126:
-		goto st_case_126
 	case 497:
 		goto st_case_497
 	case 498:
@@ -2416,12 +2414,12 @@ _resume:
 		goto st_case_514
 	case 515:
 		goto st_case_515
-	case 516:
-		goto st_case_516
+	case 126:
+		goto st_case_126
 	case 127:
 		goto st_case_127
-	case 128:
-		goto st_case_128
+	case 516:
+		goto st_case_516
 	case 517:
 		goto st_case_517
 	case 518:
@@ -2438,48 +2436,48 @@ _resume:
 		goto st_case_523
 	case 524:
 		goto st_case_524
-	case 525:
-		goto st_case_525
+	case 128:
+		goto st_case_128
 	case 129:
 		goto st_case_129
 	case 130:
 		goto st_case_130
+	case 525:
+		goto st_case_525
 	case 131:
 		goto st_case_131
-	case 526:
-		goto st_case_526
 	case 132:
 		goto st_case_132
 	case 133:
 		goto st_case_133
+	case 526:
+		goto st_case_526
 	case 134:
 		goto st_case_134
-	case 527:
-		goto st_case_527
 	case 135:
 		goto st_case_135
-	case 136:
-		goto st_case_136
+	case 527:
+		goto st_case_527
 	case 528:
 		goto st_case_528
-	case 529:
-		goto st_case_529
+	case 136:
+		goto st_case_136
 	case 137:
 		goto st_case_137
 	case 138:
 		goto st_case_138
-	case 139:
-		goto st_case_139
+	case 529:
+		goto st_case_529
 	case 530:
 		goto st_case_530
+	case 139:
+		goto st_case_139
 	case 531:
 		goto st_case_531
 	case 140:
 		goto st_case_140
 	case 532:
 		goto st_case_532
-	case 141:
-		goto st_case_141
 	case 533:
 		goto st_case_533
 	case 534:
@@ -2494,28 +2492,28 @@ _resume:
 		goto st_case_538
 	case 539:
 		goto st_case_539
-	case 540:
-		goto st_case_540
+	case 141:
+		goto st_case_141
 	case 142:
 		goto st_case_142
 	case 143:
 		goto st_case_143
+	case 540:
+		goto st_case_540
 	case 144:
 		goto st_case_144
-	case 541:
-		goto st_case_541
 	case 145:
 		goto st_case_145
 	case 146:
 		goto st_case_146
+	case 541:
+		goto st_case_541
 	case 147:
 		goto st_case_147
-	case 542:
-		goto st_case_542
 	case 148:
 		goto st_case_148
-	case 149:
-		goto st_case_149
+	case 542:
+		goto st_case_542
 	case 543:
 		goto st_case_543
 	case 544:
@@ -2554,26 +2552,26 @@ _resume:
 		goto st_case_560
 	case 561:
 		goto st_case_561
-	case 562:
-		goto st_case_562
+	case 149:
+		goto st_case_149
 	case 150:
 		goto st_case_150
-	case 151:
-		goto st_case_151
+	case 562:
+		goto st_case_562
 	case 563:
 		goto st_case_563
 	case 564:
 		goto st_case_564
+	case 151:
+		goto st_case_151
 	case 565:
 		goto st_case_565
-	case 152:
-		goto st_case_152
 	case 566:
 		goto st_case_566
+	case 152:
+		goto st_case_152
 	case 567:
 		goto st_case_567
-	case 153:
-		goto st_case_153
 	case 568:
 		goto st_case_568
 	case 569:
@@ -2608,16 +2606,16 @@ _resume:
 		goto st_case_583
 	case 584:
 		goto st_case_584
-	case 585:
-		goto st_case_585
+	case 153:
+		goto st_case_153
 	case 154:
 		goto st_case_154
+	case 585:
+		goto st_case_585
 	case 155:
 		goto st_case_155
 	case 586:
 		goto st_case_586
-	case 156:
-		goto st_case_156
 	case 587:
 		goto st_case_587
 	case 588:
@@ -2632,32 +2630,32 @@ _resume:
 		goto st_case_592
 	case 593:
 		goto st_case_593
-	case 594:
-		goto st_case_594
+	case 156:
+		goto st_case_156
 	case 157:
 		goto st_case_157
 	case 158:
 		goto st_case_158
+	case 594:
+		goto st_case_594
 	case 159:
 		goto st_case_159
-	case 595:
-		goto st_case_595
 	case 160:
 		goto st_case_160
 	case 161:
 		goto st_case_161
+	case 595:
+		goto st_case_595
 	case 162:
 		goto st_case_162
-	case 596:
-		goto st_case_596
 	case 163:
 		goto st_case_163
-	case 164:
-		goto st_case_164
+	case 596:
+		goto st_case_596
 	case 597:
 		goto st_case_597
-	case 598:
-		goto st_case_598
+	case 164:
+		goto st_case_164
 	case 165:
 		goto st_case_165
 	case 166:
@@ -2668,8 +2666,8 @@ _resume:
 		goto st_case_168
 	case 169:
 		goto st_case_169
-	case 170:
-		goto st_case_170
+	case 598:
+		goto st_case_598
 	case 599:
 		goto st_case_599
 	case 600:
@@ -2706,28 +2704,28 @@ _resume:
 		goto st_case_615
 	case 616:
 		goto st_case_616
-	case 617:
-		goto st_case_617
+	case 170:
+		goto st_case_170
 	case 171:
 		goto st_case_171
 	case 172:
 		goto st_case_172
-	case 173:
-		goto st_case_173
+	case 617:
+		goto st_case_617
 	case 618:
 		goto st_case_618
 	case 619:
 		goto st_case_619
+	case 173:
+		goto st_case_173
 	case 620:
 		goto st_case_620
-	case 174:
-		goto st_case_174
 	case 621:
 		goto st_case_621
+	case 174:
+		goto st_case_174
 	case 622:
 		goto st_case_622
-	case 175:
-		goto st_case_175
 	case 623:
 		goto st_case_623
 	case 624:
@@ -2736,76 +2734,76 @@ _resume:
 		goto st_case_625
 	case 626:
 		goto st_case_626
-	case 627:
-		goto st_case_627
+	case 175:
+		goto st_case_175
 	case 176:
 		goto st_case_176
 	case 177:
 		goto st_case_177
+	case 627:
+		goto st_case_627
 	case 178:
 		goto st_case_178
-	case 628:
-		goto st_case_628
 	case 179:
 		goto st_case_179
 	case 180:
 		goto st_case_180
+	case 628:
+		goto st_case_628
 	case 181:
 		goto st_case_181
-	case 629:
-		goto st_case_629
 	case 182:
 		goto st_case_182
-	case 183:
-		goto st_case_183
+	case 629:
+		goto st_case_629
 	case 630:
 		goto st_case_630
+	case 183:
+		goto st_case_183
 	case 631:
 		goto st_case_631
-	case 184:
-		goto st_case_184
 	case 632:
 		goto st_case_632
 	case 633:
 		goto st_case_633
-	case 634:
-		goto st_case_634
+	case 184:
+		goto st_case_184
 	case 185:
 		goto st_case_185
 	case 186:
 		goto st_case_186
+	case 634:
+		goto st_case_634
 	case 187:
 		goto st_case_187
-	case 635:
-		goto st_case_635
 	case 188:
 		goto st_case_188
 	case 189:
 		goto st_case_189
+	case 635:
+		goto st_case_635
 	case 190:
 		goto st_case_190
-	case 636:
-		goto st_case_636
 	case 191:
 		goto st_case_191
-	case 192:
-		goto st_case_192
+	case 636:
+		goto st_case_636
 	case 637:
 		goto st_case_637
-	case 638:
-		goto st_case_638
+	case 192:
+		goto st_case_192
 	case 193:
 		goto st_case_193
 	case 194:
 		goto st_case_194
+	case 638:
+		goto st_case_638
 	case 195:
 		goto st_case_195
-	case 639:
-		goto st_case_639
 	case 196:
 		goto st_case_196
-	case 197:
-		goto st_case_197
+	case 639:
+		goto st_case_639
 	case 640:
 		goto st_case_640
 	case 641:
@@ -2820,38 +2818,38 @@ _resume:
 		goto st_case_645
 	case 646:
 		goto st_case_646
-	case 647:
-		goto st_case_647
+	case 197:
+		goto st_case_197
 	case 198:
 		goto st_case_198
 	case 199:
 		goto st_case_199
+	case 647:
+		goto st_case_647
 	case 200:
 		goto st_case_200
-	case 648:
-		goto st_case_648
 	case 201:
 		goto st_case_201
 	case 202:
 		goto st_case_202
+	case 648:
+		goto st_case_648
 	case 203:
 		goto st_case_203
-	case 649:
-		goto st_case_649
 	case 204:
 		goto st_case_204
-	case 205:
-		goto st_case_205
+	case 649:
+		goto st_case_649
 	case 650:
 		goto st_case_650
-	case 651:
-		goto st_case_651
+	case 205:
+		goto st_case_205
 	case 206:
 		goto st_case_206
 	case 207:
 		goto st_case_207
-	case 208:
-		goto st_case_208
+	case 651:
+		goto st_case_651
 	case 652:
 		goto st_case_652
 	case 653:
@@ -2888,8 +2886,8 @@ _resume:
 		goto st_case_668
 	case 669:
 		goto st_case_669
-	case 670:
-		goto st_case_670
+	case 208:
+		goto st_case_208
 	case 209:
 		goto st_case_209
 	case 210:
@@ -2898,14 +2896,14 @@ _resume:
 		goto st_case_211
 	case 212:
 		goto st_case_212
+	case 670:
+		goto st_case_670
 	case 213:
 		goto st_case_213
-	case 671:
-		goto st_case_671
 	case 214:
 		goto st_case_214
-	case 215:
-		goto st_case_215
+	case 671:
+		goto st_case_671
 	case 672:
 		goto st_case_672
 	case 673:
@@ -2922,44 +2920,44 @@ _resume:
 		goto st_case_678
 	case 679:
 		goto st_case_679
-	case 680:
-		goto st_case_680
+	case 215:
+		goto st_case_215
 	case 216:
 		goto st_case_216
 	case 217:
 		goto st_case_217
+	case 680:
+		goto st_case_680
 	case 218:
 		goto st_case_218
-	case 681:
-		goto st_case_681
 	case 219:
 		goto st_case_219
 	case 220:
 		goto st_case_220
+	case 681:
+		goto st_case_681
 	case 221:
 		goto st_case_221
-	case 682:
-		goto st_case_682
 	case 222:
 		goto st_case_222
-	case 223:
-		goto st_case_223
+	case 682:
+		goto st_case_682
 	case 683:
 		goto st_case_683
-	case 684:
-		goto st_case_684
+	case 223:
+		goto st_case_223
 	case 224:
 		goto st_case_224
 	case 225:
 		goto st_case_225
+	case 684:
+		goto st_case_684
 	case 226:
 		goto st_case_226
-	case 685:
-		goto st_case_685
 	case 227:
 		goto st_case_227
-	case 228:
-		goto st_case_228
+	case 685:
+		goto st_case_685
 	case 686:
 		goto st_case_686
 	case 687:
@@ -2974,20 +2972,20 @@ _resume:
 		goto st_case_691
 	case 692:
 		goto st_case_692
-	case 693:
-		goto st_case_693
+	case 228:
+		goto st_case_228
 	case 229:
 		goto st_case_229
 	case 230:
 		goto st_case_230
+	case 693:
+		goto st_case_693
 	case 231:
 		goto st_case_231
-	case 694:
-		goto st_case_694
 	case 232:
 		goto st_case_232
-	case 233:
-		goto st_case_233
+	case 694:
+		goto st_case_694
 	case 695:
 		goto st_case_695
 	case 696:
@@ -3002,38 +3000,38 @@ _resume:
 		goto st_case_700
 	case 701:
 		goto st_case_701
-	case 702:
-		goto st_case_702
+	case 233:
+		goto st_case_233
 	case 234:
 		goto st_case_234
 	case 235:
 		goto st_case_235
+	case 702:
+		goto st_case_702
 	case 236:
 		goto st_case_236
-	case 703:
-		goto st_case_703
 	case 237:
 		goto st_case_237
 	case 238:
 		goto st_case_238
+	case 703:
+		goto st_case_703
 	case 239:
 		goto st_case_239
-	case 704:
-		goto st_case_704
 	case 240:
 		goto st_case_240
-	case 241:
-		goto st_case_241
+	case 704:
+		goto st_case_704
 	case 705:
 		goto st_case_705
-	case 706:
-		goto st_case_706
+	case 241:
+		goto st_case_241
 	case 242:
 		goto st_case_242
 	case 243:
 		goto st_case_243
-	case 244:
-		goto st_case_244
+	case 706:
+		goto st_case_706
 	case 707:
 		goto st_case_707
 	case 708:
@@ -3070,18 +3068,18 @@ _resume:
 		goto st_case_723
 	case 724:
 		goto st_case_724
-	case 725:
-		goto st_case_725
+	case 244:
+		goto st_case_244
 	case 245:
 		goto st_case_245
+	case 725:
+		goto st_case_725
 	case 246:
 		goto st_case_246
-	case 726:
-		goto st_case_726
 	case 247:
 		goto st_case_247
-	case 248:
-		goto st_case_248
+	case 726:
+		goto st_case_726
 	case 727:
 		goto st_case_727
 	case 728:
@@ -3096,104 +3094,102 @@ _resume:
 		goto st_case_732
 	case 733:
 		goto st_case_733
-	case 734:
-		goto st_case_734
+	case 248:
+		goto st_case_248
 	case 249:
 		goto st_case_249
 	case 250:
 		goto st_case_250
+	case 734:
+		goto st_case_734
 	case 251:
 		goto st_case_251
-	case 735:
-		goto st_case_735
 	case 252:
 		goto st_case_252
 	case 253:
 		goto st_case_253
+	case 735:
+		goto st_case_735
 	case 254:
 		goto st_case_254
-	case 736:
-		goto st_case_736
 	case 255:
 		goto st_case_255
-	case 256:
-		goto st_case_256
+	case 736:
+		goto st_case_736
 	case 737:
 		goto st_case_737
-	case 738:
-		goto st_case_738
+	case 256:
+		goto st_case_256
 	case 257:
 		goto st_case_257
-	case 258:
-		goto st_case_258
-	case 739:
-		goto st_case_739
-	case 261:
-		goto st_case_261
+	case 738:
+		goto st_case_738
+	case 260:
+		goto st_case_260
+	case 740:
+		goto st_case_740
 	case 741:
 		goto st_case_741
-	case 742:
-		goto st_case_742
+	case 261:
+		goto st_case_261
 	case 262:
 		goto st_case_262
 	case 263:
 		goto st_case_263
 	case 264:
 		goto st_case_264
+	case 742:
+		goto st_case_742
 	case 265:
 		goto st_case_265
 	case 743:
 		goto st_case_743
 	case 266:
 		goto st_case_266
-	case 744:
-		goto st_case_744
 	case 267:
 		goto st_case_267
 	case 268:
 		goto st_case_268
-	case 269:
-		goto st_case_269
-	case 740:
-		goto st_case_740
+	case 739:
+		goto st_case_739
+	case 258:
+		goto st_case_258
 	case 259:
 		goto st_case_259
-	case 260:
-		goto st_case_260
 	}
 	goto st_out
-	st270:
+	st269:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof270
+			goto _test_eof269
 		}
-	st_case_270:
+	st_case_269:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr35
+			goto tr33
 		case 11:
-			goto tr459
+			goto tr457
 		case 13:
-			goto tr35
+			goto tr33
 		case 32:
-			goto tr458
+			goto tr456
 		case 35:
-			goto tr35
+			goto tr33
 		case 44:
-			goto tr35
+			goto tr33
 		case 92:
-			goto tr460
+			goto tr458
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr458
+			goto tr456
 		}
-		goto tr457
-tr33:
+		goto tr455
+tr31:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st1
-tr457:
+tr455:
 //line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
@@ -3208,7 +3204,7 @@ tr457:
 			goto _test_eof1
 		}
 	st_case_1:
-//line plugins/parsers/influx/machine.go:3212
+//line plugins/parsers/influx/machine.go:3208
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr2
@@ -3221,7 +3217,7 @@ tr457:
 		case 44:
 			goto tr4
 		case 92:
-			goto st95
+			goto st94
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr1
@@ -3235,12 +3231,12 @@ tr1:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr60:
+tr58:
 	( m.cs) = 2
 //line plugins/parsers/influx/machine.go.rl:99
 
@@ -3248,7 +3244,7 @@ tr60:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -3258,7 +3254,7 @@ tr60:
 			goto _test_eof2
 		}
 	st_case_2:
-//line plugins/parsers/influx/machine.go:3262
+//line plugins/parsers/influx/machine.go:3258
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr8
@@ -3290,7 +3286,7 @@ tr6:
 			goto _test_eof3
 		}
 	st_case_3:
-//line plugins/parsers/influx/machine.go:3294
+//line plugins/parsers/influx/machine.go:3290
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr8
@@ -3299,7 +3295,7 @@ tr6:
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -3317,7 +3313,7 @@ tr2:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
@@ -3328,29 +3324,29 @@ tr8:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
-tr35:
+tr33:
 	( m.cs) = 0
 //line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
-tr39:
+tr37:
 	( m.cs) = 0
 //line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:46
@@ -3358,18 +3354,18 @@ tr39:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
-tr43:
+tr41:
 	( m.cs) = 0
 //line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -3377,18 +3373,18 @@ tr43:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
-tr47:
+tr45:
 	( m.cs) = 0
 //line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -3396,18 +3392,18 @@ tr47:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
-tr105:
+tr103:
 	( m.cs) = 0
 //line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:53
@@ -3415,18 +3411,18 @@ tr105:
 	err = ErrTimestampParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
-tr132:
+tr130:
 	( m.cs) = 0
 //line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -3434,7 +3430,7 @@ tr132:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:53
@@ -3442,18 +3438,18 @@ tr132:
 	err = ErrTimestampParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
-tr198:
+tr196:
 	( m.cs) = 0
 //line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:53
@@ -3461,18 +3457,18 @@ tr198:
 	err = ErrTimestampParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
-tr423:
+tr421:
 	( m.cs) = 0
 //line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:46
@@ -3480,7 +3476,7 @@ tr423:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -3488,30 +3484,30 @@ tr423:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
-tr426:
+tr424:
 	( m.cs) = 0
 //line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; goto _out }
 
 	goto _again
-tr1055:
+tr1053:
 //line plugins/parsers/influx/machine.go.rl:73
 
 	( m.p)--
 
-	{goto st270 }
+	{goto st269 }
 
 	goto st0
-//line plugins/parsers/influx/machine.go:3515
+//line plugins/parsers/influx/machine.go:3511
 st_case_0:
 	st0:
 		( m.cs) = 0
@@ -3527,7 +3523,7 @@ tr12:
 			goto _test_eof4
 		}
 	st_case_4:
-//line plugins/parsers/influx/machine.go:3531
+//line plugins/parsers/influx/machine.go:3527
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st5
@@ -3558,14 +3554,10 @@ tr12:
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr24
-		case 12:
-			goto tr8
-		case 13:
-			goto tr25
 		case 34:
-			goto tr26
+			goto tr25
 		case 92:
-			goto tr27
+			goto tr26
 		}
 		goto tr23
 tr23:
@@ -3586,7 +3578,7 @@ tr24:
 	m.sol++ // next char will be the first column in the line
 
 	goto st6
-tr29:
+tr28:
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
@@ -3599,38 +3591,18 @@ tr29:
 			goto _test_eof6
 		}
 	st_case_6:
-//line plugins/parsers/influx/machine.go:3603
+//line plugins/parsers/influx/machine.go:3595
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		goto st6
 tr25:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st7
-	st7:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof7
-		}
-	st_case_7:
-//line plugins/parsers/influx/machine.go:3628
-		if ( m.data)[( m.p)] == 10 {
-			goto tr29
-		}
-		goto tr8
-tr26:
-	( m.cs) = 271
+	( m.cs) = 270
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -3641,20 +3613,92 @@ tr26:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr31:
-	( m.cs) = 271
+tr29:
+	( m.cs) = 270
 //line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st270:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof270
+		}
+	st_case_270:
+//line plugins/parsers/influx/machine.go:3640
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 13:
+			goto st32
+		case 32:
+			goto st271
+		case 44:
+			goto st35
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st271
+		}
+		goto tr103
+tr921:
+	( m.cs) = 271
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr1041:
+	( m.cs) = 271
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr1044:
+	( m.cs) = 271
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr1047:
+	( m.cs) = 271
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -3664,115 +3708,43 @@ tr31:
 			goto _test_eof271
 		}
 	st_case_271:
-//line plugins/parsers/influx/machine.go:3668
+//line plugins/parsers/influx/machine.go:3712
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr101
 		case 13:
-			goto st33
+			goto st32
 		case 32:
-			goto st272
-		case 44:
-			goto st36
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st272
-		}
-		goto tr105
-tr535:
-	( m.cs) = 272
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr932:
-	( m.cs) = 272
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr935:
-	( m.cs) = 272
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr939:
-	( m.cs) = 272
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st272:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof272
-		}
-	st_case_272:
-//line plugins/parsers/influx/machine.go:3740
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 13:
-			goto st33
-		case 32:
-			goto st272
+			goto st271
 		case 45:
-			goto tr464
+			goto tr462
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr465
+				goto tr463
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st272
+			goto st271
 		}
-		goto tr426
-tr103:
+		goto tr424
+tr101:
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-	goto st273
-tr470:
-	( m.cs) = 273
+	goto st272
+tr468:
+	( m.cs) = 272
 //line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -3783,15 +3755,15 @@ tr470:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr734:
-	( m.cs) = 273
+tr730:
+	( m.cs) = 272
 //line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -3802,15 +3774,15 @@ tr734:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr952:
-	( m.cs) = 273
+tr942:
+	( m.cs) = 272
 //line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -3821,15 +3793,15 @@ tr952:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr957:
-	( m.cs) = 273
+tr948:
+	( m.cs) = 272
 //line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -3840,15 +3812,15 @@ tr957:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr962:
-	( m.cs) = 273
+tr954:
+	( m.cs) = 272
 //line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -3859,42 +3831,84 @@ tr962:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-	st273:
+	st272:
 //line plugins/parsers/influx/machine.go.rl:172
 
 	m.finishMetric = true
-	( m.cs) = 740;
+	( m.cs) = 739;
 	{( m.p)++; goto _out }
 
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof273
+			goto _test_eof272
 		}
-	st_case_273:
-//line plugins/parsers/influx/machine.go:3874
+	st_case_272:
+//line plugins/parsers/influx/machine.go:3846
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr35
+			goto tr33
 		case 11:
-			goto tr36
+			goto tr34
 		case 13:
-			goto tr35
+			goto tr33
 		case 32:
-			goto st8
+			goto st7
 		case 35:
-			goto tr35
+			goto tr33
 		case 44:
-			goto tr35
+			goto tr33
 		case 92:
-			goto tr37
+			goto tr35
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st8
+			goto st7
 		}
-		goto tr33
-tr458:
+		goto tr31
+tr456:
 //line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
+
+	goto st7
+	st7:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof7
+		}
+	st_case_7:
+//line plugins/parsers/influx/machine.go:3878
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr33
+		case 11:
+			goto tr34
+		case 13:
+			goto tr33
+		case 32:
+			goto st7
+		case 35:
+			goto tr33
+		case 44:
+			goto tr33
+		case 92:
+			goto tr35
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st7
+		}
+		goto tr31
+tr34:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st8
+tr457:
+//line plugins/parsers/influx/machine.go.rl:82
+
+	m.beginMetric = true
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
 
 	goto st8
 	st8:
@@ -3902,170 +3916,180 @@ tr458:
 			goto _test_eof8
 		}
 	st_case_8:
-//line plugins/parsers/influx/machine.go:3906
+//line plugins/parsers/influx/machine.go:3920
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr35
-		case 11:
-			goto tr36
-		case 13:
-			goto tr35
-		case 32:
-			goto st8
-		case 35:
-			goto tr35
-		case 44:
-			goto tr35
-		case 92:
 			goto tr37
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st8
-		}
-		goto tr33
-tr36:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st9
-tr459:
-//line plugins/parsers/influx/machine.go.rl:82
-
-	m.beginMetric = true
-
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st9
-	st9:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof9
-		}
-	st_case_9:
-//line plugins/parsers/influx/machine.go:3948
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr39
 		case 11:
-			goto tr40
-		case 13:
-			goto tr39
-		case 32:
 			goto tr38
+		case 13:
+			goto tr37
+		case 32:
+			goto tr36
 		case 35:
 			goto st1
 		case 44:
 			goto tr4
 		case 92:
-			goto tr37
+			goto tr35
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr38
+			goto tr36
 		}
-		goto tr33
-tr38:
-	( m.cs) = 10
+		goto tr31
+tr36:
+	( m.cs) = 9
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st9:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof9
+		}
+	st_case_9:
+//line plugins/parsers/influx/machine.go:3959
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr41
+		case 11:
+			goto tr42
+		case 13:
+			goto tr41
+		case 32:
+			goto st9
+		case 35:
+			goto tr6
+		case 44:
+			goto tr41
+		case 61:
+			goto tr31
+		case 92:
+			goto tr43
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st9
+		}
+		goto tr39
+tr39:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st10
 	st10:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof10
 		}
 	st_case_10:
-//line plugins/parsers/influx/machine.go:3987
+//line plugins/parsers/influx/machine.go:3993
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr43
-		case 11:
-			goto tr44
-		case 13:
-			goto tr43
-		case 32:
-			goto st10
-		case 35:
-			goto tr6
-		case 44:
-			goto tr43
-		case 61:
-			goto tr33
-		case 92:
 			goto tr45
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st10
-		}
-		goto tr41
-tr41:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st11
-	st11:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof11
-		}
-	st_case_11:
-//line plugins/parsers/influx/machine.go:4021
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
 		case 11:
-			goto tr48
+			goto tr46
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
 			goto tr1
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr1
 		}
-		goto st11
-tr48:
-	( m.cs) = 12
+		goto st10
+tr46:
+	( m.cs) = 11
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr51:
-	( m.cs) = 12
+tr49:
+	( m.cs) = 11
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
+
+	goto _again
+	st11:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof11
+		}
+	st_case_11:
+//line plugins/parsers/influx/machine.go:4049
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr45
+		case 11:
+			goto tr49
+		case 13:
+			goto tr45
+		case 32:
+			goto tr1
+		case 44:
+			goto tr4
+		case 61:
+			goto tr47
+		case 92:
+			goto tr43
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1
+		}
+		goto tr39
+tr4:
+	( m.cs) = 12
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr60:
+	( m.cs) = 12
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
 
 	goto _again
 	st12:
@@ -4073,365 +4097,46 @@ tr51:
 			goto _test_eof12
 		}
 	st_case_12:
-//line plugins/parsers/influx/machine.go:4077
+//line plugins/parsers/influx/machine.go:4101
 		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr51
-		case 13:
-			goto tr47
 		case 32:
-			goto tr1
+			goto tr2
 		case 44:
-			goto tr4
+			goto tr2
 		case 61:
-			goto tr49
+			goto tr2
 		case 92:
-			goto tr45
+			goto tr51
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr1
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr2
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr2
 		}
-		goto tr41
-tr4:
-	( m.cs) = 13
-//line plugins/parsers/influx/machine.go.rl:86
+		goto tr50
+tr50:
+//line plugins/parsers/influx/machine.go.rl:28
 
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
+	m.pb = m.p
 
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr62:
-	( m.cs) = 13
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+	goto st13
 	st13:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof13
 		}
 	st_case_13:
-//line plugins/parsers/influx/machine.go:4129
+//line plugins/parsers/influx/machine.go:4132
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
 		case 44:
 			goto tr2
 		case 61:
-			goto tr2
-		case 92:
 			goto tr53
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr2
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr2
-		}
-		goto tr52
-tr52:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st14
-	st14:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof14
-		}
-	st_case_14:
-//line plugins/parsers/influx/machine.go:4160
-		switch ( m.data)[( m.p)] {
-		case 32:
-			goto tr2
-		case 44:
-			goto tr2
-		case 61:
-			goto tr55
 		case 92:
-			goto st24
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr2
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr2
-		}
-		goto st14
-tr55:
-//line plugins/parsers/influx/machine.go.rl:95
-
-	m.key = m.text()
-
-	goto st15
-	st15:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof15
-		}
-	st_case_15:
-//line plugins/parsers/influx/machine.go:4191
-		switch ( m.data)[( m.p)] {
-		case 32:
-			goto tr2
-		case 44:
-			goto tr2
-		case 61:
-			goto tr2
-		case 92:
-			goto tr58
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr2
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr2
-		}
-		goto tr57
-tr57:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st16
-	st16:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof16
-		}
-	st_case_16:
-//line plugins/parsers/influx/machine.go:4222
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr2
-		case 11:
-			goto tr61
-		case 13:
-			goto tr2
-		case 32:
-			goto tr60
-		case 44:
-			goto tr62
-		case 61:
-			goto tr2
-		case 92:
-			goto st22
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
-		}
-		goto st16
-tr61:
-	( m.cs) = 17
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st17:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof17
-		}
-	st_case_17:
-//line plugins/parsers/influx/machine.go:4261
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr65
-		case 13:
-			goto tr47
-		case 32:
-			goto tr60
-		case 44:
-			goto tr62
-		case 61:
-			goto tr47
-		case 92:
-			goto tr66
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
-		}
-		goto tr64
-tr64:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st18
-	st18:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof18
-		}
-	st_case_18:
-//line plugins/parsers/influx/machine.go:4293
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr68
-		case 13:
-			goto tr47
-		case 32:
-			goto tr60
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
-		}
-		goto st18
-tr68:
-	( m.cs) = 19
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr65:
-	( m.cs) = 19
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto _again
-	st19:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof19
-		}
-	st_case_19:
-//line plugins/parsers/influx/machine.go:4349
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr65
-		case 13:
-			goto tr47
-		case 32:
-			goto tr60
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto tr66
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
-		}
-		goto tr64
-tr66:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st20
-	st20:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof20
-		}
-	st_case_20:
-//line plugins/parsers/influx/machine.go:4381
-		if ( m.data)[( m.p)] == 92 {
-			goto st21
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr47
-		}
-		goto st18
-	st21:
-//line plugins/parsers/influx/machine.go.rl:248
- ( m.p)--
- 
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof21
-		}
-	st_case_21:
-//line plugins/parsers/influx/machine.go:4402
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr68
-		case 13:
-			goto tr47
-		case 32:
-			goto tr60
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
-		}
-		goto st18
-tr58:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st22
-	st22:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof22
-		}
-	st_case_22:
-//line plugins/parsers/influx/machine.go:4434
-		if ( m.data)[( m.p)] == 92 {
 			goto st23
 		}
 		switch {
@@ -4442,50 +4147,28 @@ tr58:
 		case ( m.data)[( m.p)] >= 9:
 			goto tr2
 		}
-		goto st16
-	st23:
-//line plugins/parsers/influx/machine.go.rl:248
- ( m.p)--
- 
+		goto st13
+tr53:
+//line plugins/parsers/influx/machine.go.rl:95
+
+	m.key = m.text()
+
+	goto st14
+	st14:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof23
+			goto _test_eof14
 		}
-	st_case_23:
-//line plugins/parsers/influx/machine.go:4455
+	st_case_14:
+//line plugins/parsers/influx/machine.go:4163
 		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr2
-		case 11:
-			goto tr61
-		case 13:
-			goto tr2
 		case 32:
-			goto tr60
+			goto tr2
 		case 44:
-			goto tr62
+			goto tr2
 		case 61:
 			goto tr2
 		case 92:
-			goto st22
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
-		}
-		goto st16
-tr53:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st24
-	st24:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof24
-		}
-	st_case_24:
-//line plugins/parsers/influx/machine.go:4487
-		if ( m.data)[( m.p)] == 92 {
-			goto st25
+			goto tr56
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -4495,24 +4178,285 @@ tr53:
 		case ( m.data)[( m.p)] >= 9:
 			goto tr2
 		}
-		goto st14
-	st25:
+		goto tr55
+tr55:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st15
+	st15:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof15
+		}
+	st_case_15:
+//line plugins/parsers/influx/machine.go:4194
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr2
+		case 11:
+			goto tr59
+		case 13:
+			goto tr2
+		case 32:
+			goto tr58
+		case 44:
+			goto tr60
+		case 61:
+			goto tr2
+		case 92:
+			goto st21
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr58
+		}
+		goto st15
+tr59:
+	( m.cs) = 16
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st16:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof16
+		}
+	st_case_16:
+//line plugins/parsers/influx/machine.go:4233
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr45
+		case 11:
+			goto tr63
+		case 13:
+			goto tr45
+		case 32:
+			goto tr58
+		case 44:
+			goto tr60
+		case 61:
+			goto tr45
+		case 92:
+			goto tr64
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr58
+		}
+		goto tr62
+tr62:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st17
+	st17:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof17
+		}
+	st_case_17:
+//line plugins/parsers/influx/machine.go:4265
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr45
+		case 11:
+			goto tr66
+		case 13:
+			goto tr45
+		case 32:
+			goto tr58
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr58
+		}
+		goto st17
+tr66:
+	( m.cs) = 18
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr63:
+	( m.cs) = 18
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto _again
+	st18:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof18
+		}
+	st_case_18:
+//line plugins/parsers/influx/machine.go:4321
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr45
+		case 11:
+			goto tr63
+		case 13:
+			goto tr45
+		case 32:
+			goto tr58
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto tr64
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr58
+		}
+		goto tr62
+tr64:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st19
+	st19:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof19
+		}
+	st_case_19:
+//line plugins/parsers/influx/machine.go:4353
+		if ( m.data)[( m.p)] == 92 {
+			goto st20
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr45
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr45
+		}
+		goto st17
+	st20:
 //line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof25
+			goto _test_eof20
 		}
-	st_case_25:
-//line plugins/parsers/influx/machine.go:4508
+	st_case_20:
+//line plugins/parsers/influx/machine.go:4374
 		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr45
+		case 11:
+			goto tr66
+		case 13:
+			goto tr45
 		case 32:
-			goto tr2
+			goto tr58
 		case 44:
-			goto tr2
+			goto tr60
 		case 61:
-			goto tr55
+			goto tr12
 		case 92:
+			goto st19
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr58
+		}
+		goto st17
+tr56:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st21
+	st21:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof21
+		}
+	st_case_21:
+//line plugins/parsers/influx/machine.go:4406
+		if ( m.data)[( m.p)] == 92 {
+			goto st22
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr2
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr2
+		}
+		goto st15
+	st22:
+//line plugins/parsers/influx/machine.go.rl:248
+ ( m.p)--
+ 
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof22
+		}
+	st_case_22:
+//line plugins/parsers/influx/machine.go:4427
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr2
+		case 11:
+			goto tr59
+		case 13:
+			goto tr2
+		case 32:
+			goto tr58
+		case 44:
+			goto tr60
+		case 61:
+			goto tr2
+		case 92:
+			goto st21
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr58
+		}
+		goto st15
+tr51:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st23
+	st23:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof23
+		}
+	st_case_23:
+//line plugins/parsers/influx/machine.go:4459
+		if ( m.data)[( m.p)] == 92 {
 			goto st24
 		}
 		switch {
@@ -4523,14 +4467,42 @@ tr53:
 		case ( m.data)[( m.p)] >= 9:
 			goto tr2
 		}
-		goto st14
-tr49:
+		goto st13
+	st24:
+//line plugins/parsers/influx/machine.go.rl:248
+ ( m.p)--
+ 
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof24
+		}
+	st_case_24:
+//line plugins/parsers/influx/machine.go:4480
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto tr2
+		case 44:
+			goto tr2
+		case 61:
+			goto tr53
+		case 92:
+			goto st23
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr2
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr2
+		}
+		goto st13
+tr47:
 //line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
-	goto st26
-tr425:
+	goto st25
+tr423:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -4539,78 +4511,78 @@ tr425:
 
 	m.key = m.text()
 
-	goto st26
-	st26:
+	goto st25
+	st25:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof26
+			goto _test_eof25
 		}
-	st_case_26:
-//line plugins/parsers/influx/machine.go:4549
+	st_case_25:
+//line plugins/parsers/influx/machine.go:4521
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
 			goto tr3
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
 			goto tr1
 		case 34:
-			goto st29
+			goto st28
 		case 44:
 			goto tr4
 		case 45:
-			goto tr74
+			goto tr72
 		case 46:
-			goto tr75
+			goto tr73
 		case 48:
-			goto tr76
+			goto tr74
 		case 70:
-			goto tr78
+			goto tr76
 		case 84:
-			goto tr79
+			goto tr77
 		case 92:
-			goto st95
+			goto st94
 		case 102:
-			goto tr80
+			goto tr78
 		case 116:
-			goto tr81
+			goto tr79
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr77
+				goto tr75
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr1
 		}
 		goto st1
 tr3:
-	( m.cs) = 27
+	( m.cs) = 26
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-	st27:
+	st26:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof27
+			goto _test_eof26
 		}
-	st_case_27:
-//line plugins/parsers/influx/machine.go:4607
+	st_case_26:
+//line plugins/parsers/influx/machine.go:4579
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
-			goto tr51
+			goto tr49
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
 			goto tr1
 		case 44:
@@ -4618,24 +4590,24 @@ tr3:
 		case 61:
 			goto st1
 		case 92:
-			goto tr45
+			goto tr43
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr1
 		}
-		goto tr41
-tr45:
+		goto tr39
+tr43:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st28
-	st28:
+	goto st27
+	st27:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof28
+			goto _test_eof27
 		}
-	st_case_28:
-//line plugins/parsers/influx/machine.go:4639
+	st_case_27:
+//line plugins/parsers/influx/machine.go:4611
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -4644,88 +4616,86 @@ tr45:
 		case ( m.data)[( m.p)] >= 9:
 			goto tr8
 		}
-		goto st11
+		goto st10
+	st28:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof28
+		}
+	st_case_28:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr24
+		case 11:
+			goto tr82
+		case 13:
+			goto tr23
+		case 32:
+			goto tr81
+		case 34:
+			goto tr83
+		case 44:
+			goto tr84
+		case 92:
+			goto tr85
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr81
+		}
+		goto tr80
+tr80:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st29
 	st29:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof29
 		}
 	st_case_29:
+//line plugins/parsers/influx/machine.go:4657
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr83
 		case 10:
-			goto tr24
+			goto tr28
 		case 11:
-			goto tr84
-		case 12:
-			goto tr1
+			goto tr88
 		case 13:
-			goto tr25
+			goto st6
 		case 32:
-			goto tr83
+			goto tr87
 		case 34:
-			goto tr85
+			goto tr89
 		case 44:
-			goto tr86
+			goto tr90
 		case 92:
+			goto st140
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr87
 		}
-		goto tr82
-tr82:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st30
-	st30:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof30
-		}
-	st_case_30:
-//line plugins/parsers/influx/machine.go:4686
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
-		case 10:
-			goto tr29
-		case 11:
-			goto tr90
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr89
-		case 34:
-			goto tr91
-		case 44:
-			goto tr92
-		case 92:
-			goto st141
-		}
-		goto st30
-tr89:
-	( m.cs) = 31
+		goto st29
+tr87:
+	( m.cs) = 30
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr83:
-	( m.cs) = 31
+tr81:
+	( m.cs) = 30
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -4734,83 +4704,81 @@ tr83:
 	m.pb = m.p
 
 	goto _again
-tr231:
-	( m.cs) = 31
+tr229:
+	( m.cs) = 30
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st30:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof30
+		}
+	st_case_30:
+//line plugins/parsers/influx/machine.go:4726
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr94
+		case 13:
+			goto st6
+		case 32:
+			goto st30
+		case 34:
+			goto tr95
+		case 44:
+			goto st6
+		case 61:
+			goto st6
+		case 92:
+			goto tr96
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st30
+		}
+		goto tr92
+tr92:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st31
 	st31:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof31
 		}
 	st_case_31:
-//line plugins/parsers/influx/machine.go:4756
+//line plugins/parsers/influx/machine.go:4760
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto st31
+			goto st6
 		case 10:
-			goto tr29
-		case 11:
-			goto tr96
-		case 12:
-			goto st2
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
-			goto st31
+			goto st6
 		case 34:
-			goto tr97
-		case 44:
-			goto st6
-		case 61:
-			goto st6
-		case 92:
 			goto tr98
-		}
-		goto tr94
-tr94:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st32
-	st32:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof32
-		}
-	st_case_32:
-//line plugins/parsers/influx/machine.go:4791
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 32:
-			goto st6
-		case 34:
-			goto tr100
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		goto st32
-tr97:
-	( m.cs) = 274
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st31
+tr95:
+	( m.cs) = 273
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -4821,33 +4789,33 @@ tr97:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr100:
-	( m.cs) = 274
+tr98:
+	( m.cs) = 273
 //line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr386:
-	( m.cs) = 274
+tr384:
+	( m.cs) = 273
 //line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -4856,140 +4824,282 @@ tr386:
 	m.pb = m.p
 
 	goto _again
+	st273:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof273
+		}
+	st_case_273:
+//line plugins/parsers/influx/machine.go:4833
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto st274
+		case 13:
+			goto st32
+		case 32:
+			goto st271
+		case 44:
+			goto st35
+		case 61:
+			goto tr12
+		case 92:
+			goto st34
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st271
+		}
+		goto st3
 	st274:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof274
 		}
 	st_case_274:
-//line plugins/parsers/influx/machine.go:4865
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr101
 		case 11:
-			goto st275
+			goto st274
 		case 13:
-			goto st33
+			goto st32
 		case 32:
-			goto st272
+			goto st271
 		case 44:
-			goto st36
-		case 61:
-			goto tr12
-		case 92:
-			goto st35
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st272
-		}
-		goto st3
-	st275:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof275
-		}
-	st_case_275:
-		switch ( m.data)[( m.p)] {
-		case 10:
 			goto tr103
-		case 11:
-			goto st275
-		case 13:
-			goto st33
-		case 32:
-			goto st272
-		case 44:
-			goto tr105
 		case 45:
-			goto tr467
+			goto tr465
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr468
+				goto tr466
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st272
+			goto st271
 		}
 		goto st3
-tr472:
-	( m.cs) = 33
+tr470:
+	( m.cs) = 32
 //line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr736:
-	( m.cs) = 33
+tr732:
+	( m.cs) = 32
 //line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr954:
-	( m.cs) = 33
+tr944:
+	( m.cs) = 32
 //line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr959:
-	( m.cs) = 33
+tr950:
+	( m.cs) = 32
 //line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr964:
-	( m.cs) = 33
+tr956:
+	( m.cs) = 32
 //line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st32:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof32
+		}
+	st_case_32:
+//line plugins/parsers/influx/machine.go:4956
+		if ( m.data)[( m.p)] == 10 {
+			goto tr101
+		}
+		goto st0
+tr465:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st33
 	st33:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof33
 		}
 	st_case_33:
-//line plugins/parsers/influx/machine.go:4988
-		if ( m.data)[( m.p)] == 10 {
+//line plugins/parsers/influx/machine.go:4972
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto tr103
+		case 44:
+			goto tr103
+		case 61:
+			goto tr12
+		case 92:
+			goto st34
+		}
+		switch {
+		case ( m.data)[( m.p)] < 12:
+			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 10 {
+				goto tr103
+			}
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st275
+			}
+		default:
 			goto tr103
 		}
-		goto st0
+		goto st3
+tr466:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st275
+	st275:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof275
+		}
+	st_case_275:
+//line plugins/parsers/influx/machine.go:5007
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		case 44:
+			goto tr103
+		case 61:
+			goto tr12
+		case 92:
+			goto st34
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st278
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto st3
 tr467:
+	( m.cs) = 276
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st276:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof276
+		}
+	st_case_276:
+//line plugins/parsers/influx/machine.go:5051
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 13:
+			goto st32
+		case 32:
+			goto st276
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st276
+		}
+		goto st0
+tr469:
+	( m.cs) = 277
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st277:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof277
+		}
+	st_case_277:
+//line plugins/parsers/influx/machine.go:5082
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto st277
+		case 13:
+			goto st32
+		case 32:
+			goto st276
+		case 44:
+			goto tr8
+		case 61:
+			goto tr12
+		case 92:
+			goto st34
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st276
+		}
+		goto st3
+tr10:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -5000,149 +5110,7 @@ tr467:
 			goto _test_eof34
 		}
 	st_case_34:
-//line plugins/parsers/influx/machine.go:5004
-		switch ( m.data)[( m.p)] {
-		case 32:
-			goto tr105
-		case 44:
-			goto tr105
-		case 61:
-			goto tr12
-		case 92:
-			goto st35
-		}
-		switch {
-		case ( m.data)[( m.p)] < 12:
-			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 10 {
-				goto tr105
-			}
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st276
-			}
-		default:
-			goto tr105
-		}
-		goto st3
-tr468:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st276
-	st276:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof276
-		}
-	st_case_276:
-//line plugins/parsers/influx/machine.go:5039
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		case 44:
-			goto tr105
-		case 61:
-			goto tr12
-		case 92:
-			goto st35
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st279
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto st3
-tr469:
-	( m.cs) = 277
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st277:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof277
-		}
-	st_case_277:
-//line plugins/parsers/influx/machine.go:5083
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 13:
-			goto st33
-		case 32:
-			goto st277
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st277
-		}
-		goto st0
-tr471:
-	( m.cs) = 278
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st278:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof278
-		}
-	st_case_278:
 //line plugins/parsers/influx/machine.go:5114
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto st278
-		case 13:
-			goto st33
-		case 32:
-			goto st277
-		case 44:
-			goto tr8
-		case 61:
-			goto tr12
-		case 92:
-			goto st35
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st277
-		}
-		goto st3
-tr10:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st35
-	st35:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof35
-		}
-	st_case_35:
-//line plugins/parsers/influx/machine.go:5146
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -5150,6 +5118,36 @@ tr10:
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr8
+		}
+		goto st3
+	st278:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof278
+		}
+	st_case_278:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		case 44:
+			goto tr103
+		case 61:
+			goto tr12
+		case 92:
+			goto st34
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st279
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
 		}
 		goto st3
 	st279:
@@ -5159,19 +5157,19 @@ tr10:
 	st_case_279:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5179,7 +5177,7 @@ tr10:
 				goto st280
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st280:
@@ -5189,19 +5187,19 @@ tr10:
 	st_case_280:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5209,7 +5207,7 @@ tr10:
 				goto st281
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st281:
@@ -5219,19 +5217,19 @@ tr10:
 	st_case_281:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5239,7 +5237,7 @@ tr10:
 				goto st282
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st282:
@@ -5249,19 +5247,19 @@ tr10:
 	st_case_282:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5269,7 +5267,7 @@ tr10:
 				goto st283
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st283:
@@ -5279,19 +5277,19 @@ tr10:
 	st_case_283:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5299,7 +5297,7 @@ tr10:
 				goto st284
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st284:
@@ -5309,19 +5307,19 @@ tr10:
 	st_case_284:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5329,7 +5327,7 @@ tr10:
 				goto st285
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st285:
@@ -5339,19 +5337,19 @@ tr10:
 	st_case_285:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5359,7 +5357,7 @@ tr10:
 				goto st286
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st286:
@@ -5369,19 +5367,19 @@ tr10:
 	st_case_286:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5389,7 +5387,7 @@ tr10:
 				goto st287
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st287:
@@ -5399,19 +5397,19 @@ tr10:
 	st_case_287:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5419,7 +5417,7 @@ tr10:
 				goto st288
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st288:
@@ -5429,19 +5427,19 @@ tr10:
 	st_case_288:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5449,7 +5447,7 @@ tr10:
 				goto st289
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st289:
@@ -5459,19 +5457,19 @@ tr10:
 	st_case_289:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5479,7 +5477,7 @@ tr10:
 				goto st290
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st290:
@@ -5489,19 +5487,19 @@ tr10:
 	st_case_290:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5509,7 +5507,7 @@ tr10:
 				goto st291
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st291:
@@ -5519,19 +5517,19 @@ tr10:
 	st_case_291:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5539,7 +5537,7 @@ tr10:
 				goto st292
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st292:
@@ -5549,19 +5547,19 @@ tr10:
 	st_case_292:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5569,7 +5567,7 @@ tr10:
 				goto st293
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st293:
@@ -5579,19 +5577,19 @@ tr10:
 	st_case_293:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5599,7 +5597,7 @@ tr10:
 				goto st294
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st294:
@@ -5609,19 +5607,19 @@ tr10:
 	st_case_294:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
+			goto st34
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -5629,7 +5627,7 @@ tr10:
 				goto st295
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
 		goto st3
 	st295:
@@ -5639,112 +5637,82 @@ tr10:
 	st_case_295:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
 			goto tr469
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		case 44:
-			goto tr105
+			goto tr103
 		case 61:
 			goto tr12
 		case 92:
-			goto st35
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st296
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto st3
-	st296:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof296
-		}
-	st_case_296:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr471
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		case 44:
-			goto tr105
-		case 61:
-			goto tr12
-		case 92:
-			goto st35
+			goto st34
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr469
+			goto tr467
 		}
 		goto st3
-tr930:
-	( m.cs) = 36
+tr922:
+	( m.cs) = 35
 //line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr1046:
-	( m.cs) = 36
+tr1042:
+	( m.cs) = 35
 //line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr1048:
-	( m.cs) = 36
+tr1045:
+	( m.cs) = 35
 //line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr1050:
-	( m.cs) = 36
+tr1048:
+	( m.cs) = 35
 //line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-	st36:
+	st35:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof36
+			goto _test_eof35
 		}
-	st_case_36:
-//line plugins/parsers/influx/machine.go:5748
+	st_case_35:
+//line plugins/parsers/influx/machine.go:5716
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr8
@@ -5764,57 +5732,135 @@ tr1050:
 			goto tr8
 		}
 		goto tr6
-tr101:
+tr99:
 //line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
-	goto st37
-	st37:
+	goto st36
+	st36:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof37
+			goto _test_eof36
 		}
-	st_case_37:
-//line plugins/parsers/influx/machine.go:5779
+	st_case_36:
+//line plugins/parsers/influx/machine.go:5747
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr107
+			goto tr105
 		case 45:
-			goto tr108
+			goto tr106
 		case 46:
-			goto tr109
+			goto tr107
 		case 48:
-			goto tr110
+			goto tr108
 		case 70:
-			goto tr112
+			goto tr110
 		case 84:
-			goto tr113
+			goto tr111
 		case 92:
-			goto st75
+			goto st73
 		case 102:
-			goto tr114
+			goto tr112
 		case 116:
-			goto tr115
+			goto tr113
 		}
 		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr111
+			goto tr109
 		}
 		goto st6
-tr107:
-	( m.cs) = 297
+tr105:
+	( m.cs) = 296
 //line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st296:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof296
+		}
+	st_case_296:
+//line plugins/parsers/influx/machine.go:5792
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr492
+		case 13:
+			goto tr493
+		case 32:
+			goto tr491
+		case 34:
+			goto tr25
+		case 44:
+			goto tr494
+		case 92:
+			goto tr26
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr491
+		}
+		goto tr23
+tr491:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st297
+tr980:
+	( m.cs) = 297
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr985:
+	( m.cs) = 297
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr988:
+	( m.cs) = 297
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr991:
+	( m.cs) = 297
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -5824,117 +5870,31 @@ tr107:
 			goto _test_eof297
 		}
 	st_case_297:
-//line plugins/parsers/influx/machine.go:5828
+//line plugins/parsers/influx/machine.go:5874
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr494
-		case 12:
-			goto st272
+			goto tr219
 		case 13:
-			goto tr495
+			goto st72
 		case 32:
-			goto tr493
+			goto st297
 		case 34:
-			goto tr26
-		case 44:
-			goto tr496
-		case 92:
-			goto tr27
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr493
-		}
-		goto tr23
-tr493:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st298
-tr988:
-	( m.cs) = 298
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr993:
-	( m.cs) = 298
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr996:
-	( m.cs) = 298
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr999:
-	( m.cs) = 298
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st298:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof298
-		}
-	st_case_298:
-//line plugins/parsers/influx/machine.go:5912
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr221
-		case 12:
-			goto st272
-		case 13:
-			goto st73
-		case 32:
-			goto st298
-		case 34:
-			goto tr31
+			goto tr29
 		case 45:
-			goto tr499
+			goto tr497
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr500
+				goto tr498
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st298
+			goto st297
 		}
 		goto st6
-tr494:
+tr492:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -5945,24 +5905,24 @@ tr494:
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-	goto st299
-tr221:
+	goto st298
+tr219:
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-	goto st299
-tr639:
-	( m.cs) = 299
+	goto st298
+tr636:
+	( m.cs) = 298
 //line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -5973,8 +5933,8 @@ tr639:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr603:
-	( m.cs) = 299
+tr600:
+	( m.cs) = 298
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
@@ -5987,20 +5947,20 @@ tr603:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr823:
-	( m.cs) = 299
+tr817:
+	( m.cs) = 298
 //line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -6011,15 +5971,15 @@ tr823:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr829:
-	( m.cs) = 299
+tr822:
+	( m.cs) = 298
 //line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -6030,8 +5990,8 @@ tr829:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr810:
-	( m.cs) = 299
+tr803:
+	( m.cs) = 298
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
@@ -6044,13 +6004,13 @@ tr810:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr765:
-	( m.cs) = 299
+tr758:
+	( m.cs) = 298
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
@@ -6063,13 +6023,13 @@ tr765:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr798:
-	( m.cs) = 299
+tr791:
+	( m.cs) = 298
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
@@ -6082,13 +6042,13 @@ tr798:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr804:
-	( m.cs) = 299
+tr797:
+	( m.cs) = 298
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
@@ -6101,273 +6061,503 @@ tr804:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-	st299:
+	st298:
 //line plugins/parsers/influx/machine.go.rl:172
 
 	m.finishMetric = true
-	( m.cs) = 740;
+	( m.cs) = 739;
 	{( m.p)++; goto _out }
 
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof299
+			goto _test_eof298
 		}
-	st_case_299:
-//line plugins/parsers/influx/machine.go:6121
+	st_case_298:
+//line plugins/parsers/influx/machine.go:6081
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st38
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr117
-		case 12:
-			goto st8
+			goto tr115
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto st38
+			goto st37
 		case 34:
-			goto tr118
+			goto tr116
 		case 35:
 			goto st6
 		case 44:
 			goto st6
 		case 92:
-			goto tr87
+			goto tr85
 		}
-		goto tr82
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st37
+		}
+		goto tr80
+	st37:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof37
+		}
+	st_case_37:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr115
+		case 13:
+			goto st6
+		case 32:
+			goto st37
+		case 34:
+			goto tr116
+		case 35:
+			goto st6
+		case 44:
+			goto st6
+		case 92:
+			goto tr85
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st37
+		}
+		goto tr80
+tr115:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st38
 	st38:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof38
 		}
 	st_case_38:
+//line plugins/parsers/influx/machine.go:6142
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st38
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr117
-		case 12:
-			goto st8
-		case 13:
-			goto st7
-		case 32:
-			goto st38
-		case 34:
 			goto tr118
+		case 13:
+			goto st6
+		case 32:
+			goto tr117
+		case 34:
+			goto tr83
 		case 35:
-			goto st6
+			goto st29
 		case 44:
-			goto st6
+			goto tr90
 		case 92:
-			goto tr87
+			goto tr85
 		}
-		goto tr82
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr117
+		}
+		goto tr80
 tr117:
-//line plugins/parsers/influx/machine.go.rl:28
+	( m.cs) = 39
+//line plugins/parsers/influx/machine.go.rl:86
 
-	m.pb = m.p
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
 
-	goto st39
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
 	st39:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof39
 		}
 	st_case_39:
-//line plugins/parsers/influx/machine.go:6184
+//line plugins/parsers/influx/machine.go:6183
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr119
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr120
-		case 12:
-			goto tr38
+			goto tr121
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr119
+			goto st39
 		case 34:
-			goto tr85
+			goto tr122
 		case 35:
-			goto st30
-		case 44:
 			goto tr92
+		case 44:
+			goto st6
+		case 61:
+			goto tr80
 		case 92:
-			goto tr87
+			goto tr123
 		}
-		goto tr82
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st39
+		}
+		goto tr119
 tr119:
-	( m.cs) = 40
-//line plugins/parsers/influx/machine.go.rl:86
+//line plugins/parsers/influx/machine.go.rl:28
 
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
+	m.pb = m.p
 
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+	goto st40
 	st40:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof40
 		}
 	st_case_40:
-//line plugins/parsers/influx/machine.go:6226
+//line plugins/parsers/influx/machine.go:6219
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st40
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr123
-		case 12:
-			goto st10
-		case 13:
-			goto st7
-		case 32:
-			goto st40
-		case 34:
-			goto tr124
-		case 35:
-			goto tr94
-		case 44:
-			goto st6
-		case 61:
-			goto tr82
-		case 92:
 			goto tr125
+		case 13:
+			goto st6
+		case 32:
+			goto tr87
+		case 34:
+			goto tr126
+		case 44:
+			goto tr90
+		case 61:
+			goto tr127
+		case 92:
+			goto st92
 		}
-		goto tr121
-tr121:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
+		}
+		goto st40
+tr125:
+	( m.cs) = 41
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr129:
+	( m.cs) = 41
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st41
+	goto _again
 	st41:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof41
 		}
 	st_case_41:
-//line plugins/parsers/influx/machine.go:6263
+//line plugins/parsers/influx/machine.go:6277
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
+			goto tr129
+		case 13:
+			goto st6
+		case 32:
+			goto tr87
+		case 34:
+			goto tr122
+		case 44:
+			goto tr90
+		case 61:
 			goto tr127
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr89
-		case 34:
-			goto tr128
-		case 44:
-			goto tr92
-		case 61:
-			goto tr129
 		case 92:
-			goto st93
+			goto tr123
 		}
-		goto st41
-tr127:
-	( m.cs) = 42
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr131:
-	( m.cs) = 42
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
+		}
+		goto tr119
+tr122:
+	( m.cs) = 299
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
 	goto _again
-	st42:
+tr126:
+	( m.cs) = 299
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st299:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof42
+			goto _test_eof299
 		}
-	st_case_42:
-//line plugins/parsers/influx/machine.go:6322
+	st_case_299:
+//line plugins/parsers/influx/machine.go:6335
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr101
 		case 11:
-			goto tr131
-		case 12:
-			goto tr1
+			goto tr500
 		case 13:
-			goto st7
+			goto st32
 		case 32:
-			goto tr89
-		case 34:
-			goto tr124
+			goto tr499
 		case 44:
-			goto tr92
+			goto tr501
 		case 61:
-			goto tr129
+			goto tr47
 		case 92:
-			goto tr125
+			goto st27
 		}
-		goto tr121
-tr124:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr499
+		}
+		goto st10
+tr499:
 	( m.cs) = 300
-//line plugins/parsers/influx/machine.go.rl:28
+//line plugins/parsers/influx/machine.go.rl:86
 
-	m.pb = m.p
-
-//line plugins/parsers/influx/machine.go.rl:148
-
-	err = m.handler.AddString(m.key, m.text())
+	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr128:
+tr563:
 	( m.cs) = 300
-//line plugins/parsers/influx/machine.go.rl:148
+//line plugins/parsers/influx/machine.go.rl:99
 
-	err = m.handler.AddString(m.key, m.text())
+	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr811:
+	( m.cs) = 300
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr729:
+	( m.cs) = 300
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr941:
+	( m.cs) = 300
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr947:
+	( m.cs) = 300
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr953:
+	( m.cs) = 300
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr1005:
+	( m.cs) = 300
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr1009:
+	( m.cs) = 300
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr1013:
+	( m.cs) = 300
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -6377,295 +6567,59 @@ tr128:
 			goto _test_eof300
 		}
 	st_case_300:
-//line plugins/parsers/influx/machine.go:6381
+//line plugins/parsers/influx/machine.go:6571
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr101
 		case 11:
-			goto tr502
-		case 13:
-			goto st33
-		case 32:
-			goto tr501
-		case 44:
 			goto tr503
-		case 61:
-			goto tr49
-		case 92:
-			goto st28
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr501
-		}
-		goto st11
-tr501:
-	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr566:
-	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr641:
-	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr731:
-	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr743:
-	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr750:
-	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr757:
-	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr825:
-	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr831:
-	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr836:
-	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st301:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof301
-		}
-	st_case_301:
-//line plugins/parsers/influx/machine.go:6617
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto tr505
 		case 13:
-			goto st33
+			goto st32
 		case 32:
-			goto st301
+			goto st300
 		case 44:
-			goto tr105
+			goto tr103
 		case 45:
-			goto tr467
+			goto tr465
 		case 61:
-			goto tr105
+			goto tr103
 		case 92:
 			goto tr10
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr468
+				goto tr466
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st301
+			goto st300
 		}
 		goto tr6
-tr505:
+tr503:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st302
-	st302:
+	goto st301
+	st301:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof302
+			goto _test_eof301
 		}
-	st_case_302:
-//line plugins/parsers/influx/machine.go:6656
+	st_case_301:
+//line plugins/parsers/influx/machine.go:6610
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr101
 		case 11:
-			goto tr505
+			goto tr503
 		case 13:
-			goto st33
+			goto st32
 		case 32:
-			goto st301
+			goto st300
 		case 44:
-			goto tr105
+			goto tr103
 		case 45:
-			goto tr467
+			goto tr465
 		case 61:
 			goto tr12
 		case 92:
@@ -6674,34 +6628,34 @@ tr505:
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr468
+				goto tr466
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st301
+			goto st300
 		}
 		goto tr6
-tr502:
-	( m.cs) = 303
+tr500:
+	( m.cs) = 302
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr506:
-	( m.cs) = 303
+tr504:
+	( m.cs) = 302
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -6710,103 +6664,329 @@ tr506:
 	m.pb = m.p
 
 	goto _again
+	st302:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof302
+		}
+	st_case_302:
+//line plugins/parsers/influx/machine.go:6673
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto tr504
+		case 13:
+			goto st32
+		case 32:
+			goto tr499
+		case 44:
+			goto tr4
+		case 45:
+			goto tr505
+		case 61:
+			goto tr47
+		case 92:
+			goto tr43
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr506
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr499
+		}
+		goto tr39
+tr505:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st42
+	st42:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof42
+		}
+	st_case_42:
+//line plugins/parsers/influx/machine.go:6712
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr130
+		case 11:
+			goto tr46
+		case 13:
+			goto tr130
+		case 32:
+			goto tr1
+		case 44:
+			goto tr4
+		case 61:
+			goto tr47
+		case 92:
+			goto st27
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st303
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr1
+		}
+		goto st10
+tr506:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st303
 	st303:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof303
 		}
 	st_case_303:
-//line plugins/parsers/influx/machine.go:6719
+//line plugins/parsers/influx/machine.go:6749
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr468
 		case 11:
-			goto tr506
+			goto tr508
 		case 13:
-			goto st33
+			goto tr470
 		case 32:
-			goto tr501
-		case 44:
-			goto tr4
-		case 45:
 			goto tr507
-		case 61:
-			goto tr49
-		case 92:
-			goto tr45
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr508
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr501
-		}
-		goto tr41
-tr507:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st43
-	st43:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof43
-		}
-	st_case_43:
-//line plugins/parsers/influx/machine.go:6758
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr132
-		case 11:
-			goto tr48
-		case 13:
-			goto tr132
-		case 32:
-			goto tr1
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st304
+				goto st307
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr1
+			goto tr507
 		}
-		goto st11
-tr508:
-//line plugins/parsers/influx/machine.go.rl:28
+		goto st10
+tr512:
+	( m.cs) = 304
+//line plugins/parsers/influx/machine.go.rl:86
 
-	m.pb = m.p
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
 
-	goto st304
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr572:
+	( m.cs) = 304
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr507:
+	( m.cs) = 304
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr569:
+	( m.cs) = 304
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
 	st304:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof304
 		}
 	st_case_304:
-//line plugins/parsers/influx/machine.go:6795
+//line plugins/parsers/influx/machine.go:6852
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr101
 		case 11:
-			goto tr510
+			goto tr511
 		case 13:
-			goto tr472
+			goto st32
 		case 32:
-			goto tr509
+			goto st304
+		case 44:
+			goto tr8
+		case 61:
+			goto tr8
+		case 92:
+			goto tr10
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st304
+		}
+		goto tr6
+tr511:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st305
+	st305:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof305
+		}
+	st_case_305:
+//line plugins/parsers/influx/machine.go:6884
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto tr511
+		case 13:
+			goto st32
+		case 32:
+			goto st304
+		case 44:
+			goto tr8
+		case 61:
+			goto tr12
+		case 92:
+			goto tr10
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st304
+		}
+		goto tr6
+tr513:
+	( m.cs) = 306
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto _again
+tr508:
+	( m.cs) = 306
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st306:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof306
+		}
+	st_case_306:
+//line plugins/parsers/influx/machine.go:6950
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto tr513
+		case 13:
+			goto st32
+		case 32:
+			goto tr512
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto tr43
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr512
+		}
+		goto tr39
+	st307:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof307
+		}
+	st_case_307:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr508
+		case 13:
+			goto tr470
+		case 32:
+			goto tr507
+		case 44:
+			goto tr4
+		case 61:
+			goto tr47
+		case 92:
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -6814,205 +6994,9 @@ tr508:
 				goto st308
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
-tr514:
-	( m.cs) = 305
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr575:
-	( m.cs) = 305
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr509:
-	( m.cs) = 305
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr572:
-	( m.cs) = 305
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st305:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof305
-		}
-	st_case_305:
-//line plugins/parsers/influx/machine.go:6898
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto tr513
-		case 13:
-			goto st33
-		case 32:
-			goto st305
-		case 44:
-			goto tr8
-		case 61:
-			goto tr8
-		case 92:
-			goto tr10
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st305
-		}
-		goto tr6
-tr513:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st306
-	st306:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof306
-		}
-	st_case_306:
-//line plugins/parsers/influx/machine.go:6930
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto tr513
-		case 13:
-			goto st33
-		case 32:
-			goto st305
-		case 44:
-			goto tr8
-		case 61:
-			goto tr12
-		case 92:
-			goto tr10
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st305
-		}
-		goto tr6
-tr515:
-	( m.cs) = 307
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto _again
-tr510:
-	( m.cs) = 307
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st307:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof307
-		}
-	st_case_307:
-//line plugins/parsers/influx/machine.go:6996
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto tr515
-		case 13:
-			goto st33
-		case 32:
-			goto tr514
-		case 44:
-			goto tr4
-		case 61:
-			goto tr49
-		case 92:
-			goto tr45
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr514
-		}
-		goto tr41
+		goto st10
 	st308:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof308
@@ -7020,19 +7004,19 @@ tr510:
 	st_case_308:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7040,9 +7024,9 @@ tr510:
 				goto st309
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st309:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof309
@@ -7050,19 +7034,19 @@ tr510:
 	st_case_309:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7070,9 +7054,9 @@ tr510:
 				goto st310
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st310:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof310
@@ -7080,19 +7064,19 @@ tr510:
 	st_case_310:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7100,9 +7084,9 @@ tr510:
 				goto st311
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st311:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof311
@@ -7110,19 +7094,19 @@ tr510:
 	st_case_311:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7130,9 +7114,9 @@ tr510:
 				goto st312
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st312:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof312
@@ -7140,19 +7124,19 @@ tr510:
 	st_case_312:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7160,9 +7144,9 @@ tr510:
 				goto st313
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st313:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof313
@@ -7170,19 +7154,19 @@ tr510:
 	st_case_313:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7190,9 +7174,9 @@ tr510:
 				goto st314
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st314:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof314
@@ -7200,19 +7184,19 @@ tr510:
 	st_case_314:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7220,9 +7204,9 @@ tr510:
 				goto st315
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st315:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof315
@@ -7230,19 +7214,19 @@ tr510:
 	st_case_315:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7250,9 +7234,9 @@ tr510:
 				goto st316
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st316:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof316
@@ -7260,19 +7244,19 @@ tr510:
 	st_case_316:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7280,9 +7264,9 @@ tr510:
 				goto st317
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st317:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof317
@@ -7290,19 +7274,19 @@ tr510:
 	st_case_317:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7310,9 +7294,9 @@ tr510:
 				goto st318
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st318:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof318
@@ -7320,19 +7304,19 @@ tr510:
 	st_case_318:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7340,9 +7324,9 @@ tr510:
 				goto st319
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st319:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof319
@@ -7350,19 +7334,19 @@ tr510:
 	st_case_319:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7370,9 +7354,9 @@ tr510:
 				goto st320
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st320:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof320
@@ -7380,19 +7364,19 @@ tr510:
 	st_case_320:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7400,9 +7384,9 @@ tr510:
 				goto st321
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st321:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof321
@@ -7410,19 +7394,19 @@ tr510:
 	st_case_321:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7430,9 +7414,9 @@ tr510:
 				goto st322
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st322:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof322
@@ -7440,19 +7424,19 @@ tr510:
 	st_case_322:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7460,9 +7444,9 @@ tr510:
 				goto st323
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st323:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof323
@@ -7470,19 +7454,19 @@ tr510:
 	st_case_323:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
+			goto st27
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -7490,9 +7474,9 @@ tr510:
 				goto st324
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr509
+			goto tr507
 		}
-		goto st11
+		goto st10
 	st324:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof324
@@ -7500,89 +7484,59 @@ tr510:
 	st_case_324:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr510
+			goto tr508
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr509
+			goto tr507
 		case 44:
 			goto tr4
 		case 61:
-			goto tr49
+			goto tr47
 		case 92:
-			goto st28
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st325
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr509
-		}
-		goto st11
-	st325:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof325
-		}
-	st_case_325:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr510
-		case 13:
-			goto tr472
-		case 32:
-			goto tr509
-		case 44:
-			goto tr4
-		case 61:
-			goto tr49
-		case 92:
-			goto st28
+			goto st27
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr509
+			goto tr507
 		}
-		goto st11
-tr503:
-	( m.cs) = 44
+		goto st10
+tr501:
+	( m.cs) = 43
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr568:
-	( m.cs) = 44
+tr565:
+	( m.cs) = 43
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr819:
-	( m.cs) = 44
+tr813:
+	( m.cs) = 43
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -7592,20 +7546,20 @@ tr819:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr737:
-	( m.cs) = 44
+tr733:
+	( m.cs) = 43
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -7615,20 +7569,20 @@ tr737:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr955:
-	( m.cs) = 44
+tr945:
+	( m.cs) = 43
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -7638,20 +7592,20 @@ tr955:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr960:
-	( m.cs) = 44
+tr951:
+	( m.cs) = 43
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -7661,20 +7615,20 @@ tr960:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr965:
-	( m.cs) = 44
+tr957:
+	( m.cs) = 43
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -7684,20 +7638,20 @@ tr965:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr1014:
-	( m.cs) = 44
+tr1007:
+	( m.cs) = 43
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -7707,20 +7661,20 @@ tr1014:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr1017:
-	( m.cs) = 44
+tr1011:
+	( m.cs) = 43
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -7730,20 +7684,20 @@ tr1017:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr1020:
-	( m.cs) = 44
+tr1015:
+	( m.cs) = 43
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -7753,68 +7707,68 @@ tr1020:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st43:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof43
+		}
+	st_case_43:
+//line plugins/parsers/influx/machine.go:7721
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto tr45
+		case 44:
+			goto tr45
+		case 61:
+			goto tr45
+		case 92:
+			goto tr133
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr45
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr45
+		}
+		goto tr132
+tr132:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st44
 	st44:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof44
 		}
 	st_case_44:
-//line plugins/parsers/influx/machine.go:7767
+//line plugins/parsers/influx/machine.go:7752
 		switch ( m.data)[( m.p)] {
 		case 32:
-			goto tr47
+			goto tr45
 		case 44:
-			goto tr47
+			goto tr45
 		case 61:
-			goto tr47
-		case 92:
 			goto tr135
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr47
-		}
-		goto tr134
-tr134:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st45
-	st45:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof45
-		}
-	st_case_45:
-//line plugins/parsers/influx/machine.go:7798
-		switch ( m.data)[( m.p)] {
-		case 32:
-			goto tr47
-		case 44:
-			goto tr47
-		case 61:
-			goto tr137
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
+				goto tr45
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr47
+			goto tr45
 		}
-		goto st45
-tr137:
+		goto st44
+tr135:
 //line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
@@ -7823,53 +7777,87 @@ tr137:
 
 	m.key = m.text()
 
+	goto st45
+	st45:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof45
+		}
+	st_case_45:
+//line plugins/parsers/influx/machine.go:7787
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto tr45
+		case 34:
+			goto tr137
+		case 44:
+			goto tr45
+		case 45:
+			goto tr138
+		case 46:
+			goto tr139
+		case 48:
+			goto tr140
+		case 61:
+			goto tr45
+		case 70:
+			goto tr142
+		case 84:
+			goto tr143
+		case 92:
+			goto tr56
+		case 102:
+			goto tr144
+		case 116:
+			goto tr145
+		}
+		switch {
+		case ( m.data)[( m.p)] < 12:
+			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 10 {
+				goto tr45
+			}
+		case ( m.data)[( m.p)] > 13:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr141
+			}
+		default:
+			goto tr45
+		}
+		goto tr55
+tr137:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
 	goto st46
 	st46:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof46
 		}
 	st_case_46:
-//line plugins/parsers/influx/machine.go:7833
+//line plugins/parsers/influx/machine.go:7838
 		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr24
+		case 11:
+			goto tr148
+		case 13:
+			goto tr23
 		case 32:
-			goto tr47
+			goto tr147
 		case 34:
-			goto tr139
+			goto tr149
 		case 44:
-			goto tr47
-		case 45:
-			goto tr140
-		case 46:
-			goto tr141
-		case 48:
-			goto tr142
+			goto tr150
 		case 61:
-			goto tr47
-		case 70:
-			goto tr144
-		case 84:
-			goto tr145
+			goto tr23
 		case 92:
-			goto tr58
-		case 102:
-			goto tr146
-		case 116:
+			goto tr151
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr147
 		}
-		switch {
-		case ( m.data)[( m.p)] < 12:
-			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 10 {
-				goto tr47
-			}
-		case ( m.data)[( m.p)] > 13:
-			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr143
-			}
-		default:
-			goto tr47
-		}
-		goto tr57
-tr139:
+		goto tr146
+tr146:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -7880,100 +7868,64 @@ tr139:
 			goto _test_eof47
 		}
 	st_case_47:
-//line plugins/parsers/influx/machine.go:7884
+//line plugins/parsers/influx/machine.go:7872
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr149
 		case 10:
-			goto tr24
+			goto tr28
 		case 11:
-			goto tr150
-		case 12:
-			goto tr60
+			goto tr154
 		case 13:
-			goto tr25
+			goto st6
 		case 32:
-			goto tr149
-		case 34:
-			goto tr151
-		case 44:
-			goto tr152
-		case 61:
-			goto tr23
-		case 92:
 			goto tr153
-		}
-		goto tr148
-tr148:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st48
-	st48:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof48
-		}
-	st_case_48:
-//line plugins/parsers/influx/machine.go:7919
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
-		case 10:
-			goto tr29
-		case 11:
-			goto tr156
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
 			goto st6
 		case 92:
-			goto st63
+			goto st62
 		}
-		goto st48
-tr180:
-	( m.cs) = 49
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st47
+tr178:
+	( m.cs) = 48
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr155:
-	( m.cs) = 49
+tr153:
+	( m.cs) = 48
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr149:
-	( m.cs) = 49
+tr147:
+	( m.cs) = 48
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -7982,39 +7934,70 @@ tr149:
 	m.pb = m.p
 
 	goto _again
-	st49:
+	st48:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof49
+			goto _test_eof48
 		}
-	st_case_49:
-//line plugins/parsers/influx/machine.go:7991
+	st_case_48:
+//line plugins/parsers/influx/machine.go:7943
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st49
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr162
-		case 12:
-			goto st2
+			goto tr160
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto st49
+			goto st48
 		case 34:
-			goto tr97
+			goto tr95
 		case 44:
 			goto st6
 		case 61:
 			goto st6
 		case 92:
-			goto tr163
+			goto tr161
 		}
-		goto tr160
-tr160:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st48
+		}
+		goto tr158
+tr158:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
+
+	goto st49
+	st49:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof49
+		}
+	st_case_49:
+//line plugins/parsers/influx/machine.go:7977
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st6
+		case 10:
+			goto tr28
+		case 32:
+			goto st6
+		case 34:
+			goto tr98
+		case 44:
+			goto st6
+		case 61:
+			goto tr163
+		case 92:
+			goto st104
+		}
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st49
+tr163:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.key = m.text()
 
 	goto st50
 	st50:
@@ -8022,32 +8005,37 @@ tr160:
 			goto _test_eof50
 		}
 	st_case_50:
-//line plugins/parsers/influx/machine.go:8026
+//line plugins/parsers/influx/machine.go:8009
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 32:
-			goto st6
+			goto tr28
 		case 34:
-			goto tr100
-		case 44:
-			goto st6
-		case 61:
+			goto tr105
+		case 45:
 			goto tr165
+		case 46:
+			goto tr166
+		case 48:
+			goto tr167
+		case 70:
+			goto tr169
+		case 84:
+			goto tr170
 		case 92:
-			goto st105
+			goto st73
+		case 102:
+			goto tr171
+		case 116:
+			goto tr172
 		}
-		goto st50
+		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto tr168
+		}
+		goto st6
 tr165:
-//line plugins/parsers/influx/machine.go.rl:108
+//line plugins/parsers/influx/machine.go.rl:28
 
-	m.key = m.text()
+	m.pb = m.p
 
 	goto st51
 	st51:
@@ -8055,38 +8043,24 @@ tr165:
 			goto _test_eof51
 		}
 	st_case_51:
-//line plugins/parsers/influx/machine.go:8059
+//line plugins/parsers/influx/machine.go:8047
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr107
-		case 45:
-			goto tr167
+			goto tr29
 		case 46:
-			goto tr168
+			goto st52
 		case 48:
-			goto tr169
-		case 70:
-			goto tr171
-		case 84:
-			goto tr172
+			goto st631
 		case 92:
-			goto st75
-		case 102:
-			goto tr173
-		case 116:
-			goto tr174
+			goto st73
 		}
 		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr170
+			goto st632
 		}
 		goto st6
-tr167:
+tr166:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -8097,179 +8071,139 @@ tr167:
 			goto _test_eof52
 		}
 	st_case_52:
-//line plugins/parsers/influx/machine.go:8101
+//line plugins/parsers/influx/machine.go:8075
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
-		case 46:
-			goto st53
-		case 48:
-			goto st632
-		case 92:
-			goto st75
-		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st633
-		}
-		goto st6
-tr168:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st53
-	st53:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof53
-		}
-	st_case_53:
-//line plugins/parsers/influx/machine.go:8133
-		switch ( m.data)[( m.p)] {
-		case 10:
 			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
 		case 92:
-			goto st75
+			goto st73
 		}
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st326
+			goto st325
 		}
 		goto st6
-	st326:
+	st325:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof326
+			goto _test_eof325
 		}
-	st_case_326:
+	st_case_325:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr534
-		case 12:
-			goto tr535
+			goto tr532
 		case 13:
-			goto tr536
-		case 32:
 			goto tr533
+		case 32:
+			goto tr531
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr537
+			goto tr534
 		case 69:
-			goto st174
+			goto st173
 		case 92:
-			goto st75
+			goto st73
 		case 101:
-			goto st174
+			goto st173
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st326
+				goto st325
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr533
+			goto tr531
 		}
 		goto st6
-tr925:
+tr916:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st327
-tr533:
-	( m.cs) = 327
+	goto st326
+tr531:
+	( m.cs) = 326
 //line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr931:
-	( m.cs) = 327
+tr923:
+	( m.cs) = 326
 //line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr934:
-	( m.cs) = 327
+tr925:
+	( m.cs) = 326
 //line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr938:
-	( m.cs) = 327
+tr928:
+	( m.cs) = 326
 //line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-	st327:
+	st326:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof327
+			goto _test_eof326
 		}
-	st_case_327:
-//line plugins/parsers/influx/machine.go:8247
+	st_case_326:
+//line plugins/parsers/influx/machine.go:8183
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr275
-		case 12:
-			goto st272
+			goto tr273
 		case 13:
-			goto st103
+			goto st102
 		case 32:
-			goto st327
+			goto st326
 		case 34:
-			goto tr31
+			goto tr29
 		case 45:
-			goto tr541
+			goto tr538
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr542
+				goto tr539
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st327
+			goto st326
 		}
 		goto st6
-tr669:
+tr665:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -8280,24 +8214,24 @@ tr669:
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-	goto st328
-tr275:
+	goto st327
+tr273:
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-	goto st328
-tr534:
-	( m.cs) = 328
+	goto st327
+tr532:
+	( m.cs) = 327
 //line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -8308,8 +8242,8 @@ tr534:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr678:
-	( m.cs) = 328
+tr674:
+	( m.cs) = 327
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
@@ -8322,20 +8256,20 @@ tr678:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr741:
-	( m.cs) = 328
+tr737:
+	( m.cs) = 327
 //line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -8346,15 +8280,15 @@ tr741:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr748:
-	( m.cs) = 328
+tr743:
+	( m.cs) = 327
 //line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -8365,8 +8299,8 @@ tr748:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr755:
-	( m.cs) = 328
+tr749:
+	( m.cs) = 327
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
@@ -8379,20 +8313,20 @@ tr755:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr900:
-	( m.cs) = 328
+tr891:
+	( m.cs) = 327
 //line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -8403,152 +8337,206 @@ tr900:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-	st328:
+	st327:
 //line plugins/parsers/influx/machine.go.rl:172
 
 	m.finishMetric = true
-	( m.cs) = 740;
+	( m.cs) = 739;
 	{( m.p)++; goto _out }
 
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof328
+			goto _test_eof327
 		}
-	st_case_328:
-//line plugins/parsers/influx/machine.go:8418
+	st_case_327:
+//line plugins/parsers/influx/machine.go:8352
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st165
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr339
-		case 12:
-			goto st8
+			goto tr337
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto st165
+			goto st164
 		case 34:
-			goto tr118
+			goto tr116
 		case 35:
 			goto st6
 		case 44:
 			goto st6
 		case 92:
-			goto tr340
+			goto tr338
 		}
-		goto tr337
-tr337:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st164
+		}
+		goto tr335
+tr335:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st54
+	goto st53
+	st53:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof53
+		}
+	st_case_53:
+//line plugins/parsers/influx/machine.go:8386
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr179
+		case 13:
+			goto st6
+		case 32:
+			goto tr178
+		case 34:
+			goto tr89
+		case 44:
+			goto tr180
+		case 92:
+			goto st155
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto st53
+tr179:
+	( m.cs) = 54
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
 	st54:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof54
 		}
 	st_case_54:
-//line plugins/parsers/influx/machine.go:8453
+//line plugins/parsers/influx/machine.go:8425
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr181
-		case 12:
-			goto tr1
+			goto tr183
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr180
+			goto tr178
 		case 34:
-			goto tr91
+			goto tr122
 		case 44:
-			goto tr182
+			goto tr180
+		case 61:
+			goto st53
 		case 92:
-			goto st156
+			goto tr184
 		}
-		goto st54
-tr181:
-	( m.cs) = 55
-//line plugins/parsers/influx/machine.go.rl:86
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto tr182
+tr182:
+//line plugins/parsers/influx/machine.go.rl:28
 
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
+	m.pb = m.p
 
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+	goto st55
 	st55:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof55
 		}
 	st_case_55:
-//line plugins/parsers/influx/machine.go:8493
+//line plugins/parsers/influx/machine.go:8459
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr185
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr180
-		case 34:
-			goto tr124
-		case 44:
-			goto tr182
-		case 61:
-			goto st54
-		case 92:
 			goto tr186
+		case 13:
+			goto st6
+		case 32:
+			goto tr178
+		case 34:
+			goto tr126
+		case 44:
+			goto tr180
+		case 61:
+			goto tr187
+		case 92:
+			goto st152
 		}
-		goto tr184
-tr184:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto st55
+tr186:
+	( m.cs) = 56
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr183:
+	( m.cs) = 56
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st56
+	goto _again
 	st56:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof56
 		}
 	st_case_56:
-//line plugins/parsers/influx/machine.go:8528
+//line plugins/parsers/influx/machine.go:8517
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr188
-		case 12:
-			goto tr1
+			goto tr183
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr180
+			goto tr178
 		case 34:
-			goto tr128
+			goto tr122
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto tr184
 		}
-		goto st56
-tr188:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto tr182
+tr180:
 	( m.cs) = 57
 //line plugins/parsers/influx/machine.go.rl:86
 
@@ -8556,20 +8544,33 @@ tr188:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr185:
+tr156:
 	( m.cs) = 57
-//line plugins/parsers/influx/machine.go.rl:86
+//line plugins/parsers/influx/machine.go.rl:99
 
-	err = m.handler.SetMeasurement(m.text())
+	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr150:
+	( m.cs) = 57
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -8583,101 +8584,148 @@ tr185:
 			goto _test_eof57
 		}
 	st_case_57:
-//line plugins/parsers/influx/machine.go:8587
+//line plugins/parsers/influx/machine.go:8588
 		switch ( m.data)[( m.p)] {
 		case 9:
-			goto tr180
+			goto st6
 		case 10:
-			goto tr29
-		case 11:
-			goto tr185
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
-			goto tr180
+			goto st6
 		case 34:
-			goto tr124
+			goto tr190
 		case 44:
-			goto tr182
+			goto st6
 		case 61:
-			goto tr189
+			goto st6
 		case 92:
-			goto tr186
+			goto tr191
 		}
-		goto tr184
-tr182:
-	( m.cs) = 58
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr158:
-	( m.cs) = 58
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr152:
-	( m.cs) = 58
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto tr189
+tr189:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto _again
+	goto st58
 	st58:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof58
 		}
 	st_case_58:
-//line plugins/parsers/influx/machine.go:8659
+//line plugins/parsers/influx/machine.go:8620
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr192
+			goto tr193
 		case 44:
 			goto st6
 		case 61:
-			goto st6
+			goto tr194
 		case 92:
-			goto tr193
+			goto st69
 		}
-		goto tr191
-tr191:
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st58
+tr190:
+	( m.cs) = 328
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr193:
+	( m.cs) = 328
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st328:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof328
+		}
+	st_case_328:
+//line plugins/parsers/influx/machine.go:8676
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto st329
+		case 13:
+			goto st32
+		case 32:
+			goto st271
+		case 44:
+			goto st35
+		case 61:
+			goto tr53
+		case 92:
+			goto st23
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st271
+		}
+		goto st13
+	st329:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof329
+		}
+	st_case_329:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto st329
+		case 13:
+			goto st32
+		case 32:
+			goto st271
+		case 44:
+			goto tr196
+		case 45:
+			goto tr541
+		case 61:
+			goto tr53
+		case 92:
+			goto st23
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr542
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto st271
+		}
+		goto st13
+tr541:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -8688,178 +8736,126 @@ tr191:
 			goto _test_eof59
 		}
 	st_case_59:
-//line plugins/parsers/influx/machine.go:8692
+//line plugins/parsers/influx/machine.go:8740
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
-		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
 		case 32:
-			goto st6
-		case 34:
-			goto tr195
-		case 44:
-			goto st6
-		case 61:
 			goto tr196
+		case 44:
+			goto tr196
+		case 61:
+			goto tr53
 		case 92:
-			goto st70
+			goto st23
 		}
-		goto st59
-tr192:
-	( m.cs) = 329
+		switch {
+		case ( m.data)[( m.p)] < 12:
+			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 10 {
+				goto tr196
+			}
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st330
+			}
+		default:
+			goto tr196
+		}
+		goto st13
+tr542:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:148
-
-	err = m.handler.AddString(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr195:
-	( m.cs) = 329
-//line plugins/parsers/influx/machine.go.rl:148
-
-	err = m.handler.AddString(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st329:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof329
-		}
-	st_case_329:
-//line plugins/parsers/influx/machine.go:8749
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto st330
-		case 13:
-			goto st33
-		case 32:
-			goto st272
-		case 44:
-			goto st36
-		case 61:
-			goto tr55
-		case 92:
-			goto st24
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st272
-		}
-		goto st14
+	goto st330
 	st330:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof330
 		}
 	st_case_330:
+//line plugins/parsers/influx/machine.go:8775
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr468
 		case 11:
-			goto st330
+			goto tr543
 		case 13:
-			goto st33
+			goto tr470
 		case 32:
-			goto st272
+			goto tr467
 		case 44:
-			goto tr198
-		case 45:
-			goto tr544
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr545
+				goto st332
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st272
+			goto tr467
 		}
-		goto st14
-tr544:
-//line plugins/parsers/influx/machine.go.rl:28
+		goto st13
+tr543:
+	( m.cs) = 331
+//line plugins/parsers/influx/machine.go.rl:157
 
-	m.pb = m.p
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
 
-	goto st60
-	st60:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof60
-		}
-	st_case_60:
-//line plugins/parsers/influx/machine.go:8813
-		switch ( m.data)[( m.p)] {
-		case 32:
-			goto tr198
-		case 44:
-			goto tr198
-		case 61:
-			goto tr55
-		case 92:
-			goto st24
-		}
-		switch {
-		case ( m.data)[( m.p)] < 12:
-			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 10 {
-				goto tr198
-			}
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st331
-			}
-		default:
-			goto tr198
-		}
-		goto st14
-tr545:
-//line plugins/parsers/influx/machine.go.rl:28
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
 
-	m.pb = m.p
-
-	goto st331
+	goto _again
 	st331:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof331
 		}
 	st_case_331:
-//line plugins/parsers/influx/machine.go:8848
+//line plugins/parsers/influx/machine.go:8819
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr101
 		case 11:
-			goto tr546
+			goto st331
 		case 13:
-			goto tr472
+			goto st32
 		case 32:
-			goto tr469
+			goto st276
 		case 44:
-			goto tr198
+			goto tr2
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st276
+		}
+		goto st13
+	st332:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof332
+		}
+	st_case_332:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr543
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		case 44:
+			goto tr196
+		case 61:
+			goto tr53
+		case 92:
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -8867,48 +8863,9 @@ tr545:
 				goto st333
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
-tr546:
-	( m.cs) = 332
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st332:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof332
-		}
-	st_case_332:
-//line plugins/parsers/influx/machine.go:8892
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto st332
-		case 13:
-			goto st33
-		case 32:
-			goto st277
-		case 44:
-			goto tr2
-		case 61:
-			goto tr55
-		case 92:
-			goto st24
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st277
-		}
-		goto st14
+		goto st13
 	st333:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof333
@@ -8916,19 +8873,19 @@ tr546:
 	st_case_333:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -8936,9 +8893,9 @@ tr546:
 				goto st334
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st334:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof334
@@ -8946,19 +8903,19 @@ tr546:
 	st_case_334:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -8966,9 +8923,9 @@ tr546:
 				goto st335
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st335:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof335
@@ -8976,19 +8933,19 @@ tr546:
 	st_case_335:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -8996,9 +8953,9 @@ tr546:
 				goto st336
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st336:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof336
@@ -9006,19 +8963,19 @@ tr546:
 	st_case_336:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9026,9 +8983,9 @@ tr546:
 				goto st337
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st337:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof337
@@ -9036,19 +8993,19 @@ tr546:
 	st_case_337:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9056,9 +9013,9 @@ tr546:
 				goto st338
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st338:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof338
@@ -9066,19 +9023,19 @@ tr546:
 	st_case_338:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9086,9 +9043,9 @@ tr546:
 				goto st339
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st339:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof339
@@ -9096,19 +9053,19 @@ tr546:
 	st_case_339:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9116,9 +9073,9 @@ tr546:
 				goto st340
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st340:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof340
@@ -9126,19 +9083,19 @@ tr546:
 	st_case_340:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9146,9 +9103,9 @@ tr546:
 				goto st341
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st341:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof341
@@ -9156,19 +9113,19 @@ tr546:
 	st_case_341:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9176,9 +9133,9 @@ tr546:
 				goto st342
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st342:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof342
@@ -9186,19 +9143,19 @@ tr546:
 	st_case_342:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9206,9 +9163,9 @@ tr546:
 				goto st343
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st343:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof343
@@ -9216,19 +9173,19 @@ tr546:
 	st_case_343:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9236,9 +9193,9 @@ tr546:
 				goto st344
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st344:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof344
@@ -9246,19 +9203,19 @@ tr546:
 	st_case_344:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9266,9 +9223,9 @@ tr546:
 				goto st345
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st345:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof345
@@ -9276,19 +9233,19 @@ tr546:
 	st_case_345:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9296,9 +9253,9 @@ tr546:
 				goto st346
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st346:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof346
@@ -9306,19 +9263,19 @@ tr546:
 	st_case_346:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9326,9 +9283,9 @@ tr546:
 				goto st347
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st347:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof347
@@ -9336,19 +9293,19 @@ tr546:
 	st_case_347:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9356,9 +9313,9 @@ tr546:
 				goto st348
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st348:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof348
@@ -9366,19 +9323,19 @@ tr546:
 	st_case_348:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -9386,9 +9343,9 @@ tr546:
 				goto st349
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st14
+		goto st13
 	st349:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof349
@@ -9396,89 +9353,58 @@ tr546:
 	st_case_349:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr546
+			goto tr543
 		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		case 44:
-			goto tr198
-		case 61:
-			goto tr55
-		case 92:
-			goto st24
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st350
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto st14
-	st350:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof350
-		}
-	st_case_350:
-		switch ( m.data)[( m.p)] {
-		case 10:
 			goto tr470
-		case 11:
-			goto tr546
-		case 13:
-			goto tr472
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr198
+			goto tr196
 		case 61:
-			goto tr55
+			goto tr53
 		case 92:
-			goto st24
+			goto st23
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr469
+			goto tr467
 		}
-		goto st14
-tr196:
+		goto st13
+tr194:
 //line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
 
-	goto st61
-	st61:
+	goto st60
+	st60:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof61
+			goto _test_eof60
 		}
-	st_case_61:
-//line plugins/parsers/influx/machine.go:9459
+	st_case_60:
+//line plugins/parsers/influx/machine.go:9386
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr151
+			goto tr149
 		case 44:
 			goto st6
 		case 61:
 			goto st6
 		case 92:
-			goto tr153
+			goto tr151
 		}
-		goto tr148
-tr151:
-	( m.cs) = 351
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto tr146
+tr149:
+	( m.cs) = 350
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -9489,72 +9415,72 @@ tr151:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr157:
-	( m.cs) = 351
+tr155:
+	( m.cs) = 350
 //line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-	st351:
+	st350:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof351
+			goto _test_eof350
 		}
-	st_case_351:
-//line plugins/parsers/influx/machine.go:9516
+	st_case_350:
+//line plugins/parsers/influx/machine.go:9442
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr101
 		case 11:
-			goto tr567
+			goto tr564
 		case 13:
-			goto st33
+			goto st32
 		case 32:
-			goto tr566
+			goto tr563
 		case 44:
-			goto tr568
+			goto tr565
 		case 61:
-			goto tr132
+			goto tr130
 		case 92:
-			goto st22
+			goto st21
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr566
+			goto tr563
 		}
-		goto st16
-tr567:
-	( m.cs) = 352
+		goto st15
+tr564:
+	( m.cs) = 351
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr735:
-	( m.cs) = 352
+tr731:
+	( m.cs) = 351
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -9564,20 +9490,20 @@ tr735:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr953:
-	( m.cs) = 352
+tr943:
+	( m.cs) = 351
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -9587,20 +9513,20 @@ tr953:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr958:
-	( m.cs) = 352
+tr949:
+	( m.cs) = 351
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -9610,20 +9536,20 @@ tr958:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr963:
-	( m.cs) = 352
+tr955:
+	( m.cs) = 351
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -9633,66 +9559,66 @@ tr963:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-	st352:
+	st351:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof352
+			goto _test_eof351
 		}
-	st_case_352:
-//line plugins/parsers/influx/machine.go:9647
+	st_case_351:
+//line plugins/parsers/influx/machine.go:9573
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr101
 		case 11:
-			goto tr569
-		case 13:
-			goto st33
-		case 32:
 			goto tr566
+		case 13:
+			goto st32
+		case 32:
+			goto tr563
 		case 44:
-			goto tr62
+			goto tr60
 		case 45:
-			goto tr570
+			goto tr567
 		case 61:
-			goto tr132
+			goto tr130
 		case 92:
-			goto tr66
+			goto tr64
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr571
+				goto tr568
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr566
+			goto tr563
 		}
-		goto tr64
-tr594:
-	( m.cs) = 353
+		goto tr62
+tr591:
+	( m.cs) = 352
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr569:
-	( m.cs) = 353
+tr566:
+	( m.cs) = 352
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -9701,40 +9627,715 @@ tr569:
 	m.pb = m.p
 
 	goto _again
+	st352:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof352
+		}
+	st_case_352:
+//line plugins/parsers/influx/machine.go:9636
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto tr566
+		case 13:
+			goto st32
+		case 32:
+			goto tr563
+		case 44:
+			goto tr60
+		case 45:
+			goto tr567
+		case 61:
+			goto tr12
+		case 92:
+			goto tr64
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr568
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr563
+		}
+		goto tr62
+tr567:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st61
+	st61:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof61
+		}
+	st_case_61:
+//line plugins/parsers/influx/machine.go:9675
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr130
+		case 11:
+			goto tr66
+		case 13:
+			goto tr130
+		case 32:
+			goto tr58
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st353
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr58
+		}
+		goto st17
+tr568:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st353
 	st353:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof353
 		}
 	st_case_353:
-//line plugins/parsers/influx/machine.go:9710
+//line plugins/parsers/influx/machine.go:9712
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr468
 		case 11:
-			goto tr569
-		case 13:
-			goto st33
-		case 32:
-			goto tr566
-		case 44:
-			goto tr62
-		case 45:
 			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
 		case 61:
 			goto tr12
 		case 92:
-			goto tr66
+			goto st19
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr571
+				goto st355
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr566
+			goto tr569
 		}
-		goto tr64
+		goto st17
+tr573:
+	( m.cs) = 354
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto _again
 tr570:
+	( m.cs) = 354
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st354:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof354
+		}
+	st_case_354:
+//line plugins/parsers/influx/machine.go:9783
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto tr573
+		case 13:
+			goto st32
+		case 32:
+			goto tr572
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto tr64
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr572
+		}
+		goto tr62
+	st355:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof355
+		}
+	st_case_355:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st356
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st356:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof356
+		}
+	st_case_356:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st357
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st357:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof357
+		}
+	st_case_357:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st358
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st358:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof358
+		}
+	st_case_358:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st359
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st359:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof359
+		}
+	st_case_359:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st360
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st360:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof360
+		}
+	st_case_360:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st361
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st361:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof361
+		}
+	st_case_361:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st362
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st362:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof362
+		}
+	st_case_362:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st363
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st363:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof363
+		}
+	st_case_363:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st364
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st364:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof364
+		}
+	st_case_364:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st365
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st365:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof365
+		}
+	st_case_365:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st366
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st366:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof366
+		}
+	st_case_366:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st367
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st367:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof367
+		}
+	st_case_367:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st368
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st368:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof368
+		}
+	st_case_368:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st369
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st369:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof369
+		}
+	st_case_369:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st370
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st370:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof370
+		}
+	st_case_370:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st371
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st371:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof371
+		}
+	st_case_371:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st372
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr569
+		}
+		goto st17
+	st372:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof372
+		}
+	st_case_372:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 11:
+			goto tr570
+		case 13:
+			goto tr470
+		case 32:
+			goto tr569
+		case 44:
+			goto tr60
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr569
+		}
+		goto st17
+tr151:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -9745,751 +10346,75 @@ tr570:
 			goto _test_eof62
 		}
 	st_case_62:
-//line plugins/parsers/influx/machine.go:9749
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr132
-		case 11:
-			goto tr68
-		case 13:
-			goto tr132
-		case 32:
-			goto tr60
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st354
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr60
-		}
-		goto st18
-tr571:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st354
-	st354:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof354
-		}
-	st_case_354:
-//line plugins/parsers/influx/machine.go:9786
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st356
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-tr576:
-	( m.cs) = 355
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto _again
-tr573:
-	( m.cs) = 355
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st355:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof355
-		}
-	st_case_355:
-//line plugins/parsers/influx/machine.go:9857
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto tr576
-		case 13:
-			goto st33
-		case 32:
-			goto tr575
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto tr66
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr575
-		}
-		goto tr64
-	st356:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof356
-		}
-	st_case_356:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st357
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st357:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof357
-		}
-	st_case_357:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st358
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st358:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof358
-		}
-	st_case_358:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st359
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st359:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof359
-		}
-	st_case_359:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st360
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st360:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof360
-		}
-	st_case_360:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st361
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st361:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof361
-		}
-	st_case_361:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st362
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st362:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof362
-		}
-	st_case_362:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st363
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st363:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof363
-		}
-	st_case_363:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st364
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st364:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof364
-		}
-	st_case_364:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st365
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st365:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof365
-		}
-	st_case_365:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st366
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st366:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof366
-		}
-	st_case_366:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st367
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st367:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof367
-		}
-	st_case_367:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st368
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st368:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof368
-		}
-	st_case_368:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st369
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st369:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof369
-		}
-	st_case_369:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st370
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st370:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof370
-		}
-	st_case_370:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st371
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st371:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof371
-		}
-	st_case_371:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st372
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st372:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof372
-		}
-	st_case_372:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st373
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr572
-		}
-		goto st18
-	st373:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof373
-		}
-	st_case_373:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 11:
-			goto tr573
-		case 13:
-			goto tr472
-		case 32:
-			goto tr572
-		case 44:
-			goto tr62
-		case 61:
-			goto tr12
-		case 92:
-			goto st20
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr572
-		}
-		goto st18
-tr153:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st63
-	st63:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof63
-		}
-	st_case_63:
-//line plugins/parsers/influx/machine.go:10424
+//line plugins/parsers/influx/machine.go:10350
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st48
+			goto st47
 		case 92:
-			goto st64
+			goto st63
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
+				goto tr45
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr47
+			goto tr45
 		}
-		goto st16
-	st64:
+		goto st15
+	st63:
 //line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof64
+			goto _test_eof63
 		}
-	st_case_64:
-//line plugins/parsers/influx/machine.go:10448
+	st_case_63:
+//line plugins/parsers/influx/machine.go:10374
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr156
-		case 12:
-			goto tr60
+			goto tr154
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr155
+			goto tr153
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
 			goto st6
 		case 92:
-			goto st63
+			goto st62
 		}
-		goto st48
-tr156:
-	( m.cs) = 65
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st47
+tr154:
+	( m.cs) = 64
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr150:
-	( m.cs) = 65
+tr148:
+	( m.cs) = 64
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -10498,147 +10423,358 @@ tr150:
 	m.pb = m.p
 
 	goto _again
+	st64:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof64
+		}
+	st_case_64:
+//line plugins/parsers/influx/machine.go:10432
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr201
+		case 13:
+			goto st6
+		case 32:
+			goto tr153
+		case 34:
+			goto tr202
+		case 44:
+			goto tr156
+		case 61:
+			goto st6
+		case 92:
+			goto tr203
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto tr200
+tr200:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st65
 	st65:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof65
 		}
 	st_case_65:
-//line plugins/parsers/influx/machine.go:10507
+//line plugins/parsers/influx/machine.go:10466
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr203
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
-		case 34:
-			goto tr204
-		case 44:
-			goto tr158
-		case 61:
-			goto st6
-		case 92:
 			goto tr205
+		case 13:
+			goto st6
+		case 32:
+			goto tr153
+		case 34:
+			goto tr206
+		case 44:
+			goto tr156
+		case 61:
+			goto tr163
+		case 92:
+			goto st67
 		}
-		goto tr202
-tr202:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st65
+tr205:
+	( m.cs) = 66
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr201:
+	( m.cs) = 66
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st66
+	goto _again
 	st66:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof66
 		}
 	st_case_66:
-//line plugins/parsers/influx/machine.go:10542
+//line plugins/parsers/influx/machine.go:10524
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr207
-		case 12:
-			goto tr60
+			goto tr201
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr155
+			goto tr153
 		case 34:
-			goto tr208
+			goto tr202
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto tr203
 		}
-		goto st66
-tr207:
-	( m.cs) = 67
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr203:
-	( m.cs) = 67
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto tr200
+tr202:
+	( m.cs) = 373
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
 	goto _again
+tr206:
+	( m.cs) = 373
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st373:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof373
+		}
+	st_case_373:
+//line plugins/parsers/influx/machine.go:10582
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto tr591
+		case 13:
+			goto st32
+		case 32:
+			goto tr563
+		case 44:
+			goto tr565
+		case 61:
+			goto tr12
+		case 92:
+			goto st19
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr563
+		}
+		goto st17
+tr203:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st67
 	st67:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof67
 		}
 	st_case_67:
-//line plugins/parsers/influx/machine.go:10601
+//line plugins/parsers/influx/machine.go:10614
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
-		case 10:
-			goto tr29
-		case 11:
-			goto tr203
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
 		case 34:
-			goto tr204
-		case 44:
-			goto tr158
-		case 61:
-			goto tr165
+			goto st65
 		case 92:
-			goto tr205
+			goto st68
 		}
-		goto tr202
-tr204:
-	( m.cs) = 374
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr45
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr45
+		}
+		goto st17
+	st68:
+//line plugins/parsers/influx/machine.go.rl:248
+ ( m.p)--
+ 
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof68
+		}
+	st_case_68:
+//line plugins/parsers/influx/machine.go:10638
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr205
+		case 13:
+			goto st6
+		case 32:
+			goto tr153
+		case 34:
+			goto tr206
+		case 44:
+			goto tr156
+		case 61:
+			goto tr163
+		case 92:
+			goto st67
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st65
+tr191:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:148
+	goto st69
+	st69:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof69
+		}
+	st_case_69:
+//line plugins/parsers/influx/machine.go:10672
+		switch ( m.data)[( m.p)] {
+		case 34:
+			goto st58
+		case 92:
+			goto st70
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr45
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr45
+		}
+		goto st13
+	st70:
+//line plugins/parsers/influx/machine.go.rl:248
+ ( m.p)--
+ 
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof70
+		}
+	st_case_70:
+//line plugins/parsers/influx/machine.go:10696
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st6
+		case 10:
+			goto tr28
+		case 32:
+			goto st6
+		case 34:
+			goto tr193
+		case 44:
+			goto st6
+		case 61:
+			goto tr194
+		case 92:
+			goto st69
+		}
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st58
+tr187:
+//line plugins/parsers/influx/machine.go.rl:108
 
-	err = m.handler.AddString(m.key, m.text())
-	if err != nil {
-		( m.p)--
+	m.key = m.text()
 
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
+	goto st71
+tr344:
+//line plugins/parsers/influx/machine.go.rl:28
 
-	goto _again
-tr208:
+	m.pb = m.p
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.key = m.text()
+
+	goto st71
+	st71:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof71
+		}
+	st_case_71:
+//line plugins/parsers/influx/machine.go:10738
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr179
+		case 13:
+			goto st6
+		case 32:
+			goto tr178
+		case 34:
+			goto tr210
+		case 44:
+			goto tr180
+		case 45:
+			goto tr211
+		case 46:
+			goto tr212
+		case 48:
+			goto tr213
+		case 70:
+			goto tr215
+		case 84:
+			goto tr216
+		case 92:
+			goto st155
+		case 102:
+			goto tr217
+		case 116:
+			goto tr218
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr214
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr178
+		}
+		goto st53
+tr210:
 	( m.cs) = 374
 //line plugins/parsers/influx/machine.go.rl:148
 
@@ -10646,7 +10782,7 @@ tr208:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -10656,212 +10792,250 @@ tr208:
 			goto _test_eof374
 		}
 	st_case_374:
-//line plugins/parsers/influx/machine.go:10660
+//line plugins/parsers/influx/machine.go:10796
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr492
 		case 11:
-			goto tr594
+			goto tr593
 		case 13:
-			goto st33
+			goto tr493
 		case 32:
-			goto tr566
+			goto tr592
+		case 34:
+			goto tr83
 		case 44:
-			goto tr568
-		case 61:
-			goto tr12
+			goto tr594
 		case 92:
-			goto st20
+			goto tr85
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr566
+			goto tr592
 		}
-		goto st18
-tr205:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st68
-	st68:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof68
-		}
-	st_case_68:
-//line plugins/parsers/influx/machine.go:10692
-		switch ( m.data)[( m.p)] {
-		case 34:
-			goto st66
-		case 92:
-			goto st69
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr47
-		}
-		goto st18
-	st69:
-//line plugins/parsers/influx/machine.go.rl:248
- ( m.p)--
- 
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof69
-		}
-	st_case_69:
-//line plugins/parsers/influx/machine.go:10716
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
-		case 10:
-			goto tr29
-		case 11:
-			goto tr207
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
-		case 34:
-			goto tr208
-		case 44:
-			goto tr158
-		case 61:
-			goto tr165
-		case 92:
-			goto st68
-		}
-		goto st66
-tr193:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st70
-	st70:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof70
-		}
-	st_case_70:
-//line plugins/parsers/influx/machine.go:10751
-		switch ( m.data)[( m.p)] {
-		case 34:
-			goto st59
-		case 92:
-			goto st71
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr47
-		}
-		goto st14
-	st71:
-//line plugins/parsers/influx/machine.go.rl:248
- ( m.p)--
- 
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof71
-		}
-	st_case_71:
-//line plugins/parsers/influx/machine.go:10775
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
-		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
-		case 32:
-			goto st6
-		case 34:
-			goto tr195
-		case 44:
-			goto st6
-		case 61:
-			goto tr196
-		case 92:
-			goto st70
-		}
-		goto st59
-tr189:
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.key = m.text()
-
-	goto st72
-tr346:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.key = m.text()
-
-	goto st72
-	st72:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof72
-		}
-	st_case_72:
-//line plugins/parsers/influx/machine.go:10818
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
-		case 10:
-			goto tr29
-		case 11:
-			goto tr181
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr180
-		case 34:
-			goto tr212
-		case 44:
-			goto tr182
-		case 45:
-			goto tr213
-		case 46:
-			goto tr214
-		case 48:
-			goto tr215
-		case 70:
-			goto tr217
-		case 84:
-			goto tr218
-		case 92:
-			goto st156
-		case 102:
-			goto tr219
-		case 116:
-			goto tr220
-		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr216
-		}
-		goto st54
-tr212:
+		goto tr80
+tr623:
 	( m.cs) = 375
-//line plugins/parsers/influx/machine.go.rl:148
+//line plugins/parsers/influx/machine.go.rl:86
 
-	err = m.handler.AddString(m.key, m.text())
+	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr592:
+	( m.cs) = 375
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto _again
+tr762:
+	( m.cs) = 375
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr635:
+	( m.cs) = 375
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr757:
+	( m.cs) = 375
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr790:
+	( m.cs) = 375
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr796:
+	( m.cs) = 375
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr802:
+	( m.cs) = 375
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr816:
+	( m.cs) = 375
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr821:
+	( m.cs) = 375
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr826:
+	( m.cs) = 375
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -10871,411 +11045,183 @@ tr212:
 			goto _test_eof375
 		}
 	st_case_375:
-//line plugins/parsers/influx/machine.go:10875
+//line plugins/parsers/influx/machine.go:11049
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr595
 		case 10:
-			goto tr494
+			goto tr219
 		case 11:
 			goto tr596
-		case 12:
-			goto tr501
 		case 13:
-			goto tr495
+			goto st72
 		case 32:
-			goto tr595
+			goto st375
 		case 34:
-			goto tr85
+			goto tr95
 		case 44:
+			goto st6
+		case 45:
 			goto tr597
+		case 61:
+			goto st6
 		case 92:
-			goto tr87
+			goto tr96
 		}
-		goto tr82
-tr626:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr595:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr598
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto st375
+		}
+		goto tr92
+tr596:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto _again
-tr769:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr638:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr764:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr797:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr803:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr809:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr822:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr828:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr834:
-	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+	goto st376
 	st376:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof376
 		}
 	st_case_376:
-//line plugins/parsers/influx/machine.go:11129
+//line plugins/parsers/influx/machine.go:11090
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st376
 		case 10:
-			goto tr221
+			goto tr219
 		case 11:
-			goto tr599
-		case 12:
-			goto st301
+			goto tr596
 		case 13:
-			goto st73
+			goto st72
 		case 32:
-			goto st376
+			goto st375
 		case 34:
-			goto tr97
+			goto tr95
 		case 44:
 			goto st6
 		case 45:
-			goto tr600
+			goto tr597
 		case 61:
-			goto st6
+			goto tr99
 		case 92:
-			goto tr98
+			goto tr96
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr601
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr598
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto st375
 		}
-		goto tr94
-tr599:
+		goto tr92
+tr493:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st377
-	st377:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof377
-		}
-	st_case_377:
-//line plugins/parsers/influx/machine.go:11169
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st376
-		case 10:
-			goto tr221
-		case 11:
-			goto tr599
-		case 12:
-			goto st301
-		case 13:
-			goto st73
-		case 32:
-			goto st376
-		case 34:
-			goto tr97
-		case 44:
-			goto st6
-		case 45:
-			goto tr600
-		case 61:
-			goto tr101
-		case 92:
-			goto tr98
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr601
-		}
-		goto tr94
-tr495:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st73
-tr605:
-	( m.cs) = 73
+	goto st72
+tr602:
+	( m.cs) = 72
 //line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr642:
-	( m.cs) = 73
+tr638:
+	( m.cs) = 72
 //line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr800:
-	( m.cs) = 73
+tr793:
+	( m.cs) = 72
 //line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr806:
-	( m.cs) = 73
+tr799:
+	( m.cs) = 72
 //line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr812:
-	( m.cs) = 73
+tr805:
+	( m.cs) = 72
 //line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st72:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof72
+		}
+	st_case_72:
+//line plugins/parsers/influx/machine.go:11196
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr219
+		case 34:
+			goto tr29
+		case 92:
+			goto st73
+		}
+		goto st6
+tr26:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st73
 	st73:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof73
 		}
 	st_case_73:
-//line plugins/parsers/influx/machine.go:11274
-		if ( m.data)[( m.p)] == 10 {
-			goto tr221
+//line plugins/parsers/influx/machine.go:11217
+		switch ( m.data)[( m.p)] {
+		case 34:
+			goto st6
+		case 92:
+			goto st6
 		}
 		goto tr8
-tr600:
+tr597:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -11286,70 +11232,107 @@ tr600:
 			goto _test_eof74
 		}
 	st_case_74:
-//line plugins/parsers/influx/machine.go:11290
+//line plugins/parsers/influx/machine.go:11236
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr105
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st378
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st377
+			}
+		case ( m.data)[( m.p)] >= 12:
+			goto st6
 		}
-		goto st32
-tr601:
+		goto st31
+tr598:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st378
+	goto st377
+	st377:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof377
+		}
+	st_case_377:
+//line plugins/parsers/influx/machine.go:11273
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr600
+		case 11:
+			goto tr601
+		case 13:
+			goto tr602
+		case 32:
+			goto tr599
+		case 34:
+			goto tr98
+		case 44:
+			goto st6
+		case 61:
+			goto tr99
+		case 92:
+			goto st75
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st380
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
+		}
+		goto st31
+tr599:
+	( m.cs) = 378
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
 	st378:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof378
 		}
 	st_case_378:
-//line plugins/parsers/influx/machine.go:11326
+//line plugins/parsers/influx/machine.go:11319
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
-		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr219
 		case 13:
-			goto tr605
+			goto st72
 		case 32:
-			goto tr602
+			goto st378
 		case 34:
-			goto tr100
-		case 44:
-			goto st6
-		case 61:
-			goto tr101
+			goto tr29
 		case 92:
-			goto st76
+			goto st73
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st381
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st378
 		}
-		goto st32
-tr602:
+		goto st6
+tr601:
 	( m.cs) = 379
 //line plugins/parsers/influx/machine.go.rl:157
 
@@ -11357,7 +11340,7 @@ tr602:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -11367,26 +11350,30 @@ tr602:
 			goto _test_eof379
 		}
 	st_case_379:
-//line plugins/parsers/influx/machine.go:11371
+//line plugins/parsers/influx/machine.go:11354
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr221
-		case 12:
-			goto st277
-		case 13:
-			goto st73
-		case 32:
+			goto tr219
+		case 11:
 			goto st379
+		case 13:
+			goto st72
+		case 32:
+			goto st378
 		case 34:
-			goto tr31
+			goto tr98
+		case 44:
+			goto st6
+		case 61:
+			goto tr99
 		case 92:
 			goto st75
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto st379
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st378
 		}
-		goto st6
-tr27:
+		goto st31
+tr96:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -11397,73 +11384,12 @@ tr27:
 			goto _test_eof75
 		}
 	st_case_75:
-//line plugins/parsers/influx/machine.go:11401
+//line plugins/parsers/influx/machine.go:11388
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st6
+			goto st31
 		case 92:
-			goto st6
-		}
-		goto tr8
-tr604:
-	( m.cs) = 380
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st380:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof380
-		}
-	st_case_380:
-//line plugins/parsers/influx/machine.go:11427
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st379
-		case 10:
-			goto tr221
-		case 11:
-			goto st380
-		case 12:
-			goto st277
-		case 13:
-			goto st73
-		case 32:
-			goto st379
-		case 34:
-			goto tr100
-		case 44:
-			goto st6
-		case 61:
-			goto tr101
-		case 92:
-			goto st76
-		}
-		goto st32
-tr98:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st76
-	st76:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof76
-		}
-	st_case_76:
-//line plugins/parsers/influx/machine.go:11462
-		switch ( m.data)[( m.p)] {
-		case 34:
-			goto st32
-		case 92:
-			goto st32
+			goto st31
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -11474,570 +11400,586 @@ tr98:
 			goto tr8
 		}
 		goto st3
+	st380:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof380
+		}
+	st_case_380:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr600
+		case 11:
+			goto tr601
+		case 13:
+			goto tr602
+		case 32:
+			goto tr599
+		case 34:
+			goto tr98
+		case 44:
+			goto st6
+		case 61:
+			goto tr99
+		case 92:
+			goto st75
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st381
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
+		}
+		goto st31
 	st381:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof381
 		}
 	st_case_381:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st382
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st382
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st382:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof382
 		}
 	st_case_382:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st383
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st383
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st383:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof383
 		}
 	st_case_383:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st384
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st384
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st384:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof384
 		}
 	st_case_384:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st385
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st385
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st385:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof385
 		}
 	st_case_385:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st386
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st386
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st386:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof386
 		}
 	st_case_386:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st387
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st387
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st387:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof387
 		}
 	st_case_387:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st388
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st388
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st388:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof388
 		}
 	st_case_388:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st389
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st389
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st389:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof389
 		}
 	st_case_389:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st390
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st390
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st390:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof390
 		}
 	st_case_390:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st391
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st391
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st391:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof391
 		}
 	st_case_391:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st392
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st392
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st392:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof392
 		}
 	st_case_392:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st393
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st393
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st393:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof393
 		}
 	st_case_393:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st394
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st394
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st394:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof394
 		}
 	st_case_394:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st395
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st395
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st395:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof395
 		}
 	st_case_395:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st396
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st396
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st396:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof396
 		}
 	st_case_396:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st397
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st397
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
 		}
-		goto st32
+		goto st31
 	st397:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof397
 		}
 	st_case_397:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr604
-		case 12:
-			goto tr469
+			goto tr601
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st76
+			goto st75
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st398
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr599
 		}
-		goto st32
-	st398:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof398
-		}
-	st_case_398:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr602
-		case 10:
-			goto tr603
-		case 11:
-			goto tr604
-		case 12:
-			goto tr469
-		case 13:
-			goto tr605
-		case 32:
-			goto tr602
-		case 34:
-			goto tr100
-		case 44:
-			goto st6
-		case 61:
-			goto tr101
-		case 92:
-			goto st76
-		}
-		goto st32
-tr596:
-	( m.cs) = 399
+		goto st31
+tr593:
+	( m.cs) = 398
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -12046,15 +11988,15 @@ tr596:
 	m.pb = m.p
 
 	goto _again
-tr640:
-	( m.cs) = 399
+tr637:
+	( m.cs) = 398
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -12064,20 +12006,20 @@ tr640:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr824:
-	( m.cs) = 399
+tr818:
+	( m.cs) = 398
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -12087,20 +12029,20 @@ tr824:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr830:
-	( m.cs) = 399
+tr823:
+	( m.cs) = 398
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -12110,20 +12052,20 @@ tr830:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr835:
-	( m.cs) = 399
+tr827:
+	( m.cs) = 398
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -12133,9 +12075,61 @@ tr835:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
+
+	goto _again
+	st398:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof398
+		}
+	st_case_398:
+//line plugins/parsers/influx/machine.go:12089
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr219
+		case 11:
+			goto tr624
+		case 13:
+			goto st72
+		case 32:
+			goto tr623
+		case 34:
+			goto tr122
+		case 44:
+			goto tr90
+		case 45:
+			goto tr625
+		case 61:
+			goto st29
+		case 92:
+			goto tr123
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr626
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr623
+		}
+		goto tr119
+tr624:
+	( m.cs) = 399
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
 
 	goto _again
 	st399:
@@ -12143,44 +12137,58 @@ tr835:
 			goto _test_eof399
 		}
 	st_case_399:
-//line plugins/parsers/influx/machine.go:12147
+//line plugins/parsers/influx/machine.go:12141
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr626
 		case 10:
-			goto tr221
+			goto tr219
 		case 11:
-			goto tr627
-		case 12:
-			goto tr501
+			goto tr624
 		case 13:
-			goto st73
+			goto st72
 		case 32:
-			goto tr626
+			goto tr623
 		case 34:
-			goto tr124
+			goto tr122
 		case 44:
-			goto tr92
+			goto tr90
 		case 45:
-			goto tr628
+			goto tr625
 		case 61:
-			goto st30
+			goto tr127
 		case 92:
-			goto tr125
+			goto tr123
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr629
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr626
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr623
 		}
-		goto tr121
-tr627:
-	( m.cs) = 400
+		goto tr119
+tr90:
+	( m.cs) = 76
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr84:
+	( m.cs) = 76
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -12189,114 +12197,81 @@ tr627:
 	m.pb = m.p
 
 	goto _again
-	st400:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof400
-		}
-	st_case_400:
-//line plugins/parsers/influx/machine.go:12198
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr626
-		case 10:
-			goto tr221
-		case 11:
-			goto tr627
-		case 12:
-			goto tr501
-		case 13:
-			goto st73
-		case 32:
-			goto tr626
-		case 34:
-			goto tr124
-		case 44:
-			goto tr92
-		case 45:
-			goto tr628
-		case 61:
-			goto tr129
-		case 92:
-			goto tr125
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr629
-		}
-		goto tr121
-tr92:
-	( m.cs) = 77
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr86:
-	( m.cs) = 77
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto _again
-tr233:
-	( m.cs) = 77
+tr231:
+	( m.cs) = 76
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-	st77:
+	st76:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof77
+			goto _test_eof76
 		}
-	st_case_77:
-//line plugins/parsers/influx/machine.go:12275
+	st_case_76:
+//line plugins/parsers/influx/machine.go:12219
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr192
+			goto tr190
 		case 44:
 			goto st6
 		case 61:
 			goto st6
 		case 92:
-			goto tr224
+			goto tr222
 		}
-		goto tr223
-tr223:
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto tr221
+tr221:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
+
+	goto st77
+	st77:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof77
+		}
+	st_case_77:
+//line plugins/parsers/influx/machine.go:12251
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st6
+		case 10:
+			goto tr28
+		case 32:
+			goto st6
+		case 34:
+			goto tr193
+		case 44:
+			goto st6
+		case 61:
+			goto tr224
+		case 92:
+			goto st87
+		}
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st77
+tr224:
+//line plugins/parsers/influx/machine.go.rl:95
+
+	m.key = m.text()
 
 	goto st78
 	st78:
@@ -12304,32 +12279,31 @@ tr223:
 			goto _test_eof78
 		}
 	st_case_78:
-//line plugins/parsers/influx/machine.go:12308
+//line plugins/parsers/influx/machine.go:12283
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr195
+			goto tr149
 		case 44:
 			goto st6
 		case 61:
-			goto tr226
+			goto st6
 		case 92:
-			goto st88
+			goto tr227
 		}
-		goto st78
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto tr226
 tr226:
-//line plugins/parsers/influx/machine.go.rl:95
+//line plugins/parsers/influx/machine.go.rl:28
 
-	m.key = m.text()
+	m.pb = m.p
 
 	goto st79
 	st79:
@@ -12337,378 +12311,628 @@ tr226:
 			goto _test_eof79
 		}
 	st_case_79:
-//line plugins/parsers/influx/machine.go:12341
+//line plugins/parsers/influx/machine.go:12315
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
+			goto tr28
+		case 11:
+			goto tr230
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto st6
+			goto tr229
 		case 34:
-			goto tr151
+			goto tr155
 		case 44:
-			goto st6
+			goto tr231
 		case 61:
 			goto st6
 		case 92:
+			goto st85
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr229
 		}
-		goto tr228
-tr228:
-//line plugins/parsers/influx/machine.go.rl:28
+		goto st79
+tr230:
+	( m.cs) = 80
+//line plugins/parsers/influx/machine.go.rl:99
 
-	m.pb = m.p
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
 
-	goto st80
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
 	st80:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof80
 		}
 	st_case_80:
-//line plugins/parsers/influx/machine.go:12374
+//line plugins/parsers/influx/machine.go:12356
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
+			goto tr234
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr231
+			goto tr229
 		case 34:
-			goto tr157
+			goto tr202
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
 			goto st6
 		case 92:
-			goto st86
+			goto tr235
 		}
-		goto st80
-tr232:
-	( m.cs) = 81
-//line plugins/parsers/influx/machine.go.rl:99
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto tr233
+tr233:
+//line plugins/parsers/influx/machine.go.rl:28
 
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
+	m.pb = m.p
 
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+	goto st81
 	st81:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof81
 		}
 	st_case_81:
-//line plugins/parsers/influx/machine.go:12416
+//line plugins/parsers/influx/machine.go:12390
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr236
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr231
-		case 34:
-			goto tr204
-		case 44:
-			goto tr233
-		case 61:
-			goto st6
-		case 92:
 			goto tr237
+		case 13:
+			goto st6
+		case 32:
+			goto tr229
+		case 34:
+			goto tr206
+		case 44:
+			goto tr231
+		case 61:
+			goto tr99
+		case 92:
+			goto st83
 		}
-		goto tr235
-tr235:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto st81
+tr237:
+	( m.cs) = 82
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr234:
+	( m.cs) = 82
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st82
+	goto _again
 	st82:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof82
 		}
 	st_case_82:
-//line plugins/parsers/influx/machine.go:12451
+//line plugins/parsers/influx/machine.go:12448
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr239
-		case 12:
-			goto tr60
+			goto tr234
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr231
+			goto tr229
 		case 34:
-			goto tr208
+			goto tr202
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto tr235
 		}
-		goto st82
-tr239:
-	( m.cs) = 83
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr236:
-	( m.cs) = 83
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto tr233
+tr235:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto _again
+	goto st83
 	st83:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof83
 		}
 	st_case_83:
-//line plugins/parsers/influx/machine.go:12510
+//line plugins/parsers/influx/machine.go:12482
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
-		case 10:
-			goto tr29
-		case 11:
-			goto tr236
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr231
 		case 34:
-			goto tr204
-		case 44:
-			goto tr233
-		case 61:
-			goto tr101
+			goto st81
 		case 92:
-			goto tr237
+			goto st84
 		}
-		goto tr235
-tr237:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st84
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr45
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr45
+		}
+		goto st17
 	st84:
+//line plugins/parsers/influx/machine.go.rl:248
+ ( m.p)--
+ 
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof84
 		}
 	st_case_84:
-//line plugins/parsers/influx/machine.go:12545
+//line plugins/parsers/influx/machine.go:12506
 		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr237
+		case 13:
+			goto st6
+		case 32:
+			goto tr229
 		case 34:
-			goto st82
+			goto tr206
+		case 44:
+			goto tr231
+		case 61:
+			goto tr99
 		case 92:
-			goto st85
+			goto st83
 		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr47
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
 		}
-		goto st18
+		goto st81
+tr227:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st85
 	st85:
-//line plugins/parsers/influx/machine.go.rl:248
- ( m.p)--
- 
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof85
 		}
 	st_case_85:
-//line plugins/parsers/influx/machine.go:12569
+//line plugins/parsers/influx/machine.go:12540
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
-		case 10:
-			goto tr29
-		case 11:
-			goto tr239
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr231
 		case 34:
-			goto tr208
-		case 44:
-			goto tr233
-		case 61:
-			goto tr101
+			goto st79
 		case 92:
-			goto st84
+			goto st86
 		}
-		goto st82
-tr229:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st86
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr45
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr45
+		}
+		goto st15
 	st86:
+//line plugins/parsers/influx/machine.go.rl:248
+ ( m.p)--
+ 
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof86
 		}
 	st_case_86:
-//line plugins/parsers/influx/machine.go:12604
+//line plugins/parsers/influx/machine.go:12564
 		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr230
+		case 13:
+			goto st6
+		case 32:
+			goto tr229
 		case 34:
-			goto st80
+			goto tr155
+		case 44:
+			goto tr231
+		case 61:
+			goto st6
 		case 92:
-			goto st87
+			goto st85
 		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr47
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
 		}
-		goto st16
+		goto st79
+tr222:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st87
 	st87:
-//line plugins/parsers/influx/machine.go.rl:248
- ( m.p)--
- 
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof87
 		}
 	st_case_87:
-//line plugins/parsers/influx/machine.go:12628
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
-		case 10:
-			goto tr29
-		case 11:
-			goto tr232
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr231
-		case 34:
-			goto tr157
-		case 44:
-			goto tr233
-		case 61:
-			goto st6
-		case 92:
-			goto st86
-		}
-		goto st80
-tr224:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st88
-	st88:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof88
-		}
-	st_case_88:
-//line plugins/parsers/influx/machine.go:12663
+//line plugins/parsers/influx/machine.go:12598
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st78
+			goto st77
 		case 92:
-			goto st89
+			goto st88
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
+				goto tr45
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr47
+			goto tr45
 		}
-		goto st14
-	st89:
+		goto st13
+	st88:
 //line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof89
+			goto _test_eof88
 		}
-	st_case_89:
-//line plugins/parsers/influx/machine.go:12687
+	st_case_88:
+//line plugins/parsers/influx/machine.go:12622
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr195
+			goto tr193
 		case 44:
 			goto st6
 		case 61:
-			goto tr226
+			goto tr224
 		case 92:
-			goto st88
+			goto st87
 		}
-		goto st78
-tr628:
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st77
+tr625:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
+
+	goto st89
+	st89:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof89
+		}
+	st_case_89:
+//line plugins/parsers/influx/machine.go:12654
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr125
+		case 13:
+			goto st6
+		case 32:
+			goto tr87
+		case 34:
+			goto tr126
+		case 44:
+			goto tr90
+		case 61:
+			goto tr127
+		case 92:
+			goto st92
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st400
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr87
+		}
+		goto st40
+tr626:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st400
+	st400:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof400
+		}
+	st_case_400:
+//line plugins/parsers/influx/machine.go:12693
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr600
+		case 11:
+			goto tr628
+		case 13:
+			goto tr602
+		case 32:
+			goto tr627
+		case 34:
+			goto tr126
+		case 44:
+			goto tr90
+		case 61:
+			goto tr127
+		case 92:
+			goto st92
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st544
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
+		}
+		goto st40
+tr632:
+	( m.cs) = 401
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr769:
+	( m.cs) = 401
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr627:
+	( m.cs) = 401
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr766:
+	( m.cs) = 401
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st401:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof401
+		}
+	st_case_401:
+//line plugins/parsers/influx/machine.go:12798
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr219
+		case 11:
+			goto tr631
+		case 13:
+			goto st72
+		case 32:
+			goto st401
+		case 34:
+			goto tr95
+		case 44:
+			goto st6
+		case 61:
+			goto st6
+		case 92:
+			goto tr96
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st401
+		}
+		goto tr92
+tr631:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st402
+	st402:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof402
+		}
+	st_case_402:
+//line plugins/parsers/influx/machine.go:12832
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr219
+		case 11:
+			goto tr631
+		case 13:
+			goto st72
+		case 32:
+			goto st401
+		case 34:
+			goto tr95
+		case 44:
+			goto st6
+		case 61:
+			goto tr99
+		case 92:
+			goto tr96
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st401
+		}
+		goto tr92
+tr633:
+	( m.cs) = 403
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto _again
+tr628:
+	( m.cs) = 403
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st403:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof403
+		}
+	st_case_403:
+//line plugins/parsers/influx/machine.go:12900
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr219
+		case 11:
+			goto tr633
+		case 13:
+			goto st72
+		case 32:
+			goto tr632
+		case 34:
+			goto tr122
+		case 44:
+			goto tr90
+		case 61:
+			goto tr127
+		case 92:
+			goto tr123
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr632
+		}
+		goto tr119
+tr127:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.key = m.text()
+
+	goto st90
+tr381:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.key = m.text()
 
 	goto st90
 	st90:
@@ -12716,216 +12940,68 @@ tr628:
 			goto _test_eof90
 		}
 	st_case_90:
-//line plugins/parsers/influx/machine.go:12720
+//line plugins/parsers/influx/machine.go:12944
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr127
-		case 12:
-			goto tr1
+			goto tr88
 		case 13:
-			goto st7
-		case 32:
-			goto tr89
-		case 34:
-			goto tr128
-		case 44:
-			goto tr92
-		case 61:
-			goto tr129
-		case 92:
-			goto st93
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st401
-		}
-		goto st41
-tr629:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st401
-	st401:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof401
-		}
-	st_case_401:
-//line plugins/parsers/influx/machine.go:12758
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
-		case 10:
-			goto tr603
-		case 11:
-			goto tr631
-		case 12:
-			goto tr509
-		case 13:
-			goto tr605
-		case 32:
-			goto tr630
-		case 34:
-			goto tr128
-		case 44:
-			goto tr92
-		case 61:
-			goto tr129
-		case 92:
-			goto st93
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st545
-		}
-		goto st41
-tr635:
-	( m.cs) = 402
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr776:
-	( m.cs) = 402
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr630:
-	( m.cs) = 402
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr773:
-	( m.cs) = 402
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st402:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof402
-		}
-	st_case_402:
-//line plugins/parsers/influx/machine.go:12862
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st402
-		case 10:
-			goto tr221
-		case 11:
-			goto tr634
-		case 12:
-			goto st305
-		case 13:
-			goto st73
-		case 32:
-			goto st402
-		case 34:
-			goto tr97
-		case 44:
 			goto st6
-		case 61:
-			goto st6
-		case 92:
-			goto tr98
-		}
-		goto tr94
-tr634:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st403
-	st403:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof403
-		}
-	st_case_403:
-//line plugins/parsers/influx/machine.go:12897
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st402
-		case 10:
-			goto tr221
-		case 11:
-			goto tr634
-		case 12:
-			goto st305
-		case 13:
-			goto st73
 		case 32:
-			goto st402
+			goto tr87
 		case 34:
-			goto tr97
+			goto tr210
 		case 44:
-			goto st6
-		case 61:
-			goto tr101
+			goto tr90
+		case 45:
+			goto tr243
+		case 46:
+			goto tr244
+		case 48:
+			goto tr245
+		case 70:
+			goto tr247
+		case 84:
+			goto tr248
 		case 92:
-			goto tr98
+			goto st140
+		case 102:
+			goto tr249
+		case 116:
+			goto tr250
 		}
-		goto tr94
-tr636:
-	( m.cs) = 404
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr246
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr87
+		}
+		goto st29
+tr88:
+	( m.cs) = 91
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr82:
+	( m.cs) = 91
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -12934,178 +13010,62 @@ tr636:
 	m.pb = m.p
 
 	goto _again
-tr631:
-	( m.cs) = 404
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st404:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof404
-		}
-	st_case_404:
-//line plugins/parsers/influx/machine.go:12966
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr635
-		case 10:
-			goto tr221
-		case 11:
-			goto tr636
-		case 12:
-			goto tr514
-		case 13:
-			goto st73
-		case 32:
-			goto tr635
-		case 34:
-			goto tr124
-		case 44:
-			goto tr92
-		case 61:
-			goto tr129
-		case 92:
-			goto tr125
-		}
-		goto tr121
-tr129:
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.key = m.text()
-
-	goto st91
-tr383:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.key = m.text()
-
-	goto st91
 	st91:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof91
 		}
 	st_case_91:
-//line plugins/parsers/influx/machine.go:13011
+//line plugins/parsers/influx/machine.go:13019
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr90
-		case 12:
-			goto tr1
+			goto tr129
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr89
+			goto tr87
 		case 34:
-			goto tr212
+			goto tr122
 		case 44:
-			goto tr92
-		case 45:
-			goto tr245
-		case 46:
-			goto tr246
-		case 48:
-			goto tr247
-		case 70:
-			goto tr249
-		case 84:
-			goto tr250
+			goto tr90
+		case 61:
+			goto st29
 		case 92:
-			goto st141
-		case 102:
-			goto tr251
-		case 116:
-			goto tr252
+			goto tr123
 		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr248
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
 		}
-		goto st30
-tr90:
-	( m.cs) = 92
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr84:
-	( m.cs) = 92
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
+		goto tr119
+tr123:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto _again
+	goto st92
 	st92:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof92
 		}
 	st_case_92:
-//line plugins/parsers/influx/machine.go:13085
+//line plugins/parsers/influx/machine.go:13053
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
-		case 10:
-			goto tr29
-		case 11:
-			goto tr131
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr89
 		case 34:
-			goto tr124
-		case 44:
-			goto tr92
-		case 61:
-			goto st30
+			goto st40
 		case 92:
-			goto tr125
+			goto st40
 		}
-		goto tr121
-tr125:
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr8
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr8
+		}
+		goto st10
+tr243:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -13116,23 +13076,256 @@ tr125:
 			goto _test_eof93
 		}
 	st_case_93:
-//line plugins/parsers/influx/machine.go:13120
+//line plugins/parsers/influx/machine.go:13080
 		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr88
+		case 13:
+			goto st6
+		case 32:
+			goto tr87
 		case 34:
-			goto st41
+			goto tr89
+		case 44:
+			goto tr90
+		case 46:
+			goto st95
+		case 48:
+			goto st532
 		case 92:
-			goto st41
+			goto st140
 		}
 		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr8
+		case ( m.data)[( m.p)] > 12:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st535
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr8
+			goto tr87
 		}
-		goto st11
-tr245:
+		goto st29
+tr83:
+	( m.cs) = 404
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr89:
+	( m.cs) = 404
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr116:
+	( m.cs) = 404
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto _again
+	st404:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof404
+		}
+	st_case_404:
+//line plugins/parsers/influx/machine.go:13162
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto tr634
+		case 13:
+			goto st32
+		case 32:
+			goto tr499
+		case 44:
+			goto tr501
+		case 92:
+			goto st94
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr499
+		}
+		goto st1
+tr634:
+	( m.cs) = 405
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr812:
+	( m.cs) = 405
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr1006:
+	( m.cs) = 405
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr1010:
+	( m.cs) = 405
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr1014:
+	( m.cs) = 405
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st405:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof405
+		}
+	st_case_405:
+//line plugins/parsers/influx/machine.go:13291
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto tr504
+		case 13:
+			goto st32
+		case 32:
+			goto tr499
+		case 44:
+			goto tr4
+		case 45:
+			goto tr505
+		case 61:
+			goto st1
+		case 92:
+			goto tr43
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr506
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr499
+		}
+		goto tr39
+tr35:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st94
+tr458:
+//line plugins/parsers/influx/machine.go.rl:82
+
+	m.beginMetric = true
+
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -13143,255 +13336,17 @@ tr245:
 			goto _test_eof94
 		}
 	st_case_94:
-//line plugins/parsers/influx/machine.go:13147
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
-		case 10:
-			goto tr29
-		case 11:
-			goto tr90
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr89
-		case 34:
-			goto tr91
-		case 44:
-			goto tr92
-		case 46:
-			goto st96
-		case 48:
-			goto st533
-		case 92:
-			goto st141
-		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st536
-		}
-		goto st30
-tr85:
-	( m.cs) = 405
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-//line plugins/parsers/influx/machine.go.rl:148
-
-	err = m.handler.AddString(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr91:
-	( m.cs) = 405
-//line plugins/parsers/influx/machine.go.rl:148
-
-	err = m.handler.AddString(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr118:
-	( m.cs) = 405
-//line plugins/parsers/influx/machine.go.rl:148
-
-	err = m.handler.AddString(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto _again
-	st405:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof405
-		}
-	st_case_405:
-//line plugins/parsers/influx/machine.go:13228
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto tr637
-		case 13:
-			goto st33
-		case 32:
-			goto tr501
-		case 44:
-			goto tr503
-		case 92:
-			goto st95
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr501
-		}
-		goto st1
-tr637:
-	( m.cs) = 406
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr818:
-	( m.cs) = 406
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr1013:
-	( m.cs) = 406
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr1016:
-	( m.cs) = 406
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr1019:
-	( m.cs) = 406
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st406:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof406
-		}
-	st_case_406:
-//line plugins/parsers/influx/machine.go:13357
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto tr506
-		case 13:
-			goto st33
-		case 32:
-			goto tr501
-		case 44:
-			goto tr4
-		case 45:
-			goto tr507
-		case 61:
-			goto st1
-		case 92:
-			goto tr45
-		}
+//line plugins/parsers/influx/machine.go:13340
 		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr508
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto st0
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr501
+			goto st0
 		}
-		goto tr41
-tr37:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st95
-tr460:
-//line plugins/parsers/influx/machine.go.rl:82
-
-	m.beginMetric = true
-
+		goto st1
+tr244:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -13402,314 +13357,414 @@ tr460:
 			goto _test_eof95
 		}
 	st_case_95:
-//line plugins/parsers/influx/machine.go:13406
+//line plugins/parsers/influx/machine.go:13361
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr88
+		case 13:
+			goto st6
+		case 32:
+			goto tr87
+		case 34:
+			goto tr89
+		case 44:
+			goto tr90
+		case 92:
+			goto st140
+		}
 		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto st0
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st406
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st0
+			goto tr87
 		}
-		goto st1
-tr246:
+		goto st29
+	st406:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof406
+		}
+	st_case_406:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr636
+		case 11:
+			goto tr637
+		case 13:
+			goto tr638
+		case 32:
+			goto tr635
+		case 34:
+			goto tr89
+		case 44:
+			goto tr639
+		case 69:
+			goto st138
+		case 92:
+			goto st140
+		case 101:
+			goto st138
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st406
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr635
+		}
+		goto st29
+tr594:
+	( m.cs) = 96
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st96
+	goto _again
+tr639:
+	( m.cs) = 96
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr760:
+	( m.cs) = 96
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr794:
+	( m.cs) = 96
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr800:
+	( m.cs) = 96
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr806:
+	( m.cs) = 96
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr819:
+	( m.cs) = 96
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr824:
+	( m.cs) = 96
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr828:
+	( m.cs) = 96
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
 	st96:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof96
 		}
 	st_case_96:
-//line plugins/parsers/influx/machine.go:13427
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
-		case 10:
-			goto tr29
-		case 11:
-			goto tr90
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr89
-		case 34:
-			goto tr91
-		case 44:
-			goto tr92
-		case 92:
-			goto st141
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st407
-		}
-		goto st30
-	st407:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof407
-		}
-	st_case_407:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr638
-		case 10:
-			goto tr639
-		case 11:
-			goto tr640
-		case 12:
-			goto tr641
-		case 13:
-			goto tr642
-		case 32:
-			goto tr638
-		case 34:
-			goto tr91
-		case 44:
-			goto tr643
-		case 69:
-			goto st139
-		case 92:
-			goto st141
-		case 101:
-			goto st139
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st407
-		}
-		goto st30
-tr597:
-	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto _again
-tr643:
-	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr767:
-	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr801:
-	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr807:
-	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr813:
-	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr826:
-	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr832:
-	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr837:
-	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st97:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof97
-		}
-	st_case_97:
-//line plugins/parsers/influx/machine.go:13691
+//line plugins/parsers/influx/machine.go:13627
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr258
+			goto tr256
 		case 44:
 			goto st6
 		case 61:
 			goto st6
 		case 92:
-			goto tr259
+			goto tr257
 		}
-		goto tr257
-tr257:
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto tr255
+tr255:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st97
+	st97:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof97
+		}
+	st_case_97:
+//line plugins/parsers/influx/machine.go:13659
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st6
+		case 10:
+			goto tr28
+		case 32:
+			goto st6
+		case 34:
+			goto tr259
+		case 44:
+			goto st6
+		case 61:
+			goto tr260
+		case 92:
+			goto st136
+		}
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st97
+tr256:
+	( m.cs) = 407
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr259:
+	( m.cs) = 407
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st407:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof407
+		}
+	st_case_407:
+//line plugins/parsers/influx/machine.go:13715
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto st408
+		case 13:
+			goto st32
+		case 32:
+			goto st271
+		case 44:
+			goto st35
+		case 61:
+			goto tr135
+		case 92:
+			goto st99
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st271
+		}
+		goto st44
+	st408:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof408
+		}
+	st_case_408:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto st408
+		case 13:
+			goto st32
+		case 32:
+			goto st271
+		case 44:
+			goto tr130
+		case 45:
+			goto tr642
+		case 61:
+			goto tr135
+		case 92:
+			goto st99
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr643
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto st271
+		}
+		goto st44
+tr642:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -13720,117 +13775,107 @@ tr257:
 			goto _test_eof98
 		}
 	st_case_98:
-//line plugins/parsers/influx/machine.go:13724
+//line plugins/parsers/influx/machine.go:13779
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
-		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
 		case 32:
-			goto st6
-		case 34:
-			goto tr261
+			goto tr130
 		case 44:
-			goto st6
+			goto tr130
 		case 61:
-			goto tr262
+			goto tr135
 		case 92:
-			goto st137
+			goto st99
 		}
-		goto st98
-tr258:
-	( m.cs) = 408
+		switch {
+		case ( m.data)[( m.p)] < 12:
+			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 10 {
+				goto tr130
+			}
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st409
+			}
+		default:
+			goto tr130
+		}
+		goto st44
+tr643:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:148
-
-	err = m.handler.AddString(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr261:
-	( m.cs) = 408
-//line plugins/parsers/influx/machine.go.rl:148
-
-	err = m.handler.AddString(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st408:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof408
-		}
-	st_case_408:
-//line plugins/parsers/influx/machine.go:13781
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto st409
-		case 13:
-			goto st33
-		case 32:
-			goto st272
-		case 44:
-			goto st36
-		case 61:
-			goto tr137
-		case 92:
-			goto st100
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st272
-		}
-		goto st45
+	goto st409
 	st409:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof409
 		}
 	st_case_409:
+//line plugins/parsers/influx/machine.go:13814
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr468
 		case 11:
-			goto st409
+			goto tr644
 		case 13:
-			goto st33
+			goto tr470
 		case 32:
-			goto st272
+			goto tr467
 		case 44:
-			goto tr132
-		case 45:
-			goto tr646
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto tr647
+				goto st411
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto st272
+			goto tr467
 		}
-		goto st45
-tr646:
+		goto st44
+tr644:
+	( m.cs) = 410
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st410:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof410
+		}
+	st_case_410:
+//line plugins/parsers/influx/machine.go:13858
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto st410
+		case 13:
+			goto st32
+		case 32:
+			goto st276
+		case 44:
+			goto tr45
+		case 61:
+			goto tr135
+		case 92:
+			goto st99
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st276
+		}
+		goto st44
+tr133:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -13841,57 +13886,67 @@ tr646:
 			goto _test_eof99
 		}
 	st_case_99:
-//line plugins/parsers/influx/machine.go:13845
-		switch ( m.data)[( m.p)] {
-		case 32:
-			goto tr132
-		case 44:
-			goto tr132
-		case 61:
-			goto tr137
-		case 92:
+//line plugins/parsers/influx/machine.go:13890
+		if ( m.data)[( m.p)] == 92 {
 			goto st100
 		}
 		switch {
-		case ( m.data)[( m.p)] < 12:
-			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 10 {
-				goto tr132
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr45
 			}
-		case ( m.data)[( m.p)] > 13:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st410
-			}
-		default:
-			goto tr132
+		case ( m.data)[( m.p)] >= 9:
+			goto tr45
 		}
-		goto st45
-tr647:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st410
-	st410:
+		goto st44
+	st100:
+//line plugins/parsers/influx/machine.go.rl:248
+ ( m.p)--
+ 
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof410
+			goto _test_eof100
 		}
-	st_case_410:
-//line plugins/parsers/influx/machine.go:13880
+	st_case_100:
+//line plugins/parsers/influx/machine.go:13911
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto tr45
+		case 44:
+			goto tr45
+		case 61:
+			goto tr135
+		case 92:
+			goto st99
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr45
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr45
+		}
+		goto st44
+	st411:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof411
+		}
+	st_case_411:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -13899,100 +13954,9 @@ tr647:
 				goto st412
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
-tr648:
-	( m.cs) = 411
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st411:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof411
-		}
-	st_case_411:
-//line plugins/parsers/influx/machine.go:13924
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 11:
-			goto st411
-		case 13:
-			goto st33
-		case 32:
-			goto st277
-		case 44:
-			goto tr47
-		case 61:
-			goto tr137
-		case 92:
-			goto st100
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st277
-		}
-		goto st45
-tr135:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st100
-	st100:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof100
-		}
-	st_case_100:
-//line plugins/parsers/influx/machine.go:13956
-		if ( m.data)[( m.p)] == 92 {
-			goto st101
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr47
-		}
-		goto st45
-	st101:
-//line plugins/parsers/influx/machine.go.rl:248
- ( m.p)--
- 
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof101
-		}
-	st_case_101:
-//line plugins/parsers/influx/machine.go:13977
-		switch ( m.data)[( m.p)] {
-		case 32:
-			goto tr47
-		case 44:
-			goto tr47
-		case 61:
-			goto tr137
-		case 92:
-			goto st100
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr47
-		}
-		goto st45
+		goto st44
 	st412:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof412
@@ -14000,19 +13964,19 @@ tr135:
 	st_case_412:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14020,9 +13984,9 @@ tr135:
 				goto st413
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st413:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof413
@@ -14030,19 +13994,19 @@ tr135:
 	st_case_413:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14050,9 +14014,9 @@ tr135:
 				goto st414
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st414:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof414
@@ -14060,19 +14024,19 @@ tr135:
 	st_case_414:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14080,9 +14044,9 @@ tr135:
 				goto st415
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st415:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof415
@@ -14090,19 +14054,19 @@ tr135:
 	st_case_415:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14110,9 +14074,9 @@ tr135:
 				goto st416
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st416:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof416
@@ -14120,19 +14084,19 @@ tr135:
 	st_case_416:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14140,9 +14104,9 @@ tr135:
 				goto st417
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st417:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof417
@@ -14150,19 +14114,19 @@ tr135:
 	st_case_417:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14170,9 +14134,9 @@ tr135:
 				goto st418
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st418:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof418
@@ -14180,19 +14144,19 @@ tr135:
 	st_case_418:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14200,9 +14164,9 @@ tr135:
 				goto st419
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st419:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof419
@@ -14210,19 +14174,19 @@ tr135:
 	st_case_419:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14230,9 +14194,9 @@ tr135:
 				goto st420
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st420:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof420
@@ -14240,19 +14204,19 @@ tr135:
 	st_case_420:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14260,9 +14224,9 @@ tr135:
 				goto st421
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st421:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof421
@@ -14270,19 +14234,19 @@ tr135:
 	st_case_421:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14290,9 +14254,9 @@ tr135:
 				goto st422
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st422:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof422
@@ -14300,19 +14264,19 @@ tr135:
 	st_case_422:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14320,9 +14284,9 @@ tr135:
 				goto st423
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st423:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof423
@@ -14330,19 +14294,19 @@ tr135:
 	st_case_423:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14350,9 +14314,9 @@ tr135:
 				goto st424
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st424:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof424
@@ -14360,19 +14324,19 @@ tr135:
 	st_case_424:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14380,9 +14344,9 @@ tr135:
 				goto st425
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st425:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof425
@@ -14390,19 +14354,19 @@ tr135:
 	st_case_425:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14410,9 +14374,9 @@ tr135:
 				goto st426
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st426:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof426
@@ -14420,19 +14384,19 @@ tr135:
 	st_case_426:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14440,9 +14404,9 @@ tr135:
 				goto st427
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st427:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof427
@@ -14450,19 +14414,19 @@ tr135:
 	st_case_427:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
+			goto tr470
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -14470,9 +14434,9 @@ tr135:
 				goto st428
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+			goto tr467
 		}
-		goto st45
+		goto st44
 	st428:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof428
@@ -14480,55 +14444,25 @@ tr135:
 	st_case_428:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr470
+			goto tr468
 		case 11:
-			goto tr648
+			goto tr644
 		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		case 44:
-			goto tr132
-		case 61:
-			goto tr137
-		case 92:
-			goto st100
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st429
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto st45
-	st429:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof429
-		}
-	st_case_429:
-		switch ( m.data)[( m.p)] {
-		case 10:
 			goto tr470
-		case 11:
-			goto tr648
-		case 13:
-			goto tr472
 		case 32:
-			goto tr469
+			goto tr467
 		case 44:
-			goto tr132
+			goto tr130
 		case 61:
-			goto tr137
+			goto tr135
 		case 92:
-			goto st100
+			goto st99
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr469
+			goto tr467
 		}
-		goto st45
-tr262:
+		goto st44
+tr260:
 //line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
@@ -14537,53 +14471,54 @@ tr262:
 
 	m.key = m.text()
 
-	goto st102
-	st102:
+	goto st101
+	st101:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof102
+			goto _test_eof101
 		}
-	st_case_102:
-//line plugins/parsers/influx/machine.go:14547
+	st_case_101:
+//line plugins/parsers/influx/machine.go:14481
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr266
+			goto tr264
 		case 44:
 			goto st6
 		case 45:
-			goto tr267
+			goto tr265
 		case 46:
-			goto tr268
+			goto tr266
 		case 48:
-			goto tr269
+			goto tr267
 		case 61:
 			goto st6
 		case 70:
-			goto tr271
+			goto tr269
 		case 84:
-			goto tr272
-		case 92:
-			goto tr229
-		case 102:
-			goto tr273
-		case 116:
-			goto tr274
-		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 			goto tr270
+		case 92:
+			goto tr227
+		case 102:
+			goto tr271
+		case 116:
+			goto tr272
 		}
-		goto tr228
-tr266:
-	( m.cs) = 430
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr268
+			}
+		case ( m.data)[( m.p)] >= 12:
+			goto st6
+		}
+		goto tr226
+tr264:
+	( m.cs) = 429
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -14594,7 +14529,262 @@ tr266:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st429:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof429
+		}
+	st_case_429:
+//line plugins/parsers/influx/machine.go:14543
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr665
+		case 11:
+			goto tr666
+		case 13:
+			goto tr667
+		case 32:
+			goto tr664
+		case 34:
+			goto tr149
+		case 44:
+			goto tr668
+		case 61:
+			goto tr23
+		case 92:
+			goto tr151
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr664
+		}
+		goto tr146
+tr854:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr697:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr664:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto _again
+tr850:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr725:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr736:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr742:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr748:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr882:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr886:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr890:
+	( m.cs) = 430
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -14604,292 +14794,201 @@ tr266:
 			goto _test_eof430
 		}
 	st_case_430:
-//line plugins/parsers/influx/machine.go:14608
+//line plugins/parsers/influx/machine.go:14798
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr668
 		case 10:
-			goto tr669
+			goto tr273
 		case 11:
 			goto tr670
-		case 12:
-			goto tr566
 		case 13:
-			goto tr671
+			goto st102
 		case 32:
-			goto tr668
+			goto st430
 		case 34:
-			goto tr151
+			goto tr95
 		case 44:
-			goto tr672
+			goto st6
+		case 45:
+			goto tr671
 		case 61:
-			goto tr23
+			goto st6
 		case 92:
-			goto tr153
+			goto tr161
 		}
-		goto tr148
-tr863:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr701:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr668:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr672
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto st430
+		}
+		goto tr158
+tr670:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto _again
-tr859:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr729:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr740:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr747:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr754:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr891:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr895:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr899:
-	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+	goto st431
 	st431:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof431
 		}
 	st_case_431:
-//line plugins/parsers/influx/machine.go:14864
+//line plugins/parsers/influx/machine.go:14839
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st431
 		case 10:
-			goto tr275
+			goto tr273
 		case 11:
-			goto tr674
-		case 12:
-			goto st301
+			goto tr670
 		case 13:
-			goto st103
+			goto st102
 		case 32:
-			goto st431
+			goto st430
 		case 34:
-			goto tr97
+			goto tr95
 		case 44:
 			goto st6
 		case 45:
-			goto tr675
+			goto tr671
 		case 61:
-			goto st6
-		case 92:
 			goto tr163
+		case 92:
+			goto tr161
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr676
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr672
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto st430
 		}
-		goto tr160
-tr674:
+		goto tr158
+tr667:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st102
+tr676:
+	( m.cs) = 102
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr533:
+	( m.cs) = 102
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr739:
+	( m.cs) = 102
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr745:
+	( m.cs) = 102
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr751:
+	( m.cs) = 102
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st102:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof102
+		}
+	st_case_102:
+//line plugins/parsers/influx/machine.go:14945
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr273
+		case 34:
+			goto tr29
+		case 92:
+			goto st73
+		}
+		goto st6
+tr671:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st103
+	st103:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof103
+		}
+	st_case_103:
+//line plugins/parsers/influx/machine.go:14966
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st6
+		case 10:
+			goto tr28
+		case 32:
+			goto st6
+		case 34:
+			goto tr98
+		case 44:
+			goto st6
+		case 61:
+			goto tr163
+		case 92:
+			goto st104
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st432
+			}
+		case ( m.data)[( m.p)] >= 12:
+			goto st6
+		}
+		goto st49
+tr672:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -14900,117 +14999,111 @@ tr674:
 			goto _test_eof432
 		}
 	st_case_432:
-//line plugins/parsers/influx/machine.go:14904
+//line plugins/parsers/influx/machine.go:15003
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st431
 		case 10:
-			goto tr275
-		case 11:
 			goto tr674
-		case 12:
-			goto st301
+		case 11:
+			goto tr675
 		case 13:
-			goto st103
+			goto tr676
 		case 32:
-			goto st431
+			goto tr673
 		case 34:
-			goto tr97
+			goto tr98
 		case 44:
 			goto st6
-		case 45:
-			goto tr675
 		case 61:
-			goto tr165
-		case 92:
 			goto tr163
+		case 92:
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr676
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st435
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto tr160
-tr671:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st103
-tr680:
-	( m.cs) = 103
+		goto st49
+tr673:
+	( m.cs) = 433
 //line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr536:
-	( m.cs) = 103
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr744:
-	( m.cs) = 103
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr751:
-	( m.cs) = 103
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr758:
-	( m.cs) = 103
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st103:
+	st433:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof103
+			goto _test_eof433
 		}
-	st_case_103:
-//line plugins/parsers/influx/machine.go:15009
-		if ( m.data)[( m.p)] == 10 {
-			goto tr275
+	st_case_433:
+//line plugins/parsers/influx/machine.go:15049
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr273
+		case 13:
+			goto st102
+		case 32:
+			goto st433
+		case 34:
+			goto tr29
+		case 92:
+			goto st73
 		}
-		goto tr8
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st433
+		}
+		goto st6
 tr675:
+	( m.cs) = 434
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st434:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof434
+		}
+	st_case_434:
+//line plugins/parsers/influx/machine.go:15084
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr273
+		case 11:
+			goto st434
+		case 13:
+			goto st102
+		case 32:
+			goto st433
+		case 34:
+			goto tr98
+		case 44:
+			goto st6
+		case 61:
+			goto tr163
+		case 92:
+			goto st104
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st433
+		}
+		goto st49
+tr161:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -15021,165 +15114,12 @@ tr675:
 			goto _test_eof104
 		}
 	st_case_104:
-//line plugins/parsers/influx/machine.go:15025
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
-		case 10:
-			goto tr29
-		case 12:
-			goto tr105
-		case 13:
-			goto st7
-		case 32:
-			goto st6
-		case 34:
-			goto tr100
-		case 44:
-			goto st6
-		case 61:
-			goto tr165
-		case 92:
-			goto st105
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st433
-		}
-		goto st50
-tr676:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st433
-	st433:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof433
-		}
-	st_case_433:
-//line plugins/parsers/influx/machine.go:15061
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
-		case 10:
-			goto tr678
-		case 11:
-			goto tr679
-		case 12:
-			goto tr469
-		case 13:
-			goto tr680
-		case 32:
-			goto tr677
-		case 34:
-			goto tr100
-		case 44:
-			goto st6
-		case 61:
-			goto tr165
-		case 92:
-			goto st105
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st436
-		}
-		goto st50
-tr677:
-	( m.cs) = 434
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st434:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof434
-		}
-	st_case_434:
-//line plugins/parsers/influx/machine.go:15106
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr275
-		case 12:
-			goto st277
-		case 13:
-			goto st103
-		case 32:
-			goto st434
-		case 34:
-			goto tr31
-		case 92:
-			goto st75
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto st434
-		}
-		goto st6
-tr679:
-	( m.cs) = 435
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st435:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof435
-		}
-	st_case_435:
-//line plugins/parsers/influx/machine.go:15143
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st434
-		case 10:
-			goto tr275
-		case 11:
-			goto st435
-		case 12:
-			goto st277
-		case 13:
-			goto st103
-		case 32:
-			goto st434
-		case 34:
-			goto tr100
-		case 44:
-			goto st6
-		case 61:
-			goto tr165
-		case 92:
-			goto st105
-		}
-		goto st50
-tr163:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st105
-	st105:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof105
-		}
-	st_case_105:
-//line plugins/parsers/influx/machine.go:15178
+//line plugins/parsers/influx/machine.go:15118
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st50
+			goto st49
 		case 92:
-			goto st50
+			goto st49
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -15190,570 +15130,586 @@ tr163:
 			goto tr8
 		}
 		goto st3
+	st435:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof435
+		}
+	st_case_435:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr674
+		case 11:
+			goto tr675
+		case 13:
+			goto tr676
+		case 32:
+			goto tr673
+		case 34:
+			goto tr98
+		case 44:
+			goto st6
+		case 61:
+			goto tr163
+		case 92:
+			goto st104
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st436
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
+		}
+		goto st49
 	st436:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof436
 		}
 	st_case_436:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st437
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st437
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st437:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof437
 		}
 	st_case_437:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st438
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st438
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st438:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof438
 		}
 	st_case_438:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st439
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st439
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st439:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof439
 		}
 	st_case_439:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st440
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st440
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st440:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof440
 		}
 	st_case_440:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st441
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st441
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st441:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof441
 		}
 	st_case_441:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st442
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st442
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st442:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof442
 		}
 	st_case_442:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st443
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st443
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st443:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof443
 		}
 	st_case_443:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st444
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st444
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st444:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof444
 		}
 	st_case_444:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st445
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st445
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st445:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof445
 		}
 	st_case_445:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st446
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st446
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st446:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof446
 		}
 	st_case_446:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st447
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st447
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st447:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof447
 		}
 	st_case_447:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st448
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st448
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st448:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof448
 		}
 	st_case_448:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st449
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st449
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st449:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof449
 		}
 	st_case_449:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st450
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st450
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st450:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof450
 		}
 	st_case_450:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st451
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st451
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st451:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof451
 		}
 	st_case_451:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st452
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st452
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
 		}
-		goto st50
+		goto st49
 	st452:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof452
 		}
 	st_case_452:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr679
-		case 12:
-			goto tr469
+			goto tr675
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr100
+			goto tr98
 		case 44:
 			goto st6
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st105
+			goto st104
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st453
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr673
 		}
-		goto st50
-	st453:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof453
-		}
-	st_case_453:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr677
-		case 10:
-			goto tr678
-		case 11:
-			goto tr679
-		case 12:
-			goto tr469
-		case 13:
-			goto tr680
-		case 32:
-			goto tr677
-		case 34:
-			goto tr100
-		case 44:
-			goto st6
-		case 61:
-			goto tr165
-		case 92:
-			goto st105
-		}
-		goto st50
-tr670:
-	( m.cs) = 454
+		goto st49
+tr666:
+	( m.cs) = 453
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -15762,15 +15718,15 @@ tr670:
 	m.pb = m.p
 
 	goto _again
-tr730:
-	( m.cs) = 454
+tr726:
+	( m.cs) = 453
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -15780,20 +15736,20 @@ tr730:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr742:
-	( m.cs) = 454
+tr738:
+	( m.cs) = 453
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -15803,20 +15759,20 @@ tr742:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr749:
-	( m.cs) = 454
+tr744:
+	( m.cs) = 453
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -15826,20 +15782,20 @@ tr749:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr756:
-	( m.cs) = 454
+tr750:
+	( m.cs) = 453
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -15849,9 +15805,61 @@ tr756:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
+
+	goto _again
+	st453:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof453
+		}
+	st_case_453:
+//line plugins/parsers/influx/machine.go:15819
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr273
+		case 11:
+			goto tr698
+		case 13:
+			goto st102
+		case 32:
+			goto tr697
+		case 34:
+			goto tr202
+		case 44:
+			goto tr156
+		case 45:
+			goto tr699
+		case 61:
+			goto st6
+		case 92:
+			goto tr203
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr700
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr697
+		}
+		goto tr200
+tr698:
+	( m.cs) = 454
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
 
 	goto _again
 	st454:
@@ -15859,307 +15867,257 @@ tr756:
 			goto _test_eof454
 		}
 	st_case_454:
-//line plugins/parsers/influx/machine.go:15863
+//line plugins/parsers/influx/machine.go:15871
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr701
 		case 10:
-			goto tr275
+			goto tr273
 		case 11:
-			goto tr702
-		case 12:
-			goto tr566
+			goto tr698
 		case 13:
-			goto st103
+			goto st102
 		case 32:
-			goto tr701
+			goto tr697
 		case 34:
-			goto tr204
+			goto tr202
 		case 44:
-			goto tr158
+			goto tr156
 		case 45:
-			goto tr703
+			goto tr699
 		case 61:
-			goto st6
+			goto tr163
 		case 92:
-			goto tr205
+			goto tr203
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr704
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr700
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr697
 		}
-		goto tr202
-tr702:
-	( m.cs) = 455
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
+		goto tr200
+tr699:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto _again
+	goto st105
+	st105:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof105
+		}
+	st_case_105:
+//line plugins/parsers/influx/machine.go:15912
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr205
+		case 13:
+			goto st6
+		case 32:
+			goto tr153
+		case 34:
+			goto tr206
+		case 44:
+			goto tr156
+		case 61:
+			goto tr163
+		case 92:
+			goto st67
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st455
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr153
+		}
+		goto st65
+tr700:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st455
 	st455:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof455
 		}
 	st_case_455:
-//line plugins/parsers/influx/machine.go:15914
+//line plugins/parsers/influx/machine.go:15951
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr701
 		case 10:
-			goto tr275
+			goto tr674
 		case 11:
 			goto tr702
-		case 12:
-			goto tr566
 		case 13:
-			goto st103
+			goto tr676
 		case 32:
 			goto tr701
 		case 34:
-			goto tr204
+			goto tr206
 		case 44:
-			goto tr158
-		case 45:
-			goto tr703
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto tr205
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr704
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st459
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto tr202
-tr703:
-//line plugins/parsers/influx/machine.go.rl:28
+		goto st65
+tr861:
+	( m.cs) = 456
+//line plugins/parsers/influx/machine.go.rl:86
 
-	m.pb = m.p
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
 
-	goto st106
-	st106:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof106
-		}
-	st_case_106:
-//line plugins/parsers/influx/machine.go:15954
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
-		case 10:
-			goto tr29
-		case 11:
-			goto tr207
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
-		case 34:
-			goto tr208
-		case 44:
-			goto tr158
-		case 61:
-			goto tr165
-		case 92:
-			goto st68
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st456
-		}
-		goto st66
-tr704:
-//line plugins/parsers/influx/machine.go.rl:28
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
 
-	m.pb = m.p
+	goto _again
+tr706:
+	( m.cs) = 456
+//line plugins/parsers/influx/machine.go.rl:99
 
-	goto st456
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr858:
+	( m.cs) = 456
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr701:
+	( m.cs) = 456
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
 	st456:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof456
 		}
 	st_case_456:
-//line plugins/parsers/influx/machine.go:15992
+//line plugins/parsers/influx/machine.go:16056
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr273
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
-		case 13:
-			goto tr680
-		case 32:
 			goto tr705
+		case 13:
+			goto st102
+		case 32:
+			goto st456
 		case 34:
-			goto tr208
+			goto tr95
 		case 44:
-			goto tr158
+			goto st6
 		case 61:
-			goto tr165
+			goto st6
 		case 92:
-			goto st68
+			goto tr161
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st460
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st456
 		}
-		goto st66
-tr870:
-	( m.cs) = 457
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr710:
-	( m.cs) = 457
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr867:
-	( m.cs) = 457
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+		goto tr158
 tr705:
-	( m.cs) = 457
-//line plugins/parsers/influx/machine.go.rl:99
+//line plugins/parsers/influx/machine.go.rl:28
 
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
+	m.pb = m.p
 
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+	goto st457
 	st457:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof457
 		}
 	st_case_457:
-//line plugins/parsers/influx/machine.go:16096
+//line plugins/parsers/influx/machine.go:16090
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st457
 		case 10:
-			goto tr275
+			goto tr273
 		case 11:
-			goto tr709
-		case 12:
-			goto st305
+			goto tr705
 		case 13:
-			goto st103
+			goto st102
 		case 32:
-			goto st457
+			goto st456
 		case 34:
-			goto tr97
+			goto tr95
 		case 44:
 			goto st6
 		case 61:
-			goto st6
-		case 92:
 			goto tr163
-		}
-		goto tr160
-tr709:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st458
-	st458:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof458
-		}
-	st_case_458:
-//line plugins/parsers/influx/machine.go:16131
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st457
-		case 10:
-			goto tr275
-		case 11:
-			goto tr709
-		case 12:
-			goto st305
-		case 13:
-			goto st103
-		case 32:
-			goto st457
-		case 34:
-			goto tr97
-		case 44:
-			goto st6
-		case 61:
-			goto tr165
 		case 92:
-			goto tr163
+			goto tr161
 		}
-		goto tr160
-tr711:
-	( m.cs) = 459
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st456
+		}
+		goto tr158
+tr707:
+	( m.cs) = 458
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -16168,15 +16126,15 @@ tr711:
 	m.pb = m.p
 
 	goto _again
-tr706:
-	( m.cs) = 459
+tr702:
+	( m.cs) = 458
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -16186,604 +16144,619 @@ tr706:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st458:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof458
+		}
+	st_case_458:
+//line plugins/parsers/influx/machine.go:16158
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr273
+		case 11:
+			goto tr707
+		case 13:
+			goto st102
+		case 32:
+			goto tr706
+		case 34:
+			goto tr202
+		case 44:
+			goto tr156
+		case 61:
+			goto tr163
+		case 92:
+			goto tr203
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr706
+		}
+		goto tr200
 	st459:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof459
 		}
 	st_case_459:
-//line plugins/parsers/influx/machine.go:16200
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr710
 		case 10:
-			goto tr275
+			goto tr674
 		case 11:
-			goto tr711
-		case 12:
-			goto tr575
+			goto tr702
 		case 13:
-			goto st103
+			goto tr676
 		case 32:
-			goto tr710
+			goto tr701
 		case 34:
-			goto tr204
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto tr205
+			goto st67
 		}
-		goto tr202
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st460
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
+		}
+		goto st65
 	st460:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof460
 		}
 	st_case_460:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st461
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st461
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st461:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof461
 		}
 	st_case_461:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st462
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st462
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st462:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof462
 		}
 	st_case_462:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st463
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st463
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st463:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof463
 		}
 	st_case_463:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st464
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st464
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st464:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof464
 		}
 	st_case_464:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st465
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st465
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st465:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof465
 		}
 	st_case_465:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st466
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st466
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st466:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof466
 		}
 	st_case_466:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st467
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st467
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st467:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof467
 		}
 	st_case_467:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st468
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st468
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st468:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof468
 		}
 	st_case_468:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st469
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st469
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st469:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof469
 		}
 	st_case_469:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st470
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st470
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st470:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof470
 		}
 	st_case_470:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st471
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st471
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st471:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof471
 		}
 	st_case_471:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st472
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st472
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st472:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof472
 		}
 	st_case_472:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st473
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st473
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st473:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof473
 		}
 	st_case_473:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st474
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st474
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st474:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof474
 		}
 	st_case_474:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st475
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st475
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st475:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof475
 		}
 	st_case_475:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st476
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st476
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr701
 		}
-		goto st66
+		goto st65
 	st476:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof476
 		}
 	st_case_476:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr706
-		case 12:
-			goto tr572
+			goto tr702
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr705
+			goto tr701
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
-			goto tr165
+			goto tr163
 		case 92:
-			goto st68
+			goto st67
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st477
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr701
 		}
-		goto st66
-	st477:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof477
-		}
-	st_case_477:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr705
-		case 10:
-			goto tr678
-		case 11:
-			goto tr706
-		case 12:
-			goto tr572
-		case 13:
-			goto tr680
-		case 32:
-			goto tr705
-		case 34:
-			goto tr208
-		case 44:
-			goto tr158
-		case 61:
-			goto tr165
-		case 92:
-			goto st68
-		}
-		goto st66
-tr672:
-	( m.cs) = 107
+		goto st65
+tr668:
+	( m.cs) = 106
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -16792,15 +16765,15 @@ tr672:
 	m.pb = m.p
 
 	goto _again
-tr861:
-	( m.cs) = 107
+tr852:
+	( m.cs) = 106
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -16810,20 +16783,20 @@ tr861:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr732:
-	( m.cs) = 107
+tr727:
+	( m.cs) = 106
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -16833,20 +16806,20 @@ tr732:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr745:
-	( m.cs) = 107
+tr740:
+	( m.cs) = 106
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -16856,43 +16829,43 @@ tr745:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr746:
+	( m.cs) = 106
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
 tr752:
-	( m.cs) = 107
+	( m.cs) = 106
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr759:
-	( m.cs) = 107
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -16902,20 +16875,20 @@ tr759:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr893:
-	( m.cs) = 107
+tr884:
+	( m.cs) = 106
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -16925,20 +16898,20 @@ tr893:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr897:
-	( m.cs) = 107
+tr888:
+	( m.cs) = 106
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -16948,20 +16921,20 @@ tr897:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr902:
-	( m.cs) = 107
+tr893:
+	( m.cs) = 106
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -16971,72 +16944,70 @@ tr902:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st106:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof106
+		}
+	st_case_106:
+//line plugins/parsers/influx/machine.go:16958
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st6
+		case 10:
+			goto tr28
+		case 32:
+			goto st6
+		case 34:
+			goto tr256
+		case 44:
+			goto st6
+		case 61:
+			goto st6
+		case 92:
+			goto tr277
+		}
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto tr276
+tr276:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st107
 	st107:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof107
 		}
 	st_case_107:
-//line plugins/parsers/influx/machine.go:16985
+//line plugins/parsers/influx/machine.go:16990
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr258
+			goto tr259
 		case 44:
 			goto st6
 		case 61:
-			goto st6
-		case 92:
 			goto tr279
-		}
-		goto tr278
-tr278:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st108
-	st108:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof108
-		}
-	st_case_108:
-//line plugins/parsers/influx/machine.go:17018
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
-		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
-		case 32:
-			goto st6
-		case 34:
-			goto tr261
-		case 44:
-			goto st6
-		case 61:
-			goto tr281
 		case 92:
-			goto st122
+			goto st121
 		}
-		goto st108
-tr281:
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st107
+tr279:
 //line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
@@ -17045,52 +17016,96 @@ tr281:
 
 	m.key = m.text()
 
+	goto st108
+	st108:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof108
+		}
+	st_case_108:
+//line plugins/parsers/influx/machine.go:17026
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st6
+		case 10:
+			goto tr28
+		case 32:
+			goto st6
+		case 34:
+			goto tr264
+		case 44:
+			goto st6
+		case 45:
+			goto tr281
+		case 46:
+			goto tr282
+		case 48:
+			goto tr283
+		case 61:
+			goto st6
+		case 70:
+			goto tr285
+		case 84:
+			goto tr286
+		case 92:
+			goto tr151
+		case 102:
+			goto tr287
+		case 116:
+			goto tr288
+		}
+		switch {
+		case ( m.data)[( m.p)] > 13:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr284
+			}
+		case ( m.data)[( m.p)] >= 12:
+			goto st6
+		}
+		goto tr146
+tr281:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
 	goto st109
 	st109:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof109
 		}
 	st_case_109:
-//line plugins/parsers/influx/machine.go:17055
+//line plugins/parsers/influx/machine.go:17077
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
+			goto tr28
+		case 11:
+			goto tr154
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto st6
+			goto tr153
 		case 34:
-			goto tr266
+			goto tr155
 		case 44:
-			goto st6
-		case 45:
-			goto tr283
+			goto tr156
 		case 46:
-			goto tr284
+			goto st110
 		case 48:
-			goto tr285
+			goto st481
 		case 61:
 			goto st6
-		case 70:
-			goto tr287
-		case 84:
-			goto tr288
 		case 92:
+			goto st62
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st484
+			}
+		case ( m.data)[( m.p)] >= 9:
 			goto tr153
-		case 102:
-			goto tr289
-		case 116:
-			goto tr290
 		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr286
-		}
-		goto tr148
-tr283:
+		goto st47
+tr282:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -17101,180 +17116,202 @@ tr283:
 			goto _test_eof110
 		}
 	st_case_110:
-//line plugins/parsers/influx/machine.go:17105
+//line plugins/parsers/influx/machine.go:17120
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr156
-		case 12:
-			goto tr60
+			goto tr154
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr155
+			goto tr153
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr158
-		case 46:
-			goto st111
-		case 48:
-			goto st482
+			goto tr156
 		case 61:
 			goto st6
 		case 92:
-			goto st63
+			goto st62
 		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st485
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st477
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr153
 		}
-		goto st48
-tr284:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st111
+		goto st47
+	st477:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof477
+		}
+	st_case_477:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr532
+		case 11:
+			goto tr726
+		case 13:
+			goto tr533
+		case 32:
+			goto tr725
+		case 34:
+			goto tr155
+		case 44:
+			goto tr727
+		case 61:
+			goto st6
+		case 69:
+			goto st111
+		case 92:
+			goto st62
+		case 101:
+			goto st111
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st477
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr725
+		}
+		goto st47
 	st111:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof111
 		}
 	st_case_111:
-//line plugins/parsers/influx/machine.go:17147
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
+			goto tr154
+		case 13:
+			goto st6
+		case 32:
+			goto tr153
+		case 34:
+			goto tr293
+		case 44:
 			goto tr156
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
-		case 34:
-			goto tr157
-		case 44:
-			goto tr158
 		case 61:
 			goto st6
 		case 92:
-			goto st63
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st478
-		}
-		goto st48
-	st478:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof478
-		}
-	st_case_478:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr729
-		case 10:
-			goto tr534
-		case 11:
-			goto tr730
-		case 12:
-			goto tr731
-		case 13:
-			goto tr536
-		case 32:
-			goto tr729
-		case 34:
-			goto tr157
-		case 44:
-			goto tr732
-		case 61:
-			goto st6
-		case 69:
-			goto st112
-		case 92:
-			goto st63
-		case 101:
-			goto st112
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st478
-		}
-		goto st48
-	st112:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof112
-		}
-	st_case_112:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
-		case 10:
-			goto tr29
-		case 11:
-			goto tr156
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
-		case 34:
-			goto tr295
-		case 44:
-			goto tr158
-		case 61:
-			goto st6
-		case 92:
-			goto st63
+			goto st62
 		}
 		switch {
+		case ( m.data)[( m.p)] < 43:
+			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+				goto tr153
+			}
 		case ( m.data)[( m.p)] > 45:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st481
+				goto st480
 			}
-		case ( m.data)[( m.p)] >= 43:
-			goto st113
+		default:
+			goto st112
 		}
-		goto st48
-tr295:
-	( m.cs) = 479
+		goto st47
+tr293:
+	( m.cs) = 478
 //line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st478:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof478
+		}
+	st_case_478:
+//line plugins/parsers/influx/machine.go:17238
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto tr564
+		case 13:
+			goto st32
+		case 32:
+			goto tr563
+		case 44:
+			goto tr565
+		case 61:
+			goto tr130
+		case 92:
+			goto st21
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st479
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr563
+		}
+		goto st15
 	st479:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof479
 		}
 	st_case_479:
-//line plugins/parsers/influx/machine.go:17263
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr730
 		case 11:
-			goto tr567
+			goto tr731
 		case 13:
-			goto st33
+			goto tr732
 		case 32:
-			goto tr566
+			goto tr729
 		case 44:
-			goto tr568
+			goto tr733
 		case 61:
-			goto tr132
+			goto tr130
 		case 92:
-			goto st22
+			goto st21
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st479
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr729
+		}
+		goto st15
+	st112:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof112
+		}
+	st_case_112:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr154
+		case 13:
+			goto st6
+		case 32:
+			goto tr153
+		case 34:
+			goto tr155
+		case 44:
+			goto tr156
+		case 61:
+			goto st6
+		case 92:
+			goto st62
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -17282,9 +17319,9 @@ tr295:
 				goto st480
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr566
+			goto tr153
 		}
-		goto st16
+		goto st47
 	st480:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof480
@@ -17292,19 +17329,21 @@ tr295:
 	st_case_480:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr532
 		case 11:
-			goto tr735
+			goto tr726
 		case 13:
-			goto tr736
+			goto tr533
 		case 32:
-			goto tr731
+			goto tr725
+		case 34:
+			goto tr155
 		case 44:
-			goto tr737
+			goto tr727
 		case 61:
-			goto tr132
+			goto st6
 		case 92:
-			goto st22
+			goto st62
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -17312,291 +17351,280 @@ tr295:
 				goto st480
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr731
+			goto tr725
 		}
-		goto st16
-	st113:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof113
-		}
-	st_case_113:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
-		case 10:
-			goto tr29
-		case 11:
-			goto tr156
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
-		case 34:
-			goto tr157
-		case 44:
-			goto tr158
-		case 61:
-			goto st6
-		case 92:
-			goto st63
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st481
-		}
-		goto st48
+		goto st47
 	st481:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof481
 		}
 	st_case_481:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr729
 		case 10:
-			goto tr534
+			goto tr532
 		case 11:
-			goto tr730
-		case 12:
-			goto tr731
+			goto tr726
 		case 13:
-			goto tr536
+			goto tr533
 		case 32:
-			goto tr729
+			goto tr725
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr732
+			goto tr727
+		case 46:
+			goto st477
 		case 61:
 			goto st6
+		case 69:
+			goto st111
 		case 92:
-			goto st63
+			goto st62
+		case 101:
+			goto st111
+		case 105:
+			goto st483
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st481
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st482
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr725
 		}
-		goto st48
+		goto st47
 	st482:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof482
 		}
 	st_case_482:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr729
 		case 10:
-			goto tr534
+			goto tr532
 		case 11:
-			goto tr730
-		case 12:
-			goto tr731
+			goto tr726
 		case 13:
-			goto tr536
+			goto tr533
 		case 32:
-			goto tr729
+			goto tr725
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr732
+			goto tr727
 		case 46:
-			goto st478
+			goto st477
 		case 61:
 			goto st6
 		case 69:
-			goto st112
+			goto st111
 		case 92:
-			goto st63
+			goto st62
 		case 101:
-			goto st112
-		case 105:
-			goto st484
+			goto st111
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st483
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st482
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr725
 		}
-		goto st48
+		goto st47
 	st483:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof483
 		}
 	st_case_483:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr729
 		case 10:
-			goto tr534
+			goto tr737
 		case 11:
-			goto tr730
-		case 12:
-			goto tr731
+			goto tr738
 		case 13:
-			goto tr536
+			goto tr739
 		case 32:
-			goto tr729
+			goto tr736
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr732
-		case 46:
-			goto st478
+			goto tr740
 		case 61:
 			goto st6
-		case 69:
-			goto st112
 		case 92:
-			goto st63
-		case 101:
-			goto st112
+			goto st62
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st483
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr736
 		}
-		goto st48
+		goto st47
 	st484:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof484
 		}
 	st_case_484:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr740
 		case 10:
-			goto tr741
+			goto tr532
 		case 11:
-			goto tr742
-		case 12:
-			goto tr743
+			goto tr726
 		case 13:
-			goto tr744
+			goto tr533
 		case 32:
-			goto tr740
+			goto tr725
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr745
+			goto tr727
+		case 46:
+			goto st477
 		case 61:
 			goto st6
+		case 69:
+			goto st111
 		case 92:
-			goto st63
+			goto st62
+		case 101:
+			goto st111
+		case 105:
+			goto st483
 		}
-		goto st48
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st484
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr725
+		}
+		goto st47
+tr283:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st485
 	st485:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof485
 		}
 	st_case_485:
+//line plugins/parsers/influx/machine.go:17514
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr729
 		case 10:
-			goto tr534
+			goto tr532
 		case 11:
-			goto tr730
-		case 12:
-			goto tr731
+			goto tr726
 		case 13:
-			goto tr536
+			goto tr533
 		case 32:
-			goto tr729
+			goto tr725
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr732
+			goto tr727
 		case 46:
-			goto st478
+			goto st477
 		case 61:
 			goto st6
 		case 69:
-			goto st112
+			goto st111
 		case 92:
-			goto st63
+			goto st62
 		case 101:
-			goto st112
+			goto st111
 		case 105:
-			goto st484
+			goto st483
+		case 117:
+			goto st486
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st485
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st482
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr725
 		}
-		goto st48
-tr285:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st486
+		goto st47
 	st486:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof486
 		}
 	st_case_486:
-//line plugins/parsers/influx/machine.go:17535
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr729
 		case 10:
-			goto tr534
+			goto tr743
 		case 11:
-			goto tr730
-		case 12:
-			goto tr731
+			goto tr744
 		case 13:
-			goto tr536
+			goto tr745
 		case 32:
-			goto tr729
+			goto tr742
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr732
-		case 46:
-			goto st478
+			goto tr746
 		case 61:
 			goto st6
-		case 69:
-			goto st112
 		case 92:
-			goto st63
-		case 101:
-			goto st112
-		case 105:
-			goto st484
-		case 117:
-			goto st487
+			goto st62
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st483
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr742
 		}
-		goto st48
+		goto st47
+tr284:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st487
 	st487:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof487
 		}
 	st_case_487:
+//line plugins/parsers/influx/machine.go:17590
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr747
 		case 10:
-			goto tr748
+			goto tr532
 		case 11:
-			goto tr749
-		case 12:
-			goto tr750
+			goto tr726
 		case 13:
-			goto tr751
+			goto tr533
 		case 32:
-			goto tr747
+			goto tr725
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr752
+			goto tr727
+		case 46:
+			goto st477
 		case 61:
 			goto st6
+		case 69:
+			goto st111
 		case 92:
-			goto st63
+			goto st62
+		case 101:
+			goto st111
+		case 105:
+			goto st483
+		case 117:
+			goto st486
 		}
-		goto st48
-tr286:
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st487
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr725
+		}
+		goto st47
+tr285:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -17607,291 +17635,331 @@ tr286:
 			goto _test_eof488
 		}
 	st_case_488:
-//line plugins/parsers/influx/machine.go:17611
+//line plugins/parsers/influx/machine.go:17639
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr729
 		case 10:
-			goto tr534
+			goto tr749
 		case 11:
-			goto tr730
-		case 12:
-			goto tr731
+			goto tr750
 		case 13:
-			goto tr536
+			goto tr751
 		case 32:
-			goto tr729
+			goto tr748
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr732
-		case 46:
-			goto st478
-		case 61:
-			goto st6
-		case 69:
-			goto st112
-		case 92:
-			goto st63
-		case 101:
-			goto st112
-		case 105:
-			goto st484
-		case 117:
-			goto st487
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st488
-		}
-		goto st48
-tr287:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st489
-	st489:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof489
-		}
-	st_case_489:
-//line plugins/parsers/influx/machine.go:17659
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr754
-		case 10:
-			goto tr755
-		case 11:
-			goto tr756
-		case 12:
-			goto tr757
-		case 13:
-			goto tr758
-		case 32:
-			goto tr754
-		case 34:
-			goto tr157
-		case 44:
-			goto tr759
+			goto tr752
 		case 61:
 			goto st6
 		case 65:
+			goto st113
+		case 92:
+			goto st62
+		case 97:
+			goto st116
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr748
+		}
+		goto st47
+	st113:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof113
+		}
+	st_case_113:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr154
+		case 13:
+			goto st6
+		case 32:
+			goto tr153
+		case 34:
+			goto tr155
+		case 44:
+			goto tr156
+		case 61:
+			goto st6
+		case 76:
 			goto st114
 		case 92:
-			goto st63
-		case 97:
-			goto st117
+			goto st62
 		}
-		goto st48
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st47
 	st114:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof114
 		}
 	st_case_114:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr156
-		case 12:
-			goto tr60
+			goto tr154
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr155
+			goto tr153
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
 			goto st6
-		case 76:
+		case 83:
 			goto st115
 		case 92:
-			goto st63
+			goto st62
 		}
-		goto st48
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st47
 	st115:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof115
 		}
 	st_case_115:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr156
-		case 12:
-			goto tr60
+			goto tr154
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr155
+			goto tr153
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
 			goto st6
-		case 83:
-			goto st116
+		case 69:
+			goto st489
 		case 92:
-			goto st63
+			goto st62
 		}
-		goto st48
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st47
+	st489:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof489
+		}
+	st_case_489:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr749
+		case 11:
+			goto tr750
+		case 13:
+			goto tr751
+		case 32:
+			goto tr748
+		case 34:
+			goto tr155
+		case 44:
+			goto tr752
+		case 61:
+			goto st6
+		case 92:
+			goto st62
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr748
+		}
+		goto st47
 	st116:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof116
 		}
 	st_case_116:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
+			goto tr154
+		case 13:
+			goto st6
+		case 32:
+			goto tr153
+		case 34:
+			goto tr155
+		case 44:
 			goto tr156
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
-		case 34:
-			goto tr157
-		case 44:
-			goto tr158
-		case 61:
-			goto st6
-		case 69:
-			goto st490
-		case 92:
-			goto st63
-		}
-		goto st48
-	st490:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof490
-		}
-	st_case_490:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr754
-		case 10:
-			goto tr755
-		case 11:
-			goto tr756
-		case 12:
-			goto tr757
-		case 13:
-			goto tr758
-		case 32:
-			goto tr754
-		case 34:
-			goto tr157
-		case 44:
-			goto tr759
 		case 61:
 			goto st6
 		case 92:
-			goto st63
+			goto st62
+		case 108:
+			goto st117
 		}
-		goto st48
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st47
 	st117:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof117
 		}
 	st_case_117:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr156
-		case 12:
-			goto tr60
+			goto tr154
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr155
+			goto tr153
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
 			goto st6
 		case 92:
-			goto st63
-		case 108:
+			goto st62
+		case 115:
 			goto st118
 		}
-		goto st48
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st47
 	st118:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof118
 		}
 	st_case_118:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr156
-		case 12:
-			goto tr60
+			goto tr154
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr155
+			goto tr153
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr158
+			goto tr156
 		case 61:
 			goto st6
 		case 92:
-			goto st63
-		case 115:
-			goto st119
+			goto st62
+		case 101:
+			goto st489
 		}
-		goto st48
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st47
+tr286:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st490
+	st490:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof490
+		}
+	st_case_490:
+//line plugins/parsers/influx/machine.go:17878
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr749
+		case 11:
+			goto tr750
+		case 13:
+			goto tr751
+		case 32:
+			goto tr748
+		case 34:
+			goto tr155
+		case 44:
+			goto tr752
+		case 61:
+			goto st6
+		case 82:
+			goto st119
+		case 92:
+			goto st62
+		case 114:
+			goto st120
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr748
+		}
+		goto st47
 	st119:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof119
 		}
 	st_case_119:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr156
-		case 12:
-			goto tr60
+			goto tr154
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr155
+			goto tr153
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr158
+			goto tr156
+		case 61:
+			goto st6
+		case 85:
+			goto st115
+		case 92:
+			goto st62
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st47
+	st120:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof120
+		}
+	st_case_120:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr154
+		case 13:
+			goto st6
+		case 32:
+			goto tr153
+		case 34:
+			goto tr155
+		case 44:
+			goto tr156
 		case 61:
 			goto st6
 		case 92:
-			goto st63
-		case 101:
-			goto st490
+			goto st62
+		case 117:
+			goto st118
 		}
-		goto st48
-tr288:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr153
+		}
+		goto st47
+tr287:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -17902,95 +17970,32 @@ tr288:
 			goto _test_eof491
 		}
 	st_case_491:
-//line plugins/parsers/influx/machine.go:17906
+//line plugins/parsers/influx/machine.go:17974
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr754
 		case 10:
-			goto tr755
+			goto tr749
 		case 11:
-			goto tr756
-		case 12:
-			goto tr757
+			goto tr750
 		case 13:
-			goto tr758
+			goto tr751
 		case 32:
-			goto tr754
+			goto tr748
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr759
+			goto tr752
 		case 61:
 			goto st6
-		case 82:
-			goto st120
 		case 92:
-			goto st63
-		case 114:
-			goto st121
-		}
-		goto st48
-	st120:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof120
-		}
-	st_case_120:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
-		case 10:
-			goto tr29
-		case 11:
-			goto tr156
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
-		case 34:
-			goto tr157
-		case 44:
-			goto tr158
-		case 61:
-			goto st6
-		case 85:
+			goto st62
+		case 97:
 			goto st116
-		case 92:
-			goto st63
 		}
-		goto st48
-	st121:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof121
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr748
 		}
-	st_case_121:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr155
-		case 10:
-			goto tr29
-		case 11:
-			goto tr156
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr155
-		case 34:
-			goto tr157
-		case 44:
-			goto tr158
-		case 61:
-			goto st6
-		case 92:
-			goto st63
-		case 117:
-			goto st119
-		}
-		goto st48
-tr289:
+		goto st47
+tr288:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -18001,127 +18006,131 @@ tr289:
 			goto _test_eof492
 		}
 	st_case_492:
-//line plugins/parsers/influx/machine.go:18005
+//line plugins/parsers/influx/machine.go:18010
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr754
 		case 10:
-			goto tr755
+			goto tr749
 		case 11:
-			goto tr756
-		case 12:
-			goto tr757
+			goto tr750
 		case 13:
-			goto tr758
+			goto tr751
 		case 32:
-			goto tr754
+			goto tr748
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr759
+			goto tr752
 		case 61:
 			goto st6
 		case 92:
-			goto st63
-		case 97:
-			goto st117
-		}
-		goto st48
-tr290:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st493
-	st493:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof493
-		}
-	st_case_493:
-//line plugins/parsers/influx/machine.go:18042
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr754
-		case 10:
-			goto tr755
-		case 11:
-			goto tr756
-		case 12:
-			goto tr757
-		case 13:
-			goto tr758
-		case 32:
-			goto tr754
-		case 34:
-			goto tr157
-		case 44:
-			goto tr759
-		case 61:
-			goto st6
-		case 92:
-			goto st63
+			goto st62
 		case 114:
-			goto st121
+			goto st120
 		}
-		goto st48
-tr279:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr748
+		}
+		goto st47
+tr277:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st122
-	st122:
+	goto st121
+	st121:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof122
+			goto _test_eof121
 		}
-	st_case_122:
-//line plugins/parsers/influx/machine.go:18079
+	st_case_121:
+//line plugins/parsers/influx/machine.go:18046
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st108
+			goto st107
 		case 92:
-			goto st123
+			goto st122
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
+				goto tr45
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr47
+			goto tr45
 		}
-		goto st45
-	st123:
+		goto st44
+	st122:
 //line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof123
+			goto _test_eof122
 		}
-	st_case_123:
-//line plugins/parsers/influx/machine.go:18103
+	st_case_122:
+//line plugins/parsers/influx/machine.go:18070
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr261
+			goto tr259
 		case 44:
 			goto st6
 		case 61:
-			goto tr281
+			goto tr279
 		case 92:
-			goto st122
+			goto st121
 		}
-		goto st108
-tr267:
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st107
+tr265:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st123
+	st123:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof123
+		}
+	st_case_123:
+//line plugins/parsers/influx/machine.go:18102
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr230
+		case 13:
+			goto st6
+		case 32:
+			goto tr229
+		case 34:
+			goto tr155
+		case 44:
+			goto tr231
+		case 46:
+			goto st124
+		case 48:
+			goto st517
+		case 61:
+			goto st6
+		case 92:
+			goto st85
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st520
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr229
+		}
+		goto st79
+tr266:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -18132,38 +18141,250 @@ tr267:
 			goto _test_eof124
 		}
 	st_case_124:
-//line plugins/parsers/influx/machine.go:18136
+//line plugins/parsers/influx/machine.go:18145
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
+			goto tr230
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr231
+			goto tr229
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr233
-		case 46:
-			goto st125
-		case 48:
-			goto st518
+			goto tr231
 		case 61:
 			goto st6
 		case 92:
-			goto st86
+			goto st85
 		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st521
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st493
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr229
 		}
-		goto st80
-tr268:
+		goto st79
+	st493:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof493
+		}
+	st_case_493:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr758
+		case 11:
+			goto tr759
+		case 13:
+			goto tr638
+		case 32:
+			goto tr757
+		case 34:
+			goto tr155
+		case 44:
+			goto tr760
+		case 61:
+			goto st6
+		case 69:
+			goto st126
+		case 92:
+			goto st85
+		case 101:
+			goto st126
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st493
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr757
+		}
+		goto st79
+tr759:
+	( m.cs) = 494
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr792:
+	( m.cs) = 494
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr798:
+	( m.cs) = 494
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr804:
+	( m.cs) = 494
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st494:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof494
+		}
+	st_case_494:
+//line plugins/parsers/influx/machine.go:18306
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr219
+		case 11:
+			goto tr763
+		case 13:
+			goto st72
+		case 32:
+			goto tr762
+		case 34:
+			goto tr202
+		case 44:
+			goto tr231
+		case 45:
+			goto tr764
+		case 61:
+			goto st6
+		case 92:
+			goto tr235
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr765
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr762
+		}
+		goto tr233
+tr763:
+	( m.cs) = 495
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto _again
+	st495:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof495
+		}
+	st_case_495:
+//line plugins/parsers/influx/machine.go:18358
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr219
+		case 11:
+			goto tr763
+		case 13:
+			goto st72
+		case 32:
+			goto tr762
+		case 34:
+			goto tr202
+		case 44:
+			goto tr231
+		case 45:
+			goto tr764
+		case 61:
+			goto tr99
+		case 92:
+			goto tr235
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr765
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr762
+		}
+		goto tr233
+tr764:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -18174,330 +18395,82 @@ tr268:
 			goto _test_eof125
 		}
 	st_case_125:
-//line plugins/parsers/influx/machine.go:18178
+//line plugins/parsers/influx/machine.go:18399
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr231
-		case 34:
-			goto tr157
-		case 44:
-			goto tr233
-		case 61:
-			goto st6
-		case 92:
-			goto st86
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st494
-		}
-		goto st80
-	st494:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof494
-		}
-	st_case_494:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr764
-		case 10:
-			goto tr765
-		case 11:
-			goto tr766
-		case 12:
-			goto tr731
-		case 13:
-			goto tr642
-		case 32:
-			goto tr764
-		case 34:
-			goto tr157
-		case 44:
-			goto tr767
-		case 61:
-			goto st6
-		case 69:
-			goto st127
-		case 92:
-			goto st86
-		case 101:
-			goto st127
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st494
-		}
-		goto st80
-tr766:
-	( m.cs) = 495
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr799:
-	( m.cs) = 495
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr805:
-	( m.cs) = 495
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr811:
-	( m.cs) = 495
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st495:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof495
-		}
-	st_case_495:
-//line plugins/parsers/influx/machine.go:18337
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr769
-		case 10:
-			goto tr221
-		case 11:
-			goto tr770
-		case 12:
-			goto tr566
-		case 13:
-			goto st73
-		case 32:
-			goto tr769
-		case 34:
-			goto tr204
-		case 44:
-			goto tr233
-		case 45:
-			goto tr771
-		case 61:
-			goto st6
-		case 92:
 			goto tr237
+		case 13:
+			goto st6
+		case 32:
+			goto tr229
+		case 34:
+			goto tr206
+		case 44:
+			goto tr231
+		case 61:
+			goto tr99
+		case 92:
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr772
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st496
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr229
 		}
-		goto tr235
-tr770:
-	( m.cs) = 496
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
+		goto st81
+tr765:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto _again
+	goto st496
 	st496:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof496
 		}
 	st_case_496:
-//line plugins/parsers/influx/machine.go:18388
+//line plugins/parsers/influx/machine.go:18438
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr769
 		case 10:
-			goto tr221
+			goto tr600
 		case 11:
-			goto tr770
-		case 12:
-			goto tr566
+			goto tr767
 		case 13:
-			goto st73
+			goto tr602
 		case 32:
-			goto tr769
+			goto tr766
 		case 34:
-			goto tr204
+			goto tr206
 		case 44:
-			goto tr233
-		case 45:
-			goto tr771
-		case 61:
-			goto tr101
-		case 92:
-			goto tr237
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr772
-		}
-		goto tr235
-tr771:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st126
-	st126:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof126
-		}
-	st_case_126:
-//line plugins/parsers/influx/machine.go:18428
-		switch ( m.data)[( m.p)] {
-		case 9:
 			goto tr231
-		case 10:
-			goto tr29
-		case 11:
-			goto tr239
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr231
-		case 34:
-			goto tr208
-		case 44:
-			goto tr233
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st497
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st498
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
-tr772:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st497
-	st497:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof497
-		}
-	st_case_497:
-//line plugins/parsers/influx/machine.go:18466
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
-		case 10:
-			goto tr603
-		case 11:
-			goto tr774
-		case 12:
-			goto tr572
-		case 13:
-			goto tr605
-		case 32:
-			goto tr773
-		case 34:
-			goto tr208
-		case 44:
-			goto tr233
-		case 61:
-			goto tr101
-		case 92:
-			goto st84
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st499
-		}
-		goto st82
-tr777:
-	( m.cs) = 498
+		goto st81
+tr770:
+	( m.cs) = 497
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -18506,15 +18479,15 @@ tr777:
 	m.pb = m.p
 
 	goto _again
-tr774:
-	( m.cs) = 498
+tr767:
+	( m.cs) = 497
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -18524,913 +18497,981 @@ tr774:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st497:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof497
+		}
+	st_case_497:
+//line plugins/parsers/influx/machine.go:18511
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr219
+		case 11:
+			goto tr770
+		case 13:
+			goto st72
+		case 32:
+			goto tr769
+		case 34:
+			goto tr202
+		case 44:
+			goto tr231
+		case 61:
+			goto tr99
+		case 92:
+			goto tr235
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr769
+		}
+		goto tr233
 	st498:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof498
 		}
 	st_case_498:
-//line plugins/parsers/influx/machine.go:18538
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr776
 		case 10:
-			goto tr221
+			goto tr600
 		case 11:
-			goto tr777
-		case 12:
-			goto tr575
+			goto tr767
 		case 13:
-			goto st73
+			goto tr602
 		case 32:
-			goto tr776
+			goto tr766
 		case 34:
-			goto tr204
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto tr237
+			goto st83
 		}
-		goto tr235
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st499
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
+		}
+		goto st81
 	st499:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof499
 		}
 	st_case_499:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st500
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st500
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st500:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof500
 		}
 	st_case_500:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st501
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st501
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st501:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof501
 		}
 	st_case_501:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st502
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st502
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st502:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof502
 		}
 	st_case_502:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st503
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st503
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st503:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof503
 		}
 	st_case_503:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st504
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st504
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st504:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof504
 		}
 	st_case_504:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st505
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st505
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st505:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof505
 		}
 	st_case_505:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st506
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st506
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st506:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof506
 		}
 	st_case_506:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st507
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st507
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st507:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof507
 		}
 	st_case_507:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st508
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st508
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st508:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof508
 		}
 	st_case_508:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st509
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st509
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st509:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof509
 		}
 	st_case_509:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st510
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st510
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st510:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof510
 		}
 	st_case_510:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st511
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st511
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st511:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof511
 		}
 	st_case_511:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st512
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st512
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st512:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof512
 		}
 	st_case_512:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st513
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st513
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st513:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof513
 		}
 	st_case_513:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st514
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st514
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st514:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof514
 		}
 	st_case_514:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st515
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st515
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr766
 		}
-		goto st82
+		goto st81
 	st515:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof515
 		}
 	st_case_515:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr767
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr773
+			goto tr766
 		case 34:
-			goto tr208
+			goto tr206
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto tr99
 		case 92:
-			goto st84
+			goto st83
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st516
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr766
 		}
-		goto st82
-	st516:
+		goto st81
+	st126:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof516
+			goto _test_eof126
 		}
-	st_case_516:
+	st_case_126:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr773
 		case 10:
-			goto tr603
+			goto tr28
 		case 11:
-			goto tr774
-		case 12:
-			goto tr572
+			goto tr230
 		case 13:
-			goto tr605
+			goto st6
 		case 32:
-			goto tr773
+			goto tr229
 		case 34:
-			goto tr208
+			goto tr293
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
-			goto tr101
+			goto st6
 		case 92:
-			goto st84
+			goto st85
 		}
-		goto st82
+		switch {
+		case ( m.data)[( m.p)] < 43:
+			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+				goto tr229
+			}
+		case ( m.data)[( m.p)] > 45:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st516
+			}
+		default:
+			goto st127
+		}
+		goto st79
 	st127:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof127
 		}
 	st_case_127:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
+			goto tr230
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr231
+			goto tr229
 		case 34:
-			goto tr295
+			goto tr155
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
 			goto st6
 		case 92:
-			goto st86
+			goto st85
 		}
 		switch {
-		case ( m.data)[( m.p)] > 45:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st517
+				goto st516
 			}
-		case ( m.data)[( m.p)] >= 43:
-			goto st128
+		case ( m.data)[( m.p)] >= 9:
+			goto tr229
 		}
-		goto st80
-	st128:
+		goto st79
+	st516:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof128
+			goto _test_eof516
 		}
-	st_case_128:
+	st_case_516:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr758
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
+			goto tr759
 		case 13:
-			goto st7
+			goto tr638
 		case 32:
-			goto tr231
+			goto tr757
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr233
+			goto tr760
 		case 61:
 			goto st6
 		case 92:
-			goto st86
+			goto st85
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st517
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st516
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr757
 		}
-		goto st80
+		goto st79
 	st517:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof517
 		}
 	st_case_517:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr764
 		case 10:
-			goto tr765
+			goto tr758
 		case 11:
-			goto tr766
-		case 12:
-			goto tr731
+			goto tr759
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr764
+			goto tr757
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr767
+			goto tr760
+		case 46:
+			goto st493
 		case 61:
 			goto st6
+		case 69:
+			goto st126
 		case 92:
-			goto st86
+			goto st85
+		case 101:
+			goto st126
+		case 105:
+			goto st519
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st517
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st518
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr757
 		}
-		goto st80
+		goto st79
 	st518:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof518
 		}
 	st_case_518:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr764
 		case 10:
-			goto tr765
+			goto tr758
 		case 11:
-			goto tr766
-		case 12:
-			goto tr731
+			goto tr759
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr764
+			goto tr757
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr767
+			goto tr760
 		case 46:
-			goto st494
+			goto st493
 		case 61:
 			goto st6
 		case 69:
-			goto st127
+			goto st126
 		case 92:
-			goto st86
+			goto st85
 		case 101:
-			goto st127
-		case 105:
-			goto st520
+			goto st126
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st519
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st518
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr757
 		}
-		goto st80
+		goto st79
 	st519:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof519
 		}
 	st_case_519:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr764
 		case 10:
-			goto tr765
+			goto tr791
 		case 11:
-			goto tr766
-		case 12:
-			goto tr731
+			goto tr792
 		case 13:
-			goto tr642
+			goto tr793
 		case 32:
-			goto tr764
+			goto tr790
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr767
-		case 46:
-			goto st494
+			goto tr794
 		case 61:
 			goto st6
-		case 69:
-			goto st127
 		case 92:
-			goto st86
-		case 101:
-			goto st127
+			goto st85
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st519
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr790
 		}
-		goto st80
+		goto st79
 	st520:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof520
 		}
 	st_case_520:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr797
 		case 10:
-			goto tr798
+			goto tr758
 		case 11:
-			goto tr799
-		case 12:
-			goto tr743
+			goto tr759
 		case 13:
-			goto tr800
+			goto tr638
 		case 32:
-			goto tr797
+			goto tr757
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr801
+			goto tr760
+		case 46:
+			goto st493
 		case 61:
 			goto st6
+		case 69:
+			goto st126
 		case 92:
-			goto st86
+			goto st85
+		case 101:
+			goto st126
+		case 105:
+			goto st519
 		}
-		goto st80
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st520
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr757
+		}
+		goto st79
+tr267:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st521
 	st521:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof521
 		}
 	st_case_521:
+//line plugins/parsers/influx/machine.go:19361
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr764
 		case 10:
-			goto tr765
+			goto tr758
 		case 11:
-			goto tr766
-		case 12:
-			goto tr731
+			goto tr759
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr764
+			goto tr757
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr767
+			goto tr760
 		case 46:
-			goto st494
+			goto st493
 		case 61:
 			goto st6
 		case 69:
-			goto st127
+			goto st126
 		case 92:
-			goto st86
+			goto st85
 		case 101:
-			goto st127
+			goto st126
 		case 105:
-			goto st520
+			goto st519
+		case 117:
+			goto st522
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st521
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st518
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr757
 		}
-		goto st80
-tr269:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st522
+		goto st79
 	st522:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof522
 		}
 	st_case_522:
-//line plugins/parsers/influx/machine.go:19369
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr764
 		case 10:
-			goto tr765
+			goto tr797
 		case 11:
-			goto tr766
-		case 12:
-			goto tr731
+			goto tr798
 		case 13:
-			goto tr642
+			goto tr799
 		case 32:
-			goto tr764
+			goto tr796
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr767
-		case 46:
-			goto st494
+			goto tr800
 		case 61:
 			goto st6
-		case 69:
-			goto st127
 		case 92:
-			goto st86
-		case 101:
-			goto st127
-		case 105:
-			goto st520
-		case 117:
-			goto st523
+			goto st85
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st519
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr796
 		}
-		goto st80
+		goto st79
+tr268:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st523
 	st523:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof523
 		}
 	st_case_523:
+//line plugins/parsers/influx/machine.go:19437
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr803
 		case 10:
-			goto tr804
+			goto tr758
 		case 11:
-			goto tr805
-		case 12:
-			goto tr750
+			goto tr759
 		case 13:
-			goto tr806
+			goto tr638
 		case 32:
-			goto tr803
+			goto tr757
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr807
+			goto tr760
+		case 46:
+			goto st493
 		case 61:
 			goto st6
+		case 69:
+			goto st126
 		case 92:
-			goto st86
+			goto st85
+		case 101:
+			goto st126
+		case 105:
+			goto st519
+		case 117:
+			goto st522
 		}
-		goto st80
-tr270:
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st523
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr757
+		}
+		goto st79
+tr269:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -19441,291 +19482,331 @@ tr270:
 			goto _test_eof524
 		}
 	st_case_524:
-//line plugins/parsers/influx/machine.go:19445
+//line plugins/parsers/influx/machine.go:19486
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr764
 		case 10:
-			goto tr765
+			goto tr803
 		case 11:
-			goto tr766
-		case 12:
-			goto tr731
+			goto tr804
 		case 13:
-			goto tr642
+			goto tr805
 		case 32:
-			goto tr764
+			goto tr802
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr767
-		case 46:
-			goto st494
-		case 61:
-			goto st6
-		case 69:
-			goto st127
-		case 92:
-			goto st86
-		case 101:
-			goto st127
-		case 105:
-			goto st520
-		case 117:
-			goto st523
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st524
-		}
-		goto st80
-tr271:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st525
-	st525:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof525
-		}
-	st_case_525:
-//line plugins/parsers/influx/machine.go:19493
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr809
-		case 10:
-			goto tr810
-		case 11:
-			goto tr811
-		case 12:
-			goto tr757
-		case 13:
-			goto tr812
-		case 32:
-			goto tr809
-		case 34:
-			goto tr157
-		case 44:
-			goto tr813
+			goto tr806
 		case 61:
 			goto st6
 		case 65:
+			goto st128
+		case 92:
+			goto st85
+		case 97:
+			goto st131
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr802
+		}
+		goto st79
+	st128:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof128
+		}
+	st_case_128:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr230
+		case 13:
+			goto st6
+		case 32:
+			goto tr229
+		case 34:
+			goto tr155
+		case 44:
+			goto tr231
+		case 61:
+			goto st6
+		case 76:
 			goto st129
 		case 92:
-			goto st86
-		case 97:
-			goto st132
+			goto st85
 		}
-		goto st80
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto st79
 	st129:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof129
 		}
 	st_case_129:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
+			goto tr230
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr231
+			goto tr229
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
 			goto st6
-		case 76:
+		case 83:
 			goto st130
 		case 92:
-			goto st86
+			goto st85
 		}
-		goto st80
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto st79
 	st130:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof130
 		}
 	st_case_130:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
+			goto tr230
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr231
+			goto tr229
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
 			goto st6
-		case 83:
-			goto st131
+		case 69:
+			goto st525
 		case 92:
-			goto st86
+			goto st85
 		}
-		goto st80
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto st79
+	st525:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof525
+		}
+	st_case_525:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr803
+		case 11:
+			goto tr804
+		case 13:
+			goto tr805
+		case 32:
+			goto tr802
+		case 34:
+			goto tr155
+		case 44:
+			goto tr806
+		case 61:
+			goto st6
+		case 92:
+			goto st85
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr802
+		}
+		goto st79
 	st131:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof131
 		}
 	st_case_131:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
+			goto tr230
 		case 13:
-			goto st7
-		case 32:
-			goto tr231
-		case 34:
-			goto tr157
-		case 44:
-			goto tr233
-		case 61:
 			goto st6
-		case 69:
-			goto st526
-		case 92:
-			goto st86
-		}
-		goto st80
-	st526:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof526
-		}
-	st_case_526:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr809
-		case 10:
-			goto tr810
-		case 11:
-			goto tr811
-		case 12:
-			goto tr757
-		case 13:
-			goto tr812
 		case 32:
-			goto tr809
+			goto tr229
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr813
+			goto tr231
 		case 61:
 			goto st6
 		case 92:
-			goto st86
+			goto st85
+		case 108:
+			goto st132
 		}
-		goto st80
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto st79
 	st132:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof132
 		}
 	st_case_132:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
+			goto tr230
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr231
+			goto tr229
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
 			goto st6
 		case 92:
-			goto st86
-		case 108:
+			goto st85
+		case 115:
 			goto st133
 		}
-		goto st80
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto st79
 	st133:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof133
 		}
 	st_case_133:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
+			goto tr230
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr231
+			goto tr229
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr233
+			goto tr231
 		case 61:
 			goto st6
 		case 92:
-			goto st86
-		case 115:
-			goto st134
+			goto st85
+		case 101:
+			goto st525
 		}
-		goto st80
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto st79
+tr270:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st526
+	st526:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof526
+		}
+	st_case_526:
+//line plugins/parsers/influx/machine.go:19725
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr803
+		case 11:
+			goto tr804
+		case 13:
+			goto tr805
+		case 32:
+			goto tr802
+		case 34:
+			goto tr155
+		case 44:
+			goto tr806
+		case 61:
+			goto st6
+		case 82:
+			goto st134
+		case 92:
+			goto st85
+		case 114:
+			goto st135
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr802
+		}
+		goto st79
 	st134:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof134
 		}
 	st_case_134:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr232
-		case 12:
-			goto tr60
+			goto tr230
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr231
+			goto tr229
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr233
+			goto tr231
+		case 61:
+			goto st6
+		case 85:
+			goto st130
+		case 92:
+			goto st85
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto st79
+	st135:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof135
+		}
+	st_case_135:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr230
+		case 13:
+			goto st6
+		case 32:
+			goto tr229
+		case 34:
+			goto tr155
+		case 44:
+			goto tr231
 		case 61:
 			goto st6
 		case 92:
-			goto st86
-		case 101:
-			goto st526
+			goto st85
+		case 117:
+			goto st133
 		}
-		goto st80
-tr272:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr229
+		}
+		goto st79
+tr271:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -19736,95 +19817,32 @@ tr272:
 			goto _test_eof527
 		}
 	st_case_527:
-//line plugins/parsers/influx/machine.go:19740
+//line plugins/parsers/influx/machine.go:19821
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr809
 		case 10:
-			goto tr810
+			goto tr803
 		case 11:
-			goto tr811
-		case 12:
-			goto tr757
+			goto tr804
 		case 13:
-			goto tr812
+			goto tr805
 		case 32:
-			goto tr809
+			goto tr802
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr813
+			goto tr806
 		case 61:
 			goto st6
-		case 82:
-			goto st135
 		case 92:
-			goto st86
-		case 114:
-			goto st136
-		}
-		goto st80
-	st135:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof135
-		}
-	st_case_135:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
-		case 10:
-			goto tr29
-		case 11:
-			goto tr232
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr231
-		case 34:
-			goto tr157
-		case 44:
-			goto tr233
-		case 61:
-			goto st6
-		case 85:
+			goto st85
+		case 97:
 			goto st131
-		case 92:
-			goto st86
 		}
-		goto st80
-	st136:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof136
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr802
 		}
-	st_case_136:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr231
-		case 10:
-			goto tr29
-		case 11:
-			goto tr232
-		case 12:
-			goto tr60
-		case 13:
-			goto st7
-		case 32:
-			goto tr231
-		case 34:
-			goto tr157
-		case 44:
-			goto tr233
-		case 61:
-			goto st6
-		case 92:
-			goto st86
-		case 117:
-			goto st134
-		}
-		goto st80
-tr273:
+		goto st79
+tr272:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -19835,192 +19853,211 @@ tr273:
 			goto _test_eof528
 		}
 	st_case_528:
-//line plugins/parsers/influx/machine.go:19839
+//line plugins/parsers/influx/machine.go:19857
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr809
 		case 10:
-			goto tr810
+			goto tr803
 		case 11:
-			goto tr811
-		case 12:
-			goto tr757
+			goto tr804
 		case 13:
-			goto tr812
+			goto tr805
 		case 32:
-			goto tr809
+			goto tr802
 		case 34:
-			goto tr157
+			goto tr155
 		case 44:
-			goto tr813
+			goto tr806
 		case 61:
 			goto st6
 		case 92:
-			goto st86
-		case 97:
-			goto st132
-		}
-		goto st80
-tr274:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st529
-	st529:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof529
-		}
-	st_case_529:
-//line plugins/parsers/influx/machine.go:19876
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr809
-		case 10:
-			goto tr810
-		case 11:
-			goto tr811
-		case 12:
-			goto tr757
-		case 13:
-			goto tr812
-		case 32:
-			goto tr809
-		case 34:
-			goto tr157
-		case 44:
-			goto tr813
-		case 61:
-			goto st6
-		case 92:
-			goto st86
+			goto st85
 		case 114:
-			goto st136
+			goto st135
 		}
-		goto st80
-tr259:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr802
+		}
+		goto st79
+tr257:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st137
-	st137:
+	goto st136
+	st136:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof137
+			goto _test_eof136
 		}
-	st_case_137:
-//line plugins/parsers/influx/machine.go:19913
+	st_case_136:
+//line plugins/parsers/influx/machine.go:19893
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st98
+			goto st97
 		case 92:
-			goto st138
+			goto st137
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr47
+				goto tr45
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr47
+			goto tr45
 		}
-		goto st45
-	st138:
+		goto st44
+	st137:
 //line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof138
+			goto _test_eof137
 		}
-	st_case_138:
-//line plugins/parsers/influx/machine.go:19937
+	st_case_137:
+//line plugins/parsers/influx/machine.go:19917
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr47
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr261
+			goto tr259
 		case 44:
 			goto st6
 		case 61:
-			goto tr262
+			goto tr260
 		case 92:
-			goto st137
+			goto st136
 		}
-		goto st98
-	st139:
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st97
+	st138:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof139
+			goto _test_eof138
 		}
-	st_case_139:
+	st_case_138:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr90
-		case 12:
-			goto tr1
+			goto tr88
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr89
+			goto tr87
 		case 34:
-			goto tr317
+			goto tr315
 		case 44:
-			goto tr92
+			goto tr90
 		case 92:
-			goto st141
-		}
-		switch {
-		case ( m.data)[( m.p)] > 45:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st532
-			}
-		case ( m.data)[( m.p)] >= 43:
 			goto st140
 		}
-		goto st30
-tr317:
-	( m.cs) = 530
+		switch {
+		case ( m.data)[( m.p)] < 43:
+			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+				goto tr87
+			}
+		case ( m.data)[( m.p)] > 45:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st531
+			}
+		default:
+			goto st139
+		}
+		goto st29
+tr315:
+	( m.cs) = 529
 //line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st529:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof529
+		}
+	st_case_529:
+//line plugins/parsers/influx/machine.go:19990
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr101
+		case 11:
+			goto tr634
+		case 13:
+			goto st32
+		case 32:
+			goto tr499
+		case 44:
+			goto tr501
+		case 92:
+			goto st94
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st530
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr499
+		}
+		goto st1
 	st530:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof530
 		}
 	st_case_530:
-//line plugins/parsers/influx/machine.go:20011
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr103
+			goto tr730
 		case 11:
-			goto tr637
+			goto tr812
 		case 13:
-			goto st33
+			goto tr732
 		case 32:
-			goto tr501
+			goto tr811
 		case 44:
-			goto tr503
+			goto tr813
 		case 92:
-			goto st95
+			goto st94
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st530
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr811
+		}
+		goto st1
+	st139:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof139
+		}
+	st_case_139:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr88
+		case 13:
+			goto st6
+		case 32:
+			goto tr87
+		case 34:
+			goto tr89
+		case 44:
+			goto tr90
+		case 92:
+			goto st140
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -20028,9 +20065,9 @@ tr317:
 				goto st531
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr501
+			goto tr87
 		}
-		goto st1
+		goto st29
 	st531:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof531
@@ -20038,17 +20075,19 @@ tr317:
 	st_case_531:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr636
 		case 11:
-			goto tr818
+			goto tr637
 		case 13:
-			goto tr736
+			goto tr638
 		case 32:
-			goto tr641
+			goto tr635
+		case 34:
+			goto tr89
 		case 44:
-			goto tr819
+			goto tr639
 		case 92:
-			goto st95
+			goto st140
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -20056,84 +20095,26 @@ tr317:
 				goto st531
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr641
+			goto tr635
 		}
-		goto st1
+		goto st29
+tr85:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st140
 	st140:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof140
 		}
 	st_case_140:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
-		case 10:
-			goto tr29
-		case 11:
-			goto tr90
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr89
-		case 34:
-			goto tr91
-		case 44:
-			goto tr92
-		case 92:
-			goto st141
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st532
-		}
-		goto st30
-	st532:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof532
-		}
-	st_case_532:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr638
-		case 10:
-			goto tr639
-		case 11:
-			goto tr640
-		case 12:
-			goto tr641
-		case 13:
-			goto tr642
-		case 32:
-			goto tr638
-		case 34:
-			goto tr91
-		case 44:
-			goto tr643
-		case 92:
-			goto st141
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st532
-		}
-		goto st30
-tr87:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st141
-	st141:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof141
-		}
-	st_case_141:
-//line plugins/parsers/influx/machine.go:20132
+//line plugins/parsers/influx/machine.go:20113
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st30
+			goto st29
 		case 92:
-			goto st30
+			goto st29
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -20144,214 +20125,263 @@ tr87:
 			goto tr8
 		}
 		goto st1
+	st532:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof532
+		}
+	st_case_532:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr636
+		case 11:
+			goto tr637
+		case 13:
+			goto tr638
+		case 32:
+			goto tr635
+		case 34:
+			goto tr89
+		case 44:
+			goto tr639
+		case 46:
+			goto st406
+		case 69:
+			goto st138
+		case 92:
+			goto st140
+		case 101:
+			goto st138
+		case 105:
+			goto st534
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st533
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr635
+		}
+		goto st29
 	st533:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof533
 		}
 	st_case_533:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr638
 		case 10:
-			goto tr639
+			goto tr636
 		case 11:
-			goto tr640
-		case 12:
-			goto tr641
+			goto tr637
 		case 13:
-			goto tr642
-		case 32:
 			goto tr638
+		case 32:
+			goto tr635
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr643
+			goto tr639
 		case 46:
-			goto st407
+			goto st406
 		case 69:
-			goto st139
+			goto st138
 		case 92:
-			goto st141
+			goto st140
 		case 101:
-			goto st139
-		case 105:
-			goto st535
+			goto st138
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st534
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st533
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr635
 		}
-		goto st30
+		goto st29
 	st534:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof534
 		}
 	st_case_534:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr638
 		case 10:
-			goto tr639
+			goto tr817
 		case 11:
-			goto tr640
-		case 12:
-			goto tr641
+			goto tr818
 		case 13:
-			goto tr642
+			goto tr793
 		case 32:
-			goto tr638
+			goto tr816
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr643
-		case 46:
-			goto st407
-		case 69:
-			goto st139
+			goto tr819
 		case 92:
-			goto st141
-		case 101:
-			goto st139
+			goto st140
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st534
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr816
 		}
-		goto st30
+		goto st29
 	st535:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof535
 		}
 	st_case_535:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr822
 		case 10:
-			goto tr823
+			goto tr636
 		case 11:
-			goto tr824
-		case 12:
-			goto tr825
+			goto tr637
 		case 13:
-			goto tr800
+			goto tr638
 		case 32:
-			goto tr822
+			goto tr635
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr826
+			goto tr639
+		case 46:
+			goto st406
+		case 69:
+			goto st138
 		case 92:
-			goto st141
+			goto st140
+		case 101:
+			goto st138
+		case 105:
+			goto st534
 		}
-		goto st30
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st535
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr635
+		}
+		goto st29
+tr245:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st536
 	st536:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof536
 		}
 	st_case_536:
+//line plugins/parsers/influx/machine.go:20277
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr638
 		case 10:
-			goto tr639
+			goto tr636
 		case 11:
-			goto tr640
-		case 12:
-			goto tr641
+			goto tr637
 		case 13:
-			goto tr642
-		case 32:
 			goto tr638
+		case 32:
+			goto tr635
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr643
+			goto tr639
 		case 46:
-			goto st407
+			goto st406
 		case 69:
-			goto st139
+			goto st138
 		case 92:
-			goto st141
+			goto st140
 		case 101:
-			goto st139
+			goto st138
 		case 105:
-			goto st535
+			goto st534
+		case 117:
+			goto st537
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st536
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st533
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr635
 		}
-		goto st30
-tr247:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st537
+		goto st29
 	st537:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof537
 		}
 	st_case_537:
-//line plugins/parsers/influx/machine.go:20294
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr638
 		case 10:
-			goto tr639
+			goto tr822
 		case 11:
-			goto tr640
-		case 12:
-			goto tr641
+			goto tr823
 		case 13:
-			goto tr642
+			goto tr799
 		case 32:
-			goto tr638
+			goto tr821
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr643
-		case 46:
-			goto st407
-		case 69:
-			goto st139
+			goto tr824
 		case 92:
-			goto st141
-		case 101:
-			goto st139
-		case 105:
-			goto st535
-		case 117:
-			goto st538
+			goto st140
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st534
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr821
 		}
-		goto st30
+		goto st29
+tr246:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st538
 	st538:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof538
 		}
 	st_case_538:
+//line plugins/parsers/influx/machine.go:20349
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr828
 		case 10:
-			goto tr829
+			goto tr636
 		case 11:
-			goto tr830
-		case 12:
-			goto tr831
+			goto tr637
 		case 13:
-			goto tr806
+			goto tr638
 		case 32:
-			goto tr828
+			goto tr635
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr832
+			goto tr639
+		case 46:
+			goto st406
+		case 69:
+			goto st138
 		case 92:
-			goto st141
+			goto st140
+		case 101:
+			goto st138
+		case 105:
+			goto st534
+		case 117:
+			goto st537
 		}
-		goto st30
-tr248:
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st538
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr635
+		}
+		goto st29
+tr247:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -20362,273 +20392,309 @@ tr248:
 			goto _test_eof539
 		}
 	st_case_539:
-//line plugins/parsers/influx/machine.go:20366
+//line plugins/parsers/influx/machine.go:20396
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr638
 		case 10:
-			goto tr639
+			goto tr803
 		case 11:
-			goto tr640
-		case 12:
-			goto tr641
+			goto tr827
 		case 13:
-			goto tr642
+			goto tr805
 		case 32:
-			goto tr638
+			goto tr826
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr643
-		case 46:
-			goto st407
-		case 69:
-			goto st139
-		case 92:
-			goto st141
-		case 101:
-			goto st139
-		case 105:
-			goto st535
-		case 117:
-			goto st538
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st539
-		}
-		goto st30
-tr249:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st540
-	st540:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof540
-		}
-	st_case_540:
-//line plugins/parsers/influx/machine.go:20412
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr834
-		case 10:
-			goto tr810
-		case 11:
-			goto tr835
-		case 12:
-			goto tr836
-		case 13:
-			goto tr812
-		case 32:
-			goto tr834
-		case 34:
-			goto tr91
-		case 44:
-			goto tr837
+			goto tr828
 		case 65:
+			goto st141
+		case 92:
+			goto st140
+		case 97:
+			goto st144
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr826
+		}
+		goto st29
+	st141:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof141
+		}
+	st_case_141:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr88
+		case 13:
+			goto st6
+		case 32:
+			goto tr87
+		case 34:
+			goto tr89
+		case 44:
+			goto tr90
+		case 76:
 			goto st142
 		case 92:
-			goto st141
-		case 97:
-			goto st145
+			goto st140
 		}
-		goto st30
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
+		}
+		goto st29
 	st142:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof142
 		}
 	st_case_142:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr90
-		case 12:
-			goto tr1
+			goto tr88
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr89
+			goto tr87
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr92
-		case 76:
+			goto tr90
+		case 83:
 			goto st143
 		case 92:
-			goto st141
+			goto st140
 		}
-		goto st30
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
+		}
+		goto st29
 	st143:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof143
 		}
 	st_case_143:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr90
-		case 12:
-			goto tr1
+			goto tr88
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr89
+			goto tr87
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr92
-		case 83:
-			goto st144
+			goto tr90
+		case 69:
+			goto st540
 		case 92:
-			goto st141
+			goto st140
 		}
-		goto st30
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
+		}
+		goto st29
+	st540:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof540
+		}
+	st_case_540:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr803
+		case 11:
+			goto tr827
+		case 13:
+			goto tr805
+		case 32:
+			goto tr826
+		case 34:
+			goto tr89
+		case 44:
+			goto tr828
+		case 92:
+			goto st140
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr826
+		}
+		goto st29
 	st144:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof144
 		}
 	st_case_144:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
+			goto tr88
+		case 13:
+			goto st6
+		case 32:
+			goto tr87
+		case 34:
+			goto tr89
+		case 44:
 			goto tr90
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr89
-		case 34:
-			goto tr91
-		case 44:
-			goto tr92
-		case 69:
-			goto st541
 		case 92:
-			goto st141
+			goto st140
+		case 108:
+			goto st145
 		}
-		goto st30
-	st541:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof541
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
 		}
-	st_case_541:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr834
-		case 10:
-			goto tr810
-		case 11:
-			goto tr835
-		case 12:
-			goto tr836
-		case 13:
-			goto tr812
-		case 32:
-			goto tr834
-		case 34:
-			goto tr91
-		case 44:
-			goto tr837
-		case 92:
-			goto st141
-		}
-		goto st30
+		goto st29
 	st145:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof145
 		}
 	st_case_145:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr90
-		case 12:
-			goto tr1
+			goto tr88
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr89
+			goto tr87
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr92
+			goto tr90
 		case 92:
-			goto st141
-		case 108:
+			goto st140
+		case 115:
 			goto st146
 		}
-		goto st30
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
+		}
+		goto st29
 	st146:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof146
 		}
 	st_case_146:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr90
-		case 12:
-			goto tr1
+			goto tr88
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr89
+			goto tr87
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr92
+			goto tr90
 		case 92:
-			goto st141
-		case 115:
-			goto st147
+			goto st140
+		case 101:
+			goto st540
 		}
-		goto st30
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
+		}
+		goto st29
+tr248:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st541
+	st541:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof541
+		}
+	st_case_541:
+//line plugins/parsers/influx/machine.go:20619
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr803
+		case 11:
+			goto tr827
+		case 13:
+			goto tr805
+		case 32:
+			goto tr826
+		case 34:
+			goto tr89
+		case 44:
+			goto tr828
+		case 82:
+			goto st147
+		case 92:
+			goto st140
+		case 114:
+			goto st148
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr826
+		}
+		goto st29
 	st147:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof147
 		}
 	st_case_147:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr90
-		case 12:
-			goto tr1
+			goto tr88
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr89
+			goto tr87
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr92
+			goto tr90
+		case 85:
+			goto st143
 		case 92:
-			goto st141
-		case 101:
-			goto st541
+			goto st140
 		}
-		goto st30
-tr250:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
+		}
+		goto st29
+	st148:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof148
+		}
+	st_case_148:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr88
+		case 13:
+			goto st6
+		case 32:
+			goto tr87
+		case 34:
+			goto tr89
+		case 44:
+			goto tr90
+		case 92:
+			goto st140
+		case 117:
+			goto st146
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr87
+		}
+		goto st29
+tr249:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -20639,89 +20705,30 @@ tr250:
 			goto _test_eof542
 		}
 	st_case_542:
-//line plugins/parsers/influx/machine.go:20643
+//line plugins/parsers/influx/machine.go:20709
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr834
 		case 10:
-			goto tr810
+			goto tr803
 		case 11:
-			goto tr835
-		case 12:
-			goto tr836
+			goto tr827
 		case 13:
-			goto tr812
+			goto tr805
 		case 32:
-			goto tr834
+			goto tr826
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr837
-		case 82:
-			goto st148
+			goto tr828
 		case 92:
-			goto st141
-		case 114:
-			goto st149
-		}
-		goto st30
-	st148:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof148
-		}
-	st_case_148:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
-		case 10:
-			goto tr29
-		case 11:
-			goto tr90
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr89
-		case 34:
-			goto tr91
-		case 44:
-			goto tr92
-		case 85:
+			goto st140
+		case 97:
 			goto st144
-		case 92:
-			goto st141
 		}
-		goto st30
-	st149:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof149
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr826
 		}
-	st_case_149:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr89
-		case 10:
-			goto tr29
-		case 11:
-			goto tr90
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr89
-		case 34:
-			goto tr91
-		case 44:
-			goto tr92
-		case 92:
-			goto st141
-		case 117:
-			goto st147
-		}
-		goto st30
-tr251:
+		goto st29
+tr250:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -20732,621 +20739,642 @@ tr251:
 			goto _test_eof543
 		}
 	st_case_543:
-//line plugins/parsers/influx/machine.go:20736
+//line plugins/parsers/influx/machine.go:20743
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr834
 		case 10:
-			goto tr810
+			goto tr803
 		case 11:
-			goto tr835
-		case 12:
-			goto tr836
+			goto tr827
 		case 13:
-			goto tr812
+			goto tr805
 		case 32:
-			goto tr834
+			goto tr826
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr837
+			goto tr828
 		case 92:
-			goto st141
-		case 97:
-			goto st145
+			goto st140
+		case 114:
+			goto st148
 		}
-		goto st30
-tr252:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st544
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr826
+		}
+		goto st29
 	st544:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof544
 		}
 	st_case_544:
-//line plugins/parsers/influx/machine.go:20771
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr834
 		case 10:
-			goto tr810
+			goto tr600
 		case 11:
-			goto tr835
-		case 12:
-			goto tr836
+			goto tr628
 		case 13:
-			goto tr812
+			goto tr602
 		case 32:
-			goto tr834
+			goto tr627
 		case 34:
-			goto tr91
+			goto tr126
 		case 44:
-			goto tr837
+			goto tr90
+		case 61:
+			goto tr127
 		case 92:
-			goto st141
-		case 114:
-			goto st149
+			goto st92
 		}
-		goto st30
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st545
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
+		}
+		goto st40
 	st545:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof545
 		}
 	st_case_545:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st546
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st546
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st546:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof546
 		}
 	st_case_546:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st547
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st547
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st547:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof547
 		}
 	st_case_547:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st548
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st548
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st548:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof548
 		}
 	st_case_548:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st549
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st549
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st549:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof549
 		}
 	st_case_549:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st550
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st550
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st550:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof550
 		}
 	st_case_550:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st551
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st551
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st551:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof551
 		}
 	st_case_551:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st552
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st552
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st552:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof552
 		}
 	st_case_552:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st553
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st553
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st553:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof553
 		}
 	st_case_553:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st554
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st554
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st554:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof554
 		}
 	st_case_554:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st555
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st555
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st555:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof555
 		}
 	st_case_555:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st556
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st556
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st556:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof556
 		}
 	st_case_556:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st557
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st557
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st557:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof557
 		}
 	st_case_557:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st558
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st558
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st558:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof558
 		}
 	st_case_558:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st559
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st559
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st559:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof559
 		}
 	st_case_559:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st560
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st560
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st560:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof560
 		}
 	st_case_560:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st561
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st561
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr627
 		}
-		goto st41
+		goto st40
 	st561:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof561
 		}
 	st_case_561:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr600
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr628
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr630
+			goto tr627
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr129
+			goto tr127
 		case 92:
-			goto st93
+			goto st92
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st562
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr627
 		}
-		goto st41
-	st562:
+		goto st40
+tr211:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st149
+	st149:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof562
+			goto _test_eof149
 		}
-	st_case_562:
+	st_case_149:
+//line plugins/parsers/influx/machine.go:21348
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr630
 		case 10:
-			goto tr603
+			goto tr28
 		case 11:
-			goto tr631
-		case 12:
-			goto tr509
+			goto tr179
 		case 13:
-			goto tr605
+			goto st6
 		case 32:
-			goto tr630
+			goto tr178
 		case 34:
-			goto tr128
+			goto tr89
 		case 44:
-			goto tr92
-		case 61:
-			goto tr129
+			goto tr180
+		case 46:
+			goto st150
+		case 48:
+			goto st586
 		case 92:
-			goto st93
+			goto st155
 		}
-		goto st41
-tr213:
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st589
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr178
+		}
+		goto st53
+tr212:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -21357,36 +21385,246 @@ tr213:
 			goto _test_eof150
 		}
 	st_case_150:
-//line plugins/parsers/influx/machine.go:21361
+//line plugins/parsers/influx/machine.go:21389
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr181
-		case 12:
-			goto tr1
+			goto tr179
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr180
+			goto tr178
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr182
-		case 46:
-			goto st151
-		case 48:
-			goto st587
+			goto tr180
 		case 92:
-			goto st156
+			goto st155
 		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st590
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st562
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr178
 		}
-		goto st54
-tr214:
+		goto st53
+	st562:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof562
+		}
+	st_case_562:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr532
+		case 11:
+			goto tr851
+		case 13:
+			goto tr533
+		case 32:
+			goto tr850
+		case 34:
+			goto tr89
+		case 44:
+			goto tr852
+		case 69:
+			goto st153
+		case 92:
+			goto st155
+		case 101:
+			goto st153
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st562
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr850
+		}
+		goto st53
+tr851:
+	( m.cs) = 563
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:130
+
+	err = m.handler.AddFloat(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr883:
+	( m.cs) = 563
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:112
+
+	err = m.handler.AddInt(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr887:
+	( m.cs) = 563
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:121
+
+	err = m.handler.AddUint(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr892:
+	( m.cs) = 563
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:139
+
+	err = m.handler.AddBool(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st563:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof563
+		}
+	st_case_563:
+//line plugins/parsers/influx/machine.go:21546
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr273
+		case 11:
+			goto tr855
+		case 13:
+			goto st102
+		case 32:
+			goto tr854
+		case 34:
+			goto tr122
+		case 44:
+			goto tr180
+		case 45:
+			goto tr856
+		case 61:
+			goto st53
+		case 92:
+			goto tr184
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr857
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr854
+		}
+		goto tr182
+tr855:
+	( m.cs) = 564
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto _again
+	st564:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof564
+		}
+	st_case_564:
+//line plugins/parsers/influx/machine.go:21598
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr273
+		case 11:
+			goto tr855
+		case 13:
+			goto st102
+		case 32:
+			goto tr854
+		case 34:
+			goto tr122
+		case 44:
+			goto tr180
+		case 45:
+			goto tr856
+		case 61:
+			goto tr187
+		case 92:
+			goto tr184
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto tr857
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr854
+		}
+		goto tr182
+tr856:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -21397,199 +21635,82 @@ tr214:
 			goto _test_eof151
 		}
 	st_case_151:
-//line plugins/parsers/influx/machine.go:21401
+//line plugins/parsers/influx/machine.go:21639
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr181
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr180
-		case 34:
-			goto tr91
-		case 44:
-			goto tr182
-		case 92:
-			goto st156
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st563
-		}
-		goto st54
-	st563:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof563
-		}
-	st_case_563:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr859
-		case 10:
-			goto tr534
-		case 11:
-			goto tr860
-		case 12:
-			goto tr641
-		case 13:
-			goto tr536
-		case 32:
-			goto tr859
-		case 34:
-			goto tr91
-		case 44:
-			goto tr861
-		case 69:
-			goto st154
-		case 92:
-			goto st156
-		case 101:
-			goto st154
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st563
-		}
-		goto st54
-tr860:
-	( m.cs) = 564
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:130
-
-	err = m.handler.AddFloat(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr892:
-	( m.cs) = 564
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:112
-
-	err = m.handler.AddInt(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr896:
-	( m.cs) = 564
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:121
-
-	err = m.handler.AddUint(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr901:
-	( m.cs) = 564
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:139
-
-	err = m.handler.AddBool(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st564:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof564
-		}
-	st_case_564:
-//line plugins/parsers/influx/machine.go:21556
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr863
-		case 10:
-			goto tr275
-		case 11:
-			goto tr864
-		case 12:
-			goto tr501
-		case 13:
-			goto st103
-		case 32:
-			goto tr863
-		case 34:
-			goto tr124
-		case 44:
-			goto tr182
-		case 45:
-			goto tr865
-		case 61:
-			goto st54
-		case 92:
 			goto tr186
+		case 13:
+			goto st6
+		case 32:
+			goto tr178
+		case 34:
+			goto tr126
+		case 44:
+			goto tr180
+		case 61:
+			goto tr187
+		case 92:
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr866
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st565
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr178
 		}
-		goto tr184
-tr864:
-	( m.cs) = 565
+		goto st55
+tr857:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st565
+	st565:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof565
+		}
+	st_case_565:
+//line plugins/parsers/influx/machine.go:21678
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr674
+		case 11:
+			goto tr859
+		case 13:
+			goto tr676
+		case 32:
+			goto tr858
+		case 34:
+			goto tr126
+		case 44:
+			goto tr180
+		case 61:
+			goto tr187
+		case 92:
+			goto st152
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st567
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
+		}
+		goto st55
+tr862:
+	( m.cs) = 566
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -21598,41 +21719,58 @@ tr864:
 	m.pb = m.p
 
 	goto _again
-	st565:
+tr859:
+	( m.cs) = 566
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+//line plugins/parsers/influx/machine.go.rl:157
+
+	err = m.handler.SetTimestamp(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st566:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof565
+			goto _test_eof566
 		}
-	st_case_565:
-//line plugins/parsers/influx/machine.go:21607
+	st_case_566:
+//line plugins/parsers/influx/machine.go:21751
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr863
 		case 10:
-			goto tr275
+			goto tr273
 		case 11:
-			goto tr864
-		case 12:
-			goto tr501
+			goto tr862
 		case 13:
-			goto st103
+			goto st102
 		case 32:
-			goto tr863
+			goto tr861
 		case 34:
-			goto tr124
+			goto tr122
 		case 44:
-			goto tr182
-		case 45:
-			goto tr865
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto tr186
+			goto tr184
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr866
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr861
 		}
-		goto tr184
-tr865:
+		goto tr182
+tr184:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -21643,157 +21781,12 @@ tr865:
 			goto _test_eof152
 		}
 	st_case_152:
-//line plugins/parsers/influx/machine.go:21647
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
-		case 10:
-			goto tr29
-		case 11:
-			goto tr188
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr180
-		case 34:
-			goto tr128
-		case 44:
-			goto tr182
-		case 61:
-			goto tr189
-		case 92:
-			goto st153
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st566
-		}
-		goto st56
-tr866:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st566
-	st566:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof566
-		}
-	st_case_566:
-//line plugins/parsers/influx/machine.go:21685
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
-		case 10:
-			goto tr678
-		case 11:
-			goto tr868
-		case 12:
-			goto tr509
-		case 13:
-			goto tr680
-		case 32:
-			goto tr867
-		case 34:
-			goto tr128
-		case 44:
-			goto tr182
-		case 61:
-			goto tr189
-		case 92:
-			goto st153
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st568
-		}
-		goto st56
-tr871:
-	( m.cs) = 567
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto _again
-tr868:
-	( m.cs) = 567
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-//line plugins/parsers/influx/machine.go.rl:157
-
-	err = m.handler.SetTimestamp(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st567:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof567
-		}
-	st_case_567:
-//line plugins/parsers/influx/machine.go:21757
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr870
-		case 10:
-			goto tr275
-		case 11:
-			goto tr871
-		case 12:
-			goto tr514
-		case 13:
-			goto st103
-		case 32:
-			goto tr870
-		case 34:
-			goto tr124
-		case 44:
-			goto tr182
-		case 61:
-			goto tr189
-		case 92:
-			goto tr186
-		}
-		goto tr184
-tr186:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st153
-	st153:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof153
-		}
-	st_case_153:
-//line plugins/parsers/influx/machine.go:21792
+//line plugins/parsers/influx/machine.go:21785
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st56
+			goto st55
 		case 92:
-			goto st56
+			goto st55
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -21803,671 +21796,689 @@ tr186:
 		case ( m.data)[( m.p)] >= 9:
 			goto tr8
 		}
-		goto st11
+		goto st10
+	st567:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof567
+		}
+	st_case_567:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr674
+		case 11:
+			goto tr859
+		case 13:
+			goto tr676
+		case 32:
+			goto tr858
+		case 34:
+			goto tr126
+		case 44:
+			goto tr180
+		case 61:
+			goto tr187
+		case 92:
+			goto st152
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st568
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
+		}
+		goto st55
 	st568:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof568
 		}
 	st_case_568:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st569
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st569
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st569:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof569
 		}
 	st_case_569:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st570
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st570
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st570:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof570
 		}
 	st_case_570:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st571
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st571
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st571:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof571
 		}
 	st_case_571:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st572
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st572
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st572:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof572
 		}
 	st_case_572:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st573
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st573
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st573:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof573
 		}
 	st_case_573:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st574
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st574
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st574:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof574
 		}
 	st_case_574:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st575
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st575
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st575:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof575
 		}
 	st_case_575:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st576
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st576
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st576:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof576
 		}
 	st_case_576:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st577
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st577
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st577:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof577
 		}
 	st_case_577:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st578
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st578
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st578:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof578
 		}
 	st_case_578:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st579
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st579
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st579:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof579
 		}
 	st_case_579:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st580
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st580
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st580:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof580
 		}
 	st_case_580:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st581
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st581
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st581:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof581
 		}
 	st_case_581:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st582
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st582
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st582:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof582
 		}
 	st_case_582:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st583
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st583
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st583:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof583
 		}
 	st_case_583:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st584
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st584
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr858
 		}
-		goto st56
+		goto st55
 	st584:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof584
 		}
 	st_case_584:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr674
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr859
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr867
+			goto tr858
 		case 34:
-			goto tr128
+			goto tr126
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr189
+			goto tr187
 		case 92:
-			goto st153
+			goto st152
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st585
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr858
 		}
-		goto st56
-	st585:
+		goto st55
+	st153:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof585
+			goto _test_eof153
 		}
-	st_case_585:
+	st_case_153:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr867
 		case 10:
-			goto tr678
+			goto tr28
 		case 11:
-			goto tr868
-		case 12:
-			goto tr509
+			goto tr179
 		case 13:
-			goto tr680
+			goto st6
 		case 32:
-			goto tr867
+			goto tr178
 		case 34:
-			goto tr128
+			goto tr315
 		case 44:
-			goto tr182
-		case 61:
-			goto tr189
+			goto tr180
 		case 92:
-			goto st153
+			goto st155
 		}
-		goto st56
+		switch {
+		case ( m.data)[( m.p)] < 43:
+			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+				goto tr178
+			}
+		case ( m.data)[( m.p)] > 45:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st585
+			}
+		default:
+			goto st154
+		}
+		goto st53
 	st154:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof154
 		}
 	st_case_154:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr181
-		case 12:
-			goto tr1
+			goto tr179
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr180
+			goto tr178
 		case 34:
-			goto tr317
+			goto tr89
 		case 44:
-			goto tr182
+			goto tr180
 		case 92:
-			goto st156
-		}
-		switch {
-		case ( m.data)[( m.p)] > 45:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st586
-			}
-		case ( m.data)[( m.p)] >= 43:
 			goto st155
 		}
-		goto st54
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st585
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr178
+		}
+		goto st53
+	st585:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof585
+		}
+	st_case_585:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr532
+		case 11:
+			goto tr851
+		case 13:
+			goto tr533
+		case 32:
+			goto tr850
+		case 34:
+			goto tr89
+		case 44:
+			goto tr852
+		case 92:
+			goto st155
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st585
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr850
+		}
+		goto st53
+tr338:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st155
 	st155:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof155
 		}
 	st_case_155:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
-		case 10:
-			goto tr29
-		case 11:
-			goto tr181
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr180
-		case 34:
-			goto tr91
-		case 44:
-			goto tr182
-		case 92:
-			goto st156
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st586
-		}
-		goto st54
-	st586:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof586
-		}
-	st_case_586:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr859
-		case 10:
-			goto tr534
-		case 11:
-			goto tr860
-		case 12:
-			goto tr641
-		case 13:
-			goto tr536
-		case 32:
-			goto tr859
-		case 34:
-			goto tr91
-		case 44:
-			goto tr861
-		case 92:
-			goto st156
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st586
-		}
-		goto st54
-tr340:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st156
-	st156:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof156
-		}
-	st_case_156:
-//line plugins/parsers/influx/machine.go:22466
+//line plugins/parsers/influx/machine.go:22477
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st54
+			goto st53
 		case 92:
-			goto st54
+			goto st53
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -22478,214 +22489,263 @@ tr340:
 			goto tr8
 		}
 		goto st1
+	st586:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof586
+		}
+	st_case_586:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr532
+		case 11:
+			goto tr851
+		case 13:
+			goto tr533
+		case 32:
+			goto tr850
+		case 34:
+			goto tr89
+		case 44:
+			goto tr852
+		case 46:
+			goto st562
+		case 69:
+			goto st153
+		case 92:
+			goto st155
+		case 101:
+			goto st153
+		case 105:
+			goto st588
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st587
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr850
+		}
+		goto st53
 	st587:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof587
 		}
 	st_case_587:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr859
 		case 10:
-			goto tr534
+			goto tr532
 		case 11:
-			goto tr860
-		case 12:
-			goto tr641
+			goto tr851
 		case 13:
-			goto tr536
+			goto tr533
 		case 32:
-			goto tr859
+			goto tr850
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr861
+			goto tr852
 		case 46:
-			goto st563
+			goto st562
 		case 69:
-			goto st154
+			goto st153
 		case 92:
-			goto st156
+			goto st155
 		case 101:
-			goto st154
-		case 105:
-			goto st589
+			goto st153
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st588
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st587
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr850
 		}
-		goto st54
+		goto st53
 	st588:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof588
 		}
 	st_case_588:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr859
 		case 10:
-			goto tr534
+			goto tr737
 		case 11:
-			goto tr860
-		case 12:
-			goto tr641
+			goto tr883
 		case 13:
-			goto tr536
+			goto tr739
 		case 32:
-			goto tr859
+			goto tr882
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr861
-		case 46:
-			goto st563
-		case 69:
-			goto st154
+			goto tr884
 		case 92:
-			goto st156
-		case 101:
-			goto st154
+			goto st155
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st588
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr882
 		}
-		goto st54
+		goto st53
 	st589:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof589
 		}
 	st_case_589:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr891
 		case 10:
-			goto tr741
+			goto tr532
 		case 11:
-			goto tr892
-		case 12:
-			goto tr825
+			goto tr851
 		case 13:
-			goto tr744
+			goto tr533
 		case 32:
-			goto tr891
+			goto tr850
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr893
+			goto tr852
+		case 46:
+			goto st562
+		case 69:
+			goto st153
 		case 92:
-			goto st156
+			goto st155
+		case 101:
+			goto st153
+		case 105:
+			goto st588
 		}
-		goto st54
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st589
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr850
+		}
+		goto st53
+tr213:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st590
 	st590:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof590
 		}
 	st_case_590:
+//line plugins/parsers/influx/machine.go:22641
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr859
 		case 10:
-			goto tr534
+			goto tr532
 		case 11:
-			goto tr860
-		case 12:
-			goto tr641
+			goto tr851
 		case 13:
-			goto tr536
+			goto tr533
 		case 32:
-			goto tr859
+			goto tr850
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr861
+			goto tr852
 		case 46:
-			goto st563
+			goto st562
 		case 69:
-			goto st154
+			goto st153
 		case 92:
-			goto st156
+			goto st155
 		case 101:
-			goto st154
+			goto st153
 		case 105:
-			goto st589
+			goto st588
+		case 117:
+			goto st591
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st590
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st587
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr850
 		}
-		goto st54
-tr215:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st591
+		goto st53
 	st591:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof591
 		}
 	st_case_591:
-//line plugins/parsers/influx/machine.go:22628
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr859
 		case 10:
-			goto tr534
+			goto tr743
 		case 11:
-			goto tr860
-		case 12:
-			goto tr641
+			goto tr887
 		case 13:
-			goto tr536
+			goto tr745
 		case 32:
-			goto tr859
+			goto tr886
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr861
-		case 46:
-			goto st563
-		case 69:
-			goto st154
+			goto tr888
 		case 92:
-			goto st156
-		case 101:
-			goto st154
-		case 105:
-			goto st589
-		case 117:
-			goto st592
+			goto st155
 		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st588
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr886
 		}
-		goto st54
+		goto st53
+tr214:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st592
 	st592:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof592
 		}
 	st_case_592:
+//line plugins/parsers/influx/machine.go:22713
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr895
 		case 10:
-			goto tr748
+			goto tr532
 		case 11:
-			goto tr896
-		case 12:
-			goto tr831
+			goto tr851
 		case 13:
-			goto tr751
+			goto tr533
 		case 32:
-			goto tr895
+			goto tr850
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr897
+			goto tr852
+		case 46:
+			goto st562
+		case 69:
+			goto st153
 		case 92:
-			goto st156
+			goto st155
+		case 101:
+			goto st153
+		case 105:
+			goto st588
+		case 117:
+			goto st591
 		}
-		goto st54
-tr216:
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st592
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr850
+		}
+		goto st53
+tr215:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -22696,273 +22756,309 @@ tr216:
 			goto _test_eof593
 		}
 	st_case_593:
-//line plugins/parsers/influx/machine.go:22700
+//line plugins/parsers/influx/machine.go:22760
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr859
 		case 10:
-			goto tr534
+			goto tr891
 		case 11:
-			goto tr860
-		case 12:
-			goto tr641
+			goto tr892
 		case 13:
-			goto tr536
+			goto tr751
 		case 32:
-			goto tr859
+			goto tr890
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr861
-		case 46:
-			goto st563
-		case 69:
-			goto st154
-		case 92:
-			goto st156
-		case 101:
-			goto st154
-		case 105:
-			goto st589
-		case 117:
-			goto st592
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st593
-		}
-		goto st54
-tr217:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st594
-	st594:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof594
-		}
-	st_case_594:
-//line plugins/parsers/influx/machine.go:22746
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr899
-		case 10:
-			goto tr900
-		case 11:
-			goto tr901
-		case 12:
-			goto tr836
-		case 13:
-			goto tr758
-		case 32:
-			goto tr899
-		case 34:
-			goto tr91
-		case 44:
-			goto tr902
+			goto tr893
 		case 65:
+			goto st156
+		case 92:
+			goto st155
+		case 97:
+			goto st159
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr890
+		}
+		goto st53
+	st156:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof156
+		}
+	st_case_156:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr179
+		case 13:
+			goto st6
+		case 32:
+			goto tr178
+		case 34:
+			goto tr89
+		case 44:
+			goto tr180
+		case 76:
 			goto st157
 		case 92:
-			goto st156
-		case 97:
-			goto st160
+			goto st155
 		}
-		goto st54
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto st53
 	st157:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof157
 		}
 	st_case_157:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr181
-		case 12:
-			goto tr1
+			goto tr179
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr180
+			goto tr178
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr182
-		case 76:
+			goto tr180
+		case 83:
 			goto st158
 		case 92:
-			goto st156
+			goto st155
 		}
-		goto st54
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto st53
 	st158:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof158
 		}
 	st_case_158:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr181
-		case 12:
-			goto tr1
+			goto tr179
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr180
+			goto tr178
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr182
-		case 83:
-			goto st159
+			goto tr180
+		case 69:
+			goto st594
 		case 92:
-			goto st156
+			goto st155
 		}
-		goto st54
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto st53
+	st594:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof594
+		}
+	st_case_594:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr891
+		case 11:
+			goto tr892
+		case 13:
+			goto tr751
+		case 32:
+			goto tr890
+		case 34:
+			goto tr89
+		case 44:
+			goto tr893
+		case 92:
+			goto st155
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr890
+		}
+		goto st53
 	st159:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof159
 		}
 	st_case_159:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr181
-		case 12:
-			goto tr1
+			goto tr179
 		case 13:
-			goto st7
+			goto st6
 		case 32:
+			goto tr178
+		case 34:
+			goto tr89
+		case 44:
 			goto tr180
-		case 34:
-			goto tr91
-		case 44:
-			goto tr182
-		case 69:
-			goto st595
 		case 92:
-			goto st156
+			goto st155
+		case 108:
+			goto st160
 		}
-		goto st54
-	st595:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof595
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
 		}
-	st_case_595:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr899
-		case 10:
-			goto tr900
-		case 11:
-			goto tr901
-		case 12:
-			goto tr836
-		case 13:
-			goto tr758
-		case 32:
-			goto tr899
-		case 34:
-			goto tr91
-		case 44:
-			goto tr902
-		case 92:
-			goto st156
-		}
-		goto st54
+		goto st53
 	st160:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof160
 		}
 	st_case_160:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr181
-		case 12:
-			goto tr1
+			goto tr179
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr180
+			goto tr178
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr182
+			goto tr180
 		case 92:
-			goto st156
-		case 108:
+			goto st155
+		case 115:
 			goto st161
 		}
-		goto st54
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto st53
 	st161:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof161
 		}
 	st_case_161:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr181
-		case 12:
-			goto tr1
+			goto tr179
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr180
+			goto tr178
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr182
+			goto tr180
 		case 92:
-			goto st156
-		case 115:
-			goto st162
+			goto st155
+		case 101:
+			goto st594
 		}
-		goto st54
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto st53
+tr216:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st595
+	st595:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof595
+		}
+	st_case_595:
+//line plugins/parsers/influx/machine.go:22983
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr891
+		case 11:
+			goto tr892
+		case 13:
+			goto tr751
+		case 32:
+			goto tr890
+		case 34:
+			goto tr89
+		case 44:
+			goto tr893
+		case 82:
+			goto st162
+		case 92:
+			goto st155
+		case 114:
+			goto st163
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr890
+		}
+		goto st53
 	st162:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof162
 		}
 	st_case_162:
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr181
-		case 12:
-			goto tr1
+			goto tr179
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr180
+			goto tr178
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr182
+			goto tr180
+		case 85:
+			goto st158
 		case 92:
-			goto st156
-		case 101:
-			goto st595
+			goto st155
 		}
-		goto st54
-tr218:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto st53
+	st163:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof163
+		}
+	st_case_163:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr179
+		case 13:
+			goto st6
+		case 32:
+			goto tr178
+		case 34:
+			goto tr89
+		case 44:
+			goto tr180
+		case 92:
+			goto st155
+		case 117:
+			goto st161
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr178
+		}
+		goto st53
+tr217:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -22973,89 +23069,30 @@ tr218:
 			goto _test_eof596
 		}
 	st_case_596:
-//line plugins/parsers/influx/machine.go:22977
+//line plugins/parsers/influx/machine.go:23073
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr899
 		case 10:
-			goto tr900
+			goto tr891
 		case 11:
-			goto tr901
-		case 12:
-			goto tr836
+			goto tr892
 		case 13:
-			goto tr758
+			goto tr751
 		case 32:
-			goto tr899
+			goto tr890
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr902
-		case 82:
-			goto st163
+			goto tr893
 		case 92:
-			goto st156
-		case 114:
-			goto st164
-		}
-		goto st54
-	st163:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof163
-		}
-	st_case_163:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
-		case 10:
-			goto tr29
-		case 11:
-			goto tr181
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr180
-		case 34:
-			goto tr91
-		case 44:
-			goto tr182
-		case 85:
+			goto st155
+		case 97:
 			goto st159
-		case 92:
-			goto st156
 		}
-		goto st54
-	st164:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof164
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr890
 		}
-	st_case_164:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr180
-		case 10:
-			goto tr29
-		case 11:
-			goto tr181
-		case 12:
-			goto tr1
-		case 13:
-			goto st7
-		case 32:
-			goto tr180
-		case 34:
-			goto tr91
-		case 44:
-			goto tr182
-		case 92:
-			goto st156
-		case 117:
-			goto st162
-		}
-		goto st54
-tr219:
+		goto st53
+tr218:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -23066,137 +23103,152 @@ tr219:
 			goto _test_eof597
 		}
 	st_case_597:
-//line plugins/parsers/influx/machine.go:23070
+//line plugins/parsers/influx/machine.go:23107
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr899
 		case 10:
-			goto tr900
+			goto tr891
 		case 11:
-			goto tr901
-		case 12:
-			goto tr836
+			goto tr892
 		case 13:
-			goto tr758
+			goto tr751
 		case 32:
-			goto tr899
+			goto tr890
 		case 34:
-			goto tr91
+			goto tr89
 		case 44:
-			goto tr902
+			goto tr893
 		case 92:
-			goto st156
-		case 97:
-			goto st160
+			goto st155
+		case 114:
+			goto st163
 		}
-		goto st54
-tr220:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr890
+		}
+		goto st53
+	st164:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof164
+		}
+	st_case_164:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr337
+		case 13:
+			goto st6
+		case 32:
+			goto st164
+		case 34:
+			goto tr116
+		case 35:
+			goto st6
+		case 44:
+			goto st6
+		case 92:
+			goto tr338
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st164
+		}
+		goto tr335
+tr337:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st598
-	st598:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof598
-		}
-	st_case_598:
-//line plugins/parsers/influx/machine.go:23105
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr899
-		case 10:
-			goto tr900
-		case 11:
-			goto tr901
-		case 12:
-			goto tr836
-		case 13:
-			goto tr758
-		case 32:
-			goto tr899
-		case 34:
-			goto tr91
-		case 44:
-			goto tr902
-		case 92:
-			goto st156
-		case 114:
-			goto st164
-		}
-		goto st54
+	goto st165
 	st165:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof165
 		}
 	st_case_165:
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st165
-		case 10:
-			goto tr29
-		case 11:
-			goto tr339
-		case 12:
-			goto st8
-		case 13:
-			goto st7
-		case 32:
-			goto st165
-		case 34:
-			goto tr118
-		case 35:
-			goto st6
-		case 44:
-			goto st6
-		case 92:
-			goto tr340
-		}
-		goto tr337
-tr339:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st166
-	st166:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof166
-		}
-	st_case_166:
 //line plugins/parsers/influx/machine.go:23168
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr341
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr342
-		case 12:
-			goto tr38
-		case 13:
-			goto st7
-		case 32:
-			goto tr341
-		case 34:
-			goto tr85
-		case 35:
-			goto st54
-		case 44:
-			goto tr182
-		case 92:
 			goto tr340
+		case 13:
+			goto st6
+		case 32:
+			goto tr339
+		case 34:
+			goto tr83
+		case 35:
+			goto st53
+		case 44:
+			goto tr180
+		case 92:
+			goto tr338
 		}
-		goto tr337
-tr341:
-	( m.cs) = 167
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr339
+		}
+		goto tr335
+tr339:
+	( m.cs) = 166
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st166:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof166
+		}
+	st_case_166:
+//line plugins/parsers/influx/machine.go:23209
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr342
+		case 13:
+			goto st6
+		case 32:
+			goto st166
+		case 34:
+			goto tr122
+		case 35:
+			goto tr158
+		case 44:
+			goto st6
+		case 61:
+			goto tr335
+		case 92:
+			goto tr184
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st166
+		}
+		goto tr182
+tr342:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st167
+tr343:
+	( m.cs) = 167
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -23206,39 +23258,30 @@ tr341:
 			goto _test_eof167
 		}
 	st_case_167:
-//line plugins/parsers/influx/machine.go:23210
+//line plugins/parsers/influx/machine.go:23262
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st167
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr344
-		case 12:
-			goto st10
+			goto tr343
 		case 13:
-			goto st7
-		case 32:
-			goto st167
-		case 34:
-			goto tr124
-		case 35:
-			goto tr160
-		case 44:
 			goto st6
+		case 32:
+			goto tr339
+		case 34:
+			goto tr122
+		case 44:
+			goto tr180
 		case 61:
-			goto tr337
+			goto tr344
 		case 92:
-			goto tr186
+			goto tr184
 		}
-		goto tr184
-tr344:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st168
-tr345:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr339
+		}
+		goto tr182
+tr340:
 	( m.cs) = 168
 //line plugins/parsers/influx/machine.go.rl:28
 
@@ -23250,7 +23293,7 @@ tr345:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -23260,137 +23303,110 @@ tr345:
 			goto _test_eof168
 		}
 	st_case_168:
-//line plugins/parsers/influx/machine.go:23264
+//line plugins/parsers/influx/machine.go:23307
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr341
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr345
-		case 12:
-			goto tr38
+			goto tr343
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr341
+			goto tr339
 		case 34:
-			goto tr124
+			goto tr122
 		case 44:
-			goto tr182
+			goto tr180
 		case 61:
-			goto tr346
+			goto tr335
 		case 92:
-			goto tr186
+			goto tr184
 		}
-		goto tr184
-tr342:
-	( m.cs) = 169
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr339
+		}
+		goto tr182
+tr538:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+	goto st169
 	st169:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof169
 		}
 	st_case_169:
-//line plugins/parsers/influx/machine.go:23310
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr341
-		case 10:
-			goto tr29
-		case 11:
-			goto tr345
-		case 12:
-			goto tr38
-		case 13:
-			goto st7
-		case 32:
-			goto tr341
-		case 34:
-			goto tr124
-		case 44:
-			goto tr182
-		case 61:
-			goto tr337
-		case 92:
-			goto tr186
-		}
-		goto tr184
-tr541:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st170
-	st170:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof170
-		}
-	st_case_170:
-//line plugins/parsers/influx/machine.go:23345
+//line plugins/parsers/influx/machine.go:23341
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr105
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st599
+			goto st598
 		}
 		goto st6
-tr542:
+tr539:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st599
+	goto st598
+	st598:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof598
+		}
+	st_case_598:
+//line plugins/parsers/influx/machine.go:23365
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr674
+		case 13:
+			goto tr676
+		case 32:
+			goto tr673
+		case 34:
+			goto tr29
+		case 92:
+			goto st73
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st599
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr673
+		}
+		goto st6
 	st599:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof599
 		}
 	st_case_599:
-//line plugins/parsers/influx/machine.go:23373
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st600
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st600:
@@ -23400,25 +23416,23 @@ tr542:
 	st_case_600:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st601
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st601:
@@ -23428,25 +23442,23 @@ tr542:
 	st_case_601:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st602
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st602:
@@ -23456,25 +23468,23 @@ tr542:
 	st_case_602:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st603
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st603:
@@ -23484,25 +23494,23 @@ tr542:
 	st_case_603:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st604
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st604:
@@ -23512,25 +23520,23 @@ tr542:
 	st_case_604:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st605
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st605:
@@ -23540,25 +23546,23 @@ tr542:
 	st_case_605:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st606
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st606:
@@ -23568,25 +23572,23 @@ tr542:
 	st_case_606:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st607
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st607:
@@ -23596,25 +23598,23 @@ tr542:
 	st_case_607:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st608
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st608:
@@ -23624,25 +23624,23 @@ tr542:
 	st_case_608:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st609
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st609:
@@ -23652,25 +23650,23 @@ tr542:
 	st_case_609:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st610
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st610:
@@ -23680,25 +23676,23 @@ tr542:
 	st_case_610:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st611
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st611:
@@ -23708,25 +23702,23 @@ tr542:
 	st_case_611:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st612
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st612:
@@ -23736,25 +23728,23 @@ tr542:
 	st_case_612:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st613
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st613:
@@ -23764,25 +23754,23 @@ tr542:
 	st_case_613:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st614
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st614:
@@ -23792,25 +23780,23 @@ tr542:
 	st_case_614:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st615
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st615:
@@ -23820,25 +23806,23 @@ tr542:
 	st_case_615:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st616
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+			goto tr673
 		}
 		goto st6
 	st616:
@@ -23848,139 +23832,140 @@ tr542:
 	st_case_616:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr678
-		case 12:
-			goto tr469
+			goto tr674
 		case 13:
-			goto tr680
+			goto tr676
 		case 32:
-			goto tr677
+			goto tr673
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st617
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr677
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr673
 		}
 		goto st6
-	st617:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof617
-		}
-	st_case_617:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr678
-		case 12:
-			goto tr469
-		case 13:
-			goto tr680
-		case 32:
-			goto tr677
-		case 34:
-			goto tr31
-		case 92:
-			goto st75
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr677
-		}
-		goto st6
-tr926:
+tr917:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st171
-tr537:
-	( m.cs) = 171
+	goto st170
+tr534:
+	( m.cs) = 170
 //line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr933:
-	( m.cs) = 171
+tr924:
+	( m.cs) = 170
 //line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr936:
-	( m.cs) = 171
+tr926:
+	( m.cs) = 170
 //line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr940:
-	( m.cs) = 171
+tr929:
+	( m.cs) = 170
 //line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-	st171:
+	st170:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof171
+			goto _test_eof170
 		}
-	st_case_171:
-//line plugins/parsers/influx/machine.go:23959
+	st_case_170:
+//line plugins/parsers/influx/machine.go:23913
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr97
+			goto tr95
 		case 44:
 			goto st6
 		case 61:
 			goto st6
 		case 92:
-			goto tr349
+			goto tr347
 		}
-		goto tr348
-tr348:
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto tr346
+tr346:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
+
+	goto st171
+	st171:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof171
+		}
+	st_case_171:
+//line plugins/parsers/influx/machine.go:23945
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st6
+		case 10:
+			goto tr28
+		case 32:
+			goto st6
+		case 34:
+			goto tr98
+		case 44:
+			goto st6
+		case 61:
+			goto tr349
+		case 92:
+			goto st183
+		}
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st171
+tr349:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.key = m.text()
 
 	goto st172
 	st172:
@@ -23988,192 +23973,232 @@ tr348:
 			goto _test_eof172
 		}
 	st_case_172:
-//line plugins/parsers/influx/machine.go:23992
+//line plugins/parsers/influx/machine.go:23977
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 32:
-			goto st6
+			goto tr28
 		case 34:
-			goto tr100
-		case 44:
-			goto st6
-		case 61:
 			goto tr351
-		case 92:
-			goto st184
-		}
-		goto st172
-tr351:
-//line plugins/parsers/influx/machine.go.rl:108
-
-	m.key = m.text()
-
-	goto st173
-	st173:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof173
-		}
-	st_case_173:
-//line plugins/parsers/influx/machine.go:24025
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr353
 		case 45:
-			goto tr167
+			goto tr165
 		case 46:
-			goto tr168
+			goto tr166
 		case 48:
-			goto tr169
+			goto tr167
 		case 70:
-			goto tr354
+			goto tr352
 		case 84:
-			goto tr355
+			goto tr353
 		case 92:
-			goto st75
+			goto st73
 		case 102:
-			goto tr356
+			goto tr354
 		case 116:
-			goto tr357
+			goto tr355
 		}
 		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr170
+			goto tr168
 		}
 		goto st6
-tr353:
-	( m.cs) = 618
+tr351:
+	( m.cs) = 617
 //line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
+	st617:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof617
+		}
+	st_case_617:
+//line plugins/parsers/influx/machine.go:24022
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr665
+		case 13:
+			goto tr667
+		case 32:
+			goto tr916
+		case 34:
+			goto tr25
+		case 44:
+			goto tr917
+		case 92:
+			goto tr26
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr916
+		}
+		goto tr23
+tr167:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st618
 	st618:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof618
 		}
 	st_case_618:
-//line plugins/parsers/influx/machine.go:24074
+//line plugins/parsers/influx/machine.go:24052
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr669
-		case 12:
-			goto st272
+			goto tr532
 		case 13:
-			goto tr671
+			goto tr533
 		case 32:
-			goto tr925
+			goto tr531
 		case 34:
-			goto tr26
+			goto tr29
 		case 44:
-			goto tr926
+			goto tr534
+		case 46:
+			goto st325
+		case 69:
+			goto st173
 		case 92:
-			goto tr27
+			goto st73
+		case 101:
+			goto st173
+		case 105:
+			goto st623
+		case 117:
+			goto st624
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr925
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st619
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr531
 		}
-		goto tr23
-tr169:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st619
+		goto st6
 	st619:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof619
 		}
 	st_case_619:
-//line plugins/parsers/influx/machine.go:24106
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr534
-		case 12:
-			goto tr535
+			goto tr532
 		case 13:
-			goto tr536
-		case 32:
 			goto tr533
+		case 32:
+			goto tr531
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr537
+			goto tr534
 		case 46:
-			goto st326
+			goto st325
 		case 69:
-			goto st174
+			goto st173
 		case 92:
-			goto st75
+			goto st73
 		case 101:
-			goto st174
-		case 105:
-			goto st624
-		case 117:
-			goto st625
+			goto st173
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st620
+				goto st619
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr533
+			goto tr531
 		}
 		goto st6
+	st173:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof173
+		}
+	st_case_173:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 34:
+			goto tr356
+		case 43:
+			goto st174
+		case 45:
+			goto st174
+		case 92:
+			goto st73
+		}
+		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto st622
+		}
+		goto st6
+tr356:
+	( m.cs) = 620
+//line plugins/parsers/influx/machine.go.rl:148
+
+	err = m.handler.AddString(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
 	st620:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof620
 		}
 	st_case_620:
+//line plugins/parsers/influx/machine.go:24159
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr534
-		case 12:
-			goto tr535
+			goto tr101
 		case 13:
-			goto tr536
+			goto st32
 		case 32:
-			goto tr533
-		case 34:
-			goto tr31
+			goto st271
 		case 44:
-			goto tr537
-		case 46:
-			goto st326
-		case 69:
-			goto st174
-		case 92:
-			goto st75
-		case 101:
-			goto st174
+			goto st35
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st620
+				goto st621
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr533
+			goto st271
 		}
-		goto st6
+		goto tr103
+	st621:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof621
+		}
+	st_case_621:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr730
+		case 13:
+			goto tr732
+		case 32:
+			goto tr921
+		case 44:
+			goto tr922
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st621
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr921
+		}
+		goto tr103
 	st174:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof174
@@ -24181,62 +24206,16 @@ tr169:
 	st_case_174:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr358
-		case 43:
-			goto st175
-		case 45:
-			goto st175
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st623
+			goto st622
 		}
 		goto st6
-tr358:
-	( m.cs) = 621
-//line plugins/parsers/influx/machine.go.rl:148
-
-	err = m.handler.AddString(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st621:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof621
-		}
-	st_case_621:
-//line plugins/parsers/influx/machine.go:24221
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr103
-		case 13:
-			goto st33
-		case 32:
-			goto st272
-		case 44:
-			goto st36
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st622
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto st272
-		}
-		goto tr105
 	st622:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof622
@@ -24244,13 +24223,17 @@ tr358:
 	st_case_622:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr532
 		case 13:
-			goto tr736
+			goto tr533
 		case 32:
-			goto tr535
+			goto tr531
+		case 34:
+			goto tr29
 		case 44:
-			goto tr930
+			goto tr534
+		case 92:
+			goto st73
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
@@ -24258,28 +24241,7 @@ tr358:
 				goto st622
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr535
-		}
-		goto tr105
-	st175:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof175
-		}
-	st_case_175:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 92:
-			goto st75
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st623
+			goto tr531
 		}
 		goto st6
 	st623:
@@ -24289,27 +24251,20 @@ tr358:
 	st_case_623:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr534
-		case 12:
-			goto tr535
+			goto tr737
 		case 13:
-			goto tr536
+			goto tr739
 		case 32:
-			goto tr533
+			goto tr923
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr537
+			goto tr924
 		case 92:
-			goto st75
+			goto st73
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st623
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr533
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr923
 		}
 		goto st6
 	st624:
@@ -24319,50 +24274,68 @@ tr358:
 	st_case_624:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr741
-		case 12:
-			goto tr932
+			goto tr743
 		case 13:
-			goto tr744
+			goto tr745
 		case 32:
-			goto tr931
+			goto tr925
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr933
+			goto tr926
 		case 92:
-			goto st75
+			goto st73
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr931
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr925
 		}
 		goto st6
+tr168:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st625
 	st625:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof625
 		}
 	st_case_625:
+//line plugins/parsers/influx/machine.go:24305
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr748
-		case 12:
-			goto tr935
+			goto tr532
 		case 13:
-			goto tr751
+			goto tr533
 		case 32:
-			goto tr934
+			goto tr531
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr936
+			goto tr534
+		case 46:
+			goto st325
+		case 69:
+			goto st173
 		case 92:
-			goto st75
+			goto st73
+		case 101:
+			goto st173
+		case 105:
+			goto st623
+		case 117:
+			goto st624
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr934
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st625
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr531
 		}
 		goto st6
-tr170:
+tr352:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -24373,76 +24346,43 @@ tr170:
 			goto _test_eof626
 		}
 	st_case_626:
-//line plugins/parsers/influx/machine.go:24377
+//line plugins/parsers/influx/machine.go:24350
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr534
-		case 12:
-			goto tr535
+			goto tr749
 		case 13:
-			goto tr536
+			goto tr751
 		case 32:
-			goto tr533
+			goto tr928
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr537
-		case 46:
-			goto st326
-		case 69:
-			goto st174
+			goto tr929
+		case 65:
+			goto st175
 		case 92:
-			goto st75
-		case 101:
-			goto st174
-		case 105:
-			goto st624
-		case 117:
-			goto st625
+			goto st73
+		case 97:
+			goto st178
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st626
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr533
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr928
 		}
 		goto st6
-tr354:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st627
-	st627:
+	st175:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof627
+			goto _test_eof175
 		}
-	st_case_627:
-//line plugins/parsers/influx/machine.go:24424
+	st_case_175:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr755
-		case 12:
-			goto tr939
-		case 13:
-			goto tr758
-		case 32:
-			goto tr938
+			goto tr28
 		case 34:
-			goto tr31
-		case 44:
-			goto tr940
-		case 65:
+			goto tr29
+		case 76:
 			goto st176
 		case 92:
-			goto st75
-		case 97:
-			goto st179
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr938
+			goto st73
 		}
 		goto st6
 	st176:
@@ -24452,17 +24392,13 @@ tr354:
 	st_case_176:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
-		case 76:
+			goto tr29
+		case 83:
 			goto st177
 		case 92:
-			goto st75
+			goto st73
 		}
 		goto st6
 	st177:
@@ -24472,17 +24408,36 @@ tr354:
 	st_case_177:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
-		case 83:
-			goto st178
+			goto tr29
+		case 69:
+			goto st627
 		case 92:
-			goto st75
+			goto st73
+		}
+		goto st6
+	st627:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof627
+		}
+	st_case_627:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr749
+		case 13:
+			goto tr751
+		case 32:
+			goto tr928
+		case 34:
+			goto tr29
+		case 44:
+			goto tr929
+		case 92:
+			goto st73
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr928
 		}
 		goto st6
 	st178:
@@ -24492,42 +24447,13 @@ tr354:
 	st_case_178:
 		switch ( m.data)[( m.p)] {
 		case 10:
+			goto tr28
+		case 34:
 			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 69:
-			goto st628
 		case 92:
-			goto st75
-		}
-		goto st6
-	st628:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof628
-		}
-	st_case_628:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr755
-		case 12:
-			goto tr939
-		case 13:
-			goto tr758
-		case 32:
-			goto tr938
-		case 34:
-			goto tr31
-		case 44:
-			goto tr940
-		case 92:
-			goto st75
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr938
+			goto st73
+		case 108:
+			goto st179
 		}
 		goto st6
 	st179:
@@ -24537,16 +24463,12 @@ tr354:
 	st_case_179:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
-		case 108:
+			goto st73
+		case 115:
 			goto st180
 		}
 		goto st6
@@ -24557,17 +24479,47 @@ tr354:
 	st_case_180:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
-		case 115:
+			goto st73
+		case 101:
+			goto st627
+		}
+		goto st6
+tr353:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st628
+	st628:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof628
+		}
+	st_case_628:
+//line plugins/parsers/influx/machine.go:24503
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr749
+		case 13:
+			goto tr751
+		case 32:
+			goto tr928
+		case 34:
+			goto tr29
+		case 44:
+			goto tr929
+		case 82:
 			goto st181
+		case 92:
+			goto st73
+		case 114:
+			goto st182
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr928
 		}
 		goto st6
 	st181:
@@ -24577,20 +24529,32 @@ tr354:
 	st_case_181:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
+		case 85:
+			goto st177
 		case 92:
-			goto st75
-		case 101:
-			goto st628
+			goto st73
 		}
 		goto st6
-tr355:
+	st182:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof182
+		}
+	st_case_182:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 34:
+			goto tr29
+		case 92:
+			goto st73
+		case 117:
+			goto st180
+		}
+		goto st6
+tr354:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -24601,72 +24565,28 @@ tr355:
 			goto _test_eof629
 		}
 	st_case_629:
-//line plugins/parsers/influx/machine.go:24605
+//line plugins/parsers/influx/machine.go:24569
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr755
-		case 12:
-			goto tr939
+			goto tr749
 		case 13:
-			goto tr758
+			goto tr751
 		case 32:
-			goto tr938
+			goto tr928
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr940
-		case 82:
-			goto st182
+			goto tr929
 		case 92:
-			goto st75
-		case 114:
-			goto st183
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr938
-		}
-		goto st6
-	st182:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof182
-		}
-	st_case_182:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 85:
+			goto st73
+		case 97:
 			goto st178
-		case 92:
-			goto st75
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr928
 		}
 		goto st6
-	st183:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof183
-		}
-	st_case_183:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 92:
-			goto st75
-		case 117:
-			goto st181
-		}
-		goto st6
-tr356:
+tr355:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -24677,80 +24597,44 @@ tr356:
 			goto _test_eof630
 		}
 	st_case_630:
-//line plugins/parsers/influx/machine.go:24681
+//line plugins/parsers/influx/machine.go:24601
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr755
-		case 12:
-			goto tr939
+			goto tr749
 		case 13:
-			goto tr758
+			goto tr751
 		case 32:
-			goto tr938
+			goto tr928
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr940
+			goto tr929
 		case 92:
-			goto st75
-		case 97:
-			goto st179
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr938
-		}
-		goto st6
-tr357:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st631
-	st631:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof631
-		}
-	st_case_631:
-//line plugins/parsers/influx/machine.go:24715
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr755
-		case 12:
-			goto tr939
-		case 13:
-			goto tr758
-		case 32:
-			goto tr938
-		case 34:
-			goto tr31
-		case 44:
-			goto tr940
-		case 92:
-			goto st75
+			goto st73
 		case 114:
-			goto st183
+			goto st182
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr938
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr928
 		}
 		goto st6
-tr349:
+tr347:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st184
-	st184:
+	goto st183
+	st183:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof184
+			goto _test_eof183
 		}
-	st_case_184:
-//line plugins/parsers/influx/machine.go:24749
+	st_case_183:
+//line plugins/parsers/influx/machine.go:24633
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st172
+			goto st171
 		case 92:
-			goto st172
+			goto st171
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -24761,6 +24645,42 @@ tr349:
 			goto tr8
 		}
 		goto st3
+	st631:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof631
+		}
+	st_case_631:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr532
+		case 13:
+			goto tr533
+		case 32:
+			goto tr531
+		case 34:
+			goto tr29
+		case 44:
+			goto tr534
+		case 46:
+			goto st325
+		case 69:
+			goto st173
+		case 92:
+			goto st73
+		case 101:
+			goto st173
+		case 105:
+			goto st623
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st619
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr531
+		}
+		goto st6
 	st632:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof632
@@ -24768,109 +24688,83 @@ tr349:
 	st_case_632:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr534
-		case 12:
-			goto tr535
+			goto tr532
 		case 13:
-			goto tr536
-		case 32:
 			goto tr533
+		case 32:
+			goto tr531
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr537
+			goto tr534
 		case 46:
-			goto st326
+			goto st325
 		case 69:
-			goto st174
+			goto st173
 		case 92:
-			goto st75
+			goto st73
 		case 101:
-			goto st174
+			goto st173
 		case 105:
-			goto st624
+			goto st623
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st620
+				goto st632
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr533
+			goto tr531
 		}
 		goto st6
+tr169:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st633
 	st633:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof633
 		}
 	st_case_633:
+//line plugins/parsers/influx/machine.go:24732
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr534
-		case 12:
-			goto tr535
+			goto tr891
 		case 13:
-			goto tr536
+			goto tr751
 		case 32:
-			goto tr533
+			goto tr928
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr537
-		case 46:
-			goto st326
-		case 69:
-			goto st174
+			goto tr929
+		case 65:
+			goto st184
 		case 92:
-			goto st75
-		case 101:
-			goto st174
-		case 105:
-			goto st624
+			goto st73
+		case 97:
+			goto st187
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st633
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr533
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr928
 		}
 		goto st6
-tr171:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st634
-	st634:
+	st184:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof634
+			goto _test_eof184
 		}
-	st_case_634:
-//line plugins/parsers/influx/machine.go:24852
+	st_case_184:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr900
-		case 12:
-			goto tr939
-		case 13:
-			goto tr758
-		case 32:
-			goto tr938
+			goto tr28
 		case 34:
-			goto tr31
-		case 44:
-			goto tr940
-		case 65:
+			goto tr29
+		case 76:
 			goto st185
 		case 92:
-			goto st75
-		case 97:
-			goto st188
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr938
+			goto st73
 		}
 		goto st6
 	st185:
@@ -24880,17 +24774,13 @@ tr171:
 	st_case_185:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
-		case 76:
+			goto tr29
+		case 83:
 			goto st186
 		case 92:
-			goto st75
+			goto st73
 		}
 		goto st6
 	st186:
@@ -24900,17 +24790,36 @@ tr171:
 	st_case_186:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
-		case 83:
-			goto st187
+			goto tr29
+		case 69:
+			goto st634
 		case 92:
-			goto st75
+			goto st73
+		}
+		goto st6
+	st634:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof634
+		}
+	st_case_634:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr891
+		case 13:
+			goto tr751
+		case 32:
+			goto tr928
+		case 34:
+			goto tr29
+		case 44:
+			goto tr929
+		case 92:
+			goto st73
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr928
 		}
 		goto st6
 	st187:
@@ -24920,42 +24829,13 @@ tr171:
 	st_case_187:
 		switch ( m.data)[( m.p)] {
 		case 10:
+			goto tr28
+		case 34:
 			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 69:
-			goto st635
 		case 92:
-			goto st75
-		}
-		goto st6
-	st635:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof635
-		}
-	st_case_635:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr900
-		case 12:
-			goto tr939
-		case 13:
-			goto tr758
-		case 32:
-			goto tr938
-		case 34:
-			goto tr31
-		case 44:
-			goto tr940
-		case 92:
-			goto st75
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr938
+			goto st73
+		case 108:
+			goto st188
 		}
 		goto st6
 	st188:
@@ -24965,16 +24845,12 @@ tr171:
 	st_case_188:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
-		case 108:
+			goto st73
+		case 115:
 			goto st189
 		}
 		goto st6
@@ -24985,17 +24861,47 @@ tr171:
 	st_case_189:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
-		case 115:
+			goto st73
+		case 101:
+			goto st634
+		}
+		goto st6
+tr170:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st635
+	st635:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof635
+		}
+	st_case_635:
+//line plugins/parsers/influx/machine.go:24885
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr891
+		case 13:
+			goto tr751
+		case 32:
+			goto tr928
+		case 34:
+			goto tr29
+		case 44:
+			goto tr929
+		case 82:
 			goto st190
+		case 92:
+			goto st73
+		case 114:
+			goto st191
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr928
 		}
 		goto st6
 	st190:
@@ -25005,20 +24911,32 @@ tr171:
 	st_case_190:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
+		case 85:
+			goto st186
 		case 92:
-			goto st75
-		case 101:
-			goto st635
+			goto st73
 		}
 		goto st6
-tr172:
+	st191:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof191
+		}
+	st_case_191:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 34:
+			goto tr29
+		case 92:
+			goto st73
+		case 117:
+			goto st189
+		}
+		goto st6
+tr171:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -25029,72 +24947,28 @@ tr172:
 			goto _test_eof636
 		}
 	st_case_636:
-//line plugins/parsers/influx/machine.go:25033
+//line plugins/parsers/influx/machine.go:24951
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr900
-		case 12:
-			goto tr939
+			goto tr891
 		case 13:
-			goto tr758
+			goto tr751
 		case 32:
-			goto tr938
+			goto tr928
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr940
-		case 82:
-			goto st191
+			goto tr929
 		case 92:
-			goto st75
-		case 114:
-			goto st192
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr938
-		}
-		goto st6
-	st191:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof191
-		}
-	st_case_191:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 85:
+			goto st73
+		case 97:
 			goto st187
-		case 92:
-			goto st75
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr928
 		}
 		goto st6
-	st192:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof192
-		}
-	st_case_192:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 92:
-			goto st75
-		case 117:
-			goto st190
-		}
-		goto st6
-tr173:
+tr172:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -25105,64 +24979,62 @@ tr173:
 			goto _test_eof637
 		}
 	st_case_637:
-//line plugins/parsers/influx/machine.go:25109
+//line plugins/parsers/influx/machine.go:24983
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr900
-		case 12:
-			goto tr939
+			goto tr891
 		case 13:
-			goto tr758
+			goto tr751
 		case 32:
-			goto tr938
+			goto tr928
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr940
+			goto tr929
 		case 92:
-			goto st75
-		case 97:
-			goto st188
+			goto st73
+		case 114:
+			goto st191
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr938
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr928
 		}
 		goto st6
-tr174:
+tr160:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st638
-	st638:
+	goto st192
+	st192:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof638
+			goto _test_eof192
 		}
-	st_case_638:
-//line plugins/parsers/influx/machine.go:25143
+	st_case_192:
+//line plugins/parsers/influx/machine.go:25015
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr900
-		case 12:
-			goto tr939
+			goto tr28
+		case 11:
+			goto tr160
 		case 13:
-			goto tr758
+			goto st6
 		case 32:
-			goto tr938
+			goto st48
 		case 34:
-			goto tr31
+			goto tr95
 		case 44:
-			goto tr940
+			goto st6
+		case 61:
+			goto tr163
 		case 92:
-			goto st75
-		case 114:
-			goto st192
+			goto tr161
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr938
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st48
 		}
-		goto st6
-tr162:
+		goto tr158
+tr138:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -25173,31 +25045,37 @@ tr162:
 			goto _test_eof193
 		}
 	st_case_193:
-//line plugins/parsers/influx/machine.go:25177
+//line plugins/parsers/influx/machine.go:25049
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st49
 		case 10:
-			goto tr29
+			goto tr45
 		case 11:
-			goto tr162
-		case 12:
-			goto st2
+			goto tr59
 		case 13:
-			goto st7
+			goto tr45
 		case 32:
-			goto st49
-		case 34:
-			goto tr97
+			goto tr58
 		case 44:
-			goto st6
+			goto tr60
+		case 46:
+			goto st194
+		case 48:
+			goto st639
 		case 61:
-			goto tr165
+			goto tr45
 		case 92:
-			goto tr163
+			goto st21
 		}
-		goto tr160
-tr140:
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st642
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr58
+		}
+		goto st15
+tr139:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -25208,107 +25086,102 @@ tr140:
 			goto _test_eof194
 		}
 	st_case_194:
-//line plugins/parsers/influx/machine.go:25212
+//line plugins/parsers/influx/machine.go:25090
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
-			goto tr61
+			goto tr59
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
-			goto tr60
+			goto tr58
 		case 44:
-			goto tr62
-		case 46:
-			goto st195
-		case 48:
-			goto st640
+			goto tr60
 		case 61:
-			goto tr47
+			goto tr45
 		case 92:
-			goto st22
+			goto st21
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
-			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st643
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st638
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr60
+			goto tr58
 		}
-		goto st16
-tr141:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st195
+		goto st15
+	st638:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof638
+		}
+	st_case_638:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr730
+		case 11:
+			goto tr731
+		case 13:
+			goto tr732
+		case 32:
+			goto tr729
+		case 44:
+			goto tr733
+		case 61:
+			goto tr130
+		case 69:
+			goto st195
+		case 92:
+			goto st21
+		case 101:
+			goto st195
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st638
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr729
+		}
+		goto st15
 	st195:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof195
 		}
 	st_case_195:
-//line plugins/parsers/influx/machine.go:25253
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
-			goto tr61
+			goto tr59
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
-			goto tr60
+			goto tr58
+		case 34:
+			goto st196
 		case 44:
-			goto tr62
+			goto tr60
 		case 61:
-			goto tr47
+			goto tr45
 		case 92:
-			goto st22
+			goto st21
 		}
 		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st639
+		case ( m.data)[( m.p)] < 43:
+			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+				goto tr58
 			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr60
-		}
-		goto st16
-	st639:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof639
-		}
-	st_case_639:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr734
-		case 11:
-			goto tr735
-		case 13:
-			goto tr736
-		case 32:
-			goto tr731
-		case 44:
-			goto tr737
-		case 61:
-			goto tr132
-		case 69:
-			goto st196
-		case 92:
-			goto st22
-		case 101:
+		case ( m.data)[( m.p)] > 45:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st479
+			}
+		default:
 			goto st196
 		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st639
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr731
-		}
-		goto st16
+		goto st15
 	st196:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof196
@@ -25316,65 +25189,67 @@ tr141:
 	st_case_196:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
-			goto tr61
+			goto tr59
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
-			goto tr60
-		case 34:
-			goto st197
+			goto tr58
 		case 44:
-			goto tr62
-		case 61:
-			goto tr47
-		case 92:
-			goto st22
-		}
-		switch {
-		case ( m.data)[( m.p)] < 43:
-			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-				goto tr60
-			}
-		case ( m.data)[( m.p)] > 45:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st480
-			}
-		default:
-			goto st197
-		}
-		goto st16
-	st197:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof197
-		}
-	st_case_197:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr61
-		case 13:
-			goto tr47
-		case 32:
 			goto tr60
-		case 44:
-			goto tr62
 		case 61:
-			goto tr47
+			goto tr45
 		case 92:
-			goto st22
+			goto st21
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st480
+				goto st479
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr60
+			goto tr58
 		}
-		goto st16
+		goto st15
+	st639:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof639
+		}
+	st_case_639:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr730
+		case 11:
+			goto tr731
+		case 13:
+			goto tr732
+		case 32:
+			goto tr729
+		case 44:
+			goto tr733
+		case 46:
+			goto st638
+		case 61:
+			goto tr130
+		case 69:
+			goto st195
+		case 92:
+			goto st21
+		case 101:
+			goto st195
+		case 105:
+			goto st641
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st640
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr729
+		}
+		goto st15
 	st640:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof640
@@ -25382,37 +25257,35 @@ tr141:
 	st_case_640:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr730
 		case 11:
-			goto tr735
-		case 13:
-			goto tr736
-		case 32:
 			goto tr731
+		case 13:
+			goto tr732
+		case 32:
+			goto tr729
 		case 44:
-			goto tr737
+			goto tr733
 		case 46:
-			goto st639
+			goto st638
 		case 61:
-			goto tr132
+			goto tr130
 		case 69:
-			goto st196
+			goto st195
 		case 92:
-			goto st22
+			goto st21
 		case 101:
-			goto st196
-		case 105:
-			goto st642
+			goto st195
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st641
+				goto st640
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr731
+			goto tr729
 		}
-		goto st16
+		goto st15
 	st641:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof641
@@ -25420,35 +25293,24 @@ tr141:
 	st_case_641:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr942
 		case 11:
-			goto tr735
+			goto tr943
 		case 13:
-			goto tr736
+			goto tr944
 		case 32:
-			goto tr731
+			goto tr941
 		case 44:
-			goto tr737
-		case 46:
-			goto st639
+			goto tr945
 		case 61:
-			goto tr132
-		case 69:
-			goto st196
+			goto tr130
 		case 92:
-			goto st22
-		case 101:
-			goto st196
+			goto st21
 		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st641
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr731
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr941
 		}
-		goto st16
+		goto st15
 	st642:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof642
@@ -25456,135 +25318,157 @@ tr141:
 	st_case_642:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr952
+			goto tr730
 		case 11:
-			goto tr953
+			goto tr731
 		case 13:
-			goto tr954
+			goto tr732
 		case 32:
-			goto tr743
+			goto tr729
 		case 44:
-			goto tr955
+			goto tr733
+		case 46:
+			goto st638
 		case 61:
-			goto tr132
+			goto tr130
+		case 69:
+			goto st195
 		case 92:
-			goto st22
+			goto st21
+		case 101:
+			goto st195
+		case 105:
+			goto st641
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr743
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st642
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr729
 		}
-		goto st16
+		goto st15
+tr140:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st643
 	st643:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof643
 		}
 	st_case_643:
+//line plugins/parsers/influx/machine.go:25364
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr730
 		case 11:
-			goto tr735
-		case 13:
-			goto tr736
-		case 32:
 			goto tr731
+		case 13:
+			goto tr732
+		case 32:
+			goto tr729
 		case 44:
-			goto tr737
+			goto tr733
 		case 46:
-			goto st639
+			goto st638
 		case 61:
-			goto tr132
+			goto tr130
 		case 69:
-			goto st196
+			goto st195
 		case 92:
-			goto st22
+			goto st21
 		case 101:
-			goto st196
+			goto st195
 		case 105:
-			goto st642
+			goto st641
+		case 117:
+			goto st644
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st643
+				goto st640
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr731
+			goto tr729
 		}
-		goto st16
-tr142:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st644
+		goto st15
 	st644:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof644
 		}
 	st_case_644:
-//line plugins/parsers/influx/machine.go:25527
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr948
 		case 11:
-			goto tr735
+			goto tr949
 		case 13:
-			goto tr736
+			goto tr950
 		case 32:
-			goto tr731
+			goto tr947
 		case 44:
-			goto tr737
-		case 46:
-			goto st639
+			goto tr951
 		case 61:
-			goto tr132
-		case 69:
-			goto st196
+			goto tr130
 		case 92:
-			goto st22
-		case 101:
-			goto st196
-		case 105:
-			goto st642
-		case 117:
-			goto st645
+			goto st21
 		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st641
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr731
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr947
 		}
-		goto st16
+		goto st15
+tr141:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st645
 	st645:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof645
 		}
 	st_case_645:
+//line plugins/parsers/influx/machine.go:25436
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr957
+			goto tr730
 		case 11:
-			goto tr958
+			goto tr731
 		case 13:
-			goto tr959
+			goto tr732
 		case 32:
-			goto tr750
+			goto tr729
 		case 44:
-			goto tr960
+			goto tr733
+		case 46:
+			goto st638
 		case 61:
-			goto tr132
+			goto tr130
+		case 69:
+			goto st195
 		case 92:
-			goto st22
+			goto st21
+		case 101:
+			goto st195
+		case 105:
+			goto st641
+		case 117:
+			goto st644
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr750
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st645
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr729
 		}
-		goto st16
-tr143:
+		goto st15
+tr142:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -25595,78 +25479,58 @@ tr143:
 			goto _test_eof646
 		}
 	st_case_646:
-//line plugins/parsers/influx/machine.go:25599
+//line plugins/parsers/influx/machine.go:25483
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr954
 		case 11:
-			goto tr735
+			goto tr955
 		case 13:
-			goto tr736
+			goto tr956
 		case 32:
-			goto tr731
+			goto tr953
 		case 44:
-			goto tr737
-		case 46:
-			goto st639
+			goto tr957
 		case 61:
-			goto tr132
-		case 69:
-			goto st196
-		case 92:
-			goto st22
-		case 101:
-			goto st196
-		case 105:
-			goto st642
-		case 117:
-			goto st645
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st646
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr731
-		}
-		goto st16
-tr144:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st647
-	st647:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof647
-		}
-	st_case_647:
-//line plugins/parsers/influx/machine.go:25646
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr962
-		case 11:
-			goto tr963
-		case 13:
-			goto tr964
-		case 32:
-			goto tr757
-		case 44:
-			goto tr965
-		case 61:
-			goto tr132
+			goto tr130
 		case 65:
-			goto st198
+			goto st197
 		case 92:
-			goto st22
+			goto st21
 		case 97:
-			goto st201
+			goto st200
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr757
+			goto tr953
 		}
-		goto st16
+		goto st15
+	st197:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof197
+		}
+	st_case_197:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr45
+		case 11:
+			goto tr59
+		case 13:
+			goto tr45
+		case 32:
+			goto tr58
+		case 44:
+			goto tr60
+		case 61:
+			goto tr45
+		case 76:
+			goto st198
+		case 92:
+			goto st21
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr58
+		}
+		goto st15
 	st198:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof198
@@ -25674,26 +25538,26 @@ tr144:
 	st_case_198:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
-			goto tr61
+			goto tr59
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
-			goto tr60
+			goto tr58
 		case 44:
-			goto tr62
+			goto tr60
 		case 61:
-			goto tr47
-		case 76:
+			goto tr45
+		case 83:
 			goto st199
 		case 92:
-			goto st22
+			goto st21
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
+			goto tr58
 		}
-		goto st16
+		goto st15
 	st199:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof199
@@ -25701,26 +25565,51 @@ tr144:
 	st_case_199:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
-			goto tr61
+			goto tr59
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
-			goto tr60
+			goto tr58
 		case 44:
-			goto tr62
+			goto tr60
 		case 61:
-			goto tr47
-		case 83:
-			goto st200
+			goto tr45
+		case 69:
+			goto st647
 		case 92:
-			goto st22
+			goto st21
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
+			goto tr58
 		}
-		goto st16
+		goto st15
+	st647:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof647
+		}
+	st_case_647:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr954
+		case 11:
+			goto tr955
+		case 13:
+			goto tr956
+		case 32:
+			goto tr953
+		case 44:
+			goto tr957
+		case 61:
+			goto tr130
+		case 92:
+			goto st21
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr953
+		}
+		goto st15
 	st200:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof200
@@ -25728,51 +25617,26 @@ tr144:
 	st_case_200:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
-			goto tr61
+			goto tr59
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
-			goto tr60
+			goto tr58
 		case 44:
-			goto tr62
+			goto tr60
 		case 61:
-			goto tr47
-		case 69:
-			goto st648
+			goto tr45
 		case 92:
-			goto st22
+			goto st21
+		case 108:
+			goto st201
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
+			goto tr58
 		}
-		goto st16
-	st648:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof648
-		}
-	st_case_648:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr962
-		case 11:
-			goto tr963
-		case 13:
-			goto tr964
-		case 32:
-			goto tr757
-		case 44:
-			goto tr965
-		case 61:
-			goto tr132
-		case 92:
-			goto st22
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr757
-		}
-		goto st16
+		goto st15
 	st201:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof201
@@ -25780,26 +25644,26 @@ tr144:
 	st_case_201:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
-			goto tr61
+			goto tr59
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
-			goto tr60
+			goto tr58
 		case 44:
-			goto tr62
+			goto tr60
 		case 61:
-			goto tr47
+			goto tr45
 		case 92:
-			goto st22
-		case 108:
+			goto st21
+		case 115:
 			goto st202
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
+			goto tr58
 		}
-		goto st16
+		goto st15
 	st202:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof202
@@ -25807,26 +25671,62 @@ tr144:
 	st_case_202:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
-			goto tr61
+			goto tr59
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
-			goto tr60
+			goto tr58
 		case 44:
-			goto tr62
+			goto tr60
 		case 61:
-			goto tr47
+			goto tr45
 		case 92:
-			goto st22
-		case 115:
-			goto st203
+			goto st21
+		case 101:
+			goto st647
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
+			goto tr58
 		}
-		goto st16
+		goto st15
+tr143:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st648
+	st648:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof648
+		}
+	st_case_648:
+//line plugins/parsers/influx/machine.go:25706
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr954
+		case 11:
+			goto tr955
+		case 13:
+			goto tr956
+		case 32:
+			goto tr953
+		case 44:
+			goto tr957
+		case 61:
+			goto tr130
+		case 82:
+			goto st203
+		case 92:
+			goto st21
+		case 114:
+			goto st204
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr953
+		}
+		goto st15
 	st203:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof203
@@ -25834,27 +25734,54 @@ tr144:
 	st_case_203:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
-			goto tr61
+			goto tr59
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
-			goto tr60
+			goto tr58
 		case 44:
-			goto tr62
+			goto tr60
 		case 61:
-			goto tr47
+			goto tr45
+		case 85:
+			goto st199
 		case 92:
-			goto st22
-		case 101:
-			goto st648
+			goto st21
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
+			goto tr58
 		}
-		goto st16
-tr145:
+		goto st15
+	st204:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof204
+		}
+	st_case_204:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr45
+		case 11:
+			goto tr59
+		case 13:
+			goto tr45
+		case 32:
+			goto tr58
+		case 44:
+			goto tr60
+		case 61:
+			goto tr45
+		case 92:
+			goto st21
+		case 117:
+			goto st202
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr58
+		}
+		goto st15
+tr144:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -25865,86 +25792,30 @@ tr145:
 			goto _test_eof649
 		}
 	st_case_649:
-//line plugins/parsers/influx/machine.go:25869
+//line plugins/parsers/influx/machine.go:25796
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr962
+			goto tr954
 		case 11:
-			goto tr963
+			goto tr955
 		case 13:
-			goto tr964
+			goto tr956
 		case 32:
-			goto tr757
+			goto tr953
 		case 44:
-			goto tr965
+			goto tr957
 		case 61:
-			goto tr132
-		case 82:
-			goto st204
+			goto tr130
 		case 92:
-			goto st22
-		case 114:
-			goto st205
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr757
-		}
-		goto st16
-	st204:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof204
-		}
-	st_case_204:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr61
-		case 13:
-			goto tr47
-		case 32:
-			goto tr60
-		case 44:
-			goto tr62
-		case 61:
-			goto tr47
-		case 85:
+			goto st21
+		case 97:
 			goto st200
-		case 92:
-			goto st22
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
+			goto tr953
 		}
-		goto st16
-	st205:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof205
-		}
-	st_case_205:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr61
-		case 13:
-			goto tr47
-		case 32:
-			goto tr60
-		case 44:
-			goto tr62
-		case 61:
-			goto tr47
-		case 92:
-			goto st22
-		case 117:
-			goto st203
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr60
-		}
-		goto st16
-tr146:
+		goto st15
+tr145:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -25955,70 +25826,81 @@ tr146:
 			goto _test_eof650
 		}
 	st_case_650:
-//line plugins/parsers/influx/machine.go:25959
+//line plugins/parsers/influx/machine.go:25830
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr962
+			goto tr954
 		case 11:
-			goto tr963
+			goto tr955
 		case 13:
-			goto tr964
+			goto tr956
 		case 32:
-			goto tr757
+			goto tr953
 		case 44:
-			goto tr965
+			goto tr957
 		case 61:
-			goto tr132
+			goto tr130
 		case 92:
-			goto st22
-		case 97:
-			goto st201
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr757
-		}
-		goto st16
-tr147:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st651
-	st651:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof651
-		}
-	st_case_651:
-//line plugins/parsers/influx/machine.go:25993
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr962
-		case 11:
-			goto tr963
-		case 13:
-			goto tr964
-		case 32:
-			goto tr757
-		case 44:
-			goto tr965
-		case 61:
-			goto tr132
-		case 92:
-			goto st22
+			goto st21
 		case 114:
-			goto st205
+			goto st204
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr757
+			goto tr953
 		}
-		goto st16
-tr123:
+		goto st15
+tr121:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st206
-tr382:
+	goto st205
+tr380:
+	( m.cs) = 205
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st205:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof205
+		}
+	st_case_205:
+//line plugins/parsers/influx/machine.go:25881
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 11:
+			goto tr380
+		case 13:
+			goto st6
+		case 32:
+			goto tr117
+		case 34:
+			goto tr122
+		case 44:
+			goto tr90
+		case 61:
+			goto tr381
+		case 92:
+			goto tr123
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr117
+		}
+		goto tr119
+tr118:
 	( m.cs) = 206
 //line plugins/parsers/influx/machine.go.rl:28
 
@@ -26030,7 +25912,7 @@ tr382:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -26040,137 +25922,110 @@ tr382:
 			goto _test_eof206
 		}
 	st_case_206:
-//line plugins/parsers/influx/machine.go:26044
+//line plugins/parsers/influx/machine.go:25926
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr119
 		case 10:
-			goto tr29
+			goto tr28
 		case 11:
-			goto tr382
-		case 12:
-			goto tr38
+			goto tr380
 		case 13:
-			goto st7
+			goto st6
 		case 32:
-			goto tr119
+			goto tr117
 		case 34:
-			goto tr124
+			goto tr122
 		case 44:
-			goto tr92
+			goto tr90
 		case 61:
-			goto tr383
+			goto tr80
 		case 92:
-			goto tr125
+			goto tr123
 		}
-		goto tr121
-tr120:
-	( m.cs) = 207
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr117
+		}
+		goto tr119
+tr497:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+	goto st207
 	st207:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof207
 		}
 	st_case_207:
-//line plugins/parsers/influx/machine.go:26090
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr119
-		case 10:
-			goto tr29
-		case 11:
-			goto tr382
-		case 12:
-			goto tr38
-		case 13:
-			goto st7
-		case 32:
-			goto tr119
-		case 34:
-			goto tr124
-		case 44:
-			goto tr92
-		case 61:
-			goto tr82
-		case 92:
-			goto tr125
-		}
-		goto tr121
-tr499:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st208
-	st208:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof208
-		}
-	st_case_208:
-//line plugins/parsers/influx/machine.go:26125
+//line plugins/parsers/influx/machine.go:25960
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr105
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st652
+			goto st651
 		}
 		goto st6
-tr500:
+tr498:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st652
+	goto st651
+	st651:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof651
+		}
+	st_case_651:
+//line plugins/parsers/influx/machine.go:25984
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr600
+		case 13:
+			goto tr602
+		case 32:
+			goto tr599
+		case 34:
+			goto tr29
+		case 92:
+			goto st73
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st652
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr599
+		}
+		goto st6
 	st652:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof652
 		}
 	st_case_652:
-//line plugins/parsers/influx/machine.go:26153
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st653
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st653:
@@ -26180,25 +26035,23 @@ tr500:
 	st_case_653:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st654
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st654:
@@ -26208,25 +26061,23 @@ tr500:
 	st_case_654:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st655
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st655:
@@ -26236,25 +26087,23 @@ tr500:
 	st_case_655:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st656
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st656:
@@ -26264,25 +26113,23 @@ tr500:
 	st_case_656:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st657
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st657:
@@ -26292,25 +26139,23 @@ tr500:
 	st_case_657:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st658
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st658:
@@ -26320,25 +26165,23 @@ tr500:
 	st_case_658:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st659
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st659:
@@ -26348,25 +26191,23 @@ tr500:
 	st_case_659:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st660
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st660:
@@ -26376,25 +26217,23 @@ tr500:
 	st_case_660:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st661
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st661:
@@ -26404,25 +26243,23 @@ tr500:
 	st_case_661:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st662
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st662:
@@ -26432,25 +26269,23 @@ tr500:
 	st_case_662:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st663
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st663:
@@ -26460,25 +26295,23 @@ tr500:
 	st_case_663:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st664
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st664:
@@ -26488,25 +26321,23 @@ tr500:
 	st_case_664:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st665
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st665:
@@ -26516,25 +26347,23 @@ tr500:
 	st_case_665:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st666
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st666:
@@ -26544,25 +26373,23 @@ tr500:
 	st_case_666:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st667
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st667:
@@ -26572,25 +26399,23 @@ tr500:
 	st_case_667:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st668
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st668:
@@ -26600,25 +26425,23 @@ tr500:
 	st_case_668:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
-		case 32:
 			goto tr602
+		case 32:
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st669
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+			goto tr599
 		}
 		goto st6
 	st669:
@@ -26628,139 +26451,140 @@ tr500:
 	st_case_669:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr603
-		case 12:
-			goto tr469
+			goto tr600
 		case 13:
-			goto tr605
+			goto tr602
 		case 32:
-			goto tr602
+			goto tr599
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st670
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr602
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr599
 		}
 		goto st6
-	st670:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof670
-		}
-	st_case_670:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr603
-		case 12:
-			goto tr469
-		case 13:
-			goto tr605
-		case 32:
-			goto tr602
-		case 34:
-			goto tr31
-		case 92:
-			goto st75
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr602
-		}
-		goto st6
-tr496:
+tr494:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st209
-tr989:
-	( m.cs) = 209
+	goto st208
+tr981:
+	( m.cs) = 208
 //line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr994:
-	( m.cs) = 209
+tr986:
+	( m.cs) = 208
 //line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr997:
-	( m.cs) = 209
+tr989:
+	( m.cs) = 208
 //line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr1000:
-	( m.cs) = 209
+tr992:
+	( m.cs) = 208
 //line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-	st209:
+	st208:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof209
+			goto _test_eof208
 		}
-	st_case_209:
-//line plugins/parsers/influx/machine.go:26739
+	st_case_208:
+//line plugins/parsers/influx/machine.go:26532
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 32:
 			goto st6
 		case 34:
-			goto tr386
+			goto tr384
 		case 44:
 			goto st6
 		case 61:
 			goto st6
 		case 92:
-			goto tr387
+			goto tr385
 		}
-		goto tr385
-tr385:
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto tr383
+tr383:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
+
+	goto st209
+	st209:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof209
+		}
+	st_case_209:
+//line plugins/parsers/influx/machine.go:26564
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto st6
+		case 10:
+			goto tr28
+		case 32:
+			goto st6
+		case 34:
+			goto tr98
+		case 44:
+			goto st6
+		case 61:
+			goto tr387
+		case 92:
+			goto st223
+		}
+		if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+			goto st6
+		}
+		goto st209
+tr387:
+//line plugins/parsers/influx/machine.go.rl:108
+
+	m.key = m.text()
 
 	goto st210
 	st210:
@@ -26768,32 +26592,37 @@ tr385:
 			goto _test_eof210
 		}
 	st_case_210:
-//line plugins/parsers/influx/machine.go:26772
+//line plugins/parsers/influx/machine.go:26596
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st6
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 32:
-			goto st6
+			goto tr28
 		case 34:
-			goto tr100
-		case 44:
-			goto st6
-		case 61:
+			goto tr351
+		case 45:
 			goto tr389
+		case 46:
+			goto tr390
+		case 48:
+			goto tr391
+		case 70:
+			goto tr110
+		case 84:
+			goto tr111
 		case 92:
-			goto st224
+			goto st73
+		case 102:
+			goto tr112
+		case 116:
+			goto tr113
 		}
-		goto st210
+		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto tr392
+		}
+		goto st6
 tr389:
-//line plugins/parsers/influx/machine.go.rl:108
+//line plugins/parsers/influx/machine.go.rl:28
 
-	m.key = m.text()
+	m.pb = m.p
 
 	goto st211
 	st211:
@@ -26801,38 +26630,24 @@ tr389:
 			goto _test_eof211
 		}
 	st_case_211:
-//line plugins/parsers/influx/machine.go:26805
+//line plugins/parsers/influx/machine.go:26634
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr353
-		case 45:
-			goto tr391
+			goto tr29
 		case 46:
-			goto tr392
+			goto st212
 		case 48:
-			goto tr393
-		case 70:
-			goto tr112
-		case 84:
-			goto tr113
+			goto st672
 		case 92:
-			goto st75
-		case 102:
-			goto tr114
-		case 116:
-			goto tr115
+			goto st73
 		}
 		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto tr394
+			goto st675
 		}
 		goto st6
-tr391:
+tr390:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -26843,50 +26658,84 @@ tr391:
 			goto _test_eof212
 		}
 	st_case_212:
-//line plugins/parsers/influx/machine.go:26847
+//line plugins/parsers/influx/machine.go:26662
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
-		case 46:
-			goto st213
-		case 48:
-			goto st673
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st676
+		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto st670
 		}
 		goto st6
-tr392:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st213
+	st670:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof670
+		}
+	st_case_670:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr758
+		case 13:
+			goto tr638
+		case 32:
+			goto tr980
+		case 34:
+			goto tr29
+		case 44:
+			goto tr981
+		case 69:
+			goto st213
+		case 92:
+			goto st73
+		case 101:
+			goto st213
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st670
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr980
+		}
+		goto st6
 	st213:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof213
 		}
 	st_case_213:
-//line plugins/parsers/influx/machine.go:26879
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr356
+		case 43:
+			goto st214
+		case 45:
+			goto st214
 		case 92:
-			goto st75
+			goto st73
+		}
+		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto st671
+		}
+		goto st6
+	st214:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof214
+		}
+	st_case_214:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 34:
+			goto tr29
+		case 92:
+			goto st73
 		}
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 			goto st671
@@ -26899,77 +26748,25 @@ tr392:
 	st_case_671:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr765
-		case 12:
-			goto tr535
+			goto tr758
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr988
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
-		case 69:
-			goto st214
+			goto tr981
 		case 92:
-			goto st75
-		case 101:
-			goto st214
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st671
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr988
-		}
-		goto st6
-	st214:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof214
-		}
-	st_case_214:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr358
-		case 43:
-			goto st215
-		case 45:
-			goto st215
-		case 92:
-			goto st75
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st672
-		}
-		goto st6
-	st215:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof215
-		}
-	st_case_215:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 92:
-			goto st75
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st672
+			goto tr980
 		}
 		goto st6
 	st672:
@@ -26979,27 +26776,33 @@ tr392:
 	st_case_672:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr765
-		case 12:
-			goto tr535
+			goto tr758
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr988
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
+			goto tr981
+		case 46:
+			goto st670
+		case 69:
+			goto st213
 		case 92:
-			goto st75
+			goto st73
+		case 101:
+			goto st213
+		case 105:
+			goto st674
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st672
+				goto st673
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr988
+			goto tr980
 		}
 		goto st6
 	st673:
@@ -27009,35 +26812,31 @@ tr392:
 	st_case_673:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr765
-		case 12:
-			goto tr535
+			goto tr758
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr988
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
+			goto tr981
 		case 46:
-			goto st671
+			goto st670
 		case 69:
-			goto st214
+			goto st213
 		case 92:
-			goto st75
+			goto st73
 		case 101:
-			goto st214
-		case 105:
-			goto st675
+			goto st213
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st674
+				goto st673
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr988
+			goto tr980
 		}
 		goto st6
 	st674:
@@ -27047,33 +26846,20 @@ tr392:
 	st_case_674:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr765
-		case 12:
-			goto tr535
+			goto tr791
 		case 13:
-			goto tr642
+			goto tr793
 		case 32:
-			goto tr988
+			goto tr985
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
-		case 46:
-			goto st671
-		case 69:
-			goto st214
+			goto tr986
 		case 92:
-			goto st75
-		case 101:
-			goto st214
+			goto st73
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st674
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr988
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr985
 		}
 		goto st6
 	st675:
@@ -27083,135 +26869,149 @@ tr392:
 	st_case_675:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr798
-		case 12:
-			goto tr932
+			goto tr758
 		case 13:
-			goto tr800
+			goto tr638
 		case 32:
-			goto tr993
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr994
+			goto tr981
+		case 46:
+			goto st670
+		case 69:
+			goto st213
 		case 92:
-			goto st75
+			goto st73
+		case 101:
+			goto st213
+		case 105:
+			goto st674
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr993
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st675
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr980
 		}
 		goto st6
+tr391:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st676
 	st676:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof676
 		}
 	st_case_676:
+//line plugins/parsers/influx/machine.go:26913
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr765
-		case 12:
-			goto tr535
+			goto tr758
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr988
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
+			goto tr981
 		case 46:
-			goto st671
+			goto st670
 		case 69:
-			goto st214
+			goto st213
 		case 92:
-			goto st75
+			goto st73
 		case 101:
-			goto st214
+			goto st213
 		case 105:
-			goto st675
+			goto st674
+		case 117:
+			goto st677
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st676
+				goto st673
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr988
+			goto tr980
 		}
 		goto st6
-tr393:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st677
 	st677:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof677
 		}
 	st_case_677:
-//line plugins/parsers/influx/machine.go:27154
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr765
-		case 12:
-			goto tr535
+			goto tr797
 		case 13:
-			goto tr642
+			goto tr799
 		case 32:
 			goto tr988
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
 			goto tr989
-		case 46:
-			goto st671
-		case 69:
-			goto st214
 		case 92:
-			goto st75
-		case 101:
-			goto st214
-		case 105:
-			goto st675
-		case 117:
-			goto st678
+			goto st73
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st674
-			}
-		case ( m.data)[( m.p)] >= 9:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr988
 		}
 		goto st6
+tr392:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st678
 	st678:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof678
 		}
 	st_case_678:
+//line plugins/parsers/influx/machine.go:26981
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr804
-		case 12:
-			goto tr935
+			goto tr758
 		case 13:
-			goto tr806
+			goto tr638
 		case 32:
-			goto tr996
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr997
+			goto tr981
+		case 46:
+			goto st670
+		case 69:
+			goto st213
 		case 92:
-			goto st75
+			goto st73
+		case 101:
+			goto st213
+		case 105:
+			goto st674
+		case 117:
+			goto st677
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr996
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st678
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr980
 		}
 		goto st6
-tr394:
+tr110:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -27222,76 +27022,43 @@ tr394:
 			goto _test_eof679
 		}
 	st_case_679:
-//line plugins/parsers/influx/machine.go:27226
+//line plugins/parsers/influx/machine.go:27026
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr765
-		case 12:
-			goto tr535
+			goto tr803
 		case 13:
-			goto tr642
+			goto tr805
 		case 32:
-			goto tr988
+			goto tr991
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
-		case 46:
-			goto st671
-		case 69:
-			goto st214
+			goto tr992
+		case 65:
+			goto st215
 		case 92:
-			goto st75
-		case 101:
-			goto st214
-		case 105:
-			goto st675
-		case 117:
-			goto st678
+			goto st73
+		case 97:
+			goto st218
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st679
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr988
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr991
 		}
 		goto st6
-tr112:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st680
-	st680:
+	st215:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof680
+			goto _test_eof215
 		}
-	st_case_680:
-//line plugins/parsers/influx/machine.go:27273
+	st_case_215:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr810
-		case 12:
-			goto tr939
-		case 13:
-			goto tr812
-		case 32:
-			goto tr999
+			goto tr28
 		case 34:
-			goto tr31
-		case 44:
-			goto tr1000
-		case 65:
+			goto tr29
+		case 76:
 			goto st216
 		case 92:
-			goto st75
-		case 97:
-			goto st219
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr999
+			goto st73
 		}
 		goto st6
 	st216:
@@ -27301,17 +27068,13 @@ tr112:
 	st_case_216:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
-		case 76:
+			goto tr29
+		case 83:
 			goto st217
 		case 92:
-			goto st75
+			goto st73
 		}
 		goto st6
 	st217:
@@ -27321,17 +27084,36 @@ tr112:
 	st_case_217:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
-		case 83:
-			goto st218
+			goto tr29
+		case 69:
+			goto st680
 		case 92:
-			goto st75
+			goto st73
+		}
+		goto st6
+	st680:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof680
+		}
+	st_case_680:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr803
+		case 13:
+			goto tr805
+		case 32:
+			goto tr991
+		case 34:
+			goto tr29
+		case 44:
+			goto tr992
+		case 92:
+			goto st73
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr991
 		}
 		goto st6
 	st218:
@@ -27341,42 +27123,13 @@ tr112:
 	st_case_218:
 		switch ( m.data)[( m.p)] {
 		case 10:
+			goto tr28
+		case 34:
 			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 69:
-			goto st681
 		case 92:
-			goto st75
-		}
-		goto st6
-	st681:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof681
-		}
-	st_case_681:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr810
-		case 12:
-			goto tr939
-		case 13:
-			goto tr812
-		case 32:
-			goto tr999
-		case 34:
-			goto tr31
-		case 44:
-			goto tr1000
-		case 92:
-			goto st75
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr999
+			goto st73
+		case 108:
+			goto st219
 		}
 		goto st6
 	st219:
@@ -27386,16 +27139,12 @@ tr112:
 	st_case_219:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
-		case 108:
+			goto st73
+		case 115:
 			goto st220
 		}
 		goto st6
@@ -27406,17 +27155,47 @@ tr112:
 	st_case_220:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
 		case 92:
-			goto st75
-		case 115:
+			goto st73
+		case 101:
+			goto st680
+		}
+		goto st6
+tr111:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st681
+	st681:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof681
+		}
+	st_case_681:
+//line plugins/parsers/influx/machine.go:27179
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr803
+		case 13:
+			goto tr805
+		case 32:
+			goto tr991
+		case 34:
+			goto tr29
+		case 44:
+			goto tr992
+		case 82:
 			goto st221
+		case 92:
+			goto st73
+		case 114:
+			goto st222
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr991
 		}
 		goto st6
 	st221:
@@ -27426,20 +27205,32 @@ tr112:
 	st_case_221:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr29
+		case 85:
+			goto st217
 		case 92:
-			goto st75
-		case 101:
-			goto st681
+			goto st73
 		}
 		goto st6
-tr113:
+	st222:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof222
+		}
+	st_case_222:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 34:
+			goto tr29
+		case 92:
+			goto st73
+		case 117:
+			goto st220
+		}
+		goto st6
+tr112:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -27450,72 +27241,28 @@ tr113:
 			goto _test_eof682
 		}
 	st_case_682:
-//line plugins/parsers/influx/machine.go:27454
+//line plugins/parsers/influx/machine.go:27245
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr810
-		case 12:
-			goto tr939
+			goto tr803
 		case 13:
-			goto tr812
+			goto tr805
 		case 32:
-			goto tr999
+			goto tr991
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr1000
-		case 82:
-			goto st222
+			goto tr992
 		case 92:
-			goto st75
-		case 114:
-			goto st223
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr999
-		}
-		goto st6
-	st222:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof222
-		}
-	st_case_222:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 85:
+			goto st73
+		case 97:
 			goto st218
-		case 92:
-			goto st75
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr991
 		}
 		goto st6
-	st223:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof223
-		}
-	st_case_223:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 92:
-			goto st75
-		case 117:
-			goto st221
-		}
-		goto st6
-tr114:
+tr113:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -27526,80 +27273,44 @@ tr114:
 			goto _test_eof683
 		}
 	st_case_683:
-//line plugins/parsers/influx/machine.go:27530
+//line plugins/parsers/influx/machine.go:27277
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr810
-		case 12:
-			goto tr939
+			goto tr803
 		case 13:
-			goto tr812
+			goto tr805
 		case 32:
-			goto tr999
+			goto tr991
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr1000
+			goto tr992
 		case 92:
-			goto st75
-		case 97:
-			goto st219
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr999
-		}
-		goto st6
-tr115:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st684
-	st684:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof684
-		}
-	st_case_684:
-//line plugins/parsers/influx/machine.go:27564
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr810
-		case 12:
-			goto tr939
-		case 13:
-			goto tr812
-		case 32:
-			goto tr999
-		case 34:
-			goto tr31
-		case 44:
-			goto tr1000
-		case 92:
-			goto st75
+			goto st73
 		case 114:
-			goto st223
+			goto st222
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr999
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr991
 		}
 		goto st6
-tr387:
+tr385:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st224
-	st224:
+	goto st223
+	st223:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof224
+			goto _test_eof223
 		}
-	st_case_224:
-//line plugins/parsers/influx/machine.go:27598
+	st_case_223:
+//line plugins/parsers/influx/machine.go:27309
 		switch ( m.data)[( m.p)] {
 		case 34:
-			goto st210
+			goto st209
 		case 92:
-			goto st210
+			goto st209
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -27610,7 +27321,35 @@ tr387:
 			goto tr8
 		}
 		goto st3
-tr108:
+tr106:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st224
+	st224:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof224
+		}
+	st_case_224:
+//line plugins/parsers/influx/machine.go:27336
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 34:
+			goto tr29
+		case 46:
+			goto st225
+		case 48:
+			goto st686
+		case 92:
+			goto st73
+		}
+		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto st689
+		}
+		goto st6
+tr107:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -27621,50 +27360,84 @@ tr108:
 			goto _test_eof225
 		}
 	st_case_225:
-//line plugins/parsers/influx/machine.go:27625
+//line plugins/parsers/influx/machine.go:27364
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
-		case 46:
-			goto st226
-		case 48:
-			goto st687
+			goto tr29
 		case 92:
-			goto st75
+			goto st73
 		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st690
+		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto st684
 		}
 		goto st6
-tr109:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st226
+	st684:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof684
+		}
+	st_case_684:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr636
+		case 13:
+			goto tr638
+		case 32:
+			goto tr980
+		case 34:
+			goto tr29
+		case 44:
+			goto tr981
+		case 69:
+			goto st226
+		case 92:
+			goto st73
+		case 101:
+			goto st226
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st684
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr980
+		}
+		goto st6
 	st226:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof226
 		}
 	st_case_226:
-//line plugins/parsers/influx/machine.go:27657
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
+			goto tr28
 		case 34:
-			goto tr31
+			goto tr356
+		case 43:
+			goto st227
+		case 45:
+			goto st227
 		case 92:
-			goto st75
+			goto st73
+		}
+		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto st685
+		}
+		goto st6
+	st227:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof227
+		}
+	st_case_227:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr28
+		case 34:
+			goto tr29
+		case 92:
+			goto st73
 		}
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 			goto st685
@@ -27677,77 +27450,25 @@ tr109:
 	st_case_685:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr639
-		case 12:
-			goto tr535
+			goto tr636
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr988
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
-		case 69:
-			goto st227
+			goto tr981
 		case 92:
-			goto st75
-		case 101:
-			goto st227
+			goto st73
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 				goto st685
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr988
-		}
-		goto st6
-	st227:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof227
-		}
-	st_case_227:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr358
-		case 43:
-			goto st228
-		case 45:
-			goto st228
-		case 92:
-			goto st75
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st686
-		}
-		goto st6
-	st228:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof228
-		}
-	st_case_228:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr29
-		case 12:
-			goto tr8
-		case 13:
-			goto st7
-		case 34:
-			goto tr31
-		case 92:
-			goto st75
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st686
+			goto tr980
 		}
 		goto st6
 	st686:
@@ -27757,27 +27478,33 @@ tr109:
 	st_case_686:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr639
-		case 12:
-			goto tr535
+			goto tr636
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr988
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
+			goto tr981
+		case 46:
+			goto st684
+		case 69:
+			goto st226
 		case 92:
-			goto st75
+			goto st73
+		case 101:
+			goto st226
+		case 105:
+			goto st688
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st686
+				goto st687
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr988
+			goto tr980
 		}
 		goto st6
 	st687:
@@ -27787,35 +27514,31 @@ tr109:
 	st_case_687:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr639
-		case 12:
-			goto tr535
+			goto tr636
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr988
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
+			goto tr981
 		case 46:
-			goto st685
+			goto st684
 		case 69:
-			goto st227
+			goto st226
 		case 92:
-			goto st75
+			goto st73
 		case 101:
-			goto st227
-		case 105:
-			goto st689
+			goto st226
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st688
+				goto st687
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr988
+			goto tr980
 		}
 		goto st6
 	st688:
@@ -27825,33 +27548,20 @@ tr109:
 	st_case_688:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr639
-		case 12:
-			goto tr535
+			goto tr817
 		case 13:
-			goto tr642
+			goto tr793
 		case 32:
-			goto tr988
+			goto tr985
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
-		case 46:
-			goto st685
-		case 69:
-			goto st227
+			goto tr986
 		case 92:
-			goto st75
-		case 101:
-			goto st227
+			goto st73
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st688
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr988
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr985
 		}
 		goto st6
 	st689:
@@ -27861,182 +27571,183 @@ tr109:
 	st_case_689:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr823
-		case 12:
-			goto tr932
+			goto tr636
 		case 13:
-			goto tr800
+			goto tr638
 		case 32:
-			goto tr993
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr994
+			goto tr981
+		case 46:
+			goto st684
+		case 69:
+			goto st226
 		case 92:
-			goto st75
+			goto st73
+		case 101:
+			goto st226
+		case 105:
+			goto st688
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr993
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st689
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr980
 		}
 		goto st6
+tr108:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st690
 	st690:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof690
 		}
 	st_case_690:
+//line plugins/parsers/influx/machine.go:27615
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr639
-		case 12:
-			goto tr535
+			goto tr636
 		case 13:
-			goto tr642
+			goto tr638
 		case 32:
-			goto tr988
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr989
+			goto tr981
 		case 46:
-			goto st685
+			goto st684
 		case 69:
-			goto st227
+			goto st226
 		case 92:
-			goto st75
+			goto st73
 		case 101:
-			goto st227
+			goto st226
 		case 105:
-			goto st689
+			goto st688
+		case 117:
+			goto st691
 		}
 		switch {
-		case ( m.data)[( m.p)] > 11:
+		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st690
+				goto st687
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr988
+			goto tr980
 		}
 		goto st6
-tr110:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st691
 	st691:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof691
 		}
 	st_case_691:
-//line plugins/parsers/influx/machine.go:27932
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr639
-		case 12:
-			goto tr535
+			goto tr822
 		case 13:
-			goto tr642
+			goto tr799
 		case 32:
 			goto tr988
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
 			goto tr989
-		case 46:
-			goto st685
-		case 69:
-			goto st227
 		case 92:
-			goto st75
-		case 101:
-			goto st227
-		case 105:
-			goto st689
-		case 117:
-			goto st692
+			goto st73
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st688
-			}
-		case ( m.data)[( m.p)] >= 9:
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr988
 		}
 		goto st6
+tr109:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st692
 	st692:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof692
 		}
 	st_case_692:
+//line plugins/parsers/influx/machine.go:27683
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr829
-		case 12:
-			goto tr935
+			goto tr636
 		case 13:
-			goto tr806
+			goto tr638
 		case 32:
-			goto tr996
+			goto tr980
 		case 34:
-			goto tr31
+			goto tr29
 		case 44:
-			goto tr997
+			goto tr981
+		case 46:
+			goto st684
+		case 69:
+			goto st226
 		case 92:
-			goto st75
+			goto st73
+		case 101:
+			goto st226
+		case 105:
+			goto st688
+		case 117:
+			goto st691
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 11 {
-			goto tr996
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st692
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr980
 		}
 		goto st6
-tr111:
+tr94:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st693
-	st693:
+	goto st228
+	st228:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof693
+			goto _test_eof228
 		}
-	st_case_693:
-//line plugins/parsers/influx/machine.go:28004
+	st_case_228:
+//line plugins/parsers/influx/machine.go:27728
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr639
-		case 12:
-			goto tr535
+			goto tr28
+		case 11:
+			goto tr94
 		case 13:
-			goto tr642
+			goto st6
 		case 32:
-			goto tr988
+			goto st30
 		case 34:
-			goto tr31
+			goto tr95
 		case 44:
-			goto tr989
-		case 46:
-			goto st685
-		case 69:
-			goto st227
+			goto st6
+		case 61:
+			goto tr99
 		case 92:
-			goto st75
-		case 101:
-			goto st227
-		case 105:
-			goto st689
-		case 117:
-			goto st692
+			goto tr96
 		}
-		switch {
-		case ( m.data)[( m.p)] > 11:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st693
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr988
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto st30
 		}
-		goto st6
-tr96:
+		goto tr92
+tr72:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -28047,31 +27758,35 @@ tr96:
 			goto _test_eof229
 		}
 	st_case_229:
-//line plugins/parsers/influx/machine.go:28051
+//line plugins/parsers/influx/machine.go:27762
 		switch ( m.data)[( m.p)] {
-		case 9:
-			goto st31
 		case 10:
-			goto tr29
+			goto tr45
 		case 11:
-			goto tr96
-		case 12:
-			goto st2
+			goto tr3
 		case 13:
-			goto st7
+			goto tr45
 		case 32:
-			goto st31
-		case 34:
-			goto tr97
+			goto tr1
 		case 44:
-			goto st6
-		case 61:
-			goto tr101
+			goto tr4
+		case 46:
+			goto st230
+		case 48:
+			goto st694
 		case 92:
-			goto tr98
+			goto st94
 		}
-		goto tr94
-tr74:
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st697
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr1
+		}
+		goto st1
+tr73:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -28082,64 +27797,119 @@ tr74:
 			goto _test_eof230
 		}
 	st_case_230:
-//line plugins/parsers/influx/machine.go:28086
+//line plugins/parsers/influx/machine.go:27801
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
 			goto tr3
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
 			goto tr1
 		case 44:
 			goto tr4
-		case 46:
-			goto st231
-		case 48:
-			goto st695
 		case 92:
-			goto st95
+			goto st94
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
-			if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st698
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st693
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr1
 		}
 		goto st1
-tr75:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st231
+	st693:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof693
+		}
+	st_case_693:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr730
+		case 11:
+			goto tr812
+		case 13:
+			goto tr732
+		case 32:
+			goto tr811
+		case 44:
+			goto tr813
+		case 69:
+			goto st231
+		case 92:
+			goto st94
+		case 101:
+			goto st231
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st693
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr811
+		}
+		goto st1
 	st231:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof231
 		}
 	st_case_231:
-//line plugins/parsers/influx/machine.go:28125
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
 			goto tr3
 		case 13:
-			goto tr47
+			goto tr45
+		case 32:
+			goto tr1
+		case 34:
+			goto st232
+		case 44:
+			goto tr4
+		case 92:
+			goto st94
+		}
+		switch {
+		case ( m.data)[( m.p)] < 43:
+			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+				goto tr1
+			}
+		case ( m.data)[( m.p)] > 45:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st530
+			}
+		default:
+			goto st232
+		}
+		goto st1
+	st232:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof232
+		}
+	st_case_232:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr45
+		case 11:
+			goto tr3
+		case 13:
+			goto tr45
 		case 32:
 			goto tr1
 		case 44:
 			goto tr4
 		case 92:
-			goto st95
+			goto st94
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st694
+				goto st530
 			}
 		case ( m.data)[( m.p)] >= 9:
 			goto tr1
@@ -28152,91 +27922,33 @@ tr75:
 	st_case_694:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr730
 		case 11:
-			goto tr818
+			goto tr812
 		case 13:
-			goto tr736
+			goto tr732
 		case 32:
-			goto tr641
+			goto tr811
 		case 44:
-			goto tr819
+			goto tr813
+		case 46:
+			goto st693
 		case 69:
-			goto st232
+			goto st231
 		case 92:
-			goto st95
+			goto st94
 		case 101:
-			goto st232
+			goto st231
+		case 105:
+			goto st696
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st694
+				goto st695
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr641
-		}
-		goto st1
-	st232:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof232
-		}
-	st_case_232:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr3
-		case 13:
-			goto tr47
-		case 32:
-			goto tr1
-		case 34:
-			goto st233
-		case 44:
-			goto tr4
-		case 92:
-			goto st95
-		}
-		switch {
-		case ( m.data)[( m.p)] < 43:
-			if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-				goto tr1
-			}
-		case ( m.data)[( m.p)] > 45:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st531
-			}
-		default:
-			goto st233
-		}
-		goto st1
-	st233:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof233
-		}
-	st_case_233:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr3
-		case 13:
-			goto tr47
-		case 32:
-			goto tr1
-		case 44:
-			goto tr4
-		case 92:
-			goto st95
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st531
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr1
+			goto tr811
 		}
 		goto st1
 	st695:
@@ -28246,33 +27958,31 @@ tr75:
 	st_case_695:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr730
 		case 11:
-			goto tr818
+			goto tr812
 		case 13:
-			goto tr736
+			goto tr732
 		case 32:
-			goto tr641
+			goto tr811
 		case 44:
-			goto tr819
+			goto tr813
 		case 46:
-			goto st694
+			goto st693
 		case 69:
-			goto st232
+			goto st231
 		case 92:
-			goto st95
+			goto st94
 		case 101:
-			goto st232
-		case 105:
-			goto st697
+			goto st231
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st696
+				goto st695
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr641
+			goto tr811
 		}
 		goto st1
 	st696:
@@ -28282,31 +27992,20 @@ tr75:
 	st_case_696:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr942
 		case 11:
-			goto tr818
+			goto tr1006
 		case 13:
-			goto tr736
+			goto tr944
 		case 32:
-			goto tr641
+			goto tr1005
 		case 44:
-			goto tr819
-		case 46:
-			goto st694
-		case 69:
-			goto st232
+			goto tr1007
 		case 92:
-			goto st95
-		case 101:
-			goto st232
+			goto st94
 		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st696
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr641
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1005
 		}
 		goto st1
 	st697:
@@ -28316,127 +28015,149 @@ tr75:
 	st_case_697:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr952
+			goto tr730
 		case 11:
-			goto tr1013
+			goto tr812
 		case 13:
-			goto tr954
+			goto tr732
 		case 32:
-			goto tr825
+			goto tr811
 		case 44:
-			goto tr1014
+			goto tr813
+		case 46:
+			goto st693
+		case 69:
+			goto st231
 		case 92:
-			goto st95
+			goto st94
+		case 101:
+			goto st231
+		case 105:
+			goto st696
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr825
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st697
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr811
 		}
 		goto st1
+tr74:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st698
 	st698:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof698
 		}
 	st_case_698:
+//line plugins/parsers/influx/machine.go:28059
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr730
 		case 11:
-			goto tr818
+			goto tr812
 		case 13:
-			goto tr736
+			goto tr732
 		case 32:
-			goto tr641
+			goto tr811
 		case 44:
-			goto tr819
+			goto tr813
 		case 46:
-			goto st694
+			goto st693
 		case 69:
-			goto st232
+			goto st231
 		case 92:
-			goto st95
+			goto st94
 		case 101:
-			goto st232
+			goto st231
 		case 105:
-			goto st697
+			goto st696
+		case 117:
+			goto st699
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st698
+				goto st695
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr641
+			goto tr811
 		}
 		goto st1
-tr76:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st699
 	st699:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof699
 		}
 	st_case_699:
-//line plugins/parsers/influx/machine.go:28383
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr948
 		case 11:
-			goto tr818
+			goto tr1010
 		case 13:
-			goto tr736
+			goto tr950
 		case 32:
-			goto tr641
+			goto tr1009
 		case 44:
-			goto tr819
-		case 46:
-			goto st694
-		case 69:
-			goto st232
+			goto tr1011
 		case 92:
-			goto st95
-		case 101:
-			goto st232
-		case 105:
-			goto st697
-		case 117:
-			goto st700
+			goto st94
 		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st696
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr641
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1009
 		}
 		goto st1
+tr75:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st700
 	st700:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof700
 		}
 	st_case_700:
+//line plugins/parsers/influx/machine.go:28127
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr957
+			goto tr730
 		case 11:
-			goto tr1016
+			goto tr812
 		case 13:
-			goto tr959
+			goto tr732
 		case 32:
-			goto tr831
+			goto tr811
 		case 44:
-			goto tr1017
+			goto tr813
+		case 46:
+			goto st693
+		case 69:
+			goto st231
 		case 92:
-			goto st95
+			goto st94
+		case 101:
+			goto st231
+		case 105:
+			goto st696
+		case 117:
+			goto st699
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr831
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st700
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr811
 		}
 		goto st1
-tr77:
+tr76:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -28447,72 +28168,52 @@ tr77:
 			goto _test_eof701
 		}
 	st_case_701:
-//line plugins/parsers/influx/machine.go:28451
+//line plugins/parsers/influx/machine.go:28172
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr954
 		case 11:
-			goto tr818
+			goto tr1014
 		case 13:
-			goto tr736
+			goto tr956
 		case 32:
-			goto tr641
+			goto tr1013
 		case 44:
-			goto tr819
-		case 46:
-			goto st694
-		case 69:
-			goto st232
-		case 92:
-			goto st95
-		case 101:
-			goto st232
-		case 105:
-			goto st697
-		case 117:
-			goto st700
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st701
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr641
-		}
-		goto st1
-tr78:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st702
-	st702:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof702
-		}
-	st_case_702:
-//line plugins/parsers/influx/machine.go:28496
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr962
-		case 11:
-			goto tr1019
-		case 13:
-			goto tr964
-		case 32:
-			goto tr836
-		case 44:
-			goto tr1020
+			goto tr1015
 		case 65:
-			goto st234
+			goto st233
 		case 92:
-			goto st95
+			goto st94
 		case 97:
-			goto st237
+			goto st236
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr836
+			goto tr1013
+		}
+		goto st1
+	st233:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof233
+		}
+	st_case_233:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr45
+		case 11:
+			goto tr3
+		case 13:
+			goto tr45
+		case 32:
+			goto tr1
+		case 44:
+			goto tr4
+		case 76:
+			goto st234
+		case 92:
+			goto st94
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1
 		}
 		goto st1
 	st234:
@@ -28522,19 +28223,19 @@ tr78:
 	st_case_234:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
 			goto tr3
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
 			goto tr1
 		case 44:
 			goto tr4
-		case 76:
+		case 83:
 			goto st235
 		case 92:
-			goto st95
+			goto st94
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr1
@@ -28547,22 +28248,45 @@ tr78:
 	st_case_235:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
 			goto tr3
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
 			goto tr1
 		case 44:
 			goto tr4
-		case 83:
-			goto st236
+		case 69:
+			goto st702
 		case 92:
-			goto st95
+			goto st94
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr1
+		}
+		goto st1
+	st702:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof702
+		}
+	st_case_702:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr954
+		case 11:
+			goto tr1014
+		case 13:
+			goto tr956
+		case 32:
+			goto tr1013
+		case 44:
+			goto tr1015
+		case 92:
+			goto st94
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1013
 		}
 		goto st1
 	st236:
@@ -28572,45 +28296,22 @@ tr78:
 	st_case_236:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
 			goto tr3
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
 			goto tr1
 		case 44:
 			goto tr4
-		case 69:
-			goto st703
 		case 92:
-			goto st95
+			goto st94
+		case 108:
+			goto st237
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr1
-		}
-		goto st1
-	st703:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof703
-		}
-	st_case_703:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr962
-		case 11:
-			goto tr1019
-		case 13:
-			goto tr964
-		case 32:
-			goto tr836
-		case 44:
-			goto tr1020
-		case 92:
-			goto st95
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr836
 		}
 		goto st1
 	st237:
@@ -28620,18 +28321,18 @@ tr78:
 	st_case_237:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
 			goto tr3
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
 			goto tr1
 		case 44:
 			goto tr4
 		case 92:
-			goto st95
-		case 108:
+			goto st94
+		case 115:
 			goto st238
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
@@ -28645,22 +28346,56 @@ tr78:
 	st_case_238:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
 			goto tr3
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
 			goto tr1
 		case 44:
 			goto tr4
 		case 92:
-			goto st95
-		case 115:
-			goto st239
+			goto st94
+		case 101:
+			goto st702
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr1
+		}
+		goto st1
+tr77:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st703
+	st703:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof703
+		}
+	st_case_703:
+//line plugins/parsers/influx/machine.go:28379
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr954
+		case 11:
+			goto tr1014
+		case 13:
+			goto tr956
+		case 32:
+			goto tr1013
+		case 44:
+			goto tr1015
+		case 82:
+			goto st239
+		case 92:
+			goto st94
+		case 114:
+			goto st240
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1013
 		}
 		goto st1
 	st239:
@@ -28670,25 +28405,50 @@ tr78:
 	st_case_239:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr47
+			goto tr45
 		case 11:
 			goto tr3
 		case 13:
-			goto tr47
+			goto tr45
 		case 32:
 			goto tr1
 		case 44:
 			goto tr4
+		case 85:
+			goto st235
 		case 92:
-			goto st95
-		case 101:
-			goto st703
+			goto st94
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
 			goto tr1
 		}
 		goto st1
-tr79:
+	st240:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof240
+		}
+	st_case_240:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr45
+		case 11:
+			goto tr3
+		case 13:
+			goto tr45
+		case 32:
+			goto tr1
+		case 44:
+			goto tr4
+		case 92:
+			goto st94
+		case 117:
+			goto st238
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1
+		}
+		goto st1
+tr78:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -28699,80 +28459,28 @@ tr79:
 			goto _test_eof704
 		}
 	st_case_704:
-//line plugins/parsers/influx/machine.go:28703
+//line plugins/parsers/influx/machine.go:28463
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr962
+			goto tr954
 		case 11:
-			goto tr1019
+			goto tr1014
 		case 13:
-			goto tr964
+			goto tr956
 		case 32:
-			goto tr836
+			goto tr1013
 		case 44:
-			goto tr1020
-		case 82:
-			goto st240
+			goto tr1015
 		case 92:
-			goto st95
-		case 114:
-			goto st241
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr836
-		}
-		goto st1
-	st240:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof240
-		}
-	st_case_240:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr3
-		case 13:
-			goto tr47
-		case 32:
-			goto tr1
-		case 44:
-			goto tr4
-		case 85:
+			goto st94
+		case 97:
 			goto st236
-		case 92:
-			goto st95
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr1
+			goto tr1013
 		}
 		goto st1
-	st241:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof241
-		}
-	st_case_241:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr47
-		case 11:
-			goto tr3
-		case 13:
-			goto tr47
-		case 32:
-			goto tr1
-		case 44:
-			goto tr4
-		case 92:
-			goto st95
-		case 117:
-			goto st239
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr1
-		}
-		goto st1
-tr80:
+tr79:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -28783,66 +28491,77 @@ tr80:
 			goto _test_eof705
 		}
 	st_case_705:
-//line plugins/parsers/influx/machine.go:28787
+//line plugins/parsers/influx/machine.go:28495
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr962
+			goto tr954
 		case 11:
-			goto tr1019
+			goto tr1014
 		case 13:
-			goto tr964
+			goto tr956
 		case 32:
-			goto tr836
+			goto tr1013
 		case 44:
-			goto tr1020
+			goto tr1015
 		case 92:
-			goto st95
-		case 97:
-			goto st237
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr836
-		}
-		goto st1
-tr81:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st706
-	st706:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof706
-		}
-	st_case_706:
-//line plugins/parsers/influx/machine.go:28819
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr962
-		case 11:
-			goto tr1019
-		case 13:
-			goto tr964
-		case 32:
-			goto tr836
-		case 44:
-			goto tr1020
-		case 92:
-			goto st95
+			goto st94
 		case 114:
-			goto st241
+			goto st240
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr836
+			goto tr1013
 		}
 		goto st1
-tr44:
+tr42:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st242
-tr424:
+	goto st241
+tr422:
+	( m.cs) = 241
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st241:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof241
+		}
+	st_case_241:
+//line plugins/parsers/influx/machine.go:28544
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr421
+		case 11:
+			goto tr422
+		case 13:
+			goto tr421
+		case 32:
+			goto tr36
+		case 44:
+			goto tr4
+		case 61:
+			goto tr423
+		case 92:
+			goto tr43
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr36
+		}
+		goto tr39
+tr38:
 	( m.cs) = 242
 //line plugins/parsers/influx/machine.go.rl:28
 
@@ -28854,7 +28573,7 @@ tr424:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -28864,71 +28583,464 @@ tr424:
 			goto _test_eof242
 		}
 	st_case_242:
-//line plugins/parsers/influx/machine.go:28868
+//line plugins/parsers/influx/machine.go:28587
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr423
+			goto tr421
 		case 11:
-			goto tr424
+			goto tr422
 		case 13:
-			goto tr423
+			goto tr421
 		case 32:
-			goto tr38
+			goto tr36
 		case 44:
 			goto tr4
 		case 61:
-			goto tr425
+			goto tr31
 		case 92:
-			goto tr45
+			goto tr43
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr38
+			goto tr36
 		}
-		goto tr41
-tr40:
-	( m.cs) = 243
+		goto tr39
+tr462:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
+	goto st243
 	st243:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof243
 		}
 	st_case_243:
-//line plugins/parsers/influx/machine.go:28911
+//line plugins/parsers/influx/machine.go:28619
+		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto st706
+		}
+		goto tr424
+tr463:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st706
+	st706:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof706
+		}
+	st_case_706:
+//line plugins/parsers/influx/machine.go:28635
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr423
-		case 11:
-			goto tr424
+			goto tr468
 		case 13:
-			goto tr423
+			goto tr470
 		case 32:
-			goto tr38
-		case 44:
-			goto tr4
-		case 61:
-			goto tr33
-		case 92:
-			goto tr45
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st707
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st707:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof707
+		}
+	st_case_707:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st708
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st708:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof708
+		}
+	st_case_708:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st709
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st709:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof709
+		}
+	st_case_709:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st710
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st710:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof710
+		}
+	st_case_710:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st711
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st711:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof711
+		}
+	st_case_711:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st712
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st712:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof712
+		}
+	st_case_712:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st713
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st713:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof713
+		}
+	st_case_713:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st714
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st714:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof714
+		}
+	st_case_714:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st715
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st715:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof715
+		}
+	st_case_715:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st716
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st716:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof716
+		}
+	st_case_716:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st717
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st717:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof717
+		}
+	st_case_717:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st718
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st718:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof718
+		}
+	st_case_718:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st719
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st719:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof719
+		}
+	st_case_719:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st720
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st720:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof720
+		}
+	st_case_720:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st721
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st721:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof721
+		}
+	st_case_721:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st722
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st722:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof722
+		}
+	st_case_722:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st723
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st723:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof723
+		}
+	st_case_723:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st724
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr467
+		}
+		goto tr424
+	st724:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof724
+		}
+	st_case_724:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr468
+		case 13:
+			goto tr470
+		case 32:
+			goto tr467
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr38
+			goto tr467
 		}
-		goto tr41
-tr464:
+		goto tr424
+tr15:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -28939,432 +29051,18 @@ tr464:
 			goto _test_eof244
 		}
 	st_case_244:
-//line plugins/parsers/influx/machine.go:28943
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st707
-		}
-		goto tr426
-tr465:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st707
-	st707:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof707
-		}
-	st_case_707:
-//line plugins/parsers/influx/machine.go:28959
+//line plugins/parsers/influx/machine.go:29055
 		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
+		case 46:
+			goto st245
+		case 48:
+			goto st726
 		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st708
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
+		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto st729
 		}
-		goto tr426
-	st708:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof708
-		}
-	st_case_708:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st709
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st709:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof709
-		}
-	st_case_709:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st710
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st710:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof710
-		}
-	st_case_710:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st711
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st711:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof711
-		}
-	st_case_711:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st712
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st712:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof712
-		}
-	st_case_712:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st713
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st713:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof713
-		}
-	st_case_713:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st714
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st714:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof714
-		}
-	st_case_714:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st715
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st715:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof715
-		}
-	st_case_715:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st716
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st716:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof716
-		}
-	st_case_716:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st717
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st717:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof717
-		}
-	st_case_717:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st718
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st718:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof718
-		}
-	st_case_718:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st719
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st719:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof719
-		}
-	st_case_719:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st720
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st720:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof720
-		}
-	st_case_720:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st721
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st721:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof721
-		}
-	st_case_721:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st722
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st722:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof722
-		}
-	st_case_722:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st723
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st723:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof723
-		}
-	st_case_723:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st724
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st724:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof724
-		}
-	st_case_724:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st725
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr469
-		}
-		goto tr426
-	st725:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof725
-		}
-	st_case_725:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr470
-		case 13:
-			goto tr472
-		case 32:
-			goto tr469
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr469
-		}
-		goto tr426
-tr15:
+		goto tr8
+tr16:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -29375,31 +29073,63 @@ tr15:
 			goto _test_eof245
 		}
 	st_case_245:
-//line plugins/parsers/influx/machine.go:29379
-		switch ( m.data)[( m.p)] {
-		case 46:
-			goto st246
-		case 48:
-			goto st727
-		}
-		if 49 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st730
+//line plugins/parsers/influx/machine.go:29077
+		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto st725
 		}
 		goto tr8
-tr16:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st246
+	st725:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof725
+		}
+	st_case_725:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr730
+		case 13:
+			goto tr732
+		case 32:
+			goto tr921
+		case 44:
+			goto tr922
+		case 69:
+			goto st246
+		case 101:
+			goto st246
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st725
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr921
+		}
+		goto tr103
 	st246:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof246
 		}
 	st_case_246:
-//line plugins/parsers/influx/machine.go:29401
+		switch ( m.data)[( m.p)] {
+		case 34:
+			goto st247
+		case 43:
+			goto st247
+		case 45:
+			goto st247
+		}
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st726
+			goto st621
+		}
+		goto tr8
+	st247:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof247
+		}
+	st_case_247:
+		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+			goto st621
 		}
 		goto tr8
 	st726:
@@ -29409,53 +29139,31 @@ tr16:
 	st_case_726:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr730
 		case 13:
-			goto tr736
+			goto tr732
 		case 32:
-			goto tr535
+			goto tr921
 		case 44:
-			goto tr930
+			goto tr922
+		case 46:
+			goto st725
 		case 69:
-			goto st247
+			goto st246
 		case 101:
-			goto st247
+			goto st246
+		case 105:
+			goto st728
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st726
+				goto st727
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr535
+			goto tr921
 		}
-		goto tr105
-	st247:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof247
-		}
-	st_case_247:
-		switch ( m.data)[( m.p)] {
-		case 34:
-			goto st248
-		case 43:
-			goto st248
-		case 45:
-			goto st248
-		}
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st622
-		}
-		goto tr8
-	st248:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof248
-		}
-	st_case_248:
-		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-			goto st622
-		}
-		goto tr8
+		goto tr103
 	st727:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof727
@@ -29463,31 +29171,29 @@ tr16:
 	st_case_727:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr730
 		case 13:
-			goto tr736
+			goto tr732
 		case 32:
-			goto tr535
+			goto tr921
 		case 44:
-			goto tr930
+			goto tr922
 		case 46:
-			goto st726
+			goto st725
 		case 69:
-			goto st247
+			goto st246
 		case 101:
-			goto st247
-		case 105:
-			goto st729
+			goto st246
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st728
+				goto st727
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr535
+			goto tr921
 		}
-		goto tr105
+		goto tr103
 	st728:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof728
@@ -29495,29 +29201,18 @@ tr16:
 	st_case_728:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr942
 		case 13:
-			goto tr736
+			goto tr944
 		case 32:
-			goto tr535
+			goto tr1041
 		case 44:
-			goto tr930
-		case 46:
-			goto st726
-		case 69:
-			goto st247
-		case 101:
-			goto st247
+			goto tr1042
 		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st728
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr535
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1041
 		}
-		goto tr105
+		goto tr103
 	st729:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof729
@@ -29525,111 +29220,133 @@ tr16:
 	st_case_729:
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr952
+			goto tr730
 		case 13:
-			goto tr954
+			goto tr732
 		case 32:
-			goto tr932
+			goto tr921
 		case 44:
-			goto tr1046
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr932
-		}
-		goto tr105
-	st730:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof730
-		}
-	st_case_730:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr734
-		case 13:
-			goto tr736
-		case 32:
-			goto tr535
-		case 44:
-			goto tr930
+			goto tr922
 		case 46:
-			goto st726
+			goto st725
 		case 69:
-			goto st247
+			goto st246
 		case 101:
-			goto st247
+			goto st246
 		case 105:
-			goto st729
+			goto st728
 		}
 		switch {
 		case ( m.data)[( m.p)] > 12:
 			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st730
+				goto st729
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr535
+			goto tr921
 		}
-		goto tr105
+		goto tr103
 tr17:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st731
+	goto st730
+	st730:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof730
+		}
+	st_case_730:
+//line plugins/parsers/influx/machine.go:29260
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr730
+		case 13:
+			goto tr732
+		case 32:
+			goto tr921
+		case 44:
+			goto tr922
+		case 46:
+			goto st725
+		case 69:
+			goto st246
+		case 101:
+			goto st246
+		case 105:
+			goto st728
+		case 117:
+			goto st731
+		}
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st727
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr921
+		}
+		goto tr103
 	st731:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof731
 		}
 	st_case_731:
-//line plugins/parsers/influx/machine.go:29584
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr948
 		case 13:
-			goto tr736
+			goto tr950
 		case 32:
-			goto tr535
+			goto tr1044
 		case 44:
-			goto tr930
-		case 46:
-			goto st726
-		case 69:
-			goto st247
-		case 101:
-			goto st247
-		case 105:
-			goto st729
-		case 117:
-			goto st732
+			goto tr1045
 		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st728
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr535
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1044
 		}
-		goto tr105
+		goto tr103
+tr18:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st732
 	st732:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof732
 		}
 	st_case_732:
+//line plugins/parsers/influx/machine.go:29320
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr957
+			goto tr730
 		case 13:
-			goto tr959
+			goto tr732
 		case 32:
-			goto tr935
+			goto tr921
 		case 44:
-			goto tr1048
+			goto tr922
+		case 46:
+			goto st725
+		case 69:
+			goto st246
+		case 101:
+			goto st246
+		case 105:
+			goto st728
+		case 117:
+			goto st731
 		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr935
+		switch {
+		case ( m.data)[( m.p)] > 12:
+			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
+				goto st732
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr921
 		}
-		goto tr105
-tr18:
+		goto tr103
+tr19:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -29640,72 +29357,40 @@ tr18:
 			goto _test_eof733
 		}
 	st_case_733:
-//line plugins/parsers/influx/machine.go:29644
+//line plugins/parsers/influx/machine.go:29361
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr734
+			goto tr954
 		case 13:
-			goto tr736
+			goto tr956
 		case 32:
-			goto tr535
+			goto tr1047
 		case 44:
-			goto tr930
-		case 46:
-			goto st726
-		case 69:
-			goto st247
-		case 101:
-			goto st247
-		case 105:
-			goto st729
-		case 117:
-			goto st732
-		}
-		switch {
-		case ( m.data)[( m.p)] > 12:
-			if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
-				goto st733
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr535
-		}
-		goto tr105
-tr19:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st734
-	st734:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof734
-		}
-	st_case_734:
-//line plugins/parsers/influx/machine.go:29685
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr962
-		case 13:
-			goto tr964
-		case 32:
-			goto tr939
-		case 44:
-			goto tr1050
+			goto tr1048
 		case 65:
-			goto st249
+			goto st248
 		case 97:
-			goto st252
+			goto st251
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr939
+			goto tr1047
 		}
-		goto tr105
+		goto tr103
+	st248:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof248
+		}
+	st_case_248:
+		if ( m.data)[( m.p)] == 76 {
+			goto st249
+		}
+		goto tr8
 	st249:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof249
 		}
 	st_case_249:
-		if ( m.data)[( m.p)] == 76 {
+		if ( m.data)[( m.p)] == 83 {
 			goto st250
 		}
 		goto tr8
@@ -29714,44 +29399,44 @@ tr19:
 			goto _test_eof250
 		}
 	st_case_250:
-		if ( m.data)[( m.p)] == 83 {
-			goto st251
+		if ( m.data)[( m.p)] == 69 {
+			goto st734
 		}
 		goto tr8
+	st734:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof734
+		}
+	st_case_734:
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr954
+		case 13:
+			goto tr956
+		case 32:
+			goto tr1047
+		case 44:
+			goto tr1048
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1047
+		}
+		goto tr103
 	st251:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof251
 		}
 	st_case_251:
-		if ( m.data)[( m.p)] == 69 {
-			goto st735
+		if ( m.data)[( m.p)] == 108 {
+			goto st252
 		}
 		goto tr8
-	st735:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof735
-		}
-	st_case_735:
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr962
-		case 13:
-			goto tr964
-		case 32:
-			goto tr939
-		case 44:
-			goto tr1050
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr939
-		}
-		goto tr105
 	st252:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof252
 		}
 	st_case_252:
-		if ( m.data)[( m.p)] == 108 {
+		if ( m.data)[( m.p)] == 115 {
 			goto st253
 		}
 		goto tr8
@@ -29760,20 +29445,59 @@ tr19:
 			goto _test_eof253
 		}
 	st_case_253:
-		if ( m.data)[( m.p)] == 115 {
-			goto st254
+		if ( m.data)[( m.p)] == 101 {
+			goto st734
 		}
 		goto tr8
+tr20:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
+
+	goto st735
+	st735:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof735
+		}
+	st_case_735:
+//line plugins/parsers/influx/machine.go:29464
+		switch ( m.data)[( m.p)] {
+		case 10:
+			goto tr954
+		case 13:
+			goto tr956
+		case 32:
+			goto tr1047
+		case 44:
+			goto tr1048
+		case 82:
+			goto st254
+		case 114:
+			goto st255
+		}
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1047
+		}
+		goto tr103
 	st254:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof254
 		}
 	st_case_254:
-		if ( m.data)[( m.p)] == 101 {
-			goto st735
+		if ( m.data)[( m.p)] == 85 {
+			goto st250
 		}
 		goto tr8
-tr20:
+	st255:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof255
+		}
+	st_case_255:
+		if ( m.data)[( m.p)] == 117 {
+			goto st253
+		}
+		goto tr8
+tr21:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -29784,44 +29508,24 @@ tr20:
 			goto _test_eof736
 		}
 	st_case_736:
-//line plugins/parsers/influx/machine.go:29788
+//line plugins/parsers/influx/machine.go:29512
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr962
+			goto tr954
 		case 13:
-			goto tr964
+			goto tr956
 		case 32:
-			goto tr939
+			goto tr1047
 		case 44:
-			goto tr1050
-		case 82:
-			goto st255
-		case 114:
-			goto st256
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr939
-		}
-		goto tr105
-	st255:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof255
-		}
-	st_case_255:
-		if ( m.data)[( m.p)] == 85 {
+			goto tr1048
+		case 97:
 			goto st251
 		}
-		goto tr8
-	st256:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof256
+		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
+			goto tr1047
 		}
-	st_case_256:
-		if ( m.data)[( m.p)] == 117 {
-			goto st254
-		}
-		goto tr8
-tr21:
+		goto tr103
+tr22:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -29832,63 +29536,35 @@ tr21:
 			goto _test_eof737
 		}
 	st_case_737:
-//line plugins/parsers/influx/machine.go:29836
+//line plugins/parsers/influx/machine.go:29540
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr962
+			goto tr954
 		case 13:
-			goto tr964
+			goto tr956
 		case 32:
-			goto tr939
+			goto tr1047
 		case 44:
-			goto tr1050
-		case 97:
-			goto st252
-		}
-		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr939
-		}
-		goto tr105
-tr22:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st738
-	st738:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof738
-		}
-	st_case_738:
-//line plugins/parsers/influx/machine.go:29864
-		switch ( m.data)[( m.p)] {
-		case 10:
-			goto tr962
-		case 13:
-			goto tr964
-		case 32:
-			goto tr939
-		case 44:
-			goto tr1050
+			goto tr1048
 		case 114:
-			goto st256
+			goto st255
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto tr939
+			goto tr1047
 		}
-		goto tr105
+		goto tr103
 tr9:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-	goto st257
-	st257:
+	goto st256
+	st256:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof257
+			goto _test_eof256
 		}
-	st_case_257:
-//line plugins/parsers/influx/machine.go:29892
+	st_case_256:
+//line plugins/parsers/influx/machine.go:29568
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr8
@@ -29909,16 +29585,16 @@ tr9:
 			goto st2
 		}
 		goto tr6
-	st258:
+	st257:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof258
+			goto _test_eof257
 		}
-	st_case_258:
+	st_case_257:
 		if ( m.data)[( m.p)] == 10 {
-			goto tr440
+			goto tr438
 		}
-		goto st258
-tr440:
+		goto st257
+tr438:
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
@@ -29927,41 +29603,41 @@ tr440:
 
 //line plugins/parsers/influx/machine.go.rl:78
 
-	{goto st740 }
+	{goto st739 }
 
-	goto st739
-	st739:
+	goto st738
+	st738:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof739
+			goto _test_eof738
 		}
-	st_case_739:
-//line plugins/parsers/influx/machine.go:29939
+	st_case_738:
+//line plugins/parsers/influx/machine.go:29615
 		goto st0
-	st261:
+	st260:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof261
+			goto _test_eof260
 		}
-	st_case_261:
+	st_case_260:
 		switch ( m.data)[( m.p)] {
 		case 32:
-			goto tr35
+			goto tr33
 		case 35:
-			goto tr35
+			goto tr33
 		case 44:
-			goto tr35
+			goto tr33
 		case 92:
-			goto tr444
+			goto tr442
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr35
+				goto tr33
 			}
 		case ( m.data)[( m.p)] >= 9:
-			goto tr35
+			goto tr33
 		}
-		goto tr443
-tr443:
+		goto tr441
+tr441:
 //line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
@@ -29970,47 +29646,47 @@ tr443:
 
 	m.pb = m.p
 
-	goto st741
-	st741:
+	goto st740
+	st740:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof741
+			goto _test_eof740
 		}
-	st_case_741:
-//line plugins/parsers/influx/machine.go:29980
+	st_case_740:
+//line plugins/parsers/influx/machine.go:29656
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr2
 		case 10:
-			goto tr1058
+			goto tr1056
 		case 12:
 			goto tr2
 		case 13:
-			goto tr1059
+			goto tr1057
 		case 32:
 			goto tr2
 		case 44:
-			goto tr1060
+			goto tr1058
 		case 92:
-			goto st269
+			goto st268
 		}
-		goto st741
-tr445:
+		goto st740
+tr443:
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-	goto st742
-tr1058:
-	( m.cs) = 742
+	goto st741
+tr1056:
+	( m.cs) = 741
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -30021,15 +29697,15 @@ tr1058:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-tr1062:
-	( m.cs) = 742
+tr1060:
+	( m.cs) = 741
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -30040,20 +29716,56 @@ tr1062:
 	m.sol++ // next char will be the first column in the line
 
 	goto _again
-	st742:
+	st741:
 //line plugins/parsers/influx/machine.go.rl:172
 
 	m.finishMetric = true
-	( m.cs) = 740;
+	( m.cs) = 739;
 	{( m.p)++; goto _out }
 
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof742
+			goto _test_eof741
 		}
-	st_case_742:
-//line plugins/parsers/influx/machine.go:30055
+	st_case_741:
+//line plugins/parsers/influx/machine.go:29731
 		goto st0
-tr1059:
+tr1057:
+	( m.cs) = 261
+//line plugins/parsers/influx/machine.go.rl:86
+
+	err = m.handler.SetMeasurement(m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+tr1061:
+	( m.cs) = 261
+//line plugins/parsers/influx/machine.go.rl:99
+
+	err = m.handler.AddTag(m.key, m.text())
+	if err != nil {
+		( m.p)--
+
+		( m.cs) = 257;
+		{( m.p)++; goto _out }
+	}
+
+	goto _again
+	st261:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof261
+		}
+	st_case_261:
+//line plugins/parsers/influx/machine.go:29764
+		if ( m.data)[( m.p)] == 10 {
+			goto tr443
+		}
+		goto st0
+tr1058:
 	( m.cs) = 262
 //line plugins/parsers/influx/machine.go.rl:86
 
@@ -30061,12 +29773,12 @@ tr1059:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
 	goto _again
-tr1063:
+tr1062:
 	( m.cs) = 262
 //line plugins/parsers/influx/machine.go.rl:99
 
@@ -30074,7 +29786,7 @@ tr1063:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; goto _out }
 	}
 
@@ -30084,43 +29796,7 @@ tr1063:
 			goto _test_eof262
 		}
 	st_case_262:
-//line plugins/parsers/influx/machine.go:30088
-		if ( m.data)[( m.p)] == 10 {
-			goto tr445
-		}
-		goto st0
-tr1060:
-	( m.cs) = 263
-//line plugins/parsers/influx/machine.go.rl:86
-
-	err = m.handler.SetMeasurement(m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-tr1064:
-	( m.cs) = 263
-//line plugins/parsers/influx/machine.go.rl:99
-
-	err = m.handler.AddTag(m.key, m.text())
-	if err != nil {
-		( m.p)--
-
-		( m.cs) = 258;
-		{( m.p)++; goto _out }
-	}
-
-	goto _again
-	st263:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof263
-		}
-	st_case_263:
-//line plugins/parsers/influx/machine.go:30124
+//line plugins/parsers/influx/machine.go:29800
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
@@ -30129,7 +29805,7 @@ tr1064:
 		case 61:
 			goto tr2
 		case 92:
-			goto tr447
+			goto tr445
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -30139,11 +29815,42 @@ tr1064:
 		case ( m.data)[( m.p)] >= 9:
 			goto tr2
 		}
-		goto tr446
-tr446:
+		goto tr444
+tr444:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
+
+	goto st263
+	st263:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof263
+		}
+	st_case_263:
+//line plugins/parsers/influx/machine.go:29831
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto tr2
+		case 44:
+			goto tr2
+		case 61:
+			goto tr447
+		case 92:
+			goto st266
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr2
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr2
+		}
+		goto st263
+tr447:
+//line plugins/parsers/influx/machine.go.rl:95
+
+	m.key = m.text()
 
 	goto st264
 	st264:
@@ -30151,16 +29858,16 @@ tr446:
 			goto _test_eof264
 		}
 	st_case_264:
-//line plugins/parsers/influx/machine.go:30155
+//line plugins/parsers/influx/machine.go:29862
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
 		case 44:
 			goto tr2
 		case 61:
-			goto tr449
+			goto tr2
 		case 92:
-			goto st267
+			goto tr450
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -30170,11 +29877,42 @@ tr446:
 		case ( m.data)[( m.p)] >= 9:
 			goto tr2
 		}
-		goto st264
+		goto tr449
 tr449:
-//line plugins/parsers/influx/machine.go.rl:95
+//line plugins/parsers/influx/machine.go.rl:28
 
-	m.key = m.text()
+	m.pb = m.p
+
+	goto st742
+	st742:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof742
+		}
+	st_case_742:
+//line plugins/parsers/influx/machine.go:29893
+		switch ( m.data)[( m.p)] {
+		case 9:
+			goto tr2
+		case 10:
+			goto tr1060
+		case 12:
+			goto tr2
+		case 13:
+			goto tr1061
+		case 32:
+			goto tr2
+		case 44:
+			goto tr1062
+		case 61:
+			goto tr2
+		case 92:
+			goto st265
+		}
+		goto st742
+tr450:
+//line plugins/parsers/influx/machine.go.rl:28
+
+	m.pb = m.p
 
 	goto st265
 	st265:
@@ -30182,16 +29920,9 @@ tr449:
 			goto _test_eof265
 		}
 	st_case_265:
-//line plugins/parsers/influx/machine.go:30186
-		switch ( m.data)[( m.p)] {
-		case 32:
-			goto tr2
-		case 44:
-			goto tr2
-		case 61:
-			goto tr2
-		case 92:
-			goto tr452
+//line plugins/parsers/influx/machine.go:29924
+		if ( m.data)[( m.p)] == 92 {
+			goto st743
 		}
 		switch {
 		case ( m.data)[( m.p)] > 10:
@@ -30201,39 +29932,36 @@ tr449:
 		case ( m.data)[( m.p)] >= 9:
 			goto tr2
 		}
-		goto tr451
-tr451:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st743
+		goto st742
 	st743:
+//line plugins/parsers/influx/machine.go.rl:248
+ ( m.p)--
+ 
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof743
 		}
 	st_case_743:
-//line plugins/parsers/influx/machine.go:30217
+//line plugins/parsers/influx/machine.go:29945
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr2
 		case 10:
-			goto tr1062
+			goto tr1060
 		case 12:
 			goto tr2
 		case 13:
-			goto tr1063
+			goto tr1061
 		case 32:
 			goto tr2
 		case 44:
-			goto tr1064
+			goto tr1062
 		case 61:
 			goto tr2
 		case 92:
-			goto st266
+			goto st265
 		}
-		goto st743
-tr452:
+		goto st742
+tr445:
 //line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
@@ -30244,88 +29972,8 @@ tr452:
 			goto _test_eof266
 		}
 	st_case_266:
-//line plugins/parsers/influx/machine.go:30248
+//line plugins/parsers/influx/machine.go:29976
 		if ( m.data)[( m.p)] == 92 {
-			goto st744
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr2
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr2
-		}
-		goto st743
-	st744:
-//line plugins/parsers/influx/machine.go.rl:248
- ( m.p)--
- 
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof744
-		}
-	st_case_744:
-//line plugins/parsers/influx/machine.go:30269
-		switch ( m.data)[( m.p)] {
-		case 9:
-			goto tr2
-		case 10:
-			goto tr1062
-		case 12:
-			goto tr2
-		case 13:
-			goto tr1063
-		case 32:
-			goto tr2
-		case 44:
-			goto tr1064
-		case 61:
-			goto tr2
-		case 92:
-			goto st266
-		}
-		goto st743
-tr447:
-//line plugins/parsers/influx/machine.go.rl:28
-
-	m.pb = m.p
-
-	goto st267
-	st267:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof267
-		}
-	st_case_267:
-//line plugins/parsers/influx/machine.go:30300
-		if ( m.data)[( m.p)] == 92 {
-			goto st268
-		}
-		switch {
-		case ( m.data)[( m.p)] > 10:
-			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
-				goto tr2
-			}
-		case ( m.data)[( m.p)] >= 9:
-			goto tr2
-		}
-		goto st264
-	st268:
-//line plugins/parsers/influx/machine.go.rl:248
- ( m.p)--
- 
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof268
-		}
-	st_case_268:
-//line plugins/parsers/influx/machine.go:30321
-		switch ( m.data)[( m.p)] {
-		case 32:
-			goto tr2
-		case 44:
-			goto tr2
-		case 61:
-			goto tr449
-		case 92:
 			goto st267
 		}
 		switch {
@@ -30336,8 +29984,36 @@ tr447:
 		case ( m.data)[( m.p)] >= 9:
 			goto tr2
 		}
-		goto st264
-tr444:
+		goto st263
+	st267:
+//line plugins/parsers/influx/machine.go.rl:248
+ ( m.p)--
+ 
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof267
+		}
+	st_case_267:
+//line plugins/parsers/influx/machine.go:29997
+		switch ( m.data)[( m.p)] {
+		case 32:
+			goto tr2
+		case 44:
+			goto tr2
+		case 61:
+			goto tr447
+		case 92:
+			goto st266
+		}
+		switch {
+		case ( m.data)[( m.p)] > 10:
+			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
+				goto tr2
+			}
+		case ( m.data)[( m.p)] >= 9:
+			goto tr2
+		}
+		goto st263
+tr442:
 //line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
@@ -30346,13 +30022,13 @@ tr444:
 
 	m.pb = m.p
 
-	goto st269
-	st269:
+	goto st268
+	st268:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof269
+			goto _test_eof268
 		}
-	st_case_269:
-//line plugins/parsers/influx/machine.go:30356
+	st_case_268:
+//line plugins/parsers/influx/machine.go:30032
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -30361,65 +30037,65 @@ tr444:
 		case ( m.data)[( m.p)] >= 9:
 			goto st0
 		}
-		goto st741
-tr441:
+		goto st740
+tr439:
 //line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-	goto st740
-	st740:
+	goto st739
+	st739:
 		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof740
+			goto _test_eof739
 		}
-	st_case_740:
-//line plugins/parsers/influx/machine.go:30379
+	st_case_739:
+//line plugins/parsers/influx/machine.go:30055
 		switch ( m.data)[( m.p)] {
 		case 10:
-			goto tr441
+			goto tr439
 		case 13:
-			goto st259
+			goto st258
 		case 32:
-			goto st740
+			goto st739
 		case 35:
-			goto st260
+			goto st259
 		}
 		if 9 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 12 {
-			goto st740
+			goto st739
 		}
-		goto tr1055
+		goto tr1053
+	st258:
+		if ( m.p)++; ( m.p) == ( m.pe) {
+			goto _test_eof258
+		}
+	st_case_258:
+		if ( m.data)[( m.p)] == 10 {
+			goto tr439
+		}
+		goto st0
 	st259:
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof259
 		}
 	st_case_259:
 		if ( m.data)[( m.p)] == 10 {
-			goto tr441
+			goto tr439
 		}
-		goto st0
-	st260:
-		if ( m.p)++; ( m.p) == ( m.pe) {
-			goto _test_eof260
-		}
-	st_case_260:
-		if ( m.data)[( m.p)] == 10 {
-			goto tr441
-		}
-		goto st260
+		goto st259
 	st_out:
-	_test_eof270: ( m.cs) = 270; goto _test_eof
+	_test_eof269: ( m.cs) = 269; goto _test_eof
 	_test_eof1: ( m.cs) = 1; goto _test_eof
 	_test_eof2: ( m.cs) = 2; goto _test_eof
 	_test_eof3: ( m.cs) = 3; goto _test_eof
 	_test_eof4: ( m.cs) = 4; goto _test_eof
 	_test_eof5: ( m.cs) = 5; goto _test_eof
 	_test_eof6: ( m.cs) = 6; goto _test_eof
-	_test_eof7: ( m.cs) = 7; goto _test_eof
+	_test_eof270: ( m.cs) = 270; goto _test_eof
 	_test_eof271: ( m.cs) = 271; goto _test_eof
 	_test_eof272: ( m.cs) = 272; goto _test_eof
-	_test_eof273: ( m.cs) = 273; goto _test_eof
+	_test_eof7: ( m.cs) = 7; goto _test_eof
 	_test_eof8: ( m.cs) = 8; goto _test_eof
 	_test_eof9: ( m.cs) = 9; goto _test_eof
 	_test_eof10: ( m.cs) = 10; goto _test_eof
@@ -30444,15 +30120,15 @@ tr441:
 	_test_eof29: ( m.cs) = 29; goto _test_eof
 	_test_eof30: ( m.cs) = 30; goto _test_eof
 	_test_eof31: ( m.cs) = 31; goto _test_eof
-	_test_eof32: ( m.cs) = 32; goto _test_eof
+	_test_eof273: ( m.cs) = 273; goto _test_eof
 	_test_eof274: ( m.cs) = 274; goto _test_eof
-	_test_eof275: ( m.cs) = 275; goto _test_eof
+	_test_eof32: ( m.cs) = 32; goto _test_eof
 	_test_eof33: ( m.cs) = 33; goto _test_eof
-	_test_eof34: ( m.cs) = 34; goto _test_eof
+	_test_eof275: ( m.cs) = 275; goto _test_eof
 	_test_eof276: ( m.cs) = 276; goto _test_eof
 	_test_eof277: ( m.cs) = 277; goto _test_eof
+	_test_eof34: ( m.cs) = 34; goto _test_eof
 	_test_eof278: ( m.cs) = 278; goto _test_eof
-	_test_eof35: ( m.cs) = 35; goto _test_eof
 	_test_eof279: ( m.cs) = 279; goto _test_eof
 	_test_eof280: ( m.cs) = 280; goto _test_eof
 	_test_eof281: ( m.cs) = 281; goto _test_eof
@@ -30470,22 +30146,22 @@ tr441:
 	_test_eof293: ( m.cs) = 293; goto _test_eof
 	_test_eof294: ( m.cs) = 294; goto _test_eof
 	_test_eof295: ( m.cs) = 295; goto _test_eof
-	_test_eof296: ( m.cs) = 296; goto _test_eof
+	_test_eof35: ( m.cs) = 35; goto _test_eof
 	_test_eof36: ( m.cs) = 36; goto _test_eof
-	_test_eof37: ( m.cs) = 37; goto _test_eof
+	_test_eof296: ( m.cs) = 296; goto _test_eof
 	_test_eof297: ( m.cs) = 297; goto _test_eof
 	_test_eof298: ( m.cs) = 298; goto _test_eof
-	_test_eof299: ( m.cs) = 299; goto _test_eof
+	_test_eof37: ( m.cs) = 37; goto _test_eof
 	_test_eof38: ( m.cs) = 38; goto _test_eof
 	_test_eof39: ( m.cs) = 39; goto _test_eof
 	_test_eof40: ( m.cs) = 40; goto _test_eof
 	_test_eof41: ( m.cs) = 41; goto _test_eof
-	_test_eof42: ( m.cs) = 42; goto _test_eof
+	_test_eof299: ( m.cs) = 299; goto _test_eof
 	_test_eof300: ( m.cs) = 300; goto _test_eof
 	_test_eof301: ( m.cs) = 301; goto _test_eof
 	_test_eof302: ( m.cs) = 302; goto _test_eof
+	_test_eof42: ( m.cs) = 42; goto _test_eof
 	_test_eof303: ( m.cs) = 303; goto _test_eof
-	_test_eof43: ( m.cs) = 43; goto _test_eof
 	_test_eof304: ( m.cs) = 304; goto _test_eof
 	_test_eof305: ( m.cs) = 305; goto _test_eof
 	_test_eof306: ( m.cs) = 306; goto _test_eof
@@ -30507,7 +30183,7 @@ tr441:
 	_test_eof322: ( m.cs) = 322; goto _test_eof
 	_test_eof323: ( m.cs) = 323; goto _test_eof
 	_test_eof324: ( m.cs) = 324; goto _test_eof
-	_test_eof325: ( m.cs) = 325; goto _test_eof
+	_test_eof43: ( m.cs) = 43; goto _test_eof
 	_test_eof44: ( m.cs) = 44; goto _test_eof
 	_test_eof45: ( m.cs) = 45; goto _test_eof
 	_test_eof46: ( m.cs) = 46; goto _test_eof
@@ -30517,19 +30193,19 @@ tr441:
 	_test_eof50: ( m.cs) = 50; goto _test_eof
 	_test_eof51: ( m.cs) = 51; goto _test_eof
 	_test_eof52: ( m.cs) = 52; goto _test_eof
-	_test_eof53: ( m.cs) = 53; goto _test_eof
+	_test_eof325: ( m.cs) = 325; goto _test_eof
 	_test_eof326: ( m.cs) = 326; goto _test_eof
 	_test_eof327: ( m.cs) = 327; goto _test_eof
-	_test_eof328: ( m.cs) = 328; goto _test_eof
+	_test_eof53: ( m.cs) = 53; goto _test_eof
 	_test_eof54: ( m.cs) = 54; goto _test_eof
 	_test_eof55: ( m.cs) = 55; goto _test_eof
 	_test_eof56: ( m.cs) = 56; goto _test_eof
 	_test_eof57: ( m.cs) = 57; goto _test_eof
 	_test_eof58: ( m.cs) = 58; goto _test_eof
-	_test_eof59: ( m.cs) = 59; goto _test_eof
+	_test_eof328: ( m.cs) = 328; goto _test_eof
 	_test_eof329: ( m.cs) = 329; goto _test_eof
+	_test_eof59: ( m.cs) = 59; goto _test_eof
 	_test_eof330: ( m.cs) = 330; goto _test_eof
-	_test_eof60: ( m.cs) = 60; goto _test_eof
 	_test_eof331: ( m.cs) = 331; goto _test_eof
 	_test_eof332: ( m.cs) = 332; goto _test_eof
 	_test_eof333: ( m.cs) = 333; goto _test_eof
@@ -30549,12 +30225,12 @@ tr441:
 	_test_eof347: ( m.cs) = 347; goto _test_eof
 	_test_eof348: ( m.cs) = 348; goto _test_eof
 	_test_eof349: ( m.cs) = 349; goto _test_eof
+	_test_eof60: ( m.cs) = 60; goto _test_eof
 	_test_eof350: ( m.cs) = 350; goto _test_eof
-	_test_eof61: ( m.cs) = 61; goto _test_eof
 	_test_eof351: ( m.cs) = 351; goto _test_eof
 	_test_eof352: ( m.cs) = 352; goto _test_eof
+	_test_eof61: ( m.cs) = 61; goto _test_eof
 	_test_eof353: ( m.cs) = 353; goto _test_eof
-	_test_eof62: ( m.cs) = 62; goto _test_eof
 	_test_eof354: ( m.cs) = 354; goto _test_eof
 	_test_eof355: ( m.cs) = 355; goto _test_eof
 	_test_eof356: ( m.cs) = 356; goto _test_eof
@@ -30574,28 +30250,28 @@ tr441:
 	_test_eof370: ( m.cs) = 370; goto _test_eof
 	_test_eof371: ( m.cs) = 371; goto _test_eof
 	_test_eof372: ( m.cs) = 372; goto _test_eof
-	_test_eof373: ( m.cs) = 373; goto _test_eof
+	_test_eof62: ( m.cs) = 62; goto _test_eof
 	_test_eof63: ( m.cs) = 63; goto _test_eof
 	_test_eof64: ( m.cs) = 64; goto _test_eof
 	_test_eof65: ( m.cs) = 65; goto _test_eof
 	_test_eof66: ( m.cs) = 66; goto _test_eof
+	_test_eof373: ( m.cs) = 373; goto _test_eof
 	_test_eof67: ( m.cs) = 67; goto _test_eof
-	_test_eof374: ( m.cs) = 374; goto _test_eof
 	_test_eof68: ( m.cs) = 68; goto _test_eof
 	_test_eof69: ( m.cs) = 69; goto _test_eof
 	_test_eof70: ( m.cs) = 70; goto _test_eof
 	_test_eof71: ( m.cs) = 71; goto _test_eof
-	_test_eof72: ( m.cs) = 72; goto _test_eof
+	_test_eof374: ( m.cs) = 374; goto _test_eof
 	_test_eof375: ( m.cs) = 375; goto _test_eof
 	_test_eof376: ( m.cs) = 376; goto _test_eof
-	_test_eof377: ( m.cs) = 377; goto _test_eof
+	_test_eof72: ( m.cs) = 72; goto _test_eof
 	_test_eof73: ( m.cs) = 73; goto _test_eof
 	_test_eof74: ( m.cs) = 74; goto _test_eof
+	_test_eof377: ( m.cs) = 377; goto _test_eof
 	_test_eof378: ( m.cs) = 378; goto _test_eof
 	_test_eof379: ( m.cs) = 379; goto _test_eof
 	_test_eof75: ( m.cs) = 75; goto _test_eof
 	_test_eof380: ( m.cs) = 380; goto _test_eof
-	_test_eof76: ( m.cs) = 76; goto _test_eof
 	_test_eof381: ( m.cs) = 381; goto _test_eof
 	_test_eof382: ( m.cs) = 382; goto _test_eof
 	_test_eof383: ( m.cs) = 383; goto _test_eof
@@ -30615,7 +30291,7 @@ tr441:
 	_test_eof397: ( m.cs) = 397; goto _test_eof
 	_test_eof398: ( m.cs) = 398; goto _test_eof
 	_test_eof399: ( m.cs) = 399; goto _test_eof
-	_test_eof400: ( m.cs) = 400; goto _test_eof
+	_test_eof76: ( m.cs) = 76; goto _test_eof
 	_test_eof77: ( m.cs) = 77; goto _test_eof
 	_test_eof78: ( m.cs) = 78; goto _test_eof
 	_test_eof79: ( m.cs) = 79; goto _test_eof
@@ -30629,29 +30305,29 @@ tr441:
 	_test_eof87: ( m.cs) = 87; goto _test_eof
 	_test_eof88: ( m.cs) = 88; goto _test_eof
 	_test_eof89: ( m.cs) = 89; goto _test_eof
-	_test_eof90: ( m.cs) = 90; goto _test_eof
+	_test_eof400: ( m.cs) = 400; goto _test_eof
 	_test_eof401: ( m.cs) = 401; goto _test_eof
 	_test_eof402: ( m.cs) = 402; goto _test_eof
 	_test_eof403: ( m.cs) = 403; goto _test_eof
-	_test_eof404: ( m.cs) = 404; goto _test_eof
+	_test_eof90: ( m.cs) = 90; goto _test_eof
 	_test_eof91: ( m.cs) = 91; goto _test_eof
 	_test_eof92: ( m.cs) = 92; goto _test_eof
 	_test_eof93: ( m.cs) = 93; goto _test_eof
-	_test_eof94: ( m.cs) = 94; goto _test_eof
+	_test_eof404: ( m.cs) = 404; goto _test_eof
 	_test_eof405: ( m.cs) = 405; goto _test_eof
-	_test_eof406: ( m.cs) = 406; goto _test_eof
+	_test_eof94: ( m.cs) = 94; goto _test_eof
 	_test_eof95: ( m.cs) = 95; goto _test_eof
+	_test_eof406: ( m.cs) = 406; goto _test_eof
 	_test_eof96: ( m.cs) = 96; goto _test_eof
-	_test_eof407: ( m.cs) = 407; goto _test_eof
 	_test_eof97: ( m.cs) = 97; goto _test_eof
-	_test_eof98: ( m.cs) = 98; goto _test_eof
+	_test_eof407: ( m.cs) = 407; goto _test_eof
 	_test_eof408: ( m.cs) = 408; goto _test_eof
+	_test_eof98: ( m.cs) = 98; goto _test_eof
 	_test_eof409: ( m.cs) = 409; goto _test_eof
-	_test_eof99: ( m.cs) = 99; goto _test_eof
 	_test_eof410: ( m.cs) = 410; goto _test_eof
-	_test_eof411: ( m.cs) = 411; goto _test_eof
+	_test_eof99: ( m.cs) = 99; goto _test_eof
 	_test_eof100: ( m.cs) = 100; goto _test_eof
-	_test_eof101: ( m.cs) = 101; goto _test_eof
+	_test_eof411: ( m.cs) = 411; goto _test_eof
 	_test_eof412: ( m.cs) = 412; goto _test_eof
 	_test_eof413: ( m.cs) = 413; goto _test_eof
 	_test_eof414: ( m.cs) = 414; goto _test_eof
@@ -30669,17 +30345,17 @@ tr441:
 	_test_eof426: ( m.cs) = 426; goto _test_eof
 	_test_eof427: ( m.cs) = 427; goto _test_eof
 	_test_eof428: ( m.cs) = 428; goto _test_eof
+	_test_eof101: ( m.cs) = 101; goto _test_eof
 	_test_eof429: ( m.cs) = 429; goto _test_eof
-	_test_eof102: ( m.cs) = 102; goto _test_eof
 	_test_eof430: ( m.cs) = 430; goto _test_eof
 	_test_eof431: ( m.cs) = 431; goto _test_eof
-	_test_eof432: ( m.cs) = 432; goto _test_eof
+	_test_eof102: ( m.cs) = 102; goto _test_eof
 	_test_eof103: ( m.cs) = 103; goto _test_eof
-	_test_eof104: ( m.cs) = 104; goto _test_eof
+	_test_eof432: ( m.cs) = 432; goto _test_eof
 	_test_eof433: ( m.cs) = 433; goto _test_eof
 	_test_eof434: ( m.cs) = 434; goto _test_eof
+	_test_eof104: ( m.cs) = 104; goto _test_eof
 	_test_eof435: ( m.cs) = 435; goto _test_eof
-	_test_eof105: ( m.cs) = 105; goto _test_eof
 	_test_eof436: ( m.cs) = 436; goto _test_eof
 	_test_eof437: ( m.cs) = 437; goto _test_eof
 	_test_eof438: ( m.cs) = 438; goto _test_eof
@@ -30699,8 +30375,8 @@ tr441:
 	_test_eof452: ( m.cs) = 452; goto _test_eof
 	_test_eof453: ( m.cs) = 453; goto _test_eof
 	_test_eof454: ( m.cs) = 454; goto _test_eof
+	_test_eof105: ( m.cs) = 105; goto _test_eof
 	_test_eof455: ( m.cs) = 455; goto _test_eof
-	_test_eof106: ( m.cs) = 106; goto _test_eof
 	_test_eof456: ( m.cs) = 456; goto _test_eof
 	_test_eof457: ( m.cs) = 457; goto _test_eof
 	_test_eof458: ( m.cs) = 458; goto _test_eof
@@ -30722,17 +30398,17 @@ tr441:
 	_test_eof474: ( m.cs) = 474; goto _test_eof
 	_test_eof475: ( m.cs) = 475; goto _test_eof
 	_test_eof476: ( m.cs) = 476; goto _test_eof
-	_test_eof477: ( m.cs) = 477; goto _test_eof
+	_test_eof106: ( m.cs) = 106; goto _test_eof
 	_test_eof107: ( m.cs) = 107; goto _test_eof
 	_test_eof108: ( m.cs) = 108; goto _test_eof
 	_test_eof109: ( m.cs) = 109; goto _test_eof
 	_test_eof110: ( m.cs) = 110; goto _test_eof
+	_test_eof477: ( m.cs) = 477; goto _test_eof
 	_test_eof111: ( m.cs) = 111; goto _test_eof
 	_test_eof478: ( m.cs) = 478; goto _test_eof
-	_test_eof112: ( m.cs) = 112; goto _test_eof
 	_test_eof479: ( m.cs) = 479; goto _test_eof
+	_test_eof112: ( m.cs) = 112; goto _test_eof
 	_test_eof480: ( m.cs) = 480; goto _test_eof
-	_test_eof113: ( m.cs) = 113; goto _test_eof
 	_test_eof481: ( m.cs) = 481; goto _test_eof
 	_test_eof482: ( m.cs) = 482; goto _test_eof
 	_test_eof483: ( m.cs) = 483; goto _test_eof
@@ -30741,27 +30417,27 @@ tr441:
 	_test_eof486: ( m.cs) = 486; goto _test_eof
 	_test_eof487: ( m.cs) = 487; goto _test_eof
 	_test_eof488: ( m.cs) = 488; goto _test_eof
-	_test_eof489: ( m.cs) = 489; goto _test_eof
+	_test_eof113: ( m.cs) = 113; goto _test_eof
 	_test_eof114: ( m.cs) = 114; goto _test_eof
 	_test_eof115: ( m.cs) = 115; goto _test_eof
+	_test_eof489: ( m.cs) = 489; goto _test_eof
 	_test_eof116: ( m.cs) = 116; goto _test_eof
-	_test_eof490: ( m.cs) = 490; goto _test_eof
 	_test_eof117: ( m.cs) = 117; goto _test_eof
 	_test_eof118: ( m.cs) = 118; goto _test_eof
+	_test_eof490: ( m.cs) = 490; goto _test_eof
 	_test_eof119: ( m.cs) = 119; goto _test_eof
-	_test_eof491: ( m.cs) = 491; goto _test_eof
 	_test_eof120: ( m.cs) = 120; goto _test_eof
-	_test_eof121: ( m.cs) = 121; goto _test_eof
+	_test_eof491: ( m.cs) = 491; goto _test_eof
 	_test_eof492: ( m.cs) = 492; goto _test_eof
-	_test_eof493: ( m.cs) = 493; goto _test_eof
+	_test_eof121: ( m.cs) = 121; goto _test_eof
 	_test_eof122: ( m.cs) = 122; goto _test_eof
 	_test_eof123: ( m.cs) = 123; goto _test_eof
 	_test_eof124: ( m.cs) = 124; goto _test_eof
-	_test_eof125: ( m.cs) = 125; goto _test_eof
+	_test_eof493: ( m.cs) = 493; goto _test_eof
 	_test_eof494: ( m.cs) = 494; goto _test_eof
 	_test_eof495: ( m.cs) = 495; goto _test_eof
+	_test_eof125: ( m.cs) = 125; goto _test_eof
 	_test_eof496: ( m.cs) = 496; goto _test_eof
-	_test_eof126: ( m.cs) = 126; goto _test_eof
 	_test_eof497: ( m.cs) = 497; goto _test_eof
 	_test_eof498: ( m.cs) = 498; goto _test_eof
 	_test_eof499: ( m.cs) = 499; goto _test_eof
@@ -30781,9 +30457,9 @@ tr441:
 	_test_eof513: ( m.cs) = 513; goto _test_eof
 	_test_eof514: ( m.cs) = 514; goto _test_eof
 	_test_eof515: ( m.cs) = 515; goto _test_eof
-	_test_eof516: ( m.cs) = 516; goto _test_eof
+	_test_eof126: ( m.cs) = 126; goto _test_eof
 	_test_eof127: ( m.cs) = 127; goto _test_eof
-	_test_eof128: ( m.cs) = 128; goto _test_eof
+	_test_eof516: ( m.cs) = 516; goto _test_eof
 	_test_eof517: ( m.cs) = 517; goto _test_eof
 	_test_eof518: ( m.cs) = 518; goto _test_eof
 	_test_eof519: ( m.cs) = 519; goto _test_eof
@@ -30792,27 +30468,27 @@ tr441:
 	_test_eof522: ( m.cs) = 522; goto _test_eof
 	_test_eof523: ( m.cs) = 523; goto _test_eof
 	_test_eof524: ( m.cs) = 524; goto _test_eof
-	_test_eof525: ( m.cs) = 525; goto _test_eof
+	_test_eof128: ( m.cs) = 128; goto _test_eof
 	_test_eof129: ( m.cs) = 129; goto _test_eof
 	_test_eof130: ( m.cs) = 130; goto _test_eof
+	_test_eof525: ( m.cs) = 525; goto _test_eof
 	_test_eof131: ( m.cs) = 131; goto _test_eof
-	_test_eof526: ( m.cs) = 526; goto _test_eof
 	_test_eof132: ( m.cs) = 132; goto _test_eof
 	_test_eof133: ( m.cs) = 133; goto _test_eof
+	_test_eof526: ( m.cs) = 526; goto _test_eof
 	_test_eof134: ( m.cs) = 134; goto _test_eof
-	_test_eof527: ( m.cs) = 527; goto _test_eof
 	_test_eof135: ( m.cs) = 135; goto _test_eof
-	_test_eof136: ( m.cs) = 136; goto _test_eof
+	_test_eof527: ( m.cs) = 527; goto _test_eof
 	_test_eof528: ( m.cs) = 528; goto _test_eof
-	_test_eof529: ( m.cs) = 529; goto _test_eof
+	_test_eof136: ( m.cs) = 136; goto _test_eof
 	_test_eof137: ( m.cs) = 137; goto _test_eof
 	_test_eof138: ( m.cs) = 138; goto _test_eof
-	_test_eof139: ( m.cs) = 139; goto _test_eof
+	_test_eof529: ( m.cs) = 529; goto _test_eof
 	_test_eof530: ( m.cs) = 530; goto _test_eof
+	_test_eof139: ( m.cs) = 139; goto _test_eof
 	_test_eof531: ( m.cs) = 531; goto _test_eof
 	_test_eof140: ( m.cs) = 140; goto _test_eof
 	_test_eof532: ( m.cs) = 532; goto _test_eof
-	_test_eof141: ( m.cs) = 141; goto _test_eof
 	_test_eof533: ( m.cs) = 533; goto _test_eof
 	_test_eof534: ( m.cs) = 534; goto _test_eof
 	_test_eof535: ( m.cs) = 535; goto _test_eof
@@ -30820,17 +30496,17 @@ tr441:
 	_test_eof537: ( m.cs) = 537; goto _test_eof
 	_test_eof538: ( m.cs) = 538; goto _test_eof
 	_test_eof539: ( m.cs) = 539; goto _test_eof
-	_test_eof540: ( m.cs) = 540; goto _test_eof
+	_test_eof141: ( m.cs) = 141; goto _test_eof
 	_test_eof142: ( m.cs) = 142; goto _test_eof
 	_test_eof143: ( m.cs) = 143; goto _test_eof
+	_test_eof540: ( m.cs) = 540; goto _test_eof
 	_test_eof144: ( m.cs) = 144; goto _test_eof
-	_test_eof541: ( m.cs) = 541; goto _test_eof
 	_test_eof145: ( m.cs) = 145; goto _test_eof
 	_test_eof146: ( m.cs) = 146; goto _test_eof
+	_test_eof541: ( m.cs) = 541; goto _test_eof
 	_test_eof147: ( m.cs) = 147; goto _test_eof
-	_test_eof542: ( m.cs) = 542; goto _test_eof
 	_test_eof148: ( m.cs) = 148; goto _test_eof
-	_test_eof149: ( m.cs) = 149; goto _test_eof
+	_test_eof542: ( m.cs) = 542; goto _test_eof
 	_test_eof543: ( m.cs) = 543; goto _test_eof
 	_test_eof544: ( m.cs) = 544; goto _test_eof
 	_test_eof545: ( m.cs) = 545; goto _test_eof
@@ -30850,16 +30526,16 @@ tr441:
 	_test_eof559: ( m.cs) = 559; goto _test_eof
 	_test_eof560: ( m.cs) = 560; goto _test_eof
 	_test_eof561: ( m.cs) = 561; goto _test_eof
-	_test_eof562: ( m.cs) = 562; goto _test_eof
+	_test_eof149: ( m.cs) = 149; goto _test_eof
 	_test_eof150: ( m.cs) = 150; goto _test_eof
-	_test_eof151: ( m.cs) = 151; goto _test_eof
+	_test_eof562: ( m.cs) = 562; goto _test_eof
 	_test_eof563: ( m.cs) = 563; goto _test_eof
 	_test_eof564: ( m.cs) = 564; goto _test_eof
+	_test_eof151: ( m.cs) = 151; goto _test_eof
 	_test_eof565: ( m.cs) = 565; goto _test_eof
-	_test_eof152: ( m.cs) = 152; goto _test_eof
 	_test_eof566: ( m.cs) = 566; goto _test_eof
+	_test_eof152: ( m.cs) = 152; goto _test_eof
 	_test_eof567: ( m.cs) = 567; goto _test_eof
-	_test_eof153: ( m.cs) = 153; goto _test_eof
 	_test_eof568: ( m.cs) = 568; goto _test_eof
 	_test_eof569: ( m.cs) = 569; goto _test_eof
 	_test_eof570: ( m.cs) = 570; goto _test_eof
@@ -30877,11 +30553,11 @@ tr441:
 	_test_eof582: ( m.cs) = 582; goto _test_eof
 	_test_eof583: ( m.cs) = 583; goto _test_eof
 	_test_eof584: ( m.cs) = 584; goto _test_eof
-	_test_eof585: ( m.cs) = 585; goto _test_eof
+	_test_eof153: ( m.cs) = 153; goto _test_eof
 	_test_eof154: ( m.cs) = 154; goto _test_eof
+	_test_eof585: ( m.cs) = 585; goto _test_eof
 	_test_eof155: ( m.cs) = 155; goto _test_eof
 	_test_eof586: ( m.cs) = 586; goto _test_eof
-	_test_eof156: ( m.cs) = 156; goto _test_eof
 	_test_eof587: ( m.cs) = 587; goto _test_eof
 	_test_eof588: ( m.cs) = 588; goto _test_eof
 	_test_eof589: ( m.cs) = 589; goto _test_eof
@@ -30889,25 +30565,25 @@ tr441:
 	_test_eof591: ( m.cs) = 591; goto _test_eof
 	_test_eof592: ( m.cs) = 592; goto _test_eof
 	_test_eof593: ( m.cs) = 593; goto _test_eof
-	_test_eof594: ( m.cs) = 594; goto _test_eof
+	_test_eof156: ( m.cs) = 156; goto _test_eof
 	_test_eof157: ( m.cs) = 157; goto _test_eof
 	_test_eof158: ( m.cs) = 158; goto _test_eof
+	_test_eof594: ( m.cs) = 594; goto _test_eof
 	_test_eof159: ( m.cs) = 159; goto _test_eof
-	_test_eof595: ( m.cs) = 595; goto _test_eof
 	_test_eof160: ( m.cs) = 160; goto _test_eof
 	_test_eof161: ( m.cs) = 161; goto _test_eof
+	_test_eof595: ( m.cs) = 595; goto _test_eof
 	_test_eof162: ( m.cs) = 162; goto _test_eof
-	_test_eof596: ( m.cs) = 596; goto _test_eof
 	_test_eof163: ( m.cs) = 163; goto _test_eof
-	_test_eof164: ( m.cs) = 164; goto _test_eof
+	_test_eof596: ( m.cs) = 596; goto _test_eof
 	_test_eof597: ( m.cs) = 597; goto _test_eof
-	_test_eof598: ( m.cs) = 598; goto _test_eof
+	_test_eof164: ( m.cs) = 164; goto _test_eof
 	_test_eof165: ( m.cs) = 165; goto _test_eof
 	_test_eof166: ( m.cs) = 166; goto _test_eof
 	_test_eof167: ( m.cs) = 167; goto _test_eof
 	_test_eof168: ( m.cs) = 168; goto _test_eof
 	_test_eof169: ( m.cs) = 169; goto _test_eof
-	_test_eof170: ( m.cs) = 170; goto _test_eof
+	_test_eof598: ( m.cs) = 598; goto _test_eof
 	_test_eof599: ( m.cs) = 599; goto _test_eof
 	_test_eof600: ( m.cs) = 600; goto _test_eof
 	_test_eof601: ( m.cs) = 601; goto _test_eof
@@ -30926,56 +30602,56 @@ tr441:
 	_test_eof614: ( m.cs) = 614; goto _test_eof
 	_test_eof615: ( m.cs) = 615; goto _test_eof
 	_test_eof616: ( m.cs) = 616; goto _test_eof
-	_test_eof617: ( m.cs) = 617; goto _test_eof
+	_test_eof170: ( m.cs) = 170; goto _test_eof
 	_test_eof171: ( m.cs) = 171; goto _test_eof
 	_test_eof172: ( m.cs) = 172; goto _test_eof
-	_test_eof173: ( m.cs) = 173; goto _test_eof
+	_test_eof617: ( m.cs) = 617; goto _test_eof
 	_test_eof618: ( m.cs) = 618; goto _test_eof
 	_test_eof619: ( m.cs) = 619; goto _test_eof
+	_test_eof173: ( m.cs) = 173; goto _test_eof
 	_test_eof620: ( m.cs) = 620; goto _test_eof
-	_test_eof174: ( m.cs) = 174; goto _test_eof
 	_test_eof621: ( m.cs) = 621; goto _test_eof
+	_test_eof174: ( m.cs) = 174; goto _test_eof
 	_test_eof622: ( m.cs) = 622; goto _test_eof
-	_test_eof175: ( m.cs) = 175; goto _test_eof
 	_test_eof623: ( m.cs) = 623; goto _test_eof
 	_test_eof624: ( m.cs) = 624; goto _test_eof
 	_test_eof625: ( m.cs) = 625; goto _test_eof
 	_test_eof626: ( m.cs) = 626; goto _test_eof
-	_test_eof627: ( m.cs) = 627; goto _test_eof
+	_test_eof175: ( m.cs) = 175; goto _test_eof
 	_test_eof176: ( m.cs) = 176; goto _test_eof
 	_test_eof177: ( m.cs) = 177; goto _test_eof
+	_test_eof627: ( m.cs) = 627; goto _test_eof
 	_test_eof178: ( m.cs) = 178; goto _test_eof
-	_test_eof628: ( m.cs) = 628; goto _test_eof
 	_test_eof179: ( m.cs) = 179; goto _test_eof
 	_test_eof180: ( m.cs) = 180; goto _test_eof
+	_test_eof628: ( m.cs) = 628; goto _test_eof
 	_test_eof181: ( m.cs) = 181; goto _test_eof
-	_test_eof629: ( m.cs) = 629; goto _test_eof
 	_test_eof182: ( m.cs) = 182; goto _test_eof
-	_test_eof183: ( m.cs) = 183; goto _test_eof
+	_test_eof629: ( m.cs) = 629; goto _test_eof
 	_test_eof630: ( m.cs) = 630; goto _test_eof
+	_test_eof183: ( m.cs) = 183; goto _test_eof
 	_test_eof631: ( m.cs) = 631; goto _test_eof
-	_test_eof184: ( m.cs) = 184; goto _test_eof
 	_test_eof632: ( m.cs) = 632; goto _test_eof
 	_test_eof633: ( m.cs) = 633; goto _test_eof
-	_test_eof634: ( m.cs) = 634; goto _test_eof
+	_test_eof184: ( m.cs) = 184; goto _test_eof
 	_test_eof185: ( m.cs) = 185; goto _test_eof
 	_test_eof186: ( m.cs) = 186; goto _test_eof
+	_test_eof634: ( m.cs) = 634; goto _test_eof
 	_test_eof187: ( m.cs) = 187; goto _test_eof
-	_test_eof635: ( m.cs) = 635; goto _test_eof
 	_test_eof188: ( m.cs) = 188; goto _test_eof
 	_test_eof189: ( m.cs) = 189; goto _test_eof
+	_test_eof635: ( m.cs) = 635; goto _test_eof
 	_test_eof190: ( m.cs) = 190; goto _test_eof
-	_test_eof636: ( m.cs) = 636; goto _test_eof
 	_test_eof191: ( m.cs) = 191; goto _test_eof
-	_test_eof192: ( m.cs) = 192; goto _test_eof
+	_test_eof636: ( m.cs) = 636; goto _test_eof
 	_test_eof637: ( m.cs) = 637; goto _test_eof
-	_test_eof638: ( m.cs) = 638; goto _test_eof
+	_test_eof192: ( m.cs) = 192; goto _test_eof
 	_test_eof193: ( m.cs) = 193; goto _test_eof
 	_test_eof194: ( m.cs) = 194; goto _test_eof
+	_test_eof638: ( m.cs) = 638; goto _test_eof
 	_test_eof195: ( m.cs) = 195; goto _test_eof
-	_test_eof639: ( m.cs) = 639; goto _test_eof
 	_test_eof196: ( m.cs) = 196; goto _test_eof
-	_test_eof197: ( m.cs) = 197; goto _test_eof
+	_test_eof639: ( m.cs) = 639; goto _test_eof
 	_test_eof640: ( m.cs) = 640; goto _test_eof
 	_test_eof641: ( m.cs) = 641; goto _test_eof
 	_test_eof642: ( m.cs) = 642; goto _test_eof
@@ -30983,22 +30659,22 @@ tr441:
 	_test_eof644: ( m.cs) = 644; goto _test_eof
 	_test_eof645: ( m.cs) = 645; goto _test_eof
 	_test_eof646: ( m.cs) = 646; goto _test_eof
-	_test_eof647: ( m.cs) = 647; goto _test_eof
+	_test_eof197: ( m.cs) = 197; goto _test_eof
 	_test_eof198: ( m.cs) = 198; goto _test_eof
 	_test_eof199: ( m.cs) = 199; goto _test_eof
+	_test_eof647: ( m.cs) = 647; goto _test_eof
 	_test_eof200: ( m.cs) = 200; goto _test_eof
-	_test_eof648: ( m.cs) = 648; goto _test_eof
 	_test_eof201: ( m.cs) = 201; goto _test_eof
 	_test_eof202: ( m.cs) = 202; goto _test_eof
+	_test_eof648: ( m.cs) = 648; goto _test_eof
 	_test_eof203: ( m.cs) = 203; goto _test_eof
-	_test_eof649: ( m.cs) = 649; goto _test_eof
 	_test_eof204: ( m.cs) = 204; goto _test_eof
-	_test_eof205: ( m.cs) = 205; goto _test_eof
+	_test_eof649: ( m.cs) = 649; goto _test_eof
 	_test_eof650: ( m.cs) = 650; goto _test_eof
-	_test_eof651: ( m.cs) = 651; goto _test_eof
+	_test_eof205: ( m.cs) = 205; goto _test_eof
 	_test_eof206: ( m.cs) = 206; goto _test_eof
 	_test_eof207: ( m.cs) = 207; goto _test_eof
-	_test_eof208: ( m.cs) = 208; goto _test_eof
+	_test_eof651: ( m.cs) = 651; goto _test_eof
 	_test_eof652: ( m.cs) = 652; goto _test_eof
 	_test_eof653: ( m.cs) = 653; goto _test_eof
 	_test_eof654: ( m.cs) = 654; goto _test_eof
@@ -31017,15 +30693,15 @@ tr441:
 	_test_eof667: ( m.cs) = 667; goto _test_eof
 	_test_eof668: ( m.cs) = 668; goto _test_eof
 	_test_eof669: ( m.cs) = 669; goto _test_eof
-	_test_eof670: ( m.cs) = 670; goto _test_eof
+	_test_eof208: ( m.cs) = 208; goto _test_eof
 	_test_eof209: ( m.cs) = 209; goto _test_eof
 	_test_eof210: ( m.cs) = 210; goto _test_eof
 	_test_eof211: ( m.cs) = 211; goto _test_eof
 	_test_eof212: ( m.cs) = 212; goto _test_eof
+	_test_eof670: ( m.cs) = 670; goto _test_eof
 	_test_eof213: ( m.cs) = 213; goto _test_eof
-	_test_eof671: ( m.cs) = 671; goto _test_eof
 	_test_eof214: ( m.cs) = 214; goto _test_eof
-	_test_eof215: ( m.cs) = 215; goto _test_eof
+	_test_eof671: ( m.cs) = 671; goto _test_eof
 	_test_eof672: ( m.cs) = 672; goto _test_eof
 	_test_eof673: ( m.cs) = 673; goto _test_eof
 	_test_eof674: ( m.cs) = 674; goto _test_eof
@@ -31034,25 +30710,25 @@ tr441:
 	_test_eof677: ( m.cs) = 677; goto _test_eof
 	_test_eof678: ( m.cs) = 678; goto _test_eof
 	_test_eof679: ( m.cs) = 679; goto _test_eof
-	_test_eof680: ( m.cs) = 680; goto _test_eof
+	_test_eof215: ( m.cs) = 215; goto _test_eof
 	_test_eof216: ( m.cs) = 216; goto _test_eof
 	_test_eof217: ( m.cs) = 217; goto _test_eof
+	_test_eof680: ( m.cs) = 680; goto _test_eof
 	_test_eof218: ( m.cs) = 218; goto _test_eof
-	_test_eof681: ( m.cs) = 681; goto _test_eof
 	_test_eof219: ( m.cs) = 219; goto _test_eof
 	_test_eof220: ( m.cs) = 220; goto _test_eof
+	_test_eof681: ( m.cs) = 681; goto _test_eof
 	_test_eof221: ( m.cs) = 221; goto _test_eof
-	_test_eof682: ( m.cs) = 682; goto _test_eof
 	_test_eof222: ( m.cs) = 222; goto _test_eof
-	_test_eof223: ( m.cs) = 223; goto _test_eof
+	_test_eof682: ( m.cs) = 682; goto _test_eof
 	_test_eof683: ( m.cs) = 683; goto _test_eof
-	_test_eof684: ( m.cs) = 684; goto _test_eof
+	_test_eof223: ( m.cs) = 223; goto _test_eof
 	_test_eof224: ( m.cs) = 224; goto _test_eof
 	_test_eof225: ( m.cs) = 225; goto _test_eof
+	_test_eof684: ( m.cs) = 684; goto _test_eof
 	_test_eof226: ( m.cs) = 226; goto _test_eof
-	_test_eof685: ( m.cs) = 685; goto _test_eof
 	_test_eof227: ( m.cs) = 227; goto _test_eof
-	_test_eof228: ( m.cs) = 228; goto _test_eof
+	_test_eof685: ( m.cs) = 685; goto _test_eof
 	_test_eof686: ( m.cs) = 686; goto _test_eof
 	_test_eof687: ( m.cs) = 687; goto _test_eof
 	_test_eof688: ( m.cs) = 688; goto _test_eof
@@ -31060,13 +30736,13 @@ tr441:
 	_test_eof690: ( m.cs) = 690; goto _test_eof
 	_test_eof691: ( m.cs) = 691; goto _test_eof
 	_test_eof692: ( m.cs) = 692; goto _test_eof
-	_test_eof693: ( m.cs) = 693; goto _test_eof
+	_test_eof228: ( m.cs) = 228; goto _test_eof
 	_test_eof229: ( m.cs) = 229; goto _test_eof
 	_test_eof230: ( m.cs) = 230; goto _test_eof
+	_test_eof693: ( m.cs) = 693; goto _test_eof
 	_test_eof231: ( m.cs) = 231; goto _test_eof
-	_test_eof694: ( m.cs) = 694; goto _test_eof
 	_test_eof232: ( m.cs) = 232; goto _test_eof
-	_test_eof233: ( m.cs) = 233; goto _test_eof
+	_test_eof694: ( m.cs) = 694; goto _test_eof
 	_test_eof695: ( m.cs) = 695; goto _test_eof
 	_test_eof696: ( m.cs) = 696; goto _test_eof
 	_test_eof697: ( m.cs) = 697; goto _test_eof
@@ -31074,22 +30750,22 @@ tr441:
 	_test_eof699: ( m.cs) = 699; goto _test_eof
 	_test_eof700: ( m.cs) = 700; goto _test_eof
 	_test_eof701: ( m.cs) = 701; goto _test_eof
-	_test_eof702: ( m.cs) = 702; goto _test_eof
+	_test_eof233: ( m.cs) = 233; goto _test_eof
 	_test_eof234: ( m.cs) = 234; goto _test_eof
 	_test_eof235: ( m.cs) = 235; goto _test_eof
+	_test_eof702: ( m.cs) = 702; goto _test_eof
 	_test_eof236: ( m.cs) = 236; goto _test_eof
-	_test_eof703: ( m.cs) = 703; goto _test_eof
 	_test_eof237: ( m.cs) = 237; goto _test_eof
 	_test_eof238: ( m.cs) = 238; goto _test_eof
+	_test_eof703: ( m.cs) = 703; goto _test_eof
 	_test_eof239: ( m.cs) = 239; goto _test_eof
-	_test_eof704: ( m.cs) = 704; goto _test_eof
 	_test_eof240: ( m.cs) = 240; goto _test_eof
-	_test_eof241: ( m.cs) = 241; goto _test_eof
+	_test_eof704: ( m.cs) = 704; goto _test_eof
 	_test_eof705: ( m.cs) = 705; goto _test_eof
-	_test_eof706: ( m.cs) = 706; goto _test_eof
+	_test_eof241: ( m.cs) = 241; goto _test_eof
 	_test_eof242: ( m.cs) = 242; goto _test_eof
 	_test_eof243: ( m.cs) = 243; goto _test_eof
-	_test_eof244: ( m.cs) = 244; goto _test_eof
+	_test_eof706: ( m.cs) = 706; goto _test_eof
 	_test_eof707: ( m.cs) = 707; goto _test_eof
 	_test_eof708: ( m.cs) = 708; goto _test_eof
 	_test_eof709: ( m.cs) = 709; goto _test_eof
@@ -31108,12 +30784,12 @@ tr441:
 	_test_eof722: ( m.cs) = 722; goto _test_eof
 	_test_eof723: ( m.cs) = 723; goto _test_eof
 	_test_eof724: ( m.cs) = 724; goto _test_eof
-	_test_eof725: ( m.cs) = 725; goto _test_eof
+	_test_eof244: ( m.cs) = 244; goto _test_eof
 	_test_eof245: ( m.cs) = 245; goto _test_eof
+	_test_eof725: ( m.cs) = 725; goto _test_eof
 	_test_eof246: ( m.cs) = 246; goto _test_eof
-	_test_eof726: ( m.cs) = 726; goto _test_eof
 	_test_eof247: ( m.cs) = 247; goto _test_eof
-	_test_eof248: ( m.cs) = 248; goto _test_eof
+	_test_eof726: ( m.cs) = 726; goto _test_eof
 	_test_eof727: ( m.cs) = 727; goto _test_eof
 	_test_eof728: ( m.cs) = 728; goto _test_eof
 	_test_eof729: ( m.cs) = 729; goto _test_eof
@@ -31121,112 +30797,111 @@ tr441:
 	_test_eof731: ( m.cs) = 731; goto _test_eof
 	_test_eof732: ( m.cs) = 732; goto _test_eof
 	_test_eof733: ( m.cs) = 733; goto _test_eof
-	_test_eof734: ( m.cs) = 734; goto _test_eof
+	_test_eof248: ( m.cs) = 248; goto _test_eof
 	_test_eof249: ( m.cs) = 249; goto _test_eof
 	_test_eof250: ( m.cs) = 250; goto _test_eof
+	_test_eof734: ( m.cs) = 734; goto _test_eof
 	_test_eof251: ( m.cs) = 251; goto _test_eof
-	_test_eof735: ( m.cs) = 735; goto _test_eof
 	_test_eof252: ( m.cs) = 252; goto _test_eof
 	_test_eof253: ( m.cs) = 253; goto _test_eof
+	_test_eof735: ( m.cs) = 735; goto _test_eof
 	_test_eof254: ( m.cs) = 254; goto _test_eof
-	_test_eof736: ( m.cs) = 736; goto _test_eof
 	_test_eof255: ( m.cs) = 255; goto _test_eof
-	_test_eof256: ( m.cs) = 256; goto _test_eof
+	_test_eof736: ( m.cs) = 736; goto _test_eof
 	_test_eof737: ( m.cs) = 737; goto _test_eof
-	_test_eof738: ( m.cs) = 738; goto _test_eof
+	_test_eof256: ( m.cs) = 256; goto _test_eof
 	_test_eof257: ( m.cs) = 257; goto _test_eof
-	_test_eof258: ( m.cs) = 258; goto _test_eof
-	_test_eof739: ( m.cs) = 739; goto _test_eof
-	_test_eof261: ( m.cs) = 261; goto _test_eof
+	_test_eof738: ( m.cs) = 738; goto _test_eof
+	_test_eof260: ( m.cs) = 260; goto _test_eof
+	_test_eof740: ( m.cs) = 740; goto _test_eof
 	_test_eof741: ( m.cs) = 741; goto _test_eof
-	_test_eof742: ( m.cs) = 742; goto _test_eof
+	_test_eof261: ( m.cs) = 261; goto _test_eof
 	_test_eof262: ( m.cs) = 262; goto _test_eof
 	_test_eof263: ( m.cs) = 263; goto _test_eof
 	_test_eof264: ( m.cs) = 264; goto _test_eof
+	_test_eof742: ( m.cs) = 742; goto _test_eof
 	_test_eof265: ( m.cs) = 265; goto _test_eof
 	_test_eof743: ( m.cs) = 743; goto _test_eof
 	_test_eof266: ( m.cs) = 266; goto _test_eof
-	_test_eof744: ( m.cs) = 744; goto _test_eof
 	_test_eof267: ( m.cs) = 267; goto _test_eof
 	_test_eof268: ( m.cs) = 268; goto _test_eof
-	_test_eof269: ( m.cs) = 269; goto _test_eof
-	_test_eof740: ( m.cs) = 740; goto _test_eof
+	_test_eof739: ( m.cs) = 739; goto _test_eof
+	_test_eof258: ( m.cs) = 258; goto _test_eof
 	_test_eof259: ( m.cs) = 259; goto _test_eof
-	_test_eof260: ( m.cs) = 260; goto _test_eof
 
 	_test_eof: {}
 	if ( m.p) == ( m.eof) {
 		switch ( m.cs) {
-		case 8, 261:
+		case 7, 260:
 //line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 2, 3, 4, 5, 6, 7, 28, 31, 32, 35, 36, 37, 49, 50, 51, 52, 53, 73, 75, 76, 93, 103, 105, 141, 153, 156, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257:
+		case 2, 3, 4, 5, 6, 27, 30, 31, 34, 35, 36, 48, 49, 50, 51, 52, 72, 73, 75, 92, 102, 104, 140, 152, 155, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256:
 //line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 13, 14, 15, 22, 24, 25, 263, 264, 265, 266, 267, 268:
+		case 12, 13, 14, 21, 23, 24, 262, 263, 264, 265, 266, 267:
 //line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 244:
+		case 243:
 //line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 741:
+		case 740:
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-		case 743, 744:
+		case 742, 743:
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-		case 271, 272, 273, 274, 275, 277, 278, 297, 298, 299, 301, 302, 305, 306, 327, 328, 329, 330, 332, 376, 377, 379, 380, 402, 403, 408, 409, 411, 431, 432, 434, 435, 457, 458, 618, 621:
+		case 270, 271, 272, 273, 274, 276, 277, 296, 297, 298, 300, 301, 304, 305, 326, 327, 328, 329, 331, 375, 376, 378, 379, 401, 402, 407, 408, 410, 430, 431, 433, 434, 456, 457, 617, 620:
 //line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
-		case 10, 38, 40, 165, 167:
+		case 9, 37, 39, 164, 166:
 //line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -31234,16 +30909,16 @@ tr441:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 34, 74, 104, 170, 208:
+		case 33, 74, 103, 169, 207:
 //line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:53
@@ -31251,16 +30926,16 @@ tr441:
 	err = ErrTimestampParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 20, 44, 45, 46, 58, 59, 61, 63, 68, 70, 71, 77, 78, 79, 84, 86, 88, 89, 97, 98, 100, 101, 102, 107, 108, 109, 122, 123, 137, 138:
+		case 19, 43, 44, 45, 57, 58, 60, 62, 67, 69, 70, 76, 77, 78, 83, 85, 87, 88, 96, 97, 99, 100, 101, 106, 107, 108, 121, 122, 136, 137:
 //line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -31268,16 +30943,16 @@ tr441:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 60:
+		case 59:
 //line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:53
@@ -31285,10 +30960,10 @@ tr441:
 	err = ErrTimestampParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 270:
+		case 269:
 //line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
@@ -31304,7 +30979,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31313,17 +30988,17 @@ tr441:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 300, 303, 307, 375, 399, 400, 404, 405, 406, 530, 564, 565, 567:
+		case 299, 302, 306, 374, 398, 399, 403, 404, 405, 529, 563, 564, 566:
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31331,14 +31006,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 16, 23:
+		case 15, 22:
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31347,17 +31022,17 @@ tr441:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 351, 352, 353, 355, 374, 430, 454, 455, 459, 479, 495, 496, 498:
+		case 350, 351, 352, 354, 373, 429, 453, 454, 458, 478, 494, 495, 497:
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31365,14 +31040,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 624, 675, 689, 729:
+		case 623, 674, 688, 728:
 //line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31380,14 +31055,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 625, 678, 692, 732:
+		case 624, 677, 691, 731:
 //line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31395,14 +31070,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 326, 619, 620, 622, 623, 626, 632, 633, 671, 672, 673, 674, 676, 677, 679, 685, 686, 687, 688, 690, 691, 693, 726, 727, 728, 730, 731, 733:
+		case 325, 618, 619, 621, 622, 625, 631, 632, 670, 671, 672, 673, 675, 676, 678, 684, 685, 686, 687, 689, 690, 692, 725, 726, 727, 729, 730, 732:
 //line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31410,14 +31085,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 627, 628, 629, 630, 631, 634, 635, 636, 637, 638, 680, 681, 682, 683, 684, 734, 735, 736, 737, 738:
+		case 626, 627, 628, 629, 630, 633, 634, 635, 636, 637, 679, 680, 681, 682, 683, 733, 734, 735, 736, 737:
 //line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31425,14 +31100,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 276, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 331, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 378, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 410, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 433, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 652, 653, 654, 655, 656, 657, 658, 659, 660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670, 707, 708, 709, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719, 720, 721, 722, 723, 724, 725:
+		case 275, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 330, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 377, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 409, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 432, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 651, 652, 653, 654, 655, 656, 657, 658, 659, 660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 706, 707, 708, 709, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719, 720, 721, 722, 723, 724:
 //line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31440,13 +31115,13 @@ tr441:
 
 	m.finishMetric = true
 
-		case 9:
+		case 8:
 //line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:86
@@ -31455,7 +31130,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31464,16 +31139,16 @@ tr441:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 99:
+		case 98:
 //line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -31481,7 +31156,7 @@ tr441:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:53
@@ -31489,17 +31164,17 @@ tr441:
 	err = ErrTimestampParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 11, 12, 26, 27, 29, 30, 41, 42, 54, 55, 56, 57, 72, 91, 92, 94, 96, 139, 140, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 154, 155, 157, 158, 159, 160, 161, 162, 163, 164, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241:
+		case 10, 11, 25, 26, 28, 29, 40, 41, 53, 54, 55, 56, 71, 90, 91, 93, 95, 138, 139, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 153, 154, 156, 157, 158, 159, 160, 161, 162, 163, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240:
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31508,7 +31183,7 @@ tr441:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -31516,17 +31191,17 @@ tr441:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 535, 589, 697:
+		case 534, 588, 696:
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31536,7 +31211,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31544,14 +31219,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 538, 592, 700:
+		case 537, 591, 699:
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31561,7 +31236,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31569,14 +31244,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 407, 531, 532, 533, 534, 536, 537, 539, 563, 586, 587, 588, 590, 591, 593, 694, 695, 696, 698, 699, 701:
+		case 406, 530, 531, 532, 533, 535, 536, 538, 562, 585, 586, 587, 589, 590, 592, 693, 694, 695, 697, 698, 700:
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31586,7 +31261,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31594,14 +31269,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 540, 541, 542, 543, 544, 594, 595, 596, 597, 598, 702, 703, 704, 705, 706:
+		case 539, 540, 541, 542, 543, 593, 594, 595, 596, 597, 701, 702, 703, 704, 705:
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31611,7 +31286,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31619,14 +31294,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 304, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 401, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 566, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585:
+		case 303, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 400, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 565, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584:
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31636,7 +31311,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31644,14 +31319,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 17, 18, 19, 21, 47, 48, 64, 65, 66, 67, 69, 80, 81, 82, 83, 85, 87, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 124, 125, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205:
+		case 16, 17, 18, 20, 46, 47, 63, 64, 65, 66, 68, 79, 80, 81, 82, 84, 86, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 123, 124, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204:
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31660,7 +31335,7 @@ tr441:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -31668,17 +31343,17 @@ tr441:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 484, 520, 642:
+		case 483, 519, 641:
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31688,7 +31363,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31696,14 +31371,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 487, 523, 645:
+		case 486, 522, 644:
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31713,7 +31388,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31721,14 +31396,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 478, 480, 481, 482, 483, 485, 486, 488, 494, 517, 518, 519, 521, 522, 524, 639, 640, 641, 643, 644, 646:
+		case 477, 479, 480, 481, 482, 484, 485, 487, 493, 516, 517, 518, 520, 521, 523, 638, 639, 640, 642, 643, 645:
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31738,7 +31413,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31746,14 +31421,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 489, 490, 491, 492, 493, 525, 526, 527, 528, 529, 647, 648, 649, 650, 651:
+		case 488, 489, 490, 491, 492, 524, 525, 526, 527, 528, 646, 647, 648, 649, 650:
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31763,7 +31438,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31771,14 +31446,14 @@ tr441:
 
 	m.finishMetric = true
 
-		case 354, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 456, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 497, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516:
+		case 353, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 455, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 496, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515:
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31788,7 +31463,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31796,13 +31471,13 @@ tr441:
 
 	m.finishMetric = true
 
-		case 39, 166, 168, 169, 206, 207, 242, 243:
+		case 38, 165, 167, 168, 205, 206, 241, 242:
 //line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:86
@@ -31811,7 +31486,7 @@ tr441:
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31820,7 +31495,7 @@ tr441:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -31828,17 +31503,17 @@ tr441:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 43, 90, 152:
+		case 42, 89, 151:
 //line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31847,7 +31522,7 @@ tr441:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -31855,7 +31530,7 @@ tr441:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:53
@@ -31863,17 +31538,17 @@ tr441:
 	err = ErrTimestampParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-		case 62, 106, 126:
+		case 61, 105, 125:
 //line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
 		( m.p)--
 
-		( m.cs) = 258;
+		( m.cs) = 257;
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
@@ -31882,7 +31557,7 @@ tr441:
 	err = ErrTagParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:39
@@ -31890,7 +31565,7 @@ tr441:
 	err = ErrFieldParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 //line plugins/parsers/influx/machine.go.rl:53
@@ -31898,10 +31573,10 @@ tr441:
 	err = ErrTimestampParse
 	( m.p)--
 
-	( m.cs) = 258;
+	( m.cs) = 257;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go:31905
+//line plugins/parsers/influx/machine.go:31580
 		}
 	}
 

--- a/plugins/parsers/influx/machine.go
+++ b/plugins/parsers/influx/machine.go
@@ -7,6 +7,14 @@ import (
 	"io"
 )
 
+type readErr struct {
+	Err error
+}
+
+func (e *readErr) Error() string {
+	return e.Err.Error()
+}
+
 var (
 	ErrNameParse = errors.New("expected measurement name")
 	ErrFieldParse = errors.New("expected field")
@@ -17,11 +25,11 @@ var (
 )
 
 
-//line plugins/parsers/influx/machine.go.rl:310
+//line plugins/parsers/influx/machine.go.rl:318
 
 
 
-//line plugins/parsers/influx/machine.go:25
+//line plugins/parsers/influx/machine.go:33
 const LineProtocol_start int = 270
 const LineProtocol_first_final int = 270
 const LineProtocol_error int = 0
@@ -32,7 +40,7 @@ const LineProtocol_en_align int = 740
 const LineProtocol_en_series int = 261
 
 
-//line plugins/parsers/influx/machine.go.rl:313
+//line plugins/parsers/influx/machine.go.rl:321
 
 type Handler interface {
 	SetMeasurement(name []byte) error
@@ -66,24 +74,24 @@ func NewMachine(handler Handler) *machine {
 	}
 
 	
-//line plugins/parsers/influx/machine.go.rl:346
+//line plugins/parsers/influx/machine.go.rl:354
 	
-//line plugins/parsers/influx/machine.go.rl:347
+//line plugins/parsers/influx/machine.go.rl:355
 	
-//line plugins/parsers/influx/machine.go.rl:348
+//line plugins/parsers/influx/machine.go.rl:356
 	
-//line plugins/parsers/influx/machine.go.rl:349
+//line plugins/parsers/influx/machine.go.rl:357
 	
-//line plugins/parsers/influx/machine.go.rl:350
+//line plugins/parsers/influx/machine.go.rl:358
 	
-//line plugins/parsers/influx/machine.go.rl:351
+//line plugins/parsers/influx/machine.go.rl:359
 	
-//line plugins/parsers/influx/machine.go:82
+//line plugins/parsers/influx/machine.go:90
 	{
 	( m.cs) = LineProtocol_start
 	}
 
-//line plugins/parsers/influx/machine.go.rl:352
+//line plugins/parsers/influx/machine.go.rl:360
 
 	return m
 }
@@ -95,22 +103,22 @@ func NewSeriesMachine(handler Handler) *machine {
 	}
 
 	
-//line plugins/parsers/influx/machine.go.rl:363
+//line plugins/parsers/influx/machine.go.rl:371
 	
-//line plugins/parsers/influx/machine.go.rl:364
+//line plugins/parsers/influx/machine.go.rl:372
 	
-//line plugins/parsers/influx/machine.go.rl:365
+//line plugins/parsers/influx/machine.go.rl:373
 	
-//line plugins/parsers/influx/machine.go.rl:366
+//line plugins/parsers/influx/machine.go.rl:374
 	
-//line plugins/parsers/influx/machine.go.rl:367
+//line plugins/parsers/influx/machine.go.rl:375
 	
-//line plugins/parsers/influx/machine.go:109
+//line plugins/parsers/influx/machine.go:117
 	{
 	( m.cs) = LineProtocol_start
 	}
 
-//line plugins/parsers/influx/machine.go.rl:368
+//line plugins/parsers/influx/machine.go.rl:376
 
 	return m
 }
@@ -128,12 +136,12 @@ func (m *machine) SetData(data []byte) {
 	m.finishMetric = false
 
 	
-//line plugins/parsers/influx/machine.go:132
+//line plugins/parsers/influx/machine.go:140
 	{
 	( m.cs) = LineProtocol_start
 	}
 
-//line plugins/parsers/influx/machine.go.rl:385
+//line plugins/parsers/influx/machine.go.rl:393
 	m.cs = m.initState
 }
 
@@ -156,7 +164,7 @@ func (m *machine) Next() error {
 func (m *machine) exec() error {
 	var err error
 	
-//line plugins/parsers/influx/machine.go:160
+//line plugins/parsers/influx/machine.go:168
 	{
 	if ( m.p) == ( m.pe) {
 		goto _test_eof
@@ -3180,17 +3188,17 @@ _resume:
 		}
 		goto tr457
 tr33:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st1
 tr457:
-//line plugins/parsers/influx/machine.go.rl:74
+//line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -3200,7 +3208,7 @@ tr457:
 			goto _test_eof1
 		}
 	st_case_1:
-//line plugins/parsers/influx/machine.go:3204
+//line plugins/parsers/influx/machine.go:3212
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr2
@@ -3221,7 +3229,7 @@ tr457:
 		goto st1
 tr1:
 	( m.cs) = 2
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -3234,7 +3242,7 @@ tr1:
 	goto _again
 tr60:
 	( m.cs) = 2
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -3250,7 +3258,7 @@ tr60:
 			goto _test_eof2
 		}
 	st_case_2:
-//line plugins/parsers/influx/machine.go:3254
+//line plugins/parsers/influx/machine.go:3262
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr8
@@ -3272,7 +3280,7 @@ tr60:
 		}
 		goto tr6
 tr6:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -3282,7 +3290,7 @@ tr6:
 			goto _test_eof3
 		}
 	st_case_3:
-//line plugins/parsers/influx/machine.go:3286
+//line plugins/parsers/influx/machine.go:3294
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr8
@@ -3304,7 +3312,7 @@ tr6:
 		goto st3
 tr2:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -3315,7 +3323,7 @@ tr2:
 	goto _again
 tr8:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -3326,7 +3334,7 @@ tr8:
 	goto _again
 tr35:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:24
+//line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
@@ -3337,7 +3345,7 @@ tr35:
 	goto _again
 tr39:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:24
+//line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
@@ -3345,7 +3353,7 @@ tr39:
 	( m.cs) = 258;
 	{( m.p)++; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -3356,7 +3364,7 @@ tr39:
 	goto _again
 tr43:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:24
+//line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
@@ -3364,7 +3372,7 @@ tr43:
 	( m.cs) = 258;
 	{( m.p)++; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -3375,7 +3383,7 @@ tr43:
 	goto _again
 tr47:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -3383,7 +3391,7 @@ tr47:
 	( m.cs) = 258;
 	{( m.p)++; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -3394,7 +3402,7 @@ tr47:
 	goto _again
 tr105:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -3402,7 +3410,7 @@ tr105:
 	( m.cs) = 258;
 	{( m.p)++; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:45
+//line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
@@ -3413,7 +3421,7 @@ tr105:
 	goto _again
 tr132:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -3421,7 +3429,7 @@ tr132:
 	( m.cs) = 258;
 	{( m.p)++; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -3429,7 +3437,7 @@ tr132:
 	( m.cs) = 258;
 	{( m.p)++; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:45
+//line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
@@ -3440,7 +3448,7 @@ tr132:
 	goto _again
 tr198:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -3448,7 +3456,7 @@ tr198:
 	( m.cs) = 258;
 	{( m.p)++; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:45
+//line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
@@ -3459,7 +3467,7 @@ tr198:
 	goto _again
 tr423:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:24
+//line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
@@ -3467,7 +3475,7 @@ tr423:
 	( m.cs) = 258;
 	{( m.p)++; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -3475,7 +3483,7 @@ tr423:
 	( m.cs) = 258;
 	{( m.p)++; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -3486,7 +3494,7 @@ tr423:
 	goto _again
 tr426:
 	( m.cs) = 0
-//line plugins/parsers/influx/machine.go.rl:45
+//line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
@@ -3496,20 +3504,20 @@ tr426:
 
 	goto _again
 tr1055:
-//line plugins/parsers/influx/machine.go.rl:65
+//line plugins/parsers/influx/machine.go.rl:73
 
 	( m.p)--
 
 	{goto st270 }
 
 	goto st0
-//line plugins/parsers/influx/machine.go:3507
+//line plugins/parsers/influx/machine.go:3515
 st_case_0:
 	st0:
 		( m.cs) = 0
 		goto _out
 tr12:
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -3519,7 +3527,7 @@ tr12:
 			goto _test_eof4
 		}
 	st_case_4:
-//line plugins/parsers/influx/machine.go:3523
+//line plugins/parsers/influx/machine.go:3531
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st5
@@ -3561,17 +3569,17 @@ tr12:
 		}
 		goto tr23
 tr23:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st6
 tr24:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -3579,7 +3587,7 @@ tr24:
 
 	goto st6
 tr29:
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -3591,7 +3599,7 @@ tr29:
 			goto _test_eof6
 		}
 	st_case_6:
-//line plugins/parsers/influx/machine.go:3595
+//line plugins/parsers/influx/machine.go:3603
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -3606,7 +3614,7 @@ tr29:
 		}
 		goto st6
 tr25:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -3616,18 +3624,18 @@ tr25:
 			goto _test_eof7
 		}
 	st_case_7:
-//line plugins/parsers/influx/machine.go:3620
+//line plugins/parsers/influx/machine.go:3628
 		if ( m.data)[( m.p)] == 10 {
 			goto tr29
 		}
 		goto tr8
 tr26:
 	( m.cs) = 271
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -3640,7 +3648,7 @@ tr26:
 	goto _again
 tr31:
 	( m.cs) = 271
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -3656,7 +3664,7 @@ tr31:
 			goto _test_eof271
 		}
 	st_case_271:
-//line plugins/parsers/influx/machine.go:3660
+//line plugins/parsers/influx/machine.go:3668
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -3673,7 +3681,7 @@ tr31:
 		goto tr105
 tr535:
 	( m.cs) = 272
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -3686,7 +3694,7 @@ tr535:
 	goto _again
 tr932:
 	( m.cs) = 272
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -3699,7 +3707,7 @@ tr932:
 	goto _again
 tr935:
 	( m.cs) = 272
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -3712,7 +3720,7 @@ tr935:
 	goto _again
 tr939:
 	( m.cs) = 272
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -3728,7 +3736,7 @@ tr939:
 			goto _test_eof272
 		}
 	st_case_272:
-//line plugins/parsers/influx/machine.go:3732
+//line plugins/parsers/influx/machine.go:3740
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -3749,7 +3757,7 @@ tr939:
 		}
 		goto tr426
 tr103:
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -3758,7 +3766,7 @@ tr103:
 	goto st273
 tr470:
 	( m.cs) = 273
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -3768,7 +3776,7 @@ tr470:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -3777,7 +3785,7 @@ tr470:
 	goto _again
 tr734:
 	( m.cs) = 273
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -3787,7 +3795,7 @@ tr734:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -3796,7 +3804,7 @@ tr734:
 	goto _again
 tr952:
 	( m.cs) = 273
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -3806,7 +3814,7 @@ tr952:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -3815,7 +3823,7 @@ tr952:
 	goto _again
 tr957:
 	( m.cs) = 273
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -3825,7 +3833,7 @@ tr957:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -3834,7 +3842,7 @@ tr957:
 	goto _again
 tr962:
 	( m.cs) = 273
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -3844,7 +3852,7 @@ tr962:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -3852,7 +3860,7 @@ tr962:
 
 	goto _again
 	st273:
-//line plugins/parsers/influx/machine.go.rl:164
+//line plugins/parsers/influx/machine.go.rl:172
 
 	m.finishMetric = true
 	( m.cs) = 740;
@@ -3862,7 +3870,7 @@ tr962:
 			goto _test_eof273
 		}
 	st_case_273:
-//line plugins/parsers/influx/machine.go:3866
+//line plugins/parsers/influx/machine.go:3874
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr35
@@ -3884,7 +3892,7 @@ tr962:
 		}
 		goto tr33
 tr458:
-//line plugins/parsers/influx/machine.go.rl:74
+//line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
 
@@ -3894,7 +3902,7 @@ tr458:
 			goto _test_eof8
 		}
 	st_case_8:
-//line plugins/parsers/influx/machine.go:3898
+//line plugins/parsers/influx/machine.go:3906
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr35
@@ -3916,17 +3924,17 @@ tr458:
 		}
 		goto tr33
 tr36:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st9
 tr459:
-//line plugins/parsers/influx/machine.go.rl:74
+//line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -3936,7 +3944,7 @@ tr459:
 			goto _test_eof9
 		}
 	st_case_9:
-//line plugins/parsers/influx/machine.go:3940
+//line plugins/parsers/influx/machine.go:3948
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr39
@@ -3959,7 +3967,7 @@ tr459:
 		goto tr33
 tr38:
 	( m.cs) = 10
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -3975,7 +3983,7 @@ tr38:
 			goto _test_eof10
 		}
 	st_case_10:
-//line plugins/parsers/influx/machine.go:3979
+//line plugins/parsers/influx/machine.go:3987
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr43
@@ -3999,7 +4007,7 @@ tr38:
 		}
 		goto tr41
 tr41:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4009,7 +4017,7 @@ tr41:
 			goto _test_eof11
 		}
 	st_case_11:
-//line plugins/parsers/influx/machine.go:4013
+//line plugins/parsers/influx/machine.go:4021
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -4032,7 +4040,7 @@ tr41:
 		goto st11
 tr48:
 	( m.cs) = 12
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -4045,7 +4053,7 @@ tr48:
 	goto _again
 tr51:
 	( m.cs) = 12
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -4055,7 +4063,7 @@ tr51:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4065,7 +4073,7 @@ tr51:
 			goto _test_eof12
 		}
 	st_case_12:
-//line plugins/parsers/influx/machine.go:4069
+//line plugins/parsers/influx/machine.go:4077
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -4088,7 +4096,7 @@ tr51:
 		goto tr41
 tr4:
 	( m.cs) = 13
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -4101,7 +4109,7 @@ tr4:
 	goto _again
 tr62:
 	( m.cs) = 13
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -4117,7 +4125,7 @@ tr62:
 			goto _test_eof13
 		}
 	st_case_13:
-//line plugins/parsers/influx/machine.go:4121
+//line plugins/parsers/influx/machine.go:4129
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
@@ -4138,7 +4146,7 @@ tr62:
 		}
 		goto tr52
 tr52:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4148,7 +4156,7 @@ tr52:
 			goto _test_eof14
 		}
 	st_case_14:
-//line plugins/parsers/influx/machine.go:4152
+//line plugins/parsers/influx/machine.go:4160
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
@@ -4169,7 +4177,7 @@ tr52:
 		}
 		goto st14
 tr55:
-//line plugins/parsers/influx/machine.go.rl:87
+//line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
 
@@ -4179,7 +4187,7 @@ tr55:
 			goto _test_eof15
 		}
 	st_case_15:
-//line plugins/parsers/influx/machine.go:4183
+//line plugins/parsers/influx/machine.go:4191
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
@@ -4200,7 +4208,7 @@ tr55:
 		}
 		goto tr57
 tr57:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4210,7 +4218,7 @@ tr57:
 			goto _test_eof16
 		}
 	st_case_16:
-//line plugins/parsers/influx/machine.go:4214
+//line plugins/parsers/influx/machine.go:4222
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr2
@@ -4233,7 +4241,7 @@ tr57:
 		goto st16
 tr61:
 	( m.cs) = 17
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -4249,7 +4257,7 @@ tr61:
 			goto _test_eof17
 		}
 	st_case_17:
-//line plugins/parsers/influx/machine.go:4253
+//line plugins/parsers/influx/machine.go:4261
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -4271,7 +4279,7 @@ tr61:
 		}
 		goto tr64
 tr64:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4281,7 +4289,7 @@ tr64:
 			goto _test_eof18
 		}
 	st_case_18:
-//line plugins/parsers/influx/machine.go:4285
+//line plugins/parsers/influx/machine.go:4293
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -4304,7 +4312,7 @@ tr64:
 		goto st18
 tr68:
 	( m.cs) = 19
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -4317,7 +4325,7 @@ tr68:
 	goto _again
 tr65:
 	( m.cs) = 19
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -4327,7 +4335,7 @@ tr65:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4337,7 +4345,7 @@ tr65:
 			goto _test_eof19
 		}
 	st_case_19:
-//line plugins/parsers/influx/machine.go:4341
+//line plugins/parsers/influx/machine.go:4349
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -4359,7 +4367,7 @@ tr65:
 		}
 		goto tr64
 tr66:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4369,7 +4377,7 @@ tr66:
 			goto _test_eof20
 		}
 	st_case_20:
-//line plugins/parsers/influx/machine.go:4373
+//line plugins/parsers/influx/machine.go:4381
 		if ( m.data)[( m.p)] == 92 {
 			goto st21
 		}
@@ -4383,14 +4391,14 @@ tr66:
 		}
 		goto st18
 	st21:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof21
 		}
 	st_case_21:
-//line plugins/parsers/influx/machine.go:4394
+//line plugins/parsers/influx/machine.go:4402
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -4412,7 +4420,7 @@ tr66:
 		}
 		goto st18
 tr58:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4422,7 +4430,7 @@ tr58:
 			goto _test_eof22
 		}
 	st_case_22:
-//line plugins/parsers/influx/machine.go:4426
+//line plugins/parsers/influx/machine.go:4434
 		if ( m.data)[( m.p)] == 92 {
 			goto st23
 		}
@@ -4436,14 +4444,14 @@ tr58:
 		}
 		goto st16
 	st23:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof23
 		}
 	st_case_23:
-//line plugins/parsers/influx/machine.go:4447
+//line plugins/parsers/influx/machine.go:4455
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr2
@@ -4465,7 +4473,7 @@ tr58:
 		}
 		goto st16
 tr53:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4475,7 +4483,7 @@ tr53:
 			goto _test_eof24
 		}
 	st_case_24:
-//line plugins/parsers/influx/machine.go:4479
+//line plugins/parsers/influx/machine.go:4487
 		if ( m.data)[( m.p)] == 92 {
 			goto st25
 		}
@@ -4489,14 +4497,14 @@ tr53:
 		}
 		goto st14
 	st25:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof25
 		}
 	st_case_25:
-//line plugins/parsers/influx/machine.go:4500
+//line plugins/parsers/influx/machine.go:4508
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
@@ -4517,17 +4525,17 @@ tr53:
 		}
 		goto st14
 tr49:
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
 	goto st26
 tr425:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -4537,7 +4545,7 @@ tr425:
 			goto _test_eof26
 		}
 	st_case_26:
-//line plugins/parsers/influx/machine.go:4541
+//line plugins/parsers/influx/machine.go:4549
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -4579,7 +4587,7 @@ tr425:
 		goto st1
 tr3:
 	( m.cs) = 27
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -4595,7 +4603,7 @@ tr3:
 			goto _test_eof27
 		}
 	st_case_27:
-//line plugins/parsers/influx/machine.go:4599
+//line plugins/parsers/influx/machine.go:4607
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -4617,7 +4625,7 @@ tr3:
 		}
 		goto tr41
 tr45:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4627,7 +4635,7 @@ tr45:
 			goto _test_eof28
 		}
 	st_case_28:
-//line plugins/parsers/influx/machine.go:4631
+//line plugins/parsers/influx/machine.go:4639
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -4664,7 +4672,7 @@ tr45:
 		}
 		goto tr82
 tr82:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4674,7 +4682,7 @@ tr82:
 			goto _test_eof30
 		}
 	st_case_30:
-//line plugins/parsers/influx/machine.go:4678
+//line plugins/parsers/influx/machine.go:4686
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr89
@@ -4698,7 +4706,7 @@ tr82:
 		goto st30
 tr89:
 	( m.cs) = 31
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -4711,7 +4719,7 @@ tr89:
 	goto _again
 tr83:
 	( m.cs) = 31
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -4721,14 +4729,14 @@ tr83:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr231:
 	( m.cs) = 31
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -4744,7 +4752,7 @@ tr231:
 			goto _test_eof31
 		}
 	st_case_31:
-//line plugins/parsers/influx/machine.go:4748
+//line plugins/parsers/influx/machine.go:4756
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st31
@@ -4769,7 +4777,7 @@ tr231:
 		}
 		goto tr94
 tr94:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4779,7 +4787,7 @@ tr94:
 			goto _test_eof32
 		}
 	st_case_32:
-//line plugins/parsers/influx/machine.go:4783
+//line plugins/parsers/influx/machine.go:4791
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -4803,11 +4811,11 @@ tr94:
 		goto st32
 tr97:
 	( m.cs) = 274
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -4820,7 +4828,7 @@ tr97:
 	goto _again
 tr100:
 	( m.cs) = 274
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -4833,7 +4841,7 @@ tr100:
 	goto _again
 tr386:
 	( m.cs) = 274
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -4843,7 +4851,7 @@ tr386:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4853,7 +4861,7 @@ tr386:
 			goto _test_eof274
 		}
 	st_case_274:
-//line plugins/parsers/influx/machine.go:4857
+//line plugins/parsers/influx/machine.go:4865
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -4908,7 +4916,7 @@ tr386:
 		goto st3
 tr472:
 	( m.cs) = 33
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -4921,7 +4929,7 @@ tr472:
 	goto _again
 tr736:
 	( m.cs) = 33
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -4934,7 +4942,7 @@ tr736:
 	goto _again
 tr954:
 	( m.cs) = 33
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -4947,7 +4955,7 @@ tr954:
 	goto _again
 tr959:
 	( m.cs) = 33
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -4960,7 +4968,7 @@ tr959:
 	goto _again
 tr964:
 	( m.cs) = 33
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -4976,13 +4984,13 @@ tr964:
 			goto _test_eof33
 		}
 	st_case_33:
-//line plugins/parsers/influx/machine.go:4980
+//line plugins/parsers/influx/machine.go:4988
 		if ( m.data)[( m.p)] == 10 {
 			goto tr103
 		}
 		goto st0
 tr467:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -4992,7 +5000,7 @@ tr467:
 			goto _test_eof34
 		}
 	st_case_34:
-//line plugins/parsers/influx/machine.go:4996
+//line plugins/parsers/influx/machine.go:5004
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr105
@@ -5017,7 +5025,7 @@ tr467:
 		}
 		goto st3
 tr468:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -5027,7 +5035,7 @@ tr468:
 			goto _test_eof276
 		}
 	st_case_276:
-//line plugins/parsers/influx/machine.go:5031
+//line plugins/parsers/influx/machine.go:5039
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr470
@@ -5055,7 +5063,7 @@ tr468:
 		goto st3
 tr469:
 	( m.cs) = 277
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -5071,7 +5079,7 @@ tr469:
 			goto _test_eof277
 		}
 	st_case_277:
-//line plugins/parsers/influx/machine.go:5075
+//line plugins/parsers/influx/machine.go:5083
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -5086,7 +5094,7 @@ tr469:
 		goto st0
 tr471:
 	( m.cs) = 278
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -5102,7 +5110,7 @@ tr471:
 			goto _test_eof278
 		}
 	st_case_278:
-//line plugins/parsers/influx/machine.go:5106
+//line plugins/parsers/influx/machine.go:5114
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -5124,7 +5132,7 @@ tr471:
 		}
 		goto st3
 tr10:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -5134,7 +5142,7 @@ tr10:
 			goto _test_eof35
 		}
 	st_case_35:
-//line plugins/parsers/influx/machine.go:5138
+//line plugins/parsers/influx/machine.go:5146
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -5681,7 +5689,7 @@ tr10:
 		goto st3
 tr930:
 	( m.cs) = 36
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -5694,7 +5702,7 @@ tr930:
 	goto _again
 tr1046:
 	( m.cs) = 36
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -5707,7 +5715,7 @@ tr1046:
 	goto _again
 tr1048:
 	( m.cs) = 36
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -5720,7 +5728,7 @@ tr1048:
 	goto _again
 tr1050:
 	( m.cs) = 36
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -5736,7 +5744,7 @@ tr1050:
 			goto _test_eof36
 		}
 	st_case_36:
-//line plugins/parsers/influx/machine.go:5740
+//line plugins/parsers/influx/machine.go:5748
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr8
@@ -5757,7 +5765,7 @@ tr1050:
 		}
 		goto tr6
 tr101:
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -5767,7 +5775,7 @@ tr101:
 			goto _test_eof37
 		}
 	st_case_37:
-//line plugins/parsers/influx/machine.go:5771
+//line plugins/parsers/influx/machine.go:5779
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -5800,7 +5808,7 @@ tr101:
 		goto st6
 tr107:
 	( m.cs) = 297
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -5816,7 +5824,7 @@ tr107:
 			goto _test_eof297
 		}
 	st_case_297:
-//line plugins/parsers/influx/machine.go:5820
+//line plugins/parsers/influx/machine.go:5828
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr494
@@ -5838,14 +5846,14 @@ tr107:
 		}
 		goto tr23
 tr493:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st298
 tr988:
 	( m.cs) = 298
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -5858,7 +5866,7 @@ tr988:
 	goto _again
 tr993:
 	( m.cs) = 298
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -5871,7 +5879,7 @@ tr993:
 	goto _again
 tr996:
 	( m.cs) = 298
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -5884,7 +5892,7 @@ tr996:
 	goto _again
 tr999:
 	( m.cs) = 298
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -5900,7 +5908,7 @@ tr999:
 			goto _test_eof298
 		}
 	st_case_298:
-//line plugins/parsers/influx/machine.go:5904
+//line plugins/parsers/influx/machine.go:5912
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr221
@@ -5927,11 +5935,11 @@ tr999:
 		}
 		goto st6
 tr494:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -5939,7 +5947,7 @@ tr494:
 
 	goto st299
 tr221:
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -5948,7 +5956,7 @@ tr221:
 	goto st299
 tr639:
 	( m.cs) = 299
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -5958,7 +5966,7 @@ tr639:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -5967,13 +5975,13 @@ tr639:
 	goto _again
 tr603:
 	( m.cs) = 299
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -5986,7 +5994,7 @@ tr603:
 	goto _again
 tr823:
 	( m.cs) = 299
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -5996,7 +6004,7 @@ tr823:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -6005,7 +6013,7 @@ tr823:
 	goto _again
 tr829:
 	( m.cs) = 299
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -6015,7 +6023,7 @@ tr829:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -6024,13 +6032,13 @@ tr829:
 	goto _again
 tr810:
 	( m.cs) = 299
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -6043,13 +6051,13 @@ tr810:
 	goto _again
 tr765:
 	( m.cs) = 299
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -6062,13 +6070,13 @@ tr765:
 	goto _again
 tr798:
 	( m.cs) = 299
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -6081,13 +6089,13 @@ tr798:
 	goto _again
 tr804:
 	( m.cs) = 299
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -6099,7 +6107,7 @@ tr804:
 
 	goto _again
 	st299:
-//line plugins/parsers/influx/machine.go.rl:164
+//line plugins/parsers/influx/machine.go.rl:172
 
 	m.finishMetric = true
 	( m.cs) = 740;
@@ -6109,7 +6117,7 @@ tr804:
 			goto _test_eof299
 		}
 	st_case_299:
-//line plugins/parsers/influx/machine.go:6113
+//line plugins/parsers/influx/machine.go:6121
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st38
@@ -6162,7 +6170,7 @@ tr804:
 		}
 		goto tr82
 tr117:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -6172,7 +6180,7 @@ tr117:
 			goto _test_eof39
 		}
 	st_case_39:
-//line plugins/parsers/influx/machine.go:6176
+//line plugins/parsers/influx/machine.go:6184
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr119
@@ -6198,7 +6206,7 @@ tr117:
 		goto tr82
 tr119:
 	( m.cs) = 40
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6214,7 +6222,7 @@ tr119:
 			goto _test_eof40
 		}
 	st_case_40:
-//line plugins/parsers/influx/machine.go:6218
+//line plugins/parsers/influx/machine.go:6226
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st40
@@ -6241,7 +6249,7 @@ tr119:
 		}
 		goto tr121
 tr121:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -6251,7 +6259,7 @@ tr121:
 			goto _test_eof41
 		}
 	st_case_41:
-//line plugins/parsers/influx/machine.go:6255
+//line plugins/parsers/influx/machine.go:6263
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr89
@@ -6277,7 +6285,7 @@ tr121:
 		goto st41
 tr127:
 	( m.cs) = 42
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6290,7 +6298,7 @@ tr127:
 	goto _again
 tr131:
 	( m.cs) = 42
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6300,7 +6308,7 @@ tr131:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -6310,7 +6318,7 @@ tr131:
 			goto _test_eof42
 		}
 	st_case_42:
-//line plugins/parsers/influx/machine.go:6314
+//line plugins/parsers/influx/machine.go:6322
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr89
@@ -6336,11 +6344,11 @@ tr131:
 		goto tr121
 tr124:
 	( m.cs) = 300
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -6353,7 +6361,7 @@ tr124:
 	goto _again
 tr128:
 	( m.cs) = 300
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -6369,7 +6377,7 @@ tr128:
 			goto _test_eof300
 		}
 	st_case_300:
-//line plugins/parsers/influx/machine.go:6373
+//line plugins/parsers/influx/machine.go:6381
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -6392,7 +6400,7 @@ tr128:
 		goto st11
 tr501:
 	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6405,7 +6413,7 @@ tr501:
 	goto _again
 tr566:
 	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -6418,7 +6426,7 @@ tr566:
 	goto _again
 tr641:
 	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6428,7 +6436,7 @@ tr641:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -6441,7 +6449,7 @@ tr641:
 	goto _again
 tr731:
 	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -6451,7 +6459,7 @@ tr731:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -6464,7 +6472,7 @@ tr731:
 	goto _again
 tr743:
 	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -6474,7 +6482,7 @@ tr743:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -6487,7 +6495,7 @@ tr743:
 	goto _again
 tr750:
 	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -6497,7 +6505,7 @@ tr750:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -6510,7 +6518,7 @@ tr750:
 	goto _again
 tr757:
 	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -6520,7 +6528,7 @@ tr757:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -6533,7 +6541,7 @@ tr757:
 	goto _again
 tr825:
 	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6543,7 +6551,7 @@ tr825:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -6556,7 +6564,7 @@ tr825:
 	goto _again
 tr831:
 	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6566,7 +6574,7 @@ tr831:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -6579,7 +6587,7 @@ tr831:
 	goto _again
 tr836:
 	( m.cs) = 301
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6589,7 +6597,7 @@ tr836:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -6605,7 +6613,7 @@ tr836:
 			goto _test_eof301
 		}
 	st_case_301:
-//line plugins/parsers/influx/machine.go:6609
+//line plugins/parsers/influx/machine.go:6617
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -6634,7 +6642,7 @@ tr836:
 		}
 		goto tr6
 tr505:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -6644,7 +6652,7 @@ tr505:
 			goto _test_eof302
 		}
 	st_case_302:
-//line plugins/parsers/influx/machine.go:6648
+//line plugins/parsers/influx/machine.go:6656
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -6674,7 +6682,7 @@ tr505:
 		goto tr6
 tr502:
 	( m.cs) = 303
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6687,7 +6695,7 @@ tr502:
 	goto _again
 tr506:
 	( m.cs) = 303
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6697,7 +6705,7 @@ tr506:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -6707,7 +6715,7 @@ tr506:
 			goto _test_eof303
 		}
 	st_case_303:
-//line plugins/parsers/influx/machine.go:6711
+//line plugins/parsers/influx/machine.go:6719
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -6736,7 +6744,7 @@ tr506:
 		}
 		goto tr41
 tr507:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -6746,7 +6754,7 @@ tr507:
 			goto _test_eof43
 		}
 	st_case_43:
-//line plugins/parsers/influx/machine.go:6750
+//line plugins/parsers/influx/machine.go:6758
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr132
@@ -6773,7 +6781,7 @@ tr507:
 		}
 		goto st11
 tr508:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -6783,7 +6791,7 @@ tr508:
 			goto _test_eof304
 		}
 	st_case_304:
-//line plugins/parsers/influx/machine.go:6787
+//line plugins/parsers/influx/machine.go:6795
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr470
@@ -6811,7 +6819,7 @@ tr508:
 		goto st11
 tr514:
 	( m.cs) = 305
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6824,7 +6832,7 @@ tr514:
 	goto _again
 tr575:
 	( m.cs) = 305
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -6837,7 +6845,7 @@ tr575:
 	goto _again
 tr509:
 	( m.cs) = 305
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6847,7 +6855,7 @@ tr509:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -6860,7 +6868,7 @@ tr509:
 	goto _again
 tr572:
 	( m.cs) = 305
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -6870,7 +6878,7 @@ tr572:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -6886,7 +6894,7 @@ tr572:
 			goto _test_eof305
 		}
 	st_case_305:
-//line plugins/parsers/influx/machine.go:6890
+//line plugins/parsers/influx/machine.go:6898
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -6908,7 +6916,7 @@ tr572:
 		}
 		goto tr6
 tr513:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -6918,7 +6926,7 @@ tr513:
 			goto _test_eof306
 		}
 	st_case_306:
-//line plugins/parsers/influx/machine.go:6922
+//line plugins/parsers/influx/machine.go:6930
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -6941,7 +6949,7 @@ tr513:
 		goto tr6
 tr515:
 	( m.cs) = 307
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6951,14 +6959,14 @@ tr515:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr510:
 	( m.cs) = 307
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -6968,7 +6976,7 @@ tr510:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -6984,7 +6992,7 @@ tr510:
 			goto _test_eof307
 		}
 	st_case_307:
-//line plugins/parsers/influx/machine.go:6988
+//line plugins/parsers/influx/machine.go:6996
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -7542,7 +7550,7 @@ tr510:
 		goto st11
 tr503:
 	( m.cs) = 44
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -7555,7 +7563,7 @@ tr503:
 	goto _again
 tr568:
 	( m.cs) = 44
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -7568,7 +7576,7 @@ tr568:
 	goto _again
 tr819:
 	( m.cs) = 44
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -7578,7 +7586,7 @@ tr819:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -7591,7 +7599,7 @@ tr819:
 	goto _again
 tr737:
 	( m.cs) = 44
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -7601,7 +7609,7 @@ tr737:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -7614,7 +7622,7 @@ tr737:
 	goto _again
 tr955:
 	( m.cs) = 44
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -7624,7 +7632,7 @@ tr955:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -7637,7 +7645,7 @@ tr955:
 	goto _again
 tr960:
 	( m.cs) = 44
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -7647,7 +7655,7 @@ tr960:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -7660,7 +7668,7 @@ tr960:
 	goto _again
 tr965:
 	( m.cs) = 44
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -7670,7 +7678,7 @@ tr965:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -7683,7 +7691,7 @@ tr965:
 	goto _again
 tr1014:
 	( m.cs) = 44
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -7693,7 +7701,7 @@ tr1014:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -7706,7 +7714,7 @@ tr1014:
 	goto _again
 tr1017:
 	( m.cs) = 44
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -7716,7 +7724,7 @@ tr1017:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -7729,7 +7737,7 @@ tr1017:
 	goto _again
 tr1020:
 	( m.cs) = 44
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -7739,7 +7747,7 @@ tr1020:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -7755,7 +7763,7 @@ tr1020:
 			goto _test_eof44
 		}
 	st_case_44:
-//line plugins/parsers/influx/machine.go:7759
+//line plugins/parsers/influx/machine.go:7767
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr47
@@ -7776,7 +7784,7 @@ tr1020:
 		}
 		goto tr134
 tr134:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -7786,7 +7794,7 @@ tr134:
 			goto _test_eof45
 		}
 	st_case_45:
-//line plugins/parsers/influx/machine.go:7790
+//line plugins/parsers/influx/machine.go:7798
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr47
@@ -7807,11 +7815,11 @@ tr134:
 		}
 		goto st45
 tr137:
-//line plugins/parsers/influx/machine.go.rl:87
+//line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
 
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -7821,7 +7829,7 @@ tr137:
 			goto _test_eof46
 		}
 	st_case_46:
-//line plugins/parsers/influx/machine.go:7825
+//line plugins/parsers/influx/machine.go:7833
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr47
@@ -7862,7 +7870,7 @@ tr137:
 		}
 		goto tr57
 tr139:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -7872,7 +7880,7 @@ tr139:
 			goto _test_eof47
 		}
 	st_case_47:
-//line plugins/parsers/influx/machine.go:7876
+//line plugins/parsers/influx/machine.go:7884
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr149
@@ -7897,7 +7905,7 @@ tr139:
 		}
 		goto tr148
 tr148:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -7907,7 +7915,7 @@ tr148:
 			goto _test_eof48
 		}
 	st_case_48:
-//line plugins/parsers/influx/machine.go:7911
+//line plugins/parsers/influx/machine.go:7919
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr155
@@ -7933,7 +7941,7 @@ tr148:
 		goto st48
 tr180:
 	( m.cs) = 49
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -7946,7 +7954,7 @@ tr180:
 	goto _again
 tr155:
 	( m.cs) = 49
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -7959,7 +7967,7 @@ tr155:
 	goto _again
 tr149:
 	( m.cs) = 49
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -7969,7 +7977,7 @@ tr149:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -7979,7 +7987,7 @@ tr149:
 			goto _test_eof49
 		}
 	st_case_49:
-//line plugins/parsers/influx/machine.go:7983
+//line plugins/parsers/influx/machine.go:7991
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st49
@@ -8004,7 +8012,7 @@ tr149:
 		}
 		goto tr160
 tr160:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -8014,7 +8022,7 @@ tr160:
 			goto _test_eof50
 		}
 	st_case_50:
-//line plugins/parsers/influx/machine.go:8018
+//line plugins/parsers/influx/machine.go:8026
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -8037,7 +8045,7 @@ tr160:
 		}
 		goto st50
 tr165:
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -8047,7 +8055,7 @@ tr165:
 			goto _test_eof51
 		}
 	st_case_51:
-//line plugins/parsers/influx/machine.go:8051
+//line plugins/parsers/influx/machine.go:8059
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -8079,7 +8087,7 @@ tr165:
 		}
 		goto st6
 tr167:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -8089,7 +8097,7 @@ tr167:
 			goto _test_eof52
 		}
 	st_case_52:
-//line plugins/parsers/influx/machine.go:8093
+//line plugins/parsers/influx/machine.go:8101
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -8111,7 +8119,7 @@ tr167:
 		}
 		goto st6
 tr168:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -8121,7 +8129,7 @@ tr168:
 			goto _test_eof53
 		}
 	st_case_53:
-//line plugins/parsers/influx/machine.go:8125
+//line plugins/parsers/influx/machine.go:8133
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -8173,14 +8181,14 @@ tr168:
 		}
 		goto st6
 tr925:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st327
 tr533:
 	( m.cs) = 327
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -8193,7 +8201,7 @@ tr533:
 	goto _again
 tr931:
 	( m.cs) = 327
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -8206,7 +8214,7 @@ tr931:
 	goto _again
 tr934:
 	( m.cs) = 327
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -8219,7 +8227,7 @@ tr934:
 	goto _again
 tr938:
 	( m.cs) = 327
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -8235,7 +8243,7 @@ tr938:
 			goto _test_eof327
 		}
 	st_case_327:
-//line plugins/parsers/influx/machine.go:8239
+//line plugins/parsers/influx/machine.go:8247
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr275
@@ -8262,11 +8270,11 @@ tr938:
 		}
 		goto st6
 tr669:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -8274,7 +8282,7 @@ tr669:
 
 	goto st328
 tr275:
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -8283,7 +8291,7 @@ tr275:
 	goto st328
 tr534:
 	( m.cs) = 328
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -8293,7 +8301,7 @@ tr534:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -8302,13 +8310,13 @@ tr534:
 	goto _again
 tr678:
 	( m.cs) = 328
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -8321,7 +8329,7 @@ tr678:
 	goto _again
 tr741:
 	( m.cs) = 328
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -8331,7 +8339,7 @@ tr741:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -8340,7 +8348,7 @@ tr741:
 	goto _again
 tr748:
 	( m.cs) = 328
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -8350,7 +8358,7 @@ tr748:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -8359,13 +8367,13 @@ tr748:
 	goto _again
 tr755:
 	( m.cs) = 328
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -8378,7 +8386,7 @@ tr755:
 	goto _again
 tr900:
 	( m.cs) = 328
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -8388,7 +8396,7 @@ tr900:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -8396,7 +8404,7 @@ tr900:
 
 	goto _again
 	st328:
-//line plugins/parsers/influx/machine.go.rl:164
+//line plugins/parsers/influx/machine.go.rl:172
 
 	m.finishMetric = true
 	( m.cs) = 740;
@@ -8406,7 +8414,7 @@ tr900:
 			goto _test_eof328
 		}
 	st_case_328:
-//line plugins/parsers/influx/machine.go:8410
+//line plugins/parsers/influx/machine.go:8418
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st165
@@ -8431,7 +8439,7 @@ tr900:
 		}
 		goto tr337
 tr337:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -8441,7 +8449,7 @@ tr337:
 			goto _test_eof54
 		}
 	st_case_54:
-//line plugins/parsers/influx/machine.go:8445
+//line plugins/parsers/influx/machine.go:8453
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr180
@@ -8465,7 +8473,7 @@ tr337:
 		goto st54
 tr181:
 	( m.cs) = 55
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -8481,7 +8489,7 @@ tr181:
 			goto _test_eof55
 		}
 	st_case_55:
-//line plugins/parsers/influx/machine.go:8485
+//line plugins/parsers/influx/machine.go:8493
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr180
@@ -8506,7 +8514,7 @@ tr181:
 		}
 		goto tr184
 tr184:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -8516,7 +8524,7 @@ tr184:
 			goto _test_eof56
 		}
 	st_case_56:
-//line plugins/parsers/influx/machine.go:8520
+//line plugins/parsers/influx/machine.go:8528
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr180
@@ -8542,7 +8550,7 @@ tr184:
 		goto st56
 tr188:
 	( m.cs) = 57
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -8555,7 +8563,7 @@ tr188:
 	goto _again
 tr185:
 	( m.cs) = 57
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -8565,7 +8573,7 @@ tr185:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -8575,7 +8583,7 @@ tr185:
 			goto _test_eof57
 		}
 	st_case_57:
-//line plugins/parsers/influx/machine.go:8579
+//line plugins/parsers/influx/machine.go:8587
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr180
@@ -8601,7 +8609,7 @@ tr185:
 		goto tr184
 tr182:
 	( m.cs) = 58
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -8614,7 +8622,7 @@ tr182:
 	goto _again
 tr158:
 	( m.cs) = 58
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -8627,7 +8635,7 @@ tr158:
 	goto _again
 tr152:
 	( m.cs) = 58
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -8637,7 +8645,7 @@ tr152:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -8647,7 +8655,7 @@ tr152:
 			goto _test_eof58
 		}
 	st_case_58:
-//line plugins/parsers/influx/machine.go:8651
+//line plugins/parsers/influx/machine.go:8659
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -8670,7 +8678,7 @@ tr152:
 		}
 		goto tr191
 tr191:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -8680,7 +8688,7 @@ tr191:
 			goto _test_eof59
 		}
 	st_case_59:
-//line plugins/parsers/influx/machine.go:8684
+//line plugins/parsers/influx/machine.go:8692
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -8704,11 +8712,11 @@ tr191:
 		goto st59
 tr192:
 	( m.cs) = 329
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -8721,7 +8729,7 @@ tr192:
 	goto _again
 tr195:
 	( m.cs) = 329
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -8737,7 +8745,7 @@ tr195:
 			goto _test_eof329
 		}
 	st_case_329:
-//line plugins/parsers/influx/machine.go:8741
+//line plugins/parsers/influx/machine.go:8749
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -8791,7 +8799,7 @@ tr195:
 		}
 		goto st14
 tr544:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -8801,7 +8809,7 @@ tr544:
 			goto _test_eof60
 		}
 	st_case_60:
-//line plugins/parsers/influx/machine.go:8805
+//line plugins/parsers/influx/machine.go:8813
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr198
@@ -8826,7 +8834,7 @@ tr544:
 		}
 		goto st14
 tr545:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -8836,7 +8844,7 @@ tr545:
 			goto _test_eof331
 		}
 	st_case_331:
-//line plugins/parsers/influx/machine.go:8840
+//line plugins/parsers/influx/machine.go:8848
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr470
@@ -8864,7 +8872,7 @@ tr545:
 		goto st14
 tr546:
 	( m.cs) = 332
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -8880,7 +8888,7 @@ tr546:
 			goto _test_eof332
 		}
 	st_case_332:
-//line plugins/parsers/influx/machine.go:8884
+//line plugins/parsers/influx/machine.go:8892
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -9437,7 +9445,7 @@ tr546:
 		}
 		goto st14
 tr196:
-//line plugins/parsers/influx/machine.go.rl:87
+//line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
 
@@ -9447,7 +9455,7 @@ tr196:
 			goto _test_eof61
 		}
 	st_case_61:
-//line plugins/parsers/influx/machine.go:9451
+//line plugins/parsers/influx/machine.go:9459
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -9471,11 +9479,11 @@ tr196:
 		goto tr148
 tr151:
 	( m.cs) = 351
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -9488,7 +9496,7 @@ tr151:
 	goto _again
 tr157:
 	( m.cs) = 351
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -9504,7 +9512,7 @@ tr157:
 			goto _test_eof351
 		}
 	st_case_351:
-//line plugins/parsers/influx/machine.go:9508
+//line plugins/parsers/influx/machine.go:9516
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -9527,7 +9535,7 @@ tr157:
 		goto st16
 tr567:
 	( m.cs) = 352
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -9540,7 +9548,7 @@ tr567:
 	goto _again
 tr735:
 	( m.cs) = 352
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -9550,7 +9558,7 @@ tr735:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -9563,7 +9571,7 @@ tr735:
 	goto _again
 tr953:
 	( m.cs) = 352
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -9573,7 +9581,7 @@ tr953:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -9586,7 +9594,7 @@ tr953:
 	goto _again
 tr958:
 	( m.cs) = 352
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -9596,7 +9604,7 @@ tr958:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -9609,7 +9617,7 @@ tr958:
 	goto _again
 tr963:
 	( m.cs) = 352
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -9619,7 +9627,7 @@ tr963:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -9635,7 +9643,7 @@ tr963:
 			goto _test_eof352
 		}
 	st_case_352:
-//line plugins/parsers/influx/machine.go:9639
+//line plugins/parsers/influx/machine.go:9647
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -9665,7 +9673,7 @@ tr963:
 		goto tr64
 tr594:
 	( m.cs) = 353
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -9678,7 +9686,7 @@ tr594:
 	goto _again
 tr569:
 	( m.cs) = 353
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -9688,7 +9696,7 @@ tr569:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -9698,7 +9706,7 @@ tr569:
 			goto _test_eof353
 		}
 	st_case_353:
-//line plugins/parsers/influx/machine.go:9702
+//line plugins/parsers/influx/machine.go:9710
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -9727,7 +9735,7 @@ tr569:
 		}
 		goto tr64
 tr570:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -9737,7 +9745,7 @@ tr570:
 			goto _test_eof62
 		}
 	st_case_62:
-//line plugins/parsers/influx/machine.go:9741
+//line plugins/parsers/influx/machine.go:9749
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr132
@@ -9764,7 +9772,7 @@ tr570:
 		}
 		goto st18
 tr571:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -9774,7 +9782,7 @@ tr571:
 			goto _test_eof354
 		}
 	st_case_354:
-//line plugins/parsers/influx/machine.go:9778
+//line plugins/parsers/influx/machine.go:9786
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr470
@@ -9802,7 +9810,7 @@ tr571:
 		goto st18
 tr576:
 	( m.cs) = 355
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -9812,14 +9820,14 @@ tr576:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr573:
 	( m.cs) = 355
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -9829,7 +9837,7 @@ tr573:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -9845,7 +9853,7 @@ tr573:
 			goto _test_eof355
 		}
 	st_case_355:
-//line plugins/parsers/influx/machine.go:9849
+//line plugins/parsers/influx/machine.go:9857
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -10402,7 +10410,7 @@ tr573:
 		}
 		goto st18
 tr153:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -10412,7 +10420,7 @@ tr153:
 			goto _test_eof63
 		}
 	st_case_63:
-//line plugins/parsers/influx/machine.go:10416
+//line plugins/parsers/influx/machine.go:10424
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st48
@@ -10429,14 +10437,14 @@ tr153:
 		}
 		goto st16
 	st64:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof64
 		}
 	st_case_64:
-//line plugins/parsers/influx/machine.go:10440
+//line plugins/parsers/influx/machine.go:10448
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr155
@@ -10462,7 +10470,7 @@ tr153:
 		goto st48
 tr156:
 	( m.cs) = 65
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -10475,7 +10483,7 @@ tr156:
 	goto _again
 tr150:
 	( m.cs) = 65
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -10485,7 +10493,7 @@ tr150:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -10495,7 +10503,7 @@ tr150:
 			goto _test_eof65
 		}
 	st_case_65:
-//line plugins/parsers/influx/machine.go:10499
+//line plugins/parsers/influx/machine.go:10507
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr155
@@ -10520,7 +10528,7 @@ tr150:
 		}
 		goto tr202
 tr202:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -10530,7 +10538,7 @@ tr202:
 			goto _test_eof66
 		}
 	st_case_66:
-//line plugins/parsers/influx/machine.go:10534
+//line plugins/parsers/influx/machine.go:10542
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr155
@@ -10556,7 +10564,7 @@ tr202:
 		goto st66
 tr207:
 	( m.cs) = 67
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -10569,7 +10577,7 @@ tr207:
 	goto _again
 tr203:
 	( m.cs) = 67
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -10579,7 +10587,7 @@ tr203:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -10589,7 +10597,7 @@ tr203:
 			goto _test_eof67
 		}
 	st_case_67:
-//line plugins/parsers/influx/machine.go:10593
+//line plugins/parsers/influx/machine.go:10601
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr155
@@ -10615,11 +10623,11 @@ tr203:
 		goto tr202
 tr204:
 	( m.cs) = 374
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -10632,7 +10640,7 @@ tr204:
 	goto _again
 tr208:
 	( m.cs) = 374
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -10648,7 +10656,7 @@ tr208:
 			goto _test_eof374
 		}
 	st_case_374:
-//line plugins/parsers/influx/machine.go:10652
+//line plugins/parsers/influx/machine.go:10660
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -10670,7 +10678,7 @@ tr208:
 		}
 		goto st18
 tr205:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -10680,7 +10688,7 @@ tr205:
 			goto _test_eof68
 		}
 	st_case_68:
-//line plugins/parsers/influx/machine.go:10684
+//line plugins/parsers/influx/machine.go:10692
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st66
@@ -10697,14 +10705,14 @@ tr205:
 		}
 		goto st18
 	st69:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof69
 		}
 	st_case_69:
-//line plugins/parsers/influx/machine.go:10708
+//line plugins/parsers/influx/machine.go:10716
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr155
@@ -10729,7 +10737,7 @@ tr205:
 		}
 		goto st66
 tr193:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -10739,7 +10747,7 @@ tr193:
 			goto _test_eof70
 		}
 	st_case_70:
-//line plugins/parsers/influx/machine.go:10743
+//line plugins/parsers/influx/machine.go:10751
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st59
@@ -10756,14 +10764,14 @@ tr193:
 		}
 		goto st14
 	st71:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof71
 		}
 	st_case_71:
-//line plugins/parsers/influx/machine.go:10767
+//line plugins/parsers/influx/machine.go:10775
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -10786,17 +10794,17 @@ tr193:
 		}
 		goto st59
 tr189:
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
 	goto st72
 tr346:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -10806,7 +10814,7 @@ tr346:
 			goto _test_eof72
 		}
 	st_case_72:
-//line plugins/parsers/influx/machine.go:10810
+//line plugins/parsers/influx/machine.go:10818
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr180
@@ -10847,7 +10855,7 @@ tr346:
 		goto st54
 tr212:
 	( m.cs) = 375
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -10863,7 +10871,7 @@ tr212:
 			goto _test_eof375
 		}
 	st_case_375:
-//line plugins/parsers/influx/machine.go:10867
+//line plugins/parsers/influx/machine.go:10875
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr595
@@ -10887,7 +10895,7 @@ tr212:
 		goto tr82
 tr626:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -10900,7 +10908,7 @@ tr626:
 	goto _again
 tr595:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -10910,14 +10918,14 @@ tr595:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr769:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -10930,7 +10938,7 @@ tr769:
 	goto _again
 tr638:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -10940,7 +10948,7 @@ tr638:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -10953,7 +10961,7 @@ tr638:
 	goto _again
 tr764:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -10963,7 +10971,7 @@ tr764:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -10976,7 +10984,7 @@ tr764:
 	goto _again
 tr797:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -10986,7 +10994,7 @@ tr797:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -10999,7 +11007,7 @@ tr797:
 	goto _again
 tr803:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -11009,7 +11017,7 @@ tr803:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -11022,7 +11030,7 @@ tr803:
 	goto _again
 tr809:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -11032,7 +11040,7 @@ tr809:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -11045,7 +11053,7 @@ tr809:
 	goto _again
 tr822:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -11055,7 +11063,7 @@ tr822:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -11068,7 +11076,7 @@ tr822:
 	goto _again
 tr828:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -11078,7 +11086,7 @@ tr828:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -11091,7 +11099,7 @@ tr828:
 	goto _again
 tr834:
 	( m.cs) = 376
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -11101,7 +11109,7 @@ tr834:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -11117,7 +11125,7 @@ tr834:
 			goto _test_eof376
 		}
 	st_case_376:
-//line plugins/parsers/influx/machine.go:11121
+//line plugins/parsers/influx/machine.go:11129
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st376
@@ -11147,7 +11155,7 @@ tr834:
 		}
 		goto tr94
 tr599:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -11157,7 +11165,7 @@ tr599:
 			goto _test_eof377
 		}
 	st_case_377:
-//line plugins/parsers/influx/machine.go:11161
+//line plugins/parsers/influx/machine.go:11169
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st376
@@ -11187,14 +11195,14 @@ tr599:
 		}
 		goto tr94
 tr495:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st73
 tr605:
 	( m.cs) = 73
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -11207,7 +11215,7 @@ tr605:
 	goto _again
 tr642:
 	( m.cs) = 73
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -11220,7 +11228,7 @@ tr642:
 	goto _again
 tr800:
 	( m.cs) = 73
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -11233,7 +11241,7 @@ tr800:
 	goto _again
 tr806:
 	( m.cs) = 73
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -11246,7 +11254,7 @@ tr806:
 	goto _again
 tr812:
 	( m.cs) = 73
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -11262,13 +11270,13 @@ tr812:
 			goto _test_eof73
 		}
 	st_case_73:
-//line plugins/parsers/influx/machine.go:11266
+//line plugins/parsers/influx/machine.go:11274
 		if ( m.data)[( m.p)] == 10 {
 			goto tr221
 		}
 		goto tr8
 tr600:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -11278,7 +11286,7 @@ tr600:
 			goto _test_eof74
 		}
 	st_case_74:
-//line plugins/parsers/influx/machine.go:11282
+//line plugins/parsers/influx/machine.go:11290
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -11304,7 +11312,7 @@ tr600:
 		}
 		goto st32
 tr601:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -11314,7 +11322,7 @@ tr601:
 			goto _test_eof378
 		}
 	st_case_378:
-//line plugins/parsers/influx/machine.go:11318
+//line plugins/parsers/influx/machine.go:11326
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr602
@@ -11343,7 +11351,7 @@ tr601:
 		goto st32
 tr602:
 	( m.cs) = 379
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -11359,7 +11367,7 @@ tr602:
 			goto _test_eof379
 		}
 	st_case_379:
-//line plugins/parsers/influx/machine.go:11363
+//line plugins/parsers/influx/machine.go:11371
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr221
@@ -11379,7 +11387,7 @@ tr602:
 		}
 		goto st6
 tr27:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -11389,7 +11397,7 @@ tr27:
 			goto _test_eof75
 		}
 	st_case_75:
-//line plugins/parsers/influx/machine.go:11393
+//line plugins/parsers/influx/machine.go:11401
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st6
@@ -11399,7 +11407,7 @@ tr27:
 		goto tr8
 tr604:
 	( m.cs) = 380
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -11415,7 +11423,7 @@ tr604:
 			goto _test_eof380
 		}
 	st_case_380:
-//line plugins/parsers/influx/machine.go:11419
+//line plugins/parsers/influx/machine.go:11427
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st379
@@ -11440,7 +11448,7 @@ tr604:
 		}
 		goto st32
 tr98:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -11450,7 +11458,7 @@ tr98:
 			goto _test_eof76
 		}
 	st_case_76:
-//line plugins/parsers/influx/machine.go:11454
+//line plugins/parsers/influx/machine.go:11462
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st32
@@ -12023,7 +12031,7 @@ tr98:
 		goto st32
 tr596:
 	( m.cs) = 399
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12033,14 +12041,14 @@ tr596:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr640:
 	( m.cs) = 399
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12050,7 +12058,7 @@ tr640:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -12063,7 +12071,7 @@ tr640:
 	goto _again
 tr824:
 	( m.cs) = 399
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12073,7 +12081,7 @@ tr824:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -12086,7 +12094,7 @@ tr824:
 	goto _again
 tr830:
 	( m.cs) = 399
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12096,7 +12104,7 @@ tr830:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -12109,7 +12117,7 @@ tr830:
 	goto _again
 tr835:
 	( m.cs) = 399
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12119,7 +12127,7 @@ tr835:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -12135,7 +12143,7 @@ tr835:
 			goto _test_eof399
 		}
 	st_case_399:
-//line plugins/parsers/influx/machine.go:12139
+//line plugins/parsers/influx/machine.go:12147
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr626
@@ -12166,7 +12174,7 @@ tr835:
 		goto tr121
 tr627:
 	( m.cs) = 400
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12176,7 +12184,7 @@ tr627:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12186,7 +12194,7 @@ tr627:
 			goto _test_eof400
 		}
 	st_case_400:
-//line plugins/parsers/influx/machine.go:12190
+//line plugins/parsers/influx/machine.go:12198
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr626
@@ -12217,7 +12225,7 @@ tr627:
 		goto tr121
 tr92:
 	( m.cs) = 77
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12230,7 +12238,7 @@ tr92:
 	goto _again
 tr86:
 	( m.cs) = 77
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12240,14 +12248,14 @@ tr86:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr233:
 	( m.cs) = 77
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -12263,7 +12271,7 @@ tr233:
 			goto _test_eof77
 		}
 	st_case_77:
-//line plugins/parsers/influx/machine.go:12267
+//line plugins/parsers/influx/machine.go:12275
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -12286,7 +12294,7 @@ tr233:
 		}
 		goto tr223
 tr223:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12296,7 +12304,7 @@ tr223:
 			goto _test_eof78
 		}
 	st_case_78:
-//line plugins/parsers/influx/machine.go:12300
+//line plugins/parsers/influx/machine.go:12308
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -12319,7 +12327,7 @@ tr223:
 		}
 		goto st78
 tr226:
-//line plugins/parsers/influx/machine.go.rl:87
+//line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
 
@@ -12329,7 +12337,7 @@ tr226:
 			goto _test_eof79
 		}
 	st_case_79:
-//line plugins/parsers/influx/machine.go:12333
+//line plugins/parsers/influx/machine.go:12341
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -12352,7 +12360,7 @@ tr226:
 		}
 		goto tr228
 tr228:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12362,7 +12370,7 @@ tr228:
 			goto _test_eof80
 		}
 	st_case_80:
-//line plugins/parsers/influx/machine.go:12366
+//line plugins/parsers/influx/machine.go:12374
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr231
@@ -12388,7 +12396,7 @@ tr228:
 		goto st80
 tr232:
 	( m.cs) = 81
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -12404,7 +12412,7 @@ tr232:
 			goto _test_eof81
 		}
 	st_case_81:
-//line plugins/parsers/influx/machine.go:12408
+//line plugins/parsers/influx/machine.go:12416
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr231
@@ -12429,7 +12437,7 @@ tr232:
 		}
 		goto tr235
 tr235:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12439,7 +12447,7 @@ tr235:
 			goto _test_eof82
 		}
 	st_case_82:
-//line plugins/parsers/influx/machine.go:12443
+//line plugins/parsers/influx/machine.go:12451
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr231
@@ -12465,7 +12473,7 @@ tr235:
 		goto st82
 tr239:
 	( m.cs) = 83
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -12478,7 +12486,7 @@ tr239:
 	goto _again
 tr236:
 	( m.cs) = 83
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -12488,7 +12496,7 @@ tr236:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12498,7 +12506,7 @@ tr236:
 			goto _test_eof83
 		}
 	st_case_83:
-//line plugins/parsers/influx/machine.go:12502
+//line plugins/parsers/influx/machine.go:12510
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr231
@@ -12523,7 +12531,7 @@ tr236:
 		}
 		goto tr235
 tr237:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12533,7 +12541,7 @@ tr237:
 			goto _test_eof84
 		}
 	st_case_84:
-//line plugins/parsers/influx/machine.go:12537
+//line plugins/parsers/influx/machine.go:12545
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st82
@@ -12550,14 +12558,14 @@ tr237:
 		}
 		goto st18
 	st85:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof85
 		}
 	st_case_85:
-//line plugins/parsers/influx/machine.go:12561
+//line plugins/parsers/influx/machine.go:12569
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr231
@@ -12582,7 +12590,7 @@ tr237:
 		}
 		goto st82
 tr229:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12592,7 +12600,7 @@ tr229:
 			goto _test_eof86
 		}
 	st_case_86:
-//line plugins/parsers/influx/machine.go:12596
+//line plugins/parsers/influx/machine.go:12604
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st80
@@ -12609,14 +12617,14 @@ tr229:
 		}
 		goto st16
 	st87:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof87
 		}
 	st_case_87:
-//line plugins/parsers/influx/machine.go:12620
+//line plugins/parsers/influx/machine.go:12628
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr231
@@ -12641,7 +12649,7 @@ tr229:
 		}
 		goto st80
 tr224:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12651,7 +12659,7 @@ tr224:
 			goto _test_eof88
 		}
 	st_case_88:
-//line plugins/parsers/influx/machine.go:12655
+//line plugins/parsers/influx/machine.go:12663
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st78
@@ -12668,14 +12676,14 @@ tr224:
 		}
 		goto st14
 	st89:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof89
 		}
 	st_case_89:
-//line plugins/parsers/influx/machine.go:12679
+//line plugins/parsers/influx/machine.go:12687
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -12698,7 +12706,7 @@ tr224:
 		}
 		goto st78
 tr628:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12708,7 +12716,7 @@ tr628:
 			goto _test_eof90
 		}
 	st_case_90:
-//line plugins/parsers/influx/machine.go:12712
+//line plugins/parsers/influx/machine.go:12720
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr89
@@ -12736,7 +12744,7 @@ tr628:
 		}
 		goto st41
 tr629:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12746,7 +12754,7 @@ tr629:
 			goto _test_eof401
 		}
 	st_case_401:
-//line plugins/parsers/influx/machine.go:12750
+//line plugins/parsers/influx/machine.go:12758
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr630
@@ -12775,7 +12783,7 @@ tr629:
 		goto st41
 tr635:
 	( m.cs) = 402
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12788,7 +12796,7 @@ tr635:
 	goto _again
 tr776:
 	( m.cs) = 402
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -12801,7 +12809,7 @@ tr776:
 	goto _again
 tr630:
 	( m.cs) = 402
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12811,7 +12819,7 @@ tr630:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -12824,7 +12832,7 @@ tr630:
 	goto _again
 tr773:
 	( m.cs) = 402
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -12834,7 +12842,7 @@ tr773:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -12850,7 +12858,7 @@ tr773:
 			goto _test_eof402
 		}
 	st_case_402:
-//line plugins/parsers/influx/machine.go:12854
+//line plugins/parsers/influx/machine.go:12862
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st402
@@ -12875,7 +12883,7 @@ tr773:
 		}
 		goto tr94
 tr634:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -12885,7 +12893,7 @@ tr634:
 			goto _test_eof403
 		}
 	st_case_403:
-//line plugins/parsers/influx/machine.go:12889
+//line plugins/parsers/influx/machine.go:12897
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st402
@@ -12911,7 +12919,7 @@ tr634:
 		goto tr94
 tr636:
 	( m.cs) = 404
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12921,14 +12929,14 @@ tr636:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr631:
 	( m.cs) = 404
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -12938,7 +12946,7 @@ tr631:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -12954,7 +12962,7 @@ tr631:
 			goto _test_eof404
 		}
 	st_case_404:
-//line plugins/parsers/influx/machine.go:12958
+//line plugins/parsers/influx/machine.go:12966
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr635
@@ -12979,17 +12987,17 @@ tr631:
 		}
 		goto tr121
 tr129:
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
 	goto st91
 tr383:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -12999,7 +13007,7 @@ tr383:
 			goto _test_eof91
 		}
 	st_case_91:
-//line plugins/parsers/influx/machine.go:13003
+//line plugins/parsers/influx/machine.go:13011
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr89
@@ -13040,7 +13048,7 @@ tr383:
 		goto st30
 tr90:
 	( m.cs) = 92
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13053,7 +13061,7 @@ tr90:
 	goto _again
 tr84:
 	( m.cs) = 92
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13063,7 +13071,7 @@ tr84:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -13073,7 +13081,7 @@ tr84:
 			goto _test_eof92
 		}
 	st_case_92:
-//line plugins/parsers/influx/machine.go:13077
+//line plugins/parsers/influx/machine.go:13085
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr89
@@ -13098,7 +13106,7 @@ tr84:
 		}
 		goto tr121
 tr125:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -13108,7 +13116,7 @@ tr125:
 			goto _test_eof93
 		}
 	st_case_93:
-//line plugins/parsers/influx/machine.go:13112
+//line plugins/parsers/influx/machine.go:13120
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st41
@@ -13125,7 +13133,7 @@ tr125:
 		}
 		goto st11
 tr245:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -13135,7 +13143,7 @@ tr245:
 			goto _test_eof94
 		}
 	st_case_94:
-//line plugins/parsers/influx/machine.go:13139
+//line plugins/parsers/influx/machine.go:13147
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr89
@@ -13166,11 +13174,11 @@ tr245:
 		goto st30
 tr85:
 	( m.cs) = 405
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -13183,7 +13191,7 @@ tr85:
 	goto _again
 tr91:
 	( m.cs) = 405
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -13196,7 +13204,7 @@ tr91:
 	goto _again
 tr118:
 	( m.cs) = 405
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -13206,7 +13214,7 @@ tr118:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -13216,7 +13224,7 @@ tr118:
 			goto _test_eof405
 		}
 	st_case_405:
-//line plugins/parsers/influx/machine.go:13220
+//line plugins/parsers/influx/machine.go:13228
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -13237,7 +13245,7 @@ tr118:
 		goto st1
 tr637:
 	( m.cs) = 406
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13250,7 +13258,7 @@ tr637:
 	goto _again
 tr818:
 	( m.cs) = 406
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13260,7 +13268,7 @@ tr818:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -13273,7 +13281,7 @@ tr818:
 	goto _again
 tr1013:
 	( m.cs) = 406
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13283,7 +13291,7 @@ tr1013:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -13296,7 +13304,7 @@ tr1013:
 	goto _again
 tr1016:
 	( m.cs) = 406
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13306,7 +13314,7 @@ tr1016:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -13319,7 +13327,7 @@ tr1016:
 	goto _again
 tr1019:
 	( m.cs) = 406
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13329,7 +13337,7 @@ tr1019:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -13345,7 +13353,7 @@ tr1019:
 			goto _test_eof406
 		}
 	st_case_406:
-//line plugins/parsers/influx/machine.go:13349
+//line plugins/parsers/influx/machine.go:13357
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -13374,17 +13382,17 @@ tr1019:
 		}
 		goto tr41
 tr37:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st95
 tr460:
-//line plugins/parsers/influx/machine.go.rl:74
+//line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -13394,7 +13402,7 @@ tr460:
 			goto _test_eof95
 		}
 	st_case_95:
-//line plugins/parsers/influx/machine.go:13398
+//line plugins/parsers/influx/machine.go:13406
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -13405,7 +13413,7 @@ tr460:
 		}
 		goto st1
 tr246:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -13415,7 +13423,7 @@ tr246:
 			goto _test_eof96
 		}
 	st_case_96:
-//line plugins/parsers/influx/machine.go:13419
+//line plugins/parsers/influx/machine.go:13427
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr89
@@ -13475,7 +13483,7 @@ tr246:
 		goto st30
 tr597:
 	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13485,14 +13493,14 @@ tr597:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr643:
 	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13502,7 +13510,7 @@ tr643:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -13515,7 +13523,7 @@ tr643:
 	goto _again
 tr767:
 	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -13525,7 +13533,7 @@ tr767:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -13538,7 +13546,7 @@ tr767:
 	goto _again
 tr801:
 	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -13548,7 +13556,7 @@ tr801:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -13561,7 +13569,7 @@ tr801:
 	goto _again
 tr807:
 	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -13571,7 +13579,7 @@ tr807:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -13584,7 +13592,7 @@ tr807:
 	goto _again
 tr813:
 	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -13594,7 +13602,7 @@ tr813:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -13607,7 +13615,7 @@ tr813:
 	goto _again
 tr826:
 	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13617,7 +13625,7 @@ tr826:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -13630,7 +13638,7 @@ tr826:
 	goto _again
 tr832:
 	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13640,7 +13648,7 @@ tr832:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -13653,7 +13661,7 @@ tr832:
 	goto _again
 tr837:
 	( m.cs) = 97
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -13663,7 +13671,7 @@ tr837:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -13679,7 +13687,7 @@ tr837:
 			goto _test_eof97
 		}
 	st_case_97:
-//line plugins/parsers/influx/machine.go:13683
+//line plugins/parsers/influx/machine.go:13691
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -13702,7 +13710,7 @@ tr837:
 		}
 		goto tr257
 tr257:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -13712,7 +13720,7 @@ tr257:
 			goto _test_eof98
 		}
 	st_case_98:
-//line plugins/parsers/influx/machine.go:13716
+//line plugins/parsers/influx/machine.go:13724
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -13736,11 +13744,11 @@ tr257:
 		goto st98
 tr258:
 	( m.cs) = 408
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -13753,7 +13761,7 @@ tr258:
 	goto _again
 tr261:
 	( m.cs) = 408
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -13769,7 +13777,7 @@ tr261:
 			goto _test_eof408
 		}
 	st_case_408:
-//line plugins/parsers/influx/machine.go:13773
+//line plugins/parsers/influx/machine.go:13781
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -13823,7 +13831,7 @@ tr261:
 		}
 		goto st45
 tr646:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -13833,7 +13841,7 @@ tr646:
 			goto _test_eof99
 		}
 	st_case_99:
-//line plugins/parsers/influx/machine.go:13837
+//line plugins/parsers/influx/machine.go:13845
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr132
@@ -13858,7 +13866,7 @@ tr646:
 		}
 		goto st45
 tr647:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -13868,7 +13876,7 @@ tr647:
 			goto _test_eof410
 		}
 	st_case_410:
-//line plugins/parsers/influx/machine.go:13872
+//line plugins/parsers/influx/machine.go:13880
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr470
@@ -13896,7 +13904,7 @@ tr647:
 		goto st45
 tr648:
 	( m.cs) = 411
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -13912,7 +13920,7 @@ tr648:
 			goto _test_eof411
 		}
 	st_case_411:
-//line plugins/parsers/influx/machine.go:13916
+//line plugins/parsers/influx/machine.go:13924
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -13934,7 +13942,7 @@ tr648:
 		}
 		goto st45
 tr135:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -13944,7 +13952,7 @@ tr135:
 			goto _test_eof100
 		}
 	st_case_100:
-//line plugins/parsers/influx/machine.go:13948
+//line plugins/parsers/influx/machine.go:13956
 		if ( m.data)[( m.p)] == 92 {
 			goto st101
 		}
@@ -13958,14 +13966,14 @@ tr135:
 		}
 		goto st45
 	st101:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof101
 		}
 	st_case_101:
-//line plugins/parsers/influx/machine.go:13969
+//line plugins/parsers/influx/machine.go:13977
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr47
@@ -14521,11 +14529,11 @@ tr135:
 		}
 		goto st45
 tr262:
-//line plugins/parsers/influx/machine.go.rl:87
+//line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
 
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -14535,7 +14543,7 @@ tr262:
 			goto _test_eof102
 		}
 	st_case_102:
-//line plugins/parsers/influx/machine.go:14539
+//line plugins/parsers/influx/machine.go:14547
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -14576,11 +14584,11 @@ tr262:
 		goto tr228
 tr266:
 	( m.cs) = 430
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -14596,7 +14604,7 @@ tr266:
 			goto _test_eof430
 		}
 	st_case_430:
-//line plugins/parsers/influx/machine.go:14600
+//line plugins/parsers/influx/machine.go:14608
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr668
@@ -14622,7 +14630,7 @@ tr266:
 		goto tr148
 tr863:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -14635,7 +14643,7 @@ tr863:
 	goto _again
 tr701:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -14648,7 +14656,7 @@ tr701:
 	goto _again
 tr668:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -14658,14 +14666,14 @@ tr668:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr859:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -14675,7 +14683,7 @@ tr859:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -14688,7 +14696,7 @@ tr859:
 	goto _again
 tr729:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -14698,7 +14706,7 @@ tr729:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -14711,7 +14719,7 @@ tr729:
 	goto _again
 tr740:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -14721,7 +14729,7 @@ tr740:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -14734,7 +14742,7 @@ tr740:
 	goto _again
 tr747:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -14744,7 +14752,7 @@ tr747:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -14757,7 +14765,7 @@ tr747:
 	goto _again
 tr754:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -14767,7 +14775,7 @@ tr754:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -14780,7 +14788,7 @@ tr754:
 	goto _again
 tr891:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -14790,7 +14798,7 @@ tr891:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -14803,7 +14811,7 @@ tr891:
 	goto _again
 tr895:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -14813,7 +14821,7 @@ tr895:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -14826,7 +14834,7 @@ tr895:
 	goto _again
 tr899:
 	( m.cs) = 431
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -14836,7 +14844,7 @@ tr899:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -14852,7 +14860,7 @@ tr899:
 			goto _test_eof431
 		}
 	st_case_431:
-//line plugins/parsers/influx/machine.go:14856
+//line plugins/parsers/influx/machine.go:14864
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st431
@@ -14882,7 +14890,7 @@ tr899:
 		}
 		goto tr160
 tr674:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -14892,7 +14900,7 @@ tr674:
 			goto _test_eof432
 		}
 	st_case_432:
-//line plugins/parsers/influx/machine.go:14896
+//line plugins/parsers/influx/machine.go:14904
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st431
@@ -14922,14 +14930,14 @@ tr674:
 		}
 		goto tr160
 tr671:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st103
 tr680:
 	( m.cs) = 103
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -14942,7 +14950,7 @@ tr680:
 	goto _again
 tr536:
 	( m.cs) = 103
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -14955,7 +14963,7 @@ tr536:
 	goto _again
 tr744:
 	( m.cs) = 103
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -14968,7 +14976,7 @@ tr744:
 	goto _again
 tr751:
 	( m.cs) = 103
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -14981,7 +14989,7 @@ tr751:
 	goto _again
 tr758:
 	( m.cs) = 103
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -14997,13 +15005,13 @@ tr758:
 			goto _test_eof103
 		}
 	st_case_103:
-//line plugins/parsers/influx/machine.go:15001
+//line plugins/parsers/influx/machine.go:15009
 		if ( m.data)[( m.p)] == 10 {
 			goto tr275
 		}
 		goto tr8
 tr675:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -15013,7 +15021,7 @@ tr675:
 			goto _test_eof104
 		}
 	st_case_104:
-//line plugins/parsers/influx/machine.go:15017
+//line plugins/parsers/influx/machine.go:15025
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -15039,7 +15047,7 @@ tr675:
 		}
 		goto st50
 tr676:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -15049,7 +15057,7 @@ tr676:
 			goto _test_eof433
 		}
 	st_case_433:
-//line plugins/parsers/influx/machine.go:15053
+//line plugins/parsers/influx/machine.go:15061
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr677
@@ -15078,7 +15086,7 @@ tr676:
 		goto st50
 tr677:
 	( m.cs) = 434
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -15094,7 +15102,7 @@ tr677:
 			goto _test_eof434
 		}
 	st_case_434:
-//line plugins/parsers/influx/machine.go:15098
+//line plugins/parsers/influx/machine.go:15106
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr275
@@ -15115,7 +15123,7 @@ tr677:
 		goto st6
 tr679:
 	( m.cs) = 435
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -15131,7 +15139,7 @@ tr679:
 			goto _test_eof435
 		}
 	st_case_435:
-//line plugins/parsers/influx/machine.go:15135
+//line plugins/parsers/influx/machine.go:15143
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st434
@@ -15156,7 +15164,7 @@ tr679:
 		}
 		goto st50
 tr163:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -15166,7 +15174,7 @@ tr163:
 			goto _test_eof105
 		}
 	st_case_105:
-//line plugins/parsers/influx/machine.go:15170
+//line plugins/parsers/influx/machine.go:15178
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st50
@@ -15739,7 +15747,7 @@ tr163:
 		goto st50
 tr670:
 	( m.cs) = 454
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -15749,14 +15757,14 @@ tr670:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr730:
 	( m.cs) = 454
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -15766,7 +15774,7 @@ tr730:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -15779,7 +15787,7 @@ tr730:
 	goto _again
 tr742:
 	( m.cs) = 454
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -15789,7 +15797,7 @@ tr742:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -15802,7 +15810,7 @@ tr742:
 	goto _again
 tr749:
 	( m.cs) = 454
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -15812,7 +15820,7 @@ tr749:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -15825,7 +15833,7 @@ tr749:
 	goto _again
 tr756:
 	( m.cs) = 454
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -15835,7 +15843,7 @@ tr756:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -15851,7 +15859,7 @@ tr756:
 			goto _test_eof454
 		}
 	st_case_454:
-//line plugins/parsers/influx/machine.go:15855
+//line plugins/parsers/influx/machine.go:15863
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr701
@@ -15882,7 +15890,7 @@ tr756:
 		goto tr202
 tr702:
 	( m.cs) = 455
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -15892,7 +15900,7 @@ tr702:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -15902,7 +15910,7 @@ tr702:
 			goto _test_eof455
 		}
 	st_case_455:
-//line plugins/parsers/influx/machine.go:15906
+//line plugins/parsers/influx/machine.go:15914
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr701
@@ -15932,7 +15940,7 @@ tr702:
 		}
 		goto tr202
 tr703:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -15942,7 +15950,7 @@ tr703:
 			goto _test_eof106
 		}
 	st_case_106:
-//line plugins/parsers/influx/machine.go:15946
+//line plugins/parsers/influx/machine.go:15954
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr155
@@ -15970,7 +15978,7 @@ tr703:
 		}
 		goto st66
 tr704:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -15980,7 +15988,7 @@ tr704:
 			goto _test_eof456
 		}
 	st_case_456:
-//line plugins/parsers/influx/machine.go:15984
+//line plugins/parsers/influx/machine.go:15992
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr705
@@ -16009,7 +16017,7 @@ tr704:
 		goto st66
 tr870:
 	( m.cs) = 457
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -16022,7 +16030,7 @@ tr870:
 	goto _again
 tr710:
 	( m.cs) = 457
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -16035,7 +16043,7 @@ tr710:
 	goto _again
 tr867:
 	( m.cs) = 457
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -16045,7 +16053,7 @@ tr867:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -16058,7 +16066,7 @@ tr867:
 	goto _again
 tr705:
 	( m.cs) = 457
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -16068,7 +16076,7 @@ tr705:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -16084,7 +16092,7 @@ tr705:
 			goto _test_eof457
 		}
 	st_case_457:
-//line plugins/parsers/influx/machine.go:16088
+//line plugins/parsers/influx/machine.go:16096
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st457
@@ -16109,7 +16117,7 @@ tr705:
 		}
 		goto tr160
 tr709:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -16119,7 +16127,7 @@ tr709:
 			goto _test_eof458
 		}
 	st_case_458:
-//line plugins/parsers/influx/machine.go:16123
+//line plugins/parsers/influx/machine.go:16131
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st457
@@ -16145,7 +16153,7 @@ tr709:
 		goto tr160
 tr711:
 	( m.cs) = 459
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -16155,14 +16163,14 @@ tr711:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr706:
 	( m.cs) = 459
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -16172,7 +16180,7 @@ tr706:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -16188,7 +16196,7 @@ tr706:
 			goto _test_eof459
 		}
 	st_case_459:
-//line plugins/parsers/influx/machine.go:16192
+//line plugins/parsers/influx/machine.go:16200
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr710
@@ -16769,7 +16777,7 @@ tr706:
 		goto st66
 tr672:
 	( m.cs) = 107
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -16779,14 +16787,14 @@ tr672:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr861:
 	( m.cs) = 107
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -16796,7 +16804,7 @@ tr861:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -16809,7 +16817,7 @@ tr861:
 	goto _again
 tr732:
 	( m.cs) = 107
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -16819,7 +16827,7 @@ tr732:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -16832,7 +16840,7 @@ tr732:
 	goto _again
 tr745:
 	( m.cs) = 107
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -16842,7 +16850,7 @@ tr745:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -16855,7 +16863,7 @@ tr745:
 	goto _again
 tr752:
 	( m.cs) = 107
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -16865,7 +16873,7 @@ tr752:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -16878,7 +16886,7 @@ tr752:
 	goto _again
 tr759:
 	( m.cs) = 107
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -16888,7 +16896,7 @@ tr759:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -16901,7 +16909,7 @@ tr759:
 	goto _again
 tr893:
 	( m.cs) = 107
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -16911,7 +16919,7 @@ tr893:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -16924,7 +16932,7 @@ tr893:
 	goto _again
 tr897:
 	( m.cs) = 107
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -16934,7 +16942,7 @@ tr897:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -16947,7 +16955,7 @@ tr897:
 	goto _again
 tr902:
 	( m.cs) = 107
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -16957,7 +16965,7 @@ tr902:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -16973,7 +16981,7 @@ tr902:
 			goto _test_eof107
 		}
 	st_case_107:
-//line plugins/parsers/influx/machine.go:16977
+//line plugins/parsers/influx/machine.go:16985
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -16996,7 +17004,7 @@ tr902:
 		}
 		goto tr278
 tr278:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -17006,7 +17014,7 @@ tr278:
 			goto _test_eof108
 		}
 	st_case_108:
-//line plugins/parsers/influx/machine.go:17010
+//line plugins/parsers/influx/machine.go:17018
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -17029,11 +17037,11 @@ tr278:
 		}
 		goto st108
 tr281:
-//line plugins/parsers/influx/machine.go.rl:87
+//line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
 
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -17043,7 +17051,7 @@ tr281:
 			goto _test_eof109
 		}
 	st_case_109:
-//line plugins/parsers/influx/machine.go:17047
+//line plugins/parsers/influx/machine.go:17055
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -17083,7 +17091,7 @@ tr281:
 		}
 		goto tr148
 tr283:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -17093,7 +17101,7 @@ tr283:
 			goto _test_eof110
 		}
 	st_case_110:
-//line plugins/parsers/influx/machine.go:17097
+//line plugins/parsers/influx/machine.go:17105
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr155
@@ -17125,7 +17133,7 @@ tr283:
 		}
 		goto st48
 tr284:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -17135,7 +17143,7 @@ tr284:
 			goto _test_eof111
 		}
 	st_case_111:
-//line plugins/parsers/influx/machine.go:17139
+//line plugins/parsers/influx/machine.go:17147
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr155
@@ -17235,7 +17243,7 @@ tr284:
 		goto st48
 tr295:
 	( m.cs) = 479
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -17251,7 +17259,7 @@ tr295:
 			goto _test_eof479
 		}
 	st_case_479:
-//line plugins/parsers/influx/machine.go:17255
+//line plugins/parsers/influx/machine.go:17263
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -17513,7 +17521,7 @@ tr295:
 		}
 		goto st48
 tr285:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -17523,7 +17531,7 @@ tr285:
 			goto _test_eof486
 		}
 	st_case_486:
-//line plugins/parsers/influx/machine.go:17527
+//line plugins/parsers/influx/machine.go:17535
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr729
@@ -17589,7 +17597,7 @@ tr285:
 		}
 		goto st48
 tr286:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -17599,7 +17607,7 @@ tr286:
 			goto _test_eof488
 		}
 	st_case_488:
-//line plugins/parsers/influx/machine.go:17603
+//line plugins/parsers/influx/machine.go:17611
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr729
@@ -17637,7 +17645,7 @@ tr286:
 		}
 		goto st48
 tr287:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -17647,7 +17655,7 @@ tr287:
 			goto _test_eof489
 		}
 	st_case_489:
-//line plugins/parsers/influx/machine.go:17651
+//line plugins/parsers/influx/machine.go:17659
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr754
@@ -17884,7 +17892,7 @@ tr287:
 		}
 		goto st48
 tr288:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -17894,7 +17902,7 @@ tr288:
 			goto _test_eof491
 		}
 	st_case_491:
-//line plugins/parsers/influx/machine.go:17898
+//line plugins/parsers/influx/machine.go:17906
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr754
@@ -17983,7 +17991,7 @@ tr288:
 		}
 		goto st48
 tr289:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -17993,7 +18001,7 @@ tr289:
 			goto _test_eof492
 		}
 	st_case_492:
-//line plugins/parsers/influx/machine.go:17997
+//line plugins/parsers/influx/machine.go:18005
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr754
@@ -18020,7 +18028,7 @@ tr289:
 		}
 		goto st48
 tr290:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -18030,7 +18038,7 @@ tr290:
 			goto _test_eof493
 		}
 	st_case_493:
-//line plugins/parsers/influx/machine.go:18034
+//line plugins/parsers/influx/machine.go:18042
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr754
@@ -18057,7 +18065,7 @@ tr290:
 		}
 		goto st48
 tr279:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -18067,7 +18075,7 @@ tr279:
 			goto _test_eof122
 		}
 	st_case_122:
-//line plugins/parsers/influx/machine.go:18071
+//line plugins/parsers/influx/machine.go:18079
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st108
@@ -18084,14 +18092,14 @@ tr279:
 		}
 		goto st45
 	st123:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof123
 		}
 	st_case_123:
-//line plugins/parsers/influx/machine.go:18095
+//line plugins/parsers/influx/machine.go:18103
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -18114,7 +18122,7 @@ tr279:
 		}
 		goto st108
 tr267:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -18124,7 +18132,7 @@ tr267:
 			goto _test_eof124
 		}
 	st_case_124:
-//line plugins/parsers/influx/machine.go:18128
+//line plugins/parsers/influx/machine.go:18136
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr231
@@ -18156,7 +18164,7 @@ tr267:
 		}
 		goto st80
 tr268:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -18166,7 +18174,7 @@ tr268:
 			goto _test_eof125
 		}
 	st_case_125:
-//line plugins/parsers/influx/machine.go:18170
+//line plugins/parsers/influx/machine.go:18178
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr231
@@ -18230,7 +18238,7 @@ tr268:
 		goto st80
 tr766:
 	( m.cs) = 495
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -18240,7 +18248,7 @@ tr766:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -18253,7 +18261,7 @@ tr766:
 	goto _again
 tr799:
 	( m.cs) = 495
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -18263,7 +18271,7 @@ tr799:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -18276,7 +18284,7 @@ tr799:
 	goto _again
 tr805:
 	( m.cs) = 495
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -18286,7 +18294,7 @@ tr805:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -18299,7 +18307,7 @@ tr805:
 	goto _again
 tr811:
 	( m.cs) = 495
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -18309,7 +18317,7 @@ tr811:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -18325,7 +18333,7 @@ tr811:
 			goto _test_eof495
 		}
 	st_case_495:
-//line plugins/parsers/influx/machine.go:18329
+//line plugins/parsers/influx/machine.go:18337
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr769
@@ -18356,7 +18364,7 @@ tr811:
 		goto tr235
 tr770:
 	( m.cs) = 496
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -18366,7 +18374,7 @@ tr770:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -18376,7 +18384,7 @@ tr770:
 			goto _test_eof496
 		}
 	st_case_496:
-//line plugins/parsers/influx/machine.go:18380
+//line plugins/parsers/influx/machine.go:18388
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr769
@@ -18406,7 +18414,7 @@ tr770:
 		}
 		goto tr235
 tr771:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -18416,7 +18424,7 @@ tr771:
 			goto _test_eof126
 		}
 	st_case_126:
-//line plugins/parsers/influx/machine.go:18420
+//line plugins/parsers/influx/machine.go:18428
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr231
@@ -18444,7 +18452,7 @@ tr771:
 		}
 		goto st82
 tr772:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -18454,7 +18462,7 @@ tr772:
 			goto _test_eof497
 		}
 	st_case_497:
-//line plugins/parsers/influx/machine.go:18458
+//line plugins/parsers/influx/machine.go:18466
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr773
@@ -18483,7 +18491,7 @@ tr772:
 		goto st82
 tr777:
 	( m.cs) = 498
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -18493,14 +18501,14 @@ tr777:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr774:
 	( m.cs) = 498
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -18510,7 +18518,7 @@ tr774:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -18526,7 +18534,7 @@ tr774:
 			goto _test_eof498
 		}
 	st_case_498:
-//line plugins/parsers/influx/machine.go:18530
+//line plugins/parsers/influx/machine.go:18538
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr776
@@ -19347,7 +19355,7 @@ tr774:
 		}
 		goto st80
 tr269:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -19357,7 +19365,7 @@ tr269:
 			goto _test_eof522
 		}
 	st_case_522:
-//line plugins/parsers/influx/machine.go:19361
+//line plugins/parsers/influx/machine.go:19369
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr764
@@ -19423,7 +19431,7 @@ tr269:
 		}
 		goto st80
 tr270:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -19433,7 +19441,7 @@ tr270:
 			goto _test_eof524
 		}
 	st_case_524:
-//line plugins/parsers/influx/machine.go:19437
+//line plugins/parsers/influx/machine.go:19445
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr764
@@ -19471,7 +19479,7 @@ tr270:
 		}
 		goto st80
 tr271:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -19481,7 +19489,7 @@ tr271:
 			goto _test_eof525
 		}
 	st_case_525:
-//line plugins/parsers/influx/machine.go:19485
+//line plugins/parsers/influx/machine.go:19493
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr809
@@ -19718,7 +19726,7 @@ tr271:
 		}
 		goto st80
 tr272:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -19728,7 +19736,7 @@ tr272:
 			goto _test_eof527
 		}
 	st_case_527:
-//line plugins/parsers/influx/machine.go:19732
+//line plugins/parsers/influx/machine.go:19740
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr809
@@ -19817,7 +19825,7 @@ tr272:
 		}
 		goto st80
 tr273:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -19827,7 +19835,7 @@ tr273:
 			goto _test_eof528
 		}
 	st_case_528:
-//line plugins/parsers/influx/machine.go:19831
+//line plugins/parsers/influx/machine.go:19839
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr809
@@ -19854,7 +19862,7 @@ tr273:
 		}
 		goto st80
 tr274:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -19864,7 +19872,7 @@ tr274:
 			goto _test_eof529
 		}
 	st_case_529:
-//line plugins/parsers/influx/machine.go:19868
+//line plugins/parsers/influx/machine.go:19876
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr809
@@ -19891,7 +19899,7 @@ tr274:
 		}
 		goto st80
 tr259:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -19901,7 +19909,7 @@ tr259:
 			goto _test_eof137
 		}
 	st_case_137:
-//line plugins/parsers/influx/machine.go:19905
+//line plugins/parsers/influx/machine.go:19913
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st98
@@ -19918,14 +19926,14 @@ tr259:
 		}
 		goto st45
 	st138:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof138
 		}
 	st_case_138:
-//line plugins/parsers/influx/machine.go:19929
+//line plugins/parsers/influx/machine.go:19937
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -19983,7 +19991,7 @@ tr259:
 		goto st30
 tr317:
 	( m.cs) = 530
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -19999,7 +20007,7 @@ tr317:
 			goto _test_eof530
 		}
 	st_case_530:
-//line plugins/parsers/influx/machine.go:20003
+//line plugins/parsers/influx/machine.go:20011
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -20110,7 +20118,7 @@ tr317:
 		}
 		goto st30
 tr87:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -20120,7 +20128,7 @@ tr87:
 			goto _test_eof141
 		}
 	st_case_141:
-//line plugins/parsers/influx/machine.go:20124
+//line plugins/parsers/influx/machine.go:20132
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st30
@@ -20272,7 +20280,7 @@ tr87:
 		}
 		goto st30
 tr247:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -20282,7 +20290,7 @@ tr247:
 			goto _test_eof537
 		}
 	st_case_537:
-//line plugins/parsers/influx/machine.go:20286
+//line plugins/parsers/influx/machine.go:20294
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr638
@@ -20344,7 +20352,7 @@ tr247:
 		}
 		goto st30
 tr248:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -20354,7 +20362,7 @@ tr248:
 			goto _test_eof539
 		}
 	st_case_539:
-//line plugins/parsers/influx/machine.go:20358
+//line plugins/parsers/influx/machine.go:20366
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr638
@@ -20390,7 +20398,7 @@ tr248:
 		}
 		goto st30
 tr249:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -20400,7 +20408,7 @@ tr249:
 			goto _test_eof540
 		}
 	st_case_540:
-//line plugins/parsers/influx/machine.go:20404
+//line plugins/parsers/influx/machine.go:20412
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr834
@@ -20621,7 +20629,7 @@ tr249:
 		}
 		goto st30
 tr250:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -20631,7 +20639,7 @@ tr250:
 			goto _test_eof542
 		}
 	st_case_542:
-//line plugins/parsers/influx/machine.go:20635
+//line plugins/parsers/influx/machine.go:20643
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr834
@@ -20714,7 +20722,7 @@ tr250:
 		}
 		goto st30
 tr251:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -20724,7 +20732,7 @@ tr251:
 			goto _test_eof543
 		}
 	st_case_543:
-//line plugins/parsers/influx/machine.go:20728
+//line plugins/parsers/influx/machine.go:20736
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr834
@@ -20749,7 +20757,7 @@ tr251:
 		}
 		goto st30
 tr252:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -20759,7 +20767,7 @@ tr252:
 			goto _test_eof544
 		}
 	st_case_544:
-//line plugins/parsers/influx/machine.go:20763
+//line plugins/parsers/influx/machine.go:20771
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr834
@@ -21339,7 +21347,7 @@ tr252:
 		}
 		goto st41
 tr213:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -21349,7 +21357,7 @@ tr213:
 			goto _test_eof150
 		}
 	st_case_150:
-//line plugins/parsers/influx/machine.go:21353
+//line plugins/parsers/influx/machine.go:21361
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr180
@@ -21379,7 +21387,7 @@ tr213:
 		}
 		goto st54
 tr214:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -21389,7 +21397,7 @@ tr214:
 			goto _test_eof151
 		}
 	st_case_151:
-//line plugins/parsers/influx/machine.go:21393
+//line plugins/parsers/influx/machine.go:21401
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr180
@@ -21449,7 +21457,7 @@ tr214:
 		goto st54
 tr860:
 	( m.cs) = 564
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -21459,7 +21467,7 @@ tr860:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -21472,7 +21480,7 @@ tr860:
 	goto _again
 tr892:
 	( m.cs) = 564
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -21482,7 +21490,7 @@ tr892:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -21495,7 +21503,7 @@ tr892:
 	goto _again
 tr896:
 	( m.cs) = 564
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -21505,7 +21513,7 @@ tr896:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -21518,7 +21526,7 @@ tr896:
 	goto _again
 tr901:
 	( m.cs) = 564
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -21528,7 +21536,7 @@ tr901:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -21544,7 +21552,7 @@ tr901:
 			goto _test_eof564
 		}
 	st_case_564:
-//line plugins/parsers/influx/machine.go:21548
+//line plugins/parsers/influx/machine.go:21556
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr863
@@ -21575,7 +21583,7 @@ tr901:
 		goto tr184
 tr864:
 	( m.cs) = 565
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -21585,7 +21593,7 @@ tr864:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -21595,7 +21603,7 @@ tr864:
 			goto _test_eof565
 		}
 	st_case_565:
-//line plugins/parsers/influx/machine.go:21599
+//line plugins/parsers/influx/machine.go:21607
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr863
@@ -21625,7 +21633,7 @@ tr864:
 		}
 		goto tr184
 tr865:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -21635,7 +21643,7 @@ tr865:
 			goto _test_eof152
 		}
 	st_case_152:
-//line plugins/parsers/influx/machine.go:21639
+//line plugins/parsers/influx/machine.go:21647
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr180
@@ -21663,7 +21671,7 @@ tr865:
 		}
 		goto st56
 tr866:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -21673,7 +21681,7 @@ tr866:
 			goto _test_eof566
 		}
 	st_case_566:
-//line plugins/parsers/influx/machine.go:21677
+//line plugins/parsers/influx/machine.go:21685
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr867
@@ -21702,7 +21710,7 @@ tr866:
 		goto st56
 tr871:
 	( m.cs) = 567
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -21712,14 +21720,14 @@ tr871:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto _again
 tr868:
 	( m.cs) = 567
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -21729,7 +21737,7 @@ tr868:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -21745,7 +21753,7 @@ tr868:
 			goto _test_eof567
 		}
 	st_case_567:
-//line plugins/parsers/influx/machine.go:21749
+//line plugins/parsers/influx/machine.go:21757
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr870
@@ -21770,7 +21778,7 @@ tr868:
 		}
 		goto tr184
 tr186:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -21780,7 +21788,7 @@ tr186:
 			goto _test_eof153
 		}
 	st_case_153:
-//line plugins/parsers/influx/machine.go:21784
+//line plugins/parsers/influx/machine.go:21792
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st56
@@ -22444,7 +22452,7 @@ tr186:
 		}
 		goto st54
 tr340:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -22454,7 +22462,7 @@ tr340:
 			goto _test_eof156
 		}
 	st_case_156:
-//line plugins/parsers/influx/machine.go:22458
+//line plugins/parsers/influx/machine.go:22466
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st54
@@ -22606,7 +22614,7 @@ tr340:
 		}
 		goto st54
 tr215:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -22616,7 +22624,7 @@ tr215:
 			goto _test_eof591
 		}
 	st_case_591:
-//line plugins/parsers/influx/machine.go:22620
+//line plugins/parsers/influx/machine.go:22628
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr859
@@ -22678,7 +22686,7 @@ tr215:
 		}
 		goto st54
 tr216:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -22688,7 +22696,7 @@ tr216:
 			goto _test_eof593
 		}
 	st_case_593:
-//line plugins/parsers/influx/machine.go:22692
+//line plugins/parsers/influx/machine.go:22700
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr859
@@ -22724,7 +22732,7 @@ tr216:
 		}
 		goto st54
 tr217:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -22734,7 +22742,7 @@ tr217:
 			goto _test_eof594
 		}
 	st_case_594:
-//line plugins/parsers/influx/machine.go:22738
+//line plugins/parsers/influx/machine.go:22746
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr899
@@ -22955,7 +22963,7 @@ tr217:
 		}
 		goto st54
 tr218:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -22965,7 +22973,7 @@ tr218:
 			goto _test_eof596
 		}
 	st_case_596:
-//line plugins/parsers/influx/machine.go:22969
+//line plugins/parsers/influx/machine.go:22977
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr899
@@ -23048,7 +23056,7 @@ tr218:
 		}
 		goto st54
 tr219:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -23058,7 +23066,7 @@ tr219:
 			goto _test_eof597
 		}
 	st_case_597:
-//line plugins/parsers/influx/machine.go:23062
+//line plugins/parsers/influx/machine.go:23070
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr899
@@ -23083,7 +23091,7 @@ tr219:
 		}
 		goto st54
 tr220:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -23093,7 +23101,7 @@ tr220:
 			goto _test_eof598
 		}
 	st_case_598:
-//line plugins/parsers/influx/machine.go:23097
+//line plugins/parsers/influx/machine.go:23105
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr899
@@ -23146,7 +23154,7 @@ tr220:
 		}
 		goto tr337
 tr339:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -23156,7 +23164,7 @@ tr339:
 			goto _test_eof166
 		}
 	st_case_166:
-//line plugins/parsers/influx/machine.go:23160
+//line plugins/parsers/influx/machine.go:23168
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr341
@@ -23182,7 +23190,7 @@ tr339:
 		goto tr337
 tr341:
 	( m.cs) = 167
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -23198,7 +23206,7 @@ tr341:
 			goto _test_eof167
 		}
 	st_case_167:
-//line plugins/parsers/influx/machine.go:23202
+//line plugins/parsers/influx/machine.go:23210
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st167
@@ -23225,18 +23233,18 @@ tr341:
 		}
 		goto tr184
 tr344:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st168
 tr345:
 	( m.cs) = 168
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -23252,7 +23260,7 @@ tr345:
 			goto _test_eof168
 		}
 	st_case_168:
-//line plugins/parsers/influx/machine.go:23256
+//line plugins/parsers/influx/machine.go:23264
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr341
@@ -23278,11 +23286,11 @@ tr345:
 		goto tr184
 tr342:
 	( m.cs) = 169
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -23298,7 +23306,7 @@ tr342:
 			goto _test_eof169
 		}
 	st_case_169:
-//line plugins/parsers/influx/machine.go:23302
+//line plugins/parsers/influx/machine.go:23310
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr341
@@ -23323,7 +23331,7 @@ tr342:
 		}
 		goto tr184
 tr541:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -23333,7 +23341,7 @@ tr541:
 			goto _test_eof170
 		}
 	st_case_170:
-//line plugins/parsers/influx/machine.go:23337
+//line plugins/parsers/influx/machine.go:23345
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -23351,7 +23359,7 @@ tr541:
 		}
 		goto st6
 tr542:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -23361,7 +23369,7 @@ tr542:
 			goto _test_eof599
 		}
 	st_case_599:
-//line plugins/parsers/influx/machine.go:23365
+//line plugins/parsers/influx/machine.go:23373
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr678
@@ -23885,14 +23893,14 @@ tr542:
 		}
 		goto st6
 tr926:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st171
 tr537:
 	( m.cs) = 171
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -23905,7 +23913,7 @@ tr537:
 	goto _again
 tr933:
 	( m.cs) = 171
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -23918,7 +23926,7 @@ tr933:
 	goto _again
 tr936:
 	( m.cs) = 171
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -23931,7 +23939,7 @@ tr936:
 	goto _again
 tr940:
 	( m.cs) = 171
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -23947,7 +23955,7 @@ tr940:
 			goto _test_eof171
 		}
 	st_case_171:
-//line plugins/parsers/influx/machine.go:23951
+//line plugins/parsers/influx/machine.go:23959
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -23970,7 +23978,7 @@ tr940:
 		}
 		goto tr348
 tr348:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -23980,7 +23988,7 @@ tr348:
 			goto _test_eof172
 		}
 	st_case_172:
-//line plugins/parsers/influx/machine.go:23984
+//line plugins/parsers/influx/machine.go:23992
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -24003,7 +24011,7 @@ tr348:
 		}
 		goto st172
 tr351:
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -24013,7 +24021,7 @@ tr351:
 			goto _test_eof173
 		}
 	st_case_173:
-//line plugins/parsers/influx/machine.go:24017
+//line plugins/parsers/influx/machine.go:24025
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -24046,7 +24054,7 @@ tr351:
 		goto st6
 tr353:
 	( m.cs) = 618
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -24062,7 +24070,7 @@ tr353:
 			goto _test_eof618
 		}
 	st_case_618:
-//line plugins/parsers/influx/machine.go:24066
+//line plugins/parsers/influx/machine.go:24074
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr669
@@ -24084,7 +24092,7 @@ tr353:
 		}
 		goto tr23
 tr169:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -24094,7 +24102,7 @@ tr169:
 			goto _test_eof619
 		}
 	st_case_619:
-//line plugins/parsers/influx/machine.go:24098
+//line plugins/parsers/influx/machine.go:24106
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr534
@@ -24193,7 +24201,7 @@ tr169:
 		goto st6
 tr358:
 	( m.cs) = 621
-//line plugins/parsers/influx/machine.go.rl:140
+//line plugins/parsers/influx/machine.go.rl:148
 
 	err = m.handler.AddString(m.key, m.text())
 	if err != nil {
@@ -24209,7 +24217,7 @@ tr358:
 			goto _test_eof621
 		}
 	st_case_621:
-//line plugins/parsers/influx/machine.go:24213
+//line plugins/parsers/influx/machine.go:24221
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr103
@@ -24355,7 +24363,7 @@ tr358:
 		}
 		goto st6
 tr170:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -24365,7 +24373,7 @@ tr170:
 			goto _test_eof626
 		}
 	st_case_626:
-//line plugins/parsers/influx/machine.go:24369
+//line plugins/parsers/influx/machine.go:24377
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr534
@@ -24402,7 +24410,7 @@ tr170:
 		}
 		goto st6
 tr354:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -24412,7 +24420,7 @@ tr354:
 			goto _test_eof627
 		}
 	st_case_627:
-//line plugins/parsers/influx/machine.go:24416
+//line plugins/parsers/influx/machine.go:24424
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr755
@@ -24583,7 +24591,7 @@ tr354:
 		}
 		goto st6
 tr355:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -24593,7 +24601,7 @@ tr355:
 			goto _test_eof629
 		}
 	st_case_629:
-//line plugins/parsers/influx/machine.go:24597
+//line plugins/parsers/influx/machine.go:24605
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr755
@@ -24659,7 +24667,7 @@ tr355:
 		}
 		goto st6
 tr356:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -24669,7 +24677,7 @@ tr356:
 			goto _test_eof630
 		}
 	st_case_630:
-//line plugins/parsers/influx/machine.go:24673
+//line plugins/parsers/influx/machine.go:24681
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr755
@@ -24693,7 +24701,7 @@ tr356:
 		}
 		goto st6
 tr357:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -24703,7 +24711,7 @@ tr357:
 			goto _test_eof631
 		}
 	st_case_631:
-//line plugins/parsers/influx/machine.go:24707
+//line plugins/parsers/influx/machine.go:24715
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr755
@@ -24727,7 +24735,7 @@ tr357:
 		}
 		goto st6
 tr349:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -24737,7 +24745,7 @@ tr349:
 			goto _test_eof184
 		}
 	st_case_184:
-//line plugins/parsers/influx/machine.go:24741
+//line plugins/parsers/influx/machine.go:24749
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st172
@@ -24830,7 +24838,7 @@ tr349:
 		}
 		goto st6
 tr171:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -24840,7 +24848,7 @@ tr171:
 			goto _test_eof634
 		}
 	st_case_634:
-//line plugins/parsers/influx/machine.go:24844
+//line plugins/parsers/influx/machine.go:24852
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr900
@@ -25011,7 +25019,7 @@ tr171:
 		}
 		goto st6
 tr172:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25021,7 +25029,7 @@ tr172:
 			goto _test_eof636
 		}
 	st_case_636:
-//line plugins/parsers/influx/machine.go:25025
+//line plugins/parsers/influx/machine.go:25033
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr900
@@ -25087,7 +25095,7 @@ tr172:
 		}
 		goto st6
 tr173:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25097,7 +25105,7 @@ tr173:
 			goto _test_eof637
 		}
 	st_case_637:
-//line plugins/parsers/influx/machine.go:25101
+//line plugins/parsers/influx/machine.go:25109
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr900
@@ -25121,7 +25129,7 @@ tr173:
 		}
 		goto st6
 tr174:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25131,7 +25139,7 @@ tr174:
 			goto _test_eof638
 		}
 	st_case_638:
-//line plugins/parsers/influx/machine.go:25135
+//line plugins/parsers/influx/machine.go:25143
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr900
@@ -25155,7 +25163,7 @@ tr174:
 		}
 		goto st6
 tr162:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25165,7 +25173,7 @@ tr162:
 			goto _test_eof193
 		}
 	st_case_193:
-//line plugins/parsers/influx/machine.go:25169
+//line plugins/parsers/influx/machine.go:25177
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st49
@@ -25190,7 +25198,7 @@ tr162:
 		}
 		goto tr160
 tr140:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25200,7 +25208,7 @@ tr140:
 			goto _test_eof194
 		}
 	st_case_194:
-//line plugins/parsers/influx/machine.go:25204
+//line plugins/parsers/influx/machine.go:25212
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -25231,7 +25239,7 @@ tr140:
 		}
 		goto st16
 tr141:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25241,7 +25249,7 @@ tr141:
 			goto _test_eof195
 		}
 	st_case_195:
-//line plugins/parsers/influx/machine.go:25245
+//line plugins/parsers/influx/machine.go:25253
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -25505,7 +25513,7 @@ tr141:
 		}
 		goto st16
 tr142:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25515,7 +25523,7 @@ tr142:
 			goto _test_eof644
 		}
 	st_case_644:
-//line plugins/parsers/influx/machine.go:25519
+//line plugins/parsers/influx/machine.go:25527
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr734
@@ -25577,7 +25585,7 @@ tr142:
 		}
 		goto st16
 tr143:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25587,7 +25595,7 @@ tr143:
 			goto _test_eof646
 		}
 	st_case_646:
-//line plugins/parsers/influx/machine.go:25591
+//line plugins/parsers/influx/machine.go:25599
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr734
@@ -25624,7 +25632,7 @@ tr143:
 		}
 		goto st16
 tr144:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25634,7 +25642,7 @@ tr144:
 			goto _test_eof647
 		}
 	st_case_647:
-//line plugins/parsers/influx/machine.go:25638
+//line plugins/parsers/influx/machine.go:25646
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -25847,7 +25855,7 @@ tr144:
 		}
 		goto st16
 tr145:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25857,7 +25865,7 @@ tr145:
 			goto _test_eof649
 		}
 	st_case_649:
-//line plugins/parsers/influx/machine.go:25861
+//line plugins/parsers/influx/machine.go:25869
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -25937,7 +25945,7 @@ tr145:
 		}
 		goto st16
 tr146:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25947,7 +25955,7 @@ tr146:
 			goto _test_eof650
 		}
 	st_case_650:
-//line plugins/parsers/influx/machine.go:25951
+//line plugins/parsers/influx/machine.go:25959
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -25971,7 +25979,7 @@ tr146:
 		}
 		goto st16
 tr147:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -25981,7 +25989,7 @@ tr147:
 			goto _test_eof651
 		}
 	st_case_651:
-//line plugins/parsers/influx/machine.go:25985
+//line plugins/parsers/influx/machine.go:25993
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -26005,18 +26013,18 @@ tr147:
 		}
 		goto st16
 tr123:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st206
 tr382:
 	( m.cs) = 206
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -26032,7 +26040,7 @@ tr382:
 			goto _test_eof206
 		}
 	st_case_206:
-//line plugins/parsers/influx/machine.go:26036
+//line plugins/parsers/influx/machine.go:26044
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr119
@@ -26058,11 +26066,11 @@ tr382:
 		goto tr121
 tr120:
 	( m.cs) = 207
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -26078,7 +26086,7 @@ tr120:
 			goto _test_eof207
 		}
 	st_case_207:
-//line plugins/parsers/influx/machine.go:26082
+//line plugins/parsers/influx/machine.go:26090
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr119
@@ -26103,7 +26111,7 @@ tr120:
 		}
 		goto tr121
 tr499:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -26113,7 +26121,7 @@ tr499:
 			goto _test_eof208
 		}
 	st_case_208:
-//line plugins/parsers/influx/machine.go:26117
+//line plugins/parsers/influx/machine.go:26125
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -26131,7 +26139,7 @@ tr499:
 		}
 		goto st6
 tr500:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -26141,7 +26149,7 @@ tr500:
 			goto _test_eof652
 		}
 	st_case_652:
-//line plugins/parsers/influx/machine.go:26145
+//line plugins/parsers/influx/machine.go:26153
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr603
@@ -26665,14 +26673,14 @@ tr500:
 		}
 		goto st6
 tr496:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st209
 tr989:
 	( m.cs) = 209
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -26685,7 +26693,7 @@ tr989:
 	goto _again
 tr994:
 	( m.cs) = 209
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -26698,7 +26706,7 @@ tr994:
 	goto _again
 tr997:
 	( m.cs) = 209
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -26711,7 +26719,7 @@ tr997:
 	goto _again
 tr1000:
 	( m.cs) = 209
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -26727,7 +26735,7 @@ tr1000:
 			goto _test_eof209
 		}
 	st_case_209:
-//line plugins/parsers/influx/machine.go:26731
+//line plugins/parsers/influx/machine.go:26739
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -26750,7 +26758,7 @@ tr1000:
 		}
 		goto tr385
 tr385:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -26760,7 +26768,7 @@ tr385:
 			goto _test_eof210
 		}
 	st_case_210:
-//line plugins/parsers/influx/machine.go:26764
+//line plugins/parsers/influx/machine.go:26772
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st6
@@ -26783,7 +26791,7 @@ tr385:
 		}
 		goto st210
 tr389:
-//line plugins/parsers/influx/machine.go.rl:100
+//line plugins/parsers/influx/machine.go.rl:108
 
 	m.key = m.text()
 
@@ -26793,7 +26801,7 @@ tr389:
 			goto _test_eof211
 		}
 	st_case_211:
-//line plugins/parsers/influx/machine.go:26797
+//line plugins/parsers/influx/machine.go:26805
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -26825,7 +26833,7 @@ tr389:
 		}
 		goto st6
 tr391:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -26835,7 +26843,7 @@ tr391:
 			goto _test_eof212
 		}
 	st_case_212:
-//line plugins/parsers/influx/machine.go:26839
+//line plugins/parsers/influx/machine.go:26847
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -26857,7 +26865,7 @@ tr391:
 		}
 		goto st6
 tr392:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -26867,7 +26875,7 @@ tr392:
 			goto _test_eof213
 		}
 	st_case_213:
-//line plugins/parsers/influx/machine.go:26871
+//line plugins/parsers/influx/machine.go:26879
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -27132,7 +27140,7 @@ tr392:
 		}
 		goto st6
 tr393:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27142,7 +27150,7 @@ tr393:
 			goto _test_eof677
 		}
 	st_case_677:
-//line plugins/parsers/influx/machine.go:27146
+//line plugins/parsers/influx/machine.go:27154
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr765
@@ -27204,7 +27212,7 @@ tr393:
 		}
 		goto st6
 tr394:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27214,7 +27222,7 @@ tr394:
 			goto _test_eof679
 		}
 	st_case_679:
-//line plugins/parsers/influx/machine.go:27218
+//line plugins/parsers/influx/machine.go:27226
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr765
@@ -27251,7 +27259,7 @@ tr394:
 		}
 		goto st6
 tr112:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27261,7 +27269,7 @@ tr112:
 			goto _test_eof680
 		}
 	st_case_680:
-//line plugins/parsers/influx/machine.go:27265
+//line plugins/parsers/influx/machine.go:27273
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr810
@@ -27432,7 +27440,7 @@ tr112:
 		}
 		goto st6
 tr113:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27442,7 +27450,7 @@ tr113:
 			goto _test_eof682
 		}
 	st_case_682:
-//line plugins/parsers/influx/machine.go:27446
+//line plugins/parsers/influx/machine.go:27454
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr810
@@ -27508,7 +27516,7 @@ tr113:
 		}
 		goto st6
 tr114:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27518,7 +27526,7 @@ tr114:
 			goto _test_eof683
 		}
 	st_case_683:
-//line plugins/parsers/influx/machine.go:27522
+//line plugins/parsers/influx/machine.go:27530
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr810
@@ -27542,7 +27550,7 @@ tr114:
 		}
 		goto st6
 tr115:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27552,7 +27560,7 @@ tr115:
 			goto _test_eof684
 		}
 	st_case_684:
-//line plugins/parsers/influx/machine.go:27556
+//line plugins/parsers/influx/machine.go:27564
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr810
@@ -27576,7 +27584,7 @@ tr115:
 		}
 		goto st6
 tr387:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27586,7 +27594,7 @@ tr387:
 			goto _test_eof224
 		}
 	st_case_224:
-//line plugins/parsers/influx/machine.go:27590
+//line plugins/parsers/influx/machine.go:27598
 		switch ( m.data)[( m.p)] {
 		case 34:
 			goto st210
@@ -27603,7 +27611,7 @@ tr387:
 		}
 		goto st3
 tr108:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27613,7 +27621,7 @@ tr108:
 			goto _test_eof225
 		}
 	st_case_225:
-//line plugins/parsers/influx/machine.go:27617
+//line plugins/parsers/influx/machine.go:27625
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -27635,7 +27643,7 @@ tr108:
 		}
 		goto st6
 tr109:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27645,7 +27653,7 @@ tr109:
 			goto _test_eof226
 		}
 	st_case_226:
-//line plugins/parsers/influx/machine.go:27649
+//line plugins/parsers/influx/machine.go:27657
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr29
@@ -27910,7 +27918,7 @@ tr109:
 		}
 		goto st6
 tr110:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27920,7 +27928,7 @@ tr110:
 			goto _test_eof691
 		}
 	st_case_691:
-//line plugins/parsers/influx/machine.go:27924
+//line plugins/parsers/influx/machine.go:27932
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr639
@@ -27982,7 +27990,7 @@ tr110:
 		}
 		goto st6
 tr111:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -27992,7 +28000,7 @@ tr111:
 			goto _test_eof693
 		}
 	st_case_693:
-//line plugins/parsers/influx/machine.go:27996
+//line plugins/parsers/influx/machine.go:28004
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr639
@@ -28029,7 +28037,7 @@ tr111:
 		}
 		goto st6
 tr96:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28039,7 +28047,7 @@ tr96:
 			goto _test_eof229
 		}
 	st_case_229:
-//line plugins/parsers/influx/machine.go:28043
+//line plugins/parsers/influx/machine.go:28051
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto st31
@@ -28064,7 +28072,7 @@ tr96:
 		}
 		goto tr94
 tr74:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28074,7 +28082,7 @@ tr74:
 			goto _test_eof230
 		}
 	st_case_230:
-//line plugins/parsers/influx/machine.go:28078
+//line plugins/parsers/influx/machine.go:28086
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -28103,7 +28111,7 @@ tr74:
 		}
 		goto st1
 tr75:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28113,7 +28121,7 @@ tr75:
 			goto _test_eof231
 		}
 	st_case_231:
-//line plugins/parsers/influx/machine.go:28117
+//line plugins/parsers/influx/machine.go:28125
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr47
@@ -28361,7 +28369,7 @@ tr75:
 		}
 		goto st1
 tr76:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28371,7 +28379,7 @@ tr76:
 			goto _test_eof699
 		}
 	st_case_699:
-//line plugins/parsers/influx/machine.go:28375
+//line plugins/parsers/influx/machine.go:28383
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr734
@@ -28429,7 +28437,7 @@ tr76:
 		}
 		goto st1
 tr77:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28439,7 +28447,7 @@ tr77:
 			goto _test_eof701
 		}
 	st_case_701:
-//line plugins/parsers/influx/machine.go:28443
+//line plugins/parsers/influx/machine.go:28451
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr734
@@ -28474,7 +28482,7 @@ tr77:
 		}
 		goto st1
 tr78:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28484,7 +28492,7 @@ tr78:
 			goto _test_eof702
 		}
 	st_case_702:
-//line plugins/parsers/influx/machine.go:28488
+//line plugins/parsers/influx/machine.go:28496
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -28681,7 +28689,7 @@ tr78:
 		}
 		goto st1
 tr79:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28691,7 +28699,7 @@ tr79:
 			goto _test_eof704
 		}
 	st_case_704:
-//line plugins/parsers/influx/machine.go:28695
+//line plugins/parsers/influx/machine.go:28703
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -28765,7 +28773,7 @@ tr79:
 		}
 		goto st1
 tr80:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28775,7 +28783,7 @@ tr80:
 			goto _test_eof705
 		}
 	st_case_705:
-//line plugins/parsers/influx/machine.go:28779
+//line plugins/parsers/influx/machine.go:28787
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -28797,7 +28805,7 @@ tr80:
 		}
 		goto st1
 tr81:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28807,7 +28815,7 @@ tr81:
 			goto _test_eof706
 		}
 	st_case_706:
-//line plugins/parsers/influx/machine.go:28811
+//line plugins/parsers/influx/machine.go:28819
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -28829,18 +28837,18 @@ tr81:
 		}
 		goto st1
 tr44:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
 	goto st242
 tr424:
 	( m.cs) = 242
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -28856,7 +28864,7 @@ tr424:
 			goto _test_eof242
 		}
 	st_case_242:
-//line plugins/parsers/influx/machine.go:28860
+//line plugins/parsers/influx/machine.go:28868
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr423
@@ -28879,11 +28887,11 @@ tr424:
 		goto tr41
 tr40:
 	( m.cs) = 243
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -28899,7 +28907,7 @@ tr40:
 			goto _test_eof243
 		}
 	st_case_243:
-//line plugins/parsers/influx/machine.go:28903
+//line plugins/parsers/influx/machine.go:28911
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr423
@@ -28921,7 +28929,7 @@ tr40:
 		}
 		goto tr41
 tr464:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28931,13 +28939,13 @@ tr464:
 			goto _test_eof244
 		}
 	st_case_244:
-//line plugins/parsers/influx/machine.go:28935
+//line plugins/parsers/influx/machine.go:28943
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 			goto st707
 		}
 		goto tr426
 tr465:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -28947,7 +28955,7 @@ tr465:
 			goto _test_eof707
 		}
 	st_case_707:
-//line plugins/parsers/influx/machine.go:28951
+//line plugins/parsers/influx/machine.go:28959
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr470
@@ -29357,7 +29365,7 @@ tr465:
 		}
 		goto tr426
 tr15:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -29367,7 +29375,7 @@ tr15:
 			goto _test_eof245
 		}
 	st_case_245:
-//line plugins/parsers/influx/machine.go:29371
+//line plugins/parsers/influx/machine.go:29379
 		switch ( m.data)[( m.p)] {
 		case 46:
 			goto st246
@@ -29379,7 +29387,7 @@ tr15:
 		}
 		goto tr8
 tr16:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -29389,7 +29397,7 @@ tr16:
 			goto _test_eof246
 		}
 	st_case_246:
-//line plugins/parsers/influx/machine.go:29393
+//line plugins/parsers/influx/machine.go:29401
 		if 48 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 57 {
 			goto st726
 		}
@@ -29562,7 +29570,7 @@ tr16:
 		}
 		goto tr105
 tr17:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -29572,7 +29580,7 @@ tr17:
 			goto _test_eof731
 		}
 	st_case_731:
-//line plugins/parsers/influx/machine.go:29576
+//line plugins/parsers/influx/machine.go:29584
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr734
@@ -29622,7 +29630,7 @@ tr17:
 		}
 		goto tr105
 tr18:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -29632,7 +29640,7 @@ tr18:
 			goto _test_eof733
 		}
 	st_case_733:
-//line plugins/parsers/influx/machine.go:29636
+//line plugins/parsers/influx/machine.go:29644
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr734
@@ -29663,7 +29671,7 @@ tr18:
 		}
 		goto tr105
 tr19:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -29673,7 +29681,7 @@ tr19:
 			goto _test_eof734
 		}
 	st_case_734:
-//line plugins/parsers/influx/machine.go:29677
+//line plugins/parsers/influx/machine.go:29685
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -29766,7 +29774,7 @@ tr19:
 		}
 		goto tr8
 tr20:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -29776,7 +29784,7 @@ tr20:
 			goto _test_eof736
 		}
 	st_case_736:
-//line plugins/parsers/influx/machine.go:29780
+//line plugins/parsers/influx/machine.go:29788
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -29814,7 +29822,7 @@ tr20:
 		}
 		goto tr8
 tr21:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -29824,7 +29832,7 @@ tr21:
 			goto _test_eof737
 		}
 	st_case_737:
-//line plugins/parsers/influx/machine.go:29828
+//line plugins/parsers/influx/machine.go:29836
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -29842,7 +29850,7 @@ tr21:
 		}
 		goto tr105
 tr22:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -29852,7 +29860,7 @@ tr22:
 			goto _test_eof738
 		}
 	st_case_738:
-//line plugins/parsers/influx/machine.go:29856
+//line plugins/parsers/influx/machine.go:29864
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr962
@@ -29870,7 +29878,7 @@ tr22:
 		}
 		goto tr105
 tr9:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -29880,7 +29888,7 @@ tr9:
 			goto _test_eof257
 		}
 	st_case_257:
-//line plugins/parsers/influx/machine.go:29884
+//line plugins/parsers/influx/machine.go:29892
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr8
@@ -29911,13 +29919,13 @@ tr9:
 		}
 		goto st258
 tr440:
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
 	m.sol++ // next char will be the first column in the line
 
-//line plugins/parsers/influx/machine.go.rl:70
+//line plugins/parsers/influx/machine.go.rl:78
 
 	{goto st740 }
 
@@ -29927,7 +29935,7 @@ tr440:
 			goto _test_eof739
 		}
 	st_case_739:
-//line plugins/parsers/influx/machine.go:29931
+//line plugins/parsers/influx/machine.go:29939
 		goto st0
 	st261:
 		if ( m.p)++; ( m.p) == ( m.pe) {
@@ -29954,11 +29962,11 @@ tr440:
 		}
 		goto tr443
 tr443:
-//line plugins/parsers/influx/machine.go.rl:74
+//line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -29968,7 +29976,7 @@ tr443:
 			goto _test_eof741
 		}
 	st_case_741:
-//line plugins/parsers/influx/machine.go:29972
+//line plugins/parsers/influx/machine.go:29980
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr2
@@ -29987,7 +29995,7 @@ tr443:
 		}
 		goto st741
 tr445:
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -29996,7 +30004,7 @@ tr445:
 	goto st742
 tr1058:
 	( m.cs) = 742
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -30006,7 +30014,7 @@ tr1058:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -30015,7 +30023,7 @@ tr1058:
 	goto _again
 tr1062:
 	( m.cs) = 742
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -30025,7 +30033,7 @@ tr1062:
 		{( m.p)++; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -30033,7 +30041,7 @@ tr1062:
 
 	goto _again
 	st742:
-//line plugins/parsers/influx/machine.go.rl:164
+//line plugins/parsers/influx/machine.go.rl:172
 
 	m.finishMetric = true
 	( m.cs) = 740;
@@ -30043,11 +30051,11 @@ tr1062:
 			goto _test_eof742
 		}
 	st_case_742:
-//line plugins/parsers/influx/machine.go:30047
+//line plugins/parsers/influx/machine.go:30055
 		goto st0
 tr1059:
 	( m.cs) = 262
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -30060,7 +30068,7 @@ tr1059:
 	goto _again
 tr1063:
 	( m.cs) = 262
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -30076,14 +30084,14 @@ tr1063:
 			goto _test_eof262
 		}
 	st_case_262:
-//line plugins/parsers/influx/machine.go:30080
+//line plugins/parsers/influx/machine.go:30088
 		if ( m.data)[( m.p)] == 10 {
 			goto tr445
 		}
 		goto st0
 tr1060:
 	( m.cs) = 263
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -30096,7 +30104,7 @@ tr1060:
 	goto _again
 tr1064:
 	( m.cs) = 263
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -30112,7 +30120,7 @@ tr1064:
 			goto _test_eof263
 		}
 	st_case_263:
-//line plugins/parsers/influx/machine.go:30116
+//line plugins/parsers/influx/machine.go:30124
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
@@ -30133,7 +30141,7 @@ tr1064:
 		}
 		goto tr446
 tr446:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -30143,7 +30151,7 @@ tr446:
 			goto _test_eof264
 		}
 	st_case_264:
-//line plugins/parsers/influx/machine.go:30147
+//line plugins/parsers/influx/machine.go:30155
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
@@ -30164,7 +30172,7 @@ tr446:
 		}
 		goto st264
 tr449:
-//line plugins/parsers/influx/machine.go.rl:87
+//line plugins/parsers/influx/machine.go.rl:95
 
 	m.key = m.text()
 
@@ -30174,7 +30182,7 @@ tr449:
 			goto _test_eof265
 		}
 	st_case_265:
-//line plugins/parsers/influx/machine.go:30178
+//line plugins/parsers/influx/machine.go:30186
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
@@ -30195,7 +30203,7 @@ tr449:
 		}
 		goto tr451
 tr451:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -30205,7 +30213,7 @@ tr451:
 			goto _test_eof743
 		}
 	st_case_743:
-//line plugins/parsers/influx/machine.go:30209
+//line plugins/parsers/influx/machine.go:30217
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr2
@@ -30226,7 +30234,7 @@ tr451:
 		}
 		goto st743
 tr452:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -30236,7 +30244,7 @@ tr452:
 			goto _test_eof266
 		}
 	st_case_266:
-//line plugins/parsers/influx/machine.go:30240
+//line plugins/parsers/influx/machine.go:30248
 		if ( m.data)[( m.p)] == 92 {
 			goto st744
 		}
@@ -30250,14 +30258,14 @@ tr452:
 		}
 		goto st743
 	st744:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof744
 		}
 	st_case_744:
-//line plugins/parsers/influx/machine.go:30261
+//line plugins/parsers/influx/machine.go:30269
 		switch ( m.data)[( m.p)] {
 		case 9:
 			goto tr2
@@ -30278,7 +30286,7 @@ tr452:
 		}
 		goto st743
 tr447:
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -30288,7 +30296,7 @@ tr447:
 			goto _test_eof267
 		}
 	st_case_267:
-//line plugins/parsers/influx/machine.go:30292
+//line plugins/parsers/influx/machine.go:30300
 		if ( m.data)[( m.p)] == 92 {
 			goto st268
 		}
@@ -30302,14 +30310,14 @@ tr447:
 		}
 		goto st264
 	st268:
-//line plugins/parsers/influx/machine.go.rl:240
+//line plugins/parsers/influx/machine.go.rl:248
  ( m.p)--
  
 		if ( m.p)++; ( m.p) == ( m.pe) {
 			goto _test_eof268
 		}
 	st_case_268:
-//line plugins/parsers/influx/machine.go:30313
+//line plugins/parsers/influx/machine.go:30321
 		switch ( m.data)[( m.p)] {
 		case 32:
 			goto tr2
@@ -30330,11 +30338,11 @@ tr447:
 		}
 		goto st264
 tr444:
-//line plugins/parsers/influx/machine.go.rl:74
+//line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
 
-//line plugins/parsers/influx/machine.go.rl:20
+//line plugins/parsers/influx/machine.go.rl:28
 
 	m.pb = m.p
 
@@ -30344,7 +30352,7 @@ tr444:
 			goto _test_eof269
 		}
 	st_case_269:
-//line plugins/parsers/influx/machine.go:30348
+//line plugins/parsers/influx/machine.go:30356
 		switch {
 		case ( m.data)[( m.p)] > 10:
 			if 12 <= ( m.data)[( m.p)] && ( m.data)[( m.p)] <= 13 {
@@ -30355,7 +30363,7 @@ tr444:
 		}
 		goto st741
 tr441:
-//line plugins/parsers/influx/machine.go.rl:158
+//line plugins/parsers/influx/machine.go.rl:166
 
 	m.lineno++
 	m.sol = m.p
@@ -30367,7 +30375,7 @@ tr441:
 			goto _test_eof740
 		}
 	st_case_740:
-//line plugins/parsers/influx/machine.go:30371
+//line plugins/parsers/influx/machine.go:30379
 		switch ( m.data)[( m.p)] {
 		case 10:
 			goto tr441
@@ -31150,7 +31158,7 @@ tr441:
 	if ( m.p) == ( m.eof) {
 		switch ( m.cs) {
 		case 8, 261:
-//line plugins/parsers/influx/machine.go.rl:24
+//line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
@@ -31159,7 +31167,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 2, 3, 4, 5, 6, 7, 28, 31, 32, 35, 36, 37, 49, 50, 51, 52, 53, 73, 75, 76, 93, 103, 105, 141, 153, 156, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257:
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -31168,7 +31176,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 13, 14, 15, 22, 24, 25, 263, 264, 265, 266, 267, 268:
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31177,7 +31185,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 244:
-//line plugins/parsers/influx/machine.go.rl:45
+//line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
@@ -31186,7 +31194,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 741:
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31197,7 +31205,7 @@ tr441:
 	}
 
 		case 743, 744:
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -31208,12 +31216,12 @@ tr441:
 	}
 
 		case 271, 272, 273, 274, 275, 277, 278, 297, 298, 299, 301, 302, 305, 306, 327, 328, 329, 330, 332, 376, 377, 379, 380, 402, 403, 408, 409, 411, 431, 432, 434, 435, 457, 458, 618, 621:
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 10, 38, 40, 165, 167:
-//line plugins/parsers/influx/machine.go.rl:24
+//line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
@@ -31221,7 +31229,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -31230,7 +31238,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 34, 74, 104, 170, 208:
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -31238,7 +31246,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:45
+//line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
@@ -31247,7 +31255,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 20, 44, 45, 46, 58, 59, 61, 63, 68, 70, 71, 77, 78, 79, 84, 86, 88, 89, 97, 98, 100, 101, 102, 107, 108, 109, 122, 123, 137, 138:
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31255,7 +31263,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -31264,7 +31272,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 60:
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31272,7 +31280,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:45
+//line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
@@ -31281,16 +31289,16 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 270:
-//line plugins/parsers/influx/machine.go.rl:74
+//line plugins/parsers/influx/machine.go.rl:82
 
 	m.beginMetric = true
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 1:
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31300,7 +31308,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31309,7 +31317,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 300, 303, 307, 375, 399, 400, 404, 405, 406, 530, 564, 565, 567:
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31319,12 +31327,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 16, 23:
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -31334,7 +31342,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31343,7 +31351,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 351, 352, 353, 355, 374, 430, 454, 455, 459, 479, 495, 496, 498:
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -31353,12 +31361,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 624, 675, 689, 729:
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -31368,12 +31376,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 625, 678, 692, 732:
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -31383,12 +31391,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 326, 619, 620, 622, 623, 626, 632, 633, 671, 672, 673, 674, 676, 677, 679, 685, 686, 687, 688, 690, 691, 693, 726, 727, 728, 730, 731, 733:
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -31398,12 +31406,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 627, 628, 629, 630, 631, 634, 635, 636, 637, 638, 680, 681, 682, 683, 684, 734, 735, 736, 737, 738:
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -31413,12 +31421,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 276, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 331, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 378, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 410, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 433, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 652, 653, 654, 655, 656, 657, 658, 659, 660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670, 707, 708, 709, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719, 720, 721, 722, 723, 724, 725:
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -31428,12 +31436,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 9:
-//line plugins/parsers/influx/machine.go.rl:24
+//line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
@@ -31441,7 +31449,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31451,7 +31459,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31460,7 +31468,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 99:
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31468,7 +31476,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -31476,7 +31484,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:45
+//line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
@@ -31485,7 +31493,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 11, 12, 26, 27, 29, 30, 41, 42, 54, 55, 56, 57, 72, 91, 92, 94, 96, 139, 140, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 154, 155, 157, 158, 159, 160, 161, 162, 163, 164, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241:
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31495,7 +31503,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31503,7 +31511,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -31512,7 +31520,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 535, 589, 697:
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31522,7 +31530,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -31532,12 +31540,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 538, 592, 700:
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31547,7 +31555,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -31557,12 +31565,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 407, 531, 532, 533, 534, 536, 537, 539, 563, 586, 587, 588, 590, 591, 593, 694, 695, 696, 698, 699, 701:
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31572,7 +31580,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -31582,12 +31590,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 540, 541, 542, 543, 544, 594, 595, 596, 597, 598, 702, 703, 704, 705, 706:
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31597,7 +31605,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -31607,12 +31615,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 304, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 401, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 566, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585:
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31622,7 +31630,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -31632,12 +31640,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 17, 18, 19, 21, 47, 48, 64, 65, 66, 67, 69, 80, 81, 82, 83, 85, 87, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 124, 125, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205:
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -31647,7 +31655,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31655,7 +31663,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -31664,7 +31672,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 484, 520, 642:
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -31674,7 +31682,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:104
+//line plugins/parsers/influx/machine.go.rl:112
 
 	err = m.handler.AddInt(m.key, m.text())
 	if err != nil {
@@ -31684,12 +31692,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 487, 523, 645:
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -31699,7 +31707,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:113
+//line plugins/parsers/influx/machine.go.rl:121
 
 	err = m.handler.AddUint(m.key, m.text())
 	if err != nil {
@@ -31709,12 +31717,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 478, 480, 481, 482, 483, 485, 486, 488, 494, 517, 518, 519, 521, 522, 524, 639, 640, 641, 643, 644, 646:
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -31724,7 +31732,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:122
+//line plugins/parsers/influx/machine.go.rl:130
 
 	err = m.handler.AddFloat(m.key, m.text())
 	if err != nil {
@@ -31734,12 +31742,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 489, 490, 491, 492, 493, 525, 526, 527, 528, 529, 647, 648, 649, 650, 651:
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -31749,7 +31757,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:131
+//line plugins/parsers/influx/machine.go.rl:139
 
 	err = m.handler.AddBool(m.key, m.text())
 	if err != nil {
@@ -31759,12 +31767,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 354, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 456, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 497, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516:
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -31774,7 +31782,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:149
+//line plugins/parsers/influx/machine.go.rl:157
 
 	err = m.handler.SetTimestamp(m.text())
 	if err != nil {
@@ -31784,12 +31792,12 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:170
+//line plugins/parsers/influx/machine.go.rl:178
 
 	m.finishMetric = true
 
 		case 39, 166, 168, 169, 206, 207, 242, 243:
-//line plugins/parsers/influx/machine.go.rl:24
+//line plugins/parsers/influx/machine.go.rl:32
 
 	err = ErrNameParse
 	( m.p)--
@@ -31797,7 +31805,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31807,7 +31815,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31815,7 +31823,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -31824,7 +31832,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 43, 90, 152:
-//line plugins/parsers/influx/machine.go.rl:78
+//line plugins/parsers/influx/machine.go.rl:86
 
 	err = m.handler.SetMeasurement(m.text())
 	if err != nil {
@@ -31834,7 +31842,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31842,7 +31850,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -31850,7 +31858,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:45
+//line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
@@ -31859,7 +31867,7 @@ tr441:
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
 		case 62, 106, 126:
-//line plugins/parsers/influx/machine.go.rl:91
+//line plugins/parsers/influx/machine.go.rl:99
 
 	err = m.handler.AddTag(m.key, m.text())
 	if err != nil {
@@ -31869,7 +31877,7 @@ tr441:
 		{( m.p)++; ( m.cs) = 0; goto _out }
 	}
 
-//line plugins/parsers/influx/machine.go.rl:38
+//line plugins/parsers/influx/machine.go.rl:46
 
 	err = ErrTagParse
 	( m.p)--
@@ -31877,7 +31885,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:31
+//line plugins/parsers/influx/machine.go.rl:39
 
 	err = ErrFieldParse
 	( m.p)--
@@ -31885,7 +31893,7 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go.rl:45
+//line plugins/parsers/influx/machine.go.rl:53
 
 	err = ErrTimestampParse
 	( m.p)--
@@ -31893,14 +31901,14 @@ tr441:
 	( m.cs) = 258;
 	{( m.p)++; ( m.cs) = 0; goto _out }
 
-//line plugins/parsers/influx/machine.go:31897
+//line plugins/parsers/influx/machine.go:31905
 		}
 	}
 
 	_out: {}
 	}
 
-//line plugins/parsers/influx/machine.go.rl:407
+//line plugins/parsers/influx/machine.go.rl:415
 
 	if err != nil {
 		return err
@@ -31999,7 +32007,12 @@ func (m *streamMachine) Next() error {
 		if n == 0 && err == io.EOF {
 			m.machine.eof = m.machine.pe
 		} else if err != nil && err != io.EOF {
-			return err
+			// After the reader returns an error this function shouldn't be
+			// called again.  This will cause the machine to return EOF this
+			// is done.
+			m.machine.p = m.machine.pe
+			m.machine.eof = m.machine.pe
+			return &readErr{Err: err}
 		}
 
 		m.machine.pe += n

--- a/plugins/parsers/influx/machine.go.rl
+++ b/plugins/parsers/influx/machine.go.rl
@@ -5,6 +5,14 @@ import (
 	"io"
 )
 
+type readErr struct {
+	Err error
+}
+
+func (e *readErr) Error() string {
+	return e.Err.Error()
+}
+
 var (
 	ErrNameParse = errors.New("expected measurement name")
 	ErrFieldParse = errors.New("expected field")
@@ -502,7 +510,12 @@ func (m *streamMachine) Next() error {
 		if n == 0 && err == io.EOF {
 			m.machine.eof = m.machine.pe
 		} else if err != nil && err != io.EOF {
-			return err
+			// After the reader returns an error this function shouldn't be
+			// called again.  This will cause the machine to return EOF this
+			// is done.
+			m.machine.p = m.machine.pe
+			m.machine.eof = m.machine.pe
+			return &readErr{Err: err}
 		}
 
 		m.machine.pe += n

--- a/plugins/parsers/influx/machine.go.rl
+++ b/plugins/parsers/influx/machine.go.rl
@@ -228,7 +228,7 @@ fieldbool =
 	(true | false) >begin %bool;
 
 fieldstringchar =
-	[^\f\r\n\\"] | '\\' [\\"] | newline;
+	[^\n\\"] | '\\' [\\"] | newline;
 
 fieldstring =
 	fieldstringchar* >begin %string;

--- a/plugins/parsers/influx/machine_test.go
+++ b/plugins/parsers/influx/machine_test.go
@@ -874,6 +874,27 @@ var tests = []struct {
 		},
 	},
 	{
+		name:  "cr in string field",
+		input: []byte("cpu value=\"4\r2\""),
+		results: []Result{
+			{
+				Name:  Measurement,
+				Value: []byte("cpu"),
+			},
+			{
+				Name:  FieldKey,
+				Value: []byte("value"),
+			},
+			{
+				Name:  FieldString,
+				Value: []byte("4\r2"),
+			},
+			{
+				Name: Success,
+			},
+		},
+	},
+	{
 		name:  "bool field",
 		input: []byte("cpu value=true"),
 		results: []Result{

--- a/plugins/parsers/influx/parser.go
+++ b/plugins/parsers/influx/parser.go
@@ -174,11 +174,15 @@ func (h *StreamParser) SetTimePrecision(u time.Duration) {
 }
 
 // Next parses the next item from the stream.  You can repeat calls to this
-// function until it returns EOF.
+// function if it returns ParseError to get the next metric or error.
 func (p *StreamParser) Next() (telegraf.Metric, error) {
 	err := p.machine.Next()
 	if err == EOF {
-		return nil, EOF
+		return nil, err
+	}
+
+	if e, ok := err.(*readErr); ok {
+		return nil, e.Err
 	}
 
 	if err != nil {


### PR DESCRIPTION
In addition to the CR/FF change, this fixes a panic/inf loop if you call Next() on the parser after a io.Reader error.

closes #7406

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
