### PR TITLE
Fix for opentsdb output-plugin for NaN and Inf in float64 value

### DIFF
--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -3,6 +3,7 @@ package opentsdb
 import (
 	"fmt"
 	"log"
+	"math"
 	"net"
 	"net/url"
 	"regexp"
@@ -136,10 +137,14 @@ func (o *OpenTSDB) WriteHttp(metrics []telegraf.Metric, u *url.URL) error {
 		tags := cleanTags(m.Tags())
 
 		for fieldName, value := range m.Fields() {
-			switch value.(type) {
+			switch fv := value.(type) {
 			case int64:
 			case uint64:
 			case float64:
+				// JSON does not support these special values
+				if math.IsNaN(fv) || math.IsInf(fv, 0) {
+					continue
+				}
 			default:
 				log.Printf("D! OpenTSDB does not support metric value: [%s] of type [%T].\n", value, value)
 				continue
@@ -181,10 +186,14 @@ func (o *OpenTSDB) WriteTelnet(metrics []telegraf.Metric, u *url.URL) error {
 		tags := ToLineFormat(cleanTags(m.Tags()))
 
 		for fieldName, value := range m.Fields() {
-			switch value.(type) {
+			switch fv := value.(type) {
 			case int64:
 			case uint64:
 			case float64:
+				// JSON does not support these special values
+				if math.IsNaN(fv) || math.IsInf(fv, 0) {
+					continue
+				}
 			default:
 				log.Printf("D! OpenTSDB does not support metric value: [%s] of type [%T].\n", value, value)
 				continue


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

When in prometheus metrics we have a value with NaN or Inf, Telegraf cannot to send metrics in TSDB and write the error in stdout:

```
2020-07-28T08:42:32Z E! [agent] Error writing to outputs.opentsdb: Metric serialization error json: unsupported value: NaN
```

I fixed this error like in json serializer: https://github.com/influxdata/telegraf/blob/master/plugins/serializers/json/json.go#L61