### PR TITLE
fix: Couchbase insecure certificate validation

### DIFF
--- a/plugins/inputs/couchbase/README.md
+++ b/plugins/inputs/couchbase/README.md
@@ -20,6 +20,14 @@ This plugin gets metrics for each Couchbase node, as well as detailed metrics fo
 
   ## Filter bucket fields to include only here.
   # bucket_stats_included = ["quota_percent_used", "ops_per_sec", "disk_fetches", "item_count", "disk_used", "data_used", "mem_used"]
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification (defaults to true)
+  ## If set to false, tls_cert and tls_key are required
+  # insecure_skip_verify = true
 ```
 
 ## Measurements:

--- a/plugins/inputs/couchbase/README.md
+++ b/plugins/inputs/couchbase/README.md
@@ -27,7 +27,7 @@ This plugin gets metrics for each Couchbase node, as well as detailed metrics fo
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification (defaults to true)
   ## If set to false, tls_cert and tls_key are required
-  # insecure_skip_verify = true
+  # insecure_skip_verify = false
 ```
 
 ## Measurements:

--- a/plugins/inputs/couchbase/README.md
+++ b/plugins/inputs/couchbase/README.md
@@ -25,7 +25,7 @@ This plugin gets metrics for each Couchbase node, as well as detailed metrics fo
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
-  ## Use TLS but skip chain & host verification (defaults to true)
+  ## Use TLS but skip chain & host verification (defaults to false)
   ## If set to false, tls_cert and tls_key are required
   # insecure_skip_verify = false
 ```

--- a/plugins/inputs/couchbase/couchbase.go
+++ b/plugins/inputs/couchbase/couchbase.go
@@ -1,6 +1,7 @@
 package couchbase
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"regexp"
@@ -39,7 +40,14 @@ var sampleConfig = `
 `
 
 var regexpURI = regexp.MustCompile(`(\S+://)?(\S+\:\S+@)`)
-var client = &http.Client{Timeout: 10 * time.Second}
+var client = &http.Client{
+	Timeout: 10 * time.Second,
+	Transport: &http.Transport{
+		// The couchbase library defaults to insecure, unless certificates are provided
+		// https://github.com/couchbase/go-couchbase/blob/v0.1.0/pools.go#L68-L70
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	},
+}
 
 func (cb *Couchbase) SampleConfig() string {
 	return sampleConfig

--- a/plugins/inputs/couchbase/couchbase.go
+++ b/plugins/inputs/couchbase/couchbase.go
@@ -45,7 +45,7 @@ var sampleConfig = `
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
-  ## Use TLS but skip chain & host verification (defaults to true)
+  ## Use TLS but skip chain & host verification (defaults to false)
   ## If set to false, tls_cert and tls_key are required
   # insecure_skip_verify = false
 `

--- a/plugins/inputs/couchbase/couchbase.go
+++ b/plugins/inputs/couchbase/couchbase.go
@@ -2,7 +2,6 @@ package couchbase
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"regexp"
 	"sync"
@@ -48,7 +47,7 @@ var sampleConfig = `
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification (defaults to true)
   ## If set to false, tls_cert and tls_key are required
-  # insecure_skip_verify = true
+  # insecure_skip_verify = false
 `
 
 var regexpURI = regexp.MustCompile(`(\S+://)?(\S+\:\S+@)`)
@@ -412,11 +411,6 @@ func (cb *Couchbase) Init() error {
 		},
 	}
 
-	// Couchbase requires that a TLS cert and key be provided when insecure skip verify is disabled
-	if !cb.ClientConfig.InsecureSkipVerify && (cb.ClientConfig.TLSCert == "" || cb.ClientConfig.TLSKey == "") {
-		return fmt.Errorf("tls_cert and tls_key are required when insecure_skip_verify = false")
-	}
-
 	couchbaseClient.SetSkipVerify(cb.ClientConfig.InsecureSkipVerify)
 	couchbaseClient.SetCertFile(cb.ClientConfig.TLSCert)
 	couchbaseClient.SetKeyFile(cb.ClientConfig.TLSKey)
@@ -429,9 +423,6 @@ func init() {
 	inputs.Add("couchbase", func() telegraf.Input {
 		return &Couchbase{
 			BucketStatsIncluded: []string{"quota_percent_used", "ops_per_sec", "disk_fetches", "item_count", "disk_used", "data_used", "mem_used"},
-			ClientConfig: tls.ClientConfig{
-				InsecureSkipVerify: true,
-			},
 		}
 	})
 }

--- a/plugins/inputs/couchbase/couchbase_test.go
+++ b/plugins/inputs/couchbase/couchbase_test.go
@@ -2,6 +2,7 @@ package couchbase
 
 import (
 	"encoding/json"
+	"github.com/influxdata/telegraf/plugins/common/tls"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,9 +27,13 @@ func TestGatherServer(t *testing.T) {
 		}
 	}))
 
-	var cb Couchbase
-	cb.BucketStatsIncluded = []string{"quota_percent_used", "ops_per_sec", "disk_fetches", "item_count", "disk_used", "data_used", "mem_used"}
-	err := cb.Init()
+        cb := Couchbase{
+		BucketStatsIncluded: []string{"quota_percent_used", "ops_per_sec", "disk_fetches", "item_count", "disk_used", "data_used", "mem_used"},
+		ClientConfig: tls.ClientConfig{
+			InsecureSkipVerify: true,
+		},
+	}
+        err := cb.Init()
 	require.NoError(t, err)
 
 	var acc testutil.Accumulator
@@ -105,6 +110,9 @@ func TestGatherDetailedBucketMetrics(t *testing.T) {
 			var err error
 			var cb Couchbase
 			cb.BucketStatsIncluded = []string{"couch_total_disk_size"}
+                        cb.ClientConfig = tls.ClientConfig{
+                          InsecureSkipVerify: true,
+                        }
 			err = cb.Init()
 			require.NoError(t, err)
 			var acc testutil.Accumulator

--- a/plugins/inputs/couchbase/couchbase_test.go
+++ b/plugins/inputs/couchbase/couchbase_test.go
@@ -27,13 +27,13 @@ func TestGatherServer(t *testing.T) {
 		}
 	}))
 
-        cb := Couchbase{
+	cb := Couchbase{
 		BucketStatsIncluded: []string{"quota_percent_used", "ops_per_sec", "disk_fetches", "item_count", "disk_used", "data_used", "mem_used"},
 		ClientConfig: tls.ClientConfig{
 			InsecureSkipVerify: true,
 		},
 	}
-        err := cb.Init()
+	err := cb.Init()
 	require.NoError(t, err)
 
 	var acc testutil.Accumulator
@@ -110,9 +110,9 @@ func TestGatherDetailedBucketMetrics(t *testing.T) {
 			var err error
 			var cb Couchbase
 			cb.BucketStatsIncluded = []string{"couch_total_disk_size"}
-                        cb.ClientConfig = tls.ClientConfig{
-                          InsecureSkipVerify: true,
-                        }
+			cb.ClientConfig = tls.ClientConfig{
+				InsecureSkipVerify: true,
+			}
 			err = cb.Init()
 			require.NoError(t, err)
 			var acc testutil.Accumulator


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #9454 

Fixes a bug where the `couchbase` plugin would fail to retrieve bucket stats due to a self-signed certificate. Prior, only the bucket stats would fail because the couchbase library skips certificate verification by default unless a keypair and optional root certificate are provided.
