### PR TITLE
Remove trailing backslash from tag keys/values

### DIFF
--- a/plugins/outputs/influxdb/README.md
+++ b/plugins/outputs/influxdb/README.md
@@ -84,4 +84,9 @@ The InfluxDB output plugin writes metrics to the [InfluxDB v1.x] HTTP or UDP ser
   # influx_uint_support = false
 ```
 
+### Metrics
+￼
+Reference the [influx serializer][] for details about metric production.
+￼
 [InfluxDB v1.x]: https://github.com/influxdata/influxdb
+[influx serializer]: /plugins/serializers/influx/README.md#Metrics

--- a/plugins/outputs/influxdb_v2/README.md
+++ b/plugins/outputs/influxdb_v2/README.md
@@ -58,4 +58,9 @@ The InfluxDB output plugin writes metrics to the [InfluxDB v2.x] HTTP service.
   # insecure_skip_verify = false
 ```
 
+### Metrics
+￼
+Reference the [influx serializer][] for details about metric production.
+
 [InfluxDB v2.x]: https://github.com/influxdata/influxdb
+[influx serializer]: /plugins/serializers/influx/README.md#Metrics

--- a/plugins/serializers/influx/README.md
+++ b/plugins/serializers/influx/README.md
@@ -5,6 +5,7 @@ protocol].  This is the recommended format unless another format is required
 for interoperability.
 
 ### Configuration
+
 ```toml
 [[outputs.file]]
   ## Files to write to, "stdout" is a specially handled file.
@@ -30,5 +31,14 @@ for interoperability.
   ## existing data has been written.
   influx_uint_support = false
 ```
+
+### Metrics
+
+Conversion is direct taking into account some limitations of the Line Protocol
+format:
+- Float fields that are `NaN` or `Inf` are skipped.
+- Trailing backslash `\` characters are removed from tag keys and values.
+- Tags with a key or value that is the empty string are skipped.
+- When not using `influx_uint_support`, unsigned integers are capped at the max int64.
 
 [line protocol]: https://docs.influxdata.com/influxdb/latest/write_protocols/line_protocol_tutorial/

--- a/plugins/serializers/influx/influx.go
+++ b/plugins/serializers/influx/influx.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/influxdata/telegraf"
 )
@@ -158,6 +159,14 @@ func (s *Serializer) buildHeader(m telegraf.Metric) error {
 		// those with a trailing '\' or empty strings.
 		if key == "" || value == "" {
 			continue
+		}
+
+		if strings.HasSuffix(key, `\`) {
+			key = strings.TrimRight(key, `\`)
+		}
+
+		if strings.HasSuffix(value, `\`) {
+			value = strings.TrimRight(value, `\`)
 		}
 
 		s.header = append(s.header, ',')

--- a/plugins/serializers/influx/influx.go
+++ b/plugins/serializers/influx/influx.go
@@ -155,18 +155,18 @@ func (s *Serializer) buildHeader(m telegraf.Metric) error {
 		key := escape(tag.Key)
 		value := escape(tag.Value)
 
-		// Some keys and values are not encodeable as line protocol, such as
-		// those with a trailing '\' or empty strings.
-		if key == "" || value == "" {
-			continue
-		}
-
+		// Tag keys and values that end with a backslash cannot be encoded by
+		// line protocol.
 		if strings.HasSuffix(key, `\`) {
 			key = strings.TrimRight(key, `\`)
 		}
-
 		if strings.HasSuffix(value, `\`) {
 			value = strings.TrimRight(value, `\`)
+		}
+
+		// Tag keys and values must not be the empty string.
+		if key == "" || value == "" {
+			continue
 		}
 
 		s.header = append(s.header, ',')

--- a/plugins/serializers/influx/influx_test.go
+++ b/plugins/serializers/influx/influx_test.go
@@ -388,6 +388,38 @@ var tests = []struct {
 		output: []byte("disk,path=/ value=42i 0\n"),
 	},
 	{
+		name: "tag key backslash is trimmed and removed",
+		input: MustMetric(
+			metric.New(
+				"disk",
+				map[string]string{
+					`\`: "example.org",
+				},
+				map[string]interface{}{
+					"value": 42,
+				},
+				time.Unix(0, 0),
+			),
+		),
+		output: []byte("disk value=42i 0\n"),
+	},
+	{
+		name: "tag value backslash is trimmed and removed",
+		input: MustMetric(
+			metric.New(
+				"disk",
+				map[string]string{
+					"host": `\`,
+				},
+				map[string]interface{}{
+					"value": 42,
+				},
+				time.Unix(0, 0),
+			),
+		),
+		output: []byte("disk value=42i 0\n"),
+	},
+	{
 		name: "string newline",
 		input: MustMetric(
 			metric.New(

--- a/plugins/serializers/influx/influx_test.go
+++ b/plugins/serializers/influx/influx_test.go
@@ -324,6 +324,70 @@ var tests = []struct {
 		output: []byte("cpu,host=x\\ny value=42i 0\n"),
 	},
 	{
+		name: "empty tag value is removed",
+		input: MustMetric(
+			metric.New(
+				"cpu",
+				map[string]string{
+					"host": "",
+				},
+				map[string]interface{}{
+					"value": 42,
+				},
+				time.Unix(0, 0),
+			),
+		),
+		output: []byte("cpu value=42i 0\n"),
+	},
+	{
+		name: "empty tag key is removed",
+		input: MustMetric(
+			metric.New(
+				"cpu",
+				map[string]string{
+					"": "example.org",
+				},
+				map[string]interface{}{
+					"value": 42,
+				},
+				time.Unix(0, 0),
+			),
+		),
+		output: []byte("cpu value=42i 0\n"),
+	},
+	{
+		name: "tag value ends with backslash is trimmed",
+		input: MustMetric(
+			metric.New(
+				"disk",
+				map[string]string{
+					"path": `C:\`,
+				},
+				map[string]interface{}{
+					"value": 42,
+				},
+				time.Unix(0, 0),
+			),
+		),
+		output: []byte("disk,path=C: value=42i 0\n"),
+	},
+	{
+		name: "tag key ends with backslash is trimmed",
+		input: MustMetric(
+			metric.New(
+				"disk",
+				map[string]string{
+					`path\`: "/",
+				},
+				map[string]interface{}{
+					"value": 42,
+				},
+				time.Unix(0, 0),
+			),
+		),
+		output: []byte("disk,path=/ value=42i 0\n"),
+	},
+	{
 		name: "string newline",
 		input: MustMetric(
 			metric.New(


### PR DESCRIPTION
Currently a tag key or value with a trailing backslash will produce an error like:
```
 E! [outputs.influxdb] When writing to [http://localhost:8086]: received error unable to parse 'mem,host=loaner,path=C:\ free=3166146560i 1591645472000000000': invalid tag format; discarding points
```

With this change the trailing slashes are stripped.  Other methods were considered include using a space or a replacement char such as` _`.  I decided not to use a space since it might cause confusion when writing queries by hand and in the cli.  I decided against underscore because due to how ugly it is.

I know ideally we would have some form of https://github.com/influxdata/influxdb/issues/6037, but I believe this needs to be worked out separately from a fix for the current line protocol.

closes #7558

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
