### PR TITLE
Add Event Log support for Windows

### DIFF
--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -96,10 +96,9 @@ func runAsWindowsService(inputFilters, outputFilters, aggregatorFilters, process
 		}
 		os.Exit(0)
 	} else {
-		winlogger, err := s.Logger(nil)
 		if err == nil {
 			//When in service mode, register eventlog target andd setup default logging to eventlog
-			logger.RegisterEventLogger(winlogger)
+			logger.RegisterEventLogger(*fServiceName)
 			logger.SetupLogging(logger.LogConfig{LogTarget: logger.LogTargetEventlog})
 		}
 		err = s.Run()

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -12,6 +12,9 @@ import (
 )
 
 func run(inputFilters, outputFilters, aggregatorFilters, processorFilters []string) {
+	// Register the eventlog logging target for windows.
+	logger.RegisterEventLogger(*fServiceName)
+
 	if runtime.GOOS == "windows" && windowsRunAsService() {
 		runAsWindowsService(
 			inputFilters,
@@ -97,8 +100,6 @@ func runAsWindowsService(inputFilters, outputFilters, aggregatorFilters, process
 		os.Exit(0)
 	} else {
 		if err == nil {
-			//When in service mode, register eventlog target andd setup default logging to eventlog
-			logger.RegisterEventLogger(*fServiceName)
 			logger.SetupLogging(logger.LogConfig{LogTarget: logger.LogTargetEventlog})
 		}
 		err = s.Run()

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -99,9 +99,7 @@ func runAsWindowsService(inputFilters, outputFilters, aggregatorFilters, process
 		}
 		os.Exit(0)
 	} else {
-		if err == nil {
-			logger.SetupLogging(logger.LogConfig{LogTarget: logger.LogTargetEventlog})
-		}
+		logger.SetupLogging(logger.LogConfig{LogTarget: logger.LogTargetEventlog})
 		err = s.Run()
 
 		if err != nil {

--- a/logger/event_logger.go
+++ b/logger/event_logger.go
@@ -1,11 +1,15 @@
 package logger
 
 import (
+	"fmt"
 	"io"
+	"log"
+	"os"
+	"runtime"
 	"strings"
 
 	"github.com/influxdata/wlog"
-	"github.com/kardianos/service"
+	"golang.org/x/sys/windows/svc/eventlog"
 )
 
 const (
@@ -13,23 +17,23 @@ const (
 )
 
 type eventLogger struct {
-	logger service.Logger
+	logger *eventlog.Log
 }
 
 func (t *eventLogger) Write(b []byte) (n int, err error) {
 	loc := prefixRegex.FindIndex(b)
 	n = len(b)
 	if loc == nil {
-		err = t.logger.Info(b)
+		err = t.logger.Info(1, fmt.Sprint(b))
 	} else if n > 2 { //skip empty log messages
 		line := strings.Trim(string(b[loc[1]:]), " \t\r\n")
 		switch rune(b[loc[0]]) {
 		case 'I':
-			err = t.logger.Info(line)
+			err = t.logger.Info(1, line)
 		case 'W':
-			err = t.logger.Warning(line)
+			err = t.logger.Warning(2, line)
 		case 'E':
-			err = t.logger.Error(line)
+			err = t.logger.Error(3, line)
 		}
 	}
 
@@ -37,13 +41,24 @@ func (t *eventLogger) Write(b []byte) (n int, err error) {
 }
 
 type eventLoggerCreator struct {
-	serviceLogger service.Logger
+	logger *eventlog.Log
 }
 
 func (e *eventLoggerCreator) CreateLogger(config LogConfig) (io.Writer, error) {
-	return wlog.NewWriter(&eventLogger{logger: e.serviceLogger}), nil
+	if runtime.GOOS != "windows" {
+		log.Printf("E! Unable to use event log as the log target. Event log is only supported on windows environments. Telegraf will use stderr.")
+		return newTelegrafWriter(os.Stderr), nil
+	}
+
+	return wlog.NewWriter(&eventLogger{logger: e.logger}), nil
 }
 
-func RegisterEventLogger(serviceLogger service.Logger) {
-	registerLogger(LogTargetEventlog, &eventLoggerCreator{serviceLogger: serviceLogger})
+func RegisterEventLogger(name string) error {
+	eventLog, err := eventlog.Open(name)
+	if err != nil {
+		return err
+	}
+
+	registerLogger(LogTargetEventlog, &eventLoggerCreator{logger: eventLog})
+	return nil
 }

--- a/logger/event_logger.go
+++ b/logger/event_logger.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
-	"runtime"
 	"strings"
 
 	"github.com/influxdata/wlog"
@@ -47,11 +45,6 @@ type eventLoggerCreator struct {
 }
 
 func (e *eventLoggerCreator) CreateLogger(config LogConfig) (io.Writer, error) {
-	if runtime.GOOS != "windows" {
-		log.Printf("E! Unable to use event log as the log target. Event log is only supported on windows environments. Telegraf will use stderr.")
-		return newTelegrafWriter(os.Stderr), nil
-	}
-
 	return wlog.NewWriter(&eventLogger{logger: e.logger}), nil
 }
 

--- a/logger/event_logger.go
+++ b/logger/event_logger.go
@@ -13,6 +13,9 @@ import (
 
 const (
 	LogTargetEventlog = "eventlog"
+	eidInfo           = 1
+	eidWarning        = 2
+	eidError          = 3
 )
 
 type eventLogger struct {
@@ -28,11 +31,11 @@ func (t *eventLogger) Write(b []byte) (n int, err error) {
 		line := strings.Trim(string(b[loc[1]:]), " \t\r\n")
 		switch rune(b[loc[0]]) {
 		case 'I':
-			err = t.logger.Info(1, line)
+			err = t.logger.Info(eidInfo, line)
 		case 'W':
-			err = t.logger.Warning(2, line)
+			err = t.logger.Warning(eidWarning, line)
 		case 'E':
-			err = t.logger.Error(3, line)
+			err = t.logger.Error(eidError, line)
 		}
 	}
 

--- a/logger/event_logger.go
+++ b/logger/event_logger.go
@@ -56,6 +56,7 @@ func (e *eventLoggerCreator) CreateLogger(config LogConfig) (io.Writer, error) {
 func RegisterEventLogger(name string) error {
 	eventLog, err := eventlog.Open(name)
 	if err != nil {
+		log.Printf("E! An error occurred while initializing an event logger. %s", err)
 		return err
 	}
 

--- a/logger/event_logger.go
+++ b/logger/event_logger.go
@@ -3,7 +3,6 @@
 package logger
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"strings"

--- a/logger/event_logger.go
+++ b/logger/event_logger.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package logger
 
 import (

--- a/logger/event_logger.go
+++ b/logger/event_logger.go
@@ -24,7 +24,7 @@ func (t *eventLogger) Write(b []byte) (n int, err error) {
 	loc := prefixRegex.FindIndex(b)
 	n = len(b)
 	if loc == nil {
-		err = t.logger.Info(1, fmt.Sprint(b))
+		err = t.logger.Info(1, string(b))
 	} else if n > 2 { //skip empty log messages
 		line := strings.Trim(string(b[loc[1]:]), " \t\r\n")
 		switch rune(b[loc[0]]) {

--- a/logger/event_logger_test.go
+++ b/logger/event_logger_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kardianos/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/svc/eventlog"
 )
 
 type Levels int
@@ -30,7 +30,8 @@ type Event struct {
 
 func getEventLog(t *testing.T, since time.Time) []Event {
 	timeStr := since.UTC().Format(time.RFC3339)
-	cmd := exec.Command("wevtutil", "qe", "Application", "/rd:true", "/q:Event[System[TimeCreated[@SystemTime >= '"+timeStr+"'] and Provider[@Name='Telegraf']]]")
+	timeStr = timeStr[:19]
+	cmd := exec.Command("wevtutil", "qe", "Application", "/rd:true", "/q:Event[System[TimeCreated[@SystemTime >= '"+timeStr+"'] and Provider[@Name='telegraf']]]")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()
@@ -91,10 +92,8 @@ func TestRestrictedEventLog(t *testing.T) {
 }
 
 func prepareLogger(t *testing.T) {
-	svc, err := service.New(nil, &service.Config{Name: "Telegraf"})
+	eventLog, err := eventlog.Open("telegraf")
 	require.NoError(t, err)
-	svcLogger, err := svc.SystemLogger(nil)
-	require.NoError(t, err)
-	require.NotNil(t, svcLogger)
-	registerLogger(LogTargetEventlog, &eventLoggerCreator{serviceLogger: svcLogger})
+	require.NotNil(t, eventLog)
+	registerLogger(LogTargetEventlog, &eventLoggerCreator{logger: eventLog})
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -160,5 +160,4 @@ func init() {
 	registerLogger("", tlc)
 	registerLogger(LogTargetStderr, tlc)
 	registerLogger(LogTargetFile, tlc)
-	RegisterEventLogger("telegraf")
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -160,4 +160,5 @@ func init() {
 	registerLogger("", tlc)
 	registerLogger(LogTargetStderr, tlc)
 	registerLogger(LogTargetFile, tlc)
+	RegisterEventLogger("telegraf")
 }


### PR DESCRIPTION
This should add support to be able to configure the following in telegraf.conf:

`logtarget = "eventlog"`

Currently it only works when running telegraf as an already-installed windows service. This should enable it to work always, as long as it's configured and running on a windows machine.

resolves #7487