### PR TITLE
fix plugins/input/ras test

### DIFF
--- a/plugins/inputs/ras/ras_test.go
+++ b/plugins/inputs/ras/ras_test.go
@@ -114,7 +114,7 @@ func TestMultipleSockets(t *testing.T) {
 func TestMissingDatabase(t *testing.T) {
 	var acc testutil.Accumulator
 	ras := newRas()
-	ras.DBPath = "/tmp/test.db"
+	ras.DBPath = "/nonexistent/ras.db"
 	err := ras.Start(&acc)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
On some systems /tmp/test.db happens to exist which
makes this test fail.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
