### PR TITLE
kubernetes_inventory: Set $HOSTIP in default URL

### DIFF
--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -38,7 +38,7 @@ avoid cardinality issues:
 ```toml
 [[inputs.kube_inventory]]
   ## URL for the Kubernetes API
-  url = "https://127.0.0.1"
+  url = "https://$HOSTIP:6443"
 
   ## Namespace to use. Set to "" to use all namespaces.
   # namespace = "default"


### PR DESCRIPTION
Telegraf daemonset pod cannot contact kube-apiserver via localhost.
Should be `$HOSTIP`, and the default port is 6443.
