### PR TITLE
outputs/http: add option to control idle connection timeout

### DIFF
--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -1,7 +1,7 @@
 # HTTP Output Plugin
 
 This plugin sends metrics in a HTTP message encoded using one of the output
-data formats.  For data_formats that support batching, metrics are sent in batch format.
+data formats. For data_formats that support batching, metrics are sent in batch format.
 
 ### Configuration:
 
@@ -48,4 +48,9 @@ data formats.  For data_formats that support batching, metrics are sent in batch
   # [outputs.http.headers]
   #   # Should be set manually to "application/json" for json data_format
   #   Content-Type = "text/plain; charset=utf-8"
+
+  ## Idle (keep-alive) connection timeout.
+  ## Maximum amount of time before idle connection is closed.
+  ## Zero means no limit.
+  # idle_conn_timeout = 0
 ```

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -64,6 +64,11 @@ var sampleConfig = `
   # [outputs.http.headers]
   #   # Should be set manually to "application/json" for json data_format
   #   Content-Type = "text/plain; charset=utf-8"
+
+  ## Idle (keep-alive) connection timeout.
+  ## Maximum amount of time before idle connection is closed.
+  ## Zero means no limit.
+  # idle_conn_timeout = 0
 `
 
 const (
@@ -84,6 +89,7 @@ type HTTP struct {
 	TokenURL        string            `toml:"token_url"`
 	Scopes          []string          `toml:"scopes"`
 	ContentEncoding string            `toml:"content_encoding"`
+	IdleConnTimeout internal.Duration `toml:"idle_conn_timeout"`
 	tls.ClientConfig
 
 	client     *http.Client
@@ -104,6 +110,7 @@ func (h *HTTP) createClient(ctx context.Context) (*http.Client, error) {
 		Transport: &http.Transport{
 			TLSClientConfig: tlsCfg,
 			Proxy:           http.ProxyFromEnvironment,
+			IdleConnTimeout: h.IdleConnTimeout.Duration,
 		},
 		Timeout: h.Timeout.Duration,
 	}


### PR DESCRIPTION
This PR resolves the issue when Telegraf stays in front of Load Balancer.

Some servers has hardcoded IdleTimeut which is higher then 15 seconds (default Telegrafs keep-alive timeout). In this case Telegraf creates keep-alive connection and it is never closed because of reuse.

As a result, balancing does not work.