### PR TITLE
Resolve dependabot error by ignoring package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Dependabot isn't able to update this package do the name not matching the source
+      - dependency-name: "gopkg.in/djherbis/times.v1"


### PR DESCRIPTION
Ignoring the package `gopkg.in/djherbis/times.v1` because it is causing dependabot to throw the following error:

```
Dependabot wasn't able to update gopkg.in/djherbis/times.v1

The module path gopkg.in/djherbis/times.v1 found in your go.mod doesn't match the actual path github.com/djherbis/times found in the dependency's go.mod.

Updating the module path in your go.mod to github.com/djherbis/times should resolve this issue.
```
