### PR TITLE
Optionally gather mongodb cluster status

### DIFF
--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -11,6 +11,11 @@
   ##   mongodb://10.10.3.33:18832,
   servers = ["mongodb://127.0.0.1:27017"]
 
+  ## When true, collect cluster status.
+  ## Note that the query that counts jumbo chunks triggers a COLLSCAN, which
+  ## may have an impact on performance.
+  # gather_cluster_status = true
+
   ## When true, collect per database stats
   # gather_perdb_stats = false
 

--- a/plugins/inputs/mongodb/mongodb_server.go
+++ b/plugins/inputs/mongodb/mongodb_server.go
@@ -192,7 +192,7 @@ func (s *Server) gatherCollectionStats(colStatsDbs []string) (*ColStats, error) 
 	return results, nil
 }
 
-func (s *Server) gatherData(acc telegraf.Accumulator, gatherDbStats bool, gatherColStats bool, colStatsDbs []string) error {
+func (s *Server) gatherData(acc telegraf.Accumulator, gatherClusterStatus bool, gatherDbStats bool, gatherColStats bool, colStatsDbs []string) error {
 	s.Session.SetMode(mgo.Eventual, true)
 	s.Session.SetSocketTimeout(0)
 
@@ -218,9 +218,13 @@ func (s *Server) gatherData(acc telegraf.Accumulator, gatherDbStats bool, gather
 		}
 	}
 
-	clusterStatus, err := s.gatherClusterStatus()
-	if err != nil {
-		s.Log.Debugf("Unable to gather cluster status: %s", err.Error())
+	var clusterStatus *ClusterStatus
+	if gatherClusterStatus {
+		status, err := s.gatherClusterStatus()
+		if err != nil {
+			s.Log.Debugf("Unable to gather cluster status: %s", err.Error())
+		}
+		clusterStatus = status
 	}
 
 	shardStats, err := s.gatherShardConnPoolStats()


### PR DESCRIPTION
It can be expensive to compute these metrics. In particular, when
retrieving the amount of jumbo chunks, an index is not being used and
consequently the query triggers an expensive COLLSCAN. For big
databases, this query has negative impact on the cluster performance.

I left the default value of `gather_cluster_status` to `true` so as not to break
the current behavior. 

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
