### PR TITLE
Remove deprecation warning for v1 prom metrics

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1259,7 +1259,7 @@
 #   ## Prometheus format.  When using the prometheus input, use the same value in
 #   ## both plugins to ensure metrics are round-tripped without modification.
 #   ##
-#   ##   example: metric_version = 1; deprecated in 1.13
+#   ##   example: metric_version = 1; 
 #   ##            metric_version = 2; recommended version
 #   # metric_version = 1
 #
@@ -7577,7 +7577,7 @@
 #   ## value in both plugins to ensure metrics are round-tripped without
 #   ## modification.
 #   ##
-#   ##   example: metric_version = 1; deprecated in 1.13
+#   ##   example: metric_version = 1; 
 #   ##            metric_version = 2; recommended version
 #   # metric_version = 1
 #

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -16,7 +16,7 @@ in Prometheus format.
   ## value in both plugins to ensure metrics are round-tripped without
   ## modification.
   ##
-  ##   example: metric_version = 1; deprecated in 1.13
+  ##   example: metric_version = 1; 
   ##            metric_version = 2; recommended version
   # metric_version = 1
 

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -86,7 +86,7 @@ var sampleConfig = `
   ## value in both plugins to ensure metrics are round-tripped without
   ## modification.
   ##
-  ##   example: metric_version = 1; deprecated in 1.13
+  ##   example: metric_version = 1; 
   ##            metric_version = 2; recommended version
   # metric_version = 1
 
@@ -155,9 +155,6 @@ func (p *Prometheus) Description() string {
 }
 
 func (p *Prometheus) Init() error {
-	if p.MetricVersion != 2 {
-		p.Log.Warnf("Use of deprecated configuration: 'metric_version = 1'; please update to 'metric_version = 2'")
-	}
 
 	// Config proccessing for node scrape scope for monitor_kubernetes_pods
 	p.isNodeScrapeScope = strings.EqualFold(p.PodScrapeScope, "node")

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -14,7 +14,7 @@ all metrics on `/metrics` (default) to be polled by a Prometheus server.
   ## Prometheus format.  When using the prometheus input, use the same value in
   ## both plugins to ensure metrics are round-tripped without modification.
   ##
-  ##   example: metric_version = 1; deprecated in 1.13
+  ##   example: metric_version = 1;
   ##            metric_version = 2; recommended version
   # metric_version = 1
 

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -35,7 +35,7 @@ var sampleConfig = `
   ## Prometheus format.  When using the prometheus input, use the same value in
   ## both plugins to ensure metrics are round-tripped without modification.
   ##
-  ##   example: metric_version = 1; deprecated in 1.13
+  ##   example: metric_version = 1;
   ##            metric_version = 2; recommended version
   # metric_version = 1
 
@@ -133,7 +133,6 @@ func (p *PrometheusClient) Init() error {
 	default:
 		fallthrough
 	case 1:
-		p.Log.Warnf("Use of deprecated configuration: metric_version = 1; please update to metric_version = 2")
 		p.collector = v1.NewCollector(time.Duration(p.ExpirationInterval), p.StringAsLabel, p.Log)
 		err := registry.Register(p.collector)
 		if err != nil {


### PR DESCRIPTION
Remove deprecation warning as we currently support both v1 & v2 metrics with no plans to deprecate.
Lessens confusion around the ability to continue with v1 metrics if that is preferred. 
relates to #8617

