### PR TITLE
Add rate and interval to the basicstats aggregator plugin

### DIFF
--- a/plugins/aggregators/basicstats/README.md
+++ b/plugins/aggregators/basicstats/README.md
@@ -16,7 +16,7 @@ emitting the aggregate every `period` seconds.
   drop_original = false
 
   ## Configures which basic stats to push as fields
-  # stats = ["count","diff","min","max","mean","non_negative_diff","stdev","s2","sum"]
+  # stats = ["count","diff","rate","min","max","mean","non_negative_diff","non_negative_rate","stdev","s2","sum","interval"]
 ```
 
 - stats
@@ -28,13 +28,16 @@ emitting the aggregate every `period` seconds.
 - measurement1
     - field1_count
     - field1_diff (difference)
+    - field1_rate (rate per second)
     - field1_max
     - field1_min
     - field1_mean
     - field1_non_negative_diff (non-negative difference)
+    - field1_non_negative_rate (non-negative rate per second)
     - field1_sum
     - field1_s2 (variance)
     - field1_stdev (standard deviation)
+    - field1_interval (interval in nanoseconds)
 
 ### Tags:
 
@@ -46,8 +49,8 @@ No tags are applied by this aggregator.
 $ telegraf --config telegraf.conf --quiet
 system,host=tars load1=1 1475583980000000000
 system,host=tars load1=1 1475583990000000000
-system,host=tars load1_count=2,load1_diff=0,load1_max=1,load1_min=1,load1_mean=1,load1_sum=2,load1_s2=0,load1_stdev=0 1475584010000000000
+system,host=tars load1_count=2,load1_diff=0,load1_rate=0,load1_max=1,load1_min=1,load1_mean=1,load1_sum=2,load1_s2=0,load1_stdev=0,load1_interval=10000000000i 1475584010000000000
 system,host=tars load1=1 1475584020000000000
 system,host=tars load1=3 1475584030000000000
-system,host=tars load1_count=2,load1_diff=2,load1_max=3,load1_min=1,load1_mean=2,load1_sum=4,load1_s2=2,load1_stdev=1.414162 1475584010000000000
+system,host=tars load1_count=2,load1_diff=2,load1_rate=0.2,load1_max=3,load1_min=1,load1_mean=2,load1_sum=4,load1_s2=2,load1_stdev=1.414162,load1_interval=10000000000i 1475584010000000000
 ```

--- a/plugins/aggregators/basicstats/basicstats_test.go
+++ b/plugins/aggregators/basicstats/basicstats_test.go
@@ -19,7 +19,7 @@ var m1, _ = metric.New("m1",
 		"d": float64(2),
 		"g": int64(3),
 	},
-	time.Now(),
+	time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
 )
 var m2, _ = metric.New("m1",
 	map[string]string{"foo": "bar"},
@@ -34,7 +34,7 @@ var m2, _ = metric.New("m1",
 		"andme":    true,
 		"g":        int64(1),
 	},
-	time.Now(),
+	time.Date(2000, 1, 1, 0, 0, 0, 1e6, time.UTC),
 )
 
 func BenchmarkApply(b *testing.B) {
@@ -491,6 +491,81 @@ func TestBasicStatsWithDiff(t *testing.T) {
 		"c_diff": float64(2),
 		"d_diff": float64(4),
 		"g_diff": float64(-2),
+	}
+	expectedTags := map[string]string{
+		"foo": "bar",
+	}
+	acc.AssertContainsTaggedFields(t, "m1", expectedFields, expectedTags)
+}
+
+func TestBasicStatsWithRate(t *testing.T) {
+
+	aggregator := NewBasicStats()
+	aggregator.Stats = []string{"rate"}
+	aggregator.Log = testutil.Logger{}
+	aggregator.getConfiguredStats()
+
+	aggregator.Add(m1)
+	aggregator.Add(m2)
+
+	acc := testutil.Accumulator{}
+	aggregator.Push(&acc)
+	expectedFields := map[string]interface{}{
+		"a_rate": float64(0),
+		"b_rate": float64(2000),
+		"c_rate": float64(2000),
+		"d_rate": float64(4000),
+		"g_rate": float64(-2000),
+	}
+	expectedTags := map[string]string{
+		"foo": "bar",
+	}
+	acc.AssertContainsTaggedFields(t, "m1", expectedFields, expectedTags)
+}
+
+func TestBasicStatsWithNonNegativeRate(t *testing.T) {
+
+	aggregator := NewBasicStats()
+	aggregator.Stats = []string{"non_negative_rate"}
+	aggregator.Log = testutil.Logger{}
+	aggregator.getConfiguredStats()
+
+	aggregator.Add(m1)
+	aggregator.Add(m2)
+
+	acc := testutil.Accumulator{}
+	aggregator.Push(&acc)
+
+	expectedFields := map[string]interface{}{
+		"a_non_negative_rate": float64(0),
+		"b_non_negative_rate": float64(2000),
+		"c_non_negative_rate": float64(2000),
+		"d_non_negative_rate": float64(4000),
+	}
+	expectedTags := map[string]string{
+		"foo": "bar",
+	}
+	acc.AssertContainsTaggedFields(t, "m1", expectedFields, expectedTags)
+}
+func TestBasicStatsWithInterval(t *testing.T) {
+
+	aggregator := NewBasicStats()
+	aggregator.Stats = []string{"interval"}
+	aggregator.Log = testutil.Logger{}
+	aggregator.getConfiguredStats()
+
+	aggregator.Add(m1)
+	aggregator.Add(m2)
+
+	acc := testutil.Accumulator{}
+	aggregator.Push(&acc)
+
+	expectedFields := map[string]interface{}{
+		"a_interval": int64(time.Millisecond),
+		"b_interval": int64(time.Millisecond),
+		"c_interval": int64(time.Millisecond),
+		"d_interval": int64(time.Millisecond),
+		"g_interval": int64(time.Millisecond),
 	}
 	expectedTags := map[string]string{
 		"foo": "bar",


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Added `rate`, `non_negative_rate` and `interval` calculations to the basicstats aggregator. 