### PR TITLE
feat: set user agent when scraping prom metrics

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -435,7 +435,7 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) error 
 
 func (p *Prometheus) addHeaders(req *http.Request) {
 	for header, value := range p.headers {
-		req.Header.Set(header, value)
+		req.Header.Add(header, value)
 	}
 }
 

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -279,7 +279,6 @@ func (p *Prometheus) Gather(acc telegraf.Accumulator) error {
 			"User-Agent": internal.ProductToken(),
 			"Accept":     acceptHeader,
 		}
-
 	}
 
 	var wg sync.WaitGroup

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	parser_v2 "github.com/influxdata/telegraf/plugins/parsers/prometheus"
@@ -58,7 +59,8 @@ type Prometheus struct {
 
 	Log telegraf.Logger
 
-	client *http.Client
+	client  *http.Client
+	headers map[string]string
 
 	// Should we scrape Kubernetes services for prometheus annotations
 	MonitorPods       bool   `toml:"monitor_kubernetes_pods"`
@@ -273,6 +275,11 @@ func (p *Prometheus) Gather(acc telegraf.Accumulator) error {
 			return err
 		}
 		p.client = client
+		p.headers = map[string]string{
+			"User-Agent": internal.ProductToken(),
+			"Accept":     acceptHeader,
+		}
+
 	}
 
 	var wg sync.WaitGroup
@@ -350,7 +357,7 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) error 
 		}
 	}
 
-	req.Header.Add("Accept", acceptHeader)
+	p.addHeaders(req)
 
 	if p.BearerToken != "" {
 		token, err := ioutil.ReadFile(p.BearerToken)
@@ -425,6 +432,12 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) error 
 	}
 
 	return nil
+}
+
+func (p *Prometheus) addHeaders(req *http.Request) {
+	for header, value := range p.headers {
+		req.Header.Set(header, value)
+	}
 }
 
 /* Check if the field selector specified is valid.


### PR DESCRIPTION
### Required for all PRs:

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

this change updates the user agent used when scraping a prometheus endpoint from the generic Go-Http-Client to Telegraf/1.18 used in other plugins (the influxdb_v2 output)
