### PR TITLE
Fix for perfmon instance_name for #7325

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -626,10 +626,10 @@ SET @SQL = N'SELECT	DISTINCT
                              OR RTRIM(spi.object_name) LIKE ''%:Advanced Analytics'')
                              AND TRY_CONVERT(uniqueidentifier, spi.instance_name) 
 							 IS NOT NULL -- for cloud only
-                       THEN d.name
- 			WHEN RTRIM(object_name) LIKE ''%:Availability Replica''
+                THEN ISNULL(d.name,RTRIM(spi.instance_name)) -- Elastic Pools counters exist for all databases but sys.databases only has current DB value
+			  WHEN RTRIM(object_name) LIKE ''%:Availability Replica''
 				AND TRY_CONVERT(uniqueidentifier, spi.instance_name) IS NOT NULL -- for cloud only
-			THEN d.name + RTRIM(SUBSTRING(spi.instance_name, 37, LEN(spi.instance_name)))
+			THEN ISNULL(d.name,RTRIM(spi.instance_name)) + RTRIM(SUBSTRING(spi.instance_name, 37, LEN(spi.instance_name)))
                        ELSE RTRIM(spi.instance_name)
                 END AS instance_name,'
 		ELSE 'RTRIM(spi.instance_name) as instance_name, '


### PR DESCRIPTION
On Elastic pools, sys.dm_os_perfmon_counters has counters for all databases represented by GUIDS. To resolve the GUID to a DB name have to join with sys.databases
However sys.database only has a row for the current database and not all databases and hence the instance_name for those rows would be NULL and insert would fail with
"Cannot insert the value NULL error"

Fix is to resolve DB name for the current database, leave the GUID for perfmon counters of other databases.

closes #7325
### Required for all PRs:

- [X ] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ X] Has appropriate unit tests.
