### PR TITLE
Improve SQL connection lifecycle

### DIFF
--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -250,7 +250,7 @@ func (s *SQLServer) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (s *SQLServer) gatherServer(conn *sql.DB, server string, query Query, acc telegraf.Accumulator) error {	
+func (s *SQLServer) gatherServer(conn *sql.DB, server string, query Query, acc telegraf.Accumulator) error {
 	// execute query
 	rows, err := conn.Query(query.Script)
 	if err != nil {


### PR DESCRIPTION
Instead of opening a new SQL connection for every query, open it for a server, and use it for all queries within this server. We observed that opening a new connection for each query lead to sporadic connection errors in the Telegraf log file when monitoring 100 Azure SQL DBs with all queries enabled.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
