### PR TITLE
Close file to ensure it has been flushed

### DIFF
--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -22,7 +22,6 @@ func TestTailBadLine(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
-	defer tmpfile.Close()
 
 	_, err = tmpfile.WriteString("cpu mytag= foo usage_idle= 100\n")
 	require.NoError(t, err)
@@ -30,6 +29,8 @@ func TestTailBadLine(t *testing.T) {
 	// Write good metric so we can detect when processing is complete
 	_, err = tmpfile.WriteString("cpu usage_idle=100\n")
 	require.NoError(t, err)
+
+	tmpfile.Close()
 
 	tt := NewTail()
 	tt.Log = testutil.Logger{}
@@ -58,9 +59,9 @@ func TestTailDosLineendings(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
-	defer tmpfile.Close()
 	_, err = tmpfile.WriteString("cpu usage_idle=100\r\ncpu2 usage_idle=200\r\n")
 	require.NoError(t, err)
+	tmpfile.Close()
 
 	tt := NewTail()
 	tt.Log = testutil.Logger{}
@@ -91,10 +92,7 @@ func TestTailDosLineendings(t *testing.T) {
 func TestCSVHeadersParsedOnce(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
-	defer func() {
-		tmpfile.Close()
-		os.Remove(tmpfile.Name())
-	}()
+	defer os.Remove(tmpfile.Name())
 
 	_, err = tmpfile.WriteString(`
 measurement,time_idle
@@ -102,6 +100,7 @@ cpu,42
 cpu,42
 `)
 	require.NoError(t, err)
+	tmpfile.Close()
 
 	plugin := NewTail()
 	plugin.Log = testutil.Logger{}
@@ -152,15 +151,13 @@ cpu,42
 func TestMultipleMetricsOnFirstLine(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
-	defer func() {
-		tmpfile.Close()
-		os.Remove(tmpfile.Name())
-	}()
+	defer os.Remove(tmpfile.Name())
 
 	_, err = tmpfile.WriteString(`
 [{"time_idle": 42}, {"time_idle": 42}]
 `)
 	require.NoError(t, err)
+	tmpfile.Close()
 
 	plugin := NewTail()
 	plugin.Log = testutil.Logger{}


### PR DESCRIPTION
This is an attempt to fix the intermittent test case:

```
2020/07/10 15:10:08 D! [] Tail added for "/var/folders/pt/0xykrh9j62g34sc7znh47kbc0000gn/T/643693879"
2020/07/10 15:10:08 E! [] Malformed log line in "/var/folders/pt/0xykrh9j62g34sc7znh47kbc0000gn/T/643693879": ["cpu mytag= foo usage_idle= 100"]: metric parse error: expected field at 1:11: "cpu mytag= foo usage_idle= 100"
--- FAIL: TestTailBadLine (0.00s)
    tail_test.go:54: 
        	Error Trace:	tail_test.go:54
        	Error:      	"2020/07/10 15:10:08 D! [] Tail removed for "/var/folders/pt/0xykrh9j62g34sc7znh47kbc0000gn/T/643693879"
        	            	" does not contain "Malformed log line"
        	Test:       	TestTailBadLine
FAIL
FAIL	github.com/influxdata/telegraf/plugins/inputs/tail	0.252s
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
