### PR TITLE
Fix segfault in kube_inventory

### DIFF
--- a/plugins/inputs/kube_inventory/endpoint.go
+++ b/plugins/inputs/kube_inventory/endpoint.go
@@ -39,7 +39,9 @@ func (ki *KubernetesInventory) gatherEndpoint(e corev1.Endpoints, acc telegraf.A
 			fields["ready"] = true
 
 			tags["hostname"] = readyAddr.Hostname
-			tags["node_name"] = *readyAddr.NodeName
+			if readyAddr.NodeName != nil {
+				tags["node_name"] = *readyAddr.NodeName
+			}
 			if readyAddr.TargetRef != nil {
 				tags[strings.ToLower(readyAddr.TargetRef.Kind)] = readyAddr.TargetRef.Name
 			}
@@ -57,7 +59,9 @@ func (ki *KubernetesInventory) gatherEndpoint(e corev1.Endpoints, acc telegraf.A
 			fields["ready"] = false
 
 			tags["hostname"] = notReadyAddr.Hostname
-			tags["node_name"] = *notReadyAddr.NodeName
+			if notReadyAddr.NodeName != nil {
+				tags["node_name"] = *notReadyAddr.NodeName
+			}
 			if notReadyAddr.TargetRef != nil {
 				tags[strings.ToLower(notReadyAddr.TargetRef.Kind)] = notReadyAddr.TargetRef.Name
 			}

--- a/plugins/inputs/kube_inventory/endpoint_test.go
+++ b/plugins/inputs/kube_inventory/endpoint_test.go
@@ -157,6 +157,102 @@ func TestEndpoint(t *testing.T) {
 			},
 			hasError: false,
 		},
+		{
+			name: "endpoints missing node_name",
+			handler: &mockHandler{
+				responseMap: map[string]interface{}{
+					"/endpoints/": &v1.EndpointsList{
+						Items: []v1.Endpoints{
+							{
+								Subsets: []v1.EndpointSubset{
+									{
+										NotReadyAddresses: []v1.EndpointAddress{
+											{
+												Hostname: "storage-6",
+												TargetRef: &v1.ObjectReference{
+													Kind: "pod",
+													Name: "storage-6",
+												},
+											},
+										},
+										Ports: []v1.EndpointPort{
+											{
+												Name:     "server",
+												Protocol: "TCP",
+												Port:     8080,
+											},
+										},
+									},
+									{
+										Addresses: []v1.EndpointAddress{
+											{
+												Hostname: "storage-12",
+												TargetRef: &v1.ObjectReference{
+													Kind: "pod",
+													Name: "storage-12",
+												},
+											},
+										},
+										Ports: []v1.EndpointPort{
+											{
+												Name:     "server",
+												Protocol: "TCP",
+												Port:     8080,
+											},
+										},
+									},
+								},
+								ObjectMeta: metav1.ObjectMeta{
+									Generation:        12,
+									Namespace:         "ns1",
+									Name:              "storage",
+									CreationTimestamp: metav1.Time{Time: now},
+								},
+							},
+						},
+					},
+				},
+			},
+			output: []telegraf.Metric{
+				testutil.MustMetric(
+					"kubernetes_endpoint",
+					map[string]string{
+						"endpoint_name": "storage",
+						"namespace":     "ns1",
+						"hostname":      "storage-6",
+						"port_name":     "server",
+						"port_protocol": "TCP",
+						"pod":           "storage-6",
+					},
+					map[string]interface{}{
+						"ready":      false,
+						"port":       int32(8080),
+						"generation": int64(12),
+						"created":    now.UnixNano(),
+					},
+					time.Unix(0, 0),
+				),
+				testutil.MustMetric(
+					"kubernetes_endpoint",
+					map[string]string{
+						"endpoint_name": "storage",
+						"namespace":     "ns1",
+						"hostname":      "storage-12",
+						"port_name":     "server",
+						"port_protocol": "TCP",
+						"pod":           "storage-12",
+					},
+					map[string]interface{}{
+						"ready":      true,
+						"port":       int32(8080),
+						"generation": int64(12),
+						"created":    now.UnixNano(),
+					},
+					time.Unix(0, 0),
+				),
+			},
+			hasError: false,
+		},
 	}
 
 	for _, v := range tests {


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #9450 

Fixes a segfault in `kube_inventory` due to a nil pointer dereference when an endpoint did not have a node name by checking if the pointer is not nil before dereferencing.
