### PR TITLE
Update procstat to support cgroup globs & include systemd unit children

### DIFF
--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -26,8 +26,9 @@ Processes can be selected for monitoring using one of several methods:
   # pattern = "nginx"
   ## user as argument for pgrep (ie, pgrep -u <user>)
   # user = "nginx"
-  ## Systemd unit name
+  ## Systemd unit name or glob and if all processes of the unit should get collected
   # systemd_unit = "nginx.service"
+  # systemd_all = true
   ## CGroup name or path
   # cgroup = "systemd/system.slice/nginx.service"
 
@@ -86,6 +87,7 @@ implemented as a WMI query.  The pattern allows fuzzy matching using only
     - user (when selected)
     - systemd_unit (when defined)
     - cgroup (when defined)
+    - cgroup_full (when cgroup or systemd_unit is used with glob)
     - win_service (when defined)
   - fields:
     - child_major_faults (int)

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"time"
-	"os"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -32,7 +32,7 @@ type Procstat struct {
 	ProcessName string
 	User        string
 	SystemdUnit string
-	SystemdAll  bool `toml:"systemd_all"`
+	SystemdAll  bool   `toml:"systemd_all"`
 	CGroup      string `toml:"cgroup"`
 	PidTag      bool
 	WinService  string `toml:"win_service"`
@@ -388,7 +388,7 @@ func (p *Procstat) findPids() []PIDS_TAGS_ERR_GROUP {
 		return groups
 	} else {
 		pids, tags, err := p.SimpleFindPids(f)
-                pids_tags_err_groups = append(pids_tags_err_groups, PIDS_TAGS_ERR_GROUP{pids, tags, err})
+		pids_tags_err_groups = append(pids_tags_err_groups, PIDS_TAGS_ERR_GROUP{pids, tags, err})
 	}
 
 	return pids_tags_err_groups
@@ -468,7 +468,6 @@ func (p *Procstat) simpleSystemdUnitPIDs() ([]PID, error) {
 	return pids, nil
 }
 
-
 func (p *Procstat) cgroupPIDs() []PIDS_TAGS_ERR_GROUP {
 	var pids_tags_err_group []PIDS_TAGS_ERR_GROUP
 
@@ -483,8 +482,8 @@ func (p *Procstat) cgroupPIDs() []PIDS_TAGS_ERR_GROUP {
 	}
 	for _, item := range items {
 		pids, err := p.singleCgroupPIDs(item)
-                tags := map[string]string{"cgroup": p.CGroup, "cgroup_full": item}
-                pids_tags_err_group = append(pids_tags_err_group, PIDS_TAGS_ERR_GROUP{pids, tags, err})
+		tags := map[string]string{"cgroup": p.CGroup, "cgroup_full": item}
+		pids_tags_err_group = append(pids_tags_err_group, PIDS_TAGS_ERR_GROUP{pids, tags, err})
 	}
 
 	return pids_tags_err_group

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"time"
+	"os"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -429,23 +430,44 @@ func (p *Procstat) cgroupPIDs() ([]PID, error) {
 	if procsPath[0] != '/' {
 		procsPath = "/sys/fs/cgroup/" + procsPath
 	}
-	procsPath = filepath.Join(procsPath, "cgroup.procs")
-	out, err := ioutil.ReadFile(procsPath)
+	items, err := filepath.Glob(procsPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("glob failed '%s'", err)
 	}
-	for _, pidBS := range bytes.Split(out, []byte{'\n'}) {
-		if len(pidBS) == 0 {
+	for _, item := range items {
+		ok, err := isDir(item)
+		if err != nil {
 			continue
 		}
-		pid, err := strconv.Atoi(string(pidBS))
-		if err != nil {
-			return nil, fmt.Errorf("invalid pid '%s'", pidBS)
+		if !ok {
+			continue
 		}
-		pids = append(pids, PID(pid))
+		procsPath = filepath.Join(item, "cgroup.procs")
+		out, err := ioutil.ReadFile(procsPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, pidBS := range bytes.Split(out, []byte{'\n'}) {
+			if len(pidBS) == 0 {
+				continue
+			}
+			pid, err := strconv.Atoi(string(pidBS))
+			if err != nil {
+				return nil, fmt.Errorf("invalid pid '%s'", pidBS)
+			}
+			pids = append(pids, PID(pid))
+		}
 	}
 
 	return pids, nil
+}
+
+func isDir(path string) (bool, error) {
+	result, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return result.IsDir(), nil
 }
 
 func (p *Procstat) winServicePIDs() ([]PID, error) {

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -363,11 +363,15 @@ func TestGather_systemdUnitPIDs(t *testing.T) {
 		createPIDFinder: pidFinder([]PID{}, nil),
 		SystemdUnit:     "TestGather_systemdUnitPIDs",
 	}
-	var acc testutil.Accumulator
-	pids, tags, err := p.findPids(&acc)
-	require.NoError(t, err)
-	assert.Equal(t, []PID{11408}, pids)
-	assert.Equal(t, "TestGather_systemdUnitPIDs", tags["systemd_unit"])
+	pids_tags_err_groups := p.findPids()
+	for _, pid_tag_err_group := range pids_tags_err_groups {
+		pids := pid_tag_err_group.PIDS
+		tags := pid_tag_err_group.Tags
+		err := pid_tag_err_group.Err
+		require.NoError(t, err)
+		assert.Equal(t, []PID{11408}, pids)
+		assert.Equal(t, "TestGather_systemdUnitPIDs", tags["systemd_unit"])
+	}
 }
 
 func TestGather_cgroupPIDs(t *testing.T) {
@@ -385,11 +389,15 @@ func TestGather_cgroupPIDs(t *testing.T) {
 		createPIDFinder: pidFinder([]PID{}, nil),
 		CGroup:          td,
 	}
-	var acc testutil.Accumulator
-	pids, tags, err := p.findPids(&acc)
-	require.NoError(t, err)
-	assert.Equal(t, []PID{1234, 5678}, pids)
-	assert.Equal(t, td, tags["cgroup"])
+	pids_tags_err_groups := p.findPids()
+	for _, pid_tag_err_group := range pids_tags_err_groups {
+		pids := pid_tag_err_group.PIDS
+		tags := pid_tag_err_group.Tags
+		err := pid_tag_err_group.Err
+		require.NoError(t, err)
+		assert.Equal(t, []PID{1234, 5678}, pids)
+		assert.Equal(t, td, tags["cgroup"])
+	}
 }
 
 func TestProcstatLookupMetric(t *testing.T) {


### PR DESCRIPTION
* cgroups now support glob
* systemd_unit in combination with systemd_all will now report for all children and not just the main pid of the service
* in case cgroups or systemd_unit+all will return a group of pids they get tagged with their actual cgroup/service matched (cgroup_full)

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
