### PR TITLE
RAS plugin - fix for too many open files handlers

### DIFF
--- a/plugins/inputs/ras/ras.go
+++ b/plugins/inputs/ras/ras.go
@@ -107,11 +107,6 @@ func (r *Ras) Stop() {
 
 // Gather reads the stats provided by RASDaemon and writes it to the Accumulator.
 func (r *Ras) Gather(acc telegraf.Accumulator) error {
-	err := r.db.Ping()
-	if err != nil {
-		return fmt.Errorf("connection to DB (%s) couldn't be established: %v", r.DBPath, err)
-	}
-
 	rows, err := r.db.Query(mceQuery, r.latestTimestamp)
 	if err != nil {
 		return err

--- a/plugins/inputs/ras/ras.go
+++ b/plugins/inputs/ras/ras.go
@@ -20,6 +20,9 @@ import (
 type Ras struct {
 	DBPath string `toml:"db_path"`
 
+	Log telegraf.Logger `toml:"-"`
+	db  *sql.DB         `toml:"-"`
+
 	latestTimestamp   time.Time              `toml:"-"`
 	cpuSocketCounters map[int]metricCounters `toml:"-"`
 	serverCounters    metricCounters         `toml:"-"`
@@ -77,20 +80,39 @@ func (r *Ras) Description() string {
 	return "RAS plugin exposes counter metrics for Machine Check Errors provided by RASDaemon (sqlite3 output is required)."
 }
 
-// Gather reads the stats provided by RASDaemon and writes it to the Accumulator.
-func (r *Ras) Gather(acc telegraf.Accumulator) error {
+// Start initializes connection to DB, metrics are gathered in Gather
+func (r *Ras) Start(telegraf.Accumulator) error {
 	err := validateDbPath(r.DBPath)
 	if err != nil {
 		return err
 	}
 
-	db, err := connectToDB(r.DBPath)
+	r.db, err = connectToDB(r.DBPath)
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 
-	rows, err := db.Query(mceQuery, r.latestTimestamp)
+	return nil
+}
+
+// Stop closes any existing DB connection
+func (r *Ras) Stop() {
+	if r.db != nil {
+		err := r.db.Close()
+		if err != nil {
+			r.Log.Errorf("Error appeared during closing DB (%s): %v", r.DBPath, err)
+		}
+	}
+}
+
+// Gather reads the stats provided by RASDaemon and writes it to the Accumulator.
+func (r *Ras) Gather(acc telegraf.Accumulator) error {
+	err := r.db.Ping()
+	if err != nil {
+		return fmt.Errorf("connection to DB (%s) couldn't be established: %v", r.DBPath, err)
+	}
+
+	rows, err := r.db.Query(mceQuery, r.latestTimestamp)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/ras/ras_test.go
+++ b/plugins/inputs/ras/ras_test.go
@@ -114,7 +114,7 @@ func TestMissingDatabase(t *testing.T) {
 	var acc testutil.Accumulator
 	ras := newRas()
 	ras.DBPath = "/tmp/test.db"
-	err := ras.Gather(&acc)
+	err := ras.Start(&acc)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.

### Details
Database driver doesn't close file handler properly when `db.Close()` is called. 
This may lead to `too many open files` for Telegraf process (returned by OS).

In this fix `sql.Open()` is called once in `Start()` and `db.Close()` is also called only once in `Stop()`.

This is also optimization (open DB just once, not in every `Gather()`) and following along guide from comment for `func (db *DB) Close() error` in `sql.go`:

> // It is rare to Close a DB, as the DB handle is meant to be
> // long-lived and shared between many goroutines.

The same approach was introduced in `inputs/postgresql` plugin.