### PR TITLE
Make able statsd input plugin to push 0 to collector on the first time is the gather beign requested

### DIFF
--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -34,6 +34,15 @@
   ## Reset timings & histograms every interval (default=true)
   delete_timings = true
 
+  ## When resetting counter or the telegraf daemon, first gather will put a 0
+  ## This is useful for metric collectors systems like prometheus
+  ## where the transition from none to X value results in "none". 
+  ## With this option activated you will send first a 0 and 
+  ## then the incremented value in the next gather resulting in the 
+  ## real incremental from 0 to the current value
+  ## will push in the series: [0,value,0,value,0,value...]
+  first_counter_metric_gather_fill_with_zero = true (default=false)
+
   ## Percentiles to calculate for timing & histogram stats.
   percentiles = [50.0, 90.0, 99.0, 99.9, 99.95, 100.0]
 

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -178,7 +178,7 @@ type cachedcounter struct {
 	firstInit bool
 }
 
-func (c *cachedcounter) counterTouched() {
+func (c cachedcounter) counterTouched() {
 	c.firstInit = false
 }
 

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -293,15 +293,15 @@ func (s *Statsd) Gather(acc telegraf.Accumulator) error {
 
 	for _, m := range s.counters {
 		if m.firstInit {
-			zeroCounter := cachedcounter{
-				fields: make(map[string]interface{}),
-			}
+			zeroFields := make(map[string]interface{})
 			for k := range m.fields {
-				zeroCounter.fields[k] = int64(0)
+				zeroFields[k] = int64(0)
 			}
-			acc.AddCounter(m.name, zeroCounter.fields, m.tags, now)
+			s.Log.Warn("firstInit")
+			acc.AddCounter(m.name, zeroFields, m.tags, now)
 			m.firstInit = false
 		} else {
+			s.Log.Warn("noFirstInit")
 			acc.AddCounter(m.name, m.fields, m.tags, now)
 		}
 	}

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -1463,6 +1463,139 @@ func TestParse_Timings_Delete(t *testing.T) {
 	}
 }
 
+func TestParse_Counter_PushZero(t *testing.T) {
+	s := NewTestStatsd()
+	s.FirstCounterMetricGatherFillWithZero = true
+	fakeacc := &testutil.Accumulator{}
+	var err error
+
+	line := "my_counter:1|c"
+
+	err = s.parseStatsdLine(line)
+	if err != nil {
+		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+	}
+
+	if len(s.counters) != 1 {
+		t.Errorf("Should be 1 count, found %d", len(s.counters))
+	}
+	valueOfFirstInit := s.counters["metric_type=countermy_counter"].firstInit
+	if !valueOfFirstInit {
+		t.Errorf("first iteration on gather must result the firstInit in True: %t", valueOfFirstInit)
+	}
+
+	s.Gather(fakeacc)
+
+	valueOfFirstInit = s.counters["metric_type=countermy_counter"].firstInit
+	if valueOfFirstInit {
+		t.Errorf("first iteration on gather must result the firstInit in False: %t", valueOfFirstInit)
+	}
+
+	valueOfMetric := fakeacc.Metrics[0].Fields["value"]
+
+	if valueOfMetric != int64(0) {
+		t.Errorf("first iteration on gather must result the firstInit in accumulator to 0: %d", valueOfMetric)
+	}
+
+	fakeacc = &testutil.Accumulator{}
+
+	s.Gather(fakeacc)
+
+	valueOfFirstInit = s.counters["metric_type=countermy_counter"].firstInit
+	if valueOfFirstInit {
+		t.Errorf("next iterations on gather must result the firstInit in False: %t", valueOfFirstInit)
+	}
+
+	valueOfMetric = fakeacc.Metrics[0].Fields["value"]
+
+	if valueOfMetric != int64(1) {
+		t.Errorf("first iteration on gather must result the firstInit in accumulator to 1: %d", valueOfMetric)
+	}
+}
+
+func TestParse_Counter_PushZero_With_Delete_Counter(t *testing.T) {
+	s := NewTestStatsd()
+	s.FirstCounterMetricGatherFillWithZero = true
+	s.DeleteCounters = true
+	fakeacc := &testutil.Accumulator{}
+	var err error
+
+	line := "my_counter:1|c"
+
+	err = s.parseStatsdLine(line)
+	if err != nil {
+		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+	}
+
+	if len(s.counters) != 1 {
+		t.Errorf("Should be 1 count, found %d", len(s.counters))
+	}
+	valueOfFirstInit := s.counters["metric_type=countermy_counter"].firstInit
+	if !valueOfFirstInit {
+		t.Errorf("first iteration on gather must result the firstInit in True: %t", valueOfFirstInit)
+	}
+
+	s.Gather(fakeacc)
+
+	valueOfFirstInit = s.counters["metric_type=countermy_counter"].firstInit
+	if valueOfFirstInit {
+		t.Errorf("first iteration on gather must result the firstInit in False: %t", valueOfFirstInit)
+	}
+
+	valueOfMetric := fakeacc.Metrics[0].Fields["value"]
+
+	if valueOfMetric != int64(0) {
+		t.Errorf("first iteration on gather must result the firstInit in accumulator to 0: %d", valueOfMetric)
+	}
+
+	fakeacc = &testutil.Accumulator{}
+
+	s.Gather(fakeacc)
+
+	valueOfFirstInit = s.counters["metric_type=countermy_counter"].firstInit
+	if valueOfFirstInit {
+		t.Errorf("next iterations on gather must result the firstInit in False: %t", valueOfFirstInit)
+	}
+
+	valueOfMetric = fakeacc.Metrics[0].Fields["value"]
+
+	if valueOfMetric != int64(1) {
+		t.Errorf("first iteration on gather must result the firstInit in accumulator to 1: %d", valueOfMetric)
+	}
+
+	line = "my_counter:10|c"
+
+	err = s.parseStatsdLine(line)
+
+	fakeacc = &testutil.Accumulator{}
+
+	s.Gather(fakeacc)
+
+	valueOfFirstInit = s.counters["metric_type=countermy_counter"].firstInit
+	if valueOfFirstInit {
+		t.Errorf("next iterations on gather must result the firstInit in False: %t", valueOfFirstInit)
+	}
+	valueOfMetric = fakeacc.Metrics[0].Fields["value"]
+
+	if valueOfMetric != int64(0) {
+		t.Errorf("first iteration on gather must result the firstInit in accumulator to 0: %d", valueOfMetric)
+	}
+
+	fakeacc = &testutil.Accumulator{}
+
+	s.Gather(fakeacc)
+
+	valueOfFirstInit = s.counters["metric_type=countermy_counter"].firstInit
+	if valueOfFirstInit {
+		t.Errorf("next iterations on gather must result the firstInit in False: %t", valueOfFirstInit)
+	}
+	valueOfMetric = fakeacc.Metrics[0].Fields["value"]
+
+	if valueOfMetric != int64(10) {
+		t.Errorf("first iteration on gather must result the firstInit in accumulator to 10: %d", valueOfMetric)
+	}
+}
+
 // Tests the delete_gauges option
 func TestParse_Gauges_Delete(t *testing.T) {
 	s := NewTestStatsd()


### PR DESCRIPTION
Add option to send a 0 in the first gather for the metric. The intention of this new option is to solve things like: https://github.com/prometheus/prometheus/issues/1673
The next iterations will send the value collected.
If you use this with DeleteCounter enabled will create a series like [0,value,0,value,0,value...] 

The first idea was to use another layer to keep this behavior (like in a processor) and make able all input plugins able to do this but I saw that the effort in the processor was huge (creating a middle cache and retaining values in the first time...) so finally was done in the input plugin where we had this behavior with prometheus