### PR TITLE
Expose v4/v6-only connection-schemes through GosnmpWrapper

### DIFF
--- a/internal/snmp/wrapper.go
+++ b/internal/snmp/wrapper.go
@@ -165,18 +165,8 @@ func (gs *GosnmpWrapper) SetAgent(agent string) error {
 	}
 
 	switch u.Scheme {
-	case "tcp":
-		gs.Transport = "tcp"
-	case "tcp4":
-		gs.Transport = "tcp4"
-	case "tcp6":
-		gs.Transport = "tcp6"
-	case "udp":
-		gs.Transport = "udp"
-	case "udp4":
-		gs.Transport = "udp4"
-	case "udp6":
-		gs.Transport = "udp6"
+	case "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6":
+		gs.Transport = u.Scheme
 	default:
 		return fmt.Errorf("unsupported scheme: %v", u.Scheme)
 	}

--- a/internal/snmp/wrapper.go
+++ b/internal/snmp/wrapper.go
@@ -164,6 +164,11 @@ func (gs *GosnmpWrapper) SetAgent(agent string) error {
 		return err
 	}
 
+	// Only allow udp{4,6} and tcp{4,6}.
+	// Allowing ip{4,6} does not make sense as specifying a port
+	// requires the specification of a protocol.
+	// gosnmp does not handle these errors well, which is why
+	// they can result in cryptic errors by net.Dial.
 	switch u.Scheme {
 	case "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6":
 		gs.Transport = u.Scheme

--- a/internal/snmp/wrapper.go
+++ b/internal/snmp/wrapper.go
@@ -171,12 +171,12 @@ func (gs *GosnmpWrapper) SetAgent(agent string) error {
 		gs.Transport = "tcp4"
 	case "tcp6":
 		gs.Transport = "tcp6"
+	case "udp":
+		gs.Transport = "udp"
 	case "udp4":
 		gs.Transport = "udp4"
 	case "udp6":
 		gs.Transport = "udp6"
-	case "udp":
-		gs.Transport = "udp"
 	default:
 		return fmt.Errorf("unsupported scheme: %v", u.Scheme)
 	}

--- a/internal/snmp/wrapper.go
+++ b/internal/snmp/wrapper.go
@@ -167,6 +167,14 @@ func (gs *GosnmpWrapper) SetAgent(agent string) error {
 	switch u.Scheme {
 	case "tcp":
 		gs.Transport = "tcp"
+	case "tcp4":
+		gs.Transport = "tcp4"
+	case "tcp6":
+		gs.Transport = "tcp6"
+	case "udp4":
+		gs.Transport = "udp4"
+	case "udp6":
+		gs.Transport = "udp6"
 	case "", "udp":
 		gs.Transport = "udp"
 	default:

--- a/internal/snmp/wrapper.go
+++ b/internal/snmp/wrapper.go
@@ -175,7 +175,7 @@ func (gs *GosnmpWrapper) SetAgent(agent string) error {
 		gs.Transport = "udp4"
 	case "udp6":
 		gs.Transport = "udp6"
-	case "", "udp":
+	case "udp":
 		gs.Transport = "udp"
 	default:
 		return fmt.Errorf("unsupported scheme: %v", u.Scheme)

--- a/plugins/inputs/snmp/README.md
+++ b/plugins/inputs/snmp/README.md
@@ -22,11 +22,13 @@ information.
 ```toml
 [[inputs.snmp]]
   ## Agent addresses to retrieve values from.
-  ##   format:  agents = ["<scheme>://<hostname>:<port>"]
-  ##   scheme:  either udp, udp4, udp6, tcp, tcp4, tcp6.  
+  ##   format:  agents = ["<scheme://><hostname>:<port>"]
+  ##   scheme:  optional, either udp, udp4, udp6, tcp, tcp4, tcp6.  
   ##            default is udp
+  ##   port:    optional
   ##   example: agents = ["udp://127.0.0.1:161"]
-  ##            agents = ["udp4://v4only-snmp-agent"]
+  ##            agents = ["tcp://127.0.0.1:161"]
+  ##            agents = ["udpv4://v4only-snmp-agent"]
   agents = ["udp://127.0.0.1:161"]
 
   ## Timeout for each request.

--- a/plugins/inputs/snmp/README.md
+++ b/plugins/inputs/snmp/README.md
@@ -28,7 +28,7 @@ information.
   ##   port:    optional
   ##   example: agents = ["udp://127.0.0.1:161"]
   ##            agents = ["tcp://127.0.0.1:161"]
-  ##            agents = ["udpv4://v4only-snmp-agent"]
+  ##            agents = ["udp4://v4only-snmp-agent"]
   agents = ["udp://127.0.0.1:161"]
 
   ## Timeout for each request.

--- a/plugins/inputs/snmp/README.md
+++ b/plugins/inputs/snmp/README.md
@@ -22,8 +22,11 @@ information.
 ```toml
 [[inputs.snmp]]
   ## Agent addresses to retrieve values from.
+  ##   format:  agents = ["<scheme>://<hostname>:<port>"]
+  ##   scheme:  either udp, udp4, udp6, tcp, tcp4, tcp6.  
+  ##            default is udp
   ##   example: agents = ["udp://127.0.0.1:161"]
-  ##            agents = ["tcp://127.0.0.1:161"]
+  ##            agents = ["udp4://v4only-snmp-agent"]
   agents = ["udp://127.0.0.1:161"]
 
   ## Timeout for each request.

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -565,8 +565,8 @@ func (s *Snmp) getConnection(idx int) (snmpConnection, error) {
 	if err != nil {
 		return nil, err
 	}
-	
-  err = gs.SetAgent(agent)
+
+	err = gs.SetAgent(agent)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -31,7 +31,7 @@ const sampleConfig = `
   ##   port:    optional
   ##   example: agents = ["udp://127.0.0.1:161"]
   ##            agents = ["tcp://127.0.0.1:161"]
-  ##            agents = ["udpv4://v4only-snmp-agent"]
+  ##            agents = ["udp4://v4only-snmp-agent"]
   agents = ["udp://127.0.0.1:161"]
 
   ## Timeout for each request.

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -565,8 +565,10 @@ func (s *Snmp) getConnection(idx int) (snmpConnection, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := gs.SetAgent(agent); err != nil {
-		return nil, fmt.Errorf("setting gosnmpwrapper agent: %w", err)
+	
+  err = gs.SetAgent(agent)
+	if err != nil {
+		return nil, err
 	}
 
 	s.connectionCache[idx] = gs

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -24,7 +24,6 @@ import (
 
 const description = `Retrieves SNMP values from remote agents`
 const sampleConfig = `
-  [[inputs.snmp]]
   ## Agent addresses to retrieve values from.
   ##   format:  agents = ["<scheme://><hostname>:<port>"]
   ##   scheme:  optional, either udp, udp4, udp6, tcp, tcp4, tcp6.            

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -566,9 +566,8 @@ func (s *Snmp) getConnection(idx int) (snmpConnection, error) {
 	if err != nil {
 		return nil, err
 	}
-	gs.SetAgent(agent)
-	if err != nil {
-		return nil, err
+	if err := gs.SetAgent(agent); err != nil {
+		return nil, fmt.Errorf("setting gosnmpwrapper agent: %w", err)
 	}
 
 	s.connectionCache[idx] = gs

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -25,8 +25,11 @@ import (
 const description = `Retrieves SNMP values from remote agents`
 const sampleConfig = `
   ## Agent addresses to retrieve values from.
+  ##   format:  agents = ["<scheme>://<hostname>:<port>"]
+  ##   scheme:  either udp, udp4, udp6, tcp, tcp4, tcp6.
+  ##            default is udp
   ##   example: agents = ["udp://127.0.0.1:161"]
-  ##            agents = ["tcp://127.0.0.1:161"]
+  ##            agents = ["udp4://v4only-snmp-agent"]
   agents = ["udp://127.0.0.1:161"]
 
   ## Timeout for each request.

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -24,12 +24,15 @@ import (
 
 const description = `Retrieves SNMP values from remote agents`
 const sampleConfig = `
+  [[inputs.snmp]]
   ## Agent addresses to retrieve values from.
-  ##   format:  agents = ["<scheme>://<hostname>:<port>"]
-  ##   scheme:  either udp, udp4, udp6, tcp, tcp4, tcp6.
+  ##   format:  agents = ["<scheme://><hostname>:<port>"]
+  ##   scheme:  optional, either udp, udp4, udp6, tcp, tcp4, tcp6.            
   ##            default is udp
+  ##   port:    optional
   ##   example: agents = ["udp://127.0.0.1:161"]
-  ##            agents = ["udp4://v4only-snmp-agent"]
+  ##            agents = ["tcp://127.0.0.1:161"]
+  ##            agents = ["udpv4://v4only-snmp-agent"]
   agents = ["udp://127.0.0.1:161"]
 
   ## Timeout for each request.


### PR DESCRIPTION
Hi, 
This PR fixes https://github.com/influxdata/telegraf/issues/7879.

I modified the Gosnmpwrapper to expose tcp{4,6} and udp{4,6} as connection-scheme and pass them to Gosnmp. 
This way, one can indirectly specify the address-family to be used for snmp-requests. 
I updated the according README-files. 
In my small test-setup everything is working as intended. 

However, I did not find a unit-test for the snmp input-plugin or the wrapper to alter, so I assume this small 4 line change can (hopefully) be reviewed by hand. 
This is my first PR on a go-project ever, so please be gentle! :)

Have a nice day. 

### Required for all PRs:

- [x] Associated README.md updated.
- [ ] Has appropriate unit tests.
