### PR TITLE
SQL Server - SQL Requests - added s.[login_name]

### DIFF
--- a/plugins/inputs/sqlserver/azuresqlqueries.go
+++ b/plugins/inputs/sqlserver/azuresqlqueries.go
@@ -586,6 +586,7 @@ SELECT
 	,s.[program_name]
 	,s.[host_name]
 	,s.[nt_user_name]
+	,s.[login_name]
 	,COALESCE(r.[open_transaction_count], s.[open_transaction_count]) AS [open_transaction]
 	,LEFT (CASE COALESCE(r.[transaction_isolation_level], s.[transaction_isolation_level])
 		WHEN 0 THEN '0-Read Committed' 
@@ -1108,6 +1109,7 @@ SELECT
 	,s.[program_name]
 	,s.[host_name]
 	,s.[nt_user_name]
+	,s.[login_name]
 	,COALESCE(r.[open_transaction_count], s.[open_transaction_count]) AS [open_transaction]
 	,LEFT (CASE COALESCE(r.[transaction_isolation_level], s.[transaction_isolation_level])
 		WHEN 0 THEN '0-Read Committed' 

--- a/plugins/inputs/sqlserver/sqlserverqueries.go
+++ b/plugins/inputs/sqlserver/sqlserverqueries.go
@@ -1045,6 +1045,7 @@ SELECT
 	,s.[program_name]
 	,s.[host_name]
 	,s.[nt_user_name]
+	,s.[login_name]
 	,LEFT (CASE COALESCE(r.[transaction_isolation_level], s.[transaction_isolation_level])
 		WHEN 0 THEN ''0-Read Committed''
 		WHEN 1 THEN ''1-Read Uncommitted (NOLOCK)''


### PR DESCRIPTION
s.[login_name] tracks SQL and NT users, while [nt_user_name] tracks only NT users.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

Enchantment, as of now the username is not gathered if the request comes from a SQL login, as nt_user_name tracks only NT users.
login_name tracks both SQL and NT users.

@denzilribeiro do you want me to add this also for Azure queries?