### PR TITLE
Teamspeak input plugin query clients

### DIFF
--- a/plugins/inputs/teamspeak/README.md
+++ b/plugins/inputs/teamspeak/README.md
@@ -31,6 +31,7 @@ the [Teamspeak 3 ServerQuery Manual](http://media.teamspeak.com/ts3_literature/T
     - packets_received_total
     - bytes_sent_total
     - bytes_received_total
+    - query_clients_online
 
 ### Tags:
 
@@ -41,5 +42,5 @@ the [Teamspeak 3 ServerQuery Manual](http://media.teamspeak.com/ts3_literature/T
 ### Example output:
 
 ```
-teamspeak,virtual_server=1,name=LeopoldsServer,host=vm01 bytes_received_total=29638202639i,uptime=13567846i,total_ping=26.89,total_packet_loss=0,packets_sent_total=415821252i,packets_received_total=237069900i,bytes_sent_total=55309568252i,clients_online=11i 1507406561000000000
+teamspeak,virtual_server=1,name=LeopoldsServer,host=vm01 bytes_received_total=29638202639i,uptime=13567846i,total_ping=26.89,total_packet_loss=0,packets_sent_total=415821252i,packets_received_total=237069900i,bytes_sent_total=55309568252i,clients_online=11i,query_clients_online=1i 1507406561000000000
 ```

--- a/plugins/inputs/teamspeak/teamspeak.go
+++ b/plugins/inputs/teamspeak/teamspeak.go
@@ -83,6 +83,7 @@ func (ts *Teamspeak) Gather(acc telegraf.Accumulator) error {
 			"packets_received_total": sc.PacketsReceivedTotal,
 			"bytes_sent_total":       sc.BytesSentTotal,
 			"bytes_received_total":   sc.BytesReceivedTotal,
+			"query_clients_online":   sm.QueryClientsOnline,
 		}
 
 		acc.AddFields("teamspeak", fields, tags)

--- a/plugins/inputs/teamspeak/teamspeak_test.go
+++ b/plugins/inputs/teamspeak/teamspeak_test.go
@@ -51,6 +51,7 @@ func TestGather(t *testing.T) {
 		"packets_received_total": uint64(370),
 		"bytes_sent_total":       uint64(28058),
 		"bytes_received_total":   uint64(17468),
+		"query_clients_online":   int(1),
 	}
 
 	acc.AssertContainsFields(t, "teamspeak", fields)


### PR DESCRIPTION
### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

Add additional field `query_clients_online` to the teamspeak input plugin.
This field is useful because the `clients_online` field already included in the plugin is a total of both end-users and server query users connected to a virtual server, so having this allows you to break down the total clients by type.