### PR TITLE
Attach the pod labels to the `kubernetes_pod_volume` & `kubernetes_pod_network` metrics.

### DIFF
--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -234,6 +234,17 @@ func (k *Kubernetes) LoadJSON(url string, v interface{}) error {
 
 func buildPodMetrics(summaryMetrics *SummaryMetrics, podInfo []Metadata, labelFilter filter.Filter, acc telegraf.Accumulator) {
 	for _, pod := range summaryMetrics.Pods {
+		podLabels := make(map[string]string)
+		for _, info := range podInfo {
+			if info.Name == pod.PodRef.Name && info.Namespace == pod.PodRef.Namespace {
+				for k, v := range info.Labels {
+					if labelFilter.Match(k) {
+						podLabels[k] = v
+					}
+				}
+			}
+		}
+
 		for _, container := range pod.Containers {
 			tags := map[string]string{
 				"node_name":      summaryMetrics.Node.NodeName,
@@ -241,16 +252,9 @@ func buildPodMetrics(summaryMetrics *SummaryMetrics, podInfo []Metadata, labelFi
 				"container_name": container.Name,
 				"pod_name":       pod.PodRef.Name,
 			}
-			for _, info := range podInfo {
-				if info.Name == pod.PodRef.Name && info.Namespace == pod.PodRef.Namespace {
-					for k, v := range info.Labels {
-						if labelFilter.Match(k) {
-							tags[k] = v
-						}
-					}
-				}
+			for k, v := range podLabels {
+				tags[k] = v
 			}
-
 			fields := make(map[string]interface{})
 			fields["cpu_usage_nanocores"] = container.CPU.UsageNanoCores
 			fields["cpu_usage_core_nanoseconds"] = container.CPU.UsageCoreNanoSeconds
@@ -275,6 +279,9 @@ func buildPodMetrics(summaryMetrics *SummaryMetrics, podInfo []Metadata, labelFi
 				"namespace":   pod.PodRef.Namespace,
 				"volume_name": volume.Name,
 			}
+			for k, v := range podLabels {
+				tags[k] = v
+			}
 			fields := make(map[string]interface{})
 			fields["available_bytes"] = volume.AvailableBytes
 			fields["capacity_bytes"] = volume.CapacityBytes
@@ -286,6 +293,9 @@ func buildPodMetrics(summaryMetrics *SummaryMetrics, podInfo []Metadata, labelFi
 			"node_name": summaryMetrics.Node.NodeName,
 			"pod_name":  pod.PodRef.Name,
 			"namespace": pod.PodRef.Namespace,
+		}
+		for k, v := range podLabels {
+			tags[k] = v
 		}
 		fields := make(map[string]interface{})
 		fields["rx_bytes"] = pod.Network.RXBytes

--- a/plugins/inputs/kubernetes/kubernetes_test.go
+++ b/plugins/inputs/kubernetes/kubernetes_test.go
@@ -141,6 +141,8 @@ func TestKubernetesStats(t *testing.T) {
 		"volume_name": "volume1",
 		"namespace":   "foons",
 		"pod_name":    "foopod",
+		"app":         "foo",
+		"superkey":    "foobar",
 	}
 	acc.AssertContainsTaggedFields(t, "kubernetes_pod_volume", fields, tags)
 
@@ -154,6 +156,8 @@ func TestKubernetesStats(t *testing.T) {
 		"node_name": "node1",
 		"namespace": "foons",
 		"pod_name":  "foopod",
+		"app":       "foo",
+		"superkey":  "foobar",
 	}
 	acc.AssertContainsTaggedFields(t, "kubernetes_pod_network", fields, tags)
 }


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Resolves the issue that the pod labels are missing in the metrics `kubernetes_pod_volume` & `kubernetes_pod_network`. 