### PR TITLE
Fix opcua integration test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,10 @@ services:
     image: ncarlier/mqtt
     ports:
       - "1883:1883"
+  opcua:
+    image: open62541/open62541
+    ports:
+      - "4840:4840"
   riemann:
     image: stealthly/docker-riemann
     ports:

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -20,6 +20,9 @@ type OPCTags struct {
 }
 
 func TestClient1Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 
 	var testopctags = []OPCTags{
 		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -20,7 +20,6 @@ type OPCTags struct {
 }
 
 func TestClient1Integration(t *testing.T) {
-	t.Skip("Skipping due to dial tcp 195.254.227.245:4840: connect: connection refused")
 
 	var testopctags = []OPCTags{
 		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
@@ -32,7 +31,7 @@ func TestClient1Integration(t *testing.T) {
 	var err error
 
 	o.MetricName = "testing"
-	o.Endpoint = "opc.tcp://opcua.rocks:4840"
+	o.Endpoint = "opc.tcp://localhost:4840"
 	o.AuthMethod = "Anonymous"
 	o.ConnectTimeout = config.Duration(10 * time.Second)
 	o.RequestTimeout = config.Duration(1 * time.Second)


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Related to #8737

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Changed remote `opcua.rocks` domain to docker container on `localhost`. The docker image is the same as the original server on opcua.rocks uses: `open62541/open62541`. See https://opcua.rocks/open62541-online-test-server/ for additional info.
