### PR TITLE
inputs.ping regression: Add back required "hostPinger" function for "exec" method

### DIFF
--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-ping/ping"
+	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -259,6 +260,21 @@ func TestPingGather(t *testing.T) {
 
 	tags = map[string]string{"url": "influxdata.com"}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
+}
+
+func TestPingGatherIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode, retrieves systems ping utility")
+	}
+
+	var acc testutil.Accumulator
+	p, ok := inputs.Inputs["ping"]().(*Ping)
+	require.True(t, ok)
+	p.Urls = []string{"localhost", "influxdata.com"}
+	err := acc.GatherError(p.Gather)
+	require.NoError(t, err)
+	require.Equal(t, 0, acc.Metrics[0].Fields["result_code"])
+	require.Equal(t, 0, acc.Metrics[1].Fields["result_code"])
 }
 
 var lossyPingOutput = `


### PR DESCRIPTION
### Required for all PRs:

- [x] Has appropriate unit tests.

fixes #8766 

This pull request addresses the issue @NZSmartie found and reported in #8704. There was a regression due to the pr #8679 which removed a required function which led to a instant panic when using the "exec" method for inputs.ping. I added an integration unit test to cover for this case in the future that ensures `init()` is correct.
