### PR TITLE
fix(7642): reduce impact of finding processes by pattern

### DIFF
--- a/plugins/inputs/procstat/native_finder.go
+++ b/plugins/inputs/procstat/native_finder.go
@@ -11,8 +11,7 @@ import (
 )
 
 //NativeFinder uses gopsutil to find processes
-type NativeFinder struct {
-}
+type NativeFinder struct{}
 
 //NewNativeFinder ...
 func NewNativeFinder() (PIDFinder, error) {
@@ -59,17 +58,19 @@ func (pg *NativeFinder) PidFile(path string) ([]PID, error) {
 
 //FullPattern matches on the command line when the process was executed
 func (pg *NativeFinder) FullPattern(pattern string) ([]PID, error) {
-	var pids []PID
 	regxPattern, err := regexp.Compile(pattern)
 	if err != nil {
-		return pids, err
+		return nil, err
 	}
+
 	procs, err := pg.FastProcessList()
 	if err != nil {
-		return pids, err
+		return nil, err
 	}
+
+	var pids []PID
 	for _, p := range procs {
-		cmd, err := p.Cmdline()
+		cmd, err := p.Exe()
 		if err != nil {
 			//skip, this can be caused by the pid no longer existing
 			//or you having no permissions to access it

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -103,8 +103,8 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 			p.PidFinder = "pgrep"
 			p.createPIDFinder = defaultPIDFinder
 		}
-
 	}
+
 	if p.createProcess == nil {
 		p.createProcess = defaultProcess
 	}

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -21,12 +21,14 @@ import (
 func init() {
 	execCommand = mockExecCommand
 }
+
 func mockExecCommand(arg0 string, args ...string) *exec.Cmd {
 	args = append([]string{"-test.run=TestMockExecCommand", "--", arg0}, args...)
 	cmd := exec.Command(os.Args[0], args...)
 	cmd.Stderr = os.Stderr
 	return cmd
 }
+
 func TestMockExecCommand(t *testing.T) {
 	var cmd []string
 	for _, arg := range os.Args {
@@ -164,8 +166,8 @@ func (p *testProc) RlimitUsage(gatherUsage bool) ([]process.RlimitStat, error) {
 	return []process.RlimitStat{}, nil
 }
 
-var pid PID = PID(42)
-var exe string = "foo"
+var pid PID = 42
+var exe = "foo"
 
 func TestGather_CreateProcessErrorOk(t *testing.T) {
 	var acc testutil.Accumulator


### PR DESCRIPTION
references: #7642

<details><summary>benchmarks before this commit</summary>

```
# go test -short -bench=. -benchmem ./plugins/inputs/procstat
goos: linux
goarch: amd64
pkg: github.com/influxdata/telegraf/plugins/inputs/procstat
BenchmarkPattern-6       	   34604	     34070 ns/op	   15746 B/op	     158 allocs/op
BenchmarkFullPattern-6   	   20167	     57731 ns/op	   23082 B/op	     178 allocs/op
PASS
ok  	github.com/influxdata/telegraf/plugins/inputs/procstat	4.311s
```

</details>

<details><summary>benchmarks from this commit</summary>

```
# go test -short -bench=. -benchmem ./plugins/inputs/procstat
goos: linux
goarch: amd64
pkg: github.com/influxdata/telegraf/plugins/inputs/procstat
BenchmarkPattern-6       	   35467	     33714 ns/op	   15725 B/op	     156 allocs/op
BenchmarkFullPattern-6   	   36014	     33415 ns/op	   15726 B/op	     156 allocs/op
PASS
ok  	github.com/influxdata/telegraf/plugins/inputs/procstat	3.115s
```

</details>
