### PR TITLE
Fix CI AppVeyor 'make check' errors for go 1.15 on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,5 @@
-ifeq ($(OS), Windows_NT)
-	devnull := nul
-else
-	devnull := /dev/null
-endif
-
 next_version := 1.16.0
-tag := $(shell git describe --exact-match --tags 2>$(devnull))
+tag := $(shell git describe --exact-match --tags 2>git_describe_error.tmp; rm -f git_describe_error.tmp)
 branch := $(shell git rev-parse --abbrev-ref HEAD)
 commit := $(shell git rev-parse --short=8 HEAD)
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -4,6 +4,7 @@ package win_perf_counters
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -185,11 +186,11 @@ func TestWinPerfcountersConfigGet2(t *testing.T) {
 	if len(m.counters) == 1 {
 		require.NoError(t, nil)
 	} else if len(m.counters) == 0 {
-		var errorstring1 = "No results returned from the counterPath: " + string(len(m.counters))
+		var errorstring1 = "No results returned from the counterPath"
 		err2 := errors.New(errorstring1)
 		require.NoError(t, err2)
 	} else if len(m.counters) > 1 {
-		var errorstring1 = "Too many results returned from the counterPath: " + string(len(m.counters))
+		var errorstring1 = fmt.Sprintf("Too many results returned from the counterPath: %v", len(m.counters))
 		err2 := errors.New(errorstring1)
 		require.NoError(t, err2)
 	}
@@ -233,12 +234,12 @@ func TestWinPerfcountersConfigGet3(t *testing.T) {
 		require.NoError(t, nil)
 	} else if len(m.counters) < 2 {
 
-		var errorstring1 = "Too few results returned from the counterPath. " + string(len(m.counters))
+		var errorstring1 = fmt.Sprintf("Too few results returned from the counterPath: %v", len(m.counters))
 		err2 := errors.New(errorstring1)
 		require.NoError(t, err2)
 	} else if len(m.counters) > 2 {
 
-		var errorstring1 = "Too many results returned from the counterPath: " + string(len(m.counters))
+		var errorstring1 = fmt.Sprintf("Too many results returned from the counterPath: %v", len(m.counters))
 		err2 := errors.New(errorstring1)
 		require.NoError(t, err2)
 	}
@@ -282,12 +283,12 @@ func TestWinPerfcountersConfigGet4(t *testing.T) {
 		require.NoError(t, nil)
 	} else if len(m.counters) < 2 {
 
-		var errorstring1 = "Too few results returned from the counterPath: " + string(len(m.counters))
+		var errorstring1 = fmt.Sprintf("Too few results returned from the counterPath: %v", len(m.counters))
 		err2 := errors.New(errorstring1)
 		require.NoError(t, err2)
 	} else if len(m.counters) > 2 {
 
-		var errorstring1 = "Too many results returned from the counterPath: " + string(len(m.counters))
+		var errorstring1 = fmt.Sprintf("Too many results returned from the counterPath: %v", len(m.counters))
 		err2 := errors.New(errorstring1)
 		require.NoError(t, err2)
 	}
@@ -331,13 +332,11 @@ func TestWinPerfcountersConfigGet5(t *testing.T) {
 	if len(m.counters) == 4 {
 		require.NoError(t, nil)
 	} else if len(m.counters) < 4 {
-		var errorstring1 = "Too few results returned from the counterPath: " +
-			string(len(m.counters))
+		var errorstring1 = fmt.Sprintf("Too few results returned from the counterPath: %v", len(m.counters))
 		err2 := errors.New(errorstring1)
 		require.NoError(t, err2)
 	} else if len(m.counters) > 4 {
-		var errorstring1 = "Too many results returned from the counterPath: " +
-			string(len(m.counters))
+		var errorstring1 = fmt.Sprintf("Too many results returned from the counterPath: %v", len(m.counters))
 		err2 := errors.New(errorstring1)
 		require.NoError(t, err2)
 	}
@@ -415,13 +414,11 @@ func TestWinPerfcountersConfigGet7(t *testing.T) {
 	if len(m.counters) == 2 {
 		require.NoError(t, nil)
 	} else if len(m.counters) < 2 {
-		var errorstring1 = "Too few results returned from the counterPath: " +
-			string(len(m.counters))
+		var errorstring1 = fmt.Sprintf("Too few results returned from the counterPath: %v", len(m.counters))
 		err2 := errors.New(errorstring1)
 		require.NoError(t, err2)
 	} else if len(m.counters) > 2 {
-		var errorstring1 = "Too many results returned from the counterPath: " +
-			string(len(m.counters))
+		var errorstring1 = fmt.Sprintf("Too many results returned from the counterPath: %v", len(m.counters))
 		err2 := errors.New(errorstring1)
 		require.NoError(t, err2)
 	}


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

All recent PRs get the following CI error 
```
go vet $(go list ./... | grep -v ./plugins/parsers/influx)
# github.com/influxdata/telegraf/plugins/inputs/win_perf_counters
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:188:69: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:192:75: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:236:74: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:241:75: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:285:74: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:290:75: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:335:4: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:340:4: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:419:4: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:424:4: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
go vet has found suspicious constructs. Please remediate any reported errors
to fix them before submitting code for review.
make: *** [Makefile:132: vet] Error 1
```

This PR fixes the `go vet` error on go 1.15 windows platform.