### PR TITLE
Fix metric SetAggregate didn't work

### DIFF
--- a/metric/metric.go
+++ b/metric/metric.go
@@ -252,7 +252,7 @@ func (m *metric) Copy() telegraf.Metric {
 }
 
 func (m *metric) SetAggregate(b bool) {
-	m.aggregate = true
+	m.aggregate = b
 }
 
 func (m *metric) IsAggregate() bool {

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -334,9 +334,21 @@ func TestValueType(t *testing.T) {
 	assert.Equal(t, telegraf.Gauge, m.Type())
 }
 
+func TestSetAggregate(t *testing.T) {
+	m1 := baseMetric()
+	m1.SetAggregate(true)
+	assert.True(t, m1.IsAggregate())
+	m1.SetAggregate(false)
+	assert.False(t, m1.IsAggregate())
+}
+
 func TestCopyAggregate(t *testing.T) {
 	m1 := baseMetric()
 	m1.SetAggregate(true)
 	m2 := m1.Copy()
 	assert.True(t, m2.IsAggregate())
+
+	m1.SetAggregate(false)
+	m3 := m1.Copy()
+	assert.False(t, m3.IsAggregate())
 }


### PR DESCRIPTION
Fixes the bug that metric SetAggregate didn't work, when using sync.Pool to reserve metrics from outputs.

### Required for all PRs:
- [x] Signed CLA.
- [x] Has appropriate unit tests.