### PR TITLE
Add glibc version check for linux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ install: $(buildbin)
 	@if [ $(GOOS) != "windows" ]; then cp -fv etc/telegraf.conf $(DESTDIR)$(sysconfdir)/telegraf/telegraf.conf$(conf_suffix); fi
 	@if [ $(GOOS) != "windows" ]; then cp -fv etc/logrotate.d/telegraf $(DESTDIR)$(sysconfdir)/logrotate.d; fi
 	@if [ $(GOOS) = "windows" ]; then cp -fv etc/telegraf_windows.conf $(DESTDIR)/telegraf.conf; fi
-	@if [ $(GOOS) = "linux" ]; then scripts/check-dynamic-glibc-version.sh $(buildbin) $(glibc_version); fi
+	@if [ $(GOOS) = "linux" ]; then scripts/check-dynamic-glibc-versions.sh $(buildbin) $(glibc_version); fi
 	@if [ $(GOOS) = "linux" ]; then mkdir -pv $(DESTDIR)$(prefix)/lib/telegraf/scripts; fi
 	@if [ $(GOOS) = "linux" ]; then cp -fv scripts/telegraf.service $(DESTDIR)$(prefix)/lib/telegraf/scripts; fi
 	@if [ $(GOOS) = "linux" ]; then cp -fv scripts/init.sh $(DESTDIR)$(prefix)/lib/telegraf/scripts; fi

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ next_version := 1.16.0
 tag := $(shell git describe --exact-match --tags 2>git_describe_error.tmp; rm -f git_describe_error.tmp)
 branch := $(shell git rev-parse --abbrev-ref HEAD)
 commit := $(shell git rev-parse --short=8 HEAD)
+glibc_version := 2.17
 
 ifdef NIGHTLY
 	version := $(next_version)
@@ -191,6 +192,7 @@ install: $(buildbin)
 	@if [ $(GOOS) != "windows" ]; then cp -fv etc/telegraf.conf $(DESTDIR)$(sysconfdir)/telegraf/telegraf.conf$(conf_suffix); fi
 	@if [ $(GOOS) != "windows" ]; then cp -fv etc/logrotate.d/telegraf $(DESTDIR)$(sysconfdir)/logrotate.d; fi
 	@if [ $(GOOS) = "windows" ]; then cp -fv etc/telegraf_windows.conf $(DESTDIR)/telegraf.conf; fi
+	@if [ $(GOOS) = "linux" ]; then scripts/check-dynamic-glibc-version.sh $(buildbin) $(glibc_version); fi
 	@if [ $(GOOS) = "linux" ]; then mkdir -pv $(DESTDIR)$(prefix)/lib/telegraf/scripts; fi
 	@if [ $(GOOS) = "linux" ]; then cp -fv scripts/telegraf.service $(DESTDIR)$(prefix)/lib/telegraf/scripts; fi
 	@if [ $(GOOS) = "linux" ]; then cp -fv scripts/init.sh $(DESTDIR)$(prefix)/lib/telegraf/scripts; fi

--- a/scripts/check-dynamic-glibc-versions.sh
+++ b/scripts/check-dynamic-glibc-versions.sh
@@ -16,9 +16,16 @@ prog=$1
 max=$2
 
 #make sure dependencies are installed
+have_deps=true
 for i in objdump sort uniq sed; do
-    which $i > /dev/null
+    if ! command -v "$i" > /dev/null; then
+	echo "$i not in path"
+	have_deps=false
+    fi
 done
+if [[ $have_deps = false ]]; then
+    exit 1
+fi
 
 #compare dotted versions
 #see https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash

--- a/scripts/check-dynamic-glibc-versions.sh
+++ b/scripts/check-dynamic-glibc-versions.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+usage () {
+    echo "Check that no dynamic symbols provided by glibc are newer than a given version"
+    echo "Usage:"
+    echo "   $0 program version"
+    echo "where program is the elf binary to check and version is a dotted version string like 2.3.4"
+    exit 1
+}
+
+#validate input and display help
+[[ $# = 2 ]] || usage
+prog=$1
+max=$2
+
+#make sure dependencies are installed
+for i in objdump sort uniq sed; do
+    which $i > /dev/null
+done
+
+#compare dotted versions
+#see https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash
+vercomp () {
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    # fill empty fields in ver1 with zeros
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            # fill empty fields in ver2 with zeros
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 2
+        fi
+    done
+    return 0
+}
+
+objdump -T "$prog" | # get the dynamic symbol table
+    sed -n "s/.* GLIBC_\([0-9.]\+\).*/\1/p" | # find the entries for glibc and grab the version
+    sort | uniq | # remove duplicates
+    while read v; do
+        set +e
+        vercomp "$v" "$max" # fail if any version is newer than our max
+        comp=$?
+        set -e
+        if [[ $comp -eq 1 ]]; then
+            echo "$v is newer than $max"
+            exit 1
+        fi
+    done
+
+exit 0


### PR DESCRIPTION
This version check makes sure that telegraf on linux platforms doesn't dynamically link to a glibc that is too new.  Requiring a new glibc would cause telegraf to fail to run on older supported linux distributions.  The version it compares against is configurable in the makefile and set to 2.17 which is what RHEL 7 provides.

The check runs as part of the makefile's packages target which already runs during CI, so this will run on every PR.

CI for this PR is failing intentionally to show that it works.