### PR TITLE
kube_inventory: update label in RBAC example

### DIFF
--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -91,7 +91,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: influx:cluster:viewer
   labels:
-    rbac.authorization.k8s.io/aggregate-view-telegraf: "true"
+    rbac.authorization.k8s.io/aggregate-view-telegraf-stats: "true"
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "nodes"]


### PR DESCRIPTION
The label for `influx:cluster:viewer` ClusterRole is
`rbac.authorization.k8s.io/aggregate-view-telegraf: "true"`, but
telegraf-ds's Helm Chart expects role label of
`rbac.authorization.k8s.io/aggregate-view-telegraf-stats: "true"`.

For a better out-of-the-box experience, it should match the Helm chart
used by the customer base.

### Required for all PRs:

- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
