### PR TITLE
Add column measurement_db_type to output of all queries

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -307,7 +307,9 @@ func (s *SQLServer) accRow(query Query, acc telegraf.Accumulator, row scanner) e
 		}
 	}
 
-	tags["measurement_db_type"] = s.DatabaseType
+	if s.DatabaseType != "" {
+		tags["measurement_db_type"] = s.DatabaseType
+	}
 
 	if query.ResultByRow {
 		// add measurement to Accumulator

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -307,6 +307,8 @@ func (s *SQLServer) accRow(query Query, acc telegraf.Accumulator, row scanner) e
 		}
 	}
 
+	tags["measurement_db_type"] = s.DatabaseType
+
 	if query.ResultByRow {
 		// add measurement to Accumulator
 		acc.AddFields(measurement,


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

This column is used to distinguish between outputs of queries that have the same value in column [measurement], such as sqlAzureDBResourceStats and sqlAzureMIResourceStats.


