### PR TITLE
nats_output: use the configured credentials file

### DIFF
--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -73,8 +73,12 @@ func (n *NATS) Connect() error {
 	}
 
 	// override authentication, if any was specified
-	if n.Username != "" {
+	if n.Username != "" && n.Password != "" {
 		opts = append(opts, nats.UserInfo(n.Username, n.Password))
+	}
+
+	if n.Credentials != "" {
+		opts = append(opts, nats.UserCredentials(n.Credentials))
 	}
 
 	if n.Name != "" {


### PR DESCRIPTION
### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

The nats_output plugin never used the configured credentials file and therefore could not connect to an account-based nats system.

I modified the plugin based on the consumer plugin (https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nats_consumer/nats_consumer.go)