### PR TITLE
SQL Server - server_properties added sql_version_desc

### DIFF
--- a/plugins/inputs/sqlserver/azuresqlqueries.go
+++ b/plugins/inputs/sqlserver/azuresqlqueries.go
@@ -677,6 +677,7 @@ SELECT TOP 1
 	,cast(([reserved_storage_mb] - [storage_space_used_mb]) as bigint) AS [available_storage_mb]
 	,(SELECT DATEDIFF(MINUTE,[sqlserver_start_time],GETDATE()) from sys.dm_os_sys_info) as [uptime]
 	,SERVERPROPERTY('ProductVersion') AS [sql_version]
+	,LEFT(@@VERSION,CHARINDEX(' - ',@@VERSION)) AS [sql_version_desc]
 	,[db_online]
 	,[db_restoring]
 	,[db_recovering]

--- a/plugins/inputs/sqlserver/sqlserverqueries.go
+++ b/plugins/inputs/sqlserver/sqlserverqueries.go
@@ -216,6 +216,7 @@ SELECT
 	,CAST(SERVERPROPERTY(''EngineEdition'') AS int) AS [engine_edition]
 	,DATEDIFF(MINUTE,si.[sqlserver_start_time],GETDATE()) AS [uptime]
 	,SERVERPROPERTY(''ProductVersion'') AS [sql_version]
+	,LEFT(@@VERSION,CHARINDEX(' - ',@@VERSION)) AS [sql_version_desc]
 	,dbs.[db_online]
 	,dbs.[db_restoring]
 	,dbs.[db_recovering]


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

Closes #8252

adds a new tag with the readable value of the SQL Server Version. (in addition to the already existing numeric version number)
The tag will be added for On-prem and Azure Managed Instance