### PR TITLE
http_response: status_code match

### DIFF
--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -45,8 +45,11 @@ This input plugin checks HTTP/HTTPS connections.
   # response_string_match = "ok"
   # response_string_match = "\".*_status\".?:.?\"up\""
 
-  ## Optional status code match of the response
-  # response_status_code_match = 204
+  ## Expected response status code.
+  ## The status code of the response is compared to this value. If they match, the field
+  ## "response_status_code_match" will be 1, otherwise it will be 0. If the
+  ## expected status code is 0, the check is disabled and the field won't be added.
+  # response_status_code = 0
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -45,6 +45,9 @@ This input plugin checks HTTP/HTTPS connections.
   # response_string_match = "ok"
   # response_string_match = "\".*_status\".?:.?\"up\""
 
+  ## Optional status code match of the response
+  # response_status_code_match = 204
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
@@ -77,6 +80,7 @@ This input plugin checks HTTP/HTTPS connections.
     - response_time (float, seconds)
     - content_length (int, response body length)
     - response_string_match (int, 0 = mismatch / body read error, 1 = match)
+    - response_status_code_match (int, 0 = mismatch, 1 = match)
     - http_response_code (int, response status code)
 	- result_type (string, deprecated in 1.6: use `result` tag and `result_code` field)
     - result_code (int, [see below](#result--result_code))
@@ -87,14 +91,15 @@ Upon finishing polling the target server, the plugin registers the result of the
 
 This tag is used to expose network and plugin errors. HTTP errors are considered a successful connection.
 
-|Tag value                |Corresponding field value|Description|
---------------------------|-------------------------|-----------|
-|success                  | 0                       |The HTTP request completed, even if the HTTP code represents an error|
-|response_string_mismatch | 1                       |The option `response_string_match` was used, and the body of the response didn't match the regex. HTTP errors with content in their body (like 4xx, 5xx) will trigger this error|
-|body_read_error          | 2                       |The option `response_string_match` was used, but the plugin wasn't able to read the body of the response. Responses with empty bodies (like 3xx, HEAD, etc) will trigger this error. Or the option `response_body_field` was used and the content of the response body was not a valid utf-8. Or the size of the body of the response exceeded the `response_body_max_size` |
-|connection_failed        | 3                       |Catch all for any network error not specifically handled by the plugin|
-|timeout                  | 4                       |The plugin timed out while awaiting the HTTP connection to complete|
-|dns_error                | 5                       |There was a DNS error while attempting to connect to the host|
+|Tag value                     |Corresponding field value|Description|
+-------------------------------|-------------------------|-----------|
+|success                       | 0                       |The HTTP request completed, even if the HTTP code represents an error|
+|response_string_mismatch      | 1                       |The option `response_string_match` was used, and the body of the response didn't match the regex. HTTP errors with content in their body (like 4xx, 5xx) will trigger this error|
+|body_read_error               | 2                       |The option `response_string_match` was used, but the plugin wasn't able to read the body of the response. Responses with empty bodies (like 3xx, HEAD, etc) will trigger this error. Or the option `response_body_field` was used and the content of the response body was not a valid utf-8. Or the size of the body of the response exceeded the `response_body_max_size` |
+|connection_failed             | 3                       |Catch all for any network error not specifically handled by the plugin|
+|timeout                       | 4                       |The plugin timed out while awaiting the HTTP connection to complete|
+|dns_error                     | 5                       |There was a DNS error while attempting to connect to the host|
+|response_status_code_mismatch | 6                       |The option `response_status_code_match` was used, and the status code of the response didn't match the value.|
 
 
 ### Example Output:

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -366,7 +366,7 @@ func (h *HTTPResponse) httpGather(u string) (map[string]interface{}, map[string]
 			setResult("response_string_mismatch", fields, tags)
 			fields["response_string_match"] = 0
 		}
-	} else if h.ResponseStatusCodeMatch >= http.StatusContinue && h.ResponseStatusCodeMatch <= http.StatusNetworkAuthenticationRequired {
+	} else if h.ResponseStatusCodeMatch > 0 {
 		if resp.StatusCode == h.ResponseStatusCodeMatch {
 			setResult("success", fields, tags)
 			fields["response_status_code_match"] = 1

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -126,6 +126,9 @@ func setUpTestMux() http.Handler {
 		time.Sleep(time.Second * 2)
 		return
 	})
+	mux.HandleFunc("/nocontent", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
 	return mux
 }
 
@@ -1109,4 +1112,70 @@ func TestBasicAuth(t *testing.T) {
 	}
 	absentFields := []string{"response_string_match"}
 	checkOutput(t, &acc, expectedFields, expectedTags, absentFields, nil)
+}
+
+func TestStatusCodeMatchFail(t *testing.T) {
+	mux := setUpTestMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	h := &HTTPResponse{
+		Log:                     testutil.Logger{},
+		Address:                 ts.URL + "/nocontent",
+		ResponseStatusCodeMatch: http.StatusOK,
+		ResponseTimeout:         internal.Duration{Duration: time.Second * 20},
+	}
+
+	var acc testutil.Accumulator
+	err := h.Gather(&acc)
+	require.NoError(t, err)
+
+	expectedFields := map[string]interface{}{
+		"http_response_code":         http.StatusNoContent,
+		"response_status_code_match": 0,
+		"result_type":                "response_status_code_mismatch",
+		"result_code":                6,
+		"response_time":              nil,
+		"content_length":             nil,
+	}
+	expectedTags := map[string]interface{}{
+		"server":      nil,
+		"method":      http.MethodGet,
+		"status_code": "204",
+		"result":      "response_status_code_mismatch",
+	}
+	checkOutput(t, &acc, expectedFields, expectedTags, nil, nil)
+}
+
+func TestStatusCodeMatch(t *testing.T) {
+	mux := setUpTestMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	h := &HTTPResponse{
+		Log:                     testutil.Logger{},
+		Address:                 ts.URL + "/nocontent",
+		ResponseStatusCodeMatch: http.StatusNoContent,
+		ResponseTimeout:         internal.Duration{Duration: time.Second * 20},
+	}
+
+	var acc testutil.Accumulator
+	err := h.Gather(&acc)
+	require.NoError(t, err)
+
+	expectedFields := map[string]interface{}{
+		"http_response_code":         http.StatusNoContent,
+		"response_status_code_match": 1,
+		"result_type":                "success",
+		"result_code":                0,
+		"response_time":              nil,
+		"content_length":             nil,
+	}
+	expectedTags := map[string]interface{}{
+		"server":      nil,
+		"method":      http.MethodGet,
+		"status_code": "204",
+		"result":      "success",
+	}
+	checkOutput(t, &acc, expectedFields, expectedTags, nil, nil)
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

I've added the possibility to match on the status code instead of only the response body, can be useful if your service return a 204. 

I'm not fully satisfied because actually we can only check the body OR the status code (not both). Technically isn't difficult to be able to do both, but that require some decisions about the `result` value, if only one of these fail the value is pretty obvious but in case both check fail, do we need to create another value (`response_mismatch`?) or set the field to `response_status_code_mismatch` or `response_string_mismatch`

Thanks!