### PR TITLE
Disable RAS input plugin on specific Linux architectures: mips64, mips64le, ppc64le, riscv64 (#8317)

### DIFF
--- a/plugins/inputs/ras/README.md
+++ b/plugins/inputs/ras/README.md
@@ -1,6 +1,6 @@
 # RAS Daemon Input Plugin
 
-This plugin is only available on Linux.
+This plugin is only available on Linux (only for `386`, `amd64`, `arm` and `arm64` architectures).
 
 The `RAS` plugin gathers and counts errors provided by [RASDaemon](https://github.com/mchehab/rasdaemon).
 

--- a/plugins/inputs/ras/ras.go
+++ b/plugins/inputs/ras/ras.go
@@ -1,4 +1,5 @@
-// +build linux,!mips,!mipsle,!s390x
+// +build linux
+// +build 386 amd64 arm arm64
 
 package ras
 

--- a/plugins/inputs/ras/ras_notlinux.go
+++ b/plugins/inputs/ras/ras_notlinux.go
@@ -1,3 +1,3 @@
-// +build !linux mips mipsle s390x
+// +build !linux linux,!386,!amd64,!arm,!arm64
 
 package ras

--- a/plugins/inputs/ras/ras_test.go
+++ b/plugins/inputs/ras/ras_test.go
@@ -1,4 +1,5 @@
-// +build linux,!mips,!mipsle,!s390x
+// +build linux
+// +build 386 amd64 arm arm64
 
 package ras
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Solves: https://github.com/influxdata/telegraf/issues/8311

RAS plugin runs only for Linux `386`, `amd64`, `arm` and `arm64` platforms. This PR reflects that and corrects build tags.