### PR TITLE
input consul - added metric_version flag

### DIFF
--- a/plugins/inputs/consul/README.md
+++ b/plugins/inputs/consul/README.md
@@ -17,6 +17,13 @@ report those stats already using StatsD protocol if needed.
   ## URI scheme for the Consul server, one of "http", "https"
   # scheme = "http"
 
+  ## Metric version controls the mapping from Consul metrics into
+  ## Telegraf metrics.
+  ##
+  ##   example: metric_version = 1; deprecated in 1.15
+  ##            metric_version = 2; recommended version
+  # metric_version = 1
+
   ## ACL token used in every request
   # token = ""
 

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -20,6 +20,8 @@ type Consul struct {
 	Datacenter string
 	tls.ClientConfig
 	TagDelimiter string
+	MetricVersion int
+	Log telegraf.Logger
 
 	// client used to connect to Consul agnet
 	client *api.Client
@@ -31,6 +33,13 @@ var sampleConfig = `
 
   ## URI scheme for the Consul server, one of "http", "https"
   # scheme = "http"
+
+  ## Metric version controls the mapping from Consul metrics into
+  ## Telegraf metrics.
+  ##
+  ##   example: metric_version = 1; deprecated in 1.15
+  ##            metric_version = 2; recommended version
+  # metric_version = 1
 
   ## ACL token used in every request
   # token = ""
@@ -54,6 +63,14 @@ var sampleConfig = `
   # they will be splitted and reported as proper key:value in Telegraf
   # tag_delimiter = ":"
 `
+
+func (c *Consul) Init() error {
+	if c.MetricVersion != 2 {
+		c.Log.Warnf("Use of deprecated configuration: 'metric_version = 1'; please update to 'metric_version = 2'")
+	}
+
+	return nil
+}
 
 func (c *Consul) Description() string {
 	return "Gather health check statuses from services registered in Consul"
@@ -110,14 +127,20 @@ func (c *Consul) GatherHealthCheck(acc telegraf.Accumulator, checks []*api.Healt
 		record := make(map[string]interface{})
 		tags := make(map[string]string)
 
-		record["check_name"] = check.Name
-		record["service_id"] = check.ServiceID
-
-		record["status"] = check.Status
 		record["passing"] = 0
 		record["critical"] = 0
 		record["warning"] = 0
 		record[check.Status] = 1
+
+		if c.MetricVersion == 2 {
+			tags["check_name"] = check.Name
+			tags["service_id"] = check.ServiceID
+			tags["status"] = check.Status
+		} else {
+			record["check_name"] = check.Name
+			record["service_id"] = check.ServiceID
+			record["status"] = check.Status
+		}
 
 		tags["node"] = check.Node
 		tags["service_name"] = check.ServiceName

--- a/plugins/inputs/consul/consul_test.go
+++ b/plugins/inputs/consul/consul_test.go
@@ -76,3 +76,62 @@ func TestGatherHealthCheckWithDelimitedTags(t *testing.T) {
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
 }
+
+func TestGatherHealthCheckV2(t *testing.T) {
+	expectedFields := map[string]interface{}{
+		"passing":    1,
+		"critical":   0,
+		"warning":    0,
+	}
+
+	expectedTags := map[string]string{
+		"node":                    "localhost",
+		"check_id":                "foo.health123",
+		"check_name":              "foo.health",
+		"status":                  "passing",
+		"service_id":              "foo.123",
+		"service_name":            "foo",
+		"bar":                     "bar",
+		"env:sandbox":             "env:sandbox",
+		"tagkey:value:stillvalue": "tagkey:value:stillvalue",
+	}
+
+	var acc testutil.Accumulator
+
+	consul := &Consul{
+		MetricVersion: 2,
+	}
+	consul.GatherHealthCheck(&acc, sampleChecks)
+
+	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
+}
+
+func TestGatherHealthCheckWithDelimitedTagsV2(t *testing.T) {
+	expectedFields := map[string]interface{}{
+		"passing":    1,
+		"critical":   0,
+		"warning":    0,
+	}
+
+	expectedTags := map[string]string{
+		"node":         "localhost",
+		"check_id":     "foo.health123",
+		"check_name":   "foo.health",
+		"status":       "passing",
+		"service_id":   "foo.123",
+		"service_name": "foo",
+		"bar":          "bar",
+		"env":          "sandbox",
+		"tagkey":       "value:stillvalue",
+	}
+
+	var acc testutil.Accumulator
+
+	consul := &Consul{
+		MetricVersion: 2,
+		TagDelimiter: ":",
+	}
+	consul.GatherHealthCheck(&acc, sampleChecks)
+
+	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
+}


### PR DESCRIPTION
…  to control how to populate tags/fields of telegraf metrics. Addresses:
https://github.com/influxdata/telegraf/issues/7871
https://github.com/influxdata/telegraf/issues/2646

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
