### PR TITLE
Allow to manage errors that occur in the apply function

### DIFF
--- a/plugins/processors/starlark/README.md
+++ b/plugins/processors/starlark/README.md
@@ -154,6 +154,27 @@ def apply(metric):
 Telegraf freezes the global scope, which prevents it from being modified.
 Attempting to modify the global scope will fail with an error.
 
+**How to manage errors that occur in the apply function?**
+
+In case you need to call some code that may return an error, you can delegate the call
+to the built-in function `catch` which takes as argument a `Callable` and returns the error
+that occured if any, `None` otherwise.
+
+So for example:
+
+```python
+load("json.star", "json")
+
+def apply(metric):
+    error = catch(lambda: failing(metric))
+    if error != None:
+        # Some code to execute in case of an error
+        metric.fields["error"] = error
+    return metric
+
+def failing(metric):
+    json.decode("non-json-content")
+```
 
 ### Examples
 

--- a/plugins/processors/starlark/builtins.go
+++ b/plugins/processors/starlark/builtins.go
@@ -34,6 +34,19 @@ func deepcopy(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple,
 	return &Metric{metric: dup}, nil
 }
 
+// catch(f) evaluates f() and returns its evaluation error message
+// if it failed or None if it succeeded.
+func catch(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var fn starlark.Callable
+	if err := starlark.UnpackArgs("catch", args, kwargs, "fn", &fn); err != nil {
+		return nil, err
+	}
+	if _, err := starlark.Call(thread, fn, nil, nil); err != nil {
+		return starlark.String(err.Error()), nil
+	}
+	return starlark.None, nil
+}
+
 type builtinMethod func(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error)
 
 func builtinAttr(recv starlark.Value, name string, methods map[string]builtinMethod) (starlark.Value, error) {

--- a/plugins/processors/starlark/starlark.go
+++ b/plugins/processors/starlark/starlark.go
@@ -58,6 +58,7 @@ func (s *Starlark) Init() error {
 	builtins := starlark.StringDict{}
 	builtins["Metric"] = starlark.NewBuiltin("Metric", newMetric)
 	builtins["deepcopy"] = starlark.NewBuiltin("deepcopy", deepcopy)
+	builtins["catch"] = starlark.NewBuiltin("catch", catch)
 
 	program, err := s.sourceProgram(builtins)
 	if err != nil {


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Fix for https://github.com/influxdata/telegraf/issues/8354

## Motivation

There is no way to manage error returned in the apply function.

## Modifications:

* Adds a new built-in function called `catch` based on the function of the same name of [`starlarktest`](https://github.com/google/starlark-go/blob/master/starlarktest/starlarktest.go#L79-L88)
* Adds a new test to ensure that it works as expected
* Adds a new sub section of **Common Questions** into the `README.md` to describe how to use it 