### PR TITLE
Input sqlserver - Query Stats

### DIFF
--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -126,6 +126,7 @@ The new (version 2) metrics provide:
   blocking sessions.
 - *VolumeSpace* - uses sys.dm_os_volume_stats to get total, used and occupied space on every disk that contains a data or log file. (Note that even if enabled it won't get any data from Azure SQL Database or SQL Managed Instance). It is pointless to run this with high frequency (ie: every 10s), but it won't cause any problem.
 - *Cpu* - uses the buffer ring (sys.dm_os_ring_buffers) to get CPU data, the table is updated once per minute. (Note that even if enabled it won't get any data from Azure SQL Database or SQL Managed Instance).
+- *QueryStats* - Gets the top 50 queries by [total_elapsed_time] from sys.dm_exec_query_stats. (it's pointelss to run this every few seconds, run it every few minutes)
 
   In order to allow tracking on a per statement basis this query produces a
   unique tag for each query.  Depending on the database workload, this may

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -798,6 +798,7 @@ SET @SqlStatement = @SqlStatement + CAST(N' WHERE	(
 			instance_name IN (''_Total'')
 			AND counter_name IN (
 				''Lock Timeouts/sec'',
+				''Lock Timeouts (timeout > 0)/sec'',
 				''Number of Deadlocks/sec'',
 				''Lock Waits/sec'',
 				''Latch Waits/sec''

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -1705,12 +1705,14 @@ SELECT TOP 50
 	,CONVERT(varchar(20),qs.[query_hash],1) as [query_hash]
 	,CONVERT(varchar(20),qs.[query_plan_hash],1) as [query_plan_hash]
 	,QUOTENAME(OBJECT_SCHEMA_NAME(qt.objectid,qt.dbid)) + ''.'' +  QUOTENAME(OBJECT_NAME(qt.objectid,qt.dbid)) as stmt_object_name
-	,(SUBSTRING(qt.text, qs.[statement_start_offset] / 2 + 1,
+	,SUBSTRING(
+		qt.[text],
+		qs.[statement_start_offset] / 2 + 1,
 		(CASE WHEN qs.[statement_end_offset] = -1
-			THEN LEN(CONVERT(NVARCHAR(MAX), qt.text)) * 2
+			THEN DATALENGTH(qt.[text])
 			ELSE qs.[statement_end_offset]
-		END - qs.[statement_start_offset]) / 2)
-	) AS statement_text
+		END - qs.[statement_start_offset]) / 2 + 1
+	) AS [statement_text]
 	,DB_NAME(qt.[dbid]) stmt_db_name
 	,qs.[plan_generation_num]
 	,qs.[execution_count]
@@ -1776,12 +1778,14 @@ SELECT TOP 50
 	,CONVERT(varchar(20),qs.[query_hash],1) as [query_hash]
 	,CONVERT(varchar(20),qs.[query_plan_hash],1) as [query_plan_hash]
 	,QUOTENAME(OBJECT_SCHEMA_NAME(qt.objectid,qt.dbid)) + ''.'' +  QUOTENAME(OBJECT_NAME(qt.objectid,qt.dbid)) as stmt_object_name
-	,(SUBSTRING(qt.text, qs.[statement_start_offset] / 2 + 1,
+	,SUBSTRING(
+		qt.[text],
+		qs.[statement_start_offset] / 2 + 1,
 		(CASE WHEN qs.[statement_end_offset] = -1
-			THEN LEN(CONVERT(NVARCHAR(MAX), qt.text)) * 2
+			THEN DATALENGTH(qt.[text])
 			ELSE qs.[statement_end_offset]
-		END - qs.[statement_start_offset]) / 2)
-	) AS statement_text
+		END - qs.[statement_start_offset]) / 2 + 1
+	) AS [statement_text]
 	,DB_NAME(qt.[dbid]) stmt_db_name
 	,qs.[plan_generation_num]
 	,qs.[execution_count]

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -1736,7 +1736,8 @@ OUTER APPLY sys.dm_exec_sql_text(qs.[sql_handle]) AS qt
 ORDER BY
 	[total_elapsed_time] DESC
 '
-	EXEC sp_executesql @SqlStatement
+
+EXEC sp_executesql @SqlStatement
 
 END
 
@@ -1799,7 +1800,7 @@ ORDER BY
 	[total_elapsed_time] DESC
 '
 
-	EXEC sp_executesql @SqlStatement
+EXEC sp_executesql @SqlStatement
 	
 END
 `

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -801,7 +801,6 @@ SET @SqlStatement = @SqlStatement + CAST(N' WHERE	(
 			instance_name IN (''_Total'')
 			AND counter_name IN (
 				''Lock Timeouts/sec'',
-				''Lock Timeouts (timeout > 0)/sec'',
 				''Number of Deadlocks/sec'',
 				''Lock Waits/sec'',
 				''Latch Waits/sec''

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -66,6 +66,7 @@ query_version = 2
 ## - SqlRequests
 ## - VolumeSpace
 ## - Cpu
+## - QueryStats
 ## Version 1:
 ## - PerformanceCounters
 ## - WaitStatsCategorized
@@ -82,7 +83,7 @@ query_version = 2
 # include_query = []
 
 ## A list of queries to explicitly ignore.
-exclude_query = [ 'Schedulers' , 'SqlRequests']
+exclude_query = [ 'Schedulers' , 'SqlRequests','QueryStats']
 `
 
 // SampleConfig return the sample configuration

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -1692,53 +1692,60 @@ END
 const sqlServerQueryStatsV2 string = `
 SET DEADLOCK_PRIORITY -10;
 DECLARE
-	@EngineEdition AS tinyint = CAST(SERVERPROPERTY('EngineEdition') AS int)
+	 @EngineEdition AS tinyint = CAST(SERVERPROPERTY('EngineEdition') AS int)
+	,@SqlStatement AS nvarchar(max)
 
 IF @EngineEdition IN (5,8) /*Azure SQL DB, Managed Instance*/
-	SELECT TOP 50
-		'sqlserver_query_stats' AS [measurement]
-		,REPLACE(@@SERVERNAME,'\',':') AS [sql_instance]
-		,DB_NAME() as [database_name]
-		,qs.[query_hash]
-		,qs.[query_plan_hash]
-		,QUOTENAME(OBJECT_SCHEMA_NAME(qt.objectid,qt.dbid)) + '.' +  QUOTENAME(OBJECT_NAME(qt.objectid,qt.dbid)) as stmt_object_name
-		,(SUBSTRING(qt.text, qs.[statement_start_offset] / 2 + 1,
-			(CASE WHEN qs.[statement_end_offset] = -1
-				THEN LEN(CONVERT(NVARCHAR(MAX), qt.text)) * 2
-				ELSE qs.[statement_end_offset]
-			END - qs.[statement_start_offset]) / 2)
-		) AS statement_text
-		,DB_NAME(qt.[dbid]) stmt_db_name
-		,qs.[plan_generation_num]
-		,qs.[execution_count]
-		,qs.[total_worker_time]/1000 AS [total_worker_time_ms]
-		,qs.[total_physical_reads]
-		,qs.[total_logical_writes]
-		,qs.[total_logical_reads]
-		,qs.[total_clr_time]/1000 AS [total_clr_time_ms]
-		,qs.[total_elapsed_time]/1000 AS [total_elapsed_time_ms]
-		,qs.[total_rows]
-		,qs.[total_dop]
-		,qs.[total_grant_kb]
-		,qs.[total_used_grant_kb]
-		,qs.[total_ideal_grant_kb]
-		,qs.[total_reserved_threads]
-		,qs.[total_used_threads]
-		,qs.[total_columnstore_segment_reads]
-		,qs.[total_columnstore_segment_skips]
-		,qs.[total_spills]
-	FROM sys.dm_exec_query_stats as qs
-	OUTER APPLY sys.dm_exec_sql_text(qs.[sql_handle]) AS qt
-	ORDER BY
-		[total_elapsed_time] DESC
+BEGIN
+
+SET @SqlStatement = N'
+SELECT TOP 50
+	''sqlserver_query_stats'' AS [measurement]
+	,REPLACE(@@SERVERNAME,''\'','':'') AS [sql_instance]
+	,DB_NAME() as [database_name]
+	,CONVERT(varchar(20),qs.[query_hash],1) as [query_hash]
+	,CONVERT(varchar(20),qs.[query_plan_hash],1) as [query_plan_hash]
+	,QUOTENAME(OBJECT_SCHEMA_NAME(qt.objectid,qt.dbid)) + ''.'' +  QUOTENAME(OBJECT_NAME(qt.objectid,qt.dbid)) as stmt_object_name
+	,(SUBSTRING(qt.text, qs.[statement_start_offset] / 2 + 1,
+		(CASE WHEN qs.[statement_end_offset] = -1
+			THEN LEN(CONVERT(NVARCHAR(MAX), qt.text)) * 2
+			ELSE qs.[statement_end_offset]
+		END - qs.[statement_start_offset]) / 2)
+	) AS statement_text
+	,DB_NAME(qt.[dbid]) stmt_db_name
+	,qs.[plan_generation_num]
+	,qs.[execution_count]
+	,qs.[total_worker_time]/1000 AS [total_worker_time_ms]
+	,qs.[total_physical_reads]
+	,qs.[total_logical_writes]
+	,qs.[total_logical_reads]
+	,qs.[total_clr_time]/1000 AS [total_clr_time_ms]
+	,qs.[total_elapsed_time]/1000 AS [total_elapsed_time_ms]
+	,qs.[total_rows]
+	,qs.[total_dop]
+	,qs.[total_grant_kb]
+	,qs.[total_used_grant_kb]
+	,qs.[total_ideal_grant_kb]
+	,qs.[total_reserved_threads]
+	,qs.[total_used_threads]
+	,qs.[total_columnstore_segment_reads]
+	,qs.[total_columnstore_segment_skips]
+	,qs.[total_spills]
+FROM sys.dm_exec_query_stats as qs
+OUTER APPLY sys.dm_exec_sql_text(qs.[sql_handle]) AS qt
+ORDER BY
+	[total_elapsed_time] DESC
+'
+	EXEC sp_executesql @SqlStatement
+
+END
 
 ELSE IF @EngineEdition IN (2,3,4) /*Standard,Enterprise,Express*/
-	BEGIN
+BEGIN
 
-	DECLARE
-		 @SqlStatement AS nvarchar(max)
-		,@MajorMinorVersion AS int = CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') as nvarchar),4) AS int)*100 + CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') as nvarchar),3) AS int)
-		,@Columns AS nvarchar(MAX) = ''
+DECLARE
+	 @MajorMinorVersion AS int = CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') as nvarchar),4) AS int)*100 + CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') as nvarchar),3) AS int)
+	,@Columns AS nvarchar(MAX) = ''
 
 IF @MajorMinorVersion >= 1050 BEGIN
 	SET @Columns += N',qs.[total_rows]'
@@ -1767,8 +1774,8 @@ SELECT TOP 50
 	''sqlserver_query_stats'' AS [measurement]
 	,REPLACE(@@SERVERNAME,''\'','':'') AS [sql_instance]
 	,DB_NAME() as [database_name]
-	,qs.[query_hash]
-	,qs.[query_plan_hash]
+	,CONVERT(varchar(20),qs.[query_hash],1) as [query_hash]
+	,CONVERT(varchar(20),qs.[query_plan_hash],1) as [query_plan_hash]
 	,QUOTENAME(OBJECT_SCHEMA_NAME(qt.objectid,qt.dbid)) + ''.'' +  QUOTENAME(OBJECT_NAME(qt.objectid,qt.dbid)) as stmt_object_name
 	,(SUBSTRING(qt.text, qs.[statement_start_offset] / 2 + 1,
 		(CASE WHEN qs.[statement_end_offset] = -1
@@ -1793,6 +1800,7 @@ ORDER BY
 '
 
 	EXEC sp_executesql @SqlStatement
+	
 END
 `
 

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -1731,6 +1731,7 @@ SELECT TOP 50
 	,qs.[total_columnstore_segment_reads]
 	,qs.[total_columnstore_segment_skips]
 	,qs.[total_spills]
+	,qs.[total_page_server_reads]
 FROM sys.dm_exec_query_stats as qs
 OUTER APPLY sys.dm_exec_sql_text(qs.[sql_handle]) AS qt
 ORDER BY

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -16,7 +16,7 @@ func TestSqlServer_QueriesInclusionExclusion(t *testing.T) {
 	cases := []map[string]interface{}{
 		{
 			"IncludeQuery": []string{},
-			"ExcludeQuery": []string{"WaitStatsCategorized", "DatabaseIO", "ServerProperties", "MemoryClerk", "Schedulers", "VolumeSpace", "Cpu"},
+			"ExcludeQuery": []string{"WaitStatsCategorized", "DatabaseIO", "ServerProperties", "MemoryClerk", "Schedulers", "VolumeSpace", "Cpu", "QueryStats"},
 			"queries":      []string{"PerformanceCounters", "SqlRequests"},
 			"queriesTotal": 2,
 		},


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

closes #7789

This PR adds a new query which gets data from sys.dm_exec_query_stats.

It fetches incremental data about the top 50 queries executed on the SQL Server instance (as long as a query plan is in cache).
The information gathered is at query and exec plan level, useful to check which queries have the longest duration, which often corresponds with the heaviest or most executed queries.

The query has been tested on:
- SQL on-prem from 2008 to 2019
- Azure SQL DB


Notes:
- The query is disabled in the proposed default configuration
- It's pointless to run this every few seconds, makes sense to run it every few minutes

My personal opinion is that the information returned by this query ("QueryStats") can complete and/or enrich what is already gathered by "SqlRequests". The difference is that "QueryStats" provides data on a larger timespan, giving a higher-level overview of the situation.

Any feedback is appreciated