### PR TITLE
add --no-config option to start without a main cfg file

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -40,6 +40,7 @@ var fTestWait = flag.Int("test-wait", 0, "wait up to this many seconds for servi
 var fConfig = flag.String("config", "", "configuration file to load")
 var fConfigDirectory = flag.String("config-directory", "",
 	"directory containing additional *.conf files")
+var fNoConfig = flag.Bool("no-config", false, "Run Telegraf with no main config file. Useful with --config-directory")
 var fVersion = flag.Bool("version", false, "display the version and exit")
 var fSampleConfig = flag.Bool("sample-config", false,
 	"print out full sample configuration")
@@ -117,15 +118,18 @@ func runAgent(ctx context.Context,
 	inputFilters []string,
 	outputFilters []string,
 ) error {
+	var err error
 	log.Printf("I! Starting Telegraf %s", version)
 
 	// If no other options are specified, load the config file and run.
 	c := config.NewConfig()
 	c.OutputFilters = outputFilters
 	c.InputFilters = inputFilters
-	err := c.LoadConfig(*fConfig)
-	if err != nil {
-		return err
+	if !*fNoConfig {
+		err = c.LoadConfig(*fConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	if *fConfigDirectory != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -671,7 +671,8 @@ func getDefaultConfigPath() (string, error) {
 
 	// if we got here, we didn't find a file in a default location
 	return "", fmt.Errorf("No config file specified, and could not find one"+
-		" in $TELEGRAF_CONFIG_PATH, %s, or %s", homefile, etcfile)
+		" in $TELEGRAF_CONFIG_PATH, %s, or %s. "+
+		"Use --no-config to run Telegraf without a main config file.", homefile, etcfile)
 }
 
 // LoadConfig loads the given config file and applies it to c

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -16,6 +16,8 @@ The commands & flags are:
   --aggregator-filter <filter>   filter the aggregators to enable, separator is :
   --config <file>                configuration file to load
   --config-directory <directory> directory containing additional *.conf files
+  --no-config                    Run Telegraf with no main config file.
+                                 Useful with --config-directory.
   --plugin-directory             directory containing *.so files, this directory will be
                                  searched recursively. Any Plugin found will be loaded
                                  and namespaced.


### PR DESCRIPTION
if you're loading all of your config from the config directory, you don't necessarily need a config file