### PR TITLE
Delete log.Fatal calls and replace with error returns.

### DIFF
--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -440,13 +440,16 @@ func (o *OpcUA) setupOptions() error {
 
 	if o.Certificate == "" && o.PrivateKey == "" {
 		if o.SecurityPolicy != "None" || o.SecurityMode != "None" {
-			o.Certificate, o.PrivateKey = generateCert("urn:telegraf:gopcua:client", 2048, o.Certificate, o.PrivateKey, (365 * 24 * time.Hour))
+			o.Certificate, o.PrivateKey, err = generateCert("urn:telegraf:gopcua:client", 2048, o.Certificate, o.PrivateKey, (365 * 24 * time.Hour))
+			if err != nil {
+				return err
+			}
 		}
 	}
 
-	o.opts = generateClientOpts(endpoints, o.Certificate, o.PrivateKey, o.SecurityPolicy, o.SecurityMode, o.AuthMethod, o.Username, o.Password, time.Duration(o.RequestTimeout))
+	o.opts, err = generateClientOpts(endpoints, o.Certificate, o.PrivateKey, o.SecurityPolicy, o.SecurityMode, o.AuthMethod, o.Username, o.Password, time.Duration(o.RequestTimeout))
 
-	return nil
+	return err
 }
 
 func (o *OpcUA) getData() error {

--- a/plugins/inputs/opcua/opcua_util.go
+++ b/plugins/inputs/opcua/opcua_util.go
@@ -290,13 +290,13 @@ func generateAuth(a string, cert []byte, un, pw string) (ua.UserTokenType, opcua
 
 		if un == "" {
 			if err != nil {
-				return 0, nil, fmt.Errorf("error reading username input: %s", err)
+				return 0, nil, fmt.Errorf("error reading the username input: %s", err)
 			}
 		}
 
 		if pw == "" {
 			if err != nil {
-				return 0, nil, fmt.Errorf("error reading password input: %s", err)
+				return 0, nil, fmt.Errorf("error reading the password input: %s", err)
 			}
 		}
 

--- a/plugins/inputs/opcua/opcua_util.go
+++ b/plugins/inputs/opcua/opcua_util.go
@@ -35,7 +35,7 @@ func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.D
 	dir, _ := newTempDir()
 
 	if len(host) == 0 {
-		return "", "", fmt.Errorf("Missing required host parameter")
+		return "", "", fmt.Errorf("missing required host parameter")
 	}
 	if rsaBits == 0 {
 		rsaBits = 2048
@@ -88,7 +88,7 @@ func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.D
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to create certificate: %s", err)
+		return "", "", fmt.Errorf("failed to create certificate: %s", err)
 	}
 
 	certOut, err := os.Create(certFile)
@@ -175,7 +175,7 @@ func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, 
 		} else {
 			pk, ok := c.PrivateKey.(*rsa.PrivateKey)
 			if !ok {
-				return nil, fmt.Errorf("Invalid private key")
+				return nil, fmt.Errorf("invalid private key")
 			}
 			cert = c.Certificate[0]
 			opts = append(opts, opcua.PrivateKey(pk), opcua.Certificate(cert))
@@ -193,7 +193,7 @@ func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, 
 		secPolicy = ua.SecurityPolicyURIPrefix + policy
 		policy = ""
 	default:
-		return nil, fmt.Errorf("Invalid security policy: %s", policy)
+		return nil, fmt.Errorf("invalid security policy: %s", policy)
 	}
 
 	// Select the most appropriate authentication mode from server capabilities and user input
@@ -217,7 +217,7 @@ func generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, 
 		secMode = ua.MessageSecurityModeSignAndEncrypt
 		mode = ""
 	default:
-		return nil, fmt.Errorf("Invalid security mode: %s", mode)
+		return nil, fmt.Errorf("invalid security mode: %s", mode)
 	}
 
 	// Allow input of only one of sec-mode,sec-policy when choosing 'None'

--- a/plugins/inputs/webhooks/github/github_webhooks_models.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_models.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -107,10 +106,7 @@ func (s CommitCommentEvent) NewMetric() telegraf.Metric {
 		"commit":  s.Comment.Commit,
 		"comment": s.Comment.Body,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -137,10 +133,7 @@ func (s CreateEvent) NewMetric() telegraf.Metric {
 		"ref":     s.Ref,
 		"refType": s.RefType,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -167,10 +160,7 @@ func (s DeleteEvent) NewMetric() telegraf.Metric {
 		"ref":     s.Ref,
 		"refType": s.RefType,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -198,10 +188,7 @@ func (s DeploymentEvent) NewMetric() telegraf.Metric {
 		"environment": s.Deployment.Environment,
 		"description": s.Deployment.Description,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -232,10 +219,7 @@ func (s DeploymentStatusEvent) NewMetric() telegraf.Metric {
 		"depState":       s.DeploymentStatus.State,
 		"depDescription": s.DeploymentStatus.Description,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -260,10 +244,7 @@ func (s ForkEvent) NewMetric() telegraf.Metric {
 		"issues": s.Repository.Issues,
 		"fork":   s.Forkee.Repository,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -288,10 +269,7 @@ func (s GollumEvent) NewMetric() telegraf.Metric {
 		"forks":  s.Repository.Forks,
 		"issues": s.Repository.Issues,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -320,10 +298,7 @@ func (s IssueCommentEvent) NewMetric() telegraf.Metric {
 		"comments": s.Issue.Comments,
 		"body":     s.Comment.Body,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -352,10 +327,7 @@ func (s IssuesEvent) NewMetric() telegraf.Metric {
 		"title":    s.Issue.Title,
 		"comments": s.Issue.Comments,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -381,10 +353,7 @@ func (s MemberEvent) NewMetric() telegraf.Metric {
 		"newMember":       s.Member.User,
 		"newMemberStatus": s.Member.Admin,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -407,10 +376,7 @@ func (s MembershipEvent) NewMetric() telegraf.Metric {
 		"newMember":       s.Member.User,
 		"newMemberStatus": s.Member.Admin,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -433,10 +399,7 @@ func (s PageBuildEvent) NewMetric() telegraf.Metric {
 		"forks":  s.Repository.Forks,
 		"issues": s.Repository.Issues,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -459,10 +422,7 @@ func (s PublicEvent) NewMetric() telegraf.Metric {
 		"forks":  s.Repository.Forks,
 		"issues": s.Repository.Issues,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -496,10 +456,7 @@ func (s PullRequestEvent) NewMetric() telegraf.Metric {
 		"deletions":    s.PullRequest.Deletions,
 		"changedFiles": s.PullRequest.ChangedFiles,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -534,10 +491,7 @@ func (s PullRequestReviewCommentEvent) NewMetric() telegraf.Metric {
 		"commentFile":  s.Comment.File,
 		"comment":      s.Comment.Comment,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -566,10 +520,7 @@ func (s PushEvent) NewMetric() telegraf.Metric {
 		"before": s.Before,
 		"after":  s.After,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -594,10 +545,7 @@ func (s ReleaseEvent) NewMetric() telegraf.Metric {
 		"issues":  s.Repository.Issues,
 		"tagName": s.Release.TagName,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -620,10 +568,7 @@ func (s RepositoryEvent) NewMetric() telegraf.Metric {
 		"forks":  s.Repository.Forks,
 		"issues": s.Repository.Issues,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -650,10 +595,7 @@ func (s StatusEvent) NewMetric() telegraf.Metric {
 		"commit": s.Commit,
 		"state":  s.State,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -678,10 +620,7 @@ func (s TeamAddEvent) NewMetric() telegraf.Metric {
 		"issues":   s.Repository.Issues,
 		"teamName": s.Team.Name,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }
 
@@ -704,9 +643,6 @@ func (s WatchEvent) NewMetric() telegraf.Metric {
 		"forks":  s.Repository.Forks,
 		"issues": s.Repository.Issues,
 	}
-	m, err := metric.New(meas, t, f, time.Now())
-	if err != nil {
-		log.Fatalf("Failed to create %v event", event)
-	}
+	m, _ := metric.New(meas, t, f, time.Now())
 	return m
 }

--- a/plugins/inputs/win_eventlog/util.go
+++ b/plugins/inputs/win_eventlog/util.go
@@ -100,7 +100,6 @@ func UnrollXMLFields(data []byte, fieldsUsage map[string]int, separator string) 
 			break
 		}
 		if err != nil {
-			// log.Fatal(err)
 			break
 		}
 		var parents []string


### PR DESCRIPTION
Removing all calls other than in tests. Calls to metric.new have no chance of returning an error, so we can ignore it (it's a mistake that it returns an 'error', and could be refactored soon)