### PR TITLE
Fix percentile calculations and assign Deadline correctly

### DIFF
--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -432,11 +432,11 @@ func TestPingGatherNative(t *testing.T) {
 				PacketsSent: 5,
 				PacketsRecv: 5,
 				Rtts: []time.Duration{
-					1 * time.Millisecond,
-					2 * time.Millisecond,
 					3 * time.Millisecond,
 					4 * time.Millisecond,
+					1 * time.Millisecond,
 					5 * time.Millisecond,
+					2 * time.Millisecond,
 				},
 			},
 			ttl: 1,
@@ -475,8 +475,11 @@ func TestPingGatherNative(t *testing.T) {
 		assert.True(t, acc.HasPoint("ping", map[string]string{"url": "localhost"}, "packets_transmitted", 5))
 		assert.True(t, acc.HasPoint("ping", map[string]string{"url": "localhost"}, "packets_received", 5))
 		assert.True(t, acc.HasField("ping", "percentile50_ms"))
+		assert.Equal(t, float64(3), acc.Metrics[0].Fields["percentile50_ms"])
 		assert.True(t, acc.HasField("ping", "percentile95_ms"))
+		assert.Equal(t, float64(4.799999), acc.Metrics[0].Fields["percentile95_ms"])
 		assert.True(t, acc.HasField("ping", "percentile99_ms"))
+		assert.Equal(t, float64(4.96), acc.Metrics[0].Fields["percentile99_ms"])
 		assert.True(t, acc.HasField("ping", "percent_packet_loss"))
 		assert.True(t, acc.HasField("ping", "minimum_response_ms"))
 		assert.True(t, acc.HasField("ping", "average_response_ms"))


### PR DESCRIPTION
### Required for all PRs:

- [x] Has appropriate unit tests.

#8805

- Sort the RTTS slice before calculating the percentile, updated a unit test to verify this
- Changed inputs.ping "Deadline" config to be assigned to go-pings "Timeout"

go-ping doesn't support "timeout to wait for ping response (-W)" yet, but there is an open issue https://github.com/go-ping/ping/issues/63
