### PR TITLE
inputs.ntpq: Multiple server querying, wide mode support and decimal reach conversion

### DIFF
--- a/plugins/inputs/ntpq/README.md
+++ b/plugins/inputs/ntpq/README.md
@@ -29,8 +29,21 @@ server (RMS of difference of multiple time samples, milliseconds);
 ```toml
 # Get standard NTP query metrics, requires ntpq executable
 [[inputs.ntpq]]
-  ## If false, add -n for ntpq command. Can reduce metric gather times.
+  ## Specify servers to measure.
+  ## If no servers are specified, then localhost is used as the host.
+  # servers = ["localhost"]
+
+  ## NTP displays the reach parameter of a peer as octal number.
+  ## If you wish to convert to a regular decimal number set this to true.
+  ## Default is false to preserve backwards compability.
+  # decimal_reach = false
+
+  ## If false, set the -n ntpq flag. Can reduce metric gather time.
   dns_lookup = true
+
+  ## Try to use wide mode (-w) in output from ntpq if binary supports it.
+  ## Default is false to preserve backwards compability.
+  # wide_mode = false
 ```
 
 ### Measurements & Fields:
@@ -46,10 +59,11 @@ server (RMS of difference of multiple time samples, milliseconds);
 ### Tags:
 
 - All measurements have the following tags:
+    - server
     - refid
     - remote
-    - type
     - stratum
+    - type
 
 ### Example Output:
 

--- a/plugins/inputs/ntpq/ntpq.go
+++ b/plugins/inputs/ntpq/ntpq.go
@@ -21,14 +21,35 @@ var tagHeaders map[string]string = map[string]string{
 	"t":      "type",
 }
 
-type NTPQ struct {
-	runQ   func() ([]byte, error)
-	tagI   map[string]int
-	floatI map[string]int
-	intI   map[string]int
-
-	DNSLookup bool `toml:"dns_lookup"`
+// Mapping of ntpq header names to integer fields
+var fieldIHeaders map[string]string = map[string]string{
+	"when":   "when",
+	"poll":   "poll",
+	"reach":  "reach",
 }
+
+// Mapping of ntpq header names to float fields
+var fieldFHeaders map[string]string = map[string]string{
+	"delay":  "delay",
+	"offset": "offset",
+	"jitter": "jitter",
+}
+
+type NTPQ struct {
+	runQ         func(string) ([]byte, error)
+	tagI         map[string]int
+	floatI       map[string]int
+	intI         map[string]int
+
+	binary       string
+
+	Servers      []string `toml:"servers"`
+	DecimalReach bool     `toml:"decimal_reach"`
+	WideMode     bool     `toml:"wide_mode"`
+	DNSLookup    bool     `toml:"dns_lookup"`
+}
+
+const defaultServer = "localhost"
 
 func (n *NTPQ) Description() string {
 	return "Get standard NTP query metrics, requires ntpq executable."
@@ -36,17 +57,25 @@ func (n *NTPQ) Description() string {
 
 func (n *NTPQ) SampleConfig() string {
 	return `
+  ## Specify servers to measure.
+  ## If no servers are specified, then localhost is used as the host.
+  # servers = ["localhost"]
+
+  ## NTP displays the reach parameter of a peer as octal number.
+  ## If you wish to convert to a regular decimal number set this to true.
+  ## Default is false to preserve backwards compability.
+  # decimal_reach = false
+
   ## If false, set the -n ntpq flag. Can reduce metric gather time.
   dns_lookup = true
+
+  ## Try to use wide mode (-w) in output from ntpq if binary supports it.
+  ## Default is false to preserve backwards compability.
+  # wide_mode = false
 `
 }
 
 func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
-	out, err := n.runQ()
-	if err != nil {
-		return err
-	}
-
 	// Due to problems with a parsing, we have to use regexp expression in order
 	// to remove string that starts from '(' and ends with space
 	// see: https://github.com/influxdata/telegraf/issues/2386
@@ -55,151 +84,209 @@ func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
 		return err
 	}
 
-	lineCounter := 0
-	numColumns := 0
-	scanner := bufio.NewScanner(bytes.NewReader(out))
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		tags := make(map[string]string)
-		// if there is an ntpq state prefix, remove it and make it it's own tag
-		// see https://github.com/influxdata/telegraf/issues/1161
-		if strings.ContainsAny(string(line[0]), "*#o+x.-") {
-			tags["state_prefix"] = string(line[0])
-			line = strings.TrimLeft(line, "*#o+x.-")
+	for _, server := range n.Servers {
+		out, err := n.runQ(server);
+		if err != nil {
+			return err
 		}
 
-		line = reg.ReplaceAllString(line, "")
+		lineCounter := 0
+		numColumns := 0
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		for scanner.Scan() {
+			line := scanner.Text()
+			line = reg.ReplaceAllString(line, "")
 
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			continue
-		}
+			tags := make(map[string]string)
+			tags["server"] = string(server)
 
-		// If lineCounter == 0, then this is the header line
-		if lineCounter == 0 {
-			numColumns = len(fields)
-			for i, field := range fields {
-				// Check if field is a tag:
-				if tagKey, ok := tagHeaders[field]; ok {
-					n.tagI[tagKey] = i
-					continue
+			fields := strings.Fields(line)
+
+			// Wide mode have broken lines for long hostnames
+			if n.WideMode {
+				if len(fields) == 1 {
+					// broken line, append next line
+					scanner.Scan()
+					line := scanner.Text()
+					line = reg.ReplaceAllString(line, "")
+					fields = append(fields, strings.Fields(line)...) 
+					lineCounter++
 				}
-
-				// check if field is a float metric:
-				if _, ok := n.floatI[field]; ok {
-					n.floatI[field] = i
-					continue
-				}
-
-				// check if field is an int metric:
-				if _, ok := n.intI[field]; ok {
-					n.intI[field] = i
+			} else {
+				// not running wide mode, check if number of fields is valid
+				if len(fields) < 2 {
+					lineCounter++
 					continue
 				}
 			}
-		} else {
-			if len(fields) != numColumns {
-				continue
-			}
 
-			mFields := make(map[string]interface{})
-
-			// Get tags from output
-			for key, index := range n.tagI {
-				if index == -1 {
-					continue
-				}
-				tags[key] = fields[index]
-			}
-
-			// Get integer metrics from output
-			for key, index := range n.intI {
-				if index == -1 || index >= len(fields) {
-					continue
-				}
-				if fields[index] == "-" {
-					continue
-				}
-
-				if key == "when" {
-					when := fields[index]
-					switch {
-					case strings.HasSuffix(when, "h"):
-						m, err := strconv.Atoi(strings.TrimSuffix(fields[index], "h"))
-						if err != nil {
-							acc.AddError(fmt.Errorf("E! Error ntpq: parsing int: %s", fields[index]))
-							continue
-						}
-						// seconds in an hour
-						mFields[key] = int64(m) * 3600
+			// If lineCounter == 0, then this is the header line
+			if lineCounter == 0 {
+				numColumns = len(fields)
+				for i, field := range fields {
+					// Check if field is a tag:
+					if tagKey, ok := tagHeaders[field]; ok {
+						n.tagI[tagKey] = i
 						continue
-					case strings.HasSuffix(when, "d"):
-						m, err := strconv.Atoi(strings.TrimSuffix(fields[index], "d"))
-						if err != nil {
-							acc.AddError(fmt.Errorf("E! Error ntpq: parsing int: %s", fields[index]))
-							continue
-						}
-						// seconds in a day
-						mFields[key] = int64(m) * 86400
+					}
+
+					// check if field is a float metric:
+					if fieldKey, ok := fieldFHeaders[field]; ok {
+						n.floatI[fieldKey] = i
 						continue
-					case strings.HasSuffix(when, "m"):
-						m, err := strconv.Atoi(strings.TrimSuffix(fields[index], "m"))
-						if err != nil {
-							acc.AddError(fmt.Errorf("E! Error ntpq: parsing int: %s", fields[index]))
-							continue
-						}
-						// seconds in a day
-						mFields[key] = int64(m) * 60
+					}
+
+					// check if field is an int metric:
+					if fieldKey, ok := fieldIHeaders[field]; ok {
+						n.intI[fieldKey] = i
 						continue
 					}
 				}
 
-				m, err := strconv.Atoi(fields[index])
-				if err != nil {
-					acc.AddError(fmt.Errorf("E! Error ntpq: parsing int: %s", fields[index]))
+				// all done, skip bar next line it's the bar below the header
+				// and increase line counter and next for loop
+				scanner.Scan()
+				lineCounter++
+			} else {
+				if len(fields) != numColumns {
+					lineCounter++
 					continue
 				}
-				mFields[key] = int64(m)
+
+				mFields := make(map[string]interface{})
+
+				// Get tags from output
+				for key, index := range n.tagI {
+					if index == -1 {
+						continue
+					}
+					if key == "remote" {
+						// if there is an ntpq state prefix, remove it and make it it's own tag
+						// see https://github.com/influxdata/telegraf/issues/1161
+						if strings.ContainsAny(string(fields[index][0]), "*#o+x.-") {
+							tags["state_prefix"] = string(fields[index][0])
+							fields[index] = strings.TrimLeft(fields[index], "*#o+x.-")
+						}
+					}
+					tags[key] = fields[index]
+				}
+
+				// Get integer metrics from output
+				for key, index := range n.intI {
+					if index == -1 || index >= len(fields) {
+						continue
+					}
+					if fields[index] == "-" {
+						continue
+					}
+
+					if key == "when" {
+						when := fields[index]
+						switch {
+						case strings.HasSuffix(when, "h"):
+							m, err := strconv.Atoi(strings.TrimSuffix(fields[index], "h"))
+							if err != nil {
+								acc.AddError(fmt.Errorf("E! Error ntpq: parsing int: %s", fields[index]))
+								continue
+							}
+							// seconds in an hour
+							mFields[key] = int64(m) * 3600
+							continue
+						case strings.HasSuffix(when, "d"):
+							m, err := strconv.Atoi(strings.TrimSuffix(fields[index], "d"))
+							if err != nil {
+								acc.AddError(fmt.Errorf("E! Error ntpq: parsing int: %s", fields[index]))
+								continue
+							}
+							// seconds in a day
+							mFields[key] = int64(m) * 86400
+							continue
+						case strings.HasSuffix(when, "m"):
+							m, err := strconv.Atoi(strings.TrimSuffix(fields[index], "m"))
+							if err != nil {
+								acc.AddError(fmt.Errorf("E! Error ntpq: parsing int: %s", fields[index]))
+								continue
+							}
+							// simply just seconds
+							mFields[key] = int64(m) * 60
+							continue
+						}
+					}
+
+					if key == "reach" && n.DecimalReach {
+						reach := fields[index]
+
+						m, err := strconv.ParseInt(reach, 8, 64)
+						if err != nil {
+							acc.AddError(fmt.Errorf("E! Error ntpq: parsing octal int: %s", fields[index]))
+							continue
+						}
+
+						mFields[key] = int64(m)
+						continue
+					}
+
+					m, err := strconv.Atoi(fields[index])
+					if err != nil {
+						acc.AddError(fmt.Errorf("E! Error ntpq: parsing int: %s", fields[index]))
+						continue
+					}
+					mFields[key] = int64(m)
+				}
+
+				// get float metrics from output
+				for key, index := range n.floatI {
+					if index == -1 || index >= len(fields) {
+						continue
+					}
+					if fields[index] == "-" {
+						continue
+					}
+
+					m, err := strconv.ParseFloat(fields[index], 64)
+					if err != nil {
+						acc.AddError(fmt.Errorf("E! Error ntpq: parsing float: %s", fields[index]))
+						continue
+					}
+					mFields[key] = m
+				}
+
+				acc.AddFields("ntpq", mFields, tags)
 			}
 
-			// get float metrics from output
-			for key, index := range n.floatI {
-				if index == -1 || index >= len(fields) {
-					continue
-				}
-				if fields[index] == "-" {
-					continue
-				}
-
-				m, err := strconv.ParseFloat(fields[index], 64)
-				if err != nil {
-					acc.AddError(fmt.Errorf("E! Error ntpq: parsing float: %s", fields[index]))
-					continue
-				}
-				mFields[key] = m
-			}
-
-			acc.AddFields("ntpq", mFields, tags)
+			lineCounter++
 		}
-
-		lineCounter++
 	}
 	return nil
 }
 
-func (n *NTPQ) runq() ([]byte, error) {
-	bin, err := exec.LookPath("ntpq")
+func (n *NTPQ) runq(server string) ([]byte, error) {
+	// do we have a valid binary?
+	bin, err := exec.LookPath(n.binary)
 	if err != nil {
 		return nil, err
+	} else {
+		n.binary = bin
 	}
 
 	var cmd *exec.Cmd
-	if n.DNSLookup {
-		cmd = exec.Command(bin, "-p")
-	} else {
-		cmd = exec.Command(bin, "-p", "-n")
+
+	// build args
+	cmd_args := []string{ "-p" }
+
+	// is wide mode supported?
+	if n.WideMode {
+		cmd_args = append(cmd_args, "-w")
 	}
+
+	// should we not use dns lookups?
+	if !n.DNSLookup {
+	  cmd_args = append(cmd_args, "-n")
+	}
+
+	// append server to argument list
+	cmd_args = append(cmd_args, server)
+	cmd = exec.Command(n.binary, cmd_args...)
 
 	return cmd.Output()
 }
@@ -222,16 +309,46 @@ func newNTPQ() *NTPQ {
 
 	// Mapping of int metrics to their index in the command output
 	intI := map[string]int{
-		"when":  -1,
-		"poll":  -1,
-		"reach": -1,
+		"when":    -1,
+		"poll":    -1,
+		"reach":   -1,
 	}
 
 	n := &NTPQ{
-		tagI:   tagI,
-		floatI: floatI,
-		intI:   intI,
+		tagI:     tagI,
+		floatI:   floatI,
+		intI:     intI,
+		binary:   "ntpq",
+		WideMode: false,
 	}
+
+	// no server, default to defaultServer (localhost)
+	if len(n.Servers) == 0 {
+		n.Servers = append(n.Servers, defaultServer)
+	}
+
+	// find binary
+	if bin, err := exec.LookPath(n.binary); err == nil {
+		// binary found so lets store absolute/relative path to
+		// skip checking PATH in each LookPath call
+		n.binary = bin
+
+		if n.WideMode {
+	    // we wish to use wide mode so let's check if binary supports it
+			if _, err := exec.Command(n.binary, "-w", "-c quit").Output(); err == nil {
+				// GREAT SUCCESS
+				n.WideMode = true
+			} else {
+				// EPIC FAIL, disable it
+				n.WideMode = false
+			}
+		}
+	} else {
+		// could not find binary so check again at gather
+		// this disables wide mode until telegraf is restarted
+		n.binary = "ntpq"
+	}
+
 	n.runQ = n.runq
 	return n
 }

--- a/plugins/inputs/ntpq/ntpq.go
+++ b/plugins/inputs/ntpq/ntpq.go
@@ -23,9 +23,9 @@ var tagHeaders map[string]string = map[string]string{
 
 // Mapping of ntpq header names to integer fields
 var fieldIHeaders map[string]string = map[string]string{
-	"when":   "when",
-	"poll":   "poll",
-	"reach":  "reach",
+	"when":  "when",
+	"poll":  "poll",
+	"reach": "reach",
 }
 
 // Mapping of ntpq header names to float fields
@@ -36,12 +36,12 @@ var fieldFHeaders map[string]string = map[string]string{
 }
 
 type NTPQ struct {
-	runQ         func(string) ([]byte, error)
-	tagI         map[string]int
-	floatI       map[string]int
-	intI         map[string]int
+	runQ   func(string) ([]byte, error)
+	tagI   map[string]int
+	floatI map[string]int
+	intI   map[string]int
 
-	binary       string
+	binary string
 
 	Servers      []string `toml:"servers"`
 	DecimalReach bool     `toml:"decimal_reach"`
@@ -85,7 +85,7 @@ func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
 	}
 
 	for _, server := range n.Servers {
-		out, err := n.runQ(server);
+		out, err := n.runQ(server)
 		if err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
 					scanner.Scan()
 					line := scanner.Text()
 					line = reg.ReplaceAllString(line, "")
-					fields = append(fields, strings.Fields(line)...) 
+					fields = append(fields, strings.Fields(line)...)
 					lineCounter++
 				}
 			} else {
@@ -272,7 +272,7 @@ func (n *NTPQ) runq(server string) ([]byte, error) {
 	var cmd *exec.Cmd
 
 	// build args
-	cmd_args := []string{ "-p" }
+	cmd_args := []string{"-p"}
 
 	// is wide mode supported?
 	if n.WideMode {
@@ -281,7 +281,7 @@ func (n *NTPQ) runq(server string) ([]byte, error) {
 
 	// should we not use dns lookups?
 	if !n.DNSLookup {
-	  cmd_args = append(cmd_args, "-n")
+		cmd_args = append(cmd_args, "-n")
 	}
 
 	// append server to argument list
@@ -309,9 +309,9 @@ func newNTPQ() *NTPQ {
 
 	// Mapping of int metrics to their index in the command output
 	intI := map[string]int{
-		"when":    -1,
-		"poll":    -1,
-		"reach":   -1,
+		"when":  -1,
+		"poll":  -1,
+		"reach": -1,
 	}
 
 	n := &NTPQ{
@@ -334,7 +334,7 @@ func newNTPQ() *NTPQ {
 		n.binary = bin
 
 		if n.WideMode {
-	    // we wish to use wide mode so let's check if binary supports it
+			// we wish to use wide mode so let's check if binary supports it
 			if _, err := exec.Command(n.binary, "-w", "-c quit").Output(); err == nil {
 				// GREAT SUCCESS
 				n.WideMode = true

--- a/plugins/inputs/ntpq/ntpq_test.go
+++ b/plugins/inputs/ntpq/ntpq_test.go
@@ -649,6 +649,26 @@ func TestWideModeNTPQ(t *testing.T) {
 			"ntpq",
 			map[string]string{
 				"server":       "localhost",
+				"state_prefix": "#",
+				"remote":       "193.235.20.156",
+				"refid":        "194.58.202.148",
+				"stratum":      "2",
+				"type":         "u",
+			},
+			map[string]interface{}{
+				"when":   int64(13),
+				"poll":   int64(64),
+				"reach":  int64(377),
+				"delay":  float64(21.853),
+				"offset": float64(0.168),
+				"jitter": float64(0.129),
+			},
+			now,
+		),
+		testutil.MustMetric(
+			"ntpq",
+			map[string]string{
+				"server":       "localhost",
 				"state_prefix": "+",
 				"remote":       "time.cloudflare.com",
 				"refid":        "10.128.9.5",
@@ -796,6 +816,10 @@ var noRefID = `     remote           refid      st t when poll reach   delay   o
 `
 
 // real-world output with a mixed bag of fun
+// the following row:
+// #193.235.20.156 (ww193-235-20-156.cust.wintherwireless.se)
+// occurs when an PTR record for an IP points to an A record that doesn't point back
+// ex: 192.0.2.100 -- PTR --> foo.example.com -- A -->  192.0.2.200
 var wideModeNTPQ = `     remote           refid      st t when poll reach   delay   offset  jitter
 ==============================================================================
  0.se.pool.ntp.org
@@ -810,6 +834,8 @@ var wideModeNTPQ = `     remote           refid      st t when poll reach   dela
 +193.11.166.8    .PPS.            1 u  230 1024  377   23.804   -0.368   0.225
  193.11.166.20   .XFAC.          16 u    - 1024    0    0.000    0.000   0.000
 *svl1.ntp.se     .PPS.            1 u  880 1024  377   10.049    0.415   0.144
+#193.235.20.156 (ww193-235-20-156.cust.wintherwireless.se)
+                 194.58.202.148   2 u   13   64  377   21.853    0.168   0.129
 +time.cloudflare.com
                  10.128.9.5       3 u  511 1024  377   15.930    0.679   0.123
 `

--- a/plugins/inputs/ntpq/ntpq_test.go
+++ b/plugins/inputs/ntpq/ntpq_test.go
@@ -31,6 +31,7 @@ func TestSingleNTPQ(t *testing.T) {
 		"jitter": float64(17.462),
 	}
 	tags := map[string]string{
+		"server":       "localhost",
 		"remote":       "uschi5-ntp-002.",
 		"state_prefix": "*",
 		"refid":        "10.177.80.46",
@@ -59,6 +60,7 @@ func TestBadIntNTPQ(t *testing.T) {
 		"jitter": float64(17.462),
 	}
 	tags := map[string]string{
+		"server":       "localhost",
 		"remote":       "uschi5-ntp-002.",
 		"state_prefix": "*",
 		"refid":        "10.177.80.46",
@@ -87,6 +89,7 @@ func TestBadFloatNTPQ(t *testing.T) {
 		"jitter": float64(17.462),
 	}
 	tags := map[string]string{
+		"server":       "localhost",
 		"remote":       "uschi5-ntp-002.",
 		"state_prefix": "*",
 		"refid":        "10.177.80.46",
@@ -116,6 +119,7 @@ func TestDaysNTPQ(t *testing.T) {
 		"jitter": float64(17.462),
 	}
 	tags := map[string]string{
+		"server":       "localhost",
 		"remote":       "uschi5-ntp-002.",
 		"state_prefix": "*",
 		"refid":        "10.177.80.46",
@@ -145,6 +149,7 @@ func TestHoursNTPQ(t *testing.T) {
 		"jitter": float64(17.462),
 	}
 	tags := map[string]string{
+		"server":       "localhost",
 		"remote":       "uschi5-ntp-002.",
 		"state_prefix": "*",
 		"refid":        "10.177.80.46",
@@ -174,6 +179,7 @@ func TestMinutesNTPQ(t *testing.T) {
 		"jitter": float64(17.462),
 	}
 	tags := map[string]string{
+		"server":       "localhost",
 		"remote":       "uschi5-ntp-002.",
 		"state_prefix": "*",
 		"refid":        "10.177.80.46",
@@ -202,6 +208,7 @@ func TestBadWhenNTPQ(t *testing.T) {
 		"jitter": float64(17.462),
 	}
 	tags := map[string]string{
+		"server":       "localhost",
 		"remote":       "uschi5-ntp-002.",
 		"state_prefix": "*",
 		"refid":        "10.177.80.46",
@@ -233,6 +240,7 @@ func TestParserNTPQ(t *testing.T) {
 		"jitter": float64(1.012),
 	}
 	tags := map[string]string{
+		"server":       "localhost",
 		"remote":       "SHM(0)",
 		"state_prefix": "*",
 		"refid":        ".PPS.",
@@ -250,6 +258,7 @@ func TestParserNTPQ(t *testing.T) {
 		"jitter": float64(2.012),
 	}
 	tags = map[string]string{
+		"server":       "localhost",
 		"remote":       "SHM(1)",
 		"state_prefix": "-",
 		"refid":        ".GPS.",
@@ -267,6 +276,7 @@ func TestParserNTPQ(t *testing.T) {
 		"jitter": float64(0.101),
 	}
 	tags = map[string]string{
+		"server":       "localhost",
 		"remote":       "37.58.57.238",
 		"state_prefix": "+",
 		"refid":        "192.53.103.103",
@@ -296,6 +306,7 @@ func TestMultiNTPQ(t *testing.T) {
 		"when":   int64(740),
 	}
 	tags := map[string]string{
+		"server":  "localhost",
 		"refid":   "10.177.80.37",
 		"remote":  "83.137.98.96",
 		"stratum": "2",
@@ -312,6 +323,7 @@ func TestMultiNTPQ(t *testing.T) {
 		"when":   int64(739),
 	}
 	tags = map[string]string{
+		"server":  "localhost",
 		"refid":   "10.177.80.37",
 		"remote":  "81.7.16.52",
 		"stratum": "2",
@@ -340,6 +352,7 @@ func TestBadHeaderNTPQ(t *testing.T) {
 		"jitter": float64(17.462),
 	}
 	tags := map[string]string{
+		"server":       "localhost",
 		"remote":       "uschi5-ntp-002.",
 		"state_prefix": "*",
 		"refid":        "10.177.80.46",
@@ -367,6 +380,7 @@ func TestMissingDelayColumnNTPQ(t *testing.T) {
 		"jitter": float64(17.462),
 	}
 	tags := map[string]string{
+		"server":       "localhost",
 		"remote":       "uschi5-ntp-002.",
 		"state_prefix": "*",
 		"refid":        "10.177.80.46",
@@ -395,6 +409,7 @@ func TestNoRefID(t *testing.T) {
 	expected := []telegraf.Metric{
 		testutil.MustMetric("ntpq",
 			map[string]string{
+				"server":  "localhost",
 				"refid":   "10.177.80.37",
 				"remote":  "83.137.98.96",
 				"stratum": "2",
@@ -411,6 +426,7 @@ func TestNoRefID(t *testing.T) {
 			now),
 		testutil.MustMetric("ntpq",
 			map[string]string{
+				"server":  "localhost",
 				"refid":   "10.177.80.37",
 				"remote":  "131.188.3.221",
 				"stratum": "2",
@@ -441,13 +457,273 @@ func TestNoRefID(t *testing.T) {
 	require.NoError(t, acc.GatherError(n.Gather))
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
 }
+func TestMultipleServersNTPQ(t *testing.T) {
+	tt := tester{
+		ret: []byte(singleNTPQ),
+		err: nil,
+	}
+	n := newNTPQ()
+	n.DecimalReach = true
+	n.runQ = tt.runqTest
+	n.Servers = []string{ "test-server.example.com", "192.0.2.127" }
+
+	acc := testutil.Accumulator{}
+	assert.NoError(t, acc.GatherError(n.Gather))
+
+	fields := map[string]interface{}{
+		"when":   int64(101),
+		"poll":   int64(256),
+		"reach":  int64(31),
+		"delay":  float64(51.016),
+		"offset": float64(233.010),
+		"jitter": float64(17.462),
+	}
+	tags := map[string]string{
+		"server":       "",
+		"remote":       "uschi5-ntp-002.",
+		"state_prefix": "*",
+		"refid":        "10.177.80.46",
+		"stratum":      "2",
+		"type":         "u",
+	}
+
+	for _, server := range n.Servers {
+		tags["server"] = server
+		acc.AssertContainsTaggedFields(t, "ntpq", fields, tags)
+	}
+}
+
+func TestWideModeNTPQ(t *testing.T) {
+	now := time.Now()
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"ntpq",
+			map[string]string{
+				"server":       "localhost",
+				"remote":       "0.se.pool.ntp.org",
+				"refid":        ".POOL.",
+				"stratum":      "16",
+				"type":         "p",
+			},
+			map[string]interface{}{
+				"poll":   int64(64),
+				"reach":  int64(0),
+				"delay":  float64(0.000),
+				"offset": float64(0.000),
+				"jitter": float64(0.002),
+			},
+			now,
+		),
+		testutil.MustMetric(
+			"ntpq",
+			map[string]string{
+				"server":       "localhost",
+				"remote":       "1.se.pool.ntp.org",
+				"refid":        ".POOL.",
+				"stratum":      "16",
+				"type":         "p",
+			},
+			map[string]interface{}{
+				"poll":   int64(64),
+				"reach":  int64(0),
+				"delay":  float64(0.000),
+				"offset": float64(0.000),
+				"jitter": float64(0.002),
+			},
+			now,
+		),
+		testutil.MustMetric(
+			"ntpq",
+			map[string]string{
+				"server":       "localhost",
+				"remote":       "2.se.pool.ntp.org",
+				"refid":        ".POOL.",
+				"stratum":      "16",
+				"type":         "p",
+			},
+			map[string]interface{}{
+				"poll":   int64(64),
+				"reach":  int64(0),
+				"delay":  float64(0.000),
+				"offset": float64(0.000),
+				"jitter": float64(0.002),
+			},
+			now,
+		),
+		testutil.MustMetric(
+			"ntpq",
+			map[string]string{
+				"server":       "localhost",
+				"remote":       "3.se.pool.ntp.org",
+				"refid":        ".POOL.",
+				"stratum":      "16",
+				"type":         "p",
+			},
+			map[string]interface{}{
+				"poll":   int64(64),
+				"reach":  int64(0),
+				"delay":  float64(0.000),
+				"offset": float64(0.000),
+				"jitter": float64(0.002),
+			},
+			now,
+		),
+		testutil.MustMetric(
+			"ntpq",
+			map[string]string{
+				"server":       "localhost",
+				"remote":       "LOCAL(0)",
+				"refid":        ".LOCL.",
+				"stratum":      "10",
+				"type":         "l",
+			},
+			map[string]interface{}{
+				"when":   int64(9849600),
+				"poll":   int64(64),
+				"reach":  int64(0),
+				"delay":  float64(0.000),
+				"offset": float64(0.000),
+				"jitter": float64(0.000),
+			},
+			now,
+		),
+		testutil.MustMetric(
+			"ntpq",
+			map[string]string{
+				"server":       "localhost",
+				"state_prefix": "+",
+				"remote":       "193.11.166.8",
+				"refid":        ".PPS.",
+				"stratum":      "1",
+				"type":         "u",
+			},
+			map[string]interface{}{
+				"when":   int64(230),
+				"poll":   int64(1024),
+				"reach":  int64(377),
+				"delay":  float64(23.804),
+				"offset": float64(-0.368),
+				"jitter": float64(0.225),
+			},
+			now,
+		),
+		testutil.MustMetric(
+			"ntpq",
+			map[string]string{
+				"server":       "localhost",
+				"remote":       "193.11.166.20",
+				"refid":        ".XFAC.",
+				"stratum":      "16",
+				"type":         "u",
+			},
+			map[string]interface{}{
+				"poll":   int64(1024),
+				"reach":  int64(0),
+				"delay":  float64(0.000),
+				"offset": float64(0.000),
+				"jitter": float64(0.000),
+			},
+			now,
+		),
+		testutil.MustMetric(
+			"ntpq",
+			map[string]string{
+				"server":       "localhost",
+				"state_prefix": "*",
+				"remote":       "svl1.ntp.se",
+				"refid":        ".PPS.",
+				"stratum":      "1",
+				"type":         "u",
+			},
+			map[string]interface{}{
+				"when":   int64(880),
+				"poll":   int64(1024),
+				"reach":  int64(377),
+				"delay":  float64(10.049),
+				"offset": float64(0.415),
+				"jitter": float64(0.144),
+			},
+			now,
+		),
+		testutil.MustMetric(
+			"ntpq",
+			map[string]string{
+				"server":       "localhost",
+				"state_prefix": "+",
+				"remote":       "time.cloudflare.com",
+				"refid":        "10.128.9.5",
+				"stratum":      "3",
+				"type":         "u",
+			},
+			map[string]interface{}{
+				"when":   int64(511),
+				"poll":   int64(1024),
+				"reach":  int64(377),
+				"delay":  float64(15.930),
+				"offset": float64(0.679),
+				"jitter": float64(0.123),
+			},
+			now,
+		),
+	}
+
+	tt := tester{
+		ret: []byte(wideModeNTPQ),
+		err: nil,
+	}
+	n := newNTPQ()
+	n.WideMode = true
+	n.DNSLookup = true
+	n.runQ = tt.runqTest
+
+	acc := testutil.Accumulator{
+		TimeFunc: func() time.Time { return now },
+	}
+
+	require.NoError(t, acc.GatherError(n.Gather))
+
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
+}
+
+func TestDecimalReachNTPQ(t *testing.T) {
+	tt := tester{
+		ret: []byte(singleNTPQ),
+		err: nil,
+	}
+	n := newNTPQ()
+	n.DecimalReach = true
+	n.runQ = tt.runqTest
+
+	acc := testutil.Accumulator{}
+	assert.NoError(t, acc.GatherError(n.Gather))
+
+	fields := map[string]interface{}{
+		"when":   int64(101),
+		"poll":   int64(256),
+		"reach":  int64(31),
+		"delay":  float64(51.016),
+		"offset": float64(233.010),
+		"jitter": float64(17.462),
+	}
+	tags := map[string]string{
+		"server":				"localhost",
+		"remote":       "uschi5-ntp-002.",
+		"state_prefix": "*",
+		"refid":        "10.177.80.46",
+		"stratum":      "2",
+		"type":         "u",
+	}
+	acc.AssertContainsTaggedFields(t, "ntpq", fields, tags)
+}
+
 
 type tester struct {
 	ret []byte
 	err error
 }
 
-func (t *tester) runqTest() ([]byte, error) {
+func (t *tester) runqTest(server string) ([]byte, error) {
 	return t.ret, t.err
 }
 
@@ -519,4 +795,22 @@ var noRefID = `     remote           refid      st t when poll reach   delay   o
  83.137.98.96    10.177.80.37     2 u  740 1024  377   54.033  243.426 449514.
  91.189.94.4                      2 u  673 1024  377  143.047  274.726 449445.
  131.188.3.221   10.177.80.37     2 u  783 1024  377  111.820  261.921 449528.
+`
+// real-world output with a mixed bag of fun
+var wideModeNTPQ = `     remote           refid      st t when poll reach   delay   offset  jitter
+==============================================================================
+ 0.se.pool.ntp.org
+                 .POOL.          16 p    -   64    0    0.000    0.000   0.002
+ 1.se.pool.ntp.org
+                 .POOL.          16 p    -   64    0    0.000    0.000   0.002
+ 2.se.pool.ntp.org
+                 .POOL.          16 p    -   64    0    0.000    0.000   0.002
+ 3.se.pool.ntp.org
+                 .POOL.          16 p    -   64    0    0.000    0.000   0.002
+ LOCAL(0)        .LOCL.          10 l 114d   64    0    0.000    0.000   0.000
++193.11.166.8    .PPS.            1 u  230 1024  377   23.804   -0.368   0.225
+ 193.11.166.20   .XFAC.          16 u    - 1024    0    0.000    0.000   0.000
+*svl1.ntp.se     .PPS.            1 u  880 1024  377   10.049    0.415   0.144
++time.cloudflare.com
+                 10.128.9.5       3 u  511 1024  377   15.930    0.679   0.123
 `

--- a/plugins/inputs/ntpq/ntpq_test.go
+++ b/plugins/inputs/ntpq/ntpq_test.go
@@ -465,7 +465,7 @@ func TestMultipleServersNTPQ(t *testing.T) {
 	n := newNTPQ()
 	n.DecimalReach = true
 	n.runQ = tt.runqTest
-	n.Servers = []string{ "test-server.example.com", "192.0.2.127" }
+	n.Servers = []string{"test-server.example.com", "192.0.2.127"}
 
 	acc := testutil.Accumulator{}
 	assert.NoError(t, acc.GatherError(n.Gather))
@@ -499,11 +499,11 @@ func TestWideModeNTPQ(t *testing.T) {
 		testutil.MustMetric(
 			"ntpq",
 			map[string]string{
-				"server":       "localhost",
-				"remote":       "0.se.pool.ntp.org",
-				"refid":        ".POOL.",
-				"stratum":      "16",
-				"type":         "p",
+				"server":  "localhost",
+				"remote":  "0.se.pool.ntp.org",
+				"refid":   ".POOL.",
+				"stratum": "16",
+				"type":    "p",
 			},
 			map[string]interface{}{
 				"poll":   int64(64),
@@ -517,11 +517,11 @@ func TestWideModeNTPQ(t *testing.T) {
 		testutil.MustMetric(
 			"ntpq",
 			map[string]string{
-				"server":       "localhost",
-				"remote":       "1.se.pool.ntp.org",
-				"refid":        ".POOL.",
-				"stratum":      "16",
-				"type":         "p",
+				"server":  "localhost",
+				"remote":  "1.se.pool.ntp.org",
+				"refid":   ".POOL.",
+				"stratum": "16",
+				"type":    "p",
 			},
 			map[string]interface{}{
 				"poll":   int64(64),
@@ -535,11 +535,11 @@ func TestWideModeNTPQ(t *testing.T) {
 		testutil.MustMetric(
 			"ntpq",
 			map[string]string{
-				"server":       "localhost",
-				"remote":       "2.se.pool.ntp.org",
-				"refid":        ".POOL.",
-				"stratum":      "16",
-				"type":         "p",
+				"server":  "localhost",
+				"remote":  "2.se.pool.ntp.org",
+				"refid":   ".POOL.",
+				"stratum": "16",
+				"type":    "p",
 			},
 			map[string]interface{}{
 				"poll":   int64(64),
@@ -553,11 +553,11 @@ func TestWideModeNTPQ(t *testing.T) {
 		testutil.MustMetric(
 			"ntpq",
 			map[string]string{
-				"server":       "localhost",
-				"remote":       "3.se.pool.ntp.org",
-				"refid":        ".POOL.",
-				"stratum":      "16",
-				"type":         "p",
+				"server":  "localhost",
+				"remote":  "3.se.pool.ntp.org",
+				"refid":   ".POOL.",
+				"stratum": "16",
+				"type":    "p",
 			},
 			map[string]interface{}{
 				"poll":   int64(64),
@@ -571,11 +571,11 @@ func TestWideModeNTPQ(t *testing.T) {
 		testutil.MustMetric(
 			"ntpq",
 			map[string]string{
-				"server":       "localhost",
-				"remote":       "LOCAL(0)",
-				"refid":        ".LOCL.",
-				"stratum":      "10",
-				"type":         "l",
+				"server":  "localhost",
+				"remote":  "LOCAL(0)",
+				"refid":   ".LOCL.",
+				"stratum": "10",
+				"type":    "l",
 			},
 			map[string]interface{}{
 				"when":   int64(9849600),
@@ -610,11 +610,11 @@ func TestWideModeNTPQ(t *testing.T) {
 		testutil.MustMetric(
 			"ntpq",
 			map[string]string{
-				"server":       "localhost",
-				"remote":       "193.11.166.20",
-				"refid":        ".XFAC.",
-				"stratum":      "16",
-				"type":         "u",
+				"server":  "localhost",
+				"remote":  "193.11.166.20",
+				"refid":   ".XFAC.",
+				"stratum": "16",
+				"type":    "u",
 			},
 			map[string]interface{}{
 				"poll":   int64(1024),
@@ -682,7 +682,6 @@ func TestWideModeNTPQ(t *testing.T) {
 
 	require.NoError(t, acc.GatherError(n.Gather))
 
-
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
 }
 
@@ -707,7 +706,7 @@ func TestDecimalReachNTPQ(t *testing.T) {
 		"jitter": float64(17.462),
 	}
 	tags := map[string]string{
-		"server":				"localhost",
+		"server":       "localhost",
 		"remote":       "uschi5-ntp-002.",
 		"state_prefix": "*",
 		"refid":        "10.177.80.46",
@@ -716,7 +715,6 @@ func TestDecimalReachNTPQ(t *testing.T) {
 	}
 	acc.AssertContainsTaggedFields(t, "ntpq", fields, tags)
 }
-
 
 type tester struct {
 	ret []byte
@@ -796,6 +794,7 @@ var noRefID = `     remote           refid      st t when poll reach   delay   o
  91.189.94.4                      2 u  673 1024  377  143.047  274.726 449445.
  131.188.3.221   10.177.80.37     2 u  783 1024  377  111.820  261.921 449528.
 `
+
 // real-world output with a mixed bag of fun
 var wideModeNTPQ = `     remote           refid      st t when poll reach   delay   offset  jitter
 ==============================================================================


### PR DESCRIPTION
- support to query multiple servers (remote and/or local) - Addresses Issue #7606
- "wide mode" support and test if ntpq supports it on startup - Addresses Issue #4746
- conversion of "reach" output to something usable - Addresses Issue #2257

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
