### PR TITLE
Fix source field for icinga2 plugin (#7004)

### DIFF
--- a/plugins/inputs/icinga2/README.md
+++ b/plugins/inputs/icinga2/README.md
@@ -41,12 +41,13 @@ services and hosts. You can read Icinga2's documentation for their remote API
 ### Tags:
 
 - All measurements have the following tags:
-    - check_command
-    - display_name
-    - state
-    - source
-    - port
-    - scheme
+    - check_command - The short name of the check command
+    - display_name - The name of the service or host
+    - state - The state: UP/DOWN for hosts, OK/WARNING/CRITICAL/UNKNOWN for services
+    - source - The icinga2 host
+    - port - The icinga2 port
+    - scheme - The icinga2 protocol (http/https)
+    - server - The server the check_command is running for
 
 ### Sample Queries:
 

--- a/plugins/inputs/icinga2/icinga2.go
+++ b/plugins/inputs/icinga2/icinga2.go
@@ -43,6 +43,7 @@ type Attribute struct {
 	DisplayName  string  `json:"display_name"`
 	Name         string  `json:"name"`
 	State        float64 `json:"state"`
+	HostName     string  `json:"host_name"`
 }
 
 var levels = []string{"ok", "warning", "critical", "unknown"}
@@ -94,11 +95,18 @@ func (i *Icinga2) GatherStatus(acc telegraf.Accumulator, checks []Object) {
 			"state_code": state,
 		}
 
+		// source is dependent on 'services' or 'hosts' check
+		source := check.Attrs.Name
+		if i.ObjectType == "services" {
+			source = check.Attrs.HostName
+		}
+
 		tags := map[string]string{
 			"display_name":  check.Attrs.DisplayName,
 			"check_command": check.Attrs.CheckCommand,
+			"source":        source,
 			"state":         levels[state],
-			"source":        url.Hostname(),
+			"server":        url.Hostname(),
 			"scheme":        url.Scheme,
 			"port":          url.Port(),
 		}
@@ -136,7 +144,15 @@ func (i *Icinga2) Gather(acc telegraf.Accumulator) error {
 		i.client = client
 	}
 
-	url := fmt.Sprintf("%s/v1/objects/%s?attrs=name&attrs=display_name&attrs=state&attrs=check_command", i.Server, i.ObjectType)
+	requestUrl := "%s/v1/objects/%s?attrs=name&attrs=display_name&attrs=state&attrs=check_command"
+
+	// Note: attrs=host_name is only valid for 'services' requests, using check.Attrs.HostName for the host
+	//       'hosts' requests will need to use attrs=name only, using check.Attrs.Name for the host
+	if i.ObjectType == "services" {
+		requestUrl += "&attrs=host_name"
+	}
+
+	url := fmt.Sprintf(requestUrl, i.Server, i.ObjectType)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/plugins/inputs/icinga2/icinga2_test.go
+++ b/plugins/inputs/icinga2/icinga2_test.go
@@ -16,6 +16,7 @@ func TestGatherServicesStatus(t *testing.T) {
             "attrs": {
                 "check_command": "check-bgp-juniper-netconf",
                 "display_name": "eq-par.dc2.fr",
+                "host_name": "someserverfqdn.net",
                 "name": "ef017af8-c684-4f3f-bb20-0dfe9fcd3dbe",
                 "state": 0
             },
@@ -46,7 +47,8 @@ func TestGatherServicesStatus(t *testing.T) {
 				"display_name":  "eq-par.dc2.fr",
 				"check_command": "check-bgp-juniper-netconf",
 				"state":         "ok",
-				"source":        "localhost",
+				"source":        "someserverfqdn.net",
+				"server":        "localhost",
 				"port":          "5665",
 				"scheme":        "https",
 			},
@@ -100,7 +102,8 @@ func TestGatherHostsStatus(t *testing.T) {
 				"display_name":  "apache",
 				"check_command": "ping",
 				"state":         "critical",
-				"source":        "localhost",
+				"source":        "webserver",
+				"server":        "localhost",
 				"port":          "5665",
 				"scheme":        "https",
 			},


### PR DESCRIPTION
The plugin uses the icinga2 server name, but does not provide the actual host the check is running on.

This fixes that by adding a new field called `server`, where `server` is the icinga2 server and `source` is hostname of the service or host object that icinga2 performing the checks on.

closes #7004

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
