### PR TITLE
Reset the flush interval timer when flush is requested or batch is ready.

### DIFF
--- a/agent/tick.go
+++ b/agent/tick.go
@@ -216,6 +216,7 @@ type RollingTicker struct {
 	ch       chan time.Time
 	cancel   context.CancelFunc
 	wg       sync.WaitGroup
+	timer    *clock.Timer
 }
 
 func NewRollingTicker(interval, jitter time.Duration) *RollingTicker {
@@ -232,12 +233,12 @@ func newRollingTicker(interval, jitter time.Duration, clock clock.Clock) *Rollin
 	}
 
 	d := t.next()
-	timer := clock.Timer(d)
+	t.timer = clock.Timer(d)
 
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		t.run(ctx, timer)
+		t.run(ctx)
 	}()
 
 	return t
@@ -247,22 +248,25 @@ func (t *RollingTicker) next() time.Duration {
 	return t.interval + internal.RandomDuration(t.jitter)
 }
 
-func (t *RollingTicker) run(ctx context.Context, timer *clock.Timer) {
+func (t *RollingTicker) run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			timer.Stop()
+			t.timer.Stop()
 			return
-		case now := <-timer.C:
+		case now := <-t.timer.C:
 			select {
 			case t.ch <- now:
 			default:
 			}
 
-			d := t.next()
-			timer.Reset(d)
+			t.Reset()
 		}
 	}
+}
+
+func (t *RollingTicker) Reset() {
+	t.timer.Reset(t.next())
 }
 
 func (t *RollingTicker) Elapsed() <-chan time.Time {


### PR DESCRIPTION
Reset the flush interval timer when flush is requested or batch is ready, so that timer doesn't expire (and then falsely report that flush interval has been exceeded without writing) while one of those flushes is occurring.

resolves #8941
