### PR TITLE
Add option for loki to use system timestamp

### DIFF
--- a/plugins/outputs/loki/README.md
+++ b/plugins/outputs/loki/README.md
@@ -17,6 +17,9 @@ log line will content all fields in `key="value"` format which is easily parsabl
   ## Connection timeout, defaults to "5s" if not set.
   # timeout = "5s"
 
+  ## Use system time rather than metric time for timestamp
+  # system_timestamp = false
+
   ## Basic auth credential
   # username = "loki"
   # password = "pass"


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests. (I think the unit tests are still pretty well covered)

Loki has very strict ordering requirements. You cannot submit a log line with a timestamp older than what already exists (for a matching label set).

I've been getting HTTP 400 errors from the Loki output plugin (SNMP trap input). I added a file output and I noticed that items are written to the file slightly out of order (timestamps are not always ascending).

This change adds an option (system_timestamp) to the Loki output plugin to allow it to use the system timestamp in the Loki message, rather than the metrics provided timestamp. This should mean that timestamp values are always ascending.

@Eraac since you wrote the original Loki plugin