### PR TITLE
Added Glob pattern matching for "Windows Services" plugin

### DIFF
--- a/plugins/inputs/win_services/README.md
+++ b/plugins/inputs/win_services/README.md
@@ -8,10 +8,11 @@ Monitoring some services may require running Telegraf with administrator privile
 
 ```toml
 [[inputs.win_services]]
-  ## Names of the services to monitor. Leave empty to monitor all the available services on the host
+  ## Names of the services to monitor. Leave empty to monitor all the available services on the host. Globs accepted.
   service_names = [
     "LanmanServer",
     "TermService",
+    "Win*",
   ]
 ```
 

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -82,7 +82,8 @@ var sampleConfig = `
   ## Names of the services to monitor. Leave empty to monitor all the available services on the host. Globs accepted.
   service_names = [
     "LanmanServer",
-    "TermService",
+	"TermService",
+	"Win*",
   ]
 `
 

--- a/plugins/inputs/win_services/win_services_integration_test.go
+++ b/plugins/inputs/win_services/win_services_integration_test.go
@@ -22,7 +22,10 @@ func TestList(t *testing.T) {
 	require.NoError(t, err)
 	defer scmgr.Disconnect()
 
-	services, err := listServices(scmgr, KnownServices)
+	winServices := &WinServices{
+		ServiceNames: KnownServices,
+	}
+	services, err := winServices.listServices(scmgr)
 	require.NoError(t, err)
 	require.Len(t, services, 2, "Different number of services")
 	require.Equal(t, services[0], KnownServices[0])
@@ -38,7 +41,10 @@ func TestEmptyList(t *testing.T) {
 	require.NoError(t, err)
 	defer scmgr.Disconnect()
 
-	services, err := listServices(scmgr, []string{})
+	winServices := &WinServices{
+		ServiceNames: []string{},
+	}
+	services, err := winServices.listServices(scmgr)
 	require.NoError(t, err)
 	require.Condition(t, func() bool { return len(services) > 20 }, "Too few service")
 }

--- a/plugins/inputs/win_services/win_services_integration_test.go
+++ b/plugins/inputs/win_services/win_services_integration_test.go
@@ -25,6 +25,7 @@ func TestList(t *testing.T) {
 	winServices := &WinServices{
 		ServiceNames: KnownServices,
 	}
+	winServices.Init()
 	services, err := winServices.listServices(scmgr)
 	require.NoError(t, err)
 	require.Len(t, services, 2, "Different number of services")
@@ -44,6 +45,7 @@ func TestEmptyList(t *testing.T) {
 	winServices := &WinServices{
 		ServiceNames: []string{},
 	}
+	winServices.Init()
 	services, err := winServices.listServices(scmgr)
 	require.NoError(t, err)
 	require.Condition(t, func() bool { return len(services) > 20 }, "Too few service")
@@ -58,6 +60,7 @@ func TestGatherErrors(t *testing.T) {
 		ServiceNames: InvalidServices,
 		mgrProvider:  &MgProvider{},
 	}
+	ws.Init()
 	require.Len(t, ws.ServiceNames, 3, "Different number of services")
 	var acc testutil.Accumulator
 	require.NoError(t, ws.Gather(&acc))

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -134,6 +134,7 @@ func TestBasicInfo(t *testing.T) {
 		Log:         testutil.Logger{},
 		mgrProvider: &FakeMgProvider{testErrors[0]},
 	}
+	winServices.Init()
 	assert.NotEmpty(t, winServices.SampleConfig())
 	assert.NotEmpty(t, winServices.Description())
 }
@@ -165,6 +166,7 @@ func TestMgrErrors(t *testing.T) {
 		ServiceNames: []string{"Fake service 1"},
 		mgrProvider:  &FakeMgProvider{testErrors[3]},
 	}
+	winServices.Init()
 	var acc3 testutil.Accumulator
 
 	buf := &bytes.Buffer{}
@@ -179,6 +181,7 @@ func TestServiceErrors(t *testing.T) {
 		Log:         testutil.Logger{},
 		mgrProvider: &FakeMgProvider{testErrors[2]},
 	}
+	winServices.Init()
 	var acc1 testutil.Accumulator
 
 	buf := &bytes.Buffer{}
@@ -206,6 +209,7 @@ func TestGatherContainsTag(t *testing.T) {
 		ServiceNames: []string{"Service*"},
 		mgrProvider:  &FakeMgProvider{testSimpleData[0]},
 	}
+	winServices.Init()
 	var acc1 testutil.Accumulator
 	require.NoError(t, winServices.Gather(&acc1))
 	assert.Len(t, acc1.Errors, 0, "There should be no errors after gather")

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -123,35 +123,48 @@ var testErrors = []testData{
 		{nil, errors.New("Fake srv query error"), nil, "Fake service 2", "", 0, 0},
 		{nil, nil, errors.New("Fake srv config error"), "Fake service 3", "", 0, 0},
 	}},
-	{nil, nil, nil, []serviceTestInfo{
+	{[]string{"Fake service 1"}, nil, nil, []serviceTestInfo{
 		{errors.New("Fake srv open error"), nil, nil, "Fake service 1", "", 0, 0},
 	}},
 }
 
 func TestBasicInfo(t *testing.T) {
 
-	winServices := &WinServices{testutil.Logger{}, nil, &FakeMgProvider{testErrors[0]}}
+	winServices := &WinServices{
+		Log:         testutil.Logger{},
+		mgrProvider: &FakeMgProvider{testErrors[0]},
+	}
 	assert.NotEmpty(t, winServices.SampleConfig())
 	assert.NotEmpty(t, winServices.Description())
 }
 
 func TestMgrErrors(t *testing.T) {
 	//mgr.connect error
-	winServices := &WinServices{testutil.Logger{}, nil, &FakeMgProvider{testErrors[0]}}
+	winServices := &WinServices{
+		Log:         testutil.Logger{},
+		mgrProvider: &FakeMgProvider{testErrors[0]},
+	}
 	var acc1 testutil.Accumulator
 	err := winServices.Gather(&acc1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), testErrors[0].mgrConnectError.Error())
 
 	////mgr.listServices error
-	winServices = &WinServices{testutil.Logger{}, nil, &FakeMgProvider{testErrors[1]}}
+	winServices = &WinServices{
+		Log:         testutil.Logger{},
+		mgrProvider: &FakeMgProvider{testErrors[1]},
+	}
 	var acc2 testutil.Accumulator
 	err = winServices.Gather(&acc2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), testErrors[1].mgrListServicesError.Error())
 
 	////mgr.listServices error 2
-	winServices = &WinServices{testutil.Logger{}, []string{"Fake service 1"}, &FakeMgProvider{testErrors[3]}}
+	winServices = &WinServices{
+		Log:          testutil.Logger{},
+		ServiceNames: []string{"Fake service 1"},
+		mgrProvider:  &FakeMgProvider{testErrors[3]},
+	}
 	var acc3 testutil.Accumulator
 
 	buf := &bytes.Buffer{}
@@ -162,7 +175,10 @@ func TestMgrErrors(t *testing.T) {
 }
 
 func TestServiceErrors(t *testing.T) {
-	winServices := &WinServices{testutil.Logger{}, nil, &FakeMgProvider{testErrors[2]}}
+	winServices := &WinServices{
+		Log:         testutil.Logger{},
+		mgrProvider: &FakeMgProvider{testErrors[2]},
+	}
 	var acc1 testutil.Accumulator
 
 	buf := &bytes.Buffer{}
@@ -184,8 +200,12 @@ var testSimpleData = []testData{
 	}},
 }
 
-func TestGather2(t *testing.T) {
-	winServices := &WinServices{testutil.Logger{}, nil, &FakeMgProvider{testSimpleData[0]}}
+func TestGatherContainsTag(t *testing.T) {
+	winServices := &WinServices{
+		Log:          testutil.Logger{},
+		ServiceNames: []string{"Service*"},
+		mgrProvider:  &FakeMgProvider{testSimpleData[0]},
+	}
 	var acc1 testutil.Accumulator
 	require.NoError(t, winServices.Gather(&acc1))
 	assert.Len(t, acc1.Errors, 0, "There should be no errors after gather")


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This pull request addresses the issue  #3673
Updated the "Windows Services" plugin to allow glob patterns in the input config for including services.
I based the changes on the Docker plugin which also allows glob pattern matching.

Tested the changes locally and uploaded some information:
```
[[inputs.win_services]]
  ## Names of the services to monitor. Leave empty to monitor all the available services on the host
  service_names = [
    "Win*",
  ]
```
![image](https://user-images.githubusercontent.com/3441183/102390101-99559100-3f99-11eb-89d0-de5e31c3a210.png)

