### PR TITLE
Fix using empty string as the namespace prefix in azure_monitor output plugin

### DIFF
--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -155,10 +155,6 @@ func (a *AzureMonitor) Connect() error {
 		Timeout: a.Timeout.Duration,
 	}
 
-	if a.NamespacePrefix == "" {
-		a.NamespacePrefix = defaultNamespacePrefix
-	}
-
 	var err error
 	var region string
 	var resourceID string
@@ -646,7 +642,8 @@ func (a *AzureMonitor) Reset() {
 func init() {
 	outputs.Add("azure_monitor", func() telegraf.Output {
 		return &AzureMonitor{
-			timeFunc: time.Now,
+			timeFunc:        time.Now,
+			NamespacePrefix: defaultNamespacePrefix,
 		}
 	})
 }


### PR DESCRIPTION
Fixes #8256

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
