### PR TITLE
Added Pressure Stall Information input plugin (currently only for system-wide metrics without cgroup-based ones)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ For documentation on the latest development code see the [documentation index][d
 * [postgresql](./plugins/inputs/postgresql)
 * [powerdns](./plugins/inputs/powerdns)
 * [powerdns_recursor](./plugins/inputs/powerdns_recursor)
+* [pressure](./plugins/inputs/pressure)
 * [processes](./plugins/inputs/processes)
 * [procstat](./plugins/inputs/procstat)
 * [prometheus](./plugins/inputs/prometheus) (can be used for [Caddy server](./plugins/inputs/prometheus/README.md#usage-for-caddy-http-server))

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -137,6 +137,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/postgresql_extensible"
 	_ "github.com/influxdata/telegraf/plugins/inputs/powerdns"
 	_ "github.com/influxdata/telegraf/plugins/inputs/powerdns_recursor"
+	_ "github.com/influxdata/telegraf/plugins/inputs/pressure"
 	_ "github.com/influxdata/telegraf/plugins/inputs/processes"
 	_ "github.com/influxdata/telegraf/plugins/inputs/procstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/prometheus"

--- a/plugins/inputs/pressure/README.md
+++ b/plugins/inputs/pressure/README.md
@@ -1,0 +1,34 @@
+# Pressure input plugin
+
+This plugin gather information about system pressure stall on resources (cpu, memory or io). Only supports linux
+OSes with kernel version 4.20 or higher compiled with CONFIG_PSI option
+
+### Configuration:
+
+```toml
+# Gather system metrics about Pressure Stall (PSI)
+[[inputs.pressure]]
+```
+
+### Metrics:
+
+- metric
+    - tags:
+        - resource (cpu, memory or io)
+        - type (some or full)
+    - fields:
+        - avg10 (float64, gauge)
+        - avg60 (float64, gauge)
+        - avg300 (float64, gauge)
+        - total (uint64, gauge)
+### Example Output:
+
+This section shows example output in Line Protocol format.
+
+```
+> pressure,host=c6e73f77bce3,resource=cpu,type=some avg10=0,avg300=0,avg60=0,total=75375584i 1613481208000000000
+> pressure,host=c6e73f77bce3,resource=memory,type=some avg10=0,avg300=0,avg60=0,total=0i 1613481208000000000
+> pressure,host=c6e73f77bce3,resource=memory,type=full avg10=0,avg300=0,avg60=0,total=0i 1613481208000000000
+> pressure,host=c6e73f77bce3,resource=io,type=some avg10=0,avg300=0.01,avg60=0,total=46715138i 1613481208000000000
+> pressure,host=c6e73f77bce3,resource=io,type=full avg10=0,avg300=0.01,avg60=0,total=44824261i 1613481208000000000
+```

--- a/plugins/inputs/pressure/pressure.go
+++ b/plugins/inputs/pressure/pressure.go
@@ -1,0 +1,23 @@
+package pressure
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+type Pressure struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (_ *Pressure) SampleConfig() string { return "" }
+
+func (_ *Pressure) Description() string {
+	return "Gather system metrics about Pressure Stall (PSI)"
+}
+
+func init() {
+	inputs.Add("pressure", func() telegraf.Input {
+		return &Pressure{}
+	})
+}
+

--- a/plugins/inputs/pressure/pressure.go
+++ b/plugins/inputs/pressure/pressure.go
@@ -20,4 +20,3 @@ func init() {
 		return &Pressure{}
 	})
 }
-

--- a/plugins/inputs/pressure/pressure_linux.go
+++ b/plugins/inputs/pressure/pressure_linux.go
@@ -149,7 +149,10 @@ func parsePressureData(line []byte) *pressureFields {
 			parsingErrors++
 		}
 	}
-	tot, _ := strconv.ParseUint(strings.Split(fields[4], "=")[1], 10, 64)
+	tot, err := strconv.ParseUint(strings.Split(fields[4], "=")[1], 10, 64)
+	if err != nil {
+		parsingErrors++
+	}
 	return &pressureFields{
 		avg10:  avgs[0],
 		avg60:  avgs[1],

--- a/plugins/inputs/pressure/pressure_linux.go
+++ b/plugins/inputs/pressure/pressure_linux.go
@@ -157,4 +157,3 @@ func parsePressureData(line []byte) *pressureFields {
 		total:  tot,
 	}
 }
-

--- a/plugins/inputs/pressure/pressure_linux.go
+++ b/plugins/inputs/pressure/pressure_linux.go
@@ -1,0 +1,160 @@
+// +build linux
+
+package pressure
+
+import (
+	"bytes"
+	"github.com/influxdata/telegraf"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type pressure struct {
+	cpu struct {
+		some *pressureFields
+	}
+	memory struct {
+		some *pressureFields
+		full *pressureFields
+	}
+	io struct {
+		some *pressureFields
+		full *pressureFields
+	}
+}
+
+type pressureFields struct {
+	avg10  float64
+	avg60  float64
+	avg300 float64
+	total  uint64
+}
+
+const (
+	PSI_ROOT = "/proc/pressure/"
+)
+
+var parsingErrors uint8 = 0
+
+func (p *Pressure) Gather(acc telegraf.Accumulator) error {
+	if !checkCompatibility() {
+		p.Log.Error("System is not compatible with plugin. Probably you running kernel version <4.20 or your kernel compiled without CONFIG_PSI.")
+		return nil
+	}
+	rawCpu, err := ioutil.ReadFile(PSI_ROOT + "cpu")
+	if err != nil {
+		p.Log.Errorf("Error occurred while reading cpu pressure data: %s\n", err)
+	}
+	rawMem, err := ioutil.ReadFile(PSI_ROOT + "memory")
+	if err != nil {
+		p.Log.Errorf("Error occurred while reading memory pressure data: %s\n", err)
+	}
+	rawIo, err := ioutil.ReadFile(PSI_ROOT + "io")
+	if err != nil {
+		p.Log.Errorf("Error occurred while reading io pressure data: %s\n", err)
+	}
+	splitCpu := bytes.Split(rawCpu, []byte("\n"))
+	splitMem := bytes.Split(rawMem, []byte("\n"))
+	splitIo := bytes.Split(rawIo, []byte("\n"))
+	metrics := &pressure{
+		cpu: struct {
+			some *pressureFields
+		}{
+			some: parsePressureData(splitCpu[0]),
+		},
+		memory: struct {
+			some *pressureFields
+			full *pressureFields
+		}{
+			some: parsePressureData(splitMem[0]),
+			full: parsePressureData(splitMem[1]),
+		},
+		io: struct {
+			some *pressureFields
+			full *pressureFields
+		}{
+			some: parsePressureData(splitIo[0]),
+			full: parsePressureData(splitIo[1]),
+		},
+	}
+	if parsingErrors != 0 {
+		p.Log.Error("There was parsing errors when collecting data")
+		return nil
+	}
+	acc.AddGauge("pressure", map[string]interface{}{
+		"avg10":  metrics.cpu.some.avg10,
+		"avg60":  metrics.cpu.some.avg60,
+		"avg300": metrics.cpu.some.avg300,
+		"total":  metrics.cpu.some.total,
+	}, map[string]string{
+		"resource": "cpu",
+		"type":     "some",
+	})
+	acc.AddGauge("pressure", map[string]interface{}{
+		"avg10":  metrics.memory.some.avg10,
+		"avg60":  metrics.memory.some.avg60,
+		"avg300": metrics.memory.some.avg300,
+		"total":  metrics.memory.some.total,
+	}, map[string]string{
+		"resource": "memory",
+		"type":     "some",
+	})
+	acc.AddGauge("pressure", map[string]interface{}{
+		"avg10":  metrics.memory.full.avg10,
+		"avg60":  metrics.memory.full.avg60,
+		"avg300": metrics.memory.full.avg300,
+		"total":  metrics.memory.full.total,
+	}, map[string]string{
+		"resource": "memory",
+		"type":     "full",
+	})
+	acc.AddGauge("pressure", map[string]interface{}{
+		"avg10":  metrics.io.some.avg10,
+		"avg60":  metrics.io.some.avg60,
+		"avg300": metrics.io.some.avg300,
+		"total":  metrics.io.some.total,
+	}, map[string]string{
+		"resource": "io",
+		"type":     "some",
+	})
+	acc.AddGauge("pressure", map[string]interface{}{
+		"avg10":  metrics.io.full.avg10,
+		"avg60":  metrics.io.full.avg60,
+		"avg300": metrics.io.full.avg300,
+		"total":  metrics.io.full.total,
+	}, map[string]string{
+		"resource": "io",
+		"type":     "full",
+	})
+	return nil
+}
+
+func checkCompatibility() bool {
+	_, err := os.Stat("/proc/pressure")
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+func parsePressureData(line []byte) *pressureFields {
+	fields := strings.Fields(string(line))
+	avgs := make([]float64, 3)
+	for i := 1; i < len(fields)-1; i++ {
+		var err error
+		avgs[i-1], err = strconv.ParseFloat(strings.Split(fields[i], "=")[1], 64)
+		if err != nil {
+			parsingErrors++
+		}
+	}
+	tot, _ := strconv.ParseUint(strings.Split(fields[4], "=")[1], 10, 64)
+	return &pressureFields{
+		avg10:  avgs[0],
+		avg60:  avgs[1],
+		avg300: avgs[2],
+		total:  tot,
+	}
+}
+

--- a/plugins/inputs/pressure/pressure_others.go
+++ b/plugins/inputs/pressure/pressure_others.go
@@ -21,4 +21,3 @@ func init() {
 		return &Pressure{}
 	})
 }
-

--- a/plugins/inputs/pressure/pressure_others.go
+++ b/plugins/inputs/pressure/pressure_others.go
@@ -1,0 +1,24 @@
+// +build !linux
+
+package pressure
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+func (p *Pressure) Init() error {
+	p.Log.Warn("Only Linux platform is supported")
+	return nil
+}
+
+func (p *Pressure) Gather(acc telegraf.Accumulator) error {
+	return nil
+}
+
+func init() {
+	inputs.Add("pressure", func() telegraf.Input {
+		return &Pressure{}
+	})
+}
+

--- a/plugins/inputs/pressure/pressure_test.go
+++ b/plugins/inputs/pressure/pressure_test.go
@@ -9,13 +9,12 @@ import (
 
 var pressureData = []byte(`some avg10=0.00 avg60=0.01 avg300=0.04 total=13595686`)
 
-
 func TestParsePressureData(t *testing.T) {
 	expectedData := &pressureFields{
-		avg10:	0,
-		avg60:	0.01,
+		avg10:  0,
+		avg60:  0.01,
 		avg300: 0.04,
-		total:	uint64(13595686),
+		total:  uint64(13595686),
 	}
 	parsedData := parsePressureData(pressureData)
 	if parsingErrors != 0 {
@@ -25,5 +24,3 @@ func TestParsePressureData(t *testing.T) {
 	as := assert.New(t)
 	as.Equal(expectedData, parsedData)
 }
-
-

--- a/plugins/inputs/pressure/pressure_test.go
+++ b/plugins/inputs/pressure/pressure_test.go
@@ -1,0 +1,29 @@
+// +build linux
+
+package pressure
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var pressureData = []byte(`some avg10=0.00 avg60=0.01 avg300=0.04 total=13595686`)
+
+
+func TestParsePressureData(t *testing.T) {
+	expectedData := &pressureFields{
+		avg10:	0,
+		avg60:	0.01,
+		avg300: 0.04,
+		total:	uint64(13595686),
+	}
+	parsedData := parsePressureData(pressureData)
+	if parsingErrors != 0 {
+		t.Fatal("Parsing errors")
+	}
+
+	as := assert.New(t)
+	as.Equal(expectedData, parsedData)
+}
+
+


### PR DESCRIPTION
General information about PSI: [Link](https://www.kernel.org/doc/html/latest/accounting/psi.html)
This PR adressed to satisfy this [feature request](https://github.com/influxdata/telegraf/issues/6760)

### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
