### PR TITLE
Fix carbon2 serializer not falling through to field separate when carbon2_format field is unset

### DIFF
--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -246,20 +246,6 @@ func TestContentType(t *testing.T) {
 			expectedBody: []byte("metric=cpu field=value  42 0\n"),
 		},
 		{
-			name: "carbon2 (data format unset) is supported and falls back to include field in metric name",
-			plugin: func() *SumoLogic {
-				s := Default()
-				s.headers = map[string]string{
-					contentTypeHeader: carbon2ContentType,
-				}
-				sr, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldEmpty))
-				require.NoError(t, err)
-				s.SetSerializer(sr)
-				return s
-			},
-			expectedBody: []byte("metric=cpu_value  42 0\n"),
-		},
-		{
 			name: "carbon2 (data format = metric includes field) is supported",
 			plugin: func() *SumoLogic {
 				s := Default()

--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -62,6 +62,7 @@ func (s *Serializer) createObject(metric telegraf.Metric) []byte {
 		switch metricsFormat {
 		// Field separate is the default when no format specified.
 		case Carbon2FormatFieldEmpty:
+			fallthrough
 		case Carbon2FormatFieldSeparate:
 			m.WriteString(serializeMetricFieldSeparate(
 				metric.Name(), fieldName,

--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -12,13 +12,13 @@ import (
 type format string
 
 const (
-	Carbon2FormatFieldEmpty          = format("")
+	carbon2FormatFieldEmpty          = format("")
 	Carbon2FormatFieldSeparate       = format("field_separate")
 	Carbon2FormatMetricIncludesField = format("metric_includes_field")
 )
 
 var formats = map[format]struct{}{
-	Carbon2FormatFieldEmpty:          {},
+	carbon2FormatFieldEmpty:          {},
 	Carbon2FormatFieldSeparate:       {},
 	Carbon2FormatMetricIncludesField: {},
 }
@@ -29,8 +29,14 @@ type Serializer struct {
 
 func NewSerializer(metricsFormat string) (*Serializer, error) {
 	var f = format(metricsFormat)
+
 	if _, ok := formats[f]; !ok {
 		return nil, fmt.Errorf("unknown carbon2 format: %s", f)
+	}
+
+	// When unset, default to field separate.
+	if f == carbon2FormatFieldEmpty {
+		f = Carbon2FormatFieldSeparate
 	}
 
 	return &Serializer{
@@ -60,9 +66,6 @@ func (s *Serializer) createObject(metric telegraf.Metric) []byte {
 		}
 
 		switch metricsFormat {
-		// Field separate is the default when no format specified.
-		case Carbon2FormatFieldEmpty:
-			fallthrough
 		case Carbon2FormatFieldSeparate:
 			m.WriteString(serializeMetricFieldSeparate(
 				metric.Name(), fieldName,
@@ -102,7 +105,7 @@ func (s *Serializer) getMetricsFormat() format {
 }
 
 func (s *Serializer) IsMetricsFormatUnset() bool {
-	return s.metricsFormat == Carbon2FormatFieldEmpty
+	return s.metricsFormat == carbon2FormatFieldEmpty
 }
 
 func serializeMetricFieldSeparate(name, fieldName string) string {

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -39,11 +39,6 @@ func TestSerializeMetricFloat(t *testing.T) {
 			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=cpu0  91.5 %d\n", now.Unix()),
 		},
 		{
-			// Fall back to separate field name
-			format:   Carbon2FormatFieldEmpty,
-			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=cpu0  91.5 %d\n", now.Unix()),
-		},
-		{
 			format:   Carbon2FormatMetricIncludesField,
 			expected: fmt.Sprintf("metric=cpu_usage_idle cpu=cpu0  91.5 %d\n", now.Unix()),
 		},
@@ -79,11 +74,6 @@ func TestSerializeMetricWithEmptyStringTag(t *testing.T) {
 	}{
 		{
 			format:   Carbon2FormatFieldSeparate,
-			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=null  91.5 %d\n", now.Unix()),
-		},
-		{
-			// Fall back to separate field name
-			format:   Carbon2FormatFieldEmpty,
 			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=null  91.5 %d\n", now.Unix()),
 		},
 		{
@@ -125,11 +115,6 @@ func TestSerializeWithSpaces(t *testing.T) {
 			expected: fmt.Sprintf("metric=cpu_metric field=usage_idle_1 cpu_0=cpu_0  91.5 %d\n", now.Unix()),
 		},
 		{
-			// Fall back to separate field name
-			format:   Carbon2FormatFieldEmpty,
-			expected: fmt.Sprintf("metric=cpu_metric field=usage_idle_1 cpu_0=cpu_0  91.5 %d\n", now.Unix()),
-		},
-		{
 			format:   Carbon2FormatMetricIncludesField,
 			expected: fmt.Sprintf("metric=cpu_metric_usage_idle_1 cpu_0=cpu_0  91.5 %d\n", now.Unix()),
 		},
@@ -165,11 +150,6 @@ func TestSerializeMetricInt(t *testing.T) {
 	}{
 		{
 			format:   Carbon2FormatFieldSeparate,
-			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=cpu0  90 %d\n", now.Unix()),
-		},
-		{
-			// Fall back to separate field name
-			format:   Carbon2FormatFieldEmpty,
 			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=cpu0  90 %d\n", now.Unix()),
 		},
 		{
@@ -211,10 +191,6 @@ func TestSerializeMetricString(t *testing.T) {
 			expected: "",
 		},
 		{
-			format:   Carbon2FormatFieldEmpty,
-			expected: "",
-		},
-		{
 			format:   Carbon2FormatMetricIncludesField,
 			expected: "",
 		},
@@ -253,13 +229,6 @@ func TestSerializeBatch(t *testing.T) {
 	}{
 		{
 			format: Carbon2FormatFieldSeparate,
-			expected: `metric=cpu field=value  42 0
-metric=cpu field=value  42 0
-`,
-		},
-		{
-			// Fall back to separate field name
-			format: Carbon2FormatFieldEmpty,
 			expected: `metric=cpu field=value  42 0
 metric=cpu field=value  42 0
 `,

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -39,6 +39,11 @@ func TestSerializeMetricFloat(t *testing.T) {
 			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=cpu0  91.5 %d\n", now.Unix()),
 		},
 		{
+			// Fall back to separate field name
+			format:   Carbon2FormatFieldEmpty,
+			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=cpu0  91.5 %d\n", now.Unix()),
+		},
+		{
 			format:   Carbon2FormatMetricIncludesField,
 			expected: fmt.Sprintf("metric=cpu_usage_idle cpu=cpu0  91.5 %d\n", now.Unix()),
 		},
@@ -74,6 +79,11 @@ func TestSerializeMetricWithEmptyStringTag(t *testing.T) {
 	}{
 		{
 			format:   Carbon2FormatFieldSeparate,
+			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=null  91.5 %d\n", now.Unix()),
+		},
+		{
+			// Fall back to separate field name
+			format:   Carbon2FormatFieldEmpty,
 			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=null  91.5 %d\n", now.Unix()),
 		},
 		{
@@ -115,6 +125,11 @@ func TestSerializeWithSpaces(t *testing.T) {
 			expected: fmt.Sprintf("metric=cpu_metric field=usage_idle_1 cpu_0=cpu_0  91.5 %d\n", now.Unix()),
 		},
 		{
+			// Fall back to separate field name
+			format:   Carbon2FormatFieldEmpty,
+			expected: fmt.Sprintf("metric=cpu_metric field=usage_idle_1 cpu_0=cpu_0  91.5 %d\n", now.Unix()),
+		},
+		{
 			format:   Carbon2FormatMetricIncludesField,
 			expected: fmt.Sprintf("metric=cpu_metric_usage_idle_1 cpu_0=cpu_0  91.5 %d\n", now.Unix()),
 		},
@@ -150,6 +165,11 @@ func TestSerializeMetricInt(t *testing.T) {
 	}{
 		{
 			format:   Carbon2FormatFieldSeparate,
+			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=cpu0  90 %d\n", now.Unix()),
+		},
+		{
+			// Fall back to separate field name
+			format:   Carbon2FormatFieldEmpty,
 			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=cpu0  90 %d\n", now.Unix()),
 		},
 		{
@@ -191,6 +211,10 @@ func TestSerializeMetricString(t *testing.T) {
 			expected: "",
 		},
 		{
+			format:   Carbon2FormatFieldEmpty,
+			expected: "",
+		},
+		{
 			format:   Carbon2FormatMetricIncludesField,
 			expected: "",
 		},
@@ -229,6 +253,13 @@ func TestSerializeBatch(t *testing.T) {
 	}{
 		{
 			format: Carbon2FormatFieldSeparate,
+			expected: `metric=cpu field=value  42 0
+metric=cpu field=value  42 0
+`,
+		},
+		{
+			// Fall back to separate field name
+			format: Carbon2FormatFieldEmpty,
 			expected: `metric=cpu field=value  42 0
 metric=cpu field=value  42 0
 `,


### PR DESCRIPTION
When `carbon2_format` is unspecified or is specified as empty string there's a missing `fallthrough` which makes carbon2 serializer not produce metric names at all (noop case in `switch`).

This PR addresses that and adds a handful of tests for that case.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
