### PR TITLE
add support for SMTP server certificates over STARTTLS

### DIFF
--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -10,7 +10,7 @@ file or network connection.
 # Reads metrics from a SSL certificate
 [[inputs.x509_cert]]
   ## List certificate sources
-  sources = ["/etc/ssl/certs/ssl-cert-snakeoil.pem", "https://example.org:443"]
+  sources = ["/etc/ssl/certs/ssl-cert-snakeoil.pem", "https://example.org:443", "smtp+starttls://smtp.example.org:587"]
 
   ## Timeout for SSL connection
   # timeout = "5s"


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

closes https://github.com/influxdata/telegraf/issues/7679 .

I am not too familiar with the unit test structure for golang and telegraf. Additionally, I did not find a way to create an analogous test to that of the local TLS server.

Currently known limitations:
- slower execution for mail tarpits with slow replies like OpenBSD's spamd. Still works fine with the default timeout
- cannot define ehlo/helo values (similar situation prior to adding SNI support in this plugin)
  - could be incompatible with some SMTP server non-default configurations which may demand a specific EHLO parameter that is different than the FQDN. So far, compatible with outlook, google, servers I care for


