### PR TITLE
Optimize SeriesGrouper & aggregators.merge

### DIFF
--- a/metric/series_grouper_test.go
+++ b/metric/series_grouper_test.go
@@ -1,0 +1,37 @@
+package metric
+
+import (
+	"hash/maphash"
+	"testing"
+	"time"
+)
+
+var m, _ = New(
+	"mymetric",
+	map[string]string{
+		"host":        "host.example.com",
+		"mykey":       "myvalue",
+		"another key": "another value",
+	},
+	map[string]interface{}{
+		"f1": 1,
+		"f2": 2,
+		"f3": 3,
+		"f4": 4,
+		"f5": 5,
+		"f6": 6,
+		"f7": 7,
+		"f8": 8,
+	},
+	time.Now(),
+)
+
+var result uint64
+
+var hashSeed = maphash.MakeSeed()
+
+func BenchmarkGroupID(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		result = groupID(hashSeed, m.Name(), m.TagList(), m.Time())
+	}
+}

--- a/plugins/aggregators/merge/merge.go
+++ b/plugins/aggregators/merge/merge.go
@@ -36,13 +36,7 @@ func (a *Merge) SampleConfig() string {
 }
 
 func (a *Merge) Add(m telegraf.Metric) {
-	tags := m.Tags()
-	for _, field := range m.FieldList() {
-		err := a.grouper.Add(m.Name(), tags, m.Time(), field.Key, field.Value)
-		if err != nil {
-			a.log.Errorf("Error adding metric: %v", err)
-		}
-	}
+	a.grouper.AddMetric(m)
 }
 
 func (a *Merge) Push(acc telegraf.Accumulator) {

--- a/plugins/aggregators/merge/merge_test.go
+++ b/plugins/aggregators/merge/merge_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestSimple(t *testing.T) {
@@ -183,4 +185,69 @@ func TestReset(t *testing.T) {
 	}
 
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
+}
+
+var m1, _ = metric.New(
+	"mymetric",
+	map[string]string{
+		"host":        "host.example.com",
+		"mykey":       "myvalue",
+		"another key": "another value",
+	},
+	map[string]interface{}{
+		"f1": 1,
+		"f2": 2,
+		"f3": 3,
+		"f4": 4,
+		"f5": 5,
+		"f6": 6,
+		"f7": 7,
+		"f8": 8,
+	},
+	time.Now(),
+)
+var m2, _ = metric.New(
+	"mymetric",
+	map[string]string{
+		"host":        "host.example.com",
+		"mykey":       "myvalue",
+		"another key": "another value",
+	},
+	map[string]interface{}{
+		"f8":  8,
+		"f9":  9,
+		"f10": 10,
+		"f11": 11,
+		"f12": 12,
+		"f13": 13,
+		"f14": 14,
+		"f15": 15,
+		"f16": 16,
+	},
+	m1.Time(),
+)
+
+func BenchmarkMergeOne(b *testing.B) {
+	var merger Merge
+	merger.Init()
+	var acc testutil.NopAccumulator
+
+	for n := 0; n < b.N; n++ {
+		merger.Reset()
+		merger.Add(m1)
+		merger.Push(&acc)
+	}
+}
+
+func BenchmarkMergeTwo(b *testing.B) {
+	var merger Merge
+	merger.Init()
+	var acc testutil.NopAccumulator
+
+	for n := 0; n < b.N; n++ {
+		merger.Reset()
+		merger.Add(m1)
+		merger.Add(m2)
+		merger.Push(&acc)
+	}
 }


### PR DESCRIPTION
This introduces some optimizations for use with the aggregators.merge plugin. In my current usage of telegraf, it's heavily bottle-necking on this plugin.

----

The previous implementation of `SeriesGrouper` required breaking a metric object apart into its constituents, converting tags and keys into unoptimized maps, only to have it put them back together into another metric object. This resulted in a significant performance overhead. This overhead was further compounded when the number of fields was large.

This change adds a new `AddMetric` method to `SeriesGrouper` which preserves the metric object and removes the back-and-forth conversion.

Additionlly the method used for calculating the metric's hash was switched to use `maphash`, which is optimized for this case.

----

Benchmarks

Before:

    BenchmarkMergeOne-16          106012	     11790 ns/op
    BenchmarkMergeTwo-16           48529	     24819 ns/op
    BenchmarkGroupID-16           780018	      1608 ns/op

After:

    BenchmarkMergeOne-16          907093	      1173 ns/op
    BenchmarkMergeTwo-16          508321	      2168 ns/op
    BenchmarkGroupID-16         11217788	      99.4 ns/op

Note the `BenchmarkGroupID` isn't a direct apples-to-apples comparison, since the old method had the sort code present, and the new one does not. However earlier in my development, switching just the hash, while keeping all the other code resulted in about a 2x performance increase (831 ns/op).

----

Also since the vast majority of metrics are likely not to result in any mergers, a further optimization might be to utilize copy-on-write. Meaning use the input metric without copying it, and if a second metric is merged into it, then copy it. However the current change is a good first step, and that can be investigated later.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
