### PR TITLE
Closing all idle connections in docker input plugin

### DIFF
--- a/plugins/inputs/docker/client.go
+++ b/plugins/inputs/docker/client.go
@@ -23,6 +23,7 @@ type Client interface {
 	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
 	NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
+	Close() error
 }
 
 func NewEnvClient() (Client, error) {
@@ -75,4 +76,7 @@ func (c *SocketClient) TaskList(ctx context.Context, options types.TaskListOptio
 }
 func (c *SocketClient) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
 	return c.client.NodeList(ctx, options)
+}
+func (c *SocketClient) Close() error {
+	return c.client.Close()
 }

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -123,7 +123,7 @@ var sampleConfig = `
   ## Whether to report for each container per-device blkio (8:0, 8:1...),
   ## network (eth0, eth1, ...) and cpu (cpu0, cpu1, ...) stats or not.
   ## Usage of this setting is discouraged since it will be deprecated in favor of 'perdevice_include'.
-  ## Default value is 'true' for backwards compatibility, please set it to 'false' so that 'perdevice_include' setting 
+  ## Default value is 'true' for backwards compatibility, please set it to 'false' so that 'perdevice_include' setting
   ## is honored.
   perdevice = true
 
@@ -134,12 +134,12 @@ var sampleConfig = `
 
   ## Whether to report for each container total blkio and network stats or not.
   ## Usage of this setting is discouraged since it will be deprecated in favor of 'total_include'.
-  ## Default value is 'false' for backwards compatibility, please set it to 'true' so that 'total_include' setting 
+  ## Default value is 'false' for backwards compatibility, please set it to 'true' so that 'total_include' setting
   ## is honored.
   total = false
 
   ## Specifies for which classes a total metric should be issued. Total is an aggregated of the 'perdevice' values.
-  ## Possible values are 'cpu', 'blkio' and 'network'  
+  ## Possible values are 'cpu', 'blkio' and 'network'
   ## Total 'cpu' is reported directly by Docker daemon, and 'network' and 'blkio' totals are aggregated by this plugin.
   ## Please note that this setting has no effect if 'total' is set to 'false'
   # total_include = ["cpu", "blkio", "network"]
@@ -212,6 +212,9 @@ func (d *Docker) Gather(acc telegraf.Accumulator) error {
 		}
 		d.client = c
 	}
+
+	// Close any idle connections in the end of gathering
+	defer d.client.Close()
 
 	// Create label filters if not already created
 	if !d.filtersCreated {

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -26,6 +26,7 @@ type MockClient struct {
 	ServiceListF      func(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	TaskListF         func(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
 	NodeListF         func(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
+	CloseF            func() error
 }
 
 func (c *MockClient) Info(ctx context.Context) (types.Info, error) {
@@ -75,6 +76,10 @@ func (c *MockClient) NodeList(
 	return c.NodeListF(ctx, options)
 }
 
+func (c *MockClient) Close() error {
+	return c.CloseF()
+}
+
 var baseClient = MockClient{
 	InfoF: func(context.Context) (types.Info, error) {
 		return info, nil
@@ -96,6 +101,9 @@ var baseClient = MockClient{
 	},
 	NodeListF: func(context.Context, types.NodeListOptions) ([]swarm.Node, error) {
 		return NodeList, nil
+	},
+	CloseF: func() error {
+		return nil
 	},
 }
 
@@ -278,6 +286,9 @@ func TestDocker_WindowsMemoryContainerStats(t *testing.T) {
 				},
 				NodeListF: func(context.Context, types.NodeListOptions) ([]swarm.Node, error) {
 					return NodeList, nil
+				},
+				CloseF: func() error {
+					return nil
 				},
 			}, nil
 		},


### PR DESCRIPTION
This prevents error "too many open files" in most cases

### Required for all PRs:
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #9242 

Method `Close()` of official docker client just closes all idle connections and don't destroy client instance itself:
https://github.com/moby/moby/blob/17.05.x/client/client.go#L181
So it's safe to use inside telegraf input plugin