### PR TITLE
Fix prometheus cadvisor authentication

### DIFF
--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -88,7 +88,7 @@ func (p *Prometheus) start(ctx context.Context) error {
 				return
 			case <-time.After(time.Second):
 				if p.isNodeScrapeScope {
-					err = p.cAdvisor(ctx)
+					err = p.cAdvisor(ctx, config.BearerToken)
 					if err != nil {
 						p.Log.Errorf("Unable to monitor pods with node scrape scope: %s", err.Error())
 					}
@@ -145,10 +145,13 @@ func (p *Prometheus) watchPod(ctx context.Context, client *kubernetes.Clientset)
 	return nil
 }
 
-func (p *Prometheus) cAdvisor(ctx context.Context) error {
+func (p *Prometheus) cAdvisor(ctx context.Context, string token) error {
 	// The request will be the same each time
 	podsURL := fmt.Sprintf("https://%s:10250/pods", p.NodeIP)
 	req, err := http.NewRequest("GET", podsURL, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Add("Accept", "application/json")
+	
 	if err != nil {
 		return fmt.Errorf("error when creating request to %s to get pod list: %w", podsURL, err)
 	}

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -145,11 +145,11 @@ func (p *Prometheus) watchPod(ctx context.Context, client *kubernetes.Clientset)
 	return nil
 }
 
-func (p *Prometheus) cAdvisor(ctx context.Context, string token) error {
+func (p *Prometheus) cAdvisor(ctx context.Context, bearerToken string) error {
 	// The request will be the same each time
 	podsURL := fmt.Sprintf("https://%s:10250/pods", p.NodeIP)
 	req, err := http.NewRequest("GET", podsURL, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
 	req.Header.Add("Accept", "application/json")
 	
 	if err != nil {

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -151,7 +151,7 @@ func (p *Prometheus) cAdvisor(ctx context.Context, bearerToken string) error {
 	req, err := http.NewRequest("GET", podsURL, nil)
 	req.Header.Set("Authorization", "Bearer "+bearerToken)
 	req.Header.Add("Accept", "application/json")
-	
+
 	if err != nil {
 		return fmt.Errorf("error when creating request to %s to get pod list: %w", podsURL, err)
 	}


### PR DESCRIPTION
Building upon #8762, the kubelet API requires auth if `--anonymous-auth` flag is set to false for kubelet (which is the case for EKS). 

Enabling that flag is a huge security risk

Closes https://github.com/influxdata/telegraf/issues/9408 https://github.com/influxdata/telegraf/issues/9349

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

**Before**

```sh
$ curl -v -k "https://10.38.177.113:10250/pods"
*   Trying 10.38.177.113:10250...
* Connected to 10.38.177.113 (10.38.177.113) port 10250 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: none
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):    
* TLSv1.3 (IN), TLS handshake, Request CERT (13):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1): 
* TLSv1.3 (OUT), TLS handshake, Certificate (11):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: O=system:nodes; CN=system:node:ip-10-38-177-113.ap-southeast-1.compute.internal
*  start date: Jul  8 06:58:00 2021 GMT
*  expire date: Jul  8 06:58:00 2022 GMT
*  issuer: CN=kubernetes
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x55f65d1620e0)
> GET /pods HTTP/2
> Host: 10.38.177.113:10250
> user-agent: curl/7.77.0
> accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* Connection state changed (MAX_CONCURRENT_STREAMS == 250)!
< HTTP/2 401
< content-type: text/plain; charset=utf-8
< content-length: 12
< date: Tue, 13 Jul 2021 19:21:15 GMT
<
* Connection #0 to host 10.38.177.113 left intact
```

**After**

```sh
$ export TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
$ curl -v -k -H "Authorization: Bearer $TOKEN" "https://10.38.177.113:10250/pods"
*   Trying 10.38.177.113:10250...
* Connected to 10.38.177.113 (10.38.177.113) port 10250 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: none
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):    
* TLSv1.3 (IN), TLS handshake, Request CERT (13):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1): 
* TLSv1.3 (OUT), TLS handshake, Certificate (11):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: O=system:nodes; CN=system:node:ip-10-38-177-113.ap-southeast-1.compute.internal
*  start date: Jul  8 06:58:00 2021 GMT
*  expire date: Jul  8 06:58:00 2022 GMT
*  issuer: CN=kubernetes
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x55f84ff27500)
> GET /pods HTTP/2
> Host: 10.38.177.113:10250
> user-agent: curl/7.77.0
> accept: */*
> authorization: Bearer <redacted>
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* Connection state changed (MAX_CONCURRENT_STREAMS == 250)!
< HTTP/2 200
< content-type: application/json
< date: Tue, 13 Jul 2021 19:19:37 GMT
<
<redacted>
* Connection #0 to host 10.38.177.113 left intact
```