### PR TITLE
Fix string to int conversion in eventhub consumer

### DIFF
--- a/plugins/inputs/eventhub_consumer/eventhub_consumer.go
+++ b/plugins/inputs/eventhub_consumer/eventhub_consumer.go
@@ -376,7 +376,7 @@ func (e *EventHub) createMetrics(event *eventhub.Event) ([]telegraf.Metric, erro
 		}
 
 		if event.SystemProperties.PartitionID != nil && e.PartitionIDTag != "" {
-			metrics[i].AddTag(e.PartitionIDTag, string(*event.SystemProperties.PartitionID))
+			metrics[i].AddTag(e.PartitionIDTag, fmt.Sprintf("%d", *event.SystemProperties.PartitionID))
 		}
 		if event.SystemProperties.PartitionKey != nil && e.PartitionKeyTag != "" {
 			metrics[i].AddTag(e.PartitionKeyTag, *event.SystemProperties.PartitionKey)


### PR DESCRIPTION
The existing conversion produces a vet check (which is enabled by default starting with 1.15) when running `go test` in 1.15 as per https://golang.org/doc/go1.15#vet.

```
$ make test
go test -short -race ./...
?       github.com/influxdata/telegraf  [no test files]
# github.com/influxdata/telegraf/plugins/inputs/eventhub_consumer
plugins/inputs/eventhub_consumer/eventhub_consumer.go:379:40: conversion from int16 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
...
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
