### PR TITLE
Fix data race in kafka_consumer_test.go

### DIFF
--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -289,7 +289,7 @@ func TestConsumerGroupHandler_ConsumeClaim(t *testing.T) {
 	}
 
 	go func() {
-		err = cg.ConsumeClaim(session, claim)
+		err := cg.ConsumeClaim(session, claim)
 		require.NoError(t, err)
 	}()
 


### PR DESCRIPTION
Data race when assigning to `err` variable.

related: #7729

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
