### PR TITLE
Docker log track message offset

### DIFF
--- a/plugins/inputs/docker_log/README.md
+++ b/plugins/inputs/docker_log/README.md
@@ -45,6 +45,17 @@ The docker plugin uses the [Official Docker Client][] to gather logs from the
 
   ## Set the source tag for the metrics to the container ID hostname, eg first 12 chars
   source_tag = false
+  
+## Offset flush interval. How often the offset pointer (see below) in the
+  ## container log stream is flashed to file. Offset pointer represents the unix time stamp
+  ## in nano seconds for the last message read from log stream (default - 3 sec)
+  # offset_flush = "3s"
+
+  ## Offset storage path, make sure the user on behalf 
+  ## of which the telegraf is running has enough rights to read and write to chosen path.
+  ## default value is (cross-platform): "$HOME/telegraf" with fallback to 
+  ## "$OS_TEMP/telegraf", if user can't be detected.
+  # offset_storage_path = "/var/run/telegraf"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -7,6 +7,12 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/user"
+	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -54,6 +60,17 @@ var sampleConfig = `
   ## Set the source tag for the metrics to the container ID hostname, eg first 12 chars
   source_tag = false
 
+  ## Offset flush interval. How often the offset pointer (see below) in the
+  ## container log stream is flashed to file. Offset pointer represents the unix time stamp
+  ## in nano seconds for the last message read from log stream (default - 3 sec)
+  # offset_flush = "3s"
+
+  ## Offset storage path, make sure the user on behalf 
+  ## of which the telegraf is running has enough rights to read and write to chosen path.
+  ## default value is (cross-platform): "$HOME/telegraf" with fallback to 
+  ## "$OS_TEMP/telegraf", if user can't be detected.
+  # offset_storage_path = "/var/run/telegraf"
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
@@ -88,6 +105,8 @@ type DockerLogs struct {
 	ContainerStateInclude []string          `toml:"container_state_include"`
 	ContainerStateExclude []string          `toml:"container_state_exclude"`
 	IncludeSourceTag      bool              `toml:"source_tag"`
+	OffsetFlush           internal.Duration `toml:"offset_flush"`
+	OffsetStoragePath     string            `toml:"offset_storage_path"`
 
 	tlsint.ClientConfig
 
@@ -102,6 +121,13 @@ type DockerLogs struct {
 	wg              sync.WaitGroup
 	mu              sync.Mutex
 	containerList   map[string]context.CancelFunc
+	offsetChan      chan offsetData
+	wgOffsetFlusher sync.WaitGroup
+}
+
+type offsetData struct {
+	contID string
+	offset int64
 }
 
 func (d *DockerLogs) Description() string {
@@ -114,6 +140,8 @@ func (d *DockerLogs) SampleConfig() string {
 
 func (d *DockerLogs) Init() error {
 	var err error
+	var src os.FileInfo
+
 	if d.Endpoint == "ENV" {
 		d.client, err = d.newEnvClient()
 		if err != nil {
@@ -156,6 +184,33 @@ func (d *DockerLogs) Init() error {
 			Filters: filterArgs,
 		}
 	}
+
+	//Get default storage path
+	if d.OffsetStoragePath == "" {
+		user, err := user.Current()
+		if err != nil {
+			d.OffsetStoragePath = path.Join(os.TempDir(), "telegraf")
+		} else {
+			d.OffsetStoragePath = path.Join(user.HomeDir, "telegraf")
+		}
+		log.Printf("W! Offset storage path set to: %q", d.OffsetStoragePath)
+	}
+	//Create storage path
+	src, err = os.Stat(d.OffsetStoragePath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(d.OffsetStoragePath, 0777); err != nil {
+			return fmt.Errorf("can't create path '%s' to store offset: %s", d.OffsetStoragePath, err.Error())
+		}
+	} else if src != nil && src.Mode().IsRegular() {
+		return fmt.Errorf("'%s' already exists as a file!", d.OffsetStoragePath)
+	}
+
+	//Start offset flusher
+	d.wgOffsetFlusher.Add(1)
+	go d.flushOffset()
 
 	return nil
 }
@@ -281,9 +336,15 @@ func (d *DockerLogs) tailContainerLogs(
 		return err
 	}
 
-	tail := "0"
-	if d.FromBeginning {
-		tail = "all"
+	//Detecting offset
+	tailLogsSince, initialOffset := d.loadOffsetFormFs(container.ID)
+
+	if tailLogsSince != "" && d.FromBeginning { // If there is an offset, then it means that we already deliver logs until the offset
+		//In this case we can ignore 'fromBeginning' ,and continue from the offset
+		log.Printf("D! [inputs.docker_log] Container '%s', 'from_beginning' option ignored, since there is an offset: %s", hostnameFromID(container.ID), tailLogsSince)
+
+	} else if tailLogsSince == "" && !d.FromBeginning { //No offset and not from beginning, means that we ship logs since now.
+		tailLogsSince = time.Now().UTC().Format(time.RFC3339Nano)
 	}
 
 	logOptions := types.ContainerLogsOptions{
@@ -292,7 +353,7 @@ func (d *DockerLogs) tailContainerLogs(
 		Timestamps: true,
 		Details:    false,
 		Follow:     true,
-		Tail:       tail,
+		Since:      tailLogsSince,
 	}
 
 	logReader, err := d.client.ContainerLogs(ctx, container.ID, logOptions)
@@ -307,9 +368,9 @@ func (d *DockerLogs) tailContainerLogs(
 	// If the container is *not* using a TTY, streams for stdout and stderr are
 	// multiplexed.
 	if hasTTY {
-		return tailStream(acc, tags, container.ID, logReader, "tty")
+		return tailStream(acc, tags, container.ID, logReader, "tty", d.offsetChan, initialOffset)
 	} else {
-		return tailMultiplexed(acc, tags, container.ID, logReader)
+		return tailMultiplexed(acc, tags, container.ID, logReader, d.offsetChan, initialOffset)
 	}
 }
 
@@ -343,8 +404,19 @@ func tailStream(
 	containerID string,
 	reader io.ReadCloser,
 	stream string,
+	offsetChan chan<- offsetData,
+	initialOffset int64,
 ) error {
-	defer reader.Close()
+
+	messageOffset := initialOffset
+
+	defer func() {
+		reader.Close()
+		//Sending last offset to flusher in a blocking manner
+		if messageOffset != initialOffset {
+			offsetChan <- offsetData{containerID, messageOffset}
+		}
+	}()
 
 	tags := make(map[string]string, len(baseTags)+1)
 	for k, v := range baseTags {
@@ -366,6 +438,14 @@ func tailStream(
 					"container_id": containerID,
 					"message":      message,
 				}, tags, ts)
+
+				messageOffset = ts.UTC().UnixNano() + 1 //+1 (ns) here prevents to include current message
+
+				//Send offset to flusher (in a non blocking manner)
+				select {
+				case offsetChan <- offsetData{containerID, messageOffset}:
+				default:
+				}
 			}
 		}
 
@@ -383,6 +463,8 @@ func tailMultiplexed(
 	tags map[string]string,
 	containerID string,
 	src io.ReadCloser,
+	offsetChan chan<- offsetData,
+	initialOffset int64,
 ) error {
 	outReader, outWriter := io.Pipe()
 	errReader, errWriter := io.Pipe()
@@ -391,7 +473,7 @@ func tailMultiplexed(
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := tailStream(acc, tags, containerID, outReader, "stdout")
+		err := tailStream(acc, tags, containerID, outReader, "stdout", offsetChan, initialOffset)
 		if err != nil {
 			acc.AddError(err)
 		}
@@ -400,7 +482,7 @@ func tailMultiplexed(
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := tailStream(acc, tags, containerID, errReader, "stderr")
+		err := tailStream(acc, tags, containerID, errReader, "stderr", offsetChan, initialOffset)
 		if err != nil {
 			acc.AddError(err)
 		}
@@ -414,6 +496,69 @@ func tailMultiplexed(
 	return err
 }
 
+func (d *DockerLogs) flushOffsetToFs(contID string, offset int64) error {
+	fileName := path.Join(d.OffsetStoragePath, contID)
+	offsetByte := []byte(strconv.FormatInt(offset, 10))
+	err := ioutil.WriteFile(fileName, offsetByte, 0777)
+	if err != nil {
+		log.Printf("D! [inputs.docker_log] Can't write message offset to file %q: %v", fileName, err)
+	}
+	return err
+}
+func (d *DockerLogs) loadOffsetFormFs(contID string) (offsetString string, offsetInt int64) {
+	var (
+		err  error
+		data []byte
+	)
+	fileName := path.Join(d.OffsetStoragePath, contID)
+
+	if _, err = os.Stat(fileName); !os.IsNotExist(err) {
+		data, err = ioutil.ReadFile(fileName)
+		if err != nil {
+			log.Printf("E! [inputs.docker_log] Can't read message offset from file %q: %v", fileName, err)
+			return "", 0
+		}
+
+		offsetInt, err = strconv.ParseInt(string(data), 10, 64)
+		if err != nil {
+			log.Printf("E! [inputs.docker_log] Can't parse integer from offset file %q content %q: %v", fileName, string(data), err)
+			return "", 0
+		}
+		offsetString = time.Unix(0, offsetInt).UTC().Format(time.RFC3339Nano)
+
+		//log.Printf("D! [inputs.docker_log] Parsed offset from '%s'\nvalue: %s, %s",
+		//	fileName, string(data), offsetString)
+		return offsetString, offsetInt
+	}
+	return "", 0
+}
+
+func (d *DockerLogs) flushOffset() {
+	var containerOffsets = map[string]int64{}
+	var ticker = time.NewTicker(d.OffsetFlush.Duration)
+
+	defer ticker.Stop()
+	defer d.wgOffsetFlusher.Done()
+
+	for offset := range d.offsetChan {
+		containerOffsets[offset.contID] = offset.offset
+		select {
+		case <-ticker.C:
+			//flushing to filesystem
+			for contID, offsetInt := range containerOffsets {
+				if d.flushOffsetToFs(contID, offsetInt) == nil {
+					delete(containerOffsets, contID)
+				}
+			}
+		default:
+		}
+	}
+	//Check if there is smth. that is not flushed:
+	for contID, offsetInt := range containerOffsets {
+		d.flushOffsetToFs(contID, offsetInt)
+	}
+}
+
 // Start is a noop which is required for a *DockerLogs to implement
 // the telegraf.ServiceInput interface
 func (d *DockerLogs) Start(telegraf.Accumulator) error {
@@ -423,6 +568,10 @@ func (d *DockerLogs) Start(telegraf.Accumulator) error {
 func (d *DockerLogs) Stop() {
 	d.cancelTails()
 	d.wg.Wait()
+
+	//Stop offset flushing
+	close(d.offsetChan)
+	d.wgOffsetFlusher.Wait()
 }
 
 // Following few functions have been inherited from telegraf docker input plugin
@@ -464,6 +613,8 @@ func init() {
 			newEnvClient:  NewEnvClient,
 			newClient:     NewClient,
 			containerList: make(map[string]context.CancelFunc),
+			offsetChan:    make(chan offsetData),
+			OffsetFlush:   internal.Duration{Duration: 3 * time.Second},
 		}
 	})
 }

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -1,10 +1,13 @@
 package docker_log
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/tls"
 	"io"
+	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -165,14 +168,23 @@ func Test(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var acc testutil.Accumulator
 			plugin := &DockerLogs{
-				Timeout:          internal.Duration{Duration: time.Second * 5},
-				newClient:        func(string, *tls.Config) (Client, error) { return tt.client, nil },
-				containerList:    make(map[string]context.CancelFunc),
-				IncludeSourceTag: true,
+				Timeout:           internal.Duration{Duration: time.Second * 5},
+				newClient:         func(string, *tls.Config) (Client, error) { return tt.client, nil },
+				containerList:     make(map[string]context.CancelFunc),
+				IncludeSourceTag:  true,
+				OffsetStoragePath: ".",
+				OffsetFlush:       internal.Duration{Duration: 1 * time.Second},
+				offsetChan:        make(chan offsetData),
 			}
 
 			err := plugin.Init()
 			require.NoError(t, err)
+
+			//Remove offset files
+			containers, _ := tt.client.ContainerListF(nil, types.ContainerListOptions{})
+			for _, cont := range containers {
+				os.RemoveAll(path.Join(plugin.OffsetStoragePath, cont.ID))
+			}
 
 			err = plugin.Gather(&acc)
 			require.NoError(t, err)
@@ -183,6 +195,210 @@ func Test(t *testing.T) {
 			require.Nil(t, acc.Errors) // no errors during gathering
 
 			testutil.RequireMetricsEqual(t, tt.expected, acc.GetTelegrafMetrics())
+
+			//Remove offset files
+			for _, cont := range containers {
+				os.RemoveAll(path.Join(plugin.OffsetStoragePath, cont.ID))
+			}
 		})
 	}
+}
+
+func TestResumeFromOffset(t *testing.T) {
+	client := &MockClient{
+		ContainerListF: func(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+			return []types.Container{
+				{
+					ID:    "badcafe",
+					Names: []string{"/telegraf"},
+					Image: "influxdata/telegraf:1.11.0",
+				},
+			}, nil
+		},
+		ContainerInspectF: func(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+			return types.ContainerJSON{
+				Config: &container.Config{
+					Tty: true,
+				},
+			}, nil
+		},
+		ContainerLogsF: func(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+			data := []byte("2020-04-28T18:43:16.000000000Z message 1\n2020-04-28T18:43:17.000000000Z message 2")
+			returnedData := make([]byte, 0, len(data))
+			s := bufio.NewScanner(bytes.NewReader(data))
+			for s.Scan() {
+				parts := bytes.SplitN(s.Bytes(), []byte(" "), 2)
+				ts := MustParse(time.RFC3339Nano, string(parts[0]))
+				if ts.After(MustParse(time.RFC3339Nano, options.Since)) {
+					returnedData = append(returnedData, s.Bytes()...)
+					returnedData = append(returnedData, byte('\n'))
+				}
+			}
+
+			return &Response{Reader: bytes.NewBuffer(returnedData)}, nil
+		},
+	}
+	metrics := []telegraf.Metric{
+		testutil.MustMetric(
+			"docker_log",
+			map[string]string{
+				"container_name":    "telegraf",
+				"container_image":   "influxdata/telegraf",
+				"container_version": "1.11.0",
+				"stream":            "tty",
+				"source":            "badcafe",
+			},
+			map[string]interface{}{
+				"container_id": "badcafe",
+				"message":      "message 1",
+			},
+			MustParse(time.RFC3339Nano, "2020-04-28T18:43:16.000000000Z"),
+		),
+		testutil.MustMetric(
+			"docker_log",
+			map[string]string{
+				"container_name":    "telegraf",
+				"container_image":   "influxdata/telegraf",
+				"container_version": "1.11.0",
+				"stream":            "tty",
+				"source":            "badcafe",
+			},
+			map[string]interface{}{
+				"container_id": "badcafe",
+				"message":      "message 2",
+			},
+			MustParse(time.RFC3339Nano, "2020-04-28T18:43:17.000000000Z"),
+		),
+	}
+	acc := testutil.Accumulator{}
+
+	plugin := &DockerLogs{
+		Timeout:           internal.Duration{Duration: time.Second * 5},
+		newClient:         func(string, *tls.Config) (Client, error) { return client, nil },
+		containerList:     make(map[string]context.CancelFunc),
+		IncludeSourceTag:  true,
+		OffsetStoragePath: ".",
+		OffsetFlush:       internal.Duration{Duration: 1 * time.Second},
+		offsetChan:        make(chan offsetData),
+	}
+
+	cont, _ := client.ContainerListF(nil, types.ContainerListOptions{})
+
+	err := plugin.Init()
+	require.NoError(t, err)
+
+	os.RemoveAll(path.Join(plugin.OffsetStoragePath, cont[0].ID))
+	//Create offset file
+	plugin.flushOffsetToFs(cont[0].ID, metrics[0].Time().UnixNano()+1)
+
+	err = plugin.Gather(&acc)
+	require.NoError(t, err)
+
+	acc.Wait(len(metrics) - 1) //Should be 1 metric only
+	plugin.Stop()
+
+	require.Nil(t, acc.Errors) // no errors during gathering
+	//First metric should be filtered based on time-stamp
+	testutil.RequireMetricsEqual(t, []telegraf.Metric{metrics[1]}, acc.GetTelegrafMetrics())
+
+	//Examine offset file
+	_, tsUnix := plugin.loadOffsetFormFs(cont[0].ID)
+
+	//in the offset file it should be last message timestamp +1 ns
+	require.Equal(t, tsUnix, metrics[1].Time().UnixNano()+1)
+
+	//Remove offset file
+	os.RemoveAll(path.Join(plugin.OffsetStoragePath, cont[0].ID))
+}
+
+func TestDeliverAllMessageNoOffset(t *testing.T) {
+	client := &MockClient{
+		ContainerListF: func(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+			return []types.Container{
+				{
+					ID:    "badf00d",
+					Names: []string{"/telegraf"},
+					Image: "influxdata/telegraf:1.11.0",
+				},
+			}, nil
+		},
+		ContainerInspectF: func(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+			return types.ContainerJSON{
+				Config: &container.Config{
+					Tty: true,
+				},
+			}, nil
+		},
+		ContainerLogsF: func(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+			return &Response{Reader: bytes.NewBuffer([]byte("2020-04-28T18:43:16.000000000Z message 1\n2020-04-28T18:43:17.000000000Z message 2"))}, nil
+		},
+	}
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"docker_log",
+			map[string]string{
+				"container_name":    "telegraf",
+				"container_image":   "influxdata/telegraf",
+				"container_version": "1.11.0",
+				"stream":            "tty",
+				"source":            "badf00d",
+			},
+			map[string]interface{}{
+				"container_id": "badf00d",
+				"message":      "message 1",
+			},
+			MustParse(time.RFC3339Nano, "2020-04-28T18:43:16.000000000Z"),
+		),
+		testutil.MustMetric(
+			"docker_log",
+			map[string]string{
+				"container_name":    "telegraf",
+				"container_image":   "influxdata/telegraf",
+				"container_version": "1.11.0",
+				"stream":            "tty",
+				"source":            "badf00d",
+			},
+			map[string]interface{}{
+				"container_id": "badf00d",
+				"message":      "message 2",
+			},
+			MustParse(time.RFC3339Nano, "2020-04-28T18:43:17.000000000Z"),
+		),
+	}
+	acc := testutil.Accumulator{}
+
+	plugin := &DockerLogs{
+		Timeout:          internal.Duration{Duration: time.Second * 5},
+		newClient:        func(string, *tls.Config) (Client, error) { return client, nil },
+		containerList:    make(map[string]context.CancelFunc),
+		IncludeSourceTag: true,
+		FromBeginning:    true,
+		OffsetFlush:      internal.Duration{Duration: 10 * time.Second},
+		offsetChan:       make(chan offsetData),
+	}
+
+	err := plugin.Init()
+	require.NoError(t, err)
+
+	cont, _ := client.ContainerListF(nil, types.ContainerListOptions{})
+	os.RemoveAll(path.Join(plugin.OffsetStoragePath, cont[0].ID))
+
+	err = plugin.Gather(&acc)
+	require.NoError(t, err)
+
+	acc.Wait(len(expected))
+	plugin.Stop()
+
+	require.Nil(t, acc.Errors) // no errors during gathering
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics()) //2 metrics delivered
+
+	//Examine offset file
+	_, tsUnix := plugin.loadOffsetFormFs(expected[0].Tags()["source"])
+
+	//in the offset file it should be last message timestamp +1 ns
+	require.Equal(t, tsUnix, expected[len(expected)-1].Time().UnixNano()+1)
+
+	//Remove offset files
+	os.RemoveAll(path.Join(plugin.OffsetStoragePath, cont[0].ID))
 }

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
-	"github.com/influxdata/telegraf/internal/tls"
+	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.

This PR comes from #7068, as discussed with @danielnelson, we agreed to split #7068 to smaller parts. This the second part - track message timestamps. This allows to resume from particular message, and prevent delivering messages that already delivered. This feature inspired by fluentd.