### PR TITLE
feat(x509_cert): add proxy support

### DIFF
--- a/plugins/common/proxy/connect.go
+++ b/plugins/common/proxy/connect.go
@@ -18,6 +18,11 @@ type httpConnectProxy struct {
 }
 
 func (c *httpConnectProxy) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	// Prevent using UDP
+	if network == "udp" {
+		return nil, fmt.Errorf("cannot proxy %q traffic over HTTP CONNECT", network)
+	}
+
 	var proxyConn net.Conn
 	var err error
 	if dialer, ok := c.forward.(proxy.ContextDialer); ok {

--- a/plugins/common/proxy/connect.go
+++ b/plugins/common/proxy/connect.go
@@ -20,10 +20,10 @@ func (c *httpConnectProxy) DialContext(ctx context.Context, network, addr string
 	var proxyConn net.Conn
 	var err error
 	if dialer, ok := c.forward.(proxy.ContextDialer); ok {
-		proxyConn, err = dialer.DialContext(ctx, "tcp", addr)
+		proxyConn, err = dialer.DialContext(ctx, "tcp", c.url.Host)
 	} else {
 		// TODO: still support timeout/cancellation w/o context
-		proxyConn, err = c.forward.Dial("tcp", addr)
+		proxyConn, err = c.forward.Dial("tcp", c.url.Host)
 	}
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func (c *httpConnectProxy) DialContext(ctx context.Context, network, addr string
 	requestURL.Scheme = ""
 
 	// Build HTTP CONNECT request
-	req, err := http.NewRequest("CONNECT", requestURL.String(), nil)
+	req, err := http.NewRequest(http.MethodConnect, requestURL.String(), nil)
 	if err != nil {
 		proxyConn.Close()
 		return nil, err

--- a/plugins/common/proxy/connect.go
+++ b/plugins/common/proxy/connect.go
@@ -1,0 +1,86 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"golang.org/x/net/proxy"
+	"net"
+	"net/http"
+	"net/url"
+)
+
+// httpConnectProxy proxies (only?) TCP over a HTTP tunnel using the CONNECT method
+type httpConnectProxy struct {
+	forward proxy.Dialer
+	url     *url.URL
+}
+
+func (c *httpConnectProxy) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	var proxyConn net.Conn
+	var err error
+	if dialer, ok := c.forward.(proxy.ContextDialer); ok {
+		proxyConn, err = dialer.DialContext(ctx, "tcp", addr)
+	} else {
+		// TODO: still support timeout/cancellation w/o context
+		proxyConn, err = c.forward.Dial("tcp", addr)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Add and strip http:// to extract authority portion of the URL
+	// since CONNECT doesn't use a full URL. The request header would
+	// look something like: "CONNECT www.influxdata.com:443 HTTP/1.1"
+	requestURL, err := url.Parse("http://" + addr)
+	if err != nil {
+		proxyConn.Close()
+		return nil, err
+	}
+	requestURL.Scheme = ""
+
+	// Build HTTP CONNECT request
+	req, err := http.NewRequest("CONNECT", requestURL.String(), nil)
+	if err != nil {
+		proxyConn.Close()
+		return nil, err
+	}
+	req.Close = false
+	if password, hasAuth := c.url.User.Password(); hasAuth {
+		req.SetBasicAuth(c.url.User.Username(), password)
+	}
+
+	err = req.Write(proxyConn)
+	if err != nil {
+		proxyConn.Close()
+		return nil, err
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(proxyConn), req)
+	if err != nil {
+		proxyConn.Close()
+		return nil, err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		proxyConn.Close()
+		return nil, fmt.Errorf("failed to connect to proxy: %q", resp.Status)
+	}
+
+	return proxyConn, nil
+}
+
+func (c *httpConnectProxy) Dial(network, addr string) (net.Conn, error) {
+	return c.DialContext(context.Background(), network, addr)
+}
+
+func newHTTPConnectProxy(url *url.URL, forward proxy.Dialer) (proxy.Dialer, error) {
+	return &httpConnectProxy{forward, url}, nil
+}
+
+func init() {
+	// Register new proxy types
+	proxy.RegisterDialerType("http", newHTTPConnectProxy)
+	proxy.RegisterDialerType("https", newHTTPConnectProxy)
+}

--- a/plugins/common/proxy/connect.go
+++ b/plugins/common/proxy/connect.go
@@ -4,10 +4,11 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"golang.org/x/net/proxy"
 	"net"
 	"net/http"
 	"net/url"
+
+	"golang.org/x/net/proxy"
 )
 
 // httpConnectProxy proxies (only?) TCP over a HTTP tunnel using the CONNECT method

--- a/plugins/common/proxy/dialer.go
+++ b/plugins/common/proxy/dialer.go
@@ -5,11 +5,11 @@ import (
 	"net"
 	"time"
 
-	"golang.org/x/net/proxy"
+	netProxy "golang.org/x/net/proxy"
 )
 
 type ProxiedDialer struct {
-	dialer proxy.Dialer
+	dialer netProxy.Dialer
 }
 
 func (pd *ProxiedDialer) Dial(network, addr string) (net.Conn, error) {
@@ -17,7 +17,7 @@ func (pd *ProxiedDialer) Dial(network, addr string) (net.Conn, error) {
 }
 
 func (pd *ProxiedDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	if contextDialer, ok := pd.dialer.(proxy.ContextDialer); ok {
+	if contextDialer, ok := pd.dialer.(netProxy.ContextDialer); ok {
 		return contextDialer.DialContext(ctx, network, addr)
 	}
 

--- a/plugins/common/proxy/dialer.go
+++ b/plugins/common/proxy/dialer.go
@@ -1,0 +1,37 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+type ProxiedDialer struct {
+	dialer proxy.Dialer
+}
+
+func (pd *ProxiedDialer) Dial(network, addr string) (net.Conn, error) {
+	return pd.dialer.Dial(network, addr)
+}
+
+func (pd *ProxiedDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	if contextDialer, ok := pd.dialer.(proxy.ContextDialer); ok {
+		return contextDialer.DialContext(ctx, network, addr)
+	}
+
+	contextDialer := contextDialerShim{pd.dialer}
+	return contextDialer.DialContext(ctx, network, addr)
+}
+
+func (pd *ProxiedDialer) DialTimeout(network, addr string, timeout time.Duration) (net.Conn, error) {
+	ctx := context.Background()
+	if timeout.Seconds() != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	return pd.DialContext(ctx, network, addr)
+}

--- a/plugins/common/proxy/proxy.go
+++ b/plugins/common/proxy/proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"golang.org/x/net/proxy"
 	"net/http"
 	"net/url"
 )
@@ -21,4 +22,20 @@ func (p *HTTPProxy) Proxy() (proxyFunc, error) {
 		return http.ProxyURL(address), nil
 	}
 	return http.ProxyFromEnvironment, nil
+}
+
+type TCPProxy struct {
+	ProxyURL string `toml:"proxy_url"`
+}
+
+func (p *TCPProxy) Proxy() (proxy.Dialer, error) {
+	if len(p.ProxyURL) > 0 {
+		parsed, err := url.Parse(p.ProxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing proxy url %q: %w", p.ProxyURL, err)
+		}
+
+		return proxy.FromURL(parsed, proxy.Direct)
+	}
+	return proxy.FromEnvironment(), nil
 }

--- a/plugins/common/proxy/proxy.go
+++ b/plugins/common/proxy/proxy.go
@@ -9,39 +9,50 @@ import (
 )
 
 type HTTPProxy struct {
+	UseProxy     bool   `toml:"use_proxy"`
 	HTTPProxyURL string `toml:"http_proxy_url"`
 }
 
 type proxyFunc func(req *http.Request) (*url.URL, error)
 
 func (p *HTTPProxy) Proxy() (proxyFunc, error) {
-	if len(p.HTTPProxyURL) > 0 {
-		address, err := url.Parse(p.HTTPProxyURL)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing proxy url %q: %w", p.HTTPProxyURL, err)
+	if p.UseProxy {
+		if len(p.HTTPProxyURL) > 0 {
+			address, err := url.Parse(p.HTTPProxyURL)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing proxy url %q: %w", p.HTTPProxyURL, err)
+			}
+			return http.ProxyURL(address), nil
 		}
-		return http.ProxyURL(address), nil
+
+		return http.ProxyFromEnvironment, nil
 	}
-	return http.ProxyFromEnvironment, nil
+
+	return nil, nil
 }
 
 type TCPProxy struct {
+	UseProxy bool   `toml:"use_proxy"`
 	ProxyURL string `toml:"proxy_url"`
 }
 
 func (p *TCPProxy) Proxy() (*ProxiedDialer, error) {
 	var dialer proxy.Dialer
-	if len(p.ProxyURL) > 0 {
-		parsed, err := url.Parse(p.ProxyURL)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing proxy url %q: %w", p.ProxyURL, err)
-		}
+	if p.UseProxy {
+		if len(p.ProxyURL) > 0 {
+			parsed, err := url.Parse(p.ProxyURL)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing proxy url %q: %w", p.ProxyURL, err)
+			}
 
-		if dialer, err = proxy.FromURL(parsed, proxy.Direct); err != nil {
-			return nil, err
+			if dialer, err = proxy.FromURL(parsed, proxy.Direct); err != nil {
+				return nil, err
+			}
+		} else {
+			dialer = proxy.FromEnvironment()
 		}
 	} else {
-		dialer = proxy.FromEnvironment()
+		dialer = proxy.Direct
 	}
 
 	return &ProxiedDialer{dialer}, nil

--- a/plugins/common/proxy/proxy.go
+++ b/plugins/common/proxy/proxy.go
@@ -2,9 +2,10 @@ package proxy
 
 import (
 	"fmt"
-	"golang.org/x/net/proxy"
 	"net/http"
 	"net/url"
+
+	"golang.org/x/net/proxy"
 )
 
 type HTTPProxy struct {

--- a/plugins/common/proxy/proxy.go
+++ b/plugins/common/proxy/proxy.go
@@ -29,7 +29,7 @@ type TCPProxy struct {
 	ProxyURL string `toml:"proxy_url"`
 }
 
-func (p *TCPProxy) Proxy() (proxy.ContextDialer, error) {
+func (p *TCPProxy) Proxy() (*ProxiedDialer, error) {
 	var dialer proxy.Dialer
 	if len(p.ProxyURL) > 0 {
 		parsed, err := url.Parse(p.ProxyURL)
@@ -44,9 +44,5 @@ func (p *TCPProxy) Proxy() (proxy.ContextDialer, error) {
 		dialer = proxy.FromEnvironment()
 	}
 
-	if contextDialer, ok := dialer.(proxy.ContextDialer); ok {
-		return contextDialer, nil
-	}
-
-	return &contextDialerShim{dialer}, nil
+	return &ProxiedDialer{dialer}, nil
 }

--- a/plugins/common/proxy/proxy.go
+++ b/plugins/common/proxy/proxy.go
@@ -9,23 +9,21 @@ import (
 )
 
 type HTTPProxy struct {
-	UseProxy     bool   `toml:"use_proxy"`
-	HTTPProxyURL string `toml:"http_proxy_url"`
+	UseSystemProxy bool   `toml:"use_system_proxy"`
+	HTTPProxyURL   string `toml:"http_proxy_url"`
 }
 
 type proxyFunc func(req *http.Request) (*url.URL, error)
 
 func (p *HTTPProxy) Proxy() (proxyFunc, error) {
-	if p.UseProxy {
-		if len(p.HTTPProxyURL) > 0 {
-			address, err := url.Parse(p.HTTPProxyURL)
-			if err != nil {
-				return nil, fmt.Errorf("error parsing proxy url %q: %w", p.HTTPProxyURL, err)
-			}
-			return http.ProxyURL(address), nil
-		}
-
+	if p.UseSystemProxy {
 		return http.ProxyFromEnvironment, nil
+	} else if len(p.HTTPProxyURL) > 0 {
+		address, err := url.Parse(p.HTTPProxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing proxy url %q: %w", p.HTTPProxyURL, err)
+		}
+		return http.ProxyURL(address), nil
 	}
 
 	return nil, nil

--- a/plugins/inputs/cloudwatch/README.md
+++ b/plugins/inputs/cloudwatch/README.md
@@ -46,7 +46,8 @@ API endpoint. In the following order the plugin will attempt to authenticate.
   ##   ex: endpoint_url = "http://localhost:8000"
   # endpoint_url = ""
 
-  ## Set http_proxy (telegraf uses the system wide proxy settings if it's is not set)
+  ## Set http_proxy
+  # use_proxy = true
   # http_proxy_url = "http://localhost:8888"
 
   # The minimum period for Cloudwatch metrics is 1 minute (60s). However not all

--- a/plugins/inputs/cloudwatch/README.md
+++ b/plugins/inputs/cloudwatch/README.md
@@ -47,7 +47,7 @@ API endpoint. In the following order the plugin will attempt to authenticate.
   # endpoint_url = ""
 
   ## Set http_proxy
-  # use_proxy = true
+  # use_system_proxy = false
   # http_proxy_url = "http://localhost:8888"
 
   # The minimum period for Cloudwatch metrics is 1 minute (60s). However not all

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -360,7 +360,10 @@ func TestUpdateWindow(t *testing.T) {
 
 func TestProxyFunction(t *testing.T) {
 	c := &CloudWatch{
-		HTTPProxy: proxy.HTTPProxy{HTTPProxyURL: "http://www.penguins.com"},
+		HTTPProxy: proxy.HTTPProxy{
+			HTTPProxyURL: "http://www.penguins.com",
+			UseProxy:     true,
+		},
 	}
 
 	proxyFunction, err := c.HTTPProxy.Proxy()

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -3,6 +3,7 @@ package cloudwatch
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -361,15 +362,17 @@ func TestUpdateWindow(t *testing.T) {
 func TestProxyFunction(t *testing.T) {
 	c := &CloudWatch{
 		HTTPProxy: proxy.HTTPProxy{
-			HTTPProxyURL:   "http://www.penguins.com",
-			UseSystemProxy: true,
+			HTTPProxyURL: "http://www.penguins.com",
 		},
 	}
 
 	proxyFunction, err := c.HTTPProxy.Proxy()
 	require.NoError(t, err)
 
-	proxyResult, err := proxyFunction(&http.Request{})
+	u, err := url.Parse("https://monitoring.us-west-1.amazonaws.com/")
+	require.NoError(t, err)
+
+	proxyResult, err := proxyFunction(&http.Request{URL: u})
 	require.NoError(t, err)
 	require.Equal(t, "www.penguins.com", proxyResult.Host)
 }

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -361,8 +361,8 @@ func TestUpdateWindow(t *testing.T) {
 func TestProxyFunction(t *testing.T) {
 	c := &CloudWatch{
 		HTTPProxy: proxy.HTTPProxy{
-			HTTPProxyURL: "http://www.penguins.com",
-			UseProxy:     true,
+			HTTPProxyURL:   "http://www.penguins.com",
+			UseSystemProxy: true,
 		},
 	}
 

--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -33,7 +33,8 @@ When using a UDP address as a certificate source, the server must support
   # tls_key = "/etc/telegraf/key.pem"
   # tls_server_name = "myhost.example.org"
 
-  ## Set the proxy URL (telegraf uses the system wide proxy settings if it isn't set)
+  ## Set the proxy URL
+  # use_proxy = true
   # proxy_url = "http://localhost:8888"
 ```
 

--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -32,6 +32,9 @@ When using a UDP address as a certificate source, the server must support
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
   # tls_server_name = "myhost.example.org"
+
+  ## Set the proxy URL (telegraf uses the system wide proxy settings if it isn't set)
+  # proxy_url = "http://localhost:8888"
 ```
 
 ## Metrics

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -4,6 +4,7 @@ package x509_cert
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed"
@@ -136,7 +137,10 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 			return nil, err
 		}
 
-		ipConn, err := dialer.Dial(u.Scheme, u.Host) // TODO: add timeout
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		ipConn, err := dialer.DialContext(ctx, u.Scheme, u.Host)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -141,8 +141,12 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 			return nil, err
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
+		ctx := context.Background()
+		if timeout.Seconds() != 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
 
 		ipConn, err := dialer.DialContext(ctx, u.Scheme, u.Host)
 		if err != nil {

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -47,14 +47,18 @@ type X509Cert struct {
 	Log       telegraf.Logger
 }
 
+// Description returns description of the plugin.
+func (c *X509Cert) Description() string {
+	return description
+}
+
 var remoteURLRe = regexp.MustCompile("^((udp|tcp)[46]?|https)://")
 
 func (c *X509Cert) sourcesToURLs() error {
 	for _, source := range c.Sources {
-		if !remoteURLRe.MatchString(source) &&
-			(strings.HasPrefix(source, "file://") ||
-				strings.HasPrefix(source, "/") ||
-				strings.Index(source, ":\\") != 1) {
+		if strings.HasPrefix(source, "file://") ||
+			strings.HasPrefix(source, "/") ||
+			strings.Index(source, ":\\") != 1 {
 			source = filepath.ToSlash(strings.TrimPrefix(source, "file://"))
 			g, err := globpath.Compile(source)
 			if err != nil {

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -4,7 +4,6 @@ package x509_cert
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed"
@@ -141,14 +140,7 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 			return nil, err
 		}
 
-		ctx := context.Background()
-		if timeout.Seconds() != 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, timeout)
-			defer cancel()
-		}
-
-		ipConn, err := dialer.DialContext(ctx, u.Scheme, u.Host)
+		ipConn, err := dialer.DialTimeout(u.Scheme, u.Host, timeout)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -14,7 +14,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -45,13 +44,6 @@ type X509Cert struct {
 	globpaths []*globpath.GlobPath
 	Log       telegraf.Logger
 }
-
-// Description returns description of the plugin.
-func (c *X509Cert) Description() string {
-	return description
-}
-
-var remoteURLRe = regexp.MustCompile("^((udp|tcp)[46]?|https)://")
 
 func (c *X509Cert) sourcesToURLs() error {
 	for _, source := range c.Sources {

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -330,6 +330,7 @@ func TestGatherTCPCert(t *testing.T) {
 
 	m := &X509Cert{
 		Sources: []string{ts.URL},
+		Log:     testutil.Logger{},
 	}
 	require.NoError(t, m.Init())
 
@@ -370,6 +371,7 @@ func TestGatherCertIntegration(t *testing.T) {
 
 	m := &X509Cert{
 		Sources: []string{"https://www.influxdata.com:443"},
+		Log:     testutil.Logger{},
 	}
 	require.NoError(t, m.Init())
 
@@ -386,6 +388,7 @@ func TestGatherCertMustNotTimeoutIntegration(t *testing.T) {
 	duration := time.Duration(15) * time.Second
 	m := &X509Cert{
 		Sources: []string{"https://www.influxdata.com:443"},
+		Log:     testutil.Logger{},
 		Timeout: config.Duration(duration),
 	}
 	require.NoError(t, m.Init())

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -341,29 +341,6 @@ func TestGatherTCPCert(t *testing.T) {
 	require.True(t, acc.HasMeasurement("x509_cert"))
 }
 
-func TestStrings(t *testing.T) {
-	sc := X509Cert{}
-	require.NoError(t, sc.Init())
-
-	tests := []struct {
-		name     string
-		method   string
-		returned string
-		expected string
-	}{
-		{name: "description", method: "Description", returned: sc.Description(), expected: description},
-		{name: "sample config", method: "SampleConfig", returned: sc.SampleConfig(), expected: sampleConfig},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if test.returned != test.expected {
-				t.Errorf("Expected method %s to return '%s', found '%s'.", test.method, test.expected, test.returned)
-			}
-		})
-	}
-}
-
 func TestGatherCertIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -17,7 +17,8 @@ This plugin writes to the [Datadog Metrics API][metrics] and requires an
   ## Write URL override; useful for debugging.
   # url = "https://app.datadoghq.com/api/v1/series"
 
-  ## Set http_proxy (telegraf uses the system wide proxy settings if it isn't set)
+  ## Set http_proxy
+  # use_proxy = true
   # http_proxy_url = "http://localhost:8888"
 
   ## Override the default (none) compression used to send data.

--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -18,7 +18,7 @@ This plugin writes to the [Datadog Metrics API][metrics] and requires an
   # url = "https://app.datadoghq.com/api/v1/series"
 
   ## Set http_proxy
-  # use_proxy = true
+  # use_system_proxy = false
   # http_proxy_url = "http://localhost:8888"
 
   ## Override the default (none) compression used to send data.

--- a/plugins/outputs/websocket/README.md
+++ b/plugins/outputs/websocket/README.md
@@ -36,7 +36,7 @@ It can output data in any of the [supported output formats][formats].
   # socks5_password = "pass123"
 
   ## Optional HTTP proxy to use
-  # use_proxy = true
+  # use_system_proxy = false
   # http_proxy_url = "http://localhost:8888"
 
   ## Data format to output.

--- a/plugins/outputs/websocket/README.md
+++ b/plugins/outputs/websocket/README.md
@@ -35,6 +35,10 @@ It can output data in any of the [supported output formats][formats].
   # socks5_username = "alice"
   # socks5_password = "pass123"
 
+  ## Optional HTTP proxy to use
+  # use_proxy = true
+  # http_proxy_url = "http://localhost:8888"
+
   ## Data format to output.
   ## Each data format has it's own unique set of configuration options, read
   ## more about them here:


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #9174

Adds proxy support for the `x509_cert` plugin. The supported proxy methods are HTTP CONNECT (TCP only) and SOCKS5.

~~**Note:** #9289 should be merged before this PR since all URLs are currently parsed as globs causing telegraf to fail to pull the certificate. Similarly, the `TestGatherTCPCert` test will fail because of this.~~ Rebased to master.
