### PR TITLE
modbus: improved config format

### DIFF
--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -23,12 +23,6 @@ Registers via Modbus TCP or Modbus RTU/ASCII.
   ## Timeout for each request
   timeout = "1s"
 
-  ## Do not add Device Name as Tag
-  omit_device_name = false
-
-  ## Do not add Register Type as Tag
-  omit_register_type = false
-
   ## Maximum number of retries and the time to wait between retries
   ## when a slave-device is busy.
   # busy_retries = 0

--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -12,6 +12,7 @@ Registers via Modbus TCP or Modbus RTU/ASCII.
   ## The plugin supports connections to PLCs via MODBUS/TCP or
   ## via serial line communication in binary (RTU) or readable (ASCII) encoding
   ##
+
   ## Name of the MODBUS device to read from
   device_name = "Device"
 
@@ -48,49 +49,54 @@ Registers via Modbus TCP or Modbus RTU/ASCII.
   ## Measurements
   ##
 
-  ## Digital Variables, Discrete Inputs and Coils
-  ## measurement - the (optional) measurement name, defaults to "modbus"
-  ## name        - the variable name
-  ## address     - variable address
+  [[inputs.modbus.measurement]]
+    name = "power"
+    tags = [
+      {key = "system", value = "solar"},
+      {key = "location", value = "roof"},
+    ]
 
-  discrete_inputs = [
-    { name = "start",          address = [0]},
-    { name = "stop",           address = [1]},
-    { name = "reset",          address = [2]},
-    { name = "emergency_stop", address = [3]},
-  ]
-  coils = [
-    { name = "motor1_run",     address = [0]},
-    { name = "motor1_jog",     address = [1]},
-    { name = "motor1_stop",    address = [2]},
-  ]
+    ## Digital Variables, Discrete Inputs and Coils
+    ## name        - the variable name
+    ## address     - variable address
 
-  ## Analog Variables, Input Registers and Holding Registers
-  ## measurement - the (optional) measurement name, defaults to "modbus"
-  ## name        - the variable name
-  ## byte_order  - the ordering of bytes
-  ##  |---AB, ABCD   - Big Endian
-  ##  |---BA, DCBA   - Little Endian
-  ##  |---BADC       - Mid-Big Endian
-  ##  |---CDAB       - Mid-Little Endian
-  ## data_type  - INT16, UINT16, INT32, UINT32, INT64, UINT64, FLOAT32-IEEE (the IEEE 754 binary representation)
-  ##              FLOAT32 (deprecated), FIXED, UFIXED (fixed-point representation on input)
-  ## scale      - the final numeric variable representation
-  ## address    - variable address
+    discrete_inputs = [
+      { name = "start",          address = [0]},
+      { name = "stop",           address = [1]},
+      { name = "reset",          address = [2]},
+      { name = "emergency_stop", address = [3]},
+    ]
+    coils = [
+      { name = "motor1_run",     address = [0]},
+      { name = "motor1_jog",     address = [1]},
+      { name = "motor1_stop",    address = [2]},
+    ]
 
-  holding_registers = [
-    { name = "power_factor", byte_order = "AB",   data_type = "FIXED", scale=0.01,  address = [8]},
-    { name = "voltage",      byte_order = "AB",   data_type = "FIXED", scale=0.1,   address = [0]},
-    { name = "energy",       byte_order = "ABCD", data_type = "FIXED", scale=0.001, address = [5,6]},
-    { name = "current",      byte_order = "ABCD", data_type = "FIXED", scale=0.001, address = [1,2]},
-    { name = "frequency",    byte_order = "AB",   data_type = "UFIXED", scale=0.1,  address = [7]},
-    { name = "power",        byte_order = "ABCD", data_type = "UFIXED", scale=0.1,  address = [3,4]},
-  ]
-  input_registers = [
-    { name = "tank_level",   byte_order = "AB",   data_type = "INT16",   scale=1.0,     address = [0]},
-    { name = "tank_ph",      byte_order = "AB",   data_type = "INT16",   scale=1.0,     address = [1]},
-    { name = "pump1_speed",  byte_order = "ABCD", data_type = "INT32",   scale=1.0,     address = [3,4]},
-  ]
+    ## Analog Variables, Input Registers and Holding Registers
+    ## name        - the variable name
+    ## byte_order  - the ordering of bytes
+    ##  |---AB, ABCD   - Big Endian
+    ##  |---BA, DCBA   - Little Endian
+    ##  |---BADC       - Mid-Big Endian
+    ##  |---CDAB       - Mid-Little Endian
+    ## data_type  - INT16, UINT16, INT32, UINT32, INT64, UINT64, FLOAT32-IEEE (the IEEE 754 binary representation)
+    ##              FLOAT32, FIXED, UFIXED (fixed-point representation on input)
+    ## scale      - the final numeric variable representation
+    ## address    - variable address
+
+    holding_registers = [
+      { name = "power_factor", byte_order = "AB",   data_type = "FIXED", scale=0.01,  address = [8]},
+      { name = "voltage",      byte_order = "AB",   data_type = "FIXED", scale=0.1,   address = [0]},
+      { name = "energy",       byte_order = "ABCD", data_type = "FIXED", scale=0.001, address = [5,6]},
+      { name = "current",      byte_order = "ABCD", data_type = "FIXED", scale=0.001, address = [1,2]},
+      { name = "frequency",    byte_order = "AB",   data_type = "UFIXED", scale=0.1,  address = [7]},
+      { name = "power",        byte_order = "ABCD", data_type = "UFIXED", scale=0.1,  address = [3,4]},
+    ]
+    input_registers = [
+      { name = "tank_level",   byte_order = "AB",   data_type = "INT16",   scale=1.0,     address = [0]},
+      { name = "tank_ph",      byte_order = "AB",   data_type = "INT16",   scale=1.0,     address = [1]},
+      { name = "pump1_speed",  byte_order = "ABCD", data_type = "INT32",   scale=1.0,     address = [3,4]},
+    ]
 ```
 
 ### Metrics
@@ -137,5 +143,5 @@ from unsigned values).
 
 ```
 $ ./telegraf -config telegraf.conf -input-filter modbus -test
-modbus,device_name=OpenPLC,host=orangepizero,type=holding_register current=0,energy=0,frecuency=60,power=0,power_factor=0,voltage=123.9000015258789 1554079521000000000
+power,device_name=Device,host=orangepizero,type=holding_register,system=solar,location=roof current=0,energy=0,frecuency=60,power=0,power_factor=0,voltage=123.9000015258789 1554079521000000000
 ```

--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -12,8 +12,8 @@ Registers via Modbus TCP or Modbus RTU/ASCII.
   ## The plugin supports connections to PLCs via MODBUS/TCP or
   ## via serial line communication in binary (RTU) or readable (ASCII) encoding
   ##
-  ## Device name
-  name = "Device"
+  ## Name of the MODBUS device to read from
+  device_name = "Device"
 
   ## Slave ID - addresses a MODBUS device on the bus
   ## Range: 0 - 255 [0 = broadcast; 248 - 255 = reserved]
@@ -21,6 +21,12 @@ Registers via Modbus TCP or Modbus RTU/ASCII.
 
   ## Timeout for each request
   timeout = "1s"
+
+  ## Do not add Device Name as Tag
+  omit_device_name = false
+
+  ## Do not add Register Type as Tag
+  omit_register_type = false
 
   ## Maximum number of retries and the time to wait between retries
   ## when a slave-device is busy.
@@ -131,5 +137,5 @@ from unsigned values).
 
 ```
 $ ./telegraf -config telegraf.conf -input-filter modbus -test
-modbus.InputRegisters,host=orangepizero Current=0,Energy=0,Frecuency=60,Power=0,PowerFactor=0,Voltage=123.9000015258789 1554079521000000000
+modbus,device_name=OpenPLC,host=orangepizero,type=holding_register current=0,energy=0,frecuency=60,power=0,power_factor=0,voltage=123.9000015258789 1554079521000000000
 ```

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -747,7 +747,7 @@ func (m *Modbus) Gather(acc telegraf.Accumulator) error {
 		for _, reg := range meas.registers {
 			tags := map[string]string{
 				"device_name": m.Name,
-				"type": reg.Type,
+				"type":        reg.Type,
 			}
 			for _, tag := range meas.Tags {
 				tags[tag.Key] = tag.Value

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -29,6 +29,7 @@ type Modbus struct {
 	SlaveID          int               `toml:"slave_id"`
 	Timeout          internal.Duration `toml:"timeout"`
 	Retries          int               `toml:"busy_retries"`
+	OmitRegisterType bool              `toml:"omit_register_type"`
 	RetriesWaitTime  internal.Duration `toml:"busy_retries_wait"`
 	DiscreteInputs   []fieldContainer  `toml:"discrete_inputs"`
 	Coils            []fieldContainer  `toml:"coils"`
@@ -86,6 +87,9 @@ const sampleConfig = `
 
   ## Timeout for each request
   timeout = "1s"
+
+  ## Do not add Register Type as Tag
+  omit_register_type = false
 
   ## Maximum number of retries and the time to wait between retries
   ## when a slave-device is busy.
@@ -701,9 +705,9 @@ func (m *Modbus) Gather(acc telegraf.Accumulator) error {
 
 	grouper := metric.NewSeriesGrouper()
 	for _, reg := range m.registers {
-		tags := map[string]string{
-			"name": m.Name,
-			"type": reg.Type,
+		tags := map[string]string{"name": m.Name}
+		if !m.OmitRegisterType {
+			tags["type"] = reg.Type
 		}
 
 		for _, field := range reg.Fields {

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -200,7 +200,7 @@ func (m *Modbus) Init() error {
 		return err
 	}
 
-	for idx, _ := range m.Measurements {
+	for idx := range m.Measurements {
 		err := m.Measurements[idx].InitMeasurement()
 		if err != nil {
 			return err

--- a/plugins/inputs/modbus/modbus_test.go
+++ b/plugins/inputs/modbus/modbus_test.go
@@ -96,10 +96,15 @@ func TestCoils(t *testing.T) {
 				Name:       "TestCoils",
 				Controller: "tcp://localhost:1502",
 				SlaveID:    1,
-				Coils: []fieldContainer{
+				Measurements: []measurement{
 					{
-						Name:    ct.name,
-						Address: []uint16{ct.address},
+						Name: "TestCoils",
+						Coils: []fieldContainer{
+							{
+								Name:    ct.name,
+								Address: []uint16{ct.address},
+							},
+						},
 					},
 				},
 			}
@@ -109,9 +114,9 @@ func TestCoils(t *testing.T) {
 			var acc testutil.Accumulator
 			err = modbus.Gather(&acc)
 			assert.NoError(t, err)
-			assert.NotEmpty(t, modbus.registers)
+			assert.NotEmpty(t, modbus.Measurements[0].registers)
 
-			for _, coil := range modbus.registers {
+			for _, coil := range modbus.Measurements[0].registers {
 				assert.Equal(t, ct.read, coil.Fields[0].value)
 			}
 		})
@@ -571,13 +576,18 @@ func TestHoldingRegisters(t *testing.T) {
 				Name:       "TestHoldingRegisters",
 				Controller: "tcp://localhost:1502",
 				SlaveID:    1,
-				HoldingRegisters: []fieldContainer{
+				Measurements: []measurement{
 					{
-						Name:      hrt.name,
-						ByteOrder: hrt.byteOrder,
-						DataType:  hrt.dataType,
-						Scale:     hrt.scale,
-						Address:   hrt.address,
+						Name: "TestHoldingRegisters",
+						HoldingRegisters: []fieldContainer{
+							{
+								Name:      hrt.name,
+								ByteOrder: hrt.byteOrder,
+								DataType:  hrt.dataType,
+								Scale:     hrt.scale,
+								Address:   hrt.address,
+							},
+						},
 					},
 				},
 			}
@@ -586,9 +596,9 @@ func TestHoldingRegisters(t *testing.T) {
 			assert.NoError(t, err)
 			var acc testutil.Accumulator
 			modbus.Gather(&acc)
-			assert.NotEmpty(t, modbus.registers)
+			assert.NotEmpty(t, modbus.Measurements[0].registers)
 
-			for _, coil := range modbus.registers {
+			for _, coil := range modbus.Measurements[0].registers {
 				assert.Equal(t, hrt.read, coil.Fields[0].value)
 			}
 		})
@@ -628,10 +638,15 @@ func TestRetrySuccessful(t *testing.T) {
 			Controller: "tcp://localhost:1502",
 			SlaveID:    1,
 			Retries:    maxretries,
-			Coils: []fieldContainer{
+			Measurements: []measurement{
 				{
-					Name:    "retry_success",
-					Address: []uint16{0},
+					Name: "TestRetry",
+					Coils: []fieldContainer{
+						{
+							Name:    "retry_success",
+							Address: []uint16{0},
+						},
+					},
 				},
 			},
 		}
@@ -641,9 +656,9 @@ func TestRetrySuccessful(t *testing.T) {
 		var acc testutil.Accumulator
 		err = modbus.Gather(&acc)
 		assert.NoError(t, err)
-		assert.NotEmpty(t, modbus.registers)
+		assert.NotEmpty(t, modbus.Measurements[0].registers)
 
-		for _, coil := range modbus.registers {
+		for _, coil := range modbus.Measurements[0].registers {
 			assert.Equal(t, uint16(value), coil.Fields[0].value)
 		}
 	})
@@ -673,10 +688,15 @@ func TestRetryFail(t *testing.T) {
 			Controller: "tcp://localhost:1502",
 			SlaveID:    1,
 			Retries:    maxretries,
-			Coils: []fieldContainer{
+			Measurements: []measurement{
 				{
-					Name:    "retry_fail",
-					Address: []uint16{0},
+					Name: "TestRetryFail",
+					Coils: []fieldContainer{
+						{
+							Name:    "retry_fail",
+							Address: []uint16{0},
+						},
+					},
 				},
 			},
 		}
@@ -706,10 +726,15 @@ func TestRetryFail(t *testing.T) {
 			Controller: "tcp://localhost:1502",
 			SlaveID:    1,
 			Retries:    maxretries,
-			Coils: []fieldContainer{
+			Measurements: []measurement{
 				{
-					Name:    "retry_fail",
-					Address: []uint16{0},
+					Name: "TestRetryFail",
+					Coils: []fieldContainer{
+						{
+							Name:    "retry_fail",
+							Address: []uint16{0},
+						},
+					},
 				},
 			},
 		}


### PR DESCRIPTION
Dear influxdata team,

I prepared a few patches for the MODBUS input plugin.
Besides some smaller ones to suppress unwanted tags, there is also a breaking change to the config format.

The idea behind this update is that MODBUS devices, like PLCs, often control multiple pieces of equipment one wants to monitor and the semantics of the configuration file should reflect this.
I also think that this is more consistent with the config of other telegraf plugins than the current format.
The introduction of custom tags per measurement enables the user to use more of the potential of InfluxDB.

As an example, let's monitor two identical generators connected to the same PLC.

**Current format:**
```
[[inputs.modbus]]
...
holding_registers = [
    { measurement = "generator_roof", name = "voltage",      byte_order = "AB",   data_type = "FIXED", scale=0.1,   address = [0]},
    { measurement = "generator_roof", name = "current",      byte_order = "ABCD", data_type = "FIXED", scale=0.001, address = [1,2]},
    { measurement = "generator_roof", name = "frequency",    byte_order = "AB",   data_type = "UFIXED", scale=0.1,  address = [7]},
    { measurement = "generator_basement", name = "voltage",      byte_order = "AB",   data_type = "FIXED", scale=0.1,   address = [10]},
    { measurement = "generator_basement", name = "current",      byte_order = "ABCD", data_type = "FIXED", scale=0.001, address = [11,12]},
    { measurement = "generator_basement", name = "frequency",    byte_order = "AB",   data_type = "UFIXED", scale=0.1,  address = [17]},
  ]
```
**_Output:_**
```
generator_roof,type=holding_registers,[..] voltage=0i,current=0i,frequency=0i
generator_basement,type=holding_registers,[..] voltage=0i,current=0i,frequency=0i
```


**Proposed format:**
```
[[inputs.modbus]]
...
  [[inputs.modbus.measurement]]
    name = "generator"
    tags = [{key = "location", value = "roof"},]
    holding_registers = [
      { name = "voltage",      byte_order = "AB",   data_type = "FIXED", scale=0.1,   address = [0]},
      { name = "current",      byte_order = "ABCD", data_type = "FIXED", scale=0.001, address = [1,2]},
      { name = "frequency",    byte_order = "AB",   data_type = "UFIXED", scale=0.1,  address = [7]}
    ]

  [[inputs.modbus.measurement]]
    name = "generator"
    tags = [{key = "location", value = "basement"},]
    holding_registers = [
      { name = "voltage",      byte_order = "AB",   data_type = "FIXED", scale=0.1,   address = [10]},
      { name = "current",      byte_order = "ABCD", data_type = "FIXED", scale=0.001, address = [11,12]},
      { name = "frequency",    byte_order = "AB",   data_type = "UFIXED", scale=0.1,  address = [17]}
    ]
```
**_Output:_**
```
generator,type=holding_registers,location=roof,[..] voltage=0i,current=0i,frequency=0i
generator,type=holding_registers,location=basement,[..] voltage=0i,current=0i,frequency=0i
```

I am looking forward to your feedback and hope you consider merging.


Best regards,

Henry Schwanbeck


### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
