### PR TITLE
Fix kube_inventory readme

### DIFF
--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -229,9 +229,9 @@ subjects:
     - state_code
     - state_reason
     - terminated_reason (string, deprecated in 1.15: use `state_reason` instead)
-    - resource_requests_cpu_units
+    - resource_requests_millicpu_units
     - resource_requests_memory_bytes
-    - resource_limits_cpu_units
+    - resource_limits_millicpu_units
     - resource_limits_memory_bytes
 
 - kubernetes_service


### PR DESCRIPTION
The field values for kubernetes_pod_container has a few name mismatches with what's in code.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [ ] Has appropriate unit tests.
