### PR TITLE
Update grok package to support for field names containing '-' and '.'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/tidwall/gjson v1.6.0
 	github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e // indirect
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
-	github.com/vjeantet/grok v1.0.0
+	github.com/vjeantet/grok v1.0.1-0.20180213041522-5a86c829f3c3
 	github.com/vmware/govmomi v0.19.0
 	github.com/wavefronthq/wavefront-sdk-go v0.9.2
 	github.com/wvanbergen/kafka v0.0.0-20171203153745-e2edea948ddf

--- a/go.sum
+++ b/go.sum
@@ -569,8 +569,8 @@ github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e h1:f1yevOHP+Su
 github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
-github.com/vjeantet/grok v1.0.0 h1:uxMqatJP6MOFXsj6C1tZBnqqAThQEeqnizUZ48gSJQQ=
-github.com/vjeantet/grok v1.0.0/go.mod h1:/FWYEVYekkm+2VjcFmO9PufDU5FgXHUz9oy2EGqmQBo=
+github.com/vjeantet/grok v1.0.1-0.20180213041522-5a86c829f3c3 h1:T3ATR84Xk4b9g0QbGgLJVpRYWm/jvixqLTWRsR108sI=
+github.com/vjeantet/grok v1.0.1-0.20180213041522-5a86c829f3c3/go.mod h1:/FWYEVYekkm+2VjcFmO9PufDU5FgXHUz9oy2EGqmQBo=
 github.com/vmware/govmomi v0.19.0 h1:CR6tEByWCPOnRoRyhLzuHaU+6o2ybF3qufNRWS/MGrY=
 github.com/vmware/govmomi v0.19.0/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/wavefronthq/wavefront-sdk-go v0.9.2 h1:/LvWgZYNjHFUg+ZUX+qv+7e+M8sEMi0lM15zPp681Gk=

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -1117,22 +1117,20 @@ func TestTrimRegression(t *testing.T) {
 }
 
 func TestAdvanceFieldName(t *testing.T) {
-	// https://github.com/influxdata/telegraf/issues/4998
 	p := &Parser{
-		Patterns: []string{`%{GREEDYDATA:message.a-b}`},
+		Patterns: []string{`rts=%{NUMBER:response-time.s} local=%{IP:local-ip} remote=%{IP:remote.ip}`},
 	}
-	require.NoError(t, p.Compile())
+	assert.NoError(t, p.Compile())
 
-	actual, err := p.ParseLine(`level=info msg="ok"`)
-	require.NoError(t, err)
-
-	expected := testutil.MustMetric(
-		"",
-		map[string]string{},
+	metricA, err := p.ParseLine(`rts=1.283 local=127.0.0.1 remote=10.0.0.1`)
+	require.NotNil(t, metricA)
+	assert.NoError(t, err)
+	assert.Equal(t,
 		map[string]interface{}{
-			"message.a-b": `level=info msg="ok"`,
+			"response-time.s": "1.283",
+			"local-ip":        "127.0.0.1",
+			"remote.ip":       "10.0.0.1",
 		},
-		actual.Time(),
-	)
-	require.Equal(t, expected, actual)
+		metricA.Fields())
+	assert.Equal(t, map[string]string{}, metricA.Tags())
 }

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -1115,3 +1115,24 @@ func TestTrimRegression(t *testing.T) {
 	)
 	require.Equal(t, expected, actual)
 }
+
+func TestAdvanceFieldName(t *testing.T) {
+	// https://github.com/influxdata/telegraf/issues/4998
+	p := &Parser{
+		Patterns: []string{`%{GREEDYDATA:message.a-b}`},
+	}
+	require.NoError(t, p.Compile())
+
+	actual, err := p.ParseLine(`level=info msg="ok"`)
+	require.NoError(t, err)
+
+	expected := testutil.MustMetric(
+		"",
+		map[string]string{},
+		map[string]interface{}{
+			"message.a-b": `level=info msg="ok"`,
+		},
+		actual.Time(),
+	)
+	require.Equal(t, expected, actual)
+}


### PR DESCRIPTION
related: #4003

Currently grok package seems no longer maintained, the latest commit merged the support for field names containing '-' and '.', maybe we can update to this commit.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
