### PR TITLE
MongoDB: Added new metric "pages written from cache"

### DIFF
--- a/plugins/inputs/mongodb/mongodb_data.go
+++ b/plugins/inputs/mongodb/mongodb_data.go
@@ -206,6 +206,7 @@ var WiredTigerExtStats = map[string]string{
 	"wtcache_pages_evicted_by_app_thread":  "PagesEvictedByAppThread",
 	"wtcache_pages_queued_for_eviction":    "PagesQueuedForEviction",
 	"wtcache_pages_read_into":              "PagesReadIntoCache",
+	"wtcache_pages_written_from":           "PagesWrittenFromCache",
 	"wtcache_pages_requested_from":         "PagesRequestedFromCache",
 	"wtcache_server_evicting_pages":        "ServerEvictingPages",
 	"wtcache_worker_thread_evictingpages":  "WorkerThreadEvictingPages",

--- a/plugins/inputs/mongodb/mongodb_data_test.go
+++ b/plugins/inputs/mongodb/mongodb_data_test.go
@@ -106,7 +106,7 @@ func TestAddWiredTigerStats(t *testing.T) {
 			BytesReadInto:             0,
 			PagesEvictedByAppThread:   0,
 			PagesQueuedForEviction:    0,
-			PagesWrittenFromCache:     0,
+			PagesWrittenFromCache:     1247,
 			ServerEvictingPages:       0,
 			WorkerThreadEvictingPages: 0,
 			FaultsCnt:                 204,

--- a/plugins/inputs/mongodb/mongodb_data_test.go
+++ b/plugins/inputs/mongodb/mongodb_data_test.go
@@ -106,6 +106,7 @@ func TestAddWiredTigerStats(t *testing.T) {
 			BytesReadInto:             0,
 			PagesEvictedByAppThread:   0,
 			PagesQueuedForEviction:    0,
+			PagesWrittenFromCache:     0,
 			ServerEvictingPages:       0,
 			WorkerThreadEvictingPages: 0,
 			FaultsCnt:                 204,

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -203,6 +203,7 @@ type CacheStats struct {
 	PagesEvictedByAppThread   int64 `bson:"pages evicted by application threads"`
 	PagesQueuedForEviction    int64 `bson:"pages queued for eviction"`
 	PagesReadIntoCache        int64 `bson:"pages read into cache"`
+	PagesWrittenFromCache     int64 `bson:"pages written from cache"`
 	PagesRequestedFromCache   int64 `bson:"pages requested from the cache"`
 	ServerEvictingPages       int64 `bson:"eviction server evicting pages"`
 	WorkerThreadEvictingPages int64 `bson:"eviction worker thread evicting pages"`
@@ -703,6 +704,7 @@ type StatLine struct {
 	PagesEvictedByAppThread   int64
 	PagesQueuedForEviction    int64
 	PagesReadIntoCache        int64
+	PagesWrittenFromCache     int64
 	PagesRequestedFromCache   int64
 	ServerEvictingPages       int64
 	WorkerThreadEvictingPages int64
@@ -1080,6 +1082,7 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 		returnVal.PagesEvictedByAppThread = newStat.WiredTiger.Cache.PagesEvictedByAppThread
 		returnVal.PagesQueuedForEviction = newStat.WiredTiger.Cache.PagesQueuedForEviction
 		returnVal.PagesReadIntoCache = newStat.WiredTiger.Cache.PagesReadIntoCache
+		returnVal.PagesWrittenFromCache = newStat.WiredTiger.Cache.PagesWrittenFromCache
 		returnVal.PagesRequestedFromCache = newStat.WiredTiger.Cache.PagesRequestedFromCache
 		returnVal.ServerEvictingPages = newStat.WiredTiger.Cache.ServerEvictingPages
 		returnVal.WorkerThreadEvictingPages = newStat.WiredTiger.Cache.WorkerThreadEvictingPages


### PR DESCRIPTION
Added new metric "pages written from cache" for MongoDB
Below is the test result

 mongodb,host=my-system,hostname=127.0.0.1:27017 active_reads=1i,active_writes=0i,aggregate_command_failed=0i,aggregate_command_total=0i,assert_msg=0i,assert_regular=0i,assert_rollovers=0i,assert_user=8i,assert_warning=0i,available_reads=127i,available_writes=128i,commands=74i,commands_per_sec=12i,connections_available=203i,connections_current=1i,connections_total_created=1i,count_command_failed=0i,count_command_total=1i,cursor_no_timeout=0i,cursor_no_timeout_count=0i,cursor_pinned=0i,cursor_pinned_count=0i,cursor_timed_out=0i,cursor_timed_out_count=0i,cursor_total=0i,cursor_total_count=0i,delete_command_failed=0i,delete_command_total=0i,deletes=0i,deletes_per_sec=0i,distinct_command_failed=0i,distinct_command_total=0i,document_deleted=0i,document_inserted=0i,document_returned=1i,document_updated=0i,find_and_modify_command_failed=0i,find_and_modify_command_total=0i,find_command_failed=0i,find_command_total=30i,flushes=143i,flushes_per_sec=0i,flushes_total_time_ns=1642000000i,get_more_command_failed=0i,get_more_command_total=0i,getmores=1i,getmores_per_sec=1i,insert_command_failed=0i,insert_command_total=0i,inserts=0i,inserts_per_sec=0i,jumbo_chunks=0i,latency_commands=23646i,latency_commands_count=14i,latency_reads=2248i,latency_reads_count=2i,latency_writes=0i,latency_writes_count=0i,net_in_bytes=873i,net_in_bytes_count=1122i,net_out_bytes=51140i,net_out_bytes_count=51531i,open_connections=1i,operation_scan_and_order=0i,operation_write_conflicts=0i,page_faults=2075i,percent_cache_dirty=0,percent_cache_used=0,queries=30i,queries_per_sec=0i,queued_reads=0i,queued_writes=0i,resident_megabytes=24i,storage_freelist_search_bucket_exhausted=0i,storage_freelist_search_requests=0i,storage_freelist_search_scanned=0i,tcmalloc_central_cache_free_bytes=0i,tcmalloc_current_allocated_bytes=0i,tcmalloc_current_total_thread_cache_bytes=0i,tcmalloc_heap_size=0i,tcmalloc_max_total_thread_cache_bytes=0i,tcmalloc_pageheap_commit_count=0i,tcmalloc_pageheap_committed_bytes=0i,tcmalloc_pageheap_decommit_count=0i,tcmalloc_pageheap_free_bytes=0i,tcmalloc_pageheap_reserve_count=0i,tcmalloc_pageheap_scavenge_count=0i,tcmalloc_pageheap_total_commit_bytes=0i,tcmalloc_pageheap_total_decommit_bytes=0i,tcmalloc_pageheap_total_reserve_bytes=0i,tcmalloc_pageheap_unmapped_bytes=0i,tcmalloc_spinlock_total_delay_ns=0i,tcmalloc_thread_cache_free_bytes=0i,tcmalloc_total_free_bytes=0i,tcmalloc_transfer_cache_free_bytes=0i,total_available=0i,total_created=0i,total_docs_scanned=0i,total_in_use=0i,total_keys_scanned=0i,total_refreshing=0i,total_tickets_reads=128i,total_tickets_writes=128i,ttl_deletes=0i,ttl_deletes_per_sec=0i,ttl_passes=143i,ttl_passes_per_sec=1i,update_command_failed=0i,update_command_total=0i,updates=0i,updates_per_sec=0i,uptime_ns=8592302000000i,version="4.2.8",vsize_megabytes=5485i,wtcache_app_threads_page_read_count=6i,wtcache_app_threads_page_read_time=63i,wtcache_app_threads_page_write_count=12i,wtcache_bytes_read_into=30002i,wtcache_bytes_written_from=85607i,wtcache_current_bytes=50943i,wtcache_internal_pages_evicted=0i,wtcache_max_bytes_configured=8053063680i,wtcache_modified_pages_evicted=0i,wtcache_pages_evicted_by_app_thread=0i,wtcache_pages_queued_for_eviction=0i,wtcache_pages_read_into=14i,wtcache_pages_requested_from=1200i,wtcache_pages_written_from=14i,wtcache_server_evicting_pages=0i,wtcache_tracked_dirty_bytes=0i,wtcache_unmodified_pages_evicted=0i,wtcache_worker_thread_evictingpages=0i 1595331728000000000