### PR TITLE
Add support for datadog distributions metric

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -7295,6 +7295,9 @@
 #   ## Parses datadog extensions to the statsd format
 #   datadog_extensions = false
 #
+#   ## Parses distributions metric from datadog's extension to the statsd format
+#   datadog_distributions = false
+#
 #   ## Statsd data translation templates, more info can be read here:
 #   ## https://github.com/influxdata/telegraf/blob/master/docs/TEMPLATE_PATTERN.md
 #   # templates = [

--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -98,6 +98,10 @@ implementation. In short, the telegraf statsd listener will accept:
     - `load.time:320|ms`
     - `load.time.nanoseconds:1|h`
     - `load.time:200|ms|@0.1` <- sampled 1/10 of the time
+- Distributions
+    - `load.time:320|d`
+    - `load.time.nanoseconds:1|d`
+    - `load.time:200|d|@0.1` <- sampled 1/10 of the time
 
 It is possible to omit repetitive names and merge individual stats into a
 single line by separating them with additional colons:
@@ -172,6 +176,9 @@ metric type:
         that `P%` of all the values statsd saw for that stat during that time
         period are below x. The most common value that people use for `P` is the
         `90`, this is a great number to try to optimize.
+- Distributions
+    - The Distribution metric represents the global statistical distribution of a set of values calculated across your entire distributed infrastructure in one time interval. A Distribution can be used to instrument logical objects, like services, independently from the underlying hosts.
+    - Unlike the Histogram metric type, which aggregates on the Agent during a given time interval, a Distribution metric sends all the raw data during a time interval.
 
 ### Plugin arguments
 

--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -50,6 +50,10 @@
   ## http://docs.datadoghq.com/guides/dogstatsd/
   datadog_extensions = false
 
+  ## Parses distributions metric as specified in the datadog statsd format
+  ## https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition
+  datadog_distributions = false
+
   ## Statsd data translation templates, more info can be read here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/TEMPLATE_PATTERN.md
   # templates = [
@@ -202,6 +206,7 @@ the accuracy of percentiles but also increases the memory usage and cpu time.
 measurements and tags.
 - **parse_data_dog_tags** boolean: Enable parsing of tags in DataDog's dogstatsd format (http://docs.datadoghq.com/guides/dogstatsd/)
 - **datadog_extensions** boolean: Enable parsing of DataDog's extensions to dogstatsd format (http://docs.datadoghq.com/guides/dogstatsd/)
+- **datadog_distributions** boolean: Enable parsing of the Distribution metric in DataDog's dogstatsd format (https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition)
 - **max_ttl** config.Duration: Max duration (TTL) for each metric to stay cached/reported without being updated.
 
 ### Statsd bucket -> InfluxDB line-protocol Templates

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -770,9 +770,9 @@ func (s *Statsd) aggregate(m metric) {
 	switch m.mtype {
 	case "d":
 		cached := cacheddistributions{
-			name:   m.name,
+			name:  m.name,
 			value: m.floatvalue,
-			tags:   m.tags,
+			tags:  m.tags,
 		}
 		s.distributions = append(s.distributions, cached)
 	case "ms", "h":

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -615,7 +615,7 @@ func (s *Statsd) parseStatsdLine(line string) error {
 
 		// Validate metric type
 		switch pipesplit[1] {
-		case "g", "c", "s", "ms", "h":
+		case "g", "c", "s", "ms", "h", "d":
 			m.mtype = pipesplit[1]
 		default:
 			s.Log.Errorf("Metric type %q unsupported", pipesplit[1])
@@ -632,7 +632,7 @@ func (s *Statsd) parseStatsdLine(line string) error {
 		}
 
 		switch m.mtype {
-		case "g", "ms", "h":
+		case "g", "ms", "h", "d":
 			v, err := strconv.ParseFloat(pipesplit[0], 64)
 			if err != nil {
 				s.Log.Errorf("Parsing value to float64, unable to parse metric: %s", line)
@@ -672,6 +672,8 @@ func (s *Statsd) parseStatsdLine(line string) error {
 			m.tags["metric_type"] = "timing"
 		case "h":
 			m.tags["metric_type"] = "histogram"
+		case "d":
+			m.tags["metric_type"] = "distribution"
 		}
 		if len(lineTags) > 0 {
 			for k, v := range lineTags {

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -193,9 +193,9 @@ type cachedtimings struct {
 }
 
 type cacheddistributions struct {
-	name   string
-	fields map[string]interface{}
-	tags   map[string]string
+	name  string
+	value float64
+	tags  map[string]string
 }
 
 func (_ *Statsd) Description() string {
@@ -274,7 +274,10 @@ func (s *Statsd) Gather(acc telegraf.Accumulator) error {
 	now := time.Now()
 
 	for _, m := range s.distributions {
-		acc.AddFields(m.name, m.fields, m.tags, now)
+		fields := map[string]interface{}{
+			defaultFieldName: m.value,
+		}
+		acc.AddFields(m.name, fields, m.tags, now)
 	}
 	s.distributions = make([]cacheddistributions, 0)
 
@@ -766,11 +769,9 @@ func (s *Statsd) aggregate(m metric) {
 
 	switch m.mtype {
 	case "d":
-		fields := make(map[string]interface{})
-		fields[m.field] = m.floatvalue
 		cached := cacheddistributions{
 			name:   m.name,
-			fields: fields,
+			value: m.floatvalue,
 			tags:   m.tags,
 		}
 		s.distributions = append(s.distributions, cached)

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -276,7 +276,7 @@ func (s *Statsd) Gather(acc telegraf.Accumulator) error {
 	for _, m := range s.distributions {
 		acc.AddFields(m.name, m.fields, m.tags, now)
 	}
-	s.distributions = []cacheddistributions{}
+	s.distributions = make([]cacheddistributions, 0)
 
 	for _, m := range s.timings {
 		// Defining a template to parse field names for timers allows us to split
@@ -349,7 +349,7 @@ func (s *Statsd) Start(ac telegraf.Accumulator) error {
 	s.counters = make(map[string]cachedcounter)
 	s.sets = make(map[string]cachedset)
 	s.timings = make(map[string]cachedtimings)
-	s.distributions = []cacheddistributions{}
+	s.distributions = make([]cacheddistributions, 0)
 
 	s.Lock()
 	defer s.Unlock()

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -31,7 +31,7 @@ func NewTestStatsd() *Statsd {
 	s.counters = make(map[string]cachedcounter)
 	s.sets = make(map[string]cachedset)
 	s.timings = make(map[string]cachedtimings)
-	s.distributions = []cacheddistributions{}
+	s.distributions = make([]cacheddistributions, 0)
 
 	s.MetricSeparator = "_"
 


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.

Thanks for the awesome work you folks do :)

This PR is my attempt to add support for the [distributions](https://docs.datadoghq.com/developers/metrics/types/?tab=distribution) metric (alternate [link](https://docs.datadoghq.com/metrics/distributions/)) to maintain compatibility with Datadog metrics. This would allow us to aggregate metrics on the server rather than on the agent (i.e. aggregate on Influx rather than on Telegraf).

I've added unit tests and tested this on my local Influx and Telegraf setup. Let me know of all the changes required 👍 

Closes #8134 