### PR TITLE
SNMP input plugin: Fixed SNMPv3 encryption and authentication

### DIFF
--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -664,13 +664,12 @@ func (s *Snmp) getConnection(idx int) (snmpConnection, error) {
 	}
 
 	gs.MaxRepetitions = s.MaxRepetitions
-
 	if s.Version == 3 {
-		gs.ContextName = s.ContextName
+		gs.GoSNMP.ContextName = s.ContextName
 
 		sp := &gosnmp.UsmSecurityParameters{}
-		gs.SecurityParameters = sp
-		gs.SecurityModel = gosnmp.UserSecurityModel
+		gs.GoSNMP.SecurityParameters = sp
+		gs.GoSNMP.SecurityModel = gosnmp.UserSecurityModel
 
 		switch strings.ToLower(s.SecLevel) {
 		case "noauthnopriv", "":


### PR DESCRIPTION
This PR fixes SNMP plugin's SNMPv3 authentication and encryption. Previously the parameters were set incorrectly, hence the requests were not using USM properly. Therefore, the requests were unencrypted and garbage values were observed as seen  in #7746 

This PR passes all the existing tests, however, in my opinion the SNMP-plugin would benefit from better unit tests.
I've used snmplabs' testing service: http://snmplabs.com/snmp-simulation-service.html#snmpv3-usm

Closes #7746 
Using invalid auth or priv password yields an error:
```
[[inputs.snmp]]
agents = [ "demo.snmplabs.com:1161" ]
interval = "5s"
timeout = "5s"
retries = 3
version = 3
sec_name = "usr-md5-none"
auth_protocol = "MD5"
auth_password = "invalid"
sec_level = "authNoPriv"
 
  [[inputs.snmp.field]]
    name = "hostname"
    oid = ".1.3.6.1.2.1.1.5.0"
    is_tag = true
 
  [[inputs.snmp.field]]
    name = "uptime"
    oid = "1.3.6.1.2.1.1.3.0"
 
  [[inputs.snmp.field]]
    name = "cpmCPUTotal1min"
    oid = ".1.3.6.1.4.1.9.9.109.1.1.1.1.4.7"
```
```
./telegraf -test -config snmp.conf
2020-06-28T16:49:40Z I! Starting Telegraf
2020-06-28T16:49:42Z E! [inputs.snmp] Error in plugin: agent demo.snmplabs.com:1161: performing get on field hostname: Incoming packet is not authentic, discarding
2020-06-28T16:49:42Z E! [telegraf] Error running agent: input plugins recorded 1 errors
```

Closes #3788
Telegraf now sends messages encrypted if encryption is used:
```
[[inputs.snmp]]
agents = [ "demo.snmplabs.com:1161" ]
interval = "5s"
timeout = "5s"
retries = 3
version = 3
sec_name = "usr-md5-aes"
auth_protocol = "MD5"
auth_password = "authkey1"
priv_protocol = "AES"
priv_password = "privkey1"
sec_level = "authPriv"
 
  [[inputs.snmp.field]]
    name = "hostname"
    oid = ".1.3.6.1.2.1.1.5.0"
    is_tag = true
 
  [[inputs.snmp.field]]
    name = "uptime"
    oid = "1.3.6.1.2.1.1.3.0"
 
  [[inputs.snmp.field]]
    name = "cpmCPUTotal1min"
    oid = ".1.3.6.1.4.1.9.9.109.1.1.1.1.4.7"
```
```
./telegraf -test -config snmp.conf 
2020-06-28T17:08:08Z I! Starting Telegraf
snmp,agent_host=demo.snmplabs.com,hostname=458 uptime=1069527715i 1593364090000000000
> snmp,agent_host=demo.snmplabs.com,hostname=458 uptime=1069527715i 1593364090000000000
```

![snmp_encrypted](https://user-images.githubusercontent.com/24810630/85953784-726bba00-b97b-11ea-9cfe-2a0941cc559c.jpg)



- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
