### PR TITLE
Sumo Logic output plugin: fix unparsable config.Size from sample config

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1337,7 +1337,7 @@
 #   ## Bear in mind that in some serializer a metric even though serialized to multiple
 #   ## lines cannot be split any further so setting this very low might not work
 #   ## as expected.
-#   # max_request_body_size = 1_000_000
+#   # max_request_body_size = 1000000
 #
 #   ## Additional, Sumo specific options.
 #   ## Full list can be found here:

--- a/plugins/outputs/sumologic/README.md
+++ b/plugins/outputs/sumologic/README.md
@@ -48,7 +48,7 @@ by Sumologic HTTP Source:
   ## Bear in mind that in some serializer a metric even though serialized to multiple
   ## lines cannot be split any further so setting this very low might not work
   ## as expected.
-  # max_request_body_size = 1_000_000
+  # max_request_body_size = 1000000
 
   ## Additional, Sumo specific options.
   ## Full list can be found here:

--- a/plugins/outputs/sumologic/sumologic.go
+++ b/plugins/outputs/sumologic/sumologic.go
@@ -55,7 +55,7 @@ const (
   ## Bear in mind that in some serializer a metric even though serialized to multiple
   ## lines cannot be split any further so setting this very low might not work
   ## as expected.
-  # max_request_body_size = 1_000_000
+  # max_request_body_size = 1000000
 
   ## Additional, Sumo specific options.
   ## Full list can be found here:


### PR DESCRIPTION
After deciding to use `config.Size` in https://github.com/influxdata/telegraf/commit/e9dcade0a85701a645f11ecd11a1463b4ecc4d7f I've noticed that it uses `ParseStrictBytes` from https://github.com/alecthomas/units/blob/b9c82cb/bytes.go#L77-L85 which doesn't understand underscores in numbers.

This PR addresses that by changing what's in the sample config not to confuse users.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
