### PR TITLE
Trim trailing NULL character at the end of payload

### DIFF
--- a/plugins/parsers/json/parser.go
+++ b/plugins/parsers/json/parser.go
@@ -195,7 +195,7 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 
 	buf = bytes.TrimSpace(buf)
 	buf = bytes.TrimPrefix(buf, utf8BOM)
-	buf = bytes.Trim(buf,"\x00")
+	buf = bytes.Trim(buf, "\x00")
 	if len(buf) == 0 {
 		return make([]telegraf.Metric, 0), nil
 	}

--- a/plugins/parsers/json/parser.go
+++ b/plugins/parsers/json/parser.go
@@ -195,6 +195,7 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 
 	buf = bytes.TrimSpace(buf)
 	buf = bytes.TrimPrefix(buf, utf8BOM)
+	buf = bytes.Trim(buf,"\x00")
 	if len(buf) == 0 {
 		return make([]telegraf.Metric, 0), nil
 	}


### PR DESCRIPTION
Some producers (such as the paho embedded c mqtt client) add a null
character "\x00" to the end of a message. The JSON parser would fail on
any message from such a producer.

Pull request related with Issue #7536 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
