### PR TITLE
inputs.ping: Add an option to specify packet size

### DIFF
--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -70,6 +70,10 @@ native Go by the Telegraf process, eliminating the need to execute the system
 
   ## Use only IPv6 addresses when resolving a hostname.
   # ipv6 = false
+
+  ## Number of data bytes to be sent. Corresponds to the "-s"
+  ## option of the ping command. This only works with the native method.
+  # size = 56
 ```
 
 #### File Limit

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -18,6 +18,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
+const (
+	defaultPingDataBytesSize = 56
+)
+
 // HostPinger is a function that runs the "ping" function using a list of
 // passed arguments. This can be easily switched with a mocked ping function
 // for unit test purposes (see ping_test.go)
@@ -75,7 +79,7 @@ type Ping struct {
 	Percentiles []int
 
 	// Packet size
-	Size int
+	Size *int
 }
 
 func (*Ping) Description() string {
@@ -180,7 +184,10 @@ func (p *Ping) nativePing(destination string) (*pingStats, error) {
 	}
 
 	if p.Method == "native" {
-		pinger.Size = p.Size
+		pinger.Size = defaultPingDataBytesSize
+		if p.Size != nil {
+			pinger.Size = *p.Size
+		}
 	}
 
 	pinger.Source = p.sourceAddress

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -73,6 +73,9 @@ type Ping struct {
 
 	// Calculate the given percentiles when using native method
 	Percentiles []int
+
+	// Packet size
+	Size int
 }
 
 func (*Ping) Description() string {
@@ -125,6 +128,10 @@ const sampleConfig = `
 
   ## Use only IPv6 addresses when resolving a hostname.
   # ipv6 = false
+
+  ## Number of data bytes to be sent. Corresponds to the "-s"
+  ## option of the ping command. This only works with the native method.
+  # size = 56
 `
 
 func (*Ping) SampleConfig() string {
@@ -170,6 +177,10 @@ func (p *Ping) nativePing(destination string) (*pingStats, error) {
 
 	if p.IPv6 {
 		pinger.SetNetwork("ip6")
+	}
+
+	if p.Method == "native" {
+		pinger.Size = p.Size
 	}
 
 	pinger.Source = p.sourceAddress


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9222 

This patch adds an option to specify the number of data bytes to be sent.
This corresponds to the "-s" in the ping(8) command.

It is only applicable for the "native" method.
<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
