### PR TITLE
Change rpm dist packaging type for arm64 to aarch64 - same as goarch …

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -616,6 +616,9 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                         package_arch = arch.replace("static_", "")
                     elif package_type == "rpm" and arch == 'armhf':
                         package_arch = 'armv6hl'
+                    elif package_type == "rpm" and arch == 'arm64':
+                        # Adjust arm64 rpm package arch
+                        package_arch = 'aarch64'
                     else:
                         package_arch = arch
                     if not version:


### PR DESCRIPTION
…arm64 but requires aarch64 rpm

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
