### PR TITLE
Fix crash in lustre2 input plugin, when field name and value

### DIFF
--- a/plugins/inputs/lustre2/lustre2.go
+++ b/plugins/inputs/lustre2/lustre2.go
@@ -11,6 +11,7 @@ package lustre2
 import (
 	"io/ioutil"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -363,6 +364,8 @@ func (l *Lustre2) GetLustreProcStats(fileglob string, wantedFields []*mapping, a
 		return err
 	}
 
+	fieldSplitter := regexp.MustCompile(`[ :]+`)
+
 	for _, file := range files {
 		/* Turn /proc/fs/lustre/obdfilter/<ost_name>/stats and similar
 		 * into just the object store target name
@@ -393,7 +396,11 @@ func (l *Lustre2) GetLustreProcStats(fileglob string, wantedFields []*mapping, a
 				if len(line) < 1 {
 					continue
 				}
-				parts := strings.Fields(line)
+
+				parts := fieldSplitter.Split(line, -1)
+				if len(parts[0]) == 0 {
+					parts = parts[1:]
+				}
 
 				var fields map[string]interface{}
 				fields, ok := l.allFields[tags{name, jobid}]
@@ -404,7 +411,7 @@ func (l *Lustre2) GetLustreProcStats(fileglob string, wantedFields []*mapping, a
 
 				for _, wanted := range wantedFields {
 					var data uint64
-					if strings.TrimSuffix(parts[0], ":") == wanted.inProc {
+					if parts[0] == wanted.inProc {
 						wantedField := wanted.field
 						// if not set, assume field[1]. Shouldn't be field[0], as
 						// that's a string

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -45,7 +45,7 @@ const obdfilterJobStatsContents = `job_stats:
 - job_id:          cluster-testjob1
   snapshot_time:   1461772761
   read_bytes:      { samples:           1, unit: bytes, min:    4096, max:    4096, sum:            4096 }
-  write_bytes:     { samples:          25, unit: bytes, min: 1048576, max: 1048576, sum:        26214400 }
+  write_bytes:     { samples:          25, unit: bytes, min: 1048576, max:16777216, sum:        26214400 }
   getattr:         { samples:           0, unit:  reqs }
   setattr:         { samples:           0, unit:  reqs }
   punch:           { samples:           1, unit:  reqs }
@@ -257,7 +257,7 @@ func TestLustre2GeneratesJobstatsMetrics(t *testing.T) {
 		"jobstats_read_bytes":      uint64(4096),
 		"jobstats_write_calls":     uint64(25),
 		"jobstats_write_min_size":  uint64(1048576),
-		"jobstats_write_max_size":  uint64(1048576),
+		"jobstats_write_max_size":  uint64(16777216),
 		"jobstats_write_bytes":     uint64(26214400),
 		"jobstats_ost_getattr":     uint64(0),
 		"jobstats_ost_setattr":     uint64(0),


### PR DESCRIPTION
are not separated by whitespace, which happens when numbers grow large (#7966)

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
