### PR TITLE
Fix reading config files starting with http:

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -915,6 +915,8 @@ func loadConfig(config string) ([]byte, error) {
 		switch u.Scheme {
 		case "https", "http":
 			return fetchConfig(u)
+		default:
+			return nil, fmt.Errorf("scheme %q not supported", u.Scheme)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,10 @@ var (
 		`\`, `\\`,
 	)
 	httpLoadConfigRetryInterval = 10 * time.Second
+
+	// fetchURLRe is a regex to determine whether the requested file should
+	// be fetched from a remote or read from the filesystem.
+	fetchURLRe = regexp.MustCompile(`^\w+://`)
 )
 
 // Config specifies the URL/user/password for the database that telegraf
@@ -902,20 +906,18 @@ func escapeEnv(value string) string {
 }
 
 func loadConfig(config string) ([]byte, error) {
-	u, err := url.Parse(config)
-	if err != nil {
-		return nil, err
-	}
+	if fetchURLRe.MatchString(config) {
+		u, err := url.Parse(config)
+		if err != nil {
+			return nil, err
+		}
 
-	if u.Host == "" {
-		return ioutil.ReadFile(config)
-	}
-
-	switch u.Scheme {
-	case "https", "http":
-		return fetchConfig(u)
-	default:
-		// If it isn't a https or file scheme, try it as a file
+		switch u.Scheme {
+		case "https", "http":
+			return fetchConfig(u)
+		default:
+			// If it isn't a https scheme, try it as a file
+		}
 	}
 
 	return ioutil.ReadFile(config)

--- a/config/config.go
+++ b/config/config.go
@@ -903,7 +903,7 @@ func escapeEnv(value string) string {
 
 func loadConfig(config string) ([]byte, error) {
 	content, err := ioutil.ReadFile(config)
-	if os.IsNotExist(err) {
+	if err != nil {
 		u, err := url.Parse(config)
 		if err != nil {
 			return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -915,11 +915,10 @@ func loadConfig(config string) ([]byte, error) {
 		switch u.Scheme {
 		case "https", "http":
 			return fetchConfig(u)
-		default:
-			// If it isn't a https scheme, try it as a file
 		}
 	}
 
+	// If it isn't a https scheme, try it as a file
 	return ioutil.ReadFile(config)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -902,18 +902,22 @@ func escapeEnv(value string) string {
 }
 
 func loadConfig(config string) ([]byte, error) {
-	u, err := url.Parse(config)
-	if err != nil {
-		return nil, err
+	content, err := ioutil.ReadFile(config)
+	if os.IsNotExist(err) {
+		u, err := url.Parse(config)
+		if err != nil {
+			return nil, err
+		}
+
+		switch u.Scheme {
+		case "https", "http":
+			return fetchConfig(u)
+		default:
+			// If it isn't a https scheme, an error occurred
+		}
 	}
 
-	switch u.Scheme {
-	case "https", "http":
-		return fetchConfig(u)
-	default:
-		// If it isn't a https scheme, try it as a file.
-	}
-	return ioutil.ReadFile(config)
+	return content, err
 }
 
 func fetchConfig(u *url.URL) ([]byte, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -51,9 +51,9 @@ var (
 	)
 	httpLoadConfigRetryInterval = 10 * time.Second
 
-	// fetchUrlRe is a regex to determine whether the requested file should
+	// fetchURLRe is a regex to determine whether the requested file should
 	// be fetched from a remote or read from the filesystem.
-	fetchUrlRe = regexp.MustCompile(`^\w+://`)
+	fetchURLRe = regexp.MustCompile(`^\w+://`)
 )
 
 // Config specifies the URL/user/password for the database that telegraf
@@ -906,7 +906,7 @@ func escapeEnv(value string) string {
 }
 
 func loadConfig(config string) ([]byte, error) {
-	if fetchUrlRe.MatchString(config) {
+	if fetchURLRe.MatchString(config) {
 		u, err := url.Parse(config)
 		if err != nil {
 			return nil, err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -331,7 +331,7 @@ func TestConfig_URLLikeFileName(t *testing.T) {
 
 	if runtime.GOOS == "windows" {
 		// The error file not found error message is different on windows
-		require.Equal(t, "Error loading config file http:##www.example.com.conf: open http:##www.example.com.conf: The system cannot find the file specified", err.Error())
+		require.Equal(t, "Error loading config file http:##www.example.com.conf: open http:##www.example.com.conf: The system cannot find the file specified.", err.Error())
 	} else {
 		require.Equal(t, "Error loading config file http:##www.example.com.conf: open http:##www.example.com.conf: no such file or directory", err.Error())
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -323,6 +323,13 @@ func TestConfig_URLRetries3FailsThenPasses(t *testing.T) {
 	require.Equal(t, 4, responseCounter)
 }
 
+func TestConfig_URLLikeFileName(t *testing.T) {
+	c := NewConfig()
+	err := c.LoadConfig("http:##www.example.com.conf")
+	require.Error(t, err)
+	require.Equal(t, "Error loading config file http:##www.example.com.conf: open http:##www.example.com.conf: no such file or directory", err.Error())
+}
+
 /*** Mockup INPUT plugin for testing to avoid cyclic dependencies ***/
 type MockupInputPlugin struct {
 	Servers      []string `toml:"servers"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -327,7 +328,13 @@ func TestConfig_URLLikeFileName(t *testing.T) {
 	c := NewConfig()
 	err := c.LoadConfig("http:##www.example.com.conf")
 	require.Error(t, err)
-	require.Equal(t, "Error loading config file http:##www.example.com.conf: open http:##www.example.com.conf: no such file or directory", err.Error())
+
+	if runtime.GOOS == "windows" {
+		// The error file not found error message is different on windows
+		require.Equal(t, "Error loading config file http:##www.example.com.conf: open http:##www.example.com.conf: The system cannot find the file specified", err.Error())
+	} else {
+		require.Equal(t, "Error loading config file http:##www.example.com.conf: open http:##www.example.com.conf: no such file or directory", err.Error())
+	}
 }
 
 /*** Mockup INPUT plugin for testing to avoid cyclic dependencies ***/


### PR DESCRIPTION
resolves #9218 

Fixed an error where telegraf attempted to fetch files starting with `http:` or `https:` over HTTP/S rather than read them from the filesystem.
