### PR TITLE
Plugin state persistance

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/units"
@@ -13,6 +14,17 @@ type Duration time.Duration
 
 // Size is an int64
 type Size int64
+
+func (d *Duration) MarshalTOML() ([]byte, error) {
+	if d == nil || *d == 0 {
+		return []byte(`"0s"`), nil
+	}
+	s := time.Duration(*d).String()
+	s = strings.TrimSuffix(s, "0s")
+	s = strings.TrimSuffix(s, "0m")
+
+	return []byte(`"` + s + `"`), nil
+}
 
 // UnmarshalTOML parses the duration from the TOML config file
 func (d *Duration) UnmarshalTOML(b []byte) error {
@@ -55,6 +67,13 @@ func (d *Duration) UnmarshalTOML(b []byte) error {
 
 func (d *Duration) UnmarshalText(text []byte) error {
 	return d.UnmarshalTOML(text)
+}
+
+func (s *Size) MarshalTOML() ([]byte, error) {
+	if s == nil {
+		return []byte("0"), nil
+	}
+	return []byte(strconv.FormatInt(int64(*s), 10)), nil
 }
 
 func (s *Size) UnmarshalTOML(b []byte) error {

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -30,7 +30,65 @@ func TestConfigDuration(t *testing.T) {
 	require.Equal(t, p.Ordered, true)
 }
 
-func TestDuration(t *testing.T) {
+func TestDuration_Marshal(t *testing.T) {
+	var d config.Duration
+	var p *config.Duration
+
+	b, err := p.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"0s"`, string(b))
+
+	b, err = d.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"0s"`, string(b))
+
+	d = config.Duration(1 * time.Millisecond)
+	b, err = d.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"1ms"`, string(b))
+
+	d = config.Duration(1 * time.Second)
+	b, err = d.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"1s"`, string(b))
+
+	d = config.Duration(1 * time.Minute)
+	b, err = d.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"1m"`, string(b))
+
+	d = config.Duration(1 * time.Hour)
+	b, err = d.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"1h"`, string(b))
+
+	d = config.Duration(36 * time.Hour)
+	b, err = d.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"36h"`, string(b))
+
+	d = config.Duration(6*time.Hour + 12*time.Minute)
+	b, err = d.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"6h12m"`, string(b))
+
+	d = config.Duration(6*time.Hour + 12*time.Minute + 5*time.Second)
+	b, err = d.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"6h12m5s"`, string(b))
+
+	d = config.Duration(6*time.Hour + 12*time.Minute + 5*time.Second + 39*time.Millisecond)
+	b, err = d.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"6h12m5.039s"`, string(b))
+
+	d = config.Duration(6*time.Hour + 12*time.Minute + 5*time.Second + 39*time.Millisecond + 23*time.Microsecond)
+	b, err = d.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, `"6h12m5.039023s"`, string(b))
+}
+
+func TestDuration_Unmarshal(t *testing.T) {
 	var d config.Duration
 
 	require.NoError(t, d.UnmarshalTOML([]byte(`"1s"`)))
@@ -53,7 +111,40 @@ func TestDuration(t *testing.T) {
 	require.Equal(t, time.Second, time.Duration(d))
 }
 
-func TestSize(t *testing.T) {
+func TestSize_Marshal(t *testing.T) {
+	var s config.Size
+	var p *config.Size
+
+	b, err := p.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, "0", string(b))
+
+	b, err = s.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, "0", string(b))
+
+	s = config.Size(11)
+	b, err = s.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, "11", string(b))
+
+	s = config.Size(11 * 1024)
+	b, err = s.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, "11264", string(b))
+
+	s = config.Size(11 * 1024 * 1024)
+	b, err = s.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, "11534336", string(b))
+
+	s = config.Size(454867870564751864)
+	b, err = s.MarshalTOML()
+	require.NoError(t, err)
+	require.Equal(t, "454867870564751864", string(b))
+}
+
+func TestSize_Unmarshal(t *testing.T) {
 	var s config.Size
 
 	require.NoError(t, s.UnmarshalTOML([]byte(`"1B"`)))

--- a/persister/persister.go
+++ b/persister/persister.go
@@ -1,0 +1,200 @@
+package persister
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/models"
+	"github.com/influxdata/telegraf/persister/store"
+)
+
+const SampleConfig = `
+# Configuration for plugin state persistance
+[persister]
+	## Enables or disables state persistance.
+	# enabled = false
+
+  ## File for storing/loading the states to/from. If left empty, the persister is disabled.
+	# filename = ""
+
+	## Format of the state file. Can be
+	##   "json" -- save the states in JSON format
+	# file_format = "json"
+
+	## Indentation level for nicely formatted (e.g. JSON) output.
+	## If zero, no indentation is performed, saving diskspace but hampers readability.
+	# indent = 0
+`
+
+// Persister is the instance for persisting states
+type Persister struct {
+	Enabled  bool   `toml:"enabled"`
+	Filename string `toml:"filename"`
+	Format   string `toml:"file_format"`
+	Indent   int    `toml:"indent"`
+
+	register map[string]telegraf.StatefulPlugin
+	store    store.Store
+	logger   telegraf.Logger
+}
+
+// Non-plugin facing (public) interface
+
+func (p *Persister) Init() error {
+	if !p.Enabled {
+		return fmt.Errorf("init called on disabled persister")
+	}
+
+	p.logger = models.NewLogger("agent", "persister", "persister")
+
+	switch p.Format {
+	case "", "json":
+		if p.Filename == "" {
+			return fmt.Errorf("invalid filename for \"json\" store")
+		}
+		p.store = &store.JSONStore{
+			Filename: p.Filename,
+			Indent:   p.Indent,
+		}
+	default:
+		return fmt.Errorf("unknown file-format %q for persister", p.Format)
+	}
+	if err := p.store.Init(); err != nil {
+		return fmt.Errorf("initializing store failed: %v", err)
+	}
+
+	p.register = make(map[string]telegraf.StatefulPlugin)
+
+	return nil
+}
+
+func (p *Persister) NewPluginWrapper(prefix string, plugin interface{}) (*PersisterPluginWrapper, error) {
+	id, err := generatePluginID(prefix, plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	wrapper := PersisterPluginWrapper{
+		id:        id,
+		persister: p,
+	}
+
+	return &wrapper, nil
+}
+
+func (p *Persister) Register(prefix string, plugin telegraf.StatefulPlugin) error {
+	if p.register == nil {
+		return fmt.Errorf("not initialized")
+	}
+
+	id, err := generatePluginID(prefix, plugin)
+	if err != nil {
+		return err
+	}
+	p.logger.Debugf("Registering plugin %q with id %q...", prefix, id)
+
+	if _, found := p.register[id]; found {
+		return fmt.Errorf("plugin with ID %q already registered", id)
+	}
+	p.register[id] = plugin
+	p.SetState(id, plugin.GetState())
+
+	return nil
+}
+
+func (p *Persister) GetState(id string) (interface{}, bool) {
+	if p.store == nil {
+		return nil, false
+	}
+
+	return p.store.GetState(id)
+}
+
+func (p *Persister) SetState(id string, state interface{}) error {
+	if p.store == nil {
+		return fmt.Errorf("not initialized")
+	}
+	p.logger.Debugf("Setting state of %q to %v", id, state)
+	return p.store.SetState(id, state)
+}
+
+func (p *Persister) Load() error {
+	if p.register == nil || p.store == nil {
+		return fmt.Errorf("not initialized")
+	}
+
+	// Read the states from disk
+	if err := p.store.Read(); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			p.logger.Infof("State file %q does not exist... Skip restoring states...", p.Filename)
+			return nil
+		}
+		return fmt.Errorf("reading states file failed: %v", err)
+	}
+
+	// Get the initialized state as blueprint for unmarshalling
+	for id, state := range p.store.GetStates() {
+		// Check if we have a plugin with that ID
+		plugin, found := p.register[id]
+		if !found {
+			p.logger.Info("No plugin for ID %q... Skipping.", id)
+			continue
+		}
+
+		// Set the state in the plugin
+		if err := plugin.SetState(state); err != nil {
+			return fmt.Errorf("setting state of %v failed: %v", id, err)
+		}
+	}
+
+	return nil
+}
+
+func (p *Persister) Store() error {
+	if p.register == nil || p.store == nil {
+		return fmt.Errorf("not initialized")
+	}
+
+	// Update the states before writing
+	p.collect()
+
+	// Write the states to disk
+	return p.store.Write()
+}
+
+// Plugin manipulation
+
+func (p *Persister) SetPersisterOnPlugin(prefix string, plugin interface{}) {
+	value := reflect.Indirect(reflect.ValueOf(plugin))
+	wrapper, err := p.NewPluginWrapper(prefix, plugin)
+	if err != nil {
+		return
+	}
+
+	field := value.FieldByName("Persister")
+	if !field.IsValid() {
+		return
+	}
+
+	switch field.Type().String() {
+	case "telegraf.StatePersister":
+		if field.CanSet() {
+			field.Set(reflect.ValueOf(wrapper))
+		}
+	default:
+		p.logger.Warnf("Plugin %q defines a 'Persister' field on its struct of an unexpected type %q. Expected telegraf.StatePersister",
+			value.Type().Name(), field.Type().String())
+	}
+}
+
+// Internal
+
+func (p *Persister) collect() {
+	for id, plugin := range p.register {
+		state := plugin.GetState()
+		p.SetState(id, state)
+	}
+}

--- a/persister/persister_test.go
+++ b/persister/persister_test.go
@@ -1,0 +1,399 @@
+package persister
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/common/tls"
+
+	"github.com/stretchr/testify/require"
+)
+
+const characters = "abcdedfghijklmnopqrst"
+const special = "0123456789"
+
+func generateRandomString(length int) string {
+	set := characters + strings.ToUpper(characters) + special
+	buf := make([]byte, length)
+	for i := 0; i < length; i++ {
+		buf[i] = set[rand.Intn(len(set))]
+	}
+	return string(buf)
+}
+
+func generateID(t *testing.T, name, id string) string {
+	hash := sha256.New()
+
+	_, err := hash.Write(append([]byte(name), 0))
+	require.NoError(t, err, "hashing name failed")
+
+	_, err = hash.Write(append([]byte(id), 0))
+	require.NoError(t, err, "hashing state ID failed")
+
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func TestPersister_NotInitialized(t *testing.T) {
+	plugin := MockupPluginID{
+		Servers:  []string{"server A"},
+		Methods:  []string{"a", "b", "c"},
+		Settings: map[string]string{},
+		Port:     42,
+	}
+	require.NoError(t, plugin.Init())
+
+	persister := Persister{}
+	err := persister.SetState("abcde", plugin.GetState())
+	require.Error(t, err)
+	require.Equal(t, "not initialized", err.Error())
+
+	err = persister.Register("input.mockup", &plugin)
+	require.Error(t, err)
+	require.Equal(t, "not initialized", err.Error())
+
+	state, found := persister.GetState("abcde")
+	require.False(t, found)
+	require.Nil(t, state)
+
+	err = persister.Load()
+	require.Error(t, err)
+	require.Equal(t, "not initialized", err.Error())
+
+	err = persister.Store()
+	require.Error(t, err)
+	require.Equal(t, "not initialized", err.Error())
+}
+
+func TestPersister_InvalidParams(t *testing.T) {
+	persister := Persister{}
+	err := persister.Init()
+	require.Error(t, err)
+	require.Equal(t, "init called on disabled persister", err.Error())
+
+	persister = Persister{Enabled: true}
+	err = persister.Init()
+	require.Error(t, err)
+	require.Equal(t, "invalid filename for \"json\" store", err.Error())
+
+	persister = Persister{Enabled: true, Format: "json"}
+	err = persister.Init()
+	require.Error(t, err)
+	require.Equal(t, "invalid filename for \"json\" store", err.Error())
+
+	persister = Persister{Enabled: true, Format: "invalid"}
+	err = persister.Init()
+	require.Error(t, err)
+	require.Equal(t, "unknown file-format \"invalid\" for persister", err.Error())
+}
+
+func TestPersister_Init(t *testing.T) {
+	persister := Persister{
+		Enabled:  true,
+		Filename: "some random file",
+	}
+	require.NoError(t, persister.Init())
+}
+
+func TestPersister_IDGeneration(t *testing.T) {
+	plugins := []MockupPlugin{}
+
+	for i := 0; i < 10; i++ {
+		p := MockupPlugin{
+			Servers:  []string{generateRandomString(16)},
+			Methods:  []string{"a", "b", "c"},
+			Settings: map[string]string{},
+			Port:     i,
+		}
+
+		for j := 0; j < 5; j++ {
+			p.Settings[generateRandomString(10)] = generateRandomString(10)
+		}
+
+		p.Setups = make([]MockupPluginSettings, 5)
+		for j := 0; j < 5; j++ {
+			p.Setups[j] = MockupPluginSettings{
+				Name:     fmt.Sprintf("setup_%d", j),
+				Factor:   float64(j) / 100.0,
+				Enabled:  (j%2 == 0),
+				BitField: []int{j*10 + 1, j*10 + 2, j*10 + 3, j*10 + 4},
+			}
+		}
+		require.NoError(t, p.Init())
+
+		plugins = append(plugins, p)
+	}
+
+	id, err := generatePluginID("", &plugins[0])
+	require.Empty(t, id)
+	require.Error(t, err)
+	require.Equal(t, "empty prefix", err.Error())
+
+	// Compare generated IDs
+	for i, pi := range plugins {
+		ref, err := generatePluginID("input.mockup", pi)
+		require.NoErrorf(t, err, "%d: generating reference ID failed for: %v", i, pi)
+
+		// Cross-comparison
+		for j, pj := range plugins {
+			test, err := generatePluginID("input.mockup", pj)
+			require.NoErrorf(t, err, "%d: generating testing ID failed for: %v", j, pj)
+
+			// IDs at the same index should be identical, all others different
+			if i == j {
+				require.Equalf(t, ref, test, "difference for %d: \n%v (%v)\n%v (%v)", i, pi, ref, pj, test)
+			} else {
+				require.NotEqualf(t, ref, test, "equal for %d, %d", i, j)
+			}
+		}
+	}
+}
+
+func TestPersister_PluginStateID(t *testing.T) {
+	plugin := MockupPluginID{
+		Servers:  []string{"server A"},
+		Methods:  []string{"a", "b", "c"},
+		Settings: map[string]string{},
+		Port:     42,
+	}
+	require.NoError(t, plugin.Init())
+
+	persister := Persister{
+		Enabled:  true,
+		Filename: "some random file",
+	}
+	require.NoError(t, persister.Init())
+
+	// Compare generated IDs
+	expected := generateID(t, "input.mockup", plugin.GetPluginStateID())
+	id, err := generatePluginID("input.mockup", &plugin)
+	require.NoError(t, err)
+	require.Equal(t, expected, id)
+}
+
+func TestPersister_StateCollection(t *testing.T) {
+	plugin := MockupPlugin{
+		Servers:  []string{"server A"},
+		Methods:  []string{"a", "b", "c"},
+		Settings: map[string]string{},
+		Port:     42,
+	}
+	require.NoError(t, plugin.Init())
+
+	persister := Persister{
+		Enabled:  true,
+		Filename: "some random file",
+	}
+	require.NoError(t, persister.Init())
+	require.NoError(t, persister.Register("input.mockup", &plugin))
+
+	id, err := generatePluginID("input.mockup", plugin)
+	require.NoError(t, err)
+
+	// We store the state at register time
+	t0, _ := time.Parse(time.RFC3339, "2021-04-24T23:42:00+02:00")
+	expectedState := MockupState{
+		Name:     "mockup",
+		Bits:     []int{},
+		Modified: t0,
+	}
+	state, found := persister.GetState(id)
+	require.True(t, found)
+	require.Equal(t, expectedState, state)
+
+	// State should not change when collected anew
+	persister.collect()
+	state, found = persister.GetState(id)
+	require.True(t, found)
+	require.Equal(t, expectedState, state)
+
+	// Check that we have a copy
+	plugin.state.Name = "wurz"
+	plugin.state.Version = 15
+	state, found = persister.GetState(id)
+	require.True(t, found)
+	require.Equal(t, expectedState, state)
+
+	// Check if update works
+	persister.collect()
+	state, found = persister.GetState(id)
+	require.True(t, found)
+	require.NotEqual(t, expectedState, state)
+	expectedState.Name = "wurz"
+	expectedState.Version = 15
+	require.Equal(t, expectedState, state)
+}
+
+func TestPersister_StoreLoad(t *testing.T) {
+	plugins := []telegraf.StatefulPlugin{
+		&MockupPlugin{
+			Servers:  []string{"server A"},
+			Methods:  []string{"a", "b", "c"},
+			Settings: map[string]string{},
+			Port:     42,
+		},
+		&MockupPlugin{
+			Servers:  []string{"server B"},
+			Methods:  []string{"a", "b", "c"},
+			Settings: map[string]string{},
+			Port:     23,
+		},
+		&MockupPluginID{
+			Servers:  []string{"server A"},
+			Methods:  []string{"a", "b", "c"},
+			Settings: map[string]string{},
+			Port:     42,
+		},
+	}
+
+	// Reserve a temporary state file
+	filename := filepath.Join(t.TempDir(), "telegraf_test_state-store_load.json")
+	require.NotEmpty(t, filename)
+	fmt.Printf("using temporary file %q...\n", filename)
+
+	persisterStore := Persister{
+		Enabled:  true,
+		Filename: filename,
+	}
+	require.NoError(t, persisterStore.Init())
+
+	expected := make([]interface{}, 0, len(plugins))
+	for _, plugin := range plugins {
+		require.NoError(t, plugin.(telegraf.Initializer).Init())
+		require.NoError(t, persisterStore.Register("input.mockup", plugin))
+		// Store the state for later comparison
+		expected = append(expected, plugin.GetState())
+	}
+
+	// Write state
+	require.NoError(t, persisterStore.Store())
+
+	// Modify states such that we can verify loading
+	for i, plugin := range plugins {
+		if p, ok := plugin.(*MockupPlugin); ok {
+			appendToState(&p.state)
+			require.NotEqual(t, expected[i], plugin.GetState())
+			continue
+		}
+		if p, ok := plugin.(*MockupPluginID); ok {
+			appendToState(&p.state)
+			require.NotEqual(t, expected[i], plugin.GetState())
+		}
+	}
+
+	persisterLoad := Persister{
+		Enabled:  true,
+		Filename: filename,
+	}
+	require.NoError(t, persisterLoad.Init())
+	for i, plugin := range plugins {
+		require.NoError(t, persisterLoad.Register("input.mockup", plugin))
+		require.NotEqual(t, expected[i], plugin.GetState())
+	}
+
+	// Read state
+	require.NoError(t, persisterLoad.Load())
+	for i, plugin := range plugins {
+		require.Equal(t, expected[i], plugin.GetState())
+	}
+}
+
+/*** Mockup plugin for testing to avoid cyclic dependencies ***/
+type MockupState struct {
+	Name     string
+	Version  uint64
+	Offset   uint64
+	Bits     []int
+	Modified time.Time
+}
+
+type MockupPluginSettings struct {
+	Name     string  `toml:"name"`
+	Factor   float64 `toml:"factor"`
+	Enabled  bool    `toml:"enabled"`
+	BitField []int   `toml:"bits"`
+}
+
+type MockupPlugin struct {
+	Servers          []string               `toml:"servers"`
+	Methods          []string               `toml:"methods"`
+	Settings         map[string]string      `toml:"wurstbrot"`
+	Port             int                    `toml:"port"`
+	Setups           []MockupPluginSettings `toml:"setup"`
+	StateManipulator func(s *MockupState)   `toml:"-"`
+	Log              telegraf.Logger        `toml:"-"`
+	tls.ServerConfig
+
+	command string
+	file    string
+	state   MockupState
+}
+
+func (m *MockupPlugin) Init() error {
+	t0, _ := time.Parse(time.RFC3339, "2021-04-24T23:42:00+02:00")
+	m.state = MockupState{
+		Name:     "mockup",
+		Bits:     []int{},
+		Modified: t0,
+	}
+
+	return nil
+}
+
+func (m *MockupPlugin) GetState() interface{} {
+	state := m.state
+	if m.StateManipulator != nil {
+		m.StateManipulator(&m.state)
+	}
+	return state
+}
+
+// SetState is called by the Persister once after loading and _after_
+// the call to the plugin's Init() function if there is any.
+func (m *MockupPlugin) SetState(state interface{}) error {
+	s, ok := state.(MockupState)
+	if !ok {
+		return fmt.Errorf("invalid state type %T", state)
+	}
+	m.state = s
+
+	return nil
+}
+
+func (m *MockupPlugin) SampleConfig() string                  { return "Mockup test plugin" }
+func (m *MockupPlugin) Description() string                   { return "Mockup test plugin" }
+func (m *MockupPlugin) Gather(acc telegraf.Accumulator) error { return nil }
+
+type MockupPluginID MockupPlugin
+
+func (m *MockupPluginID) GetPluginStateID() string {
+	return "an identitiy"
+}
+
+func (m *MockupPluginID) Init() error {
+	return (*MockupPlugin)(m).Init()
+}
+
+func (m *MockupPluginID) GetState() interface{} {
+	return m.state
+}
+
+// SetState is called by the Persister once after loading and _after_
+// the call to the plugin's Init() function if there is any.
+func (m *MockupPluginID) SetState(state interface{}) error {
+	return (*MockupPlugin)(m).SetState(state)
+}
+
+func appendToState(s *MockupState) {
+	s.Name += "_a"
+	s.Version++
+	s.Offset += 2
+	s.Bits = append(s.Bits, len(s.Bits))
+	s.Modified = time.Now()
+}

--- a/persister/plugin_id.go
+++ b/persister/plugin_id.go
@@ -1,0 +1,123 @@
+package persister
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf"
+)
+
+func processTable(table *ast.Table) (map[string]string, error) {
+	result := make(map[string]string)
+	for key, value := range table.Fields {
+		switch v := value.(type) {
+		case *ast.KeyValue:
+			result[key] = v.Value.Source()
+		case *ast.Table:
+			childs, err := processTable(v)
+			if err != nil {
+				return nil, fmt.Errorf("parsing table for %q failed: %v", key, err)
+			}
+			for k, v := range childs {
+				result[key+"."+k] = v
+			}
+		case []*ast.Table:
+			for i, t := range v {
+				childs, err := processTable(t)
+				if err != nil {
+					return nil, fmt.Errorf("parsing table for %q #%d failed: %v", key, i, err)
+				}
+				for k, v := range childs {
+					pk := fmt.Sprintf("%s#%d.%s", key, i, k)
+					result[pk] = v
+				}
+			}
+		default:
+			fmt.Printf("ignoring unknown node type %T in key %q", value, key)
+			continue
+		}
+	}
+	return result, nil
+}
+
+func normalizePluginConfig(plugin interface{}) ([]telegraf.Tag, error) {
+	// Convert the plugin configuration back to toml to reconstruct
+	// the user-specified configuration.
+	config, err := toml.Marshal(plugin)
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract user-configuration from plugin: %v", err)
+	}
+
+	// We need to ensure that the marshalled TOML text is _always_ the same for the same input and does not change
+	// for identical configuration (especially for maps this might be questionable).
+	// So we restore the TOML configuration from the plugin values, parse the AST such that we get canonnical
+	// entries for the configurations and sort them...
+	root, err := toml.Parse(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse user-configuration from plugin: %v", err)
+	}
+
+	options, err := processTable(root)
+	if err != nil {
+		return nil, fmt.Errorf("unable to process AST for plugin: %v", err)
+	}
+
+	result := make([]telegraf.Tag, 0, len(options))
+	for k, v := range options {
+		result = append(result, telegraf.Tag{k, v})
+	}
+	sort.SliceStable(result, func(i, j int) bool { return result[i].Key < result[j].Key })
+
+	// fmt.Println("-----------")
+	// for i, x := range result {
+	// 	fmt.Printf("%d: %q:%q\n", i, x.Key, x.Value)
+	// }
+	// fmt.Println("-----------")
+
+	return result, nil
+}
+
+func generatePluginID(prefix string, plugin interface{}) (string, error) {
+	if prefix == "" {
+		return "", fmt.Errorf("empty prefix")
+	}
+
+	hash := sha256.New()
+
+	// Prefix the ID with the name to prevent access to other plugin types
+	if _, err := hash.Write(append([]byte(prefix), 0)); err != nil {
+		return "", fmt.Errorf("hashing name failed: %v", err)
+	}
+
+	if generator, ok := plugin.(telegraf.StatefulPluginWithID); ok {
+		// Add the plugin generated ID
+		id := generator.GetPluginStateID()
+
+		if _, err := hash.Write(append([]byte(id), 0)); err != nil {
+			return "", fmt.Errorf("hashing state ID failed: %v", err)
+		}
+	} else {
+		// Process the plugin to extract a normalized stable configuration.
+		config, err := normalizePluginConfig(plugin)
+		if err != nil {
+			return "", err
+		}
+
+		// Add the config elements to the hash
+		for _, kv := range config {
+			if _, err := hash.Write([]byte(kv.Key + ":" + kv.Value)); err != nil {
+				return "", fmt.Errorf("hashing configuration entry %q failed: %v", kv.Key, err)
+			}
+			if _, err := hash.Write([]byte{0}); err != nil {
+				return "", fmt.Errorf("adding hash configuration-entry end marker failed: %v", err)
+			}
+		}
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/persister/store/store.go
+++ b/persister/store/store.go
@@ -1,0 +1,11 @@
+package store
+
+type Store interface {
+	Init() error
+	SetState(id string, state interface{}) error
+	GetState(id string) (interface{}, bool)
+	GetStates() map[string]interface{}
+
+	Read() error
+	Write() error
+}

--- a/persister/store/store_json.go
+++ b/persister/store/store_json.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+)
+
+type JSONStore struct {
+	Filename string
+	Indent   int
+
+	states map[string]interface{}
+}
+
+func (s *JSONStore) Init() error {
+	s.states = make(map[string]interface{})
+	return nil
+}
+
+func (s *JSONStore) SetState(id string, state interface{}) error {
+	s.states[id] = state
+	return nil
+}
+
+func (s *JSONStore) GetState(id string) (interface{}, bool) {
+	state, found := s.states[id]
+	return state, found
+}
+
+func (s *JSONStore) GetStates() map[string]interface{} {
+	return s.states
+}
+
+func (s *JSONStore) Read() error {
+	// Read the states from disk
+	in, err := ioutil.ReadFile(s.Filename)
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal the id-states map
+	states := make(map[string]string)
+	if err := json.Unmarshal(in, &states); err != nil {
+		return fmt.Errorf("unmarshalling id-states mapping failed: %v", err)
+	}
+
+	// Get the initialized state as blueprint for unmarshalling
+	for id, serialized := range states {
+		state, found := s.states[id]
+		if !found {
+			return fmt.Errorf("state not found for %v", id)
+		}
+		// Create a new empty state of the "state"-type. As we need a pointer
+		// of the state, we cannot dereference it here due to the unknown
+		// nature of the state-type.
+		newState := reflect.New(reflect.TypeOf(state)).Interface()
+		if err := json.Unmarshal([]byte(serialized), newState); err != nil {
+			return fmt.Errorf("unmarshalling state of %v failed: %v", id, err)
+		}
+		// Dereference the pointer of the new state and set the plugin's state
+		s.states[id] = reflect.ValueOf(newState).Elem().Interface()
+	}
+
+	return nil
+}
+
+func (s *JSONStore) Write() error {
+	states := make(map[string]string)
+
+	// Serialize the single states to JSON
+	for id, state := range s.states {
+		serialized, err := json.Marshal(state)
+		if err != nil {
+			return fmt.Errorf("marshalling state %v failed: %v", id, err)
+		}
+		states[id] = string(serialized)
+	}
+
+	// Marshall the serialized id-state map
+	out, err := json.Marshal(states)
+	if err != nil {
+		return fmt.Errorf("marshalling id-states mapping failed: %v", err)
+	}
+
+	// Indent if requested
+	if s.Indent > 0 {
+		var buf bytes.Buffer
+		if err := json.Indent(&buf, out, "", strings.Repeat(" ", s.Indent)); err != nil {
+			return fmt.Errorf("indentation failed: %v", err)
+		}
+		out = buf.Bytes()
+	}
+
+	// Write the states to disk
+	f, err := os.Create(s.Filename)
+	if err != nil {
+		return fmt.Errorf("creating states file failed: %v", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(out); err != nil {
+		return fmt.Errorf("writing states file failed: %v", err)
+	}
+
+	return nil
+}

--- a/persister/wrapper.go
+++ b/persister/wrapper.go
@@ -1,0 +1,10 @@
+package persister
+
+type PersisterPluginWrapper struct {
+	id        string     // plugin instance ID
+	persister *Persister // underlying persister instance
+}
+
+func (w *PersisterPluginWrapper) UpdateState(state interface{}) error {
+	return w.persister.SetState(w.id, state)
+}

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -42,7 +42,8 @@ type Tail struct {
 	CharacterEncoding   string   `toml:"character_encoding"`
 	PathTag             string   `toml:"path_tag"`
 
-	Log        telegraf.Logger `toml:"-"`
+	Log telegraf.Logger `toml:"-"`
+
 	tailers    map[string]*tail.Tail
 	offsets    map[string]int64
 	parserFunc parsers.ParserFunc
@@ -156,9 +157,27 @@ func (t *Tail) Init() error {
 	}
 	t.sem = make(semaphore, t.MaxUndeliveredLines)
 
+	// init offsets
+	t.offsets = make(map[string]int64)
+
 	var err error
 	t.decoder, err = encoding.NewDecoder(t.CharacterEncoding)
 	return err
+}
+
+func (t *Tail) GetState() interface{} {
+	return t.offsets
+}
+
+func (t *Tail) SetState(state interface{}) error {
+	offsets_state, ok := state.(map[string]int64)
+	if !ok {
+		return errors.New("state has to be of type 'map[string]int64'")
+	}
+	for k, v := range offsets_state {
+		t.offsets[k] = v
+	}
+	return nil
 }
 
 func (t *Tail) Gather(_ telegraf.Accumulator) error {
@@ -194,8 +213,6 @@ func (t *Tail) Start(acc telegraf.Accumulator) error {
 
 	err = t.tailNewFiles(t.FromBeginning)
 
-	// clear offsets
-	t.offsets = make(map[string]int64)
 	// assumption that once Start is called, all parallel plugins have already been initialized
 	offsetsMutex.Lock()
 	offsets = make(map[string]int64)
@@ -420,6 +437,7 @@ func (t *Tail) Stop() {
 			offset, err := tailer.Tell()
 			if err == nil {
 				t.Log.Debugf("Recording offset %d for %q", offset, tailer.Filename)
+				t.offsets[tailer.Filename] = offset
 			} else {
 				t.Log.Errorf("Recording offset for %q: %s", tailer.Filename, err.Error())
 			}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [X] Wrote appropriate unit tests.

This PR adds the machinery to persist the "state" of a plugin over multiple telegraf runs. A plugin's state is defined by the plugin itself and only has the requirement of being serializable (to JSON currently). The framework consists of

1. An interface definition that plugins have to adhere to provide a state (`GetState()`) and receive a state on load (`SetState()`).
2. A storage backend to persist the data. Currently a JSON file is used.
3. Means to derive a unique ID of plugins that is consistent over multiple runs of telegraf. Here, currently the plugins name and TOML configuration is used. That is, the ID is consistent over multiple starts of telegraf iff the (effective) config is unchanged.
3. The logic of getting and setting states in the agent.

Additionally, we provide ways to push updates to the persister (`UpdateState()`). However, there is no guarantee of when the state is actually written to disk. Last but not least, there is a way for the plugin to provide an ID itself by implementing `GetPluginStateID()`.

To decide which persisted state belongs to which plugin, we compute the plugin IDs and compare them with the stored IDs. Only those plugin states are restored that can be found by ID.

A proof-of-concept is implemented for the `inputs.tail` plugin to persist the last-read position across telegraf restarts, avoiding loss of lines or rereading of the whole file.

This PR is related to #8489 but only implements part of the machinery defined there. Regarding state persistence the following differences are prominent:
1. #8489 has a more extensible storage API. This PR can be moved to the approach used there if we split up #8489.
2. #8489 currently does not provide a mechanism to store plugin states across telegraf runs.
2. The ID computation in #8489 does not survive a restart and will not be suited to persist states across restarts.

Feedback, ideas and critique welcome! :-)