### PR TITLE
Log SubscribeResponse_Error message and code

### DIFF
--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -240,14 +240,17 @@ func (c *GNMI) subscribeGNMI(ctx context.Context, address string, tlscfg *tls.Co
 	return nil
 }
 
-// HandleSubscribeResponse message from gNMI and parse contained telemetry data
 func (c *GNMI) handleSubscribeResponse(address string, reply *gnmi.SubscribeResponse) {
-	// Check if response is a gNMI Update and if we have a prefix to derive the measurement name
-	response, ok := reply.Response.(*gnmi.SubscribeResponse_Update)
-	if !ok {
-		return
+	switch response := reply.Response.(type) {
+	case *gnmi.SubscribeResponse_Update:
+		c.handleSubscribeResponseUpdate(address, response)
+	case *gnmi.SubscribeResponse_Error:
+		c.Log.Errorf("Subscribe error (%d), %q", response.Error.Code, response.Error.Message)
 	}
+}
 
+// Handle SubscribeResponse_Update message from gNMI and parse contained telemetry data
+func (c *GNMI) handleSubscribeResponseUpdate(address string, response *gnmi.SubscribeResponse_Update) {
 	var prefix, prefixAliasPath string
 	grouper := metric.NewSeriesGrouper()
 	timestamp := time.Unix(0, response.Update.Timestamp)

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -403,6 +403,30 @@ func TestNotification(t *testing.T) {
 	}
 }
 
+type MockLogger struct {
+	telegraf.Logger
+	lastFormat string
+	lastArgs   []interface{}
+}
+
+func (l *MockLogger) Errorf(format string, args ...interface{}) {
+	l.lastFormat = format
+	l.lastArgs = args
+}
+
+func TestSubscribeResponseError(t *testing.T) {
+	me := "mock error message"
+	var mc uint32 = 7
+	ml := &MockLogger{}
+	plugin := &GNMI{Log: ml}
+	errorResponse := &gnmi.SubscribeResponse_Error{
+		Error: &gnmi.Error{Message: me, Code: mc}}
+	plugin.handleSubscribeResponse(
+		"127.0.0.1:0", &gnmi.SubscribeResponse{Response: errorResponse})
+	require.NotEmpty(t, ml.lastFormat)
+	require.Equal(t, ml.lastArgs, []interface{}{mc, me})
+}
+
 func TestRedial(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)


### PR DESCRIPTION
Added logging of the SubscribeResonse_Error response types to fix #8482 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] ~Associated README.md updated.~ n/a
- [x] Has appropriate unit tests.
