### PR TITLE
Remove deprecated and unused SetAggregate() and IsAggregate() functions.

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -122,14 +122,4 @@ type Metric interface {
 	// Drop marks the metric as processed successfully without being written
 	// to any output.
 	Drop()
-
-	// SetAggregate indicates the metric is an aggregated value.
-	//
-	// This method may be removed in the future and its use is discouraged.
-	SetAggregate(bool)
-
-	// IsAggregate returns true if the Metric is an aggregate.
-	//
-	// This method may be removed in the future and its use is discouraged.
-	IsAggregate() bool
 }

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -15,8 +15,7 @@ type metric struct {
 	fields []*telegraf.Field
 	tm     time.Time
 
-	tp        telegraf.ValueType
-	aggregate bool
+	tp telegraf.ValueType
 }
 
 func New(
@@ -68,12 +67,11 @@ func New(
 // removed.
 func FromMetric(other telegraf.Metric) telegraf.Metric {
 	m := &metric{
-		name:      other.Name(),
-		tags:      make([]*telegraf.Tag, len(other.TagList())),
-		fields:    make([]*telegraf.Field, len(other.FieldList())),
-		tm:        other.Time(),
-		tp:        other.Type(),
-		aggregate: other.IsAggregate(),
+		name:   other.Name(),
+		tags:   make([]*telegraf.Tag, len(other.TagList())),
+		fields: make([]*telegraf.Field, len(other.FieldList())),
+		tm:     other.Time(),
+		tp:     other.Type(),
 	}
 
 	for i, tag := range other.TagList() {
@@ -233,12 +231,11 @@ func (m *metric) SetTime(t time.Time) {
 
 func (m *metric) Copy() telegraf.Metric {
 	m2 := &metric{
-		name:      m.name,
-		tags:      make([]*telegraf.Tag, len(m.tags)),
-		fields:    make([]*telegraf.Field, len(m.fields)),
-		tm:        m.tm,
-		tp:        m.tp,
-		aggregate: m.aggregate,
+		name:   m.name,
+		tags:   make([]*telegraf.Tag, len(m.tags)),
+		fields: make([]*telegraf.Field, len(m.fields)),
+		tm:     m.tm,
+		tp:     m.tp,
 	}
 
 	for i, tag := range m.tags {
@@ -249,14 +246,6 @@ func (m *metric) Copy() telegraf.Metric {
 		m2.fields[i] = &telegraf.Field{Key: field.Key, Value: field.Value}
 	}
 	return m2
-}
-
-func (m *metric) SetAggregate(aggregate bool) {
-	m.aggregate = aggregate
-}
-
-func (m *metric) IsAggregate() bool {
-	return m.aggregate
 }
 
 func (m *metric) HashID() uint64 {

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -333,10 +333,3 @@ func TestValueType(t *testing.T) {
 
 	assert.Equal(t, telegraf.Gauge, m.Type())
 }
-
-func TestCopyAggregate(t *testing.T) {
-	m1 := baseMetric()
-	m1.SetAggregate(true)
-	m2 := m1.Copy()
-	assert.True(t, m2.IsAggregate())
-}

--- a/models/running_aggregator.go
+++ b/models/running_aggregator.go
@@ -117,10 +117,6 @@ func (r *RunningAggregator) MakeMetric(metric telegraf.Metric) telegraf.Metric {
 		r.Config.Tags,
 		nil)
 
-	if m != nil {
-		m.SetAggregate(true)
-	}
-
 	r.MetricsPushed.Incr(1)
 
 	return m


### PR DESCRIPTION
### Required for all PRs:

- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

The mentioned functions are deprecated, their use was discouraged and they are not used anywhere anymore. According to a comment of @reimda in PR #8183 those functions should be removed.