### PR TITLE
Fix inconsistent metric types in mysql

### DIFF
--- a/plugins/inputs/mysql/v2/convert.go
+++ b/plugins/inputs/mysql/v2/convert.go
@@ -21,12 +21,20 @@ func ParseInt(value sql.RawBytes) (interface{}, error) {
 	return v, err
 }
 
+func ParseUint(value sql.RawBytes) (interface{}, error) {
+	return strconv.ParseUint(string(value), 10, 64)
+}
+
 func ParseBoolAsInteger(value sql.RawBytes) (interface{}, error) {
 	if bytes.EqualFold(value, []byte("YES")) || bytes.EqualFold(value, []byte("ON")) {
 		return int64(1), nil
 	}
 
 	return int64(0), nil
+}
+
+func ParseString(value sql.RawBytes) (interface{}, error) {
+	return string(value), nil
 }
 
 func ParseGTIDMode(value sql.RawBytes) (interface{}, error) {
@@ -70,12 +78,27 @@ func ParseValue(value sql.RawBytes) (interface{}, error) {
 }
 
 var GlobalStatusConversions = map[string]ConversionFunc{
-	"ssl_ctx_verify_depth": ParseInt,
-	"ssl_verify_depth":     ParseInt,
+	"innodb_available_undo_logs":    ParseUint,
+	"innodb_buffer_pool_pages_misc": ParseUint,
+	"innodb_data_pending_fsyncs":    ParseUint,
+	"ssl_ctx_verify_depth":          ParseUint,
+	"ssl_verify_depth":              ParseUint,
 }
 
 var GlobalVariableConversions = map[string]ConversionFunc{
-	"gtid_mode": ParseGTIDMode,
+	"delay_key_write":                  ParseString,        // ON, OFF, ALL
+	"enforce_gtid_consistency":         ParseString,        // ON, OFF, WARN
+	"event_scheduler":                  ParseBoolAsInteger, // YES, NO, DISABLED
+	"gtid_mode":                        ParseGTIDMode,
+	"have_openssl":                     ParseBoolAsInteger, // alias for have_ssl
+	"have_ssl":                         ParseBoolAsInteger, // YES, DISABLED
+	"have_symlink":                     ParseBoolAsInteger, // YES, NO, DISABLED
+	"session_track_gtids":              ParseString,
+	"session_track_transaction_info":   ParseString,
+	"slave_skip_errors":                ParseString,
+	"ssl_fips_mode":                    ParseString,
+	"transaction_write_set_extraction": ParseString,
+	"use_secondary_engine":             ParseString,
 }
 
 func ConvertGlobalStatus(key string, value sql.RawBytes) (interface{}, error) {


### PR DESCRIPTION
Fixed two issues with inconsistent metric types in mysql:

* mysql variables that are stored as uint64 in mysql and are too big for int64 (currently parsed as float by telegraf)
* mysql variables with "ON", "OFF" and other string values (currently parsed as integer for "ON"/"OFF" and string otherwise)

The fix included uint parsing (if int fails) and a mapping for some MySQL statuses/variables, pinning them to a specific type.

Note that InfluxDB 1.x doesn't support uint, so outputted values will be capped to max int, but that's a problem with the InfluxDB plugin and not MySQL. (Possible fix: add influxdb option to output uints as floats).

Fixes #8319, #5711, #5055, #7421

See #5529, #6624

This could be easily extended to fix #6671 as well.