### PR TITLE
Add line to template docs about measurement

### DIFF
--- a/docs/TEMPLATE_PATTERN.md
+++ b/docs/TEMPLATE_PATTERN.md
@@ -22,6 +22,7 @@ correspond to the field name.
 Any part of the template that is not a keyword is treated as a tag key. This
 can also be specified multiple times.
 
+**NOTE:** `measurement` must be specified in your template.
 **NOTE:** `field*` cannot be used in conjunction with `measurement*`.
 
 ### Examples


### PR DESCRIPTION
If you supply a template without measurement included it returns an error asking you to specify measurement. This was not currently mentioned in the templating docs. 
