### PR TITLE
inputs: add syncthing

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -170,6 +170,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/statsd"
 	_ "github.com/influxdata/telegraf/plugins/inputs/suricata"
 	_ "github.com/influxdata/telegraf/plugins/inputs/swap"
+	_ "github.com/influxdata/telegraf/plugins/inputs/syncthing"
 	_ "github.com/influxdata/telegraf/plugins/inputs/synproxy"
 	_ "github.com/influxdata/telegraf/plugins/inputs/syslog"
 	_ "github.com/influxdata/telegraf/plugins/inputs/sysstat"

--- a/plugins/inputs/syncthing/README.md
+++ b/plugins/inputs/syncthing/README.md
@@ -1,0 +1,60 @@
+# Syncthing Input Plugin
+
+The Syncthing input plugin collects information from one Syncthing API endpoint.
+
+## Configuration:
+
+```toml
+## Syncthing host
+url = "http://localhost:8384"
+
+# token_file = "/path/to/file"
+## OR
+# token = "<api-access-token>"
+
+## Optional TLS Config
+# tls_ca = "/etc/telegraf/ca.pem"
+# tls_cert = "/etc/telegraf/cert.pem"
+# tls_key = "/etc/telegraf/key.pem"
+## Use TLS but skip chain & host verification
+# insecure_skip_verify = false
+
+## Amount of time allowed to complete the HTTP request
+# timeout = "5s"
+```
+
+## Measurements collected
+
+### syncthing_folder
+
+Tags:
+ * `id` - the folder ID
+ * `label` - the label (name) you have assigned to the folder
+ * `path` - the sync path on the local filesystem
+
+Fields: 
+ * `paused` - if the folder is paused
+ * `needed` - how many files are needed to be in sync
+
+### syncthing_device
+
+Tags:
+ * `device_id` - the device id that is connected
+ * `name` - the name of the connected device 
+
+Fields:
+ * `address` - the IP address of the connected device
+ * `client_version` - the version of Syncthing that the connected device is using
+ * `connected` - if the device is connected
+ * `crypto` - which version of TLS the device is using for encryption
+ * `in_bytes_total` - how many bytes have been received by this device
+ * `out_bytes_total` - how many bytes have been sent to this device
+ * `paused` - if the device connection has been paused
+
+### Example output
+
+```
+syncthing_connection,device_id=AIDPJXN-35PEWDU-IJKFJLV-BFELH5K-2PSCUKR-CNUEHI5-CIIDIA3-ITKWTUU,host=bilbos-laptop,name=samwise-desktop address="192.168.2.243:22000",client_version="v1.6.1",connected=true,crypto="TLS1.3-TLS_AES_128_CCM_SHA256",in_bytes_total=14i,out_bytes_total=14i,paused=false 1603647083000000000
+syncthing_connection,device_id=USCWXIF-37NATKW-AXIYI4I-CDWV7L2-CXUTPUT-3V2URIM-ZPMADVS-2HBMTUA,host=bilbos-laptop,name=NAS address="192.168.2.91:22000",client_version="v1.4.0",connected=true,crypto="TLS1.3-TLS_AES_128_CCM_SHA256",in_bytes_total=314i,out_bytes_total=303i,paused=false 1603647083000000000
+syncthing_folder,host=bilbos-laptop,id=rq7yw-sk82y,label=dotfiles,path=/home/bilbo/sync/dotfiles need=0i,paused=false 1603647083000000000
+```

--- a/plugins/inputs/syncthing/client.go
+++ b/plugins/inputs/syncthing/client.go
@@ -1,0 +1,75 @@
+package syncthing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+func (s *Syncthing) SystemConnections(ctx context.Context, host string) (*SystemConnections, error) {
+	cons := new(SystemConnections)
+	err := s.GetJSON(ctx, host, ConnectionsEndpoint, cons, nil)
+	return cons, err
+}
+
+func (s *Syncthing) SystemStatus(ctx context.Context, host string) (*SystemStatus, error) {
+	st := new(SystemStatus)
+	err := s.GetJSON(ctx, host, SystemStatusEndpoint, st, nil)
+	return st, err
+}
+
+// Need queries https://docs.syncthing.net/rest/db-need-get.html to find out how many files are needed
+// to become in sync
+func (s *Syncthing) Need(ctx context.Context, host string, folderID string) (*Need, error) {
+	r := new(Need)
+	q := url.Values{}
+	q.Add("folder", folderID)
+
+	err := s.GetJSON(ctx, host, NeedEndpoint, r, q)
+	return r, err
+}
+
+func (s *Syncthing) SystemConfig(ctx context.Context, host string) (*SystemConfig, error) {
+	r := new(SystemConfig)
+	err := s.GetJSON(ctx, host, SysconfigEndpoint, r, nil)
+	return r, err
+}
+
+func (s *Syncthing) GetJSON(ctx context.Context, host string, uri string, v interface{}, parms url.Values) error {
+	rurl, err := url.Parse(host)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse request URI")
+	}
+	rurl.Path = uri
+
+	if len(parms) > 0 {
+		rurl.RawQuery = parms.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rurl.String(), nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create HTTP request")
+	}
+	req.Header.Set(AuthHeader, s.Token)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("bad status code (%d) from http %q: body: %q", resp.StatusCode, rurl, body)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		return errors.Wrapf(err, "failed to decode response body from %q", rurl.String())
+	}
+	return nil
+}

--- a/plugins/inputs/syncthing/models.go
+++ b/plugins/inputs/syncthing/models.go
@@ -1,0 +1,94 @@
+package syncthing
+
+import (
+	"time"
+)
+
+// SystemConnections returns the list of configured devices and some metadata associated with them. The list also contains the local device itself as not connected.
+// The connection types are TCP (Client), TCP (Server), Relay (Client) and Relay (Server).
+// GET /rest/system/connections
+// https://docs.syncthing.net/rest/system-connections-get.html
+type SystemConnections struct {
+	Connections map[string]*Connection `json:"connections"`
+}
+
+type Connection struct {
+	ID            string `json:"id"`
+	Address       string `json:"address"`
+	At            string `json:"at"`
+	ClientVersion string `json:"clientVersion"`
+	Connected     bool   `json:"connected"`
+	Crypto        string `json:"crypto"`
+	InBytesTotal  int    `json:"inBytesTotal"`
+	OutBytesTotal int    `json:"outBytesTotal"`
+	Paused        bool   `json:"paused"`
+	Type          string `json:"type"`
+	DeviceName    string `json:"device_name"`
+}
+
+// SystemVersion Returns the current version information.
+// GET /rest/system/version
+type SystemVersion struct {
+	Arch        string `json:"arch"`
+	LongVersion string `json:"longVersion"`
+	Os          string `json:"os"`
+	Version     string `json:"version"`
+}
+
+// Need Takes one mandatory parameter, folder, and returns lists of files which are needed by this device in order for
+// it to become in sync.
+// GET /rest/db/need
+type Need struct {
+	// DO NOT want these because we don't need the specific information
+	// Progress []FileInfo `json:"progress"`
+	// Queued   []FileInfo `json:"queued"`
+	// Rest     []FileInfo `json:"rest"`
+	Total int `json:"total"`
+}
+
+// SystemConfig is the current system configuration
+// GET /rest/system/config
+type SystemConfig struct {
+	Version        int               `json:"version"`
+	Folders        []*Folders        `json:"folders"`
+	Devices        []*Device         `json:"devices"`
+	PendingDevices []*PendingFolders `json:"pendingDevices"`
+}
+
+func (s *SystemConfig) DeviceByID(id string) *Device {
+	for _, d := range s.Devices {
+		if d.ID == id {
+			return d
+		}
+	}
+	return nil
+}
+
+type Folders struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	Path   string `json:"path"`
+	Paused bool   `json:"paused"`
+}
+
+type PendingFolders struct {
+	Time  time.Time `json:"time"`
+	ID    string    `json:"id"`
+	Label string    `json:"label"`
+}
+
+type Device struct {
+	ID             string           `json:"deviceID"`
+	Name           string           `json:"name"`
+	Paused         bool             `json:"paused"`
+	PendingFolders []PendingFolders `json:"pendingFolders"`
+	MaxRequestKiB  int              `json:"maxRequestKiB"`
+}
+
+// SystemStatus returns information about current system status and resource usage. The CPU percent value has been deprecated from the API and will always report 0.
+// GET /rest/system/status
+// https://docs.syncthing.net/rest/system-status-get.html
+type SystemStatus struct {
+	MyID      string    `json:"myID"`
+	StartTime time.Time `json:"startTime"`
+}

--- a/plugins/inputs/syncthing/syncthing.go
+++ b/plugins/inputs/syncthing/syncthing.go
@@ -1,0 +1,203 @@
+package syncthing
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/common/tls"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/pkg/errors"
+)
+
+const (
+	SysconfigEndpoint    = "/rest/system/config"
+	ConnectionsEndpoint  = "/rest/system/connections"
+	SystemStatusEndpoint = "/rest/system/status"
+	NeedEndpoint         = "/rest/db/need"
+)
+
+type Syncthing struct {
+	URL       string `toml:"url"`
+	TokenFile string `toml:"token_file"`
+	Token     string `toml:"token"`
+	tls.ClientConfig
+
+	Timeout internal.Duration `toml:"timeout"`
+
+	client *http.Client
+
+	// The parser will automatically be set by Telegraf core code because
+	// this plugin implements the ParserInput interface (i.e. the SetParser method)
+	parser parsers.Parser
+}
+
+const (
+	AuthHeader = "X-API-KEY"
+
+	sampleConfig = `
+	  ## Syncthing host
+	  url = "http://localhost:8384"
+
+	  # token_file = "/path/to/file"
+	  ## OR
+	  # token = "<api-access-token>"
+
+	  ## Optional TLS Config
+	  # tls_ca = "/etc/telegraf/ca.pem"
+	  # tls_cert = "/etc/telegraf/cert.pem"
+	  # tls_key = "/etc/telegraf/key.pem"
+	  ## Use TLS but skip chain & host verification
+	  # insecure_skip_verify = false
+
+	  ## Amount of time allowed to complete the HTTP request
+	  # timeout = "5s"
+	`
+)
+
+// SampleConfig returns the default configuration of the Input
+func (*Syncthing) SampleConfig() string {
+	return sampleConfig
+}
+
+// Description returns a one-sentence description on the Input
+func (*Syncthing) Description() string {
+	return "Read syncthing metrics from one or more endpoints"
+}
+
+func (s *Syncthing) Init() error {
+	tlsCfg, err := s.ClientConfig.TLSConfig()
+	if err != nil {
+		return err
+	}
+
+	if s.TokenFile != "" {
+		b, err := ioutil.ReadFile(s.TokenFile)
+		if err != nil {
+			return errors.Wrap(err, "failed to read token file")
+		}
+		s.Token = string(b)
+	}
+
+	s.Token = strings.TrimSpace(s.Token)
+	if s.Token == "" {
+		return errors.New("required token was not provided")
+	}
+
+	s.client = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig:     tlsCfg,
+			Proxy:               http.ProxyFromEnvironment,
+			TLSHandshakeTimeout: s.Timeout.Duration,
+			Dial: (&net.Dialer{
+				Timeout: s.Timeout.Duration,
+			}).Dial,
+		},
+		Timeout: s.Timeout.Duration,
+	}
+
+	return nil
+}
+
+// Gather takes in an accumulator and adds the metrics that the Input
+// gathers. This is called every "interval"
+func (s *Syncthing) Gather(acc telegraf.Accumulator) error {
+	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout.Duration)
+	defer cancel()
+	sysstatus, err := s.SystemStatus(ctx, s.URL)
+	if err != nil {
+		return errors.Wrap(err, "failed to gather system status")
+	}
+
+	sysconfig, err := s.SystemConfig(ctx, s.URL)
+	if err != nil {
+		return errors.Wrap(err, "failed to gather system config")
+	}
+
+	conns, err := s.SystemConnections(ctx, s.URL)
+	if err != nil {
+		return errors.Wrap(err, "failed to gather system connections")
+	}
+
+	myID := sysstatus.MyID
+	now := time.Now()
+
+	devices := sysconfig.Devices[:0]
+	for _, dev := range sysconfig.Devices {
+		if dev.ID != myID {
+			devices = append(devices, dev)
+		}
+	}
+	sysconfig.Devices = devices
+
+	addConnections(acc, sysconfig, conns, now)
+
+	s.addFolders(ctx, s.URL, acc, sysconfig, now)
+
+	return nil
+}
+
+// SetParser takes the data_format from the config and finds the right parser for that format
+func (s *Syncthing) SetParser(parser parsers.Parser) {
+	s.parser = parser
+}
+
+func (s *Syncthing) addFolders(ctx context.Context, host string, acc telegraf.Accumulator, sysconfig *SystemConfig, t time.Time) {
+	for _, folder := range sysconfig.Folders {
+		n, err := s.Need(ctx, host, folder.ID)
+		if err != nil {
+			acc.AddError(errors.Wrapf(err, "failed to lookup folder needs for %q:%q", folder.ID, folder.Label))
+			continue
+		}
+		fields := map[string]interface{}{
+			"paused": folder.Paused,
+			"need":   n.Total,
+		}
+		tags := map[string]string{
+			"label": folder.Label,
+			"id":    folder.ID,
+			"path":  folder.Path,
+		}
+		acc.AddFields("syncthing_folder", fields, tags, t)
+	}
+}
+
+func addConnections(acc telegraf.Accumulator, sysconfig *SystemConfig, conns *SystemConnections, t time.Time) {
+	for id, con := range conns.Connections {
+		dev := sysconfig.DeviceByID(id)
+		if dev == nil {
+			// self
+			continue
+		}
+
+		tags := map[string]string{
+			"device_id": id,
+			"name":      dev.Name,
+		}
+		fields := map[string]interface{}{
+			"client_version":  con.ClientVersion,
+			"address":         con.Address,
+			"connected":       con.Connected,
+			"crypto":          con.Crypto,
+			"in_bytes_total":  con.InBytesTotal,
+			"out_bytes_total": con.OutBytesTotal,
+			"paused":          con.Paused,
+		}
+		acc.AddFields("syncthing_connection", fields, tags, t)
+	}
+}
+
+func init() {
+	inputs.Add("syncthing", func() telegraf.Input {
+		return &Syncthing{
+			URL:     "http://localhost:8384",
+			Timeout: internal.Duration{Duration: time.Second * 5},
+		}
+	})
+}

--- a/plugins/inputs/syncthing/syncthing_fixtures_test.go
+++ b/plugins/inputs/syncthing/syncthing_fixtures_test.go
@@ -1,0 +1,173 @@
+package syncthing_test
+
+import (
+	"text/template"
+)
+
+type TestValues struct {
+	FolderID      string
+	FolderLabel   string
+	FolderPath    string
+	DeviceID      string
+	InBytesTotal  int
+	OutBytesTotal int
+	TotalNeeded   int
+	DeviceAddress string
+	DeviceName    string
+	ClientVersion string
+	Connected     bool
+	Crypto        string
+	Paused        bool
+	MyID          string
+}
+
+var (
+	sysconfigJSON    = template.Must(template.New("sysconfig").Parse(systemConfigTemplate))
+	folderNeedJSON   = template.Must(template.New("folderNeed").Parse(folderNeedTemplate))
+	connectionJSON   = template.Must(template.New("connection").Parse(connectionsTemplate))
+	systemStatusJSON = template.Must(template.New("sysstatus").Parse(systemStatusTemplate))
+)
+
+func init() {
+}
+
+const (
+	systemStatusTemplate = `
+	{
+		"myID": "{{ .MyID }}",
+		"startTime": "2016-06-06T19:41:43.039284753+02:00"
+	}
+	`
+
+	systemConfigTemplate = `
+	{
+	  "version": 30,
+	  "folders": [
+	    {
+	      "id": "{{ .FolderID }}",
+	      "label": "{{ .FolderLabel }}",
+	      "filesystemType": "basic",
+	      "path": "{{ .FolderPath }}",
+	      "type": "sendreceive",
+	      "devices": [
+		{
+		  "deviceID": "{{ .DeviceID }}",
+		  "introducedBy": ""
+		}
+	      ],
+	      "rescanIntervalS": 60,
+	      "fsWatcherEnabled": false,
+	      "fsWatcherDelayS": 10,
+	      "ignorePerms": false,
+	      "autoNormalize": true,
+	      "minDiskFree": {
+		"value": 1,
+		"unit": "%"
+	      },
+	      "versioning": {
+		"type": "simple",
+		"params": {
+		  "keep": "5"
+		}
+	      },
+	      "copiers": 0,
+	      "pullerMaxPendingKiB": 0,
+	      "hashers": 0,
+	      "order": "random",
+	      "ignoreDelete": false,
+	      "scanProgressIntervalS": 0,
+	      "pullerPauseS": 0,
+	      "maxConflicts": 10,
+	      "disableSparseFiles": false,
+	      "disableTempIndexes": false,
+	      "paused": false,
+	      "weakHashThresholdPct": 25,
+	      "markerName": ".stfolder",
+	      "copyOwnershipFromParent": false,
+	      "modTimeWindowS": 0
+	    }
+	  ],
+	  "devices": [
+	    {
+	      "deviceID": "{{ .DeviceID }}",
+	      "name": "{{ .DeviceName }}",
+	      "addresses": [
+		"dynamic",
+		"tcp://192.168.1.2:22000"
+	      ],
+	      "compression": "metadata",
+	      "certName": "",
+	      "introducer": false,
+	      "skipIntroductionRemovals": false,
+	      "introducedBy": "",
+	      "paused": false,
+	      "allowedNetworks": [],
+	      "autoAcceptFolders": false,
+	      "maxSendKbps": 0,
+	      "maxRecvKbps": 0,
+	      "ignoredFolders": [],
+	      "pendingFolders": [],
+	      "maxRequestKiB": 0
+	    }
+	  ]
+	}`
+
+	folderNeedTemplate = `
+	{
+	  "progress": [
+	    {
+	      "flags": "0755",
+	      "sequence": 6,
+	      "modified": "2015-04-20T23:06:12+09:00",
+	      "name": "ls",
+	      "size": 34640,
+	      "version": [
+		"5157751870738175669:1"
+	      ]
+	    }
+	  ],
+	  "queued": [],
+	  "rest": [],
+	  "page": 1,
+	  "perpage": 100,
+	  "total": {{ .TotalNeeded }}
+	}`
+
+	connectionsTemplate = `
+	{
+	   "total" : {
+		  "paused" : false,
+		  "clientVersion" : "",
+		  "at" : "2015-11-07T17:29:47.691637262+01:00",
+		  "connected" : false,
+		  "inBytesTotal" : 1479,
+		  "type" : "",
+		  "outBytesTotal" : 1318,
+		  "address" : ""
+	   },
+	   "connections" : {
+		  "{{ .DeviceID }}" : {
+		     "connected" : {{ .Connected }},
+		     "inBytesTotal" : {{ .InBytesTotal }},
+		     "paused" : {{ .Paused }},
+		     "at" : "2015-11-07T17:29:47.691548971+01:00",
+		     "clientVersion" : "{{ .ClientVersion }}",
+		     "address" : "{{ .DeviceAddress }}",
+		     "type" : "TCP (Client)",
+		     "crypto" : "{{ .Crypto }}",
+		     "outBytesTotal" : {{ .OutBytesTotal }}
+		  },
+		  "DOVII4U-SQEEESM-VZ2CVTC-CJM4YN5-QNV7DCU-5U3ASRL-YVFG6TH-W5DV5AA" : {
+		     "outBytesTotal" : 0,
+		     "type" : "",
+		     "address" : "",
+		     "at" : "0001-01-01T00:00:00Z",
+		     "clientVersion" : "",
+		     "paused" : false,
+		     "inBytesTotal" : 0,
+		     "connected" : false
+		  }
+	   }
+	}
+	`
+)

--- a/plugins/inputs/syncthing/syncthing_test.go
+++ b/plugins/inputs/syncthing/syncthing_test.go
@@ -1,0 +1,227 @@
+package syncthing_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/inputs/syncthing"
+	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncthing_Init_FailsWhenNoTokenProvided(t *testing.T) {
+	err := (&syncthing.Syncthing{}).Init()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token")
+}
+
+func TestSyncthing_Init_FailsWhenTokenFileIsUnreadable(t *testing.T) {
+	err := (&syncthing.Syncthing{
+		TokenFile: "/8y4hickjasdf",
+	}).Init()
+	require.Error(t, err)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected NotExist error, but got %q", err.Error())
+	}
+}
+
+func TestSyncthing_Init_PassesTokenHeader(t *testing.T) {
+	const token = `laskdhlkfajhfhasdfd`
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		actual := r.Header.Get(syncthing.AuthHeader)
+		if assert.Equal(t, actual, token) {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer fakeServer.Close()
+
+	url := fakeServer.URL
+	plugin := &syncthing.Syncthing{
+		URL:     url,
+		Timeout: internal.Duration{Duration: time.Second},
+		Token:   token,
+	}
+
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	err := acc.GatherError(plugin.Gather)
+	require.Error(t, err)
+}
+
+func TestSyncthing_Connections(t *testing.T) {
+	testValues := &TestValues{
+		FolderID:      "GXWxf-3zgnU",
+		FolderLabel:   "MyFolder",
+		FolderPath:    "/some/path",
+		DeviceID:      "YZJBJFX-RDBL7WY-6ZGKJ2D-4MJB4E7-ZATDSYU-LDY3L63-MFLUWYE-AEMXJAC",
+		InBytesTotal:  550,
+		OutBytesTotal: 62763,
+		TotalNeeded:   872768,
+		DeviceAddress: "192.168.2.2",
+		DeviceName:    "MyDevice",
+		ClientVersion: "v1.60.1",
+		Connected:     true,
+		Crypto:        "TLS-1.3",
+		Paused:        false,
+		MyID:          "P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2",
+	}
+
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case syncthing.SystemStatusEndpoint:
+			_ = systemStatusJSON.Execute(w, testValues)
+		case syncthing.SysconfigEndpoint:
+			_ = sysconfigJSON.Execute(w, testValues)
+		case syncthing.ConnectionsEndpoint:
+			_ = connectionJSON.Execute(w, testValues)
+		case syncthing.NeedEndpoint:
+			_ = folderNeedJSON.Execute(w, testValues)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer fakeServer.Close()
+
+	url := fakeServer.URL + syncthing.SysconfigEndpoint
+	plugin := &syncthing.Syncthing{
+		URL:     url,
+		Timeout: internal.Duration{Duration: time.Second},
+		Token:   "token",
+	}
+	const metricName = "syncthing_connection"
+
+	p, _ := parsers.NewParser(&parsers.Config{
+		DataFormat: "json",
+		MetricName: metricName,
+	})
+	plugin.SetParser(p)
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Init())
+	require.NoError(t, acc.GatherError(plugin.Gather))
+
+	// basic check to see if we got the right field, value and tag
+	metric, ok := acc.Get(metricName)
+	require.True(t, ok, "metric name was not found: %q", metricName)
+
+	require.Equal(t, metric.Measurement, metricName)
+
+	expectedTags := map[string]interface{}{
+		"name":      testValues.DeviceName,
+		"device_id": testValues.DeviceID,
+	}
+
+	for k, v := range expectedTags {
+		assert.Contains(t, metric.Tags, k)
+		assert.EqualValues(t, v, metric.Tags[k])
+	}
+
+	expectedFields := map[string]interface{}{
+		"address":         testValues.DeviceAddress,
+		"client_version":  testValues.ClientVersion,
+		"connected":       testValues.Connected,
+		"crypto":          testValues.Crypto,
+		"in_bytes_total":  testValues.InBytesTotal,
+		"out_bytes_total": testValues.OutBytesTotal,
+		"paused":          testValues.Paused,
+	}
+
+	for k, v := range expectedFields {
+		assert.Contains(t, metric.Fields, k)
+		assert.EqualValues(t, v, metric.Fields[k])
+	}
+}
+
+func TestSyncthing_Folders(t *testing.T) {
+	const (
+		sysconfigEndpoint   = "/rest/system/config"
+		connectionsEndpoint = "/rest/system/connections"
+		needEndpoint        = "/rest/db/need"
+	)
+
+	testValues := &TestValues{
+		FolderID:      "GXWxf-3zgnU",
+		FolderPath:    "/some/path",
+		DeviceID:      "YZJBJFX-RDBL7WY-6ZGKJ2D-4MJB4E7-ZATDSYU-LDY3L63-MFLUWYE-AEMXJAC",
+		InBytesTotal:  550,
+		OutBytesTotal: 62763,
+		TotalNeeded:   872768,
+		DeviceAddress: "192.168.2.2",
+		DeviceName:    "MyDevice",
+		ClientVersion: "v1.60.1",
+		Connected:     true,
+		Crypto:        "TLS-1.3",
+		Paused:        false,
+		MyID:          "P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2",
+	}
+
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case syncthing.SystemStatusEndpoint:
+			_ = systemStatusJSON.Execute(w, testValues)
+		case sysconfigEndpoint:
+			_ = sysconfigJSON.Execute(w, testValues)
+		case connectionsEndpoint:
+			_ = connectionJSON.Execute(w, testValues)
+		case needEndpoint:
+			_ = folderNeedJSON.Execute(w, testValues)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer fakeServer.Close()
+
+	url := fakeServer.URL + sysconfigEndpoint
+	plugin := &syncthing.Syncthing{
+		URL:     url,
+		Timeout: internal.Duration{Duration: time.Second},
+		Token:   "token",
+	}
+	const metricName = "syncthing_folder"
+
+	p, _ := parsers.NewParser(&parsers.Config{
+		DataFormat: "json",
+		MetricName: metricName,
+	})
+	plugin.SetParser(p)
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Init())
+	require.NoError(t, acc.GatherError(plugin.Gather))
+
+	// basic check to see if we got the right field, value and tag
+	metric, ok := acc.Get(metricName)
+	require.True(t, ok, "metric name was not found: %q", metricName)
+
+	require.Equal(t, metric.Measurement, metricName)
+
+	expectedFields := map[string]interface{}{
+		"paused": testValues.Paused,
+		"need":   testValues.TotalNeeded,
+	}
+	expectedTags := map[string]string{
+		"label": testValues.FolderLabel,
+		"id":    testValues.FolderID,
+		"path":  testValues.FolderPath,
+	}
+
+	for k, v := range expectedTags {
+		assert.Contains(t, metric.Tags, k)
+		assert.EqualValues(t, v, metric.Tags[k])
+	}
+
+	for k, v := range expectedFields {
+		assert.Contains(t, metric.Fields, k)
+		assert.EqualValues(t, v, metric.Fields[k])
+	}
+}


### PR DESCRIPTION
This adds an input for [Syncthing REST API](https://docs.syncthing.net/dev/rest.html).
It creates two measurements described in detail in the README. I would like to improve
on this over time as there is much more information that would be useful, but for now
I think this covers the major parts. We can identify if a device/folder is "Out of sync".

### syncthing_folder

Tags:
 * `id` - the folder ID
 * `label` - the label (name) you have assigned to the folder
 * `path` - the sync path on the local filesystem

Fields: 
 * `paused` - if the folder is paused
 * `needed` - how many files are needed to be in sync

### syncthing_device

Tags:
 * `device_id` - the device id that is connected
 * `name` - the name of the connected device 

Fields:
 * `address` - the IP address of the connected device
 * `client_version` - the version of Syncthing that the connected device is using
 * `connected` - if the device is connected
 * `crypto` - which version of TLS the device is using for encryption
 * `in_bytes_total` - how many bytes have been received by this device
 * `out_bytes_total` - how many bytes have been sent to this device
 * `paused` - if the device connection has been paused


### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
