### PR TITLE
Fix max open requests to one if idempotent writes is set to true

### DIFF
--- a/plugins/common/kafka/config.go
+++ b/plugins/common/kafka/config.go
@@ -34,10 +34,14 @@ func (k *WriteConfig) SetConfig(config *sarama.Config) error {
 	config.Producer.Return.Successes = true
 	config.Producer.Idempotent = k.IdempotentWrites
 	config.Producer.Retry.Max = k.MaxRetry
+
 	if k.MaxMessageBytes > 0 {
 		config.Producer.MaxMessageBytes = k.MaxMessageBytes
 	}
 	config.Producer.RequiredAcks = sarama.RequiredAcks(k.RequiredAcks)
+	if config.Producer.Idempotent {
+		config.Net.MaxOpenRequests = 1
+	}
 	return k.Config.SetConfig(config)
 }
 

--- a/plugins/common/kafka/config.go
+++ b/plugins/common/kafka/config.go
@@ -34,7 +34,6 @@ func (k *WriteConfig) SetConfig(config *sarama.Config) error {
 	config.Producer.Return.Successes = true
 	config.Producer.Idempotent = k.IdempotentWrites
 	config.Producer.Retry.Max = k.MaxRetry
-
 	if k.MaxMessageBytes > 0 {
 		config.Producer.MaxMessageBytes = k.MaxMessageBytes
 	}


### PR DESCRIPTION
Currently if idempotent_writes is set to true telegraf crashes

Idempotent_writes requires max open requests to be set to 1 (defaults to 5)

Change config to set max open requests to 1 under the hood when idempotent_writes is turned on

