### PR TITLE
Close running outputs when reloading

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -447,6 +447,17 @@ func stopServiceInputs(inputs []*models.RunningInput) {
 	}
 }
 
+// stopRunningOutputs stops all running outputs.
+func stopRunningOutputs(outputs []*models.RunningOutput) {
+	for _, output := range outputs {
+		log.Printf("I! [agent] stop running output: %s", output.LogName())
+		err := output.Output.Close()
+		if err != nil {
+			log.Printf("E! [agent] Error stop running output: %v", err)
+		}
+	}
+}
+
 // gather runs an input's gather function periodically until the context is
 // done.
 func (a *Agent) gatherLoop(
@@ -784,6 +795,9 @@ func (a *Agent) runOutputs(
 	log.Println("I! [agent] Hang on, flushing any cached metrics before shutdown")
 	cancel()
 	wg.Wait()
+
+	log.Printf("D! [agent] Stopping running outputs")
+	stopRunningOutputs(unit.outputs)
 
 	return nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -450,11 +450,7 @@ func stopServiceInputs(inputs []*models.RunningInput) {
 // stopRunningOutputs stops all running outputs.
 func stopRunningOutputs(outputs []*models.RunningOutput) {
 	for _, output := range outputs {
-		log.Printf("I! [agent] stop running output: %s", output.LogName())
-		err := output.Output.Close()
-		if err != nil {
-			log.Printf("E! [agent] Error stop running output: %v", err)
-		}
+		output.Close()
 	}
 }
 
@@ -796,7 +792,7 @@ func (a *Agent) runOutputs(
 	cancel()
 	wg.Wait()
 
-	log.Printf("I [agent] Stopping running outputs")
+	log.Println("I! [agent] Stopping running outputs")
 	stopRunningOutputs(unit.outputs)
 
 	return nil

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -796,7 +796,7 @@ func (a *Agent) runOutputs(
 	cancel()
 	wg.Wait()
 
-	log.Printf("D! [agent] Stopping running outputs")
+	log.Printf("I [agent] Stopping running outputs")
 	stopRunningOutputs(unit.outputs)
 
 	return nil

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -106,6 +106,7 @@ func reloadLoop(
 				cancel()
 			}
 		}()
+
 		err := runAgent(ctx, inputFilters, outputFilters)
 		if err != nil && err != context.Canceled {
 			log.Fatalf("E! [telegraf] Error running agent: %v", err)


### PR DESCRIPTION
closes #8726, closes #8185

As we know, telegraf will reload when getting a SIGHUP signal. If we go deeper into the reload loop, we can see "runAgent" is called without closing running outputs.

This will cause some issues like reload failure and connection leaking.

- Reload failure

1. Add prometheus configuration
```
[[outputs.prometheus_client]]
  listen = ":9273"
  path = "/metrics"
  metric_version = 2
```

2. Send a SIGHUP to the process

3. We will get the "address already in use" error:
```
2021-01-28T08:47:59Z I! Starting Telegraf 
2021-01-28T08:47:59Z I! Loaded inputs: x509_cert
2021-01-28T08:47:59Z I! Loaded aggregators: 
2021-01-28T08:47:59Z I! Loaded processors: 
2021-01-28T08:47:59Z I! Loaded outputs: prometheus_client
2021-01-28T08:47:59Z I! Tags enabled: host=Zachary-MBP.local
2021-01-28T08:47:59Z I! [agent] Config: Interval:20s, Quiet:false, Hostname:"Zachary-MBP.local", Flush Interval:20s
2021-01-28T08:47:59Z I! [outputs.prometheus_client] Listening on http://[::]:9273/metrics
2021-01-28T08:48:12Z I! Reloading Telegraf config
2021-01-28T08:48:12Z I! [agent] Hang on, flushing any cached metrics before shutdown
2021-01-28T08:48:12Z I! Starting Telegraf 
2021-01-28T08:48:12Z I! Loaded inputs: x509_cert
2021-01-28T08:48:12Z I! Loaded aggregators: 
2021-01-28T08:48:12Z I! Loaded processors: 
2021-01-28T08:48:12Z I! Loaded outputs: prometheus_client
2021-01-28T08:48:12Z I! Tags enabled: host=Zachary-MBP.local
2021-01-28T08:48:12Z I! [agent] Config: Interval:20s, Quiet:false, Hostname:"Zachary-MBP.local", Flush Interval:20s
2021-01-28T08:48:12Z E! [agent] Failed to connect to [outputs.prometheus_client], retrying in 15s, error was 'listen tcp :9273: bind: address already in use'
2021-01-28T08:48:27Z E! [telegraf] Error running agent: connecting output outputs.prometheus_client: Error connecting to output "outputs.prometheus_client": listen tcp :9273: bind: address already in use
```

- Connection leaking 

1. Add influxdb output 
```
[[outputs.influxdb_v2]]
urls = ["http://127.0.0.1:8086"]
```

2. Sent SIGHUP several times.

3. We can find more than one tcp connection to influxdb server:
```
Zachary-MBP:telegraf zachary$ lsof -p 34680
COMMAND    PID    USER   FD     TYPE             DEVICE  SIZE/OFF                NODE NAME
telegraf 34680 zachary  cwd      DIR                1,4      1408            26952554 /Users/zachary/Projects/golang/telegraf
telegraf 34680 zachary  txt      REG                1,4 117061680            27081706 /Users/zachary/Projects/golang/telegraf/telegraf
telegraf 34680 zachary  txt      REG                1,4     34032            24991620 /Library/Preferences/Logging/.plist-cache.eRVHsOgp
telegraf 34680 zachary  txt      REG                1,4     62747            26934247 /private/var/db/analyticsd/events.whitelist
telegraf 34680 zachary  txt      REG                1,4   2528384 1152921500312783762 /usr/lib/dyld
telegraf 34680 zachary  txt      REG                1,4  30148944 1152921500312795328 /usr/share/icu/icudt66l.dat
telegraf 34680 zachary    0u     CHR               16,1   0t14589                1483 /dev/ttys001
telegraf 34680 zachary    1u     CHR               16,1   0t14589                1483 /dev/ttys001
telegraf 34680 zachary    2u     CHR               16,1   0t14589                1483 /dev/ttys001
telegraf 34680 zachary    3     PIPE 0xdbb151f6d2284bc1     16384                     ->0x500c3504a5abf149
telegraf 34680 zachary    4     PIPE 0x500c3504a5abf149     16384                     ->0xdbb151f6d2284bc1
telegraf 34680 zachary    5u  KQUEUE                                                  count=0, state=0xa
telegraf 34680 zachary    6     PIPE 0x7060bc4282b87de5     16384                     ->0x58c782c11bf250d
telegraf 34680 zachary    7     PIPE  0x58c782c11bf250d     16384                     ->0x7060bc4282b87de5
telegraf 34680 zachary    8u    unix 0xba652578907083cf       0t0                     ->0xba6525787cd608e7
telegraf 34680 zachary    9r     CHR               17,1    0t4096                 593 /dev/urandom
telegraf 34680 zachary   10u    IPv4 0xba6525789e21f5d7       0t0                 TCP localhost:64693->localhost:8086 (ESTABLISHED)
telegraf 34680 zachary   11u    IPv4 0xba65257897816267       0t0                 TCP localhost:64841->localhost:8086 (ESTABLISHED)
telegraf 34680 zachary   12u    IPv4 0xba65257888979267       0t0                 TCP localhost:64847->localhost:8086 (ESTABLISHED)
telegraf 34680 zachary   13u    IPv4 0xba6525789ad5b267       0t0                 TCP localhost:64853->localhost:8086 (ESTABLISHED)
telegraf 34680 zachary   14u    IPv4 0xba65257898eb0fef       0t0                 TCP localhost:64859->localhost:8086 (ESTABLISHED)
telegraf 34680 zachary   15u    IPv4 0xba6525789e129697       0t0                 TCP localhost:64865->localhost:8086 (ESTABLISHED)
telegraf 34680 zachary   16u    IPv4 0xba6525789ad5d0af       0t0                 TCP localhost:64870->localhost:8086 (ESTABLISHED)
telegraf 34680 zachary   17u    IPv4 0xba6525788bc6f267       0t0                 TCP localhost:64876->localhost:8086 (ESTABLISHED)
telegraf 34680 zachary   18u    IPv4 0xba6525789e13fc7f       0t0                 TCP localhost:64884->localhost:8086 (ESTABLISHED)
```
4. This issue was mentioned before. "client.Close()" was add in the influxdb output, but "(i *InfluxDB) Close()" method is never called during the reload.

I add some code to fix this.

### Required for all PRs:

- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
