### PR TITLE
Add UTF-8 sanitizer to Strings plugin

### DIFF
--- a/plugins/processors/strings/README.md
+++ b/plugins/processors/strings/README.md
@@ -80,10 +80,11 @@ If you'd like to apply multiple processings to the same `tag_key` or `field_key`
   # [[processors.strings.base64decode]]
   #   field = "message"
 
-  ## Sanitize a string to ensure it is a valid utf-8 string. Non-valid characters are replaced by 'new'
+  ## Sanitize a string to ensure it is a valid utf-8 string
+  ## Each run of invalid UTF-8 byte sequences is replaced by the replacement string, which may be empty
   # [[processors.strings.valid_utf8]]
   #   field = "message"
-  #   new = ""
+  #   replacement = ""
 ```
 
 #### Trim, TrimLeft, TrimRight

--- a/plugins/processors/strings/README.md
+++ b/plugins/processors/strings/README.md
@@ -14,6 +14,7 @@ Implemented functions are:
 - replace
 - left
 - base64decode
+- valid_utf8
 
 Please note that in this implementation these are processed in the order that they appear above.
 
@@ -78,6 +79,11 @@ If you'd like to apply multiple processings to the same `tag_key` or `field_key`
   ## Decode a base64 encoded utf-8 string
   # [[processors.strings.base64decode]]
   #   field = "message"
+
+  ## Sanitize a string to ensure it is a valid utf-8 string. Non-valid characters are replaced by 'new'
+  # [[processors.strings.valid_utf8]]
+  #   field = "message"
+  #   new = ""
 ```
 
 #### Trim, TrimLeft, TrimRight

--- a/plugins/processors/strings/strings.go
+++ b/plugins/processors/strings/strings.go
@@ -43,6 +43,7 @@ type converter struct {
 	Old         string
 	New         string
 	Width       int
+	Replacement string
 
 	fn ConvertFunc
 }
@@ -100,10 +101,11 @@ const sampleConfig = `
   # [[processors.strings.base64decode]]
   #   field = "message"
 
-  ## Sanitize a string to ensure it is a valid utf-8 string. Non-valid characters are replaced by 'new'
+  ## Sanitize a string to ensure it is a valid utf-8 string
+  ## Each run of invalid UTF-8 byte sequences is replaced by the replacement string, which may be empty
   # [[processors.strings.valid_utf8]]
   #   field = "message"
-  #   new = ""
+  #   replacement = ""
 `
 
 func (s *Strings) SampleConfig() string {
@@ -326,7 +328,7 @@ func (s *Strings) initOnce() {
 	}
 	for _, c := range s.ValidUTF8 {
 		c := c
-		c.fn = func(s string) string { return strings.ToValidUTF8(s, c.New) }
+		c.fn = func(s string) string { return strings.ToValidUTF8(s, c.Replacement) }
 		s.converters = append(s.converters, c)
 	}
 

--- a/plugins/processors/strings/strings.go
+++ b/plugins/processors/strings/strings.go
@@ -22,6 +22,7 @@ type Strings struct {
 	Replace      []converter `toml:"replace"`
 	Left         []converter `toml:"left"`
 	Base64Decode []converter `toml:"base64decode"`
+	ValidUTF8    []converter `toml:"valid_utf8"`
 
 	converters []converter
 	init       bool
@@ -98,6 +99,11 @@ const sampleConfig = `
   ## Decode a base64 encoded utf-8 string
   # [[processors.strings.base64decode]]
   #   field = "message"
+
+  ## Sanitize a string to ensure it is a valid utf-8 string. Non-valid characters are replaced by 'new'
+  # [[processors.strings.valid_utf8]]
+  #   field = "message"
+  #   new = ""
 `
 
 func (s *Strings) SampleConfig() string {
@@ -316,6 +322,11 @@ func (s *Strings) initOnce() {
 			}
 			return s
 		}
+		s.converters = append(s.converters, c)
+	}
+	for _, c := range s.ValidUTF8 {
+		c := c
+		c.fn = func(s string) string { return strings.ToValidUTF8(s, c.New) }
 		s.converters = append(s.converters, c)
 	}
 

--- a/plugins/processors/strings/strings_test.go
+++ b/plugins/processors/strings/strings_test.go
@@ -1047,3 +1047,113 @@ func TestBase64Decode(t *testing.T) {
 		})
 	}
 }
+
+func TestValidUTF8(t *testing.T) {
+	tests := []struct {
+		name     string
+		plugin   *Strings
+		metric   []telegraf.Metric
+		expected []telegraf.Metric
+	}{
+		{
+			name: "valid utf-8 keeps original string",
+			plugin: &Strings{
+				ValidUTF8: []converter{
+					{
+						Field: "message",
+						New:   "r",
+					},
+				},
+			},
+			metric: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"message": "howdy",
+					},
+					time.Unix(0, 0),
+				),
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"message": "howdy",
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			name: "non-valid utf-8 modifies original string",
+			plugin: &Strings{
+				ValidUTF8: []converter{
+					{
+						Field: "message",
+						New:   "r",
+					},
+				},
+			},
+			metric: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"message": "howdy" + string([]byte{0xff}),
+					},
+					time.Unix(0, 0),
+				),
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"message": "howdyr",
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			name: "non-valid utf-8 and empty replacement removes invalid characters",
+			plugin: &Strings{
+				ValidUTF8: []converter{
+					{
+						Field: "message",
+						New:   "",
+					},
+				},
+			},
+			metric: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"message": "howdy" + string([]byte{0xff}),
+					},
+					time.Unix(0, 0),
+				),
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"message": "howdy",
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.plugin.Apply(tt.metric...)
+			testutil.RequireMetricsEqual(t, tt.expected, actual)
+		})
+	}
+}

--- a/plugins/processors/strings/strings_test.go
+++ b/plugins/processors/strings/strings_test.go
@@ -1060,8 +1060,8 @@ func TestValidUTF8(t *testing.T) {
 			plugin: &Strings{
 				ValidUTF8: []converter{
 					{
-						Field: "message",
-						New:   "r",
+						Field:       "message",
+						Replacement: "r",
 					},
 				},
 			},
@@ -1091,8 +1091,8 @@ func TestValidUTF8(t *testing.T) {
 			plugin: &Strings{
 				ValidUTF8: []converter{
 					{
-						Field: "message",
-						New:   "r",
+						Field:       "message",
+						Replacement: "r",
 					},
 				},
 			},
@@ -1101,7 +1101,7 @@ func TestValidUTF8(t *testing.T) {
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
-						"message": "howdy" + string([]byte{0xff}),
+						"message": "ho" + string([]byte{0xff}) + "wdy",
 					},
 					time.Unix(0, 0),
 				),
@@ -1111,7 +1111,7 @@ func TestValidUTF8(t *testing.T) {
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
-						"message": "howdyr",
+						"message": "horwdy",
 					},
 					time.Unix(0, 0),
 				),
@@ -1122,8 +1122,8 @@ func TestValidUTF8(t *testing.T) {
 			plugin: &Strings{
 				ValidUTF8: []converter{
 					{
-						Field: "message",
-						New:   "",
+						Field:       "message",
+						Replacement: "",
 					},
 				},
 			},
@@ -1132,7 +1132,7 @@ func TestValidUTF8(t *testing.T) {
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
-						"message": "howdy" + string([]byte{0xff}),
+						"message": "ho" + string([]byte{0xff}) + "wdy",
 					},
 					time.Unix(0, 0),
 				),


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Adds a new option for the Strings processer to sanitize strings so that they conform to utf-8