### PR TITLE
Prometheus Remote Write protocol support

### DIFF
--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/snappy"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
@@ -266,6 +268,17 @@ func (h *HTTPListenerV2) collectBody(res http.ResponseWriter, req *http.Request)
 	if err != nil {
 		tooLarge(res)
 		return nil, false
+	}
+
+	// Handle snappy request bodies
+	if req.Header.Get("Content-Encoding") == "snappy" {
+		bytes, err = snappy.Decode(nil, bytes)
+		if err != nil {
+			res.Header().Set("Content-Type", "application/json")
+			res.WriteHeader(http.StatusBadRequest)
+			res.Write([]byte(`{"error":"http: snappy decode error"}`))
+			return nil, false
+		}
 	}
 
 	return bytes, true

--- a/plugins/parsers/prometheusremotewrite/parser.go
+++ b/plugins/parsers/prometheusremotewrite/parser.go
@@ -3,7 +3,6 @@ package prometheusremotewrite
 import (
 	"fmt"
 	"math"
-	"net/http"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -16,7 +15,6 @@ import (
 
 type Parser struct {
 	DefaultTags map[string]string
-	Header      http.Header
 }
 
 func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
@@ -46,8 +44,7 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		delete(tags, model.MetricNameLabel)
 
 		for _, s := range ts.Samples {
-			fields := make(map[string]interface{})
-			fields = getNameAndValue(&s, metricName)
+			fields := getNameAndValue(&s, metricName)
 
 			// converting to telegraf metric
 			if len(fields) > 0 {

--- a/plugins/parsers/prometheusremotewrite/parser.go
+++ b/plugins/parsers/prometheusremotewrite/parser.go
@@ -1,0 +1,104 @@
+package prometheusremotewrite
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/common/model"
+)
+
+type Parser struct {
+	DefaultTags map[string]string
+	Header      http.Header
+}
+
+func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
+	var metrics []telegraf.Metric
+	var err error
+	var req prompb.WriteRequest
+
+
+	if err := proto.Unmarshal(buf, &req); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal request body: %s", err)
+	}
+
+
+	now := time.Now()
+
+	for _, ts := range req.Timeseries {
+		tags := map[string]string{}
+		for key, value := range p.DefaultTags {
+			tags[key] = value
+		}
+
+		for _, l := range ts.Labels {
+			tags[l.Name] = l.Value
+		}
+
+		metricName := tags[model.MetricNameLabel]
+		delete(tags, model.MetricNameLabel)
+
+		for _, s := range ts.Samples {
+			fields := make(map[string]interface{})
+			fields = getNameAndValue(&s, metricName)
+
+			// converting to telegraf metric
+			if len(fields) > 0 {
+				t := getTimestamp(&s, now)
+				metric, err := metric.New("prometheusremotewrite", tags, fields, t)
+				if err == nil {
+					metrics = append(metrics, metric)
+				}
+			}
+		}
+	}
+
+	return metrics, err
+}
+
+func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
+	metrics, err := p.Parse([]byte(line))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(metrics) < 1 {
+		return nil, fmt.Errorf("No metrics in line")
+	}
+
+	if len(metrics) > 1 {
+		return nil, fmt.Errorf("More than one metric in line")
+	}
+
+	return metrics[0], nil
+}
+
+func (p *Parser) SetDefaultTags(tags map[string]string) {
+	p.DefaultTags = tags
+}
+
+// Get name and value from metric
+func getNameAndValue(s *prompb.Sample, metricName string) map[string]interface{} {
+	fields := make(map[string]interface{})
+	if !math.IsNaN(s.Value) {
+		fields[metricName] = s.Value
+	}
+	return fields
+}
+
+func getTimestamp(s *prompb.Sample, now time.Time) time.Time {
+	var t time.Time
+	if s.Timestamp > 0 {
+		t = time.Unix(0, s.Timestamp*1000000)
+	} else {
+		t = now
+	}
+	return t
+}

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers/logfmt"
 	"github.com/influxdata/telegraf/plugins/parsers/nagios"
 	"github.com/influxdata/telegraf/plugins/parsers/prometheus"
+	"github.com/influxdata/telegraf/plugins/parsers/prometheusremotewrite"
 	"github.com/influxdata/telegraf/plugins/parsers/value"
 	"github.com/influxdata/telegraf/plugins/parsers/wavefront"
 )
@@ -237,6 +238,8 @@ func NewParser(config *Config) (Parser, error) {
 		)
 	case "prometheus":
 		parser, err = NewPrometheusParser(config.DefaultTags)
+	case "prometheusremotewrite":
+		parser, err = NewPrometheusRemoteWriteParser(config.DefaultTags)
 	default:
 		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
 	}
@@ -347,6 +350,12 @@ func NewFormUrlencodedParser(
 
 func NewPrometheusParser(defaultTags map[string]string) (Parser, error) {
 	return &prometheus.Parser{
+		DefaultTags: defaultTags,
+	}, nil
+}
+
+func NewPrometheusRemoteWriteParser(defaultTags map[string]string) (Parser, error) {
+	return &prometheusremotewrite.Parser{
 		DefaultTags: defaultTags,
 	}, nil
 }


### PR DESCRIPTION
### Prometheus Remote Write protocol
This is basic implementation of Prometheus Remote Write Protocol. Includes:
- Snappy Content-Encoding support
- Prometheus Remote Write parser

Must be used with http_listener_v2

Sample input configuration:
```
[[inputs.http_listener_v2]]
  service_address = ":10000"
  data_format = "prometheusremotewrite"

```

Closes #8682 