### PR TITLE
Fix: sync nfsclient ops map in nfsclient struct

### DIFF
--- a/plugins/inputs/nfsclient/nfsclient.go
+++ b/plugins/inputs/nfsclient/nfsclient.go
@@ -467,6 +467,9 @@ func (n *NFSClient) Init() error {
 		}
 	}
 
+	n.nfs3Ops = nfs3Ops
+	n.nfs4Ops = nfs4Ops
+
 	if len(n.IncludeMounts) > 0 {
 		n.Log.Debugf("Including these mount patterns: %v", n.IncludeMounts)
 	} else {


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9127 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Fixed an incorrect mapping inside the nfsclient plugin input.

In the `Init` function of the nfsclient plugin, `nfs3Ops` and `nfs4Ops` is prepared in a local map inside but never attached to the underlying `nfsclient` struct.

Passing an empty map to 

```go
		if (version == "3" && n.nfs3Ops[first]) || (version == "4" && n.nfs4Ops[first]) {
			tags["operation"] = first
			if len(nline) <= len(nfsopFields) {
				for i, t := range nline {
					fields[nfsopFields[i]] = t
				}
				acc.AddFields("nfs_ops", fields, tags)
			}
		}
```
Result in `n.nfs3Ops[first]` or `n.nfs4Ops[first]` to be false, and this branch of the code is never reached.