### PR TITLE
update HTTP v2 listener readme

### DIFF
--- a/plugins/inputs/http_listener_v2/README.md
+++ b/plugins/inputs/http_listener_v2/README.md
@@ -1,7 +1,8 @@
 # HTTP Listener v2 Input Plugin
 
 HTTP Listener v2 is a service input plugin that listens for metrics sent via
-HTTP. Metrics may be sent in any supported [data format][data_format].
+HTTP. Metrics may be sent in any supported [data format][data_format] unless they are
+[InfluxDB Line Protocol][line_protocol]. If they are in line protocol use the [InfluxDB Listener Input Plugin][influxdb_listener] instead. 
 
 **Note:** The plugin previously known as `http_listener` has been renamed
 `influxdb_listener`.  If you would like Telegraf to act as a proxy/relay for
@@ -57,7 +58,7 @@ This is a sample configuration for the plugin.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
-  data_format = "influx"
+  data_format = "json"
 ```
 
 ### Metrics:
@@ -83,3 +84,4 @@ curl -i -XGET 'http://localhost:8080/telegraf?host=server01&value=0.42'
 
 [data_format]: /docs/DATA_FORMATS_INPUT.md
 [influxdb_listener]: /plugins/inputs/influxdb_listener/README.md
+[line_protocol]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/

--- a/plugins/inputs/http_listener_v2/README.md
+++ b/plugins/inputs/http_listener_v2/README.md
@@ -1,12 +1,13 @@
 # HTTP Listener v2 Input Plugin
 
 HTTP Listener v2 is a service input plugin that listens for metrics sent via
-HTTP. Metrics may be sent in any supported [data format][data_format] unless they are
-[InfluxDB Line Protocol][line_protocol]. If they are in line protocol use the [InfluxDB Listener Input Plugin][influxdb_listener] instead. 
+HTTP. Metrics may be sent in any supported [data format][data_format]. For metrics in 
+[InfluxDB Line Protocol][line_protocol] it's recommended to use the [`influxdb_listener`][influxdb_listener] 
+or [`influxdb_v2_listener`][influxdb_v2_listener] instead. 
 
 **Note:** The plugin previously known as `http_listener` has been renamed
 `influxdb_listener`.  If you would like Telegraf to act as a proxy/relay for
-InfluxDB it is recommended to use [`influxdb_listener`][influxdb_listener].
+InfluxDB it is recommended to use [`influxdb_listener`][influxdb_listener] or [`influxdb_v2_listener`][influxdb_v2_listener].
 
 ### Configuration:
 
@@ -85,3 +86,4 @@ curl -i -XGET 'http://localhost:8080/telegraf?host=server01&value=0.42'
 [data_format]: /docs/DATA_FORMATS_INPUT.md
 [influxdb_listener]: /plugins/inputs/influxdb_listener/README.md
 [line_protocol]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/
+[influxdb_v2_listener]: /plugins/inputs/influxdb_v2_listener/README.md


### PR DESCRIPTION
default config should _not_ be set to `data_format = "influx"` since if users are reading in influx LP they should be using the `inputs.influxdb_listener`. 
- Add note about using `inputs.influxdb_listener
- Change data format in default config to `data_format.= "json"`