### PR TITLE
feat(plugins/input/jenkins): add build number field to jenkins_job measurement

### DIFF
--- a/plugins/inputs/jenkins/README.md
+++ b/plugins/inputs/jenkins/README.md
@@ -88,6 +88,7 @@ This plugin does not require a plugin on jenkins and it makes use of Jenkins API
     - port
   - fields:
     - duration (ms)
+    - number
     - result_code (0 = SUCCESS, 1 = FAILURE, 2 = NOT_BUILD, 3 = UNSTABLE, 4 = ABORTED)
 
 ### Sample Queries:

--- a/plugins/inputs/jenkins/jenkins.go
+++ b/plugins/inputs/jenkins/jenkins.go
@@ -419,6 +419,7 @@ type jobBuild struct {
 type buildResponse struct {
 	Building  bool   `json:"building"`
 	Duration  int64  `json:"duration"`
+	Number    int64  `json:"number"`
 	Result    string `json:"result"`
 	Timestamp int64  `json:"timestamp"`
 }
@@ -436,6 +437,7 @@ type jobRequest struct {
 	name    string
 	parents []string
 	layer   int
+	number  int64
 }
 
 func (jr jobRequest) combined() []string {
@@ -471,6 +473,7 @@ func (j *Jenkins) gatherJobBuild(jr jobRequest, b *buildResponse, acc telegraf.A
 	fields := make(map[string]interface{})
 	fields["duration"] = b.Duration
 	fields["result_code"] = mapResultCode(b.Result)
+	fields["number"] = b.Number
 
 	acc.AddFields(measurementJob, fields, tags, b.GetTimestamp())
 }

--- a/plugins/inputs/jenkins/jenkins_test.go
+++ b/plugins/inputs/jenkins/jenkins_test.go
@@ -530,12 +530,14 @@ func TestGatherJobs(t *testing.T) {
 						Building:  false,
 						Result:    "SUCCESS",
 						Duration:  25558,
+						Number:    3,
 						Timestamp: (time.Now().Unix() - int64(time.Minute.Seconds())) * 1000,
 					},
 					"/job/job2/1/api/json": &buildResponse{
 						Building:  false,
 						Result:    "FAILURE",
 						Duration:  1558,
+						Number:    1,
 						Timestamp: (time.Now().Unix() - int64(time.Minute.Seconds())) * 1000,
 					},
 				},
@@ -549,6 +551,7 @@ func TestGatherJobs(t *testing.T) {
 						},
 						Fields: map[string]interface{}{
 							"duration":    int64(25558),
+							"number":      int64(3),
 							"result_code": 0,
 						},
 					},
@@ -559,6 +562,7 @@ func TestGatherJobs(t *testing.T) {
 						},
 						Fields: map[string]interface{}{
 							"duration":    int64(1558),
+							"number":      int64(1),
 							"result_code": 1,
 						},
 					},
@@ -583,6 +587,7 @@ func TestGatherJobs(t *testing.T) {
 						Building:  false,
 						Result:    "SUCCESS",
 						Duration:  25558,
+						Number:    3,
 						Timestamp: (time.Now().Unix() - int64(time.Minute.Seconds())) * 1000,
 					},
 				},
@@ -596,6 +601,7 @@ func TestGatherJobs(t *testing.T) {
 						},
 						Fields: map[string]interface{}{
 							"duration":    int64(25558),
+							"number":      int64(3),
 							"result_code": 0,
 						},
 					},
@@ -658,24 +664,28 @@ func TestGatherJobs(t *testing.T) {
 						Building:  false,
 						Result:    "FAILURE",
 						Duration:  1558,
+						Number:    1,
 						Timestamp: (time.Now().Unix() - int64(time.Minute.Seconds())) * 1000,
 					},
 					"/job/apps/job/k8s-cloud/job/PR-101/4/api/json": &buildResponse{
 						Building:  false,
 						Result:    "SUCCESS",
 						Duration:  76558,
+						Number:    4,
 						Timestamp: (time.Now().Unix() - int64(time.Minute.Seconds())) * 1000,
 					},
 					"/job/apps/job/k8s-cloud/job/PR-100/1/api/json": &buildResponse{
 						Building:  false,
 						Result:    "SUCCESS",
 						Duration:  91558,
+						Number:    1,
 						Timestamp: (time.Now().Unix() - int64(time.Minute.Seconds())) * 1000,
 					},
 					"/job/apps/job/k8s-cloud/job/PR%201/1/api/json": &buildResponse{
 						Building:  false,
 						Result:    "SUCCESS",
 						Duration:  87832,
+						Number:    1,
 						Timestamp: (time.Now().Unix() - int64(time.Minute.Seconds())) * 1000,
 					},
 				},
@@ -690,6 +700,7 @@ func TestGatherJobs(t *testing.T) {
 						},
 						Fields: map[string]interface{}{
 							"duration":    int64(87832),
+							"number":      int64(1),
 							"result_code": 0,
 						},
 					},
@@ -701,6 +712,7 @@ func TestGatherJobs(t *testing.T) {
 						},
 						Fields: map[string]interface{}{
 							"duration":    int64(91558),
+							"number":      int64(1),
 							"result_code": 0,
 						},
 					},
@@ -712,6 +724,7 @@ func TestGatherJobs(t *testing.T) {
 						},
 						Fields: map[string]interface{}{
 							"duration":    int64(76558),
+							"number":      int64(4),
 							"result_code": 0,
 						},
 					},
@@ -723,6 +736,7 @@ func TestGatherJobs(t *testing.T) {
 						},
 						Fields: map[string]interface{}{
 							"duration":    int64(1558),
+							"number":      int64(1),
 							"result_code": 1,
 						},
 					},


### PR DESCRIPTION
This PR adds `number` field to `jenkins_job` measurement. It allows eg. to create links to specific builds in dashboards.

Example output (`telegraf --config telegraf.conf --input-filter jenkins --test`):
```
2020-08-26T14:42:29Z I! Starting Telegraf 
> jenkins,host=jenkins.bonitoo4influxdata.com,port=8443,source=localhost busy_executors=2i,total_executors=8i 1598452951000000000
...
> jenkins_job,host=jenkins.bonitoo4influxdata.com,name=deploy-tickstack-eprise-partial,port=8443,result=SUCCESS,source=localhost duration=108962i,number=1091i,result_code=0i 1598450671000000000
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
