### PR TITLE
GNMI plugin should not take off the first character of field keys when no 'alias path' exists.

### DIFF
--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -290,11 +290,11 @@ func (c *GNMI) handleSubscribeResponseUpdate(address string, response *gnmi.Subs
 		// Group metrics
 		for k, v := range fields {
 			key := k
-			if len(aliasPath) < len(key) {
+			if len(aliasPath) < len(key) && len(aliasPath) != 0 {
 				// This may not be an exact prefix, due to naming style
 				// conversion on the key.
 				key = key[len(aliasPath)+1:]
-			} else {
+			} else if len(aliasPath) >= len(key) {
 				// Otherwise use the last path element as the field key.
 				key = path.Base(key)
 

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -498,27 +498,13 @@ func TestRedial(t *testing.T) {
 
 func TestHandleSubscribeResponseUpdate(t *testing.T) {
 	a := "172.1.1.2:6702"
-	u := &gnmi.SubscribeResponse_Update{
-		Update: &gnmi.Notification{
-			Timestamp: time.Now().UnixNano(),
-			Prefix: &gnmi.Path{
-				Origin: "Monta",
-				Elem: []*gnmi.PathElem{
-					{Name: "oc-if:interfaces"},
-					{Name: "oc-if:interface"},
-					{Name: "oc-if:state"},
-					{Name: "oc-if:counters"}},
-			},
-			Update: []*gnmi.Update{{
-				Path: &gnmi.Path{Origin: "Monta", Elem: []*gnmi.PathElem{{Name: "in-1024-to-1518-octet-pkts"}}},
-				Val:  &gnmi.TypedValue{Value: &gnmi.TypedValue_UintVal{UintVal: uint64(324504)}}}}}}
+	u := &gnmi.SubscribeResponse_Update{Update: &gnmi.Notification{Timestamp: time.Now().UnixNano(), Prefix: &gnmi.Path{Origin: "Monta"}, Update: []*gnmi.Update{{Path: &gnmi.Path{Origin: "Monta", Elem: []*gnmi.PathElem{{Name: "in-1024-to-1518-octet-pkts"}}}, Val: &gnmi.TypedValue{Value: &gnmi.TypedValue_UintVal{UintVal: uint64(324504)}}}}}}
 
 	acc := &testutil.Accumulator{}
 	p := &GNMI{acc: acc, Log: testutil.Logger{}}
 	p.handleSubscribeResponseUpdate(a, u)
-
 	assert.Len(t, acc.Metrics, 1)
 	for key, _ := range acc.Metrics[0].Fields {
-		assert.Equal(t, "Monta:/oc_if:interfaces/oc_if:interface/oc_if:state/oc_if:countersMonta:/in_1024_to_1518_octet_pkts", key)
+		assert.Equal(t, "Monta:Monta:/in_1024_to_1518_octet_pkts", key)
 	}
 }

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -507,14 +507,11 @@ func TestHandleSubscribeResponseUpdate(t *testing.T) {
 					{Name: "oc-if:interfaces"},
 					{Name: "oc-if:interface"},
 					{Name: "oc-if:state"},
-					{Name: "oc-if:counters"},
-				},
+					{Name: "oc-if:counters"}},
 			},
-			Update: []*gnmi.Update{
-				{
-					Path: &gnmi.Path{Origin: "Monta", Elem: []*gnmi.PathElem{{Name: "in-1024-to-1518-octet-pkts"}}},
-					Val:  &gnmi.TypedValue{Value: &gnmi.TypedValue_UintVal{UintVal: uint64(324504)}},
-				}}}}
+			Update: []*gnmi.Update{{
+				Path: &gnmi.Path{Origin: "Monta", Elem: []*gnmi.PathElem{{Name: "in-1024-to-1518-octet-pkts"}}},
+				Val:  &gnmi.TypedValue{Value: &gnmi.TypedValue_UintVal{UintVal: uint64(324504)}}}}}}
 
 	acc := &testutil.Accumulator{}
 	p := &GNMI{acc: acc, Log: testutil.Logger{}}

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -495,16 +495,3 @@ func TestRedial(t *testing.T) {
 	grpcServer.Stop()
 	wg.Wait()
 }
-
-func TestHandleSubscribeResponseUpdate(t *testing.T) {
-	a := "172.1.1.2:6702"
-	u := &gnmi.SubscribeResponse_Update{Update: &gnmi.Notification{Timestamp: time.Now().UnixNano(), Prefix: &gnmi.Path{Origin: "Monta"}, Update: []*gnmi.Update{{Path: &gnmi.Path{Origin: "Monta", Elem: []*gnmi.PathElem{{Name: "in-1024-to-1518-octet-pkts"}}}, Val: &gnmi.TypedValue{Value: &gnmi.TypedValue_UintVal{UintVal: uint64(324504)}}}}}}
-
-	acc := &testutil.Accumulator{}
-	p := &GNMI{acc: acc, Log: testutil.Logger{}}
-	p.handleSubscribeResponseUpdate(a, u)
-	assert.Len(t, acc.Metrics, 1)
-	for key, _ := range acc.Metrics[0].Fields {
-		assert.Equal(t, "Monta:Monta:/in_1024_to_1518_octet_pkts", key)
-	}
-}

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -496,7 +496,7 @@ func TestRedial(t *testing.T) {
 	wg.Wait()
 }
 
-func Test_handleSubscribeResponseUpdate(t *testing.T) {
+func TestHandleSubscribeResponseUpdate(t *testing.T) {
 	a := "172.1.1.2:6702"
 	u := &gnmi.SubscribeResponse_Update{
 		Update: &gnmi.Notification{


### PR DESCRIPTION
resolves #8653