### PR TITLE
Devo output plugin

### DIFF
--- a/plugins/outputs/all/all.go
+++ b/plugins/outputs/all/all.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/outputs/cloudwatch"
 	_ "github.com/influxdata/telegraf/plugins/outputs/cratedb"
 	_ "github.com/influxdata/telegraf/plugins/outputs/datadog"
+	_ "github.com/influxdata/telegraf/plugins/outputs/devo"
 	_ "github.com/influxdata/telegraf/plugins/outputs/discard"
 	_ "github.com/influxdata/telegraf/plugins/outputs/dynatrace"
 	_ "github.com/influxdata/telegraf/plugins/outputs/elasticsearch"

--- a/plugins/outputs/devo/README.md
+++ b/plugins/outputs/devo/README.md
@@ -1,5 +1,8 @@
 # Devo Output Plugin
-This plugin send metrics in influx data format to Devo platform by tcp, udp and tcp+tls connection.
+This plugin sends metrics in any serializable data format to Devo platform by tcp, udp and tcp+tls connection.
+
+You can use the `devo_tag` label in your metrics to properly tag your events when you send to Devo. If no valid
+data is serializable an empty message will be generated.
 
 ### Configuration:
 

--- a/plugins/outputs/devo/README.md
+++ b/plugins/outputs/devo/README.md
@@ -1,0 +1,59 @@
+# Devo Output Plugin
+This plugin send metrics in influx data format to Devo platform by tcp, udp and tcp+tls connection.
+
+### Configuration:
+
+```toml
+# Configuration for Devo platform to send metrics to
+[[outputs.devo]]
+  ## URL to connect to
+  ## address = "tcp://127.0.0.1:8094"
+  ## address = "tcp://example.com:http"
+  # address = "tcp://us.elb.relay.logtrust.net:443"
+
+  ## Optional TLS Config, Required when sending directly to Devo
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## Default severity value. Severity and Facility are used to calculate the
+  ## message PRI value (RFC5424#section-6.2.1).  Used when no metric field
+  ## with key "severity_code" is defined.  If unset, 5 (notice) is the default
+  # default_severity_code = 5
+
+  ## Default facility value. Facility and Severity are used to calculate the
+  ## message PRI value (RFC5424#section-6.2.1).  Used when no metric field with
+  ## key "facility_code" is defined.  If unset, 1 (user-level) is the default
+  # default_facility_code = 1
+
+  ## Period between keep alive probes.
+  ## Only applies to TCP sockets.
+  ## 0 disables keep alive probes.
+  ## Defaults to the OS configuration.
+  # keep_alive_period = "5m"
+
+  ## Content encoding for packet-based connections (i.e. UDP, unixgram).
+  ## Can be set to "gzip" or to "identity" to apply no encoding.
+  ##
+  # content_encoding = "identity"
+
+  ## Data format to generate.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  # data_format = "json"
+
+  ## Default Devo tag value
+  ## Used when no metric tag with key "devo_tag" is defined.
+  ## If unset, "my.app.telegraf.default" is the default
+  ## refer here for more information:
+  ## https://docs.devo.com/confluence/ndt/parsers-and-collectors/about-devo-tags
+  # default_tag = "my.app.telegraf.untagged"
+
+  ## You can also manually set your hostname to identify where these metrics come from
+  ## if your logs do not have identifiable information attached to them. Otherwise
+  ## the plugin will try to get the hostname from your OS directly.
+  # default_hostname = "unknown"
+```

--- a/plugins/outputs/devo/devo.go
+++ b/plugins/outputs/devo/devo.go
@@ -15,16 +15,16 @@ import (
 )
 
 type DevoWriter struct {
-  Address         		string
-	ContentEncoding 		string `toml:"content_encoding"`
-	DefaultHostname			string
+	Address             string
+	ContentEncoding     string `toml:"content_encoding"`
+	DefaultHostname     string
 	DefaultSeverityCode uint8
 	DefaultFacilityCode uint8
-	DefaultTag					string
-	KeepAlivePeriod 		*internal.Duration
-	mapper							*DevoMapper
-  encoder 						internal.ContentEncoder
-  net.Conn
+	DefaultTag          string
+	KeepAlivePeriod     *internal.Duration
+	mapper              *DevoMapper
+	encoder             internal.ContentEncoder
+	net.Conn
 	serializers.Serializer
 	tlsint.ClientConfig
 }
@@ -205,21 +205,21 @@ func (s *DevoWriter) initializeDevoMapper() {
 		return
 	}
 	s.mapper = &DevoMapper{
-		DefaultTag: s.DefaultTag,
+		DefaultTag:          s.DefaultTag,
 		DefaultSeverityCode: s.DefaultSeverityCode,
 		DefaultFacilityCode: s.DefaultFacilityCode,
-		DefaultHostname: s.DefaultHostname,
+		DefaultHostname:     s.DefaultHostname,
 	}
 }
 
 func newDevoWriter() *DevoWriter {
 	s, _ := serializers.NewInfluxSerializer()
 	return &DevoWriter{
-		Serializer: s,
-		DefaultTag: "my.app.telegraf.untagged",
+		Serializer:          s,
+		DefaultTag:          "my.app.telegraf.untagged",
 		DefaultSeverityCode: uint8(5), // notice
 		DefaultFacilityCode: uint8(1), //user-level
-		DefaultHostname: "unknown",
+		DefaultHostname:     "unknown",
 	}
 }
 

--- a/plugins/outputs/devo/devo.go
+++ b/plugins/outputs/devo/devo.go
@@ -1,0 +1,228 @@
+package devo
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
+	"github.com/influxdata/telegraf/plugins/outputs"
+	"github.com/influxdata/telegraf/plugins/serializers"
+)
+
+type DevoWriter struct {
+  Address         		string
+	ContentEncoding 		string `toml:"content_encoding"`
+	DefaultHostname			string
+	DefaultSeverityCode uint8
+	DefaultFacilityCode uint8
+	DefaultTag					string
+	KeepAlivePeriod 		*internal.Duration
+	mapper							*DevoMapper
+  encoder 						internal.ContentEncoder
+  net.Conn
+	serializers.Serializer
+	tlsint.ClientConfig
+}
+
+func (dw *DevoWriter) Description() string {
+	return "Devo writer which formats messages to specified encoding and send to Devo"
+}
+
+func (dw *DevoWriter) SampleConfig() string {
+	return `
+  ## URL to connect to
+  # address = "tcp://127.0.0.1:8094"
+  # address = "tcp://example.com:http"
+  # address = "tcp4://127.0.0.1:8094"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+	## Default severity value. Severity and Facility are used to calculate the
+  ## message PRI value (RFC5424#section-6.2.1).  Used when no metric field
+  ## with key "severity_code" is defined.  If unset, 5 (notice) is the default
+  # default_severity_code = 5
+
+  ## Default facility value. Facility and Severity are used to calculate the
+  ## message PRI value (RFC5424#section-6.2.1).  Used when no metric field with
+  ## key "facility_code" is defined.  If unset, 1 (user-level) is the default
+  # default_facility_code = 1
+
+  ## Period between keep alive probes.
+  ## Only applies to TCP sockets.
+  ## 0 disables keep alive probes.
+  ## Defaults to the OS configuration.
+  # keep_alive_period = "5m"
+
+  ## Content encoding for packet-based connections (i.e. UDP, unixgram).
+  ## Can be set to "gzip" or to "identity" to apply no encoding.
+  ##
+  # content_encoding = "identity"
+
+  ## Data format to generate.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  # data_format = "json"
+
+	## Default Devo tag value
+	## Used when no metric tag with key "devo_tag" is defined.
+	## If unset, "my.app.telegraf.default" is the default
+  ## refer here for more information:
+  ## https://docs.devo.com/confluence/ndt/parsers-and-collectors/about-devo-tags
+	# default_tag = "my.app.telegraf.default"
+
+	## You can also manually set your hostname to identify where these metrics come from
+	## if your logs do not have identifiable information attached to them. Otherwise
+	## the plugin will try to get the hostname from your OS directly.
+	# default_hostname = "unknown"
+`
+}
+
+func (dw *DevoWriter) SetSerializer(s serializers.Serializer) {
+	dw.Serializer = s
+}
+
+func (dw *DevoWriter) Connect() error {
+	dw.initializeDevoMapper()
+
+	spl := strings.SplitN(dw.Address, "://", 2)
+	if len(spl) != 2 {
+		return fmt.Errorf("invalid address: %s", dw.Address)
+	}
+
+	tlsCfg, err := dw.ClientConfig.TLSConfig()
+	if err != nil {
+		return err
+	}
+
+	var c net.Conn
+	if tlsCfg == nil {
+		c, err = net.Dial(spl[0], spl[1])
+	} else {
+		c, err = tls.Dial(spl[0], spl[1], tlsCfg)
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := dw.setKeepAlive(c); err != nil {
+		log.Printf("unable to configure keep alive (%s): %s", dw.Address, err)
+	}
+	//set encoder
+	dw.encoder, err = internal.NewContentEncoder(dw.ContentEncoding)
+	if err != nil {
+		return err
+	}
+
+	dw.Conn = c
+	return nil
+}
+
+func (dw *DevoWriter) setKeepAlive(c net.Conn) error {
+	if dw.KeepAlivePeriod == nil {
+		return nil
+	}
+	tcpc, ok := c.(*net.TCPConn)
+	if !ok {
+		return fmt.Errorf("cannot set keep alive on a %s socket", strings.SplitN(dw.Address, "://", 2)[0])
+	}
+	if dw.KeepAlivePeriod.Duration == 0 {
+		return tcpc.SetKeepAlive(false)
+	}
+	if err := tcpc.SetKeepAlive(true); err != nil {
+		return err
+	}
+	return tcpc.SetKeepAlivePeriod(dw.KeepAlivePeriod.Duration)
+}
+
+// Write writes the given metrics to the destination.
+// If an error is encountered, it is up to the caller to retry the same write again later.
+// Not parallel safe.
+func (dw *DevoWriter) Write(metrics []telegraf.Metric) error {
+	if dw.Conn == nil {
+		// previous write failed with permanent error and socket was closed.
+		if err := dw.Connect(); err != nil {
+			return err
+		}
+	}
+
+	for _, m := range metrics {
+		bs, err := dw.Serialize(m)
+		if err != nil {
+			log.Printf("D! [outputs.devo] Could not serialize metric: %v", err)
+			continue
+		}
+
+		bs, err = dw.mapper.devoMapper(m, bs)
+		if err != nil {
+			log.Printf("D! [outputs.devo] Could not devo serialize metric: %v", err)
+			continue
+		}
+
+		bs, err = dw.encoder.Encode(bs)
+		if err != nil {
+			log.Printf("D! [outputs.devo] Could not encode metric: %v", err)
+			continue
+		}
+
+		if _, err := dw.Conn.Write(bs); err != nil {
+			//TODO log & keep going with remaining strings
+			if err, ok := err.(net.Error); !ok || !err.Temporary() {
+				// permanent error. close the connection
+				dw.Close()
+				dw.Conn = nil
+				return fmt.Errorf("closing connection: %v", err)
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Close closes the connection. Noop if already closed.
+func (dw *DevoWriter) Close() error {
+	if dw.Conn == nil {
+		return nil
+	}
+	err := dw.Conn.Close()
+	dw.Conn = nil
+	return err
+}
+
+func (s *DevoWriter) initializeDevoMapper() {
+	if s.mapper != nil {
+		return
+	}
+	s.mapper = &DevoMapper{
+		DefaultTag: s.DefaultTag,
+		DefaultSeverityCode: s.DefaultSeverityCode,
+		DefaultFacilityCode: s.DefaultFacilityCode,
+		DefaultHostname: s.DefaultHostname,
+	}
+}
+
+func newDevoWriter() *DevoWriter {
+	s, _ := serializers.NewInfluxSerializer()
+	return &DevoWriter{
+		Serializer: s,
+		DefaultTag: "my.app.telegraf.untagged",
+		DefaultSeverityCode: uint8(5), // notice
+		DefaultFacilityCode: uint8(1), //user-level
+		DefaultHostname: "unknown",
+	}
+}
+
+func init() {
+	outputs.Add("devo", func() telegraf.Output { return newDevoWriter() })
+}

--- a/plugins/outputs/devo/devo_serializer.go
+++ b/plugins/outputs/devo/devo_serializer.go
@@ -1,0 +1,102 @@
+package devo
+
+import (
+	"os"
+	"fmt"
+	"time"
+	"strconv"
+	"math"
+
+	"github.com/influxdata/telegraf"
+)
+
+type DevoMapper struct {
+	DefaultHostname     string
+	DefaultSeverityCode uint8
+	DefaultFacilityCode uint8
+	DefaultTag     			string
+}
+
+func (ds *DevoMapper) devoMapper(metric telegraf.Metric, msg []byte) ([]byte, error) {
+	err := error(nil)
+
+	devoTag := ds.DefaultTag
+	severityCode := ds.DefaultSeverityCode
+	facilityCode := ds.DefaultFacilityCode
+	hostname := ds.DefaultHostname
+
+
+	if value, ok := metric.GetTag("devo_tag"); ok {
+		devoTag = formatValue(value)
+	}
+
+	if value, ok := getFieldCode(metric, "severity_code"); ok {
+		severityCode = *value
+	}
+
+	if value, ok := getFieldCode(metric, "facility_code"); ok {
+		facilityCode = *value
+	}
+
+	priority := strconv.Itoa((int((8 * facilityCode) + severityCode)))
+
+	if value, ok := metric.GetTag("hostname"); ok {
+		hostname = formatValue(value)
+	} else if value, ok := metric.GetTag("source"); ok {
+		hostname = formatValue(value)
+	} else if value, ok := metric.GetTag("host"); ok {
+		hostname = formatValue(value)
+	} else if value, err := os.Hostname(); err == nil {
+		hostname = value
+	}
+
+	timestamp := metric.Time()
+	if value, ok := metric.GetField("timestamp"); ok {
+		switch v := value.(type) {
+		case int64:
+			timestamp = time.Unix(0, v).UTC()
+		}
+	}
+	sendTime := timestamp.Format(time.RFC3339)
+
+	devomsg := fmt.Sprintf("<%s>%s %s %s: %s", priority, sendTime, hostname, devoTag, msg)
+
+	return []byte(devomsg), err
+}
+
+func getFieldCode(metric telegraf.Metric, fieldKey string) (*uint8, bool) {
+	if value, ok := metric.GetField(fieldKey); ok {
+		if v, err := strconv.ParseUint(formatValue(value), 10, 8); err == nil {
+			r := uint8(v)
+			return &r, true
+		}
+	}
+	return nil, false
+}
+
+func formatValue(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case bool:
+		if v {
+			return "1"
+		}
+		return "0"
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case float64:
+		if math.IsNaN(v) {
+			return ""
+		}
+
+		if math.IsInf(v, 0) {
+			return ""
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	}
+
+	return ""
+}

--- a/plugins/outputs/devo/devo_serializer.go
+++ b/plugins/outputs/devo/devo_serializer.go
@@ -1,11 +1,11 @@
 package devo
 
 import (
-	"os"
 	"fmt"
-	"time"
-	"strconv"
 	"math"
+	"os"
+	"strconv"
+	"time"
 
 	"github.com/influxdata/telegraf"
 )
@@ -14,7 +14,7 @@ type DevoMapper struct {
 	DefaultHostname     string
 	DefaultSeverityCode uint8
 	DefaultFacilityCode uint8
-	DefaultTag     			string
+	DefaultTag          string
 }
 
 func (ds *DevoMapper) devoMapper(metric telegraf.Metric, msg []byte) ([]byte, error) {
@@ -24,7 +24,6 @@ func (ds *DevoMapper) devoMapper(metric telegraf.Metric, msg []byte) ([]byte, er
 	severityCode := ds.DefaultSeverityCode
 	facilityCode := ds.DefaultFacilityCode
 	hostname := ds.DefaultHostname
-
 
 	if value, ok := metric.GetTag("devo_tag"); ok {
 		devoTag = formatValue(value)

--- a/plugins/outputs/devo/devo_serializer_test.go
+++ b/plugins/outputs/devo/devo_serializer_test.go
@@ -1,0 +1,127 @@
+package devo
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDevoMapperWithDefaults(t *testing.T) {
+	dw := newDevoWriter()
+	dw.initializeDevoMapper()
+
+	// Init metrics
+	m1, _ := metric.New(
+		"testmetric",
+		map[string]string{},
+		map[string]interface{}{},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+	hostname, err := os.Hostname()
+	assert.NoError(t, err)
+  bs, err := dw.Serialize(m1)
+  bs, _ = dw.mapper.devoMapper(m1, bs)
+  str := string(bs)
+	assert.Equal(t, "<13>2010-11-10T23:00:00Z "+hostname+" my.app.telegraf.untagged: ", str, "Wrong syslog message")
+}
+
+func TestDevoMapperWithHostname(t *testing.T) {
+	dw := newDevoWriter()
+	dw.initializeDevoMapper()
+
+	// Init metrics
+	m1, _ := metric.New(
+		"testmetric",
+		map[string]string{
+			"hostname": "testhost",
+			"source":   "sourcevalue",
+			"host":     "hostvalue",
+		},
+		map[string]interface{}{},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+  bs, _ := dw.Serialize(m1)
+  bs, _ = dw.mapper.devoMapper(m1, bs)
+  str := string(bs)
+	assert.Equal(t, "<13>2010-11-10T23:00:00Z testhost my.app.telegraf.untagged: ", str, "Wrong syslog message")
+}
+func TestDevoMapperWithHostnameSourceFallback(t *testing.T) {
+	dw := newDevoWriter()
+	dw.initializeDevoMapper()
+
+	// Init metrics
+	m1, _ := metric.New(
+		"testmetric",
+		map[string]string{
+			"source": "sourcevalue",
+			"host":   "hostvalue",
+		},
+		map[string]interface{}{},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+  bs, _ := dw.Serialize(m1)
+  bs, _ = dw.mapper.devoMapper(m1, bs)
+  str := string(bs)
+	assert.Equal(t, "<13>2010-11-10T23:00:00Z sourcevalue my.app.telegraf.untagged: ", str, "Wrong syslog message")
+}
+
+func TestDevoMapperWithHostnameHostFallback(t *testing.T) {
+	dw := newDevoWriter()
+	dw.initializeDevoMapper()
+
+	// Init metrics
+	m1, _ := metric.New(
+		"testmetric",
+		map[string]string{
+			"host": "hostvalue",
+		},
+		map[string]interface{}{},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+  bs, _ := dw.Serialize(m1)
+  bs, _ = dw.mapper.devoMapper(m1, bs)
+  str := string(bs)
+	assert.Equal(t, "<13>2010-11-10T23:00:00Z hostvalue my.app.telegraf.untagged: ", str, "Wrong syslog message")
+}
+
+func TestDevoMapperWithNoErrors(t *testing.T) {
+	// Init mapper
+	dw := newDevoWriter()
+	dw.initializeDevoMapper()
+
+	// Init metrics
+	m1, _ := metric.New(
+		"testmetric",
+		map[string]string{
+			"appname":            "testapp",
+      "devo_tag":           "my.app.telegraf.devotagapp",
+			"hostname":           "testhost",
+			"tag1":               "bar",
+			"default@32473_tag2": "foobar",
+			"bar@123_tag3":       "barfoobar",
+			"foo@456_tag4":       "foobarfoo",
+		},
+		map[string]interface{}{
+			"severity_code":        uint64(2),
+			"facility_code":        uint64(3),
+			"msg":                  "Test message",
+			"procid":               uint64(25),
+			"version":              uint16(2),
+			"msgid":                int64(555),
+			"timestamp":            time.Date(2010, time.November, 10, 23, 30, 0, 0, time.UTC).UnixNano(),
+			"value1":               int64(2),
+			"default@32473_value2": "default",
+			"bar@123_value3":       int64(2),
+			"foo@456_value4":       "foo",
+		},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+
+  bs, err := dw.Serialize(m1)
+  bs, err = dw.mapper.devoMapper(m1, bs)
+	require.NoError(t, err)
+}

--- a/plugins/outputs/devo/devo_serializer_test.go
+++ b/plugins/outputs/devo/devo_serializer_test.go
@@ -23,9 +23,9 @@ func TestDevoMapperWithDefaults(t *testing.T) {
 	)
 	hostname, err := os.Hostname()
 	assert.NoError(t, err)
-  bs, err := dw.Serialize(m1)
-  bs, _ = dw.mapper.devoMapper(m1, bs)
-  str := string(bs)
+	bs, err := dw.Serialize(m1)
+	bs, _ = dw.mapper.devoMapper(m1, bs)
+	str := string(bs)
 	assert.Equal(t, "<13>2010-11-10T23:00:00Z "+hostname+" my.app.telegraf.untagged: ", str, "Wrong syslog message")
 }
 
@@ -44,9 +44,9 @@ func TestDevoMapperWithHostname(t *testing.T) {
 		map[string]interface{}{},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-  bs, _ := dw.Serialize(m1)
-  bs, _ = dw.mapper.devoMapper(m1, bs)
-  str := string(bs)
+	bs, _ := dw.Serialize(m1)
+	bs, _ = dw.mapper.devoMapper(m1, bs)
+	str := string(bs)
 	assert.Equal(t, "<13>2010-11-10T23:00:00Z testhost my.app.telegraf.untagged: ", str, "Wrong syslog message")
 }
 func TestDevoMapperWithHostnameSourceFallback(t *testing.T) {
@@ -63,9 +63,9 @@ func TestDevoMapperWithHostnameSourceFallback(t *testing.T) {
 		map[string]interface{}{},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-  bs, _ := dw.Serialize(m1)
-  bs, _ = dw.mapper.devoMapper(m1, bs)
-  str := string(bs)
+	bs, _ := dw.Serialize(m1)
+	bs, _ = dw.mapper.devoMapper(m1, bs)
+	str := string(bs)
 	assert.Equal(t, "<13>2010-11-10T23:00:00Z sourcevalue my.app.telegraf.untagged: ", str, "Wrong syslog message")
 }
 
@@ -82,9 +82,9 @@ func TestDevoMapperWithHostnameHostFallback(t *testing.T) {
 		map[string]interface{}{},
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-  bs, _ := dw.Serialize(m1)
-  bs, _ = dw.mapper.devoMapper(m1, bs)
-  str := string(bs)
+	bs, _ := dw.Serialize(m1)
+	bs, _ = dw.mapper.devoMapper(m1, bs)
+	str := string(bs)
 	assert.Equal(t, "<13>2010-11-10T23:00:00Z hostvalue my.app.telegraf.untagged: ", str, "Wrong syslog message")
 }
 
@@ -98,7 +98,7 @@ func TestDevoMapperWithNoErrors(t *testing.T) {
 		"testmetric",
 		map[string]string{
 			"appname":            "testapp",
-      "devo_tag":           "my.app.telegraf.devotagapp",
+			"devo_tag":           "my.app.telegraf.devotagapp",
 			"hostname":           "testhost",
 			"tag1":               "bar",
 			"default@32473_tag2": "foobar",
@@ -121,7 +121,7 @@ func TestDevoMapperWithNoErrors(t *testing.T) {
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 
-  bs, err := dw.Serialize(m1)
-  bs, err = dw.mapper.devoMapper(m1, bs)
+	bs, err := dw.Serialize(m1)
+	bs, err = dw.mapper.devoMapper(m1, bs)
 	require.NoError(t, err)
 }

--- a/plugins/outputs/devo/devo_test.go
+++ b/plugins/outputs/devo/devo_test.go
@@ -45,11 +45,11 @@ func testSocketWriter_stream(t *testing.T, dw *DevoWriter, lconn net.Conn) {
 	metrics := []telegraf.Metric{}
 	metrics = append(metrics, testutil.TestMetric(1, "test"))
 	mbs1out, _ := dw.Serialize(metrics[0])
-  mbs1out, _ = dw.mapper.devoMapper(metrics[0], mbs1out)
+	mbs1out, _ = dw.mapper.devoMapper(metrics[0], mbs1out)
 	mbs1out, _ = dw.encoder.Encode(mbs1out)
 	metrics = append(metrics, testutil.TestMetric(2, "test"))
 	mbs2out, _ := dw.Serialize(metrics[1])
-  mbs2out, _ = dw.mapper.devoMapper(metrics[1], mbs2out)
+	mbs2out, _ = dw.mapper.devoMapper(metrics[1], mbs2out)
 	mbs2out, _ = dw.encoder.Encode(mbs2out)
 
 	err := dw.Write(metrics)
@@ -69,12 +69,12 @@ func testSocketWriter_packet(t *testing.T, dw *DevoWriter, lconn net.PacketConn)
 	metrics := []telegraf.Metric{}
 	metrics = append(metrics, testutil.TestMetric(1, "test"))
 	mbs1out, _ := dw.Serialize(metrics[0])
-  mbs1out, _ = dw.mapper.devoMapper(metrics[0], mbs1out)
+	mbs1out, _ = dw.mapper.devoMapper(metrics[0], mbs1out)
 	mbs1out, _ = dw.encoder.Encode(mbs1out)
 	mbs1str := string(mbs1out)
 	metrics = append(metrics, testutil.TestMetric(2, "test"))
 	mbs2out, _ := dw.Serialize(metrics[1])
-  mbs2out, _ = dw.mapper.devoMapper(metrics[1], mbs2out)
+	mbs2out, _ = dw.mapper.devoMapper(metrics[1], mbs2out)
 	mbs2out, _ = dw.encoder.Encode(mbs2out)
 	mbs2str := string(mbs2out)
 
@@ -127,7 +127,7 @@ func TestSocketWriter_Write_reconnect(t *testing.T) {
 	assert.NoError(t, lerr)
 
 	mbsout, _ := dw.Serialize(metrics[0])
-  mbsout, _ = dw.mapper.devoMapper(metrics[0], mbsout)
+	mbsout, _ = dw.mapper.devoMapper(metrics[0], mbsout)
 	buf := make([]byte, 256)
 	n, err := lconn.Read(buf)
 	require.NoError(t, err)

--- a/plugins/outputs/devo/devo_test.go
+++ b/plugins/outputs/devo/devo_test.go
@@ -1,0 +1,135 @@
+package devo
+
+import (
+	"bufio"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDevoWriter_tcp(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	dw := newDevoWriter()
+	dw.Address = "tcp://" + listener.Addr().String()
+
+	err = dw.Connect()
+	require.NoError(t, err)
+
+	lconn, err := listener.Accept()
+	require.NoError(t, err)
+
+	testSocketWriter_stream(t, dw, lconn)
+}
+
+func TestDevoWriter_udp(t *testing.T) {
+	listener, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	dw := newDevoWriter()
+	dw.Address = "udp://" + listener.LocalAddr().String()
+
+	err = dw.Connect()
+	require.NoError(t, err)
+
+	testSocketWriter_packet(t, dw, listener)
+}
+
+func testSocketWriter_stream(t *testing.T, dw *DevoWriter, lconn net.Conn) {
+	metrics := []telegraf.Metric{}
+	metrics = append(metrics, testutil.TestMetric(1, "test"))
+	mbs1out, _ := dw.Serialize(metrics[0])
+  mbs1out, _ = dw.mapper.devoMapper(metrics[0], mbs1out)
+	mbs1out, _ = dw.encoder.Encode(mbs1out)
+	metrics = append(metrics, testutil.TestMetric(2, "test"))
+	mbs2out, _ := dw.Serialize(metrics[1])
+  mbs2out, _ = dw.mapper.devoMapper(metrics[1], mbs2out)
+	mbs2out, _ = dw.encoder.Encode(mbs2out)
+
+	err := dw.Write(metrics)
+	require.NoError(t, err)
+
+	scnr := bufio.NewScanner(lconn)
+	require.True(t, scnr.Scan())
+	mstr1in := scnr.Text() + "\n"
+	require.True(t, scnr.Scan())
+	mstr2in := scnr.Text() + "\n"
+
+	assert.Equal(t, string(mbs1out), mstr1in)
+	assert.Equal(t, string(mbs2out), mstr2in)
+}
+
+func testSocketWriter_packet(t *testing.T, dw *DevoWriter, lconn net.PacketConn) {
+	metrics := []telegraf.Metric{}
+	metrics = append(metrics, testutil.TestMetric(1, "test"))
+	mbs1out, _ := dw.Serialize(metrics[0])
+  mbs1out, _ = dw.mapper.devoMapper(metrics[0], mbs1out)
+	mbs1out, _ = dw.encoder.Encode(mbs1out)
+	mbs1str := string(mbs1out)
+	metrics = append(metrics, testutil.TestMetric(2, "test"))
+	mbs2out, _ := dw.Serialize(metrics[1])
+  mbs2out, _ = dw.mapper.devoMapper(metrics[1], mbs2out)
+	mbs2out, _ = dw.encoder.Encode(mbs2out)
+	mbs2str := string(mbs2out)
+
+	err := dw.Write(metrics)
+	require.NoError(t, err)
+
+	buf := make([]byte, 256)
+	var mstrins []string
+	for len(mstrins) < 2 {
+		n, _, err := lconn.ReadFrom(buf)
+		require.NoError(t, err)
+		mstrins = append(mstrins, string(buf[:n]))
+	}
+	require.Len(t, mstrins, 2)
+
+	assert.Equal(t, mbs1str, mstrins[0])
+	assert.Equal(t, mbs2str, mstrins[1])
+}
+
+func TestSocketWriter_Write_reconnect(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	dw := newDevoWriter()
+	dw.Address = "tcp://" + listener.Addr().String()
+
+	err = dw.Connect()
+	require.NoError(t, err)
+	dw.Conn.(*net.TCPConn).SetReadBuffer(256)
+
+	lconn, err := listener.Accept()
+	require.NoError(t, err)
+	lconn.(*net.TCPConn).SetWriteBuffer(256)
+	lconn.Close()
+	dw.Conn = nil
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var lerr error
+	go func() {
+		lconn, lerr = listener.Accept()
+		wg.Done()
+	}()
+
+	metrics := []telegraf.Metric{testutil.TestMetric(1, "testerr")}
+	err = dw.Write(metrics)
+	require.NoError(t, err)
+
+	wg.Wait()
+	assert.NoError(t, lerr)
+
+	mbsout, _ := dw.Serialize(metrics[0])
+  mbsout, _ = dw.mapper.devoMapper(metrics[0], mbsout)
+	buf := make([]byte, 256)
+	n, err := lconn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, string(mbsout), string(buf[:n]))
+}


### PR DESCRIPTION
The Devo output plugin allows for messages to be sent directly to Devo or a Devo Relay. Devo tags can be set by using input tags and messages can be serialized using any existing serializer.
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
