### PR TITLE
CloudWatch output plugin enhancement to exclude dimensions

### DIFF
--- a/plugins/outputs/cloudwatch/README.md
+++ b/plugins/outputs/cloudwatch/README.md
@@ -48,4 +48,21 @@ aggregator to calculate those fields. If not all statistic fields are available,
 all fields would still be sent as raw metrics.
 
 ### high_resolution_metrics
-Enable high resolution metrics (1 second precision) instead of standard ones (60 seconds precision)
+
+Enable high resolution metrics (1 second precision) instead of standard ones (60 seconds precision).
+
+### dimensions_excluded
+
+Remove dimension keys and their corresponding values.
+
+Example:
+
+```toml
+[[outputs.cloudwatch]]
+  region = "us-east-1"
+  namespace = "namespace"
+  write_statistics = false
+  high_resolution_metrics = false
+  [outputs.cloudwatch.dimensions_excluded]
+    dimension_to_remove = true
+```

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -25,7 +25,7 @@ func TestBuildDimensions(t *testing.T) {
 	assert := assert.New(t)
 
 	testPoint := testutil.TestMetric(1)
-	dimensions := BuildDimensions(testPoint.Tags())
+	dimensions := BuildDimensions(testPoint.Tags(), make(map[string]bool))
 
 	tagKeys := make([]string, len(testPoint.Tags()))
 	i := 0
@@ -75,11 +75,11 @@ func TestBuildMetricDatums(t *testing.T) {
 		testutil.TestMetric(float64(1.174272e+108)), // largest should be 1.174271e+108
 	}
 	for _, point := range validMetrics {
-		datums := BuildMetricDatum(false, false, point)
+		datums := BuildMetricDatum(false, make(map[string]bool), false, point, )
 		assert.Equal(1, len(datums), fmt.Sprintf("Valid point should create a Datum {value: %v}", point))
 	}
 	for _, point := range invalidMetrics {
-		datums := BuildMetricDatum(false, false, point)
+		datums := BuildMetricDatum(false, make(map[string]bool), false, point)
 		assert.Equal(0, len(datums), fmt.Sprintf("Valid point should not create a Datum {value: %v}", point))
 	}
 
@@ -89,7 +89,7 @@ func TestBuildMetricDatums(t *testing.T) {
 		map[string]interface{}{"value_max": float64(10), "value_min": float64(0), "value_sum": float64(100), "value_count": float64(20)},
 		time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-	datums := BuildMetricDatum(true, false, statisticMetric)
+	datums := BuildMetricDatum(true, make(map[string]bool), false, statisticMetric)
 	assert.Equal(1, len(datums), fmt.Sprintf("Valid point should create a Datum {value: %v}", statisticMetric))
 
 	multiFieldsMetric, _ := metric.New(
@@ -98,7 +98,7 @@ func TestBuildMetricDatums(t *testing.T) {
 		map[string]interface{}{"valueA": float64(10), "valueB": float64(0), "valueC": float64(100), "valueD": float64(20)},
 		time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-	datums = BuildMetricDatum(true, false, multiFieldsMetric)
+	datums = BuildMetricDatum(true, make(map[string]bool), false, multiFieldsMetric)
 	assert.Equal(4, len(datums), fmt.Sprintf("Each field should create a Datum {value: %v}", multiFieldsMetric))
 
 	multiStatisticMetric, _ := metric.New(
@@ -112,7 +112,7 @@ func TestBuildMetricDatums(t *testing.T) {
 		},
 		time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
-	datums = BuildMetricDatum(true, false, multiStatisticMetric)
+	datums = BuildMetricDatum(true, make(map[string]bool), false, multiStatisticMetric)
 	assert.Equal(7, len(datums), fmt.Sprintf("Valid point should create a Datum {value: %v}", multiStatisticMetric))
 }
 
@@ -124,13 +124,34 @@ func TestMetricDatumResolution(t *testing.T) {
 
 	metric := testutil.TestMetric(1)
 
-	standardResolutionDatum := BuildMetricDatum(false, false, metric)
+	standardResolutionDatum := BuildMetricDatum(false, make(map[string]bool), false, metric)
 	actualStandardResolutionValue := *standardResolutionDatum[0].StorageResolution
 	assert.Equal(expectedStandardResolutionValue, actualStandardResolutionValue)
 
-	highResolutionDatum := BuildMetricDatum(false, true, metric)
+	highResolutionDatum := BuildMetricDatum(false, make(map[string]bool), true, metric)
 	actualHighResolutionValue := *highResolutionDatum[0].StorageResolution
 	assert.Equal(expectedHighResolutionValue, actualHighResolutionValue)
+}
+
+func TestBuildMetricDatums_SkipDimensionsExcluded(t *testing.T) {
+	input := testutil.MustMetric(
+		"cpu",
+		map[string]string{
+			"host": "example.org",
+			"foo":  "bar",
+		},
+		map[string]interface{}{
+			"value": int64(42),
+		},
+		time.Unix(0, 0),
+	)
+
+	dimensionsExcluded := map[string]bool{
+		"foo": true,
+	}
+
+	datums := BuildMetricDatum(true, dimensionsExcluded, false, input)
+	require.Len(t, datums[0].Dimensions, 1)
 }
 
 func TestBuildMetricDatums_SkipEmptyTags(t *testing.T) {
@@ -146,7 +167,7 @@ func TestBuildMetricDatums_SkipEmptyTags(t *testing.T) {
 		time.Unix(0, 0),
 	)
 
-	datums := BuildMetricDatum(true, false, input)
+	datums := BuildMetricDatum(true, make(map[string]bool), false, input)
 	require.Len(t, datums[0].Dimensions, 1)
 }
 


### PR DESCRIPTION
Adds feature to remove specified dimensions before sending to CloudWatch. For example CloudWatch has a [maximum limit on the length of dimension names and values](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html) of 255 characters. In our particular use case, Flink metrics gathered by Prometheus and sent to CloudWatch, Flink can often generate `task_name` dimensions that far exceed this limit. When this occurs the following error is logged by Telegraf:

```
2020-11-14T08:50:12Z E! [agent] Error writing to outputs.cloudwatch: InvalidParameterValue: The parameter MetricData.member.2.Dimensions.member.8.Value must be shorter than 257 characters.
```

Another option to solving this is to automatically remove dimensions with length greater than 255. Upon consideration I thought this would be too unexpected for the user. I'm open to reconsidering this.

This feature is used by declaring the dimensions to be excluded like this:

```
[[outputs.cloudwatch]]
  region = "us-east-1"
  namespace = "namespace"
  [outputs.cloudwatch.dimensions_excluded]
    dimension_to_remove = true
```

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
