### PR TITLE
Issue 8914 x509sni

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -66,8 +66,7 @@ func (c *X509Cert) SampleConfig() string {
 func (c *X509Cert) sourcesToURLs() error {
 	for _, source := range c.Sources {
 		if strings.HasPrefix(source, "file://") ||
-			strings.HasPrefix(source, "/") ||
-			strings.Index(source, ":\\") != 1 {
+			strings.HasPrefix(source, "/") {
 			source = filepath.ToSlash(strings.TrimPrefix(source, "file://"))
 			g, err := globpath.Compile(source)
 			if err != nil {
@@ -82,7 +81,6 @@ func (c *X509Cert) sourcesToURLs() error {
 			if err != nil {
 				return fmt.Errorf("failed to parse cert location - %s", err.Error())
 			}
-
 			c.locations = append(c.locations, u)
 		}
 	}

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -125,6 +125,9 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 		conn := tls.Client(ipConn, c.tlsCfg)
 		defer conn.Close()
 
+		// reset SNI between requests
+		defer func() { c.tlsCfg.ServerName = "" }()
+
 		hsErr := conn.Handshake()
 		if hsErr != nil {
 			return nil, hsErr
@@ -311,6 +314,14 @@ func (c *X509Cert) Init() error {
 		tlsCfg = &tls.Config{}
 	}
 
+	if tlsCfg.ServerName != "" && c.ServerName == "" {
+		// Save SNI from tlsCfg.ServerName to c.ServerName and reset tlsCfg.ServerName.
+		// We need to reset c.tlsCfg.ServerName for each certificate when there's
+		// no explicit SNI (c.tlsCfg.ServerName or c.ServerName) otherwise we'll always (re)use
+		// first uri HostName for all certs (see issue 8914)
+		c.ServerName = tlsCfg.ServerName
+		tlsCfg.ServerName = ""
+	}
 	c.tlsCfg = tlsCfg
 
 	return nil

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -316,6 +316,16 @@ func TestGatherCertMustNotTimeout(t *testing.T) {
 	assert.True(t, acc.HasMeasurement("x509_cert"))
 }
 
+func TestSourcesToURLs(t *testing.T) {
+	m := &X509Cert{
+		Sources: []string{"https://www.influxdata.com:443", "tcp://influxdata.com:443", "file:///dummy_test_path_file.pem", "/tmp/dummy_test_path_glob*.pem"},
+	}
+	require.NoError(t, m.Init())
+
+	assert.Equal(t, len(m.globpaths), 2)
+	assert.Equal(t, len(m.locations), 2)
+}
+
 func TestServerName(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md. (no need to update README)
- [x] Wrote appropriate unit tests. (tests already exist)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #8914
resolves #9278
resolves #9384

1. commit  448eac0 tries to ensure that fileglobs are not tried for remote uris (sources starting with tcp://, udp:// or https://). This is because strings.Index(source, ":\\\\") != 1 (https://github.com/influxdata/telegraf/blob/master/plugins/inputs/x509_cert/x509_cert.go#L70) matches almost all sources -> fileglobs are tried for remote sources.
2. commit 4e1e6f3 tries to ensure that c.tlsCfg.ServerName is reset between multiple certs/sources. Without this telegraf uses same SNI for multiple certs. Leading to telegraf requesting wrong certificates and failing validation because SNI/SAN doesn't match. (Longer discussion in: https://github.com/influxdata/telegraf/issues/8914)
