### PR TITLE
Removing .lgtm.yml

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,2 +1,0 @@
-queries:
-  - exclude: py/*


### PR DESCRIPTION
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).

This configuration file didn't disable the Python analysis like it was intended to. Removing and disabled automated lgtm code reviews.

