### PR TITLE
Make prometheus serializer update timestamps and expiration time as new data arrives

### DIFF
--- a/plugins/serializers/prometheus/README.md
+++ b/plugins/serializers/prometheus/README.md
@@ -8,7 +8,11 @@ use the `metric_version = 2` option in order to properly round trip metrics.
 not be correct if the metric spans multiple batches.  This issue can be
 somewhat, but not fully, mitigated by using outputs that support writing in
 "batch format".  When using histogram and summary types, it is recommended to
-use only the `prometheus_client` output.
+use only the `prometheus_client` output. Histogram and Summary types
+also update their expiration time based on the most recently received data.
+If incoming metrics stop updating specific buckets or quantiles but continue
+reporting others every bucket/quantile will continue to exist.
+
 
 ### Configuration
 

--- a/plugins/serializers/prometheus/collection.go
+++ b/plugins/serializers/prometheus/collection.go
@@ -243,6 +243,7 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 				}
 			} else {
 				m.Time = metric.Time()
+				m.AddTime = now
 			}
 			switch {
 			case strings.HasSuffix(field.Key, "_bucket"):
@@ -293,6 +294,7 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 				}
 			} else {
 				m.Time = metric.Time()
+				m.AddTime = now
 			}
 			switch {
 			case strings.HasSuffix(field.Key, "_sum"):

--- a/plugins/serializers/prometheus/collection.go
+++ b/plugins/serializers/prometheus/collection.go
@@ -241,6 +241,8 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 					AddTime:   now,
 					Histogram: &Histogram{},
 				}
+			} else {
+				m.Time = metric.Time()
 			}
 			switch {
 			case strings.HasSuffix(field.Key, "_bucket"):
@@ -289,6 +291,8 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 					AddTime: now,
 					Summary: &Summary{},
 				}
+			} else {
+				m.Time = metric.Time()
 			}
 			switch {
 			case strings.HasSuffix(field.Key, "_sum"):

--- a/plugins/serializers/prometheus/collection_test.go
+++ b/plugins/serializers/prometheus/collection_test.go
@@ -425,3 +425,209 @@ func TestCollectionExpire(t *testing.T) {
 		})
 	}
 }
+
+func TestExportTimestamps(t *testing.T) {
+	tests := []struct {
+		name     string
+		now      time.Time
+		age      time.Duration
+		input    []Input
+		expected []*dto.MetricFamily
+	}{
+		{
+			name: "histogram bucket updates",
+			now:  time.Unix(0, 0),
+			age:  10 * time.Second,
+			input: []Input{
+				{
+					metric: testutil.MustMetric(
+						"prometheus",
+						map[string]string{},
+						map[string]interface{}{
+							"http_request_duration_seconds_sum":   10.0,
+							"http_request_duration_seconds_count": 2,
+						},
+						time.Unix(15, 0),
+						telegraf.Histogram,
+					),
+					addtime: time.Unix(0, 0),
+				}, {
+					metric: testutil.MustMetric(
+						"prometheus",
+						map[string]string{"le": "0.05"},
+						map[string]interface{}{
+							"http_request_duration_seconds_bucket": 1.0,
+						},
+						time.Unix(15, 0),
+						telegraf.Histogram,
+					),
+					addtime: time.Unix(0, 0),
+				}, {
+					metric: testutil.MustMetric(
+						"prometheus",
+						map[string]string{"le": "+Inf"},
+						map[string]interface{}{
+							"http_request_duration_seconds_bucket": 1.0,
+						},
+						time.Unix(15, 0),
+						telegraf.Histogram,
+					),
+					addtime: time.Unix(0, 0),
+				}, {
+					// Next interval
+					metric: testutil.MustMetric(
+						"prometheus",
+						map[string]string{},
+						map[string]interface{}{
+							"http_request_duration_seconds_sum":   20.0,
+							"http_request_duration_seconds_count": 4,
+						},
+						time.Unix(20, 0), // Updated timestamp
+						telegraf.Histogram,
+					),
+					addtime: time.Unix(0, 0),
+				}, {
+					metric: testutil.MustMetric(
+						"prometheus",
+						map[string]string{"le": "0.05"},
+						map[string]interface{}{
+							"http_request_duration_seconds_bucket": 2.0,
+						},
+						time.Unix(20, 0),// Updated timestamp
+						telegraf.Histogram,
+					),
+					addtime: time.Unix(0, 0),
+				}, {
+					metric: testutil.MustMetric(
+						"prometheus",
+						map[string]string{"le": "+Inf"},
+						map[string]interface{}{
+							"http_request_duration_seconds_bucket": 2.0,
+						},
+						time.Unix(20, 0), // Updated timestamp
+						telegraf.Histogram,
+					),
+					addtime: time.Unix(0, 0),
+				},
+			},
+			expected: []*dto.MetricFamily{
+				{
+					Name: proto.String("http_request_duration_seconds"),
+					Help: proto.String(helpString),
+					Type: dto.MetricType_HISTOGRAM.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{},
+							TimestampMs: proto.Int64(time.Unix(20, 0).UnixNano() / int64(time.Millisecond)),
+							Histogram: &dto.Histogram{
+								SampleCount: proto.Uint64(4),
+								SampleSum:   proto.Float64(20.0),
+								Bucket: []*dto.Bucket{
+									{
+										UpperBound:      proto.Float64(0.05),
+										CumulativeCount: proto.Uint64(2),
+									},
+									{
+										UpperBound:      proto.Float64(math.Inf(1)),
+										CumulativeCount: proto.Uint64(2),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "summary quantile updates",
+			now:  time.Unix(0, 0),
+			age:  10 * time.Second,
+			input: []Input{
+				{
+					metric: testutil.MustMetric(
+						"prometheus",
+						map[string]string{},
+						map[string]interface{}{
+							"rpc_duration_seconds_sum":   1.0,
+							"rpc_duration_seconds_count": 1,
+						},
+						time.Unix(15, 0),
+						telegraf.Summary,
+					),
+					addtime: time.Unix(0, 0),
+				}, {
+					metric: testutil.MustMetric(
+						"prometheus",
+						map[string]string{"quantile": "0.01"},
+						map[string]interface{}{
+							"rpc_duration_seconds": 1.0,
+						},
+						time.Unix(15, 0),
+						telegraf.Summary,
+					),
+					addtime: time.Unix(0, 0),
+				}, {
+					// Updated Summary
+					metric: testutil.MustMetric(
+						"prometheus",
+						map[string]string{},
+						map[string]interface{}{
+							"rpc_duration_seconds_sum":   2.0,
+							"rpc_duration_seconds_count": 2,
+						},
+						time.Unix(20, 0), // Updated timestamp
+						telegraf.Summary,
+					),
+					addtime: time.Unix(0, 0),
+				}, {
+					metric: testutil.MustMetric(
+						"prometheus",
+						map[string]string{"quantile": "0.01"},
+						map[string]interface{}{
+							"rpc_duration_seconds": 2.0,
+						},
+						time.Unix(20, 0), // Updated timestamp
+						telegraf.Summary,
+					),
+					addtime: time.Unix(0, 0),
+				},
+			},
+			expected: []*dto.MetricFamily{
+				{
+					Name: proto.String("rpc_duration_seconds"),
+					Help: proto.String(helpString),
+					Type: dto.MetricType_SUMMARY.Enum(),
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{},
+							TimestampMs: proto.Int64(time.Unix(20, 0).UnixNano() / int64(time.Millisecond)),
+							Summary: &dto.Summary{
+								SampleCount: proto.Uint64(2),
+								SampleSum:   proto.Float64(2.0),
+								Quantile: []*dto.Quantile{
+									{
+										Quantile: proto.Float64(0.01),
+										Value:    proto.Float64(2),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCollection(FormatConfig{TimestampExport: ExportTimestamp})
+			for _, item := range tt.input {
+				c.Add(item.metric, item.addtime)
+			}
+			c.Expire(tt.now, tt.age)
+
+			actual := c.GetProto()
+
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/plugins/serializers/prometheus/collection_test.go
+++ b/plugins/serializers/prometheus/collection_test.go
@@ -647,7 +647,7 @@ func TestExportTimestamps(t *testing.T) {
 	}{
 		{
 			name: "histogram bucket updates",
-			now:  time.Unix(0, 0),
+			now:  time.Unix(23, 0),
 			age:  10 * time.Second,
 			input: []Input{
 				{
@@ -661,7 +661,7 @@ func TestExportTimestamps(t *testing.T) {
 						time.Unix(15, 0),
 						telegraf.Histogram,
 					),
-					addtime: time.Unix(0, 0),
+					addtime: time.Unix(23, 0),
 				}, {
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -672,7 +672,7 @@ func TestExportTimestamps(t *testing.T) {
 						time.Unix(15, 0),
 						telegraf.Histogram,
 					),
-					addtime: time.Unix(0, 0),
+					addtime: time.Unix(23, 0),
 				}, {
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -683,7 +683,7 @@ func TestExportTimestamps(t *testing.T) {
 						time.Unix(15, 0),
 						telegraf.Histogram,
 					),
-					addtime: time.Unix(0, 0),
+					addtime: time.Unix(23, 0),
 				}, {
 					// Next interval
 					metric: testutil.MustMetric(
@@ -696,7 +696,7 @@ func TestExportTimestamps(t *testing.T) {
 						time.Unix(20, 0), // Updated timestamp
 						telegraf.Histogram,
 					),
-					addtime: time.Unix(0, 0),
+					addtime: time.Unix(23, 0),
 				}, {
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -707,7 +707,7 @@ func TestExportTimestamps(t *testing.T) {
 						time.Unix(20, 0), // Updated timestamp
 						telegraf.Histogram,
 					),
-					addtime: time.Unix(0, 0),
+					addtime: time.Unix(23, 0),
 				}, {
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -718,7 +718,7 @@ func TestExportTimestamps(t *testing.T) {
 						time.Unix(20, 0), // Updated timestamp
 						telegraf.Histogram,
 					),
-					addtime: time.Unix(0, 0),
+					addtime: time.Unix(23, 0),
 				},
 			},
 			expected: []*dto.MetricFamily{
@@ -751,7 +751,7 @@ func TestExportTimestamps(t *testing.T) {
 		},
 		{
 			name: "summary quantile updates",
-			now:  time.Unix(0, 0),
+			now:  time.Unix(23, 0),
 			age:  10 * time.Second,
 			input: []Input{
 				{
@@ -765,7 +765,7 @@ func TestExportTimestamps(t *testing.T) {
 						time.Unix(15, 0),
 						telegraf.Summary,
 					),
-					addtime: time.Unix(0, 0),
+					addtime: time.Unix(23, 0),
 				}, {
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -776,7 +776,7 @@ func TestExportTimestamps(t *testing.T) {
 						time.Unix(15, 0),
 						telegraf.Summary,
 					),
-					addtime: time.Unix(0, 0),
+					addtime: time.Unix(23, 0),
 				}, {
 					// Updated Summary
 					metric: testutil.MustMetric(
@@ -789,7 +789,7 @@ func TestExportTimestamps(t *testing.T) {
 						time.Unix(20, 0), // Updated timestamp
 						telegraf.Summary,
 					),
-					addtime: time.Unix(0, 0),
+					addtime: time.Unix(23, 0),
 				}, {
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -800,7 +800,7 @@ func TestExportTimestamps(t *testing.T) {
 						time.Unix(20, 0), // Updated timestamp
 						telegraf.Summary,
 					),
-					addtime: time.Unix(0, 0),
+					addtime: time.Unix(23, 0),
 				},
 			},
 			expected: []*dto.MetricFamily{


### PR DESCRIPTION

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #8170 

Replaces #8257

#8257 partially implements a fix for #8170 but this PR expands it to also resolve the expiration issue to the Summary type.

It also updates both the Histogram and Summary `timestampMs` field when new data arrives for a particular Histogram or Summary. I talk about this problem in [this](https://github.com/influxdata/telegraf/issues/8170#issuecomment-816261054) comment on #8170. Below expands on it.

If you have configured `[[outputs.prometheus_client]]` to `export_timestamps = true` then without the updating of `timestampMs` on new data coming in you end up in a situation like below.

Say you are pushing prometheus data to telegraf. The first batch might look something like below with a timestamp of `1617722541063`

```
metric_name{application="the-application",quantile="0.5"} 1 1617722540000
metric_name{application="the-application",quantile="0.75"} 2 1617722540000
metric_name{application="the-application",quantile="0.95"} 3 1617722540000
metric_name{application="the-application",quantile="0.98"} 3.3 1617722540000
metric_name{application="the-application",quantile="0.99"} 3.4 1617722540000
metric_name{application="the-application",quantile="0.999"} 10 1617722540000
metric_name_sum{application="the-application"} 207.501625198 1617722540000
metric_name_count{application="the-application"} 18000 1617722540000

```

About 10 seconds later, you publish an update to telegraf.

```
metric_name{application="the-application",quantile="0.5"} 0.9  1617722550000
metric_name{application="the-application",quantile="0.75"} 1.5 1617722550000
metric_name{application="the-application",quantile="0.95"} 2 1617722550000
metric_name{application="the-application",quantile="0.98"} 3 1617722550000
metric_name{application="the-application",quantile="0.99"} 3.5 1617722550000
metric_name{application="the-application",quantile="0.999"} 10 1617722550000
metric_name_sum{application="the-application"} 310 1617722550000
metric_name_count{application="the-application"} 18281 1617722550000
```

If telegraf is then scrapped by prometheus and `export_timestamp = true`, the initial first received timestamp is exported instead of the correct second timestamp. Updating `timestampMs` as new data comes in resolves this issue.
