### PR TITLE
Add missing nvme attributes to smart plugin

### DIFF
--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -103,10 +103,48 @@ var (
 			},
 		},
 		"Available Spare": {
-			Name: "Available_Spare",
-			Parse: func(fields, deviceFields map[string]interface{}, str string) error {
-				return parseCommaSeparatedInt(fields, deviceFields, strings.TrimSuffix(str, "%"))
-			},
+			Name:  "Available_Spare",
+			Parse: parsePercentageInt,
+		},
+		"Available Spare Threshold": {
+			Name:  "Available_Spare_Threshold",
+			Parse: parsePercentageInt,
+		},
+		"Percentage Used": {
+			Name:  "Percentage_Used",
+			Parse: parsePercentageInt,
+		},
+		"Data Units Read": {
+			Name:  "Data_Units_Read",
+			Parse: parseDataUnits,
+		},
+		"Data Units Written": {
+			Name:  "Data_Units_Written",
+			Parse: parseDataUnits,
+		},
+		"Host Read Commands": {
+			Name:  "Host_Read_Commands",
+			Parse: parseCommaSeparatedInt,
+		},
+		"Host Write Commands": {
+			Name:  "Host_Write_Commands",
+			Parse: parseCommaSeparatedInt,
+		},
+		"Controller Busy Time": {
+			Name:  "Controller_Busy_Time",
+			Parse: parseCommaSeparatedInt,
+		},
+		"Unsafe Shutdowns": {
+			Name:  "Unsafe_Shutdowns",
+			Parse: parseCommaSeparatedInt,
+		},
+		"Warning  Comp. Temperature Time": {
+			Name:  "Warning_Temperature_Time",
+			Parse: parseCommaSeparatedInt,
+		},
+		"Critical Comp. Temperature Time": {
+			Name:  "Critical_Temperature_Time",
+			Parse: parseCommaSeparatedInt,
 		},
 	}
 )
@@ -430,6 +468,15 @@ func parseCommaSeparatedInt(fields, _ map[string]interface{}, str string) error 
 	fields["raw_value"] = i
 
 	return nil
+}
+
+func parsePercentageInt(fields, deviceFields map[string]interface{}, str string) error {
+	return parseCommaSeparatedInt(fields, deviceFields, strings.TrimSuffix(str, "%"))
+}
+
+func parseDataUnits(fields, deviceFields map[string]interface{}, str string) error {
+	units := strings.Fields(str)[0]
+	return parseCommaSeparatedInt(fields, deviceFields, units)
 }
 
 func parseTemperature(fields, deviceFields map[string]interface{}, str string) error {

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -614,6 +614,18 @@ func TestGatherNvme(t *testing.T) {
 		testutil.MustMetric("smart_attribute",
 			map[string]string{
 				"device":    ".",
+				"name":      "Available_Spare_Threshold",
+				"serial_no": "D704940282?",
+				"model":     "TS128GMTE850",
+			},
+			map[string]interface{}{
+				"raw_value": 10,
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
 				"id":        "194",
 				"name":      "Temperature_Celsius",
 				"serial_no": "D704940282?",
@@ -633,6 +645,114 @@ func TestGatherNvme(t *testing.T) {
 			},
 			map[string]interface{}{
 				"raw_value": int64(9),
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Percentage_Used",
+				"serial_no": "D704940282?",
+				"model":     "TS128GMTE850",
+			},
+			map[string]interface{}{
+				"raw_value": int64(16),
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Data_Units_Read",
+				"serial_no": "D704940282?",
+				"model":     "TS128GMTE850",
+			},
+			map[string]interface{}{
+				"raw_value": int64(11836935),
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Data_Units_Written",
+				"serial_no": "D704940282?",
+				"model":     "TS128GMTE850",
+			},
+			map[string]interface{}{
+				"raw_value": int64(62288091),
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Host_Read_Commands",
+				"serial_no": "D704940282?",
+				"model":     "TS128GMTE850",
+			},
+			map[string]interface{}{
+				"raw_value": int64(135924188),
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Host_Write_Commands",
+				"serial_no": "D704940282?",
+				"model":     "TS128GMTE850",
+			},
+			map[string]interface{}{
+				"raw_value": int64(7715573429),
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Controller_Busy_Time",
+				"serial_no": "D704940282?",
+				"model":     "TS128GMTE850",
+			},
+			map[string]interface{}{
+				"raw_value": int64(4042),
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Unsafe_Shutdowns",
+				"serial_no": "D704940282?",
+				"model":     "TS128GMTE850",
+			},
+			map[string]interface{}{
+				"raw_value": int64(355),
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Warning_Temperature_Time",
+				"serial_no": "D704940282?",
+				"model":     "TS128GMTE850",
+			},
+			map[string]interface{}{
+				"raw_value": int64(11),
+			},
+			time.Now(),
+		),
+		testutil.MustMetric("smart_attribute",
+			map[string]string{
+				"device":    ".",
+				"name":      "Critical_Temperature_Time",
+				"serial_no": "D704940282?",
+				"model":     "TS128GMTE850",
+			},
+			map[string]interface{}{
+				"raw_value": int64(7),
 			},
 			time.Now(),
 		),
@@ -1089,7 +1209,7 @@ Power On Hours: 6,038
 Unsafe Shutdowns: 355
 Media and Data Integrity Errors: 0
 Error Information Log Entries: 119,699
-Warning Comp. Temperature Time: 0
-Critical Comp. Temperature Time: 0
+Warning  Comp. Temperature Time: 11
+Critical Comp. Temperature Time: 7
 `
 )


### PR DESCRIPTION
This PR adds additional nvme specific attributes to smart plugin.
The attributes are verified with [NVMe Specification 1.4](https://nvmexpress.org/wp-content/uploads/NVM-Express-1_4-2019.06.10-Ratified.pdf) and tested with Crucial MP510.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
       There is no mention of specific attributes in smart README file.
- [x] Has appropriate unit tests.
