### PR TITLE
chore: extend gitignore to ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /telegraf.exe
 /telegraf.gz
 /vendor
+.DS_Store


### PR DESCRIPTION
this PR adds the mac `.DS_Store` files to the `.gitignore` file