### PR TITLE
enhance: allow prometheus set default metric name

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -61,6 +61,10 @@ in Prometheus format.
   # tls_key = /path/to/keyfile
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## Optional change default metric name
+  # change_default_name = true
+  # default_name = "prometheus
 ```
 
 `urls` can contain a unix socket as well. If a different path is required (default is `/metrics` for both http[s] and unix) for a unix socket, add `path` as a query parameter as follows: `unix:///var/run/prometheus.sock?path=/custom/metrics`
@@ -168,4 +172,19 @@ prometheus,cpu=cpu0,url=http://example.org:9273/metrics cpu_usage_user=1.5136226
 prometheus,cpu=cpu1,url=http://example.org:9273/metrics cpu_usage_user=5.829145728641773 1505776751000000000
 prometheus,cpu=cpu2,url=http://example.org:9273/metrics cpu_usage_user=2.119071644805144 1505776751000000000
 prometheus,cpu=cpu3,url=http://example.org:9273/metrics cpu_usage_user=1.5228426395944945 1505776751000000000
+```
+
+**Output (when metric_version = 2, change_default_name = true, default_name = "changed")**
+```
+changed,quantile=1,url=http://example.org:9273/metrics go_gc_duration_seconds=0.005574303 1556075100000000000
+changed,quantile=0.75,url=http://example.org:9273/metrics go_gc_duration_seconds=0.0001046 1556075100000000000
+changed,quantile=0.5,url=http://example.org:9273/metrics go_gc_duration_seconds=0.0000719 1556075100000000000
+changed,quantile=0.25,url=http://example.org:9273/metrics go_gc_duration_seconds=0.0000579 1556075100000000000
+changed,quantile=0,url=http://example.org:9273/metrics go_gc_duration_seconds=0.0000349 1556075100000000000
+changed,url=http://example.org:9273/metrics go_gc_duration_seconds_count=324,go_gc_duration_seconds_sum=0.091340353 1556075100000000000
+changed,url=http://example.org:9273/metrics go_goroutines=15 1556075100000000000
+changed,cpu=cpu0,url=http://example.org:9273/metrics cpu_usage_user=1.513622603430151 1505776751000000000
+changed,cpu=cpu1,url=http://example.org:9273/metrics cpu_usage_user=5.829145728641773 1505776751000000000
+changed,cpu=cpu2,url=http://example.org:9273/metrics cpu_usage_user=2.119071644805144 1505776751000000000
+changed,cpu=cpu3,url=http://example.org:9273/metrics cpu_usage_user=1.5228426395944945 1505776751000000000
 ```

--- a/plugins/parsers/prometheus/parser_test.go
+++ b/plugins/parsers/prometheus/parser_test.go
@@ -449,3 +449,33 @@ func TestParserProtobufHeader(t *testing.T) {
 	}
 	testutil.RequireMetricsEqual(t, expected, metrics, testutil.IgnoreTime(), testutil.SortMetrics())
 }
+
+func TestDefautName(t *testing.T) {
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"expected",
+			map[string]string{
+				"osVersion":        "CentOS Linux 7 (Core)",
+				"cadvisorRevision": "",
+				"cadvisorVersion":  "",
+				"dockerVersion":    "1.8.2",
+				"kernelVersion":    "3.10.0-229.20.1.el7.x86_64",
+			},
+			map[string]interface{}{
+				"cadvisor_version_info": float64(1),
+			},
+			time.Unix(0, 0),
+			telegraf.Gauge,
+		),
+	}
+
+	parser := Parser{
+		ChangeDefaultName: true,
+		DefaultName:       "expected",
+	}
+	metrics, err := parser.Parse([]byte(validUniqueGauge))
+
+	assert.NoError(t, err)
+	assert.Len(t, metrics, 1)
+	testutil.RequireMetricsEqual(t, expected, metrics, testutil.IgnoreTime(), testutil.SortMetrics())
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

This change allow change prometheus inputs parse default metric to `prometheus`.

### Example Output:

**Source**
```
# HELP cpu_usage_user Telegraf collected metric
# TYPE cpu_usage_user gauge
cpu_usage_user{cpu="cpu0"} 1.4112903225816156
cpu_usage_user{cpu="cpu1"} 0.702106318955865
cpu_usage_user{cpu="cpu2"} 2.0161290322588776
cpu_usage_user{cpu="cpu3"} 1.5045135406226022
```

**Output (when metric_version = 2)**
```
prometheus,cpu=cpu0,url=http://example.org:9273/metrics cpu_usage_user=1.513622603430151 1505776751000000000
prometheus,cpu=cpu1,url=http://example.org:9273/metrics cpu_usage_user=5.829145728641773 1505776751000000000
prometheus,cpu=cpu2,url=http://example.org:9273/metrics cpu_usage_user=2.119071644805144 1505776751000000000
prometheus,cpu=cpu3,url=http://example.org:9273/metrics cpu_usage_user=1.5228426395944945 1505776751000000000
```

**Output (when metric_version = 2, change_default_name = true, default_name = "changed")**
```
changed,cpu=cpu0,url=http://example.org:9273/metrics cpu_usage_user=1.513622603430151 1505776751000000000
changed,cpu=cpu1,url=http://example.org:9273/metrics cpu_usage_user=5.829145728641773 1505776751000000000
changed,cpu=cpu2,url=http://example.org:9273/metrics cpu_usage_user=2.119071644805144 1505776751000000000
changed,cpu=cpu3,url=http://example.org:9273/metrics cpu_usage_user=1.5228426395944945 1505776751000000000
```