### PR TITLE
proxmox: ignore QEMU templates and iron out a few bugs

### DIFF
--- a/plugins/inputs/proxmox/README.md
+++ b/plugins/inputs/proxmox/README.md
@@ -11,8 +11,8 @@ Telegraf minimum version: Telegraf 1.16.0
   ## API connection configuration. The API token was introduced in Proxmox v6.2. Required permissions for user and token: PVEAuditor role on /.
   base_url = "https://localhost:8006/api2/json"
   api_token = "USER@REALM!TOKENID=UUID"
-  ## Optional node name config
-  # node_name = "localhost"
+  ## Node name, defaults to OS hostname
+  # node_name = ""
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/proxmox/proxmox_test.go
+++ b/plugins/inputs/proxmox/proxmox_test.go
@@ -1,12 +1,13 @@
 package proxmox
 
 import (
-	"github.com/bmizerany/assert"
-	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/bmizerany/assert"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 var nodeSearchDomainTestData = `{"data":{"search":"test.example.com","dns1":"1.0.0.1"}}`

--- a/plugins/inputs/proxmox/structs.go
+++ b/plugins/inputs/proxmox/structs.go
@@ -2,11 +2,12 @@ package proxmox
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/url"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/common/tls"
-	"net/http"
-	"net/url"
 )
 
 type Proxmox struct {
@@ -57,6 +58,7 @@ type VmConfig struct {
 	Data struct {
 		Searchdomain string `json:"searchdomain"`
 		Hostname     string `json:"hostname"`
+		Template     int    `json:"template"`
 	} `json:"data"`
 }
 


### PR DESCRIPTION
### Changes
- Ignore QEMU templates
- Fix logger calls (`Error` -> `Errorf`)
- Changed confusing error `node_name not found` to `search domain is not set`
- Fix creator to return a pointer to new struct on every call (now it uses the same struct every time, which results in gathering only the last input of proxmox in the configuration)
- Updated README.md to acknowledge the default value of `node_name`

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
