### PR TITLE
sensors: Handle error sentences from sensors

### DIFF
--- a/internal/exec.go
+++ b/internal/exec.go
@@ -20,6 +20,20 @@ func CombinedOutputTimeout(c *exec.Cmd, timeout time.Duration) ([]byte, error) {
 	return b.Bytes(), err
 }
 
+// StdOutputTimeout runs the given command with the given timeout and
+// returns the output of stdout.
+// If the command times out, it attempts to kill the process.
+func StdOutputTimeout(c *exec.Cmd, timeout time.Duration) ([]byte, error) {
+	var b bytes.Buffer
+	c.Stdout = &b
+	c.Stderr = nil
+	if err := c.Start(); err != nil {
+		return nil, err
+	}
+	err := WaitTimeout(c, timeout)
+	return b.Bytes(), err
+}
+
 // RunTimeout runs the given command with the given timeout.
 // If the command times out, it attempts to kill the process.
 func RunTimeout(c *exec.Cmd, timeout time.Duration) error {

--- a/plugins/inputs/sensors/sensors.go
+++ b/plugins/inputs/sensors/sensors.go
@@ -60,7 +60,7 @@ func (s *Sensors) parse(acc telegraf.Accumulator) error {
 	fields := map[string]interface{}{}
 	chip := ""
 	cmd := execCommand(s.path, "-A", "-u")
-	out, err := internal.CombinedOutputTimeout(cmd, s.Timeout.Duration)
+	out, err := internal.StdOutputTimeout(cmd, s.Timeout.Duration)
 	if err != nil {
 		return fmt.Errorf("failed to run command %s: %s - %s", strings.Join(cmd.Args, " "), err, string(out))
 	}


### PR DESCRIPTION
Amdgpu drivers produces an output that cannot be handled by sensors:

root@qt5222:~# sensors -A -u
amdgpu-pci-0300
vddgfx:
ERROR: Can't get value of subfeature in0_input: Can't read
vddnb:
ERROR: Can't get value of subfeature in1_input: Can't read
edge:
  temp1_input: 40.000
  temp1_crit: 80.000
  temp1_crit_hyst: 0.000

00000400100-mdio-4
temp1:
  temp1_input: 59.000
  temp1_crit: 100.000
  temp1_max_alarm: 0.000

This results in an invalid parsing of its ouput. Eg:

> sensors,chip=ERROR:\ Can't\ get\ value\ of\ subfeature\ in0_input:\ Can't\ read,feature=isl_curr_soc,host=qt5222,serial=${SERIAL_NUMBER} curr_input=1.6 1592920794000000000

The invalid parsing is due to the different buffer size of stdout and
stderr. Which results on stderr output out of sync with stdout.

Since we do not need the output of stderr, simply ignore it.

Signed-off-by: Ricardo Ribalda <ricardo@ribalda.com>

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
