### PR TITLE
Add support for Solus distribution

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -101,5 +101,8 @@ elif [[ -f /etc/os-release ]]; then
         else
             install_chkconfig
         fi
+    elif [[ "$NAME" = "Solus" ]]; then
+        # Solus logic
+        install_systemd /usr/lib/systemd/system/telegraf.service
     fi
 fi

--- a/scripts/post-remove.sh
+++ b/scripts/post-remove.sh
@@ -59,5 +59,8 @@ elif [[ -f /etc/os-release ]]; then
             # Amazon Linux logic
             disable_chkconfig
         fi
+    elif [[ "$NAME" = "Solus" ]]; then
+        rm -f /etc/default/telegraf
+        disable_systemd /usr/lib/systemd/system/telegraf.service
     fi
 fi


### PR DESCRIPTION
Since the pre/post install scripts check for distribution names, a lot of perfectly valid distributions are left out just because they are not "ubuntu", "debian" or "redhat". This PR simply adds a check for Solus to (un)install the systemd file.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
