### PR TITLE
Fix inputs.snmp init when no mibs installed

### DIFF
--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -255,19 +255,22 @@ func (f *Field) init() error {
 		return nil
 	}
 
-	_, oidNum, oidText, conversion, err := SnmpTranslate(f.Oid)
-	if err != nil {
-		return fmt.Errorf("translating: %w", err)
-	}
-	f.Oid = oidNum
-	if f.Name == "" {
-		f.Name = oidText
-	}
-	if f.Conversion == "" {
-		f.Conversion = conversion
-	}
+	// check if oid needs translation or name is not set
+	if strings.ContainsAny(f.Oid, ":abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") || f.Name == "" {
+		_, oidNum, oidText, conversion, err := SnmpTranslate(f.Oid)
+		if err != nil {
+			return fmt.Errorf("translating: %w", err)
+		}
+		f.Oid = oidNum
+		if f.Name == "" {
+			f.Name = oidText
+		}
+		if f.Conversion == "" {
+			f.Conversion = conversion
+		}
 
-	//TODO use textual convention conversion from the MIB
+		//TODO use textual convention conversion from the MIB
+	}
 
 	f.initialized = true
 	return nil


### PR DESCRIPTION
### Required for all PRs:

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

The snmp plugin would log translating errors if the required mibs are not installed, even when a lookup is not actually needed, because the user has the numerical `oid` and `name` already configured.

Now the plugin will not attempt a lookup if these are configured like that.
