### PR TITLE
Configurable execd processor buffer size

### DIFF
--- a/plugins/processors/execd/README.md
+++ b/plugins/processors/execd/README.md
@@ -31,6 +31,10 @@ Telegraf minimum version: Telegraf 1.15.0
 
   ## Delay before the process is restarted after an unexpected termination
   # restart_delay = "10s"
+
+  ## Buffer size for storing metrics received from the process in bytes
+  ## The minimum allowed value is 4096
+  # buffer_size = 65536
 ```
 
 ### Example

--- a/plugins/processors/execd/README.md
+++ b/plugins/processors/execd/README.md
@@ -32,7 +32,7 @@ Telegraf minimum version: Telegraf 1.15.0
   ## Delay before the process is restarted after an unexpected termination
   # restart_delay = "10s"
 
-  ## Buffer size for storing metrics received from the process in bytes
+  ## Buffer size in bytes for storing metrics received from the process
   ## The minimum allowed value is 4096
   # buffer_size = 65536
 ```

--- a/plugins/processors/execd/execd.go
+++ b/plugins/processors/execd/execd.go
@@ -24,7 +24,7 @@ const sampleConfig = `
   ## Delay before the process is restarted after an unexpected termination
   restart_delay = "10s"
 
-  ## Buffer size for storing metrics received from the process in bytes
+  ## Buffer size in bytes for storing metrics received from the process
   ## The minimum allowed value is 4096
   buffer_size = 65536
 `

--- a/plugins/processors/execd/execd.go
+++ b/plugins/processors/execd/execd.go
@@ -70,7 +70,7 @@ func (e *Execd) Description() string {
 func (e *Execd) Start(acc telegraf.Accumulator) error {
 	if l := e.BufferSize; l > 0 && l <= e.minBufferSize {
 		e.Log.Warn(fmt.Sprintf("The buffer size cannot be less than the allowed minimum value - %d. ", e.minBufferSize) +
-					"The default value will be used.")
+			"The default value will be used.")
 		e.BufferSize = e.defBufferSize
 	}
 

--- a/plugins/processors/execd/execd.go
+++ b/plugins/processors/execd/execd.go
@@ -23,13 +23,20 @@ const sampleConfig = `
 
   ## Delay before the process is restarted after an unexpected termination
   restart_delay = "10s"
+
+  ## Buffer size for storing metrics received from the process in bytes
+  ## The minimum allowed value is 4096
+  buffer_size = 65536
 `
 
 type Execd struct {
 	Command      []string        `toml:"command"`
 	RestartDelay config.Duration `toml:"restart_delay"`
+	BufferSize   int             `toml:"buffer_size"`
 	Log          telegraf.Logger
 
+	minBufferSize    int
+	defBufferSize    int
 	parserConfig     *parsers.Config
 	parser           parsers.Parser
 	serializerConfig *serializers.Config
@@ -47,6 +54,8 @@ func New() *Execd {
 		serializerConfig: &serializers.Config{
 			DataFormat: "influx",
 		},
+		minBufferSize: 4096,
+		defBufferSize: 65536,
 	}
 }
 
@@ -59,6 +68,16 @@ func (e *Execd) Description() string {
 }
 
 func (e *Execd) Start(acc telegraf.Accumulator) error {
+	if l := e.BufferSize; l > 0 && l <= e.minBufferSize {
+		e.Log.Warn(fmt.Sprintf("The buffer size cannot be less than the allowed minimum value - %d. ", e.minBufferSize) +
+					"The default value will be used.")
+		e.BufferSize = e.defBufferSize
+	}
+
+	if e.BufferSize == 0 {
+		e.BufferSize = e.defBufferSize
+	}
+
 	var err error
 	e.parser, err = parsers.NewParser(e.parserConfig)
 	if err != nil {
@@ -118,6 +137,8 @@ func (e *Execd) Stop() error {
 
 func (e *Execd) cmdReadOut(out io.Reader) {
 	scanner := bufio.NewScanner(out)
+	scanBuf := make([]byte, e.minBufferSize)
+	scanner.Buffer(scanBuf, e.BufferSize)
 
 	for scanner.Scan() {
 		metrics, err := e.parser.Parse(scanner.Bytes())


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

Closes https://github.com/influxdata/telegraf/issues/8142
Also related with https://github.com/influxdata/telegraf/pull/8121