### PR TITLE
Add include_nodes filter for jenkins

### DIFF
--- a/plugins/inputs/jenkins/README.md
+++ b/plugins/inputs/jenkins/README.md
@@ -45,7 +45,9 @@ This plugin does not require a plugin on jenkins and it makes use of Jenkins API
   # job_include = [ "*" ]
   # job_exclude = [ ]
 
-  ## Nodes to exclude from gathering
+  ## Nodes to include or exclude from gathering
+  ## When using both lists, node_exclude has priority.
+  # node_include = [ "*" ]
   # node_exclude = [ ]
 
   ## Worker pool for jenkins plugin only

--- a/plugins/inputs/jenkins/jenkins.go
+++ b/plugins/inputs/jenkins/jenkins.go
@@ -200,7 +200,7 @@ func (j *Jenkins) gatherNodeData(n node, acc telegraf.Accumulator) error {
 	tags["node_name"] = n.DisplayName
 
 	// filter out excluded or not included node_name
-	if j.nodeFilter != nil && !j.nodeFilter.Match(tags["node_name"]) {
+	if !j.nodeFilter.Match(tags["node_name"]) {
 		return nil
 	}
 
@@ -297,7 +297,7 @@ func (j *Jenkins) getJobDetail(jr jobRequest, acc telegraf.Accumulator) error {
 	}
 
 	// filter out excluded or not included jobs
-	if j.jobFilter != nil && !j.jobFilter.Match(jr.hierarchyName()) {
+	if !j.jobFilter.Match(jr.hierarchyName()) {
 		return nil
 	}
 

--- a/plugins/inputs/jenkins/jenkins_test.go
+++ b/plugins/inputs/jenkins/jenkins_test.go
@@ -156,7 +156,7 @@ func TestGatherNodeData(t *testing.T) {
 			},
 		},
 		{
-			name: "filtered nodes",
+			name: "filtered nodes (excluded)",
 			input: mockHandler{
 				responseMap: map[string]interface{}{
 					"/api/json": struct{}{},
@@ -166,6 +166,35 @@ func TestGatherNodeData(t *testing.T) {
 						Computers: []node{
 							{DisplayName: "ignore-1"},
 							{DisplayName: "ignore-2"},
+						},
+					},
+				},
+			},
+			output: &testutil.Accumulator{
+				Metrics: []*testutil.Metric{
+					{
+						Tags: map[string]string{
+							"source": "127.0.0.1",
+						},
+						Fields: map[string]interface{}{
+							"busy_executors":  4,
+							"total_executors": 8,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "filtered nodes (included)",
+			input: mockHandler{
+				responseMap: map[string]interface{}{
+					"/api/json": struct{}{},
+					"/computer/api/json": nodeResponse{
+						BusyExecutors:  4,
+						TotalExecutors: 8,
+						Computers: []node{
+							{DisplayName: "filtered-1"},
+							{DisplayName: "filtered-1"},
 						},
 					},
 				},
@@ -306,6 +335,7 @@ func TestGatherNodeData(t *testing.T) {
 				URL:             ts.URL,
 				ResponseTimeout: config.Duration(time.Microsecond),
 				NodeExclude:     []string{"ignore-1", "ignore-2"},
+				NodeInclude:     []string{"master", "slave"},
 			}
 			te := j.initialize(&http.Client{Transport: &http.Transport{}})
 			acc := new(testutil.Accumulator)


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #9047 

Adds the ability to explicitly include nodes for the `jenkins_node` metric. Previously, you could only exclude nodes from being collected.

Like the `job_exclude` and `job_include` filters, `node_exclude` takes precedence over `node_include` if they are both present.