### PR TITLE
7692 - The processors are no more initialized

### DIFF
--- a/models/running_processor_test.go
+++ b/models/running_processor_test.go
@@ -28,6 +28,37 @@ func (p *MockProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	return p.ApplyF(in...)
 }
 
+// MockProcessorToInit is a Processor that needs to be initialized.
+type MockProcessorToInit struct {
+	HasBeenInit bool
+}
+
+func (p *MockProcessorToInit) SampleConfig() string {
+	return ""
+}
+
+func (p *MockProcessorToInit) Description() string {
+	return ""
+}
+
+func (p *MockProcessorToInit) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	return in
+}
+
+func (p *MockProcessorToInit) Init() error {
+	p.HasBeenInit = true
+	return nil
+}
+
+func TestRunningProcessor_Init(t *testing.T) {
+	mock := MockProcessorToInit{}
+	rp := &RunningProcessor{
+		Processor: processors.NewStreamingProcessorFromProcessor(&mock),
+	}
+	rp.Init()
+	require.True(t, mock.HasBeenInit)
+}
+
 // TagProcessor returns a Processor whose Apply function adds the tag and
 // value.
 func TagProcessor(key, value string) *MockProcessor {

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -91,7 +91,7 @@ This tag is used to expose network and plugin errors. HTTP errors are considered
 --------------------------|-------------------------|-----------|
 |success                  | 0                       |The HTTP request completed, even if the HTTP code represents an error|
 |response_string_mismatch | 1                       |The option `response_string_match` was used, and the body of the response didn't match the regex. HTTP errors with content in their body (like 4xx, 5xx) will trigger this error|
-|body_read_error          | 2                       |The option `response_string_match` was used, but the plugin wasn't able to read the body of the response. Responses with empty bodies (like 3xx, HEAD, etc) will trigger this error. Or the option `response_body_field` was used and the content of the response body was not a valid uft-8. Or the size of the body of the response exceeded the `response_body_max_size` |
+|body_read_error          | 2                       |The option `response_string_match` was used, but the plugin wasn't able to read the body of the response. Responses with empty bodies (like 3xx, HEAD, etc) will trigger this error. Or the option `response_body_field` was used and the content of the response body was not a valid utf-8. Or the size of the body of the response exceeded the `response_body_max_size` |
 |connection_failed        | 3                       |Catch all for any network error not specifically handled by the plugin|
 |timeout                  | 4                       |The plugin timed out while awaiting the HTTP connection to complete|
 |dns_error                | 5                       |There was a DNS error while attempting to connect to the host|

--- a/plugins/processors/streamingprocessor.go
+++ b/plugins/processors/streamingprocessor.go
@@ -41,6 +41,19 @@ func (sp *streamingProcessor) Stop() error {
 	return nil
 }
 
+// Make the streamingProcessor of type Initializer to be able
+// to call the Init method of the wrapped processor if
+// needed
+func (sp *streamingProcessor) Init() error {
+	if p, ok := sp.processor.(telegraf.Initializer); ok {
+		err := p.Init()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Unwrap lets you retrieve the original telegraf.Processor from the
 // StreamingProcessor. This is necessary because the toml Unmarshaller won't
 // look inside composed types.


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
