### PR TITLE
Fix import of sqlite and ignore it on all platforms that require CGO.

### DIFF
--- a/plugins/inputs/sql/drivers_sqlite.go
+++ b/plugins/inputs/sql/drivers_sqlite.go
@@ -1,4 +1,4 @@
-// +build linux,freebsd
+// +build linux,freebsd,darwin
 // +build !mips !mips64
 
 package sql

--- a/plugins/outputs/sql/sqlite.go
+++ b/plugins/outputs/sql/sqlite.go
@@ -1,4 +1,4 @@
-// +build linux,freebsd
+// +build linux,freebsd,darwin
 // +build !mips !mips64
 
 package sql

--- a/plugins/outputs/sql/sqlite.go
+++ b/plugins/outputs/sql/sqlite.go
@@ -1,9 +1,5 @@
-// +build !mips
-// +build !mipsle
-// +build !s390x
-// +build !ppc64le
-// +build !windows
-// +build !freebsd
+// +build linux,freebsd
+// +build !mips !mips64
 
 package sql
 

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -1,5 +1,5 @@
-// +build linux
-// +build 386 amd64 arm arm64
+// +build linux,freebsd
+// +build !mips !mips64
 
 package sql
 


### PR DESCRIPTION
### Required for all PRs:

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

Fix unintended pulling in of CGO by importing the sqlite SQL driver. CGO is required for some platforms when using sqlite. We simply do not support sqlite for those platforms and get rid of the CGO dependency. Fixes CI errors like
```
[...]
package github.com/influxdata/telegraf/cmd/telegraf
	imports github.com/influxdata/telegraf/plugins/outputs/all
	imports github.com/influxdata/telegraf/plugins/outputs/sql
	imports modernc.org/sqlite
	imports modernc.org/libc
	imports modernc.org/libc/unistd: build constraints exclude all Go files in /go/pkg/mod/modernc.org/libc@v1.9.5/unistd
[...]
``` 