### PR TITLE
fix crash when socket_listener receiving invalid data

### DIFF
--- a/plugins/inputs/socket_listener/socket_listener.go
+++ b/plugins/inputs/socket_listener/socket_listener.go
@@ -114,6 +114,7 @@ func (ssl *streamSocketListener) read(c net.Conn) {
 	decoder, err := internal.NewStreamContentDecoder(ssl.ContentEncoding, c)
 	if err != nil {
 		ssl.Log.Error("Read error: %v", err)
+		return
 	}
 
 	scnr := bufio.NewScanner(decoder)


### PR DESCRIPTION
Socket_listener cause Telegraf crash when receiving invalid data if `NewStreamContentDecoder` returning error. `decoder` is nil at that time that cause `scnr.Scan` to dereference null pointer.

```
E! [inputs.socket_listener] Read error: %vunexpected EOF
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x5951da]

goroutine 25 [running]:
bufio.(*Scanner).Scan(0xc000669ec0, 0xbfed4a168ea3030f)
	/usr/local/go/src/bufio/scan.go:214 +0x7a
[global_tags]
github.com/influxdata/telegraf/plugins/inputs/socket_listener.(*streamSocketListener).read(0xc0005c4800, 0x33d9d80, 0xc000010008)
	/go/src/github.com/influxdata/telegraf/plugins/inputs/socket_listener/socket_listener.go:124 +0x1ae
github.com/influxdata/telegraf/plugins/inputs/socket_listener.(*streamSocketListener).listen.func1(0xc0001107f0, 0xc0005c4800, 0x33d9d80, 0xc000010008)
	/go/src/github.com/influxdata/telegraf/plugins/inputs/socket_listener/socket_listener.go:74 +0x6b
created by github.com/influxdata/telegraf/plugins/inputs/socket_listener.(*streamSocketListener).listen
	/go/src/github.com/influxdata/telegraf/plugins/inputs/socket_listener/socket_listener.go:72 +0x26b
```

The fix is easy: just stop when we have an error.

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
