### PR TITLE
feat: initial spike for state hooks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,9 @@ type Config struct {
 	Aggregators []*models.RunningAggregator
 	// Processors have a slice wrapper type because they need to be sorted
 	Processors models.RunningProcessors
+
+	// State storage
+	State telegraf.State
 }
 
 func NewConfig() *Config {
@@ -77,6 +80,7 @@ func NewConfig() *Config {
 			FlushInterval:              internal.Duration{Duration: 10 * time.Second},
 			LogTarget:                  "file",
 			LogfileRotationMaxArchives: 5,
+			State:                      "",
 		},
 
 		Tags:          make(map[string]string),
@@ -170,6 +174,11 @@ type AgentConfig struct {
 
 	Hostname     string
 	OmitHostname bool
+
+	// If this is a non-empty string, then Telegraf will attempt to persist any
+	// state from state enabled plugins within the configured State store.
+	State          string `toml:"state"`
+	StateDirectory string `tomp:"state_directory"`
 }
 
 // Inputs returns a list of strings of the configured inputs.
@@ -321,6 +330,8 @@ var agentConfig = `
   ## If set to true, do no set the "host" tag in the telegraf agent.
   omit_hostname = false
 
+  ## Should state from state enabled plugins be persisted?
+  # state = "json"
 `
 
 var outputHeader = `

--- a/input.go
+++ b/input.go
@@ -22,3 +22,15 @@ type ServiceInput interface {
 	// Stop stops the services and closes any necessary channels and connections
 	Stop()
 }
+
+// StatefulInput allow a ServiceInput to store any arbitrary information that can be restored
+// in the event that Telegraf or the plugin is restarted
+type StatefulInput interface {
+	ServiceInput
+
+	// Sync writes the state of the plugin to the StateStore
+	Sync() interface{}
+
+	// Load
+	Load(interface{}) error
+}

--- a/plugins/state/json/json.go
+++ b/plugins/state/json/json.go
@@ -1,0 +1,59 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// JSON ...
+type JSON struct {
+	Directory string
+}
+
+// Open ...
+func (j *JSON) Open() error {
+	fmt.Printf("JSON Open: %v\n", j.Directory)
+
+	return os.MkdirAll(j.Directory, 0644)
+
+}
+
+// Close ...
+func (j *JSON) Close() {
+	fmt.Printf("JSON Close: %v\n", j.Directory)
+}
+
+// Load
+
+func (j *JSON) Load(logName string) (interface{}, error) {
+	fileName := filepath.Join(j.Directory, logName)
+	jsonString, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	loadedState := make(map[string]interface{})
+	err = json.Unmarshal(jsonString, &loadedState)
+	if err != nil {
+		return nil, err
+	}
+
+	return loadedState, nil
+}
+
+// Store
+func (j *JSON) Store(logName string, state interface{}) error {
+	fileName := filepath.Join(j.Directory, logName)
+
+	jsonState, _ := json.Marshal(state)
+
+	return ioutil.WriteFile(fileName, jsonState, 0644)
+}
+
+// Flush ...
+func (j *JSON) Flush() {
+	fmt.Printf("JSON Flush\n")
+}

--- a/state.go
+++ b/state.go
@@ -1,0 +1,10 @@
+package telegraf
+
+// StateStore ...
+type State interface {
+	Open() error
+	Close()
+	Store(string, interface{}) error
+	Load(string) (interface{}, error)
+	Flush()
+}


### PR DESCRIPTION
This is a rather rough idea, seeking feedback before cleaning up the code.

This PR aims to provide the means for input plugins to become stateful. By adding 2 functions, they can provide a means for Telegraf to save and load their state. As a PoC, I've implemented this for `tail` with rather minimum effort.

This implementation contains a `JSON` state plugin that stores the state on the filesystem. Though I've kept it generic enough for this to be modified for other stores. 

The `syncStateLoop` reuses the flush configuration, as I assume that the state should be inline with writes out of Telegraf. Currently the state sync doesn't care if a write fails, but this could be worked in.

Also, the state system fails when using a plugin twice; as it currently uses `logName` from `models.RunningInput` to identify the plugin. This would need thought through also.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
