### PR TITLE
Prometheus [Input] plugin - Optimizing for bigger kubernetes clusters (500+ pods) when scraping thru 'monitor_kubernetes_pods'

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -179,6 +179,8 @@ following works:
 - gopkg.in/tomb.v2 [BSD 3-Clause Clear License](https://github.com/go-tomb/tomb/blob/v2/LICENSE)
 - gopkg.in/yaml.v2 [Apache License 2.0](https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE)
 - gopkg.in/yaml.v3 [Apache License 2.0](https://github.com/go-yaml/yaml/blob/v3/LICENSE)
+- k8s.io/apimachinery [Apache License 2.0](https://github.com/kubernetes/apimachinery/blob/master/LICENSE)
+- k8s.io/klog [Apache License 2.0](https://github.com/kubernetes/klog/blob/master/LICENSE)
 - modernc.org/libc [BSD 3-Clause "New" or "Revised" License](https://gitlab.com/cznic/libc/-/blob/master/LICENSE)
 - modernc.org/memory [BSD 3-Clause "New" or "Revised" License](https://gitlab.com/cznic/memory/-/blob/master/LICENSE)
 - modernc.org/sqlite [BSD 3-Clause "New" or "Revised" License](https://gitlab.com/cznic/sqlite/-/blob/master/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools v2.2.0+incompatible
 	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
-	k8s.io/apimachinery v0.17.1 // indirect
+	k8s.io/apimachinery v0.17.1
 	modernc.org/sqlite v1.7.4
 )
 

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools v2.2.0+incompatible
 	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
-	k8s.io/apimachinery v0.17.1
+	k8s.io/apimachinery v0.17.1 // indirect
 	modernc.org/sqlite v1.7.4
 )
 

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -35,7 +35,7 @@ in Prometheus format.
   # monitor_kubernetes_pods = true
   ## Get the list of pods to scrape from either:
   ##    - version 1 (default): the kubernetes watch api (cluster-wide)
-  ##    - version 2: the local cadvisor api (node-wide); for scalability
+  ##    - version 2: the local cadvisor api (node-wide); for scalability. Note that the environment variable NODE_IP must be set to the host IP.
   # monitor_kubernetes_pods_version = 1
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"
@@ -92,7 +92,14 @@ Currently the following annotation are supported:
 
 Using the `monitor_kubernetes_pods_namespace` option allows you to limit which pods you are scraping.
 
-Using `monitor_kubernetes_pods_version = 2` allows more scalable scraping for pods which will scrape pods only in the node that telegraf is running. It will fetch the pod list locally from the node's kubelet. This will require running Telegraf as a daemonset in the cluster.
+Using `monitor_kubernetes_pods_version = 2` allows more scalable scraping for pods which will scrape pods only in the node that telegraf is running. It will fetch the pod list locally from the node's kubelet. This will require running Telegraf as a daemonset in the cluster. Note that the environment variable NODE_IP must be set to the host IP. This can be done in the yaml of the pod running telegraf: 
+```
+env:
+  - name: NODE_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+ ```
 
 #### Bearer Token
 

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -33,9 +33,12 @@ in Prometheus format.
   ## - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
   ## - prometheus.io/port: If port is not 9102 use this annotation
   # monitor_kubernetes_pods = true
-  ## Get the list of pods to scrape from either:
-  ##    - version 1 (default): the kubernetes watch api (cluster-wide)
-  ##    - version 2: the local cadvisor api (node-wide); for scalability. Note that the environment variable NODE_IP must be set to the host IP.
+  ## Get the list of pods to scrape with either the scope of
+  ## - cluster: the kubernetes watch api (default), no need to specify
+  ## - node: the local cadvisor api; for scalability. Note that the environment variable NODE_IP must be set to the host IP.
+  # pod_scrape_scope = "cluster"
+  ## Only for node scrape scope: interval in seconds for how often to get updated pod list for scraping
+  # pod_scrape_interval = 60
   # monitor_kubernetes_pods_version = 1
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"
@@ -92,7 +95,7 @@ Currently the following annotation are supported:
 
 Using the `monitor_kubernetes_pods_namespace` option allows you to limit which pods you are scraping.
 
-Using `monitor_kubernetes_pods_version = 2` allows more scalable scraping for pods which will scrape pods only in the node that telegraf is running. It will fetch the pod list locally from the node's kubelet. This will require running Telegraf as a daemonset in the cluster. Note that the environment variable NODE_IP must be set to the host IP. This can be done in the yaml of the pod running telegraf: 
+Using `pod_scrape_scope = "node"` allows more scalable scraping for pods which will scrape pods only in the node that telegraf is running. It will fetch the pod list locally from the node's kubelet. This will require running Telegraf in every node of the cluster. Note that the environment variable NODE_IP must be set to the host IP. This can be done in the yaml of the pod running telegraf:
 ```
 env:
   - name: NODE_IP
@@ -100,6 +103,8 @@ env:
       fieldRef:
         fieldPath: status.hostIP
  ```
+
+If using node level scrape scope, `pod_scrape_interval` specifies how often (in seconds) the pod list for scraping should updated.
 
 #### Bearer Token
 

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -39,7 +39,6 @@ in Prometheus format.
   # pod_scrape_scope = "cluster"
   ## Only for node scrape scope: interval in seconds for how often to get updated pod list for scraping
   # pod_scrape_interval = 60
-  # monitor_kubernetes_pods_version = 1
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"
   # monitor_kubernetes_pods_namespace = ""

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -35,9 +35,13 @@ in Prometheus format.
   # monitor_kubernetes_pods = true
   ## Get the list of pods to scrape with either the scope of
   ## - cluster: the kubernetes watch api (default), no need to specify
-  ## - node: the local cadvisor api; for scalability. Note that the environment variable NODE_IP must be set to the host IP.
+  ## - node: the local cadvisor api; for scalability. Note that the config node_ip or the environment variable NODE_IP must be set to the host IP.
   # pod_scrape_scope = "cluster"
+  ## Only for node scrape scope: node IP of the node that telegraf is running on.
+  ## Either this config or the environment variable NODE_IP must be set.
+  # node_ip = "10.180.1.1"
   ## Only for node scrape scope: interval in seconds for how often to get updated pod list for scraping
+  ## Default is 60 seconds.
   # pod_scrape_interval = 60
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"
@@ -94,7 +98,7 @@ Currently the following annotation are supported:
 
 Using the `monitor_kubernetes_pods_namespace` option allows you to limit which pods you are scraping.
 
-Using `pod_scrape_scope = "node"` allows more scalable scraping for pods which will scrape pods only in the node that telegraf is running. It will fetch the pod list locally from the node's kubelet. This will require running Telegraf in every node of the cluster. Note that the environment variable NODE_IP must be set to the host IP. This can be done in the yaml of the pod running telegraf:
+Using `pod_scrape_scope = "node"` allows more scalable scraping for pods which will scrape pods only in the node that telegraf is running. It will fetch the pod list locally from the node's kubelet. This will require running Telegraf in every node of the cluster. Note that either `node_ip` must be specified in the config or the environment variable `NODE_IP` must be set to the host IP. The latter can be done in the yaml of the pod running telegraf:
 ```
 env:
   - name: NODE_IP
@@ -103,7 +107,7 @@ env:
         fieldPath: status.hostIP
  ```
 
-If using node level scrape scope, `pod_scrape_interval` specifies how often (in seconds) the pod list for scraping should updated.
+If using node level scrape scope, `pod_scrape_interval` specifies how often (in seconds) the pod list for scraping should updated. If not specified, the default is 60 seconds.
 
 #### Bearer Token
 

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -98,7 +98,7 @@ Currently the following annotation are supported:
 
 Using the `monitor_kubernetes_pods_namespace` option allows you to limit which pods you are scraping.
 
-Using `pod_scrape_scope = "node"` allows more scalable scraping for pods which will scrape pods only in the node that telegraf is running. It will fetch the pod list locally from the node's kubelet. This will require running Telegraf in every node of the cluster. Note that either `node_ip` must be specified in the config or the environment variable `NODE_IP` must be set to the host IP. The latter can be done in the yaml of the pod running telegraf:
+Using `pod_scrape_scope = "node"` allows more scalable scraping for pods which will scrape pods only in the node that telegraf is running. It will fetch the pod list locally from the node's kubelet. This will require running Telegraf in every node of the cluster. Note that either `node_ip` must be specified in the config or the environment variable `NODE_IP` must be set to the host IP. ThisThe latter can be done in the yaml of the pod running telegraf:
 ```
 env:
   - name: NODE_IP

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -33,6 +33,10 @@ in Prometheus format.
   ## - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
   ## - prometheus.io/port: If port is not 9102 use this annotation
   # monitor_kubernetes_pods = true
+  ## Get the list of pods to scrape from either:
+	## - version 1 (default): the kubernetes watch api (cluster-wide)
+	## - version 2: the local cadvisor api (node-wide); for scalability
+	# monitor_kubernetes_pods_version = 1
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"
   # monitor_kubernetes_pods_namespace = ""

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -34,9 +34,9 @@ in Prometheus format.
   ## - prometheus.io/port: If port is not 9102 use this annotation
   # monitor_kubernetes_pods = true
   ## Get the list of pods to scrape from either:
-	##    - version 1 (default): the kubernetes watch api (cluster-wide)
-	##    - version 2: the local cadvisor api (node-wide); for scalability
-	# monitor_kubernetes_pods_version = 1
+  ##    - version 1 (default): the kubernetes watch api (cluster-wide)
+  ##    - version 2: the local cadvisor api (node-wide); for scalability
+  # monitor_kubernetes_pods_version = 1
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"
   # monitor_kubernetes_pods_namespace = ""
@@ -91,6 +91,8 @@ Currently the following annotation are supported:
 * `prometheus.io/port` Used to override the port. (default 9102)
 
 Using the `monitor_kubernetes_pods_namespace` option allows you to limit which pods you are scraping.
+
+Using `monitor_kubernetes_pods_version = 2` allows more scalable scraping for pods which will scrape pods only in the node that telegraf is running. It will fetch the pod list locally from the node's kubelet. This will require running Telegraf as a daemonset in the cluster.
 
 #### Bearer Token
 

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -34,8 +34,8 @@ in Prometheus format.
   ## - prometheus.io/port: If port is not 9102 use this annotation
   # monitor_kubernetes_pods = true
   ## Get the list of pods to scrape from either:
-	## - version 1 (default): the kubernetes watch api (cluster-wide)
-	## - version 2: the local cadvisor api (node-wide); for scalability
+	##    - version 1 (default): the kubernetes watch api (cluster-wide)
+	##    - version 2: the local cadvisor api (node-wide); for scalability
 	# monitor_kubernetes_pods_version = 1
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -151,6 +152,11 @@ func (p *Prometheus) watch(ctx context.Context, client *k8s.Client) error {
 
 func (p *Prometheus) cAdvisor(ctx context.Context, client *k8s.Client) error {
 	p.Log.Infof("Using monitor pods version 2 to get pod list using cAdvisor.")
+	
+	nodeIP := os.Getenv("NODE_IP")
+	if nodeIP == "" {
+		return errors.New("The environment variable NODE_IP is not set. Cannot get pod list for monitor_kubernetes_pods using version 2.")
+	}
 
 	// Parse label and field selectors - will be used to filter pods after cAdvisor call
 	labelSelector, err := labels.Parse(p.KubernetesLabelSelector)

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -176,7 +176,7 @@ func (p *Prometheus) cAdvisor(ctx context.Context, client *k8s.Client) error {
 	}
 	client.SetHeaders(req.Header)
 
-	// Update right away so code is not waiting 60s initially
+	// Update right away so code is not waiting the length of the cAdvisorCallInterval initially
 	err = updateCadvisorPodList(ctx, p, client, req, labelSelector, fieldSelector)
 	if err != nil {
 		return err
@@ -217,7 +217,7 @@ func updateCadvisorPodList(ctx context.Context, p *Prometheus, client *k8s.Clien
 	p.kubernetesPods = nil
 
 	// Register pod only if it has an annotation to scrape, if it is ready,
-  // and if namespace and selectors are specified and match
+	// and if namespace and selectors are specified and match
 	for _, pod := range pods {
 		if pod.GetMetadata().GetAnnotations()["prometheus.io/scrape"] == "true" &&
 			podReady(pod.Status.GetContainerStatuses()) &&

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -19,8 +19,8 @@ import (
 	"github.com/ericchiang/k8s"
 	corev1 "github.com/ericchiang/k8s/apis/core/v1"
 	"github.com/ghodss/yaml"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
+	"github.com/kubernetes/apimachinery/pkg/fields"
+	"github.com/kubernetes/apimachinery/pkg/labels"
 )
 
 type payload struct {

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -157,7 +157,7 @@ func (p *Prometheus) cAdvisor(ctx context.Context, client *k8s.Client) error {
 	tlsConfig.InsecureSkipVerify = true
 
 	// The request will be the same each time
-	podsUrl := fmt.Sprintf("https://%s:10250/pods", p.nodeIP)
+	podsUrl := fmt.Sprintf("https://%s:10250/pods", p.NodeIP)
 	req, err := http.NewRequest("GET", podsUrl, nil)
 	if err != nil {
 		return fmt.Errorf("Error when creating request to %s to get pod list: %w", podsUrl, err)

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -177,7 +177,6 @@ func (p *Prometheus) cAdvisor(ctx context.Context, client *k8s.Client) error {
 	tlsConfig.InsecureSkipVerify = true
 
 	// The request will be the same each time
-	nodeIP := os.Getenv("NODE_IP")
 	podsUrl := fmt.Sprintf("https://%s:10250/pods", nodeIP)
 	req, err := http.NewRequest("GET", podsUrl, nil)
 	if err != nil {

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -152,7 +152,7 @@ func (p *Prometheus) watch(ctx context.Context, client *k8s.Client) error {
 
 func (p *Prometheus) cAdvisor(ctx context.Context, client *k8s.Client) error {
 	p.Log.Infof("Using monitor pods version 2 to get pod list using cAdvisor.")
-	
+
 	nodeIP := os.Getenv("NODE_IP")
 	if nodeIP == "" {
 		return errors.New("The environment variable NODE_IP is not set. Cannot get pod list for monitor_kubernetes_pods using version 2.")
@@ -204,7 +204,7 @@ func (p *Prometheus) cAdvisor(ctx context.Context, client *k8s.Client) error {
 }
 
 func updateCadvisorPodList(ctx context.Context, p *Prometheus, client *k8s.Client, req *http.Request,
-		labelSelector labels.Selector, fieldSelector fields.Selector) error {
+	labelSelector labels.Selector, fieldSelector fields.Selector) error {
 
 	resp, err := client.Client.Do(req)
 	if err != nil {
@@ -232,7 +232,7 @@ func updateCadvisorPodList(ctx context.Context, p *Prometheus, client *k8s.Clien
 			podHasMatchingNamespace(pod, p) &&
 			podHasMatchingLabelSelector(pod, labelSelector) &&
 			podHasMatchingFieldSelector(pod, fieldSelector) {
-				registerPod(pod, p)
+			registerPod(pod, p)
 		}
 
 	}
@@ -243,14 +243,14 @@ func updateCadvisorPodList(ctx context.Context, p *Prometheus, client *k8s.Clien
 }
 
 func fieldSelectorIsSupported(fieldSelector fields.Selector) bool {
-	supportedFieldsToSelect := map[string]bool {
-			"spec.nodeName" : true,
-			"spec.restartPolicy" : true,
-			"spec.schedulerName" : true,
-			"spec.serviceAccountName" : true,
-			"status.phase" : true,
-			"status.podIP" : true,
-			"status.nominatedNodeName" : true,
+	supportedFieldsToSelect := map[string]bool{
+		"spec.nodeName":            true,
+		"spec.restartPolicy":       true,
+		"spec.schedulerName":       true,
+		"spec.serviceAccountName":  true,
+		"status.phase":             true,
+		"status.podIP":             true,
+		"status.nominatedNodeName": true,
 	}
 
 	for _, requirement := range fieldSelector.Requirements() {
@@ -289,7 +289,7 @@ func podHasMatchingFieldSelector(pod *corev1.Pod, fieldSelector fields.Selector)
 
 	// Spec and Status shouldn't be nil.
 	// Error handling just in case something goes wrong but won't crash telegraf
-	if (podSpec == nil || podStatus == nil) {
+	if podSpec == nil || podStatus == nil {
 		return false
 	}
 

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -254,7 +254,8 @@ func podHasMatchingLabelSelector(pod *corev1.Pod, selector labels.Selector) bool
 func podHasMatchingFieldSelector(pod *corev1.Pod, p *Prometheus, fieldSelector fields.Selector) bool {
 	var fs fields.Set = make(map[string]string)
 	
-	for field := range fs {
+	for _, requirement := range fieldSelector.Requirements() {
+		field := requirement.Field
 
 		// Not all fields can be selected. See link above for the list
 		var value string

--- a/plugins/inputs/prometheus/kubernetes_test.go
+++ b/plugins/inputs/prometheus/kubernetes_test.go
@@ -201,14 +201,6 @@ func TestInvalidFieldSelector(t *testing.T) {
 	assert.NotEqual(t, err, nil)
 }
 
-func TestUnsupportedFieldSelector(t *testing.T) {
-	fieldSelectorString := "spec.containerName=container"
-	prom := &Prometheus{Log: testutil.Logger{}, KubernetesFieldSelector: fieldSelectorString}
-
-	fieldSelector, _ := fields.ParseSelector(prom.KubernetesFieldSelector)
-	assert.Equal(t, false, fieldSelectorIsSupported(fieldSelector))
-}
-
 func pod() *v1.Pod {
 	p := &v1.Pod{Metadata: &metav1.ObjectMeta{}, Status: &v1.PodStatus{}, Spec: &v1.PodSpec{}}
 	p.Status.PodIP = str("127.0.0.1")

--- a/plugins/inputs/prometheus/kubernetes_test.go
+++ b/plugins/inputs/prometheus/kubernetes_test.go
@@ -9,7 +9,7 @@ import (
 
 	v1 "github.com/ericchiang/k8s/apis/core/v1"
 	metav1 "github.com/ericchiang/k8s/apis/meta/v1"
-	
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 )

--- a/plugins/inputs/prometheus/kubernetes_test.go
+++ b/plugins/inputs/prometheus/kubernetes_test.go
@@ -10,8 +10,8 @@ import (
 	v1 "github.com/ericchiang/k8s/apis/core/v1"
 	metav1 "github.com/ericchiang/k8s/apis/meta/v1"
 
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
+	"github.com/kubernetes/apimachinery/pkg/fields"
+	"github.com/kubernetes/apimachinery/pkg/labels"
 )
 
 func TestScrapeURLNoAnnotations(t *testing.T) {
@@ -179,7 +179,7 @@ func TestPodHasMatchingLabelSelector(t *testing.T) {
 }
 
 func TestPodHasMatchingFieldSelector(t *testing.T) {
-	fieldSelectorString := "status.podIP=127.0.0.1,spec.restartPolicy=Always,spec.NodeName!=nodeName,status"
+	fieldSelectorString := "status.podIP=127.0.0.1,spec.restartPolicy=Always,spec.NodeName!=nodeName"
 	prom := &Prometheus{Log: testutil.Logger{}, KubernetesFieldSelector: fieldSelectorString}
 	pod := pod()
 	pod.Spec.RestartPolicy = str("Always")

--- a/plugins/inputs/prometheus/kubernetes_test.go
+++ b/plugins/inputs/prometheus/kubernetes_test.go
@@ -9,6 +9,9 @@ import (
 
 	v1 "github.com/ericchiang/k8s/apis/core/v1"
 	metav1 "github.com/ericchiang/k8s/apis/meta/v1"
+	
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestScrapeURLNoAnnotations(t *testing.T) {
@@ -140,6 +143,70 @@ func TestPodSelector(t *testing.T) {
 
 		assert.Equal(t, len(output), len(c.expected))
 	}
+}
+
+func TestPodHasMatchingNamespace(t *testing.T) {
+	prom := &Prometheus{Log: testutil.Logger{}, PodNamespace: "default"}
+
+	pod := pod()
+	pod.Metadata.Name = str("Pod1")
+	pod.Metadata.Namespace = str("default")
+	shouldMatch := podHasMatchingNamespace(pod, prom)
+	assert.Equal(t, true, shouldMatch)
+
+	pod.Metadata.Name = str("Pod2")
+	pod.Metadata.Namespace = str("namespace")
+	shouldNotMatch := podHasMatchingNamespace(pod, prom)
+	assert.Equal(t, false, shouldNotMatch)
+}
+
+func TestPodHasMatchingLabelSelector(t *testing.T) {
+	labelSelectorString := "label0==label0,label1=label1,label2!=label,label3 in (label1,label2, label3),label4 notin (label1, label2,label3),label5,!label6"
+	prom := &Prometheus{Log: testutil.Logger{}, KubernetesLabelSelector: labelSelectorString}
+
+	pod := pod()
+	pod.Metadata.Labels = make(map[string]string)
+	pod.Metadata.Labels["label0"] = "label0"
+	pod.Metadata.Labels["label1"] = "label1"
+	pod.Metadata.Labels["label2"] = "label2"
+	pod.Metadata.Labels["label3"] = "label3"
+	pod.Metadata.Labels["label4"] = "label4"
+	pod.Metadata.Labels["label5"] = "label5"
+
+	labelSelector, err := labels.Parse(prom.KubernetesLabelSelector)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, true, podHasMatchingLabelSelector(pod, labelSelector))
+}
+
+func TestPodHasMatchingFieldSelector(t *testing.T) {
+	fieldSelectorString := "status.podIP=127.0.0.1,spec.restartPolicy=Always,spec.NodeName!=nodeName,status"
+	prom := &Prometheus{Log: testutil.Logger{}, KubernetesFieldSelector: fieldSelectorString}
+	pod := pod()
+	pod.Spec.RestartPolicy = str("Always")
+	pod.Spec.NodeName = str("node1000")
+
+	fieldSelector, err := fields.ParseSelector(prom.KubernetesFieldSelector)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, true, podHasMatchingFieldSelector(pod, fieldSelector))
+}
+
+func TestInvalidFieldSelector(t *testing.T) {
+	fieldSelectorString := "status.podIP=127.0.0.1,spec.restartPolicy=Always,spec.NodeName!=nodeName,spec.nodeName"
+	prom := &Prometheus{Log: testutil.Logger{}, KubernetesFieldSelector: fieldSelectorString}
+	pod := pod()
+	pod.Spec.RestartPolicy = str("Always")
+	pod.Spec.NodeName = str("node1000")
+
+	_, err := fields.ParseSelector(prom.KubernetesFieldSelector)
+	assert.NotEqual(t, err, nil)
+}
+
+func TestUnsupportedFieldSelector(t *testing.T) {
+	fieldSelectorString := "spec.containerName=container"
+	prom := &Prometheus{Log: testutil.Logger{}, KubernetesFieldSelector: fieldSelectorString}
+
+	fieldSelector, _ := fields.ParseSelector(prom.KubernetesFieldSelector)
+	assert.Equal(t, false, fieldSelectorIsSupported(fieldSelector))
 }
 
 func pod() *v1.Pod {

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -185,7 +184,6 @@ func (p *Prometheus) GetAllURLs() (map[string]URLAndAddress, error) {
 		allURLs[URL.String()] = URLAndAddress{URL: URL, OriginalURL: URL}
 	}
 
-	log.Printf("[cAdvisor Changes Log] locking in p.GetAllURLs()")
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	// loop through all pods scraped via the prometheus annotation on the pods
@@ -213,7 +211,6 @@ func (p *Prometheus) GetAllURLs() (map[string]URLAndAddress, error) {
 			}
 		}
 	}
-	log.Printf("[cAdvisor Changes Log] unlocking in p.GetAllURLs()")
 	return allURLs, nil
 }
 

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -94,9 +94,13 @@ var sampleConfig = `
   ##     set this to 'https' & most likely set the tls config.
   ## - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
   ## - prometheus.io/port: If port is not 9102 use this annotation
-  # monitor_kubernetes_pods = true
+	# monitor_kubernetes_pods = true
+	## Get the list of pods to scrape either from
+	## - version 1 (default): the kubernetes watch api (cluster-wide)
+	## - version 2: the local cadvisor api (node-wide); for scaling
+	# monitor_kubernetes_pods_version = 1
   ## Restricts Kubernetes monitoring to a single namespace
-  ##   ex: monitor_kubernetes_pods_namespace = "default"
+	##   ex: monitor_kubernetes_pods_namespace = "default"
   # monitor_kubernetes_pods_namespace = ""
   # label selector to target pods which have the label
   # kubernetes_label_selector = "env=dev,app=nginx"

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -57,12 +57,13 @@ type Prometheus struct {
 	client *http.Client
 
 	// Should we scrape Kubernetes services for prometheus annotations
-	MonitorPods    bool   `toml:"monitor_kubernetes_pods"`
-	PodNamespace   string `toml:"monitor_kubernetes_pods_namespace"`
-	lock           sync.Mutex
-	kubernetesPods map[string]URLAndAddress
-	cancel         context.CancelFunc
-	wg             sync.WaitGroup
+	MonitorPods        bool   `toml:"monitor_kubernetes_pods"`
+	MonitorPodsVersion int    `toml:"monitor_kubernetes_pods_version"`
+	PodNamespace       string `toml:"monitor_kubernetes_pods_namespace"`
+	lock               sync.Mutex
+	kubernetesPods     map[string]URLAndAddress
+	cancel             context.CancelFunc
+	wg                 sync.WaitGroup
 }
 
 var sampleConfig = `

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -97,7 +97,7 @@ var sampleConfig = `
   # monitor_kubernetes_pods = true
   ## Get the list of pods to scrape either from
   ## - version 1 (default): the kubernetes watch api (cluster-wide)
-  ## - version 2: the local cadvisor api (node-wide); for scaling
+  ## - version 2: the local cadvisor api (node-wide); for scalability. Note that the environment variable NODE_IP must be set to the host IP.
   # monitor_kubernetes_pods_version = 1
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -184,6 +185,7 @@ func (p *Prometheus) GetAllURLs() (map[string]URLAndAddress, error) {
 		allURLs[URL.String()] = URLAndAddress{URL: URL, OriginalURL: URL}
 	}
 
+	log.Printf("[cAdvisor Changes Log] locking in p.GetAllURLs()")
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	// loop through all pods scraped via the prometheus annotation on the pods
@@ -211,6 +213,7 @@ func (p *Prometheus) GetAllURLs() (map[string]URLAndAddress, error) {
 			}
 		}
 	}
+	log.Printf("[cAdvisor Changes Log] unlocking in p.GetAllURLs()")
 	return allURLs, nil
 }
 

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -94,13 +94,13 @@ var sampleConfig = `
   ##     set this to 'https' & most likely set the tls config.
   ## - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
   ## - prometheus.io/port: If port is not 9102 use this annotation
-	# monitor_kubernetes_pods = true
-	## Get the list of pods to scrape either from
-	## 		- version 1 (default): the kubernetes watch api (cluster-wide)
-	## 		- version 2: the local cadvisor api (node-wide); for scaling
-	# monitor_kubernetes_pods_version = 1
+  # monitor_kubernetes_pods = true
+  ## Get the list of pods to scrape either from
+  ## - version 1 (default): the kubernetes watch api (cluster-wide)
+  ## - version 2: the local cadvisor api (node-wide); for scaling
+  # monitor_kubernetes_pods_version = 1
   ## Restricts Kubernetes monitoring to a single namespace
-	##   ex: monitor_kubernetes_pods_namespace = "default"
+  ##   ex: monitor_kubernetes_pods_namespace = "default"
   # monitor_kubernetes_pods_namespace = ""
   # label selector to target pods which have the label
   # kubernetes_label_selector = "env=dev,app=nginx"

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -63,7 +63,7 @@ type Prometheus struct {
 	// Should we scrape Kubernetes services for prometheus annotations
 	MonitorPods       bool   `toml:"monitor_kubernetes_pods"`
 	PodScrapeScope    string `toml:"pod_scrape_scope"`
-	NodeIP						string `toml:"node_ip"`
+	NodeIP            string `toml:"node_ip"`
 	PodScrapeInterval int    `toml:"pod_scrape_interval"`
 	PodNamespace      string `toml:"monitor_kubernetes_pods_namespace"`
 	lock              sync.Mutex

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -96,8 +96,8 @@ var sampleConfig = `
   ## - prometheus.io/port: If port is not 9102 use this annotation
 	# monitor_kubernetes_pods = true
 	## Get the list of pods to scrape either from
-	## - version 1 (default): the kubernetes watch api (cluster-wide)
-	## - version 2: the local cadvisor api (node-wide); for scaling
+	## 		- version 1 (default): the kubernetes watch api (cluster-wide)
+	## 		- version 2: the local cadvisor api (node-wide); for scaling
 	# monitor_kubernetes_pods_version = 1
   ## Restricts Kubernetes monitoring to a single namespace
 	##   ex: monitor_kubernetes_pods_namespace = "default"

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -258,8 +258,11 @@ func TestInitConfigErrors(t *testing.T) {
 		PodScrapeInterval: 60,
 	}
 
+	// Both invalid IP addresses
+	p.NodeIP = "10.240.0.0.0"
+	os.Setenv("NODE_IP", "10.000.0.0.0")
 	err := p.Init()
-	expectedMessage := "The environment variable NODE_IP is not set. Cannot get pod list for monitor_kubernetes_pods using node scrape scope"
+	expectedMessage := "The node_ip config and the environment variable NODE_IP are not set or invalid. Cannot get pod list for monitor_kubernetes_pods using node scrape scope"
 	assert.Equal(t, expectedMessage, err.Error())
 	os.Setenv("NODE_IP", "10.000.0.0")
 


### PR DESCRIPTION
### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

PR for the issue https://github.com/influxdata/telegraf/issues/8705.

If monitor_kubernetes_pods = true and the new monitor_kubernetes_pods_version = 2 is specified, the pod list is queried locally on the node every 60s instead of using the watch api. This allows for scalability for large clusters so the pods to scrape are distributed among the nodes, which requires telegraf to be run as a daemonset. The same annotations to choose which pods to scrape are used and the optional filtering by namespace and selectors is also the same, with this filtering done afterwards. The feature is backwards compatible and is used if and only if monitor_kubernetes_pods_version = 2 is specified in the config.