### PR TITLE
Chrony input: Implement "use_sudo" and "commands" options (#5425)

### DIFF
--- a/plugins/inputs/chrony/README.md
+++ b/plugins/inputs/chrony/README.md
@@ -58,11 +58,30 @@ Delete second or Not synchronised.
 [[inputs.chrony]]
   ## If true, chronyc tries to perform a DNS lookup for the time server.
   # dns_lookup = false
+
+  ## Run chronyc binary with sudo.
+  ## Required if chronyd cmdport is disabled, or when running the "serverstats" command.
+  ## Sudo must be configured to allow the telegraf user to run chronyc without a password.
+  ## That configuration may look something like:
+  ## telegraf ALL=(ALL:ALL) NOPASSWD:/usr/bin/chronyc
+  # use_sudo = false
+
+  ## Location of the chronyc binary, if not in PATH
+  # binary = "chronyc"
+
+  ## "tracking" is the default. Some commands with useful fields are "serverstats", "smoothing", "rtcdata", and "ntpdata".
+  ## To run "ntpdata" command for a specific source, append the Name or IP of the source after a space, eg. "ntpdata 10.1.2.3"
+  ## To run "ntpdata" command multiple times for different sources, use multiple instances of this input plugin to allow for adding different tags.
+  # commands = ["tracking"]
+
 ```
 
-### Measurements & Fields:
+### Measurements, Fields and Tags:
+
+If you modify the `commands` list you will return different fields and tags. Numeric values that can be parsed as float will become fields. All other values will be tags. When using the default command `tracking`, you will receive:
 
 - chrony
+  - Fields
     - system_time (float, seconds)
     - last_offset (float, seconds)
     - rms_offset (float, seconds)
@@ -72,10 +91,7 @@ Delete second or Not synchronised.
     - root_delay (float, seconds)
     - root_dispersion (float, seconds)
     - update_interval (float, seconds)
-
-### Tags:
-
-- All measurements have the following tags:
+  - Tags
     - reference_id
     - stratum
     - leap_status

--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -14,13 +14,23 @@ import (
 )
 
 var (
-	execCommand = exec.Command // execCommand is used to mock commands in tests.
+	// Used to mock commands in tests
+	execCommand  = exec.Command
+	execLookPath = exec.LookPath
 )
 
 type Chrony struct {
-	DNSLookup bool `toml:"dns_lookup"`
+	DNSLookup bool     `toml:"dns_lookup"`
+	UseSudo   bool     `toml:"use_sudo"`
+	Binary    string   `toml:"binary"`
+	Commands  []string `toml:"commands"`
+
 	path      string
+	arguments []string
 }
+
+var defaultBinary = "chronyc"
+var defaultCommands = []string{"tracking"}
 
 func (*Chrony) Description() string {
 	return "Get standard chrony metrics, requires chronyc executable."
@@ -30,26 +40,60 @@ func (*Chrony) SampleConfig() string {
 	return `
   ## If true, chronyc tries to perform a DNS lookup for the time server.
   # dns_lookup = false
+
+  ## Run chronyc binary with sudo.
+  ## Required if chronyd cmdport is disabled, or when running the "serverstats" command.
+  ## Sudo must be configured to allow the telegraf user to run chronyc without a password.
+  ## That configuration may look something like:
+  ## telegraf ALL=(ALL:ALL) NOPASSWD:/usr/bin/chronyc
+  # use_sudo = false
+
+  ## Location of the chronyc binary, if not in PATH
+  # binary = "chronyc"
+
+  ## "tracking" is the default. Some commands with useful fields are "serverstats", "smoothing", "rtcdata", and "ntpdata".
+  ## To run "ntpdata" command for a specific source, append the Name or IP of the source after a space, eg. "ntpdata 10.1.2.3"
+  ## To run "ntpdata" command multiple times for different sources, use multiple instances of this input plugin to allow for adding different tags.
+  # commands = ["tracking"]
   `
 }
 
 func (c *Chrony) Init() error {
 	var err error
-	c.path, err = exec.LookPath("chronyc")
+	c.path, err = execLookPath(c.Binary)
 	if err != nil {
-		return errors.New("chronyc not found: verify that chrony is installed and that chronyc is in your PATH")
+		return errors.New("chronyc binary not found: verify that chrony is installed and that chronyc is in your PATH, or that the binary option contains a valid path.")
 	}
+
+	if c.UseSudo {
+		// Change the exec path to the path to sudo, and add the path to chronyc as the first argument
+
+		c.arguments = append(c.arguments, c.path)
+
+		c.path, err = execLookPath("sudo")
+		if err != nil {
+			return errors.New("sudo not found: verify that sudo is installed and in your PATH")
+		}
+	}
+
+	// -m is required to pass multiple commands
+	c.arguments = append(c.arguments, "-m")
+
+	if !c.DNSLookup {
+		c.arguments = append(c.arguments, "-n")
+	}
+
+	if len(c.Commands) == 0 {
+		return errors.New("No commands specified - try the default [\"tracking\"]")
+	}
+
+	c.arguments = append(c.arguments, c.Commands...)
+
 	return nil
 }
 
 func (c *Chrony) Gather(acc telegraf.Accumulator) error {
-	flags := []string{}
-	if !c.DNSLookup {
-		flags = append(flags, "-n")
-	}
-	flags = append(flags, "tracking")
-
-	cmd := execCommand(c.path, flags...)
+	cmd := execCommand(c.path, c.arguments...)
 	out, err := internal.CombinedOutputTimeout(cmd, time.Second*5)
 	if err != nil {
 		return fmt.Errorf("failed to run command %s: %s - %s", strings.Join(cmd.Args, " "), err, string(out))
@@ -89,13 +133,17 @@ func processChronycOutput(out string) (map[string]interface{}, map[string]string
 	fields := map[string]interface{}{}
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	for _, line := range lines {
+		if len(strings.TrimSpace(line)) == 0 {
+			// When running multiple commands, there are sometimes empty lines between output
+			continue
+		}
 		stats := strings.Split(line, ":")
 		if len(stats) < 2 {
 			return nil, nil, fmt.Errorf("unexpected output from chronyc, expected ':' in %s", out)
 		}
 		name := strings.ToLower(strings.Replace(strings.TrimSpace(stats[0]), " ", "_", -1))
-		// ignore reference time
-		if strings.Contains(name, "ref_time") {
+		// ignore reference time - different keys for "tracking" vs "ntpdata" commands
+		if strings.Contains(name, "ref_time") || strings.Contains(name, "reference_time") {
 			continue
 		}
 		valueFields := strings.Fields(stats[1])
@@ -126,6 +174,9 @@ func processChronycOutput(out string) (map[string]interface{}, map[string]string
 
 func init() {
 	inputs.Add("chrony", func() telegraf.Input {
-		return &Chrony{}
+		return &Chrony{
+			Binary:   defaultBinary,
+			Commands: defaultCommands,
+		}
 	})
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

closes #5425 

Adds some new options to the `chrony` input plugin:

* `use_sudo` - allows running `chronyc` as root. Required if `chronyd` has `cmdport` disabled.
* `binary` - allows specifying a different path to the `chronyc` command.
* `commands` - allows specifying multiple `chronyc` commands.

```toml
# Get standard chrony metrics, requires chronyc executable.
[[inputs.chrony]]
  ## If true, chronyc tries to perform a DNS lookup for the time server.
  # dns_lookup = false

  ## Run chronyc binary with sudo.
  ## Required if chronyd cmdport is disabled, or when running the "serverstats" command.
  ## Sudo must be configured to allow the telegraf user to run chronyc without a password.
  ## That configuration may look something like:
  ## telegraf ALL=(ALL:ALL) NOPASSWD:/usr/bin/chronyc
  # use_sudo = false

  ## Location of the chronyc binary, if not in PATH
  # binary = "chronyc"

  ## "tracking" is the default. Some commands with useful fields are "serverstats", "smoothing", "rtcdata", and "ntpdata".
  ## To run "ntpdata" command for a specific source, append the Name or IP of the source after a space, eg. "ntpdata 10.1.2.3"
  ## To run "ntpdata" command multiple times for different sources, use multiple instances of this input plugin to allow for adding different tags.
  # commands = ["tracking"]
```