### PR TITLE
Ignore soniah/gosnmp dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     ignore:
       # Dependabot isn't able to update this package do the name not matching the source
       - dependency-name: "gopkg.in/djherbis/times.v1"
+      # Updating this package is blocked by: https://github.com/gosnmp/gosnmp/issues/284
+      - dependency-name: "github.com/soniah/gosnmp"      


### PR DESCRIPTION
Updating config to have dependabot ignore soniah/gosnmp dependency for now until the issue #9203 is resolved.