### PR TITLE
SNMP Trap community string tag

### DIFF
--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -87,6 +87,7 @@ On Mac OS, listening on privileged ports is unrestricted on versions
 	- version (string, "1" or "2c" or "3")
 	- context_name (string, value from v3 trap)
 	- engine_id (string, value from v3 trap)
+	- community (string, value from 1 or 2c trap)
   - fields:
 	- Fields are mapped from variables in the trap. Field names are
       the trap variable names after MIB lookup. Field values are trap
@@ -94,8 +95,8 @@ On Mac OS, listening on privileged ports is unrestricted on versions
 
 ### Example Output
 ```
-snmp_trap,mib=SNMPv2-MIB,name=coldStart,oid=.1.3.6.1.6.3.1.1.5.1,source=192.168.122.102,version=2c snmpTrapEnterprise.0="linux",sysUpTimeInstance=1i 1574109187723429814
-snmp_trap,mib=NET-SNMP-AGENT-MIB,name=nsNotifyShutdown,oid=.1.3.6.1.4.1.8072.4.0.2,source=192.168.122.102,version=2c sysUpTimeInstance=5803i,snmpTrapEnterprise.0="netSnmpNotificationPrefix" 1574109186555115459
+snmp_trap,mib=SNMPv2-MIB,name=coldStart,oid=.1.3.6.1.6.3.1.1.5.1,source=192.168.122.102,version=2c,community=public snmpTrapEnterprise.0="linux",sysUpTimeInstance=1i 1574109187723429814
+snmp_trap,mib=NET-SNMP-AGENT-MIB,name=nsNotifyShutdown,oid=.1.3.6.1.4.1.8072.4.0.2,source=192.168.122.102,version=2c,community=public sysUpTimeInstance=5803i,snmpTrapEnterprise.0="netSnmpNotificationPrefix" 1574109186555115459
 ```
 
 [net-snmp]: http://www.net-snmp.org/

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -357,6 +357,10 @@ func makeTrapHandler(s *SnmpTrap) handler {
 				// SNMP RFCs like 3411 and 5343 show engine ID as a hex string
 				tags["engine_id"] = fmt.Sprintf("%x", packet.ContextEngineID)
 			}
+		} else {
+			if packet.Community != "" {
+				tags["community"] = packet.Community
+			}
 		}
 
 		s.acc.AddFields("snmp_trap", fields, tags, tm)

--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -224,11 +224,12 @@ func TestReceiveTrap(t *testing.T) {
 				testutil.MustMetric(
 					"snmp_trap", // name
 					map[string]string{ // tags
-						"oid":     ".1.3.6.1.6.3.1.1.5.1",
-						"name":    "coldStart",
-						"mib":     "SNMPv2-MIB",
-						"version": "2c",
-						"source":  "127.0.0.1",
+						"oid":       ".1.3.6.1.6.3.1.1.5.1",
+						"name":      "coldStart",
+						"mib":       "SNMPv2-MIB",
+						"version":   "2c",
+						"source":    "127.0.0.1",
+						"community": "public",
 					},
 					map[string]interface{}{ // fields
 						"sysUpTimeInstance": now,
@@ -305,6 +306,7 @@ func TestReceiveTrap(t *testing.T) {
 						"version":       "1",
 						"source":        "127.0.0.1",
 						"agent_address": "10.20.30.40",
+						"community":     "public",
 					},
 					map[string]interface{}{ // fields
 						"sysUpTimeInstance": uint(now),
@@ -358,6 +360,7 @@ func TestReceiveTrap(t *testing.T) {
 						"version":       "1",
 						"source":        "127.0.0.1",
 						"agent_address": "10.20.30.40",
+						"community":     "public",
 					},
 					map[string]interface{}{ // fields
 						"sysUpTimeInstance": uint(now),


### PR DESCRIPTION
If the community string is available, add it as a tag.  This will allow use of tagpass to drop traps that don't have the expected community string.

closes #8182