### PR TITLE
fix bug: inputs.chrony :Init function is not executed resulting in empty path

### DIFF
--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -43,12 +43,11 @@ func (c *Chrony) init() error {
 }
 
 func (c *Chrony) Gather(acc telegraf.Accumulator) error {
-	// manually execute chronyc lookup
-	err := c.init() 
-        if err != nil {
+	var err error
+	err = c.init()
+	if err != nil {
 		return err
 	}
-
 	flags := []string{}
 	if !c.DNSLookup {
 		flags = append(flags, "-n")

--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -33,7 +33,7 @@ func (*Chrony) SampleConfig() string {
   `
 }
 
-func (c *Chrony) Init() error {
+func (c *Chrony) init() error {
 	var err error
 	c.path, err = exec.LookPath("chronyc")
 	if err != nil {
@@ -43,6 +43,12 @@ func (c *Chrony) Init() error {
 }
 
 func (c *Chrony) Gather(acc telegraf.Accumulator) error {
+	//Manually execute chronyc lookup
+	err := c. init() 
+        if err != nil {
+		return err
+	}
+
 	flags := []string{}
 	if !c.DNSLookup {
 		flags = append(flags, "-n")

--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -43,8 +43,8 @@ func (c *Chrony) init() error {
 }
 
 func (c *Chrony) Gather(acc telegraf.Accumulator) error {
-	//Manually execute chronyc lookup
-	err := c. init() 
+	// manually execute chronyc lookup
+	err := c.init() 
         if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Required for all PRs:

fix bug: inputs.chrony :Init function is not executed resulting in empty path