### PR TITLE
Use consistent container name in docker input plugin

### DIFF
--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -434,7 +434,7 @@ func (d *Docker) gatherContainer(
 	var cname string
 	for _, name := range container.Names {
 		trimmedName := strings.TrimPrefix(name, "/")
-		if len(strings.Split(trimmedName, "/")) == 1 {
+		if !strings.Contains(trimmedName, "/") {
 			cname = trimmedName
 			break
 		}

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -434,14 +434,17 @@ func (d *Docker) gatherContainer(
 	var cname string
 	for _, name := range container.Names {
 		trimmedName := strings.TrimPrefix(name, "/")
-		match := d.containerFilter.Match(trimmedName)
-		if match {
+		if len(strings.Split(trimmedName, "/")) == 1 {
 			cname = trimmedName
 			break
 		}
 	}
 
 	if cname == "" {
+		return nil
+	}
+
+	if !d.containerFilter.Match(cname) {
 		return nil
 	}
 
@@ -479,11 +482,6 @@ func (d *Docker) gatherContainer(
 		return fmt.Errorf("error decoding: %v", err)
 	}
 	daemonOSType := r.OSType
-
-	// use common (printed at `docker ps`) name for container
-	if v.Name != "" {
-		tags["container_name"] = strings.TrimPrefix(v.Name, "/")
-	}
 
 	// Add labels to tags
 	for k, label := range container.Labels {


### PR DESCRIPTION
### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

## Before this PR

I have noticed that the docker input plugin occasionally gathers metrics for containers with a container name that does not match the configured filter. For example, I have a container named `influxdb` and have configured the docker input plugin with `container_name_include = ["influxdb"]`, but the docker input plugin sometimes produces metrics with a `container_name` tag of something like `689a5b5f3679_influxdb`.

Upon further investigation, I discovered that this happens when the metrics are gathered while docker-compose is recreating the container. When docker-compose recreates the container, it temporarily renames the original container to `{id}_{name}` before removing it.
- https://github.com/docker/compose/blob/b9249168bd280429820e2ae72c0b86006ccfc19d/compose/service.py#L610
- https://github.com/docker/compose/blob/b9249168bd280429820e2ae72c0b86006ccfc19d/compose/container.py#L263-L270

The docker input plugin uses the name from the `ListContainer` call when checking the filter, but uses the name from the `ContainerStats` call when setting the `container_name` tag. If the container is renamed between these calls, it will result in the confusing behavior described above.

## After this PR

The docker input plugin uses the name from the `ListContainer` call both when checking the filter and when setting the `container_name` tag.

Because we want the `container_name` tag to be the canonical container name, this PR removes support for matching based on all container names and now only matches on the default container name. Other container names come from links (see https://github.com/moby/moby/pull/14128), which is a legacy feature that has been deprecated for a while. See https://docs.docker.com/network/links/.

This implementation now matches the behavior of `docker ps` (when used without `--no-trunc`). You can see the current implementation here:
https://github.com/docker/cli/blob/cde469bf1aad14146d57710205399899e465aadc/cli/command/formatter/container.go#L124-L138

This behavior in the docker CLI was first introduced over 5 years ago in https://github.com/moby/moby/pull/8505.

I can't think of a good reason to allow matching on names from links, especially given that they are deprecated, so it seemed reasonable to make this change.