### PR TITLE
execd-systemd-timings: Add telegraf-execd-systemd-timings to the list

### DIFF
--- a/EXTERNAL_PLUGINS.md
+++ b/EXTERNAL_PLUGINS.md
@@ -12,3 +12,4 @@ Pull requests welcome.
 - [youtube](https://github.com/inabagumi/youtube-telegraf-plugin) - Gather account information from YouTube channels
 - [awsalarms](https://github.com/vipinvkmenon/awsalarms) - Simple plugin to gather/monitor alarms generated  in AWS.
 - [octoprint](https://github.com/BattleBas/octoprint-telegraf-plugin) - Gather 3d print information from the octoprint API.
+- [systemd-timings](https://github.com/pdmorrow/telegraf-execd-systemd-timings) - Gather systemd boot and unit timestamp metrics.


### PR DESCRIPTION
This external plugin can be used to collect systemd boot timing metrics
as well as individual unit start/stop timing metrics.

Signed-off-by: Peter Morrow <pemorrow@linux.microsoft.com>

### Required for all PRs:

- [ X ] Signed [CLA](https://influxdata.com/community/cla/).
- [ X ] Associated README.md updated.
- [ X ] Has appropriate unit tests.
