### PR TITLE
Http plugin add cookie auth

### DIFF
--- a/plugins/common/cookie/cookie.go
+++ b/plugins/common/cookie/cookie.go
@@ -1,0 +1,91 @@
+package cookie
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+	"time"
+
+	"github.com/influxdata/telegraf/config"
+)
+
+type CookieAuthConfig struct {
+	URL    string `toml:"cookie_auth_url"`
+	Method string `toml:"cookie_auth_method"`
+
+	// HTTP Basic Auth Credentials
+	Username string `toml:"cookie_auth_username"`
+	Password string `toml:"cookie_auth_password"`
+
+	Body    string          `toml:"cookie_auth_body"`
+	Renewal config.Duration `toml:"cookie_auth_renewal"`
+
+	client *http.Client
+}
+
+func (c *CookieAuthConfig) Start(client *http.Client) (err error) {
+	c.client = client
+
+	c.setDefaults()
+
+	// add cookie jar to HTTP client
+	if c.client.Jar, err = cookiejar.New(nil); err != nil {
+		return err
+	}
+
+	// continual auth renewal
+	ticker := time.NewTicker(time.Duration(c.Renewal))
+	go func() {
+		for range ticker.C {
+			_ = c.auth()
+		}
+	}()
+
+	// initial auth will immediately error out the Init() if auth fails
+	return c.auth()
+}
+
+func (c *CookieAuthConfig) setDefaults() {
+	if c.Renewal == 0 {
+		c.Renewal = config.Duration(5 * time.Minute)
+	}
+	if c.Method == "" {
+		c.Method = http.MethodPost
+	}
+}
+
+func (c *CookieAuthConfig) auth() error {
+	var body io.ReadCloser
+	if c.Body != "" {
+		body = ioutil.NopCloser(strings.NewReader(c.Body))
+		defer body.Close()
+	}
+
+	req, err := http.NewRequest(c.Method, c.URL, body)
+	if err != nil {
+		return err
+	}
+
+	if c.Username != "" || c.Password != "" {
+		req.SetBasicAuth(c.Username, c.Password)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if _, err = io.Copy(ioutil.Discard, resp.Body); err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad response code: %v", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/plugins/common/cookie/cookie.go
+++ b/plugins/common/cookie/cookie.go
@@ -48,8 +48,8 @@ func (c *CookieAuthConfig) Start(client *http.Client, log telegraf.Logger) (err 
 		ticker := time.NewTicker(time.Duration(c.Renewal))
 		go func() {
 			for range ticker.C {
-				if err = c.auth(); err != nil {
-					log.Errorf("Error in plugin: [url=%v]: %v", c.URL, err)
+				if err := c.auth(); err != nil && log != nil {
+					log.Errorf("renewal failed for %q: %v", c.URL, err)
 				}
 			}
 		}()

--- a/plugins/common/cookie/cookie_test.go
+++ b/plugins/common/cookie/cookie_test.go
@@ -85,15 +85,15 @@ func (s fakeServer) checkResp(t *testing.T, expCode int) {
 	}
 }
 
-func (s fakeServer) checkAuthCount(t *testing.T, expCount int) {
+func (s fakeServer) checkAuthCount(t *testing.T, atLeast int32) {
 	t.Helper()
-	require.EqualValues(t, expCount, atomic.LoadInt32(s.int32))
+	require.GreaterOrEqual(t, atomic.LoadInt32(s.int32), atLeast)
 }
 
 func TestAuthConfig_Start(t *testing.T) {
 	const (
-		renewal      = 20 * time.Millisecond
-		renewalCheck = 55 * time.Millisecond
+		renewal      = 10 * time.Millisecond
+		renewalCheck = 5 * renewal
 	)
 	type fields struct {
 		Method   string

--- a/plugins/common/cookie/cookie_test.go
+++ b/plugins/common/cookie/cookie_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/cookie"
+	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -188,7 +189,7 @@ func TestAuthConfig_Start(t *testing.T) {
 				renewal:  renewal,
 				endpoint: authEndpointWithBasicAuth,
 			},
-			wantErr: fmt.Errorf("bad response code: 401"),
+			wantErr: fmt.Errorf("cookie auth renewal received status code: 401 (Unauthorized)"),
 			assert: func(t *testing.T, c *cookie.CookieAuthConfig, srv fakeServer) {
 				// should have never Cookie Authed
 				srv.checkAuthCount(t, 0)
@@ -229,7 +230,7 @@ func TestAuthConfig_Start(t *testing.T) {
 				renewal:  renewal,
 				endpoint: authEndpointWithBody,
 			},
-			wantErr: fmt.Errorf("bad response code: 401"),
+			wantErr: fmt.Errorf("cookie auth renewal received status code: 401 (Unauthorized)"),
 			assert: func(t *testing.T, c *cookie.CookieAuthConfig, srv fakeServer) {
 				// should have never Cookie Authed
 				srv.checkAuthCount(t, 0)
@@ -254,7 +255,7 @@ func TestAuthConfig_Start(t *testing.T) {
 				Renewal:  config.Duration(tt.args.renewal),
 			}
 
-			if err := c.Start(srv.Client()); tt.wantErr != nil {
+			if err := c.Start(srv.Client(), testutil.Logger{Name: "cookie_auth"}); tt.wantErr != nil {
 				require.EqualError(t, err, tt.wantErr.Error())
 			} else {
 				require.NoError(t, err)

--- a/plugins/common/cookie/cookie_test.go
+++ b/plugins/common/cookie/cookie_test.go
@@ -1,0 +1,248 @@
+package cookie_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/common/cookie"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	reqUser                   = "testUser"
+	reqPasswd                 = "testPassword"
+	reqBody                   = "a body"
+	authEndpoint              = "/auth"
+	authEndpointWithBasicAuth = "/authWithCreds"
+	authEndpointWithBody      = "/authWithBody"
+)
+
+var fakeCookie = &http.Cookie{
+	Name:  "test-cookie",
+	Value: "this is an auth cookie",
+}
+
+type fakeServer struct {
+	*httptest.Server
+	*int32
+}
+
+func newFakeServer(t *testing.T) fakeServer {
+	var c int32
+	return fakeServer{
+		Server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case authEndpoint:
+				atomic.AddInt32(&c, 1)        // increment auth counter
+				http.SetCookie(w, fakeCookie) // set fake cookie
+			case authEndpointWithBody:
+				body, err := ioutil.ReadAll(r.Body)
+				require.NoError(t, err)
+				if !cmp.Equal([]byte(reqBody), body) {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				atomic.AddInt32(&c, 1)        // increment auth counter
+				http.SetCookie(w, fakeCookie) // set fake cookie
+			case authEndpointWithBasicAuth:
+				u, p, ok := r.BasicAuth()
+				if !ok || u != reqUser || p != reqPasswd {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				atomic.AddInt32(&c, 1)        // increment auth counter
+				http.SetCookie(w, fakeCookie) // set fake cookie
+			default:
+				// ensure cookie exists on request
+				if _, err := r.Cookie(fakeCookie.Name); err != nil {
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
+				_, _ = w.Write([]byte("good test response"))
+			}
+		})),
+		int32: &c,
+	}
+}
+
+func (s fakeServer) checkResp(t *testing.T, expCode int) {
+	t.Helper()
+	resp, err := s.Client().Get(s.URL + "/endpoint")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, expCode, resp.StatusCode)
+
+	if expCode == http.StatusOK {
+		require.Len(t, resp.Request.Cookies(), 1)
+		require.Equal(t, "test-cookie", resp.Request.Cookies()[0].Name)
+	}
+}
+
+func (s fakeServer) checkAuthCount(t *testing.T, expCount int) {
+	require.EqualValues(t, expCount, atomic.LoadInt32(s.int32))
+}
+
+func TestAuthConfig_Start(t *testing.T) {
+	type fields struct {
+		Method   string
+		Username string
+		Password string
+		Body     string
+	}
+	type args struct {
+		renewal  time.Duration
+		endpoint string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr error
+		assert  func(t *testing.T, c *cookie.CookieAuthConfig, srv fakeServer)
+	}{
+		{
+			name:    "sets renewal default",
+			wantErr: fmt.Errorf("bad response code: 403"),
+			assert: func(t *testing.T, c *cookie.CookieAuthConfig, srv fakeServer) {
+				// default renewal set
+				require.EqualValues(t, 5*time.Minute, c.Renewal)
+				// should have never Cookie Authed
+				srv.checkAuthCount(t, 0)
+				srv.checkResp(t, http.StatusForbidden)
+			},
+		},
+		{
+			name: "success no creds, no body, default method",
+			args: args{
+				renewal:  20 * time.Millisecond,
+				endpoint: authEndpoint,
+			},
+			assert: func(t *testing.T, c *cookie.CookieAuthConfig, srv fakeServer) {
+				// should have Cookie Authed once
+				srv.checkAuthCount(t, 1)
+				// default method set
+				require.Equal(t, http.MethodPost, c.Method)
+				srv.checkResp(t, http.StatusOK)
+				time.Sleep(59 * time.Millisecond)
+				// should have Cookie Authed twice more
+				srv.checkAuthCount(t, 3)
+				srv.checkResp(t, http.StatusOK)
+			},
+		},
+		{
+			name: "success with creds, no body",
+			fields: fields{
+				Method:   http.MethodPost,
+				Username: reqUser,
+				Password: reqPasswd,
+			},
+			args: args{
+				renewal:  20 * time.Millisecond,
+				endpoint: authEndpointWithBasicAuth,
+			},
+			assert: func(t *testing.T, c *cookie.CookieAuthConfig, srv fakeServer) {
+				// should have Cookie Authed once
+				srv.checkAuthCount(t, 1)
+				srv.checkResp(t, http.StatusOK)
+				time.Sleep(59 * time.Millisecond)
+				// should have Cookie Authed twice more
+				srv.checkAuthCount(t, 3)
+				srv.checkResp(t, http.StatusOK)
+			},
+		},
+		{
+			name: "failure with bad creds",
+			fields: fields{
+				Method:   http.MethodPost,
+				Username: reqUser,
+				Password: "a bad password",
+			},
+			args: args{
+				renewal:  20 * time.Millisecond,
+				endpoint: authEndpointWithBasicAuth,
+			},
+			wantErr: fmt.Errorf("bad response code: 401"),
+			assert: func(t *testing.T, c *cookie.CookieAuthConfig, srv fakeServer) {
+				// should have never Cookie Authed
+				srv.checkAuthCount(t, 0)
+				srv.checkResp(t, http.StatusForbidden)
+				time.Sleep(59 * time.Millisecond)
+				// should have still never Cookie Authed
+				srv.checkAuthCount(t, 0)
+				srv.checkResp(t, http.StatusForbidden)
+			},
+		},
+		{
+			name: "success with no creds, with good body",
+			fields: fields{
+				Method: http.MethodPost,
+				Body:   reqBody,
+			},
+			args: args{
+				renewal:  20 * time.Millisecond,
+				endpoint: authEndpointWithBody,
+			},
+			assert: func(t *testing.T, c *cookie.CookieAuthConfig, srv fakeServer) {
+				// should have Cookie Authed once
+				srv.checkAuthCount(t, 1)
+				srv.checkResp(t, http.StatusOK)
+				time.Sleep(59 * time.Millisecond)
+				// should have Cookie Authed twice more
+				srv.checkAuthCount(t, 3)
+				srv.checkResp(t, http.StatusOK)
+			},
+		},
+		{
+			name: "failure with bad body",
+			fields: fields{
+				Method: http.MethodPost,
+				Body:   "a bad body",
+			},
+			args: args{
+				renewal:  20 * time.Millisecond,
+				endpoint: authEndpointWithBody,
+			},
+			wantErr: fmt.Errorf("bad response code: 401"),
+			assert: func(t *testing.T, c *cookie.CookieAuthConfig, srv fakeServer) {
+				// should have never Cookie Authed
+				srv.checkAuthCount(t, 0)
+				srv.checkResp(t, http.StatusForbidden)
+				time.Sleep(59 * time.Millisecond)
+				// should have still never Cookie Authed
+				srv.checkAuthCount(t, 0)
+				srv.checkResp(t, http.StatusForbidden)
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newFakeServer(t)
+			c := &cookie.CookieAuthConfig{
+				URL:      srv.URL + tt.args.endpoint,
+				Method:   tt.fields.Method,
+				Username: tt.fields.Username,
+				Password: tt.fields.Password,
+				Body:     tt.fields.Body,
+				Renewal:  config.Duration(tt.args.renewal),
+			}
+
+			if err := c.Start(srv.Client()); tt.wantErr != nil {
+				require.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.assert != nil {
+				tt.assert(t, c, srv)
+			}
+		})
+	}
+}

--- a/plugins/common/cookie/cookie_test.go
+++ b/plugins/common/cookie/cookie_test.go
@@ -102,7 +102,7 @@ func (s fakeServer) checkAuthCount(t *testing.T, atLeast int32) {
 
 func TestAuthConfig_Start(t *testing.T) {
 	const (
-		renewal      = 10 * time.Millisecond
+		renewal      = 50 * time.Millisecond
 		renewalCheck = 5 * renewal
 	)
 	type fields struct {
@@ -151,7 +151,7 @@ func TestAuthConfig_Start(t *testing.T) {
 				require.Equal(t, http.MethodPost, c.Method)
 				srv.checkResp(t, http.StatusOK)
 				time.Sleep(renewalCheck)
-				// should have Cookie Authed twice more
+				// should have Cookie Authed at least twice more
 				srv.checkAuthCount(t, 3)
 				srv.checkResp(t, http.StatusOK)
 			},
@@ -172,7 +172,7 @@ func TestAuthConfig_Start(t *testing.T) {
 				srv.checkAuthCount(t, 1)
 				srv.checkResp(t, http.StatusOK)
 				time.Sleep(renewalCheck)
-				// should have Cookie Authed twice more
+				// should have Cookie Authed at least twice more
 				srv.checkAuthCount(t, 3)
 				srv.checkResp(t, http.StatusOK)
 			},
@@ -214,7 +214,7 @@ func TestAuthConfig_Start(t *testing.T) {
 				srv.checkAuthCount(t, 1)
 				srv.checkResp(t, http.StatusOK)
 				time.Sleep(renewalCheck)
-				// should have Cookie Authed twice more
+				// should have Cookie Authed at least twice more
 				srv.checkAuthCount(t, 3)
 				srv.checkResp(t, http.StatusOK)
 			},

--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/cookie"
 	oauthConfig "github.com/influxdata/telegraf/plugins/common/oauth"
@@ -23,7 +24,7 @@ type HTTPClientConfig struct {
 	cookie.CookieAuthConfig
 }
 
-func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, error) {
+func (h *HTTPClientConfig) CreateClient(ctx context.Context, log telegraf.Logger) (*http.Client, error) {
 	tlsCfg, err := h.ClientConfig.TLSConfig()
 	if err != nil {
 		return nil, err
@@ -53,7 +54,7 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, erro
 	client = h.OAuth2Config.CreateOauth2Client(ctx, client)
 
 	if h.CookieAuthConfig.URL != "" {
-		if err := h.CookieAuthConfig.Start(client); err != nil {
+		if err := h.CookieAuthConfig.Start(client, log); err != nil {
 			return nil, err
 		}
 	}

--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/common/cookie"
 	oauthConfig "github.com/influxdata/telegraf/plugins/common/oauth"
 	"github.com/influxdata/telegraf/plugins/common/proxy"
 	"github.com/influxdata/telegraf/plugins/common/tls"
@@ -19,6 +20,7 @@ type HTTPClientConfig struct {
 	proxy.HTTPProxy
 	tls.ClientConfig
 	oauthConfig.OAuth2Config
+	cookie.CookieAuthConfig
 }
 
 func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, error) {
@@ -49,6 +51,12 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context) (*http.Client, erro
 	}
 
 	client = h.OAuth2Config.CreateOauth2Client(ctx, client)
+
+	if h.CookieAuthConfig.URL != "" {
+		if err := h.CookieAuthConfig.Start(client); err != nil {
+			return nil, err
+		}
+	}
 
 	return client, nil
 }

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -82,3 +82,7 @@ The default values below are added if the input format does not specify a value:
 - http
   - tags:
     - url
+
+### Optional Cookie Authentication Settings:
+
+The optional Cookie Authentication Settings will retrieve a cookie from the given authorization endpoint, and use it in subsequent API requests.  This is useful for services that do not provide OAuth or Basic Auth authentication, e.g. the [Tesla Powerwall API](https://www.tesla.com/support/energy/powerwall/own/monitoring-from-home-network), which uses a Cookie Auth Body to retrieve an authorization cookie.  The Cookie Auth Renewal interval will renew the authorization by retrieving a new cookie at the given interval.

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -22,12 +22,6 @@ The HTTP input plugin collects metrics from one or more HTTP(S) endpoints.  The 
   ## HTTP entity-body to send with POST/PUT requests.
   # body = ""
 
-  ## Cookie-based authentication
-  # cookie_auth_url = "https://localhost/authMe"
-  # cookie_auth_method = "POST" # default: POST
-  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
-  # cookie_auth_renewal = "8h" # default: "5m"
-
   ## HTTP Content-Encoding for write request body, can be set to "gzip" to
   ## compress body or "identity" to apply no encoding.
   # content_encoding = "identity"
@@ -55,6 +49,14 @@ The HTTP input plugin collects metrics from one or more HTTP(S) endpoints.  The 
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## Optional Cookie authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST"
+  # cookie_auth_username = "username"
+  # cookie_auth_password = "pa$$word"
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  # cookie_auth_renewal = "5m"
 
   ## Amount of time allowed to complete the HTTP request
   # timeout = "5s"

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -22,6 +22,12 @@ The HTTP input plugin collects metrics from one or more HTTP(S) endpoints.  The 
   ## HTTP entity-body to send with POST/PUT requests.
   # body = ""
 
+  ## Cookie-based authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST" # default: POST
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  # cookie_auth_renewal = "8h" # default: "5m"
+
   ## HTTP Content-Encoding for write request body, can be set to "gzip" to
   ## compress body or "identity" to apply no encoding.
   # content_encoding = "identity"

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -56,6 +56,7 @@ The HTTP input plugin collects metrics from one or more HTTP(S) endpoints.  The 
   # cookie_auth_username = "username"
   # cookie_auth_password = "pa$$word"
   # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
   # cookie_auth_renewal = "5m"
 
   ## Amount of time allowed to complete the HTTP request

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -90,6 +90,7 @@ var sampleConfig = `
   # cookie_auth_username = "username"
   # cookie_auth_password = "pa$$word"
   # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
   # cookie_auth_renewal = "5m"
 
   ## Amount of time allowed to complete the HTTP request

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -35,6 +35,7 @@ type HTTP struct {
 
 	client *http.Client
 	httpconfig.HTTPClientConfig
+	Log telegraf.Logger `toml:"-"`
 
 	// The parser will automatically be set by Telegraf core code because
 	// this plugin implements the ParserInput interface (i.e. the SetParser method)
@@ -118,7 +119,7 @@ func (*HTTP) Description() string {
 
 func (h *HTTP) Init() error {
 	ctx := context.Background()
-	client, err := h.HTTPClientConfig.CreateClient(ctx)
+	client, err := h.HTTPClientConfig.CreateClient(ctx, h.Log)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -6,14 +6,21 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/cookiejar"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
+)
+
+var (
+	defaultCookieAuthRenewal = 5 * time.Minute
+	defaultCookieAuthMethod  = http.MethodPost
 )
 
 type HTTP struct {
@@ -27,6 +34,12 @@ type HTTP struct {
 	// HTTP Basic Auth Credentials
 	Username string `toml:"username"`
 	Password string `toml:"password"`
+
+	// Cookie authentication
+	CookieAuthURL     string        `toml:"cookie_auth_url"`
+	CookieAuthMethod  string        `toml:"cookie_auth_method"`
+	CookieAuthBody    string        `toml:"cookie_auth_body"`
+	CookieAuthRenewal time.Duration `toml:"cookie_auth_renewal"`
 
 	// Absolute path to file with Bearer token
 	BearerToken string `toml:"bearer_token"`
@@ -63,6 +76,12 @@ var sampleConfig = `
 
   ## HTTP entity-body to send with POST/PUT requests.
   # body = ""
+
+  ## Cookie-based authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST" [default: POST]
+  # cookie_auth_body = {"username": "user", "password": "pa$$word", "authenticate": "me"}
+  # cookie_auth_renewal = 8h [default: 5m]
 
   ## HTTP Content-Encoding for write request body, can be set to "gzip" to
   ## compress body or "identity" to apply no encoding.
@@ -116,9 +135,64 @@ func (h *HTTP) Init() error {
 
 	h.client = client
 
+	if h.CookieAuthURL != "" {
+		// cookie auth defaults
+		if h.CookieAuthRenewal == 0 {
+			h.CookieAuthRenewal = defaultCookieAuthRenewal
+		}
+		if h.CookieAuthMethod == "" {
+			h.CookieAuthMethod = defaultCookieAuthMethod
+		}
+		// add cookie jar to HTTP client
+		if h.client.Jar, err = cookiejar.New(nil); err != nil {
+			return err
+		}
+		// start auth ticker
+		if authErr := h.startCookieAuth(); authErr != nil {
+			return authErr
+		}
+	}
+
 	// Set default as [200]
 	if len(h.SuccessStatusCodes) == 0 {
 		h.SuccessStatusCodes = []int{200}
+	}
+	return nil
+}
+
+func (h *HTTP) startCookieAuth() error {
+	// continual auth ticker
+	ticker := time.NewTicker(h.CookieAuthRenewal)
+	go func() {
+		for range ticker.C {
+			_ = h.doCookieAuth()
+		}
+	}()
+
+	// initial auth will immediately error out the Init() if auth fails
+	return h.doCookieAuth()
+}
+
+func (h *HTTP) doCookieAuth() error {
+	request, err := h.newRequest(h.CookieAuthURL, h.CookieAuthMethod, h.CookieAuthBody)
+	if err != nil {
+		return err
+	}
+	defer request.Body.Close()
+
+	errBadRespCode := fmt.Errorf("bad response code")
+	resp, respErr := h.client.Do(request)
+	if respErr != nil {
+		return respErr
+	}
+	if _, err = io.Copy(ioutil.Discard, resp.Body); err != nil {
+		return err
+	}
+	if err = resp.Body.Close(); err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: %v", errBadRespCode, resp.StatusCode)
 	}
 	return nil
 }
@@ -158,41 +232,11 @@ func (h *HTTP) gatherURL(
 	acc telegraf.Accumulator,
 	url string,
 ) error {
-	body, err := makeRequestBodyReader(h.ContentEncoding, h.Body)
+	request, err := h.newRequest(url, h.Method, h.Body)
 	if err != nil {
 		return err
 	}
-	defer body.Close()
-
-	request, err := http.NewRequest(h.Method, url, body)
-	if err != nil {
-		return err
-	}
-
-	if h.BearerToken != "" {
-		token, err := ioutil.ReadFile(h.BearerToken)
-		if err != nil {
-			return err
-		}
-		bearer := "Bearer " + strings.Trim(string(token), "\n")
-		request.Header.Set("Authorization", bearer)
-	}
-
-	if h.ContentEncoding == "gzip" {
-		request.Header.Set("Content-Encoding", "gzip")
-	}
-
-	for k, v := range h.Headers {
-		if strings.ToLower(k) == "host" {
-			request.Host = v
-		} else {
-			request.Header.Add(k, v)
-		}
-	}
-
-	if h.Username != "" || h.Password != "" {
-		request.SetBasicAuth(h.Username, h.Password)
-	}
+	defer request.Body.Close()
 
 	resp, err := h.client.Do(request)
 	if err != nil {
@@ -235,8 +279,46 @@ func (h *HTTP) gatherURL(
 	return nil
 }
 
+func (h *HTTP) newRequest(url, method, body string) (*http.Request, error) {
+	bodyRC, err := makeRequestBodyReader(h.ContentEncoding, body)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequest(method, url, bodyRC)
+	if err != nil {
+		return nil, err
+	}
+
+	if h.BearerToken != "" {
+		token, err := ioutil.ReadFile(h.BearerToken)
+		if err != nil {
+			return nil, err
+		}
+		bearer := "Bearer " + strings.Trim(string(token), "\n")
+		request.Header.Set("Authorization", bearer)
+	}
+
+	if h.ContentEncoding == "gzip" {
+		request.Header.Set("Content-Encoding", "gzip")
+	}
+
+	for k, v := range h.Headers {
+		if strings.ToLower(k) == "host" {
+			request.Host = v
+		} else {
+			request.Header.Add(k, v)
+		}
+	}
+
+	if h.Username != "" || h.Password != "" {
+		request.SetBasicAuth(h.Username, h.Password)
+	}
+	return request, nil
+}
+
 func makeRequestBodyReader(contentEncoding, body string) (io.ReadCloser, error) {
-	var reader io.Reader = strings.NewReader(body)
+	reader := strings.NewReader(body)
 	if contentEncoding == "gzip" {
 		rc, err := internal.CompressWithGzip(reader)
 		if err != nil {

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -80,9 +80,9 @@ var sampleConfig = `
 
   ## Cookie-based authentication
   # cookie_auth_url = "https://localhost/authMe"
-  # cookie_auth_method = "POST" [default: POST]
+  # cookie_auth_method = "POST" # default: POST
   # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
-  # cookie_auth_renewal = '8h' [default: '5m']
+  # cookie_auth_renewal = "8h" # default: "5m"
 
   ## HTTP Content-Encoding for write request body, can be set to "gzip" to
   ## compress body or "identity" to apply no encoding.

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	oauth "github.com/influxdata/telegraf/plugins/common/oauth"
@@ -333,4 +334,59 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestHTTPwithCookieAuth(t *testing.T) {
+	testCookie := &http.Cookie{
+		Name:  "test-cookie",
+		Value: "this is an auth cookie",
+	}
+	var authCount int
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/endpoint" {
+			_, err := r.Cookie("test-cookie")
+			require.NoError(t, err)
+			_, _ = w.Write([]byte(simpleJSON))
+		} else if r.URL.Path == "/auth" {
+			authCount++
+			http.SetCookie(w, testCookie)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer fakeServer.Close()
+
+	url := fakeServer.URL + "/endpoint"
+	plugin := &plugin.HTTP{
+		URLs:              []string{url},
+		CookieAuthURL:     fakeServer.URL + "/auth",
+		CookieAuthRenewal: 20 * time.Millisecond,
+	}
+	metricName := "metricName"
+
+	p, _ := parsers.NewParser(&parsers.Config{
+		DataFormat: "json",
+		MetricName: "metricName",
+	})
+	plugin.SetParser(p)
+
+	require.NoError(t, plugin.Init())
+	require.Equal(t, 1, authCount)
+	require.Equal(t, http.MethodPost, plugin.CookieAuthMethod)
+
+	// wait for cookie auth renewal
+	time.Sleep(59 * time.Millisecond)
+	require.Equal(t, 3, authCount)
+
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(plugin.Gather))
+	require.Len(t, acc.Metrics, 1)
+
+	// basic check to see if we got the right field, value and tag
+	var metric = acc.Metrics[0]
+	require.Equal(t, metric.Measurement, metricName)
+	require.Len(t, acc.Metrics[0].Fields, 1)
+	require.Equal(t, acc.Metrics[0].Fields["a"], 1.2)
+	require.Equal(t, acc.Metrics[0].Tags["url"], url)
+
 }

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/influxdata/telegraf/config"
+
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	oauth "github.com/influxdata/telegraf/plugins/common/oauth"
 	plugin "github.com/influxdata/telegraf/plugins/inputs/http"
@@ -360,7 +362,7 @@ func TestHTTPwithCookieAuth(t *testing.T) {
 	plugin := &plugin.HTTP{
 		URLs:              []string{url},
 		CookieAuthURL:     fakeServer.URL + "/auth",
-		CookieAuthRenewal: 20 * time.Millisecond,
+		CookieAuthRenewal: config.Duration(20 * time.Millisecond),
 	}
 	metricName := "metricName"
 

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -63,3 +63,7 @@ data formats. For data_formats that support batching, metrics are sent in batch 
   ## Zero means no limit.
   # idle_conn_timeout = 0
 ```
+
+### Optional Cookie Authentication Settings:
+
+The optional Cookie Authentication Settings will retrieve a cookie from the given authorization endpoint, and use it in subsequent API requests.  This is useful for services that do not provide OAuth or Basic Auth authentication, e.g. the [Tesla Powerwall API](https://www.tesla.com/support/energy/powerwall/own/monitoring-from-home-network), which uses a Cookie Auth Body to retrieve an authorization cookie.  The Cookie Auth Renewal interval will renew the authorization by retrieving a new cookie at the given interval.

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -34,6 +34,14 @@ data formats. For data_formats that support batching, metrics are sent in batch 
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
+  ## Optional Cookie authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST"
+  # cookie_auth_username = "username"
+  # cookie_auth_password = "pa$$word"
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  # cookie_auth_renewal = "5m"
+
   ## Data format to output.
   ## Each data format has it's own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -40,6 +40,7 @@ data formats. For data_formats that support batching, metrics are sent in batch 
   # cookie_auth_username = "username"
   # cookie_auth_password = "pa$$word"
   # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
   # cookie_auth_renewal = "5m"
 
   ## Data format to output.

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -94,6 +94,7 @@ type HTTP struct {
 	ContentEncoding string            `toml:"content_encoding"`
 	tls.ClientConfig
 	httpconfig.HTTPClientConfig
+	Log telegraf.Logger `toml:"-"`
 
 	client     *http.Client
 	serializer serializers.Serializer
@@ -113,7 +114,7 @@ func (h *HTTP) Connect() error {
 	}
 
 	ctx := context.Background()
-	client, err := h.HTTPClientConfig.CreateClient(ctx)
+	client, err := h.HTTPClientConfig.CreateClient(ctx, h.Log)
 	if err != nil {
 		return err
 	}

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -49,6 +49,14 @@ var sampleConfig = `
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
+  ## Optional Cookie authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST"
+  # cookie_auth_username = "username"
+  # cookie_auth_password = "pa$$word"
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  # cookie_auth_renewal = "5m"
+
   ## Data format to output.
   ## Each data format has it's own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -55,6 +55,7 @@ var sampleConfig = `
   # cookie_auth_username = "username"
   # cookie_auth_password = "pa$$word"
   # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
   # cookie_auth_renewal = "5m"
 
   ## Data format to output.


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #5932

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

1. Added a few configuration options for `inputs.http` cookie auth: 
   auth url 
   body 
   method
   refresh interval
2. HTTP Client is updated to use a CookieJar
3. During plugin `Init()`, a initial auth is attempted and is successful, a Go routine is fired off for cookie auth renewal