### PR TITLE
Update dynatrace output

### DIFF
--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -55,14 +55,6 @@ You can learn more about how to use the Dynatrace API [here](https://www.dynatra
 
 ## Configuration
 
-### `url`
-
-*required*: `false`
-
-*default*: Local OneAgent endpoint
-
-Set your Dynatrace environment URL (e.g.: `https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest`) if you do not use a OneAgent or wish to export metrics directly to a Dynatrace metrics v2 endpoint. If a URL is set to anything other than the local OneAgent endpoint, then an API token is required.
-
 ```toml
 [[outputs.dynatrace]]
   ## Leave empty or use the local ingest endpoint of your OneAgent monitored host (e.g.: http://127.0.0.1:14499/metrics/ingest).
@@ -75,6 +67,22 @@ Set your Dynatrace environment URL (e.g.: `https://{your-environment-id}.live.dy
   insecure_skip_verify = false
   ## If you want to convert values represented as gauges to counters, add the metric names here
   additional_counters = [ ]
+
+  ## Optional dimensions to be added to every metric
+  default_dimensions = {
+    some_key = "some value"
+  }
+```
+
+### `url`
+
+*required*: `false`
+
+*default*: Local OneAgent endpoint
+
+Set your Dynatrace environment URL (e.g.: `https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest`) if you do not use a OneAgent or wish to export metrics directly to a Dynatrace metrics v2 endpoint. If a URL is set to anything other than the local OneAgent endpoint, then an API token is required.
+
+```toml
 url = "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"
 ```
 

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -28,7 +28,7 @@ Note: The name and identifier of the host running Telegraf will be added as a di
   ## No options are required. By default, metrics will be exported via the OneAgent on the local host.
 ```
 
-## Running standalone
+### Running standalone
 
 If you run the Telegraf agent on a host or VM without a OneAgent you will need to configure the environment API endpoint to send the metrics to and an API token for security.
 
@@ -80,7 +80,7 @@ You can learn more about how to use the Dynatrace API [here](https://www.dynatra
 
 *default*: Local OneAgent endpoint
 
-Set your Dynatrace environment URL (e.g.: `https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest`) if you do not use a OneAgent or wish to export metrics directly to a Dynatrace metrics v2 endpoint. If a URL is set to anything other than the local OneAgent endpoint, then an API token is required.
+Set your Dynatrace environment URL (e.g.: `https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest`, see the [Dynatrace documentation](https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/post-ingest-metrics/) for details) if you do not use a OneAgent or wish to export metrics directly to a Dynatrace metrics v2 endpoint. If a URL is set to anything other than the local OneAgent endpoint, then an API token is required.
 
 ```toml
 url = "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -16,7 +16,7 @@ The Dynatrace exporter may be enabled by adding an `[[outputs.dynatrace]]` secti
 All configurations are optional, but if a `url` other than the OneAgent metric ingestion endpoint is specified then an `api_token` is required.
 To see all available options, see [Configuration](#configuration) below.
 
-### Running alongside Dynatrace OneAgent
+### Running alongside Dynatrace OneAgent (preferred)
 
 If you run the Telegraf agent on a host or VM that is monitored by the Dynatrace OneAgent then you only need to enable the plugin, but need no further configuration. The Dynatrace Telegraf output plugin will send all metrics to the OneAgent which will use its secure and load balanced connection to send the metrics to your Dynatrace SaaS or Managed environment.
 Depending on your environment, you might have to enable metrics ingestion on the OneAgent first as described in the [Dynatrace documentation](https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/telegraf/).

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -69,9 +69,8 @@ You can learn more about how to use the Dynatrace API [here](https://www.dynatra
   additional_counters = [ ]
 
   ## Optional dimensions to be added to every metric
-  default_dimensions = {
-    some_key = "some value"
-  }
+  [outputs.dynatrace.default_dimensions]
+  default_key = "default value"
 ```
 
 ### `url`
@@ -133,9 +132,8 @@ additional_counters = [ ]
 Default dimensions that will be added to every exported metric.
 
 ```toml
-default_dimensions = {
-  key = "value"
-}
+[outputs.dynatrace.default_dimensions]
+default_key = "default value"
 ```
 
 ## Limitations

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -29,8 +29,8 @@ type Dynatrace struct {
 	AddCounterMetrics []string          `toml:"additional_counters"`
 	DefaultDimensions map[string]string `toml:"default_dimensions"`
 
-	defaultDimensions dimensions.NormalizedDimensionList
-	staticDimensions  dimensions.NormalizedDimensionList
+	normalizedDefaultDimensions dimensions.NormalizedDimensionList
+	normalizedStaticDimensions  dimensions.NormalizedDimensionList
 
 	tls.ClientConfig
 
@@ -150,9 +150,9 @@ func (d *Dynatrace) Write(metrics []telegraf.Metric) error {
 				dtMetric.WithPrefix(d.Prefix),
 				dtMetric.WithDimensions(
 					dimensions.MergeLists(
-						d.defaultDimensions,
+						d.normalizedDefaultDimensions,
 						dimensions.NewNormalizedDimensionList(dims...),
-						d.staticDimensions,
+						d.normalizedStaticDimensions,
 					),
 				),
 				dtMetric.WithTimestamp(tm.Time()),
@@ -253,8 +253,8 @@ func (d *Dynatrace) Init() error {
 	for key, value := range d.DefaultDimensions {
 		dims = append(dims, dimensions.NewDimension(key, value))
 	}
-	d.defaultDimensions = dimensions.NewNormalizedDimensionList(dims...)
-	d.staticDimensions = dimensions.MergeLists(
+	d.normalizedDefaultDimensions = dimensions.NewNormalizedDimensionList(dims...)
+	d.normalizedStaticDimensions = dimensions.MergeLists(
 		dimensions.NewNormalizedDimensionList(dimensions.NewDimension("dt.metrics.source", "telegraf")),
 		oneagentenrichment.GetOneAgentMetadata(),
 	)

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -253,9 +253,7 @@ func (d *Dynatrace) Init() error {
 		dims = append(dims, dimensions.NewDimension(key, value))
 	}
 	d.normalizedDefaultDimensions = dimensions.NewNormalizedDimensionList(dims...)
-	d.normalizedStaticDimensions = dimensions.MergeLists(
-		dimensions.NewNormalizedDimensionList(dimensions.NewDimension("dt.metrics.source", "telegraf")),
-	)
+	d.normalizedStaticDimensions = dimensions.NewNormalizedDimensionList(dimensions.NewDimension("dt.metrics.source", "telegraf"))
 
 	return nil
 }

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -74,8 +74,9 @@ const sampleConfig = `
   additional_counters = [ ]
 
   ## Optional dimensions to be added to every metric
-  [[outputs.dynatrace.default_dimensions]]
-	some_key = "some value"
+  # default_dimensions = {
+  #   some_key = "some value"
+  # }
 `
 
 // Connect Connects the Dynatrace output plugin to the Telegraf stream

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -73,9 +73,8 @@ const sampleConfig = `
   additional_counters = [ ]
 
   ## Optional dimensions to be added to every metric
-  # default_dimensions = {
-  #   some_key = "some value"
-  # }
+  # [outputs.dynatrace.default_dimensions]
+  # default_key = "default value"
 `
 
 // Connect Connects the Dynatrace output plugin to the Telegraf stream

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -255,7 +255,6 @@ func (d *Dynatrace) Init() error {
 	d.normalizedDefaultDimensions = dimensions.NewNormalizedDimensionList(dims...)
 	d.normalizedStaticDimensions = dimensions.MergeLists(
 		dimensions.NewNormalizedDimensionList(dimensions.NewDimension("dt.metrics.source", "telegraf")),
-		// oneagentenrichment.GetOneAgentMetadata(),
 	)
 
 	return nil

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -21,16 +21,16 @@ import (
 
 // Dynatrace Configuration for the Dynatrace output plugin
 type Dynatrace struct {
-	URL               string          `toml:"url"`
-	APIToken          string          `toml:"api_token"`
-	Prefix            string          `toml:"prefix"`
-	Log               telegraf.Logger `toml:"-"`
-	Timeout           config.Duration `toml:"timeout"`
-	AddCounterMetrics []string        `toml:"additional_counters"`
+	URL               string            `toml:"url"`
+	APIToken          string            `toml:"api_token"`
+	Prefix            string            `toml:"prefix"`
+	Log               telegraf.Logger   `toml:"-"`
+	Timeout           config.Duration   `toml:"timeout"`
+	AddCounterMetrics []string          `toml:"additional_counters"`
+	DefaultDimensions map[string]string `toml:"default_dimensions"`
 
-	defaultDimensionMap map[string]string `toml:"default_dimensions"`
-	defaultDimensions   dimensions.NormalizedDimensionList
-	staticDimensions    dimensions.NormalizedDimensionList
+	defaultDimensions dimensions.NormalizedDimensionList
+	staticDimensions  dimensions.NormalizedDimensionList
 
 	tls.ClientConfig
 
@@ -250,7 +250,7 @@ func (d *Dynatrace) Init() error {
 	}
 
 	dims := []dimensions.Dimension{}
-	for key, value := range d.defaultDimensionMap {
+	for key, value := range d.DefaultDimensions {
 		dims = append(dims, dimensions.NewDimension(key, value))
 	}
 	d.defaultDimensions = dimensions.NewNormalizedDimensionList(dims...)

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -16,7 +16,6 @@ import (
 	dtMetric "github.com/dynatrace-oss/dynatrace-metric-utils-go/metric"
 	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/apiconstants"
 	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/dimensions"
-	"github.com/dynatrace-oss/dynatrace-metric-utils-go/oneagentenrichment"
 )
 
 // Dynatrace Configuration for the Dynatrace output plugin
@@ -256,7 +255,7 @@ func (d *Dynatrace) Init() error {
 	d.normalizedDefaultDimensions = dimensions.NewNormalizedDimensionList(dims...)
 	d.normalizedStaticDimensions = dimensions.MergeLists(
 		dimensions.NewNormalizedDimensionList(dimensions.NewDimension("dt.metrics.source", "telegraf")),
-		oneagentenrichment.GetOneAgentMetadata(),
+		// oneagentenrichment.GetOneAgentMetadata(),
 	)
 
 	return nil


### PR DESCRIPTION
- export timestamps
- enrich dimensions with OneAgent data
- Add default dimensions feature

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
  - Seems the readme already mentioned the associated default_dimensions feature for some reason
- [x] Wrote appropriate unit tests.
