### PR TITLE
Fix segfault in processors/parser

### DIFF
--- a/plugins/parsers/xml/parser.go
+++ b/plugins/parsers/xml/parser.go
@@ -39,12 +39,10 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	t := time.Now()
 
 	// Parse the XML
-	p.Log.Debugf("Buffer: %q", string(buf))
 	doc, err := xmlquery.Parse(strings.NewReader(string(buf)))
 	if err != nil {
 		return nil, err
 	}
-	p.Log.Debugf("doc: %v", doc)
 
 	// Queries
 	metrics := make([]telegraf.Metric, 0)

--- a/plugins/parsers/xml/parser.go
+++ b/plugins/parsers/xml/parser.go
@@ -39,10 +39,12 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	t := time.Now()
 
 	// Parse the XML
+	p.Log.Debugf("Buffer: %q", string(buf))
 	doc, err := xmlquery.Parse(strings.NewReader(string(buf)))
 	if err != nil {
 		return nil, err
 	}
+	p.Log.Debugf("doc: %v", doc)
 
 	// Queries
 	metrics := make([]telegraf.Metric, 0)

--- a/plugins/processors/parser/parser.go
+++ b/plugins/processors/parser/parser.go
@@ -4,15 +4,17 @@ import (
 	"log"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/processors"
 )
 
 type Parser struct {
 	parsers.Config
-	DropOriginal bool     `toml:"drop_original"`
-	Merge        string   `toml:"merge"`
-	ParseFields  []string `toml:"parse_fields"`
+	DropOriginal bool            `toml:"drop_original"`
+	Merge        string          `toml:"merge"`
+	ParseFields  []string        `toml:"parse_fields"`
+	Log          telegraf.Logger `toml:"-"`
 	Parser       parsers.Parser
 }
 
@@ -50,6 +52,7 @@ func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 			log.Printf("E! [processors.parser] could not create parser: %v", err)
 			return metrics
 		}
+		models.SetLoggerOnPlugin(p.Parser, p.Log)
 	}
 
 	results := []telegraf.Metric{}

--- a/plugins/processors/parser/parser.go
+++ b/plugins/processors/parser/parser.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"log"
-
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/parsers"
@@ -49,7 +47,7 @@ func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 		var err error
 		p.parser, err = parsers.NewParser(&p.Config)
 		if err != nil {
-			log.Printf("E! [processors.parser] could not create parser: %v", err)
+			p.Log.Errorf("could not create parser: %v", err)
 			return metrics
 		}
 		models.SetLoggerOnPlugin(p.parser, p.Log)
@@ -70,7 +68,7 @@ func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 					case string:
 						fromFieldMetric, err := p.parseField(value)
 						if err != nil {
-							log.Printf("E! [processors.parser] could not parse field %s: %v", key, err)
+							p.Log.Errorf("could not parse field %s: %v", key, err)
 						}
 
 						for _, m := range fromFieldMetric {
@@ -84,7 +82,7 @@ func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 						// prior to returning.
 						newMetrics = append(newMetrics, fromFieldMetric...)
 					default:
-						log.Printf("E! [processors.parser] field '%s' not a string, skipping", key)
+						p.Log.Errorf("field '%s' not a string, skipping", key)
 					}
 				}
 			}

--- a/plugins/processors/parser/parser.go
+++ b/plugins/processors/parser/parser.go
@@ -15,7 +15,7 @@ type Parser struct {
 	Merge        string          `toml:"merge"`
 	ParseFields  []string        `toml:"parse_fields"`
 	Log          telegraf.Logger `toml:"-"`
-	Parser       parsers.Parser
+	parser       parsers.Parser
 }
 
 var SampleConfig = `
@@ -45,14 +45,14 @@ func (p *Parser) Description() string {
 }
 
 func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
-	if p.Parser == nil {
+	if p.parser == nil {
 		var err error
-		p.Parser, err = parsers.NewParser(&p.Config)
+		p.parser, err = parsers.NewParser(&p.Config)
 		if err != nil {
 			log.Printf("E! [processors.parser] could not create parser: %v", err)
 			return metrics
 		}
-		models.SetLoggerOnPlugin(p.Parser, p.Log)
+		models.SetLoggerOnPlugin(p.parser, p.Log)
 	}
 
 	results := []telegraf.Metric{}
@@ -117,7 +117,7 @@ func merge(base telegraf.Metric, metrics []telegraf.Metric) telegraf.Metric {
 }
 
 func (p *Parser) parseField(value string) ([]telegraf.Metric, error) {
-	return p.Parser.Parse([]byte(value))
+	return p.parser.Parse([]byte(value))
 }
 
 func init() {

--- a/plugins/processors/parser/parser_test.go
+++ b/plugins/processors/parser/parser_test.go
@@ -10,13 +10,12 @@ import (
 
 	"github.com/influxdata/telegraf/testutil"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 //compares metrics without comparing time
 func compareMetrics(t *testing.T, expected, actual []telegraf.Metric) {
-	assert.Equal(t, len(expected), len(actual))
+	require.Equal(t, len(expected), len(actual))
 	for i, metric := range actual {
 		require.Equal(t, expected[i].Name(), metric.Name())
 		require.Equal(t, expected[i].Fields(), metric.Fields())

--- a/plugins/processors/parser/parser_test.go
+++ b/plugins/processors/parser/parser_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/parsers"
+
+	"github.com/influxdata/telegraf/testutil"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -503,6 +506,7 @@ func TestApply(t *testing.T) {
 				ParseFields:  tt.parseFields,
 				DropOriginal: tt.dropOriginal,
 				Merge:        tt.merge,
+				Log:          testutil.Logger{Name: "processor.parser"},
 			}
 
 			output := parser.Apply(tt.input)
@@ -573,6 +577,7 @@ func TestBadApply(t *testing.T) {
 			parser := Parser{
 				Config:      tt.config,
 				ParseFields: tt.parseFields,
+				Log:         testutil.Logger{Name: "processor.parser"},
 			}
 
 			output := parser.Apply(tt.input)

--- a/plugins/processors/parser/parser_test.go
+++ b/plugins/processors/parser/parser_test.go
@@ -16,10 +16,10 @@ import (
 //compares metrics without comparing time
 func compareMetrics(t *testing.T, expected, actual []telegraf.Metric) {
 	require.Equal(t, len(expected), len(actual))
-	for i, metric := range actual {
-		require.Equal(t, expected[i].Name(), metric.Name())
-		require.Equal(t, expected[i].Fields(), metric.Fields())
-		require.Equal(t, expected[i].Tags(), metric.Tags())
+	for i, m := range actual {
+		require.Equal(t, expected[i].Name(), m.Name())
+		require.Equal(t, expected[i].Fields(), m.Fields())
+		require.Equal(t, expected[i].Tags(), m.Tags())
 	}
 }
 
@@ -588,17 +588,17 @@ func TestBadApply(t *testing.T) {
 
 // Benchmarks
 
-func getMetricFields(metric telegraf.Metric) interface{} {
+func getMetricFields(m telegraf.Metric) interface{} {
 	key := "field3"
-	if value, ok := metric.Fields()[key]; ok {
+	if value, ok := m.Fields()[key]; ok {
 		return value
 	}
 	return nil
 }
 
-func getMetricFieldList(metric telegraf.Metric) interface{} {
+func getMetricFieldList(m telegraf.Metric) interface{} {
 	key := "field3"
-	fields := metric.FieldList()
+	fields := m.FieldList()
 	for _, field := range fields {
 		if field.Key == key {
 			return field.Value


### PR DESCRIPTION
### Required for all PRs:
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

resolves #9282

Parsers can use the telegraf logging facility by defining a `Log` field. When using those parsers in inputs the logging facility is automatically set by telegraf after instantiation. However, in this processor the parsers are instantiated manually and setting the log facility is omitted. This in turn leads to segfault-panics for all parsers that rely on the logging facility.

This PR fixes the issue by passing its (newly added) logging facility on to the parser and in this step also gets rid of the unrecommended usage of the `log` package.
Additionally, some minor improvements like making the parser private and fixing the remaining linter issues are performed.