### PR TITLE
Add HTTP proxy to datadog output

### DIFF
--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -16,6 +16,9 @@ This plugin writes to the [Datadog Metrics API][metrics] and requires an
 
   ## Write URL override; useful for debugging.
   # url = "https://app.datadoghq.com/api/v1/series"
+
+  ## Set http_proxy (telegraf uses the system wide proxy settings if it's is not set)
+  # http_proxy_url = "http://localhost:8888"
 ```
 
 ### Metrics

--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -17,7 +17,7 @@ This plugin writes to the [Datadog Metrics API][metrics] and requires an
   ## Write URL override; useful for debugging.
   # url = "https://app.datadoghq.com/api/v1/series"
 
-  ## Set http_proxy (telegraf uses the system wide proxy settings if it's is not set)
+  ## Set http_proxy (telegraf uses the system wide proxy settings if it isn't set)
   # http_proxy_url = "http://localhost:8888"
 ```
 

--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -36,7 +36,7 @@ var sampleConfig = `
   ## Write URL override; useful for debugging.
   # url = "https://app.datadoghq.com/api/v1/series"
 
-  ## Set http_proxy (telegraf uses the system wide proxy settings if it's is not set)
+  ## Set http_proxy (telegraf uses the system wide proxy settings if it isn't set)
   # http_proxy_url = "http://localhost:8888"
 `
 


### PR DESCRIPTION
### Required for all PRs:
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #8388 

Added configuring a HTTP proxy for the DataDog output through the config file.
