### PR TITLE
Fix schema mess-up for x509 with https

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -102,14 +102,15 @@ func (c *X509Cert) serverName(u *url.URL) (string, error) {
 }
 
 func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certificate, error) {
+	protocol := u.Scheme
 	switch u.Scheme {
 	case "https":
-		u.Scheme = "tcp"
+		protocol = "tcp"
 		fallthrough
 	case "udp", "udp4", "udp6":
 		fallthrough
 	case "tcp", "tcp4", "tcp6":
-		ipConn, err := net.DialTimeout(u.Scheme, u.Host, timeout)
+		ipConn, err := net.DialTimeout(protocol, u.Host, timeout)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Required for all PRs:
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

When using the x509_cert plugin with `https` sources, the `source` tag should contain the specified source. However, in #6952 we messed up that tag by unintentionally changing the scheme of the source to `tcp` for `https` sources as described in #9384. The present PR fixes this issue by _not_ messing with the scheme directly.

**Please note: This PR is based on  and should be merged after #9289!**

resolves #9384