### PR TITLE
feat: Support AWS Web Identity Provider

### DIFF
--- a/config/aws/credentials.go
+++ b/config/aws/credentials.go
@@ -9,16 +9,16 @@ import (
 )
 
 type CredentialConfig struct {
-	Region               string
-	AccessKey            string
-	SecretKey            string
-	RoleARN              string
-	Profile              string
-	Filename             string
-	Token                string
-	EndpointURL          string
-	RoleSessionName      string
-	WebIdentityTokenFile string
+	Region               string `toml:"region"`
+	AccessKey            string `toml:"access_key"`
+	SecretKey            string `toml:"secret_key"`
+	RoleARN              string `toml:"role_arn"`
+	Profile              string `toml:"profile"`
+	Filename             string `toml:"shared_credential_file"`
+	Token                string `toml:"token"`
+	EndpointURL          string `toml:"endpoint_url"`
+	RoleSessionName      string `toml:"role_session_name"`
+	WebIdentityTokenFile string `toml:"web_identity_token_file"`
 }
 
 func (c *CredentialConfig) Credentials() client.ConfigProvider {

--- a/config/aws/credentials.go
+++ b/config/aws/credentials.go
@@ -9,14 +9,16 @@ import (
 )
 
 type CredentialConfig struct {
-	Region      string
-	AccessKey   string
-	SecretKey   string
-	RoleARN     string
-	Profile     string
-	Filename    string
-	Token       string
-	EndpointURL string
+	Region               string
+	AccessKey            string
+	SecretKey            string
+	RoleARN              string
+	Profile              string
+	Filename             string
+	Token                string
+	EndpointURL          string
+	RoleSessionName      string
+	WebIdentityTokenFile string
 }
 
 func (c *CredentialConfig) Credentials() client.ConfigProvider {
@@ -49,6 +51,12 @@ func (c *CredentialConfig) assumeCredentials() client.ConfigProvider {
 		Region:   aws.String(c.Region),
 		Endpoint: &c.EndpointURL,
 	}
-	config.Credentials = stscreds.NewCredentials(rootCredentials, c.RoleARN)
+
+	if c.WebIdentityTokenFile != "" {
+		config.Credentials = stscreds.NewWebIdentityCredentials(rootCredentials, c.RoleARN, c.RoleSessionName, c.WebIdentityTokenFile)
+	} else {
+		config.Credentials = stscreds.NewCredentials(rootCredentials, c.RoleARN)
+	}
+
 	return session.New(config)
 }

--- a/plugins/inputs/cloudwatch/README.md
+++ b/plugins/inputs/cloudwatch/README.md
@@ -23,18 +23,20 @@ API endpoint. In the following order the plugin will attempt to authenticate.
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) Assumed credentials via STS if role_arn is specified
-  ## 2) explicit credentials from 'access_key' and 'secret_key'
-  ## 3) shared profile from 'profile'
-  ## 4) environment variables
-  ## 5) shared credentials file
-  ## 6) EC2 Instance Profile
-  # access_key = ""
-  # secret_key = ""
-  # token = ""
-  # role_arn = ""
-  # profile = ""
-  # shared_credential_file = ""
+  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 2) Assumed credentials via STS if role_arn is specified
+  ## 3) explicit credentials from 'access_key' and 'secret_key'
+  ## 4) shared profile from 'profile'
+  ## 5) environment variables
+  ## 6) shared credentials file
+  ## 7) EC2 Instance Profile
+  #access_key = ""
+  #secret_key = ""
+  #token = ""
+  #role_arn = ""
+  #web_identity_token_file = ""
+  #profile = ""
+  #shared_credential_file = ""
 
   ## Endpoint to make request against, the correct endpoint is automatically
   ## determined and this option should only be set if you wish to override the

--- a/plugins/inputs/cloudwatch/README.md
+++ b/plugins/inputs/cloudwatch/README.md
@@ -35,6 +35,7 @@ API endpoint. In the following order the plugin will attempt to authenticate.
   #token = ""
   #role_arn = ""
   #web_identity_token_file = ""
+  #role_session_name = ""
   #profile = ""
   #shared_credential_file = ""
 

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -98,7 +98,8 @@ func (c *CloudWatch) SampleConfig() string {
   # secret_key = ""
   # token = ""
   # role_arn = ""
-  #web_identity_token_file = ""
+  # web_identity_token_file = ""
+  # role_session_name = ""
   # profile = ""
   # shared_credential_file = ""
 

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -25,14 +25,6 @@ import (
 
 // CloudWatch contains the configuration and cache for the cloudwatch plugin.
 type CloudWatch struct {
-	Region           string          `toml:"region"`
-	AccessKey        string          `toml:"access_key"`
-	SecretKey        string          `toml:"secret_key"`
-	RoleARN          string          `toml:"role_arn"`
-	Profile          string          `toml:"profile"`
-	CredentialPath   string          `toml:"shared_credential_file"`
-	Token            string          `toml:"token"`
-	EndpointURL      string          `toml:"endpoint_url"`
 	StatisticExclude []string        `toml:"statistic_exclude"`
 	StatisticInclude []string        `toml:"statistic_include"`
 	Timeout          config.Duration `toml:"timeout"`
@@ -55,6 +47,8 @@ type CloudWatch struct {
 	queryDimensions map[string]*map[string]string
 	windowStart     time.Time
 	windowEnd       time.Time
+
+	internalaws.CredentialConfig
 }
 
 // Metric defines a simplified Cloudwatch metric.
@@ -258,18 +252,6 @@ func (c *CloudWatch) Gather(acc telegraf.Accumulator) error {
 }
 
 func (c *CloudWatch) initializeCloudWatch() error {
-	credentialConfig := &internalaws.CredentialConfig{
-		Region:      c.Region,
-		AccessKey:   c.AccessKey,
-		SecretKey:   c.SecretKey,
-		RoleARN:     c.RoleARN,
-		Profile:     c.Profile,
-		Filename:    c.CredentialPath,
-		Token:       c.Token,
-		EndpointURL: c.EndpointURL,
-	}
-	configProvider := credentialConfig.Credentials()
-
 	proxy, err := c.HTTPProxy.Proxy()
 	if err != nil {
 		return err
@@ -295,7 +277,7 @@ func (c *CloudWatch) initializeCloudWatch() error {
 	}
 
 	loglevel := aws.LogOff
-	c.client = cwClient.New(configProvider, cfg.WithLogLevel(loglevel))
+	c.client = cwClient.New(c.CredentialConfig.Credentials(), cfg.WithLogLevel(loglevel))
 
 	// Initialize regex matchers for each Dimension value.
 	for _, m := range c.Metrics {

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -87,16 +87,18 @@ func (c *CloudWatch) SampleConfig() string {
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) Assumed credentials via STS if role_arn is specified
-  ## 2) explicit credentials from 'access_key' and 'secret_key'
-  ## 3) shared profile from 'profile'
-  ## 4) environment variables
-  ## 5) shared credentials file
-  ## 6) EC2 Instance Profile
+  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 2) Assumed credentials via STS if role_arn is specified
+  ## 3) explicit credentials from 'access_key' and 'secret_key'
+  ## 4) shared profile from 'profile'
+  ## 5) environment variables
+  ## 6) shared credentials file
+  ## 7) EC2 Instance Profile
   # access_key = ""
   # secret_key = ""
   # token = ""
   # role_arn = ""
+  #web_identity_token_file = ""
   # profile = ""
   # shared_credential_file = ""
 

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/config"
+	internalaws "github.com/influxdata/telegraf/config/aws"
 	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/plugins/common/proxy"
 	"github.com/influxdata/telegraf/testutil"
@@ -105,7 +106,9 @@ func TestGather(t *testing.T) {
 	duration, _ := time.ParseDuration("1m")
 	internalDuration := config.Duration(duration)
 	c := &CloudWatch{
-		Region:    "us-east-1",
+		CredentialConfig: internalaws.CredentialConfig{
+			Region: "us-east-1",
+		},
 		Namespace: "AWS/ELB",
 		Delay:     internalDuration,
 		Period:    internalDuration,
@@ -189,7 +192,9 @@ func TestSelectMetrics(t *testing.T) {
 	duration, _ := time.ParseDuration("1m")
 	internalDuration := config.Duration(duration)
 	c := &CloudWatch{
-		Region:    "us-east-1",
+		CredentialConfig: internalaws.CredentialConfig{
+			Region: "us-east-1",
+		},
 		Namespace: "AWS/ELB",
 		Delay:     internalDuration,
 		Period:    internalDuration,

--- a/plugins/inputs/kinesis_consumer/README.md
+++ b/plugins/inputs/kinesis_consumer/README.md
@@ -13,16 +13,18 @@ and creates metrics using one of the supported [input data formats][].
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) Assumed credentials via STS if role_arn is specified
-  ## 2) explicit credentials from 'access_key' and 'secret_key'
-  ## 3) shared profile from 'profile'
-  ## 4) environment variables
-  ## 5) shared credentials file
-  ## 6) EC2 Instance Profile
+  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 2) Assumed credentials via STS if role_arn is specified
+  ## 3) explicit credentials from 'access_key' and 'secret_key'
+  ## 4) shared profile from 'profile'
+  ## 5) environment variables
+  ## 6) shared credentials file
+  ## 7) EC2 Instance Profile
   # access_key = ""
   # secret_key = ""
   # token = ""
   # role_arn = ""
+  #web_identity_token_file = ""
   # profile = ""
   # shared_credential_file = ""
 

--- a/plugins/inputs/kinesis_consumer/README.md
+++ b/plugins/inputs/kinesis_consumer/README.md
@@ -24,7 +24,8 @@ and creates metrics using one of the supported [input data formats][].
   # secret_key = ""
   # token = ""
   # role_arn = ""
-  #web_identity_token_file = ""
+  # web_identity_token_file = ""
+  # role_session_name = ""
   # profile = ""
   # shared_credential_file = ""
 

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -79,16 +79,18 @@ var sampleConfig = `
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) Assumed credentials via STS if role_arn is specified
-  ## 2) explicit credentials from 'access_key' and 'secret_key'
-  ## 3) shared profile from 'profile'
-  ## 4) environment variables
-  ## 5) shared credentials file
-  ## 6) EC2 Instance Profile
+  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 2) Assumed credentials via STS if role_arn is specified
+  ## 3) explicit credentials from 'access_key' and 'secret_key'
+  ## 4) shared profile from 'profile'
+  ## 5) environment variables
+  ## 6) shared credentials file
+  ## 7) EC2 Instance Profile
   # access_key = ""
   # secret_key = ""
   # token = ""
   # role_arn = ""
+  #web_identity_token_file = ""
   # profile = ""
   # shared_credential_file = ""
 

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -90,7 +90,8 @@ var sampleConfig = `
   # secret_key = ""
   # token = ""
   # role_arn = ""
-  #web_identity_token_file = ""
+  # web_identity_token_file = ""
+  # role_session_name = ""
   # profile = ""
   # shared_credential_file = ""
 

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -30,14 +30,6 @@ type (
 	}
 
 	KinesisConsumer struct {
-		Region                 string    `toml:"region"`
-		AccessKey              string    `toml:"access_key"`
-		SecretKey              string    `toml:"secret_key"`
-		RoleARN                string    `toml:"role_arn"`
-		Profile                string    `toml:"profile"`
-		Filename               string    `toml:"shared_credential_file"`
-		Token                  string    `toml:"token"`
-		EndpointURL            string    `toml:"endpoint_url"`
 		StreamName             string    `toml:"streamname"`
 		ShardIteratorType      string    `toml:"shard_iterator_type"`
 		DynamoDB               *DynamoDB `toml:"checkpoint_dynamodb"`
@@ -62,6 +54,8 @@ type (
 		processContentEncodingFunc processContent
 
 		lastSeqNum *big.Int
+
+		internalaws.CredentialConfig
 	}
 
 	checkpoint struct {
@@ -156,18 +150,7 @@ func (k *KinesisConsumer) SetParser(parser parsers.Parser) {
 }
 
 func (k *KinesisConsumer) connect(ac telegraf.Accumulator) error {
-	credentialConfig := &internalaws.CredentialConfig{
-		Region:      k.Region,
-		AccessKey:   k.AccessKey,
-		SecretKey:   k.SecretKey,
-		RoleARN:     k.RoleARN,
-		Profile:     k.Profile,
-		Filename:    k.Filename,
-		Token:       k.Token,
-		EndpointURL: k.EndpointURL,
-	}
-	configProvider := credentialConfig.Credentials()
-	client := kinesis.New(configProvider)
+	client := kinesis.New(k.CredentialConfig.Credentials())
 
 	k.checkpoint = &noopCheckpoint{}
 	if k.DynamoDB != nil {

--- a/plugins/outputs/cloudwatch/README.md
+++ b/plugins/outputs/cloudwatch/README.md
@@ -14,6 +14,9 @@ API endpoint. In the following order the plugin will attempt to authenticate.
 6. [Shared Credentials](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file)
 7. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
+If you are using credentials from a web identity provider, you can specify the session name using `role_session_name`. If
+left empty, the current timestamp will be used.
+
 The IAM user needs only the `cloudwatch:PutMetricData` permission.
 
 ## Config

--- a/plugins/outputs/cloudwatch/README.md
+++ b/plugins/outputs/cloudwatch/README.md
@@ -6,12 +6,13 @@ This plugin will send metrics to Amazon CloudWatch.
 
 This plugin uses a credential chain for Authentication with the CloudWatch
 API endpoint. In the following order the plugin will attempt to authenticate.
-1. Assumed credentials via STS if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules)
-2. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
-3. Shared profile from `profile` attribute
-4. [Environment Variables](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#environment-variables)
-5. [Shared Credentials](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file)
-6. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+1. Web identity provider credentials via STS if `role_arn` and `web_identity_token_file` are specified
+2. Assumed credentials via STS if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules)
+3. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
+4. Shared profile from `profile` attribute
+5. [Environment Variables](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#environment-variables)
+6. [Shared Credentials](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file)
+7. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
 The IAM user needs only the `cloudwatch:PutMetricData` permission.
 

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -15,15 +15,6 @@ import (
 )
 
 type CloudWatch struct {
-	Region      string `toml:"region"`
-	AccessKey   string `toml:"access_key"`
-	SecretKey   string `toml:"secret_key"`
-	RoleARN     string `toml:"role_arn"`
-	Profile     string `toml:"profile"`
-	Filename    string `toml:"shared_credential_file"`
-	Token       string `toml:"token"`
-	EndpointURL string `toml:"endpoint_url"`
-
 	Namespace             string `toml:"namespace"` // CloudWatch Metrics Namespace
 	HighResolutionMetrics bool   `toml:"high_resolution_metrics"`
 	svc                   *cloudwatch.CloudWatch
@@ -31,6 +22,8 @@ type CloudWatch struct {
 	WriteStatistics bool `toml:"write_statistics"`
 
 	Log telegraf.Logger `toml:"-"`
+
+	internalaws.CredentialConfig
 }
 
 type statisticType int
@@ -202,18 +195,7 @@ func (c *CloudWatch) Description() string {
 }
 
 func (c *CloudWatch) Connect() error {
-	credentialConfig := &internalaws.CredentialConfig{
-		Region:      c.Region,
-		AccessKey:   c.AccessKey,
-		SecretKey:   c.SecretKey,
-		RoleARN:     c.RoleARN,
-		Profile:     c.Profile,
-		Filename:    c.Filename,
-		Token:       c.Token,
-		EndpointURL: c.EndpointURL,
-	}
-	configProvider := credentialConfig.Credentials()
-	c.svc = cloudwatch.New(configProvider)
+	c.svc = cloudwatch.New(c.CredentialConfig.Credentials())
 	return nil
 }
 

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -164,6 +164,7 @@ var sampleConfig = `
   #token = ""
   #role_arn = ""
   #web_identity_token_file = ""
+  #role_session_name = ""
   #profile = ""
   #shared_credential_file = ""
 

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -152,16 +152,18 @@ var sampleConfig = `
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) Assumed credentials via STS if role_arn is specified
-  ## 2) explicit credentials from 'access_key' and 'secret_key'
-  ## 3) shared profile from 'profile'
-  ## 4) environment variables
-  ## 5) shared credentials file
-  ## 6) EC2 Instance Profile
+  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 2) Assumed credentials via STS if role_arn is specified
+  ## 3) explicit credentials from 'access_key' and 'secret_key'
+  ## 4) shared profile from 'profile'
+  ## 5) environment variables
+  ## 6) shared credentials file
+  ## 7) EC2 Instance Profile
   #access_key = ""
   #secret_key = ""
   #token = ""
   #role_arn = ""
+  #web_identity_token_file = ""
   #profile = ""
   #shared_credential_file = ""
 

--- a/plugins/outputs/cloudwatch_logs/README.md
+++ b/plugins/outputs/cloudwatch_logs/README.md
@@ -35,16 +35,19 @@ The IAM user needs the following permissions ( https://docs.aws.amazon.com/Amazo
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) Assumed credentials via STS if role_arn is specified
-  ## 2) explicit credentials from 'access_key' and 'secret_key'
-  ## 3) shared profile from 'profile'
-  ## 4) environment variables
-  ## 5) shared credentials file
-  ## 6) EC2 Instance Profile
+  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 2) Assumed credentials via STS if role_arn is specified
+  ## 3) explicit credentials from 'access_key' and 'secret_key'
+  ## 4) shared profile from 'profile'
+  ## 5) environment variables
+  ## 6) shared credentials file
+  ## 7) EC2 Instance Profile
   #access_key = ""
   #secret_key = ""
   #token = ""
   #role_arn = ""
+  #web_identity_token_file = ""
+  #role_session_name = ""
   #profile = ""
   #shared_credential_file = ""
   

--- a/plugins/outputs/cloudwatch_logs/README.md
+++ b/plugins/outputs/cloudwatch_logs/README.md
@@ -6,12 +6,13 @@ This plugin will send logs to Amazon CloudWatch.
 
 This plugin uses a credential chain for Authentication with the CloudWatch Logs
 API endpoint. In the following order the plugin will attempt to authenticate.
-1. Assumed credentials via STS if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules)
-2. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
-3. Shared profile from `profile` attribute
-4. [Environment Variables](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#environment-variables)
-5. [Shared Credentials](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file)
-6. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+1. Web identity provider credentials via STS if `role_arn` and `web_identity_token_file` are specified
+2. Assumed credentials via STS if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules)
+3. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
+4. Shared profile from `profile` attribute
+5. [Environment Variables](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#environment-variables)
+6. [Shared Credentials](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file)
+7. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
 The IAM user needs the following permissions ( https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/permissions-reference-cwl.html):
 - `logs:DescribeLogGroups` - required for check if configured log group exist	

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
@@ -96,6 +96,7 @@ region = "us-east-1"
 #token = ""
 #role_arn = ""
 #web_identity_token_file = ""
+#role_session_name = ""
 #profile = ""
 #shared_credential_file = ""
 

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
@@ -33,15 +33,6 @@ type cloudWatchLogs interface {
 
 // CloudWatchLogs plugin object definition
 type CloudWatchLogs struct {
-	Region      string `toml:"region"`
-	AccessKey   string `toml:"access_key"`
-	SecretKey   string `toml:"secret_key"`
-	RoleARN     string `toml:"role_arn"`
-	Profile     string `toml:"profile"`
-	Filename    string `toml:"shared_credential_file"`
-	Token       string `toml:"token"`
-	EndpointURL string `toml:"endpoint_url"`
-
 	LogGroup string                   `toml:"log_group"`
 	lg       *cloudwatchlogs.LogGroup //log group data
 
@@ -59,6 +50,8 @@ type CloudWatchLogs struct {
 	svc cloudWatchLogs //cloudwatch logs service
 
 	Log telegraf.Logger `toml:"-"`
+
+	internalaws.CredentialConfig
 }
 
 const (
@@ -191,19 +184,7 @@ func (c *CloudWatchLogs) Connect() error {
 	var logGroupsOutput = &cloudwatchlogs.DescribeLogGroupsOutput{NextToken: &dummyToken}
 	var err error
 
-	credentialConfig := &internalaws.CredentialConfig{
-		Region:      c.Region,
-		AccessKey:   c.AccessKey,
-		SecretKey:   c.SecretKey,
-		RoleARN:     c.RoleARN,
-		Profile:     c.Profile,
-		Filename:    c.Filename,
-		Token:       c.Token,
-		EndpointURL: c.EndpointURL,
-	}
-	configProvider := credentialConfig.Credentials()
-
-	c.svc = cloudwatchlogs.New(configProvider)
+	c.svc = cloudwatchlogs.New(c.CredentialConfig.Credentials())
 	if c.svc == nil {
 		return fmt.Errorf("can't create cloudwatch logs service endpoint")
 	}

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
@@ -84,16 +84,18 @@ region = "us-east-1"
 
 ## Amazon Credentials
 ## Credentials are loaded in the following order
-## 1) Assumed credentials via STS if role_arn is specified
-## 2) explicit credentials from 'access_key' and 'secret_key'
-## 3) shared profile from 'profile'
-## 4) environment variables
-## 5) shared credentials file
-## 6) EC2 Instance Profile
+## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+## 2) Assumed credentials via STS if role_arn is specified
+## 3) explicit credentials from 'access_key' and 'secret_key'
+## 4) shared profile from 'profile'
+## 5) environment variables
+## 6) shared credentials file
+## 7) EC2 Instance Profile
 #access_key = ""
 #secret_key = ""
 #token = ""
 #role_arn = ""
+#web_identity_token_file = ""
 #profile = ""
 #shared_credential_file = ""
 

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs_test.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/influxdata/telegraf"
+	internalaws "github.com/influxdata/telegraf/config/aws"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -82,9 +83,11 @@ func TestInit(t *testing.T) {
 			name:                "log group is not set",
 			expectedErrorString: "log group is not set",
 			plugin: &CloudWatchLogs{
-				Region:       "eu-central-1",
-				AccessKey:    "dummy",
-				SecretKey:    "dummy",
+				CredentialConfig: internalaws.CredentialConfig{
+					Region:    "eu-central-1",
+					AccessKey: "dummy",
+					SecretKey: "dummy",
+				},
 				LogGroup:     "",
 				LogStream:    "tag:source",
 				LDMetricName: "docker_log",
@@ -98,9 +101,11 @@ func TestInit(t *testing.T) {
 			name:                "log stream is not set",
 			expectedErrorString: "log stream is not set",
 			plugin: &CloudWatchLogs{
-				Region:       "eu-central-1",
-				AccessKey:    "dummy",
-				SecretKey:    "dummy",
+				CredentialConfig: internalaws.CredentialConfig{
+					Region:    "eu-central-1",
+					AccessKey: "dummy",
+					SecretKey: "dummy",
+				},
 				LogGroup:     "TestLogGroup",
 				LogStream:    "",
 				LDMetricName: "docker_log",
@@ -114,9 +119,11 @@ func TestInit(t *testing.T) {
 			name:                "log data metrics name is not set",
 			expectedErrorString: "log data metrics name is not set",
 			plugin: &CloudWatchLogs{
-				Region:       "eu-central-1",
-				AccessKey:    "dummy",
-				SecretKey:    "dummy",
+				CredentialConfig: internalaws.CredentialConfig{
+					Region:    "eu-central-1",
+					AccessKey: "dummy",
+					SecretKey: "dummy",
+				},
 				LogGroup:     "TestLogGroup",
 				LogStream:    "tag:source",
 				LDMetricName: "",
@@ -130,9 +137,11 @@ func TestInit(t *testing.T) {
 			name:                "log data source is not set",
 			expectedErrorString: "log data source is not set",
 			plugin: &CloudWatchLogs{
-				Region:       "eu-central-1",
-				AccessKey:    "dummy",
-				SecretKey:    "dummy",
+				CredentialConfig: internalaws.CredentialConfig{
+					Region:    "eu-central-1",
+					AccessKey: "dummy",
+					SecretKey: "dummy",
+				},
 				LogGroup:     "TestLogGroup",
 				LogStream:    "tag:source",
 				LDMetricName: "docker_log",
@@ -147,9 +156,11 @@ func TestInit(t *testing.T) {
 			expectedErrorString: "log data source is not properly formatted, ':' is missed.\n" +
 				"Should be 'tag:<tag_mame>' or 'field:<field_name>'",
 			plugin: &CloudWatchLogs{
-				Region:       "eu-central-1",
-				AccessKey:    "dummy",
-				SecretKey:    "dummy",
+				CredentialConfig: internalaws.CredentialConfig{
+					Region:    "eu-central-1",
+					AccessKey: "dummy",
+					SecretKey: "dummy",
+				},
 				LogGroup:     "TestLogGroup",
 				LogStream:    "tag:source",
 				LDMetricName: "docker_log",
@@ -164,9 +175,11 @@ func TestInit(t *testing.T) {
 			expectedErrorString: "log data source is not properly formatted.\n" +
 				"Should be 'tag:<tag_mame>' or 'field:<field_name>'",
 			plugin: &CloudWatchLogs{
-				Region:       "eu-central-1",
-				AccessKey:    "dummy",
-				SecretKey:    "dummy",
+				CredentialConfig: internalaws.CredentialConfig{
+					Region:    "eu-central-1",
+					AccessKey: "dummy",
+					SecretKey: "dummy",
+				},
 				LogGroup:     "TestLogGroup",
 				LogStream:    "tag:source",
 				LDMetricName: "docker_log",
@@ -179,9 +192,11 @@ func TestInit(t *testing.T) {
 		{
 			name: "valid config",
 			plugin: &CloudWatchLogs{
-				Region:       "eu-central-1",
-				AccessKey:    "dummy",
-				SecretKey:    "dummy",
+				CredentialConfig: internalaws.CredentialConfig{
+					Region:    "eu-central-1",
+					AccessKey: "dummy",
+					SecretKey: "dummy",
+				},
 				LogGroup:     "TestLogGroup",
 				LogStream:    "tag:source",
 				LDMetricName: "docker_log",
@@ -225,10 +240,12 @@ func TestConnect(t *testing.T) {
 	defer ts.Close()
 
 	plugin := &CloudWatchLogs{
-		Region:       "eu-central-1",
-		AccessKey:    "dummy",
-		SecretKey:    "dummy",
-		EndpointURL:  ts.URL,
+		CredentialConfig: internalaws.CredentialConfig{
+			Region:      "eu-central-1",
+			AccessKey:   "dummy",
+			SecretKey:   "dummy",
+			EndpointURL: ts.URL,
+		},
 		LogGroup:     "TestLogGroup",
 		LogStream:    "tag:source",
 		LDMetricName: "docker_log",
@@ -263,10 +280,12 @@ func TestWrite(t *testing.T) {
 	defer ts.Close()
 
 	plugin := &CloudWatchLogs{
-		Region:       "eu-central-1",
-		AccessKey:    "dummy",
-		SecretKey:    "dummy",
-		EndpointURL:  ts.URL,
+		CredentialConfig: internalaws.CredentialConfig{
+			Region:      "eu-central-1",
+			AccessKey:   "dummy",
+			SecretKey:   "dummy",
+			EndpointURL: ts.URL,
+		},
 		LogGroup:     "TestLogGroup",
 		LogStream:    "tag:source",
 		LDMetricName: "docker_log",

--- a/plugins/outputs/kinesis/README.md
+++ b/plugins/outputs/kinesis/README.md
@@ -13,12 +13,13 @@ maybe useful for users to review Amazons official documentation which is availab
 
 This plugin uses a credential chain for Authentication with the Kinesis API endpoint. In the following order the plugin
 will attempt to authenticate.
-1. Assumed credentials via STS if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules)
-2. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
-3. Shared profile from `profile` attribute
-4. [Environment Variables](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#environment-variables)
-5. [Shared Credentials](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file)
-6. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+1. Web identity provider credentials via STS if `role_arn` and `web_identity_token_file` are specified
+2. Assumed credentials via STS if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules)
+3. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
+4. Shared profile from `profile` attribute
+5. [Environment Variables](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#environment-variables)
+6. [Shared Credentials](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file)
+7. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
 
 ## Config

--- a/plugins/outputs/kinesis/README.md
+++ b/plugins/outputs/kinesis/README.md
@@ -21,6 +21,9 @@ will attempt to authenticate.
 6. [Shared Credentials](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file)
 7. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
+If you are using credentials from a web identity provider, you can specify the session name using `role_session_name`. If
+left empty, the current timestamp will be used.
+
 
 ## Config
 

--- a/plugins/outputs/kinesis/kinesis.go
+++ b/plugins/outputs/kinesis/kinesis.go
@@ -56,6 +56,7 @@ var sampleConfig = `
   #token = ""
   #role_arn = ""
   #web_identity_token_file = ""
+  #role_session_name = ""
   #profile = ""
   #shared_credential_file = ""
 

--- a/plugins/outputs/kinesis/kinesis.go
+++ b/plugins/outputs/kinesis/kinesis.go
@@ -44,16 +44,18 @@ var sampleConfig = `
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) Assumed credentials via STS if role_arn is specified
-  ## 2) explicit credentials from 'access_key' and 'secret_key'
-  ## 3) shared profile from 'profile'
-  ## 4) environment variables
-  ## 5) shared credentials file
-  ## 6) EC2 Instance Profile
+  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 2) Assumed credentials via STS if role_arn is specified
+  ## 3) explicit credentials from 'access_key' and 'secret_key'
+  ## 4) shared profile from 'profile'
+  ## 5) environment variables
+  ## 6) shared credentials file
+  ## 7) EC2 Instance Profile
   #access_key = ""
   #secret_key = ""
   #token = ""
   #role_arn = ""
+  #web_identity_token_file = ""
   #profile = ""
   #shared_credential_file = ""
 

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -11,17 +11,19 @@ The Timestream output plugin writes metrics to the [Amazon Timestream] service.
   region = "us-east-1"
   
   ## Amazon Credentials
-  ## Credentials are loaded in the following order:
-  ## 1) Assumed credentials via STS if role_arn is specified
-  ## 2) Explicit credentials from 'access_key' and 'secret_key'
-  ## 3) Shared profile from 'profile'
-  ## 4) Environment variables
-  ## 5) Shared credentials file
-  ## 6) EC2 Instance Profile
+  ## Credentials are loaded in the following order
+  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 2) Assumed credentials via STS if role_arn is specified
+  ## 3) explicit credentials from 'access_key' and 'secret_key'
+  ## 4) shared profile from 'profile'
+  ## 5) environment variables
+  ## 6) shared credentials file
+  ## 7) EC2 Instance Profile
   #access_key = ""
   #secret_key = ""
   #token = ""
   #role_arn = ""
+  #web_identity_token_file = ""
   #profile = ""
   #shared_credential_file = ""
   

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -24,6 +24,7 @@ The Timestream output plugin writes metrics to the [Amazon Timestream] service.
   #token = ""
   #role_arn = ""
   #web_identity_token_file = ""
+  #role_session_name = ""
   #profile = ""
   #shared_credential_file = ""
   

--- a/plugins/outputs/timestream/timestream.go
+++ b/plugins/outputs/timestream/timestream.go
@@ -60,16 +60,18 @@ var sampleConfig = `
   
   ## Amazon Credentials
   ## Credentials are loaded in the following order:
-  ## 1) Assumed credentials via STS if role_arn is specified
-  ## 2) Explicit credentials from 'access_key' and 'secret_key'
-  ## 3) Shared profile from 'profile'
-  ## 4) Environment variables
-  ## 5) Shared credentials file
-  ## 6) EC2 Instance Profile
+  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 2) Assumed credentials via STS if role_arn is specified
+  ## 3) explicit credentials from 'access_key' and 'secret_key'
+  ## 4) shared profile from 'profile'
+  ## 5) environment variables
+  ## 6) shared credentials file
+  ## 7) EC2 Instance Profile
   #access_key = ""
   #secret_key = ""
   #token = ""
   #role_arn = ""
+  #web_identity_token_file = ""
   #profile = ""
   #shared_credential_file = ""
   

--- a/plugins/outputs/timestream/timestream.go
+++ b/plugins/outputs/timestream/timestream.go
@@ -19,15 +19,6 @@ import (
 
 type (
 	Timestream struct {
-		Region      string `toml:"region"`
-		AccessKey   string `toml:"access_key"`
-		SecretKey   string `toml:"secret_key"`
-		RoleARN     string `toml:"role_arn"`
-		Profile     string `toml:"profile"`
-		Filename    string `toml:"shared_credential_file"`
-		Token       string `toml:"token"`
-		EndpointURL string `toml:"endpoint_url"`
-
 		MappingMode             string `toml:"mapping_mode"`
 		DescribeDatabaseOnStart bool   `toml:"describe_database_on_start"`
 		DatabaseName            string `toml:"database_name"`
@@ -42,6 +33,8 @@ type (
 
 		Log telegraf.Logger
 		svc WriteClient
+
+		internalaws.CredentialConfig
 	}
 
 	WriteClient interface {
@@ -225,17 +218,7 @@ func (t *Timestream) Connect() error {
 
 	t.Log.Infof("Constructing Timestream client for '%s' mode", t.MappingMode)
 
-	credentialConfig := &internalaws.CredentialConfig{
-		Region:      t.Region,
-		AccessKey:   t.AccessKey,
-		SecretKey:   t.SecretKey,
-		RoleARN:     t.RoleARN,
-		Profile:     t.Profile,
-		Filename:    t.Filename,
-		Token:       t.Token,
-		EndpointURL: t.EndpointURL,
-	}
-	svc := WriteFactory(credentialConfig)
+	svc := WriteFactory(&t.CredentialConfig)
 
 	if t.DescribeDatabaseOnStart {
 		t.Log.Infof("Describing database '%s' in region '%s'", t.DatabaseName, t.Region)

--- a/plugins/outputs/timestream/timestream.go
+++ b/plugins/outputs/timestream/timestream.go
@@ -72,6 +72,7 @@ var sampleConfig = `
   #token = ""
   #role_arn = ""
   #web_identity_token_file = ""
+  #role_session_name = ""
   #profile = ""
   #shared_credential_file = ""
   


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #9073 

Adds support for authenticating with the AWS API using a [Web Identity Provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html) using the fields `role_arn`, `web_identity_token_file` and `role_session_name`. However, only `role_arn` and `web_identity_token_file` are required to use this authentication method as `role_session_name` will default to the current timestamp.
