### PR TITLE
fix docker build. update dockerfiles to Go 1.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,11 @@ deps:
 telegraf:
 	go build -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
+# Used by dockerfile builds
+.PHONY: go-install
+go-install:
+	go install -ldflags "-w -s $(LDFLAGS)" ./cmd/telegraf
+
 .PHONY: test
 test:
 	go test -short $(race_detector) ./...

--- a/scripts/alpine.docker
+++ b/scripts/alpine.docker
@@ -1,10 +1,10 @@
-FROM golang:1.13.13 as builder
+FROM golang:1.14.7 as builder
 WORKDIR /go/src/github.com/influxdata/telegraf
 
 COPY . /go/src/github.com/influxdata/telegraf
 RUN CGO_ENABLED=0 make go-install
 
-FROM alpine:3.6
+FROM alpine:3.12
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \
     update-ca-certificates

--- a/scripts/stretch.docker
+++ b/scripts/stretch.docker
@@ -1,4 +1,4 @@
-FROM golang:1.13.13 as builder
+FROM golang:1.14.7-stretch as builder
 WORKDIR /go/src/github.com/influxdata/telegraf
 
 COPY . /go/src/github.com/influxdata/telegraf


### PR DESCRIPTION
Looks like `make go-install` should probably not have been removed, as it was still in use. Likely daniel thought that it was not relevant to the new makefile setup, which focuses on creating our package builds, however the docker file also expects to be able to call into it so it doesn't have to manage env variables. This is likely a reasonable assumption, and not realistic to expect only one consumer of the `Makefile`, so I've added the function back in.