### PR TITLE
change to NewStreamParser to accept larger inputs from scanner

### DIFF
--- a/plugins/common/shim/processor.go
+++ b/plugins/common/shim/processor.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/agent"
-	"github.com/influxdata/telegraf/plugins/processors"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
+	"github.com/influxdata/telegraf/plugins/processors"
 )
 
 // AddProcessor adds the processor to the shim. Later calls to Run() will run this.
@@ -47,7 +47,6 @@ func (s *Shim) RunProcessor() error {
 		s.writeProcessedMetrics()
 		wg.Done()
 	}()
-
 
 	parser := influx.NewStreamParser(s.stdin)
 	for {

--- a/plugins/common/shim/processor.go
+++ b/plugins/common/shim/processor.go
@@ -1,15 +1,14 @@
 package shim
 
 import (
-	"bufio"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/agent"
-	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/processors"
+	"github.com/influxdata/telegraf/plugins/parsers/influx"
 )
 
 // AddProcessor adds the processor to the shim. Later calls to Run() will run this.
@@ -37,12 +36,7 @@ func (s *Shim) RunProcessor() error {
 	acc := agent.NewAccumulator(s, s.metricCh)
 	acc.SetPrecision(time.Nanosecond)
 
-	parser, err := parsers.NewInfluxParser()
-	if err != nil {
-		return fmt.Errorf("Failed to create new parser: %w", err)
-	}
-
-	err = s.Processor.Start(acc)
+	err := s.Processor.Start(acc)
 	if err != nil {
 		return fmt.Errorf("failed to start processor: %w", err)
 	}
@@ -54,13 +48,22 @@ func (s *Shim) RunProcessor() error {
 		wg.Done()
 	}()
 
-	scanner := bufio.NewScanner(s.stdin)
-	for scanner.Scan() {
-		m, err := parser.ParseLine(scanner.Text())
+
+	parser := influx.NewStreamParser(s.stdin)
+	for {
+		m, err := parser.Next()
 		if err != nil {
-			fmt.Fprintf(s.stderr, "Failed to parse metric: %s\b", err)
+			if err == influx.EOF {
+				break // stream ended
+			}
+			if parseErr, isParseError := err.(*influx.ParseError); isParseError {
+				fmt.Fprintf(s.stderr, "Failed to parse metric: %s\b", parseErr)
+				continue
+			}
+			fmt.Fprintf(s.stderr, "Failure during reading stdin: %s\b", err)
 			continue
 		}
+
 		s.Processor.Add(m, acc)
 	}
 

--- a/plugins/common/shim/processor_test.go
+++ b/plugins/common/shim/processor_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -16,7 +17,21 @@ import (
 )
 
 func TestProcessorShim(t *testing.T) {
-	p := &testProcessor{}
+	testSendAndRecieve(t, "f1", "fv1")
+}
+
+func TestProcessorShimWithLargerThanDefaultScannerBufferSize(t *testing.T) {
+	letters := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]rune, bufio.MaxScanTokenSize * 2)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+
+	testSendAndRecieve(t, "f1", string(b))
+}
+
+func testSendAndRecieve(t *testing.T, fieldKey string, fieldValue string) {
+	p := &testProcessor{"hi", "mom"}
 
 	stdinReader, stdinWriter := io.Pipe()
 	stdoutReader, stdoutWriter := io.Pipe()
@@ -46,6 +61,7 @@ func TestProcessorShim(t *testing.T) {
 		},
 		map[string]interface{}{
 			"v": 1,
+			fieldKey: fieldValue,
 		},
 		time.Now(),
 	)
@@ -62,19 +78,25 @@ func TestProcessorShim(t *testing.T) {
 	mOut, err := parser.ParseLine(out)
 	require.NoError(t, err)
 
-	val, ok := mOut.GetTag("hi")
+	val, ok := mOut.GetTag(p.tagName)
 	require.True(t, ok)
-	require.Equal(t, "mom", val)
-
+	require.Equal(t, p.tagValue, val)
+	val2, ok := mOut.Fields()[fieldKey]
+	require.True(t, ok)
+	require.Equal(t, fieldValue, val2)
 	go ioutil.ReadAll(r)
 	wg.Wait()
 }
 
-type testProcessor struct{}
+
+type testProcessor struct{
+	tagName string
+	tagValue string
+}
 
 func (p *testProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	for _, metric := range in {
-		metric.AddTag("hi", "mom")
+		metric.AddTag(p.tagName, p.tagValue)
 	}
 	return in
 }

--- a/plugins/common/shim/processor_test.go
+++ b/plugins/common/shim/processor_test.go
@@ -22,7 +22,7 @@ func TestProcessorShim(t *testing.T) {
 
 func TestProcessorShimWithLargerThanDefaultScannerBufferSize(t *testing.T) {
 	letters := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	b := make([]rune, bufio.MaxScanTokenSize * 2)
+	b := make([]rune, bufio.MaxScanTokenSize*2)
 	for i := range b {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
@@ -60,7 +60,7 @@ func testSendAndRecieve(t *testing.T, fieldKey string, fieldValue string) {
 			"a": "b",
 		},
 		map[string]interface{}{
-			"v": 1,
+			"v":      1,
 			fieldKey: fieldValue,
 		},
 		time.Now(),
@@ -88,9 +88,8 @@ func testSendAndRecieve(t *testing.T, fieldKey string, fieldValue string) {
 	wg.Wait()
 }
 
-
-type testProcessor struct{
-	tagName string
+type testProcessor struct {
+	tagName  string
 	tagValue string
 }
 


### PR DESCRIPTION
# Description

Whilst creating an external processor plugin, I was utilising the shim to provide the reading from stdin and writing to stdout:

````
   // create the shim. This is what will run your plugins.
   s := shim.New()

   // Check for settings from a config toml file,
   err = s.LoadConfig(configFile)
   if err != nil {
      fmt.Fprintf(os.Stderr, "Err loading input: %s\n", err)
      os.Exit(1)
   }

   // run the plugin until stdin closes or we receive a termination signal
   if err := s.Run(shim.PollIntervalDisabled); err != nil {
      fmt.Fprintf(os.Stderr, "Err: %s\n", err)
      os.Exit(1)
   }
````

When running the processor plugin I was seeing that the processor was being terminated and restarted with the error message in telegraf's stderr:
````
write error: Broken pipe
````

However, when I moved the plugin away from using the shim for the processor's stdin and stdout management to that of what is in the example listed on https://github.com/influxdata/telegraf/tree/master/plugins/processors/execd which is using `parser := influx.NewStreamParser(os.Stdin)` in a `for {` loop; I did not encounter the error.

-----

Looking at the code for the shim's processor it is using: `scanner := bufio.NewScanner(s.stdin)`
This has a default buffer of 64k.  Outputting the Err() on the scanner reported `bufio.scanner token too long`.  I was hitting the max default buffer size of 64k for the Scanner.   

The reason for hitting this 64k limit is that I was taking the "string" (data_type:value) from a kinesis stream and  sending it to the processor for manipulation.  On occasions the data from kinesis was larger than the 64k; and the Scanner reported the token too long which propagated up to the processor process exiting and being restarted.

----

# PR Change

Moved the processor's shim from the `bufio.NewScanner` to that of the  `influx.NewStreamParser(os.Stdin)` from the example.  Moving to that I had no issues with the processor exiting.

I'm unsure if there's a reason for using the bufio.NewScanner in the shim vs the using the influx StreamParser.

I added a test to cover this larger than the 64k buffer.  The test hangs on the old code that uses the scanner (I didn't into the test code to look into the why for the hang on the old code).