### PR TITLE
Proposal of enabled linters and their settings.

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           version: v1.38
           only-new-issues: true
-          args: --timeout=5m0s
   golangci-master:
     if: github.ref == 'refs/heads/master'
     name: lint-master-all
@@ -33,4 +32,4 @@ jobs:
         with:
           version: v1.38
           only-new-issues: true
-          args: --timeout=5m0s --issues-exit-code=0
+          args: --issues-exit-code=0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,6 +155,7 @@ run:
     - scripts
     - docs
     - etc
+    - plugins/parsers/influx/plugins #workaround to skip weird "plugins/parsers/influx/plugins/parsers/influx" directory
 
   # which files to skip: they will be analyzed, but issues from them
   # won't be reported. Default value is empty list, but there is

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,36 +1,150 @@
 linters:
   enable:
+    - bodyclose
+    - deadcode
+    - dogsled
+    - errcheck
+    - funlen
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ifshort
+    - ineffassign
+    - nakedret
+    - nilerr
+    - predeclared
     - revive
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+  disable:
+    - asciicheck
+    - depguard
+    - dupl
+    - exhaustive
+    - gci
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - goerr113
+    - gofmt
+    - gofumpt
+    - goheader
+    - golint
+    - gomnd
+    - gomodguard
+    - interfacer
+    - lll
+    - makezero
+    - maligned
+    - megacheck
+    - misspell
+    - nestif
+    - nlreturn
+    - noctx
+    - nolintlint
+    - paralleltest
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - stylecheck
+    - testpackage
+    - thelper
+    - tparallel
+    - wastedassign
+    - whitespace
+    - wrapcheck
+    - wsl
 
 linters-settings:
   revive:
     rules:
+      - name: argument-limit
+        arguments: [ 4 ]
+      - name: atomic
+      - name: bare-return
       - name: blank-imports
+      - name: bool-literal-in-expr
+      - name: call-to-gc
+      - name: confusing-naming
+      - name: confusing-results
+      - name: cognitive-complexity
+        arguments: [ 7 ]
+      - name: constant-logical-expr
       - name: context-as-argument
       - name: context-keys-type
+      - name: cyclomatic
+        arguments: [ 3 ]
+      - name: deep-exit
+      - name: defer
       - name: dot-imports
+      - name: duplicated-imports
+      - name: early-return
+      - name: empty-block
+      - name: empty-lines
+      - name: error-naming
       - name: error-return
       - name: error-strings
-      - name: error-naming
+      - name: errorf
       - name: exported
+      - name: flag-parameter
+      - name: function-result-limit
+        arguments: [ 3 ]
+      - name: get-return
+      - name: identical-branches
       - name: if-return
       - name: increment-decrement
-      - name: var-naming
-      - name: var-declaration
+      - name: indent-error-flow
+      - name: imports-blacklist
+        arguments: [ "log" ]
+      - name: import-shadowing
+      - name: line-length-limit
+        arguments: [ 120 ]
+      - name: max-public-structs
+        arguments: [ 3 ]
+      - name: modifies-parameter
+      - name: modifies-value-receiver
       - name: package-comments
       - name: range
+      - name: range-val-in-closure
+      - name: range-val-address
       - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: indent-error-flow
-      - name: errorf
-      - name: empty-block
-      - name: superfluous-else
-      - name: unused-parameter
-      - name: unreachable-code
       - name: redefines-builtin-id
+      - name: string-of-int
+      - name: struct-tag
+      - name: superfluous-else
+      - name: time-naming
+      - name: var-naming
+      - name: var-declaration
+      - name: unconditional-recursion
+      - name: unexported-naming
+      - name: unexported-return
+      - name: unhandled-error
+        arguments: [ "fmt.Printf" ]
+      - name: unnecessary-stmt
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: unused-receiver
+      - name: waitgroup-by-value
 
 run:
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 0
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
+
   # which dirs to skip: issues from them won't be reported;
   # can use regexp here: generated.*, regexp is applied on full path;
   # default value is empty list, but default dirs are skipped independently
@@ -52,17 +166,16 @@ run:
     - plugins/parsers/influx/machine.go*
 
 issues:
-  # List of regexps of issue texts to exclude, empty list by default.
-  # But independently from this option we use default exclude patterns,
-  # it can be disabled by `exclude-use-default: false`. To list all
-  # excluded by default patterns execute `golangci-lint run --help`
-  exclude:
-    - don't use an underscore in package name
-    - exported.*should have comment.*or be unexported
-    - comment on exported.*should be of the form
-
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
+
+  # Show only new issues created after git revision `HEAD~`
+  # Great for CI setups
+  # It's not practical to fix all existing issues at the moment of integration: much better to not allow issues in new code.
+  # new-from-rev: "HEAD~"
+
+output:
+  format: tab

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -139,9 +139,6 @@ linters-settings:
       - name: waitgroup-by-value
 
 run:
-  # exit code when at least one issue was found, default is 1
-  issues-exit-code: 0
-
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,11 @@
 linters:
   enable:
     - bodyclose
-    - deadcode
     - dogsled
     - errcheck
-    - funlen
     - goprintffuncname
-    - gosec
     - gosimple
     - govet
-    - ifshort
     - ineffassign
     - nakedret
     - nilerr
@@ -17,7 +13,6 @@ linters:
     - revive
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
@@ -25,9 +20,11 @@ linters:
     - varcheck
   disable:
     - asciicheck
+    - deadcode
     - depguard
     - dupl
     - exhaustive
+    - funlen
     - gci
     - gochecknoglobals
     - gochecknoinits
@@ -41,9 +38,12 @@ linters:
     - gofmt
     - gofumpt
     - goheader
+    - goimports
     - golint
     - gomnd
     - gomodguard
+    - gosec
+    - ifshort
     - interfacer
     - lll
     - makezero
@@ -58,6 +58,7 @@ linters:
     - prealloc
     - rowserrcheck
     - scopelint
+    - structcheck
     - stylecheck
     - testpackage
     - thelper
@@ -71,7 +72,7 @@ linters-settings:
   revive:
     rules:
       - name: argument-limit
-        arguments: [ 4 ]
+        arguments: [ 6 ]
       - name: atomic
       - name: bare-return
       - name: blank-imports
@@ -79,13 +80,9 @@ linters-settings:
       - name: call-to-gc
       - name: confusing-naming
       - name: confusing-results
-      - name: cognitive-complexity
-        arguments: [ 7 ]
       - name: constant-logical-expr
       - name: context-as-argument
       - name: context-keys-type
-      - name: cyclomatic
-        arguments: [ 3 ]
       - name: deep-exit
       - name: defer
       - name: dot-imports
@@ -97,48 +94,45 @@ linters-settings:
       - name: error-return
       - name: error-strings
       - name: errorf
-      - name: exported
       - name: flag-parameter
       - name: function-result-limit
         arguments: [ 3 ]
-      - name: get-return
       - name: identical-branches
       - name: if-return
-      - name: increment-decrement
-      - name: indent-error-flow
       - name: imports-blacklist
         arguments: [ "log" ]
       - name: import-shadowing
-      - name: line-length-limit
-        arguments: [ 120 ]
-      - name: max-public-structs
-        arguments: [ 3 ]
+      - name: increment-decrement
+      - name: indent-error-flow
       - name: modifies-parameter
       - name: modifies-value-receiver
       - name: package-comments
       - name: range
-      - name: range-val-in-closure
       - name: range-val-address
+      - name: range-val-in-closure
       - name: receiver-naming
       - name: redefines-builtin-id
       - name: string-of-int
       - name: struct-tag
       - name: superfluous-else
       - name: time-naming
-      - name: var-naming
-      - name: var-declaration
       - name: unconditional-recursion
       - name: unexported-naming
-      - name: unexported-return
       - name: unhandled-error
-        arguments: [ "fmt.Printf" ]
       - name: unnecessary-stmt
       - name: unreachable-code
       - name: unused-parameter
-      - name: unused-receiver
+      - name: var-declaration
+      - name: var-naming
       - name: waitgroup-by-value
+  nakedret:
+    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
+    max-func-lines: 1
 
 run:
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 0
+
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 5m
 
@@ -149,10 +143,10 @@ run:
   # "/" will be replaced by current OS file path separator to properly work
   # on Windows.
   skip-dirs:
-    - scripts
+    - assets
     - docs
     - etc
-    - plugins/parsers/influx/plugins #workaround to skip weird "plugins/parsers/influx/plugins/parsers/influx" directory
+    - scripts
 
   # which files to skip: they will be analyzed, but issues from them
   # won't be reported. Default value is empty list, but there is
@@ -169,6 +163,14 @@ issues:
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
+
+  exclude:
+    - don't use an underscore in package name #revive:var-naming
+
+  exclude-rules:
+    - path: plugins/parsers/influx
+      linters:
+        - govet
 
   # Show only new issues created after git revision `HEAD~`
   # Great for CI setups

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,9 +130,6 @@ linters-settings:
     max-func-lines: 1
 
 run:
-  # exit code when at least one issue was found, default is 1
-  issues-exit-code: 0
-
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 5m
 

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ ifeq (, $(shell which golangci-lint))
 	exit 1
 endif
 
-	golangci-lint run --timeout 5m0s --issues-exit-code 0
+	golangci-lint run
 
 .PHONY: tidy
 tidy:

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ ifeq (, $(shell which golangci-lint))
 	exit 1
 endif
 
-	golangci-lint run
+	golangci-lint -v run
 
 .PHONY: tidy
 tidy:


### PR DESCRIPTION
- Most valuable (TBD?) linters for `golangci-lint` enabled, for `revive` linter almost all rules enabled. Both linters and rules should reviewed to get list of what should stay enabled.
- `golangci-lint` bumped from `v1.37.0` to `v1.38.0`
- settings from `Makefile` moved to config file