### PR TITLE
Support float64 in enum processor

### DIFF
--- a/plugins/processors/enum/README.md
+++ b/plugins/processors/enum/README.md
@@ -2,7 +2,7 @@
 
 The Enum Processor allows the configuration of value mappings for metric tags or fields.
 The main use-case for this is to rewrite status codes such as _red_, _amber_ and
-_green_ by numeric values such as 0, 1, 2. The plugin supports string, int and bool
+_green_ by numeric values such as 0, 1, 2. The plugin supports string, int, float64 and bool
 types for the field values. Multiple tags or fields can be configured with separate
 value mappings for each. Default mapping values can be configured to be
 used for all values, which are not contained in the value_mappings. The

--- a/plugins/processors/enum/enum.go
+++ b/plugins/processors/enum/enum.go
@@ -145,6 +145,8 @@ func adjustValue(in interface{}) interface{} {
 		return strconv.FormatBool(val)
 	case int64:
 		return strconv.FormatInt(val, 10)
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64)
 	case uint64:
 		return strconv.FormatUint(val, 10)
 	default:

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -63,6 +63,7 @@ func TestRetainsMetric(t *testing.T) {
 	assertFieldValue(t, "test", "string_value", fields)
 	assertFieldValue(t, 200, "int_value", fields)
 	assertFieldValue(t, 500, "uint_value", fields)
+	assertFieldValue(t, float64(3.14), "float_value", fields)
 	assertFieldValue(t, true, "true_value", fields)
 	assert.Equal(t, "m1", target.Name())
 	assert.Equal(t, source.Tags(), target.Tags())
@@ -76,15 +77,6 @@ func TestMapsSingleStringValueTag(t *testing.T) {
 	tags := calculateProcessedTags(mapper, createTestMetric())
 
 	assertTagValue(t, "valuable", "tag", tags)
-}
-
-func TestNoFailureOnMappingsOnNonSupportedValuedFields(t *testing.T) {
-	mapper := EnumMapper{Mappings: []Mapping{{Field: "float_value", ValueMappings: map[string]interface{}{"3.14": "pi"}}}}
-	err := mapper.Init()
-	require.Nil(t, err)
-	fields := calculateProcessedValues(mapper, createTestMetric())
-
-	assertFieldValue(t, float64(3.14), "float_value", fields)
 }
 
 func TestMappings(t *testing.T) {
@@ -112,6 +104,12 @@ func TestMappings(t *testing.T) {
 			"target_value":   []interface{}{"500", "500", "500", "test", "false", "5"},
 			"mapped_value":   []interface{}{"internal_error", 1, false, false, false, false},
 			"expected_value": []interface{}{"internal_error", 1, false, 500, 500, 500},
+		},
+		{
+			"field_name":     []interface{}{"float_value"},
+			"target_value":   []interface{}{"3.14", "3.14", "3.14", "3.14", "not_float", "5"},
+			"mapped_value":   []interface{}{"pi", 1, false, float64(100.2), float64(3.14), "pi"},
+			"expected_value": []interface{}{"pi", 1, false, float64(100.2), float64(3.14), float64(3.14)},
 		},
 	}
 


### PR DESCRIPTION
This adds float64 support to enum processor.

### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
