### PR TITLE
Fix docker-image make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ clean:
 
 .PHONY: docker-image
 docker-image:
-	docker build -f scripts/stretch.docker -t "telegraf:$(COMMIT)" .
+	docker build -f scripts/stretch.docker -t "telegraf:$(commit)" .
 
 plugins/parsers/influx/machine.go: plugins/parsers/influx/machine.go.rl
 	ragel -Z -G2 $^ -o $@


### PR DESCRIPTION
`COMMIT` doesn't seem to be defined anywhere which causes:

```
docker build -f scripts/stretch.docker -t "telegraf:" .
invalid argument "telegraf:" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
make: *** [docker-image] Error 125
```

whereas `commit` is defined in https://github.com/influxdata/telegraf/blob/master/Makefile#L10

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
