### PR TITLE
Add configurable timeout to bind input plugin http call

### DIFF
--- a/plugins/inputs/bind/README.md
+++ b/plugins/inputs/bind/README.md
@@ -20,6 +20,7 @@ not enable support for JSON statistics in their BIND packages.
   trailing slash in the URL. Default is "http://localhost:8053/xml/v3".
 - **gather_memory_contexts** bool: Report per-context memory statistics.
 - **gather_views** bool: Report per-view query statistics.
+- **timeout** Timeout for http requests made by bind nameserver (example: "4s").
 
 The following table summarizes the URL formats which should be used, depending on your BIND
 version and configured statistics channel.

--- a/plugins/inputs/bind/bind_test.go
+++ b/plugins/inputs/bind/bind_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,9 @@ func TestBindJsonStats(t *testing.T) {
 		Urls:                 []string{ts.URL + "/json/v1"},
 		GatherMemoryContexts: true,
 		GatherViews:          true,
+		client: http.Client{
+			Timeout: 4 * time.Second,
+		},
 	}
 
 	var acc testutil.Accumulator
@@ -190,6 +194,9 @@ func TestBindXmlStatsV2(t *testing.T) {
 		Urls:                 []string{ts.URL + "/xml/v2"},
 		GatherMemoryContexts: true,
 		GatherViews:          true,
+		client: http.Client{
+			Timeout: 4 * time.Second,
+		},
 	}
 
 	var acc testutil.Accumulator
@@ -392,6 +399,9 @@ func TestBindXmlStatsV3(t *testing.T) {
 		Urls:                 []string{ts.URL + "/xml/v3"},
 		GatherMemoryContexts: true,
 		GatherViews:          true,
+		client: http.Client{
+			Timeout: 4 * time.Second,
+		},
 	}
 
 	var acc testutil.Accumulator

--- a/plugins/inputs/bind/json_stats.go
+++ b/plugins/inputs/bind/json_stats.go
@@ -155,7 +155,7 @@ func (b *Bind) readStatsJSON(addr *url.URL, acc telegraf.Accumulator) error {
 	for _, suffix := range [...]string{"/server", "/net", "/mem"} {
 		scrapeUrl := addr.String() + suffix
 
-		resp, err := client.Get(scrapeUrl)
+		resp, err := b.client.Get(scrapeUrl)
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/bind/xml_stats_v2.go
+++ b/plugins/inputs/bind/xml_stats_v2.go
@@ -89,7 +89,7 @@ func addXMLv2Counter(acc telegraf.Accumulator, commonTags map[string]string, sta
 func (b *Bind) readStatsXMLv2(addr *url.URL, acc telegraf.Accumulator) error {
 	var stats v2Root
 
-	resp, err := client.Get(addr.String())
+	resp, err := b.client.Get(addr.String())
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/bind/xml_stats_v3.go
+++ b/plugins/inputs/bind/xml_stats_v3.go
@@ -140,7 +140,7 @@ func (b *Bind) readStatsXMLv3(addr *url.URL, acc telegraf.Accumulator) error {
 	for _, suffix := range [...]string{"/server", "/net", "/mem"} {
 		scrapeUrl := addr.String() + suffix
 
-		resp, err := client.Get(scrapeUrl)
+		resp, err := b.client.Get(scrapeUrl)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

closes #8443 

**The Fix:**
- Created `Init()` function with configurable timeout param