### PR TITLE
make sure parse error includes offending text

### DIFF
--- a/plugins/parsers/influx/parser.go
+++ b/plugins/parsers/influx/parser.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 	"time"
 
@@ -33,12 +32,21 @@ type ParseError struct {
 
 func (e *ParseError) Error() string {
 	buffer := e.buf[e.LineOffset:]
-	eol := strings.IndexAny(buffer, "\r\n")
-	if eol >= 0 {
-		buffer = buffer[:eol]
-	}
 	if len(buffer) > maxErrorBufferSize {
-		buffer = buffer[:maxErrorBufferSize] + "..."
+		startEllipsis := true
+		offset := e.Offset - e.LineOffset
+		start := offset - maxErrorBufferSize
+		if start < 0 {
+			startEllipsis = false
+			start = 0
+		}
+		// if we trimmed it the column won't line up. it'll always be the last character,
+		// because the parser doesn't continue past it, but point it out anyway so
+		// it's obvious where the issue is.
+		buffer = buffer[start:offset] + "<-- here"
+		if startEllipsis {
+			buffer = "..." + buffer
+		}
 	}
 	return fmt.Sprintf("metric parse error: %s at %d:%d: %q", e.msg, e.LineNumber, e.Column, buffer)
 }

--- a/plugins/parsers/influx/parser.go
+++ b/plugins/parsers/influx/parser.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,6 +33,10 @@ type ParseError struct {
 
 func (e *ParseError) Error() string {
 	buffer := e.buf[e.LineOffset:]
+	eol := strings.IndexAny(buffer, "\r\n")
+	if eol >= 0 {
+		buffer = buffer[:eol]
+	}
 	if len(buffer) > maxErrorBufferSize {
 		startEllipsis := true
 		offset := e.Offset - e.LineOffset

--- a/plugins/parsers/influx/parser_test.go
+++ b/plugins/parsers/influx/parser_test.go
@@ -834,7 +834,7 @@ func TestStreamParserErrorString(t *testing.T) {
 			name:  "buffer too long",
 			input: []byte("cpu " + strings.Repeat("ab", maxErrorBufferSize) + "=invalid\ncpu value=42"),
 			errs: []string{
-				"metric parse error: expected field at 1:2054: \"cpu " + strings.Repeat("ab", maxErrorBufferSize)[:maxErrorBufferSize-4] + "...\"",
+				"metric parse error: expected field at 1:2054: \"...b" + strings.Repeat("ab", maxErrorBufferSize/2-1) + "=<-- here\"",
 			},
 		},
 		{

--- a/plugins/parsers/influx/parser_test.go
+++ b/plugins/parsers/influx/parser_test.go
@@ -790,7 +790,7 @@ func TestParserErrorString(t *testing.T) {
 		{
 			name:      "buffer too long",
 			input:     []byte("cpu " + strings.Repeat("ab", maxErrorBufferSize) + "=invalid\ncpu value=42"),
-			errString: "metric parse error: expected field at 1:2054: \"cpu " + strings.Repeat("ab", maxErrorBufferSize)[:maxErrorBufferSize-4] + "...\"",
+			errString: "metric parse error: expected field at 1:2054: \"...b" + strings.Repeat("ab", maxErrorBufferSize/2-1) + "=<-- here\"",
 		},
 		{
 			name:      "multiple line error",


### PR DESCRIPTION
Error message before this PR:
```
2020-05-21T22:54:10Z E! [inputs.file] Error in plugin: metric parse error: expected field at 45:1543: "remote_status,platform=some,env=prd,dst=clf code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code..."
```
Problem: offending text not visible

Error message after this PR:
```
2020-05-21T22:45:10Z E! [inputs.file] Error in plugin: metric parse error: expected field at 45:1543: "...ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,code=200i,ok=1i,response_microsec=55500i,d<-- here"
```
Solution: trim front of line instead of tail, point out offending character.
Potential issues with solution: It's possible the record-identifying information is missing. A potential improvement to this PR would be to trim from the middle of the record until it is under the max size. Looking for feedback before making this change.

Things I learned of note: the parser appears to never returns text after the parse error.

Related to https://github.com/influxdata/telegraf/issues/7413