### PR TITLE
Support new Suricata JSON format which includes arrays and strings

### DIFF
--- a/plugins/inputs/suricata/suricata.go
+++ b/plugins/inputs/suricata/suricata.go
@@ -148,6 +148,15 @@ func flexFlatten(outmap map[string]interface{}, field string, v interface{}, del
 				return err
 			}
 		}
+	case []interface{}:
+		for _, v := range t {
+			err := flexFlatten(outmap, field, v, delimiter)
+			if err != nil {
+				return err
+			}
+		}
+	case string:
+		outmap[field] = v
 	case float64:
 		outmap[field] = v.(float64)
 	default:

--- a/plugins/inputs/suricata/suricata_test.go
+++ b/plugins/inputs/suricata/suricata_test.go
@@ -318,16 +318,6 @@ func TestSuricataParse(t *testing.T) {
 				},
 				time.Unix(0, 0),
 			),
-			testutil.MustMetric(
-				"suricata",
-				map[string]string{
-					"thread": "total",
-				},
-				map[string]interface{}{
-					"uptime": float64(123),
-				},
-				time.Unix(0, 0),
-			),
 		},
 	},
 	}

--- a/plugins/inputs/suricata/suricata_test.go
+++ b/plugins/inputs/suricata/suricata_test.go
@@ -298,7 +298,6 @@ func TestSuricataStartStop(t *testing.T) {
 }
 
 func TestSuricataParse(t *testing.T) {
-
 	tests := []struct {
 		filename string
 		expected []telegraf.Metric

--- a/plugins/inputs/suricata/testdata/test2.json
+++ b/plugins/inputs/suricata/testdata/test2.json
@@ -2,7 +2,6 @@
     "timestamp": "2021-06-08T06:34:49.237367+0000",
     "event_type": "stats",
     "stats": {
-        "uptime": 123,
         "threads": {
             "W#01-ens2f1": {
                 "detect": {

--- a/plugins/inputs/suricata/testdata/test2.json
+++ b/plugins/inputs/suricata/testdata/test2.json
@@ -1,0 +1,22 @@
+{
+    "timestamp": "2021-06-08T06:34:49.237367+0000",
+    "event_type": "stats",
+    "stats": {
+        "uptime": 123,
+        "threads": {
+            "W#01-ens2f1": {
+                "detect": {
+                    "engines": [
+                        {
+                            "id": 0,
+                            "last_reload": "2021-06-08T06:33:05.084872+0000",
+                            "rules_loaded": 22712,
+                            "rules_failed": 0
+                        }
+                    ],
+                    "alert": 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- [x] Wrote appropriate unit tests.

resolves #9330

As described in #9330, the plugin didn't support array's in JSON being written by Suricata. I've updated the plugin to handle the case if an array or a string is encountered. 
