### PR TITLE
systemd_units: add --plain to command invocation (#7990)

### DIFF
--- a/plugins/inputs/systemd_units/README.md
+++ b/plugins/inputs/systemd_units/README.md
@@ -1,7 +1,7 @@
 # systemd Units Input Plugin
 
 The systemd_units plugin gathers systemd unit status on Linux. It relies on
-`systemctl list-units --all --type=service` to collect data on service status.
+`systemctl list-units --all --plain --type=service` to collect data on service status.
 
 The results are tagged with the unit name and provide enumerated fields for
 loaded, active and running fields, indicating the unit health.

--- a/plugins/inputs/systemd_units/systemd_units_linux.go
+++ b/plugins/inputs/systemd_units/systemd_units_linux.go
@@ -198,13 +198,13 @@ func setSystemctl(Timeout internal.Duration, UnitType string) (*bytes.Buffer, er
 		return nil, err
 	}
 
-	cmd := exec.Command(systemctlPath, "list-units", "--all", fmt.Sprintf("--type=%s", UnitType), "--no-legend")
+	cmd := exec.Command(systemctlPath, "list-units", "--all", "--plain", fmt.Sprintf("--type=%s", UnitType), "--no-legend")
 
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err = internal.RunTimeout(cmd, Timeout.Duration)
 	if err != nil {
-		return &out, fmt.Errorf("error running systemctl list-units --all --type=%s --no-legend: %s", UnitType, err)
+		return &out, fmt.Errorf("error running systemctl list-units --all --plain --type=%s --no-legend: %s", UnitType, err)
 	}
 
 	return &out, nil


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests. (unit tests do not change)

This addresses #7990. Tested on Arch Linux running v246 and Debian Buster running v241 