### PR TITLE
Add support for env variables to shim config

### DIFF
--- a/plugins/inputs/execd/shim/testdata/plugin.conf
+++ b/plugins/inputs/execd/shim/testdata/plugin.conf
@@ -1,0 +1,4 @@
+[[inputs.test]]
+	service_name = "awesome name"
+	secret_token = "${SECRET_TOKEN}"
+	secret_value = "$SECRET_VALUE"


### PR DESCRIPTION
Enable `shim` to interpret environment variables by changing `config.parseConfig` to public.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
