### PR TITLE
[inputs.github] Add query of pull-request statistics

### DIFF
--- a/plugins/inputs/github/README.md
+++ b/plugins/inputs/github/README.md
@@ -23,6 +23,14 @@ alternative method for collecting repository information.
 
   ## Timeout for HTTP requests.
   # http_timeout = "5s"
+
+  ## List of additional fields to query.
+	## NOTE: Getting those fields might involve issuing additional API-calls, so please
+	##       make sure you do not exceed the rate-limit of GitHub.
+	##
+	## Available fields are:
+	## 	- pull-requests			-- number of open and closed pull requests (2 API-calls per repository)
+  # additional_fields = []
 ```
 
 ### Metrics
@@ -52,11 +60,21 @@ When the [internal][] input is enabled:
     - remaining - How many requests you have remaining (per hour)
     - blocks - How many requests have been blocked due to rate limit
 
+When specifying `additional_fields` the plugin will collect the specified properties.
+**NOTE:** Querying this additional fields might require to perform additional API-calls.
+Please make sure you don't exceed the query rate-limit by specifying too many additional fields.
+In the following we list the available options with the required API-calls and the resulting fields
+
+- "pull-requests" (2 API-calls per repository)
+  - fields:
+    - open_pull_requests (int)
+    - closed_pull_requests (int)
+
 ### Example Output
 
 ```
 github_repository,language=Go,license=MIT\ License,name=telegraf,owner=influxdata forks=2679i,networks=2679i,open_issues=794i,size=23263i,stars=7091i,subscribers=316i,watchers=7091i 1563901372000000000
-internal_github,access_token=Unauthenticated rate_limit_remaining=59i,rate_limit_limit=60i,rate_limit_blocks=0i 1552653551000000000
+internal_github,access_token=Unauthenticated closed_pull_requests=3522i,rate_limit_remaining=59i,rate_limit_limit=60i,rate_limit_blocks=0i,open_pull_requests=260i 1552653551000000000
 ```
 
 [GitHub]: https://www.github.com


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [ ] Has appropriate unit tests.

This adds the possibility to query the number of "open" and "closed" pull-requests from a GitHub repository. We hide this behind a new `additional_fields` option to limit the effect to the rate-limit as two new queries are necessary for the new fields.