### PR TITLE
Allow histograms with no buckets and summary without quantiles

### DIFF
--- a/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
@@ -51,6 +51,34 @@ cpu_time_idle{host="example.org"} 42
 `),
 		},
 		{
+			name: "summary no quantiles",
+			output: &PrometheusClient{
+				Listen:            ":0",
+				MetricVersion:     2,
+				CollectorsExclude: []string{"gocollector", "process"},
+				Path:              "/metrics",
+				Log:               Logger,
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"prometheus",
+					map[string]string{},
+					map[string]interface{}{
+						"rpc_duration_seconds_sum":   1.7560473e+07,
+						"rpc_duration_seconds_count": 2693,
+					},
+					time.Unix(0, 0),
+					telegraf.Summary,
+				),
+			},
+			expected: []byte(`
+# HELP rpc_duration_seconds Telegraf collected metric
+# TYPE rpc_duration_seconds summary
+rpc_duration_seconds_sum 1.7560473e+07
+rpc_duration_seconds_count 2693
+`),
+		},
+		{
 			name: "when export timestamp is true timestamp is present in the metric",
 			output: &PrometheusClient{
 				Listen:            ":0",
@@ -236,6 +264,37 @@ cpu_time_idle{host="example.org"} 42
 cpu_usage_idle_bucket{cpu="cpu1",le="0"} 0
 cpu_usage_idle_bucket{cpu="cpu1",le="50"} 7
 cpu_usage_idle_bucket{cpu="cpu1",le="100"} 20
+cpu_usage_idle_bucket{cpu="cpu1",le="+Inf"} 20
+cpu_usage_idle_sum{cpu="cpu1"} 2000
+cpu_usage_idle_count{cpu="cpu1"} 20
+`),
+		},
+		{
+			name: "histogram no buckets",
+			output: &PrometheusClient{
+				Listen:            ":0",
+				MetricVersion:     2,
+				CollectorsExclude: []string{"gocollector", "process"},
+				Path:              "/metrics",
+				Log:               Logger,
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{
+						"cpu": "cpu1",
+					},
+					map[string]interface{}{
+						"usage_idle_sum":   2000.0,
+						"usage_idle_count": 20.0,
+					},
+					time.Unix(0, 0),
+					telegraf.Histogram,
+				),
+			},
+			expected: []byte(`
+# HELP cpu_usage_idle Telegraf collected metric
+# TYPE cpu_usage_idle histogram
 cpu_usage_idle_bucket{cpu="cpu1",le="+Inf"} 20
 cpu_usage_idle_sum{cpu="cpu1"} 2000
 cpu_usage_idle_count{cpu="cpu1"} 20

--- a/plugins/serializers/prometheus/collection.go
+++ b/plugins/serializers/prometheus/collection.go
@@ -446,10 +446,6 @@ func (c *Collection) GetProto() []*dto.MetricFamily {
 					})
 				}
 
-				if len(buckets) == 0 {
-					continue
-				}
-
 				m.Histogram = &dto.Histogram{
 					Bucket:      buckets,
 					SampleCount: proto.Uint64(metric.Histogram.Count),
@@ -462,10 +458,6 @@ func (c *Collection) GetProto() []*dto.MetricFamily {
 						Quantile: proto.Float64(quantile.Quantile),
 						Value:    proto.Float64(quantile.Value),
 					})
-				}
-
-				if len(quantiles) == 0 {
-					continue
 				}
 
 				m.Summary = &dto.Summary{

--- a/plugins/serializers/prometheus/prometheus_test.go
+++ b/plugins/serializers/prometheus/prometheus_test.go
@@ -108,6 +108,11 @@ http_requests_total{code="400",method="post"} 3
 				telegraf.Histogram,
 			),
 			expected: []byte(`
+# HELP http_request_duration_seconds Telegraf collected metric
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{le="+Inf"} 144320
+http_request_duration_seconds_sum 53423
+http_request_duration_seconds_count 144320
 `),
 		},
 		{
@@ -645,6 +650,27 @@ cpu_time_user{cpu="cpu0"} 92904.33
 cpu_time_user{cpu="cpu1"} 96912.57
 cpu_time_user{cpu="cpu2"} 96034.08
 cpu_time_user{cpu="cpu3"} 94148
+`),
+		},
+		{
+			name: "summary with no quantile",
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"prometheus",
+					map[string]string{},
+					map[string]interface{}{
+						"rpc_duration_seconds_sum":   1.7560473e+07,
+						"rpc_duration_seconds_count": 2693,
+					},
+					time.Unix(0, 0),
+					telegraf.Summary,
+				),
+			},
+			expected: []byte(`
+# HELP rpc_duration_seconds Telegraf collected metric
+# TYPE rpc_duration_seconds summary
+rpc_duration_seconds_sum 1.7560473e+07
+rpc_duration_seconds_count 2693
 `),
 		},
 	}


### PR DESCRIPTION
I don't remember why I disallowed this originally, but it doesn't seem to be a requirement to have quantiles for a summary or buckets for a histogram.

closes: #7705

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
