### PR TITLE
Linter fixes (unhandled errors) -- Part 2

### DIFF
--- a/plugins/inputs/activemq/activemq_test.go
+++ b/plugins/inputs/activemq/activemq_test.go
@@ -30,7 +30,7 @@ func TestGatherQueuesMetrics(t *testing.T) {
 
 	queues := Queues{}
 
-	xml.Unmarshal([]byte(s), &queues)
+	require.NoError(t, xml.Unmarshal([]byte(s), &queues))
 
 	records := make(map[string]interface{})
 	tags := make(map[string]string)
@@ -49,7 +49,7 @@ func TestGatherQueuesMetrics(t *testing.T) {
 	activeMQ := new(ActiveMQ)
 	activeMQ.Server = "localhost"
 	activeMQ.Port = 8161
-	activeMQ.Init()
+	require.NoError(t, activeMQ.Init())
 
 	activeMQ.GatherQueuesMetrics(&acc, queues)
 	acc.AssertContainsTaggedFields(t, "activemq_queues", records, tags)
@@ -76,7 +76,7 @@ func TestGatherTopicsMetrics(t *testing.T) {
 
 	topics := Topics{}
 
-	xml.Unmarshal([]byte(s), &topics)
+	require.NoError(t, xml.Unmarshal([]byte(s), &topics))
 
 	records := make(map[string]interface{})
 	tags := make(map[string]string)
@@ -95,7 +95,7 @@ func TestGatherTopicsMetrics(t *testing.T) {
 	activeMQ := new(ActiveMQ)
 	activeMQ.Server = "localhost"
 	activeMQ.Port = 8161
-	activeMQ.Init()
+	require.NoError(t, activeMQ.Init())
 
 	activeMQ.GatherTopicsMetrics(&acc, topics)
 	acc.AssertContainsTaggedFields(t, "activemq_topics", records, tags)
@@ -110,7 +110,7 @@ func TestGatherSubscribersMetrics(t *testing.T) {
 
 	subscribers := Subscribers{}
 
-	xml.Unmarshal([]byte(s), &subscribers)
+	require.NoError(t, xml.Unmarshal([]byte(s), &subscribers))
 
 	records := make(map[string]interface{})
 	tags := make(map[string]string)
@@ -135,7 +135,7 @@ func TestGatherSubscribersMetrics(t *testing.T) {
 	activeMQ := new(ActiveMQ)
 	activeMQ.Server = "localhost"
 	activeMQ.Port = 8161
-	activeMQ.Init()
+	require.NoError(t, activeMQ.Init())
 
 	activeMQ.GatherSubscribersMetrics(&acc, subscribers)
 	acc.AssertContainsTaggedFields(t, "activemq_subscribers", records, tags)
@@ -149,13 +149,16 @@ func TestURLs(t *testing.T) {
 		switch r.URL.Path {
 		case "/admin/xml/queues.jsp":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("<queues></queues>"))
+			_, err := w.Write([]byte("<queues></queues>"))
+			require.NoError(t, err)
 		case "/admin/xml/topics.jsp":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("<topics></topics>"))
+			_, err := w.Write([]byte("<topics></topics>"))
+			require.NoError(t, err)
 		case "/admin/xml/subscribers.jsp":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("<subscribers></subscribers>"))
+			_, err := w.Write([]byte("<subscribers></subscribers>"))
+			require.NoError(t, err)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 			t.Fatalf("unexpected path: " + r.URL.Path)

--- a/plugins/inputs/apache/apache_test.go
+++ b/plugins/inputs/apache/apache_test.go
@@ -31,7 +31,8 @@ Scoreboard: WW_____W_RW_R_W__RRR____WR_W___WW________W_WW_W_____R__R_WR__WRWR_RR
 func TestHTTPApache(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, apacheStatus)
+		_, err := fmt.Fprintln(w, apacheStatus)
+		require.NoError(t, err)
 	}))
 	defer ts.Close()
 

--- a/plugins/inputs/apcupsd/apcupsd_test.go
+++ b/plugins/inputs/apcupsd/apcupsd_test.go
@@ -43,7 +43,7 @@ func listen(ctx context.Context, t *testing.T, out [][]byte) (string, error) {
 				continue
 			}
 			defer conn.Close()
-			conn.SetReadDeadline(time.Now().Add(time.Second))
+			require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
 
 			in := make([]byte, 128)
 			n, err := conn.Read(in)

--- a/plugins/inputs/aurora/aurora.go
+++ b/plugins/inputs/aurora/aurora.go
@@ -190,7 +190,9 @@ func (a *Aurora) gatherRole(ctx context.Context, origin *url.URL) (RoleType, err
 	if err != nil {
 		return Unknown, err
 	}
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		return Unknown, fmt.Errorf("closing body failed: %v", err)
+	}
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/plugins/inputs/aurora/aurora_test.go
+++ b/plugins/inputs/aurora/aurora_test.go
@@ -46,7 +46,8 @@ func TestAurora(t *testing.T) {
 					"variable_scrape_micros_total_per_sec": 1485.0
 				}`
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(body))
+				_, err := w.Write([]byte(body))
+				require.NoError(t, err)
 			},
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
@@ -86,7 +87,8 @@ func TestAurora(t *testing.T) {
 			},
 			varsjson: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("{}"))
+				_, err := w.Write([]byte("{}"))
+				require.NoError(t, err)
 			},
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
@@ -104,7 +106,8 @@ func TestAurora(t *testing.T) {
 					"foo": "bar"
 				}`
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(body))
+				_, err := w.Write([]byte(body))
+				require.NoError(t, err)
 			},
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
@@ -123,7 +126,8 @@ func TestAurora(t *testing.T) {
 					"foo": 1e309
 				}`
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(body))
+				_, err := w.Write([]byte(body))
+				require.NoError(t, err)
 			},
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
@@ -142,7 +146,8 @@ func TestAurora(t *testing.T) {
 					"foo": 9223372036854775808
 				}`
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(body))
+				_, err := w.Write([]byte(body))
+				require.NoError(t, err)
 			},
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
@@ -158,7 +163,8 @@ func TestAurora(t *testing.T) {
 			varsjson: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				body := `{]`
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(body))
+				_, err := w.Write([]byte(body))
+				require.NoError(t, err)
 			},
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
@@ -176,7 +182,8 @@ func TestAurora(t *testing.T) {
 					"value": 42
 				}`
 				w.WriteHeader(http.StatusServiceUnavailable)
-				w.Write([]byte(body))
+				_, err := w.Write([]byte(body))
+				require.NoError(t, err)
 			},
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
@@ -244,7 +251,8 @@ func TestBasicAuth(t *testing.T) {
 				require.Equal(t, tt.username, username)
 				require.Equal(t, tt.password, password)
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("{}"))
+				_, err := w.Write([]byte("{}"))
+				require.NoError(t, err)
 			})
 
 			var acc testutil.Accumulator

--- a/plugins/inputs/bcache/bcache.go
+++ b/plugins/inputs/bcache/bcache.go
@@ -6,6 +6,7 @@ package bcache
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -128,7 +129,7 @@ func (b *Bcache) Gather(acc telegraf.Accumulator) error {
 	}
 	bdevs, _ := filepath.Glob(bcachePath + "/*/bdev*")
 	if len(bdevs) < 1 {
-		return errors.New("Can't find any bcache device")
+		return errors.New("can't find any bcache device")
 	}
 	for _, bdev := range bdevs {
 		if restrictDevs {
@@ -137,7 +138,9 @@ func (b *Bcache) Gather(acc telegraf.Accumulator) error {
 				continue
 			}
 		}
-		b.gatherBcache(bdev, acc)
+		if err := b.gatherBcache(bdev, acc); err != nil {
+			return fmt.Errorf("gathering bcache failed: %v", err)
+		}
 	}
 	return nil
 }

--- a/plugins/inputs/beanstalkd/beanstalkd.go
+++ b/plugins/inputs/beanstalkd/beanstalkd.go
@@ -62,7 +62,10 @@ func (b *Beanstalkd) Gather(acc telegraf.Accumulator) error {
 	for _, tube := range tubes {
 		wg.Add(1)
 		go func(tube string) {
-			b.gatherTubeStats(connection, tube, acc)
+			err := b.gatherTubeStats(connection, tube, acc)
+			if err != nil {
+				acc.AddError(err)
+			}
 			wg.Done()
 		}(tube)
 	}

--- a/plugins/inputs/beat/beat_test.go
+++ b/plugins/inputs/beat/beat_test.go
@@ -10,18 +10,15 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func Test_BeatStats(test *testing.T) {
+func Test_BeatStats(t *testing.T) {
 	var beat6StatsAccumulator testutil.Accumulator
 	var beatTest = NewBeat()
 	// System stats are disabled by default
 	beatTest.Includes = []string{"beat", "libbeat", "system", "filebeat"}
-	err := beatTest.Init()
-	if err != nil {
-		panic(fmt.Sprintf("could not init beat: %s", err))
-	}
+	require.NoError(t, beatTest.Init())
 	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		var jsonFilePath string
 
@@ -31,36 +28,26 @@ func Test_BeatStats(test *testing.T) {
 		case suffixStats:
 			jsonFilePath = "beat6_stats.json"
 		default:
-			panic("Cannot handle request")
+			require.FailNow(t, "cannot handle request")
 		}
 
 		data, err := ioutil.ReadFile(jsonFilePath)
-		if err != nil {
-			panic(fmt.Sprintf("could not read from data file %s", jsonFilePath))
-		}
-		if _, err := w.Write(data); err != nil {
-			panic("could not write data")
-		}
+		require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
+		_, err = w.Write(data)
+		require.NoError(t, err, "could not write data")
 	}))
 	requestURL, err := url.Parse(beatTest.URL)
-	if err != nil {
-		test.Logf("Can't parse URL %s", beatTest.URL)
-	}
+	require.NoErrorf(t, err, "can't parse URL %s", beatTest.URL)
 	fakeServer.Listener, err = net.Listen("tcp", fmt.Sprintf("%s:%s", requestURL.Hostname(), requestURL.Port()))
-	if err != nil {
-		test.Logf("Can't listen for %s: %v", requestURL, err)
-	}
+	require.NoErrorf(t, err, "can't listen for %s: %v", requestURL, err)
 
 	fakeServer.Start()
 	defer fakeServer.Close()
 
-	err = beatTest.Gather(&beat6StatsAccumulator)
-	if err != nil {
-		test.Logf("Can't gather stats")
-	}
+	require.NoError(t, err, beatTest.Gather(&beat6StatsAccumulator))
 
 	beat6StatsAccumulator.AssertContainsTaggedFields(
-		test,
+		t,
 		"beat",
 		map[string]interface{}{
 			"cpu_system_ticks":      float64(626970),
@@ -86,7 +73,7 @@ func Test_BeatStats(test *testing.T) {
 		},
 	)
 	beat6StatsAccumulator.AssertContainsTaggedFields(
-		test,
+		t,
 		"beat_filebeat",
 		map[string]interface{}{
 			"events_active":             float64(0),
@@ -109,7 +96,7 @@ func Test_BeatStats(test *testing.T) {
 		},
 	)
 	beat6StatsAccumulator.AssertContainsTaggedFields(
-		test,
+		t,
 		"beat_libbeat",
 		map[string]interface{}{
 			"config_module_running":     float64(0),
@@ -149,7 +136,7 @@ func Test_BeatStats(test *testing.T) {
 		},
 	)
 	beat6StatsAccumulator.AssertContainsTaggedFields(
-		test,
+		t,
 		"beat_system",
 		map[string]interface{}{
 			"cpu_cores":    float64(32),
@@ -170,15 +157,12 @@ func Test_BeatStats(test *testing.T) {
 	)
 }
 
-func Test_BeatRequest(test *testing.T) {
+func Test_BeatRequest(t *testing.T) {
 	var beat6StatsAccumulator testutil.Accumulator
 	beatTest := NewBeat()
 	// System stats are disabled by default
 	beatTest.Includes = []string{"beat", "libbeat", "system", "filebeat"}
-	err := beatTest.Init()
-	if err != nil {
-		panic(fmt.Sprintf("could not init beat: %s", err))
-	}
+	require.NoError(t, beatTest.Init())
 	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		var jsonFilePath string
 
@@ -188,32 +172,24 @@ func Test_BeatRequest(test *testing.T) {
 		case suffixStats:
 			jsonFilePath = "beat6_stats.json"
 		default:
-			panic("Cannot handle request")
+			require.FailNow(t, "cannot handle request")
 		}
 
 		data, err := ioutil.ReadFile(jsonFilePath)
+		require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
+		require.Equal(t, request.Host, "beat.test.local")
+		require.Equal(t, request.Method, "POST")
+		require.Equal(t, request.Header.Get("Authorization"), "Basic YWRtaW46UFdE")
+		require.Equal(t, request.Header.Get("X-Test"), "test-value")
 
-		if err != nil {
-			panic(fmt.Sprintf("could not read from data file %s", jsonFilePath))
-		}
-		assert.Equal(test, request.Host, "beat.test.local")
-		assert.Equal(test, request.Method, "POST")
-		assert.Equal(test, request.Header.Get("Authorization"), "Basic YWRtaW46UFdE")
-		assert.Equal(test, request.Header.Get("X-Test"), "test-value")
-
-		if _, err := w.Write(data); err != nil {
-			panic("could not write data")
-		}
+		_, err = w.Write(data)
+		require.NoError(t, err, "could not write data")
 	}))
 
 	requestURL, err := url.Parse(beatTest.URL)
-	if err != nil {
-		test.Logf("Can't parse URL %s", beatTest.URL)
-	}
+	require.NoErrorf(t, err, "can't parse URL %s", beatTest.URL)
 	fakeServer.Listener, err = net.Listen("tcp", fmt.Sprintf("%s:%s", requestURL.Hostname(), requestURL.Port()))
-	if err != nil {
-		test.Logf("Can't listen for %s: %v", requestURL, err)
-	}
+	require.NoErrorf(t, err, "can't listen for %s: %v", requestURL, err)
 	fakeServer.Start()
 	defer fakeServer.Close()
 
@@ -223,8 +199,5 @@ func Test_BeatRequest(test *testing.T) {
 	beatTest.Username = "admin"
 	beatTest.Password = "PWD"
 
-	err = beatTest.Gather(&beat6StatsAccumulator)
-	if err != nil {
-		test.Logf("Can't gather stats")
-	}
+	require.NoError(t, beatTest.Gather(&beat6StatsAccumulator))
 }

--- a/plugins/inputs/beat/beat_test.go
+++ b/plugins/inputs/beat/beat_test.go
@@ -35,11 +35,12 @@ func Test_BeatStats(test *testing.T) {
 		}
 
 		data, err := ioutil.ReadFile(jsonFilePath)
-
 		if err != nil {
 			panic(fmt.Sprintf("could not read from data file %s", jsonFilePath))
 		}
-		w.Write(data)
+		if _, err := w.Write(data); err != nil {
+			panic("could not write data")
+		}
 	}))
 	requestURL, err := url.Parse(beatTest.URL)
 	if err != nil {
@@ -200,7 +201,9 @@ func Test_BeatRequest(test *testing.T) {
 		assert.Equal(test, request.Header.Get("Authorization"), "Basic YWRtaW46UFdE")
 		assert.Equal(test, request.Header.Get("X-Test"), "test-value")
 
-		w.Write(data)
+		if _, err := w.Write(data); err != nil {
+			panic("could not write data")
+		}
 	}))
 
 	requestURL, err := url.Parse(beatTest.URL)

--- a/plugins/inputs/bind/json_stats.go
+++ b/plugins/inputs/bind/json_stats.go
@@ -58,7 +58,9 @@ func addJSONCounter(acc telegraf.Accumulator, commonTags map[string]string, stat
 			tags[k] = v
 		}
 
-		grouper.Add("bind_counter", tags, ts, name, value)
+		if err := grouper.Add("bind_counter", tags, ts, name, value); err != nil {
+			acc.AddError(fmt.Errorf("adding field %q to group failed: %v", name, err))
+		}
 	}
 
 	//Add grouped metrics
@@ -133,7 +135,9 @@ func (b *Bind) addStatsJSON(stats jsonStats, acc telegraf.Accumulator, urlTag st
 						"type":   cntrType,
 					}
 
-					grouper.Add("bind_counter", tags, ts, cntrName, value)
+					if err := grouper.Add("bind_counter", tags, ts, cntrName, value); err != nil {
+						acc.AddError(fmt.Errorf("adding tags %q to group failed: %v", tags, err))
+					}
 				}
 			}
 		}

--- a/plugins/inputs/bind/xml_stats_v2.go
+++ b/plugins/inputs/bind/xml_stats_v2.go
@@ -75,7 +75,9 @@ func addXMLv2Counter(acc telegraf.Accumulator, commonTags map[string]string, sta
 			tags[k] = v
 		}
 
-		grouper.Add("bind_counter", tags, ts, c.Name, c.Value)
+		if err := grouper.Add("bind_counter", tags, ts, c.Name, c.Value); err != nil {
+			acc.AddError(fmt.Errorf("adding field %q to group failed: %v", c.Name, err))
+		}
 	}
 
 	//Add grouped metrics

--- a/plugins/inputs/bind/xml_stats_v3.go
+++ b/plugins/inputs/bind/xml_stats_v3.go
@@ -81,7 +81,9 @@ func (b *Bind) addStatsXMLv3(stats v3Stats, acc telegraf.Accumulator, hostPort s
 
 			tags := map[string]string{"url": hostPort, "source": host, "port": port, "type": cg.Type}
 
-			grouper.Add("bind_counter", tags, ts, c.Name, c.Value)
+			if err := grouper.Add("bind_counter", tags, ts, c.Name, c.Value); err != nil {
+				acc.AddError(fmt.Errorf("adding tags %q to group failed: %v", tags, err))
+			}
 		}
 	}
 
@@ -118,7 +120,9 @@ func (b *Bind) addStatsXMLv3(stats v3Stats, acc telegraf.Accumulator, hostPort s
 						"type":   cg.Type,
 					}
 
-					grouper.Add("bind_counter", tags, ts, c.Name, c.Value)
+					if err := grouper.Add("bind_counter", tags, ts, c.Name, c.Value); err != nil {
+						acc.AddError(fmt.Errorf("adding tags %q to group failed: %v", tags, err))
+					}
 				}
 			}
 		}

--- a/plugins/inputs/bond/bond_test.go
+++ b/plugins/inputs/bond/bond_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 var sampleTest802 = `
@@ -65,12 +66,12 @@ func TestGatherBondInterface(t *testing.T) {
 	var acc testutil.Accumulator
 	bond := &Bond{}
 
-	bond.gatherBondInterface("bond802", sampleTest802, &acc)
+	require.NoError(t, bond.gatherBondInterface("bond802", sampleTest802, &acc))
 	acc.AssertContainsTaggedFields(t, "bond", map[string]interface{}{"status": 1}, map[string]string{"bond": "bond802"})
 	acc.AssertContainsTaggedFields(t, "bond_slave", map[string]interface{}{"failures": 0, "status": 1}, map[string]string{"bond": "bond802", "interface": "eth1"})
 	acc.AssertContainsTaggedFields(t, "bond_slave", map[string]interface{}{"failures": 3, "status": 1}, map[string]string{"bond": "bond802", "interface": "eth2"})
 
-	bond.gatherBondInterface("bondAB", sampleTestAB, &acc)
+	require.NoError(t, bond.gatherBondInterface("bondAB", sampleTestAB, &acc))
 	acc.AssertContainsTaggedFields(t, "bond", map[string]interface{}{"active_slave": "eth2", "status": 1}, map[string]string{"bond": "bondAB"})
 	acc.AssertContainsTaggedFields(t, "bond_slave", map[string]interface{}{"failures": 2, "status": 0}, map[string]string{"bond": "bondAB", "interface": "eth3"})
 	acc.AssertContainsTaggedFields(t, "bond_slave", map[string]interface{}{"failures": 0, "status": 1}, map[string]string{"bond": "bondAB", "interface": "eth2"})

--- a/plugins/inputs/ceph/ceph.go
+++ b/plugins/inputs/ceph/ceph.go
@@ -253,8 +253,10 @@ func (m *metric) name() string {
 	buf := bytes.Buffer{}
 	for i := len(m.pathStack) - 1; i >= 0; i-- {
 		if buf.Len() > 0 {
+			//nolint:errcheck,revive // should never return an error
 			buf.WriteString(".")
 		}
+		//nolint:errcheck,revive // should never return an error
 		buf.WriteString(m.pathStack[i])
 	}
 	return buf.String()

--- a/plugins/inputs/ceph/ceph_test.go
+++ b/plugins/inputs/ceph/ceph_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -25,41 +25,41 @@ type expectedResult struct {
 
 func TestParseSockId(t *testing.T) {
 	s := parseSockID(sockFile(osdPrefix, 1), osdPrefix, sockSuffix)
-	assert.Equal(t, s, "1")
+	require.Equal(t, s, "1")
 }
 
 func TestParseMonDump(t *testing.T) {
 	dump, err := parseDump(monPerfDump)
-	assert.NoError(t, err)
-	assert.InEpsilon(t, int64(5678670180), dump["cluster"]["osd_kb_used"], epsilon)
-	assert.InEpsilon(t, 6866.540527000, dump["paxos"]["store_state_latency.sum"], epsilon)
+	require.NoError(t, err)
+	require.InEpsilon(t, int64(5678670180), dump["cluster"]["osd_kb_used"], epsilon)
+	require.InEpsilon(t, 6866.540527000, dump["paxos"]["store_state_latency.sum"], epsilon)
 }
 
 func TestParseOsdDump(t *testing.T) {
 	dump, err := parseDump(osdPerfDump)
-	assert.NoError(t, err)
-	assert.InEpsilon(t, 552132.109360000, dump["filestore"]["commitcycle_interval.sum"], epsilon)
-	assert.Equal(t, float64(0), dump["mutex-FileJournal::finisher_lock"]["wait.avgcount"])
+	require.NoError(t, err)
+	require.InEpsilon(t, 552132.109360000, dump["filestore"]["commitcycle_interval.sum"], epsilon)
+	require.Equal(t, float64(0), dump["mutex-FileJournal::finisher_lock"]["wait.avgcount"])
 }
 
 func TestParseMdsDump(t *testing.T) {
 	dump, err := parseDump(mdsPerfDump)
-	assert.NoError(t, err)
-	assert.InEpsilon(t, 2408386.600934982, dump["mds"]["reply_latency.sum"], epsilon)
-	assert.Equal(t, float64(0), dump["throttle-write_buf_throttle"]["wait.avgcount"])
+	require.NoError(t, err)
+	require.InEpsilon(t, 2408386.600934982, dump["mds"]["reply_latency.sum"], epsilon)
+	require.Equal(t, float64(0), dump["throttle-write_buf_throttle"]["wait.avgcount"])
 }
 
 func TestParseRgwDump(t *testing.T) {
 	dump, err := parseDump(rgwPerfDump)
-	assert.NoError(t, err)
-	assert.InEpsilon(t, 0.002219876, dump["rgw"]["get_initial_lat.sum"], epsilon)
-	assert.Equal(t, float64(0), dump["rgw"]["put_initial_lat.avgcount"])
+	require.NoError(t, err)
+	require.InEpsilon(t, 0.002219876, dump["rgw"]["get_initial_lat.sum"], epsilon)
+	require.Equal(t, float64(0), dump["rgw"]["put_initial_lat.avgcount"])
 }
 
 func TestDecodeStatus(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	err := decodeStatus(acc, clusterStatusDump)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, r := range cephStatusResults {
 		acc.AssertContainsTaggedFields(t, r.metric, r.fields, r.tags)
@@ -69,7 +69,7 @@ func TestDecodeStatus(t *testing.T) {
 func TestDecodeDf(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	err := decodeDf(acc, cephDFDump)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, r := range cephDfResults {
 		acc.AssertContainsTaggedFields(t, r.metric, r.fields, r.tags)
@@ -79,14 +79,14 @@ func TestDecodeDf(t *testing.T) {
 func TestDecodeOSDPoolStats(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	err := decodeOsdPoolStats(acc, cephODSPoolStatsDump)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, r := range cephOSDPoolStatsResults {
 		acc.AssertContainsTaggedFields(t, r.metric, r.fields, r.tags)
 	}
 }
 
-func TestGather(_ *testing.T) {
+func TestGather(t *testing.T) {
 	saveFind := findSockets
 	saveDump := perfDump
 	defer func() {
@@ -104,15 +104,15 @@ func TestGather(_ *testing.T) {
 
 	acc := &testutil.Accumulator{}
 	c := &Ceph{}
-	c.Gather(acc)
+	require.NoError(t, c.Gather(acc))
 }
 
 func TestFindSockets(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "socktest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(tmpdir)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}()
 	c := &Ceph{
 		CephBinary:             "foo",
@@ -129,10 +129,10 @@ func TestFindSockets(t *testing.T) {
 	}
 
 	for _, st := range sockTestParams {
-		createTestFiles(tmpdir, st)
+		require.NoError(t, createTestFiles(tmpdir, st))
 
 		sockets, err := findSockets(c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		for i := 1; i <= st.osds; i++ {
 			assertFoundSocket(t, tmpdir, typeOsd, i, sockets)
@@ -147,7 +147,7 @@ func TestFindSockets(t *testing.T) {
 		for i := 1; i <= st.rgws; i++ {
 			assertFoundSocket(t, tmpdir, typeRgw, i, sockets)
 		}
-		cleanupTestFiles(tmpdir, st)
+		require.NoError(t, cleanupTestFiles(tmpdir, st))
 	}
 }
 
@@ -165,54 +165,61 @@ func assertFoundSocket(t *testing.T, dir, sockType string, i int, sockets []*soc
 	expected := filepath.Join(dir, sockFile(prefix, i))
 	found := false
 	for _, s := range sockets {
-		fmt.Printf("Checking %s\n", s.socket)
+		_, err := fmt.Printf("Checking %s\n", s.socket)
+		require.NoError(t, err)
 		if s.socket == expected {
 			found = true
-			assert.Equal(t, s.sockType, sockType, "Unexpected socket type for '%s'", s)
-			assert.Equal(t, s.sockID, strconv.Itoa(i))
+			require.Equal(t, s.sockType, sockType, "Unexpected socket type for '%s'", s)
+			require.Equal(t, s.sockID, strconv.Itoa(i))
 		}
 	}
-	assert.True(t, found, "Did not find socket: %s", expected)
+	require.True(t, found, "Did not find socket: %s", expected)
 }
 
 func sockFile(prefix string, i int) string {
 	return strings.Join([]string{prefix, strconv.Itoa(i), sockSuffix}, ".")
 }
 
-func createTestFiles(dir string, st *SockTest) {
-	writeFile := func(prefix string, i int) {
+func createTestFiles(dir string, st *SockTest) error {
+	writeFile := func(prefix string, i int) error {
 		f := sockFile(prefix, i)
 		fpath := filepath.Join(dir, f)
-		ioutil.WriteFile(fpath, []byte(""), 0777)
+		return ioutil.WriteFile(fpath, []byte(""), 0777)
 	}
-	tstFileApply(st, writeFile)
+	return tstFileApply(st, writeFile)
 }
 
-func cleanupTestFiles(dir string, st *SockTest) {
-	rmFile := func(prefix string, i int) {
+func cleanupTestFiles(dir string, st *SockTest) error {
+	rmFile := func(prefix string, i int) error {
 		f := sockFile(prefix, i)
 		fpath := filepath.Join(dir, f)
-		err := os.Remove(fpath)
-		if err != nil {
-			fmt.Printf("Error removing test file %s: %v\n", fpath, err)
+		return os.Remove(fpath)
+	}
+	return tstFileApply(st, rmFile)
+}
+
+func tstFileApply(st *SockTest, fn func(string, int) error) error {
+	for i := 1; i <= st.osds; i++ {
+		if err := fn(osdPrefix, i); err != nil {
+			return err
 		}
 	}
-	tstFileApply(st, rmFile)
-}
-
-func tstFileApply(st *SockTest, fn func(prefix string, i int)) {
-	for i := 1; i <= st.osds; i++ {
-		fn(osdPrefix, i)
-	}
 	for i := 1; i <= st.mons; i++ {
-		fn(monPrefix, i)
+		if err := fn(monPrefix, i); err != nil {
+			return err
+		}
 	}
 	for i := 1; i <= st.mdss; i++ {
-		fn(mdsPrefix, i)
+		if err := fn(mdsPrefix, i); err != nil {
+			return err
+		}
 	}
 	for i := 1; i <= st.rgws; i++ {
-		fn(rgwPrefix, i)
+		if err := fn(rgwPrefix, i); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 type SockTest struct {

--- a/plugins/inputs/chrony/chrony_test.go
+++ b/plugins/inputs/chrony/chrony_test.go
@@ -94,11 +94,14 @@ Leap status     : Not synchronized
 
 	if cmd == "chronyc" {
 		if args[0] == "tracking" {
+			//nolint:errcheck,revive // test will fail anyway
 			fmt.Fprint(os.Stdout, lookup+mockData)
 		} else {
+			//nolint:errcheck,revive // test will fail anyway
 			fmt.Fprint(os.Stdout, noLookup+mockData)
 		}
 	} else {
+		//nolint:errcheck,revive // test will fail anyway
 		fmt.Fprint(os.Stdout, "command not found")
 		os.Exit(1)
 	}

--- a/plugins/inputs/clickhouse/clickhouse_test.go
+++ b/plugins/inputs/clickhouse/clickhouse_test.go
@@ -57,7 +57,7 @@ func TestGather(t *testing.T) {
 			enc := json.NewEncoder(w)
 			switch query := r.URL.Query().Get("query"); {
 			case strings.Contains(query, "system.parts"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						Database string   `json:"database"`
 						Table    string   `json:"table"`
@@ -74,8 +74,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "system.events"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						Metric string   `json:"metric"`
 						Value  chUInt64 `json:"value"`
@@ -90,8 +91,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "system.metrics"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						Metric string   `json:"metric"`
 						Value  chUInt64 `json:"value"`
@@ -106,8 +108,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "system.asynchronous_metrics"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						Metric string   `json:"metric"`
 						Value  chUInt64 `json:"value"`
@@ -122,8 +125,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "zk_exists"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						ZkExists chUInt64 `json:"zk_exists"`
 					}{
@@ -132,8 +136,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "zk_root_nodes"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						ZkRootNodes chUInt64 `json:"zk_root_nodes"`
 					}{
@@ -142,8 +147,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "replication_queue_exists"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						ReplicationQueueExists chUInt64 `json:"replication_queue_exists"`
 					}{
@@ -152,8 +158,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "replication_too_many_tries_replicas"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						TooManyTriesReplicas chUInt64 `json:"replication_too_many_tries_replicas"`
 						NumTriesReplicas     chUInt64 `json:"replication_num_tries_replicas"`
@@ -164,8 +171,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "system.detached_parts"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						DetachedParts chUInt64 `json:"detached_parts"`
 					}{
@@ -174,8 +182,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "system.dictionaries"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						Origin         string   `json:"origin"`
 						Status         string   `json:"status"`
@@ -188,8 +197,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "system.mutations"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						Failed    chUInt64 `json:"failed"`
 						Completed chUInt64 `json:"completed"`
@@ -202,8 +212,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "system.disks"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						Name            string   `json:"name"`
 						Path            string   `json:"path"`
@@ -218,8 +229,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "system.processes"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						QueryType      string  `json:"query_type"`
 						Percentile50   float64 `json:"p50"`
@@ -246,8 +258,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "text_log_exists"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						TextLogExists chUInt64 `json:"text_log_exists"`
 					}{
@@ -256,8 +269,9 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "system.text_log"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						Level                 string   `json:"level"`
 						LastMessagesLast10Min chUInt64 `json:"messages_last_10_min"`
@@ -284,6 +298,7 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			}
 		}))
 		ch = &ClickHouse{
@@ -294,7 +309,7 @@ func TestGather(t *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	ch.Gather(acc)
+	assert.NoError(t, ch.Gather(acc))
 
 	acc.AssertContainsTaggedFields(t, "clickhouse_tables",
 		map[string]interface{}{
@@ -427,7 +442,7 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 			enc := json.NewEncoder(w)
 			switch query := r.URL.Query().Get("query"); {
 			case strings.Contains(query, "zk_exists"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						ZkExists chUInt64 `json:"zk_exists"`
 					}{
@@ -436,8 +451,9 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "replication_queue_exists"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						ReplicationQueueExists chUInt64 `json:"replication_queue_exists"`
 					}{
@@ -446,8 +462,9 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			case strings.Contains(query, "text_log_exists"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						TextLogExists chUInt64 `json:"text_log_exists"`
 					}{
@@ -456,6 +473,7 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			}
 		}))
 		ch = &ClickHouse{
@@ -467,7 +485,7 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	ch.Gather(acc)
+	assert.NoError(t, ch.Gather(acc))
 
 	acc.AssertDoesNotContainMeasurement(t, "clickhouse_zookeeper")
 	acc.AssertDoesNotContainMeasurement(t, "clickhouse_replication_queue")
@@ -482,9 +500,10 @@ func TestWrongJSONMarshalling(t *testing.T) {
 			}
 			enc := json.NewEncoder(w)
 			//wrong data section json
-			enc.Encode(result{
+			err := enc.Encode(result{
 				Data: []struct{}{},
 			})
+			assert.NoError(t, err)
 		}))
 		ch = &ClickHouse{
 			Servers: []string{
@@ -495,7 +514,7 @@ func TestWrongJSONMarshalling(t *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	ch.Gather(acc)
+	assert.NoError(t, ch.Gather(acc))
 
 	assert.Equal(t, 0, len(acc.Metrics))
 	allMeasurements := []string{
@@ -528,7 +547,7 @@ func TestOfflineServer(t *testing.T) {
 			},
 		}
 	)
-	ch.Gather(acc)
+	assert.NoError(t, ch.Gather(acc))
 
 	assert.Equal(t, 0, len(acc.Metrics))
 	allMeasurements := []string{
@@ -548,7 +567,7 @@ func TestOfflineServer(t *testing.T) {
 	assert.GreaterOrEqual(t, len(allMeasurements), len(acc.Errors))
 }
 
-func TestAutoDiscovery(_ *testing.T) {
+func TestAutoDiscovery(t *testing.T) {
 	var (
 		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			type result struct {
@@ -557,7 +576,7 @@ func TestAutoDiscovery(_ *testing.T) {
 			enc := json.NewEncoder(w)
 			switch query := r.URL.Query().Get("query"); {
 			case strings.Contains(query, "system.clusters"):
-				enc.Encode(result{
+				err := enc.Encode(result{
 					Data: []struct {
 						Cluster  string   `json:"test"`
 						Hostname string   `json:"localhost"`
@@ -570,6 +589,7 @@ func TestAutoDiscovery(_ *testing.T) {
 						},
 					},
 				})
+				assert.NoError(t, err)
 			}
 		}))
 		ch = &ClickHouse{
@@ -582,5 +602,5 @@ func TestAutoDiscovery(_ *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	ch.Gather(acc)
+	assert.NoError(t, ch.Gather(acc))
 }

--- a/plugins/inputs/cloud_pubsub_push/pubsub_push.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push.go
@@ -169,7 +169,7 @@ func (p *PubSubPush) Start(acc telegraf.Accumulator) error {
 	go func() {
 		defer p.wg.Done()
 		if tlsConf != nil {
-			if err := p.server.ListenAndServeTLS("", ""); err != nil {
+			if err := p.server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 				p.Log.Errorf("listening and serving TLS failed: %v", err)
 			}
 		} else {

--- a/plugins/inputs/cloud_pubsub_push/pubsub_push.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push.go
@@ -169,9 +169,13 @@ func (p *PubSubPush) Start(acc telegraf.Accumulator) error {
 	go func() {
 		defer p.wg.Done()
 		if tlsConf != nil {
-			p.server.ListenAndServeTLS("", "")
+			if err := p.server.ListenAndServeTLS("", ""); err != nil {
+				p.Log.Errorf("listening and serving TLS failed: %v", err)
+			}
 		} else {
-			p.server.ListenAndServe()
+			if err := p.server.ListenAndServe(); err != nil {
+				p.Log.Errorf("listening and serving TLS failed: %v", err)
+			}
 		}
 	}()
 
@@ -181,6 +185,7 @@ func (p *PubSubPush) Start(acc telegraf.Accumulator) error {
 // Stop cleans up all resources
 func (p *PubSubPush) Stop() {
 	p.cancel()
+	//nolint:errcheck,revive // we cannot do anything if the shutdown fails
 	p.server.Shutdown(p.ctx)
 	p.wg.Wait()
 }

--- a/plugins/inputs/cloud_pubsub_push/pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push_test.go
@@ -156,6 +156,7 @@ func TestServeHTTP(t *testing.T) {
 			defer wg.Done()
 			for m := range d {
 				ro.AddMetric(m)
+				//nolint:errcheck,revive // test will fail anyway if the write fails
 				ro.Write()
 			}
 		}(dst)

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -570,7 +570,9 @@ func (c *CloudWatch) aggregateMetrics(
 		tags["region"] = c.Region
 
 		for i := range result.Values {
-			grouper.Add(namespace, tags, *result.Timestamps[i], *result.Label, *result.Values[i])
+			if err := grouper.Add(namespace, tags, *result.Timestamps[i], *result.Label, *result.Values[i]); err != nil {
+				acc.AddError(err)
+			}
 		}
 	}
 

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -239,7 +239,7 @@ func TestGenerateStatisticsInputParams(t *testing.T) {
 		Period:    internalDuration,
 	}
 
-	c.initializeCloudWatch()
+	require.NoError(t, c.initializeCloudWatch())
 
 	now := time.Now()
 
@@ -276,7 +276,7 @@ func TestGenerateStatisticsInputParamsFiltered(t *testing.T) {
 		Period:    internalDuration,
 	}
 
-	c.initializeCloudWatch()
+	require.NoError(t, c.initializeCloudWatch())
 
 	now := time.Now()
 

--- a/plugins/inputs/conntrack/conntrack_test.go
+++ b/plugins/inputs/conntrack/conntrack_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func restoreDflts(savedFiles, savedDirs []string) {
@@ -28,18 +28,18 @@ func TestNoFilesFound(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	err := c.Gather(acc)
 
-	assert.EqualError(t, err, "Conntrack input failed to collect metrics. "+
+	require.EqualError(t, err, "Conntrack input failed to collect metrics. "+
 		"Is the conntrack kernel module loaded?")
 }
 
 func TestDefaultsUsed(t *testing.T) {
 	defer restoreDflts(dfltFiles, dfltDirs)
 	tmpdir, err := ioutil.TempDir("", "tmp1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpdir)
 
 	tmpFile, err := ioutil.TempFile(tmpdir, "ip_conntrack_count")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
 
 	dfltDirs = []string{tmpdir}
@@ -47,11 +47,11 @@ func TestDefaultsUsed(t *testing.T) {
 	dfltFiles = []string{fname}
 
 	count := 1234321
-	ioutil.WriteFile(tmpFile.Name(), []byte(strconv.Itoa(count)), 0660)
+	require.NoError(t, ioutil.WriteFile(tmpFile.Name(), []byte(strconv.Itoa(count)), 0660))
 	c := &Conntrack{}
 	acc := &testutil.Accumulator{}
 
-	c.Gather(acc)
+	require.NoError(t, c.Gather(acc))
 	acc.AssertContainsFields(t, inputName, map[string]interface{}{
 		fname: float64(count)})
 }
@@ -59,12 +59,13 @@ func TestDefaultsUsed(t *testing.T) {
 func TestConfigsUsed(t *testing.T) {
 	defer restoreDflts(dfltFiles, dfltDirs)
 	tmpdir, err := ioutil.TempDir("", "tmp1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(tmpdir)
 
 	cntFile, err := ioutil.TempFile(tmpdir, "nf_conntrack_count")
+	require.NoError(t, err)
 	maxFile, err := ioutil.TempFile(tmpdir, "nf_conntrack_max")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(cntFile.Name())
 	defer os.Remove(maxFile.Name())
 
@@ -75,12 +76,12 @@ func TestConfigsUsed(t *testing.T) {
 
 	count := 1234321
 	max := 9999999
-	ioutil.WriteFile(cntFile.Name(), []byte(strconv.Itoa(count)), 0660)
-	ioutil.WriteFile(maxFile.Name(), []byte(strconv.Itoa(max)), 0660)
+	require.NoError(t, ioutil.WriteFile(cntFile.Name(), []byte(strconv.Itoa(count)), 0660))
+	require.NoError(t, ioutil.WriteFile(maxFile.Name(), []byte(strconv.Itoa(max)), 0660))
 	c := &Conntrack{}
 	acc := &testutil.Accumulator{}
 
-	c.Gather(acc)
+	require.NoError(t, c.Gather(acc))
 
 	fix := func(s string) string {
 		return strings.Replace(s, "nf_", "ip_", 1)

--- a/plugins/inputs/couchdb/couchdb.go
+++ b/plugins/inputs/couchdb/couchdb.go
@@ -140,9 +140,9 @@ func (c *CouchDB) fetchAndInsertData(accumulator telegraf.Accumulator, host stri
 		req.SetBasicAuth(c.BasicUsername, c.BasicPassword)
 	}
 
-	response, error := c.client.Do(req)
-	if error != nil {
-		return error
+	response, err := c.client.Do(req)
+	if err != nil {
+		return err
 	}
 	defer response.Body.Close()
 
@@ -152,7 +152,9 @@ func (c *CouchDB) fetchAndInsertData(accumulator telegraf.Accumulator, host stri
 
 	stats := Stats{}
 	decoder := json.NewDecoder(response.Body)
-	decoder.Decode(&stats)
+	if err := decoder.Decode(&stats); err != nil {
+		return fmt.Errorf("failed to decode stats from couchdb: HTTP body %q", response.Body)
+	}
 
 	fields := map[string]interface{}{}
 

--- a/plugins/inputs/dcos/client.go
+++ b/plugins/inputs/dcos/client.go
@@ -292,6 +292,7 @@ func (c *ClusterClient) doGet(ctx context.Context, url string, v interface{}) er
 		return err
 	}
 	defer func() {
+		//nolint:errcheck,revive // we cannot do anything if the closing fails
 		resp.Body.Close()
 		<-c.semaphore
 	}()

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -39,7 +39,7 @@ const sampleConfig = `
   ## The amount of time a file is allowed to sit in the directory before it is picked up.
   ## This time can generally be low but if you choose to have a very large file written to the directory and it's potentially slow,
   ## set this higher so that the plugin will wait until the file is fully copied to the directory.
-  # directory_duration_threshold = "50ms" 
+  # directory_duration_threshold = "50ms"
   #
   ## A list of the only file names to monitor, if necessary. Supports regex. If left blank, all files are ingested.
   # files_to_monitor = ["^.*\.csv"]
@@ -118,6 +118,7 @@ func (monitor *DirectoryMonitor) Gather(_ telegraf.Accumulator) error {
 
 		// We've been cancelled via Stop().
 		if monitor.context.Err() != nil {
+			//nolint:nilerr // context cancelation is not an error
 			return nil
 		}
 
@@ -266,7 +267,9 @@ func (monitor *DirectoryMonitor) parseFile(parser parsers.Parser, reader io.Read
 			firstLine = false
 		}
 
-		monitor.sendMetrics(metrics)
+		if err := monitor.sendMetrics(metrics); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -295,13 +298,16 @@ func (monitor *DirectoryMonitor) parseLine(parser parsers.Parser, line []byte, f
 	}
 }
 
-func (monitor *DirectoryMonitor) sendMetrics(metrics []telegraf.Metric) {
+func (monitor *DirectoryMonitor) sendMetrics(metrics []telegraf.Metric) error {
 	// Report the metrics for the file.
 	for _, m := range metrics {
 		// Block until metric can be written.
-		monitor.sem.Acquire(monitor.context, 1)
+		if err := monitor.sem.Acquire(monitor.context, 1); err != nil {
+			return err
+		}
 		monitor.acc.AddTrackingMetricGroup([]telegraf.Metric{m})
 	}
+	return nil
 }
 
 func (monitor *DirectoryMonitor) moveFile(filePath string, directory string) {
@@ -344,7 +350,7 @@ func (monitor *DirectoryMonitor) SetParserFunc(fn parsers.ParserFunc) {
 
 func (monitor *DirectoryMonitor) Init() error {
 	if monitor.Directory == "" || monitor.FinishedDirectory == "" {
-		return errors.New("Missing one of the following required config options: directory, finished_directory.")
+		return errors.New("missing one of the following required config options: directory, finished_directory")
 	}
 
 	if monitor.FileQueueSize <= 0 {

--- a/plugins/inputs/directory_monitor/directory_monitor_test.go
+++ b/plugins/inputs/directory_monitor/directory_monitor_test.go
@@ -49,15 +49,20 @@ func TestCSVGZImport(t *testing.T) {
 	// Write csv file to process into the 'process' directory.
 	f, err := os.Create(filepath.Join(processDirectory, testCsvFile))
 	require.NoError(t, err)
-	f.WriteString("thing,color\nsky,blue\ngrass,green\nclifford,red\n")
-	f.Close()
+	_, err = f.WriteString("thing,color\nsky,blue\ngrass,green\nclifford,red\n")
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
 
 	// Write csv.gz file to process into the 'process' directory.
 	var b bytes.Buffer
 	w := gzip.NewWriter(&b)
-	w.Write([]byte("thing,color\nsky,blue\ngrass,green\nclifford,red\n"))
-	w.Close()
+	_, err = w.Write([]byte("thing,color\nsky,blue\ngrass,green\nclifford,red\n"))
+	require.NoError(t, err)
+	err = w.Close()
+	require.NoError(t, err)
 	err = ioutil.WriteFile(filepath.Join(processDirectory, testCsvGzFile), b.Bytes(), 0666)
+	require.NoError(t, err)
 
 	// Start plugin before adding file.
 	err = r.Start(&acc)
@@ -112,8 +117,10 @@ func TestMultipleJSONFileImports(t *testing.T) {
 	// Write csv file to process into the 'process' directory.
 	f, err := os.Create(filepath.Join(processDirectory, testJSONFile))
 	require.NoError(t, err)
-	f.WriteString("{\"Name\": \"event1\",\"Speed\": 100.1,\"Length\": 20.1}\n{\"Name\": \"event2\",\"Speed\": 500,\"Length\": 1.4}\n{\"Name\": \"event3\",\"Speed\": 200,\"Length\": 10.23}\n{\"Name\": \"event4\",\"Speed\": 80,\"Length\": 250}\n{\"Name\": \"event5\",\"Speed\": 120.77,\"Length\": 25.97}")
-	f.Close()
+	_, err = f.WriteString("{\"Name\": \"event1\",\"Speed\": 100.1,\"Length\": 20.1}\n{\"Name\": \"event2\",\"Speed\": 500,\"Length\": 1.4}\n{\"Name\": \"event3\",\"Speed\": 200,\"Length\": 10.23}\n{\"Name\": \"event4\",\"Speed\": 80,\"Length\": 250}\n{\"Name\": \"event5\",\"Speed\": 120.77,\"Length\": 25.97}")
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
 
 	err = r.Start(&acc)
 	r.Log = testutil.Logger{}

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -58,10 +58,10 @@ func (d *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	}
 	// Final open of the confirmed (or the previously detected/used) udev file
 	f, err := os.Open(udevDataPath)
-	defer f.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
 	di := map[string]string{}
 
@@ -80,9 +80,12 @@ func (d *DiskIO) diskInfo(devName string) (map[string]string, error) {
 		}
 		if l[:2] == "S:" {
 			if devlinks.Len() > 0 {
+				//nolint:errcheck,revive // this will never fail
 				devlinks.WriteString(" ")
 			}
+			//nolint:errcheck,revive // this will never fail
 			devlinks.WriteString("/dev/")
+			//nolint:errcheck,revive // this will never fail
 			devlinks.WriteString(l[2:])
 			continue
 		}

--- a/plugins/inputs/diskio/diskio_linux_test.go
+++ b/plugins/inputs/diskio/diskio_linux_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,18 +58,18 @@ func TestDiskInfo(t *testing.T) {
 	defer clean()
 	di, err := s.diskInfo("null")
 	require.NoError(t, err)
-	assert.Equal(t, "myval1", di["MY_PARAM_1"])
-	assert.Equal(t, "myval2", di["MY_PARAM_2"])
-	assert.Equal(t, "/dev/foo/bar/devlink /dev/foo/bar/devlink1", di["DEVLINKS"])
+	require.Equal(t, "myval1", di["MY_PARAM_1"])
+	require.Equal(t, "myval2", di["MY_PARAM_2"])
+	require.Equal(t, "/dev/foo/bar/devlink /dev/foo/bar/devlink1", di["DEVLINKS"])
 
 	// test that data is cached
 	clean()
 
 	di, err = s.diskInfo("null")
 	require.NoError(t, err)
-	assert.Equal(t, "myval1", di["MY_PARAM_1"])
-	assert.Equal(t, "myval2", di["MY_PARAM_2"])
-	assert.Equal(t, "/dev/foo/bar/devlink /dev/foo/bar/devlink1", di["DEVLINKS"])
+	require.Equal(t, "myval1", di["MY_PARAM_1"])
+	require.Equal(t, "myval2", di["MY_PARAM_2"])
+	require.Equal(t, "/dev/foo/bar/devlink /dev/foo/bar/devlink1", di["DEVLINKS"])
 	// unfortunately we can't adjust mtime on /dev/null to test cache invalidation
 }
 
@@ -98,7 +97,7 @@ func TestDiskIOStats_diskName(t *testing.T) {
 		}
 		defer setupNullDisk(t, &s, "null")()
 		name, _ := s.diskName("null")
-		assert.Equal(t, tc.expected, name, "Templates: %#v", tc.templates)
+		require.Equal(t, tc.expected, name, "Templates: %#v", tc.templates)
 	}
 }
 
@@ -110,5 +109,5 @@ func TestDiskIOStats_diskTags(t *testing.T) {
 	}
 	defer setupNullDisk(t, s, "null")()
 	dt := s.diskTags("null")
-	assert.Equal(t, map[string]string{"MY_PARAM_2": "myval2"}, dt)
+	require.Equal(t, map[string]string{"MY_PARAM_2": "myval2"}, dt)
 }

--- a/plugins/inputs/diskio/diskio_linux_test.go
+++ b/plugins/inputs/diskio/diskio_linux_test.go
@@ -19,7 +19,7 @@ S:foo/bar/devlink1
 `)
 
 // setupNullDisk sets up fake udev info as if /dev/null were a disk.
-func setupNullDisk(t *testing.T, s *DiskIO, devName string) func() error {
+func setupNullDisk(t *testing.T, s *DiskIO, devName string) func() {
 	td, err := ioutil.TempFile("", ".telegraf.DiskInfoTest")
 	require.NoError(t, err)
 
@@ -37,9 +37,10 @@ func setupNullDisk(t *testing.T, s *DiskIO, devName string) func() error {
 	}
 	origUdevPath := ic.udevDataPath
 
-	cleanFunc := func() error {
+	cleanFunc := func() {
 		ic.udevDataPath = origUdevPath
-		return os.Remove(td.Name())
+		//nolint:errcheck,revive // we cannot do anything if file cannot be removed
+		os.Remove(td.Name())
 	}
 
 	ic.udevDataPath = td.Name()
@@ -63,8 +64,7 @@ func TestDiskInfo(t *testing.T) {
 	assert.Equal(t, "/dev/foo/bar/devlink /dev/foo/bar/devlink1", di["DEVLINKS"])
 
 	// test that data is cached
-	err = clean()
-	require.NoError(t, err)
+	clean()
 
 	di, err = s.diskInfo("null")
 	require.NoError(t, err)

--- a/plugins/inputs/disque/disque.go
+++ b/plugins/inputs/disque/disque.go
@@ -68,8 +68,7 @@ func (d *Disque) Gather(acc telegraf.Accumulator) error {
 		url := &url.URL{
 			Host: ":7711",
 		}
-		d.gatherServer(url, acc)
-		return nil
+		return d.gatherServer(url, acc)
 	}
 
 	var wg sync.WaitGroup
@@ -114,7 +113,9 @@ func (d *Disque) gatherServer(addr *url.URL, acc telegraf.Accumulator) error {
 		if addr.User != nil {
 			pwd, set := addr.User.Password()
 			if set && pwd != "" {
-				c.Write([]byte(fmt.Sprintf("AUTH %s\r\n", pwd)))
+				if _, err := c.Write([]byte(fmt.Sprintf("AUTH %s\r\n", pwd))); err != nil {
+					return err
+				}
 
 				r := bufio.NewReader(c)
 
@@ -132,9 +133,13 @@ func (d *Disque) gatherServer(addr *url.URL, acc telegraf.Accumulator) error {
 	}
 
 	// Extend connection
-	d.c.SetDeadline(time.Now().Add(defaultTimeout))
+	if err := d.c.SetDeadline(time.Now().Add(defaultTimeout)); err != nil {
+		return err
+	}
 
-	d.c.Write([]byte("info\r\n"))
+	if _, err := d.c.Write([]byte("info\r\n")); err != nil {
+		return err
+	}
 
 	r := bufio.NewReader(d.c)
 

--- a/plugins/inputs/disque/disque_test.go
+++ b/plugins/inputs/disque/disque_test.go
@@ -38,8 +38,12 @@ func TestDisqueGeneratesMetricsIntegration(t *testing.T) {
 				return
 			}
 
-			fmt.Fprintf(c, "$%d\n", len(testOutput))
-			c.Write([]byte(testOutput))
+			if _, err := fmt.Fprintf(c, "$%d\n", len(testOutput)); err != nil {
+				return
+			}
+			if _, err := c.Write([]byte(testOutput)); err != nil {
+				return
+			}
 		}
 	}()
 
@@ -104,8 +108,12 @@ func TestDisqueCanPullStatsFromMultipleServersIntegration(t *testing.T) {
 				return
 			}
 
-			fmt.Fprintf(c, "$%d\n", len(testOutput))
-			c.Write([]byte(testOutput))
+			if _, err := fmt.Fprintf(c, "$%d\n", len(testOutput)); err != nil {
+				return
+			}
+			if _, err := c.Write([]byte(testOutput)); err != nil {
+				return
+			}
 		}
 	}()
 

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -911,7 +911,7 @@ func TestDockerGatherSwarmInfo(t *testing.T) {
 	err := acc.GatherError(d.Gather)
 	require.NoError(t, err)
 
-	d.gatherSwarmInfo(&acc)
+	require.NoError(t, d.gatherSwarmInfo(&acc))
 
 	// test docker_container_net measurement
 	acc.AssertContainsTaggedFields(t,

--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -398,8 +398,11 @@ func tailMultiplexed(
 	}()
 
 	_, err := stdcopy.StdCopy(outWriter, errWriter, src)
+	//nolint:errcheck,revive // we cannot do anything if the closing fails
 	outWriter.Close()
+	//nolint:errcheck,revive // we cannot do anything if the closing fails
 	errWriter.Close()
+	//nolint:errcheck,revive // we cannot do anything if the closing fails
 	src.Close()
 	wg.Wait()
 	return err

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -138,8 +138,8 @@ func Test(t *testing.T) {
 				ContainerLogsF: func(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
 					var buf bytes.Buffer
 					w := stdcopy.NewStdWriter(&buf, stdcopy.Stdout)
-					w.Write([]byte("2020-04-28T18:42:16.432691200Z hello from stdout"))
-					return &Response{Reader: &buf}, nil
+					_, err := w.Write([]byte("2020-04-28T18:42:16.432691200Z hello from stdout"))
+					return &Response{Reader: &buf}, err
 				},
 			},
 			expected: []telegraf.Metric{

--- a/plugins/inputs/ecs/ecs_test.go
+++ b/plugins/inputs/ecs/ecs_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // codified golden objects for tests
@@ -800,10 +800,10 @@ func TestResolveEndpoint(t *testing.T) {
 		{
 			name: "Endpoint is not set, ECS_CONTAINER_METADATA_URI is set => use v3 metadata",
 			preF: func() {
-				os.Setenv("ECS_CONTAINER_METADATA_URI", "v3-endpoint.local")
+				require.NoError(t, os.Setenv("ECS_CONTAINER_METADATA_URI", "v3-endpoint.local"))
 			},
 			afterF: func() {
-				os.Unsetenv("ECS_CONTAINER_METADATA_URI")
+				require.NoError(t, os.Unsetenv("ECS_CONTAINER_METADATA_URI"))
 			},
 			given: Ecs{
 				EndpointURL: "",
@@ -825,7 +825,7 @@ func TestResolveEndpoint(t *testing.T) {
 
 			act := tt.given
 			resolveEndpoint(&act)
-			assert.Equal(t, tt.exp, act)
+			require.Equal(t, tt.exp, act)
 		})
 	}
 }

--- a/plugins/inputs/elasticsearch/elasticsearch_test.go
+++ b/plugins/inputs/elasticsearch/elasticsearch_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/influxdata/telegraf/testutil"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,14 +48,7 @@ func (t *transportMock) RoundTrip(r *http.Request) (*http.Response, error) {
 	return res, nil
 }
 
-func (t *transportMock) CancelRequest(_ *http.Request) {
-}
-
-func checkIsMaster(es *Elasticsearch, server string, expected bool, t *testing.T) {
-	if es.serverInfo[server].isMaster() != expected {
-		assert.Fail(t, "IsMaster set incorrectly")
-	}
-}
+func (t *transportMock) CancelRequest(_ *http.Request) {}
 
 func checkNodeStatsResult(t *testing.T, acc *testutil.Accumulator) {
 	tags := defaultTags()
@@ -79,11 +71,8 @@ func TestGather(t *testing.T) {
 	es.serverInfo["http://example.com:9200"] = defaultServerInfo()
 
 	var acc testutil.Accumulator
-	if err := acc.GatherError(es.Gather); err != nil {
-		t.Fatal(err)
-	}
-
-	checkIsMaster(es, es.Servers[0], false, t)
+	require.NoError(t, acc.GatherError(es.Gather))
+	require.False(t, es.serverInfo[es.Servers[0]].isMaster(), "IsMaster set incorrectly")
 	checkNodeStatsResult(t, &acc)
 }
 
@@ -96,11 +85,8 @@ func TestGatherIndividualStats(t *testing.T) {
 	es.serverInfo["http://example.com:9200"] = defaultServerInfo()
 
 	var acc testutil.Accumulator
-	if err := acc.GatherError(es.Gather); err != nil {
-		t.Fatal(err)
-	}
-
-	checkIsMaster(es, es.Servers[0], false, t)
+	require.NoError(t, acc.GatherError(es.Gather))
+	require.False(t, es.serverInfo[es.Servers[0]].isMaster(), "IsMaster set incorrectly")
 
 	tags := defaultTags()
 	acc.AssertDoesNotContainsTaggedFields(t, "elasticsearch_indices", nodestatsIndicesExpected, tags)
@@ -122,11 +108,8 @@ func TestGatherNodeStats(t *testing.T) {
 	es.serverInfo["http://example.com:9200"] = defaultServerInfo()
 
 	var acc testutil.Accumulator
-	if err := es.gatherNodeStats("junk", &acc); err != nil {
-		t.Fatal(err)
-	}
-
-	checkIsMaster(es, es.Servers[0], false, t)
+	require.NoError(t, es.gatherNodeStats("junk", &acc))
+	require.False(t, es.serverInfo[es.Servers[0]].isMaster(), "IsMaster set incorrectly")
 	checkNodeStatsResult(t, &acc)
 }
 
@@ -141,8 +124,7 @@ func TestGatherClusterHealthEmptyClusterHealth(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, es.gatherClusterHealth("junk", &acc))
-
-	checkIsMaster(es, es.Servers[0], false, t)
+	require.False(t, es.serverInfo[es.Servers[0]].isMaster(), "IsMaster set incorrectly")
 
 	acc.AssertContainsTaggedFields(t, "elasticsearch_cluster_health",
 		clusterHealthExpected,
@@ -168,8 +150,7 @@ func TestGatherClusterHealthSpecificClusterHealth(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, es.gatherClusterHealth("junk", &acc))
-
-	checkIsMaster(es, es.Servers[0], false, t)
+	require.False(t, es.serverInfo[es.Servers[0]].isMaster(), "IsMaster set incorrectly")
 
 	acc.AssertContainsTaggedFields(t, "elasticsearch_cluster_health",
 		clusterHealthExpected,
@@ -195,8 +176,7 @@ func TestGatherClusterHealthAlsoIndicesHealth(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, es.gatherClusterHealth("junk", &acc))
-
-	checkIsMaster(es, es.Servers[0], false, t)
+	require.False(t, es.serverInfo[es.Servers[0]].isMaster(), "IsMaster set incorrectly")
 
 	acc.AssertContainsTaggedFields(t, "elasticsearch_cluster_health",
 		clusterHealthExpected,
@@ -227,19 +207,14 @@ func TestGatherClusterStatsMaster(t *testing.T) {
 	es.serverInfo["http://example.com:9200"] = info
 
 	IsMasterResultTokens := strings.Split(string(IsMasterResult), " ")
-	if masterID != IsMasterResultTokens[0] {
-		assert.Fail(t, "catmaster is incorrect")
-	}
+	require.Equal(t, masterID, IsMasterResultTokens[0], "catmaster is incorrect")
 
 	// now get node status, which determines whether we're master
 	var acc testutil.Accumulator
 	es.Local = true
 	es.client.Transport = newTransportMock(nodeStatsResponse)
-	if err := es.gatherNodeStats("junk", &acc); err != nil {
-		t.Fatal(err)
-	}
-
-	checkIsMaster(es, es.Servers[0], true, t)
+	require.NoError(t, es.gatherNodeStats("junk", &acc))
+	require.True(t, es.serverInfo[es.Servers[0]].isMaster(), "IsMaster set incorrectly")
 	checkNodeStatsResult(t, &acc)
 
 	// now test the clusterstats method
@@ -270,20 +245,16 @@ func TestGatherClusterStatsNonMaster(t *testing.T) {
 	require.NoError(t, err)
 
 	IsNotMasterResultTokens := strings.Split(string(IsNotMasterResult), " ")
-	if masterID != IsNotMasterResultTokens[0] {
-		assert.Fail(t, "catmaster is incorrect")
-	}
+	require.Equal(t, masterID, IsNotMasterResultTokens[0], "catmaster is incorrect")
 
 	// now get node status, which determines whether we're master
 	var acc testutil.Accumulator
 	es.Local = true
 	es.client.Transport = newTransportMock(nodeStatsResponse)
-	if err := es.gatherNodeStats("junk", &acc); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, es.gatherNodeStats("junk", &acc))
 
 	// ensure flag is clear so Cluster Stats would not be done
-	checkIsMaster(es, es.Servers[0], false, t)
+	require.False(t, es.serverInfo[es.Servers[0]].isMaster(), "IsMaster set incorrectly")
 	checkNodeStatsResult(t, &acc)
 }
 
@@ -296,9 +267,7 @@ func TestGatherClusterIndicesStats(t *testing.T) {
 	es.serverInfo["http://example.com:9200"] = defaultServerInfo()
 
 	var acc testutil.Accumulator
-	if err := es.gatherIndicesStats("junk", &acc); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, es.gatherIndicesStats("junk", &acc))
 
 	acc.AssertContainsTaggedFields(t, "elasticsearch_indices_stats_primaries",
 		clusterIndicesExpected,
@@ -313,12 +282,10 @@ func TestGatherDateStampedIndicesStats(t *testing.T) {
 	es.client.Transport = newTransportMock(dateStampedIndicesResponse)
 	es.serverInfo = make(map[string]serverInfo)
 	es.serverInfo["http://example.com:9200"] = defaultServerInfo()
-	es.Init()
+	require.NoError(t, es.Init())
 
 	var acc testutil.Accumulator
-	if err := es.gatherIndicesStats(es.Servers[0]+"/"+strings.Join(es.IndicesInclude, ",")+"/_stats", &acc); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, es.gatherIndicesStats(es.Servers[0]+"/"+strings.Join(es.IndicesInclude, ",")+"/_stats", &acc))
 
 	// includes 2 most recent indices for "twitter", only expect the most recent two.
 	acc.AssertContainsTaggedFields(t, "elasticsearch_indices_stats_primaries",
@@ -357,9 +324,7 @@ func TestGatherClusterIndiceShardsStats(t *testing.T) {
 	es.serverInfo["http://example.com:9200"] = defaultServerInfo()
 
 	var acc testutil.Accumulator
-	if err := es.gatherIndicesStats("junk", &acc); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, es.gatherIndicesStats("junk", &acc))
 
 	acc.AssertContainsTaggedFields(t, "elasticsearch_indices_stats_primaries",
 		clusterIndicesExpected,

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -111,6 +111,7 @@ func (c CommandRunner) truncate(buf bytes.Buffer) bytes.Buffer {
 		buf.Truncate(i)
 	}
 	if didTruncate {
+		//nolint:errcheck,revive // Will always return nil or panic
 		buf.WriteString("...")
 	}
 	return buf

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -200,12 +200,14 @@ func TestTruncate(t *testing.T) {
 			name: "should not truncate",
 			bufF: func() *bytes.Buffer {
 				var b bytes.Buffer
-				b.WriteString("hello world")
+				_, err := b.WriteString("hello world")
+				require.NoError(t, err)
 				return &b
 			},
 			expF: func() *bytes.Buffer {
 				var b bytes.Buffer
-				b.WriteString("hello world")
+				_, err := b.WriteString("hello world")
+				require.NoError(t, err)
 				return &b
 			},
 		},
@@ -213,12 +215,14 @@ func TestTruncate(t *testing.T) {
 			name: "should truncate up to the new line",
 			bufF: func() *bytes.Buffer {
 				var b bytes.Buffer
-				b.WriteString("hello world\nand all the people")
+				_, err := b.WriteString("hello world\nand all the people")
+				require.NoError(t, err)
 				return &b
 			},
 			expF: func() *bytes.Buffer {
 				var b bytes.Buffer
-				b.WriteString("hello world...")
+				_, err := b.WriteString("hello world...")
+				require.NoError(t, err)
 				return &b
 			},
 		},
@@ -227,16 +231,17 @@ func TestTruncate(t *testing.T) {
 			bufF: func() *bytes.Buffer {
 				var b bytes.Buffer
 				for i := 0; i < 2*MaxStderrBytes; i++ {
-					b.WriteByte('b')
+					require.NoError(t, b.WriteByte('b'))
 				}
 				return &b
 			},
 			expF: func() *bytes.Buffer {
 				var b bytes.Buffer
 				for i := 0; i < MaxStderrBytes; i++ {
-					b.WriteByte('b')
+					require.NoError(t, b.WriteByte('b'))
 				}
-				b.WriteString("...")
+				_, err := b.WriteString("...")
+				require.NoError(t, err)
 				return &b
 			},
 		},

--- a/plugins/inputs/execd/execd_posix.go
+++ b/plugins/inputs/execd/execd_posix.go
@@ -23,17 +23,19 @@ func (e *Execd) Gather(_ telegraf.Accumulator) error {
 	}
 	switch e.Signal {
 	case "SIGHUP":
-		osProcess.Signal(syscall.SIGHUP)
+		return osProcess.Signal(syscall.SIGHUP)
 	case "SIGUSR1":
-		osProcess.Signal(syscall.SIGUSR1)
+		return osProcess.Signal(syscall.SIGUSR1)
 	case "SIGUSR2":
-		osProcess.Signal(syscall.SIGUSR2)
+		return osProcess.Signal(syscall.SIGUSR2)
 	case "STDIN":
 		if osStdin, ok := e.process.Stdin.(*os.File); ok {
-			osStdin.SetWriteDeadline(time.Now().Add(1 * time.Second))
+			if err := osStdin.SetWriteDeadline(time.Now().Add(1 * time.Second)); err != nil {
+				return fmt.Errorf("setting write deadline failed: %s", err)
+			}
 		}
 		if _, err := io.WriteString(e.process.Stdin, "\n"); err != nil {
-			return fmt.Errorf("Error writing to stdin: %s", err)
+			return fmt.Errorf("writing to stdin failed: %s", err)
 		}
 	case "none":
 	default:

--- a/plugins/inputs/execd/execd_test.go
+++ b/plugins/inputs/execd/execd_test.go
@@ -153,20 +153,22 @@ var counter = flag.Bool("counter", false,
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if *counter {
-		runCounterProgram()
+		if err := runCounterProgram(); err != nil {
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 	code := m.Run()
 	os.Exit(code)
 }
 
-func runCounterProgram() {
+func runCounterProgram() error {
 	i := 0
 	serializer, err := serializers.NewInfluxSerializer()
 	if err != nil {
 		//nolint:errcheck,revive // Test will fail anyway
 		fmt.Fprintln(os.Stderr, "ERR InfluxSerializer failed to load")
-		os.Exit(1)
+		return err
 	}
 
 	scanner := bufio.NewScanner(os.Stdin)
@@ -184,10 +186,11 @@ func runCounterProgram() {
 		if err != nil {
 			//nolint:errcheck,revive // Test will fail anyway
 			fmt.Fprintf(os.Stderr, "ERR %v\n", err)
-			os.Exit(1)
+			return err
 		}
 		if _, err := fmt.Fprint(os.Stdout, string(b)); err != nil {
-			os.Exit(1)
+			return err
 		}
 	}
+	return nil
 }

--- a/plugins/inputs/execd/execd_test.go
+++ b/plugins/inputs/execd/execd_test.go
@@ -164,6 +164,7 @@ func runCounterProgram() {
 	i := 0
 	serializer, err := serializers.NewInfluxSerializer()
 	if err != nil {
+		//nolint:errcheck,revive // Test will fail anyway
 		fmt.Fprintln(os.Stderr, "ERR InfluxSerializer failed to load")
 		os.Exit(1)
 	}
@@ -181,9 +182,12 @@ func runCounterProgram() {
 
 		b, err := serializer.Serialize(m)
 		if err != nil {
+			//nolint:errcheck,revive // Test will fail anyway
 			fmt.Fprintf(os.Stderr, "ERR %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Fprint(os.Stdout, string(b))
+		if _, err := fmt.Fprint(os.Stdout, string(b)); err != nil {
+			os.Exit(1)
+		}
 	}
 }

--- a/plugins/inputs/execd/shim/goshim.go
+++ b/plugins/inputs/execd/shim/goshim.go
@@ -57,8 +57,7 @@ var (
 
 // New creates a new shim interface
 func New() *Shim {
-	fmt.Fprintf(os.Stderr, "%s is deprecated; please change your import to %s\n",
-		oldpkg, newpkg)
+	_, _ = fmt.Fprintf(os.Stderr, "%s is deprecated; please change your import to %s\n", oldpkg, newpkg)
 	return &Shim{
 		stdin:  os.Stdin,
 		stdout: os.Stdout,
@@ -155,7 +154,9 @@ loop:
 				return fmt.Errorf("failed to serialize metric: %s", err)
 			}
 			// Write this to stdout
-			fmt.Fprint(s.stdout, string(b))
+			if _, err := fmt.Fprint(s.stdout, string(b)); err != nil {
+				return fmt.Errorf("failed to write %q to stdout: %s", string(b), err)
+			}
 		}
 	}
 
@@ -232,11 +233,17 @@ func (s *Shim) startGathering(ctx context.Context, input telegraf.Input, acc tel
 			return
 		case <-gatherPromptCh:
 			if err := input.Gather(acc); err != nil {
-				fmt.Fprintf(s.stderr, "failed to gather metrics: %s", err)
+				if _, perr := fmt.Fprintf(s.stderr, "failed to gather metrics: %s", err); perr != nil {
+					acc.AddError(err)
+					acc.AddError(perr)
+				}
 			}
 		case <-t.C:
 			if err := input.Gather(acc); err != nil {
-				fmt.Fprintf(s.stderr, "failed to gather metrics: %s", err)
+				if _, perr := fmt.Fprintf(s.stderr, "failed to gather metrics: %s", err); perr != nil {
+					acc.AddError(err)
+					acc.AddError(perr)
+				}
 			}
 		}
 	}

--- a/plugins/inputs/execd/shim/shim_posix_test.go
+++ b/plugins/inputs/execd/shim/shim_posix_test.go
@@ -37,7 +37,7 @@ func TestShimUSR1SignalingWorks(t *testing.T) {
 				return // test is done
 			default:
 				// test isn't done, keep going.
-				process.Signal(syscall.SIGUSR1)
+				require.NoError(t, process.Signal(syscall.SIGUSR1))
 				time.Sleep(200 * time.Millisecond)
 			}
 		}
@@ -51,7 +51,7 @@ func TestShimUSR1SignalingWorks(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "measurement,tag=tag field=1i 1234000005678\n", out)
 
-	stdinWriter.Close()
+	require.NoError(t, stdinWriter.Close())
 	readUntilEmpty(r)
 
 	<-exited

--- a/plugins/inputs/execd/shim/shim_test.go
+++ b/plugins/inputs/execd/shim/shim_test.go
@@ -36,7 +36,8 @@ func TestShimStdinSignalingWorks(t *testing.T) {
 
 	metricProcessed, exited := runInputPlugin(t, 40*time.Second, stdinReader, stdoutWriter, nil)
 
-	stdinWriter.Write([]byte("\n"))
+	_, err := stdinWriter.Write([]byte("\n"))
+	require.NoError(t, err)
 
 	<-metricProcessed
 
@@ -45,7 +46,7 @@ func TestShimStdinSignalingWorks(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "measurement,tag=tag field=1i 1234000005678\n", out)
 
-	stdinWriter.Close()
+	require.NoError(t, stdinWriter.Close())
 
 	readUntilEmpty(r)
 
@@ -71,7 +72,7 @@ func runInputPlugin(t *testing.T, interval time.Duration, stdin io.Reader, stdou
 		shim.stderr = stderr
 	}
 
-	shim.AddInput(inp)
+	require.NoError(t, shim.AddInput(inp))
 	go func() {
 		err := shim.Run(interval)
 		require.NoError(t, err)
@@ -112,8 +113,8 @@ func (i *testInput) Stop() {
 }
 
 func TestLoadConfig(t *testing.T) {
-	os.Setenv("SECRET_TOKEN", "xxxxxxxxxx")
-	os.Setenv("SECRET_VALUE", `test"\test`)
+	require.NoError(t, os.Setenv("SECRET_TOKEN", "xxxxxxxxxx"))
+	require.NoError(t, os.Setenv("SECRET_VALUE", `test"\test`))
 
 	inputs.Add("test", func() telegraf.Input {
 		return &serviceInput{}

--- a/plugins/inputs/fail2ban/fail2ban_test.go
+++ b/plugins/inputs/fail2ban/fail2ban_test.go
@@ -101,25 +101,31 @@ func TestHelperProcess(_ *testing.T) {
 	cmd, args := args[3], args[4:]
 
 	if !strings.HasSuffix(cmd, "fail2ban-client") {
+		//nolint:errcheck,revive // Test will fail anyway
 		fmt.Fprint(os.Stdout, "command not found")
 		os.Exit(1)
 	}
 
 	if len(args) == 1 && args[0] == "status" {
+		//nolint:errcheck,revive // Test will fail anyway
 		fmt.Fprint(os.Stdout, execStatusOutput)
 		os.Exit(0)
 	} else if len(args) == 2 && args[0] == "status" {
 		if args[1] == "sshd" {
+			//nolint:errcheck,revive // Test will fail anyway
 			fmt.Fprint(os.Stdout, execStatusSshdOutput)
 			os.Exit(0)
 		} else if args[1] == "postfix" {
+			//nolint:errcheck,revive // Test will fail anyway
 			fmt.Fprint(os.Stdout, execStatusPostfixOutput)
 			os.Exit(0)
 		} else if args[1] == "dovecot" {
+			//nolint:errcheck,revive // Test will fail anyway
 			fmt.Fprint(os.Stdout, execStatusDovecotOutput)
 			os.Exit(0)
 		}
 	}
+	//nolint:errcheck,revive // Test will fail anyway
 	fmt.Fprint(os.Stdout, "invalid argument")
 	os.Exit(1)
 }

--- a/plugins/inputs/fibaro/fibaro_test.go
+++ b/plugins/inputs/fibaro/fibaro_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,7 +161,8 @@ func TestJSONSuccess(t *testing.T) {
 			payload = devicesJSON
 		}
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, payload)
+		_, err := fmt.Fprintln(w, payload)
+		require.NoError(t, err)
 	}))
 	defer ts.Close()
 
@@ -178,7 +178,7 @@ func TestJSONSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Gather should add 5 metrics
-	assert.Equal(t, uint64(5), acc.NMetrics())
+	require.Equal(t, uint64(5), acc.NMetrics())
 
 	// Ensure fields / values are correct - Device 1
 	tags := map[string]string{"deviceId": "1", "section": "Section 1", "room": "Room 1", "name": "Device 1", "type": "com.fibaro.binarySwitch"}

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/parsers/csv"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +28,7 @@ func TestRefreshFilePaths(t *testing.T) {
 
 	err = r.refreshFilePaths()
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(r.filenames))
+	require.Equal(t, 2, len(r.filenames))
 }
 
 func TestFileTag(t *testing.T) {
@@ -47,7 +46,7 @@ func TestFileTag(t *testing.T) {
 		DataFormat: "json",
 	}
 	nParser, err := parsers.NewParser(&parserConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.parser = nParser
 
 	err = r.Gather(&acc)
@@ -55,8 +54,8 @@ func TestFileTag(t *testing.T) {
 
 	for _, m := range acc.Metrics {
 		for key, value := range m.Tags {
-			assert.Equal(t, r.FileTag, key)
-			assert.Equal(t, filepath.Base(r.Files[0]), value)
+			require.Equal(t, r.FileTag, key)
+			require.Equal(t, filepath.Base(r.Files[0]), value)
 		}
 	}
 }
@@ -74,12 +73,12 @@ func TestJSONParserCompile(t *testing.T) {
 		TagKeys:    []string{"parent_ignored_child"},
 	}
 	nParser, err := parsers.NewParser(&parserConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.parser = nParser
 
-	r.Gather(&acc)
-	assert.Equal(t, map[string]string{"parent_ignored_child": "hi"}, acc.Metrics[0].Tags)
-	assert.Equal(t, 5, len(acc.Metrics[0].Fields))
+	require.NoError(t, r.Gather(&acc))
+	require.Equal(t, map[string]string{"parent_ignored_child": "hi"}, acc.Metrics[0].Tags)
+	require.Equal(t, 5, len(acc.Metrics[0].Fields))
 }
 
 func TestGrokParser(t *testing.T) {
@@ -98,10 +97,10 @@ func TestGrokParser(t *testing.T) {
 
 	nParser, err := parsers.NewParser(&parserConfig)
 	r.parser = nParser
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = r.Gather(&acc)
-	assert.Equal(t, len(acc.Metrics), 2)
+	require.Equal(t, len(acc.Metrics), 2)
 }
 
 func TestCharacterEncoding(t *testing.T) {

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -35,7 +35,7 @@ func TestNoFiltersOnChildDir(t *testing.T) {
 
 	tags := map[string]string{"directory": getTestdataDir() + "/subdir"}
 	acc := testutil.Accumulator{}
-	acc.GatherError(fc.Gather)
+	require.NoError(t, acc.GatherError(fc.Gather))
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(len(matches))))
 	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(600)))
 }
@@ -48,7 +48,7 @@ func TestNoRecursiveButSuperMeta(t *testing.T) {
 
 	tags := map[string]string{"directory": getTestdataDir() + "/subdir"}
 	acc := testutil.Accumulator{}
-	acc.GatherError(fc.Gather)
+	require.NoError(t, acc.GatherError(fc.Gather))
 
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(len(matches))))
 	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(200)))
@@ -77,7 +77,7 @@ func TestDoubleAndSimpleStar(t *testing.T) {
 	tags := map[string]string{"directory": getTestdataDir() + "/subdir/nested2"}
 
 	acc := testutil.Accumulator{}
-	acc.GatherError(fc.Gather)
+	require.NoError(t, acc.GatherError(fc.Gather))
 
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(len(matches))))
 	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(400)))
@@ -235,7 +235,7 @@ func getFakeFileSystem(basePath string) fakeFileSystem {
 func fileCountEquals(t *testing.T, fc FileCount, expectedCount int, expectedSize int) {
 	tags := map[string]string{"directory": getTestdataDir()}
 	acc := testutil.Accumulator{}
-	acc.GatherError(fc.Gather)
+	require.NoError(t, acc.GatherError(fc.Gather))
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(expectedCount)))
 	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(expectedSize)))
 }

--- a/plugins/inputs/filestat/filestat_test.go
+++ b/plugins/inputs/filestat/filestat_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"
@@ -30,7 +29,7 @@ func TestGatherNoMd5(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	acc.GatherError(fs.Gather)
+	require.NoError(t, acc.GatherError(fs.Gather))
 
 	tags1 := map[string]string{
 		"file": filepath.Join(testdataDir, "log1.log"),
@@ -61,7 +60,7 @@ func TestGatherExplicitFiles(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	acc.GatherError(fs.Gather)
+	require.NoError(t, acc.GatherError(fs.Gather))
 
 	tags1 := map[string]string{
 		"file": filepath.Join(testdataDir, "log1.log"),
@@ -94,10 +93,10 @@ func TestNonExistentFile(t *testing.T) {
 	require.NoError(t, acc.GatherError(fs.Gather))
 
 	acc.AssertContainsFields(t, "filestat", map[string]interface{}{"exists": int64(0)})
-	assert.False(t, acc.HasField("filestat", "error"))
-	assert.False(t, acc.HasField("filestat", "md5_sum"))
-	assert.False(t, acc.HasField("filestat", "size_bytes"))
-	assert.False(t, acc.HasField("filestat", "modification_time"))
+	require.False(t, acc.HasField("filestat", "error"))
+	require.False(t, acc.HasField("filestat", "md5_sum"))
+	require.False(t, acc.HasField("filestat", "size_bytes"))
+	require.False(t, acc.HasField("filestat", "modification_time"))
 }
 
 func TestGatherGlob(t *testing.T) {
@@ -109,7 +108,7 @@ func TestGatherGlob(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	acc.GatherError(fs.Gather)
+	require.NoError(t, acc.GatherError(fs.Gather))
 
 	tags1 := map[string]string{
 		"file": filepath.Join(testdataDir, "log1.log"),
@@ -135,7 +134,7 @@ func TestGatherSuperAsterisk(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	acc.GatherError(fs.Gather)
+	require.NoError(t, acc.GatherError(fs.Gather))
 
 	tags1 := map[string]string{
 		"file": filepath.Join(testdataDir, "log1.log"),
@@ -167,7 +166,7 @@ func TestModificationTime(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	acc.GatherError(fs.Gather)
+	require.NoError(t, acc.GatherError(fs.Gather))
 
 	tags1 := map[string]string{
 		"file": filepath.Join(testdataDir, "log1.log"),
@@ -185,7 +184,7 @@ func TestNoModificationTime(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	acc.GatherError(fs.Gather)
+	require.NoError(t, acc.GatherError(fs.Gather))
 
 	tags1 := map[string]string{
 		"file": filepath.Join(testdataDir, "non_existent_file"),
@@ -196,11 +195,11 @@ func TestNoModificationTime(t *testing.T) {
 
 func TestGetMd5(t *testing.T) {
 	md5, err := getMd5(filepath.Join(testdataDir, "test.conf"))
-	assert.NoError(t, err)
-	assert.Equal(t, "5a7e9b77fa25e7bb411dbd17cf403c1f", md5)
+	require.NoError(t, err)
+	require.Equal(t, "5a7e9b77fa25e7bb411dbd17cf403c1f", md5)
 
 	md5, err = getMd5("/tmp/foo/bar/fooooo")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func getTestdataDir() string {

--- a/plugins/inputs/fireboard/fireboard_test.go
+++ b/plugins/inputs/fireboard/fireboard_test.go
@@ -16,7 +16,8 @@ func TestFireboard(t *testing.T) {
 	// Create a test server with the const response JSON
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, response)
+		_, err := fmt.Fprintln(w, response)
+		require.NoError(t, err)
 	}))
 	defer ts.Close()
 

--- a/plugins/inputs/fluentd/fluentd_test.go
+++ b/plugins/inputs/fluentd/fluentd_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // sampleJSON from fluentd version '0.14.9'
@@ -122,7 +122,8 @@ func Test_Gather(t *testing.T) {
 
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, "%s", string(sampleJSON))
+		_, err := fmt.Fprintf(w, "%s", string(sampleJSON))
+		require.NoError(t, err)
 	}))
 
 	requestURL, err := url.Parse(fluentdTest.Endpoint)
@@ -144,15 +145,15 @@ func Test_Gather(t *testing.T) {
 		t.Errorf("acc.HasMeasurement: expected fluentd")
 	}
 
-	assert.Equal(t, expectedOutput[0].PluginID, acc.Metrics[0].Tags["plugin_id"])
-	assert.Equal(t, expectedOutput[0].PluginType, acc.Metrics[0].Tags["plugin_type"])
-	assert.Equal(t, expectedOutput[0].PluginCategory, acc.Metrics[0].Tags["plugin_category"])
-	assert.Equal(t, *expectedOutput[0].RetryCount, acc.Metrics[0].Fields["retry_count"])
+	require.Equal(t, expectedOutput[0].PluginID, acc.Metrics[0].Tags["plugin_id"])
+	require.Equal(t, expectedOutput[0].PluginType, acc.Metrics[0].Tags["plugin_type"])
+	require.Equal(t, expectedOutput[0].PluginCategory, acc.Metrics[0].Tags["plugin_category"])
+	require.Equal(t, *expectedOutput[0].RetryCount, acc.Metrics[0].Fields["retry_count"])
 
-	assert.Equal(t, expectedOutput[1].PluginID, acc.Metrics[1].Tags["plugin_id"])
-	assert.Equal(t, expectedOutput[1].PluginType, acc.Metrics[1].Tags["plugin_type"])
-	assert.Equal(t, expectedOutput[1].PluginCategory, acc.Metrics[1].Tags["plugin_category"])
-	assert.Equal(t, *expectedOutput[1].RetryCount, acc.Metrics[1].Fields["retry_count"])
-	assert.Equal(t, *expectedOutput[1].BufferQueueLength, acc.Metrics[1].Fields["buffer_queue_length"])
-	assert.Equal(t, *expectedOutput[1].BufferTotalQueuedSize, acc.Metrics[1].Fields["buffer_total_queued_size"])
+	require.Equal(t, expectedOutput[1].PluginID, acc.Metrics[1].Tags["plugin_id"])
+	require.Equal(t, expectedOutput[1].PluginType, acc.Metrics[1].Tags["plugin_type"])
+	require.Equal(t, expectedOutput[1].PluginCategory, acc.Metrics[1].Tags["plugin_category"])
+	require.Equal(t, *expectedOutput[1].RetryCount, acc.Metrics[1].Fields["retry_count"])
+	require.Equal(t, *expectedOutput[1].BufferQueueLength, acc.Metrics[1].Fields["buffer_queue_length"])
+	require.Equal(t, *expectedOutput[1].BufferTotalQueuedSize, acc.Metrics[1].Fields["buffer_total_queued_size"])
 }

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -332,7 +332,7 @@ func (c *GNMI) handleSubscribeResponseUpdate(address string, response *gnmi.Subs
 
 // HandleTelemetryField and add it to a measurement
 func (c *GNMI) handleTelemetryField(update *gnmi.Update, tags map[string]string, prefix string) (string, map[string]interface{}) {
-	path, aliasPath, err := c.handlePath(update.Path, tags, prefix)
+	gpath, aliasPath, err := c.handlePath(update.Path, tags, prefix)
 	if err != nil {
 		c.Log.Errorf("handling path %q failed: %v", update.Path, err)
 	}
@@ -342,7 +342,7 @@ func (c *GNMI) handleTelemetryField(update *gnmi.Update, tags map[string]string,
 
 	// Make sure a value is actually set
 	if update.Val == nil || update.Val.Value == nil {
-		c.Log.Infof("Discarded empty or legacy type value with path: %q", path)
+		c.Log.Infof("Discarded empty or legacy type value with path: %q", gpath)
 		return aliasPath, nil
 	}
 
@@ -369,7 +369,7 @@ func (c *GNMI) handleTelemetryField(update *gnmi.Update, tags map[string]string,
 		jsondata = val.JsonVal
 	}
 
-	name := strings.Replace(path, "-", "_", -1)
+	name := strings.Replace(gpath, "-", "_", -1)
 	fields := make(map[string]interface{})
 	if value != nil {
 		fields[name] = value

--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,13 +26,15 @@ func (s statServer) serverSocket(l net.Listener) {
 		}
 
 		go func(c net.Conn) {
+			defer c.Close()
+
 			buf := make([]byte, 1024)
 			n, _ := c.Read(buf)
 
 			data := buf[:n]
 			if string(data) == "show stat\n" {
+				//nolint:errcheck,revive // we return anyway
 				c.Write([]byte(csvOutputSample))
-				c.Close()
 			}
 		}(conn)
 	}
@@ -45,15 +46,18 @@ func TestHaproxyGeneratesMetricsWithAuthentication(t *testing.T) {
 		username, password, ok := r.BasicAuth()
 		if !ok {
 			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, "Unauthorized")
+			_, err := fmt.Fprint(w, "Unauthorized")
+			require.NoError(t, err)
 			return
 		}
 
 		if username == "user" && password == "password" {
-			fmt.Fprint(w, csvOutputSample)
+			_, err := fmt.Fprint(w, csvOutputSample)
+			require.NoError(t, err)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, "Unauthorized")
+			_, err := fmt.Fprint(w, "Unauthorized")
+			require.NoError(t, err)
 		}
 	}))
 	defer ts.Close()
@@ -83,13 +87,14 @@ func TestHaproxyGeneratesMetricsWithAuthentication(t *testing.T) {
 		Servers: []string{ts.URL},
 	}
 
-	r.Gather(&acc)
+	require.NoError(t, r.Gather(&acc))
 	require.NotEmpty(t, acc.Errors)
 }
 
 func TestHaproxyGeneratesMetricsWithoutAuthentication(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, csvOutputSample)
+		_, err := fmt.Fprint(w, csvOutputSample)
+		require.NoError(t, err)
 	}))
 	defer ts.Close()
 
@@ -99,8 +104,7 @@ func TestHaproxyGeneratesMetricsWithoutAuthentication(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := r.Gather(&acc)
-	require.NoError(t, err)
+	require.NoError(t, r.Gather(&acc))
 
 	tags := map[string]string{
 		"server": ts.Listener.Addr().String(),
@@ -121,7 +125,7 @@ func TestHaproxyGeneratesMetricsUsingSocket(t *testing.T) {
 	_badmask := filepath.Join(os.TempDir(), "test-fail-haproxy*.sock")
 
 	for i := 0; i < 5; i++ {
-		binary.Read(rand.Reader, binary.LittleEndian, &randomNumber)
+		require.NoError(t, binary.Read(rand.Reader, binary.LittleEndian, &randomNumber))
 		sockname := filepath.Join(os.TempDir(), fmt.Sprintf("test-haproxy%d.sock", randomNumber))
 
 		sock, err := net.Listen("unix", sockname)
@@ -161,7 +165,7 @@ func TestHaproxyGeneratesMetricsUsingSocket(t *testing.T) {
 	// This mask should not match any socket
 	r.Servers = []string{_badmask}
 
-	r.Gather(&acc)
+	require.NoError(t, r.Gather(&acc))
 	require.NotEmpty(t, acc.Errors)
 }
 
@@ -174,12 +178,13 @@ func TestHaproxyDefaultGetFromLocalhost(t *testing.T) {
 
 	err := r.Gather(&acc)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "127.0.0.1:1936/haproxy?stats/;csv")
+	require.Contains(t, err.Error(), "127.0.0.1:1936/haproxy?stats/;csv")
 }
 
 func TestHaproxyKeepFieldNames(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, csvOutputSample)
+		_, err := fmt.Fprint(w, csvOutputSample)
+		require.NoError(t, err)
 	}))
 	defer ts.Close()
 
@@ -190,8 +195,7 @@ func TestHaproxyKeepFieldNames(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := r.Gather(&acc)
-	require.NoError(t, err)
+	require.NoError(t, r.Gather(&acc))
 
 	tags := map[string]string{
 		"server": ts.Listener.Addr().String(),

--- a/plugins/inputs/internal/internal_test.go
+++ b/plugins/inputs/internal/internal_test.go
@@ -6,21 +6,21 @@ import (
 	"github.com/influxdata/telegraf/selfstat"
 	"github.com/influxdata/telegraf/testutil"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSelfPlugin(t *testing.T) {
 	s := NewSelf()
 	acc := &testutil.Accumulator{}
 
-	s.Gather(acc)
-	assert.True(t, acc.HasMeasurement("internal_memstats"))
+	require.NoError(t, s.Gather(acc))
+	require.True(t, acc.HasMeasurement("internal_memstats"))
 
 	// test that a registered stat is incremented
 	stat := selfstat.Register("mytest", "test", map[string]string{"test": "foo"})
 	stat.Incr(1)
 	stat.Incr(2)
-	s.Gather(acc)
+	require.NoError(t, s.Gather(acc))
 	acc.AssertContainsTaggedFields(t, "internal_mytest",
 		map[string]interface{}{
 			"test": int64(3),
@@ -34,7 +34,7 @@ func TestSelfPlugin(t *testing.T) {
 
 	// test that a registered stat is set properly
 	stat.Set(101)
-	s.Gather(acc)
+	require.NoError(t, s.Gather(acc))
 	acc.AssertContainsTaggedFields(t, "internal_mytest",
 		map[string]interface{}{
 			"test": int64(101),
@@ -51,7 +51,7 @@ func TestSelfPlugin(t *testing.T) {
 	timing := selfstat.RegisterTiming("mytest", "test_ns", map[string]string{"test": "foo"})
 	timing.Incr(100)
 	timing.Incr(200)
-	s.Gather(acc)
+	require.NoError(t, s.Gather(acc))
 	acc.AssertContainsTaggedFields(t, "internal_mytest",
 		map[string]interface{}{
 			"test":    int64(101),


### PR DESCRIPTION
### Required for all PRs:

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

This PR fixes more than 220 golangci-lint issues on unhandled error values in the plugins/input directory. It covers all input plugins starting with `a` to `hd`. Now there are only the following five issues remaining

> plugins/inputs/gnmi/gnmi_test.go:427:57                                              staticcheck    SA1019: gnmi.Error is deprecated: Do not use. 
plugins/inputs/kafka_consumer/kafka_consumer_test.go:282:17                          errcheck       Error return value of `cg.ConsumeClaim` is not checked
plugins/inputs/phpfpm/child.go:115:2                                                 revive         unhandled-error: Unhandled error in call to function fmt.Fprintf
plugins/inputs/phpfpm/child.go:116:16                                                errcheck       Error return value of `r.header.Write` is not checked

However, fixing those will need someone knowing the plugins and the code and are thus left untouched by this PR.