### PR TITLE
Don't remove prometheus histograms on expire_interval

### DIFF
--- a/plugins/serializers/prometheus/README.md
+++ b/plugins/serializers/prometheus/README.md
@@ -8,7 +8,9 @@ use the `metric_version = 2` option in order to properly round trip metrics.
 not be correct if the metric spans multiple batches.  This issue can be
 somewhat, but not fully, mitigated by using outputs that support writing in
 "batch format".  When using histogram and summary types, it is recommended to
-use only the `prometheus_client` output.
+use only the `prometheus_client` output. When histogram buckets change,
+old buckets are not automatically expired and might require restarting telegraf
+agent.
 
 ### Configuration
 

--- a/plugins/serializers/prometheus/collection.go
+++ b/plugins/serializers/prometheus/collection.go
@@ -281,6 +281,10 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 			default:
 				continue
 			}
+			// always update AddTime otherwise histogram is removed on
+			// every expiration_interval (without this AddTime is updated
+			// only when histogram is first created).
+			m.AddTime = now
 
 			entry.Metrics[metricKey] = m
 		case telegraf.Summary:


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.

This ensures that prometheus histograms don't expire(whole histogram removed) on every expire_interval (issue https://github.com/influxdata/telegraf/issues/8170). 