### PR TITLE
Support for bytes encoding for "gnmi" input plugin

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -17,7 +17,7 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR (64-
   username = "cisco"
   password = "cisco"
 
-  ## gNMI encoding requested (one of: "proto", "json", "json_ietf")
+  ## gNMI encoding requested (one of: "proto", "json", "json_ietf", "bytes")
   # encoding = "proto"
 
   ## redial in case of failures after

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -179,7 +179,7 @@ func (c *GNMI) newSubscribeRequest() (*gnmi.SubscribeRequest, error) {
 		return nil, err
 	}
 
-	if c.Encoding != "proto" && c.Encoding != "json" && c.Encoding != "json_ietf" {
+	if c.Encoding != "proto" && c.Encoding != "json" && c.Encoding != "json_ietf" && c.Encoding != "bytes" {
 		return nil, fmt.Errorf("unsupported encoding %s", c.Encoding)
 	}
 
@@ -486,7 +486,7 @@ const sampleConfig = `
  username = "cisco"
  password = "cisco"
 
- ## gNMI encoding requested (one of: "proto", "json", "json_ietf")
+ ## gNMI encoding requested (one of: "proto", "json", "json_ietf", "bytes")
  # encoding = "proto"
 
  ## redial in case of failures after


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

## Purpose of the PR
This PR adds support for `bytes` encoding for the gNMI messages as per [2.3.2 of gNMI specification](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#232-bytes).

The code [already had a support for `bytes`](https://github.com/influxdata/telegraf/blob/effe112473a6bd8991ef8c12e293353c92f1d538/plugins/inputs/gnmi/gnmi.go#L337-L338) encoded values, it [was just not allowed](https://github.com/influxdata/telegraf/blob/effe112473a6bd8991ef8c12e293353c92f1d538/plugins/inputs/gnmi/gnmi.go#L182) to specify this encoding in the appropriate check before.

The only changes made to the plugin were to allow to specify `bytes` as the `encoding`.

## Example
Config file:
```toml
[[inputs.gnmi]]
  addresses = ["r1:14946"]
  username = "admin"
  password = "nokia"

  encoding = "bytes"

  redial = "10s"

  [[inputs.gnmi.subscription]]
    name = "test-bytes-encoding"
    path = "/state/system/version/version-number"
    subscription_mode = "sample"
    sample_interval = "2s"

[[outputs.file]]
  files = ["stdout", "/tmp/metrics.out"]
  data_format = "influx"
```

Output:
```
❯ ./telegraf --config __test_config.toml
2020-08-04T09:29:36Z I! Starting Telegraf 
2020-08-04T09:29:36Z I! Loaded inputs: gnmi
2020-08-04T09:29:36Z I! Loaded aggregators: 
2020-08-04T09:29:36Z I! Loaded processors: 
2020-08-04T09:29:36Z I! Loaded outputs: file
2020-08-04T09:29:36Z I! Tags enabled: host=mbp-2.local
2020-08-04T09:29:36Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"mbp-2.local", Flush Interval:10s
test-bytes-encoding,host=mbp-2.local,path=/state/system/version,source=0.tcp.eu.ngrok.io version_number="B-20.5.R1" 1596533379127528433
```