### PR TITLE
Only run CI for certain file changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,8 @@ executors:
 
 commands:
   check-changed-files-or-halt:
-      parameters:
-        pattern:
-          type: string
       steps:
-        - run: git show -m HEAD --name-only --pretty="" | egrep -q '<< parameters.pattern >>' || circleci step halt
+        - run: git diff master --name-only --no-color | grep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum))|Makefile$" || circleci step halt
   test-go:
     parameters:
       goarch:
@@ -38,6 +35,7 @@ commands:
         default: "amd64"
     steps:
       - checkout
+      - check-changed-files-or-halt
       - attach_workspace:
           at: '/go'
       - run: 'GOARCH=<< parameters.goarch >> make'
@@ -51,6 +49,7 @@ commands:
         default: false
     steps:
       - checkout
+      - check-changed-files-or-halt
       - attach_workspace:
           at: '/go'
       - when:
@@ -76,8 +75,7 @@ jobs:
       - checkout
       - restore_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
-      - check-changed-files-or-halt:
-          pattern: ^(config.yml)|(.go|mod|sum)|(Makefile)$
+      - check-changed-files-or-halt
       - run: 'make deps'
       - run: 'make tidy'
       - save_cache:
@@ -134,8 +132,7 @@ jobs:
         shell: powershell.exe
     steps:
       - checkout
-      - check-changed-files-or-halt:
-          pattern: ^(config.yml)|(.go|mod|sum)|(Makefile)$
+      - check-changed-files-or-halt
       - run: choco upgrade golang --version=1.16.2
       - run: choco install make
       - run: git config --system core.longpaths true
@@ -160,6 +157,7 @@ jobs:
         shell: powershell.exe
     steps:
       - checkout
+      - check-changed-files-or-halt
       - attach_workspace:
           at: '/build'
       - run:
@@ -184,6 +182,7 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - check-changed-files-or-halt
       - attach_workspace:
           at: '.'
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,12 @@ executors:
       GOFLAGS: -p=8
 
 commands:
+  check-changed-files-or-halt:
+      parameters:
+        pattern:
+          type: string
+      steps:
+        - run: git show -m HEAD --name-only --pretty="" | egrep -q '<< parameters.pattern >>' || circleci step halt
   test-go:
     parameters:
       goarch:
@@ -70,6 +76,8 @@ jobs:
       - checkout
       - restore_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
+      - check-changed-files-or-halt:
+          pattern: ^(config.yml)|(.go|mod|sum)|(Makefile)$
       - run: 'make deps'
       - run: 'make tidy'
       - save_cache:
@@ -105,6 +113,8 @@ jobs:
       - checkout
       - restore_cache:
           key: mac-go-mod-v0-{{ checksum "go.sum" }}
+      - check-changed-files-or-halt:
+          pattern: ^(config.yml)|(.go|mod|sum)|(Makefile)$
       - run: 'sh ./scripts/mac_installgo.sh'
       - save_cache:
           name: 'Saving cache'
@@ -124,6 +134,8 @@ jobs:
         shell: powershell.exe
     steps:
       - checkout
+      - check-changed-files-or-halt:
+          pattern: ^(config.yml)|(.go|mod|sum)|(Makefile)$
       - run: choco upgrade golang --version=1.16.2
       - run: choco install make
       - run: git config --system core.longpaths true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,9 @@ executors:
 commands:
   check-changed-files-or-halt:
       steps:
-        - run: git diff master --name-only --no-color | grep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum))|Makefile$" || circleci step halt
+        - run: 
+            command: git diff master --name-only --no-color | grep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum))|Makefile$" || circleci step halt
+            shell: bash.exe
   test-go:
     parameters:
       goarch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ executors:
 commands:
   check-changed-files-or-halt:
       steps:
-        - run: git diff master --name-only --no-color | grep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum))|Makefile$" || circleci step halt
+        - run: git diff master --name-only --no-color | egrep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum))|Makefile$" || circleci step halt
   check-changed-files-or-halt-windows:
       steps:
         - run: 
-            command: git diff master --name-only --no-color | grep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum))|Makefile$" || circleci step halt
+            command: git diff master --name-only --no-color | egrep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum))|Makefile$" || circleci step halt
             shell: bash.exe
   test-go:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ executors:
 commands:
   check-changed-files-or-halt:
       steps:
+        - run: git diff master --name-only --no-color | grep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum))|Makefile$" || circleci step halt
+  check-changed-files-or-halt-windows:
+      steps:
         - run: 
             command: git diff master --name-only --no-color | grep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum))|Makefile$" || circleci step halt
             shell: bash.exe
@@ -133,7 +136,7 @@ jobs:
         shell: powershell.exe
     steps:
       - checkout
-      - check-changed-files-or-halt
+      - check-changed-files-or-halt-windows
       - run: choco upgrade golang --version=1.16.2
       - run: choco install make
       - run: git config --system core.longpaths true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,8 +111,7 @@ jobs:
       - checkout
       - restore_cache:
           key: mac-go-mod-v0-{{ checksum "go.sum" }}
-      - check-changed-files-or-halt:
-          pattern: ^(config.yml)|(.go|mod|sum)|(Makefile)$
+      - check-changed-files-or-halt
       - run: 'sh ./scripts/mac_installgo.sh'
       - save_cache:
           name: 'Saving cache'


### PR DESCRIPTION
Updated circle-ci config to check for certain patterns in the latest commit to see if the jobs should run. Credit to this blog post for the idea: https://dev.to/acro5piano/exit-circleci-jobs-if-changed-files-do-not-match-specific-pattern-mel