### PR TITLE
Update template, remove CLA checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
 ### Required for all PRs:
 
-- [ ] Signed [CLA](https://influxdata.com/community/cla/).
 - [ ] Associated README.md updated.
 - [ ] Has appropriate unit tests.


### PR DESCRIPTION
Removed the CLA checkbox now that the telegraf-tiger bot enforces the signing of the CLA.
