### PR TITLE
improve mntr regex to match user specific keys.

### DIFF
--- a/plugins/inputs/zookeeper/zookeeper.go
+++ b/plugins/inputs/zookeeper/zookeeper.go
@@ -17,7 +17,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-var zookeeperFormatRE = regexp.MustCompile(`^zk_([\w\.\-]+)\s+([\w\.\-]+)`)
+var zookeeperFormatRE = regexp.MustCompile(`^zk_(\w[\w\.\-]*)\s+([\w\.\-]+)`)
 
 // Zookeeper is a zookeeper plugin
 type Zookeeper struct {

--- a/plugins/inputs/zookeeper/zookeeper.go
+++ b/plugins/inputs/zookeeper/zookeeper.go
@@ -17,7 +17,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-var zookeeperFormatRE = regexp.MustCompile(`^zk_(\w+)\s+([\w\.\-]+)`)
+var zookeeperFormatRE = regexp.MustCompile(`^zk_([\w\.\-]+)\s+([\w\.\-]+)`)
 
 // Zookeeper is a zookeeper plugin
 type Zookeeper struct {


### PR DESCRIPTION
### Required for all PRs:

Found zookeeper input plugin error as below:

> [inputs.zookeeper] Error in plugin: unexpected line in mntr response: "zk_avg_pull-daily-attendence-data-testByQA_read_per_namespace\t137.1803"

This PR is to improve mntr regex to match user specific keys.

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
