### PR TITLE
fix: don't require listeners to be present in rabbitmq /api/overview JSON

### DIFF
--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -405,7 +405,7 @@ func gatherOverview(r *RabbitMQ, acc telegraf.Accumulator) {
 		return
 	}
 
-	if overview.QueueTotals == nil || overview.ObjectTotals == nil || overview.MessageStats == nil || overview.Listeners == nil {
+	if overview.QueueTotals == nil || overview.ObjectTotals == nil || overview.MessageStats == nil {
 		acc.AddError(fmt.Errorf("Wrong answer from rabbitmq. Probably auth issue"))
 		return
 	}


### PR DESCRIPTION
resolves #9300

Not all rabbitmq servers return a listeners section in their overview json. This PR removes the requirement for a listeners section to be present.

This doesn't affect the format or accuracy of the fields gathered from the overview. The clustering_listeners and amqp_listeners fields will continue to be in the rabbitmq_overview metric even if the listeners section is missing, just with zeros as their values.
