### PR TITLE
Add bookmarking support to win_eventlog

### DIFF
--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -202,6 +202,14 @@ Locale should be present on the computer. English locale is usually available on
 
 <https://docs.microsoft.com/en-us/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a>
 
+### Bookmarking
+
+win_eventlog plugin tracks processed events and automatically saves bookmarks in Windows Registry. So even if Windows is rebooted or plugin was in stopped state for some time, no events will be missed.
+
+Current event bookmark is saved under `Software\InfluxData\Telegraf` key in the `EventBookmark` string value. By default plugin tries to use `HKEY_LOCAL_MACHINE` hive, assuming it has Administrator privileges, but if it can't open key in this hive for writing, it tries to use `HKEY_CURRENT_USER` hive instead.
+
+If even `HKEY_CURRENT_USER` couldn't be opened (telegraf is started with no priviliges at all) or there was no previous bookmark saved, plugin subscribes to events starting from the current time.
+
 ### Example Output
 
 Some values are changed for anonymity.

--- a/plugins/inputs/win_eventlog/syscall_windows.go
+++ b/plugins/inputs/win_eventlog/syscall_windows.go
@@ -22,7 +22,8 @@ type EvtSubscribeFlag uint32
 // EVT_SUBSCRIBE_FLAGS enumeration
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa385588(v=vs.85).aspx
 const (
-	EvtSubscribeToFutureEvents EvtSubscribeFlag = 1
+	EvtSubscribeToFutureEvents     EvtSubscribeFlag = 1
+	EvtSubscribeStartAfterBookmark EvtSubscribeFlag = 3
 )
 
 // EvtRenderFlag uint32
@@ -34,6 +35,7 @@ const (
 	//revive:disable:var-naming
 	// Render the event as an XML string. For details on the contents of the
 	// XML string, see the Event schema.
-	EvtRenderEventXml EvtRenderFlag = 1
+	EvtRenderEventXml = iota + 1
+	EvtRenderBookmark
 	//revive:enable:var-naming
 )


### PR DESCRIPTION
win_eventlog plugin tracks processed events and automatically saves bookmarks in Windows Registry. So even if Windows is rebooted or plugin was in stopped state for some time, no events will be missed.

Current event bookmark is saved under `Software\InfluxData\Telegraf` key in the `EventBookmark` string value. By default plugin tries to use `HKEY_LOCAL_MACHINE` hive, assuming it has Administrator privileges, but if it can't open key in this hive for writing, it tries to use `HKEY_CURRENT_USER` hive instead.

If even `HKEY_CURRENT_USER` couldn't be opened (telegraf is started with no priviliges at all) or there was no previous bookmark saved, plugin subscribes to events starting from the current time.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
