### PR TITLE
Fix kube_inventory not connecting to specified URL

### DIFF
--- a/plugins/inputs/kube_inventory/client.go
+++ b/plugins/inputs/kube_inventory/client.go
@@ -29,6 +29,7 @@ func newClient(baseURL, namespace, bearerToken string, timeout time.Duration, tl
 			CertFile:   tlsConfig.TLSCert,
 			KeyFile:    tlsConfig.TLSKey,
 		},
+		Host:          baseURL,
 		BearerToken:   bearerToken,
 		ContentConfig: rest.ContentConfig{},
 	})


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md. N/A
- [x] Wrote appropriate unit tests. N/A

resolves #9293 

Fixes a bug where `kube_inventory` would always connect to `localhost` instead of the URL specified in the plugin configuration.
