### PR TITLE
Fixed minor issue in datacenter name lookup code

### DIFF
--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -437,7 +437,7 @@ func (e *Endpoint) discover(ctx context.Context) error {
 			}
 
 			// Fill in datacenter names where available (no need to do it for Datacenters)
-			if res.name != "Datacenter" {
+			if res.name != "datacenter" {
 				for k, obj := range objects {
 					if obj.parentRef != nil {
 						obj.dcname, _ = e.getDatacenterName(ctx, client, dcNameCache, *obj.parentRef)


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Due to a spelling error in an if-statement, the code to resolve names of datacenters was called even when the name was known. This also caused a somewhat misleading debug message to be shown.