### PR TITLE
feat: Added possibility to detect local config file changes and reload

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -689,7 +689,7 @@ func (c *Config) LoadDirectory(path string) error {
 //   2. $HOME/.telegraf/telegraf.conf
 //   3. /etc/telegraf/telegraf.conf
 //
-func getDefaultConfigPath() (string, error) {
+func GetDefaultConfigPath() (string, error) {
 	envfile := os.Getenv("TELEGRAF_CONFIG_PATH")
 	homefile := os.ExpandEnv("${HOME}/.telegraf/telegraf.conf")
 	etcfile := "/etc/telegraf/telegraf.conf"
@@ -716,9 +716,7 @@ func getDefaultConfigPath() (string, error) {
 func (c *Config) LoadConfig(path string) error {
 	var err error
 	if path == "" {
-		if path, err = getDefaultConfigPath(); err != nil {
-			return err
-		}
+		return fmt.Errorf("Empty config path")
 	}
 	data, err := loadConfig(path)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -149,6 +149,7 @@ require (
 	gopkg.in/ldap.v3 v3.1.0
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
 	gopkg.in/olivere/elastic.v5 v5.0.70
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools v2.2.0+incompatible
 	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
@@ -156,5 +157,8 @@ require (
 	modernc.org/sqlite v1.7.4
 )
 
-// replaced due to https://github.com/satori/go.uuid/issues/73
-replace github.com/satori/go.uuid => github.com/gofrs/uuid v3.2.0+incompatible
+replace (
+	github.com/influxdata/tail => github.com/bonitoo-io/tail v1.0.1-0.20201208111917-9ddddda047d4
+	// replaced due to https://github.com/satori/go.uuid/issues/73
+	github.com/satori/go.uuid => github.com/gofrs/uuid v3.2.0+incompatible
+)

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/bitly/go-hostpool v0.1.0 h1:XKmsF6k5el6xHG3WPJ8U0Ku/ye7njX7W81Ng7O2io
 github.com/bitly/go-hostpool v0.1.0/go.mod h1:4gOCgp6+NZnVqlKyZ/iBZFTAJKembaVENUpMkpg42fw=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/bonitoo-io/tail v1.0.1-0.20201208111917-9ddddda047d4 h1:YHP5sJ7+Lttnw1jJ79HZG8wkbCID9fjD/1J5VKoAfY0=
+github.com/bonitoo-io/tail v1.0.1-0.20201208111917-9ddddda047d4/go.mod h1:VeiWgI3qaGdJWust2fP27a6J+koITo/1c/UhxeOxgaM=
 github.com/caio/go-tdigest v2.3.0+incompatible h1:zP6nR0nTSUzlSqqr7F/LhslPlSZX/fZeGmgmwj2cxxY=
 github.com/caio/go-tdigest v2.3.0+incompatible/go.mod h1:sHQM/ubZStBUmF1WbB8FAm8q9GjDajLC5T7ydxE3JHI=
 github.com/cenkalti/backoff v2.0.0+incompatible h1:5IIPUHhlnUZbcHQsQou5k1Tn58nJkeJL9U+ig5CHJbY=
@@ -348,8 +350,6 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/influxdata/go-syslog/v2 v2.0.1 h1:l44S4l4Q8MhGQcoOxJpbo+QQYxJqp0vdgIVHh4+DO0s=
 github.com/influxdata/go-syslog/v2 v2.0.1/go.mod h1:hjvie1UTaD5E1fTnDmxaCw8RRDrT4Ve+XHr5O2dKSCo=
-github.com/influxdata/tail v1.0.1-0.20200707181643-03a791b270e4 h1:K3A5vHPs/p8OjI4SL3l1+hs/98mhxTVDcV1Ap0c265E=
-github.com/influxdata/tail v1.0.1-0.20200707181643-03a791b270e4/go.mod h1:VeiWgI3qaGdJWust2fP27a6J+koITo/1c/UhxeOxgaM=
 github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65 h1:vvyMtD5LTJc1W9sQKjDkAWdcg0478CszSdzlHtiAXCY=
 github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65/go.mod h1:zApaNFpP/bTpQItGZNNUMISDMDAnTXu9UqJ4yT3ocz8=
 github.com/influxdata/wlog v0.0.0-20160411224016-7c63b0a71ef8 h1:W2IgzRCb0L9VzMujq/QuTaZUKcH8096jWwP519mHN6Q=

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -16,6 +16,9 @@ The commands & flags are:
   --aggregator-filter <filter>   filter the aggregators to enable, separator is :
   --config <file>                configuration file to load
   --config-directory <directory> directory containing additional *.conf files
+  --watch-config                 Telegraf will restart on local config changes. Monitor changes 
+                                 using either fs notifications or polling.  Valid values: 'inotify' or 'poll'. 
+                                 Monitoring is off by default.
   --plugin-directory             directory containing *.so files, this directory will be
                                  searched recursively. Any Plugin found will be loaded
                                  and namespaced.

--- a/internal/usage_windows.go
+++ b/internal/usage_windows.go
@@ -16,6 +16,9 @@ The commands & flags are:
   --aggregator-filter <filter>   filter the aggregators to enable, separator is :
   --config <file>                configuration file to load
   --config-directory <directory> directory containing additional *.conf files
+  --watch-config                 Telegraf will restart on local config changes. Monitor changes 
+                                 using either fs notifications or polling.  Valid values: 'inotify' or 'poll'. 
+                                 Monitoring is off by default.
   --debug                        turn on debug logging
   --input-filter <filter>        filter the inputs to enable, separator is :
   --input-list                   print available input plugins.


### PR DESCRIPTION
Closes #7187

There are situations (e.g. Kubernetes environment, Windows service) when restarting Telegraf due to config changes is cumbersome, and sending _SIGHUP_ signal to achieve that is difficult.

Telegraf watching its config for changes will make this easy.

**This PR adds watching for a single local config file only, not config dir or URL .**

Watching is made using the `infuxdata/tail` lib and it is possible to be enabled via cmd option `watch-config` with two possible values:
 - inotify - uses fsnotify from tail
 - poll - uses polling from tail 

However, polling from tail needs a fix (https://github.com/influxdata/tail/pull/9) and until the tail is fixed, it is redirected to the fork with a simple fix.

### Required for all PRs:

- [X] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
