### PR TITLE
Add snmp_trap integration test with docker-compose

### DIFF
--- a/plugins/inputs/snmp_trap/integration_test/Dockerfile.netsnmp
+++ b/plugins/inputs/snmp_trap/integration_test/Dockerfile.netsnmp
@@ -1,0 +1,5 @@
+FROM bitnami/minideb:buster
+
+RUN install_packages snmp
+
+ENTRYPOINT ["/app/send.sh"]

--- a/plugins/inputs/snmp_trap/integration_test/Dockerfile.test
+++ b/plugins/inputs/snmp_trap/integration_test/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM golang:1.15-alpine
+
+RUN set -ex; \
+    apk update; \
+    apk add --no-cache git iproute2
+
+WORKDIR /go/src/github.com/influxdata/telegraf/plugins/inputs/snmp_trap
+
+CMD CGO_ENABLED=0 go test -run Integration

--- a/plugins/inputs/snmp_trap/integration_test/docker-compose.test.yml
+++ b/plugins/inputs/snmp_trap/integration_test/docker-compose.test.yml
@@ -1,0 +1,40 @@
+#version 3 doesn't have depends_on condition service_healthy
+version: '2.4'
+
+networks:
+  integration:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.0.0.0/8 # test expects netsnmp containter to be 10.0.0.3
+
+services:
+  telegraf_test:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.test
+    networks:
+      - integration
+    volumes:
+      - ../../../..:/go/src/github.com/influxdata/telegraf
+    healthcheck:
+#I haven't been able to get any shell command to work when provided as a string
+#      test: "ss -lun|grep :12399"
+#A list starting with CMD-SHELL is supposed to be equivalent but does work
+      test: ["CMD-SHELL", "ss -lun|grep :12399"]
+      interval: 1s
+      retries: 40
+      #enough to download and build module dependencies,
+      #build and run the test, then open the port
+  netsnmp:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.netsnmp
+    restart: on-failure
+    networks:
+      - integration
+    depends_on:
+      telegraf_test:
+        condition: service_healthy
+    volumes:
+      - .:/app #the image runs /app/send.sh

--- a/plugins/inputs/snmp_trap/integration_test/run.sh
+++ b/plugins/inputs/snmp_trap/integration_test/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose -f docker-compose.test.yml up --build

--- a/plugins/inputs/snmp_trap/integration_test/send.sh
+++ b/plugins/inputs/snmp_trap/integration_test/send.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "in send.sh"
+snmptrap -v 2c -c community udp:telegraf_test:12399 1234567 .1.3.6.1.6.3.1.1.5.3.0 0 s "This is a test linkDown trap from v2c"
+echo $?

--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -1320,3 +1320,164 @@ func TestReceiveTrap(t *testing.T) {
 	}
 
 }
+
+func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	var now uint32
+	now = 1234567
+
+	var fakeTime time.Time
+	fakeTime = time.Unix(456456456, 456)
+
+	type entry struct {
+		oid string
+		e   mibEntry
+	}
+
+	var tests = []struct {
+		name string
+
+		// send
+		version gosnmp.SnmpVersion
+		trap    gosnmp.SnmpTrap // include pdus
+		// V3 auth and priv parameters
+		secName   string // v3 username
+		secLevel  string // v3 security level
+		authProto string // Auth protocol: "", MD5 or SHA
+		authPass  string // Auth passphrase
+		privProto string // Priv protocol: "", DES or AES
+		privPass  string // Priv passphrase
+
+		// V3 sender context
+		contextName string
+		engineID    string
+
+		// receive
+		entries []entry
+		metrics []telegraf.Metric
+	}{
+		//ordinary v2c coldStart trap
+		{
+			name:    "v2c coldStart",
+			version: gosnmp.Version2c,
+			trap: gosnmp.SnmpTrap{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  ".1.3.6.1.2.1.1.3.0",
+						Type:  gosnmp.TimeTicks,
+						Value: now,
+					},
+					{
+						Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
+						Type:  gosnmp.ObjectIdentifier,
+						Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
+					},
+				},
+			},
+			entries: []entry{
+				{
+					oid: ".0.0",
+					e: mibEntry{
+						"SNMPv2-MIB",
+						"snmpTrapOID.0",
+					},
+				},
+				{
+					oid: ".1.3.6.1.6.3.1.1.5.3.0",
+					e: mibEntry{
+						"SNMPv2-MIB",
+						"linkDown.0",
+					},
+				},
+				{
+					oid: ".1.3.6.1.2.1.1.3.0",
+					e: mibEntry{
+						"UNUSED_MIB_NAME",
+						"sysUpTimeInstance",
+					},
+				},
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"snmp_trap", // name
+					map[string]string{ // tags
+						"oid":       ".1.3.6.1.6.3.1.1.5.3.0",
+						"name":      "linkDown.0",
+						"mib":       "SNMPv2-MIB",
+						"version":   "2c",
+						"source":    "10.0.0.3",
+						"community": "community",
+					},
+					map[string]interface{}{ // fields
+						"snmpTrapOID.0":     "This is a test linkDown trap from v2c",
+						"sysUpTimeInstance": uint64(1234567),
+					},
+					fakeTime,
+				),
+			},
+		},
+	}
+
+	tt := tests[0]
+
+	// We would prefer to specify port 0 and let the network
+	// stack choose an unused port for us but TrapListener
+	// doesn't have a way to return the autoselected port.
+	// Instead, we'll use an unusual port and hope it's
+	// unused.
+	const port = 12399
+
+	// Hook into the trap handler so the test knows when the
+	// trap has been received
+	received := make(chan int)
+	wrap := func(f handler) handler {
+		return func(p *gosnmp.SnmpPacket, a *net.UDPAddr) {
+			f(p, a)
+			received <- 0
+		}
+	}
+
+	// Set up the service input plugin
+	s := &SnmpTrap{
+		ServiceAddress:     "udp://:" + strconv.Itoa(port),
+		makeHandlerWrapper: wrap,
+		timeFunc: func() time.Time {
+			return fakeTime
+		},
+		Log:          testutil.Logger{},
+		Version:      tt.version.String(),
+		SecName:      tt.secName,
+		SecLevel:     tt.secLevel,
+		AuthProtocol: tt.authProto,
+		AuthPassword: tt.authPass,
+		PrivProtocol: tt.privProto,
+		PrivPassword: tt.privPass,
+	}
+	require.Nil(t, s.Init())
+	// Don't look up oid with snmptranslate.
+	s.execCmd = fakeExecCmd
+	var acc testutil.Accumulator
+	require.Nil(t, s.Start(&acc))
+	defer s.Stop()
+
+	// Preload the cache with the oids we'll use in this test
+	// so snmptranslate and mibs don't need to be installed.
+	for _, entry := range tt.entries {
+		s.load(entry.oid, entry.e)
+	}
+
+	// Wait for trap to be received
+	select {
+	case <-received:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for trap to be received")
+	}
+
+	// Verify plugin output
+	testutil.RequireMetricsEqual(t,
+		tt.metrics, acc.GetTelegrafMetrics(),
+		testutil.SortMetrics())
+}


### PR DESCRIPTION
This is an integration test for the snmp_trap plugin.  It uses netsnmp to send a trap to telegraf.  The two processes are run in containers managed by docker-compose.

Snmp_trap is a plugin that listens on UDP.  Unlike TCP, it's not possible for a remote host to test whether a program is listening on a UDP port.  That means for this test, synchronization of the containers is critical to prevent a race condition between the containers.  This PR uses docker-compose v2's ability to enforce container health dependency to make sure telegraf is listening before letting netsnmp send the trap.

Currently only version 2 trap is tested.  I would like eventually to expand to version 3 traps including encryption, but I want to get this running regularly by an automated process before expanding coverage.