### PR TITLE
Add the ability to control MaxProcessingTime on Sarama lib

### DIFF
--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -65,6 +65,15 @@ and use the old zookeeper connection method.
   ## waiting until the next flush_interval.
   # max_undelivered_messages = 1000
 
+  ## The maximum amount of time the consumer expects a message takes to
+  ## process for the user. If writing to the Messages channel takes longer
+  ## than this, that partition will stop fetching more messages until it
+  ## can proceed again.
+  ##
+  ## Note that, since the Messages channel is buffered, the actual grace time is
+  ## (MaxProcessingTime * ChannelBufferSize). Defaults - MaxProcessingTime: 100ms, ChannelBufferSize: 256.
+  # max_processing_time = 100
+
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -155,6 +155,14 @@ func TestInit(t *testing.T) {
 				require.True(t, plugin.config.Net.TLS.Enable)
 			},
 		},
+		{
+			name: "negative MaxProcessingTime",
+			plugin: &KafkaConsumer{
+				MaxProcessingTime: -1,
+				Log:               testutil.Logger{},
+			},
+			initError: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Hi :smile:
This PR adds the ability to control MaxProcessingTime on the [Sarama](https://github.com/Shopify/sarama/blob/master/config.go#L325) lib.

We reached to this solution after this https://github.com/influxdata/telegraf/issues/7622 issue, where we wanted to slightly increased it, but anyway I think that it could be nice to allow the users to control it if he wants to.

I've updated the README files and wrote unit tests, but I didn't cover a scenario where a user set this parameter as a `string` (same goes to other `int` parameters that already exist before - let me know if you want me add it). Anyway, the error that a user gets while setting it as `string` is decent and understandable.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.


Thanks :pray: 