### PR TITLE
Fix typo in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ debs += telegraf_$(deb_version)_s390x.deb
 rpms += telegraf-$(rpm_version).s390x.rpm
 endif
 
-ifdef ppc641e
+ifdef ppc64le
 tars += telegraf-$(tar_version)_linux_ppc64le.tar.gz
 rpms += telegraf-$(rpm_version).ppc64le.rpm
 debs += telegraf_$(deb_version)_ppc64el.deb


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Not sure why building the ppc64le packages was working at all, but there was a typo.