### PR TITLE
Add a --once flag that will run the entire pipeline exactly once and exit

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -37,6 +37,7 @@ var fQuiet = flag.Bool("quiet", false,
 	"run in quiet mode")
 var fTest = flag.Bool("test", false, "enable test mode: gather metrics, print them out, and exit. Note: Test mode only runs inputs, not processors, aggregators, or outputs")
 var fTestWait = flag.Int("test-wait", 0, "wait up to this many seconds for service inputs to complete in test mode")
+var fOnce = flag.Bool("once", false, "run each input/processor/aggregator/output once and exit")
 var fConfig = flag.String("config", "", "configuration file to load")
 var fConfigDirectory = flag.String("config-directory", "",
 	"directory containing additional *.conf files")
@@ -179,6 +180,10 @@ func runAgent(ctx context.Context,
 	log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))
 	log.Printf("I! Loaded outputs: %s", strings.Join(c.OutputNames(), " "))
 	log.Printf("I! Tags enabled: %s", c.ListTags())
+
+	if *fOnce {
+		return ag.RunOnce(ctx)
+	}
 
 	if *fPidfile != "" {
 		f, err := os.OpenFile(*fPidfile, os.O_CREATE|os.O_WRONLY, 0644)

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -37,6 +37,7 @@ The commands & flags are:
                                  processors, aggregators, or outputs
   --test-wait                    wait up to this many seconds for service
                                  inputs to complete in test mode
+  --once                         run each input/processor/aggregator/output once and exit
   --usage <plugin>               print usage for a plugin, ie, 'telegraf --usage mysql'
   --version                      display the version and exit
 

--- a/internal/usage_windows.go
+++ b/internal/usage_windows.go
@@ -34,6 +34,7 @@ The commands & flags are:
                                  processors, aggregators, or outputs
   --test-wait                    wait up to this many seconds for service
                                  inputs to complete in test mode
+  --once                         run each input/processor/aggregator/output once and exit
   --usage <plugin>               print usage for a plugin, ie, 'telegraf --usage mysql'
   --version                      display the version and exit
 


### PR DESCRIPTION
I have need of #2546 so I figured I'd give implementing it a shot.
Instead of taking the approach of #6537 I decided instead to see what would happen if we didn't modify *any* existing code and just duplicated the relevant bits. As was suggested on that PR, there isn't a huge amount of code to be shared between a single run and the usual long-running loop.

Its possible that bits could be refactored out (e.g the filtering and overrides before writing to output) but even in those cases its note a huge amount of code that has been duplicated anyways.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
