### PR TITLE
Keep field name for csv timestamp column (don't implicitly convert)

### DIFF
--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -204,6 +204,12 @@ outer:
 				}
 			}
 
+			// If the field name is the timestamp column, then keep field name as is.
+			if fieldName == p.TimestampColumn {
+				recordFields[fieldName] = value
+				continue
+			}
+
 			// Try explicit conversion only when column types is defined.
 			if len(p.ColumnTypes) > 0 {
 				// Throw error if current column count exceeds defined types.

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -85,6 +85,26 @@ func TestTimestamp(t *testing.T) {
 	require.Equal(t, metrics[1].Time().UnixNano(), int64(1257609906000000000))
 }
 
+func TestTimestampYYYYMMDDHHmm(t *testing.T) {
+	p, err := NewParser(
+		&Config{
+			HeaderRowCount:    1,
+			ColumnNames:       []string{"first", "second", "third"},
+			MeasurementColumn: "third",
+			TimestampColumn:   "first",
+			TimestampFormat:   "200601021504",
+			TimeFunc:          DefaultTime,
+		},
+	)
+	testCSV := `line1,line2,line3
+200905231605,70,test_name
+200907111605,80,test_name2`
+	metrics, err := p.Parse([]byte(testCSV))
+
+	require.NoError(t, err)
+	require.Equal(t, metrics[0].Time().UnixNano(), int64(1243094700000000000))
+	require.Equal(t, metrics[1].Time().UnixNano(), int64(1247328300000000000))
+}
 func TestTimestampError(t *testing.T) {
 	p, err := NewParser(
 		&Config{


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.


**Root Cause Analysis:**
Within the csv parser, the field name for the `csv_timestamp_column` is, initially, converted from a `string` into an `int`. This causes the field name (for example: `202011131605`) to be interpreted as a Unix format (instead of the Go reference time `200601021504`).

**The Fix:**
- Prevent implicit type conversion on the timestamp column, so that `parseTimestamp` can correctly parse the time as unix or UTC
- Added a unit test to verify `TimestampFormat:   "200601021504"`

closes #7288 