### PR TITLE
Support for AWS Cloudwatch Alarms #7931

### DIFF
--- a/EXTERNAL_PLUGINS.md
+++ b/EXTERNAL_PLUGINS.md
@@ -8,3 +8,4 @@ Pull requests welcome.
 - [rand](https://github.com/ssoroka/rand) - Generate random numbers
 - [twitter](https://github.com/inabagumi/twitter-telegraf-plugin) - Gather account information from Twitter accounts
 - [youtube](https://github.com/inabagumi/youtube-telegraf-plugin) - Gather account information from YouTube channels
+- [awsalarms](https://github.com/vipinvkmenon/awsalarms) - Simple plugin to gather/monitor alarms generated  in AWS.


### PR DESCRIPTION
This documentation update points to a simple execd shim that can
poll AWS Alarms at given time intervals.

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
