### PR TITLE
procstat speed improvement

### DIFF
--- a/plugins/inputs/procstat/native_finder.go
+++ b/plugins/inputs/procstat/native_finder.go
@@ -64,7 +64,7 @@ func (pg *NativeFinder) FullPattern(pattern string) ([]PID, error) {
 	if err != nil {
 		return pids, err
 	}
-	procs, err := process.Processes()
+	procs, err := pg.FastProcessList()
 	if err != nil {
 		return pids, err
 	}
@@ -80,4 +80,17 @@ func (pg *NativeFinder) FullPattern(pattern string) ([]PID, error) {
 		}
 	}
 	return pids, err
+}
+
+func (pg *NativeFinder) FastProcessList() ([]*process.Process, error) {
+	pids, err := process.Pids()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*process.Process, len(pids))
+	for i, pid := range pids {
+		result[i] = &process.Process{Pid: pid}
+	}
+	return result, nil
 }

--- a/plugins/inputs/procstat/native_finder_notwindows.go
+++ b/plugins/inputs/procstat/native_finder_notwindows.go
@@ -4,8 +4,6 @@ package procstat
 
 import (
 	"regexp"
-
-	"github.com/shirou/gopsutil/process"
 )
 
 //Pattern matches on the process name
@@ -15,7 +13,7 @@ func (pg *NativeFinder) Pattern(pattern string) ([]PID, error) {
 	if err != nil {
 		return pids, err
 	}
-	procs, err := process.Processes()
+	procs, err := pg.FastProcessList()
 	if err != nil {
 		return pids, err
 	}

--- a/plugins/inputs/procstat/native_finder_windows.go
+++ b/plugins/inputs/procstat/native_finder_windows.go
@@ -2,8 +2,6 @@ package procstat
 
 import (
 	"regexp"
-
-	"github.com/shirou/gopsutil/process"
 )
 
 // Pattern matches on the process name
@@ -13,7 +11,7 @@ func (pg *NativeFinder) Pattern(pattern string) ([]PID, error) {
 	if err != nil {
 		return pids, err
 	}
-	procs, err := process.Processes()
+	procs, err := pg.FastProcessList()
 	if err != nil {
 		return pids, err
 	}


### PR DESCRIPTION
darwin:
before
```
$ go test -short ./plugins/inputs/procstat/... -bench=. -benchmem
goos: darwin
goarch: amd64
pkg: github.com/influxdata/telegraf/plugins/inputs/procstat
BenchmarkPattern-12        	       1	1600582288 ns/op	 5874216 B/op	   48391 allocs/op
BenchmarkFullPattern-12    	       1	3620761444 ns/op	11612472 B/op	   86876 allocs/op
PASS
ok  	github.com/influxdata/telegraf/plugins/inputs/procstat	5.450s
```
after
```
$ go test -short ./plugins/inputs/procstat/... -bench=. -benchmem
goos: darwin
goarch: amd64
pkg: github.com/influxdata/telegraf/plugins/inputs/procstat
BenchmarkPattern-12        	      57	  25058656 ns/op	  309886 B/op	    2991 allocs/op
BenchmarkFullPattern-12    	       1	1798469106 ns/op	 6176720 B/op	   41895 allocs/op
PASS
ok  	github.com/influxdata/telegraf/plugins/inputs/procstat	3.466s
```