### PR TITLE
Include DMG files when syncing release artifacts to AWS

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -178,4 +178,5 @@ aws s3 sync ./ "s3://$BUCKET/" \
 	--include "*.zip" \
 	--include "*.DIGESTS" \
 	--include "*.asc" \
+	--include "*.dmg" \
 	--acl public-read


### PR DESCRIPTION
This is needed because the new notarized Mac artifact is in DMG format.