### PR TITLE
Feature: merge multiple "--config" and "--config-directory" flags

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -31,8 +31,8 @@ import (
 type sliceFlags []string
 
 func (i *sliceFlags) String() string {
- 	s := strings.Join(*i, " ")
-    return "[" + s + "]"
+	s := strings.Join(*i, " ")
+	return "[" + s + "]"
 }
 
 func (i *sliceFlags) Set(value string) error {
@@ -143,15 +143,15 @@ func runAgent(ctx context.Context,
 		err = c.LoadConfig("")
 		if err != nil {
 			return err
-		}			
+		}
 	}
-	for _, fConfig := range fConfigs{
+	for _, fConfig := range fConfigs {
 		err = c.LoadConfig(fConfig)
 		if err != nil {
 			return err
-		}			
+		}
 	}
-	
+
 	for _, fConfigDirectory := range fConfigDirs {
 		err = c.LoadDirectory(fConfigDirectory)
 		if err != nil {

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -84,12 +84,18 @@ func runAsWindowsService(inputFilters, outputFilters, aggregatorFilters, process
 	// Handle the --service flag here to prevent any issues with tooling that
 	// may not have an interactive session, e.g. installing from Ansible.
 	if *fService != "" {
-		if *fConfig != "" {
-			svcConfig.Arguments = []string{"--config", *fConfig}
+		var err error
+		if len(fConfigs) > 0 {
+			svcConfig.Arguments = []string{}	
 		}
-		if *fConfigDirectory != "" {
-			svcConfig.Arguments = append(svcConfig.Arguments, "--config-directory", *fConfigDirectory)
+		for _, fConfig := range fConfigs {
+			svcConfig.Arguments = append(svcConfig.Arguments, "--config", fConfig)
 		}
+
+		for _, fConfigDirectory := range fConfigDirs {
+			svcConfig.Arguments = append(svcConfig.Arguments, "--config-directory", fConfigDirectory)
+		}
+
 		//set servicename to service cmd line, to have a custom name after relaunch as a service
 		svcConfig.Arguments = append(svcConfig.Arguments, "--service-name", *fServiceName)
 

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -84,7 +84,6 @@ func runAsWindowsService(inputFilters, outputFilters, aggregatorFilters, process
 	// Handle the --service flag here to prevent any issues with tooling that
 	// may not have an interactive session, e.g. installing from Ansible.
 	if *fService != "" {
-		var err error
 		if len(fConfigs) > 0 {
 			svcConfig.Arguments = []string{}
 		}

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -86,7 +86,7 @@ func runAsWindowsService(inputFilters, outputFilters, aggregatorFilters, process
 	if *fService != "" {
 		var err error
 		if len(fConfigs) > 0 {
-			svcConfig.Arguments = []string{}	
+			svcConfig.Arguments = []string{}
 		}
 		for _, fConfig := range fConfigs {
 			svcConfig.Arguments = append(svcConfig.Arguments, "--config", fConfig)


### PR DESCRIPTION
This adds a feature mentioned in this issue https://github.com/influxdata/telegraf/issues/7501

The only change in functionality is that telegraf will now merge multiple "--config" and "--config-directory" flags into the config, rather than only using value of the last flag.


### Required for all PRs:

- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
