### PR TITLE
added is_active parameter to snmp input plugin

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -827,6 +827,13 @@ func (c *Config) LoadConfigData(data []byte) error {
 					}
 				case []*ast.Table:
 					for _, t := range pluginSubTable {
+						isActive  := false						
+						if _, ok := t.Fields["is_active"]; ok {
+							c.getFieldBool(t, "is_active", &isActive)
+							if !isActive {
+								continue
+							}	
+						}
 						if err = c.addInput(pluginName, t); err != nil {
 							return fmt.Errorf("error parsing %s, %w", pluginName, err)
 						}
@@ -1474,7 +1481,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 		"prefix", "prometheus_export_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label",
 		"separator", "splunkmetric_hec_routing", "splunkmetric_multimetric", "tag_keys",
 		"tagdrop", "tagexclude", "taginclude", "tagpass", "tags", "template", "templates",
-		"value_field_name", "wavefront_source_override", "wavefront_use_strict", "xml":
+		"value_field_name", "wavefront_source_override", "wavefront_use_strict", "xml", "is_active":
 
 		// ignore fields that are common to all plugins.
 	default:

--- a/config/config.go
+++ b/config/config.go
@@ -827,6 +827,8 @@ func (c *Config) LoadConfigData(data []byte) error {
 					}
 				case []*ast.Table:
 					for _, t := range pluginSubTable {
+						// If it's not specify then it's accepted true 
+						// Config file filter
 						isActive  := false						
 						if _, ok := t.Fields["is_active"]; ok {
 							c.getFieldBool(t, "is_active", &isActive)

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -5676,6 +5676,9 @@
 #   ## The GETBULK max-repetitions parameter.
 #   # max_repetitions = 10
 #
+#   ## Multiple config file active/passive parameter
+#   # is_active = true
+#
 #   ## SNMPv3 authentication and encryption options.
 #   ##
 #   ## Security Name.

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -5677,6 +5677,9 @@
 #   # max_repetitions = 10
 #
 #   ## Multiple config file active/passive parameter
+#   ## When use multiple config(like telegraf.d) and that config can be use actively in the future
+#   ## then you can use this parameter.
+#   ## If it's not specify then it is accepted true 
 #   # is_active = true
 #
 #   ## SNMPv3 authentication and encryption options.

--- a/internal/snmp/config.go
+++ b/internal/snmp/config.go
@@ -31,4 +31,7 @@ type ClientConfig struct {
 	EngineID     string `toml:"-"`
 	EngineBoots  uint32 `toml:"-"`
 	EngineTime   uint32 `toml:"-"`
+
+	//Values : true, false
+	IsActive bool `toml:"is_active"`
 }


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
If we need to multiple config file (telegraf.d) and just active/passive (not any other config) then there is no other way but  delete and create. is_active make this for snmp config and support  other input implementations.