### PR TITLE
Parallel build fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,10 @@ commands:
             - run: 'mips=1 mipsel=1 arm64=1 amd64=1 static=1 armel=1 armhf=1 s390x=1 ppc641e=1 i386=1 windows=1 darwin=1 NIGHTLY=1 make package'
             - run: 'make upload-nightly'
       - unless:
-          condition: << parameters.nightly >>
+          condition:
+            or:
+              - << parameters.nightly >>
+              - << parameters.release >>
           steps:
             - run: '<< parameters.type >>=1 make package'
       - store_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ endif
 ifdef amd64
 tars += telegraf-$(tar_version)_freebsd_amd64.tar.gz
 tars += telegraf-$(tar_version)_linux_amd64.tar.gz
-debs := telegraf_$(deb_version)_amd64.deb
+debs += telegraf_$(deb_version)_amd64.deb
 rpms += telegraf-$(rpm_version).x86_64.rpm
 endif
 


### PR DESCRIPTION
The recent parallel build PRs #9096 and #9172 left the circleci package-build command broken for releases, and the debian package lists incomplete. I cherry picked those two PRs to the release-1.18 branch for 1.18.2 and had to add these fixes in order for CI to complete and produce all the expected packages.