### PR TITLE
fixed network test 

### DIFF
--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -52,7 +52,11 @@ type HTTPResponse struct {
 	Log telegraf.Logger
 
 	compiledStringMatch *regexp.Regexp
-	client              *http.Client
+	client              httpClient
+}
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
 }
 
 // Description returns the plugin Description

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -905,6 +906,17 @@ func TestBadRegex(t *testing.T) {
 	checkOutput(t, &acc, nil, nil, absentFields, absentTags)
 }
 
+type fakeClient struct {
+	statusCode int
+	err        error
+}
+
+func (f *fakeClient) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: f.statusCode,
+	}, f.err
+}
+
 func TestNetworkErrors(t *testing.T) {
 	// DNS error
 	h := &HTTPResponse{
@@ -914,6 +926,7 @@ func TestNetworkErrors(t *testing.T) {
 		Method:          "GET",
 		ResponseTimeout: internal.Duration{Duration: time.Second * 20},
 		FollowRedirects: false,
+		client:          &fakeClient{err: &url.Error{Err: &net.OpError{Err: &net.DNSError{Err: "DNS error"}}}},
 	}
 
 	var acc testutil.Accumulator


### PR DESCRIPTION
Fixed network test by adding a mock client for failing test coming back with connection failure instead of dns failure