### PR TITLE
Document using group membership to allow access to /dev/pf for pf input plugin

### DIFF
--- a/plugins/inputs/pf/README.md
+++ b/plugins/inputs/pf/README.md
@@ -7,6 +7,7 @@ The pf plugin retrieves this information by invoking the `pfstat` command. The `
 * Run telegraf as root. This is strongly discouraged.
 * Change the ownership and permissions for /dev/pf such that the user telegraf runs at can read the /dev/pf device file. This is probably not that good of an idea either.
 * Configure sudo to grant telegraf to run `pfctl` as root. This is the most restrictive option, but require sudo setup.
+* Add "telegraf" to the "proxy" group as /dev/pf is owned by root:proxy. 
 
 ### Using sudo
 


### PR DESCRIPTION
Adding the "telegraf" user to the "proxy" group gives it the required permissions to read from /dev/pf.

This PR is to resolve a comment left by @reimda https://github.com/influxdata/telegraf/pull/9200#issuecomment-830457595 . With my testing of Telegraf on Freebsd ARMv7 (21.02.2-RELEASE (arm)), I found you needed to add the Telegraf user to the "Proxy" group in order to gain access to /dev/pf. I do not have sudo installed on my router, so this was the path I took to resolve the permissions issues.

As this specific step isn't suggested in the README, adding. 

### Required for all PRs:
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

resolves #
Provides another method of giving Telegraf's user the correct permissions to read from /dev/pf for pf metrics. 
