### PR TITLE
Fix data race in plugin output cloud_pubsub tests

### DIFF
--- a/plugins/outputs/cloud_pubsub/pubsub_test.go
+++ b/plugins/outputs/cloud_pubsub/pubsub_test.go
@@ -3,8 +3,10 @@ package cloud_pubsub
 import (
 	"testing"
 
-	"cloud.google.com/go/pubsub"
 	"encoding/base64"
+
+	"cloud.google.com/go/pubsub"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/testutil"
@@ -73,7 +75,7 @@ func TestPubSub_WriteMultiple(t *testing.T) {
 	for _, testM := range testMetrics {
 		verifyRawMetricPublished(t, testM.m, topic.published)
 	}
-	assert.Equalf(t, 1, topic.bundleCount, "unexpected bundle count")
+	assert.Equalf(t, 1, topic.getBundleCount(), "unexpected bundle count")
 }
 
 func TestPubSub_WriteOverCountThreshold(t *testing.T) {
@@ -97,7 +99,7 @@ func TestPubSub_WriteOverCountThreshold(t *testing.T) {
 	for _, testM := range testMetrics {
 		verifyRawMetricPublished(t, testM.m, topic.published)
 	}
-	assert.Equalf(t, 2, topic.bundleCount, "unexpected bundle count")
+	assert.Equalf(t, 2, topic.getBundleCount(), "unexpected bundle count")
 }
 
 func TestPubSub_WriteOverByteThreshold(t *testing.T) {
@@ -120,7 +122,7 @@ func TestPubSub_WriteOverByteThreshold(t *testing.T) {
 	for _, testM := range testMetrics {
 		verifyRawMetricPublished(t, testM.m, topic.published)
 	}
-	assert.Equalf(t, 2, topic.bundleCount, "unexpected bundle count")
+	assert.Equalf(t, 2, topic.getBundleCount(), "unexpected bundle count")
 }
 
 func TestPubSub_WriteBase64Single(t *testing.T) {

--- a/plugins/outputs/cloud_pubsub/topic_stubbed.go
+++ b/plugins/outputs/cloud_pubsub/topic_stubbed.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/pubsub"
 	"encoding/base64"
+
+	"cloud.google.com/go/pubsub"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/parsers"
@@ -123,8 +124,7 @@ func (t *stubTopic) Publish(ctx context.Context, msg *pubsub.Message) publishRes
 	}
 
 	bundled := &bundledMsg{msg, r}
-	err := t.bundler.Add(bundled, len(msg.Data))
-	if err != nil {
+	if err := t.bundler.Add(bundled, len(msg.Data)); err != nil {
 		t.Fatalf("unexpected error while adding to bundle: %v", err)
 	}
 	return r
@@ -209,4 +209,10 @@ func (r *stubResult) Get(ctx context.Context) (string, error) {
 	case <-r.done:
 		return fmt.Sprintf("id-%s", r.metricIds[0]), nil
 	}
+}
+
+func (t *stubTopic) getBundleCount() int {
+	t.bLock.Lock()
+	defer t.bLock.Unlock()
+	return t.bundleCount
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.

Relates to issue #7729 - fixes data race in output plugin cloud_pubsub tests'.

```
go test -short -race ./plugins/outputs/cloud_pubsub/...
```

Before:
```
WARNING: DATA RACE
Read at 0x00c00041a078 by goroutine 16:
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.TestPubSub_WriteMultiple()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/pubsub_test.go:76 +0x3d1
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb

Previous write at 0x00c00041a078 by goroutine 19:
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.(*stubTopic).sendBundle.func1()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/topic_stubbed.go:176 +0x3f4
  google.golang.org/api/support/bundler.(*Bundler).handle()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:322 +0xc0

Goroutine 16 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:56 +0x223

Goroutine 19 (finished) created at:
  google.golang.org/api/support/bundler.(*Bundler).enqueueCurBundle()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:179 +0x12a
  google.golang.org/api/support/bundler.(*Bundler).Flush()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:376 +0x55
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.(*stubTopic).Stop()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/topic_stubbed.go:102 +0xb1
==================
--- FAIL: TestPubSub_WriteMultiple (0.00s)
    testing.go:906: race detected during execution of test
==================
WARNING: DATA RACE
Read at 0x00c00041a0f8 by goroutine 21:
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.TestPubSub_WriteOverCountThreshold()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/pubsub_test.go:100 +0x522
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb

Previous write at 0x00c00041a0f8 by goroutine 23:
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.(*stubTopic).sendBundle.func1()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/topic_stubbed.go:176 +0x3f4
  google.golang.org/api/support/bundler.(*Bundler).handle()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:322 +0xc0

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:56 +0x223

Goroutine 23 (finished) created at:
  google.golang.org/api/support/bundler.(*Bundler).enqueueCurBundle()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:179 +0x12a
  google.golang.org/api/support/bundler.(*Bundler).add()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:281 +0x324
  google.golang.org/api/support/bundler.(*Bundler).Add()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:247 +0x186
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.(*stubTopic).Publish()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/topic_stubbed.go:126 +0x466
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.(*PubSub).Write()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/pubsub.go:140 +0x227
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.TestPubSub_WriteOverCountThreshold()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/pubsub_test.go:92 +0x3ca
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
==================
--- FAIL: TestPubSub_WriteOverCountThreshold (0.00s)
    testing.go:906: race detected during execution of test
==================
WARNING: DATA RACE
Read at 0x00c00041a178 by goroutine 29:
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.TestPubSub_WriteOverByteThreshold()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/pubsub_test.go:123 +0x3e9
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb

Previous write at 0x00c00041a178 by goroutine 31:
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.(*stubTopic).sendBundle.func1()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/topic_stubbed.go:176 +0x3f4
  google.golang.org/api/support/bundler.(*Bundler).handle()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:322 +0xc0

Goroutine 29 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:56 +0x223

Goroutine 31 (finished) created at:
  google.golang.org/api/support/bundler.(*Bundler).enqueueCurBundle()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:179 +0x12a
  google.golang.org/api/support/bundler.(*Bundler).add()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:281 +0x324
  google.golang.org/api/support/bundler.(*Bundler).Add()
      /Users/jakubwarczarek/go/pkg/mod/google.golang.org/api@v0.20.0/support/bundler/bundler.go:247 +0x186
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.(*stubTopic).Publish()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/topic_stubbed.go:126 +0x466
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.(*PubSub).Write()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/pubsub.go:140 +0x227
  github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub.TestPubSub_WriteOverByteThreshold()
      /Users/jakubwarczarek/Documents/my/telegraf/plugins/outputs/cloud_pubsub/pubsub_test.go:115 +0x291
  testing.tRunner()
      /usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0x1eb
==================
--- FAIL: TestPubSub_WriteOverByteThreshold (0.00s)
    testing.go:906: race detected during execution of test
FAIL
FAIL	github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub	0.402s
```

After:

```
ok  	github.com/influxdata/telegraf/plugins/outputs/cloud_pubsub	0.412s
```