### PR TITLE
Add OData-Version header to requests

### DIFF
--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -181,6 +181,7 @@ func (r *Redfish) getData(url string, payload interface{}) error {
 	req.SetBasicAuth(r.Username, r.Password)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("OData-Version", "4.0")
 	resp, err := r.client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
When using the redfish plugin against an HPE iLO4 host it fails parsing the responses. This is due to a backwards compatibility in iLO4 to before the standardization of field naming in embedded links. Setting the optional `OData-Version` on request headers signals the server to reply in a redfish 1.0 conformant format (https://hewlettpackard.github.io/ilo-rest-api-docs/ilo4/#redfish-1-0-conformance). This will not change the responses from already compliant hosts (tested against iDRAC)  

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Fixes #8093