### PR TITLE
Improve eventhub_consumer input documentation

### DIFF
--- a/plugins/inputs/eventhub_consumer/README.md
+++ b/plugins/inputs/eventhub_consumer/README.md
@@ -18,8 +18,6 @@ The main focus for development of this plugin is Azure IoT hub:
   ## This requires one of the following sets of environment variables to be set:
   ##
   ## 1) Expected Environment Variables:
-  ##    - "EVENTHUB_NAMESPACE"
-  ##    - "EVENTHUB_NAME"
   ##    - "EVENTHUB_CONNECTION_STRING"
   ##
   ## 2) Expected Environment Variables:
@@ -28,8 +26,17 @@ The main focus for development of this plugin is Azure IoT hub:
   ##    - "EVENTHUB_KEY_NAME"
   ##    - "EVENTHUB_KEY_VALUE"
 
+  ## 3) Expected Environment Variables:
+  ##    - "EVENTHUB_NAMESPACE"
+  ##    - "EVENTHUB_NAME"
+  ##    - "AZURE_TENANT_ID"
+  ##    - "AZURE_CLIENT_ID"
+  ##    - "AZURE_CLIENT_SECRET"
+
   ## Uncommenting the option below will create an Event Hub client based solely on the connection string.
   ## This can either be the associated environment variable or hard coded directly.
+  ## If this option is uncommented, environment variables will be ignored.
+  ## Connection string should contain EventHubName (EntityPath)
   # connection_string = ""
 
   ## Set persistence directory to a valid folder to use a file persister instead of an in-memory persister
@@ -88,7 +95,7 @@ The main focus for development of this plugin is Azure IoT hub:
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
-  data_format = "influx"
+  data_format = "json"
 ```
 
 #### Environment Variables

--- a/plugins/inputs/eventhub_consumer/README.md
+++ b/plugins/inputs/eventhub_consumer/README.md
@@ -8,7 +8,7 @@ The main focus for development of this plugin is Azure IoT hub:
 
 1. Create an Azure IoT Hub by following any of the guides provided here: https://docs.microsoft.com/en-us/azure/iot-hub/
 2. Create a device, for example a [simulated Raspberry Pi](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-raspberry-pi-web-simulator-get-started)
-3. The connection string needed for the plugin is located under _Shared access policies_, both the _iothubowner_ and _service_ policies should work
+3. The connection string needed for the plugin is located under *Shared access policies*, both the *iothubowner* and *service* policies should work
 
 ### Configuration
 
@@ -95,7 +95,7 @@ The main focus for development of this plugin is Azure IoT hub:
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
-  data_format = "json"
+  data_format = "influx"
 ```
 
 #### Environment Variables
@@ -103,62 +103,3 @@ The main focus for development of this plugin is Azure IoT hub:
 [Full documentation of the available environment variables][envvar].
 
 [envvar]: https://github.com/Azure/azure-event-hubs-go#environment-variables
-
-### Example
-
-If we stream diagnostic setting 'AllMetrics' from one of Azure services to Eventhub,
-our EventHub data may look like this:
-
-```json
-{
-  "records": [
-    {
-      "count": 3,
-      "total": 6,
-      "average": 2,
-      "resourceId": "/SUBSCRIPTIONS/123-**-456/LONG-STRING-HERE",
-      "time": "2020-12-03T06:46:00.0000000Z",
-      "metricName": "someMetricNameHere",
-      "timeGrain": "PT1M"
-    }
-  ]
-}
-```
-
-If so, our plugin configuration (one of the options) should be:
-
-```toml
-  ## We will keep connection_string commented, as we want to use environment variables
-  # connection_string = ""
-
-  ## Options between connection_string and data_format will be default and are not specified here
-
-  ## Our data is in json, we should explicitly specify this.
-  ## More information on telegraf json parser can be found here:
-  ## https://github.com/influxdata/telegraf/tree/master/plugins/parsers/json
-  data_format = "json"
-
-  ## We need to parse a specific chunk of our data: records array
-  ## If we don't specify this, our data will be parsed as an object with one value.
-  ## What we want is to parse an array of objects
-  json_query = "records"
-
-  ## We need to explicitly specify in which field to find the name of our metric, as well as the time
-  json_name_key = "metricName"
-  json_time_key = "time"
-
-  ## Explicitly specify time format (in this case it's RCF3339Nano)
-  json_time_format = "2006-1-2T15:4:5.999999999Z07:00"
-  json_timezone = "UTC"
-
-  ## All string/boolean fields should be explicitly specified, otherwise they will be ignored.
-  ## In our example we have 2 string fields: resourceId and timeGrain.
-  ## Here we define resourceId as a tag and we omit timeGrain as we don't want this field
-  tag_keys = ["resourceId"]
-  ## If we wanted timeGrain to be present, but not as a tag, we could do it like this:
-  # json_string_fields = ["timeGrain"]
-
-  ## We want to add a custom tag to all the parsed metrics
-  [inputs.eventhub_consumer.tags]
-    azure_env = "development"
-```

--- a/plugins/inputs/eventhub_consumer/eventhub_consumer.go
+++ b/plugins/inputs/eventhub_consumer/eventhub_consumer.go
@@ -146,7 +146,7 @@ func (*EventHub) SampleConfig() string {
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
-  data_format = "json"
+  data_format = "influx"
   `
 }
 

--- a/plugins/inputs/eventhub_consumer/eventhub_consumer.go
+++ b/plugins/inputs/eventhub_consumer/eventhub_consumer.go
@@ -69,8 +69,6 @@ func (*EventHub) SampleConfig() string {
   ## This requires one of the following sets of environment variables to be set:
   ##
   ## 1) Expected Environment Variables:
-  ##    - "EVENTHUB_NAMESPACE"
-  ##    - "EVENTHUB_NAME"
   ##    - "EVENTHUB_CONNECTION_STRING"
   ##
   ## 2) Expected Environment Variables:
@@ -79,8 +77,17 @@ func (*EventHub) SampleConfig() string {
   ##    - "EVENTHUB_KEY_NAME"
   ##    - "EVENTHUB_KEY_VALUE"
 
+  ## 3) Expected Environment Variables:
+  ##    - "EVENTHUB_NAMESPACE"
+  ##    - "EVENTHUB_NAME"
+  ##    - "AZURE_TENANT_ID"
+  ##    - "AZURE_CLIENT_ID"
+  ##    - "AZURE_CLIENT_SECRET"
+
   ## Uncommenting the option below will create an Event Hub client based solely on the connection string.
   ## This can either be the associated environment variable or hard coded directly.
+  ## If this option is uncommented, environment variables will be ignored.
+  ## Connection string should contain EventHubName (EntityPath)
   # connection_string = ""
 
   ## Set persistence directory to a valid folder to use a file persister instead of an in-memory persister
@@ -139,7 +146,7 @@ func (*EventHub) SampleConfig() string {
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
-  data_format = "influx"
+  data_format = "json"
   `
 }
 


### PR DESCRIPTION
This PR improves documentation (README and sample config) for eventhub_consumer input plugin:

* clarifies the usage of env vars and adds example.
* addresses issues like: #8643
