### PR TITLE
Sqlserver input: require authentication method to be specified

### DIFF
--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -52,6 +52,10 @@ GO
     "Server=192.168.1.10;Port=1433;User Id=<user>;Password=<pw>;app name=telegraf;log=1;",
   ]
 
+  ## Authentication method
+  ## valid methods: "default", "AAD"
+  # auth_method = "default"
+
   ## "database_type" enables a specific set of queries depending on the database type. If specified, it replaces azuredb = true/false and query_version = 2
   ## In the config file, the sql server plugin section should be repeated each with a set of servers for a specific database_type.
   ## Possible values for database_type are - "AzureSQLDB" or "AzureSQLManagedInstance" or "SQLServer"
@@ -197,11 +201,12 @@ EXECUTE ('GRANT VIEW DATABASE STATE TO [<Monitoring_VM_Name>]')
 - On the SQL Server resource of the database(s) being monitored, go to "Firewalls and Virtual Networks" tab and allowlist the monitoring VM IP address.
 - On the Monitoring VM, update the telegraf config file with the database connection string in the following format. Please note AAD based auth is currently only supported for Azure SQL Database and Azure SQL Managed Instance (but not for SQL Server), as described [here](https://docs.microsoft.com/en-us/azure/azure-sql/database/security-overview#authentication).
 - On the Monitoring VM, update the telegraf config file with the database connection string in the following format.
-- On the Monitoring VM, update the telegraf config file with the database connection string in the following format. The connection string only provides the server and database name, but no password (since the VM's system-assigned managed identity would be used for authentication).
+- On the Monitoring VM, update the telegraf config file with the database connection string in the following format. The connection string only provides the server and database name, but no password (since the VM's system-assigned managed identity would be used for authentication). The auth method must be set to "AAD"
 ```toml
   servers = [
     "Server=<Azure_SQL_Server_Name>.database.windows.net;Port=1433;Database=<Azure_SQL_Database_Name>;app name=telegraf;log=1;",
   ]
+  auth_method = "AAD"
 ```
 - Please note AAD based auth is currently only supported for Azure SQL Database and Azure SQL Managed Instance (but not for SQL Server), as described [here](https://docs.microsoft.com/en-us/azure/azure-sql/database/security-overview#authentication).
 

--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -53,8 +53,8 @@ GO
   ]
 
   ## Authentication method
-  ## valid methods: "default", "AAD"
-  # auth_method = "default"
+  ## valid methods: "connection_string", "AAD"
+  # auth_method = "connection_string"
 
   ## "database_type" enables a specific set of queries depending on the database type. If specified, it replaces azuredb = true/false and query_version = 2
   ## In the config file, the sql server plugin section should be repeated each with a set of servers for a specific database_type.

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -82,8 +82,8 @@ servers = [
 ]
 
 ## Authentication method
-## valid methods: "default", "AAD"
-# auth_method = "default"
+## valid methods: "connection_string", "AAD"
+# auth_method = "connection_string"
 
 ## "database_type" enables a specific set of queries depending on the database type. If specified, it replaces azuredb = true/false and query_version = 2
 ## In the config file, the sql server plugin section should be repeated each with a set of servers for a specific database_type.
@@ -292,7 +292,7 @@ func (s *SQLServer) Start(acc telegraf.Accumulator) error {
 		var pool *sql.DB
 
 		switch strings.ToLower(s.AuthMethod) {
-		case "default":
+		case "connection_string":
 			// Use the DSN (connection string) directly. In this case,
 			// empty username/password causes use of Windows
 			// integrated authentication.
@@ -562,7 +562,7 @@ func init() {
 	inputs.Add("sqlserver", func() telegraf.Input {
 		return &SQLServer{
 			Servers:    []string{defaultServer},
-			AuthMethod: "default",
+			AuthMethod: "connection_string",
 		}
 	})
 }

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -81,6 +81,10 @@ servers = [
   "Server=192.168.1.10;Port=1433;User Id=<user>;Password=<pw>;app name=telegraf;log=1;",
 ]
 
+## Authentication method
+## valid methods: "default", "AAD"
+# auth_method = "default"
+
 ## "database_type" enables a specific set of queries depending on the database type. If specified, it replaces azuredb = true/false and query_version = 2
 ## In the config file, the sql server plugin section should be repeated each with a set of servers for a specific database_type.
 ## Possible values for database_type are - "AzureSQLDB" or "AzureSQLManagedInstance" or "SQLServer"

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -191,6 +191,7 @@ func TestSqlServer_HealthMetric(t *testing.T) {
 		Servers:      []string{fakeServer1, fakeServer2},
 		IncludeQuery: []string{"DatabaseSize", "MemoryClerk"},
 		HealthMetric: true,
+		AuthMethod:   "default",
 	}
 
 	s2 := &SQLServer{

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -191,12 +191,13 @@ func TestSqlServer_HealthMetric(t *testing.T) {
 		Servers:      []string{fakeServer1, fakeServer2},
 		IncludeQuery: []string{"DatabaseSize", "MemoryClerk"},
 		HealthMetric: true,
-		AuthMethod:   "default",
+		AuthMethod:   "connection_string",
 	}
 
 	s2 := &SQLServer{
 		Servers:      []string{fakeServer1},
 		IncludeQuery: []string{"DatabaseSize"},
+		AuthMethod:   "connection_string",
 	}
 
 	// acc1 should have the health metric because it is specified in the config


### PR DESCRIPTION
The sqlserver input plugin uses windows authentication (aka integrated security) when there is no username and password in the connection string.

#8822 added support for AAD authentication but only when there is no password in the connection string. Since the new check for no password happens before the previous connection logic, this causes windows authentication to be unavailable, which is a regression.

This PR adds a setting to enable AAD authentication. This allows use of windows authentication as before. It's backward compatible because the default of the new setting is the old behavior. New users who want to use AAD will to opt in to the new auth behavior by changing the setting to "AAD".

resolves #9362 
