### PR TITLE
Update README to list only supported versions of SQL server

### DIFF
--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -5,8 +5,7 @@ lightweight and use Dynamic Management Views supplied by SQL Server.
 
 ### The SQL Server plugin supports the following editions/versions of SQL Server
 - SQL Server
-  - 2008 SP3 (with CU3)
-  - SQL Server 2008 R2 SP3 and newer versions
+  - SQL Server 2012 and newer versions
 - Azure SQL Database (Single)
 - Azure SQL Managed Instance
 
@@ -24,7 +23,7 @@ GRANT VIEW ANY DEFINITION TO [telegraf];
 GO
 ```
 
-For Azure SQL Database, you require the View Database State permission and can create a user with a password directly in the database.
+For Azure SQL Database(with S2 and above service level objectives), you require the View Database State permission and can create a user with a password directly in the database.
 ```sql
 CREATE USER [telegraf] WITH PASSWORD = N'mystrongpassword';
 GO


### PR DESCRIPTION
Unsupported versions of Sql Server: 2011 and older versions of SQL server 
Azure SQL Database: VIEW DATABASE STATE permission does not apply for certain DMV like sys.dm_os_performance_counters where databases fall under tier Basic, S0 and S1 service level objectives. It is supported for higher version of service level objective(S2 and above) - https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-ver15

### Required for all PRs:

- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
