### PR TITLE
Handle error when initializing the auth object in Azure Monitor output plugin

### DIFF
--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -193,7 +193,7 @@ func (a *AzureMonitor) Connect() error {
 
 	a.auth, err = auth.NewAuthorizerFromEnvironmentWithResource(defaultAuthResource)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	a.Reset()


### PR DESCRIPTION
If this error isn't handled, it seems as though the 'auth' object can end up being nil and ultimately causing a panic. 

(Hopefully) resolves #9044