### PR TITLE
add XML examples

### DIFF
--- a/plugins/parsers/xml/testcases/cdc-vaccines.conf
+++ b/plugins/parsers/xml/testcases/cdc-vaccines.conf
@@ -1,0 +1,50 @@
+# Example for parsing COVID-19 Vaccine Distribution Allocations by Jurisdiction from CDC
+# 
+#
+# Expected Output:
+# cdc-vaccines,state=Connecticut,url=https://data.cdc.gov/api/views/saz5-9hgg/rows.xml,vaccine_type=Pfizer 1st_dose_allocations=60840i,2nd_dose_allocations=60840i 1617580800000000000
+# cdc-vaccines,state=Maine,url=https://data.cdc.gov/api/views/saz5-9hgg/rows.xml,vaccine_type=Pfizer 1st_dose_allocations=23400i,2nd_dose_allocations=23400i 1617580800000000000
+# cdc-vaccines,state=Massachusetts,url=https://data.cdc.gov/api/views/saz5-9hgg/rows.xml,vaccine_type=Pfizer 1st_dose_allocations=117000i,2nd_dose_allocations=117000i 1617580800000000000
+# cdc-vaccines,state=New\ York,url=https://data.cdc.gov/api/views/saz5-9hgg/rows.xml,vaccine_type=Pfizer 1st_dose_allocations=188370i,2nd_dose_allocations=188370i 1617580800000000000
+# cdc-vaccines,state=New\ York\ City,url=https://data.cdc.gov/api/views/saz5-9hgg/rows.xml,vaccine_type=Pfizer 1st_dose_allocations=143910i,2nd_dose_allocations=143910i 1617580800000000000
+
+
+[[inputs.http]]
+  ##  CDC data URLs from which to read XML metrics
+  urls = [
+    "https://data.cdc.gov/api/views/b7pe-5nws/rows.xml", # Moderna
+    "https://data.cdc.gov/api/views/saz5-9hgg/rows.xml", # Pfizer
+    "https://data.cdc.gov/api/views/w9zu-fywh/rows.xml" # Janssen/Johnson&Johnson
+    ]
+  data_format = "xml"
+  ## Drop hostname from list of tags
+  tagexclude = ["host"]
+
+    [[inputs.http.xml]]
+        metric_selection = "//row"
+        metric_name = "'cdc-vaccines'"
+        timestamp = "week_of_allocations"
+        timestamp_format = "2006-01-02T15:04:05"
+
+        [inputs.http.xml.tags]
+            state   = "jurisdiction"
+
+        [inputs.http.xml.fields_int]
+            1st_dose_allocations = "_1st_dose_allocations"
+            2nd_dose_allocations = "_2nd_dose_allocations"
+
+
+[[processors.enum]]
+  [[processors.enum.mapping]]
+    ## Name of the tag to map. Globs accepted.
+    tag = "url"
+
+    ## Destination tag or field to be used for the mapped value.  By default the
+    ## source tag or field is used, overwriting the original value.
+    dest = "vaccine_type"
+
+    ## Table of mappings
+    [processors.enum.mapping.value_mappings]
+      "https://data.cdc.gov/api/views/b7pe-5nws/rows.xml" = "Moderna"
+      "https://data.cdc.gov/api/views/saz5-9hgg/rows.xml" = "Pfizer"
+      "https://data.cdc.gov/api/views/w9zu-fywh/rows.xml" = "Janssen"

--- a/plugins/parsers/xml/testcases/cyclehire-london.conf
+++ b/plugins/parsers/xml/testcases/cyclehire-london.conf
@@ -11,11 +11,11 @@
 
 
 
-[[inputs.file]]
+[[inputs.tail]]
   files = ["testcases/cyclehire-london.xml"]
   data_format = "xml"
 
-  [[inputs.file.xml]]
+  [[inputs.tail.xml]]
     metric_selection = "response/child::location"
     metric_name = "string('bikes')"
 
@@ -26,9 +26,9 @@
     field_name = "name(@*[1])"
     field_value = "number(@*[1])"
 
-    [inputs.file.xml.tags]
+    [inputs.tail.xml.tags]
       address = "@name"
       id = "@id"
 
-    [inputs.file.xml.fields]
+    [inputs.tail.xml.fields]
       placement = "string(temporary)"

--- a/plugins/parsers/xml/testcases/cyclehire-london.conf
+++ b/plugins/parsers/xml/testcases/cyclehire-london.conf
@@ -1,0 +1,34 @@
+# Example for parsing London bicycle for hire station data using the XML parser.
+#
+# File:
+#   testcases/cyclehire-london.xml
+#
+# Expected Output:
+# bikes,address=River\ Street\ \,\ Clerkenwell,host=MBP15-SWANG.local,id=1 installDate=1278947280000,lat=51.52916347,long=-0.109970527,nbBikes=10,nbDocks=19,nbEmptyDocks=9,placement="false",terminalName=1023 1617397861000000000
+# bikes,address=Phillimore\ Gardens\,\ Kensington,host=MBP15-SWANG.local,id=2 installDate=1278585780000,lat=51.49960695,long=-0.197574246,nbBikes=28,nbDocks=37,nbEmptyDocks=9,placement="false",terminalName=1018 1617397861000000000
+# bikes,address=Christopher\ Street\,\ Liverpool\ Street,host=MBP15-SWANG.local,id=3 installDate=1278240360000,lat=51.52128377,long=-0.084605692,nbBikes=2,nbDocks=32,nbEmptyDocks=30,placement="false",terminalName=1012 1617397861000000000
+#
+
+
+
+[[inputs.file]]
+  files = ["testcases/cyclehire-london.xml"]
+  data_format = "xml"
+
+  [[inputs.file.xml]]
+    metric_selection = "response/child::location"
+    metric_name = "string('bikes')"
+
+    timestamp = "/stations/@lastUpdate"
+    timestamp_format = "unix_ms"
+
+    field_selection = "child::info"
+    field_name = "name(@*[1])"
+    field_value = "number(@*[1])"
+
+    [inputs.file.xml.tags]
+      address = "@name"
+      id = "@id"
+
+    [inputs.file.xml.fields]
+      placement = "string(temporary)"

--- a/plugins/parsers/xml/testcases/cyclehire-london.xml
+++ b/plugins/parsers/xml/testcases/cyclehire-london.xml
@@ -1,0 +1,55 @@
+<!-- based on https://tfl.gov.uk/tfl/syndication/feeds/cycle-hire/livecyclehireupdates.xml -->
+<stations lastUpdate="1617397861012" version="2.0">
+</stations>
+<response>
+    <location id="1" name="River Street , Clerkenwell">
+        <info terminalName="001023"/>
+        <info lat="51.52916347"/>
+        <info long="-0.109970527"/>
+        <info installDate="1278947280000"/>
+        <temporary>false</temporary>
+        <info nbBikes="10"/>
+        <info nbEmptyDocks="9"/>
+        <info nbDocks="19"/>
+    </location>
+    <location id="2" name="Phillimore Gardens, Kensington">
+        <info terminalName="001018"/>
+        <info lat="51.49960695"/>
+        <info long="-0.197574246"/>
+        <info installDate="1278585780000"/>
+        <temporary>false</temporary>
+        <info nbBikes="28"/>
+        <info nbEmptyDocks="9"/>
+        <info nbDocks="37"/>
+    </location>
+    <location id="3" name="Christopher Street, Liverpool Street">
+        <info terminalName="001012"/>
+        <info lat="51.52128377"/>
+        <info long="-0.084605692"/>
+        <info installDate="1278240360000"/>
+        <temporary>false</temporary>
+        <info nbBikes="2"/>
+        <info nbEmptyDocks="30"/>
+        <info nbDocks="32"/>
+    </location>
+    <location id="4" name="St. Chad's Street, King's Cross">
+        <info terminalName="001013"/>
+        <info lat="51.53005939"/>
+        <info long="-0.120973687"/>
+        <info installDate="1278241080000"/>
+        <temporary>false</temporary>
+        <info nbBikes="1"/>
+        <info nbEmptyDocks="22"/>
+        <info nbDocks="23"/>
+    </location>
+    <location id="5" name="Sedding Street, Sloane Square">
+        <info terminalName="003420"/>
+        <info lat="51.49313"/>
+        <info long="-0.156876"/>
+        <info installDate="1278241440000"/>
+        <temporary>false</temporary>
+        <info nbBikes="22"/>
+        <info nbEmptyDocks="5"/>
+        <info nbDocks="27"/>
+    </location>
+</response>


### PR DESCRIPTION
added XML examples:
- cdc COVID-19 vaccine HTTP/XML config 
- London bikeshare XML file
- London bikeshare file/XML config