### PR TITLE
Add OAuth2 to HTTP input

### DIFF
--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -2,10 +2,10 @@ package httpconfig
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/proxy"
 	"github.com/influxdata/telegraf/plugins/common/tls"
@@ -20,6 +20,7 @@ type HTTPClientConfig struct {
 	ClientSecret string   `toml:"client_secret"`
 	TokenURL     string   `toml:"token_url"`
 	Scopes       []string `toml:"scopes"`
+	Log          telegraf.Logger
 
 	Timeout config.Duration `toml:"timeout"`
 
@@ -63,7 +64,7 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, erro
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
 		client = oauthConfig.Client(ctx)
 	} else if h.ClientID != "" || h.ClientSecret != "" || h.TokenURL != "" {
-		log.Printf("One of the following fields is empty: Client ID, Client Secret or Token URL. Skipping OAuth.")
+		h.Log.Warnf("One of the following fields is empty: Client ID, Client Secret or Token URL. Skipping OAuth.")
 	}
 
 	return client, nil

--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -2,6 +2,7 @@ package httpconfig
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"time"
 
@@ -61,6 +62,8 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, erro
 		}
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
 		client = oauthConfig.Client(ctx)
+	} else if h.ClientID != "" || h.ClientSecret != "" || h.TokenURL != "" {
+		log.Printf("One of the following fields is empty: Client ID, Client Secret or Token URL. Skipping OAuth.")
 	}
 
 	return client, nil

--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Common HTTP client struct.
-type HttpClientConfig struct {
+type HTTPClientConfig struct {
 	// OAuth2 Credentials
 	ClientID     string   `toml:"client_id"`
 	ClientSecret string   `toml:"client_secret"`
@@ -26,20 +26,20 @@ type HttpClientConfig struct {
 	tls.ClientConfig
 }
 
-func (h *HttpClientConfig) CreateClient(ctx context.Context) (*http.Client, error) {
+func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, error) {
 	tlsCfg, err := h.ClientConfig.TLSConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	proxy, err := h.HTTPProxy.Proxy()
+	prox, err := h.HTTPProxy.Proxy()
 	if err != nil {
 		return nil, err
 	}
 
 	transport := &http.Transport{
 		TLSClientConfig: tlsCfg,
-		Proxy:           proxy,
+		Proxy:           prox,
 	}
 
 	timeout := h.Timeout

--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -1,0 +1,67 @@
+package httpconfig
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/common/proxy"
+	"github.com/influxdata/telegraf/plugins/common/tls"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// Common HTTP client struct.
+type HttpClientConfig struct {
+	// OAuth2 Credentials
+	ClientID     string   `toml:"client_id"`
+	ClientSecret string   `toml:"client_secret"`
+	TokenURL     string   `toml:"token_url"`
+	Scopes       []string `toml:"scopes"`
+
+	Timeout config.Duration `toml:"timeout"`
+
+	proxy.HTTPProxy
+	tls.ClientConfig
+}
+
+func (h *HttpClientConfig) CreateClient(ctx context.Context) (*http.Client, error) {
+	tlsCfg, err := h.ClientConfig.TLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	proxy, err := h.HTTPProxy.Proxy()
+	if err != nil {
+		return nil, err
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: tlsCfg,
+		Proxy:           proxy,
+	}
+
+	timeout := h.Timeout
+	if timeout == 0 {
+		timeout = config.Duration(time.Second * 5)
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   time.Duration(timeout),
+	}
+
+	if h.ClientID != "" && h.ClientSecret != "" && h.TokenURL != "" {
+		oauthConfig := clientcredentials.Config{
+			ClientID:     h.ClientID,
+			ClientSecret: h.ClientSecret,
+			TokenURL:     h.TokenURL,
+			Scopes:       h.Scopes,
+		}
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
+		client = oauthConfig.Client(ctx)
+	}
+
+	return client, nil
+}

--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -22,7 +22,8 @@ type HTTPClientConfig struct {
 	Scopes       []string `toml:"scopes"`
 	Log          telegraf.Logger
 
-	Timeout config.Duration `toml:"timeout"`
+	Timeout         config.Duration `toml:"timeout"`
+	IdleConnTimeout config.Duration `toml:"idle_conn_timeout"`
 
 	proxy.HTTPProxy
 	tls.ClientConfig
@@ -42,6 +43,7 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, erro
 	transport := &http.Transport{
 		TLSClientConfig: tlsCfg,
 		Proxy:           prox,
+		IdleConnTimeout: time.Duration(h.IdleConnTimeout),
 	}
 
 	timeout := h.Timeout

--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -5,28 +5,20 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	oauth2Config "github.com/influxdata/telegraf/plugins/common/oauth2"
 	"github.com/influxdata/telegraf/plugins/common/proxy"
 	"github.com/influxdata/telegraf/plugins/common/tls"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/clientcredentials"
 )
 
 // Common HTTP client struct.
 type HTTPClientConfig struct {
-	// OAuth2 Credentials
-	ClientID     string   `toml:"client_id"`
-	ClientSecret string   `toml:"client_secret"`
-	TokenURL     string   `toml:"token_url"`
-	Scopes       []string `toml:"scopes"`
-	Log          telegraf.Logger
-
 	Timeout         config.Duration `toml:"timeout"`
 	IdleConnTimeout config.Duration `toml:"idle_conn_timeout"`
 
 	proxy.HTTPProxy
 	tls.ClientConfig
+	oauth2Config.OAuth2Config
 }
 
 func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, error) {
@@ -56,18 +48,7 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, erro
 		Timeout:   time.Duration(timeout),
 	}
 
-	if h.ClientID != "" && h.ClientSecret != "" && h.TokenURL != "" {
-		oauthConfig := clientcredentials.Config{
-			ClientID:     h.ClientID,
-			ClientSecret: h.ClientSecret,
-			TokenURL:     h.TokenURL,
-			Scopes:       h.Scopes,
-		}
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
-		client = oauthConfig.Client(ctx)
-	} else if h.ClientID != "" || h.ClientSecret != "" || h.TokenURL != "" {
-		h.Log.Warnf("One of the following fields is empty: Client ID, Client Secret or Token URL. Skipping OAuth.")
-	}
+	client = h.OAuth2Config.CreateOauth2Client(client, ctx)
 
 	return client, nil
 }

--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf/config"
-	oauth2Config "github.com/influxdata/telegraf/plugins/common/oauth2"
+	oauthConfig "github.com/influxdata/telegraf/plugins/common/oauth"
 	"github.com/influxdata/telegraf/plugins/common/proxy"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 )
@@ -18,7 +18,7 @@ type HTTPClientConfig struct {
 
 	proxy.HTTPProxy
 	tls.ClientConfig
-	oauth2Config.OAuth2Config
+	oauthConfig.OAuth2Config
 }
 
 func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, error) {
@@ -48,7 +48,7 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, erro
 		Timeout:   time.Duration(timeout),
 	}
 
-	client = h.OAuth2Config.CreateOauth2Client(client, ctx)
+	client = h.OAuth2Config.CreateOauth2Client(ctx, client)
 
 	return client, nil
 }

--- a/plugins/common/oauth/config.go
+++ b/plugins/common/oauth/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/influxdata/telegraf"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -15,8 +14,6 @@ type OAuth2Config struct {
 	ClientSecret string   `toml:"client_secret"`
 	TokenURL     string   `toml:"token_url"`
 	Scopes       []string `toml:"scopes"`
-
-	Log telegraf.Logger
 }
 
 func (o *OAuth2Config) CreateOauth2Client(ctx context.Context, client *http.Client) *http.Client {
@@ -29,8 +26,6 @@ func (o *OAuth2Config) CreateOauth2Client(ctx context.Context, client *http.Clie
 		}
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
 		client = oauthConfig.Client(ctx)
-	} else if o.ClientID != "" || o.ClientSecret != "" || o.TokenURL != "" {
-		o.Log.Warnf("One of the following fields is empty: Client ID, Client Secret or Token URL. Skipping OAuth.")
 	}
 
 	return client

--- a/plugins/common/oauth/config.go
+++ b/plugins/common/oauth/config.go
@@ -1,4 +1,4 @@
-package oauth2
+package oauth
 
 import (
 	"context"
@@ -19,7 +19,7 @@ type OAuth2Config struct {
 	Log telegraf.Logger
 }
 
-func (o *OAuth2Config) CreateOauth2Client(client *http.Client, ctx context.Context) *http.Client {
+func (o *OAuth2Config) CreateOauth2Client(ctx context.Context, client *http.Client) *http.Client {
 	if o.ClientID != "" && o.ClientSecret != "" && o.TokenURL != "" {
 		oauthConfig := clientcredentials.Config{
 			ClientID:     o.ClientID,

--- a/plugins/common/oauth2/config.go
+++ b/plugins/common/oauth2/config.go
@@ -1,0 +1,37 @@
+package oauth2
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/influxdata/telegraf"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+type OAuth2Config struct {
+	// OAuth2 Credentials
+	ClientID     string   `toml:"client_id"`
+	ClientSecret string   `toml:"client_secret"`
+	TokenURL     string   `toml:"token_url"`
+	Scopes       []string `toml:"scopes"`
+
+	Log telegraf.Logger
+}
+
+func (o *OAuth2Config) CreateOauth2Client(client *http.Client, ctx context.Context) *http.Client {
+	if o.ClientID != "" && o.ClientSecret != "" && o.TokenURL != "" {
+		oauthConfig := clientcredentials.Config{
+			ClientID:     o.ClientID,
+			ClientSecret: o.ClientSecret,
+			TokenURL:     o.TokenURL,
+			Scopes:       o.Scopes,
+		}
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
+		client = oauthConfig.Client(ctx)
+	} else if o.ClientID != "" || o.ClientSecret != "" || o.TokenURL != "" {
+		o.Log.Warnf("One of the following fields is empty: Client ID, Client Secret or Token URL. Skipping OAuth.")
+	}
+
+	return client
+}

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -34,6 +34,12 @@ The HTTP input plugin collects metrics from one or more HTTP(S) endpoints.  The 
   # username = "username"
   # password = "pa$$word"
 
+  ## OAuth2 Client Credentials Grant
+  # client_id = "clientid"
+  # client_secret = "secret"
+  # token_url = "https://indentityprovider/oauth2/v1/token"
+  # scopes = ["urn:opc:idm:__myscopes__"]
+
   ## HTTP Proxy support
   # http_proxy_url = ""
 

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -34,7 +34,7 @@ The HTTP input plugin collects metrics from one or more HTTP(S) endpoints.  The 
   # username = "username"
   # password = "pa$$word"
 
-  ## OAuth2 Client Credentials Grant
+  ## OAuth2 Client Credentials. 'client_id', 'client_secret', and 'token_url' are required to use OAuth2.
   # client_id = "clientid"
   # client_secret = "secret"
   # token_url = "https://indentityprovider/oauth2/v1/token"

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -34,7 +34,7 @@ The HTTP input plugin collects metrics from one or more HTTP(S) endpoints.  The 
   # username = "username"
   # password = "pa$$word"
 
-  ## OAuth2 Client Credentials. 'client_id', 'client_secret', and 'token_url' are required to use OAuth2.
+  ## OAuth2 Client Credentials. The options 'client_id', 'client_secret', and 'token_url' are required to use OAuth2.
   # client_id = "clientid"
   # client_secret = "secret"
   # token_url = "https://indentityprovider/oauth2/v1/token"

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -34,7 +34,7 @@ type HTTP struct {
 	SuccessStatusCodes []int `toml:"success_status_codes"`
 
 	client *http.Client
-	httpconfig.HttpClientConfig
+	httpconfig.HTTPClientConfig
 
 	// The parser will automatically be set by Telegraf core code because
 	// this plugin implements the ParserInput interface (i.e. the SetParser method)
@@ -109,7 +109,7 @@ func (*HTTP) Description() string {
 
 func (h *HTTP) Init() error {
 	ctx := context.Background()
-	client, err := h.HttpClientConfig.CreateClient(ctx)
+	client, err := h.HTTPClientConfig.CreateClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -286,7 +286,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 			name: "success",
 			plugin: &plugin.HTTP{
 				URLs: []string{u.String() + "/write"},
-				HttpClientConfig: httpconfig.HttpClientConfig{
+				HTTPClientConfig: httpconfig.HTTPClientConfig{
 					ClientID:     "howdy",
 					ClientSecret: "secret",
 					TokenURL:     u.String() + "/token",

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	plugin "github.com/influxdata/telegraf/plugins/inputs/http"
@@ -247,6 +248,80 @@ func TestBodyAndContentEncoding(t *testing.T) {
 
 			var acc testutil.Accumulator
 			require.NoError(t, tt.plugin.Init())
+			err = tt.plugin.Gather(&acc)
+			require.NoError(t, err)
+		})
+	}
+}
+
+type TestHandlerFunc func(t *testing.T, w http.ResponseWriter, r *http.Request)
+
+func TestOAuthClientCredentialsGrant(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	var token = "2YotnFZFEjr1zCsicMWpAA"
+
+	u, err := url.Parse(fmt.Sprintf("http://%s", ts.Listener.Addr().String()))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		plugin       *plugin.HTTP
+		tokenHandler TestHandlerFunc
+		handler      TestHandlerFunc
+	}{
+		{
+			name: "no credentials",
+			plugin: &plugin.HTTP{
+				URLs: []string{u.String()},
+			},
+			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				require.Len(t, r.Header["Authorization"], 0)
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "success",
+			plugin: &plugin.HTTP{
+				URLs:         []string{u.String() + "/write"},
+				ClientID:     "howdy",
+				ClientSecret: "secret",
+				TokenURL:     u.String() + "/token",
+				Scopes:       []string{"urn:opc:idm:__myscopes__"},
+			},
+			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				values := url.Values{}
+				values.Add("access_token", token)
+				values.Add("token_type", "bearer")
+				values.Add("expires_in", "3600")
+				w.Write([]byte(values.Encode()))
+			},
+			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, []string{"Bearer " + token}, r.Header["Authorization"])
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/write":
+					tt.handler(t, w, r)
+				case "/token":
+					tt.tokenHandler(t, w, r)
+				}
+			})
+
+			parser, _ := parsers.NewValueParser("metric", "string", "", nil)
+			tt.plugin.SetParser(parser)
+			err = tt.plugin.Init()
+			require.NoError(t, err)
+
+			var acc testutil.Accumulator
 			err = tt.plugin.Gather(&acc)
 			require.NoError(t, err)
 		})

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"testing"
 
+	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	plugin "github.com/influxdata/telegraf/plugins/inputs/http"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/testutil"
@@ -284,11 +285,13 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 		{
 			name: "success",
 			plugin: &plugin.HTTP{
-				URLs:         []string{u.String() + "/write"},
-				ClientID:     "howdy",
-				ClientSecret: "secret",
-				TokenURL:     u.String() + "/token",
-				Scopes:       []string{"urn:opc:idm:__myscopes__"},
+				URLs: []string{u.String() + "/write"},
+				HttpClientConfig: httpconfig.HttpClientConfig{
+					ClientID:     "howdy",
+					ClientSecret: "secret",
+					TokenURL:     u.String() + "/token",
+					Scopes:       []string{"urn:opc:idm:__myscopes__"},
+				},
 			},
 			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -296,7 +296,8 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 				values.Add("access_token", token)
 				values.Add("token_type", "bearer")
 				values.Add("expires_in", "3600")
-				w.Write([]byte(values.Encode()))
+				_, err := w.Write([]byte(values.Encode()))
+				require.NoError(t, err)
 			},
 			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, []string{"Bearer " + token}, r.Header["Authorization"])

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
+	"github.com/influxdata/telegraf/plugins/common/oauth2"
 	plugin "github.com/influxdata/telegraf/plugins/inputs/http"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/testutil"
@@ -287,10 +288,12 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 			plugin: &plugin.HTTP{
 				URLs: []string{u.String() + "/write"},
 				HTTPClientConfig: httpconfig.HTTPClientConfig{
-					ClientID:     "howdy",
-					ClientSecret: "secret",
-					TokenURL:     u.String() + "/token",
-					Scopes:       []string{"urn:opc:idm:__myscopes__"},
+					OAuth2Config: oauth2.OAuth2Config{
+						ClientID:     "howdy",
+						ClientSecret: "secret",
+						TokenURL:     u.String() + "/token",
+						Scopes:       []string{"urn:opc:idm:__myscopes__"},
+					},
 				},
 			},
 			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
-	"github.com/influxdata/telegraf/plugins/common/oauth2"
+	oauth "github.com/influxdata/telegraf/plugins/common/oauth"
 	plugin "github.com/influxdata/telegraf/plugins/inputs/http"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/testutil"
@@ -288,7 +288,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 			plugin: &plugin.HTTP{
 				URLs: []string{u.String() + "/write"},
 				HTTPClientConfig: httpconfig.HTTPClientConfig{
-					OAuth2Config: oauth2.OAuth2Config{
+					OAuth2Config: oauth.OAuth2Config{
 						ClientID:     "howdy",
 						ClientSecret: "secret",
 						TokenURL:     u.String() + "/token",

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -11,13 +11,11 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
+	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/clientcredentials"
 )
 
 const (
@@ -80,18 +78,13 @@ const (
 
 type HTTP struct {
 	URL             string            `toml:"url"`
-	Timeout         config.Duration   `toml:"timeout"`
 	Method          string            `toml:"method"`
 	Username        string            `toml:"username"`
 	Password        string            `toml:"password"`
 	Headers         map[string]string `toml:"headers"`
-	ClientID        string            `toml:"client_id"`
-	ClientSecret    string            `toml:"client_secret"`
-	TokenURL        string            `toml:"token_url"`
-	Scopes          []string          `toml:"scopes"`
 	ContentEncoding string            `toml:"content_encoding"`
-	IdleConnTimeout config.Duration   `toml:"idle_conn_timeout"`
 	tls.ClientConfig
+	httpconfig.HTTPClientConfig
 
 	client     *http.Client
 	serializer serializers.Serializer
@@ -99,35 +92,6 @@ type HTTP struct {
 
 func (h *HTTP) SetSerializer(serializer serializers.Serializer) {
 	h.serializer = serializer
-}
-
-func (h *HTTP) createClient(ctx context.Context) (*http.Client, error) {
-	tlsCfg, err := h.ClientConfig.TLSConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsCfg,
-			Proxy:           http.ProxyFromEnvironment,
-			IdleConnTimeout: time.Duration(h.IdleConnTimeout),
-		},
-		Timeout: time.Duration(h.Timeout),
-	}
-
-	if h.ClientID != "" && h.ClientSecret != "" && h.TokenURL != "" {
-		oauthConfig := clientcredentials.Config{
-			ClientID:     h.ClientID,
-			ClientSecret: h.ClientSecret,
-			TokenURL:     h.TokenURL,
-			Scopes:       h.Scopes,
-		}
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
-		client = oauthConfig.Client(ctx)
-	}
-
-	return client, nil
 }
 
 func (h *HTTP) Connect() error {
@@ -139,12 +103,8 @@ func (h *HTTP) Connect() error {
 		return fmt.Errorf("invalid method [%s] %s", h.URL, h.Method)
 	}
 
-	if h.Timeout == 0 {
-		h.Timeout = config.Duration(defaultClientTimeout)
-	}
-
 	ctx := context.Background()
-	client, err := h.createClient(ctx)
+	client, err := h.HTTPClientConfig.CreateClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -229,9 +189,8 @@ func (h *HTTP) write(reqBody []byte) error {
 func init() {
 	outputs.Add("http", func() telegraf.Output {
 		return &HTTP{
-			Timeout: config.Duration(defaultClientTimeout),
-			Method:  defaultMethod,
-			URL:     defaultURL,
+			Method: defaultMethod,
+			URL:    defaultURL,
 		}
 	})
 }

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -380,13 +380,14 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 		{
 			name: "success",
 			plugin: &HTTP{
-				URL:          u.String() + "/write",
+				URL: u.String() + "/write",
 				HTTPClientConfig: httpconfig.HTTPClientConfig{
 					ClientID:     "howdy",
 					ClientSecret: "secret",
 					TokenURL:     u.String() + "/token",
 					Scopes:       []string{"urn:opc:idm:__myscopes__"},
-				},			},
+				},
+			},
 			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				values := url.Values{}

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
-	"github.com/influxdata/telegraf/plugins/common/oauth2"
+	oauth "github.com/influxdata/telegraf/plugins/common/oauth"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/stretchr/testify/require"
 )
@@ -383,7 +383,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 			plugin: &HTTP{
 				URL: u.String() + "/write",
 				HTTPClientConfig: httpconfig.HTTPClientConfig{
-					OAuth2Config: oauth2.OAuth2Config{
+					OAuth2Config: oauth.OAuth2Config{
 						ClientID:     "howdy",
 						ClientSecret: "secret",
 						TokenURL:     u.String() + "/token",

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
+	"github.com/influxdata/telegraf/plugins/common/oauth2"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/stretchr/testify/require"
 )
@@ -382,10 +383,12 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 			plugin: &HTTP{
 				URL: u.String() + "/write",
 				HTTPClientConfig: httpconfig.HTTPClientConfig{
-					ClientID:     "howdy",
-					ClientSecret: "secret",
-					TokenURL:     u.String() + "/token",
-					Scopes:       []string{"urn:opc:idm:__myscopes__"},
+					OAuth2Config: oauth2.OAuth2Config{
+						ClientID:     "howdy",
+						ClientSecret: "secret",
+						TokenURL:     u.String() + "/token",
+						Scopes:       []string{"urn:opc:idm:__myscopes__"},
+					},
 				},
 			},
 			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
+	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/stretchr/testify/require"
 )
@@ -380,11 +381,12 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 			name: "success",
 			plugin: &HTTP{
 				URL:          u.String() + "/write",
-				ClientID:     "howdy",
-				ClientSecret: "secret",
-				TokenURL:     u.String() + "/token",
-				Scopes:       []string{"urn:opc:idm:__myscopes__"},
-			},
+				HTTPClientConfig: httpconfig.HTTPClientConfig{
+					ClientID:     "howdy",
+					ClientSecret: "secret",
+					TokenURL:     u.String() + "/token",
+					Scopes:       []string{"urn:opc:idm:__myscopes__"},
+				},			},
 			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				values := url.Values{}


### PR DESCRIPTION
This should add support for oauth2 authentication ability for the http input client. Be advised that this is mostly directly taken from the HTTP output plugin. Should resolve #5309