### PR TITLE
Added "name" parameter to NATS output plugin

### DIFF
--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -6,6 +6,10 @@ This plugin writes to a (list of) specified NATS instance(s).
 [[outputs.nats]]
   ## URLs of NATS servers
   servers = ["nats://localhost:4222"]
+
+  ## Optional client name
+  # name = ""
+
   ## Optional credentials
   # username = ""
   # password = ""

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -15,6 +15,7 @@ import (
 type NATS struct {
 	Servers     []string `toml:"servers"`
 	Secure      bool     `toml:"secure"`
+	Name        string   `toml:"name"`
 	Username    string   `toml:"username"`
 	Password    string   `toml:"password"`
 	Credentials string   `toml:"credentials"`
@@ -29,6 +30,9 @@ type NATS struct {
 var sampleConfig = `
   ## URLs of NATS servers
   servers = ["nats://localhost:4222"]
+
+  ## Optional client name
+  # name = ""
 
   ## Optional credentials
   # username = ""
@@ -71,6 +75,10 @@ func (n *NATS) Connect() error {
 	// override authentication, if any was specified
 	if n.Username != "" {
 		opts = append(opts, nats.UserInfo(n.Username, n.Password))
+	}
+
+	if n.Name != "" {
+		opts = append(opts, nats.Name(n.Name))
 	}
 
 	if n.Secure {

--- a/plugins/outputs/nats/nats_test.go
+++ b/plugins/outputs/nats/nats_test.go
@@ -17,6 +17,7 @@ func TestConnectAndWrite(t *testing.T) {
 	s, _ := serializers.NewInfluxSerializer()
 	n := &NATS{
 		Servers:    server,
+		Name:       "telegraf",
 		Subject:    "telegraf",
 		serializer: s,
 	}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Added `name` parameter to the NATS output plugin. The connection name simplifies monitoring, debugging and reporting. 

See: https://docs.nats.io/developing-with-nats/connecting/name