### PR TITLE
feat: Build configuration tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ help:
 
 .PHONY: allyesconfig
 allyesconfig:
-	go run buildconfig/bob.go --allyesconfig
+	go run buildconfig/bob.go --allyesconfig --save
 
 .PHONY: config
 config:

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ help:
 	@echo '   telegraf-$(tar_version)_arch.zip'
 
 
+.PHONY: allyesconfig
+allyesconfig:
+	go run buildconfig/bob.go --allyesconfig
+
 .PHONY: config
 config:
 	go run buildconfig/bob.go --fallback
@@ -135,7 +139,7 @@ fmtcheck:
 	fi
 
 .PHONY: vet
-vet:
+vet: allyesconfig
 	@echo 'go vet $$(go list ./... | grep -v ./plugins/parsers/influx)'
 	@go vet $$(go list ./... | grep -v ./plugins/parsers/influx) ; if [ $$? -ne 0 ]; then \
 		echo ""; \
@@ -178,7 +182,7 @@ lint-branch:
 	golangci-lint run --new-from-rev master
 
 .PHONY: tidy
-tidy:
+tidy: allyesconfig
 	go mod verify
 	go mod tidy
 	@if ! git diff --quiet go.mod go.sum; then \

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ deps:
 	go mod download -x
 
 .PHONY: telegraf
-telegraf:
+telegraf: config
 	go build -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
 # Used by dockerfile builds

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ pkgdir ?= build/dist
 
 .PHONY: all
 all:
+	@$(MAKE) config
 	@$(MAKE) deps
 	@$(MAKE) telegraf
 
@@ -92,6 +93,10 @@ help:
 	@echo '   telegraf-$(tar_version)_arch.tar.gz'
 	@echo '   telegraf-$(tar_version)_arch.zip'
 
+
+.PHONY: config
+config:
+	go run buildconfig/bob.go --fallback
 
 .PHONY: deps
 deps:
@@ -196,6 +201,10 @@ clean:
 	rm -f telegraf
 	rm -f telegraf.exe
 	rm -rf build
+	rm -f plugins/aggregators/all/all.go
+	rm -f plugins/inputs/all/all.go
+	rm -f plugins/outputs/all/all.go
+	rm -f plugins/processors/all/all.go
 
 .PHONY: docker-image
 docker-image:

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,9 @@ help:
 allyesconfig:
 	go run buildconfig/bob.go --allyesconfig --save
 
+testconfig:
+	go run buildconfig/bob.go --allyesconfig
+
 .PHONY: config
 config:
 	go run buildconfig/bob.go --fallback
@@ -117,7 +120,7 @@ go-install:
 	go install -mod=mod -ldflags "-w -s $(LDFLAGS)" ./cmd/telegraf
 
 .PHONY: test
-test: allyesconfig
+test: testconfig
 	go test -short $(race_detector) ./...
 
 .PHONY: test-integration
@@ -139,7 +142,7 @@ fmtcheck:
 	fi
 
 .PHONY: vet
-vet: allyesconfig
+vet: testconfig
 	@echo 'go vet $$(go list ./... | grep -v ./plugins/parsers/influx)'
 	@go vet $$(go list ./... | grep -v ./plugins/parsers/influx) ; if [ $$? -ne 0 ]; then \
 		echo ""; \
@@ -182,7 +185,7 @@ lint-branch:
 	golangci-lint run --new-from-rev master
 
 .PHONY: tidy
-tidy: allyesconfig
+tidy: testconfig
 	go mod verify
 	go mod tidy
 	@if ! git diff --quiet go.mod go.sum; then \
@@ -198,7 +201,7 @@ test-all: fmtcheck vet
 	go test $(race_detector) ./...
 
 .PHONY: check-deps
-check-deps:
+check-deps: testconfig
 	./scripts/check-deps.sh
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ go-install:
 	go install -mod=mod -ldflags "-w -s $(LDFLAGS)" ./cmd/telegraf
 
 .PHONY: test
-test:
+test: allyesconfig
 	go test -short $(race_detector) ./...
 
 .PHONY: test-integration

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ help:
 	@echo '  lint-install - install linter'
 	@echo '  check-deps   - check docs/LICENSE_OF_DEPENDENCIES.md'
 	@echo '  clean        - delete build artifacts'
+	@echo '  distclean    - delete build artifacts and configuration file'
 	@echo '  package      - build all supported packages, override include_packages to only build a subset'
 	@echo '                 e.g.: make package include_packages="amd64.deb"'
 	@echo ''
@@ -205,6 +206,10 @@ clean:
 	rm -f plugins/inputs/all/all.go
 	rm -f plugins/outputs/all/all.go
 	rm -f plugins/processors/all/all.go
+
+.PHONY: distclean
+distclean: clean
+	rm -rf build.conf
 
 .PHONY: docker-image
 docker-image:

--- a/buildconfig/bob.go
+++ b/buildconfig/bob.go
@@ -12,7 +12,7 @@ import (
 	"github.com/influxdata/toml"
 )
 
-const usageText = `Bob-the-builder, The configuration tool for generating stripped-down telegraf binaries.
+const usageText = `Bob is a configuration tool for generating stripped-down telegraf binaries.
 
 Usage:
 

--- a/buildconfig/bob.go
+++ b/buildconfig/bob.go
@@ -7,6 +7,7 @@ import (
 	"log" // nolint:revive
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/influxdata/toml"
 )
@@ -113,6 +114,7 @@ func generatePluginsFile(category string, plugins []string) error {
 	if _, err := f.WriteString("package all\n\nimport (\n"); err != nil {
 		return err
 	}
+	sort.Strings(plugins)
 	for _, plugin := range plugins {
 		fn := fmt.Sprintf("\t_ \"github.com/influxdata/telegraf/plugins/%s/%s\"\n", category, plugin)
 		if _, err := f.WriteString(fn); err != nil {

--- a/buildconfig/bob.go
+++ b/buildconfig/bob.go
@@ -1,0 +1,306 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/influxdata/toml"
+)
+
+const usageText = `Bob-the-builder, The configuration tool for generating stripped-down telegraf binaries.
+
+Usage:
+
+  bob [flags] [config file]
+
+The flags are:
+
+  --allyesconfig                 generate a configuration with all plugins enabled
+  --allnoconfig                  generate a configuration with all plugins disabled
+  --list                         list all configurable plugins
+  --save                         save configuration to file
+
+  config file                    file to read the configuration from (default: build.conf)
+
+Examples:
+
+  # generate telegraf with all plugins enabled:
+  go run buildconfig/bob.go --allyesconfig
+  make
+
+  # generate config with all plugins disabled for manual selection of few plugins
+  go run buildconfig/bob.go --allnoconfig --save
+
+  # build with custom config file
+  go run buildconfig/bob.go mybuildsetup.conf
+  make
+`
+
+var fConfigYes = flag.Bool("allyesconfig", false, "generate a configuration with all plugins enabled and exit")
+var fConfigNo = flag.Bool("allnoconfig", false, "generate a configuration with all plugins disabled and exit")
+var fList = flag.Bool("list", false, "list all configurable plugins")
+var fSave = flag.Bool("save", false, "save configuration to file")
+
+type buildConfig struct {
+	Inputs      map[string]bool
+	Outputs     map[string]bool
+	Processors  map[string]bool
+	Aggregators map[string]bool
+}
+
+func getPlugins(category string, excludes ...string) ([]string, error) {
+	dirname := filepath.Join("plugins", category)
+	files, err := ioutil.ReadDir(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	plugins := []string{}
+	for _, file := range files {
+		if !file.IsDir() {
+			continue
+		}
+
+		include := true
+		for _, e := range excludes {
+			if file.Name() == e {
+				include = false
+				break
+			}
+		}
+		if include {
+			plugins = append(plugins, file.Name())
+		}
+	}
+
+	return plugins, nil
+}
+
+func generatePluginsFile(category string, plugins []string) error {
+	path := filepath.Join("plugins", category, "all")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		os.Mkdir(path, 0755)
+	}
+
+	filename := filepath.Join(path, "all.go")
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString("package all\n\nimport (\n"); err != nil {
+		return err
+	}
+	for _, plugin := range plugins {
+		fn := fmt.Sprintf("\t_ \"github.com/influxdata/telegraf/plugins/%s/%s\"\n", category, plugin)
+		if _, err := f.WriteString(fn); err != nil {
+			return err
+		}
+	}
+	if _, err := f.WriteString(")\n"); err != nil {
+		return err
+	}
+	f.Sync()
+
+	return nil
+}
+
+func getAllPlugins(categories []string) (map[string][]string, error) {
+	plugins := make(map[string][]string)
+
+	for _, category := range categories {
+		plugins[category] = make([]string, 0)
+		pluginslist, err := getPlugins(category, "all")
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range pluginslist {
+			plugins[category] = append(plugins[category], p)
+		}
+	}
+
+	return plugins, nil
+}
+
+func getConfiguredPlugins(cfg buildConfig, allPlugins map[string][]string) map[string][]string {
+	config := make(map[string][]string)
+
+	categories := map[string](map[string]bool) {
+		"inputs": cfg.Inputs,
+		"outputs": cfg.Outputs,
+		"processors": cfg.Processors,
+		"aggregators": cfg.Aggregators,
+	}
+
+	for category, list := range categories {
+		config[category] = make([]string, 0)
+		for k, v := range list {
+			if !v {
+				continue
+			}
+			if k == "*" {
+				if list, ok := allPlugins[category]; ok {
+					config[category] = list
+				} else {
+					log.Printf("W! [bob] No all-plugins list for category %q", category)
+				}
+				break
+			} else {
+				config[category] = append(config[category], k)
+			}
+		}
+	}
+
+	return config
+}
+
+func readConfig(filename string) (buildConfig, error) {
+	log.Printf("I! [bob] Reading configuration from %q...", filename)
+	buf, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return buildConfig{}, err
+	}
+	var config buildConfig
+	if err := toml.Unmarshal(buf, &config); err != nil {
+		return buildConfig{}, err
+	}
+	return config, nil
+}
+
+func toConfig(plugins map[string][]string, val bool) buildConfig {
+	config := buildConfig{}
+
+	// Convert to config format
+	config.Inputs = make(map[string]bool)
+	config.Outputs = make(map[string]bool)
+	config.Processors = make(map[string]bool)
+	config.Aggregators = make(map[string]bool)
+	if list, ok := plugins["inputs"]; ok {
+		for _, plugin := range list {
+			config.Inputs[plugin] = val
+		}
+	}
+	if list, ok := plugins["outputs"]; ok {
+		for _, plugin := range list {
+			config.Outputs[plugin] = val
+		}
+	}
+	if list, ok := plugins["processors"]; ok {
+		for _, plugin := range list {
+			config.Processors[plugin] = val
+		}
+	}
+	if list, ok := plugins["aggregators"]; ok {
+		for _, plugin := range list {
+			config.Aggregators[plugin] = val
+		}
+	}
+
+	return config
+}
+
+func writeConfig(filename string, config buildConfig) error {
+	log.Printf("I! [bob] Writing configuration to %q...", filename)
+	buf, err := toml.Marshal(config)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filename, buf, 0644)
+}
+
+func printPlugins(plugins map[string][]string) {
+	for name, list := range plugins {
+		fmt.Printf("%s:\n", name)
+		for _, plugin := range list {
+			fmt.Printf("\t%s\n", plugin)
+		}
+	}
+}
+
+func usage() {
+	fmt.Println(usageText)
+	os.Exit(0)
+}
+
+func main() {
+	flag.Usage = usage
+	flag.Parse()
+	args := flag.Args()
+
+	// Check the command-line options
+	if len(args) > 1 {
+		log.Fatalf("E! [bob] Too many command line arguments!")
+	}
+
+	// Determine config filename
+	configFile := "build.conf"
+	if len(args) > 0 {
+		configFile = args[0]
+	}
+
+	// Define the categories we can handle
+	categories := []string{"inputs", "outputs", "processors", "aggregators"}
+
+	// Get the list of all configurable plugins
+	allPlugins, err := getAllPlugins(categories)
+	if err != nil {
+		log.Fatalf("E! [bob] Cannot determine list of configurable plugins: %v", err)
+	}
+
+	// Handle listing request
+	if *fList {
+		if *fSave {
+			config := toConfig(allPlugins, false)
+			err = writeConfig(configFile, config)
+			if err != nil {
+				log.Fatalf("E! [bob] Cannot write list of plugins to %q: %v", configFile, err)
+			}
+		} else {
+			printPlugins(allPlugins)
+		}
+		return
+	}
+
+	// Generate all yes/no configurations if specified
+	var config buildConfig
+	if *fConfigYes && *fConfigNo {
+		log.Fatalf("E! [bob] Cannot use 'allyesconfig' and 'allnoconfig' at the same time!")
+	} else if *fConfigYes {
+		config = toConfig(allPlugins, true)
+		if *fSave {
+			err = writeConfig(configFile, config)
+			if err != nil {
+				log.Fatalf("E! [bob] Cannot write list of plugins to %q: %v", configFile, err)
+			}
+		}
+	} else if *fConfigNo {
+		config = toConfig(allPlugins, false)
+		if *fSave {
+			err = writeConfig(configFile, config)
+			if err != nil {
+				log.Fatalf("E! [bob] Cannot write list of plugins to %q: %v", configFile, err)
+			}
+		}
+	} else {
+		// Read the build configuration file
+		config, err = readConfig(configFile)
+		if err != nil {
+			log.Fatalf("E! [bob] Cannot read configuration file %q: %v", configFile, err)
+		}
+	}
+
+	// Filter only activated plugins and generate the include files
+	configuredPlugins := getConfiguredPlugins(config, allPlugins)
+	for category, plugins := range configuredPlugins {
+		log.Printf("I! [bob] Generating %s-plugins file with %d entries...", category, len(plugins))
+		err = generatePluginsFile(category, plugins)
+		if err != nil {
+			log.Fatalf("E! [bob] Cannot generate %s-plugins file: %v", category, err)
+		}
+	}
+}

--- a/buildconfig/bob.go
+++ b/buildconfig/bob.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
+	"log" // nolint:revive
 	"os"
 	"path/filepath"
 
@@ -77,7 +77,7 @@ func getPlugins(category string, excludes ...string) ([]string, error) {
 			continue
 		}
 
-		if matches, _ := filepath.Glob(filepath.Join(dirname, file.Name(), "*.go")); matches != nil && len(matches) > 0 {
+		if matches, _ := filepath.Glob(filepath.Join(dirname, file.Name(), "*.go")); len(matches) > 0 {
 			// No subprojects expected
 			plugins = append(plugins, file.Name())
 		} else {
@@ -98,7 +98,9 @@ func getPlugins(category string, excludes ...string) ([]string, error) {
 func generatePluginsFile(category string, plugins []string) error {
 	path := filepath.Join("plugins", category, "all")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		os.Mkdir(path, 0755)
+		if err := os.Mkdir(path, 0755); err != nil {
+			return fmt.Errorf("creating dir %q failed: %v", path, err)
+		}
 	}
 
 	filename := filepath.Join(path, "all.go")
@@ -120,9 +122,7 @@ func generatePluginsFile(category string, plugins []string) error {
 	if _, err := f.WriteString(")\n"); err != nil {
 		return err
 	}
-	f.Sync()
-
-	return nil
+	return f.Sync()
 }
 
 func getAllPlugins(categories []string) (map[string][]string, error) {
@@ -134,9 +134,7 @@ func getAllPlugins(categories []string) (map[string][]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		for _, p := range pluginslist {
-			plugins[category] = append(plugins[category], p)
-		}
+		plugins[category] = append(plugins[category], pluginslist...)
 	}
 
 	return plugins, nil
@@ -165,9 +163,8 @@ func getConfiguredPlugins(cfg buildConfig, allPlugins map[string][]string) map[s
 					log.Printf("W! [bob] No all-plugins list for category %q", category)
 				}
 				break
-			} else {
-				config[category] = append(config[category], k)
 			}
+			config[category] = append(config[category], k)
 		}
 	}
 
@@ -230,16 +227,18 @@ func writeConfig(filename string, config buildConfig) error {
 
 func printPlugins(plugins map[string][]string) {
 	for name, list := range plugins {
+		//nolint:revive
 		fmt.Printf("%s:\n", name)
 		for _, plugin := range list {
+			//nolint:revive
 			fmt.Printf("\t%s\n", plugin)
 		}
 	}
 }
 
 func usage() {
+	//nolint:revive
 	fmt.Println(usageText)
-	os.Exit(0)
 }
 
 func main() {


### PR DESCRIPTION
### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

resolve: https://github.com/influxdata/telegraf/issues/9556

Add a script to configure integrated plugins an generate all.go files such that we can build stripped-down versions of the telegraf binaries. For configuration you can either edit a `build.conf` file in TOML format to manually select plugins or use the `--allyesconfig` or `--allnoconfig` flags.
To generate a config file to play with use
```
# go run buildconfig/bob.go --list --save
```
equivalent to 
```
# go run buildconfig/bob.go --allnoconfig --save
```
As a shortcut, `*` asterix in a category includes all plugins of that category.
[build_modbus_starlark_influxdb.conf.txt](https://github.com/influxdata/telegraf/files/5652787/build_modbus_starlark_influxdb.conf.txt)


The effect is enormous, a current build is about **93.5MiB** and can be
reproduced with
```
# go run buildconfig/bob.go --allyesconfig
2020/12/07 13:49:21 I! [bob] Generating outputs-plugins file with 41 entries...
2020/12/07 13:49:21 I! [bob] Generating processors-plugins file with 24 entries...
2020/12/07 13:49:21 I! [bob] Generating aggregators-plugins file with 6 entries...
2020/12/07 13:49:21 I! [bob] Generating inputs-plugins file with 188 entries...
# make
```

Contrary to this, when generating a telegraf *only* containing the
*modbus* input, *influxdb* output and *starlark* processor plugin using the
attached config via
```
# go run buildconfig/bob.go build_modbus_starlark_influxdb.conf
2020/12/07 13:49:07 I! [bob] Reading configuration from "build_modbus_starlark_influxdb.conf"...
2020/12/07 13:49:07 I! [bob] Generating processors-plugins file with 1 entries...
2020/12/07 13:49:07 I! [bob] Generating aggregators-plugins file with 0 entries...
2020/12/07 13:49:07 I! [bob] Generating inputs-plugins file with 1 entries...
2020/12/07 13:49:07 I! [bob] Generating outputs-plugins file with 1 entries...
# make
```
the resulting binary is only **15.7MiB**! The effect of course depends on the included plugins.

Currently, *bob* can only handle *inputs*, *outputs*, *processors* and *aggregators* plugins. *parsers* and *serializers* to not use a `all.go` based schema for registration and therefor would need extra-love.
