### PR TITLE
update influxdb_v2 config documentation in main

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -87,16 +87,16 @@ INFLUX_BUCKET="replace_with_your_bucket_name"
 # For InfluxDB OSS 2:
 [[outputs.influxdb_v2]]
   urls = ["${INFLUX_HOST}"]
-  token = ["${INFLUX_TOKEN}"]
-  org = ["${INFLUX_ORG}"]
-  bucket = ["${INFLUX_BUCKET}"]
+  token = "${INFLUX_TOKEN}"
+  organization = "${INFLUX_ORG}"
+  bucket = "${INFLUX_BUCKET}"
 
 # For InfluxDB Cloud 2:
 [[outputs.influxdb_v2]]
   urls = ["${INFLUX_HOST}"]
-  token = ["${INFLUX_TOKEN}"]
-  org = ["${INFLUX_ORG}"]
-  bucket = ["${INFLUX_BUCKET}"]
+  token = "${INFLUX_TOKEN}"
+  organization = "${INFLUX_ORG}"
+  bucket = "${INFLUX_BUCKET}"
 ```
 
 The above files will produce the following effective configuration file to be
@@ -117,7 +117,7 @@ parsed:
 [[outputs.influxdb_v2]]
   urls = ["http://127.0.0.1:8086"] # double check the port. could be 9999 if using OSS Beta
   token = "replace_with_your_token"
-  org = "your_username"
+  organization = "your_username"
   bucket = "replace_with_your_bucket_name"
 
 # For InfluxDB Cloud 2:
@@ -126,7 +126,7 @@ parsed:
   INFLUX_HOST="https://us-west-2-1.aws.cloud2.influxdata.com"
   # Other Cloud URLs at https://v2.docs.influxdata.com/v2.0/reference/urls/#influxdb-cloud-urls
   token = "replace_with_your_token"
-  org = "yourname@yourcompany.com"
+  organization = "yourname@yourcompany.com"
   bucket = "replace_with_your_bucket_name"
 ```
 


### PR DESCRIPTION
[Per the v2 output readme](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/influxdb_v2/README.md) and trial/error the fields aren't arrays, and "org" is actually "organization".

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
