### PR TITLE
documentation: typo cloud_pubsub plugin

### DIFF
--- a/plugins/inputs/cloud_pubsub/README.md
+++ b/plugins/inputs/cloud_pubsub/README.md
@@ -7,8 +7,8 @@ and creates metrics using one of the supported [input data formats][].
 ### Configuration
 
 ```toml
-[[inputs.pubsub]]
-## Required. Name of Google Cloud Platform (GCP) Project that owns
+[[inputs.cloud_pubsub]]
+  ## Required. Name of Google Cloud Platform (GCP) Project that owns
   ## the given PubSub subscription.
   project = "my-project"
 
@@ -31,7 +31,7 @@ and creates metrics using one of the supported [input data formats][].
   ## If the streaming pull for a PubSub Subscription fails (receiver),
   ## the agent attempts to restart receiving messages after this many seconds.
   # retry_delay_seconds = 5
-  
+
   ## Optional. Maximum byte length of a message to consume.
   ## Larger messages are dropped with an error. If less than 0 or unspecified,
   ## treated as no limit.
@@ -75,7 +75,7 @@ and creates metrics using one of the supported [input data formats][].
   ## 1. Note this setting does not limit the number of messages that can be
   ## processed concurrently (use "max_outstanding_messages" instead).
   # max_receiver_go_routines = 0
-  
+
   ## Optional. If true, Telegraf will attempt to base64 decode the 
   ## PubSub message data before parsing. Many GCP services that
   ## output JSON to Google PubSub base64-encode the JSON payload.


### PR DESCRIPTION
Small typo in the documentation for the cloud_pubsub input plugin

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
