### PR TITLE
Add content encoding support to MQTT

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -7358,6 +7358,10 @@
 #   ## Use TLS but skip chain & host verification
 #   # insecure_skip_verify = false
 #
+#   ## Content encoding for message payloads, can be set to "gzip" to or
+#   ## "identity" to apply no encoding.
+#   # content_encoding = "identity"
+#
 #   ## Data format to consume.
 #   ## Each data format has its own unique set of configuration options, read
 #   ## more about them here:


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

In our project we are compressing the data we send over the MQTT server. The MQTT input plugin doesn't support this, so I added it. I copied all the code from the `amqp_consumer` plugin, and it seems to work fine. I can't actually write Go code so I can't add unit tests for this.

I don't expect anyone to accept this PR, I'm just putting this here in case anyone else needs this functionality (and maybe wants to improve on it).

P.s. the sentence `Content encoding for message payloads, can be set to "gzip" to or "identity" to apply no encoding` doesn't seem right, but the exact sentence pops up multiple times in this repo, hence why I didn't change it.