### PR TITLE
Add support for once mode; run processors and aggregators during test.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -212,6 +212,10 @@ func (a *Agent) Once(ctx context.Context, wait time.Duration) error {
 		return err
 	}
 
+	if models.GlobalGatherErrors.Get() != 0 {
+		return fmt.Errorf("input plugins recorded %d errors", models.GlobalGatherErrors.Get())
+	}
+
 	unsent := 0
 	for _, output := range a.Config.Outputs {
 		unsent += output.BufferLength()

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -67,6 +67,7 @@ var fServiceDisplayName = flag.String("service-display-name", "Telegraf Data Col
 var fRunAsConsole = flag.Bool("console", false, "run as console application (windows only)")
 var fPlugins = flag.String("plugin-directory", "",
 	"path to directory containing external plugins")
+var fRunOnce = flag.Bool("once", false, "run one gather and exit")
 
 var (
 	version string
@@ -170,8 +171,13 @@ func runAgent(ctx context.Context,
 	logger.SetupLogging(logConfig)
 
 	if *fTest || *fTestWait != 0 {
-		testWaitDuration := time.Duration(*fTestWait) * time.Second
-		return ag.Test(ctx, testWaitDuration)
+		wait := time.Duration(*fTestWait) * time.Second
+		return ag.Test(ctx, wait)
+	}
+
+	if *fRunOnce {
+		wait := time.Duration(*fTestWait) * time.Second
+		return ag.Once(ctx, wait)
 	}
 
 	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -170,14 +170,14 @@ func runAgent(ctx context.Context,
 
 	logger.SetupLogging(logConfig)
 
-	if *fTest || *fTestWait != 0 {
-		wait := time.Duration(*fTestWait) * time.Second
-		return ag.Test(ctx, wait)
-	}
-
 	if *fRunOnce {
 		wait := time.Duration(*fTestWait) * time.Second
 		return ag.Once(ctx, wait)
+	}
+
+	if *fTest || *fTestWait != 0 {
+		wait := time.Duration(*fTestWait) * time.Second
+		return ag.Test(ctx, wait)
 	}
 
 	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -32,11 +32,10 @@ The commands & flags are:
                                  Valid values are 'agent', 'global_tags', 'outputs',
                                  'processors', 'aggregators' and 'inputs'
   --sample-config                print out full sample configuration
-  --test                         enable test mode: gather metrics, print them out,
-                                 and exit. Note: Test mode only runs inputs, not
-                                 processors, aggregators, or outputs
+  --once                         enable once mode: gather metrics once, write them, and exit
+  --test                         enable test mode: gather metrics once and print them
   --test-wait                    wait up to this many seconds for service
-                                 inputs to complete in test mode
+                                 inputs to complete in test or once mode
   --usage <plugin>               print usage for a plugin, ie, 'telegraf --usage mysql'
   --version                      display the version and exit
 

--- a/internal/usage_windows.go
+++ b/internal/usage_windows.go
@@ -29,11 +29,10 @@ The commands & flags are:
   --section-filter               filter config sections to output, separator is :
                                  Valid values are 'agent', 'global_tags', 'outputs',
                                  'processors', 'aggregators' and 'inputs'
-  --test                         enable test mode: gather metrics, print them out,
-                                 and exit. Note: Test mode only runs inputs, not
-                                 processors, aggregators, or outputs
+  --once                         enable once mode: gather metrics once, write them, and exit
+  --test                         enable test mode: gather metrics once and print them
   --test-wait                    wait up to this many seconds for service
-                                 inputs to complete in test mode
+                                 inputs to complete in test or once mode
   --usage <plugin>               print usage for a plugin, ie, 'telegraf --usage mysql'
   --version                      display the version and exit
 

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -261,3 +261,7 @@ func (r *RunningOutput) LogBufferStatus() {
 func (r *RunningOutput) Log() telegraf.Logger {
 	return r.log
 }
+
+func (r *RunningOutput) BufferLength() int {
+	return r.buffer.Len()
+}

--- a/plugins/outputs/file/file.go
+++ b/plugins/outputs/file/file.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -103,7 +102,6 @@ func (f *File) Description() string {
 }
 
 func (f *File) Write(metrics []telegraf.Metric) error {
-	return errors.New("output err")
 	var writeErr error = nil
 
 	if f.UseBatchFormat {

--- a/plugins/outputs/file/file.go
+++ b/plugins/outputs/file/file.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -102,6 +103,7 @@ func (f *File) Description() string {
 }
 
 func (f *File) Write(metrics []telegraf.Metric) error {
+	return errors.New("output err")
 	var writeErr error = nil
 
 	if f.UseBatchFormat {


### PR DESCRIPTION
This PR contains several changes over #7408:
- Resolved conflicts on #7408 due to ticker changes.
- Fixed buffering issues by running full pipeline.
- Added special handling for cpu/mongodb/procstat to mirror `--test` behavior.
- Allowed using `--once` with the `--test-wait` flag.
- Renamed cli option to `--once` (let me know if you think this is to terse)
- Updated usage message
- Combined with `--test`, which now runs processors and aggregators at last.

There are several behavior changes compared to current behavior:
- `--test` now runs all inputs, previously stopped on first failure.  Exit code is based on agent internal/selfstats.
- `--test` mode now runs all inputs concurrently, this means that output lines will generally be mixed.

closes #6190
closes #7408
closes #7415

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
