### PR TITLE
Fix Mac script to install go

### DIFF
--- a/scripts/check-file-changes.sh
+++ b/scripts/check-file-changes.sh
@@ -5,7 +5,7 @@ BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 echo $BRANCH
 if [[ "$BRANCH" != "master" ]] && [[ "$BRANCH" != release* ]]; then # This should never skip for master and release branches
     # Ask git for all the differences between this branch and master
-    # Then use grep to look for changes in the .circleci/ directory, anything named *.go* or *.mod* or *.sum* or *.sh* or *Makefile
+    # Then use grep to look for changes in the .circleci/ directory, anything named *.go or *.mod or *.sum or *.sh or Makefile
     # If no match is found, then circleci step halt will stop the CI job but mark it successful
     git diff master --name-only --no-color | egrep -e "^(\.circleci\/.*)$|^(.*\.(go|mod|sum|sh))$|^Makefile$" || circleci step halt;
 fi

--- a/scripts/check-file-changes.sh
+++ b/scripts/check-file-changes.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
+# To prevent the tests/builds to run for only a doc change, this script checks what files have changed in a pull request.
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 echo $BRANCH
-if [[ "$BRANCH" != "master" ]] && [[ "$BRANCH" != release* ]]; then
-    git diff master --name-only --no-color | egrep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum|sh))|Makefile$" || circleci step halt;
+if [[ "$BRANCH" != "master" ]] && [[ "$BRANCH" != release* ]]; then # This should never skip for master and release branches
+    # Ask git for all the differences between this branch and master
+    # Then use grep to look for changes in the .circleci/ directory, anything named *.go* or *.mod* or *.sum* or *.sh* or *Makefile
+    # If no match is found, then circleci step halt will stop the CI job but mark it successful
+    git diff master --name-only --no-color | egrep -e "^(\.circleci\/.*)$|^(.*\.(go|mod|sum|sh))$|^Makefile$" || circleci step halt;
 fi

--- a/scripts/check-file-changes.sh
+++ b/scripts/check-file-changes.sh
@@ -2,6 +2,6 @@
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 echo $BRANCH
-if [[ "$BRANCH" != "master" ]] && [[ "$BRANCH"!= release* ]]; then
+if [[ "$BRANCH" != "master" ]] && [[ "$BRANCH" != release* ]]; then
     git diff master --name-only --no-color | egrep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum|sh))|Makefile$" || circleci step halt;
 fi

--- a/scripts/check-file-changes.sh
+++ b/scripts/check-file-changes.sh
@@ -2,6 +2,6 @@
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 echo $BRANCH
-if [[ "$BRANCH" != "master" ]]; then
-    git diff master --name-only --no-color | egrep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum))|Makefile$" || circleci step halt;
+if [[ "$BRANCH" != "master" ]] || [[ "$BRANCH" = release* ]]; then
+    git diff master --name-only --no-color | egrep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum|sh))|Makefile$" || circleci step halt;
 fi

--- a/scripts/check-file-changes.sh
+++ b/scripts/check-file-changes.sh
@@ -2,6 +2,6 @@
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 echo $BRANCH
-if [[ "$BRANCH" != "master" ]] || [[ "$BRANCH" = release* ]]; then
+if [[ "$BRANCH" != "master" ]] && [[ "$BRANCH"!= release* ]]; then
     git diff master --name-only --no-color | egrep -e "^(\.circleci\/.*)|(.*\.(go|mod|sum|sh))|Makefile$" || circleci step halt;
 fi

--- a/scripts/mac_installgo.sh
+++ b/scripts/mac_installgo.sh
@@ -3,8 +3,8 @@
 set -eux
 
 GO_ARCH="darwin-amd64"
-GO_VERSION="1.16.2"
-GO_VERSION_SHA="c98cde81517c5daf427f3071412f39d5bc58f6120e90a0d94cc51480fa04dbc1" # from https://golang.org/dl
+GO_VERSION="1.16.5"
+GO_VERSION_SHA="be761716d5bfc958a5367440f68ba6563509da2f539ad1e1864bd42fe553f277" # from https://golang.org/dl
 
 # This path is cachable. (Saving in /usr/local/ would cause issues restoring the cache.)
 path="/usr/local/Cellar"

--- a/scripts/mac_installgo.sh
+++ b/scripts/mac_installgo.sh
@@ -12,12 +12,9 @@ path="/usr/local/Cellar"
 # Download Go and verify Go tarball. (Note: we aren't using brew because
 # it is slow to update and we can't pull specific minor versions.)
 setup_go () {
-
-    brew install coreutils # Install sha256sum util
-
     echo "installing go"
-    curl -OL https://golang.org/dl/go${GO_VERSION}.${GO_ARCH}.tar.gz --output go${GO_VERSION}.${GO_ARCH}.tar.gz
-    echo "${GO_VERSION_SHA} go${GO_VERSION}.${GO_ARCH}.tar.gz" | sha256sum --check
+    curl -L https://golang.org/dl/go${GO_VERSION}.${GO_ARCH}.tar.gz --output go${GO_VERSION}.${GO_ARCH}.tar.gz
+    echo "${GO_VERSION_SHA} go${GO_VERSION}.${GO_ARCH}.tar.gz" | shasum -a 256 --check
     sudo rm -rf ${path}/go
     sudo tar -C $path -xzf go${GO_VERSION}.${GO_ARCH}.tar.gz
     ln -sf ${path}/go/bin/go /usr/local/bin/go

--- a/scripts/mac_installgo.sh
+++ b/scripts/mac_installgo.sh
@@ -12,9 +12,12 @@ path="/usr/local/Cellar"
 # Download Go and verify Go tarball. (Note: we aren't using brew because
 # it is slow to update and we can't pull specific minor versions.)
 setup_go () {
+
+    brew install coreutils # Install sha256sum util
+
     echo "installing go"
     curl -OL https://golang.org/dl/go${GO_VERSION}.${GO_ARCH}.tar.gz --output go${GO_VERSION}.${GO_ARCH}.tar.gz
-    echo "${GO_SHA} go${GO_VERSION}.${GO_ARCH}.tar.gz" | sha256sum --check
+    echo "${GO_VERSION_SHA} go${GO_VERSION}.${GO_ARCH}.tar.gz" | sha256sum --check
     sudo rm -rf ${path}/go
     sudo tar -C $path -xzf go${GO_VERSION}.${GO_ARCH}.tar.gz
     ln -sf ${path}/go/bin/go /usr/local/bin/go

--- a/scripts/mac_installgo.sh
+++ b/scripts/mac_installgo.sh
@@ -14,7 +14,7 @@ path="/usr/local/Cellar"
 setup_go () {
     echo "installing go"
     curl -L https://golang.org/dl/go${GO_VERSION}.${GO_ARCH}.tar.gz --output go${GO_VERSION}.${GO_ARCH}.tar.gz
-    echo "${GO_VERSION_SHA} go${GO_VERSION}.${GO_ARCH}.tar.gz" | shasum -a 256 --check
+    echo "${GO_VERSION_SHA}  go${GO_VERSION}.${GO_ARCH}.tar.gz" | shasum -a 256 --check
     sudo rm -rf ${path}/go
     sudo tar -C $path -xzf go${GO_VERSION}.${GO_ARCH}.tar.gz
     ln -sf ${path}/go/bin/go /usr/local/bin/go


### PR DESCRIPTION
This pull request caused a bug in the shell script to install Go for mac: https://github.com/influxdata/telegraf/pull/9335 causing the Mac build to fail currently: https://app.circleci.com/pipelines/github/influxdata/telegraf/5226/workflows/6e336a4d-749b-42fb-83d0-3cf0ba309879/jobs/95226. This wasn't caught in the pull request due to the script `check-file-changes.sh` which didn't run the CI if a shell script changed. Also updated the `check-file-changes.sh` script to take into consideration for release branches which was another issue with the script.

@pierwill can you help verify that this change looks good?