### PR TITLE
Fix json_v2 parser to handle nested objects in arrays properly

### DIFF
--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -381,6 +381,7 @@ func (p *Parser) processObjects(objects []JSONObject, input []byte) ([]telegraf.
 // If the object has multiple array's as elements it won't comine those, they will remain separate metrics
 func (p *Parser) combineObject(result MetricNode) ([]MetricNode, error) {
 	var results []MetricNode
+	var combineObjectResult []MetricNode
 	if result.IsArray() || result.IsObject() {
 		var err error
 		var prevArray bool
@@ -437,7 +438,7 @@ func (p *Parser) combineObject(result MetricNode) ([]MetricNode, error) {
 			arrayNode.Tag = tag
 			if val.IsObject() {
 				prevArray = false
-				_, err = p.combineObject(arrayNode)
+				combineObjectResult, err = p.combineObject(arrayNode)
 				if err != nil {
 					return false
 				}
@@ -475,6 +476,12 @@ func (p *Parser) combineObject(result MetricNode) ([]MetricNode, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if len(results) == 0 {
+		// If the results are empty, use the results of the call to combine object
+		// This happens with nested objects in array's, see the test array_of_objects
+		results = combineObjectResult
 	}
 
 	return results, nil

--- a/plugins/parsers/json_v2/parser_test.go
+++ b/plugins/parsers/json_v2/parser_test.go
@@ -22,6 +22,10 @@ func TestData(t *testing.T) {
 		test string
 	}{
 		{
+			name: "Test having an array of objects",
+			test: "array_of_objects",
+		},
+		{
 			name: "Test using just fields and tags",
 			test: "fields_and_tags",
 		},

--- a/plugins/parsers/json_v2/testdata/array_of_objects/expected.out
+++ b/plugins/parsers/json_v2/testdata/array_of_objects/expected.out
@@ -1,0 +1,2 @@
+file properties_mag=5.17
+file properties_mag=6.2

--- a/plugins/parsers/json_v2/testdata/array_of_objects/input.json
+++ b/plugins/parsers/json_v2/testdata/array_of_objects/input.json
@@ -1,0 +1,14 @@
+{
+    "features": [
+        {
+            "properties": {
+                "mag": 5.17
+            }
+        },
+        {
+            "properties": {
+                "mag": 6.2
+            }
+        }
+    ]
+}

--- a/plugins/parsers/json_v2/testdata/array_of_objects/telegraf.conf
+++ b/plugins/parsers/json_v2/testdata/array_of_objects/telegraf.conf
@@ -1,0 +1,9 @@
+# Example taken from: https://github.com/influxdata/telegraf/issues/5940
+
+[[inputs.file]]
+    files = ["./testdata/array_of_objects/input.json"]
+    data_format = "json_v2"
+    [[inputs.file.json_v2]]
+            [[inputs.file.json_v2.object]]
+                path = "features"
+


### PR DESCRIPTION
- [x] Wrote appropriate unit tests.

@sjwang90 found an issue when parsing the following JSON that would result in empty metrics:

```json
{
    "features": [
        {
            "properties": {
                "mag": 5.17
            }
        }
    ]
}
```

Config used:

```toml
[[inputs.file]]
    files = ["./testdata/test/input.json"]
    data_format = "json_v2"
    [[inputs.file.json_v2]]
            [[inputs.file.json_v2.object]]
                path = "features"
```

This pull request resolves this problem by updating the part where the metrics were being discarded.