### PR TITLE
Add default retry for load config via url

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -924,14 +924,9 @@ func fetchConfig(u *url.URL) ([]byte, error) {
 	req.Header.Set("User-Agent", internal.ProductToken())
 
 	retries := 3
-	for i := 1; i <= retries; i++ {
+	for i := 0; i <= retries; i++ {
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			if i < retries {
-				log.Printf("Unable to connect to HTTP config server.  Retry %d of %d in %s. %s", i, retries, httpLoadConfigRetryInterval, err)
-				time.Sleep(httpLoadConfigRetryInterval)
-				continue
-			}
 			return nil, fmt.Errorf("Retry %d of %d failed connecting to HTTP config server %s", i, retries, err)
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ var (
 		`"`, `\"`,
 		`\`, `\\`,
 	)
+	httpLoadConfigRetryInterval = 10 * time.Second
 )
 
 // Config specifies the URL/user/password for the database that telegraf
@@ -921,17 +922,32 @@ func fetchConfig(u *url.URL) ([]byte, error) {
 	}
 	req.Header.Add("Accept", "application/toml")
 	req.Header.Set("User-Agent", internal.ProductToken())
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
+
+	retries := 3
+	for i := 1; i <= retries; i++ {
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			if i < retries {
+				log.Printf("Unable to connect to HTTP config server.  Retry %d of %d in %s. %s", i, retries, httpLoadConfigRetryInterval, err)
+				time.Sleep(httpLoadConfigRetryInterval)
+				continue
+			}
+			return nil, fmt.Errorf("Retry %d of %d failed connecting to HTTP config server %s", i, retries, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			if i < retries {
+				log.Printf("Error getting HTTP config.  Retry %d of %d in %s.  Status=%d", i, retries, httpLoadConfigRetryInterval, resp.StatusCode)
+				time.Sleep(httpLoadConfigRetryInterval)
+				continue
+			}
+			return nil, fmt.Errorf("Retry %d of %d failed to retrieve remote config: %s", i, retries, resp.Status)
+		}
+		defer resp.Body.Close()
+		return ioutil.ReadAll(resp.Body)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to retrieve remote config: %s", resp.Status)
-	}
-
-	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return nil, nil
 }
 
 // parseConfig loads a TOML configuration from a provided path and

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -277,4 +279,38 @@ func TestConfig_AzureMonitorNamespacePrefix(t *testing.T) {
 	azureMonitor, ok = c.Outputs[0].Output.(*azure_monitor.AzureMonitor)
 	assert.Equal(t, "", azureMonitor.NamespacePrefix)
 	assert.Equal(t, true, ok)
+}
+
+func TestConfig_URLRetries3Fails(t *testing.T) {
+	httpLoadConfigRetryInterval = 0 * time.Second
+	responseCounter := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		responseCounter++
+	}))
+	defer ts.Close()
+
+	c := NewConfig()
+	err := c.LoadConfig(ts.URL)
+	require.Error(t, err)
+	require.Equal(t, 3, responseCounter)
+}
+
+func TestConfig_URLRetries2FailsThenPasses(t *testing.T) {
+	httpLoadConfigRetryInterval = 0 * time.Second
+	responseCounter := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if responseCounter <= 1 {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		responseCounter++
+	}))
+	defer ts.Close()
+
+	c := NewConfig()
+	err := c.LoadConfig(ts.URL)
+	require.NoError(t, err)
+	require.Equal(t, 3, responseCounter)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -293,14 +293,14 @@ func TestConfig_URLRetries3Fails(t *testing.T) {
 	c := NewConfig()
 	err := c.LoadConfig(ts.URL)
 	require.Error(t, err)
-	require.Equal(t, 3, responseCounter)
+	require.Equal(t, 4, responseCounter)
 }
 
-func TestConfig_URLRetries2FailsThenPasses(t *testing.T) {
+func TestConfig_URLRetries3FailsThenPasses(t *testing.T) {
 	httpLoadConfigRetryInterval = 0 * time.Second
 	responseCounter := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if responseCounter <= 1 {
+		if responseCounter <= 2 {
 			w.WriteHeader(http.StatusNotFound)
 		} else {
 			w.WriteHeader(http.StatusOK)
@@ -312,5 +312,5 @@ func TestConfig_URLRetries2FailsThenPasses(t *testing.T) {
 	c := NewConfig()
 	err := c.LoadConfig(ts.URL)
 	require.NoError(t, err)
-	require.Equal(t, 3, responseCounter)
+	require.Equal(t, 4, responseCounter)
 }


### PR DESCRIPTION
Closes #7338

Related #7349, #7662 

This is a temporary fix which we intend to improve on:

- Retries three times at 10s intervals when receiving an error on loading config from a url incase of the endpoint being down.

- Log attempts and the specific failure response codes.

- Does not use env variables or add new flags 

- Tests added to demonstrate that on the final failure it will return the error.

