### PR TITLE
Kinesis_consumer input plugin - fix repeating parser error

### DIFF
--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -230,8 +230,8 @@ func (k *KinesisConsumer) connect(ac telegraf.Accumulator) error {
 			}
 			err := k.onMessage(k.acc, r)
 			if err != nil {
-				k.sem <- struct{}{}
-				return consumer.ScanStatus{Error: err}
+				<- k.sem
+				k.Log.Errorf("Scan parser error: %s", err.Error())
 			}
 
 			return consumer.ScanStatus{}

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -230,7 +230,7 @@ func (k *KinesisConsumer) connect(ac telegraf.Accumulator) error {
 			}
 			err := k.onMessage(k.acc, r)
 			if err != nil {
-				<- k.sem
+				<-k.sem
 				k.Log.Errorf("Scan parser error: %s", err.Error())
 			}
 


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #8784 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Simply log error message instead of returning it which results in the malformed data to be skipped rather than repeated
