### PR TITLE
plugins/inputs/dovecot: Add support for unix domain sockets

### DIFF
--- a/plugins/inputs/dovecot/README.md
+++ b/plugins/inputs/dovecot/README.md
@@ -14,6 +14,9 @@ the [upgrading steps][upgrading].
   ## specify dovecot servers via an address:port list
   ##  e.g.
   ##    localhost:24242
+  ## or as an UDS socket
+  ##  e.g.
+  ##    /var/run/dovecot/old-stats
   ##
   ## If no servers are specified, then localhost is used as the host.
   servers = ["localhost:24242"]


### PR DESCRIPTION
It's safer for dovecot to export metrics via a UDS instead of tcp port,
this will add support for that option.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #9215 

dovecot: Add support for unix domain sockets as well