### PR TITLE
Fix race issue in tick_test.go

### DIFF
--- a/agent/tick_test.go
+++ b/agent/tick_test.go
@@ -21,6 +21,7 @@ func TestAlignedTicker(t *testing.T) {
 	until := since.Add(60 * time.Second)
 
 	ticker := newAlignedTicker(since, interval, jitter, clock)
+	defer ticker.Stop()
 
 	expected := []time.Time{
 		time.Unix(10, 0).UTC(),
@@ -32,11 +33,12 @@ func TestAlignedTicker(t *testing.T) {
 	}
 
 	actual := []time.Time{}
+
+	clock.Add(10 * time.Second)
 	for !clock.Now().After(until) {
 		select {
 		case tm := <-ticker.Elapsed():
 			actual = append(actual, tm.UTC())
-		default:
 		}
 		clock.Add(10 * time.Second)
 	}
@@ -53,6 +55,7 @@ func TestAlignedTickerJitter(t *testing.T) {
 	until := since.Add(60 * time.Second)
 
 	ticker := newAlignedTicker(since, interval, jitter, clock)
+	defer ticker.Stop()
 
 	last := since
 	for !clock.Now().After(until) {
@@ -75,6 +78,7 @@ func TestAlignedTickerMissedTick(t *testing.T) {
 	since := clock.Now()
 
 	ticker := newAlignedTicker(since, interval, jitter, clock)
+	defer ticker.Stop()
 
 	clock.Add(25 * time.Second)
 	tm := <-ticker.Elapsed()
@@ -94,6 +98,7 @@ func TestUnalignedTicker(t *testing.T) {
 	until := since.Add(60 * time.Second)
 
 	ticker := newUnalignedTicker(interval, jitter, clock)
+	defer ticker.Stop()
 
 	expected := []time.Time{
 		time.Unix(1, 0).UTC(),
@@ -128,6 +133,7 @@ func TestRollingTicker(t *testing.T) {
 	until := since.Add(60 * time.Second)
 
 	ticker := newUnalignedTicker(interval, jitter, clock)
+	defer ticker.Stop()
 
 	expected := []time.Time{
 		time.Unix(1, 0).UTC(),
@@ -166,6 +172,7 @@ func TestAlignedTickerDistribution(t *testing.T) {
 	since := clock.Now()
 
 	ticker := newAlignedTicker(since, interval, jitter, clock)
+	defer ticker.Stop()
 	dist := simulatedDist(ticker, clock)
 	printDist(dist)
 	require.True(t, 350 < dist.Count)
@@ -185,6 +192,7 @@ func TestUnalignedTickerDistribution(t *testing.T) {
 	clock := clock.NewMock()
 
 	ticker := newUnalignedTicker(interval, jitter, clock)
+	defer ticker.Stop()
 	dist := simulatedDist(ticker, clock)
 	printDist(dist)
 	require.True(t, 350 < dist.Count)
@@ -204,6 +212,7 @@ func TestRollingTickerDistribution(t *testing.T) {
 	clock := clock.NewMock()
 
 	ticker := newRollingTicker(interval, jitter, clock)
+	defer ticker.Stop()
 	dist := simulatedDist(ticker, clock)
 	printDist(dist)
 	require.True(t, 275 < dist.Count)

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aristanetworks/goarista v0.0.0-20190325233358-a123909ec740
 	github.com/armon/go-metrics v0.3.0 // indirect
 	github.com/aws/aws-sdk-go v1.30.9
-	github.com/benbjohnson/clock v1.0.2
+	github.com/benbjohnson/clock v1.0.3
 	github.com/bitly/go-hostpool v0.1.0 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/caio/go-tdigest v2.3.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/armon/go-metrics v0.3.0 h1:B7AQgHi8QSEi4uHu7Sbsga+IJDU+CENgjxoo81vDUq
 github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD+gJD3GYs=
 github.com/aws/aws-sdk-go v1.30.9 h1:DntpBUKkchINPDbhEzDRin1eEn1TG9TZFlzWPf0i8to=
 github.com/aws/aws-sdk-go v1.30.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
-github.com/benbjohnson/clock v1.0.2 h1:Z0CN0Yb4ig9sGPXkvAQcGJfnrrMQ5QYLCMPRi9iD7YE=
-github.com/benbjohnson/clock v1.0.2/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
+github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
+github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=


### PR DESCRIPTION
Fix for test failure:
```
--- FAIL: TestAlignedTicker (0.04s)
    tick_test.go:44: 
        	Error Trace:	tick_test.go:44
        	Error:      	Not equal: 
        	            	expected: []time.Time{time.Time{wall:0x0, ext:62135596810, loc:(*time.Location)(nil)}, time.Time{wall:0x0, ext:62135596820, loc:(*time.Location)(nil)}, time.Time{wall:0x0, ext:62135596830, loc:(*time.Location)(nil)}, time.Time{wall:0x0, ext:62135596840, loc:(*time.Location)(nil)}, time.Time{wall:0x0, ext:62135596850, loc:(*time.Location)(nil)}, time.Time{wall:0x0, ext:62135596860, loc:(*time.Location)(nil)}}
        	            	actual  : []time.Time{time.Time{wall:0x0, ext:62135596810, loc:(*time.Location)(nil)}, time.Time{wall:0x0, ext:62135596820, loc:(*time.Location)(nil)}, time.Time{wall:0x0, ext:62135596830, loc:(*time.Location)(nil)}, time.Time{wall:0x0, ext:62135596840, loc:(*time.Location)(nil)}, time.Time{wall:0x0, ext:62135596850, loc:(*time.Location)(nil)}}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,2 @@
        	            	-([]time.Time) (len=6) {
        	            	+([]time.Time) (len=5) {
        	            	  (time.Time) 1970-01-01 00:00:10 +0000 UTC,
        	            	@@ -5,4 +5,3 @@
        	            	  (time.Time) 1970-01-01 00:00:40 +0000 UTC,
        	            	- (time.Time) 1970-01-01 00:00:50 +0000 UTC,
        	            	- (time.Time) 1970-01-01 00:01:00 +0000 UTC
        	            	+ (time.Time) 1970-01-01 00:00:50 +0000 UTC
        	            	 }
        	Test:       	TestAlignedTicker
FAIL
FAIL	github.com/influxdata/telegraf/agent	0.298s
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
