### PR TITLE
Sort plugin names in logs on load

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -180,10 +180,19 @@ func runAgent(ctx context.Context,
 		return ag.Test(ctx, wait)
 	}
 
-	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))
-	log.Printf("I! Loaded aggregators: %s", strings.Join(c.AggregatorNames(), " "))
-	log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))
-	log.Printf("I! Loaded outputs: %s", strings.Join(c.OutputNames(), " "))
+	// Format loaded plugins in a deterministic manner so that
+	// log output can be easily compared between runs
+	formatLoadedPlugins := func(plugins []string) string {
+		sortedPlugins := make([]string, len(plugins))
+		copy(sortedPlugins, plugins)
+		sort.Strings(sortedPlugins)
+		return strings.Join(sortedPlugins, " ")
+	}
+
+	log.Printf("I! Loaded inputs: %s", formatLoadedPlugins(c.InputNames()))
+	log.Printf("I! Loaded aggregators: %s", formatLoadedPlugins(c.AggregatorNames()))
+	log.Printf("I! Loaded processors: %s", formatLoadedPlugins(c.ProcessorNames()))
+	log.Printf("I! Loaded outputs: %s", formatLoadedPlugins(c.OutputNames()))
 	log.Printf("I! Tags enabled: %s", c.ListTags())
 
 	if *fPidfile != "" {


### PR DESCRIPTION
Previously, plugins were printed non-deterministically in the log.
This made it difficult to compare active plugins between runs.

This commit formats the plugin list in a deterministic order for easy comparison.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Closes: #7710 