### PR TITLE
Added 3 fuzzers

### DIFF
--- a/testutil/fuzzing/fuzz.go
+++ b/testutil/fuzzing/fuzz.go
@@ -5,7 +5,7 @@ package fuzz
 // https://github.com/dvyukov/go-fuzz
 
 // To run the fuzzer locally, follow these steps:
-// 1) go get github.com/google/zoekt
+// 1) go get github.com/influxdata/telegraf
 // 2) go get -u github.com/dvyukov/go-fuzz/go-fuzz
 // 3) go get -u github.com/dvyukov/go-fuzz/go-fuzz-build
 // 4) cd into dir of fuzz.go

--- a/testutil/fuzzing/fuzz.go
+++ b/testutil/fuzzing/fuzz.go
@@ -1,0 +1,73 @@
+package fuzz
+
+// This file implements fuzzers using go-fuzz.
+// More information about go-fuzz can be found here:
+// https://github.com/dvyukov/go-fuzz
+
+// To run the fuzzer locally, follow these steps:
+// 1) go get github.com/google/zoekt
+// 2) go get -u github.com/dvyukov/go-fuzz/go-fuzz
+// 3) go get -u github.com/dvyukov/go-fuzz/go-fuzz-build
+// 4) cd into dir of fuzz.go
+// 5) $GOPATH/bin/go-fuzz-build
+// 6) $GOPATH/bin/go-fuzz
+
+import (
+	"github.com/influxdata/telegraf/plugins/parsers/csv"
+	"github.com/influxdata/telegraf/plugins/parsers/json"
+	"time"
+)
+
+var DefaultTime = func() time.Time {
+	return time.Unix(3600, 0)
+}
+
+func FuzzCsvParse(data []byte) int {
+	parser, err := csv.NewParser(
+		&csv.Config{
+			ColumnNames: []string{"first", "second", "third"},
+			TagColumns:  []string{"third"},
+			TimeFunc:    DefaultTime,
+		},
+	)
+	if err != nil {
+		return -1
+	}
+	_, err = parser.Parse(data)
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
+func FuzzCsvParseLine(data []byte) int {
+	parser, err := csv.NewParser(
+		&csv.Config{
+			ColumnNames: []string{"first", "second", "third"},
+			TagColumns:  []string{"third"},
+			TimeFunc:    DefaultTime,
+		},
+	)
+	if err != nil {
+		return -1
+	}
+	_, err = parser.ParseLine(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
+func FuzzJSONParse(data []byte) int {
+	parser, err := json.New(&json.Config{
+		MetricName: "fuzz_test",
+	})
+	if err != nil {
+		return -1
+	}
+	_, err = parser.Parse(data)
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

This PR answers https://github.com/influxdata/telegraf/issues/6271 by adding 3 fuzzers.

Dear maintainers of Telegraf,

I am reaching out to you because I have worked on integrating continuous fuzzing into your project by way of OSS-fuzz. The fuzzers in this PR are implemented with [go-fuzz](https://github.com/dvyukov/go-fuzz) which provides a simple api and is the most popular fuzzer for Go at the moment.

Fuzzers implemented in go-fuzz can be run both locally or continuously through a platform like OSS-fuzz, which is a project by Google that dedicates hardware to run fuzzers for open source projects free of charge. While OSS-fuzz is a free service, it is offered with an implied expectation that bugs are fixed, and when a bug is found by OSS-fuzz maintainers get sent a link to a detailed bug report by email and the bug report is private for 90 days after which it becomes public. Other Go-projects already integrated into OSS-fuzz include: [Prometheus](https://github.com/prometheus/prometheus), [Kubernetes](https://github.com/kubernetes/kubernetes), [fasthttp](https://github.com/valyala/fasthttp), [fastjson](https://github.com/valyala/fastjson), [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway), [TiDB](https://github.com/pingcap/tidb/).

ADA Logics is a contributor of open source security, and we have integrated dozens of projects into OSS-fuzz. The fuzzers in this PR are tested on OSS-fuzz's infrastructure and all I need from your side are the email addresses that should receive the bug reports and then I am happy to complete the integration to OSS-fuzz.

In lieu of adding a README file, I have included steps to run the fuzzer locally with go-fuzz. 

Kind regards
Adam