### PR TITLE
Update PR template to encourage linking to issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,25 @@
 ### Required for all PRs:
 
-- [ ] Associated README.md updated.
-- [ ] Has appropriate unit tests.
+<!-- Complete the tasks in the following list. Change [ ] to [x] to
+show completion. -->
+
+- [ ] Updated associated README.md.
+- [ ] Wrote appropriate unit tests.
+
+<!-- Link to issues that describe the need for the change. Issues
+should include context that will help reviewers understand why the
+change is needed.
+
+Make sure to link issues and using a keyword like "resolves #1234".
+https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+-->
+
+resolves #
+
+<!-- Finally, include a summary of the code change itself. This
+description should tell reviewers how the issues were resolved.
+
+example: Fixed an off by one error in counter variable in type FooBar.
+
+example: Added an input plugin to gather yak shaving metrics using
+golang library yaktech/shaver. -->


### PR DESCRIPTION
Update the PR template to encourage contributors to link the PR to the issues it resolves.  Also ask contributors to use github issues to describe why the change is needed and then summarize how the issues were resolved in the PR description.