### PR TITLE
fixed percentiles not being able to be ints

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -14,6 +14,9 @@ type Duration time.Duration
 // Size is an int64
 type Size int64
 
+// Number will get parsed as an int or float depending on what is passed
+type Number float64
+
 // UnmarshalTOML parses the duration from the TOML config file
 func (d *Duration) UnmarshalTOML(b []byte) error {
 	var err error
@@ -85,4 +88,14 @@ func (s *Size) UnmarshalTOML(b []byte) error {
 
 func (s *Size) UnmarshalText(text []byte) error {
 	return s.UnmarshalTOML(text)
+}
+
+func (n *Number) UnmarshalTOML(b []byte) error {
+	value, err := strconv.ParseFloat(string(b), 64)
+	if err != nil {
+		return err
+	}
+
+	*n = Number(value)
+	return nil
 }

--- a/config/types.go
+++ b/config/types.go
@@ -14,9 +14,6 @@ type Duration time.Duration
 // Size is an int64
 type Size int64
 
-// Number will get parsed as an int or float depending on what is passed
-type Number float64
-
 // UnmarshalTOML parses the duration from the TOML config file
 func (d *Duration) UnmarshalTOML(b []byte) error {
 	var err error
@@ -88,14 +85,4 @@ func (s *Size) UnmarshalTOML(b []byte) error {
 
 func (s *Size) UnmarshalText(text []byte) error {
 	return s.UnmarshalTOML(text)
-}
-
-func (n *Number) UnmarshalTOML(b []byte) error {
-	value, err := strconv.ParseFloat(string(b), 64)
-	if err != nil {
-		return err
-	}
-
-	*n = Number(value)
-	return nil
 }

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -37,20 +37,6 @@ const (
 
 var errParsing = errors.New("error parsing statsd line")
 
-type Number struct {
-	Value float64
-}
-
-func (n *Number) UnmarshalTOML(b []byte) error {
-	value, err := strconv.ParseFloat(string(b), 64)
-	if err != nil {
-		return err
-	}
-
-	n.Value = value
-	return nil
-}
-
 // Statsd allows the importing of statsd and dogstatsd data.
 type Statsd struct {
 	// Protocol used on listener - udp or tcp
@@ -65,7 +51,7 @@ type Statsd struct {
 
 	// Percentiles specifies the percentiles that will be calculated for timing
 	// and histogram stats.
-	Percentiles     []Number
+	Percentiles     []config.Number
 	PercentileLimit int
 
 	DeleteGauges   bool
@@ -320,8 +306,8 @@ func (s *Statsd) Gather(acc telegraf.Accumulator) error {
 			fields[prefix+"lower"] = stats.Lower()
 			fields[prefix+"count"] = stats.Count()
 			for _, percentile := range s.Percentiles {
-				name := fmt.Sprintf("%s%v_percentile", prefix, percentile.Value)
-				fields[name] = stats.Percentile(percentile.Value)
+				name := fmt.Sprintf("%s%v_percentile", prefix, percentile)
+				fields[name] = stats.Percentile(float64(percentile))
 			}
 		}
 

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -37,6 +37,19 @@ const (
 
 var errParsing = errors.New("error parsing statsd line")
 
+// Number will get parsed as an int or float depending on what is passed
+type Number float64
+
+func (n *Number) UnmarshalTOML(b []byte) error {
+	value, err := strconv.ParseFloat(string(b), 64)
+	if err != nil {
+		return err
+	}
+
+	*n = Number(value)
+	return nil
+}
+
 // Statsd allows the importing of statsd and dogstatsd data.
 type Statsd struct {
 	// Protocol used on listener - udp or tcp
@@ -51,7 +64,7 @@ type Statsd struct {
 
 	// Percentiles specifies the percentiles that will be calculated for timing
 	// and histogram stats.
-	Percentiles     []config.Number
+	Percentiles     []Number
 	PercentileLimit int
 
 	DeleteGauges   bool

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -397,7 +397,7 @@ func TestParse_Counters(t *testing.T) {
 // Tests low-level functionality of timings
 func TestParse_Timings(t *testing.T) {
 	s := NewTestStatsd()
-	s.Percentiles = []float64{90.0}
+	s.Percentiles = []Number{{Value: 90.0}}
 	acc := &testutil.Accumulator{}
 
 	// Test that timings work
@@ -1186,7 +1186,7 @@ func TestParse_MeasurementsWithMultipleValues(t *testing.T) {
 func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 	s := NewTestStatsd()
 	s.Templates = []string{"measurement.field"}
-	s.Percentiles = []float64{90.0}
+	s.Percentiles = []Number{{Value: 90.0}}
 	acc := &testutil.Accumulator{}
 
 	validLines := []string{
@@ -1234,7 +1234,7 @@ func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 func TestParse_TimingsMultipleFieldsWithoutTemplate(t *testing.T) {
 	s := NewTestStatsd()
 	s.Templates = []string{}
-	s.Percentiles = []float64{90.0}
+	s.Percentiles = []Number{{Value: 90.0}}
 	acc := &testutil.Accumulator{}
 
 	validLines := []string{

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -1664,3 +1664,12 @@ func TestUdp(t *testing.T) {
 		testutil.IgnoreTime(),
 	)
 }
+
+func TestParse_Ints(t *testing.T) {
+	s := NewTestStatsd()
+	s.Percentiles = []config.Number{90}
+	acc := &testutil.Accumulator{}
+
+	require.NoError(t, s.Gather(acc))
+	require.Equal(t, s.Percentiles, []config.Number{90.0})
+}

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -397,7 +397,7 @@ func TestParse_Counters(t *testing.T) {
 // Tests low-level functionality of timings
 func TestParse_Timings(t *testing.T) {
 	s := NewTestStatsd()
-	s.Percentiles = []config.Number{90.0}
+	s.Percentiles = []Number{90.0}
 	acc := &testutil.Accumulator{}
 
 	// Test that timings work
@@ -1186,7 +1186,7 @@ func TestParse_MeasurementsWithMultipleValues(t *testing.T) {
 func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 	s := NewTestStatsd()
 	s.Templates = []string{"measurement.field"}
-	s.Percentiles = []config.Number{90.0}
+	s.Percentiles = []Number{90.0}
 	acc := &testutil.Accumulator{}
 
 	validLines := []string{
@@ -1234,7 +1234,7 @@ func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 func TestParse_TimingsMultipleFieldsWithoutTemplate(t *testing.T) {
 	s := NewTestStatsd()
 	s.Templates = []string{}
-	s.Percentiles = []config.Number{90.0}
+	s.Percentiles = []Number{90.0}
 	acc := &testutil.Accumulator{}
 
 	validLines := []string{
@@ -1667,9 +1667,9 @@ func TestUdp(t *testing.T) {
 
 func TestParse_Ints(t *testing.T) {
 	s := NewTestStatsd()
-	s.Percentiles = []config.Number{90}
+	s.Percentiles = []Number{90}
 	acc := &testutil.Accumulator{}
 
 	require.NoError(t, s.Gather(acc))
-	require.Equal(t, s.Percentiles, []config.Number{90.0})
+	require.Equal(t, s.Percentiles, []Number{90.0})
 }

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -397,7 +397,7 @@ func TestParse_Counters(t *testing.T) {
 // Tests low-level functionality of timings
 func TestParse_Timings(t *testing.T) {
 	s := NewTestStatsd()
-	s.Percentiles = []Number{{Value: 90.0}}
+	s.Percentiles = []config.Number{90.0}
 	acc := &testutil.Accumulator{}
 
 	// Test that timings work
@@ -1186,7 +1186,7 @@ func TestParse_MeasurementsWithMultipleValues(t *testing.T) {
 func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 	s := NewTestStatsd()
 	s.Templates = []string{"measurement.field"}
-	s.Percentiles = []Number{{Value: 90.0}}
+	s.Percentiles = []config.Number{90.0}
 	acc := &testutil.Accumulator{}
 
 	validLines := []string{
@@ -1234,7 +1234,7 @@ func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 func TestParse_TimingsMultipleFieldsWithoutTemplate(t *testing.T) {
 	s := NewTestStatsd()
 	s.Templates = []string{}
-	s.Percentiles = []Number{{Value: 90.0}}
+	s.Percentiles = []config.Number{90.0}
 	acc := &testutil.Accumulator{}
 
 	validLines := []string{


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9441 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
added a Number struct and an unmarshal that will allow for ints or floats