### PR TITLE
Fix output name to match directory name for sensu output plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ For documentation on the latest development code see the [documentation index][d
 * [prometheus](./plugins/outputs/prometheus_client)
 * [riemann](./plugins/outputs/riemann)
 * [riemann_legacy](./plugins/outputs/riemann_legacy)
-* [sensu-go](./plugins/outputs/sensu)
+* [sensu](./plugins/outputs/sensu)
 * [signalfx](./plugins/outputs/signalfx)
 * [socket_writer](./plugins/outputs/socket_writer)
 * [stackdriver](./plugins/outputs/stackdriver) (Google Cloud Monitoring)

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1328,7 +1328,7 @@
 
 
 # # Send aggregate metrics to Sensu Monitor
-# [[outputs.sensu-go]]
+# [[outputs.sensu]]
 #   ## BACKEND API URL is the Sensu Backend API root URL to send metrics to
 #   ## (protocol, host, and port only). The output plugin will automatically
 #   ## append the corresponding backend API path
@@ -1393,7 +1393,7 @@
 #   ## Check specification
 #   ## The check name is the name to give the Sensu check associated with the event
 #   ## created. This maps to check.metatadata.name in the event.
-#   [outputs.sensu-go.check]
+#   [outputs.sensu.check]
 #   name = "telegraf"
 #
 #   ## Entity specification
@@ -1404,17 +1404,17 @@
 #   ## backend_api_url and entity_name is not set, the value returned by
 #   ## os.Hostname() will be used; if the output plugin is configured to send
 #   ## events to an agent_api_url, entity_name and entity_namespace are not used.
-#   # [outputs.sensu-go.entity]
+#   # [outputs.sensu.entity]
 #   #   name = "server-01"
 #   #   namespace = "default"
 #
 #   ## Metrics specification
 #   ## Configure the tags for the metrics that are sent as part of the Sensu event
-#   # [outputs.sensu-go.tags]
+#   # [outputs.sensu.tags]
 #   #   source = "telegraf"
 #
 #   ## Configure the handler(s) for processing the provided metrics
-#   # [outputs.sensu-go.metrics]
+#   # [outputs.sensu.metrics]
 #   #   handlers = ["influxdb","elasticsearch"]
 
 

--- a/plugins/outputs/sensu/README.md
+++ b/plugins/outputs/sensu/README.md
@@ -6,7 +6,7 @@ HTTP events API.
 ### Configuration:
 
 ```toml
-[[outputs.sensu-go]]
+[[outputs.sensu]]
   ## BACKEND API URL is the Sensu Backend API root URL to send metrics to 
   ## (protocol, host, and port only). The output plugin will automatically 
   ## append the corresponding backend API path
@@ -71,7 +71,7 @@ HTTP events API.
   ## Check specification
   ## The check name is the name to give the Sensu check associated with the event
   ## created. This maps to check.metatadata.name in the event.
-  [outputs.sensu-go.check]
+  [outputs.sensu.check]
     name = "telegraf"
 
   ## Entity specification
@@ -82,16 +82,16 @@ HTTP events API.
   ## backend_api_url and entity_name is not set, the value returned by 
   ## os.Hostname() will be used; if the output plugin is configured to send
   ## events to an agent_api_url, entity_name and entity_namespace are not used. 
-  # [outputs.sensu-go.entity]
+  # [outputs.sensu.entity]
   #   name = "server-01"
   #   namespace = "default"
 
   ## Metrics specification
   ## Configure the tags for the metrics that are sent as part of the Sensu event
-  # [outputs.sensu-go.tags]
+  # [outputs.sensu.tags]
   #   source = "telegraf"
 
   ## Configure the handler(s) for processing the provided metrics
-  # [outputs.sensu-go.metrics]
+  # [outputs.sensu.metrics]
   #   handlers = ["influxdb","elasticsearch"]
 ```

--- a/plugins/outputs/sensu/sensu.go
+++ b/plugins/outputs/sensu/sensu.go
@@ -167,7 +167,7 @@ var sampleConfig = `
   ## Check specification
   ## The check name is the name to give the Sensu check associated with the event
   ## created. This maps to check.metatadata.name in the event.
-  [outputs.sensu-go.check]
+  [outputs.sensu.check]
   name = "telegraf"
 
   ## Entity specification
@@ -178,17 +178,17 @@ var sampleConfig = `
   ## backend_api_url and entity_name is not set, the value returned by
   ## os.Hostname() will be used; if the output plugin is configured to send
   ## events to an agent_api_url, entity_name and entity_namespace are not used.
-  # [outputs.sensu-go.entity]
+  # [outputs.sensu.entity]
   #   name = "server-01"
   #   namespace = "default"
 
   ## Metrics specification
   ## Configure the tags for the metrics that are sent as part of the Sensu event
-  # [outputs.sensu-go.tags]
+  # [outputs.sensu.tags]
   #   source = "telegraf"
 
   ## Configure the handler(s) for processing the provided metrics
-  # [outputs.sensu-go.metrics]
+  # [outputs.sensu.metrics]
   #   handlers = ["influxdb","elasticsearch"]
 `
 
@@ -401,7 +401,7 @@ func (s *Sensu) Init() error {
 }
 
 func init() {
-	outputs.Add("sensu-go", func() telegraf.Output {
+	outputs.Add("sensu", func() telegraf.Output {
 		// Default configuration values
 
 		// make a string from the defaultUrl const


### PR DESCRIPTION
Per request from @sjwang90, fix the plugin name for sensu to match the directory name.

### Required for all PRs:

- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
