### PR TITLE
Add node groups to opcua input plugin

### DIFF
--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -98,6 +98,6 @@ To gather data from this node enter the following line into the 'nodes' property
 ### Example Output
 
 ```
-opcua,name=temp,id=n\=3;s\=Temperature temp=79.0,quality="OK (0x0)" 1597820490000000000
+opcua,id=n\=3;s\=Temperature temp=79.0,quality="OK (0x0)" 1597820490000000000
 
 ```

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -10,7 +10,7 @@ Plugin minimum tested version: 1.16
 ```toml
 [[inputs.opcua]]
   ## Metric name
-  # name = "localhost"
+  # metric_name = "opcua"
   #
   ## OPC UA Endpoint URL
   # endpoint = "opc.tcp://localhost:4840"
@@ -47,15 +47,15 @@ Plugin minimum tested version: 1.16
   # password = ""
   #
   ## Node ID configuration
-  ## name       			- the variable name
-  ## namespace  			- integer value 0 thru 3
+  ## field_name			- the field name
+  ## namespace				- integer value 0 thru 3
   ## identifier_type		- s=string, i=numeric, g=guid, b=opaque
   ## identifier			- tag as shown in opcua browser
   ## Example:
   ## {name="ProductUri", namespace="0", identifier_type="i", identifier="2262"}
   nodes = [
-    {name="", namespace="", identifier_type="", identifier=""},
-    {name="", namespace="", identifier_type="", identifier=""},
+    {field_name="", namespace="", identifier_type="", identifier=""},
+    {field_name="", namespace="", identifier_type="", identifier=""},
   ]
 ```
 
@@ -66,13 +66,13 @@ An OPC UA node ID may resemble: "n=3;s=Temperature". In this example:
 - This example temperature node has a value of 79.0
 To gather data from this node enter the following line into the 'nodes' property above:
 ```
-{name="temp", namespace="3", identifier_type="s", identifier="Temperature"},
+{field_name="temp", namespace="3", identifier_type="s", identifier="Temperature"},
 ```
 
 
 ### Example Output
 
 ```
-localhost,name=temp,id=n\=3;s\=Temperature temp=79.0,quality="OK (0x0)" 1597820490000000000
+opcua,name=temp,id=n\=3;s\=Temperature temp=79.0,quality="OK (0x0)" 1597820490000000000
 
 ```

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -10,7 +10,7 @@ Plugin minimum tested version: 1.16
 ```toml
 [[inputs.opcua]]
   ## Metric name
-  # metric_name = "opcua"
+  # name = "opcua"
   #
   ## OPC UA Endpoint URL
   # endpoint = "opc.tcp://localhost:4840"
@@ -47,15 +47,15 @@ Plugin minimum tested version: 1.16
   # password = ""
   #
   ## Node ID configuration
-  ## field_name        - field name to use in the output
+  ## name              - field name to use in the output
   ## namespace         - OPC UA namespace of the node (integer value 0 thru 3)
   ## identifier_type   - OPC UA ID type (s=string, i=numeric, g=guid, b=opaque)
   ## identifier        - OPC UA ID (tag as shown in opcua browser)
   ## Example:
   ## {name="ProductUri", namespace="0", identifier_type="i", identifier="2262"}
   # nodes = [
-  #  {field_name="", namespace="", identifier_type="", identifier=""},
-  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #  {name="", namespace="", identifier_type="", identifier=""},
+  #  {name="", namespace="", identifier_type="", identifier=""},
   #]
   #
   ## Node Group
@@ -65,9 +65,9 @@ Plugin minimum tested version: 1.16
   ##
   ## Multiple node groups are allowed
   #[[inputs.opcua.group]]
-  ## Group Metric name. Overrides the top level metric_name.  If unset, the
-  ## top level metric_name is used.
-  # metric_name =
+  ## Group Metric name. Overrides the top level name.  If unset, the
+  ## top level name is used.
+  # name =
   #
   ## Group default namespace. If a node in the group doesn't set its
   ## namespace, this is used.
@@ -79,8 +79,8 @@ Plugin minimum tested version: 1.16
   #
   ## Node ID Configuration.  Array of nodes with the same settings as above.
   # nodes = [
-  #  {field_name="", namespace="", identifier_type="", identifier=""},
-  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #  {name="", namespace="", identifier_type="", identifier=""},
+  #  {name="", namespace="", identifier_type="", identifier=""},
   #]
 ```
 

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -9,7 +9,7 @@ Plugin minimum tested version: 1.16
 
 ```toml
 [[inputs.opcua]]
-  ## Device name
+  ## Metric name
   # name = "localhost"
   #
   ## OPC UA Endpoint URL
@@ -51,30 +51,28 @@ Plugin minimum tested version: 1.16
   ## namespace  			- integer value 0 thru 3
   ## identifier_type		- s=string, i=numeric, g=guid, b=opaque
   ## identifier			- tag as shown in opcua browser
-  ## data_type  			- boolean, byte, short, int, uint, uint16, int16,
-  ##                        uint32, int32, float, double, string, datetime, number
   ## Example:
-  ## {name="ProductUri", namespace="0", identifier_type="i", identifier="2262", data_type="string", description="http://open62541.org"}
+  ## {name="ProductUri", namespace="0", identifier_type="i", identifier="2262"}
   nodes = [
-    {name="", namespace="", identifier_type="", identifier="", data_type="", description=""},
-    {name="", namespace="", identifier_type="", identifier="", data_type="", description=""},
+    {name="", namespace="", identifier_type="", identifier=""},
+    {name="", namespace="", identifier_type="", identifier=""},
   ]
 ```
 
 ### Example Node Configuration
-An OPC UA node ID may resemble: "n=3,s=Temperature". In this example:
+An OPC UA node ID may resemble: "n=3;s=Temperature". In this example:
 - n=3 is indicating the `namespace` is 3
 - s=Temperature is indicting that the `identifier_type` is a string and `identifier` value is 'Temperature'
-- This example temperature node has a value of 79.0, which makes the `data_type` a 'float'.
+- This example temperature node has a value of 79.0
 To gather data from this node enter the following line into the 'nodes' property above:
 ```
-{name="LabelName", namespace="3", identifier_type="s", identifier="Temperature", data_type="float", description="Description of node"},
+{name="temp", namespace="3", identifier_type="s", identifier="Temperature"},
 ```
 
 
 ### Example Output
 
 ```
-opcua,host=3c70aee0901e,name=Random,type=double Random=0.018158170305814902 1597820490000000000
+localhost,name=temp,id=n\=3;s\=Temperature temp=79.0,quality="OK (0x0)" 1597820490000000000
 
 ```

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -47,16 +47,41 @@ Plugin minimum tested version: 1.16
   # password = ""
   #
   ## Node ID configuration
-  ## field_name			- the field name
-  ## namespace				- integer value 0 thru 3
-  ## identifier_type		- s=string, i=numeric, g=guid, b=opaque
-  ## identifier			- tag as shown in opcua browser
+  ## field_name        - field name to use in the output
+  ## namespace         - OPC UA namespace of the node (integer value 0 thru 3)
+  ## identifier_type   - OPC UA ID type (s=string, i=numeric, g=guid, b=opaque)
+  ## identifier        - OPC UA ID (tag as shown in opcua browser)
   ## Example:
   ## {name="ProductUri", namespace="0", identifier_type="i", identifier="2262"}
-  nodes = [
-    {field_name="", namespace="", identifier_type="", identifier=""},
-    {field_name="", namespace="", identifier_type="", identifier=""},
-  ]
+  # nodes = [
+  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #]
+  #
+  ## Node Group
+  ## Sets defaults for OPC UA namespace and ID type so they aren't required in
+  ## every node.  A group can also have a metric name that overrides the main
+  ## plugin metric name.
+  ##
+  ## Multiple node groups are allowed
+  #[[inputs.opcua.group]]
+  ## Group Metric name. Overrides the top level metric_name.  If unset, the
+  ## top level metric_name is used.
+  # metric_name =
+  #
+  ## Group default namespace. If a node in the group doesn't set its
+  ## namespace, this is used.
+  # namespace =
+  #
+  ## Group default identifier type. If a node in the group doesn't set its
+  ## namespace, this is used.
+  # identifier_type =
+  #
+  ## Node ID Configuration.  Array of nodes with the same settings as above.
+  # nodes = [
+  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #]
 ```
 
 ### Example Node Configuration

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -51,8 +51,9 @@ Plugin minimum tested version: 1.16
   ## namespace         - OPC UA namespace of the node (integer value 0 thru 3)
   ## identifier_type   - OPC UA ID type (s=string, i=numeric, g=guid, b=opaque)
   ## identifier        - OPC UA ID (tag as shown in opcua browser)
+  ## tags              - extra tags to be added to the output metric (optional)
   ## Example:
-  ## {name="ProductUri", namespace="0", identifier_type="i", identifier="2262"}
+  ## {name="ProductUri", namespace="0", identifier_type="i", identifier="2262", tags=[["tag1","value1"],["tag2","value2]]}
   # nodes = [
   #  {name="", namespace="", identifier_type="", identifier=""},
   #  {name="", namespace="", identifier_type="", identifier=""},
@@ -84,7 +85,7 @@ Plugin minimum tested version: 1.16
   #]
 ```
 
-### Example Node Configuration
+### Node Configuration
 An OPC UA node ID may resemble: "n=3;s=Temperature". In this example:
 - n=3 is indicating the `namespace` is 3
 - s=Temperature is indicting that the `identifier_type` is a string and `identifier` value is 'Temperature'
@@ -94,10 +95,49 @@ To gather data from this node enter the following line into the 'nodes' property
 {field_name="temp", namespace="3", identifier_type="s", identifier="Temperature"},
 ```
 
-
-### Example Output
-
+This node configuration produces a metric like this:
 ```
 opcua,id=n\=3;s\=Temperature temp=79.0,quality="OK (0x0)" 1597820490000000000
 
+```
+
+### Group Configuration
+Groups can set default values for the namespace, identifier type, and
+tags settings.  The default values apply to all the nodes in the
+group.  If a default is set, a node may omit the setting altogether.
+This simplifies node configuration, especially when many nodes share
+the same namespace or identifier type.
+
+The output metric will include tags set in the group and the node.  If
+a tag with the same name is set in both places, the tag value from the
+node is used.
+
+This example group configuration has two groups with two nodes each:
+```
+  [[inputs.opcua.group]]
+  name="group1_metric_name"
+  namespace="3"
+  identifier_type="i"
+  tags=[["group1_tag", "val1"]]
+  nodes = [
+    {name="name", identifier="1001", tags=[["node1_tag", "val2"]]},
+    {name="name", identifier="1002", tags=[["node1_tag", "val3"]]},
+  ]
+  [[inputs.opcua.group]]
+  name="group2_metric_name"
+  namespace="3"
+  identifier_type="i"
+  tags=[["group2_tag", "val3"]]
+  nodes = [
+    {name="saw", identifier="1003", tags=[["node2_tag", "val4"]]},
+    {name="sin", identifier="1004"},
+  ]
+```
+
+It produces metrics like these:
+```
+group1_metric_name,group1_tag=val1,id=ns\=3;i\=1001,node1_tag=val2 name=0,Quality="OK (0x0)" 1606893246000000000
+group1_metric_name,group1_tag=val1,id=ns\=3;i\=1002,node1_tag=val3 name=-1.389117,Quality="OK (0x0)" 1606893246000000000
+group2_metric_name,group2_tag=val3,id=ns\=3;i\=1003,node2_tag=val4 Quality="OK (0x0)",saw=-1.6 1606893246000000000
+group2_metric_name,group2_tag=val3,id=ns\=3;i\=1004 sin=1.902113,Quality="OK (0x0)" 1606893246000000000
 ```

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -50,12 +50,15 @@ type OpcUA struct {
 
 // OPCTag type
 type NodeSettings struct {
-	FieldName      string `toml:"name"`
-	Namespace      string `toml:"namespace"`
-	IdentifierType string `toml:"identifier_type"`
-	Identifier     string `toml:"identifier"`
-	DataType       string `toml:"data_type"`   // Kept for backward compatibility but was never used.
-	Description    string `toml:"description"` // Kept for backward compatibility but was never used.
+	FieldName      string     `toml:"name"`
+	Namespace      string     `toml:"namespace"`
+	IdentifierType string     `toml:"identifier_type"`
+	Identifier     string     `toml:"identifier"`
+	DataType       string     `toml:"data_type"`   // Kept for backward compatibility but was never used.
+	Description    string     `toml:"description"` // Kept for backward compatibility but was never used.
+	TagsSlice      [][]string `toml:"tags"`
+
+	tags map[string]string
 }
 
 type Node struct {
@@ -69,6 +72,7 @@ type GroupSettings struct {
 	Namespace      string         `toml:"namespace"`       // Can be overridden by node setting
 	IdentifierType string         `toml:"identifier_type"` // Can be overridden by node setting
 	Nodes          []NodeSettings `toml:"nodes"`
+	Tags           [][]string     `toml:"tags"`
 }
 
 // OPCData type

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -81,7 +81,6 @@ const (
 
 const description = `Retrieve data from OPCUA devices`
 const sampleConfig = `
-[[inputs.opcua]]
   ## Device name
   # name = "localhost"
   #

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -93,8 +93,8 @@ const (
 
 const description = `Retrieve data from OPCUA devices`
 const sampleConfig = `
-  ## Device name
-  # name = "localhost"
+  ## Metric name
+  # metric_name = "opcua"
   #
   ## OPC UA Endpoint URL
   # endpoint = "opc.tcp://localhost:4840"
@@ -131,18 +131,41 @@ const sampleConfig = `
   # password = ""
   #
   ## Node ID configuration
-  ## name       			- the variable name
-  ## namespace  			- integer value 0 thru 3
-  ## identifier_type		- s=string, i=numeric, g=guid, b=opaque
-  ## identifier			- tag as shown in opcua browser
-  ## data_type  			- boolean, byte, short, int, uint, uint16, int16,
-  ##                        uint32, int32, float, double, string, datetime, number
+  ## field_name        - field name to use in the output
+  ## namespace         - OPC UA namespace of the node (integer value 0 thru 3)
+  ## identifier_type   - OPC UA ID type (s=string, i=numeric, g=guid, b=opaque)
+  ## identifier        - OPC UA ID (tag as shown in opcua browser)
   ## Example:
-  ## {name="ProductUri", namespace="0", identifier_type="i", identifier="2262", data_type="string", description="http://open62541.org"}
-  nodes = [
-    {name="", namespace="", identifier_type="", identifier="", data_type="", description=""},
-    {name="", namespace="", identifier_type="", identifier="", data_type="", description=""},
-  ]
+  ## {name="ProductUri", namespace="0", identifier_type="i", identifier="2262"}
+  # nodes = [
+  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #]
+  #
+  ## Node Group
+  ## Sets defaults for OPC UA namespace and ID type so they aren't required in
+  ## every node.  A group can also have a metric name that overrides the main
+  ## plugin metric name.
+  ##
+  ## Multiple node groups are allowed
+  #[[inputs.opcua.group]]
+  ## Group Metric name. Overrides the top level metric_name.  If unset, the
+  ## top level metric_name is used.
+  # metric_name =
+  #
+  ## Group default namespace. If a node in the group doesn't set its
+  ## namespace, this is used.
+  # namespace =
+  #
+  ## Group default identifier type. If a node in the group doesn't set its
+  ## namespace, this is used.
+  # identifier_type =
+  #
+  ## Node ID Configuration.  Array of nodes with the same settings as above.
+  # nodes = [
+  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #]
 `
 
 // Description will appear directly above the plugin definition in the config file

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -390,7 +390,7 @@ func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
 		}
 
 		fields[o.NodeData[i].TagName] = o.NodeData[i].Value
-		fields["Quality"] = strings.TrimSpace(fmt.Sprint(o.NodeData[i].Quality))
+		fields["quality"] = strings.TrimSpace(fmt.Sprint(o.NodeData[i].Quality))
 		acc.AddFields(o.Name, fields, tags)
 	}
 	return nil

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -53,7 +53,6 @@ type OPCTag struct {
 	Namespace      string `toml:"namespace"`
 	IdentifierType string `toml:"identifier_type"`
 	Identifier     string `toml:"identifier"`
-	DataType       string `toml:"data_type"`
 	Description    string `toml:"description"`
 }
 
@@ -228,13 +227,6 @@ func (o *OpcUA) validateOPCTags() error {
 			break
 		default:
 			return fmt.Errorf("invalid identifier type '%s' in '%s'", item.IdentifierType, item.Name)
-		}
-		// search data type
-		switch item.DataType {
-		case "boolean", "byte", "short", "int", "uint", "uint16", "int16", "uint32", "int32", "float", "double", "string", "datetime", "number":
-			break
-		default:
-			return fmt.Errorf("invalid data type '%s' in '%s'", item.DataType, item.Name)
 		}
 
 		// build nodeid

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -419,8 +419,7 @@ func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
 	for i, n := range o.nodes {
 		fields := make(map[string]interface{})
 		tags := map[string]string{
-			"name": n.tag.FieldName,
-			"id":   n.idStr,
+			"id": n.idStr,
 		}
 
 		fields[o.nodeData[i].TagName] = o.nodeData[i].Value

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -54,6 +54,8 @@ type NodeSettings struct {
 	Namespace      string `toml:"namespace"`
 	IdentifierType string `toml:"identifier_type"`
 	Identifier     string `toml:"identifier"`
+	DataType       string `toml:"data_type"`   // Kept for backward compatibility but was never used.
+	Description    string `toml:"description"` // Kept for backward compatibility but was never used.
 }
 
 type Node struct {

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -18,7 +18,7 @@ import (
 
 // OpcUA type
 type OpcUA struct {
-	MetricName     string          `toml:"metric_name"`
+	MetricName     string          `toml:"name"`
 	Endpoint       string          `toml:"endpoint"`
 	SecurityPolicy string          `toml:"security_policy"`
 	SecurityMode   string          `toml:"security_mode"`
@@ -50,7 +50,7 @@ type OpcUA struct {
 
 // OPCTag type
 type NodeSettings struct {
-	FieldName      string `toml:"field_name"`
+	FieldName      string `toml:"name"`
 	Namespace      string `toml:"namespace"`
 	IdentifierType string `toml:"identifier_type"`
 	Identifier     string `toml:"identifier"`
@@ -63,7 +63,7 @@ type Node struct {
 }
 
 type GroupSettings struct {
-	MetricName     string         `toml:"metric_name"`     // Overrides plugin's setting
+	MetricName     string         `toml:"name"`            // Overrides plugin's setting
 	Namespace      string         `toml:"namespace"`       // Can be overridden by node setting
 	IdentifierType string         `toml:"identifier_type"` // Can be overridden by node setting
 	Nodes          []NodeSettings `toml:"nodes"`
@@ -94,7 +94,7 @@ const (
 const description = `Retrieve data from OPCUA devices`
 const sampleConfig = `
   ## Metric name
-  # metric_name = "opcua"
+  # name = "opcua"
   #
   ## OPC UA Endpoint URL
   # endpoint = "opc.tcp://localhost:4840"
@@ -131,15 +131,15 @@ const sampleConfig = `
   # password = ""
   #
   ## Node ID configuration
-  ## field_name        - field name to use in the output
+  ## name              - field name to use in the output
   ## namespace         - OPC UA namespace of the node (integer value 0 thru 3)
   ## identifier_type   - OPC UA ID type (s=string, i=numeric, g=guid, b=opaque)
   ## identifier        - OPC UA ID (tag as shown in opcua browser)
   ## Example:
   ## {name="ProductUri", namespace="0", identifier_type="i", identifier="2262"}
   # nodes = [
-  #  {field_name="", namespace="", identifier_type="", identifier=""},
-  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #  {name="", namespace="", identifier_type="", identifier=""},
+  #  {name="", namespace="", identifier_type="", identifier=""},
   #]
   #
   ## Node Group
@@ -149,9 +149,9 @@ const sampleConfig = `
   ##
   ## Multiple node groups are allowed
   #[[inputs.opcua.group]]
-  ## Group Metric name. Overrides the top level metric_name.  If unset, the
-  ## top level metric_name is used.
-  # metric_name =
+  ## Group Metric name. Overrides the top level name.  If unset, the
+  ## top level name is used.
+  # name =
   #
   ## Group default namespace. If a node in the group doesn't set its
   ## namespace, this is used.
@@ -163,8 +163,8 @@ const sampleConfig = `
   #
   ## Node ID Configuration.  Array of nodes with the same settings as above.
   # nodes = [
-  #  {field_name="", namespace="", identifier_type="", identifier=""},
-  #  {field_name="", namespace="", identifier_type="", identifier=""},
+  #  {name="", namespace="", identifier_type="", identifier=""},
+  #  {name="", namespace="", identifier_type="", identifier=""},
   #]
 `
 
@@ -275,11 +275,11 @@ func (o *OpcUA) validateOPCTags() error {
 	for _, node := range o.nodes {
 		//check empty name
 		if node.tag.FieldName == "" {
-			return fmt.Errorf("empty field_name in '%s'", node.tag.FieldName)
+			return fmt.Errorf("empty name in '%s'", node.tag.FieldName)
 		}
 		//search name duplicate
 		if nameEncountered[node.tag.FieldName] {
-			return fmt.Errorf("field_name '%s' is duplicated", node.tag.FieldName)
+			return fmt.Errorf("name '%s' is duplicated", node.tag.FieldName)
 		} else {
 			nameEncountered[node.tag.FieldName] = true
 		}

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -343,9 +343,8 @@ func newMP(n *Node) metricParts {
 
 func (o *OpcUA) validateOPCTags() error {
 	nameEncountered := map[metricParts]struct{}{}
-	for i := range o.nodes {
-		node := &o.nodes[i]
-		mp := newMP(node)
+	for _, node := range o.nodes {
+		mp := newMP(&node)
 		//check empty name
 		if node.tag.FieldName == "" {
 			return fmt.Errorf("empty name in '%s'", node.tag.FieldName)

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -450,7 +450,7 @@ func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
 		}
 
 		fields[o.nodeData[i].TagName] = o.nodeData[i].Value
-		fields["quality"] = strings.TrimSpace(fmt.Sprint(o.nodeData[i].Quality))
+		fields["Quality"] = strings.TrimSpace(fmt.Sprint(o.nodeData[i].Quality))
 		acc.AddFields(n.metricName, fields, tags)
 	}
 	return nil

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -307,7 +307,8 @@ func (o *OpcUA) InitNodes() error {
 
 func (o *OpcUA) validateOPCTags() error {
 	nameEncountered := map[string]bool{}
-	for _, node := range o.nodes {
+	for i := range o.nodes {
+		node := &o.nodes[i]
 		//check empty name
 		if node.tag.FieldName == "" {
 			return fmt.Errorf("empty name in '%s'", node.tag.FieldName)
@@ -480,6 +481,9 @@ func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
 		fields := make(map[string]interface{})
 		tags := map[string]string{
 			"id": n.idStr,
+		}
+		for k, v := range n.metricTags {
+			tags[k] = v
 		}
 
 		fields[o.nodeData[i].TagName] = o.nodeData[i].Value

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -53,7 +53,6 @@ type OPCTag struct {
 	Namespace      string `toml:"namespace"`
 	IdentifierType string `toml:"identifier_type"`
 	Identifier     string `toml:"identifier"`
-	Description    string `toml:"description"`
 }
 
 // OPCData type

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -88,8 +88,8 @@ auth_method = "Anonymous"
 username = ""
 password = ""
 nodes = [
-  {name="name", namespace="", identifier_type="", identifier="", description=""},
-  {name="name2", namespace="", identifier_type="", identifier="", description=""},
+  {name="name", namespace="", identifier_type="", identifier=""},
+  {name="name2", namespace="", identifier_type="", identifier=""},
 ]
 `
 

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -76,7 +76,7 @@ func MapOPCTag(tags OPCTags) (out NodeSettings) {
 func TestConfig(t *testing.T) {
 	toml := `
 [[inputs.opcua]]
-metric_name = "localhost"
+name = "localhost"
 endpoint = "opc.tcp://localhost:4840"
 connect_timeout = "10s"
 request_timeout = "5s"
@@ -88,19 +88,19 @@ auth_method = "Anonymous"
 username = ""
 password = ""
 nodes = [
-  {field_name="name", namespace="1", identifier_type="s", identifier="one"},
-  {field_name="name2", namespace="2", identifier_type="s", identifier="two"},
+  {name="name", namespace="1", identifier_type="s", identifier="one"},
+  {name="name2", namespace="2", identifier_type="s", identifier="two"},
 ]
 [[inputs.opcua.group]]
-metric_name = "foo"
+name = "foo"
 namespace = "3"
 identifier_type = "i"
-nodes = [{field_name="name3", identifier="3000"}]
+nodes = [{name="name3", identifier="3000"}]
 [[inputs.opcua.group]]
-metric_name = "bar"
+name = "bar"
 namespace = "0"
 identifier_type = "i"
-nodes = [{field_name="name4", identifier="4000"}]
+nodes = [{name="name4", identifier="4000"}]
 `
 
 	c := config.NewConfig()

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -96,6 +96,11 @@ metric_name = "foo"
 namespace = "3"
 identifier_type = "i"
 nodes = [{field_name="name3", identifier="3000"}]
+[[inputs.opcua.group]]
+metric_name = "bar"
+namespace = "0"
+identifier_type = "i"
+nodes = [{field_name="name4", identifier="4000"}]
 `
 
 	c := config.NewConfig()
@@ -111,11 +116,11 @@ nodes = [{field_name="name3", identifier="3000"}]
 	require.Equal(t, o.RootNodes[0].FieldName, "name")
 	require.Equal(t, o.RootNodes[1].FieldName, "name2")
 
-	require.Len(t, o.Groups, 1)
+	require.Len(t, o.Groups, 2)
 	require.Equal(t, o.Groups[0].MetricName, "foo")
 	require.Len(t, o.Groups[0].Nodes, 1)
 	require.Equal(t, o.Groups[0].Nodes[0].Identifier, "3000")
 
 	require.NoError(t, o.InitNodes())
-	require.Len(t, o.nodes, 3)
+	require.Len(t, o.nodes, 4)
 }

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -151,6 +151,13 @@ func TestTagsSliceToMap_dupeKey(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestTagsSliceToMap_empty(t *testing.T) {
+	_, err := tagsSliceToMap([][]string{{"foo", ""}})
+	assert.Equal(t, fmt.Errorf("tag 1 has empty value"), err)
+	_, err = tagsSliceToMap([][]string{{"", "bar"}})
+	assert.Equal(t, fmt.Errorf("tag 1 has empty name"), err)
+}
+
 func TestValidateOPCTags(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -163,18 +170,18 @@ func TestValidateOPCTags(t *testing.T) {
 				{
 					metricName: "mn",
 					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
-					metricTags: map[string]string{"t1": "", "t2": ""},
+					metricTags: map[string]string{"t1": "v1", "t2": "v2"},
 				},
 				{
 					metricName: "mn",
 					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
-					metricTags: map[string]string{"t1": "", "t2": ""},
+					metricTags: map[string]string{"t1": "v1", "t2": "v2"},
 				},
 			},
-			fmt.Errorf("name 'fn' is duplicated"),
+			fmt.Errorf("name 'fn' is duplicated (metric name 'mn', tags 't1=v1, t2=v2')"),
 		},
 		{
-			"different metric tags",
+			"different metric tag names",
 			[]Node{
 				{
 					metricName: "mn",
@@ -185,6 +192,22 @@ func TestValidateOPCTags(t *testing.T) {
 					metricName: "mn",
 					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
 					metricTags: map[string]string{"t1": "", "t3": ""},
+				},
+			},
+			nil,
+		},
+		{
+			"different metric tag values",
+			[]Node{
+				{
+					metricName: "mn",
+					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
+					metricTags: map[string]string{"t1": "foo", "t2": ""},
+				},
+				{
+					metricName: "mn",
+					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
+					metricTags: map[string]string{"t1": "bar", "t2": ""},
 				},
 			},
 			nil,

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -150,3 +150,85 @@ func TestTagsSliceToMap_dupeKey(t *testing.T) {
 	_, err := tagsSliceToMap([][]string{{"foo", "bar"}, {"foo", "bat"}})
 	assert.Error(t, err)
 }
+
+func TestValidateOPCTags(t *testing.T) {
+	tests := []struct {
+		name  string
+		nodes []Node
+		err   error
+	}{
+		{
+			"same",
+			[]Node{
+				{
+					metricName: "mn",
+					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
+					metricTags: map[string]string{"t1": "", "t2": ""},
+				},
+				{
+					metricName: "mn",
+					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
+					metricTags: map[string]string{"t1": "", "t2": ""},
+				},
+			},
+			fmt.Errorf("name 'fn' is duplicated"),
+		},
+		{
+			"different metric tags",
+			[]Node{
+				{
+					metricName: "mn",
+					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
+					metricTags: map[string]string{"t1": "", "t2": ""},
+				},
+				{
+					metricName: "mn",
+					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
+					metricTags: map[string]string{"t1": "", "t3": ""},
+				},
+			},
+			nil,
+		},
+		{
+			"different metric names",
+			[]Node{
+				{
+					metricName: "mn",
+					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
+					metricTags: map[string]string{"t1": "", "t2": ""},
+				},
+				{
+					metricName: "mn2",
+					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
+					metricTags: map[string]string{"t1": "", "t2": ""},
+				},
+			},
+			nil,
+		},
+		{
+			"different field names",
+			[]Node{
+				{
+					metricName: "mn",
+					tag:        NodeSettings{FieldName: "fn", IdentifierType: "s"},
+					metricTags: map[string]string{"t1": "", "t2": ""},
+				},
+				{
+					metricName: "mn",
+					tag:        NodeSettings{FieldName: "fn2", IdentifierType: "s"},
+					metricTags: map[string]string{"t1": "", "t2": ""},
+				},
+			},
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := OpcUA{
+				nodes: tt.nodes,
+			}
+			require.Equal(t, tt.err, o.validateOPCTags())
+		})
+	}
+}

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -32,7 +32,7 @@ func TestClient1(t *testing.T) {
 	var o OpcUA
 	var err error
 
-	o.Name = "testing"
+	o.MetricName = "testing"
 	o.Endpoint = "opc.tcp://opcua.rocks:4840"
 	o.AuthMethod = "Anonymous"
 	o.ConnectTimeout = config.Duration(10 * time.Second)
@@ -57,16 +57,16 @@ func TestClient1(t *testing.T) {
 			value := reflect.ValueOf(v.Value)
 			compare := fmt.Sprintf("%v", value.Interface())
 			if compare != testopctags[i].Want {
-				t.Errorf("Tag %s: Values %v for type %s  does not match record", o.NodeList[i].Name, value.Interface(), types)
+				t.Errorf("Tag %s: Values %v for type %s  does not match record", o.NodeList[i].FieldName, value.Interface(), types)
 			}
 		} else {
-			t.Errorf("Tag: %s has value: %v", o.NodeList[i].Name, v.Value)
+			t.Errorf("Tag: %s has value: %v", o.NodeList[i].FieldName, v.Value)
 		}
 	}
 }
 
 func MapOPCTag(tags OPCTags) (out OPCTag) {
-	out.Name = tags.Name
+	out.FieldName = tags.Name
 	out.Namespace = tags.Namespace
 	out.IdentifierType = tags.IdentifierType
 	out.Identifier = tags.Identifier
@@ -76,7 +76,7 @@ func MapOPCTag(tags OPCTags) (out OPCTag) {
 func TestConfig(t *testing.T) {
 	toml := `
 [[inputs.opcua]]
-name = "localhost"
+metric_name = "localhost"
 endpoint = "opc.tcp://localhost:4840"
 connect_timeout = "10s"
 request_timeout = "5s"
@@ -88,8 +88,8 @@ auth_method = "Anonymous"
 username = ""
 password = ""
 nodes = [
-  {name="name", namespace="", identifier_type="", identifier=""},
-  {name="name2", namespace="", identifier_type="", identifier=""},
+  {field_name="name", namespace="1", identifier_type="s", identifier="one"},
+  {field_name="name2", namespace="2", identifier_type="s", identifier="two"},
 ]
 `
 
@@ -103,6 +103,6 @@ nodes = [
 	require.True(t, ok)
 
 	require.Len(t, o.NodeList, 2)
-	require.Equal(t, o.NodeList[0].Name, "name")
-	require.Equal(t, o.NodeList[1].Name, "name2")
+	require.Equal(t, o.NodeList[0].FieldName, "name")
+	require.Equal(t, o.NodeList[1].FieldName, "name2")
 }

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -15,7 +15,6 @@ type OPCTags struct {
 	Namespace      string
 	IdentifierType string
 	Identifier     string
-	DataType       string
 	Want           string
 }
 
@@ -25,9 +24,9 @@ func TestClient1(t *testing.T) {
 	}
 
 	var testopctags = []OPCTags{
-		{"ProductName", "0", "i", "2261", "string", "open62541 OPC UA Server"},
-		{"ProductUri", "0", "i", "2262", "string", "http://open62541.org"},
-		{"ManufacturerName", "0", "i", "2263", "string", "open62541"},
+		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
+		{"ProductUri", "0", "i", "2262", "http://open62541.org"},
+		{"ManufacturerName", "0", "i", "2263", "open62541"},
 	}
 
 	var o OpcUA
@@ -71,7 +70,6 @@ func MapOPCTag(tags OPCTags) (out OPCTag) {
 	out.Namespace = tags.Namespace
 	out.IdentifierType = tags.IdentifierType
 	out.Identifier = tags.Identifier
-	out.DataType = tags.DataType
 	return out
 }
 
@@ -90,8 +88,8 @@ auth_method = "Anonymous"
 username = ""
 password = ""
 nodes = [
-  {name="name", namespace="", identifier_type="", identifier="", data_type="", description=""},
-  {name="name2", namespace="", identifier_type="", identifier="", data_type="", description=""},
+  {name="name", namespace="", identifier_type="", identifier="", description=""},
+  {name="name2", namespace="", identifier_type="", identifier="", description=""},
 ]
 `
 

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -131,7 +131,7 @@ nodes = [{name="name4", identifier="4000", tags=[["tag1", "override"]]}]
 }
 
 func TestTagsSliceToMap(t *testing.T) {
-	m, err := tagsSliceToMap([][]string{[]string{"foo", "bar"}, []string{"baz", "bat"}})
+	m, err := tagsSliceToMap([][]string{{"foo", "bar"}, {"baz", "bat"}})
 	assert.NoError(t, err)
 	assert.Len(t, m, 2)
 	assert.Equal(t, m["foo"], "bar")
@@ -140,13 +140,13 @@ func TestTagsSliceToMap(t *testing.T) {
 
 func TestTagsSliceToMap_twoStrings(t *testing.T) {
 	var err error
-	_, err = tagsSliceToMap([][]string{[]string{"foo", "bar", "baz"}})
+	_, err = tagsSliceToMap([][]string{{"foo", "bar", "baz"}})
 	assert.Error(t, err)
-	_, err = tagsSliceToMap([][]string{[]string{"foo"}})
+	_, err = tagsSliceToMap([][]string{{"foo"}})
 	assert.Error(t, err)
 }
 
 func TestTagsSliceToMap_dupeKey(t *testing.T) {
-	_, err := tagsSliceToMap([][]string{[]string{"foo", "bar"}, []string{"foo", "bat"}})
+	_, err := tagsSliceToMap([][]string{{"foo", "bar"}, {"foo", "bat"}})
 	assert.Error(t, err)
 }


### PR DESCRIPTION
Remove unneeded node settings (data_type and description).

Add the concept of a node group.  Groups have default settings for all nodes in the group.  They also are able to override the plugin's metric name so multiple metric names can be used in a single plugin instance.

Remove the name tag which wasn't useful because it duplicated the OPC UA value's field name.

Expose stats to telegraf internal plugin.