### PR TITLE
inputs.x509_cert: Fix timeout issue 

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -280,6 +280,7 @@ func init() {
 	inputs.Add("x509_cert", func() telegraf.Input {
 		return &X509Cert{
 			Sources: []string{},
+			Timeout: internal.Duration{Duration: 5 * time.Second},
 		}
 	})
 }

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -280,7 +280,7 @@ func init() {
 	inputs.Add("x509_cert", func() telegraf.Input {
 		return &X509Cert{
 			Sources: []string{},
-			Timeout: internal.Duration{Duration: 5 * time.Second},
+			Timeout: internal.Duration{Duration: 5 * time.Second}, // set default timeout to 5s
 		}
 	})
 }

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -280,7 +280,6 @@ func init() {
 	inputs.Add("x509_cert", func() telegraf.Input {
 		return &X509Cert{
 			Sources: []string{},
-			Timeout: internal.Duration{Duration: 5},
 		}
 	})
 }

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -3,7 +3,6 @@ package x509_cert
 import (
 	"crypto/tls"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -365,23 +364,6 @@ func TestGatherCertMustNotTimeout(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, acc.Errors)
 	assert.True(t, acc.HasMeasurement("x509_cert"))
-}
-
-func TestGatherCertMustTimeoutWithNoDuration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-	m := &X509Cert{
-		Sources: []string{"https://www.influxdata.com:443"},
-		Timeout: internal.Duration{Duration: 5}, // duration is set to 5 when adding to inputs
-	}
-	m.Init()
-
-	var acc testutil.Accumulator
-	err := m.Gather(&acc)
-	require.NoError(t, err)
-	require.Contains(t, acc.Errors, errors.New("cannot get SSL cert 'https://www.influxdata.com:443': dial tcp: i/o timeout"))
-	assert.False(t, acc.HasMeasurement("x509_cert"))
 }
 
 func TestServerName(t *testing.T) {


### PR DESCRIPTION
closes #8809

If timeout is not configured, it will be set to "5ns" when adding to inputs. This cause the timeout issue #8809. Test case for reproducing is added in commit ac4cda1.

I fix the issue by setting timeout to "0s".