### PR TITLE
Fix execd processor test

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -78,6 +78,8 @@ func (p *Process) Stop() {
 		// signal our intent to shutdown and not restart the process
 		p.cancel()
 	}
+	// close stdin so the app can shut down gracefully.
+	p.Stdin.Close()
 	p.mainLoopWg.Wait()
 }
 

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -78,8 +78,6 @@ func (p *Process) Stop() {
 		// signal our intent to shutdown and not restart the process
 		p.cancel()
 	}
-	// close stdin so the app can shut down gracefully.
-	p.Stdin.Close()
 	p.mainLoopWg.Wait()
 }
 

--- a/plugins/processors/execd/execd_test.go
+++ b/plugins/processors/execd/execd_test.go
@@ -50,9 +50,18 @@ func TestExternalProcessorWorks(t *testing.T) {
 		e.Add(m, acc)
 	}
 
-	acc.Wait(1)
-	require.NoError(t, e.Stop())
-	acc.Wait(9)
+	go func(t *testing.T) {
+		for {
+			n := acc.NMetrics()
+			if n == 10 {
+				if err := e.Stop(); err != nil {
+					fmt.Fprintf(os.Stderr, "failed to stop execd: %v", err)
+				}
+				return
+			}
+		}
+	}(t)
+	acc.Wait(10)
 
 	metrics = acc.GetTelegrafMetrics()
 	m := metrics[0]

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -55,6 +55,8 @@ func (a *Accumulator) NMetrics() uint64 {
 }
 
 func (a *Accumulator) GetTelegrafMetrics() []telegraf.Metric {
+	a.Lock()
+	defer a.Unlock()
 	metrics := []telegraf.Metric{}
 	for _, m := range a.Metrics {
 		metrics = append(metrics, FromTestMetric(m))


### PR DESCRIPTION
On some occasions ingest part of the test (runCountMultiplierProgram)
does not manage to read all the metrics from stdin that are sent to it
before the process is stopped (and stdin closed) by the test. We can
then observe errors like "Error reading stderr" or "Error reading stdout"
(from the test process). This happens more often when the number of
metrics sent in the test increases.

Even less often, a deadlock might occur when the test does not consume
all the metrics and it waits on acc.Wait() for sync.Cond broadcast that
never arrives as in [1].

To fix this spin a separate goroutine which will check that accumulator
received all the expected metrics and only then stop the count
multiplier process.

[1]: https://app.circleci.com/pipelines/github/SumoLogic/telegraf/39/workflows/4a7fd631-25f9-4f99-8134-fe9ff267fc31/jobs/210

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
