### PR TITLE
Trim form_urlencoded whitespace before parsing field values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1839,6 +1839,18 @@ func getParserConfig(name string, tbl *ast.Table) (*parsers.Config, error) {
 		}
 	}
 
+	if node, ok := tbl.Fields["trim_field_data_space"]; ok {
+		if kv, ok := node.(*ast.KeyValue); ok {
+			if str, ok := kv.Value.(*ast.Boolean); ok {
+				val, err := strconv.ParseBool(str.Value)
+				c.FormUrlencodedTrimFieldDataSpace = val
+				if err != nil {
+					return nil, fmt.Errorf("E! parsing to bool: %v", err)
+				}
+			}
+		}
+	}
+
 	c.MetricName = name
 
 	delete(tbl.Fields, "data_format")
@@ -1883,6 +1895,7 @@ func getParserConfig(name string, tbl *ast.Table) (*parsers.Config, error) {
 	delete(tbl.Fields, "csv_timezone")
 	delete(tbl.Fields, "csv_trim_space")
 	delete(tbl.Fields, "form_urlencoded_tag_keys")
+	delete(tbl.Fields, "trim_field_data_space")
 
 	return c, nil
 }

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -449,7 +449,7 @@ func TestWriteHTTPTransformHeaderValuesToTagsBulkWrite(t *testing.T) {
 }
 
 func TestWriteHTTPQueryParams(t *testing.T) {
-	parser, _ := parsers.NewFormUrlencodedParser("query_measurement", nil, []string{"tagKey"})
+	parser, _ := parsers.NewFormUrlencodedParser("query_measurement", nil, []string{"tagKey"}, false)
 	listener := newTestHTTPListenerV2()
 	listener.DataSource = "query"
 	listener.Parser = parser
@@ -471,7 +471,7 @@ func TestWriteHTTPQueryParams(t *testing.T) {
 }
 
 func TestWriteHTTPFormData(t *testing.T) {
-	parser, _ := parsers.NewFormUrlencodedParser("query_measurement", nil, []string{"tagKey"})
+	parser, _ := parsers.NewFormUrlencodedParser("query_measurement", nil, []string{"tagKey"}, false)
 	listener := newTestHTTPListenerV2()
 	listener.Parser = parser
 

--- a/plugins/parsers/form_urlencoded/README.md
+++ b/plugins/parsers/form_urlencoded/README.md
@@ -41,6 +41,7 @@ Config:
   data_source = "query"
   data_format = "form_urlencoded"
   form_urlencoded_tag_keys = ["tag1"]
+  # trim_field_data_space = true
 ```
 
 Request:
@@ -51,6 +52,30 @@ curl -i -XGET 'http://localhost:8080/telegraf?tag1=foo&field1=0.42&field2=42'
 Output:
 ```
 mymetric,tag1=foo field1=0.42,field2=42
+```
+
+URL-encoded white space characters can be trimmed for field values first (but
+no such trimming is done for tag keys).
+
+Config:
+```toml
+[[inputs.http_listener_v2]]
+  name_override = "mymetric"
+  service_address = ":8080"
+  data_source = "query"
+  data_format = "form_urlencoded"
+  form_urlencoded_tag_keys = ["tag1"]
+  trim_field_data_space = true
+```
+
+Request:
+```bash
+curl -i -XGET 'http://localhost:8080/telegraf?tag1=%20%20foo%20%20&field1=%20%20%200.42&field2=42%20%20'
+```
+
+Output:
+```
+mymetric,tag1=\ \ foo\ \  field1=0.42,field2=42
 ```
 
 [query string]: https://en.wikipedia.org/wiki/Query_string

--- a/plugins/parsers/form_urlencoded/parser.go
+++ b/plugins/parsers/form_urlencoded/parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -18,10 +19,11 @@ var (
 
 // Parser decodes "application/x-www-form-urlencoded" data into metrics
 type Parser struct {
-	MetricName  string
-	DefaultTags map[string]string
-	TagKeys     []string
-	AllowedKeys []string
+	MetricName         string
+	DefaultTags        map[string]string
+	TagKeys            []string
+	AllowedKeys        []string
+	TrimFieldDataSpace bool `toml:"trim_field_data_space"`
 }
 
 // Parse converts a slice of bytes in "application/x-www-form-urlencoded" format into metrics
@@ -110,6 +112,17 @@ func (p Parser) parseFields(values url.Values) map[string]interface{} {
 
 	for key, value := range values {
 		if len(key) == 0 || len(value) == 0 {
+			continue
+		}
+
+		if p.TrimFieldDataSpace {
+			field, err := strconv.ParseFloat(strings.TrimSpace(value[0]), 64)
+			if err != nil {
+				continue
+			}
+
+			fields[key] = field
+
 			continue
 		}
 

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -147,7 +147,9 @@ type Config struct {
 	CSVTrimSpace         bool     `toml:"csv_trim_space"`
 
 	// FormData configuration
-	FormUrlencodedTagKeys []string `toml:"form_urlencoded_tag_keys"`
+	FormUrlencodedTagKeys            []string `toml:"form_urlencoded_tag_keys"`
+	// Field data should be trimmed before value is parsed
+	FormUrlencodedTrimFieldDataSpace bool     `toml:"trim_field_data_space"`
 }
 
 // NewParser returns a Parser interface based on the given config.
@@ -231,6 +233,7 @@ func NewParser(config *Config) (Parser, error) {
 			config.MetricName,
 			config.DefaultTags,
 			config.FormUrlencodedTagKeys,
+			config.FormUrlencodedTrimFieldDataSpace,
 		)
 	default:
 		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
@@ -332,10 +335,12 @@ func NewFormUrlencodedParser(
 	metricName string,
 	defaultTags map[string]string,
 	tagKeys []string,
+	trimFieldDataSpace bool,
 ) (Parser, error) {
 	return &form_urlencoded.Parser{
-		MetricName:  metricName,
-		DefaultTags: defaultTags,
-		TagKeys:     tagKeys,
+		MetricName:         metricName,
+		DefaultTags:        defaultTags,
+		TagKeys:            tagKeys,
+		TrimFieldDataSpace: trimFieldDataSpace,
 	}, nil
 }


### PR DESCRIPTION
Signed-off-by: Matouš Jan Fialka <mjf@mjf.cz>

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

### Motivation

We use `[[http_listener_v2]]` and devices using `GET` method. The devices are notoriously buggy and are often sending numerical values as space-padded text in URL encoding (i.e. `temp=%20%20%2012.3&unit=celsius`)  in field datum. Therefor we need to have the field datum sanitized ("trimmed") **before it get parsed** by `form_urlencoded` parser.