### PR TITLE
Improve processor.ifname startup performance

### DIFF
--- a/plugins/processors/ifname/ifname.go
+++ b/plugins/processors/ifname/ifname.go
@@ -201,13 +201,13 @@ func (d *IfName) Start(acc telegraf.Accumulator) error {
 		return fmt.Errorf("parsing SNMP client config: %w", err)
 	}
 
-	d.ifTable, err = d.makeTable("IF-MIB::ifTable")
+	d.ifTable, err = d.makeTable("IF-MIB::ifDescr")
 	if err != nil {
-		return fmt.Errorf("looking up ifTable in local MIB: %w", err)
+		return fmt.Errorf("looking up ifDescr in local MIB: %w", err)
 	}
-	d.ifXTable, err = d.makeTable("IF-MIB::ifXTable")
+	d.ifXTable, err = d.makeTable("IF-MIB::ifName")
 	if err != nil {
-		return fmt.Errorf("looking up ifXTable in local MIB: %w", err)
+		return fmt.Errorf("looking up ifName in local MIB: %w", err)
 	}
 
 	fn := func(m telegraf.Metric) []telegraf.Metric {
@@ -347,11 +347,13 @@ func init() {
 	})
 }
 
-func makeTableNoMock(tableName string) (*si.Table, error) {
+func makeTableNoMock(fieldName string) (*si.Table, error) {
 	var err error
 	tab := si.Table{
-		Oid:        tableName,
 		IndexAsTag: true,
+		Fields: []si.Field{
+			{Oid: fieldName},
+		},
 	}
 
 	err = tab.Init()


### PR DESCRIPTION
### Required for all PRs:

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

resolves #8801

Changed the `makeTable` function to only have the required field to walk.

Improvement of `time telegraf --test` when having only a single snmp agent was from:
```
real    1m12.939s
user    0m2.196s
sys     0m0.612s
```
To 
```
real    0m1.526s
user    0m0.394s
sys     0m0.130s
```