### PR TITLE
Log an error on SNMPv3 requests where authentication fails (#7929)

### DIFF
--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -415,6 +415,8 @@ func (t Table) Build(gs snmpConnection, walk bool) (*RTable, error) {
 			// index, and being added on the same row.
 			if pkt, err := gs.Get([]string{oid}); err != nil {
 				return nil, fmt.Errorf("performing get on field %s: %w", f.Name, err)
+			} else if pkt != nil && pkt.PDUType == gosnmp.Report {
+				return nil, fmt.Errorf("received SNMP report instead of response for field %s: check authentication?", f.Name)
 			} else if pkt != nil && len(pkt.Variables) > 0 && pkt.Variables[0].Type != gosnmp.NoSuchObject && pkt.Variables[0].Type != gosnmp.NoSuchInstance {
 				ent := pkt.Variables[0]
 				fv, err := fieldConvert(f.Conversion, ent.Value)


### PR DESCRIPTION
gosnmp does not return any error when an SNMP get request fails due to authentication.
The SNMP agent will return a "report" PDU instead of a "get-response" PDU in this case.

A check has been added to verify the packet's PDUType is not "Report"

I have not yet added documentation or unit tests.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
