### PR TITLE
Addresses issues in PR 4928

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -415,6 +415,36 @@ func parseTime(format string, timestamp interface{}, location string) (time.Time
 		if err != nil {
 			return time.Unix(0, 0), err
 		}
+		switch strings.ToLower(format) {
+		case "ansic":
+			format = time.ANSIC
+		case "unixdate":
+			format = time.UnixDate
+		case "rubydate":
+			format = time.RubyDate
+		case "rfc822":
+			format = time.RFC822
+		case "rfc822z":
+			format = time.RFC822Z
+		case "rfc850":
+			format = time.RFC850
+		case "rfc1123":
+			format = time.RFC1123
+		case "rfc1123z":
+			format = time.RFC1123Z
+		case "rfc3339":
+			format = time.RFC3339
+		case "rfc3339nano":
+			format = time.RFC3339Nano
+		case "stamp":
+			format = time.Stamp
+		case "stampmilli":
+			format = time.StampMilli
+		case "stampmicro":
+			format = time.StampMicro
+		case "stampnano":
+			format = time.StampNano
+		}
 		return time.ParseInLocation(format, ts, loc)
 	default:
 		return time.Unix(0, 0), errors.New("unsupported type")

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -376,6 +376,54 @@ func TestParseTimestamp(t *testing.T) {
 		return tm
 	}
 
+	unixdate := func(value string) time.Time {
+		tm, err := time.Parse(time.UnixDate, value)
+		require.NoError(t, err)
+		return tm
+	}
+
+	rubydate := func(value string) time.Time {
+		tm, err := time.Parse(time.RubyDate, value)
+		require.NoError(t, err)
+		return tm
+	}
+
+	rfc822 := func(value string) time.Time {
+		tm, err := time.Parse(time.RFC822, value)
+		require.NoError(t, err)
+		return tm
+	}
+
+	rfc822z := func(value string) time.Time {
+		tm, err := time.Parse(time.RFC822Z, value)
+		require.NoError(t, err)
+		return tm
+	}
+
+	rfc850 := func(value string) time.Time {
+		tm, err := time.Parse(time.RFC850, value)
+		require.NoError(t, err)
+		return tm
+	}
+
+	rfc1123 := func(value string) time.Time {
+		tm, err := time.Parse(time.RFC1123, value)
+		require.NoError(t, err)
+		return tm
+	}
+
+	rfc1123z := func(value string) time.Time {
+		tm, err := time.Parse(time.RFC1123Z, value)
+		require.NoError(t, err)
+		return tm
+	}
+
+	rfc3339nano := func(value string) time.Time {
+		tm, err := time.Parse(time.RFC3339Nano, value)
+		require.NoError(t, err)
+		return tm
+	}
+
 	tests := []struct {
 		name      string
 		format    string
@@ -480,8 +528,64 @@ func TestParseTimestamp(t *testing.T) {
 		{
 			name:      "ANSIC",
 			format:    "ANSIC",
-			timestamp: "Mon Jan _2 15:04:05 2006",
-			expected:  ansic("Mon Jan _2 15:04:05 2006"),
+			timestamp: "Mon Jan 2 15:04:05 2006",
+			expected:  ansic("Mon Jan 2 15:04:05 2006"),
+		},
+
+		{
+			name:      "UnixDate",
+			format:    "UnixDate",
+			timestamp: "Mon Jan 2 15:04:05 MST 2006",
+			expected:  unixdate("Mon Jan 2 15:04:05 MST 2006"),
+		},
+
+		{
+			name:      "RubyDate",
+			format:    "RubyDate",
+			timestamp: "Mon Jan 02 15:04:05 -0700 2006",
+			expected:  rubydate("Mon Jan 02 15:04:05 -0700 2006"),
+		},
+
+		{
+			name:      "RFC822",
+			format:    "RFC822",
+			timestamp: "02 Jan 06 15:04 MST",
+			expected:  rfc822("02 Jan 06 15:04 MST"),
+		},
+
+		{
+			name:      "RFC822Z",
+			format:    "RFC822Z",
+			timestamp: "02 Jan 06 15:04 -0700",
+			expected:  rfc822z("02 Jan 06 15:04 -0700"),
+		},
+
+		{
+			name:      "RFC850",
+			format:    "RFC850",
+			timestamp: "Monday, 02-Jan-06 15:04:05 MST",
+			expected:  rfc850("Monday, 02-Jan-06 15:04:05 MST"),
+		},
+
+		{
+			name:      "RFC1123",
+			format:    "RFC1123",
+			timestamp: "Mon, 02 Jan 2006 15:04:05 MST",
+			expected:  rfc1123("Mon, 02 Jan 2006 15:04:05 MST"),
+		},
+
+		{
+			name:      "RFC1123Z",
+			format:    "RFC1123Z",
+			timestamp: "Mon, 02 Jan 2006 15:04:05 -0700",
+			expected:  rfc1123z("Mon, 02 Jan 2006 15:04:05 -0700"),
+		},
+
+		{
+			name:      "RFC3339Nano",
+			format:    "RFC3339Nano",
+			timestamp: "2006-01-02T15:04:05.999999999Z07:00",
+			expected:  rfc3339nano("2006-01-02T15:04:05.999999999Z07:00"),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -367,9 +367,12 @@ func TestAlignTime(t *testing.T) {
 func TestParseTimestamp(t *testing.T) {
 	rfc3339 := func(value string) time.Time {
 		tm, err := time.Parse(time.RFC3339Nano, value)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
+		return tm
+	}
+	ansic := func(value string) time.Time {
+		tm, err := time.Parse(time.ANSIC, value)
+		require.NoError(t, err)
 		return tm
 	}
 
@@ -466,6 +469,19 @@ func TestParseTimestamp(t *testing.T) {
 			format:    "unix_ns",
 			timestamp: "1568338208000000500",
 			expected:  rfc3339("2019-09-13T01:30:08.000000500Z"),
+		},
+		{
+			name:      "rfc339 test",
+			format:    "RFC3339",
+			timestamp: "2018-10-26T13:30:33Z",
+			expected:  rfc3339("2018-10-26T13:30:33Z"),
+		},
+
+		{
+			name:      "ANSIC",
+			format:    "ANSIC",
+			timestamp: "Mon Jan _2 15:04:05 2006",
+			expected:  ansic("Mon Jan _2 15:04:05 2006"),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -424,6 +424,30 @@ func TestParseTimestamp(t *testing.T) {
 		return tm
 	}
 
+	stamp := func(value string) time.Time {
+		tm, err := time.Parse(time.Stamp, value)
+		require.NoError(t, err)
+		return tm
+	}
+
+	stampmilli := func(value string) time.Time {
+		tm, err := time.Parse(time.StampMilli, value)
+		require.NoError(t, err)
+		return tm
+	}
+
+	stampmicro := func(value string) time.Time {
+		tm, err := time.Parse(time.StampMicro, value)
+		require.NoError(t, err)
+		return tm
+	}
+
+	stampnano := func(value string) time.Time {
+		tm, err := time.Parse(time.StampNano, value)
+		require.NoError(t, err)
+		return tm
+	}
+
 	tests := []struct {
 		name      string
 		format    string
@@ -584,8 +608,36 @@ func TestParseTimestamp(t *testing.T) {
 		{
 			name:      "RFC3339Nano",
 			format:    "RFC3339Nano",
-			timestamp: "2006-01-02T15:04:05.999999999Z07:00",
-			expected:  rfc3339nano("2006-01-02T15:04:05.999999999Z07:00"),
+			timestamp: "2006-01-02T15:04:05.999999999-07:00",
+			expected:  rfc3339nano("2006-01-02T15:04:05.999999999-07:00"),
+		},
+
+		{
+			name:      "Stamp",
+			format:    "Stamp",
+			timestamp: "Jan 2 15:04:05",
+			expected:  stamp("Jan 2 15:04:05"),
+		},
+
+		{
+			name:      "StampMilli",
+			format:    "StampMilli",
+			timestamp: "Jan 2 15:04:05.000",
+			expected:  stampmilli("Jan 2 15:04:05.000"),
+		},
+
+		{
+			name:      "StampMicro",
+			format:    "StampMicro",
+			timestamp: "Jan 2 15:04:05.000000",
+			expected:  stampmicro("Jan 2 15:04:05.000000"),
+		},
+
+		{
+			name:      "StampNano",
+			format:    "StampNano",
+			timestamp: "Jan 2 15:04:05.000000000",
+			expected:  stampnano("Jan 2 15:04:05.000000000"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
I've added the code to allow for different formats in json_timestamp_parser. 

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests. (mid-way through this process)


resolves #4928 


