### PR TITLE
inputs.ping: Always SetPrivileged(true) in native mode

### DIFF
--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -127,6 +127,10 @@ setting capabilities.
 
 [man 7 capabilities]: http://man7.org/linux/man-pages/man7/capabilities.7.html
 
+#### Other OS Permissions
+
+When using `method = "native"`, you will need permissions similar to the executable ping program for your OS. 
+
 ### Metrics
 
 - ping

--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -102,7 +102,7 @@ $ systemctl edit telegraf
 #### Linux Permissions
 
 When using `method = "native"`, Telegraf will attempt to use privileged raw
-ICMP sockets.  On most systems, doing so requires `CAP_NET_RAW` capabilities.
+ICMP sockets.  On most systems, doing so requires `CAP_NET_RAW` capabilities or for Telegraf to be run as root.
 
 With systemd:
 ```sh
@@ -126,17 +126,6 @@ Reference [`man 7 capabilities`][man 7 capabilities] for more information about
 setting capabilities.
 
 [man 7 capabilities]: http://man7.org/linux/man-pages/man7/capabilities.7.html
-
-On Linux the default behaviour is to restrict creation of ping sockets for everybody. Execute the below command to enable creation of ping sockets for all possible user groups. The integers provided to ping_group_range defines the range of user groups that are permited to create ping sockets, were 2147483647 (the max of a signed int 2^31) is the max group identifier (GID).
-
-```sh
-$ sudo sysctl -w net.ipv4.ping_group_range="0 2147483647"
-```
-
-Reference [`man 7 icmp`][man 7 icmp] for more information about ICMP echo
-sockets and the `ping_group_range` setting.
-
-[man 7 icmp]: http://man7.org/linux/man-pages/man7/icmp.7.html
 
 ### Metrics
 

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -166,10 +166,7 @@ func (p *Ping) nativePing(destination string) (*pingStats, error) {
 		return nil, fmt.Errorf("failed to create new pinger: %w", err)
 	}
 
-	// Required for windows. Despite the method name, this should work without the need to elevate privileges and has been tested on Windows 10
-	if runtime.GOOS == "windows" {
-		pinger.SetPrivileged(true)
-	}
+	pinger.SetPrivileged(true)
 
 	if p.IPv6 {
 		pinger.SetNetwork("ip6")

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -190,7 +190,14 @@ func (p *Ping) nativePing(destination string) (*pingStats, error) {
 	pinger.Count = p.Count
 	err = pinger.Run()
 	if err != nil {
-		return nil, fmt.Errorf("failed to run pinger: %w", err)
+		if strings.Contains(err.Error(), "operation not permitted") {
+			if runtime.GOOS == "linux" {
+				return nil, fmt.Errorf("permission changes required, enable CAP_NET_RAW capabilities (refer to the ping plugin's README.md for more info)")
+			}
+
+			return nil, fmt.Errorf("permission changes required, refer to the ping plugin's README.md for more info")
+		}
+		return nil, fmt.Errorf("%w", err)
 	}
 
 	ps.Statistics = *pinger.Statistics()


### PR DESCRIPTION
resolve #8919

As pointed out by the users in the above issue, the inputs.ping implementation was incomplete. The documentation made it seem you needed to set CAP_NET_RAW and set sysctl, while the CAP_NET_RAW solution wouldn't work without the call to SetPrivileged(true). As well when using FreeBSD you either need root or set CAP_NET_RAW in order to send ICMP packets, therefore requiring SetPrivileged(true). 

When [SetPrivileged(true)](https://github.com/go-ping/ping/blob/42a6788a51373f490c628ee52c81ef54cbe02c6c/ping.go#L313-L323) is not set the library go-ping will attempt to send a [UDP ping](https://nmap.org/book/man-host-discovery.html) which isn't as reliable as a ICMP ping. While a UDP ping doesn't require any permissions it will only work if the endpoint is configured to reply. This change will make using ICMP ping as the default behavior, requiring elevated permissions.

Output examples with the changes in this PR:

Example of what happens when not giving the correct permissions, it outputs an error saying the operation is not permitted:

```
❯ ./telegraf --config ~/Documents/Telegraf/telegraf.conf --test
2021-03-30T14:56:17Z I! Starting Telegraf 
2021-03-30T14:56:17Z E! [inputs.ping] ping failed: failed to run pinger: listen ip4:icmp : socket: operation not permitted
> ping,host=sspaink-influxdata,url=example.org result_code=2i 1617116178000000000
2021-03-30T14:56:17Z E! [telegraf] Error running agent: input plugins recorded 1 errors
```

Working example:

```
❯ sudo ./telegraf --config ~/Documents/Telegraf/telegraf.conf --test
2021-03-30T14:58:49Z I! Starting Telegraf 
> ping,host=sspaink-influxdata,url=example.org average_response_ms=13.390971,maximum_response_ms=13.390971,minimum_response_ms=13.390971,packets_received=1i,packets_transmitted=1i,percent_packet_loss=0,result_code=0i,standard_deviation_ms=0,ttl=56i 1617116330000000000
```
