### PR TITLE
Display error message on badly formatted config string array (eg. namepass)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1538,6 +1538,9 @@ func (c *Config) getFieldStringSlice(tbl *ast.Table, fieldName string, target *[
 						*target = append(*target, str.Value)
 					}
 				}
+			} else {
+				c.addError(tbl, fmt.Errorf("unexpected format while parsing %q, expecting string array/slice format", fieldName))
+				return
 			}
 		}
 	}
@@ -1554,6 +1557,9 @@ func (c *Config) getFieldTagFilter(tbl *ast.Table, fieldName string, target *[]m
 								tagfilter.Filter = append(tagfilter.Filter, str.Value)
 							}
 						}
+					} else {
+						c.addError(tbl, fmt.Errorf("unexpected format while parsing %q, expecting string array/slice format on each entry", fieldName))
+						return
 					}
 					*target = append(*target, tagfilter)
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -1539,7 +1539,7 @@ func (c *Config) getFieldStringSlice(tbl *ast.Table, fieldName string, target *[
 					}
 				}
 			} else {
-				c.addError(tbl, fmt.Errorf("unexpected format while parsing %q, expecting string array/slice format", fieldName))
+				c.addError(tbl, fmt.Errorf("found unexpected format while parsing %q, expecting string array/slice format", fieldName))
 				return
 			}
 		}
@@ -1558,7 +1558,7 @@ func (c *Config) getFieldTagFilter(tbl *ast.Table, fieldName string, target *[]m
 							}
 						}
 					} else {
-						c.addError(tbl, fmt.Errorf("unexpected format while parsing %q, expecting string array/slice format on each entry", fieldName))
+						c.addError(tbl, fmt.Errorf("found unexpected format while parsing %q, expecting string array/slice format on each entry", fieldName))
 						return
 					}
 					*target = append(*target, tagfilter)


### PR DESCRIPTION
resolves #7616 