### PR TITLE
Make JSON format compatible with nulls

### DIFF
--- a/plugins/parsers/json/parser_test.go
+++ b/plugins/parsers/json/parser_test.go
@@ -893,6 +893,18 @@ func TestParse(t *testing.T) {
 			expected: []telegraf.Metric{},
 		},
 		{
+			name:     "parse null",
+			config:   &Config{},
+			input:    []byte(`null`),
+			expected: []telegraf.Metric{},
+		},
+		{
+			name:     "parse null with query",
+			config:   &Config{Query: "result.data"},
+			input:    []byte(`{"error":null,"result":{"data":null,"items_per_page":10,"total_items":0,"total_pages":0}}`),
+			expected: []telegraf.Metric{},
+		},
+		{
 			name: "parse simple array",
 			config: &Config{
 				MetricName: "json",


### PR DESCRIPTION
Telegraf expects either an object or an array of objects but nulls are valid JSON values. This commit detects if query returns a null or the document is a null to return an empty metric instead of an error.

For example, with this configuration:

test.json:

```json
{"error":null,"result":{"data":null,"items_per_page":10,"total_items":0,"total_pages":0}}
```

test.conf:

```
[[inputs.file]]
  files = ["test.json"]
  data_format = "json"
  json_query = "result.data"
```

The query returns `null`:

```
$ cat test.json | jq ".result.data"
null
```

Latest version returns an error:

```
$ docker run -it -v $(pwd):/mnt/ -w "/mnt" --rm -e telegraf:latest telegraf -test -debug -config test.conf
2021-04-09T09:31:08Z I! Starting Telegraf 1.18.1
2021-04-09T09:31:08Z D! [agent] Initializing plugins
2021-04-09T09:31:08Z D! [agent] Starting service inputs
2021-04-09T09:31:08Z E! [inputs.file] Error in plugin: E! Query path must lead to a JSON object or array of objects, but lead to: Null
2021-04-09T09:31:08Z D! [agent] Stopping service inputs
2021-04-09T09:31:08Z D! [agent] Input channel closed
2021-04-09T09:31:08Z D! [agent] Stopped Successfully
2021-04-09T09:31:08Z E! [telegraf] Error running agent: input plugins recorded 1 errors
```

This commits skip the error:

```
$ ./telegraf -test -debug -config test.conf
2021-04-09T09:34:02Z I! Starting Telegraf 
2021-04-09T09:34:02Z D! [agent] Initializing plugins
2021-04-09T09:34:02Z D! [agent] Starting service inputs
2021-04-09T09:34:02Z D! [agent] Stopping service inputs
2021-04-09T09:34:02Z D! [agent] Input channel closed
2021-04-09T09:34:02Z D! [agent] Stopped Successfully
```

In the end, in both cases, no metric is written to the outputs.

Same tests for a null document:

test.json:

```json
null
```

Document is valid:

```
$ cat test.json | jq
null
```

Unpatched:

```
$ docker run -it -v $(pwd):/mnt/ -w "/mnt" --rm -e telegraf:latest telegraf -test -debug -config test.conf
2021-04-09T09:42:17Z I! Starting Telegraf 1.18.1
2021-04-09T09:42:17Z D! [agent] Initializing plugins
2021-04-09T09:42:17Z D! [agent] Starting service inputs
2021-04-09T09:42:17Z E! [inputs.file] Error in plugin: E! Query path must lead to a JSON object or array of objects, but lead to: Null
2021-04-09T09:42:17Z D! [agent] Stopping service inputs
2021-04-09T09:42:17Z D! [agent] Input channel closed
2021-04-09T09:42:17Z D! [agent] Stopped Successfully
2021-04-09T09:42:17Z E! [telegraf] Error running agent: input plugins recorded 1 errors
```

Patched:

```
$ ./telegraf -test -debug -config test.conf
2021-04-09T09:42:33Z I! Starting Telegraf 
2021-04-09T09:42:33Z D! [agent] Initializing plugins
2021-04-09T09:42:33Z D! [agent] Starting service inputs
2021-04-09T09:42:33Z D! [agent] Stopping service inputs
2021-04-09T09:42:33Z D! [agent] Input channel closed
2021-04-09T09:42:33Z D! [agent] Stopped Successfully
```

### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Return an empty list of metrics when:
* result type is `gjson.Null` if a query is detected
* type of parsed JSON document is nil