### PR TITLE
Add the math module to the Starlark Processor

### DIFF
--- a/plugins/processors/starlark/README.md
+++ b/plugins/processors/starlark/README.md
@@ -222,6 +222,7 @@ def apply(metric):
 - [drop fields with unexpected type](/plugins/processors/starlark/testdata/drop_fields_with_unexpected_type.star) - Drop fields containing unexpected value types.
 - [iops](/plugins/processors/starlark/testdata/iops.star) - obtain IOPS (to aggregate, to produce max_iops)
 - [json](/plugins/processors/starlark/testdata/json.star) - an example of processing JSON from a field in a metric
+- [math](/plugins/processors/starlark/testdata/math.star) - Use a math function to compute the value of a field. [The list of the supported math functions and constants](https://pkg.go.dev/go.starlark.net/lib/math).
 - [number logic](/plugins/processors/starlark/testdata/number_logic.star) - transform a numerical value to another numerical value
 - [pivot](/plugins/processors/starlark/testdata/pivot.star) - Pivots a key's value to be the key for another key.
 - [ratio](/plugins/processors/starlark/testdata/ratio.star) - Compute the ratio of two integer fields

--- a/plugins/processors/starlark/starlark.go
+++ b/plugins/processors/starlark/starlark.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/processors"
+	"go.starlark.net/lib/math"
 	"go.starlark.net/lib/time"
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
@@ -252,6 +253,10 @@ func loadFunc(module string, logger telegraf.Logger) (starlark.StringDict, error
 	case "logging.star":
 		return starlark.StringDict{
 			"log": LogModule(logger),
+		}, nil
+	case "math.star":
+		return starlark.StringDict{
+			"math": math.Module,
 		}, nil
 	case "time.star":
 		return starlark.StringDict{

--- a/plugins/processors/starlark/testdata/math.star
+++ b/plugins/processors/starlark/testdata/math.star
@@ -1,0 +1,14 @@
+# Example showing how the math module can be used to compute the value of a field.
+#
+# Example Input:
+# math value=10000i 1465839830100400201
+#
+# Example Output:
+# math result=4 1465839830100400201
+
+load('math.star', 'math')
+# loads all the functions and constants defined in the math module
+
+def apply(metric):
+    metric.fields["result"] = math.log(metric.fields.pop('value'), 10)
+    return metric


### PR DESCRIPTION
### Required for all PRs:


- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #8985 

## Motivation

The math module has been added recently to the upstream project `starlark-go`, we would like to make the Starlark processor support it too

## Modifications:

* Adds the math module in the list of external modules to load
* Adds a simple example showing how to use it
* Update the `README.md` to refer the new example

## Result

We can use math functions in the Starlark scripts executed by the Starlark Processor.

