### PR TITLE
Speed up package step by running in parallel.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
     steps:
       - run:
           command: |
-            echo "Tests complete."
+            echo "Go tests complete."
 
   share-artifacts:
     executor: aws-cli/default  
@@ -286,15 +286,13 @@ workflows:
               only: /.*/
       - 'test-awaiter': 
           requires:
-            - 'test-go-windows'
-            - 'test-go-mac'
             - 'test-go-1_15'
             - 'test-go-1_15-386'
             - 'test-go-1_16'
             - 'test-go-1_16-386'
       - 'windows-package':
           requires: 
-            - 'test-awaiter'
+            - 'test-go-windows'
       - 'debian-package':
           requires: 
             - 'test-awaiter'
@@ -303,24 +301,21 @@ workflows:
             - 'test-awaiter'
       - 'mac-package':
           requires: 
-            - 'test-awaiter'
+            - 'test-go-mac'
       - 'freebsd-package':
           requires: 
             - 'test-awaiter'
       - 'linux-package':
           requires: 
             - 'test-awaiter'
-      - 'package-consolidate':
-          requires:
-          - 'windows-package'
-          - 'debian-package'
-          - 'centos-package'
-          - 'mac-package'
-          - 'freebsd-package'
-          - 'linux-package'
       - 'share-artifacts':
           requires:
-            - 'package-consolidate'
+            - 'linux-package'
+            - 'freebsd-package'
+            - 'mac-package'
+            - 'centos-package'
+            - 'debian-package'
+            - 'windows-package'
           filters:
             branches:
               ignore:
@@ -338,6 +333,18 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
+      - 'package-sign-windows':
+          requires:
+            - 'release'
+          filters:
+              tags:
+                only: /.*/
+      - 'package-sign-mac':
+           requires:
+             - 'package-sign-windows' 
+           filters:
+              tags:
+                only: /.*/
 
   nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ commands:
             - run: 'debian=1 centos=1 mac=1 freebsd=1 linux=1 windows=1 NIGHTLY=1 make package'
             - run: 'make upload-nightly'
       - unless:
-          condition: << parameters.nightly >> or << parameters.release >>
+          condition: << parameters.nightly >>
           steps:
             - run: '<< parameters.type >>=1 make package'
       - store_artifacts:
@@ -234,7 +234,6 @@ jobs:
       - run:
           command: |
             echo "Go tests complete."
-
   share-artifacts:
     executor: aws-cli/default  
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,13 @@ jobs:
       - store_artifacts:
           path: './dist'
           destination: 'build/dist'
+  test-awaiter:
+    executor: go-1_16
+    steps:
+      - run:
+          command: |
+            sh ./scripts/mac-signing.sh
+
   share-artifacts:
     executor: aws-cli/default  
     steps:
@@ -241,12 +248,68 @@ workflows:
   version: 2
   check:
     jobs:
-      - 'windows-package'
-      - 'debian-package'
-      - 'centos-package'
-      - 'mac-package'
-      - 'freebsd-package'
-      - 'linux-package'
+      - 'deps':
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-1_15':
+          requires:
+            - 'deps'
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-1_15-386':
+          requires:
+            - 'deps'
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-1_16':
+          requires:
+            - 'deps'
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-1_16-386':
+          requires:
+            - 'deps'
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-mac':
+          filters:
+            tags: # only runs on tags if you specify this filter
+              only: /.*/
+      - 'test-go-windows':
+          filters:
+            tags:
+              only: /.*/
+      - 'test-awaiter': 
+          requires:
+            - 'test-go-windows'
+            - 'test-go-mac'
+            - 'test-go-1_15'
+            - 'test-go-1_15-386'
+            - 'test-go-1_16'
+            - 'test-go-1_16-386'
+      - 'windows-package':
+          requires: 
+            - 'test-awaiter'
+      - 'debian-package':
+          requires: 
+            - 'test-awaiter'
+      - 'centos-package':
+          requires: 
+            - 'test-awaiter'
+      - 'mac-package':
+          requires: 
+            - 'test-awaiter'
+      - 'freebsd-package':
+          requires: 
+            - 'test-awaiter'
+      - 'linux-package':
+          requires: 
+            - 'test-awaiter'
       - 'package-consolidate':
           requires:
           - 'windows-package'
@@ -255,12 +318,27 @@ workflows:
           - 'mac-package'
           - 'freebsd-package'
           - 'linux-package'
-      - 'package-sign-windows':
+      - 'share-artifacts':
           requires:
             - 'package-consolidate'
-      - 'package-sign-mac':
+          filters:
+            branches:
+              ignore:
+                - master
+      - 'release':
           requires:
-            - 'package-consolidate'
+            - 'test-go-windows'
+            - 'test-go-mac'
+            - 'test-go-1_15'
+            - 'test-go-1_15-386'
+            - 'test-go-1_16'
+            - 'test-go-1_16-386'
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+
   nightly:
     jobs:
       - 'deps'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,11 +38,14 @@ commands:
       - run: 'GOARCH=<< parameters.goarch >> make check'
       - run: 'GOARCH=<< parameters.goarch >> make check-deps'
       - run: 'GOARCH=<< parameters.goarch >> make test'
-  windows-package:
+  package:
     parameters:
       nightly:
         type: boolean
         default: false
+      type:
+        type: string
+        default: "linux"
     steps:
       - checkout
       - attach_workspace:
@@ -55,132 +58,7 @@ commands:
       - unless:
           condition: << parameters.nightly >>
           steps:
-            - run: 'windows=1 make package'
-      - store_artifacts:
-          path: './build/dist'
-          destination: 'build/dist'
-      - persist_to_workspace:
-          root: './build'
-          paths:
-            - 'dist'
-  mac-package:
-    parameters:
-      nightly:
-        type: boolean
-        default: false
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '/go'
-      - when:
-          condition: << parameters.nightly >>
-          steps: 
-            - run: 'NIGHTLY=1 make package'
-            - run: 'make upload-nightly'
-      - unless:
-          condition: << parameters.nightly >>
-          steps:
-            - run: 'mac=1 make package'
-      - store_artifacts:
-          path: './build/dist'
-          destination: 'build/dist'
-      - persist_to_workspace:
-          root: './build'
-          paths:
-            - 'dist'
-  debian-package:
-    parameters:
-      nightly:
-        type: boolean
-        default: false
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '/go'
-      - when:
-          condition: << parameters.nightly >>
-          steps: 
-            - run: 'debian=1 make package'
-            - run: 'make upload-nightly'
-      - unless:
-          condition: << parameters.nightly >>
-          steps:
-            - run: 'debian=1 make package'
-      - store_artifacts:
-          path: './build/dist'
-          destination: 'build/dist'
-      - persist_to_workspace:
-          root: './build'
-          paths:
-            - 'dist'
-  centos-package:
-    parameters:
-      nightly:
-        type: boolean
-        default: false
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '/go'
-      - when:
-          condition: << parameters.nightly >>
-          steps: 
-            - run: 'centos=1 make package'
-            - run: 'make upload-nightly'
-      - unless:
-          condition: << parameters.nightly >>
-          steps:
-            - run: 'centos=1 make package'
-      - store_artifacts:
-          path: './build/dist'
-          destination: 'build/dist'
-      - persist_to_workspace:
-          root: './build'
-          paths:
-            - 'dist'
-  freebsd-package:
-    parameters:
-      nightly:
-        type: boolean
-        default: false
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '/go'
-      - when:
-          condition: << parameters.nightly >>
-          steps: 
-            - run: 'freebsd=1 make package'
-            - run: 'make upload-nightly'
-      - unless:
-          condition: << parameters.nightly >>
-          steps:
-            - run: 'freebsd=1 make package'
-      - store_artifacts:
-          path: './build/dist'
-          destination: 'build/dist'
-      - persist_to_workspace:
-          root: './build'
-          paths:
-            - 'dist'
-  linux-package:
-    parameters:
-      nightly:
-        type: boolean
-        default: false
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '/go'
-      - when:
-          condition: << parameters.nightly >>
-          steps: 
-            - run: 'make package'
-            - run: 'make upload-nightly'
-      - unless:
-          condition: << parameters.nightly >>
-          steps:
-            - run: 'linux=1 make package'
+            - run: '<< parameters.type >> make package'
       - store_artifacts:
           path: './build/dist'
           destination: 'build/dist'
@@ -257,36 +135,42 @@ jobs:
   windows-package:
     executor: go-1_16
     steps:
-      - windows-package
+      - package:
+          type: windows
   debian-package:
     executor: go-1_16
     steps:
-      - debian-package
+      - package:
+          type: debian
   centos-package:
     executor: go-1_16
     steps:
-      - centos-package
+      - package:
+          type: centos
   mac-package:
     executor: go-1_16
     steps:
-      - mac-package
+      - package:
+          type: mac
   freebsd-package:
     executor: go-1_16
     steps:
-      - freebsd-package
+      - package:
+          type: freebsd
   linux-package:
     executor: go-1_16
     steps:
-      - linux-package
+      - package:
+          type: linux
 
   release:
     executor: go-1_16
     steps:
-      - windows-package
+      - package
   nightly:
     executor: go-1_16
     steps:
-      - windows-package:
+      - package:
           nightly: true
   package-sign-windows:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
       - run: 'GOARCH=<< parameters.goarch >> make check'
       - run: 'GOARCH=<< parameters.goarch >> make check-deps'
       - run: 'GOARCH=<< parameters.goarch >> make test'
-  package:
+  windows-package:
     parameters:
       nightly:
         type: boolean
@@ -56,6 +56,131 @@ commands:
           condition: << parameters.nightly >>
           steps:
             - run: 'windows=1 make package'
+      - store_artifacts:
+          path: './build/dist'
+          destination: 'build/dist'
+      - persist_to_workspace:
+          root: './build'
+          paths:
+            - 'dist'
+  mac-package:
+    parameters:
+      nightly:
+        type: boolean
+        default: false
+    steps:
+      - checkout
+      - attach_workspace:
+          at: '/go'
+      - when:
+          condition: << parameters.nightly >>
+          steps: 
+            - run: 'NIGHTLY=1 make package'
+            - run: 'make upload-nightly'
+      - unless:
+          condition: << parameters.nightly >>
+          steps:
+            - run: 'mac=1 make package'
+      - store_artifacts:
+          path: './build/dist'
+          destination: 'build/dist'
+      - persist_to_workspace:
+          root: './build'
+          paths:
+            - 'dist'
+  debian-package:
+    parameters:
+      nightly:
+        type: boolean
+        default: false
+    steps:
+      - checkout
+      - attach_workspace:
+          at: '/go'
+      - when:
+          condition: << parameters.nightly >>
+          steps: 
+            - run: 'debian=1 make package'
+            - run: 'make upload-nightly'
+      - unless:
+          condition: << parameters.nightly >>
+          steps:
+            - run: 'debian=1 make package'
+      - store_artifacts:
+          path: './build/dist'
+          destination: 'build/dist'
+      - persist_to_workspace:
+          root: './build'
+          paths:
+            - 'dist'
+  centos-package:
+    parameters:
+      nightly:
+        type: boolean
+        default: false
+    steps:
+      - checkout
+      - attach_workspace:
+          at: '/go'
+      - when:
+          condition: << parameters.nightly >>
+          steps: 
+            - run: 'centos=1 make package'
+            - run: 'make upload-nightly'
+      - unless:
+          condition: << parameters.nightly >>
+          steps:
+            - run: 'centos=1 make package'
+      - store_artifacts:
+          path: './build/dist'
+          destination: 'build/dist'
+      - persist_to_workspace:
+          root: './build'
+          paths:
+            - 'dist'
+  freebsd-package:
+    parameters:
+      nightly:
+        type: boolean
+        default: false
+    steps:
+      - checkout
+      - attach_workspace:
+          at: '/go'
+      - when:
+          condition: << parameters.nightly >>
+          steps: 
+            - run: 'freebsd=1 make package'
+            - run: 'make upload-nightly'
+      - unless:
+          condition: << parameters.nightly >>
+          steps:
+            - run: 'freebsd=1 make package'
+      - store_artifacts:
+          path: './build/dist'
+          destination: 'build/dist'
+      - persist_to_workspace:
+          root: './build'
+          paths:
+            - 'dist'
+  linux-package:
+    parameters:
+      nightly:
+        type: boolean
+        default: false
+    steps:
+      - checkout
+      - attach_workspace:
+          at: '/go'
+      - when:
+          condition: << parameters.nightly >>
+          steps: 
+            - run: 'make package'
+            - run: 'make upload-nightly'
+      - unless:
+          condition: << parameters.nightly >>
+          steps:
+            - run: 'linux=1 make package'
       - store_artifacts:
           path: './build/dist'
           destination: 'build/dist'
@@ -129,18 +254,39 @@ jobs:
       - run: git config --system core.longpaths true
       - run: make test-windows
 
-  package:
+  windows-package:
     executor: go-1_16
     steps:
-      - package
+      - windows-package
+  debian-package:
+    executor: go-1_16
+    steps:
+      - debian-package
+  centos-package:
+    executor: go-1_16
+    steps:
+      - centos-package
+  mac-package:
+    executor: go-1_16
+    steps:
+      - mac-package
+  freebsd-package:
+    executor: go-1_16
+    steps:
+      - freebsd-package
+  linux-package:
+    executor: go-1_16
+    steps:
+      - linux-package
+
   release:
     executor: go-1_16
     steps:
-      - package
+      - windows-package
   nightly:
     executor: go-1_16
     steps:
-      - package:
+      - windows-package:
           nightly: true
   package-sign-windows:
     executor:
@@ -193,82 +339,12 @@ workflows:
   version: 2
   check:
     jobs:
-      - 'deps':
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-1_15':
-          requires:
-            - 'deps'
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-1_15-386':
-          requires:
-            - 'deps'
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-1_16':
-          requires:
-            - 'deps'
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-1_16-386':
-          requires:
-            - 'deps'
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-mac':
-          filters:
-            tags: # only runs on tags if you specify this filter
-              only: /.*/
-      - 'test-go-windows':
-          filters:
-            tags:
-              only: /.*/
-      - 'package':
-          requires:
-            - 'test-go-windows'
-            - 'test-go-mac'
-            - 'test-go-1_15'
-            - 'test-go-1_15-386'
-            - 'test-go-1_16'
-            - 'test-go-1_16-386'
-      - 'share-artifacts':
-          requires:
-            - 'package'
-          filters:
-            branches:
-              ignore:
-                - master
-      - 'release':
-          requires:
-            - 'test-go-windows'
-            - 'test-go-mac'
-            - 'test-go-1_15'
-            - 'test-go-1_15-386'
-            - 'test-go-1_16'
-            - 'test-go-1_16-386'
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
-      - 'package-sign-windows':
-          requires:
-            - 'release'
-          filters:
-              tags:
-                only: /.*/
-      - 'package-sign-mac':
-           requires:
-             - 'package-sign-windows' 
-           filters:
-              tags:
-                only: /.*/
+      - 'windows-package'
+      - 'debian-package'
+      - 'centos-package'
+      - 'mac-package'
+      - 'freebsd-package'
+      - 'linux-package'
   nightly:
     jobs:
       - 'deps'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
     steps:
       - run:
           command: |
-            sh ./scripts/mac-signing.sh
+            echo "Tests complete."
 
   share-artifacts:
     executor: aws-cli/default  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,42 +284,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - 'test-awaiter': 
-          requires:
-            - 'test-go-1_15'
-            - 'test-go-1_15-386'
-            - 'test-go-1_16'
-            - 'test-go-1_16-386'
-      - 'windows-package':
-          requires: 
-            - 'test-go-windows'
-      - 'debian-package':
-          requires: 
-            - 'test-awaiter'
-      - 'centos-package':
-          requires: 
-            - 'test-awaiter'
-      - 'mac-package':
-          requires: 
-            - 'test-go-mac'
-      - 'freebsd-package':
-          requires: 
-            - 'test-awaiter'
-      - 'linux-package':
-          requires: 
-            - 'test-awaiter'
-      - 'share-artifacts':
-          requires:
-            - 'linux-package'
-            - 'freebsd-package'
-            - 'mac-package'
-            - 'centos-package'
-            - 'debian-package'
-            - 'windows-package'
-          filters:
-            branches:
-              ignore:
-                - master
       - 'release':
           requires:
             - 'test-go-windows'
@@ -328,11 +292,6 @@ workflows:
             - 'test-go-1_15-386'
             - 'test-go-1_16'
             - 'test-go-1_16-386'
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
       - 'package-sign-windows':
           requires:
             - 'release'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,42 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - 'test-awaiter': 
+          requires:
+            - 'test-go-1_15'
+            - 'test-go-1_15-386'
+            - 'test-go-1_16'
+            - 'test-go-1_16-386'
+      - 'windows-package':
+          requires: 
+            - 'test-go-windows'
+      - 'debian-package':
+          requires: 
+            - 'test-awaiter'
+      - 'centos-package':
+          requires: 
+            - 'test-awaiter'
+      - 'mac-package':
+          requires: 
+            - 'test-go-mac'
+      - 'freebsd-package':
+          requires: 
+            - 'test-awaiter'
+      - 'linux-package':
+          requires: 
+            - 'test-awaiter'
+      - 'share-artifacts':
+          requires:
+            - 'linux-package'
+            - 'freebsd-package'
+            - 'mac-package'
+            - 'centos-package'
+            - 'debian-package'
+            - 'windows-package'
+          filters:
+            branches:
+              ignore:
+                - master
       - 'release':
           requires:
             - 'test-go-windows'
@@ -292,6 +328,11 @@ workflows:
             - 'test-go-1_15-386'
             - 'test-go-1_16'
             - 'test-go-1_16-386'
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
       - 'package-sign-windows':
           requires:
             - 'release'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
       - unless:
           condition: << parameters.nightly >>
           steps:
-            - run: 'make package'
+            - run: 'windows=1 make package'
       - store_artifacts:
           path: './build/dist'
           destination: 'build/dist'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ commands:
             - run: 'debian=1 centos=1 mac=1 freebsd=1 linux=1 windows=1 NIGHTLY=1 make package'
             - run: 'make upload-nightly'
       - unless:
-          condition: << parameters.nightly >>
+          condition: << parameters.nightly >> or << parameters.release >>
           steps:
             - run: '<< parameters.type >>=1 make package'
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ commands:
       - unless:
           condition: << parameters.nightly >>
           steps:
-            - run: '<< parameters.type >> make package'
+            - run: '<< parameters.type >>=1 make package'
       - store_artifacts:
           path: './build/dist'
           destination: 'build/dist'
@@ -172,6 +172,16 @@ jobs:
     steps:
       - package:
           nightly: true
+  package:
+    executor:
+        name: win/default
+        shell: powershell.exe
+    steps:
+      - attach_workspace:
+          at: '/build'
+      - store_artifacts:
+          path: './build/dist'
+          destination: 'build/dist'
   package-sign-windows:
     executor:
         name: win/default
@@ -229,6 +239,14 @@ workflows:
       - 'mac-package'
       - 'freebsd-package'
       - 'linux-package'
+      - 'package':
+          requires:
+          - 'windows-package'
+          - 'debian-package'
+          - 'centos-package'
+          - 'mac-package'
+          - 'freebsd-package'
+          - 'linux-package'
   nightly:
     jobs:
       - 'deps'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,22 +38,29 @@ commands:
       - run: 'GOARCH=<< parameters.goarch >> make check'
       - run: 'GOARCH=<< parameters.goarch >> make check-deps'
       - run: 'GOARCH=<< parameters.goarch >> make test'
-  package:
+  package-build:
     parameters:
+      release:
+        type: boolean
+        default: false
       nightly:
         type: boolean
         default: false
       type:
         type: string
-        default: "linux"
+        default: ""
     steps:
       - checkout
       - attach_workspace:
           at: '/go'
       - when:
+          condition: << parameters.release >>
+          steps: 
+            - run: 'debian=1 centos=1 mac=1 freebsd=1 linux=1 windows=1 make package'
+      - when:
           condition: << parameters.nightly >>
           steps: 
-            - run: 'NIGHTLY=1 make package'
+            - run: 'debian=1 centos=1 mac=1 freebsd=1 linux=1 windows=1 NIGHTLY=1 make package'
             - run: 'make upload-nightly'
       - unless:
           condition: << parameters.nightly >>
@@ -135,44 +142,45 @@ jobs:
   windows-package:
     executor: go-1_16
     steps:
-      - package:
+      - package-build:
           type: windows
   debian-package:
     executor: go-1_16
     steps:
-      - package:
+      - package-build:
           type: debian
   centos-package:
     executor: go-1_16
     steps:
-      - package:
+      - package-build:
           type: centos
   mac-package:
     executor: go-1_16
     steps:
-      - package:
+      - package-build:
           type: mac
   freebsd-package:
     executor: go-1_16
     steps:
-      - package:
+      - package-build:
           type: freebsd
   linux-package:
     executor: go-1_16
     steps:
-      - package:
+      - package-build:
           type: linux
 
   release:
     executor: go-1_16
     steps:
-      - package
+      - package-build:
+          release: true
   nightly:
     executor: go-1_16
     steps:
-      - package:
+      - package-build:
           nightly: true
-  package:
+  package-consolidate:
     executor:
         name: win/default
         shell: powershell.exe
@@ -239,7 +247,7 @@ workflows:
       - 'mac-package'
       - 'freebsd-package'
       - 'linux-package'
-      - 'package':
+      - 'package-consolidate':
           requires:
           - 'windows-package'
           - 'debian-package'
@@ -247,6 +255,12 @@ workflows:
           - 'mac-package'
           - 'freebsd-package'
           - 'linux-package'
+      - 'package-sign-windows':
+          requires:
+            - 'package-consolidate'
+      - 'package-sign-mac':
+          requires:
+            - 'package-consolidate'
   nightly:
     jobs:
       - 'deps'

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ $(buildbin):
 	@mkdir -pv $(dir $@)
 	go build -o $(dir $@) -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
-ifeq ($(call ifdef_any_of,debian all),)
+ifdef debian
 debs := telegraf_$(deb_version)_amd64.deb
 debs += telegraf_$(deb_version)_arm64.deb
 debs += telegraf_$(deb_version)_armel.deb
@@ -240,7 +240,7 @@ debs += telegraf_$(deb_version)_s390x.deb
 debs += telegraf_$(deb_version)_ppc64el.deb
 endif
 
-ifeq ($(call ifdef_any_of,centos all),)
+ifdef centos
 rpms += telegraf-$(rpm_version).aarch64.rpm
 rpms += telegraf-$(rpm_version).armel.rpm
 rpms += telegraf-$(rpm_version).armv6hl.rpm
@@ -250,16 +250,16 @@ rpms += telegraf-$(rpm_version).ppc64le.rpm
 rpms += telegraf-$(rpm_version).x86_64.rpm
 endif
 
-ifeq ($(call ifdef_any_of,mac all),)
+ifdef mac
 tars += telegraf-$(tar_version)_darwin_amd64.tar.gz
 endif
 
-ifeq ($(call ifdef_any_of,freebsd all),)
+ifdef freebsd
 tars += telegraf-$(tar_version)_freebsd_amd64.tar.gz
 tars += telegraf-$(tar_version)_freebsd_i386.tar.gz
 endif
 
-ifeq ($(call ifdef_any_of,linux all),)
+ifdef linux
 tars += telegraf-$(tar_version)_linux_amd64.tar.gz
 tars += telegraf-$(tar_version)_linux_arm64.tar.gz
 tars += telegraf-$(tar_version)_linux_armel.tar.gz
@@ -272,7 +272,7 @@ tars += telegraf-$(tar_version)_linux_ppc64le.tar.gz
 tars += telegraf-$(tar_version)_static_linux_amd64.tar.gz
 endif
 
-ifeq ($(call ifdef_any_of,windows all),)
+ifdef windows
 zips += telegraf-$(tar_version)_windows_amd64.zip
 zips += telegraf-$(tar_version)_windows_i386.zip
 endif

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ $(buildbin):
 	@mkdir -pv $(dir $@)
 	go build -o $(dir $@) -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
-ifdef debian
+ifdef debian || all
 debs := telegraf_$(deb_version)_amd64.deb
 debs += telegraf_$(deb_version)_arm64.deb
 debs += telegraf_$(deb_version)_armel.deb
@@ -240,7 +240,7 @@ debs += telegraf_$(deb_version)_s390x.deb
 debs += telegraf_$(deb_version)_ppc64el.deb
 endif
 
-ifdef centos
+ifdef centos || all
 rpms += telegraf-$(rpm_version).aarch64.rpm
 rpms += telegraf-$(rpm_version).armel.rpm
 rpms += telegraf-$(rpm_version).armv6hl.rpm
@@ -250,16 +250,16 @@ rpms += telegraf-$(rpm_version).ppc64le.rpm
 rpms += telegraf-$(rpm_version).x86_64.rpm
 endif
 
-ifdef mac
+ifdef mac || all
 tars += telegraf-$(tar_version)_darwin_amd64.tar.gz
 endif
 
-ifdef freebsd
+ifdef freebsd || all
 tars += telegraf-$(tar_version)_freebsd_amd64.tar.gz
 tars += telegraf-$(tar_version)_freebsd_i386.tar.gz
 endif
 
-ifdef linux
+ifdef linux || all
 tars += telegraf-$(tar_version)_linux_amd64.tar.gz
 tars += telegraf-$(tar_version)_linux_arm64.tar.gz
 tars += telegraf-$(tar_version)_linux_armel.tar.gz
@@ -272,7 +272,7 @@ tars += telegraf-$(tar_version)_linux_ppc64le.tar.gz
 tars += telegraf-$(tar_version)_static_linux_amd64.tar.gz
 endif
 
-ifdef windows
+ifdef windows || all
 zips += telegraf-$(tar_version)_windows_amd64.zip
 zips += telegraf-$(tar_version)_windows_i386.zip
 endif

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ $(buildbin):
 	@mkdir -pv $(dir $@)
 	go build -o $(dir $@) -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
-ifdef debian || all
+ifneq ($(call ifdef_any_of,debian all),)
 debs := telegraf_$(deb_version)_amd64.deb
 debs += telegraf_$(deb_version)_arm64.deb
 debs += telegraf_$(deb_version)_armel.deb
@@ -240,7 +240,7 @@ debs += telegraf_$(deb_version)_s390x.deb
 debs += telegraf_$(deb_version)_ppc64el.deb
 endif
 
-ifdef centos || all
+ifneq ($(call ifdef_any_of,centos all),)
 rpms += telegraf-$(rpm_version).aarch64.rpm
 rpms += telegraf-$(rpm_version).armel.rpm
 rpms += telegraf-$(rpm_version).armv6hl.rpm
@@ -250,16 +250,16 @@ rpms += telegraf-$(rpm_version).ppc64le.rpm
 rpms += telegraf-$(rpm_version).x86_64.rpm
 endif
 
-ifdef mac || all
+ifneq ($(call ifdef_any_of,mac all),)
 tars += telegraf-$(tar_version)_darwin_amd64.tar.gz
 endif
 
-ifdef freebsd || all
+ifneq ($(call ifdef_any_of,freebsd all),)
 tars += telegraf-$(tar_version)_freebsd_amd64.tar.gz
 tars += telegraf-$(tar_version)_freebsd_i386.tar.gz
 endif
 
-ifdef linux || all
+ifneq ($(call ifdef_any_of,linux all),)
 tars += telegraf-$(tar_version)_linux_amd64.tar.gz
 tars += telegraf-$(tar_version)_linux_arm64.tar.gz
 tars += telegraf-$(tar_version)_linux_armel.tar.gz
@@ -272,7 +272,7 @@ tars += telegraf-$(tar_version)_linux_ppc64le.tar.gz
 tars += telegraf-$(tar_version)_static_linux_amd64.tar.gz
 endif
 
-ifdef windows || all
+ifneq ($(call ifdef_any_of,windows all),)
 zips += telegraf-$(tar_version)_windows_amd64.zip
 zips += telegraf-$(tar_version)_windows_i386.zip
 endif

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ $(buildbin):
 	@mkdir -pv $(dir $@)
 	go build -o $(dir $@) -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
-ifneq ($(call ifdef_any_of,debian all),)
+ifeq ($(call ifdef_any_of,debian all),)
 debs := telegraf_$(deb_version)_amd64.deb
 debs += telegraf_$(deb_version)_arm64.deb
 debs += telegraf_$(deb_version)_armel.deb
@@ -240,7 +240,7 @@ debs += telegraf_$(deb_version)_s390x.deb
 debs += telegraf_$(deb_version)_ppc64el.deb
 endif
 
-ifneq ($(call ifdef_any_of,centos all),)
+ifeq ($(call ifdef_any_of,centos all),)
 rpms += telegraf-$(rpm_version).aarch64.rpm
 rpms += telegraf-$(rpm_version).armel.rpm
 rpms += telegraf-$(rpm_version).armv6hl.rpm
@@ -250,16 +250,16 @@ rpms += telegraf-$(rpm_version).ppc64le.rpm
 rpms += telegraf-$(rpm_version).x86_64.rpm
 endif
 
-ifneq ($(call ifdef_any_of,mac all),)
+ifeq ($(call ifdef_any_of,mac all),)
 tars += telegraf-$(tar_version)_darwin_amd64.tar.gz
 endif
 
-ifneq ($(call ifdef_any_of,freebsd all),)
+ifeq ($(call ifdef_any_of,freebsd all),)
 tars += telegraf-$(tar_version)_freebsd_amd64.tar.gz
 tars += telegraf-$(tar_version)_freebsd_i386.tar.gz
 endif
 
-ifneq ($(call ifdef_any_of,linux all),)
+ifeq ($(call ifdef_any_of,linux all),)
 tars += telegraf-$(tar_version)_linux_amd64.tar.gz
 tars += telegraf-$(tar_version)_linux_arm64.tar.gz
 tars += telegraf-$(tar_version)_linux_armel.tar.gz
@@ -272,7 +272,7 @@ tars += telegraf-$(tar_version)_linux_ppc64le.tar.gz
 tars += telegraf-$(tar_version)_static_linux_amd64.tar.gz
 endif
 
-ifneq ($(call ifdef_any_of,windows all),)
+ifeq ($(call ifdef_any_of,windows all),)
 zips += telegraf-$(tar_version)_windows_amd64.zip
 zips += telegraf-$(tar_version)_windows_i386.zip
 endif

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ tars += telegraf-$(tar_version)_static_linux_amd64.tar.gz
 zips += telegraf-$(tar_version)_windows_amd64.zip
 zips += telegraf-$(tar_version)_windows_i386.zip
 
-dists := $(debs) $(rpms) $(tars) $(zips)
+dists := $(zips)
 
 .PHONY: package
 package: $(dists)

--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ $(buildbin):
 	@mkdir -pv $(dir $@)
 	go build -o $(dir $@) -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
+ifdef debian
 debs := telegraf_$(deb_version)_amd64.deb
 debs += telegraf_$(deb_version)_arm64.deb
 debs += telegraf_$(deb_version)_armel.deb
@@ -237,7 +238,9 @@ debs += telegraf_$(deb_version)_mips.deb
 debs += telegraf_$(deb_version)_mipsel.deb
 debs += telegraf_$(deb_version)_s390x.deb
 debs += telegraf_$(deb_version)_ppc64el.deb
+endif
 
+ifdef centos
 rpms += telegraf-$(rpm_version).aarch64.rpm
 rpms += telegraf-$(rpm_version).armel.rpm
 rpms += telegraf-$(rpm_version).armv6hl.rpm
@@ -245,10 +248,18 @@ rpms += telegraf-$(rpm_version).i386.rpm
 rpms += telegraf-$(rpm_version).s390x.rpm
 rpms += telegraf-$(rpm_version).ppc64le.rpm
 rpms += telegraf-$(rpm_version).x86_64.rpm
+endif
 
+ifdef mac
 tars += telegraf-$(tar_version)_darwin_amd64.tar.gz
+endif
+
+ifdef freebsd
 tars += telegraf-$(tar_version)_freebsd_amd64.tar.gz
 tars += telegraf-$(tar_version)_freebsd_i386.tar.gz
+endif
+
+ifdef linux
 tars += telegraf-$(tar_version)_linux_amd64.tar.gz
 tars += telegraf-$(tar_version)_linux_arm64.tar.gz
 tars += telegraf-$(tar_version)_linux_armel.tar.gz
@@ -259,11 +270,14 @@ tars += telegraf-$(tar_version)_linux_mipsel.tar.gz
 tars += telegraf-$(tar_version)_linux_s390x.tar.gz
 tars += telegraf-$(tar_version)_linux_ppc64le.tar.gz
 tars += telegraf-$(tar_version)_static_linux_amd64.tar.gz
+endif
 
+ifdef windows
 zips += telegraf-$(tar_version)_windows_amd64.zip
 zips += telegraf-$(tar_version)_windows_i386.zip
+endif
 
-dists := $(zips)
+dists := $(debs) $(rpms) $(tars) $(zips)
 
 .PHONY: package
 package: $(dists)


### PR DESCRIPTION
resolves #9098

Before this change, a full check suite on a PR took about 30-33 minutes. After this change, I've seen consistent results around 19 minutes. Note that the `make package` command will no longer work for generating all packages, each OS type has to be specified in an argument (such as `windows=1 make package`). This will also require an update to telegraf tiger which will be a separate PR.