### PR TITLE
CloudWatch output plugin: Add a Note about shared_credential_file field initialization

### DIFF
--- a/plugins/outputs/cloudwatch/README.md
+++ b/plugins/outputs/cloudwatch/README.md
@@ -15,6 +15,10 @@ API endpoint. In the following order the plugin will attempt to authenticate.
 
 The IAM user needs only the `cloudwatch:PutMetricData` permission.
 
+Note that if `EC2 Instance Profile` Authentication method is preferred, the `shared_credential_file` must be
+initialized to an empty string anyways due to predefined Authentication precedence. Otherwise it would error
+out with "no such file".
+
 ## Config
 
 For this output plugin to function correctly the following variables


### PR DESCRIPTION


### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
