### PR TITLE
prefer testify error funcs over nil checks

### DIFF
--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -269,11 +269,11 @@ func TestCompressWithGzipEarlyClose(t *testing.T) {
 
 func TestVersionAlreadySet(t *testing.T) {
 	err := SetVersion("foo")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = SetVersion("bar")
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.IsType(t, VersionAlreadySetError, err)
 
 	assert.Equal(t, "foo", Version())

--- a/plugins/inputs/bind/bind_test.go
+++ b/plugins/inputs/bind/bind_test.go
@@ -25,7 +25,7 @@ func TestBindJsonStats(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(b.Gather)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Use subtests for counters, since they are similar structure
 	type fieldSet struct {
@@ -195,7 +195,7 @@ func TestBindXmlStatsV2(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(b.Gather)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Use subtests for counters, since they are similar structure
 	type fieldSet struct {
@@ -397,7 +397,7 @@ func TestBindXmlStatsV3(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(b.Gather)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Use subtests for counters, since they are similar structure
 	type fieldSet struct {

--- a/plugins/inputs/cassandra/cassandra_test.go
+++ b/plugins/inputs/cassandra/cassandra_test.go
@@ -153,7 +153,7 @@ func TestHttpJsonJavaMultiValue(t *testing.T) {
 	acc.SetDebug(true)
 	err := acc.GatherError(cassandra.Gather)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(acc.Metrics))
 
 	fields := map[string]interface{}{
@@ -182,7 +182,7 @@ func TestHttpJsonJavaMultiType(t *testing.T) {
 	acc.SetDebug(true)
 	err := acc.GatherError(cassandra.Gather)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(acc.Metrics))
 
 	fields := map[string]interface{}{
@@ -217,7 +217,7 @@ func TestHttpJsonCassandraMultiValue(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(cassandra.Gather)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(acc.Metrics))
 
 	fields := map[string]interface{}{
@@ -249,7 +249,7 @@ func TestHttpJsonCassandraNestedMultiValue(t *testing.T) {
 	acc.SetDebug(true)
 	err := acc.GatherError(cassandra.Gather)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(acc.Metrics))
 
 	fields1 := map[string]interface{}{

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -218,7 +218,7 @@ func TestSelectMetrics(t *testing.T) {
 	// We've asked for 2 (out of 4) metrics, over all 3 load balancers in all 2
 	// AZs. We should get 12 metrics.
 	assert.Equal(t, 12, len(filtered[0].metrics))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGenerateStatisticsInputParams(t *testing.T) {

--- a/plugins/inputs/filecount/filesystem_helpers_test.go
+++ b/plugins/inputs/filecount/filesystem_helpers_test.go
@@ -13,7 +13,7 @@ func TestMTime(t *testing.T) {
 
 	fs := getTestFileSystem()
 	fileInfo, err := fs.Stat("/testdata/foo")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, mtime, fileInfo.ModTime())
 }
 
@@ -22,7 +22,7 @@ func TestSize(t *testing.T) {
 	size := int64(4096)
 	fs := getTestFileSystem()
 	fileInfo, err := fs.Stat("/testdata")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, size, fileInfo.Size())
 }
 
@@ -31,7 +31,7 @@ func TestIsDir(t *testing.T) {
 	dir := true
 	fs := getTestFileSystem()
 	fileInfo, err := fs.Stat("/testdata")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, dir, fileInfo.IsDir())
 }
 
@@ -40,7 +40,7 @@ func TestRealFS(t *testing.T) {
 	var fs fileSystem = osFS{}
 	//the following file exists on disk - and not in our fake fs
 	fileInfo, err := fs.Stat(getTestdataDir() + "/qux")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, false, fileInfo.IsDir())
 	require.Equal(t, int64(446), fileInfo.Size())
 
@@ -52,7 +52,7 @@ func TestRealFS(t *testing.T) {
 	require.Equal(t, expectedError, err.Error())
 	// and verify that what we DO expect to find, we do
 	fileInfo, err = fs.Stat("/testdata/foo")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func getTestFileSystem() fakeFileSystem {

--- a/plugins/inputs/github/github_test.go
+++ b/plugins/inputs/github/github_test.go
@@ -13,11 +13,11 @@ func TestNewGithubClient(t *testing.T) {
 	httpClient := &http.Client{}
 	g := &GitHub{}
 	client, err := g.newGithubClient(httpClient)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Contains(t, client.BaseURL.String(), "api.github.com")
 	g.EnterpriseBaseURL = "api.example.com/"
 	enterpriseClient, err := g.newGithubClient(httpClient)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Contains(t, enterpriseClient.BaseURL.String(), "api.example.com")
 }
 
@@ -51,7 +51,7 @@ func TestSplitRepositoryNameWithNoSlash(t *testing.T) {
 		t.Run(tt, func(t *testing.T) {
 			_, _, err := splitRepositoryName(tt)
 
-			require.NotNil(t, err)
+			require.Error(t, err)
 		})
 	}
 }

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -23,7 +23,7 @@ func TestParsePath(t *testing.T) {
 	path := "/foo/bar/bla[shoo=woo][shoop=/woop/]/z"
 	parsed, err := parsePath("theorigin", path, "thetarget")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, parsed.Origin, "theorigin")
 	assert.Equal(t, parsed.Target, "thetarget")
 	assert.Equal(t, parsed.Element, []string{"foo", "bar", "bla[shoo=woo][shoop=/woop/]", "z"})
@@ -31,7 +31,7 @@ func TestParsePath(t *testing.T) {
 		{Name: "bla", Key: map[string]string{"shoo": "woo", "shoop": "/woop/"}}, {Name: "z"}})
 
 	parsed, err = parsePath("", "", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, *parsed, gnmi.Path{})
 
 	parsed, err = parsePath("", "/foo[[", "")

--- a/plugins/inputs/jolokia/jolokia_test.go
+++ b/plugins/inputs/jolokia/jolokia_test.go
@@ -160,7 +160,7 @@ func TestHttpJsonMultiValue(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(jolokia.Gather)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(acc.Metrics))
 
 	fields := map[string]interface{}{
@@ -184,7 +184,7 @@ func TestHttpJsonBulkResponse(t *testing.T) {
 	var acc testutil.Accumulator
 	err := jolokia.Gather(&acc)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(acc.Metrics))
 
 	fields := map[string]interface{}{
@@ -212,7 +212,7 @@ func TestHttpJsonThreeLevelMultiValue(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(jolokia.Gather)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(acc.Metrics))
 
 	fields := map[string]interface{}{

--- a/plugins/inputs/statsd/datadog_test.go
+++ b/plugins/inputs/statsd/datadog_test.go
@@ -81,13 +81,13 @@ func TestEventGather(t *testing.T) {
 		t.Run(tests[i].name, func(t *testing.T) {
 			err := s.parseEventMessage(tests[i].now, tests[i].message, tests[i].hostname)
 			if tests[i].err {
-				require.NotNil(t, err)
+				require.Error(t, err)
 			} else {
-				require.Nil(t, err)
+				require.NoError(t, err)
 			}
 			require.Equal(t, uint64(i+1), acc.NMetrics())
 
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, tests[i].expected.title, acc.Metrics[i].Measurement)
 			require.Equal(t, tests[i].expected.tags, acc.Metrics[i].Tags)
 			require.Equal(t, tests[i].expected.fields, acc.Metrics[i].Fields)
@@ -388,7 +388,7 @@ func TestEvents(t *testing.T) {
 		t.Run(tests[i].name, func(t *testing.T) {
 			acc.ClearMetrics()
 			err := s.parseEventMessage(tests[i].args.now, tests[i].args.message, tests[i].args.hostname)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			m := acc.Metrics[0]
 			require.Equal(t, tests[i].expected.title, m.Measurement)
 			require.Equal(t, tests[i].expected.text, m.Fields["text"])

--- a/plugins/inputs/syslog/rfc5426_test.go
+++ b/plugins/inputs/syslog/rfc5426_test.go
@@ -238,7 +238,7 @@ func testRFC5426(t *testing.T, protocol string, address string, bestEffort bool)
 			// Connect
 			conn, err := net.Dial(protocol, address)
 			require.NotNil(t, conn)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			// Write
 			_, err = conn.Write(tc.data)
@@ -326,7 +326,7 @@ func TestTimeIncrement_udp(t *testing.T) {
 	conn, err := net.Dial("udp", address)
 	require.NotNil(t, conn)
 	defer conn.Close()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Write
 	_, e := conn.Write([]byte("<1>1 - - - - - -"))

--- a/plugins/parsers/collectd/parser_test.go
+++ b/plugins/parsers/collectd/parser_test.go
@@ -110,7 +110,7 @@ var multiMetric = testCase{
 
 func TestNewCollectdParser(t *testing.T) {
 	parser, err := NewCollectdParser("", "", []string{}, "join")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, parser.popts.SecurityLevel, network.None)
 	require.NotNil(t, parser.popts.PasswordLookup)
 	require.Nil(t, parser.popts.TypesDB)
@@ -121,14 +121,14 @@ func TestParse(t *testing.T) {
 
 	for _, tc := range cases {
 		buf, err := writeValueList(tc.vl)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		bytes, err := buf.Bytes()
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		parser := &CollectdParser{}
-		require.Nil(t, err)
+		require.NoError(t, err)
 		metrics, err := parser.Parse(bytes)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		assertEqualMetrics(t, tc.expected, metrics)
 	}
@@ -136,30 +136,30 @@ func TestParse(t *testing.T) {
 
 func TestParseMultiValueSplit(t *testing.T) {
 	buf, err := writeValueList(multiMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	bytes, err := buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	parser := &CollectdParser{ParseMultiValue: "split"}
 	metrics, err := parser.Parse(bytes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 2, len(metrics))
 }
 
 func TestParse_DefaultTags(t *testing.T) {
 	buf, err := writeValueList(singleMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	bytes, err := buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	parser := &CollectdParser{}
 	parser.SetDefaultTags(map[string]string{
 		"foo": "bar",
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	metrics, err := parser.Parse(bytes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, "bar", metrics[0].Tags()["foo"])
 }
@@ -178,45 +178,45 @@ func TestParse_SignSecurityLevel(t *testing.T) {
 
 	// Signed data
 	buf, err := writeValueList(singleMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	buf.Sign("user0", "bar")
 	bytes, err := buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	metrics, err := parser.Parse(bytes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assertEqualMetrics(t, singleMetric.expected, metrics)
 
 	// Encrypted data
 	buf, err = writeValueList(singleMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	buf.Encrypt("user0", "bar")
 	bytes, err = buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	metrics, err = parser.Parse(bytes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assertEqualMetrics(t, singleMetric.expected, metrics)
 
 	// Plain text data skipped
 	buf, err = writeValueList(singleMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	bytes, err = buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	metrics, err = parser.Parse(bytes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, []telegraf.Metric{}, metrics)
 
 	// Wrong password error
 	buf, err = writeValueList(singleMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	buf.Sign("x", "y")
 	bytes, err = buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	metrics, err = parser.Parse(bytes)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestParse_EncryptSecurityLevel(t *testing.T) {
@@ -233,57 +233,57 @@ func TestParse_EncryptSecurityLevel(t *testing.T) {
 
 	// Signed data skipped
 	buf, err := writeValueList(singleMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	buf.Sign("user0", "bar")
 	bytes, err := buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	metrics, err := parser.Parse(bytes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, []telegraf.Metric{}, metrics)
 
 	// Encrypted data
 	buf, err = writeValueList(singleMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	buf.Encrypt("user0", "bar")
 	bytes, err = buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	metrics, err = parser.Parse(bytes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assertEqualMetrics(t, singleMetric.expected, metrics)
 
 	// Plain text data skipped
 	buf, err = writeValueList(singleMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	bytes, err = buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	metrics, err = parser.Parse(bytes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, []telegraf.Metric{}, metrics)
 
 	// Wrong password error
 	buf, err = writeValueList(singleMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	buf.Sign("x", "y")
 	bytes, err = buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	metrics, err = parser.Parse(bytes)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestParseLine(t *testing.T) {
 	buf, err := writeValueList(singleMetric.vl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	bytes, err := buf.Bytes()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	parser, err := NewCollectdParser("", "", []string{}, "split")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	metric, err := parser.ParseLine(string(bytes))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	assertEqualMetrics(t, singleMetric.expected, []telegraf.Metric{metric})
 }

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -400,7 +400,7 @@ func TestParseEpochDecimal(t *testing.T) {
 
 			if tt.noMatch {
 				require.Nil(t, m)
-				require.Nil(t, err)
+				require.NoError(t, err)
 				return
 			}
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

[NoError](https://godoc.org/github.com/stretchr/testify/require#NoError) is for asserting no error was return
[Error](https://godoc.org/github.com/stretchr/testify/require#Error) is for asserting an error was returned

## Why these are better than Nil and NotNil
```golang
return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
```
```golang
return Fail(t, "An error is expected but got nil.", msgAndArgs...)
```
When these fail their message explicitly calls out that we were or were not expecting an error. This communicates the intent of the assertion.
