### PR TITLE
Disable fmt/fmtcheck targets on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ endif
 
 
 GOFILES ?= $(shell git ls-files '*.go')
-GOFMT ?= $(shell gofmt -l -s $(filter-out plugins/parsers/influx/machine.go, $(GOFILES)))
+GOFILES_FMT ?= $(filter-out plugins/parsers/influx/machine.go, $(GOFILES))
 
 prefix ?= /usr/local
 bindir ?= $(prefix)/bin
@@ -100,13 +100,15 @@ test:
 
 .PHONY: fmt
 fmt:
-	@gofmt -s -w $(filter-out plugins/parsers/influx/machine.go, $(GOFILES))
+	@gofmt -s -w $(GOFILES_FMT)
 
 .PHONY: fmtcheck
 fmtcheck:
-	@if [ ! -z "$(GOFMT)" ]; then \
+	@set -eo pipefail; \
+	GOFMT_OUTPUT=$$(gofmt -l -s $(GOFILES_FMT)); \
+	if [ ! -z "$(GOFMT_OUTPUT)" ]; then \
 		echo "[ERROR] gofmt has found errors in the following files:"  ; \
-		echo "$(GOFMT)" ; \
+		echo "$(GOFMT_OUTPUT)" ; \
 		echo "" ;\
 		echo "Run make fmt to fix them." ; \
 		exit 1 ;\

--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,17 @@ test:
 
 .PHONY: fmt
 fmt:
+ifeq ($(OS),Windows_NT)
+	@echo "make fmt not supported on Windows, run 'go fmt' in the modified directories instead"
+else
 	@gofmt -s -w $(GOFILES_FMT)
+endif
 
 .PHONY: fmtcheck
 fmtcheck:
+ifeq ($(OS),Windows_NT)
+	@echo "make fmtcheck not supported on Windows, run 'go fmt' in the modified directories instead"
+else
 	@set -e; \
 	GOFMT_OUTPUT=$$(gofmt -l -s $(GOFILES_FMT)); \
 	if [ ! -z "$${GOFMT_OUTPUT}" ]; then \
@@ -113,6 +120,7 @@ fmtcheck:
 		echo "Run make fmt to fix them." ; \
 		exit 1 ;\
 	fi
+endif
 
 .PHONY: test-windows
 test-windows:

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ fmt:
 
 .PHONY: fmtcheck
 fmtcheck:
-	@set -eo pipefail; \
+	@set -e; \
 	GOFMT_OUTPUT=$$(gofmt -l -s $(GOFILES_FMT)); \
 	if [ ! -z "$(GOFMT_OUTPUT)" ]; then \
 		echo "[ERROR] gofmt has found errors in the following files:"  ; \

--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,9 @@ fmt:
 fmtcheck:
 	@set -e; \
 	GOFMT_OUTPUT=$$(gofmt -l -s $(GOFILES_FMT)); \
-	if [ ! -z "$(GOFMT_OUTPUT)" ]; then \
+	if [ ! -z "$${GOFMT_OUTPUT}" ]; then \
 		echo "[ERROR] gofmt has found errors in the following files:"  ; \
-		echo "$(GOFMT_OUTPUT)" ; \
+		echo "$${GOFMT_OUTPUT}" ; \
 		echo "" ;\
 		echo "Run make fmt to fix them." ; \
 		exit 1 ;\


### PR DESCRIPTION
I noticed that in Windows CI builds, the `make check` target, specifically the `fmtcheck` target, silently fails, e.g. https://ci.appveyor.com/project/sspaink/telegraf/builds/37051098#L71

```
make check
process_begin: CreateProcess(C:\go\bin\gofmt.exe, gofmt -l -s accumulator.go agent/accumulator.go agent/accumulator_test.go
...
testutil/metric_test.go testutil/testutil.go testutil/testutil_test.go testutil/tls.go, ...) failed.
Makefile:107: pipe: Bad file descriptor
```

This is because the Makefile attempts to run `gofmt` by passing it a list of every `*.go` file except a certain generated file. This list is almost 40000 characters long, and on Windows, the [maximum is 32768 characters](https://stackoverflow.com/a/28452546), so it fails to execute. This is a Windows CreateProcess API call limitation, so it will fail regardless of the shell used.

CI however, continued working, because make does not fail when variables with shell function values fail. The end result is a lot of error logging bloating out the CI logs for no useful purpose.

This PR changes the following -
* moves the `gofmt` execution into the `fmtcheck` target script itself and configures the script to fail if it fails. 
* replaces `make fmt` and `make fmtcheck` on Windows with a message instead (this was broken anyway, so there's nothing is being lost, plus the Linux builds will fail if there are any formatting errors)
* some minor refactoring of the variables

The longer term solution will probably be to move to something like golangci-lint, which has its own config for [excluding files](https://golangci-lint.run/usage/configuration/#command-line-options), removing the need for lengthy `git ls-files` listing. I didn't make that change because it's an additional tool that all devs will need to install on their systems, so it probably needs further discussion.

Alternatively, the generated code could be moved into a separate Go package, and that entire package could be excluded from `gofmt` instead. The list of packages is smaller (only 19074 characters), under Windows' 32k limit. 

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
