### PR TITLE
add non-retryable debug logging

### DIFF
--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -177,6 +177,7 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 					return fmt.Errorf("Wavefront sending error: %v", err)
 				}
 				w.Log.Errorf("non-retryable error during Wavefront.Write: %v", err)
+				w.Log.Debugf("Non-retryable metric data: Name: %v, Value: %v, Timestamp: %v, Source: %v, PointTags: %v ", point.Metric, point.Value, point.Timestamp, point.Source, point.Tags)
 			}
 		}
 	}


### PR DESCRIPTION
Adds debug level logging for metric data that is not retryable. fixes #8405 

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
