### PR TITLE
Show how to return a custom error with the Starlark processor

### DIFF
--- a/plugins/processors/starlark/README.md
+++ b/plugins/processors/starlark/README.md
@@ -189,6 +189,7 @@ def failing(metric):
 - [logging](/plugins/processors/starlark/testdata/logging.star) - Log messages with the logger of Telegraf
 - [multiple metrics](/plugins/processors/starlark/testdata/multiple_metrics.star) - Return multiple metrics by using [a list](https://docs.bazel.build/versions/master/skylark/lib/list.html) of metrics.
 - [multiple metrics from json array](/plugins/processors/starlark/testdata/multiple_metrics_with_json.star) - Builds a new metric from each element of a json array then returns all the created metrics.
+- [custom error](/plugins/processors/starlark/testdata/fail.star) - Return a custom error with [fail](https://docs.bazel.build/versions/master/skylark/lib/globals.html#fail).
 
 [All examples](/plugins/processors/starlark/testdata) are in the testdata folder.
 

--- a/plugins/processors/starlark/testdata/fail.star
+++ b/plugins/processors/starlark/testdata/fail.star
@@ -1,4 +1,5 @@
 # Example of the way to return a custom error thanks to the built-in function fail
+# Returning an error will drop the current metric. Consider using logging instead if you want to keep the metric.
 #
 # Example Input:
 # fail value=1 1465839830100400201

--- a/plugins/processors/starlark/testdata/fail.star
+++ b/plugins/processors/starlark/testdata/fail.star
@@ -1,0 +1,12 @@
+# Example of the way to return a custom error thanks to the built-in function fail
+#
+# Example Input:
+# fail value=1 1465839830100400201
+#
+# Example Output Error:
+# fail: The field value should be greater than 1
+
+def apply(metric):
+    if metric.fields["value"] <= 1:
+        return fail("The field value should be greater than 1")
+    return metric


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Fix for #8403 

## Motivation

It seems to be unclear for end-users to return a custom error with the Starlark processor

## Modifications

* Adds a new Starlark script to show how to return a custom error thanks to the function [fail](https://docs.bazel.build/versions/master/skylark/lib/globals.html#fail)
* Adds the corresponding unit test that proves that it works as expected
* Refers the new Starlark script from the `README.md`
