### PR TITLE
clarify docs and add warning if execd is misconfigured

### DIFF
--- a/plugins/inputs/execd/README.md
+++ b/plugins/inputs/execd/README.md
@@ -17,7 +17,8 @@ STDERR from the process will be relayed to Telegraf as errors in the logs.
 
 ```toml
 [[inputs.execd]]
-  ## Program to run as daemon
+  ## One program to run as daemon.
+  ## NOTE: process and each argument should each be their own string
   command = ["telegraf-smartctl", "-d", "/dev/sda"]
 
   ## Define how the process is signaled on each collection interval.

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -79,7 +79,9 @@ func (e *Execd) Start(acc telegraf.Accumulator) error {
 		// if there was only one argument, and it contained spaces, warn the user
 		// that they may have configured it wrong.
 		if len(e.Command) == 1 && strings.Contains(e.Command[0], " ") {
-			e.Log.Warn("Command contained spaces but no arguments. Check docs to make sure you've configured inputs.execd Command correctly.")
+			e.Log.Warn("The inputs.execd Command contained spaces but no arguments. " +
+				"This setting expects the program and arguments as an array of strings, " +
+				"not as a space-delimited string. See the plugin readme for an example.")
 		}
 		return fmt.Errorf("failed to start process %s: %w", e.Command, err)
 	}

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -75,6 +76,11 @@ func (e *Execd) Start(acc telegraf.Accumulator) error {
 	e.process.ReadStderrFn = e.cmdReadErr
 
 	if err = e.process.Start(); err != nil {
+		// if there was only one argument, and it contained spaces, warn the user
+		// that they may have configured it wrong.
+		if len(e.Command) == 1 && strings.Contains(e.Command[0], " ") {
+			e.Log.Warn("Command contained spaces but no arguments. Check docs to make sure you've configured inputs.execd Command correctly.")
+		}
 		return fmt.Errorf("failed to start process %s: %w", e.Command, err)
 	}
 

--- a/plugins/outputs/execd/README.md
+++ b/plugins/outputs/execd/README.md
@@ -8,7 +8,8 @@ Telegraf minimum version: Telegraf 1.15.0
 
 ```toml
 [[outputs.execd]]
-  ## Program to run as daemon
+  ## One program to run as daemon.
+  ## NOTE: process and each argument should each be their own string
   command = ["my-telegraf-output", "--some-flag", "value"]
 
   ## Delay before the process is restarted after an unexpected termination

--- a/plugins/outputs/execd/execd.go
+++ b/plugins/outputs/execd/execd.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -69,6 +70,11 @@ func (e *Execd) Init() error {
 
 func (e *Execd) Connect() error {
 	if err := e.process.Start(); err != nil {
+		// if there was only one argument, and it contained spaces, warn the user
+		// that they may have configured it wrong.
+		if len(e.Command) == 1 && strings.Contains(e.Command[0], " ") {
+			e.Log.Warn("Command contained spaces but no arguments. Check docs to make sure you've configured outputs.execd Command correctly.")
+		}
 		return fmt.Errorf("failed to start process %s: %w", e.Command, err)
 	}
 

--- a/plugins/outputs/execd/execd.go
+++ b/plugins/outputs/execd/execd.go
@@ -73,7 +73,9 @@ func (e *Execd) Connect() error {
 		// if there was only one argument, and it contained spaces, warn the user
 		// that they may have configured it wrong.
 		if len(e.Command) == 1 && strings.Contains(e.Command[0], " ") {
-			e.Log.Warn("Command contained spaces but no arguments. Check docs to make sure you've configured outputs.execd Command correctly.")
+			e.Log.Warn("The outputs.execd Command contained spaces but no arguments. " +
+				"This setting expects the program and arguments as an array of strings, " +
+				"not as a space-delimited string. See the plugin readme for an example.")
 		}
 		return fmt.Errorf("failed to start process %s: %w", e.Command, err)
 	}

--- a/plugins/processors/execd/README.md
+++ b/plugins/processors/execd/README.md
@@ -24,7 +24,8 @@ Telegraf minimum version: Telegraf 1.15.0
 
 ```toml
 [[processor.execd]]
-  ## Program to run as daemon
+  ## One program to run as daemon.
+  ## NOTE: process and each argument should each be their own string
   ## eg: command = ["/path/to/your_program", "arg1", "arg2"]
   command = ["cat"]
 

--- a/plugins/processors/execd/execd.go
+++ b/plugins/processors/execd/execd.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -79,6 +80,11 @@ func (e *Execd) Start(acc telegraf.Accumulator) error {
 	e.process.ReadStderrFn = e.cmdReadErr
 
 	if err = e.process.Start(); err != nil {
+		// if there was only one argument, and it contained spaces, warn the user
+		// that they may have configured it wrong.
+		if len(e.Command) == 1 && strings.Contains(e.Command[0], " ") {
+			e.Log.Warn("Command contained spaces but no arguments. Check docs to make sure you've configured processors.execd Command correctly.")
+		}
 		return fmt.Errorf("failed to start process %s: %w", e.Command, err)
 	}
 

--- a/plugins/processors/execd/execd.go
+++ b/plugins/processors/execd/execd.go
@@ -83,7 +83,9 @@ func (e *Execd) Start(acc telegraf.Accumulator) error {
 		// if there was only one argument, and it contained spaces, warn the user
 		// that they may have configured it wrong.
 		if len(e.Command) == 1 && strings.Contains(e.Command[0], " ") {
-			e.Log.Warn("Command contained spaces but no arguments. Check docs to make sure you've configured processors.execd Command correctly.")
+			e.Log.Warn("The processors.execd Command contained spaces but no arguments. " +
+				"This setting expects the program and arguments as an array of strings, " +
+				"not as a space-delimited string. See the plugin readme for an example.")
 		}
 		return fmt.Errorf("failed to start process %s: %w", e.Command, err)
 	}


### PR DESCRIPTION
Addresses some of the concerns raised in https://github.com/influxdata/telegraf/issues/7859. Clarify docs and warn users if the plugin appears to be used in an unintended way.