### PR TITLE
feat: add test input plugin

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -182,6 +182,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/teamspeak"
 	_ "github.com/influxdata/telegraf/plugins/inputs/temp"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tengine"
+	_ "github.com/influxdata/telegraf/plugins/inputs/test"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tomcat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/trig"
 	_ "github.com/influxdata/telegraf/plugins/inputs/twemproxy"

--- a/plugins/inputs/test/README.md
+++ b/plugins/inputs/test/README.md
@@ -1,0 +1,31 @@
+# Test Input Plugin
+
+The test plugin parses passed metrics in the config file.
+
+**Note:** If you wish to parse a **complete** file then use the [file][] input 
+plugin instead.
+
+**Note:** If you wish to parse only newly appended lines use the [tail][] input
+plugin instead.
+
+### Configuration:
+
+```toml
+[[inputs.test]]
+  ## Metrics to parse each interval.
+  metrics = [
+    'weather,state=ny temperature=81.3',
+    'weather,state=ca temperature=75.1'
+  ]
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"
+
+```
+
+[input data format]: /docs/DATA_FORMATS_INPUT.md
+[file]: /plugins/inputs/file
+[tail]: /plugins/inputs/tail

--- a/plugins/inputs/test/test.go
+++ b/plugins/inputs/test/test.go
@@ -1,0 +1,67 @@
+package test
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/parsers"
+)
+
+// taken ffrom file.go as an example but needs to be reworked
+type Test struct {
+	Metrics           []string `toml:"metrics"`
+	parser            parsers.Parser
+}
+
+const sampleConfig = `
+	[[inputs.test]]
+	## Metrics to parse each interval.
+	metrics = [
+		'weather,state=ny temperature=81.3',
+		'weather,state=ca temperature=75.1'
+	  ]
+
+	## Data format to consume.
+	## Each data format has its own unique set of configuration options, read
+	## more about them here:
+	## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+	data_format = "influx"
+	`
+
+// SampleConfig returns the default configuration of the Input
+func (t *Test) SampleConfig() string {
+	return sampleConfig
+}
+
+//not sure if this is necessary or not
+func (f *Test) Description() string {
+	return "Parse a passed metric each interval"
+}
+
+func (t *Test) Init() error {
+	var err error
+	return err
+}
+
+func (t *Test) Gather(acc telegraf.Accumulator) error {
+	for _, raw := range t.Metrics {
+		metric, err := t.parser.Parse([]byte(raw))
+		if err != nil {
+			return err 
+		}
+
+		for _, m := range metric {
+			acc.AddMetric(m)
+		}
+	}
+	return nil
+}
+
+func (t *Test) SetParser(p parsers.Parser) {
+	t.parser = p
+}
+
+func init() {
+	inputs.Add("test", func() telegraf.Input {
+		return &Test{}
+	})
+}

--- a/plugins/inputs/test/test.go
+++ b/plugins/inputs/test/test.go
@@ -8,8 +8,8 @@ import (
 
 // taken ffrom file.go as an example but needs to be reworked
 type Test struct {
-	Metrics           []string `toml:"metrics"`
-	parser            parsers.Parser
+	Metrics []string `toml:"metrics"`
+	parser  parsers.Parser
 }
 
 const sampleConfig = `
@@ -46,7 +46,7 @@ func (t *Test) Gather(acc telegraf.Accumulator) error {
 	for _, raw := range t.Metrics {
 		metric, err := t.parser.Parse([]byte(raw))
 		if err != nil {
-			return err 
+			return err
 		}
 
 		for _, m := range metric {

--- a/plugins/inputs/test/test.go
+++ b/plugins/inputs/test/test.go
@@ -32,8 +32,7 @@ func (t *Test) SampleConfig() string {
 	return sampleConfig
 }
 
-//not sure if this is necessary or not
-func (f *Test) Description() string {
+func (t *Test) Description() string {
 	return "Parse a passed metric each interval"
 }
 

--- a/plugins/inputs/test/test_test.go
+++ b/plugins/inputs/test/test_test.go
@@ -67,4 +67,3 @@ func TestGrokParser(t *testing.T) {
 	require.Equal(t, 2, len(acc.Metrics))
 	require.Equal(t, 6, len(acc.Metrics[0].Fields))
 }
-

--- a/plugins/inputs/test/test_test.go
+++ b/plugins/inputs/test/test_test.go
@@ -1,0 +1,70 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// All test taken from file_test.go I tried to keep only the ones I thought would be useful
+
+func TestJSONParserCompile(t *testing.T) {
+	var acc testutil.Accumulator
+	r := Test{
+		Metrics: []string{`{
+			"parent": {
+				"child": 3.0,
+				"ignored_child": "hi"
+			},
+			"ignored_null": null,
+			"integer": 4,
+			"list": [3, 4],
+			"ignored_parent": {
+				"another_ignored_null": null,
+				"ignored_string": "hello, world!"
+			},
+			"another_list": [4]
+		}`},
+	}
+	err := r.Init()
+	require.NoError(t, err)
+	parserConfig := parsers.Config{
+		DataFormat: "json",
+		TagKeys:    []string{"parent_ignored_child"},
+	}
+	nParser, err := parsers.NewParser(&parserConfig)
+	require.NoError(t, err)
+	r.parser = nParser
+
+	require.NoError(t, r.Gather(&acc))
+	require.Equal(t, map[string]string{"parent_ignored_child": "hi"}, acc.Metrics[0].Tags)
+	require.Equal(t, 5, len(acc.Metrics[0].Fields))
+}
+
+func TestGrokParser(t *testing.T) {
+	r := Test{
+		Metrics: []string{
+			`127.0.0.1 user-identifier frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326`,
+			`128.0.0.1 user-identifier tony [10/Oct/2000:13:55:36 -0800] "GET /apache_pb.gif HTTP/1.0" 300 45`,
+		},
+	}
+	require.NoError(t, r.Init())
+
+	parserConfig := parsers.Config{
+		DataFormat:   "grok",
+		GrokPatterns: []string{"%{COMMON_LOG_FORMAT}"},
+	}
+
+	nParser, err := parsers.NewParser(&parserConfig)
+	r.parser = nParser
+	require.NoError(t, err)
+
+	var acc testutil.Accumulator
+	require.NoError(t, r.Gather(&acc))
+
+	require.Equal(t, 2, len(acc.Metrics))
+	require.Equal(t, 6, len(acc.Metrics[0].Fields))
+}
+


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #9316

Added an input plugin to gather constant metrics as defined by the plugin's configuration. Each interval the defined metrics are parsed from the desired format and outputted.


