### PR TITLE
[output.wavefront] Introduced "immediate_flush" flag

### DIFF
--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -54,7 +54,7 @@ This plugin writes to a [Wavefront](https://www.wavefront.com) proxy, in Wavefro
   ## normally done by the Wavefront SDK. This can be used if you are experiencing buffer overruns. The sending 
   ## of metrics will block for a longer time, but this will be handled gracefully by the internal buffering in
   ## Telegraf.
-  #immediate_flush = false
+  #immediate_flush = true
 ```
 
 

--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -49,6 +49,12 @@ This plugin writes to a [Wavefront](https://www.wavefront.com) proxy, in Wavefro
   ## Truncate metric tags to a total of 254 characters for the tag name value. Wavefront will reject any 
   ## data point exceeding this limit if not truncated. Defaults to 'false' to provide backwards compatibility.
   #truncate_tags = false
+
+  ## Flush the internal buffers after each batch. This effectively bypasses the background sending of metrics
+  ## normally done by the Wavefront SDK. This can be used if you are experiencing buffer overruns. The sending 
+  ## of metrics will block for a longer time, but this will be handled gracefully by the internal buffering in
+  ## Telegraf.
+  #immediate_flush = false
 ```
 
 

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -106,7 +106,7 @@ var sampleConfig = `
   ## normally done by the Wavefront SDK. This can be used if you are experiencing buffer overruns. The sending 
   ## of metrics will block for a longer time, but this will be handled gracefully by the internal buffering in
   ## Telegraf.
-  #immediate_flush = false
+  #immediate_flush = true
 
   ## Define a mapping, namespaced by metric prefix, from string values to numeric values
   ##   deprecated in 1.9; use the enum processor plugin
@@ -351,7 +351,7 @@ func init() {
 			ConvertPaths:    true,
 			ConvertBool:     true,
 			TruncateTags:    false,
-			ImmediateFlush:  false,
+			ImmediateFlush:  true,
 		}
 	})
 }

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -102,6 +102,12 @@ var sampleConfig = `
   ## data point exceeding this limit if not truncated. Defaults to 'false' to provide backwards compatibility.
   #truncate_tags = false
 
+  ## Flush the internal buffers after each batch. This effectively bypasses the background sending of metrics
+  ## normally done by the Wavefront SDK. This can be used if you are experiencing buffer overruns. The sending 
+  ## of metrics will block for a longer time, but this will be handled gracefully by the internal buffering in
+  ## Telegraf.
+  #immediate_flush = false
+
   ## Define a mapping, namespaced by metric prefix, from string values to numeric values
   ##   deprecated in 1.9; use the enum processor plugin
   #[[outputs.wavefront.string_to_number.elasticsearch]]

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -25,6 +25,7 @@ type Wavefront struct {
 	UseRegex        bool
 	UseStrict       bool
 	TruncateTags    bool
+	ImmediateFlush  bool
 	SourceOverride  []string
 	StringToNumber  map[string][]map[string]float64
 
@@ -123,12 +124,16 @@ func (w *Wavefront) Connect() error {
 		w.Log.Warn("The string_to_number option is deprecated; please use the enum processor instead")
 	}
 
+	flushSeconds := 5
+	if w.ImmediateFlush {
+		flushSeconds = 86400 // Set a very long flush interval if we're flushing directly
+	}
 	if w.Url != "" {
 		w.Log.Debug("connecting over http/https using Url: %s", w.Url)
 		sender, err := wavefront.NewDirectSender(&wavefront.DirectConfiguration{
 			Server:               w.Url,
 			Token:                w.Token,
-			FlushIntervalSeconds: 5,
+			FlushIntervalSeconds: flushSeconds,
 		})
 		if err != nil {
 			return fmt.Errorf("Wavefront: Could not create Wavefront Sender for Url: %s", w.Url)
@@ -139,7 +144,7 @@ func (w *Wavefront) Connect() error {
 		sender, err := wavefront.NewProxySender(&wavefront.ProxyConfiguration{
 			Host:                 w.Host,
 			MetricsPort:          w.Port,
-			FlushIntervalSeconds: 5,
+			FlushIntervalSeconds: flushSeconds,
 		})
 		if err != nil {
 			return fmt.Errorf("Wavefront: Could not create Wavefront Sender for Host: %q and Port: %d", w.Host, w.Port)
@@ -165,6 +170,10 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 				return fmt.Errorf("Wavefront sending error: %s", err.Error())
 			}
 		}
+	}
+	if w.ImmediateFlush {
+		w.Log.Debugf("Flushing batch of %d points", len(metrics))
+		return w.sender.Flush()
 	}
 	return nil
 }
@@ -336,6 +345,7 @@ func init() {
 			ConvertPaths:    true,
 			ConvertBool:     true,
 			TruncateTags:    false,
+			ImmediateFlush:  false,
 		}
 	})
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Addresses an issue mentioned in #7409 concerning the "double buffering" done by the Wavefront SDK. The SDK is designed to send metrics asynchronously in order to minimize the delay experienced by a caller. This behavior is not ideal when used with Telegraf, since Telegraf will assume the connection to Wavefront can accept data very quickly. When the internal buffer in the Wavefront SDK overflows, it will drop metrics. Meanwhile, Telegraf will still think the metrics are flowing at a very high rate and will keep flooding the SDK. 

To avoid extensive redesign of the SDK, this PR adds a flag, ```immediate_flush``` that flushes the internal SDK buffers after each batch. This will ensure that the buffer never fills with more records than the batch size and also has the side effect of providing "back pressure" to the Telegraf core. Thanks to that back pressure, Telegraf will no longer be "tricked" into thinking the connection has virtually unlimited capacity and can take whatever the action it needs to manage the throughput gracefully. 