### PR TITLE
Set RestartSec to keep systemd service running after consecutive crash

### DIFF
--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -9,6 +9,7 @@ User=telegraf
 ExecStart=/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d $TELEGRAF_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
+RestartSec=10
 RestartForceExitStatus=SIGPIPE
 KillMode=control-group
 


### PR DESCRIPTION
RestartSec defaults to an aggressive 100ms. When Telegraf fails due to an out of memory issue (caused by another process on a system) We need systemd to give the OOM killer time to handle the issue before restarting Telegraf.

Without waiting the Telegraf service will crash multiple times in a short span of ~1second. This puts the service into a failed state that will not try restarting.

https://github.com/influxdata/telegraf/issues/7429

### Required for all PRs:
- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
