### PR TITLE
Move golangci-lint from circle-ci to github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,14 +71,6 @@ commands:
           paths:
             - 'dist'
 jobs:
-  linter:
-    executor: go-1_16
-    steps:
-      - checkout
-      - restore_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
-      - run: wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.37.0
-      - run: make lint
   deps:
     executor: go-1_16
     steps:
@@ -209,7 +201,6 @@ workflows:
   version: 2
   check:
     jobs:
-      - 'linter'
       - 'macdeps':
           filters:
             tags:
@@ -287,7 +278,6 @@ workflows:
                 only: /.*/
   nightly:
     jobs:
-      - 'linter'
       - 'deps'
       - 'macdeps'
       - 'test-go-1_15':

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,5 +15,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.29
+          version: v1.38
           only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,19 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  golangci-pr:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    # Trigger every day at 16:00 UTC
+    - cron:  '0 16 * * *'
 jobs:
   golangci-pr:
     name: lint
@@ -17,3 +20,4 @@ jobs:
         with:
           version: v1.38
           only-new-issues: true
+          args: --timeout=5m0s


### PR DESCRIPTION
Golangci-lint project provides a github action: https://github.com/golangci/golangci-lint-action

This pr adds a config to enable the github action (replacing circle-ci), this should be faster with caching enabled and not having to download the golangci-lint binary each time.