### PR TITLE
added a check for oid and name to prevent empty metrics

### DIFF
--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -173,6 +173,12 @@ type Table struct {
 
 // Init() builds & initializes the nested fields.
 func (t *Table) Init() error {
+	//makes sure oid or name is set in config file
+	//otherwise snmp will produce metrics with an empty name
+	if t.Oid == "" && t.Name == "" {
+		return fmt.Errorf("SNMP table in config file is not named. One or both of the oid and name settings must be set")
+	}
+
 	if t.initialized {
 		return nil
 	}

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -199,11 +199,12 @@ func TestSnmpInit_noTranslate(t *testing.T) {
 			{Oid: ".1.1.1.3"},
 		},
 		Tables: []Table{
-			{Fields: []Field{
-				{Oid: ".1.1.1.4", Name: "four", IsTag: true},
-				{Oid: ".1.1.1.5", Name: "five"},
-				{Oid: ".1.1.1.6"},
-			}},
+			{Name: "testing",
+				Fields: []Field{
+					{Oid: ".1.1.1.4", Name: "four", IsTag: true},
+					{Oid: ".1.1.1.5", Name: "five"},
+					{Oid: ".1.1.1.6"},
+				}},
 		},
 	}
 
@@ -233,6 +234,21 @@ func TestSnmpInit_noTranslate(t *testing.T) {
 	assert.Equal(t, ".1.1.1.6", s.Tables[0].Fields[2].Oid)
 	assert.Equal(t, ".1.1.1.6", s.Tables[0].Fields[2].Name)
 	assert.Equal(t, false, s.Tables[0].Fields[2].IsTag)
+}
+
+func TestSnmpInit_noName_noOid(t *testing.T) {
+	s := &Snmp{
+		Tables: []Table{
+			{Fields: []Field{
+				{Oid: ".1.1.1.4", Name: "four", IsTag: true},
+				{Oid: ".1.1.1.5", Name: "five"},
+				{Oid: ".1.1.1.6"},
+			}},
+		},
+	}
+
+	err := s.init()
+	require.Error(t, err)
 }
 
 func TestGetSNMPConnection_v2(t *testing.T) {


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #8840 SNMP input can produce metrics with empty metric name

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Added a check for empty oid and empty name
fixed an existing unit test to give the table a name
and added a test for a table with empty oid and empty name