### PR TITLE
Linter fixes for plugins/inputs/[fg]*

### DIFF
--- a/plugins/inputs/fail2ban/fail2ban_test.go
+++ b/plugins/inputs/fail2ban/fail2ban_test.go
@@ -103,29 +103,35 @@ func TestHelperProcess(_ *testing.T) {
 	if !strings.HasSuffix(cmd, "fail2ban-client") {
 		//nolint:errcheck,revive // Test will fail anyway
 		fmt.Fprint(os.Stdout, "command not found")
+		//nolint:revive // os.Exit called intentionally
 		os.Exit(1)
 	}
 
 	if len(args) == 1 && args[0] == "status" {
 		//nolint:errcheck,revive // Test will fail anyway
 		fmt.Fprint(os.Stdout, execStatusOutput)
+		//nolint:revive // os.Exit called intentionally
 		os.Exit(0)
 	} else if len(args) == 2 && args[0] == "status" {
 		if args[1] == "sshd" {
 			//nolint:errcheck,revive // Test will fail anyway
 			fmt.Fprint(os.Stdout, execStatusSshdOutput)
+			//nolint:revive // os.Exit called intentionally
 			os.Exit(0)
 		} else if args[1] == "postfix" {
 			//nolint:errcheck,revive // Test will fail anyway
 			fmt.Fprint(os.Stdout, execStatusPostfixOutput)
+			//nolint:revive // os.Exit called intentionally
 			os.Exit(0)
 		} else if args[1] == "dovecot" {
 			//nolint:errcheck,revive // Test will fail anyway
 			fmt.Fprint(os.Stdout, execStatusDovecotOutput)
+			//nolint:revive // os.Exit called intentionally
 			os.Exit(0)
 		}
 	}
 	//nolint:errcheck,revive // Test will fail anyway
 	fmt.Fprint(os.Stdout, "invalid argument")
+	//nolint:revive // os.Exit called intentionally
 	os.Exit(1)
 }

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -11,15 +11,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/parsers/csv"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRefreshFilePaths(t *testing.T) {
 	wd, err := os.Getwd()
+	require.NoError(t, err)
+
 	r := File{
 		Files: []string{filepath.Join(wd, "dev/testfiles/**.log")},
 	}
@@ -100,7 +103,8 @@ func TestGrokParser(t *testing.T) {
 	require.NoError(t, err)
 
 	err = r.Gather(&acc)
-	require.Equal(t, len(acc.Metrics), 2)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(acc.Metrics))
 }
 
 func TestCharacterEncoding(t *testing.T) {

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -104,7 +104,7 @@ func TestGrokParser(t *testing.T) {
 
 	err = r.Gather(&acc)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(acc.Metrics))
+	require.Len(t, acc.Metrics, 2)
 }
 
 func TestCharacterEncoding(t *testing.T) {

--- a/plugins/inputs/filecount/filesystem_helpers_test.go
+++ b/plugins/inputs/filecount/filesystem_helpers_test.go
@@ -53,11 +53,12 @@ func TestRealFS(t *testing.T) {
 	fs = getTestFileSystem()
 	// now, the same test as above will return an error as the file doesn't exist in our fake fs
 	expectedError := "Stat " + getTestdataDir() + "/qux: No such file or directory"
-	fileInfo, err = fs.Stat(getTestdataDir() + "/qux")
-	require.Equal(t, expectedError, err.Error())
+	_, err = fs.Stat(getTestdataDir() + "/qux")
+	require.Error(t, err, expectedError)
 	// and verify that what we DO expect to find, we do
 	fileInfo, err = fs.Stat("/testdata/foo")
 	require.NoError(t, err)
+	require.NotNil(t, fileInfo)
 }
 
 func getTestFileSystem() fakeFileSystem {

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -114,11 +114,11 @@ func (f *FileStat) Gather(acc telegraf.Accumulator) error {
 			}
 
 			if f.Md5 {
-				md5, err := getMd5(fileName)
+				md5Hash, err := getMd5(fileName)
 				if err != nil {
 					acc.AddError(err)
 				} else {
-					fields["md5_sum"] = md5
+					fields["md5_sum"] = md5Hash
 				}
 			}
 

--- a/plugins/inputs/filestat/filestat_test.go
+++ b/plugins/inputs/filestat/filestat_test.go
@@ -198,7 +198,7 @@ func TestGetMd5(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "5a7e9b77fa25e7bb411dbd17cf403c1f", md5)
 
-	md5, err = getMd5("/tmp/foo/bar/fooooo")
+	_, err = getMd5("/tmp/foo/bar/fooooo")
 	require.Error(t, err)
 }
 

--- a/plugins/inputs/fluentd/fluentd.go
+++ b/plugins/inputs/fluentd/fluentd.go
@@ -63,11 +63,11 @@ func parse(data []byte) (datapointArray []pluginData, err error) {
 
 	if err = json.Unmarshal(data, &endpointData); err != nil {
 		err = fmt.Errorf("processing JSON structure")
-		return
+		return nil, err
 	}
 
 	datapointArray = append(datapointArray, endpointData.Payload...)
-	return
+	return datapointArray, err
 }
 
 // Description - display description

--- a/plugins/inputs/fluentd/fluentd_test.go
+++ b/plugins/inputs/fluentd/fluentd_test.go
@@ -8,8 +8,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 // sampleJSON from fluentd version '0.14.9'
@@ -127,6 +128,8 @@ func Test_Gather(t *testing.T) {
 	}))
 
 	requestURL, err := url.Parse(fluentdTest.Endpoint)
+	require.NoError(t, err)
+	require.NotNil(t, requestURL)
 
 	ts.Listener, _ = net.Listen("tcp", fmt.Sprintf("%s:%s", requestURL.Hostname(), requestURL.Port()))
 

--- a/plugins/inputs/github/github.go
+++ b/plugins/inputs/github/github.go
@@ -8,12 +8,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v32/github"
+	githubLib "github.com/google/go-github/v32/github"
+	"golang.org/x/oauth2"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/selfstat"
-	"golang.org/x/oauth2"
 )
 
 // GitHub - plugin main structure
@@ -23,7 +24,7 @@ type GitHub struct {
 	AdditionalFields  []string        `toml:"additional_fields"`
 	EnterpriseBaseURL string          `toml:"enterprise_base_url"`
 	HTTPTimeout       config.Duration `toml:"http_timeout"`
-	githubClient      *github.Client
+	githubClient      *githubLib.Client
 
 	obfuscatedToken string
 
@@ -68,7 +69,7 @@ func (g *GitHub) Description() string {
 }
 
 // Create GitHub Client
-func (g *GitHub) createGitHubClient(ctx context.Context) (*github.Client, error) {
+func (g *GitHub) createGitHubClient(ctx context.Context) (*githubLib.Client, error) {
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
@@ -93,11 +94,11 @@ func (g *GitHub) createGitHubClient(ctx context.Context) (*github.Client, error)
 	return g.newGithubClient(httpClient)
 }
 
-func (g *GitHub) newGithubClient(httpClient *http.Client) (*github.Client, error) {
+func (g *GitHub) newGithubClient(httpClient *http.Client) (*githubLib.Client, error) {
 	if g.EnterpriseBaseURL != "" {
-		return github.NewEnterpriseClient(g.EnterpriseBaseURL, "", httpClient)
+		return githubLib.NewEnterpriseClient(g.EnterpriseBaseURL, "", httpClient)
 	}
-	return github.NewClient(httpClient), nil
+	return githubLib.NewClient(httpClient), nil
 }
 
 // Gather GitHub Metrics
@@ -172,16 +173,16 @@ func (g *GitHub) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (g *GitHub) handleRateLimit(response *github.Response, err error) {
+func (g *GitHub) handleRateLimit(response *githubLib.Response, err error) {
 	if err == nil {
 		g.RateLimit.Set(int64(response.Rate.Limit))
 		g.RateRemaining.Set(int64(response.Rate.Remaining))
-	} else if _, ok := err.(*github.RateLimitError); ok {
+	} else if _, ok := err.(*githubLib.RateLimitError); ok {
 		g.RateLimitErrors.Incr(1)
 	}
 }
 
-func splitRepositoryName(repositoryName string) (string, string, error) {
+func splitRepositoryName(repositoryName string) (owner string, repository string, err error) {
 	splits := strings.SplitN(repositoryName, "/", 2)
 
 	if len(splits) != 2 {
@@ -191,7 +192,7 @@ func splitRepositoryName(repositoryName string) (string, string, error) {
 	return splits[0], splits[1], nil
 }
 
-func getLicense(rI *github.Repository) string {
+func getLicense(rI *githubLib.Repository) string {
 	if licenseName := rI.GetLicense().GetName(); licenseName != "" {
 		return licenseName
 	}
@@ -199,7 +200,7 @@ func getLicense(rI *github.Repository) string {
 	return "None"
 }
 
-func getTags(repositoryInfo *github.Repository) map[string]string {
+func getTags(repositoryInfo *githubLib.Repository) map[string]string {
 	return map[string]string{
 		"owner":    repositoryInfo.GetOwner().GetLogin(),
 		"name":     repositoryInfo.GetName(),
@@ -208,7 +209,7 @@ func getTags(repositoryInfo *github.Repository) map[string]string {
 	}
 }
 
-func getFields(repositoryInfo *github.Repository) map[string]interface{} {
+func getFields(repositoryInfo *githubLib.Repository) map[string]interface{} {
 	return map[string]interface{}{
 		"stars":       repositoryInfo.GetStargazersCount(),
 		"subscribers": repositoryInfo.GetSubscribersCount(),
@@ -221,9 +222,9 @@ func getFields(repositoryInfo *github.Repository) map[string]interface{} {
 }
 
 func (g *GitHub) getPullRequestFields(ctx context.Context, owner, repo string) (map[string]interface{}, error) {
-	options := github.SearchOptions{
+	options := githubLib.SearchOptions{
 		TextMatch: false,
-		ListOptions: github.ListOptions{
+		ListOptions: githubLib.ListOptions{
 			PerPage: 100,
 			Page:    1,
 		},

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -9,54 +9,54 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/testutil"
-	"github.com/openconfig/gnmi/proto/gnmi"
-	"github.com/stretchr/testify/assert"
+	gnmiLib "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestParsePath(t *testing.T) {
 	path := "/foo/bar/bla[shoo=woo][shoop=/woop/]/z"
 	parsed, err := parsePath("theorigin", path, "thetarget")
 
-	assert.NoError(t, err)
-	assert.Equal(t, parsed.Origin, "theorigin")
-	assert.Equal(t, parsed.Target, "thetarget")
-	assert.Equal(t, parsed.Element, []string{"foo", "bar", "bla[shoo=woo][shoop=/woop/]", "z"})
-	assert.Equal(t, parsed.Elem, []*gnmi.PathElem{{Name: "foo"}, {Name: "bar"},
-		{Name: "bla", Key: map[string]string{"shoo": "woo", "shoop": "/woop/"}}, {Name: "z"}})
+	require.NoError(t, err)
+	require.Equal(t, "theorigin", parsed.Origin)
+	require.Equal(t, "thetarget", parsed.Target)
+	require.Equal(t, []string{"foo", "bar", "bla[shoo=woo][shoop=/woop/]", "z"}, parsed.Element)
+	require.Equal(t, []*gnmiLib.PathElem{{Name: "foo"}, {Name: "bar"},
+		{Name: "bla", Key: map[string]string{"shoo": "woo", "shoop": "/woop/"}}, {Name: "z"}}, parsed.Elem)
 
 	parsed, err = parsePath("", "", "")
-	assert.NoError(t, err)
-	assert.Equal(t, *parsed, gnmi.Path{})
+	require.NoError(t, err)
+	require.Equal(t, gnmiLib.Path{}, *parsed)
 
 	parsed, err = parsePath("", "/foo[[", "")
-	assert.Nil(t, parsed)
-	assert.Equal(t, errors.New("Invalid gNMI path: /foo[[/"), err)
+	require.Nil(t, parsed)
+	require.Equal(t, errors.New("Invalid gNMI path: /foo[[/"), err)
 }
 
 type MockServer struct {
-	SubscribeF func(gnmi.GNMI_SubscribeServer) error
+	SubscribeF func(gnmiLib.GNMI_SubscribeServer) error
 	GRPCServer *grpc.Server
 }
 
-func (s *MockServer) Capabilities(context.Context, *gnmi.CapabilityRequest) (*gnmi.CapabilityResponse, error) {
+func (s *MockServer) Capabilities(context.Context, *gnmiLib.CapabilityRequest) (*gnmiLib.CapabilityResponse, error) {
 	return nil, nil
 }
 
-func (s *MockServer) Get(context.Context, *gnmi.GetRequest) (*gnmi.GetResponse, error) {
+func (s *MockServer) Get(context.Context, *gnmiLib.GetRequest) (*gnmiLib.GetResponse, error) {
 	return nil, nil
 }
 
-func (s *MockServer) Set(context.Context, *gnmi.SetRequest) (*gnmi.SetResponse, error) {
+func (s *MockServer) Set(context.Context, *gnmiLib.SetRequest) (*gnmiLib.SetResponse, error) {
 	return nil, nil
 }
 
-func (s *MockServer) Subscribe(server gnmi.GNMI_SubscribeServer) error {
+func (s *MockServer) Subscribe(server gnmiLib.GNMI_SubscribeServer) error {
 	return s.SubscribeF(server)
 }
 
@@ -66,12 +66,12 @@ func TestWaitError(t *testing.T) {
 
 	grpcServer := grpc.NewServer()
 	gnmiServer := &MockServer{
-		SubscribeF: func(server gnmi.GNMI_SubscribeServer) error {
+		SubscribeF: func(server gnmiLib.GNMI_SubscribeServer) error {
 			return fmt.Errorf("testerror")
 		},
 		GRPCServer: grpcServer,
 	}
-	gnmi.RegisterGNMIServer(grpcServer, gnmiServer)
+	gnmiLib.RegisterGNMIServer(grpcServer, gnmiServer)
 
 	plugin := &GNMI{
 		Log:       testutil.Logger{},
@@ -107,7 +107,7 @@ func TestUsernamePassword(t *testing.T) {
 
 	grpcServer := grpc.NewServer()
 	gnmiServer := &MockServer{
-		SubscribeF: func(server gnmi.GNMI_SubscribeServer) error {
+		SubscribeF: func(server gnmiLib.GNMI_SubscribeServer) error {
 			metadata, ok := metadata.FromIncomingContext(server.Context())
 			if !ok {
 				return errors.New("failed to get metadata")
@@ -127,7 +127,7 @@ func TestUsernamePassword(t *testing.T) {
 		},
 		GRPCServer: grpcServer,
 	}
-	gnmi.RegisterGNMIServer(grpcServer, gnmiServer)
+	gnmiLib.RegisterGNMIServer(grpcServer, gnmiServer)
 
 	plugin := &GNMI{
 		Log:       testutil.Logger{},
@@ -159,12 +159,12 @@ func TestUsernamePassword(t *testing.T) {
 		errors.New("aborted gNMI subscription: rpc error: code = Unknown desc = success"))
 }
 
-func mockGNMINotification() *gnmi.Notification {
-	return &gnmi.Notification{
+func mockGNMINotification() *gnmiLib.Notification {
+	return &gnmiLib.Notification{
 		Timestamp: 1543236572000000000,
-		Prefix: &gnmi.Path{
+		Prefix: &gnmiLib.Path{
 			Origin: "type",
-			Elem: []*gnmi.PathElem{
+			Elem: []*gnmiLib.PathElem{
 				{
 					Name: "model",
 					Key:  map[string]string{"foo": "bar"},
@@ -172,35 +172,35 @@ func mockGNMINotification() *gnmi.Notification {
 			},
 			Target: "subscription",
 		},
-		Update: []*gnmi.Update{
+		Update: []*gnmiLib.Update{
 			{
-				Path: &gnmi.Path{
-					Elem: []*gnmi.PathElem{
+				Path: &gnmiLib.Path{
+					Elem: []*gnmiLib.PathElem{
 						{Name: "some"},
 						{
 							Name: "path",
 							Key:  map[string]string{"name": "str", "uint64": "1234"}},
 					},
 				},
-				Val: &gnmi.TypedValue{Value: &gnmi.TypedValue_IntVal{IntVal: 5678}},
+				Val: &gnmiLib.TypedValue{Value: &gnmiLib.TypedValue_IntVal{IntVal: 5678}},
 			},
 			{
-				Path: &gnmi.Path{
-					Elem: []*gnmi.PathElem{
+				Path: &gnmiLib.Path{
+					Elem: []*gnmiLib.PathElem{
 						{Name: "other"},
 						{Name: "path"},
 					},
 				},
-				Val: &gnmi.TypedValue{Value: &gnmi.TypedValue_StringVal{StringVal: "foobar"}},
+				Val: &gnmiLib.TypedValue{Value: &gnmiLib.TypedValue_StringVal{StringVal: "foobar"}},
 			},
 			{
-				Path: &gnmi.Path{
-					Elem: []*gnmi.PathElem{
+				Path: &gnmiLib.Path{
+					Elem: []*gnmiLib.PathElem{
 						{Name: "other"},
 						{Name: "this"},
 					},
 				},
-				Val: &gnmi.TypedValue{Value: &gnmi.TypedValue_StringVal{StringVal: "that"}},
+				Val: &gnmiLib.TypedValue{Value: &gnmiLib.TypedValue_StringVal{StringVal: "that"}},
 			},
 		},
 	}
@@ -229,20 +229,20 @@ func TestNotification(t *testing.T) {
 				},
 			},
 			server: &MockServer{
-				SubscribeF: func(server gnmi.GNMI_SubscribeServer) error {
+				SubscribeF: func(server gnmiLib.GNMI_SubscribeServer) error {
 					notification := mockGNMINotification()
-					err := server.Send(&gnmi.SubscribeResponse{Response: &gnmi.SubscribeResponse_Update{Update: notification}})
+					err := server.Send(&gnmiLib.SubscribeResponse{Response: &gnmiLib.SubscribeResponse_Update{Update: notification}})
 					if err != nil {
 						return err
 					}
-					err = server.Send(&gnmi.SubscribeResponse{Response: &gnmi.SubscribeResponse_SyncResponse{SyncResponse: true}})
+					err = server.Send(&gnmiLib.SubscribeResponse{Response: &gnmiLib.SubscribeResponse_SyncResponse{SyncResponse: true}})
 					if err != nil {
 						return err
 					}
 					notification.Prefix.Elem[0].Key["foo"] = "bar2"
 					notification.Update[0].Path.Elem[1].Key["name"] = "str2"
-					notification.Update[0].Val = &gnmi.TypedValue{Value: &gnmi.TypedValue_JsonVal{JsonVal: []byte{'"', '1', '2', '3', '"'}}}
-					return server.Send(&gnmi.SubscribeResponse{Response: &gnmi.SubscribeResponse_Update{Update: notification}})
+					notification.Update[0].Val = &gnmiLib.TypedValue{Value: &gnmiLib.TypedValue_JsonVal{JsonVal: []byte{'"', '1', '2', '3', '"'}}}
+					return server.Send(&gnmiLib.SubscribeResponse{Response: &gnmiLib.SubscribeResponse_Update{Update: notification}})
 				},
 			},
 			expected: []telegraf.Metric{
@@ -318,14 +318,14 @@ func TestNotification(t *testing.T) {
 				},
 			},
 			server: &MockServer{
-				SubscribeF: func(server gnmi.GNMI_SubscribeServer) error {
-					response := &gnmi.SubscribeResponse{
-						Response: &gnmi.SubscribeResponse_Update{
-							Update: &gnmi.Notification{
+				SubscribeF: func(server gnmiLib.GNMI_SubscribeServer) error {
+					response := &gnmiLib.SubscribeResponse{
+						Response: &gnmiLib.SubscribeResponse_Update{
+							Update: &gnmiLib.Notification{
 								Timestamp: 1543236572000000000,
-								Prefix: &gnmi.Path{
+								Prefix: &gnmiLib.Path{
 									Origin: "type",
-									Elem: []*gnmi.PathElem{
+									Elem: []*gnmiLib.PathElem{
 										{
 											Name: "state",
 										},
@@ -342,11 +342,11 @@ func TestNotification(t *testing.T) {
 									},
 									Target: "subscription",
 								},
-								Update: []*gnmi.Update{
+								Update: []*gnmiLib.Update{
 									{
-										Path: &gnmi.Path{},
-										Val: &gnmi.TypedValue{
-											Value: &gnmi.TypedValue_IntVal{IntVal: 42},
+										Path: &gnmiLib.Path{},
+										Val: &gnmiLib.TypedValue{
+											Value: &gnmiLib.TypedValue_IntVal{IntVal: 42},
 										},
 									},
 								},
@@ -382,7 +382,7 @@ func TestNotification(t *testing.T) {
 
 			grpcServer := grpc.NewServer()
 			tt.server.GRPCServer = grpcServer
-			gnmi.RegisterGNMIServer(grpcServer, tt.server)
+			gnmiLib.RegisterGNMIServer(grpcServer, tt.server)
 
 			var acc testutil.Accumulator
 			err = tt.plugin.Start(&acc)
@@ -424,10 +424,10 @@ func TestSubscribeResponseError(t *testing.T) {
 	ml := &MockLogger{}
 	plugin := &GNMI{Log: ml}
 	// TODO: FIX SA1019: gnmi.Error is deprecated: Do not use.
-	errorResponse := &gnmi.SubscribeResponse_Error{Error: &gnmi.Error{Message: me, Code: mc}}
-	plugin.handleSubscribeResponse("127.0.0.1:0", &gnmi.SubscribeResponse{Response: errorResponse})
+	errorResponse := &gnmiLib.SubscribeResponse_Error{Error: &gnmiLib.Error{Message: me, Code: mc}}
+	plugin.handleSubscribeResponse("127.0.0.1:0", &gnmiLib.SubscribeResponse{Response: errorResponse})
 	require.NotEmpty(t, ml.lastFormat)
-	require.Equal(t, ml.lastArgs, []interface{}{mc, me})
+	require.Equal(t, []interface{}{mc, me}, ml.lastArgs)
 }
 
 func TestRedial(t *testing.T) {
@@ -443,13 +443,13 @@ func TestRedial(t *testing.T) {
 
 	grpcServer := grpc.NewServer()
 	gnmiServer := &MockServer{
-		SubscribeF: func(server gnmi.GNMI_SubscribeServer) error {
+		SubscribeF: func(server gnmiLib.GNMI_SubscribeServer) error {
 			notification := mockGNMINotification()
-			return server.Send(&gnmi.SubscribeResponse{Response: &gnmi.SubscribeResponse_Update{Update: notification}})
+			return server.Send(&gnmiLib.SubscribeResponse{Response: &gnmiLib.SubscribeResponse_Update{Update: notification}})
 		},
 		GRPCServer: grpcServer,
 	}
-	gnmi.RegisterGNMIServer(grpcServer, gnmiServer)
+	gnmiLib.RegisterGNMIServer(grpcServer, gnmiServer)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -473,16 +473,16 @@ func TestRedial(t *testing.T) {
 
 	grpcServer = grpc.NewServer()
 	gnmiServer = &MockServer{
-		SubscribeF: func(server gnmi.GNMI_SubscribeServer) error {
+		SubscribeF: func(server gnmiLib.GNMI_SubscribeServer) error {
 			notification := mockGNMINotification()
 			notification.Prefix.Elem[0].Key["foo"] = "bar2"
 			notification.Update[0].Path.Elem[1].Key["name"] = "str2"
-			notification.Update[0].Val = &gnmi.TypedValue{Value: &gnmi.TypedValue_BoolVal{BoolVal: false}}
-			return server.Send(&gnmi.SubscribeResponse{Response: &gnmi.SubscribeResponse_Update{Update: notification}})
+			notification.Update[0].Val = &gnmiLib.TypedValue{Value: &gnmiLib.TypedValue_BoolVal{BoolVal: false}}
+			return server.Send(&gnmiLib.SubscribeResponse{Response: &gnmiLib.SubscribeResponse_Update{Update: notification}})
 		},
 		GRPCServer: grpcServer,
 	}
-	gnmi.RegisterGNMIServer(grpcServer, gnmiServer)
+	gnmiLib.RegisterGNMIServer(grpcServer, gnmiServer)
 
 	wg.Add(1)
 	go func() {

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -423,7 +423,7 @@ func TestSubscribeResponseError(t *testing.T) {
 	var mc uint32 = 7
 	ml := &MockLogger{}
 	plugin := &GNMI{Log: ml}
-	//nolint:staticcheck // TODO: FIX SA1019: gnmi.Error is deprecated: Do not use.
+	// TODO: FIX SA1019: gnmi.Error is deprecated: Do not use.
 	errorResponse := &gnmiLib.SubscribeResponse_Error{Error: &gnmiLib.Error{Message: me, Code: mc}}
 	plugin.handleSubscribeResponse("127.0.0.1:0", &gnmiLib.SubscribeResponse{Response: errorResponse})
 	require.NotEmpty(t, ml.lastFormat)

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -423,7 +423,7 @@ func TestSubscribeResponseError(t *testing.T) {
 	var mc uint32 = 7
 	ml := &MockLogger{}
 	plugin := &GNMI{Log: ml}
-	// TODO: FIX SA1019: gnmi.Error is deprecated: Do not use.
+	//nolint:staticcheck // TODO: FIX SA1019: gnmi.Error is deprecated: Do not use.
 	errorResponse := &gnmiLib.SubscribeResponse_Error{Error: &gnmiLib.Error{Message: me, Code: mc}}
 	plugin.handleSubscribeResponse("127.0.0.1:0", &gnmiLib.SubscribeResponse{Response: errorResponse})
 	require.NotEmpty(t, ml.lastFormat)


### PR DESCRIPTION
Following findings were fixed:
```
plugins/inputs/fail2ban/fail2ban_test.go:106:3            revive       deep-exit: calls to os.Exit only in main() or init() functions
plugins/inputs/fail2ban/fail2ban_test.go:112:3            revive       deep-exit: calls to os.Exit only in main() or init() functions
plugins/inputs/fail2ban/fail2ban_test.go:117:4            revive       deep-exit: calls to os.Exit only in main() or init() functions
plugins/inputs/fail2ban/fail2ban_test.go:121:4            revive       deep-exit: calls to os.Exit only in main() or init() functions
plugins/inputs/fail2ban/fail2ban_test.go:125:4            revive       deep-exit: calls to os.Exit only in main() or init() functions
plugins/inputs/fail2ban/fail2ban_test.go:130:2            revive       deep-exit: calls to os.Exit only in main() or init() functions
plugins/inputs/file/file_test.go:102:2                    ineffassign  ineffectual assignment to err
plugins/inputs/file/file_test.go:22:6                     ineffassign  ineffectual assignment to err
plugins/inputs/filecount/filesystem_helpers_test.go:56:2  staticcheck  SA4006: this value of `fileInfo` is never used
plugins/inputs/filecount/filesystem_helpers_test.go:59:2  staticcheck  SA4006: this value of `fileInfo` is never used
plugins/inputs/filestat/filestat.go:117:5                 revive       import-shadowing: The name 'md5' shadows an import name
plugins/inputs/filestat/filestat_test.go:201:2            ineffassign  ineffectual assignment to md5
plugins/inputs/fluentd/fluentd.go:66:3                    revive       bare-return: avoid using bare returns, please add return expressions
plugins/inputs/fluentd/fluentd.go:70:2                    nakedret     naked return in func `parse` with 10 lines of code
plugins/inputs/fluentd/fluentd_test.go:129:14             ineffassign  ineffectual assignment to err
plugins/inputs/github/github.go:184:1                     revive       confusing-results: unnamed results of the same type may be confusing, consider using named results
plugins/inputs/github/github.go:1:9                       revive       import-shadowing: The name 'github' shadows an import name
plugins/inputs/gnmi/gnmi.go:136:13                        revive       import-shadowing: The name 'path' shadows an import name
plugins/inputs/gnmi/gnmi.go:1:9                           revive       import-shadowing: The name 'gnmi' shadows an import name
plugins/inputs/gnmi/gnmi.go:328:9                         revive       import-shadowing: The name 'metric' shadows an import name
plugins/inputs/gnmi/gnmi.go:390:27                        revive       import-shadowing: The name 'path' shadows an import name
plugins/inputs/gnmi/gnmi.go:438:31                        revive       import-shadowing: The name 'path' shadows an import name
plugins/inputs/gnmi/gnmi.go:54:2                          revive       confusing-naming: Field 'aliases' differs only by capitalization to other field in the struct type GNMI
plugins/inputs/gnmi/gnmi_test.go:1:9                      revive       import-shadowing: The name 'gnmi' shadows an import name

```