### PR TITLE
Add Predicates on valuecounter to emit only fields whose aggregated value match the predicate(s)

### DIFF
--- a/plugins/aggregators/valuecounter/README.md
+++ b/plugins/aggregators/valuecounter/README.md
@@ -15,6 +15,10 @@ Counting fields with a high number of potential values may produce significant
 amounts of new fields and memory usage, take care to only count fields with a
 limited set of values.
 
+To only emit fields values that have a final aggregated count you can specify
+one or more predicates via the config `aggregators.valuecounter.predicate`.  The
+supported predicates are: `greater_than`, `less_than`, `equal_to` and `not_equal_to`.
+
 ### Configuration:
 
 ```toml
@@ -27,6 +31,10 @@ limited set of values.
   drop_original = false
   ## The fields for which the values will be counted
   fields = ["status"]
+  ## Only emit fields whose aggregation is greater than 10
+  [[aggregators.valuecounter.predicate]]
+    type = "greater_than"
+    value = 10
 ```
 
 ### Measurements & Fields:
@@ -54,6 +62,14 @@ telegraf.conf:
 [[aggregators.valuecounter]]
   namepass = ["access"]
   fields = ["response"]
+  # Only emit fields that have an aggregation of 1 to 99
+  [[aggregators.valuecounter.predicate]]
+    type = "less_than"
+    value = 100
+    
+  [[aggregators.valuecounter.predicate]]
+    type = "greater_than"
+    value = 0  
 ```
 
 /tmp/tst.log

--- a/plugins/aggregators/valuecounter/valuecounter.go
+++ b/plugins/aggregators/valuecounter/valuecounter.go
@@ -93,18 +93,15 @@ func (vc *ValueCounter) Add(in telegraf.Metric) {
 func (vc *ValueCounter) Push(acc telegraf.Accumulator) {
 	for _, agg := range vc.cache {
 		fields := map[string]interface{}{}
-
+	FieldCount:
 		for field, count := range agg.fieldCount {
-			var matched = 0
 			for _, predicate := range vc.Predicates {
-				if predicate.predicateFunc(count, predicate.Value) {
-					matched++
+				if !predicate.predicateFunc(count, predicate.Value) {
+					continue FieldCount
 				}
 			}
 
-			if matched == len(vc.Predicates) {
-				fields[field] = count
-			}
+			fields[field] = count
 		}
 
 		acc.AddFields(agg.name, fields, agg.tags)
@@ -133,7 +130,6 @@ func knownPredicateFunctions() (map[string]predicate, []string) {
 }
 
 func (vc *ValueCounter) configurePredicates() error {
-
 	predicateFunctions, knownPredicates := knownPredicateFunctions()
 	var requestedPredicateTypes []string
 	for _, t := range vc.Predicates {

--- a/plugins/aggregators/valuecounter/valuecounter_test.go
+++ b/plugins/aggregators/valuecounter/valuecounter_test.go
@@ -1,6 +1,9 @@
 package valuecounter
 
 import (
+	"fmt"
+	"github.com/influxdata/telegraf/config"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
@@ -122,4 +125,168 @@ func TestWithReset(t *testing.T) {
 		"status_OK":  2,
 	}
 	acc.AssertContainsTaggedFields(t, "m1", expectedFields, expectedTags)
+}
+
+func newMetric(key string, value string) telegraf.Metric {
+	var m1, _ = metric.New("m1",
+		map[string]string{"foo": "bar"},
+		map[string]interface{}{
+			key: value,
+		},
+		time.Now())
+	return m1
+}
+
+type TestTrackingAccumulator struct {
+	telegraf.TrackingAccumulator
+	Metrics *[]map[string]interface{}
+}
+
+func (t TestTrackingAccumulator) AddFields(name string, fields map[string]interface{}, tags map[string]string, time ...time.Time) {
+	*t.Metrics = append(*t.Metrics, fields)
+}
+
+func TestGreaterThanPredicate(t *testing.T) {
+	c := config.NewConfig()
+	err := c.LoadConfigData([]byte(`
+[[aggregators.valuecounter]]
+  ## The period on which to flush & clear the aggregator.
+  period = "30s"
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+  ## The fields for which the values will be counted
+  fields = ["app", "path"]
+  ## Only include fields for which the predicate is true
+  [[aggregators.valuecounter.predicate]]
+    type = "greater_than"
+    value = 2
+`))
+	assert.Nil(t, err)
+	fmt.Print(c.Aggregators[0].Aggregator.Description())
+
+	assert.Len(t, c.Aggregators, 1)
+	assert.IsType(t, &ValueCounter{}, c.Aggregators[0].Aggregator)
+
+	valueCounter := c.Aggregators[0].Aggregator.(*ValueCounter)
+	assert.Len(t, valueCounter.Predicates, 1)
+
+	err = valueCounter.Init()
+	assert.Nil(t, err)
+
+	valueCounter.Add(newMetric("app", "trafik"))
+	valueCounter.Add(newMetric("app", "trafik"))
+	valueCounter.Add(newMetric("app", "trafik"))
+	valueCounter.Add(newMetric("path", "/"))
+	valueCounter.Add(newMetric("path", "/"))
+
+	var aggregatedMetrics []map[string]interface{}
+
+	valueCounter.Push(TestTrackingAccumulator{Metrics: &aggregatedMetrics})
+
+	assert.Len(t, aggregatedMetrics, 1)
+
+	assert.Contains(t, aggregatedMetrics[0], "app_trafik")
+	assert.Equal(t, 3, aggregatedMetrics[0]["app_trafik"].(int))
+
+	assert.NotContains(t, "path_/", aggregatedMetrics[0])
+}
+
+func TestLessThanPredicate(t *testing.T) {
+	c := config.NewConfig()
+	err := c.LoadConfigData([]byte(`
+[[aggregators.valuecounter]]
+  ## The period on which to flush & clear the aggregator.
+  period = "30s"
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+  ## The fields for which the values will be counted
+  fields = ["app", "path"]
+  ## Only include fields for which the predicate is true
+  [[aggregators.valuecounter.predicate]]
+    type = "less_than"
+    value = 3
+`))
+	assert.Nil(t, err)
+	fmt.Print(c.Aggregators[0].Aggregator.Description())
+
+	assert.Len(t, c.Aggregators, 1)
+	assert.IsType(t, &ValueCounter{}, c.Aggregators[0].Aggregator)
+
+	valueCounter := c.Aggregators[0].Aggregator.(*ValueCounter)
+	assert.Len(t, valueCounter.Predicates, 1)
+
+	err = valueCounter.Init()
+	assert.Nil(t, err)
+
+	valueCounter.Add(newMetric("app", "trafik"))
+	valueCounter.Add(newMetric("app", "trafik"))
+	valueCounter.Add(newMetric("app", "trafik"))
+	valueCounter.Add(newMetric("path", "/"))
+	valueCounter.Add(newMetric("path", "/"))
+
+	var aggregatedMetrics []map[string]interface{}
+
+	valueCounter.Push(TestTrackingAccumulator{Metrics: &aggregatedMetrics})
+
+	assert.Len(t, aggregatedMetrics, 1)
+
+	assert.Contains(t, aggregatedMetrics[0], "path_/")
+	assert.Equal(t, 2, aggregatedMetrics[0]["path_/"].(int))
+
+	assert.NotContains(t, aggregatedMetrics[0], "app_trafik")
+}
+
+func TestMultiplePredicates(t *testing.T) {
+	c := config.NewConfig()
+	err := c.LoadConfigData([]byte(`
+[[aggregators.valuecounter]]
+  ## The period on which to flush & clear the aggregator.
+  period = "30s"
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+  ## The fields for which the values will be counted
+  fields = ["app", "path"]
+  ## Only include fields for which the predicate is true
+  [[aggregators.valuecounter.predicate]]
+    type = "less_than"
+    value = 3
+
+  [[aggregators.valuecounter.predicate]]
+    type = "greater_than"
+    value = 1
+`))
+	assert.Nil(t, err)
+	fmt.Print(c.Aggregators[0].Aggregator.Description())
+
+	assert.Len(t, c.Aggregators, 1)
+	assert.IsType(t, &ValueCounter{}, c.Aggregators[0].Aggregator)
+
+	valueCounter := c.Aggregators[0].Aggregator.(*ValueCounter)
+	assert.Len(t, valueCounter.Predicates, 2)
+
+	err = valueCounter.Init()
+	assert.Nil(t, err)
+
+	valueCounter.Add(newMetric("app", "trafik"))
+	valueCounter.Add(newMetric("app", "trafik"))
+	valueCounter.Add(newMetric("app", "trafik"))
+	valueCounter.Add(newMetric("path", "/"))
+	valueCounter.Add(newMetric("path", "/"))
+	valueCounter.Add(newMetric("host", "google"))
+
+	var aggregatedMetrics []map[string]interface{}
+
+	valueCounter.Push(TestTrackingAccumulator{Metrics: &aggregatedMetrics})
+
+	assert.Len(t, aggregatedMetrics, 1)
+
+	assert.Contains(t, aggregatedMetrics[0], "path_/")
+	assert.Equal(t, 2, aggregatedMetrics[0]["path_/"].(int))
+
+	assert.NotContains(t, aggregatedMetrics[0], "app_trafik")
+	assert.NotContains(t, aggregatedMetrics[0], "host_google")
+
 }


### PR DESCRIPTION
# Description

The valuecounter plugin counts the occurrence of values in fields and emits the counter once every 'period' seconds.
We wish to add the ability to only emit the counter if it is above a certain value.  

An example use: aggregating the number of "errors" generated by applications, and outputting the list of those applications who have been erring above a threshold.

# PR

Have added the ability to specify one of more predicates on the valuecounter.  These are evaluated in the Push.
Have included predicates for greater_than, less_than, equal_to and not_equal_to.


