### PR TITLE
Update mac cache version number in circle-ci to avoid conflicts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,14 +93,14 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: mac-go-mod-v2-{{ checksum "go.sum" }}
+          key: mac-go-mod-v3-{{ checksum "go.sum" }}
       - run: 'brew update'
-      - run: 'brew install go@1.16'
+      - run: 'brew install go@1.16.1'
       - run: 'make deps'
       - run: 'make tidy'
       - save_cache:
           name: 'go module cache'
-          key: mac-go-mod-v2-{{ checksum "go.sum" }}
+          key: mac-go-mod-v3-{{ checksum "go.sum" }}
           paths:
             - '~/go/pkg/mod'
             - '/usr/local/Cellar/go'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
       - restore_cache:
           key: mac-go-mod-v3-{{ checksum "go.sum" }}
       - run: 'brew update'
-      - run: 'brew install go@1.16.1'
+      - run: 'brew install go@1.16'
       - run: 'make deps'
       - run: 'make tidy'
       - save_cache:


### PR DESCRIPTION
Update cache version to avoid using old version and causing failure.

similar update: https://github.com/influxdata/telegraf/pull/8516