### PR TITLE
Update doc to add new external plugin: OctoPrint

### DIFF
--- a/EXTERNAL_PLUGINS.md
+++ b/EXTERNAL_PLUGINS.md
@@ -11,3 +11,4 @@ Pull requests welcome.
 - [twitter](https://github.com/inabagumi/twitter-telegraf-plugin) - Gather account information from Twitter accounts
 - [youtube](https://github.com/inabagumi/youtube-telegraf-plugin) - Gather account information from YouTube channels
 - [awsalarms](https://github.com/vipinvkmenon/awsalarms) - Simple plugin to gather/monitor alarms generated  in AWS.
+- [octoprint](https://github.com/BattleBas/octoprint-telegraf-plugin) - Gather 3d print information from the octoprint API.


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

I would like to add a link to a new [external input plugin](https://github.com/BattleBas/octoprint-telegraf-plugin) I created to gather data from the [OctoPrint](https://octoprint.org/) API.
At the moment it gathers 3d printing state (operational, printing, etc.) and tool temperature (hotend, bed). The information looks great in InfluxDB 2.0 cloud dashboards, I look forward to add more info.

The [documentation](https://github.com/influxdata/telegraf/blob/master/plugins/common/shim/README.md#Congratulations) recommended I make a pull request to include new plugins and I thought that was a good idea.

Cheers!