### PR TITLE
Config Option to Enable Logging with Local Time

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -174,7 +174,7 @@ func runAgent(ctx context.Context,
 		RotationInterval:    ag.Config.Agent.LogfileRotationInterval,
 		RotationMaxSize:     ag.Config.Agent.LogfileRotationMaxSize,
 		RotationMaxArchives: ag.Config.Agent.LogfileRotationMaxArchives,
-		UseLocalTime:        ag.Config.Agent.LogWithLocalTime,
+		LogWithTimezone:     ag.Config.Agent.LogWithTimezone,
 	}
 
 	logger.SetupLogging(logConfig)

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -174,6 +174,7 @@ func runAgent(ctx context.Context,
 		RotationInterval:    ag.Config.Agent.LogfileRotationInterval,
 		RotationMaxSize:     ag.Config.Agent.LogfileRotationMaxSize,
 		RotationMaxArchives: ag.Config.Agent.LogfileRotationMaxArchives,
+		UseLocalTime:        ag.Config.Agent.LogWithLocalTime,
 	}
 
 	logger.SetupLogging(logConfig)

--- a/config/config.go
+++ b/config/config.go
@@ -359,14 +359,14 @@ var agentConfig = `
   ## If set to -1, no archives are removed.
   # logfile_rotation_max_archives = 5
 
-  ## Inidicates whether or not to use local time as the logging prefix.
-  # log_with_local_time = false
+  ## Pick a timezone to use when logging or type 'local' for local time.
+  ## Example: America/Chicago
+  # log_with_timezone = ""
 
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""
   ## If set to true, do no set the "host" tag in the telegraf agent.
   omit_hostname = false
-
 `
 
 var outputHeader = `

--- a/config/config.go
+++ b/config/config.go
@@ -188,8 +188,8 @@ type AgentConfig struct {
 	// If set to -1, no archives are removed.
 	LogfileRotationMaxArchives int `toml:"logfile_rotation_max_archives"`
 
-	// Inidicates whether or not to use local time as the logging prefix.
-	LogWithLocalTime bool `toml:"log_with_local_time"`
+	// Pick a timezone to use when logging or type 'local' for local time.
+	LogWithTimezone string `toml:"log_with_timezone"`
 
 	Hostname     string
 	OmitHostname bool

--- a/config/config.go
+++ b/config/config.go
@@ -188,6 +188,9 @@ type AgentConfig struct {
 	// If set to -1, no archives are removed.
 	LogfileRotationMaxArchives int `toml:"logfile_rotation_max_archives"`
 
+	// Inidicates whether or not to use local time as the logging prefix.
+	LogWithLocalTime bool `toml:"log_with_local_time"`
+
 	Hostname     string
 	OmitHostname bool
 }
@@ -355,6 +358,9 @@ var agentConfig = `
   ## Maximum number of rotated archives to keep, any older logs are deleted.
   ## If set to -1, no archives are removed.
   # logfile_rotation_max_archives = 5
+
+  ## Inidicates whether or not to use local time as the logging prefix.
+  # log_with_local_time = false
 
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -219,8 +219,9 @@ The agent table configures Telegraf and the defaults used across all plugins.
   Maximum number of rotated archives to keep, any older logs are deleted.  If
   set to -1, no archives are removed.
 
-- **log_with_local_time**:
-  Inidicates whether or not to use local time as the logging prefix.
+- **log_with_timezone**:
+  Pick a timezone to use when logging or type 'local' for local time.
+  [See this page for options/formats.](https://socketloop.com/tutorials/golang-display-list-of-timezones-with-gmt)
 
 - **hostname**:
   Override default hostname, if empty use os.Hostname()

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -220,7 +220,7 @@ The agent table configures Telegraf and the defaults used across all plugins.
   set to -1, no archives are removed.
 
 - **log_with_timezone**:
-  Pick a timezone to use when logging or type 'local' for local time.
+  Pick a timezone to use when logging or type 'local' for local time. Example: 'America/Chicago'.
   [See this page for options/formats.](https://socketloop.com/tutorials/golang-display-list-of-timezones-with-gmt)
 
 - **hostname**:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -219,6 +219,9 @@ The agent table configures Telegraf and the defaults used across all plugins.
   Maximum number of rotated archives to keep, any older logs are deleted.  If
   set to -1, no archives are removed.
 
+- **log_with_local_time**:
+  Inidicates whether or not to use local time as the logging prefix.
+
 - **hostname**:
   Override default hostname, if empty use os.Hostname()
 - **omit_hostname**:

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -90,8 +90,9 @@
   ## If set to -1, no archives are removed.
   # logfile_rotation_max_archives = 5
 
-  ## Inidicates whether or not to use local time as the logging prefix.
-  # log_with_local_time = false
+  ## Pick a timezone to use when logging or type 'local' for local time.
+  ## See https://socketloop.com/tutorials/golang-display-list-of-timezones-with-gmt for timezone formatting options.
+  # log_with_timezone = ""
 
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -90,6 +90,9 @@
   ## If set to -1, no archives are removed.
   # logfile_rotation_max_archives = 5
 
+  ## Inidicates whether or not to use local time as the logging prefix.
+  # log_with_local_time = false
+
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""
   ## If set to true, do no set the "host" tag in the telegraf agent.

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -90,7 +90,7 @@
   ## If set to -1, no archives are removed.
   # logfile_rotation_max_archives = 5
 
-  ## Pick a timezone to use when logging or type 'local' for local time.
+  ## Pick a timezone to use when logging or type 'local' for local time. Example: 'America/Chicago'.
   ## See https://socketloop.com/tutorials/golang-display-list-of-timezones-with-gmt for timezone formatting options.
   # log_with_timezone = ""
 

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -90,8 +90,9 @@
   ## If set to -1, no archives are removed.
   # logfile_rotation_max_archives = 5
 
-  ## Inidicates whether or not to use local time as the logging prefix.
-  # log_with_local_time = false
+  ## Pick a timezone to use when logging or type 'local' for local time.
+  ## See https://socketloop.com/tutorials/golang-display-list-of-timezones-with-gmt for timezone formatting options.
+  # log_with_timezone = ""
 
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -90,6 +90,9 @@
   ## If set to -1, no archives are removed.
   # logfile_rotation_max_archives = 5
 
+  ## Inidicates whether or not to use local time as the logging prefix.
+  # log_with_local_time = false
+
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""
   ## If set to true, do no set the "host" tag in the telegraf agent.

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -90,7 +90,7 @@
   ## If set to -1, no archives are removed.
   # logfile_rotation_max_archives = 5
 
-  ## Pick a timezone to use when logging or type 'local' for local time.
+  ## Pick a timezone to use when logging or type 'local' for local time. Example: 'America/Chicago'.
   ## See https://socketloop.com/tutorials/golang-display-list-of-timezones-with-gmt for timezone formatting options.
   # log_with_timezone = ""
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -89,8 +89,8 @@ func (t *telegrafLog) Close() error {
 }
 
 // newTelegrafWriter returns a logging-wrapped writer.
-func newTelegrafWriter(w io.Writer, config LogConfig) (io.Writer, error) {
-	timezoneName := config.LogWithTimezone
+func newTelegrafWriter(w io.Writer, c LogConfig) (io.Writer, error) {
+	timezoneName := c.LogWithTimezone
 
 	if strings.ToLower(timezoneName) == "local" {
 		timezoneName = "Local"

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -137,7 +137,10 @@ func TestLogTargetSettings(t *testing.T) {
 func BenchmarkTelegrafLogWrite(b *testing.B) {
 	var msg = []byte("test")
 	var buf bytes.Buffer
-	w := newTelegrafWriter(&buf, LogConfig{})
+	w, err := newTelegrafWriter(&buf, LogConfig{})
+	if err != nil {
+		panic("Unable to create log writer.")
+	}
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
 		w.Write(msg)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -137,7 +137,7 @@ func TestLogTargetSettings(t *testing.T) {
 func BenchmarkTelegrafLogWrite(b *testing.B) {
 	var msg = []byte("test")
 	var buf bytes.Buffer
-	w := newTelegrafWriter(&buf)
+	w := newTelegrafWriter(&buf, LogConfig{})
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
 		w.Write(msg)


### PR DESCRIPTION
This hopefully resolves #3462.

You'd be able to enable `log_with_local_time` so that all logs will use the time of the machine it's being ran on. This will apply for all types of logs (stdout, file). 