### PR TITLE
Add support for fields and protocol lookups in port_name.

### DIFF
--- a/plugins/processors/port_name/README.md
+++ b/plugins/processors/port_name/README.md
@@ -1,8 +1,10 @@
 # Port Name Lookup Processor Plugin
 
-Use the `port_name` processor to convert a tag containing a well-known port number to the registered service name.
+Use the `port_name` processor to convert a tag or field containing a well-known port number to the registered service name.
 
-Tag can contain a number ("80") or number and protocol separated by slash ("443/tcp"). If protocol is not provided it defaults to tcp but can be changed with the default_protocol setting.
+Tag or field can contain a number ("80") or number and protocol separated by slash ("443/tcp"). If protocol is not provided it defaults to tcp but can be changed with the default_protocol setting. An additional tag or field can be specified for the protocol.
+
+If the source was found in tag, the service name will be added as a tag. If the source was found in a field, the service name will also be a field.
 
 Telegraf minimum version: Telegraf 1.15.0
 
@@ -12,12 +14,20 @@ Telegraf minimum version: Telegraf 1.15.0
 [[processors.port_name]]
   ## Name of tag holding the port number
   # tag = "port"
+  ## Or name of the field holding the port number
+  # field = "port"
 
-  ## Name of output tag where service name will be added
+  ## Name of output tag or field (depending on the source) where service name will be added
   # dest = "service"
 
   ## Default tcp or udp
   # default_protocol = "tcp"
+
+  ## Tag containing the protocol (tcp or udp, case-insensitive)
+  # protocol_tag = "proto"
+
+  ## Field containing the protocol (tcp or udp, case-insensitive)
+  # protocol_field = "proto"
 ```
 
 ### Example

--- a/plugins/processors/port_name/port_name.go
+++ b/plugins/processors/port_name/port_name.go
@@ -124,9 +124,9 @@ func (d *PortName) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 					d.Log.Errorf("Unexpected type %t in source field; must be string or int", v)
 					continue
 				case int64:
-					portProto = strconv.FormatInt(field.(int64), 10)
+					portProto = strconv.FormatInt(v, 10)
 				case string:
-					portProto = field.(string)
+					portProto = v
 				}
 				fromField = true
 			}
@@ -173,7 +173,7 @@ func (d *PortName) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 					d.Log.Errorf("Unexpected type %t in protocol field; must be string", v)
 					continue
 				case string:
-					proto = field.(string)
+					proto = v
 				}
 			}
 		}

--- a/plugins/processors/port_name/port_name.go
+++ b/plugins/processors/port_name/port_name.go
@@ -125,6 +125,8 @@ func (d *PortName) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 					continue
 				case int64:
 					portProto = strconv.FormatInt(v, 10)
+				case uint64:
+					portProto = strconv.FormatUint(v, 10)
 				case string:
 					portProto = v
 				}

--- a/plugins/processors/port_name/port_name_test.go
+++ b/plugins/processors/port_name/port_name_test.go
@@ -28,12 +28,15 @@ func TestFakeServices(t *testing.T) {
 
 func TestTable(t *testing.T) {
 	var tests = []struct {
-		name     string
-		tag      string
-		dest     string
-		prot     string
-		input    []telegraf.Metric
-		expected []telegraf.Metric
+		name      string
+		tag       string
+		field     string
+		dest      string
+		prot      string
+		protField string
+		protTag   string
+		input     []telegraf.Metric
+		expected  []telegraf.Metric
 	}{
 		{
 			name: "ordinary tcp default",
@@ -239,6 +242,93 @@ func TestTable(t *testing.T) {
 				),
 			},
 		},
+		{
+			name:  "read from field instead of tag",
+			field: "foo",
+			dest:  "bar",
+			prot:  "tcp",
+			input: []telegraf.Metric{
+				testutil.MustMetric(
+					"meas",
+					map[string]string{},
+					map[string]interface{}{
+						"foo": "80",
+					},
+					time.Unix(0, 0),
+				),
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"meas",
+					map[string]string{},
+					map[string]interface{}{
+						"foo": "80",
+						"bar": "http",
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			name:      "read proto from field",
+			field:     "foo",
+			dest:      "bar",
+			prot:      "udp",
+			protField: "proto",
+			input: []telegraf.Metric{
+				testutil.MustMetric(
+					"meas",
+					map[string]string{},
+					map[string]interface{}{
+						"foo":   "80",
+						"proto": "tcp",
+					},
+					time.Unix(0, 0),
+				),
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"meas",
+					map[string]string{},
+					map[string]interface{}{
+						"foo":   "80",
+						"bar":   "http",
+						"proto": "tcp",
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			name:    "read proto from tag",
+			tag:     "foo",
+			dest:    "bar",
+			prot:    "udp",
+			protTag: "proto",
+			input: []telegraf.Metric{
+				testutil.MustMetric(
+					"meas",
+					map[string]string{
+						"foo":   "80",
+						"proto": "tcp",
+					},
+					map[string]interface{}{},
+					time.Unix(0, 0),
+				),
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"meas",
+					map[string]string{
+						"foo":   "80",
+						"bar":   "http",
+						"proto": "tcp",
+					},
+					map[string]interface{}{},
+					time.Unix(0, 0),
+				),
+			},
+		},
 	}
 
 	r := strings.NewReader(fakeServices)
@@ -248,8 +338,11 @@ func TestTable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := PortName{
 				SourceTag:       tt.tag,
+				SourceField:     tt.field,
 				Dest:            tt.dest,
 				DefaultProtocol: tt.prot,
+				ProtocolField:   tt.protField,
+				ProtocolTag:     tt.protTag,
 				Log:             testutil.Logger{},
 			}
 

--- a/plugins/processors/port_name/port_name_test.go
+++ b/plugins/processors/port_name/port_name_test.go
@@ -248,7 +248,7 @@ func TestTable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := PortName{
 				SourceTag:       tt.tag,
-				DestTag:         tt.dest,
+				Dest:            tt.dest,
 				DefaultProtocol: tt.prot,
 				Log:             testutil.Logger{},
 			}


### PR DESCRIPTION
Improve functionality of the `port_name` plugin by:
- allowing source to be provided as a field (not only as a tag)
- output will be provided as a field if input was a field as well
- additional tag/field can be provided to specify the protocol (tcp/udp)

Documentation and tests are updated accordingly.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
