### PR TITLE
Add addTag debugg in ifname plugin

### DIFF
--- a/plugins/processors/ifname/ifname.go
+++ b/plugins/processors/ifname/ifname.go
@@ -139,13 +139,13 @@ func (d *IfName) Init() error {
 func (d *IfName) addTag(metric telegraf.Metric) error {
 	agent, ok := metric.GetTag(d.AgentTag)
 	if !ok {
-		//agent tag missing
+		d.Log.Warn("Agent tag missing.")
 		return nil
 	}
 
 	num_s, ok := metric.GetTag(d.SourceTag)
 	if !ok {
-		//source tag missing
+		d.Log.Warn("Source tag missing.")
 		return nil
 	}
 


### PR DESCRIPTION
This allows for debugging why metrics are not processed. (like in #8012)

I'm only not sure about the used severity.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
