### PR TITLE
Allow timestamping gnmi notifications locally

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -23,6 +23,9 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR (64-
   ## redial in case of failures after
   redial = "10s"
 
+  # timestamp updates using the collector's time instead of the timestamp of the update
+  # use_local_timestamp = true
+
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"


### PR DESCRIPTION
Sometimes it can be useful to use a local, on receive timestamp for
gnmi notifications. This is the case for sample subscriptions. The
gnmi spec requires that the update timestamps are the time when the
value from the underlying data source (e.g. counter hardware) changed.
This value might not change for a long time, resulting in a timestamp
way back in the past. For such situations, it can be useful to use the
current time on the server, turning the semantics of the timestamp
into "This was the value on the device at time T according to the
collector" from "This was when the value last changed on the device."

Fixes #8411

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
