### PR TITLE
Add ability to handle 'binary logs' mySQL query with 3 columns, in case 3 columns are sent (MySQL 8 and greater)

### DIFF
--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -724,7 +724,7 @@ func (m *Mysql) gatherBinaryLogs(db *sql.DB, serv string, acc telegraf.Accumulat
 	}
 	numColumns := len(columns)
 
-	// Iterate over rows and count the size and count of files
+	// iterate over rows and count the size and count of files
 	for rows.Next() {
 		if numColumns == 3 {
 			if err := rows.Scan(&fileName, &fileSize, &encrypted); err != nil {

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -724,7 +724,7 @@ func (m *Mysql) gatherBinaryLogs(db *sql.DB, serv string, acc telegraf.Accumulat
 	}
 	numColumns := len(columns)
 
-	// iterate over rows and count the size and count of files
+	// Iterate over rows and count the size and count of files
 	for rows.Next() {
 		if numColumns == 3 {
 			if err := rows.Scan(&fileName, &fileSize, &encrypted); err != nil {


### PR DESCRIPTION
Add ability to handle 'binary logs' mySQL query with 3 columns, in case 3 columns are sent (MySQL 8 and greater). The third column is called 'encrypted', hence the placeholder variable name.

resolves #9063 