### PR TITLE
resetting wavefront proxy connection

### DIFF
--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -174,6 +174,8 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 			err := w.sender.SendMetric(point.Metric, point.Value, point.Timestamp, point.Source, point.Tags)
 			if err != nil {
 				if isRetryable(err) {
+					// resetting wavefront proxy connection when proxy IP is changed
+					w.sender.Close()
 					return fmt.Errorf("Wavefront sending error: %v", err)
 				}
 				w.Log.Errorf("non-retryable error during Wavefront.Write: %v", err)


### PR DESCRIPTION
This is a bug fix.
Currently, if the proxy IP is changed you have to restart telegraf to reset the TCP connection.

Current behavior 

```
2021-02-04T07:42:00Z W! [outputs.wavefront] Metric buffer overflow; 1004 metrics have been dropped
2021-02-04T07:42:00Z E! [agent] Error writing to outputs.wavefront: Wavefront sending error: write tcp 10.0.8.1:54000->10.0.8.2:2878: i/o timeout
2021-02-04T07:42:00Z W! [outputs.wavefront] Metric buffer overflow; 979 metrics have been dropped
2021-02-04T07:42:00Z E! [agent] Error writing to outputs.wavefront: Wavefront sending error: write tcp 10.0.8.1:54000->10.0.8.2:2878: i/o timeout
2021-02-04T07:42:00Z W! [outputs.wavefront] Metric buffer overflow; 980 metrics have been dropped
2021-02-04T07:42:00Z E! [agent] Error writing to outputs.wavefront: Wavefront sending error: write tcp 10.0.8.1:54000->10.0.8.2:2878: i/o timeout
2021-02-04T07:42:00Z W! [outputs.wavefront] Metric buffer overflow; 1019 metrics have been dropped
2021-02-04T07:42:00Z E! [agent] Error writing to outputs.wavefront: Wavefront sending error: write tcp 10.0.8.1:54000->10.0.8.2:2878: i/o timeout
2021-02-04T07:42:00Z W! [outputs.wavefront] Metric buffer overflow; 1001 metrics have been dropped
2021-02-04T07:42:00Z E! [agent] Error writing to outputs.wavefront: Wavefront sending error: write tcp 10.0.8.1:54000->10.0.8.2:2878: i/o timeout
2021-02-04T07:42:00Z W! [outputs.wavefront] Metric buffer overflow; 892 metrics have been dropped
2021-02-04T07:42:00Z E! [agent] Error writing to outputs.wavefront: Wavefront sending error: write tcp 10.0.8.1:54000->10.0.8.2:2878: i/o timeout
```
After: 

```
2021-02-05T06:35:00Z D! [outputs.wavefront] Flushing batch of 1000 points
2021-02-05T06:35:00Z D! [outputs.wavefront] Wrote batch of 1000 metrics in 14.722024ms
2021-02-05T06:35:00Z D! [outputs.wavefront] Buffer fullness: 551 / 10000 metrics
2021-02-05T06:35:56Z D! [outputs.wavefront] Flushing batch of 551 points
2021-02-05T06:35:56Z D! [outputs.wavefront] Wrote batch of 551 metrics in 6.108074ms
2021-02-05T06:35:56Z D! [outputs.wavefront] Buffer fullness: 0 / 10000 metrics
2021-02-05T06:36:10Z I! resetting wavefront proxy connection
2021-02-05T06:36:10Z I! write tcp 10.0.8.1:50022->10.0.8.2:2878: i/o timeout
2021-02-05T06:36:10Z D! [outputs.wavefront] Buffer fullness: 10000 / 10000 metrics
2021-02-05T06:36:10Z E! [agent] Error writing to outputs.wavefront: Wavefront sending error: write tcp 10.0.8.1:50022->10.0.8.2:2878: i/o timeout
2021-02-05T06:36:10Z I! connected to Wavefront proxy at address: internal-wavefront-proxy.com:12878
2021-02-05T06:36:10Z D! [outputs.wavefront] Flushing batch of 1000 points
2021-02-05T06:36:10Z D! [outputs.wavefront] Wrote batch of 1000 metrics in 10.667991ms
2021-02-05T06:36:10Z D! [outputs.wavefront] Buffer fullness: 1000 / 10000 metrics
2021-02-05T06:36:56Z D! [outputs.wavefront] Flushing batch of 1000 points
```