### PR TITLE
improve the error log message for snmp trap

### DIFF
--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -284,7 +284,7 @@ func makeTrapHandler(s *SnmpTrap) handler {
 			if trapOid != "" {
 				e, err := s.lookup(trapOid)
 				if err != nil {
-					s.Log.Errorf("Error resolving V1 OID: %v", err)
+					s.Log.Errorf("Error resolving V1 OID, oid=%s, source=%s: %v", trapOid, tags["source"], err)
 					return
 				}
 				setTrapOid(tags, trapOid, e)
@@ -322,7 +322,7 @@ func makeTrapHandler(s *SnmpTrap) handler {
 				var err error
 				e, err = s.lookup(val)
 				if nil != err {
-					s.Log.Errorf("Error resolving value OID: %v", err)
+					s.Log.Errorf("Error resolving value OID, oid=%s, source=%s: %v", val, tags["source"], err)
 					return
 				}
 
@@ -340,7 +340,7 @@ func makeTrapHandler(s *SnmpTrap) handler {
 
 			e, err := s.lookup(v.Name)
 			if nil != err {
-				s.Log.Errorf("Error resolving OID: %v", err)
+				s.Log.Errorf("Error resolving OID oid=%s, source=%s: %v", v.Name, tags["source"], err)
 				return
 			}
 


### PR DESCRIPTION
add OID value and source information into the error log and make it easier for troubleshooting

before:
```
2020-11-24T06:04:55Z E! [inputs.snmp_trap] Error resolving OID: exit status 2
```

after:
```
2020-11-24T06:04:55Z E! [inputs.snmp_trap] Error resolving OID, oid=.1.3.6.1.4.1.9.9.41, source=10.1.1.2.: exit status 2
```
#8535 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
