### PR TITLE
documentation: typo outputs cloud_pubsub

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -387,7 +387,7 @@
 #   # base64_data = false
 #
 #   ## Optional. PubSub attributes to add to metrics.
-#   # [[outputs.cloud_pubsub.attributes]]
+#   # [outputs.cloud_pubsub.attributes]
 #   #   my_attr = "tag_value"
 
 

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -387,7 +387,7 @@
 #   # base64_data = false
 #
 #   ## Optional. PubSub attributes to add to metrics.
-#   # [[inputs.pubsub.attributes]]
+#   # [[outputs.cloud_pubsub.attributes]]
 #   #   my_attr = "tag_value"
 
 

--- a/plugins/outputs/cloud_pubsub/README.md
+++ b/plugins/outputs/cloud_pubsub/README.md
@@ -56,7 +56,7 @@ generate it using `telegraf --usage cloud_pubsub`.
   # base64_data = false
 
   ## Optional. PubSub attributes to add to metrics.
-  # [[outputs.cloud_pubsub.attributes]]
+  # [outputs.cloud_pubsub.attributes]
   #   my_attr = "tag_value"
 ```
 

--- a/plugins/outputs/cloud_pubsub/README.md
+++ b/plugins/outputs/cloud_pubsub/README.md
@@ -51,12 +51,12 @@ generate it using `telegraf --usage cloud_pubsub`.
 
   ## Optional. Specifies a timeout for requests to the PubSub API.
   # publish_timeout = "30s"
-  
+
   ## Optional. If true, published PubSub message data will be base64-encoded.
   # base64_data = false
-  
+
   ## Optional. PubSub attributes to add to metrics.
-  # [[inputs.pubsub.attributes]]
+  # [[outputs.cloud_pubsub.attributes]]
   #   my_attr = "tag_value"
 ```
 

--- a/plugins/outputs/cloud_pubsub/pubsub.go
+++ b/plugins/outputs/cloud_pubsub/pubsub.go
@@ -62,7 +62,7 @@ const sampleConfig = `
   # base64_data = false
 
   ## Optional. PubSub attributes to add to metrics.
-  # [[inputs.pubsub.attributes]]
+  # [[outputs.cloud_pubsub.attributes]]
   #   my_attr = "tag_value"
 `
 

--- a/plugins/outputs/cloud_pubsub/pubsub.go
+++ b/plugins/outputs/cloud_pubsub/pubsub.go
@@ -62,7 +62,7 @@ const sampleConfig = `
   # base64_data = false
 
   ## Optional. PubSub attributes to add to metrics.
-  # [[outputs.cloud_pubsub.attributes]]
+  # [outputs.cloud_pubsub.attributes]
   #   my_attr = "tag_value"
 `
 


### PR DESCRIPTION
Small typo in the documentation for the cloud_pubsub output plugin.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
