### PR TITLE
feat: add functionality to get values from redis commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/glinton/ping v0.1.4-0.20200311211934-5ac87da8cd96
 	github.com/go-logfmt/logfmt v0.4.0
 	github.com/go-ole/go-ole v1.2.1 // indirect
-	github.com/go-redis/redis v6.12.0+incompatible
+	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/goburrow/modbus v0.1.0
 	github.com/goburrow/serial v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
-github.com/go-redis/redis v6.12.0+incompatible h1:s+64XI+z/RXqGHz2fQSgRJOEwqqSXeX3dliF7iVkMbE=
-github.com/go-redis/redis v6.12.0+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
+github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=

--- a/plugins/inputs/redis/README.md
+++ b/plugins/inputs/redis/README.md
@@ -14,6 +14,11 @@
   ## If no servers are specified, then localhost is used as the host.
   ## If no port is specified, 6379 is used
   servers = ["tcp://localhost:6379"]
+  ## Optional. Specify redis commands to retrieve values
+  # [[inputs.redis.commands]]
+  # command = ["get", "sample-key"]
+  # field = "sample-key-value"
+  # type = "string"
 
   ## specify server password
   # password = "s#cr@t%"

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -19,7 +19,7 @@ import (
 
 type RedisCommand struct {
 	Command []interface{}
-	Key     string
+	Field   string
 	Type    string
 }
 
@@ -51,29 +51,13 @@ func (r *RedisClient) Do(returnType string, args ...interface{}) (interface{}, e
 
 	switch returnType {
 	case "integer":
-		intVal, err := rawVal.Int64()
-		if err != nil {
-			return nil, err
-		}
-		return intVal, nil
+		return rawVal.Int64()
 	case "string":
-		strVal, err := rawVal.String()
-		if err != nil {
-			return nil, err
-		}
-		return strVal, nil
+		return rawVal.String()
 	case "float":
-		floatVal, err := rawVal.Float64()
-		if err != nil {
-			return nil, err
-		}
-		return floatVal, nil
+		return rawVal.Float64()
 	default:
-		strVal, err := rawVal.String()
-		if err != nil {
-			return nil, err
-		}
-		return strVal, nil
+		return rawVal.String()
 	}
 }
 
@@ -103,9 +87,10 @@ var sampleConfig = `
   ## If no port is specified, 6379 is used
   servers = ["tcp://localhost:6379"]
 
-  ## Optional. Specify redis commands to retrieve values, under key "commands"
+  ## Optional. Specify redis commands to retrieve values
+  # [[inputs.redis.commands]]
   # command = ["get", "sample-key"]
-  # key = "sample-key-value"
+  # field = "sample-key-value"
   # type = "string"
 
   ## specify server password
@@ -239,7 +224,7 @@ func (r *Redis) gatherCommandValues(client Client, acc telegraf.Accumulator) err
 			return err
 		}
 
-		fields[command.Key] = val
+		fields[command.Field] = val
 	}
 
 	acc.AddFields("redis_commands", fields, client.BaseTags())

--- a/plugins/inputs/redis/redis_test.go
+++ b/plugins/inputs/redis/redis_test.go
@@ -54,7 +54,7 @@ func TestRedis_Commands(t *testing.T) {
 
 	rc := &RedisCommand{
 		Command: []interface{}{"llen", "test-list"},
-		Key:     redisListKey,
+		Field:   redisListKey,
 		Type:    "integer",
 	}
 

--- a/plugins/inputs/redis/redis_test.go
+++ b/plugins/inputs/redis/redis_test.go
@@ -7,10 +7,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-redis/redis"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type testClient struct {
+}
+
+func (t *testClient) BaseTags() map[string]string {
+	return map[string]string{"host": "redis.net"}
+}
+
+func (t *testClient) Info() *redis.StringCmd {
+	return nil
+}
+
+func (t *testClient) Do(returnType string, args ...interface{}) (interface{}, error) {
+	return 2, nil
+}
 
 func TestRedisConnect(t *testing.T) {
 	if testing.Short() {
@@ -28,6 +44,33 @@ func TestRedisConnect(t *testing.T) {
 
 	err := acc.GatherError(r.Gather)
 	require.NoError(t, err)
+}
+
+func TestRedis_Commands(t *testing.T) {
+	const redisListKey = "test-list-length"
+	var acc testutil.Accumulator
+
+	tc := &testClient{}
+
+	rc := &RedisCommand{
+		Command: []interface{}{"llen", "test-list"},
+		Key:     redisListKey,
+		Type:    "integer",
+	}
+
+	r := &Redis{
+		Commands: []*RedisCommand{rc},
+		clients:  []Client{tc},
+	}
+
+	err := r.gatherCommandValues(tc, &acc)
+	require.NoError(t, err)
+
+	fields := map[string]interface{}{
+		redisListKey: 2,
+	}
+
+	acc.AssertContainsFields(t, "redis_commands", fields)
 }
 
 func TestRedis_ParseMetrics(t *testing.T) {


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This PR is an attempt to pull additional metrics on redis from arbitrary commands. The logic in this PR accounts for types (`string`, `integer`, and `float`), and we could add more types.

Issue addressed: https://github.com/influxdata/idpe/issues/8711
Community issue Addressed: https://github.com/influxdata/telegraf/issues/1027
