### PR TITLE
character selection to combine the metric name and field for graphite tag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1951,6 +1951,14 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 		}
 	}
 
+	if node, ok := tbl.Fields["graphite_separator"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if str, ok := kv.Value.(*ast.String); ok {
+				c.GraphiteTagSeparator = str.Value
+			}
+		}
+	}
+
 	if node, ok := tbl.Fields["json_timestamp_units"]; ok {
 		if kv, ok := node.(*ast.KeyValue); ok {
 			if str, ok := kv.Value.(*ast.String); ok {
@@ -2055,6 +2063,7 @@ func buildSerializer(name string, tbl *ast.Table) (serializers.Serializer, error
 	delete(tbl.Fields, "influx_sort_fields")
 	delete(tbl.Fields, "influx_uint_support")
 	delete(tbl.Fields, "graphite_tag_support")
+	delete(tbl.Fields, "graphite_separator")
 	delete(tbl.Fields, "data_format")
 	delete(tbl.Fields, "prefix")
 	delete(tbl.Fields, "template")

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -572,6 +572,8 @@
 #
 #   ## Enable Graphite tags support
 #   # graphite_tag_support = false
+#   ## Character for separating metric name and field for Graphite tags
+#   # graphite_separator = "."
 #
 #   ## timeout in seconds for the write connection to graphite
 #   timeout = 2

--- a/plugins/outputs/graphite/README.md
+++ b/plugins/outputs/graphite/README.md
@@ -34,6 +34,9 @@ see the [Graphite Data Format](../../../docs/DATA_FORMATS_OUTPUT.md)
   ## Enable Graphite tags support
   # graphite_tag_support = false
 
+  ## Character for separating metric name and field for Graphite tags
+  # graphite_separator = "."
+
   ## timeout in seconds for the write connection to graphite
   timeout = 2
 

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -16,7 +16,8 @@ import (
 )
 
 type Graphite struct {
-	GraphiteTagSupport bool
+	GraphiteTagSupport   bool
+	GraphiteTagSeparator string
 	// URL is only for backwards compatibility
 	Servers   []string
 	Prefix    string
@@ -40,6 +41,9 @@ var sampleConfig = `
 
   ## Enable Graphite tags support
   # graphite_tag_support = false
+
+  ## Character for separating metric name and field for Graphite tags
+  # graphite_separator = "."
 
   ## Graphite templates patterns
   ## 1. Template for cpu
@@ -145,7 +149,7 @@ func checkEOF(conn net.Conn) {
 func (g *Graphite) Write(metrics []telegraf.Metric) error {
 	// Prepare data
 	var batch []byte
-	s, err := serializers.NewGraphiteSerializer(g.Prefix, g.Template, g.GraphiteTagSupport, g.Templates)
+	s, err := serializers.NewGraphiteSerializer(g.Prefix, g.Template, g.GraphiteTagSupport, g.GraphiteTagSeparator, g.Templates)
 	if err != nil {
 		return err
 	}

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -86,7 +86,7 @@ func (i *Instrumental) Write(metrics []telegraf.Metric) error {
 		}
 	}
 
-	s, err := serializers.NewGraphiteSerializer(i.Prefix, i.Template, false, i.Templates)
+	s, err := serializers.NewGraphiteSerializer(i.Prefix, i.Template, false, ".", i.Templates)
 	if err != nil {
 		return err
 	}

--- a/plugins/serializers/graphite/README.md
+++ b/plugins/serializers/graphite/README.md
@@ -22,7 +22,7 @@ method is used, otherwise the [Template Pattern](templates) is used.
   prefix = "telegraf"
   ## Graphite template pattern
   template = "host.tags.measurement.field"
-  
+
   ## Graphite templates patterns
   ## 1. Template for cpu
   ## 2. Template for disk*
@@ -35,6 +35,8 @@ method is used, otherwise the [Template Pattern](templates) is used.
 
   ## Support Graphite tags, recommended to enable when using Graphite 1.1 or later.
   # graphite_tag_support = false
+  ## Character for separating metric name and field for Graphite tags
+  # graphite_separator = "."
 ```
 
 #### graphite_tag_support
@@ -53,6 +55,13 @@ cpu,cpu=cpu-total,dc=us-east-1,host=tars usage_idle=98.09,usage_user=0.89 145532
 =>
 cpu.usage_user;cpu=cpu-total;dc=us-east-1;host=tars 0.89 1455320690
 cpu.usage_idle;cpu=cpu-total;dc=us-east-1;host=tars 98.09 1455320690
+```
+When change option `graphite_separator` example to "_"
+```
+cpu,cpu=cpu-total,dc=us-east-1,host=tars usage_idle=98.09,usage_user=0.89 1455320660004257758
+=>
+cpu_usage_user;cpu=cpu-total;dc=us-east-1;host=tars 0.89 1455320690
+cpu_usage_idle;cpu=cpu-total;dc=us-east-1;host=tars 98.09 1455320690
 ```
 
 [templates]: /docs/TEMPLATE_PATTERN.md

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -36,10 +36,11 @@ type GraphiteTemplate struct {
 }
 
 type GraphiteSerializer struct {
-	Prefix     string
-	Template   string
-	TagSupport bool
-	Templates  []*GraphiteTemplate
+	Prefix       string
+	Template     string
+	TagSupport   bool
+	TagSeparator string
+	Templates    []*GraphiteTemplate
 }
 
 func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
@@ -55,7 +56,7 @@ func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 			if fieldValue == "" {
 				continue
 			}
-			bucket := SerializeBucketNameWithTags(metric.Name(), metric.Tags(), s.Prefix, fieldName)
+			bucket := SerializeBucketNameWithTags(metric.Name(), metric.Tags(), s.Prefix, s.TagSeparator, fieldName)
 			metricString := fmt.Sprintf("%s %s %d\n",
 				// insert "field" section of template
 				bucket,
@@ -246,6 +247,7 @@ func SerializeBucketNameWithTags(
 	measurement string,
 	tags map[string]string,
 	prefix string,
+	separator string,
 	field string,
 ) string {
 	var out string
@@ -259,13 +261,13 @@ func SerializeBucketNameWithTags(
 	sort.Strings(tagsCopy)
 
 	if prefix != "" {
-		out = prefix + "."
+		out = prefix + separator
 	}
 
 	out += measurement
 
 	if field != "value" {
-		out += "." + field
+		out += separator + field
 	}
 
 	out = sanitize(out)

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -51,6 +51,9 @@ type Config struct {
 	// Support tags in graphite protocol
 	GraphiteTagSupport bool `toml:"graphite_tag_support"`
 
+	// Character for separating metric name and field for Graphite tags
+	GraphiteTagSeparator string `toml:"graphite_separator"`
+
 	// Maximum line length in bytes; influx format only
 	InfluxMaxLineBytes int `toml:"influx_max_line_bytes"`
 
@@ -107,7 +110,7 @@ func NewSerializer(config *Config) (Serializer, error) {
 	case "influx":
 		serializer, err = NewInfluxSerializerConfig(config)
 	case "graphite":
-		serializer, err = NewGraphiteSerializer(config.Prefix, config.Template, config.GraphiteTagSupport, config.Templates)
+		serializer, err = NewGraphiteSerializer(config.Prefix, config.Template, config.GraphiteTagSupport, config.GraphiteTagSeparator, config.Templates)
 	case "json":
 		serializer, err = NewJsonSerializer(config.TimestampUnits)
 	case "splunkmetric":
@@ -191,7 +194,7 @@ func NewInfluxSerializer() (Serializer, error) {
 	return influx.NewSerializer(), nil
 }
 
-func NewGraphiteSerializer(prefix, template string, tag_support bool, templates []string) (Serializer, error) {
+func NewGraphiteSerializer(prefix, template string, tag_support bool, separator string, templates []string) (Serializer, error) {
 	graphiteTemplates, defaultTemplate, err := graphite.InitGraphiteTemplates(templates)
 
 	if err != nil {
@@ -202,10 +205,15 @@ func NewGraphiteSerializer(prefix, template string, tag_support bool, templates 
 		template = defaultTemplate
 	}
 
+	if separator == "" {
+		separator = "."
+	}
+
 	return &graphite.GraphiteSerializer{
-		Prefix:     prefix,
-		Template:   template,
-		TagSupport: tag_support,
-		Templates:  graphiteTemplates,
+		Prefix:       prefix,
+		Template:     template,
+		TagSupport:   tag_support,
+		TagSeparator: separator,
+		Templates:    graphiteTemplates,
 	}, nil
 }


### PR DESCRIPTION
Fix #7539

Add character selection to combine the metric name and field for graphite tag metrics.