### PR TITLE
Remedy malformed data in http post request

### DIFF
--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -156,11 +156,6 @@ func (h *HTTP) gatherURL(
 	acc telegraf.Accumulator,
 	url string,
 ) error {
-	//body, err := makeRequestBodyReader(h.ContentEncoding, h.Body)
-	//if err != nil {
-	//	return err
-	//}
-	//defer body.Close()
 
 	var body io.Reader
 	if h.Body != "" {
@@ -168,7 +163,6 @@ func (h *HTTP) gatherURL(
 	}
 	request, err := http.NewRequest(h.Method, url, body)
 
-	//request, err := http.NewRequest(h.Method, url, body)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -157,10 +157,11 @@ func (h *HTTP) gatherURL(
 	url string,
 ) error {
 
-	var body io.Reader
-	if h.Body != "" {
-		body = strings.NewReader(h.Body)
+	body, err := makeRequestBodyReader(h.ContentEncoding, h.Body)
+	if err != nil {
+		return err
 	}
+
 	request, err := http.NewRequest(h.Method, url, body)
 
 	if err != nil {
@@ -233,7 +234,7 @@ func (h *HTTP) gatherURL(
 	return nil
 }
 
-func makeRequestBodyReader(contentEncoding, body string) (io.ReadCloser, error) {
+func makeRequestBodyReader(contentEncoding, body string) (io.Reader, error) {
 	var reader io.Reader = strings.NewReader(body)
 	if contentEncoding == "gzip" {
 		rc, err := internal.CompressWithGzip(reader)
@@ -242,7 +243,7 @@ func makeRequestBodyReader(contentEncoding, body string) (io.ReadCloser, error) 
 		}
 		return rc, nil
 	}
-	return ioutil.NopCloser(reader), nil
+	return reader, nil
 }
 
 func init() {

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -156,13 +156,19 @@ func (h *HTTP) gatherURL(
 	acc telegraf.Accumulator,
 	url string,
 ) error {
-	body, err := makeRequestBodyReader(h.ContentEncoding, h.Body)
-	if err != nil {
-		return err
-	}
-	defer body.Close()
+	//body, err := makeRequestBodyReader(h.ContentEncoding, h.Body)
+	//if err != nil {
+	//	return err
+	//}
+	//defer body.Close()
 
+	var body io.Reader
+	if h.Body != "" {
+		body = strings.NewReader(h.Body)
+	}
 	request, err := http.NewRequest(h.Method, url, body)
+
+	//request, err := http.NewRequest(h.Method, url, body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.


This PR fixes an issue I noticed with the http input plugin, specifically when sending a POST request with a body it would be malformed as seen here:
![image](https://user-images.githubusercontent.com/19910435/89746932-37998d80-dab4-11ea-9bae-373d917360a7.png)

These changes correctly send the request body shown here:
![image](https://user-images.githubusercontent.com/19910435/89746946-4b44f400-dab4-11ea-9c6b-46c7d1152ebc.png)

I borrowed the code from here https://github.com/influxdata/telegraf/blob/c73ed8ca6c4a81b70d1e1aeb80f6d277bdde5b77/plugins/inputs/http_response/http_response.go#L258 after I did some digging around and noticed this plugin seemed to send the data correctly