### PR TITLE
Update supported regions in azure monitor

### DIFF
--- a/plugins/outputs/azure_monitor/README.md
+++ b/plugins/outputs/azure_monitor/README.md
@@ -54,15 +54,7 @@ written as a dimension on each Azure Monitor metric.
    [enable system-assigned managed identity][enable msi].
 2. Use a region that supports Azure Monitor Custom Metrics,
    For regions with Custom Metrics support, an endpoint will be available with
-   the format `https://<region>.monitoring.azure.com`. The following regions
-   are currently known to be supported:
-    - East US (eastus)
-    - West US 2 (westus2)
-    - South Central US (southcentralus)
-    - West Central US (westcentralus)
-    - North Europe (northeurope)
-    - West Europe (westeurope)
-    - Southeast Asia (southeastasia)
+   the format `https://<region>.monitoring.azure.com`.
 
 [resource provider]: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-supported-services
 [enable msi]: https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/qs-configure-portal-windows-vm


### PR DESCRIPTION
### Required for all PRs:

- [x] Associated README.md updated.
- [x] ~~Has appropriate unit tests.~~ does not modify code

## Why

Azure Monitor Custom Metrics is supported in All Public Cloud Regions. ref https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-custom-overview#supported-regions
I think that should update README.

## What

Update Azure Monitor README.
I deleted "The following regions are currently known to be supported", because of already supported All Public Regions. 
