### PR TITLE
Fix bool serialization when using carbon2

### DIFF
--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -59,7 +59,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 func (s *Serializer) createObject(metric telegraf.Metric) []byte {
 	var m bytes.Buffer
 	for fieldName, fieldValue := range metric.Fields() {
-		if !isNumeric(fieldValue) {
+		if isString(fieldValue) {
 			continue
 		}
 
@@ -85,7 +85,7 @@ func (s *Serializer) createObject(metric telegraf.Metric) []byte {
 			m.WriteString(" ")
 		}
 		m.WriteString(" ")
-		m.WriteString(fmt.Sprintf("%v", fieldValue))
+		m.WriteString(formatValue(fieldValue))
 		m.WriteString(" ")
 		m.WriteString(strconv.FormatInt(metric.Time().Unix(), 10))
 		m.WriteString("\n")
@@ -107,11 +107,33 @@ func serializeMetricIncludeField(name, fieldName string) string {
 	)
 }
 
-func isNumeric(v interface{}) bool {
+func formatValue(fieldValue interface{}) string {
+	switch v := fieldValue.(type) {
+	case bool:
+		// Print bools as 0s and 1s
+		return fmt.Sprintf("%d", bool2int(v))
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func isString(v interface{}) bool {
 	switch v.(type) {
 	case string:
-		return false
-	default:
 		return true
+	default:
+		return false
 	}
+}
+
+func bool2int(b bool) int {
+	// Slightly more optimized than a usual if ... return ... else return ... .
+	// See: https://0x0f.me/blog/golang-compiler-optimization/
+	var i int
+	if b {
+		i = 1
+	} else {
+		i = 0
+	}
+	return i
 }


### PR DESCRIPTION
To align with other serializers e.g. prometheus, this PR addresses the way carbon2 serializer serializes `bool`s.
Instead of `false` and `true` it should output `0` and `1` respectively. Some systems do not accept string formatted `bool`s and return errors.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
