### PR TITLE
SqlServer - rename measurement "sqlserver_disk_space" to "sqlserver_volume_space"

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -1577,7 +1577,7 @@ EngineEdition:
 IF SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 	BEGIN
 	SELECT DISTINCT
-		'sqlserver_disk_space' AS [measurement]
+		'sqlserver_volume_space' AS [measurement]
 		,SERVERPROPERTY('machinename') AS [server_name]
 		,REPLACE(@@SERVERNAME,'\',':') AS [sql_instance]
 		,IIF( RIGHT(vs.[volume_mount_point],1) = '\'	/*Tag value cannot end with \ */


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.


Since this new measurement has not been released yet, there should be no problem in renaming to better match the query name in the configuration file, but also makes it more meaningful, in fact a volume does not always correspond to a disk.
- the configuration query name is "VolumeSpace"
- the current measurement name is "sqlserver_disk_space"
- the new name is "sqlserver_volume_space"