### PR TITLE
Fix data race in plugins/inputs/tail/tail_test.go

### DIFF
--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -118,7 +118,6 @@ func TestTailBadLine(t *testing.T) {
 
 	acc := testutil.Accumulator{}
 	require.NoError(t, tt.Start(&acc))
-	defer tt.Stop()
 
 	buf := &bytes.Buffer{}
 	log.SetOutput(buf)
@@ -129,6 +128,7 @@ func TestTailBadLine(t *testing.T) {
 	require.NoError(t, err)
 
 	time.Sleep(500 * time.Millisecond)
+	tt.Stop()
 	assert.Contains(t, buf.String(), "Malformed log line")
 }
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.

Relates to issue #7729 - fixes data race in input plugin tail tests'.

```
go test -short -race ./plugins/inputs/tail/... 
```

Before:
```
2020/07/02 21:54:28 D! [] Tail added for "/var/folders/lh/yzgq0xxj1kbc5cbchsjzps_40000gn/T/961769049"
2020/07/02 21:54:28 D! [] Tail removed for "/var/folders/lh/yzgq0xxj1kbc5cbchsjzps_40000gn/T/961769049"
2020/07/02 21:54:28 D! [] Tail added for "/var/folders/lh/yzgq0xxj1kbc5cbchsjzps_40000gn/T/918683620"
2020/07/02 21:54:28 D! [] Recording offset 61 for "/var/folders/lh/yzgq0xxj1kbc5cbchsjzps_40000gn/T/918683620"
2020/07/02 21:54:28 D! [] Tail removed for "/var/folders/lh/yzgq0xxj1kbc5cbchsjzps_40000gn/T/918683620"
2020/07/02 21:54:28 D! [] Tail added for "/var/folders/lh/yzgq0xxj1kbc5cbchsjzps_40000gn/T/134852083"
==================
WARNING: DATA RACE
Read at 0x00c00020e528 by goroutine 19:
  bytes.(*Buffer).String()
      /usr/local/Cellar/go/1.14.4/libexec/src/bytes/buffer.go:65 +0x6ca
  github.com/influxdata/telegraf/plugins/inputs/tail.TestTailBadLine()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail_test.go:132 +0x640
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb

Previous write at 0x00c00020e528 by goroutine 22:
  bytes.(*Buffer).grow()
      /usr/local/Cellar/go/1.14.4/libexec/src/bytes/buffer.go:147 +0x27f
  bytes.(*Buffer).Write()
      /usr/local/Cellar/go/1.14.4/libexec/src/bytes/buffer.go:172 +0x154
  log.(*Logger).Output()
      /usr/local/Cellar/go/1.14.4/libexec/src/log/log.go:181 +0x39d
  log.Printf()
      /usr/local/Cellar/go/1.14.4/libexec/src/log/log.go:320 +0xb5
  github.com/influxdata/telegraf/testutil.Logger.Errorf()
      /Users/jakubwarczarek/Documents/my/telegraf/testutil/log.go:14 +0x112
  github.com/influxdata/telegraf/testutil.(*Logger).Errorf()
      <autogenerated>:1 +0x3c
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).receiver()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:263 +0x7aa
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).tailNewFiles.func1()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:210 +0xb7

Goroutine 19 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:54 +0x223

Goroutine 22 (running) created at:
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).tailNewFiles()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:208 +0x6ed
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).Start()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:138 +0x247
  github.com/influxdata/telegraf/plugins/inputs/tail.TestTailBadLine()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail_test.go:120 +0x424
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
==================
==================
WARNING: DATA RACE
Read at 0x00c00020e510 by goroutine 19:
  bytes.(*Buffer).String()
      /usr/local/Cellar/go/1.14.4/libexec/src/bytes/buffer.go:65 +0x6e4
  github.com/influxdata/telegraf/plugins/inputs/tail.TestTailBadLine()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail_test.go:132 +0x640
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb

Previous write at 0x00c00020e510 by goroutine 22:
  bytes.(*Buffer).grow()
      /usr/local/Cellar/go/1.14.4/libexec/src/bytes/buffer.go:144 +0x23c
  bytes.(*Buffer).Write()
      /usr/local/Cellar/go/1.14.4/libexec/src/bytes/buffer.go:172 +0x154
  log.(*Logger).Output()
      /usr/local/Cellar/go/1.14.4/libexec/src/log/log.go:181 +0x39d
  log.Printf()
      /usr/local/Cellar/go/1.14.4/libexec/src/log/log.go:320 +0xb5
  github.com/influxdata/telegraf/testutil.Logger.Errorf()
      /Users/jakubwarczarek/Documents/my/telegraf/testutil/log.go:14 +0x112
  github.com/influxdata/telegraf/testutil.(*Logger).Errorf()
      <autogenerated>:1 +0x3c
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).receiver()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:263 +0x7aa
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).tailNewFiles.func1()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:210 +0xb7

Goroutine 19 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:54 +0x223

Goroutine 22 (running) created at:
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).tailNewFiles()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:208 +0x6ed
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).Start()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:138 +0x247
  github.com/influxdata/telegraf/plugins/inputs/tail.TestTailBadLine()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail_test.go:120 +0x424
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
==================
==================
WARNING: DATA RACE
Read at 0x00c0001781c0 by goroutine 19:
  runtime.slicebytetostring()
      /usr/local/Cellar/go/1.14.4/libexec/src/runtime/string.go:75 +0x0
  bytes.(*Buffer).String()
      /usr/local/Cellar/go/1.14.4/libexec/src/bytes/buffer.go:65 +0x737
  github.com/influxdata/telegraf/plugins/inputs/tail.TestTailBadLine()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail_test.go:132 +0x640
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb

Previous write at 0x00c0001781c0 by goroutine 22:
  runtime.slicecopy()
      /usr/local/Cellar/go/1.14.4/libexec/src/runtime/slice.go:197 +0x0
  bytes.(*Buffer).Write()
      /usr/local/Cellar/go/1.14.4/libexec/src/bytes/buffer.go:174 +0x115
  log.(*Logger).Output()
      /usr/local/Cellar/go/1.14.4/libexec/src/log/log.go:181 +0x39d
  log.Printf()
      /usr/local/Cellar/go/1.14.4/libexec/src/log/log.go:320 +0xb5
  github.com/influxdata/telegraf/testutil.Logger.Errorf()
      /Users/jakubwarczarek/Documents/my/telegraf/testutil/log.go:14 +0x112
  github.com/influxdata/telegraf/testutil.(*Logger).Errorf()
      <autogenerated>:1 +0x3c
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).receiver()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:263 +0x7aa
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).tailNewFiles.func1()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:210 +0xb7

Goroutine 19 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:54 +0x223

Goroutine 22 (running) created at:
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).tailNewFiles()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:208 +0x6ed
  github.com/influxdata/telegraf/plugins/inputs/tail.(*Tail).Start()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail.go:138 +0x247
  github.com/influxdata/telegraf/plugins/inputs/tail.TestTailBadLine()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/inputs/tail/tail_test.go:120 +0x424
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
==================
--- FAIL: TestTailBadLine (0.51s)
    testing.go:906: race detected during execution of test
FAIL
FAIL    github.com/influxdata/telegraf/plugins/inputs/tail      0.793s
```

After:

```
ok        github.com/influxdata/telegraf/plugins/inputs/tail
```