### PR TITLE
Update string parsing of allocatable cpu cores in kube_inventory

### DIFF
--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -190,10 +190,10 @@ subjects:
   - tags:
     - node_name
   - fields:
-    - capacity_cpu_cores
+    - capacity_millicpu_cores
     - capacity_memory_bytes
     - capacity_pods
-    - allocatable_cpu_cores
+    - allocatable_millicpu_cores
     - allocatable_memory_bytes
     - allocatable_pods
 

--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -190,9 +190,11 @@ subjects:
   - tags:
     - node_name
   - fields:
+    - capacity_cpu_cores
     - capacity_millicpu_cores
     - capacity_memory_bytes
     - capacity_pods
+    - allocatable_cpu_cores
     - allocatable_millicpu_cores
     - allocatable_memory_bytes
     - allocatable_pods

--- a/plugins/inputs/kube_inventory/node.go
+++ b/plugins/inputs/kube_inventory/node.go
@@ -31,7 +31,7 @@ func (ki *KubernetesInventory) gatherNode(n v1.Node, acc telegraf.Accumulator) e
 	for resourceName, val := range n.Status.Capacity {
 		switch resourceName {
 		case "cpu":
-			fields["capacity_cpu_cores"] = atoi(val.GetString_())
+			fields["capacity_millicpu_cores"] = convertQuantity(val.GetString_(), 1000)
 		case "memory":
 			fields["capacity_memory_bytes"] = convertQuantity(val.GetString_(), 1)
 		case "pods":
@@ -42,7 +42,7 @@ func (ki *KubernetesInventory) gatherNode(n v1.Node, acc telegraf.Accumulator) e
 	for resourceName, val := range n.Status.Allocatable {
 		switch resourceName {
 		case "cpu":
-			fields["allocatable_cpu_cores"] = convertQuantity(val.GetString_(), 1)
+			fields["allocatable_millicpu_cores"] = convertQuantity(val.GetString_(), 1000)
 		case "memory":
 			fields["allocatable_memory_bytes"] = convertQuantity(val.GetString_(), 1)
 		case "pods":

--- a/plugins/inputs/kube_inventory/node.go
+++ b/plugins/inputs/kube_inventory/node.go
@@ -31,6 +31,7 @@ func (ki *KubernetesInventory) gatherNode(n v1.Node, acc telegraf.Accumulator) e
 	for resourceName, val := range n.Status.Capacity {
 		switch resourceName {
 		case "cpu":
+			fields["capacity_cpu_cores"] = convertQuantity(val.GetString_(), 1)
 			fields["capacity_millicpu_cores"] = convertQuantity(val.GetString_(), 1000)
 		case "memory":
 			fields["capacity_memory_bytes"] = convertQuantity(val.GetString_(), 1)
@@ -42,6 +43,7 @@ func (ki *KubernetesInventory) gatherNode(n v1.Node, acc telegraf.Accumulator) e
 	for resourceName, val := range n.Status.Allocatable {
 		switch resourceName {
 		case "cpu":
+			fields["allocatable_cpu_cores"] = convertQuantity(val.GetString_(), 1)
 			fields["allocatable_millicpu_cores"] = convertQuantity(val.GetString_(), 1000)
 		case "memory":
 			fields["allocatable_memory_bytes"] = convertQuantity(val.GetString_(), 1)

--- a/plugins/inputs/kube_inventory/node.go
+++ b/plugins/inputs/kube_inventory/node.go
@@ -42,7 +42,7 @@ func (ki *KubernetesInventory) gatherNode(n v1.Node, acc telegraf.Accumulator) e
 	for resourceName, val := range n.Status.Allocatable {
 		switch resourceName {
 		case "cpu":
-			fields["allocatable_cpu_cores"] = atoi(val.GetString_())
+			fields["allocatable_cpu_cores"] = convertQuantity(val.GetString_(), 1)
 		case "memory":
 			fields["allocatable_memory_bytes"] = convertQuantity(val.GetString_(), 1)
 		case "pods":

--- a/plugins/inputs/kube_inventory/node_test.go
+++ b/plugins/inputs/kube_inventory/node_test.go
@@ -103,12 +103,12 @@ func TestNode(t *testing.T) {
 					{
 						Measurement: nodeMeasurement,
 						Fields: map[string]interface{}{
-							"capacity_millicpu_cores":      int64(16000),
-							"capacity_memory_bytes":        int64(1.28837533696e+11),
-							"capacity_pods":                int64(110),
-							"allocatable_millicpu_cores":   int64(1000),
-							"allocatable_memory_bytes":     int64(1.28732676096e+11),
-							"allocatable_pods":             int64(110),
+							"capacity_millicpu_cores":    int64(16000),
+							"capacity_memory_bytes":      int64(1.28837533696e+11),
+							"capacity_pods":              int64(110),
+							"allocatable_millicpu_cores": int64(1000),
+							"allocatable_memory_bytes":   int64(1.28732676096e+11),
+							"allocatable_pods":           int64(110),
 						},
 						Tags: map[string]string{
 							"node_name": "node1",

--- a/plugins/inputs/kube_inventory/node_test.go
+++ b/plugins/inputs/kube_inventory/node_test.go
@@ -56,7 +56,7 @@ func TestNode(t *testing.T) {
 										"pods":                    {String_: toStrPtr("110")},
 									},
 									Allocatable: map[string]*resource.Quantity{
-										"cpu":                     {String_: toStrPtr("16000m")},
+										"cpu":                     {String_: toStrPtr("1000m")},
 										"ephemeral_storage_bytes": {String_: toStrPtr("44582761194")},
 										"hugepages_1Gi_bytes":     {String_: toStrPtr("0")},
 										"hugepages_2Mi_bytes":     {String_: toStrPtr("0")},
@@ -103,10 +103,10 @@ func TestNode(t *testing.T) {
 					{
 						Measurement: nodeMeasurement,
 						Fields: map[string]interface{}{
-							"capacity_cpu_cores":       int64(16),
+							"capacity_millicpu_cores":       int64(16000),
 							"capacity_memory_bytes":    int64(1.28837533696e+11),
 							"capacity_pods":            int64(110),
-							"allocatable_cpu_cores":    int64(16),
+							"allocatable_millicpu_cores":    int64(1000),
 							"allocatable_memory_bytes": int64(1.28732676096e+11),
 							"allocatable_pods":         int64(110),
 						},

--- a/plugins/inputs/kube_inventory/node_test.go
+++ b/plugins/inputs/kube_inventory/node_test.go
@@ -103,9 +103,11 @@ func TestNode(t *testing.T) {
 					{
 						Measurement: nodeMeasurement,
 						Fields: map[string]interface{}{
+							"capacity_cpu_cores":         int64(16),
 							"capacity_millicpu_cores":    int64(16000),
 							"capacity_memory_bytes":      int64(1.28837533696e+11),
 							"capacity_pods":              int64(110),
+							"allocatable_cpu_cores":      int64(1),
 							"allocatable_millicpu_cores": int64(1000),
 							"allocatable_memory_bytes":   int64(1.28732676096e+11),
 							"allocatable_pods":           int64(110),

--- a/plugins/inputs/kube_inventory/node_test.go
+++ b/plugins/inputs/kube_inventory/node_test.go
@@ -56,7 +56,7 @@ func TestNode(t *testing.T) {
 										"pods":                    {String_: toStrPtr("110")},
 									},
 									Allocatable: map[string]*resource.Quantity{
-										"cpu":                     {String_: toStrPtr("16")},
+										"cpu":                     {String_: toStrPtr("16000m")},
 										"ephemeral_storage_bytes": {String_: toStrPtr("44582761194")},
 										"hugepages_1Gi_bytes":     {String_: toStrPtr("0")},
 										"hugepages_2Mi_bytes":     {String_: toStrPtr("0")},

--- a/plugins/inputs/kube_inventory/node_test.go
+++ b/plugins/inputs/kube_inventory/node_test.go
@@ -103,12 +103,12 @@ func TestNode(t *testing.T) {
 					{
 						Measurement: nodeMeasurement,
 						Fields: map[string]interface{}{
-							"capacity_millicpu_cores":       int64(16000),
-							"capacity_memory_bytes":    int64(1.28837533696e+11),
-							"capacity_pods":            int64(110),
-							"allocatable_millicpu_cores":    int64(1000),
-							"allocatable_memory_bytes": int64(1.28732676096e+11),
-							"allocatable_pods":         int64(110),
+							"capacity_millicpu_cores":      int64(16000),
+							"capacity_memory_bytes":        int64(1.28837533696e+11),
+							"capacity_pods":                int64(110),
+							"allocatable_millicpu_cores":   int64(1000),
+							"allocatable_memory_bytes":     int64(1.28732676096e+11),
+							"allocatable_pods":             int64(110),
 						},
 						Tags: map[string]string{
 							"node_name": "node1",


### PR DESCRIPTION
The Allocatable cpu value returned from Kubernetes can have a milli suffix, which gets parsed as 0 when stored in allocatable_cpu_cores.

This change updates the metric to be millicpus to prevent truncation of decimals.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [X] Associated README.md updated.
- [X] Has appropriate unit tests.
