### PR TITLE
Update Go to 1.16.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  win: circleci/windows@2.4.0  
+  win: circleci/windows@2.4.0
   aws-cli: circleci/aws-cli@1.4.0
 
 executors:
@@ -13,7 +13,7 @@ executors:
   go-1_16:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.16.2'
+      - image: 'quay.io/influxdb/telegraf-ci:1.16.5'
     environment:
       GOFLAGS: -p=8
   mac:
@@ -30,7 +30,7 @@ commands:
         - run: ./scripts/check-file-changes.sh
   check-changed-files-or-halt-windows:
       steps:
-        - run: 
+        - run:
             command: ./scripts/check-file-changes.sh
             shell: bash.exe
   test-go:
@@ -65,11 +65,11 @@ commands:
           at: '/go'
       - when:
           condition: << parameters.release >>
-          steps: 
+          steps:
             - run: 'mips=1 mipsel=1 arm64=1 amd64=1 static=1 armel=1 armhf=1 s390x=1 ppc641e=1 i386=1 windows=1 darwin=1 make package'
       - when:
           condition: << parameters.nightly >>
-          steps: 
+          steps:
             - run: 'mips=1 mipsel=1 arm64=1 amd64=1 static=1 armel=1 armhf=1 s390x=1 ppc641e=1 i386=1 windows=1 darwin=1 NIGHTLY=1 make package'
             - run: 'make upload-nightly'
       - unless:
@@ -150,7 +150,7 @@ jobs:
     steps:
       - checkout
       - check-changed-files-or-halt-windows
-      - run: choco upgrade golang --version=1.16.2
+      - run: choco upgrade golang --version=1.16.5
       - run: choco install make
       - run: git config --system core.longpaths true
       - run: make test-windows
@@ -283,14 +283,14 @@ jobs:
           command: |
             echo "Go tests complete."
   share-artifacts:
-    executor: aws-cli/default  
+    executor: aws-cli/default
     steps:
       - run:
           command: |
             PR=${CIRCLE_PULL_REQUEST##*/}
             printf -v payload '{ "pullRequestNumber": "%s" }' "$PR"
-            curl -X POST "https://182c7jdgog.execute-api.us-east-1.amazonaws.com/prod/shareArtifacts" --data "$payload"   
-                      
+            curl -X POST "https://182c7jdgog.execute-api.us-east-1.amazonaws.com/prod/shareArtifacts" --data "$payload"
+
 workflows:
   version: 2
   check:
@@ -331,47 +331,47 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - 'test-awaiter': 
+      - 'test-awaiter':
           requires:
             - 'test-go-1_15'
             - 'test-go-1_15-386'
             - 'test-go-1_16'
             - 'test-go-1_16-386'
       - 'windows-package':
-          requires: 
+          requires:
             - 'test-go-windows'
       - 'darwin-package':
-          requires: 
+          requires:
             - 'test-go-mac'
       - 'i386-package':
-          requires: 
+          requires:
             - 'test-awaiter'
       - 'ppc641e-package':
-          requires: 
+          requires:
             - 'test-awaiter'
       - 's390x-package':
-          requires: 
+          requires:
             - 'test-awaiter'
       - 'armel-package':
-          requires: 
+          requires:
             - 'test-awaiter'
       - 'amd64-package':
-          requires: 
+          requires:
             - 'test-awaiter'
       - 'arm64-package':
-          requires: 
+          requires:
             - 'test-awaiter'
       - 'armhf-package':
-          requires: 
+          requires:
             - 'test-awaiter'
       - 'static-package':
           requires:
             - 'test-awaiter'
       - 'mipsel-package':
-          requires: 
+          requires:
             - 'test-awaiter'
       - 'mips-package':
-          requires: 
+          requires:
             - 'test-awaiter'
       - 'share-artifacts':
           requires:
@@ -412,7 +412,7 @@ workflows:
                 only: /.*/
       - 'package-sign-mac':
            requires:
-             - 'package-sign-windows' 
+             - 'package-sign-windows'
            filters:
               tags:
                 only: /.*/

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ tidy:
 	go mod verify
 	go mod tidy
 	@if ! git diff --quiet go.mod go.sum; then \
-		echo "please run go mod tidy and check in changes"; \
+		echo "please run go mod tidy and check in changes, you might have to use the same version of Go as the CI"; \
 		exit 1; \
 	fi
 
@@ -201,8 +201,8 @@ ci-1.15:
 
 .PHONY: ci-1.16
 ci-1.16:
-	docker build -t quay.io/influxdb/telegraf-ci:1.16.2 - < scripts/ci-1.16.docker
-	docker push quay.io/influxdb/telegraf-ci:1.16.2
+	docker build -t quay.io/influxdb/telegraf-ci:1.16.5 - < scripts/ci-1.16.docker
+	docker push quay.io/influxdb/telegraf-ci:1.16.5
 
 .PHONY: install
 install: $(buildbin)
@@ -251,7 +251,7 @@ debs += telegraf_$(deb_version)_amd64.deb
 rpms += telegraf-$(rpm_version).x86_64.rpm
 endif
 
-ifdef static 
+ifdef static
 tars += telegraf-$(tar_version)_static_linux_amd64.tar.gz
 endif
 
@@ -266,7 +266,7 @@ tars += telegraf-$(tar_version)_linux_armhf.tar.gz
 tars += telegraf-$(tar_version)_freebsd_armv7.tar.gz
 debs += telegraf_$(deb_version)_armhf.deb
 rpms += telegraf-$(rpm_version).armv6hl.rpm
-endif 
+endif
 
 ifdef s390x
 tars += telegraf-$(tar_version)_linux_s390x.tar.gz

--- a/scripts/alpine.docker
+++ b/scripts/alpine.docker
@@ -1,4 +1,4 @@
-FROM golang:1.16.2 as builder
+FROM golang:1.16.5 as builder
 WORKDIR /go/src/github.com/influxdata/telegraf
 
 COPY . /go/src/github.com/influxdata/telegraf

--- a/scripts/buster.docker
+++ b/scripts/buster.docker
@@ -1,4 +1,4 @@
-FROM golang:1.16.2-buster as builder
+FROM golang:1.16.5-buster as builder
 WORKDIR /go/src/github.com/influxdata/telegraf
 
 COPY . /go/src/github.com/influxdata/telegraf

--- a/scripts/ci-1.16.docker
+++ b/scripts/ci-1.16.docker
@@ -1,4 +1,4 @@
-FROM golang:1.16.2
+FROM golang:1.16.5
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/mac_installgo.sh
+++ b/scripts/mac_installgo.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version="1.16.2"
+version="1.16.5"
 # This path is cachable, while saving directly in /usr/local/ will cause issues restoring the cache
 path="/usr/local/Cellar"
 


### PR DESCRIPTION
Release notes: https://golang.org/doc/devel/release#go1.16

Updating the CI to use 1.16.5