### PR TITLE
Fixed race condition on TestThreadStats

### DIFF
--- a/plugins/inputs/suricata/suricata_test.go
+++ b/plugins/inputs/suricata/suricata_test.go
@@ -119,7 +119,7 @@ func TestThreadStats(t *testing.T) {
 	c.Write([]byte(ex3))
 	c.Write([]byte("\n"))
 	c.Close()
-	acc.Wait(1)
+	acc.Wait(2)
 
 	expected := []telegraf.Metric{
 		testutil.MustMetric(

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -54,6 +54,8 @@ func (a *Accumulator) NMetrics() uint64 {
 	return atomic.LoadUint64(&a.nMetrics)
 }
 
+// GetTelegrafMetrics returns all the metrics collected by the accumulator
+// If you are getting race conditions here then you are not waiting for all of your metrics to arrive: see Wait()
 func (a *Accumulator) GetTelegrafMetrics() []telegraf.Metric {
 	metrics := []telegraf.Metric{}
 	for _, m := range a.Metrics {


### PR DESCRIPTION
Changed the acc to wait for 2 as its receiving an empty metric and appears to be counting that empty metric against the wait count 