### PR TITLE
fix segfaults in sflow plugin by checking if protocol headers are set

### DIFF
--- a/plugins/inputs/sflow/types.go
+++ b/plugins/inputs/sflow/types.go
@@ -118,12 +118,22 @@ type RawPacketHeaderFlowData struct {
 }
 
 func (h RawPacketHeaderFlowData) GetTags() map[string]string {
-	t := h.Header.GetTags()
+	var t map[string]string
+	if h.Header != nil {
+		t = h.Header.GetTags()
+	} else {
+		t = map[string]string{}
+	}
 	t["header_protocol"] = HeaderProtocolMap[h.HeaderProtocol]
 	return t
 }
 func (h RawPacketHeaderFlowData) GetFields() map[string]interface{} {
-	f := h.Header.GetFields()
+	var f map[string]interface{}
+	if h.Header != nil {
+		f = h.Header.GetFields()
+	} else {
+		f = map[string]interface{}{}
+	}
 	f["bytes"] = h.Bytes
 	f["frame_length"] = h.FrameLength
 	f["header_length"] = h.HeaderLength
@@ -143,14 +153,22 @@ type EthHeader struct {
 }
 
 func (h EthHeader) GetTags() map[string]string {
-	t := h.IPHeader.GetTags()
+	var t map[string]string
+	if h.IPHeader != nil {
+		t = h.IPHeader.GetTags()
+	} else {
+		t = map[string]string{}
+	}
 	t["src_mac"] = net.HardwareAddr(h.SourceMAC[:]).String()
 	t["dst_mac"] = net.HardwareAddr(h.DestinationMAC[:]).String()
 	t["ether_type"] = h.EtherType
 	return t
 }
 func (h EthHeader) GetFields() map[string]interface{} {
-	return h.IPHeader.GetFields()
+	if h.IPHeader != nil {
+		return h.IPHeader.GetFields()
+	}
+	return map[string]interface{}{}
 }
 
 type ProtocolHeader ContainsMetricData

--- a/plugins/inputs/sflow/types_test.go
+++ b/plugins/inputs/sflow/types_test.go
@@ -1,0 +1,43 @@
+package sflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawPacketHeaderFlowData(t *testing.T) {
+	h := RawPacketHeaderFlowData{
+		HeaderProtocol: HeaderProtocolTypeEthernetISO88023,
+		FrameLength:    64,
+		Bytes:          64,
+		StrippedOctets: 0,
+		HeaderLength:   0,
+		Header:         nil,
+	}
+	tags := h.GetTags()
+	fields := h.GetFields()
+
+	require.NotNil(t, fields)
+	require.NotNil(t, tags)
+	require.Contains(t, tags, "header_protocol")
+	require.Equal(t, 1, len(tags))
+}
+
+// process a raw ethernet packet without any encapsulated protocol
+func TestEthHeader(t *testing.T) {
+	h := EthHeader{
+		DestinationMAC:        [6]byte{0xca, 0xff, 0xee, 0xff, 0xe, 0x0},
+		SourceMAC:             [6]byte{0xde, 0xad, 0xbe, 0xef, 0x0, 0x0},
+		TagProtocolIdentifier: 0x88B5, // IEEE Std 802 - Local Experimental Ethertype
+		TagControlInformation: 0,
+		EtherTypeCode:         0,
+		EtherType:             "",
+		IPHeader:              nil,
+	}
+	tags := h.GetTags()
+	fields := h.GetFields()
+
+	require.NotNil(t, fields)
+	require.NotNil(t, tags)
+}


### PR DESCRIPTION
prior to calling getFields() or getTags() on them.

If a protocol header is not available, an empty map is returned.

updates: #7937

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>

### Required for all PRs:

- [ ] Associated README.md updated.
- [x] Has appropriate unit tests.
