### PR TITLE
Allow any key usage type on x509 certificate

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -211,6 +211,7 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 			// name validation against the URL hostname.
 			opts := x509.VerifyOptions{
 				Intermediates: x509.NewCertPool(),
+				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 			}
 			if i == 0 {
 				if c.ServerName == "" {

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -142,6 +142,7 @@ func TestGatherLocal(t *testing.T) {
 		{name: "not a certificate", mode: 0640, content: "test", error: true},
 		{name: "wrong certificate", mode: 0640, content: wrongCert, error: true},
 		{name: "correct certificate", mode: 0640, content: pki.ReadServerCert()},
+		{name: "correct client certificate", mode: 0640, content: pki.ReadClientCert()},
 		{name: "correct certificate and extra trailing space", mode: 0640, content: pki.ReadServerCert() + " "},
 		{name: "correct certificate and extra leading space", mode: 0640, content: " " + pki.ReadServerCert()},
 		{name: "correct multiple certificates", mode: 0640, content: pki.ReadServerCert() + pki.ReadCACert()},


### PR DESCRIPTION
closes  #7754

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
