### PR TITLE
Add agent host tag configuration option

### DIFF
--- a/plugins/inputs/snmp/README.md
+++ b/plugins/inputs/snmp/README.md
@@ -35,6 +35,9 @@ information.
   ## SNMP community string.
   # community = "public"
 
+  ## Agent host tag
+  # agent_host_tag = "agent_host"
+
   ## Number of retries to attempt.
   # retries = 3
 

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -34,6 +34,9 @@ const sampleConfig = `
   ## SNMP version; can be 1, 2, or 3.
   # version = 2
 
+  ## Agent host tag; the tag used to reference the source host
+  # agent_host_tag = "agent_host"
+
   ## SNMP community string.
   # community = "public"
 
@@ -95,6 +98,9 @@ type Snmp struct {
 	// udp://1.2.3.4:161).  If the scheme is not specified then "udp" is used.
 	Agents []string `toml:"agents"`
 
+	// The tag used to name the agent host
+	AgentHostTag string `toml:"agent_host_tag"`
+
 	snmp.ClientConfig
 
 	Tables []Table `toml:"table"`
@@ -126,6 +132,10 @@ func (s *Snmp) init() error {
 		if err := s.Fields[i].init(); err != nil {
 			return fmt.Errorf("initializing field %s: %w", s.Fields[i].Name, err)
 		}
+	}
+
+	if len(s.AgentHostTag) == 0 {
+		s.AgentHostTag = "agent_host"
 	}
 
 	s.initialized = true
@@ -374,8 +384,8 @@ func (s *Snmp) gatherTable(acc telegraf.Accumulator, gs snmpConnection, t Table,
 				}
 			}
 		}
-		if _, ok := tr.Tags["agent_host"]; !ok {
-			tr.Tags["agent_host"] = gs.Host()
+		if _, ok := tr.Tags[s.AgentHostTag]; !ok {
+			tr.Tags[s.AgentHostTag] = gs.Host()
 		}
 		acc.AddFields(rt.Name, tr.Fields, tr.Tags, rt.Time)
 	}

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -90,7 +90,7 @@ func TestSampleConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := &Snmp{
-		Agents: []string{"udp://127.0.0.1:161"},
+		Agents:       []string{"udp://127.0.0.1:161"},
 		AgentHostTag: "",
 		ClientConfig: config.ClientConfig{
 			Timeout:        internal.Duration{Duration: 5 * time.Second},

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -91,6 +91,7 @@ func TestSampleConfig(t *testing.T) {
 
 	expected := &Snmp{
 		Agents: []string{"udp://127.0.0.1:161"},
+		AgentHostTag: "",
 		ClientConfig: config.ClientConfig{
 			Timeout:        internal.Duration{Duration: 5 * time.Second},
 			Version:        2,
@@ -634,7 +635,7 @@ func TestGather(t *testing.T) {
 
 	m := acc.Metrics[0]
 	assert.Equal(t, "mytable", m.Measurement)
-	assert.Equal(t, "tsc", m.Tags["agent_host"])
+	assert.Equal(t, "tsc", m.Tags[s.AgentHostTag])
 	assert.Equal(t, "baz", m.Tags["myfield1"])
 	assert.Len(t, m.Fields, 2)
 	assert.Equal(t, 234, m.Fields["myfield2"])
@@ -644,7 +645,7 @@ func TestGather(t *testing.T) {
 
 	m2 := acc.Metrics[1]
 	assert.Equal(t, "myOtherTable", m2.Measurement)
-	assert.Equal(t, "tsc", m2.Tags["agent_host"])
+	assert.Equal(t, "tsc", m2.Tags[s.AgentHostTag])
 	assert.Equal(t, "baz", m2.Tags["myfield1"])
 	assert.Len(t, m2.Fields, 1)
 	assert.Equal(t, 123456, m2.Fields["myOtherField"])


### PR DESCRIPTION
The agent hostname is hardcoded in agent_host tag. Expose this as a variable and make it configurable in order to avoid extra processing later on.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

In reply to feature request https://github.com/influxdata/telegraf/issues/8060