### PR TITLE
fix: fix sticky field `running` of `procstat_lookup`for inputs/procstat

### DIFF
--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -10,6 +10,7 @@ import (
 
 type Process interface {
 	PID() PID
+	Exists() (bool, error)
 	Tags() map[string]string
 
 	PageFaults() (*process.PageFaultsStat, error)
@@ -54,6 +55,14 @@ func NewProc(pid PID) (Process, error) {
 		tags:        make(map[string]string),
 	}
 	return proc, nil
+}
+
+func (p *Proc) Exists() (bool, error) {
+	exists, err := process.PidExists(int32(p.PID()))
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
 }
 
 func (p *Proc) Tags() map[string]string {

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -323,6 +323,10 @@ func (p *Procstat) updateProcesses(pids []PID, tags map[string]string, prevInfo 
 			if name, _ := info.Name(); name == "" {
 				continue
 			}
+			if exists, err := info.Exists(); err != nil || !exists {
+				// process has gone
+				continue
+			}
 			procs[pid] = info
 		} else {
 			proc, err := p.createProcess(pid)

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -95,15 +95,21 @@ func (pg *testPgrep) FullPattern(_ string) ([]PID, error) {
 }
 
 type testProc struct {
-	pid  PID
-	tags map[string]string
+	pid    PID
+	exists bool
+	tags   map[string]string
 }
 
 func newTestProc(_ PID) (Process, error) {
 	proc := &testProc{
-		tags: make(map[string]string),
+		exists: true,
+		tags:   make(map[string]string),
 	}
 	return proc, nil
+}
+
+func (p *testProc) Exists() (bool, error) {
+	return p.exists, nil
 }
 
 func (p *testProc) PID() PID {


### PR DESCRIPTION
On update the processes by the given PIDs, remove PIDs if they are not alive anymore.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
