### PR TITLE
Exec with tags

### DIFF
--- a/plugins/inputs/exec/README.md
+++ b/plugins/inputs/exec/README.md
@@ -16,6 +16,15 @@ This plugin can be used to poll for custom metrics from any source.
     "/tmp/collect_*.sh"
   ]
 
+  ## additional parameters that will be added to the metrics as tags
+  ## Lines correspond to the command lines, so first line of parameters are 
+  ## added to metrics of first command and so on. 
+  ## If one command should not have additional tags, add an empty array.
+  tags = [
+    [ ],
+    [ [ "tag_1", "value_tag_1" ], [ "tag_2", "value_tag_2" ] ],
+  ]
+ 
   ## Timeout for each command to complete.
   timeout = "5s"
 

--- a/plugins/inputs/exec/README.md
+++ b/plugins/inputs/exec/README.md
@@ -23,6 +23,7 @@ This plugin can be used to poll for custom metrics from any source.
   tags = [
     [ ],
     [ [ "tag_1", "value_tag_1" ], [ "tag_2", "value_tag_2" ] ],
+    [ [ "tag_3", "value_tag_3" ] ]
   ]
  
   ## Timeout for each command to complete.

--- a/plugins/inputs/exec/dev/telegraf.conf
+++ b/plugins/inputs/exec/dev/telegraf.conf
@@ -10,6 +10,11 @@
     "echo 'deal,computer_name=hostb message=\"stuff\" 1530654676316265790'",
   ]
 
+  tags = [
+    [ ["tag_1", "value_hosta_1"] ],
+    [ ["tag_1", "value_hostb_1"], ["tag_2", "value_hostb_2"] ]
+  ]
+
 [[processors.regex]]
   [[processors.regex.tags]]
     key = "computer_name"

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -32,7 +32,8 @@ const sampleConfig = `
   ## add an empty array.
   tags = [
     [ ],
-    [ [ "tag_1", "value_tag_1" ], [ "tag_2", "value_tag_2" ] ],
+	[ [ "tag_1", "value_tag_1" ], [ "tag_2", "value_tag_2" ] ],
+	[ [ "tag_3", "value_tag_3" ] ]
   ]
 
   ## Timeout for each command to complete.

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -279,3 +279,24 @@ func TestRemoveCarriageReturns(t *testing.T) {
 		}
 	}
 }
+
+func TestAddAdditionalTags(t *testing.T) {
+	parser, _ := parsers.NewValueParser("metric", "string", nil)
+	e := NewExec()
+	e.Commands = []string{"echo metric_value"}
+	e.Tags = [][][]string{{{"tag_1", "value_tag_1"}}}
+	e.SetParser(parser)
+
+	var acc testutil.Accumulator
+	err := acc.GatherError(e.Gather)
+	require.NoError(t, err)
+
+	fields := map[string]interface{}{
+		"value": "metric_value",
+	}
+	tags := map[string]string{
+		"tag_1": "value_tag_1",
+	}
+	acc.AssertContainsFields(t, "metric", fields)
+	acc.AssertContainsTaggedFields(t, "metric", fields, tags)
+}

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -283,8 +283,8 @@ func TestRemoveCarriageReturns(t *testing.T) {
 func TestAddAdditionalTags(t *testing.T) {
 	parser, _ := parsers.NewValueParser("metric", "string", nil)
 	e := NewExec()
-	e.Commands = []string{"echo metric_value"}
-	e.Tags = [][][]string{{{"tag_1", "value_tag_1"}}}
+	e.Commands = []string{"echo metric_value", "echo metric_value"}
+	e.Tags = [][][]string{{}, {{"tag_1", "value_tag_1"}}}
 	e.SetParser(parser)
 
 	var acc testutil.Accumulator


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

We needed the feature to add additional tags to metrics right in telegraf before pushing the data to the influxdb. As it is a very general feature we wanted to share it with you in the hope of getting this into upstream.

With this feature you can add a `tags` array to a `[input.exec]` configuration. Within this tags array you can add an array for every command in which you define arrays for tags that are added automatically to the metrics of that command. Tag lines correspond to the lines of commands, so first tag array is applied to first commands metrics and so on. 

Example: 

```
commands = [
  "/tmp/test.sh",
  "/usr/bin/mycollector --foo=bar",
  "/tmp/collect_*.sh"
]

## additional parameters that will be added to the metrics as tags
## Lines correspond to the command lines, so first line of parameters are 
## added to metrics of first command and so on. If one command should not have additional tags,
## add an empty array.
tags = [
  [ ],
  [ [ "tag_1", "value_tag_1" ], [ "tag_2", "value_tag_2" ] ],
  [ [ "tag_3", "value_tag_3" ] ]
]
```
First command `/tmp/test.sh` will get no tags, second command `/usr/bin/mycollector --foo=bar" will get `tag_1` and `tag_2` as tags and third command will get `tag_3`.