### PR TITLE
Make Wavefront internal sender's buffer size configurable

### DIFF
--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -1,6 +1,7 @@
 # Wavefront Output Plugin
 
-This plugin writes to a [Wavefront](https://www.wavefront.com) proxy, in Wavefront data format over TCP.
+This plugin writes in [Wavefront](https://www.wavefront.com) data format to a Wavefront proxy 
+(over HTTP or TCP) or directly to the Wavefront service (over HTTP).
 
 
 ### Configuration:
@@ -18,6 +19,18 @@ This plugin writes to a [Wavefront](https://www.wavefront.com) proxy, in Wavefro
 
   ## Port that the Wavefront proxy server listens on. Do not use if url is specified
   #port = 2878
+
+  ## Size of internal buffers beyond which received data is dropped. Applicable only if url is specified.
+  ## Buffers are not pre-allocated to max size and vary based on actual usage.
+  ## Defaults to 50,000. Higher values could use more memory.
+  #max_buffer_size = 50000
+
+  ## Max batch of data sent per flush interval. Applicable only if url is specified.
+  ## Defaults to 10,000. Recommended not to exceed 40,000. 
+  #batch_size = 10000
+
+  ## Interval (in seconds) at which to flush data. Defaults to 5 seconds.
+  #flush_interval_seconds = 5
 
   ## prefix for metrics keys
   #prefix = "my.specific.prefix."

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -14,16 +14,52 @@ import (
 // default config used by Tests
 func defaultWavefront() *Wavefront {
 	return &Wavefront{
-		Host:            "localhost",
-		Port:            2878,
-		Prefix:          "testWF.",
-		SimpleFields:    false,
-		MetricSeparator: ".",
-		ConvertPaths:    true,
-		ConvertBool:     true,
-		UseRegex:        false,
-		Log:             testutil.Logger{},
+		Host:                 "localhost",
+		Port:                 2878,
+		FlushIntervalSeconds: 10,
+		Prefix:               "testWF.",
+		SimpleFields:         false,
+		MetricSeparator:      ".",
+		ConvertPaths:         true,
+		ConvertBool:          true,
+		UseRegex:             false,
+		Log:                  testutil.Logger{},
 	}
+}
+
+func defaultWavefrontDirect() *Wavefront {
+	return &Wavefront{
+		Url:                  "http://localhost:2878",
+		Token:                "123",
+		MaxBufferSize:        100000,
+		BatchSize:            20000,
+		FlushIntervalSeconds: 10,
+		Prefix:               "testWF.",
+		SimpleFields:         false,
+		MetricSeparator:      ".",
+		ConvertPaths:         true,
+		ConvertBool:          true,
+		UseRegex:             false,
+		Log:                  testutil.Logger{},
+	}
+}
+
+func TestBuildDirectConfig(t *testing.T) {
+	w := defaultWavefrontDirect()
+	directConfig := w.buildDirectConfig()
+	require.Equal(t, w.Url, directConfig.Server)
+	require.Equal(t, w.Token, directConfig.Token)
+	require.Equal(t, w.MaxBufferSize, directConfig.MaxBufferSize)
+	require.Equal(t, w.BatchSize, directConfig.BatchSize)
+	require.Equal(t, w.FlushIntervalSeconds, directConfig.FlushIntervalSeconds)
+}
+
+func TestBuildProxyConfig(t *testing.T) {
+	w := defaultWavefront()
+	proxyConfig := w.buildProxyConfig()
+	require.Equal(t, w.Host, proxyConfig.Host)
+	require.Equal(t, w.Port, proxyConfig.MetricsPort)
+	require.Equal(t, w.FlushIntervalSeconds, proxyConfig.FlushIntervalSeconds)
 }
 
 func TestBuildMetrics(t *testing.T) {


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Updating Wavefront Output Plugin with buffer size configuration option (#7409) and related config options.