### PR TITLE
Update circleci mac golang version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults:
       - image: 'quay.io/influxdb/telegraf-ci:1.15.5'
   mac: &mac
     macos:
-      xcode: 11.3.1
+      xcode: 12.1.0
     working_directory: '~/go/src/github.com/influxdata/telegraf'
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,13 +42,13 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: mac-go-mod-v1-{{ checksum "go.sum" }}
+          key: mac-go-mod-v2-{{ checksum "go.sum" }}
       - run: 'brew install go' # latest
       - run: 'make deps'
       - run: 'make tidy'
       - save_cache:
           name: 'go module cache'
-          key: mac-go-mod-v1-{{ checksum "go.sum" }}
+          key: mac-go-mod-v2-{{ checksum "go.sum" }}
           paths:
             - '~/go/pkg/mod'
             - '/usr/local/Cellar/go'


### PR DESCRIPTION
The current circleci mac executor has an old homebrew which provides golang 1.13.6.  This is used in CI macdeps and test-go-darwin.  Homebrew itself can provide a newer golang but updating it takes a few minutes each CI run.

This PR switches to a newer circleci executor and updates the cache key to avoid reusing the cache from the previous executor.  (see https://circleci.com/docs/2.0/caching/#managing-caches)  The newer executor has an updated homebrew that provides golang 1.15.3 without updating.

#8391 and #8496 depend on updated golang during CI