### PR TITLE
outputs/warp10: url encode comma in tags value

### DIFF
--- a/plugins/outputs/warp10/warp10.go
+++ b/plugins/outputs/warp10/warp10.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -174,7 +175,9 @@ func buildTags(tags []*telegraf.Tag) []string {
 	tagsString := make([]string, len(tags)+1)
 	indexSource := 0
 	for index, tag := range tags {
-		tagsString[index] = fmt.Sprintf("%s=%s", tag.Key, tag.Value)
+		key := url.QueryEscape(tag.Key)
+		value := url.QueryEscape(tag.Value)
+		tagsString[index] = fmt.Sprintf("%s=%s", key, value)
 		indexSource = index
 	}
 	indexSource++

--- a/plugins/outputs/warp10/warp10_test.go
+++ b/plugins/outputs/warp10/warp10_test.go
@@ -24,6 +24,22 @@ func TestWriteWarp10(t *testing.T) {
 	require.Exactly(t, "1257894000000000// unit.testtest1.value{source=telegraf,tag1=value1} 1.000000\n", payload)
 }
 
+func TestWriteWarp10EncodedTags(t *testing.T) {
+	w := Warp10{
+		Prefix:  "unit.test",
+		WarpURL: "http://localhost:8090",
+		Token:   "WRITE",
+	}
+
+	metrics := testutil.MockMetrics()
+	for _, metric := range metrics {
+		metric.AddTag("encoded{tag", "value1,value2")
+	}
+
+	payload := w.GenWarp10Payload(metrics)
+	require.Exactly(t, "1257894000000000// unit.testtest1.value{encoded%7Btag=value1%2Cvalue2,source=telegraf,tag1=value1} 1.000000\n", payload)
+}
+
 func TestHandleWarp10Error(t *testing.T) {
 	w := Warp10{
 		Prefix:  "unit.test",


### PR DESCRIPTION
Hello,

The warp10 specification requires the commas in tag values to be URL encoded as `%2C`. This PR fixes this behavior. 

I'm not very familiar with Golang, let me know if there is anything I should do better.

EDIT: Without this, Warp10 will reject the input and reply a parse error. This is the case with the current Elasticsearch input plugin for example.

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
