### PR TITLE
Migrate syslog/v2 to syslog/v3 (adds RFC3164 support to inputs.syslog) (#4593)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/harlow/kinesis-consumer v0.3.1-0.20181230152818-2f58b136fee0
 	github.com/hashicorp/consul/api v1.8.1
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
-	github.com/influxdata/go-syslog/v2 v2.0.1
+	github.com/influxdata/go-syslog/v3 v3.0.0
 	github.com/influxdata/influxdb-observability/common v0.0.0-20210429174543-86ae73cafd31
 	github.com/influxdata/influxdb-observability/otel2influx v0.0.0-20210429174543-86ae73cafd31
 	github.com/influxdata/influxdb-observability/otlp v0.0.0-20210429174543-86ae73cafd31

--- a/go.sum
+++ b/go.sum
@@ -860,8 +860,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/apcupsd v0.0.0-20210427145308-694d5caead0e h1:3J1OB4RDKwXs5l8uEV6BP/tucOJOPDQysiT7/9cuXzA=
 github.com/influxdata/apcupsd v0.0.0-20210427145308-694d5caead0e/go.mod h1:WYK/Z/aXq9cbMFIL5ihcA4sX/r/3/WCas/Qvs/2fXcA=
 github.com/influxdata/flux v0.65.0/go.mod h1:BwN2XG2lMszOoquQaFdPET8FRQfrXiZsWmcMO9rkaVY=
-github.com/influxdata/go-syslog/v2 v2.0.1 h1:l44S4l4Q8MhGQcoOxJpbo+QQYxJqp0vdgIVHh4+DO0s=
-github.com/influxdata/go-syslog/v2 v2.0.1/go.mod h1:hjvie1UTaD5E1fTnDmxaCw8RRDrT4Ve+XHr5O2dKSCo=
+github.com/influxdata/go-syslog/v3 v3.0.0 h1:jichmjSZlYK0VMmlz+k4WeOQd7z745YLsvGMqwtYt4I=
+github.com/influxdata/go-syslog/v3 v3.0.0/go.mod h1:tulsOp+CecTAYC27u9miMgq21GqXRW6VdKbOG+QSP4Q=
 github.com/influxdata/influxdb v1.8.2/go.mod h1:SIzcnsjaHRFpmlxpJ4S3NT64qtEKYweNTUMb/vh0OMQ=
 github.com/influxdata/influxdb-observability/common v0.0.0-20210428231528-a010f53e3e02/go.mod h1:PMngVYsW4uwtzIVmj0ZfLL9UIOwo7Vs+09QHkoYMZv8=
 github.com/influxdata/influxdb-observability/common v0.0.0-20210429174543-86ae73cafd31 h1:pfWcpiOrWLJvicIpCiFR8vqrkVbAuKUttWvQDmSlfUM=

--- a/plugins/inputs/syslog/README.md
+++ b/plugins/inputs/syslog/README.md
@@ -55,6 +55,11 @@ Syslog messages should be formatted according to
   ## By default best effort parsing is off.
   # best_effort = false
 
+  ## The RFC standard to use for message parsing
+  ## By default RFC5424 is used. RFC3164 only supports UDP transport (no streaming support)
+  ## Must be one of "RFC5424", or "RFC3164".
+  # syslog_standard = "RFC5424"
+
   ## Character to prepend to SD-PARAMs (default = "_").
   ## A syslog message can contain multiple parameters and multiple identifiers within structured data section.
   ## Eg., [id1 name1="val1" name2="val2"][id2 name1="val1" nameA="valA"]
@@ -155,9 +160,12 @@ echo "<13>1 2018-10-01T12:00:00.0Z example.org root - - - test" | nc -u 127.0.0.
 
 #### RFC3164
 
-RFC3164 encoded messages are not currently supported.  You may see the following error if a message encoded in this format:
-```
-E! Error in plugin [inputs.syslog]: expecting a version value in the range 1-999 [col 5]
-```
+RFC3164 encoded messages are supported for UDP only, but not all vendors output valid RFC3164 messages by default
 
-You can use rsyslog to translate RFC3164 syslog messages into RFC5424 format.
+- E.g. Cisco IOS
+
+If you see the following error, it is due to a message encoded in this format:
+ ```
+ E! Error in plugin [inputs.syslog]: expecting a version value in the range 1-999 [col 5]
+ ```
+ You can use rsyslog to translate RFC3164 syslog messages into RFC5424 format.

--- a/plugins/inputs/syslog/commons_test.go
+++ b/plugins/inputs/syslog/commons_test.go
@@ -29,14 +29,15 @@ type testCaseStream struct {
 	werr           int // how many errors we expect in the strict mode?
 }
 
-func newUDPSyslogReceiver(address string, bestEffort bool) *Syslog {
+func newUDPSyslogReceiver(address string, bestEffort bool, rfc syslogRFC) *Syslog {
 	return &Syslog{
 		Address: address,
 		now: func() time.Time {
 			return defaultTime
 		},
-		BestEffort: bestEffort,
-		Separator:  "_",
+		BestEffort:     bestEffort,
+		SyslogStandard: rfc,
+		Separator:      "_",
 	}
 }
 
@@ -47,10 +48,11 @@ func newTCPSyslogReceiver(address string, keepAlive *config.Duration, maxConn in
 		now: func() time.Time {
 			return defaultTime
 		},
-		Framing:     f,
-		ReadTimeout: &d,
-		BestEffort:  bestEffort,
-		Separator:   "_",
+		Framing:        f,
+		ReadTimeout:    &d,
+		BestEffort:     bestEffort,
+		SyslogStandard: syslogRFC5424,
+		Separator:      "_",
 	}
 	if keepAlive != nil {
 		s.KeepAlivePeriod = keepAlive

--- a/plugins/inputs/syslog/rfc3164_test.go
+++ b/plugins/inputs/syslog/rfc3164_test.go
@@ -1,0 +1,123 @@
+package syslog
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func timeMustParse(value string) time.Time {
+	format := "Jan 2 15:04:05 2006"
+	t, err := time.Parse(format, value)
+	if err != nil {
+		panic(fmt.Sprintf("couldn't parse time: %v", value))
+	}
+	return t
+}
+
+func getTestCasesForRFC3164() []testCasePacket {
+	currentYear := time.Now().Year()
+	ts := timeMustParse(fmt.Sprintf("Dec 2 16:31:03 %d", currentYear)).UnixNano()
+	testCases := []testCasePacket{
+		{
+			name: "complete",
+			data: []byte("<13>Dec  2 16:31:03 host app: Test"),
+			wantBestEffort: testutil.MustMetric(
+				"syslog",
+				map[string]string{
+					"appname":  "app",
+					"severity": "notice",
+					"hostname": "host",
+					"facility": "user",
+				},
+				map[string]interface{}{
+					"timestamp":     ts,
+					"message":       "Test",
+					"facility_code": 1,
+					"severity_code": 5,
+				},
+				defaultTime,
+			),
+			wantStrict: testutil.MustMetric(
+				"syslog",
+				map[string]string{
+					"appname":  "app",
+					"severity": "notice",
+					"hostname": "host",
+					"facility": "user",
+				},
+				map[string]interface{}{
+					"timestamp":     ts,
+					"message":       "Test",
+					"facility_code": 1,
+					"severity_code": 5,
+				},
+				defaultTime,
+			),
+		},
+	}
+
+	return testCases
+}
+
+func testRFC3164(t *testing.T, protocol string, address string, bestEffort bool) {
+	for _, tc := range getTestCasesForRFC3164() {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create receiver
+			receiver := newUDPSyslogReceiver(protocol+"://"+address, bestEffort, syslogRFC3164)
+			acc := &testutil.Accumulator{}
+			require.NoError(t, receiver.Start(acc))
+			defer receiver.Stop()
+
+			// Connect
+			conn, err := net.Dial(protocol, address)
+			require.NotNil(t, conn)
+			require.NoError(t, err)
+
+			// Write
+			_, err = conn.Write(tc.data)
+			conn.Close()
+			if err != nil {
+				if err, ok := err.(*net.OpError); ok {
+					if err.Err.Error() == "write: message too long" {
+						return
+					}
+				}
+			}
+
+			// Waiting ...
+			if tc.wantStrict == nil && tc.werr || bestEffort && tc.werr {
+				acc.WaitError(1)
+			}
+			if tc.wantBestEffort != nil && bestEffort || tc.wantStrict != nil && !bestEffort {
+				acc.Wait(1) // RFC3164 mandates a syslog message per UDP packet
+			}
+
+			// Compare
+			var got telegraf.Metric
+			var want telegraf.Metric
+			if len(acc.Metrics) > 0 {
+				got = acc.GetTelegrafMetrics()[0]
+			}
+			if bestEffort {
+				want = tc.wantBestEffort
+			} else {
+				want = tc.wantStrict
+			}
+			testutil.RequireMetricEqual(t, want, got)
+		})
+	}
+}
+
+func TestRFC3164BestEffort_udp(t *testing.T) {
+	testRFC3164(t, "udp", address, true)
+}
+
+func TestRFC3164Strict_udp(t *testing.T) {
+	testRFC3164(t, "udp", address, false)
+}

--- a/plugins/inputs/syslog/rfc5426_test.go
+++ b/plugins/inputs/syslog/rfc5426_test.go
@@ -232,7 +232,7 @@ func testRFC5426(t *testing.T, protocol string, address string, bestEffort bool)
 	for _, tc := range getTestCasesForRFC5426() {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create receiver
-			receiver := newUDPSyslogReceiver(protocol+"://"+address, bestEffort)
+			receiver := newUDPSyslogReceiver(protocol+"://"+address, bestEffort, syslogRFC5424)
 			acc := &testutil.Accumulator{}
 			require.NoError(t, receiver.Start(acc))
 			defer receiver.Stop()
@@ -325,10 +325,11 @@ func TestTimeIncrement_udp(t *testing.T) {
 
 	// Create receiver
 	receiver := &Syslog{
-		Address:    "udp://" + address,
-		now:        getNow,
-		BestEffort: false,
-		Separator:  "_",
+		Address:        "udp://" + address,
+		now:            getNow,
+		BestEffort:     false,
+		SyslogStandard: syslogRFC5424,
+		Separator:      "_",
 	}
 	acc := &testutil.Accumulator{}
 	require.NoError(t, receiver.Start(acc))

--- a/plugins/outputs/syslog/syslog.go
+++ b/plugins/outputs/syslog/syslog.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/go-syslog/v2/nontransparent"
-	"github.com/influxdata/go-syslog/v2/rfc5424"
+	"github.com/influxdata/go-syslog/v3/nontransparent"
+	"github.com/influxdata/go-syslog/v3/rfc5424"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	framing "github.com/influxdata/telegraf/internal/syslog"

--- a/plugins/outputs/syslog/syslog_mapper.go
+++ b/plugins/outputs/syslog/syslog_mapper.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/go-syslog/v2/rfc5424"
+	"github.com/influxdata/go-syslog/v3/rfc5424"
 	"github.com/influxdata/telegraf"
 )
 


### PR DESCRIPTION
# Add RFC3164 Support for inputs.syslog  (#4593)

This PR replaces `go-syslog/v2` usage with `go-syslog/v3` so that the `inputs.syslog` plugin can use the [new RFC3164 support](https://github.com/influxdata/go-syslog/pull/27). Resolves #4593 

## Usage
When defining the inputs, a user will specify the `syslog_standard` option (Either "5424" *[default]* or "3164"). The `best_effort` option will also apply when "3164" is used.

## Notes
I was really hoping that this would let me use telegraf direction for Cisco syslog messages, but from my understanding it seems they have some problems with current go-syslog parsing:

Format: `<PRI>SEQNUM:HOST:MONTHDAY YEARHOUR:MINUTES:SECONDS.MILLISECONDSTIMEZONE:%APPNAME-SEVERITY-MSGID:%TAGS:MESSAGE`

Example: `<187>37972: Nov 21 16:53:33.429: %LINK-3-UPDOWN: Interface GigabitEthernet0/8, changed state to down`

- Seq field instead of version number
- No hostname provided
- Severity level, app, and MsgId is encoded in the `%APPNAME-SEVERITY-MSGID` format

@goller Is handing these messages something that might be in scope for the RFC3164 parser in go-syslog?

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
