### PR TITLE
Carbon2 serializer: sanitize metric name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1390,6 +1390,7 @@ func (c *Config) buildSerializer(name string, tbl *ast.Table) (serializers.Seria
 	c.getFieldString(tbl, "template", &sc.Template)
 	c.getFieldStringSlice(tbl, "templates", &sc.Templates)
 	c.getFieldString(tbl, "carbon2_format", &sc.Carbon2Format)
+	c.getFieldString(tbl, "carbon2_sanitize_replace_char", &sc.Carbon2SanitizeReplaceChar)
 	c.getFieldInt(tbl, "influx_max_line_bytes", &sc.InfluxMaxLineBytes)
 
 	c.getFieldBool(tbl, "influx_sort_fields", &sc.InfluxSortFields)
@@ -1451,9 +1452,9 @@ func (c *Config) buildOutput(name string, tbl *ast.Table) (*models.OutputConfig,
 
 func (c *Config) missingTomlField(typ reflect.Type, key string) error {
 	switch key {
-	case "alias", "carbon2_format", "collectd_auth_file", "collectd_parse_multivalue",
-		"collectd_security_level", "collectd_typesdb", "collection_jitter", "csv_column_names",
-		"csv_column_types", "csv_comment", "csv_delimiter", "csv_header_row_count",
+	case "alias", "carbon2_format", "carbon2_sanitize_replace_char", "collectd_auth_file",
+		"collectd_parse_multivalue", "collectd_security_level", "collectd_typesdb", "collection_jitter",
+		"csv_column_names", "csv_column_types", "csv_comment", "csv_delimiter", "csv_header_row_count",
 		"csv_measurement_column", "csv_skip_columns", "csv_skip_rows", "csv_tag_columns",
 		"csv_timestamp_column", "csv_timestamp_format", "csv_timezone", "csv_trim_space", "csv_skip_values",
 		"data_format", "data_type", "delay", "drop", "drop_original", "dropwizard_metric_registry_path",

--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -95,7 +95,7 @@ func TestMethod(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate))
+			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			plugin := tt.plugin()
@@ -172,7 +172,7 @@ func TestStatusCode(t *testing.T) {
 				w.WriteHeader(tt.statusCode)
 			})
 
-			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate))
+			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			tt.plugin.SetSerializer(serializer)
@@ -198,7 +198,7 @@ func TestContentType(t *testing.T) {
 				s.headers = map[string]string{
 					contentTypeHeader: carbon2ContentType,
 				}
-				sr, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate))
+				sr, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
 				require.NoError(t, err)
 				s.SetSerializer(sr)
 				return s
@@ -212,7 +212,7 @@ func TestContentType(t *testing.T) {
 				s.headers = map[string]string{
 					contentTypeHeader: carbon2ContentType,
 				}
-				sr, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatMetricIncludesField))
+				sr, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatMetricIncludesField), carbon2.DefaultSanitizeReplaceChar)
 				require.NoError(t, err)
 				s.SetSerializer(sr)
 				return s
@@ -309,7 +309,7 @@ func TestContentEncodingGzip(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate))
+			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			plugin := tt.plugin()
@@ -344,7 +344,7 @@ func TestDefaultUserAgent(t *testing.T) {
 			MaxRequstBodySize: Default().MaxRequstBodySize,
 		}
 
-		serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate))
+		serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
 		require.NoError(t, err)
 
 		plugin.SetSerializer(serializer)
@@ -595,7 +595,7 @@ func TestMaxRequestBodySize(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate))
+			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			plugin := tt.plugin()
@@ -627,7 +627,7 @@ func TestTryingToSendEmptyMetricsDoesntFail(t *testing.T) {
 	plugin := Default()
 	plugin.URL = u.String()
 
-	serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate))
+	serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
 	require.NoError(t, err)
 	plugin.SetSerializer(serializer)
 

--- a/plugins/serializers/carbon2/README.md
+++ b/plugins/serializers/carbon2/README.md
@@ -21,6 +21,11 @@ The `carbon2` serializer translates the Telegraf metric format to the [Carbon2 f
   ## * "metric_includes_field"
   ## * "" - defaults to "field_separate"
   # carbon2_format = "field_separate"
+
+  ## Character used for replacing sanitized characters. By default ":" is used.
+  ## The following character set is being replaced with sanitize replace char:
+  ## !@#$%^&*()+`'\"[]{};<>,?/\\|=
+  # carbon2_sanitize_replace_char = ":"
 ```
 
 Standard form:
@@ -51,6 +56,17 @@ metric=name_field_1 host=foo  30 1234567890
 metric=name_field_2 host=foo  4 1234567890
 metric=name_field_N host=foo  59 1234567890
 ```
+
+### Metric name sanitization
+
+In order to sanitize the metric name one can specify `carbon2_sanitize_replace_char`
+in order to replace the following characters in the metric name:
+
+```
+!@#$%^&*()+`'\"[]{};<>,?/\\|=
+```
+
+By default they will be replaced with `:`.
 
 ## Metrics
 

--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -2,6 +2,7 @@ package carbon2
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -24,8 +25,8 @@ var formats = map[format]struct{}{
 }
 
 const (
-	replaceChar    rune = ':'
-	sanitizedChars      = "!@#$%^&*()+`'\"[]{};<>,?/\\|="
+	DefaultSanitizeReplaceChar = ":"
+	sanitizedChars             = "!@#$%^&*()+`'\"[]{};<>,?/\\|="
 )
 
 type Serializer struct {
@@ -33,7 +34,13 @@ type Serializer struct {
 	sanitizeReplacer *strings.Replacer
 }
 
-func NewSerializer(metricsFormat string) (*Serializer, error) {
+func NewSerializer(metricsFormat string, sanitizeReplaceChar string) (*Serializer, error) {
+	if sanitizeReplaceChar == "" {
+		sanitizeReplaceChar = DefaultSanitizeReplaceChar
+	} else if len(sanitizeReplaceChar) > 1 {
+		return nil, errors.New("sanitize replace char has to be a singular character")
+	}
+
 	var f = format(metricsFormat)
 
 	if _, ok := formats[f]; !ok {
@@ -47,7 +54,7 @@ func NewSerializer(metricsFormat string) (*Serializer, error) {
 
 	return &Serializer{
 		metricsFormat:    f,
-		sanitizeReplacer: createSanitizeReplacer(sanitizedChars, replaceChar),
+		sanitizeReplacer: createSanitizeReplacer(sanitizedChars, rune(sanitizeReplaceChar[0])),
 	}, nil
 }
 

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -310,3 +310,69 @@ metric=cpu_value  42 0
 		})
 	}
 }
+
+func TestSerializeMetricIsProperlySanitized(t *testing.T) {
+	now := time.Now()
+
+	testcases := []struct {
+		metricFunc func() (telegraf.Metric, error)
+		format     format
+		expected   string
+	}{
+		{
+			metricFunc: func() (telegraf.Metric, error) {
+				fields := map[string]interface{}{
+					"usage_idle": float64(91.5),
+				}
+				return metric.New("cpu=1", nil, fields, now)
+			},
+			format:   Carbon2FormatFieldSeparate,
+			expected: fmt.Sprintf("metric=cpu:1 field=usage_idle  91.5 %d\n", now.Unix()),
+		},
+		{
+			metricFunc: func() (telegraf.Metric, error) {
+				fields := map[string]interface{}{
+					"usage_idle": float64(91.5),
+				}
+				return metric.New("cpu=1=tmp$custom", nil, fields, now)
+			},
+			format:   Carbon2FormatFieldSeparate,
+			expected: fmt.Sprintf("metric=cpu:1:tmp:custom field=usage_idle  91.5 %d\n", now.Unix()),
+		},
+		{
+			metricFunc: func() (telegraf.Metric, error) {
+				fields := map[string]interface{}{
+					"usage_idle": float64(91.5),
+				}
+				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
+			},
+			format:   Carbon2FormatFieldSeparate,
+			expected: fmt.Sprintf("metric=cpu:1:tmp:custom:namespace field=usage_idle  91.5 %d\n", now.Unix()),
+		},
+		{
+			metricFunc: func() (telegraf.Metric, error) {
+				fields := map[string]interface{}{
+					"usage_idle": float64(91.5),
+				}
+				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
+			},
+			format:   Carbon2FormatMetricIncludesField,
+			expected: fmt.Sprintf("metric=cpu:1:tmp:custom:namespace_usage_idle  91.5 %d\n", now.Unix()),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(string(tc.format), func(t *testing.T) {
+			m, err := tc.metricFunc()
+			require.NoError(t, err)
+
+			s, err := NewSerializer(string(tc.format))
+			require.NoError(t, err)
+
+			buf, err := s.Serialize(m)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, string(buf))
+		})
+	}
+}

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -46,7 +46,7 @@ func TestSerializeMetricFloat(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format))
+			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			buf, err := s.Serialize(m)
@@ -84,7 +84,7 @@ func TestSerializeMetricWithEmptyStringTag(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format))
+			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			buf, err := s.Serialize(m)
@@ -122,7 +122,7 @@ func TestSerializeWithSpaces(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format))
+			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			buf, err := s.Serialize(m)
@@ -160,7 +160,7 @@ func TestSerializeMetricInt(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format))
+			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			buf, err := s.Serialize(m)
@@ -198,7 +198,7 @@ func TestSerializeMetricString(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format))
+			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			buf, err := s.Serialize(m)
@@ -255,7 +255,7 @@ func TestSerializeMetricBool(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format))
+			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			buf, err := s.Serialize(tc.metric)
@@ -300,7 +300,7 @@ metric=cpu_value  42 0
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format))
+			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
 			require.NoError(t, err)
 
 			buf, err := s.SerializeBatch(metrics)
@@ -315,9 +315,11 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 	now := time.Now()
 
 	testcases := []struct {
-		metricFunc func() (telegraf.Metric, error)
-		format     format
-		expected   string
+		metricFunc  func() (telegraf.Metric, error)
+		format      format
+		expected    string
+		replaceChar string
+		expectedErr bool
 	}{
 		{
 			metricFunc: func() (telegraf.Metric, error) {
@@ -326,8 +328,20 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1", nil, fields, now)
 			},
-			format:   Carbon2FormatFieldSeparate,
-			expected: fmt.Sprintf("metric=cpu:1 field=usage_idle  91.5 %d\n", now.Unix()),
+			format:      Carbon2FormatFieldSeparate,
+			expected:    fmt.Sprintf("metric=cpu:1 field=usage_idle  91.5 %d\n", now.Unix()),
+			replaceChar: DefaultSanitizeReplaceChar,
+		},
+		{
+			metricFunc: func() (telegraf.Metric, error) {
+				fields := map[string]interface{}{
+					"usage_idle": float64(91.5),
+				}
+				return metric.New("cpu=1", nil, fields, now)
+			},
+			format:      Carbon2FormatFieldSeparate,
+			expected:    fmt.Sprintf("metric=cpu_1 field=usage_idle  91.5 %d\n", now.Unix()),
+			replaceChar: "_",
 		},
 		{
 			metricFunc: func() (telegraf.Metric, error) {
@@ -336,8 +350,9 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom", nil, fields, now)
 			},
-			format:   Carbon2FormatFieldSeparate,
-			expected: fmt.Sprintf("metric=cpu:1:tmp:custom field=usage_idle  91.5 %d\n", now.Unix()),
+			format:      Carbon2FormatFieldSeparate,
+			expected:    fmt.Sprintf("metric=cpu:1:tmp:custom field=usage_idle  91.5 %d\n", now.Unix()),
+			replaceChar: DefaultSanitizeReplaceChar,
 		},
 		{
 			metricFunc: func() (telegraf.Metric, error) {
@@ -346,8 +361,9 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
 			},
-			format:   Carbon2FormatFieldSeparate,
-			expected: fmt.Sprintf("metric=cpu:1:tmp:custom:namespace field=usage_idle  91.5 %d\n", now.Unix()),
+			format:      Carbon2FormatFieldSeparate,
+			expected:    fmt.Sprintf("metric=cpu:1:tmp:custom:namespace field=usage_idle  91.5 %d\n", now.Unix()),
+			replaceChar: DefaultSanitizeReplaceChar,
 		},
 		{
 			metricFunc: func() (telegraf.Metric, error) {
@@ -356,8 +372,31 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
 			},
-			format:   Carbon2FormatMetricIncludesField,
-			expected: fmt.Sprintf("metric=cpu:1:tmp:custom:namespace_usage_idle  91.5 %d\n", now.Unix()),
+			format:      Carbon2FormatMetricIncludesField,
+			expected:    fmt.Sprintf("metric=cpu:1:tmp:custom:namespace_usage_idle  91.5 %d\n", now.Unix()),
+			replaceChar: DefaultSanitizeReplaceChar,
+		},
+		{
+			metricFunc: func() (telegraf.Metric, error) {
+				fields := map[string]interface{}{
+					"usage_idle": float64(91.5),
+				}
+				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
+			},
+			format:      Carbon2FormatMetricIncludesField,
+			expected:    fmt.Sprintf("metric=cpu_1_tmp_custom_namespace_usage_idle  91.5 %d\n", now.Unix()),
+			replaceChar: "_",
+		},
+		{
+			metricFunc: func() (telegraf.Metric, error) {
+				fields := map[string]interface{}{
+					"usage_idle": float64(91.5),
+				}
+				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
+			},
+			format:      Carbon2FormatMetricIncludesField,
+			expectedErr: true,
+			replaceChar: "___",
 		},
 	}
 
@@ -366,7 +405,12 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 			m, err := tc.metricFunc()
 			require.NoError(t, err)
 
-			s, err := NewSerializer(string(tc.format))
+			s, err := NewSerializer(string(tc.format), tc.replaceChar)
+			if tc.expectedErr {
+				require.Error(t, err)
+				return
+			}
+
 			require.NoError(t, err)
 
 			buf, err := s.Serialize(m)

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -53,6 +53,9 @@ type Config struct {
 	// Carbon2 metric format.
 	Carbon2Format string `toml:"carbon2_format"`
 
+	// Character used for metric name sanitization in Carbon2.
+	Carbon2SanitizeReplaceChar string `toml:"carbon2_sanitize_replace_char"`
+
 	// Support tags in graphite protocol
 	GraphiteTagSupport bool `toml:"graphite_tag_support"`
 
@@ -123,7 +126,7 @@ func NewSerializer(config *Config) (Serializer, error) {
 	case "nowmetric":
 		serializer, err = NewNowSerializer()
 	case "carbon2":
-		serializer, err = NewCarbon2Serializer(config.Carbon2Format)
+		serializer, err = NewCarbon2Serializer(config.Carbon2Format, config.Carbon2SanitizeReplaceChar)
 	case "wavefront":
 		serializer, err = NewWavefrontSerializer(config.Prefix, config.WavefrontUseStrict, config.WavefrontSourceOverride)
 	case "prometheus":
@@ -186,8 +189,8 @@ func NewJSONSerializer(timestampUnits time.Duration) (Serializer, error) {
 	return json.NewSerializer(timestampUnits)
 }
 
-func NewCarbon2Serializer(carbon2format string) (Serializer, error) {
-	return carbon2.NewSerializer(carbon2format)
+func NewCarbon2Serializer(carbon2format string, carbon2SanitizeReplaceChar string) (Serializer, error) {
+	return carbon2.NewSerializer(carbon2format, carbon2SanitizeReplaceChar)
 }
 
 func NewSplunkmetricSerializer(splunkmetricHecRouting bool, splunkmetricMultimetric bool) (Serializer, error) {


### PR DESCRIPTION
Sanitize metric name: replace problematic characters with `:`.

Fixes: https://github.com/influxdata/telegraf/issues/8974

Future PRs might introduce configuration of this feature, i.e. the character to replace with.

### Required for all PRs:

- [x] Has appropriate unit tests.
