### PR TITLE
Remove all log.Fatal() calls from within telegraf plugin code, replace with error handling.

### DIFF
--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -440,13 +440,16 @@ func (o *OpcUA) setupOptions() error {
 
 	if o.Certificate == "" && o.PrivateKey == "" {
 		if o.SecurityPolicy != "None" || o.SecurityMode != "None" {
-			o.Certificate, o.PrivateKey = generateCert("urn:telegraf:gopcua:client", 2048, o.Certificate, o.PrivateKey, (365 * 24 * time.Hour))
+			o.Certificate, o.PrivateKey, err = generateCert("urn:telegraf:gopcua:client", 2048, o.Certificate, o.PrivateKey, (365 * 24 * time.Hour))
+			if err != nil {
+				return err
+			}
 		}
 	}
 
-	o.opts = generateClientOpts(endpoints, o.Certificate, o.PrivateKey, o.SecurityPolicy, o.SecurityMode, o.AuthMethod, o.Username, o.Password, time.Duration(o.RequestTimeout))
+	o.opts, err = generateClientOpts(endpoints, o.Certificate, o.PrivateKey, o.SecurityPolicy, o.SecurityMode, o.AuthMethod, o.Username, o.Password, time.Duration(o.RequestTimeout))
 
-	return nil
+	return err
 }
 
 func (o *OpcUA) getData() error {

--- a/plugins/inputs/opcua/opcua_util.go
+++ b/plugins/inputs/opcua/opcua_util.go
@@ -145,7 +145,7 @@ func pemBlockForKey(priv interface{}) *pem.Block {
 }
 
 // OPT FUNCTIONS
-
+//revive:disable-next-line:argument-limit
 func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, policy, mode, auth, username, password string, requestTimeout time.Duration) ([]opcua.Option, error) {
 	opts := []opcua.Option{}
 	appuri := "urn:telegraf:gopcua:client"

--- a/plugins/inputs/opcua/opcua_util.go
+++ b/plugins/inputs/opcua/opcua_util.go
@@ -145,8 +145,9 @@ func pemBlockForKey(priv interface{}) *pem.Block {
 }
 
 // OPT FUNCTIONS
-//revive:disable-next-line
+//revive:disable
 func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, policy, mode, auth, username, password string, requestTimeout time.Duration) ([]opcua.Option, error) {
+	//revive:enable
 	opts := []opcua.Option{}
 	appuri := "urn:telegraf:gopcua:client"
 	appname := "Telegraf"

--- a/plugins/inputs/opcua/opcua_util.go
+++ b/plugins/inputs/opcua/opcua_util.go
@@ -31,7 +31,7 @@ func newTempDir() (string, error) {
 	return dir, err
 }
 
-func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.Duration) (string, string, error) {
+func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.Duration) (cert string, key string, err error) {
 	dir, _ := newTempDir()
 
 	if len(host) == 0 {
@@ -97,7 +97,6 @@ func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.D
 	}
 	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
 		return "", "", fmt.Errorf("failed to write data to %s: %s", certFile, err)
-
 	}
 	if err := certOut.Close(); err != nil {
 		return "", "", fmt.Errorf("error closing %s: %s", certFile, err)

--- a/plugins/inputs/opcua/opcua_util.go
+++ b/plugins/inputs/opcua/opcua_util.go
@@ -145,7 +145,7 @@ func pemBlockForKey(priv interface{}) *pem.Block {
 }
 
 // OPT FUNCTIONS
-//revive:disable-next-line:argument-limit
+//revive:disable-next-line
 func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, policy, mode, auth, username, password string, requestTimeout time.Duration) ([]opcua.Option, error) {
 	opts := []opcua.Option{}
 	appuri := "urn:telegraf:gopcua:client"

--- a/plugins/inputs/opcua/opcua_util.go
+++ b/plugins/inputs/opcua/opcua_util.go
@@ -31,11 +31,11 @@ func newTempDir() (string, error) {
 	return dir, err
 }
 
-func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.Duration) (string, string) {
+func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.Duration) (string, string, error) {
 	dir, _ := newTempDir()
 
 	if len(host) == 0 {
-		log.Fatalf("Missing required host parameter")
+		return "", "", fmt.Errorf("Missing required host parameter")
 	}
 	if rsaBits == 0 {
 		rsaBits = 2048
@@ -49,7 +49,7 @@ func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.D
 
 	priv, err := rsa.GenerateKey(rand.Reader, rsaBits)
 	if err != nil {
-		log.Fatalf("failed to generate private key: %s", err)
+		return "", "", fmt.Errorf("failed to generate private key: %s", err)
 	}
 
 	notBefore := time.Now()
@@ -58,7 +58,7 @@ func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.D
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		log.Fatalf("failed to generate serial number: %s", err)
+		return "", "", fmt.Errorf("failed to generate serial number: %s", err)
 	}
 
 	template := x509.Certificate{
@@ -88,33 +88,34 @@ func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.D
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
 	if err != nil {
-		log.Fatalf("Failed to create certificate: %s", err)
+		return "", "", fmt.Errorf("Failed to create certificate: %s", err)
 	}
 
 	certOut, err := os.Create(certFile)
 	if err != nil {
-		log.Fatalf("failed to open %s for writing: %s", certFile, err)
+		return "", "", fmt.Errorf("failed to open %s for writing: %s", certFile, err)
 	}
 	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		log.Fatalf("failed to write data to %s: %s", certFile, err)
+		return "", "", fmt.Errorf("failed to write data to %s: %s", certFile, err)
+
 	}
 	if err := certOut.Close(); err != nil {
-		log.Fatalf("error closing %s: %s", certFile, err)
+		return "", "", fmt.Errorf("error closing %s: %s", certFile, err)
 	}
 
 	keyOut, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		log.Printf("failed to open %s for writing: %s", keyFile, err)
-		return "", ""
+		return "", "", nil
 	}
 	if err := pem.Encode(keyOut, pemBlockForKey(priv)); err != nil {
-		log.Fatalf("failed to write data to %s: %s", keyFile, err)
+		return "", "", fmt.Errorf("failed to write data to %s: %s", keyFile, err)
 	}
 	if err := keyOut.Close(); err != nil {
-		log.Fatalf("error closing %s: %s", keyFile, err)
+		return "", "", fmt.Errorf("error closing %s: %s", keyFile, err)
 	}
 
-	return certFile, keyFile
+	return certFile, keyFile, nil
 }
 
 func publicKey(priv interface{}) interface{} {
@@ -146,7 +147,7 @@ func pemBlockForKey(priv interface{}) *pem.Block {
 
 // OPT FUNCTIONS
 
-func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, policy, mode, auth, username, password string, requestTimeout time.Duration) []opcua.Option {
+func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, policy, mode, auth, username, password string, requestTimeout time.Duration) ([]opcua.Option, error) {
 	opts := []opcua.Option{}
 	appuri := "urn:telegraf:gopcua:client"
 	appname := "Telegraf"
@@ -157,9 +158,13 @@ func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, 
 
 	opts = append(opts, opcua.RequestTimeout(requestTimeout))
 
+	var err error
 	if certFile == "" && keyFile == "" {
 		if policy != "None" || mode != "None" {
-			certFile, keyFile = generateCert(appuri, 2048, certFile, keyFile, (365 * 24 * time.Hour))
+			certFile, keyFile, err = generateCert(appuri, 2048, certFile, keyFile, (365 * 24 * time.Hour))
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -172,7 +177,7 @@ func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, 
 		} else {
 			pk, ok := c.PrivateKey.(*rsa.PrivateKey)
 			if !ok {
-				log.Fatalf("Invalid private key")
+				return nil, fmt.Errorf("Invalid private key")
 			}
 			cert = c.Certificate[0]
 			opts = append(opts, opcua.PrivateKey(pk), opcua.Certificate(cert))
@@ -190,11 +195,15 @@ func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, 
 		secPolicy = ua.SecurityPolicyURIPrefix + policy
 		policy = ""
 	default:
-		log.Fatalf("Invalid security policy: %s", policy)
+		return nil, fmt.Errorf("Invalid security policy: %s", policy)
 	}
 
 	// Select the most appropriate authentication mode from server capabilities and user input
-	authMode, authOption := generateAuth(auth, cert, username, password)
+	authMode, authOption, err := generateAuth(auth, cert, username, password)
+	if err != nil {
+		return nil, err
+	}
+
 	opts = append(opts, authOption)
 
 	var secMode ua.MessageSecurityMode
@@ -210,7 +219,7 @@ func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, 
 		secMode = ua.MessageSecurityModeSignAndEncrypt
 		mode = ""
 	default:
-		log.Fatalf("Invalid security mode: %s", mode)
+		return nil, fmt.Errorf("Invalid security mode: %s", mode)
 	}
 
 	// Allow input of only one of sec-mode,sec-policy when choosing 'None'
@@ -252,24 +261,23 @@ func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, 
 	}
 
 	if serverEndpoint == nil { // Didn't find an endpoint with matching policy and mode.
-		log.Printf("unable to find suitable server endpoint with selected sec-policy and sec-mode")
-		log.Fatalf("quitting")
+		return nil, fmt.Errorf("unable to find suitable server endpoint with selected sec-policy and sec-mode")
 	}
 
 	secPolicy = serverEndpoint.SecurityPolicyURI
 	secMode = serverEndpoint.SecurityMode
 
 	// Check that the selected endpoint is a valid combo
-	err := validateEndpointConfig(endpoints, secPolicy, secMode, authMode)
+	err = validateEndpointConfig(endpoints, secPolicy, secMode, authMode)
 	if err != nil {
-		log.Fatalf("error validating input: %s", err)
+		return nil, fmt.Errorf("error validating input: %s", err)
 	}
 
 	opts = append(opts, opcua.SecurityFromEndpoint(serverEndpoint, authMode))
-	return opts
+	return opts, nil
 }
 
-func generateAuth(a string, cert []byte, un, pw string) (ua.UserTokenType, opcua.Option) {
+func generateAuth(a string, cert []byte, un, pw string) (ua.UserTokenType, opcua.Option, error) {
 	var err error
 
 	var authMode ua.UserTokenType
@@ -284,13 +292,13 @@ func generateAuth(a string, cert []byte, un, pw string) (ua.UserTokenType, opcua
 
 		if un == "" {
 			if err != nil {
-				log.Fatalf("error reading username input: %s", err)
+				return 0, nil, fmt.Errorf("error reading username input: %s", err)
 			}
 		}
 
 		if pw == "" {
 			if err != nil {
-				log.Fatalf("error reading username input: %s", err)
+				return 0, nil, fmt.Errorf("error reading password input: %s", err)
 			}
 		}
 
@@ -311,7 +319,7 @@ func generateAuth(a string, cert []byte, un, pw string) (ua.UserTokenType, opcua
 		authOption = opcua.AuthAnonymous()
 	}
 
-	return authMode, authOption
+	return authMode, authOption, nil
 }
 
 func validateEndpointConfig(endpoints []*ua.EndpointDescription, secPolicy string, secMode ua.MessageSecurityMode, authMode ua.UserTokenType) error {

--- a/plugins/inputs/webhooks/github/github_webhooks_models.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_models.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -107,10 +106,7 @@ func (s CommitCommentEvent) NewMetric() telegraf.Metric {
 		"commit":  s.Comment.Commit,
 		"comment": s.Comment.Body,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -137,10 +133,7 @@ func (s CreateEvent) NewMetric() telegraf.Metric {
 		"ref":     s.Ref,
 		"refType": s.RefType,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -167,10 +160,7 @@ func (s DeleteEvent) NewMetric() telegraf.Metric {
 		"ref":     s.Ref,
 		"refType": s.RefType,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -198,10 +188,7 @@ func (s DeploymentEvent) NewMetric() telegraf.Metric {
 		"environment": s.Deployment.Environment,
 		"description": s.Deployment.Description,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -232,10 +219,7 @@ func (s DeploymentStatusEvent) NewMetric() telegraf.Metric {
 		"depState":       s.DeploymentStatus.State,
 		"depDescription": s.DeploymentStatus.Description,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -260,10 +244,7 @@ func (s ForkEvent) NewMetric() telegraf.Metric {
 		"issues": s.Repository.Issues,
 		"fork":   s.Forkee.Repository,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -288,10 +269,7 @@ func (s GollumEvent) NewMetric() telegraf.Metric {
 		"forks":  s.Repository.Forks,
 		"issues": s.Repository.Issues,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -320,10 +298,7 @@ func (s IssueCommentEvent) NewMetric() telegraf.Metric {
 		"comments": s.Issue.Comments,
 		"body":     s.Comment.Body,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -352,10 +327,7 @@ func (s IssuesEvent) NewMetric() telegraf.Metric {
 		"title":    s.Issue.Title,
 		"comments": s.Issue.Comments,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -381,10 +353,7 @@ func (s MemberEvent) NewMetric() telegraf.Metric {
 		"newMember":       s.Member.User,
 		"newMemberStatus": s.Member.Admin,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -407,10 +376,7 @@ func (s MembershipEvent) NewMetric() telegraf.Metric {
 		"newMember":       s.Member.User,
 		"newMemberStatus": s.Member.Admin,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -433,10 +399,7 @@ func (s PageBuildEvent) NewMetric() telegraf.Metric {
 		"forks":  s.Repository.Forks,
 		"issues": s.Repository.Issues,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -459,10 +422,7 @@ func (s PublicEvent) NewMetric() telegraf.Metric {
 		"forks":  s.Repository.Forks,
 		"issues": s.Repository.Issues,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -496,10 +456,7 @@ func (s PullRequestEvent) NewMetric() telegraf.Metric {
 		"deletions":    s.PullRequest.Deletions,
 		"changedFiles": s.PullRequest.ChangedFiles,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -534,10 +491,7 @@ func (s PullRequestReviewCommentEvent) NewMetric() telegraf.Metric {
 		"commentFile":  s.Comment.File,
 		"comment":      s.Comment.Comment,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -566,10 +520,7 @@ func (s PushEvent) NewMetric() telegraf.Metric {
 		"before": s.Before,
 		"after":  s.After,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -594,10 +545,7 @@ func (s ReleaseEvent) NewMetric() telegraf.Metric {
 		"issues":  s.Repository.Issues,
 		"tagName": s.Release.TagName,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -620,10 +568,7 @@ func (s RepositoryEvent) NewMetric() telegraf.Metric {
 		"forks":  s.Repository.Forks,
 		"issues": s.Repository.Issues,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -650,10 +595,7 @@ func (s StatusEvent) NewMetric() telegraf.Metric {
 		"commit": s.Commit,
 		"state":  s.State,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -678,10 +620,7 @@ func (s TeamAddEvent) NewMetric() telegraf.Metric {
 		"issues":   s.Repository.Issues,
 		"teamName": s.Team.Name,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -704,9 +643,6 @@ func (s WatchEvent) NewMetric() telegraf.Metric {
 		"forks":  s.Repository.Forks,
 		"issues": s.Repository.Issues,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }

--- a/plugins/inputs/win_eventlog/util.go
+++ b/plugins/inputs/win_eventlog/util.go
@@ -100,7 +100,6 @@ func UnrollXMLFields(data []byte, fieldsUsage map[string]int, separator string) 
 			break
 		}
 		if err != nil {
-			// log.Fatal(err)
 			break
 		}
 		var parents []string


### PR DESCRIPTION
Plugins are meant to return errors that can be handled by Telegraf rather than terminating the process on their own. I've left log.Fatal usage in other places in the project, but only for tests.