### PR TITLE
Fix data race in plugins/inputs/suricata/suricata_test.go

### DIFF
--- a/plugins/inputs/suricata/suricata_test.go
+++ b/plugins/inputs/suricata/suricata_test.go
@@ -74,14 +74,6 @@ func TestSuricata(t *testing.T) {
 
 	acc.Wait(1)
 
-	s = Suricata{
-		Source:    tmpfn,
-		Delimiter: ".",
-		Log: testutil.Logger{
-			Name: "inputs.suricata",
-		},
-	}
-
 	expected := []telegraf.Metric{
 		testutil.MustMetric(
 			"suricata",


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.

Relates to issue #7729 - fixes data race in input plugin suricata tests'.

```
go test -short -race ./plugins/inputs/suricata/...
```

Before:
```log
==================
WARNING: DATA RACE
Write at 0x00c0000b4020 by goroutine 18:
  github.com/influxdata/telegraf/plugins/inputs/suricata.TestSuricata()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/suricata/suricata_test.go:77 +0x68d
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb

Previous read at 0x00c0000b4020 by goroutine 20:
  github.com/influxdata/telegraf/plugins/inputs/suricata.(*Suricata).handleServerConnection()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/suricata/suricata.go:116 +0x6e

Goroutine 18 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:60 +0x223

Goroutine 20 (running) created at:
  github.com/influxdata/telegraf/plugins/inputs/suricata.(*Suricata).Start.func1()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/suricata/suricata.go:76 +0xd4
==================
--- FAIL: TestSuricata (0.00s)
    testing.go:906: race detected during execution of test
FAIL
FAIL	github.com/influxdata/telegraf/plugins/inputs/suricata	0.810s
FAIL
```

After:

```
ok  	github.com/influxdata/telegraf/plugins/inputs/suricata
```