### PR TITLE
fix: reading multiple holding registers in modbus input plugin

### DIFF
--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -229,19 +229,20 @@ func (m *Modbus) InitRegister(fields []fieldContainer, name string) error {
 	// [1, 2, 3, 5, 6, 10, 11, 12, 14]
 	// (1, 3) , (5, 2) , (10, 3), (14 , 1)
 	for range addrs {
-		quantity := 1
-		if ii < len(addrs) {
-			start := addrs[ii]
-			end := start
-
-			for ii < len(addrs)-1 && addrs[ii+1]-addrs[ii] == 1 && quantity < maxQuantity {
-				end = addrs[ii+1]
-				ii++
-				quantity++
-			}
-			ii++
-			registersRange = append(registersRange, registerRange{start, end - start + 1})
+		if ii >= len(addrs) {
+			break
 		}
+		quantity := 1
+		start := addrs[ii]
+		end := start
+
+		for ii < len(addrs)-1 && addrs[ii+1]-addrs[ii] == 1 && quantity < maxQuantity {
+			end = addrs[ii+1]
+			ii++
+			quantity++
+		}
+		ii++
+		registersRange = append(registersRange, registerRange{start, end - start + 1})
 	}
 
 	m.registers = append(m.registers, register{name, registersRange, fields})

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -241,7 +241,7 @@ func (m *Modbus) InitRegister(fields []fieldContainer, name string) error {
 			ii++
 			quantity++
 		}
-		ii++
+
 		registersRange = append(registersRange, registerRange{start, end - start + 1})
 	}
 

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -221,9 +221,7 @@ func (m *Modbus) InitRegister(fields []fieldContainer, name string) error {
 	var registersRange []registerRange
 	if name == cDiscreteInputs || name == cCoils {
 		maxQuantity = 2000
-	}
-
-	if name == cInputRegisters || name == cHoldingRegisters {
+	} else if name == cInputRegisters || name == cHoldingRegisters {
 		maxQuantity = 125
 	}
 

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -241,6 +241,7 @@ func (m *Modbus) InitRegister(fields []fieldContainer, name string) error {
 			ii++
 			quantity++
 		}
+		ii++
 
 		registersRange = append(registersRange, registerRange{start, end - start + 1})
 	}
@@ -444,7 +445,7 @@ func (m *Modbus) getFields() error {
 					for bitPosition := 0; bitPosition < 8; bitPosition++ {
 						bitRawValues[address] = getBitValue(readValue, bitPosition)
 						address = address + 1
-						if address+1 > rr.length {
+						if address > rr.address+rr.length {
 							break
 						}
 					}

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -217,19 +217,29 @@ func (m *Modbus) InitRegister(fields []fieldContainer, name string) error {
 	sort.Slice(addrs, func(i, j int) bool { return addrs[i] < addrs[j] })
 
 	ii := 0
+	maxQuantity := 1
 	var registersRange []registerRange
+	if name == cDiscreteInputs || name == cCoils {
+		maxQuantity = 2000
+	}
+
+	if name == cInputRegisters || name == cHoldingRegisters {
+		maxQuantity = 125
+	}
 
 	// Get range of consecutive integers
 	// [1, 2, 3, 5, 6, 10, 11, 12, 14]
 	// (1, 3) , (5, 2) , (10, 3), (14 , 1)
 	for range addrs {
+		quantity := 1
 		if ii < len(addrs) {
 			start := addrs[ii]
 			end := start
 
-			for ii < len(addrs)-1 && addrs[ii+1]-addrs[ii] == 1 {
+			for ii < len(addrs)-1 && addrs[ii+1]-addrs[ii] == 1 && quantity < maxQuantity {
 				end = addrs[ii+1]
 				ii++
+				quantity++
 			}
 			ii++
 			registersRange = append(registersRange, registerRange{start, end - start + 1})


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

- Fix https://github.com/influxdata/telegraf/issues/7227

if you try to read multiple consecutive addresses , modbus return error "quantity 346 must be between 1 and 125".
this happens because we have a limitation with the number of registers that we can retrieve, 125 for holding registers and Input registers and 2000 for discrete inputs and coils