### PR TITLE
Fix arch name in deb/rpm builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,8 @@ deb_s390x := s390x
 deb_arm5 := armel
 deb_arm6 := armhf
 deb_arm647 := arm64
+deb_mips := mips
+deb_mipsle := mipsel
 deb_arch = $(deb_$(GOARCH)$(GOARM))
 
 .PHONY: $(debs)

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ rpm_s390x := s390x
 rpm_arm5 := armel
 rpm_arm6 := armv6hl
 rpm_arm647 := aarch64
-rpm_arch := $(rpm_$(GOARCH)$(GOARM))
+rpm_arch = $(rpm_$(GOARCH)$(GOARM))
 
 .PHONY: $(rpms)
 $(rpms):
@@ -282,7 +282,7 @@ deb_s390x := s390x
 deb_arm5 := armel
 deb_arm6 := armhf
 deb_arm647 := arm64
-deb_arch := $(deb_$(GOARCH)$(GOARM))
+deb_arch = $(deb_$(GOARCH)$(GOARM))
 
 .PHONY: $(debs)
 $(debs):


### PR DESCRIPTION
This fixes an issue with the 1.15.0 builds of the rpm and deb packages for non-amd64 platforms which have the arch set incorrectly and cannot be installed.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
