### PR TITLE
 add json parsing support to starlark

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/wvanbergen/kafka v0.0.0-20171203153745-e2edea948ddf
 	github.com/wvanbergen/kazoo-go v0.0.0-20180202103751-f72d8611297a // indirect
 	github.com/yuin/gopher-lua v0.0.0-20180630135845-46796da1b0b4 // indirect
-	go.starlark.net v0.0.0-20191227232015-caa3e9aa5008
+	go.starlark.net v0.0.0-20200901195727-6e684ef5eeee
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a

--- a/go.sum
+++ b/go.sum
@@ -585,6 +585,8 @@ go.opencensus.io v0.22.3 h1:8sGtKOrtQqkN1bp2AtX+misvLIlOmsEsNd+9NIcPEm8=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.starlark.net v0.0.0-20191227232015-caa3e9aa5008 h1:PUpdYMZifLwPlUnFfT/2Hkqr7p0SSpOR7xrDiPaD52k=
 go.starlark.net v0.0.0-20191227232015-caa3e9aa5008/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=
+go.starlark.net v0.0.0-20200901195727-6e684ef5eeee h1:N4eRtIIYHZE5Mw/Km/orb+naLdwAe+lv2HCxRR5rEBw=
+go.starlark.net v0.0.0-20200901195727-6e684ef5eeee/go.mod h1:f0znQkUKRrkk36XxWbGjMqQM8wGv/xHBVE2qc3B5oFU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -720,6 +722,7 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6 h1:DvY3Zkh7KabQE/kfzMvYvKirSiguP9Q/veMtkYyf0o8=
 golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -583,8 +583,6 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3 h1:8sGtKOrtQqkN1bp2AtX+misvLIlOmsEsNd+9NIcPEm8=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
-go.starlark.net v0.0.0-20191227232015-caa3e9aa5008 h1:PUpdYMZifLwPlUnFfT/2Hkqr7p0SSpOR7xrDiPaD52k=
-go.starlark.net v0.0.0-20191227232015-caa3e9aa5008/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=
 go.starlark.net v0.0.0-20200901195727-6e684ef5eeee h1:N4eRtIIYHZE5Mw/Km/orb+naLdwAe+lv2HCxRR5rEBw=
 go.starlark.net v0.0.0-20200901195727-6e684ef5eeee/go.mod h1:f0znQkUKRrkk36XxWbGjMqQM8wGv/xHBVE2qc3B5oFU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -710,8 +708,6 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c h1:Vco5b+cuG5NNfORVxZy6bYZQ7rsigisU1WQFkvQ0L5E=
-golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191003212358-c178f38b412c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/plugins/processors/starlark/starlark.go
+++ b/plugins/processors/starlark/starlark.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/processors"
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkjson"
 )
 
 const (
@@ -51,6 +52,7 @@ func (s *Starlark) Init() error {
 
 	s.thread = &starlark.Thread{
 		Print: func(_ *starlark.Thread, msg string) { s.Log.Debug(msg) },
+		Load:  loadFunc,
 	}
 
 	builtins := starlark.StringDict{}
@@ -212,4 +214,13 @@ func init() {
 	processors.AddStreaming("starlark", func() telegraf.StreamingProcessor {
 		return &Starlark{}
 	})
+}
+
+func loadFunc(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+	switch module {
+	case "json":
+		return starlarkjson.Module.Members, nil
+	default:
+		return nil, errors.New("module " + module + " is not available")
+	}
 }

--- a/plugins/processors/starlark/starlark.go
+++ b/plugins/processors/starlark/starlark.go
@@ -218,7 +218,7 @@ func init() {
 
 func loadFunc(thread *starlark.Thread, module string) (starlark.StringDict, error) {
 	switch module {
-	case "starlarkjson":
+	case "json.star":
 		return starlark.StringDict{
 			"json": starlarkjson.Module,
 		}, nil

--- a/plugins/processors/starlark/starlark.go
+++ b/plugins/processors/starlark/starlark.go
@@ -218,8 +218,10 @@ func init() {
 
 func loadFunc(thread *starlark.Thread, module string) (starlark.StringDict, error) {
 	switch module {
-	case "json":
-		return starlarkjson.Module.Members, nil
+	case "starlarkjson":
+		return starlark.StringDict{
+			"json": starlarkjson.Module,
+		}, nil
 	default:
 		return nil, errors.New("module " + module + " is not available")
 	}

--- a/plugins/processors/starlark/testdata/json.star
+++ b/plugins/processors/starlark/testdata/json.star
@@ -12,6 +12,6 @@ load("json", "encode", "decode", "indent")
 def apply(metric):
     j = decode(metric.fields.get('value'))
     metric.fields.pop('value')
-    metric.tags["label"] = j.get("label")
-    metric.fields["count"] = j.get("count")
+    metric.tags["label"] = j["label"]
+    metric.fields["count"] = j["count"]
     return metric

--- a/plugins/processors/starlark/testdata/json.star
+++ b/plugins/processors/starlark/testdata/json.star
@@ -1,4 +1,5 @@
-#
+# Example of parsing json out of a field and modifying the metric with it.
+# this is great to use in conjunction with the value parser.
 #
 # Example Input:
 # json value="{\"label\": \"hero\", \"count\": 14}" 1465839830100400201

--- a/plugins/processors/starlark/testdata/json.star
+++ b/plugins/processors/starlark/testdata/json.star
@@ -7,10 +7,11 @@
 # Example Output:
 # json,label=hero count=14i 1465839830100400201
 
-load("json", "encode", "decode", "indent")
+load("starlarkjson", "json")
+# loads json.encode(), json.decode(), json.indent()
 
 def apply(metric):
-    j = decode(metric.fields.get('value'))
+    j = json.decode(metric.fields.get('value'))
     metric.fields.pop('value')
     metric.tags["label"] = j["label"]
     metric.fields["count"] = j["count"]

--- a/plugins/processors/starlark/testdata/json.star
+++ b/plugins/processors/starlark/testdata/json.star
@@ -1,0 +1,16 @@
+#
+#
+# Example Input:
+# json value="{\"label\": \"hero\", \"count\": 14}" 1465839830100400201
+#
+# Example Output:
+# json,label=hero count=14i 1465839830100400201
+
+load("json", "encode", "decode", "indent")
+
+def apply(metric):
+    j = decode(metric.fields.get('value'))
+    metric.fields.pop('value')
+    metric.tags["label"] = j.get("label")
+    metric.fields["count"] = j.get("count")
+    return metric

--- a/plugins/processors/starlark/testdata/json.star
+++ b/plugins/processors/starlark/testdata/json.star
@@ -7,7 +7,7 @@
 # Example Output:
 # json,label=hero count=14i 1465839830100400201
 
-load("starlarkjson", "json")
+load("json.star", "json")
 # loads json.encode(), json.decode(), json.indent()
 
 def apply(metric):


### PR DESCRIPTION
eg

```python
# Example of parsing json out of a field and modifying the metric with it.
# this is great to use in conjunction with the value parser.
#
# Example Input:
# json value="{\"label\": \"hero\", \"count\": 14}" 1465839830100400201
#
# Example Output:
# json,label=hero count=14i 1465839830100400201

load("json", "encode", "decode", "indent")

 def apply(metric):
    j = decode(metric.fields.get('value'))
    metric.fields.pop('value')
    metric.tags["label"] = j.get("label")
    metric.fields["count"] = j.get("count")
    return metric
```