### PR TITLE
fix: plugins/parsers/influx: avoid ParseError.Error panic

### DIFF
--- a/plugins/parsers/influx/parser.go
+++ b/plugins/parsers/influx/parser.go
@@ -33,9 +33,9 @@ type ParseError struct {
 
 func (e *ParseError) Error() string {
 	buffer := e.buf[e.LineOffset:]
-	eol := strings.IndexAny(buffer, "\r\n")
+	eol := strings.IndexAny(buffer, "\n")
 	if eol >= 0 {
-		buffer = buffer[:eol]
+		buffer = strings.TrimSuffix(buffer[:eol], "\r")
 	}
 	if len(buffer) > maxErrorBufferSize {
 		startEllipsis := true


### PR DESCRIPTION
A line ends at `\n` or `\r\n`, but not `\r` on its own. The ParseError.Error
logic was assuming that any carriage return terminates the line.
This caused a crash when the buffer is big, there's a single `\r` character and the
error offset was after that, because it assumed that the offset is always before
the end of the current line (a reasonable assumption as long as the line-termination
logic agrees between the Error method and the parsing code).

This bug found by running `go-fuzz`.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Has appropriate unit tests.
