### PR TITLE
Remote write compliance updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
-	github.com/prometheus/common v0.13.0
+	github.com/prometheus/common v0.15.0
 	github.com/prometheus/procfs v0.1.3
 	github.com/prometheus/prometheus v1.8.2-0.20200911110723-e83ef207b6c2
 	github.com/riemann/riemann-go-client v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -960,8 +960,9 @@ github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
-github.com/prometheus/common v0.13.0 h1:vJlpe9wPgDRM1Z+7Wj3zUUjY1nr6/1jNKyl7llliccg=
 github.com/prometheus/common v0.13.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
+github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
+github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -274,6 +274,11 @@ func (s *Serializer) createLabels(metric telegraf.Metric) []prompb.Label {
 			continue
 		}
 
+		// remove tags with empty values
+		if tag.Value == "" {
+			continue
+		}
+
 		labels = append(labels, prompb.Label{Name: name, Value: tag.Value})
 	}
 

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -615,6 +615,28 @@ rpc_duration_seconds_count 2693
 rpc_duration_seconds_sum 17560473
 `),
 		},
+		{
+			name: "empty label string value",
+			config: FormatConfig{
+				MetricSortOrder: SortMetrics,
+				StringHandling:  StringAsLabel,
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"prometheus",
+					map[string]string{
+						"cpu": "",
+					},
+					map[string]interface{}{
+						"time_idle": 42.0,
+					},
+					time.Unix(0, 0),
+				),
+			},
+			expected: []byte(`
+			time_idle 42
+`),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
relates to #9166

- upgraded to prometheus/common [v0.15.0](https://github.com/prometheus/common/releases/tag/v0.15.0) as it includes an[ update to text parsing](https://github.com/prometheus/common/pull/263) to not allow duplicate labels 

this change will mean we pass the prometheus remote write [repeated labels compliance test](https://github.com/prometheus/compliance/blob/main/remote_write/cases/labels.go#L38) which we are currently failing

- added a check to the prometheus serializer to see if the tags value is "", if it is we drop the tag

this change will mean we mass the prometheus remote write [empty labels compliance test](https://github.com/prometheus/compliance/blob/main/remote_write/cases/labels.go#L65), added a test for the above
