### PR TITLE
Feat/add stepped processor plugin

### DIFF
--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/processors/reverse_dns"
 	_ "github.com/influxdata/telegraf/plugins/processors/s2geo"
 	_ "github.com/influxdata/telegraf/plugins/processors/starlark"
+	_ "github.com/influxdata/telegraf/plugins/processors/stepped"
 	_ "github.com/influxdata/telegraf/plugins/processors/strings"
 	_ "github.com/influxdata/telegraf/plugins/processors/tag_limit"
 	_ "github.com/influxdata/telegraf/plugins/processors/template"

--- a/plugins/processors/stepped/README.md
+++ b/plugins/processors/stepped/README.md
@@ -1,10 +1,10 @@
 # Stepped Processor Plugin
 
-Insert a record for the previous unique field value and tag set just before the current one to display field as stepped. See [Step Function](https://en.wikipedia.org/wiki/Step_function). 
+Emit a metric of the previous unique field value and tag with the timestamp set just before the current one to display the field as stepped. See [Step Function](https://en.wikipedia.org/wiki/Step_function). 
 
 ## How?
 
-The stepped processor plugin caches the last field value for a set of tags. When processing, it compares the processing metrics against the cache, if a field in `unique_fields` has changed between the current value and cache, then this processor emits an addition metric that is the last value at the timestamp of the current record minus the `step_offset`. Add a metric to the cache if it has a `unique_field` and isn't already in the cache. Remove a metric from the cache if it hasn't been updated in `cache_interval`. Identical `unique_field` values will update the timestamp in the cache.
+The stepped processor plugin caches the last field value for a set of tags. When processing, it compares the processing metrics against the cache, if a field in `unique_fields` has changed between the current value and cache, then this processor emits an additional metric that is the last value at the timestamp of the current record minus the `step_offset`. Add a metric to the cache if it has a `unique_field` and isn't already in the cache. Remove a metric from the cache if it hasn't been updated in `cache_interval`. Identical `unique_field` values will update the timestamp in the cache.
 
 Note that different fields don't overwrite the cache metric and get merged. Consider the following stream:
 

--- a/plugins/processors/stepped/README.md
+++ b/plugins/processors/stepped/README.md
@@ -1,0 +1,68 @@
+# Stepped Processor Plugin
+
+Insert a record for the previous unique field value and tag set just before the current one to display field as stepped. See [Step Function](https://en.wikipedia.org/wiki/Step_function). 
+
+## How?
+
+The stepped processor plugin caches the last field value for a set of tags. When processing, it compares the processing metrics against the cache, if a field in `unique_fields` has changed between the current value and cache, then this processor emits an addition metric that is the last value at the timestamp of the current record minus the `step_offset`. If a metric with a `unique_field` isn't in the cache it is added. If a metric hasn't been seen in `cache_interval` it is removed from cache.
+
+Note that different fields don't overwrite the cache metric and get merged. Consider the following stream:
+
+```
+m1,tag1=1 value=0  1600000000000000000
+m1,tag1=1 temp=295 1600000001000000000
+```
+
+The cache would update on the second metric to include the field from the first.
+
+```diff
+- m1,tag1=1 value=0          1600000000000000000
++ m1,tag1=1 value=0,temp=295 1600000001000000000
+```
+
+## Properties
+
+| Property       | Description                                                                                                                                 |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| unique_fields  | The fields to compare when stepping the signal, the stepped plugin will only emit a stepped metric if a value in this field(s) has changed. |
+| step_offset    | The duration from the current record to step back from                                                                                      |
+| cache_interval | How long to cache the last value for, before purging. Used to drop stale metrics.                                                           |
+
+
+## Typical Use Cases
+
+The use case for a stepped function is for fields that cannot be interpolated by default. Examples include strings, booleans, and storing states/levels as integers.
+
+### Configuration
+
+```toml
+[[processors.stepped]]
+	## Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+	## Unique Fields
+	unique_fields = ["value"]
+
+	## Step value offset
+	step_offset = "1ns"
+
+	## Maximum time to cache last value
+	cache_interval = "720h"
+```
+
+
+### Example
+
+```diff
+m1,tag1=1 value=0 1600000000000000000
++ m1,tag1=1 value=0 1609999999999999999
+m1,tag1=1 value=1 1610000000000000000
+```
+
+As Graph
+
+```
+    __             __
+   ╱              |
+  ╱       ->      |
+_╱             ___|
+```

--- a/plugins/processors/stepped/README.md
+++ b/plugins/processors/stepped/README.md
@@ -4,7 +4,7 @@ Insert a record for the previous unique field value and tag set just before the 
 
 ## How?
 
-The stepped processor plugin caches the last field value for a set of tags. When processing, it compares the processing metrics against the cache, if a field in `unique_fields` has changed between the current value and cache, then this processor emits an addition metric that is the last value at the timestamp of the current record minus the `step_offset`. If a metric with a `unique_field` isn't in the cache it is added. If a metric hasn't been seen in `cache_interval` it is removed from cache.
+The stepped processor plugin caches the last field value for a set of tags. When processing, it compares the processing metrics against the cache, if a field in `unique_fields` has changed between the current value and cache, then this processor emits an addition metric that is the last value at the timestamp of the current record minus the `step_offset`. Add a metric to the cache if it has a `unique_field` and isn't already in the cache. Remove a metric from the cache if it hasn't been updated in `cache_interval`. Identical `unique_field` values will update the timestamp in the cache.
 
 Note that different fields don't overwrite the cache metric and get merged. Consider the following stream:
 

--- a/plugins/processors/stepped/README.md
+++ b/plugins/processors/stepped/README.md
@@ -66,3 +66,10 @@ As Graph
   ╱       ->      |
 _╱             ___|
 ```
+
+## Contact
+
+- Author: Tom Hollingworth
+- Email: tom.hollingworth@spruiktec.com
+- Github: [@tomhollingworth](https://github.com/tomhollingworth)
+- Influx Community Slack: [@tomhollingworth](https://influxcommunity.slack.com)

--- a/plugins/processors/stepped/stepped.go
+++ b/plugins/processors/stepped/stepped.go
@@ -1,0 +1,169 @@
+package stepped
+
+import (
+	"sort"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+var sampleConfig = `
+	## Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+	## Unique Fields
+	unique_fields = ["value"]
+
+	## Step value offset
+	step_offset = "1ns"
+
+	## Maximum time to cache last value
+	cache_interval = "720h"
+`
+
+type Stepped struct {
+	Fields         []string          `toml:"unique_fields"`
+	StepOffset     string            `toml:"step_offset"`
+	RetainInterval internal.Duration `toml:"cache_interval"`
+	FlushTime      time.Time
+	Cache          map[uint64]telegraf.Metric
+	Dur            time.Duration
+}
+
+func (d *Stepped) Init() error {
+	dur, err := time.ParseDuration(d.StepOffset)
+
+	if dur.Nanoseconds() > 0 {
+		dur = dur * -1
+	}
+	if err != nil {
+		return err
+	}
+	d.Dur = dur
+	return nil
+}
+
+func (d *Stepped) SampleConfig() string {
+	return sampleConfig
+}
+
+func (d *Stepped) Description() string {
+	return "Insert a record for the previous unique field value and tag set just before the current one to display field as stepped."
+}
+
+// Remove single item from slice
+func remove(slice []telegraf.Metric, i int) []telegraf.Metric {
+	slice[len(slice)-1], slice[i] = slice[i], slice[len(slice)-1]
+	return slice[:len(slice)-1]
+}
+
+// Remove expired items from cache
+func (d *Stepped) cleanup() {
+	// No need to cleanup cache too often. Lets save some CPU
+	if time.Since(d.FlushTime) < d.RetainInterval.Duration {
+		return
+	}
+	d.FlushTime = time.Now()
+	keep := make(map[uint64]telegraf.Metric, 0)
+	for id, metric := range d.Cache {
+		if time.Since(metric.Time()) < d.RetainInterval.Duration {
+			keep[id] = metric
+		}
+	}
+	d.Cache = keep
+}
+
+// Save item to cache
+func (d *Stepped) save(metric telegraf.Metric, id uint64) {
+	d.Cache[id] = metric.Copy()
+}
+
+// Remove item from cache
+func (d *Stepped) remove(id uint64) {
+	d.Cache[id].Drop()
+}
+
+// Check if string in list of strings
+func contains(s []string, searchterm string) bool {
+	i := sort.SearchStrings(s, searchterm)
+	return i < len(s) && s[i] == searchterm
+}
+
+// Apply the main processing method
+func (d *Stepped) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
+	steppedMetrics := []telegraf.Metric{}
+	for _, metric := range metrics {
+		id := metric.HashID()
+		m, ok := d.Cache[id]
+
+		// If not in cache then just save it
+		if !ok {
+			d.save(metric, id)
+			continue
+		}
+
+		// If cache item has expired then remove it
+		if time.Since(m.Time()) >= d.RetainInterval.Duration {
+			d.remove(id)
+			continue
+		}
+
+		// Otherwise lets refresh this cache value
+		m.SetTime(metric.Time())
+
+		// For each field compare value with the cached one
+		changedFields := []string{}
+		for _, f := range metric.FieldList() {
+			found := contains(d.Fields, f.Key)
+			if found {
+				// Found check if value has changed
+				if value, ok := m.GetField(f.Key); ok {
+					if value != f.Value {
+						// Record this has changed
+						changedFields = append(changedFields, f.Key)
+						break
+					}
+				} else {
+					// This field isn't in the cached metric but it's the
+					// same series and timestamp. Merge it into the cached
+					// metric.
+					m.AddField(f.Key, f.Value)
+				}
+			}
+		}
+		// If any field value has changed then refresh the cache
+		if len(changedFields) > 0 {
+			steppedMetric := m.Copy()
+
+			for _, f := range m.FieldList() {
+				found := contains(changedFields, f.Key)
+				if !found {
+					// Remove from stepped Metric
+					steppedMetric.RemoveField(f.Key)
+				} else {
+					// Update Cache
+					if value, ok := metric.GetField(f.Key); ok {
+						m.AddField(f.Key, value)
+					}
+				}
+			}
+			steppedMetric.SetTime(steppedMetric.Time().Add(d.Dur))
+			steppedMetric.Accept()
+			steppedMetrics = append(steppedMetrics, steppedMetric)
+		}
+
+		d.save(m, id)
+	}
+	d.cleanup()
+	return append(steppedMetrics, metrics...)
+}
+
+func init() {
+	processors.Add("stepped", func() telegraf.Processor {
+		return &Stepped{
+			FlushTime: time.Now(),
+			Cache:     make(map[uint64]telegraf.Metric),
+		}
+	})
+}

--- a/plugins/processors/stepped/stepped.go
+++ b/plugins/processors/stepped/stepped.go
@@ -49,7 +49,7 @@ func (d *Stepped) SampleConfig() string {
 }
 
 func (d *Stepped) Description() string {
-	return "Insert a record for the previous unique field value and tag set just before the current one to display field as stepped."
+	return "Emit a metric of the previous unique field value and tag with the timestamp set just before the current one to display the field as stepped."
 }
 
 // Remove single item from slice

--- a/plugins/processors/stepped/stepped_test.go
+++ b/plugins/processors/stepped/stepped_test.go
@@ -1,0 +1,352 @@
+package stepped
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/metric"
+)
+
+func createMetric(name string, value int64, when time.Time) telegraf.Metric {
+	m, _ := metric.New(name,
+		map[string]string{"tag": "tag_value"},
+		map[string]interface{}{"value": value},
+		when,
+	)
+	return m
+}
+
+func createStepped(initTime time.Time, fields []string) Stepped {
+	result := Stepped{
+		Fields:         fields,
+		FlushTime:      initTime,
+		StepOffset:     "1ns",
+		RetainInterval: internal.Duration{Duration: 30 * 24 * time.Hour},
+		Cache:          make(map[uint64]telegraf.Metric),
+	}
+
+	err := result.Init()
+
+	if err != nil {
+		panic(err)
+	}
+
+	return result
+}
+
+// Check if field list contains a key
+func assertFieldListContainsKey(t *testing.T, fieldList []*telegraf.Field, searchterm string) {
+	found := false
+	for _, f := range fieldList {
+		if searchterm == f.Key {
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+}
+
+func assertCacheRefresh(t *testing.T, proc *Stepped, item telegraf.Metric) {
+	id := item.HashID()
+	name := item.Name()
+	// cache is not empty
+	require.NotEqual(t, 0, len(proc.Cache))
+	// cache has metric with proper id
+	cache, present := proc.Cache[id]
+	require.True(t, present)
+	// cache has metric with proper name
+	require.Equal(t, name, cache.Name())
+	// cached metric has proper field
+	cValue, present := cache.GetField("value")
+	require.True(t, present)
+	iValue, _ := item.GetField("value")
+	require.Equal(t, cValue, iValue)
+	// cached metric has proper timestamp
+	require.Equal(t, cache.Time(), item.Time())
+}
+
+func assertCacheHit(t *testing.T, proc *Stepped, item telegraf.Metric) {
+	id := item.HashID()
+	name := item.Name()
+	// cache is not empty
+	require.NotEqual(t, 0, len(proc.Cache))
+	// cache has metric with proper id
+	cache, present := proc.Cache[id]
+	require.True(t, present)
+	// cache has metric with proper name
+	require.Equal(t, name, cache.Name())
+	// cached metric has proper field
+	cValue, present := cache.GetField("value")
+	require.True(t, present)
+	iValue, _ := item.GetField("value")
+	require.Equal(t, cValue, iValue)
+	// cached metric did NOT change timestamp
+	require.NotEqual(t, cache.Time(), item.Time())
+}
+
+func assertMetricStepped(t *testing.T, proc *Stepped, items []telegraf.Metric) {
+	// At Least 2 metrics
+	require.Greater(t, len(items), 1)
+
+	firstMetric := items[0]
+	secondMetric := items[1]
+
+	// Check Metric Name & Tags
+	require.Equal(t, firstMetric.Name(), secondMetric.Name(), "Metric names should match")
+	require.Equal(t, firstMetric.TagList(), secondMetric.TagList(), "Metric tags should match")
+
+	// Check Fields Don't Match
+	require.NotEqual(t, firstMetric.FieldList(), secondMetric.FieldList(), "Metric fields should not match")
+
+	// Check for Field Unique
+	for _, f := range proc.Fields {
+		assertFieldListContainsKey(t, firstMetric.FieldList(), f)
+		assertFieldListContainsKey(t, secondMetric.FieldList(), f)
+	}
+
+	// Check Timestamp off by offset
+	firstMetricTime := secondMetric.Time().Add(proc.Dur)
+	require.True(t, firstMetricTime.Equal(firstMetric.Time()))
+}
+
+func assertNotMetricStepped(t *testing.T, proc *Stepped, items []telegraf.Metric) {
+	// At Least 2 metrics
+	require.LessOrEqual(t, len(items), 1)
+}
+
+func assertMetricPassed(t *testing.T, target []telegraf.Metric, source telegraf.Metric) {
+	// target is not empty
+	require.NotEqual(t, 0, len(target))
+	// target has metric with proper name
+	require.Equal(t, "m1", target[0].Name())
+	// target metric has proper field
+	tValue, present := target[0].GetField("value")
+	require.True(t, present)
+	sValue, present := source.GetField("value")
+	require.Equal(t, tValue, sValue)
+	// target metric has proper timestamp
+	require.Equal(t, target[0].Time(), source.Time())
+}
+
+func assertMetricSuppressed(t *testing.T, target []telegraf.Metric, source telegraf.Metric) {
+	// target is empty
+	require.Equal(t, 0, len(target))
+}
+
+func TestStepped_ProcRetainsMetric(t *testing.T) {
+	stepped := createStepped(time.Now(), []string{"value"})
+	source := createMetric("m1", 1, time.Now())
+	target := stepped.Apply(source)
+
+	assertCacheRefresh(t, &stepped, source)
+	assertMetricPassed(t, target, source)
+}
+
+func TestStepped_RepeatedValueUpdatesCache(t *testing.T) {
+	stepped := createStepped(time.Now(), []string{"value"})
+	// Create metric in the past
+	source := createMetric("m1", 1, time.Now().Add(-1*time.Second))
+	target := stepped.Apply(source)
+	source = createMetric("m1", 1, time.Now())
+	target = stepped.Apply(source)
+
+	assertCacheRefresh(t, &stepped, source)
+	assertMetricPassed(t, target, source)
+}
+
+func TestStepped_SingleStepped(t *testing.T) {
+	stepped := createStepped(time.Now(), []string{"value"})
+	ts1 := createMetric("m1", 1, time.Now())
+	target := stepped.Apply(ts1)
+
+	assertCacheRefresh(t, &stepped, ts1)
+
+	ts2 := createMetric("m1", 2, time.Now())
+	target = stepped.Apply(ts2)
+
+	assertCacheRefresh(t, &stepped, ts2)
+	assertMetricStepped(t, &stepped, target)
+}
+
+func TestStepped_PassAfterCacheExpire(t *testing.T) {
+	stepped := createStepped(time.Now(), []string{"value"})
+	// Create metric in the past
+	source := createMetric("m1", 1, time.Now())
+	target := stepped.Apply(source)
+
+	source = createMetric("m1", 1, time.Now().Add(-90*24*time.Hour))
+	target = stepped.Apply(source)
+	assertMetricPassed(t, target, source)
+
+	source = createMetric("m1", 2, time.Now())
+	target = stepped.Apply(source)
+
+	assertNotMetricStepped(t, &stepped, target)
+}
+
+func TestStepped_CacheRetainsMetrics(t *testing.T) {
+	stepped := createStepped(time.Now(), []string{"value"})
+	// Create metric in the past 3sec
+	source := createMetric("m1", 1, time.Now().Add(-3*time.Hour))
+	stepped.Apply(source)
+	// Create metric in the past 2sec
+	source = createMetric("m1", 1, time.Now().Add(-2*time.Hour))
+	stepped.Apply(source)
+	source = createMetric("m1", 1, time.Now())
+	stepped.Apply(source)
+
+	assertCacheRefresh(t, &stepped, source)
+}
+
+func TestStepped_CacheShrink(t *testing.T) {
+	// Time offset is more than 2 * RetainInterval
+	stepped := createStepped(time.Now().Add(-60*24*time.Hour), []string{"value"})
+	// Time offset is more than 1 * RetainInterval
+	source := createMetric("m1", 1, time.Now().Add(-30*24*time.Hour))
+	stepped.Apply(source)
+
+	require.Equal(t, 0, len(stepped.Cache))
+}
+
+func TestStepped_SameTimestamp(t *testing.T) {
+	now := time.Now()
+	stepped := createStepped(now, []string{"foo"})
+	var in telegraf.Metric
+	var out []telegraf.Metric
+
+	in, _ = metric.New("metric",
+		map[string]string{"tag": "value"},
+		map[string]interface{}{"foo": 1}, // field
+		now,
+	)
+	out = stepped.Apply(in)
+	require.Equal(t, []telegraf.Metric{in}, out) // pass
+
+	in, _ = metric.New("metric",
+		map[string]string{"tag": "value"},
+		map[string]interface{}{"bar": 1}, // different field
+		now,
+	)
+	out = stepped.Apply(in)
+	require.Equal(t, []telegraf.Metric{in}, out) // pass
+
+	in, _ = metric.New("metric",
+		map[string]string{"tag": "value"},
+		map[string]interface{}{"bar": 2}, // same field different value
+		now,
+	)
+	out = stepped.Apply(in)
+	require.Equal(t, []telegraf.Metric{in}, out) // pass
+
+	in, _ = metric.New("metric",
+		map[string]string{"tag": "value"},
+		map[string]interface{}{"bar": 2}, // same field same value
+		now,
+	)
+	out = stepped.Apply(in)
+	require.Equal(t, []telegraf.Metric{in}, out) // pass
+}
+
+func TestStepped_LotsOfTagsAndFields(t *testing.T) {
+	now := time.Now()
+	stepped := createStepped(time.Now(), []string{"value"})
+	tags := make(map[string]string)
+	tags["host"] = "user-Virtual-Machine"
+	tags["topic"] = "Site/Area/Line/Status/StateCurrent"
+	fields := make(map[string]interface{})
+	fields["value"] = "Idle"
+	fields["lower"] = 10
+	source, _ := metric.New("mqtt_consumer", tags, fields, now.Add(-1*time.Minute))
+	stepped.Apply(source)
+	fields["value"] = "Starting"
+	fields["lower"] = 10
+
+	source, _ = metric.New("mqtt_consumer", tags, fields, now)
+	target := stepped.Apply(source)
+
+	assertMetricStepped(t, &stepped, target)
+
+}
+
+func TestStepped_MergedMetric(t *testing.T) {
+	t1 := time.Date(2020, 10, 20, 8, 0, 0, 0, time.UTC)
+	t2 := time.Date(2020, 10, 20, 9, 0, 0, 0, time.UTC)
+	t3 := time.Date(2020, 10, 20, 10, 0, 0, 0, time.UTC)
+
+	stepped := createStepped(t1, []string{"value1", "value2"})
+
+	in1, _ := metric.New("metric",
+		map[string]string{"tag": "value"},
+		map[string]interface{}{"value1": 1},
+		t1,
+	)
+	in2, _ := metric.New("metric",
+		map[string]string{"tag": "value"},
+		map[string]interface{}{"value2": 2},
+		t2,
+	)
+	in3, _ := metric.New("metric",
+		map[string]string{"tag": "value"},
+		map[string]interface{}{"value1": 2},
+		t3,
+	)
+	target := stepped.Apply(in1)
+	target = stepped.Apply(in2)
+
+	// Assert Cache Contains both values
+	id := in1.HashID()
+	name := in1.Name()
+	require.Equal(t, id, in2.HashID())
+	require.Equal(t, name, in2.Name())
+
+	require.Equal(t, 1, len(stepped.Cache))
+	// cache has metric with proper id
+	cache, present := stepped.Cache[id]
+	require.True(t, present)
+	// cache has metric with proper name
+	require.Equal(t, name, cache.Name())
+	// cached metric has proper field
+	cValue, present := cache.GetField("value1")
+	require.True(t, present)
+	iValue, _ := in1.GetField("value1")
+	require.Equal(t, cValue, iValue)
+	cValue, present = cache.GetField("value2")
+	require.True(t, present)
+	iValue, _ = in2.GetField("value2")
+	require.Equal(t, cValue, iValue)
+	// cached metric has proper timestamp
+	log.Printf("%s = %s\n", in2.Time(), cache.Time())
+	require.Equal(t, cache.Time(), in2.Time())
+
+	target = stepped.Apply(in3)
+
+	// Asset Stepped
+	require.Equal(t, 2, len(target))
+	cache, present = stepped.Cache[id]
+	require.True(t, present)
+	// cache has metric with proper name
+	require.Equal(t, name, cache.Name())
+
+	require.Equal(t, cache.Time(), in3.Time())
+	// cached metric has proper field
+	cValue, present = cache.GetField("value1")
+	require.True(t, present)
+	iValue, _ = in3.GetField("value1")
+	require.Equal(t, cValue, iValue)
+	cValue, present = cache.GetField("value2")
+	require.True(t, present)
+	iValue, _ = in2.GetField("value2")
+	require.Equal(t, cValue, iValue)
+
+	// Target has old field
+	m1 := target[0]
+	cValue, present = m1.GetField("value1")
+	require.True(t, present)
+	iValue, _ = in1.GetField("value1")
+	require.Equal(t, cValue, iValue)
+}


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.

## What?

This pull request is for a community contributed processor plugin. It emits a metric of the previous unique field value and tag set with the timestamp just before the current one to display field as stepped. See [Step Function](https://en.wikipedia.org/wiki/Step_function).

## Why?

Some metrics are discrete by nature, for example string or boolean fields. When querying and visualizing data downstream it is advantageous to know the previous value on stepped metrics for calculations and visualization. Whilst this could be considered part of the visualization effort and query effort, those responsible parties for capturing the data in the first place are better situated to indicate that a metric is stepped or not.

## How?

The stepped processor plugin caches the last field value for a set of tags. When processing, it compares the processing metrics against the cache, if a field in `unique_fields` has changed between the current value and cache, then this processor emits an addition metric that is the last value at the timestamp of the current record minus the `step_offset`. Add a metric to the cache if it has a `unique_field` and isn't already in the cache. Remove a metric from the cache if it hasn't been updated in `cache_interval`. Identical `unique_field` values will update the timestamp in the cache.