### PR TITLE
Starlark example dropbytype

### DIFF
--- a/plugins/processors/starlark/README.md
+++ b/plugins/processors/starlark/README.md
@@ -158,6 +158,7 @@ Attempting to modify the global scope will fail with an error.
 ### Examples
 
 - [drop string fields](/plugins/processors/starlark/testdata/drop_string_fields.star) - Drop fields containing string values.
+- [drop fields with unexpected type](/plugins/processors/starlark/testdata/drop_fields_with_unexpected_type.star) - Drop fields containing unexpected value types.
 - [json](/plugins/processors/starlark/testdata/json.star) - an example of processing JSON from a field in a metric
 - [number logic](/plugins/processors/starlark/testdata/number_logic.star) - transform a numerical value to another numerical value
 - [pivot](/plugins/processors/starlark/testdata/pivot.star) - Pivots a key's value to be the key for another key.

--- a/plugins/processors/starlark/README.md
+++ b/plugins/processors/starlark/README.md
@@ -157,6 +157,7 @@ Attempting to modify the global scope will fail with an error.
 
 ### Examples
 
+- [drop string fields](/plugins/processors/starlark/testdata/drop_string_fields.star) - Drop fields containing string values.
 - [json](/plugins/processors/starlark/testdata/json.star) - an example of processing JSON from a field in a metric
 - [number logic](/plugins/processors/starlark/testdata/number_logic.star) - transform a numerical value to another numerical value
 - [pivot](/plugins/processors/starlark/testdata/pivot.star) - Pivots a key's value to be the key for another key.

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -2478,6 +2478,40 @@ func TestScript(t *testing.T) {
 			},
 		},
 		{
+			name: "drop fields with unexpected type",
+			plugin: &Starlark{
+				Script: "testdata/drop_fields_with_unexpected_type.star",
+				Log:    testutil.Logger{},
+			},
+			input: []telegraf.Metric{
+				testutil.MustMetric("device",
+					map[string]string{},
+					map[string]interface{}{
+						"a": 42,
+						"b": "42",
+						"c": 42.0,
+						"d": "42.0",
+						"e": true,
+						"f": 23.0,
+					},
+					time.Unix(0, 0),
+				),
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric("device",
+					map[string]string{},
+					map[string]interface{}{
+						"a": 42,
+						"c": 42.0,
+						"d": "42.0",
+						"e": true,
+						"f": 23.0,
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
 			name: "scale",
 			plugin: &Starlark{
 				Script: "testdata/scale.star",

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -2447,6 +2447,37 @@ func TestScript(t *testing.T) {
 			},
 		},
 		{
+			name: "drop fields by type",
+			plugin: &Starlark{
+				Script: "testdata/drop_string_fields.star",
+				Log:    testutil.Logger{},
+			},
+			input: []telegraf.Metric{
+				testutil.MustMetric("device",
+					map[string]string{},
+					map[string]interface{}{
+						"a": 42,
+						"b": "42",
+						"c": 42.0,
+						"d": "42.0",
+						"e": true,
+					},
+					time.Unix(0, 0),
+				),
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric("device",
+					map[string]string{},
+					map[string]interface{}{
+						"a": 42,
+						"c": 42.0,
+						"e": true,
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
 			name: "scale",
 			plugin: &Starlark{
 				Script: "testdata/scale.star",

--- a/plugins/processors/starlark/testdata/drop_fields_with_unexpected_type.star
+++ b/plugins/processors/starlark/testdata/drop_fields_with_unexpected_type.star
@@ -10,15 +10,15 @@
 # measurement,host=hostname a=1i,b=4.2,c=42.0,d="v3.14",e=true,f=23.0 1597255410000000000
 # measurement,host=hostname a=1i,c=42.0,d="v3.14",e=true,f=23.0 1597255410000000000
 
+expected_type = {
+    "a": "int",
+    "b": "float",
+    "c": "float",
+    "d": "string",
+    "e": "bool"
+}
+    
 def apply(metric):
-    expected_type = {
-        "a": "int",
-        "b": "float",
-        "c": "float",
-        "d": "string",
-        "e": "bool"
-    }
-
     for k, v in metric.fields.items():
         if type(v) != expected_type.get(k, type(v)):
             metric.fields.pop(k)

--- a/plugins/processors/starlark/testdata/drop_fields_with_unexpected_type.star
+++ b/plugins/processors/starlark/testdata/drop_fields_with_unexpected_type.star
@@ -1,0 +1,26 @@
+# Drop fields if they NOT contain values of an expected type.
+#
+# In this example we ignore fields with an unknown expected type and do not drop them.
+#
+# Example Input:
+# measurement,host=hostname a=1i,b=4.2,c=42.0,d="v3.14",e=true,f=23.0 1597255410000000000
+# measurement,host=hostname a=1i,b="somestring",c=42.0,d="v3.14",e=true,f=23.0 1597255410000000000
+#
+# Example Output:
+# measurement,host=hostname a=1i,b=4.2,c=42.0,d="v3.14",e=true,f=23.0 1597255410000000000
+# measurement,host=hostname a=1i,c=42.0,d="v3.14",e=true,f=23.0 1597255410000000000
+
+def apply(metric):
+    expected_type = {
+        "a": "int",
+        "b": "float",
+        "c": "float",
+        "d": "string",
+        "e": "bool"
+    }
+
+    for k, v in metric.fields.items():
+        if type(v) != expected_type.get(k, type(v)):
+            metric.fields.pop(k)
+
+    return metric

--- a/plugins/processors/starlark/testdata/drop_string_fields.star
+++ b/plugins/processors/starlark/testdata/drop_string_fields.star
@@ -1,0 +1,14 @@
+# Drop fields if they contain a string.
+#
+# Example Input:
+# measurement,host=hostname a=1,b="somestring" 1597255410000000000
+#
+# Example Output:
+# measurement,host=hostname a=1 1597255410000000000
+
+def apply(metric):
+    for k, v in metric.fields.items():
+        if type(v) == "string":
+            metric.fields.pop(k)
+
+    return metric


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [X] Has appropriate unit tests.

Starlark example for dropping fields of metrics by the value type. This is a suitable replacement for PR #3763.