### PR TITLE
Add setting to enable caching in ipmitool

### DIFF
--- a/plugins/inputs/ipmi_sensor/README.md
+++ b/plugins/inputs/ipmi_sensor/README.md
@@ -68,6 +68,7 @@ Any of the following parameters will be added to the aformentioned query if they
   # use_cache = false
 
   ## Path to the ipmitools cache file (defaults to OS temp dir)
+  ## The provided path must exist and must be writable
   # cache_path = ""
 ```
 

--- a/plugins/inputs/ipmi_sensor/README.md
+++ b/plugins/inputs/ipmi_sensor/README.md
@@ -61,12 +61,13 @@ Any of the following parameters will be added to the aformentioned query if they
 
   ## Optionally provide the hex key for the IMPI connection.
   # hex_key = ""
+
   ## If ipmitool should use a cache
   ## for me ipmitool runs about 2 to 10 times faster with cache enabled on HP G10 servers (when using ubuntu20.04)
-  ## the cache file may not work well for you if some sensensors come up late
+  ## the cache file may not work well for you if some sensors come up late
   # use_cache = true
-  
-  ## Path to the ipmitools cache file (defaults to OS temp dir)	  ## Path to the ipmitools cache file (defaults to OS temp dir e.g. /tmp)
+
+  ## Path to the ipmitools cache file (defaults to OS temp dir)
   # cache_path = ""
 ```
 

--- a/plugins/inputs/ipmi_sensor/README.md
+++ b/plugins/inputs/ipmi_sensor/README.md
@@ -61,6 +61,11 @@ Any of the following parameters will be added to the aformentioned query if they
 
   ## Optionally provide the hex key for the IMPI connection.
   # hex_key = ""
+  ## If ipmitool should use a cache
+  use_cache = true
+
+  ## Path to the ipmitools cache file (defaults to OS temp dir)
+  cache_path = "/tmp"
 ```
 
 ### Measurements

--- a/plugins/inputs/ipmi_sensor/README.md
+++ b/plugins/inputs/ipmi_sensor/README.md
@@ -65,7 +65,7 @@ Any of the following parameters will be added to the aformentioned query if they
   ## If ipmitool should use a cache
   ## for me ipmitool runs about 2 to 10 times faster with cache enabled on HP G10 servers (when using ubuntu20.04)
   ## the cache file may not work well for you if some sensors come up late
-  # use_cache = true
+  # use_cache = false
 
   ## Path to the ipmitools cache file (defaults to OS temp dir)
   # cache_path = ""

--- a/plugins/inputs/ipmi_sensor/README.md
+++ b/plugins/inputs/ipmi_sensor/README.md
@@ -62,10 +62,12 @@ Any of the following parameters will be added to the aformentioned query if they
   ## Optionally provide the hex key for the IMPI connection.
   # hex_key = ""
   ## If ipmitool should use a cache
-  use_cache = true
-
-  ## Path to the ipmitools cache file (defaults to OS temp dir)
-  cache_path = "/tmp"
+  ## for me ipmitool runs about 2 to 10 times faster with cache enabled on HP G10 servers (when using ubuntu20.04)
+  ## the cache file may not work well for you if some sensensors come up late
+  # use_cache = true
+  
+  ## Path to the ipmitools cache file (defaults to OS temp dir)	  ## Path to the ipmitools cache file (defaults to OS temp dir e.g. /tmp)
+  # cache_path = ""
 ```
 
 ### Measurements

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 	"os"
+	"path/filepath"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
@@ -76,8 +77,8 @@ var sampleConfig = `
   ## If ipmitool should use a cache
   use_cache = true
 
-  ## Path to the ipmitools cache file
-  cache_path = "/tmp/"
+  ## Path to the ipmitools cache file (defaults to OS temp dir)
+  cache_path = "/tmp"
 `
 
 // SampleConfig returns the documentation about the sample configuration
@@ -129,7 +130,7 @@ func (m *Ipmi) parse(acc telegraf.Accumulator, server string) error {
 	}
 	opts = append(opts, "sdr")
 	if m.UseCache {
-		cacheFile := m.CachePath + "/" + server + "_ipmi_cache"
+		cacheFile := filepath.Join(m.CachePath, server + "_ipmi_cache")
 		_, err := os.Stat(cacheFile)
 		if os.IsNotExist(err) {
 			dumpOpts := opts
@@ -328,7 +329,7 @@ func init() {
 	}
 	m.Timeout = internal.Duration{Duration: time.Second * 20}
 	m.UseCache = true
-	m.CachePath = "/tmp"
+	m.CachePath = os.TempDir()
 	inputs.Add("ipmi_sensor", func() telegraf.Input {
 		m := m
 		return &m

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -5,14 +5,14 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-	"os"
-	"path/filepath"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
@@ -132,7 +132,7 @@ func (m *Ipmi) parse(acc telegraf.Accumulator, server string) error {
 	}
 	opts = append(opts, "sdr")
 	if m.UseCache {
-		cacheFile := filepath.Join(m.CachePath, server + "_ipmi_cache")
+		cacheFile := filepath.Join(m.CachePath, server+"_ipmi_cache")
 		_, err := os.Stat(cacheFile)
 		if os.IsNotExist(err) {
 			dumpOpts := opts

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -77,7 +77,7 @@ var sampleConfig = `
   ## If ipmitool should use a cache
   ## for me ipmitool runs about 2 to 10 times faster with cache enabled on HP G10 servers (when using ubuntu20.04)
   ## the cache file may not work well for you if some sensors come up late
-  # use_cache = true
+  # use_cache = false
 
   ## Path to the ipmitools cache file (defaults to OS temp dir)
   # cache_path = ""
@@ -329,7 +329,7 @@ func init() {
 		m.Path = path
 	}
 	m.Timeout = internal.Duration{Duration: time.Second * 20}
-	m.UseCache = true
+	m.UseCache = false
 	m.CachePath = os.TempDir()
 	inputs.Add("ipmi_sensor", func() telegraf.Input {
 		m := m

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -75,10 +75,12 @@ var sampleConfig = `
   # hex_key = ""
 
   ## If ipmitool should use a cache
-  use_cache = true
+  ## for me ipmitool runs about 2 to 10 times faster enabled on HP G10 servers (when using ubuntu20.04)
+  ## the cache file may not work well for you if some sensensors come up late
+  # use_cache = true
 
-  ## Path to the ipmitools cache file (defaults to OS temp dir)
-  cache_path = "/tmp"
+  ## Path to the ipmitools cache file (defaults to OS temp dir)	  ## Path to the ipmitools cache file (defaults to OS temp dir e.g. /tmp)
+  # cache_path = ""
 `
 
 // SampleConfig returns the documentation about the sample configuration
@@ -149,7 +151,6 @@ func (m *Ipmi) parse(acc telegraf.Accumulator, server string) error {
 				return fmt.Errorf("failed to run command %s: %s - %s", strings.Join(cmd.Args, " "), err, string(out))
 			}
 		}
-		// -S /tmp/cache_file speeds up ipmitool runs (by 2 to 10 times on HP servers)
 		opts = append(opts, "-S")
 		opts = append(opts, cacheFile)
 	}

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -75,11 +75,11 @@ var sampleConfig = `
   # hex_key = ""
 
   ## If ipmitool should use a cache
-  ## for me ipmitool runs about 2 to 10 times faster enabled on HP G10 servers (when using ubuntu20.04)
-  ## the cache file may not work well for you if some sensensors come up late
+  ## for me ipmitool runs about 2 to 10 times faster with cache enabled on HP G10 servers (when using ubuntu20.04)
+  ## the cache file may not work well for you if some sensors come up late
   # use_cache = true
 
-  ## Path to the ipmitools cache file (defaults to OS temp dir)	  ## Path to the ipmitools cache file (defaults to OS temp dir e.g. /tmp)
+  ## Path to the ipmitools cache file (defaults to OS temp dir)
   # cache_path = ""
 `
 

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -80,6 +80,7 @@ var sampleConfig = `
   # use_cache = false
 
   ## Path to the ipmitools cache file (defaults to OS temp dir)
+  ## The provided path must exist and must be writable
   # cache_path = ""
 `
 


### PR DESCRIPTION
I had the issue that ipmi data was reported with gaps on a 30s interval on HP G10 servers (latest firmware).
The gaps where due to the ipmitool command was not always finishing within the 20s timeout. Even changeing the timeout to 30s was not always giving it enough time to respond.
ipmi-sensors from freeipmi tools which is used in some prometheus ipmi exporters is running way faster but does not provide all information I needed.
At some point I just realized there is a cache option for ipmitool. Using this option speeds the tool up by something between 3x and 6x for most of my runs so it holds the deadline given by timeout and I can record the data not even in 30s intervals but also now in 15s intervals.

In case you merge this or agree with it, I would appreciate a hacktoberfest-accepted label.

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
