### PR TITLE
fix x509 cert timeout issue

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -215,7 +215,7 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 			return nil
 		}
 
-		certs, err := c.getCert(u, c.Timeout.Duration*time.Second)
+		certs, err := c.getCert(u, c.Timeout.Duration)
 		if err != nil {
 			acc.AddError(fmt.Errorf("cannot get SSL cert '%s': %s", location, err.Error()))
 		}

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -3,7 +3,6 @@ package x509_cert
 import (
 	"crypto/tls"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -351,7 +350,7 @@ func TestGatherCert(t *testing.T) {
 	assert.True(t, acc.HasMeasurement("x509_cert"))
 }
 
-func TestGatherCertMustTimeout(t *testing.T) {
+func TestGatherCertMustNotTimeout(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -365,8 +364,8 @@ func TestGatherCertMustTimeout(t *testing.T) {
 	var acc testutil.Accumulator
 	err := m.Gather(&acc)
 	require.NoError(t, err)
-	require.Contains(t, acc.Errors, errors.New("cannot get SSL cert 'https://www.influxdata.com:443': dial tcp: i/o timeout"))
-	assert.False(t, acc.HasMeasurement("x509_cert"))
+	require.Empty(t, acc.Errors)
+	assert.True(t, acc.HasMeasurement("x509_cert"))
 }
 
 func TestServerName(t *testing.T) {


### PR DESCRIPTION
I encountered a timeout issue when using x509 cert input plugin.

This timeout issue can be reproduced by the test case in commit 9fd1066 or this configuration
```
[[inputs.x509_cert]]
sources = ["https://www.influxdata.com:443"]
timeout = "15s"
```

I fixed this issue by removing redundant code and test cases are added.