### PR TITLE
SQL Server - added new counter - Lock Timeouts (timeout > 0)/sec

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -798,6 +798,7 @@ SET @SqlStatement = @SqlStatement + CAST(N' WHERE	(
 			instance_name IN (''_Total'')
 			AND counter_name IN (
 				''Lock Timeouts/sec'',
+				''Lock Timeouts (timeout > 0)/sec'',
 				''Number of Deadlocks/sec'',
 				''Lock Waits/sec'',
 				''Latch Waits/sec''


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

closes #6978

Added a new counter 'Lock Timeouts (timeout > 0)/sec' to the sqlserver_performance measurement.

