### PR TITLE
Fixes #9177 - Specify wanted ipmi metrics

### DIFF
--- a/plugins/inputs/ipmi_sensor/README.md
+++ b/plugins/inputs/ipmi_sensor/README.md
@@ -70,6 +70,10 @@ Any of the following parameters will be added to the aformentioned query if they
   ## Path to the ipmitools cache file (defaults to OS temp dir)
   ## The provided path must exist and must be writable
   # cache_path = ""
+
+  ## Store specific IPMI sensor data
+  ## If no value is specified all sensor data will be stored
+  # wantedmetrics = [ "inlet_temp" ]
 ```
 
 ### Measurements


### PR DESCRIPTION
This change makes it possible to store specific ipmi metrics to the
ouptut.

### Required for all PRs:

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

resolves #9177

Added an option to specify which ipmi metrics one wishes to collect and store. Similar to collectd's ipmi plugin: https://collectd.org/wiki/index.php/Plugin:IPMI