### PR TITLE
Add sudo option for intel_rdt plugin

### DIFF
--- a/plugins/inputs/intel_rdt/README.md
+++ b/plugins/inputs/intel_rdt/README.md
@@ -24,6 +24,27 @@ Note: pqos tool needs root privileges to work properly.
 
 Metrics will be constantly reported from the following `pqos` commands within the given interval:
 
+#### If telegraf does not run as the root user
+
+The `pqos` command requires root level access to run.  There are two options to
+overcome this if you run telegraf as a non-root user.
+
+It is possible to update the pqos binary with setuid using `chmod u+s
+/path/to/pqos`.  This approach is simple and requires no modification to the
+Telegraf configuration, however pqos is not a read-only tool and there are
+security implications for making such a command setuid root.
+
+Alternately, you may enable sudo to allow `pqos` to run correctly, as follows:
+
+Add the following to your sudoers file (assumes telegraf runs as a user named `telegraf`):
+
+```
+telegraf ALL=(ALL) NOPASSWD:/usr/sbin/pqos -r --iface-os --mon-file-type=csv --mon-interval=*
+```
+
+If you wish to use sudo, you must also add `use_sudo = true` to the Telegraf
+configuration (see below).
+
 #### In case of cores monitoring:
 ```
 pqos -r --iface-os --mon-file-type=csv --mon-interval=INTERVAL --mon-core=all:[CORES]\;mbt:[CORES]
@@ -76,6 +97,10 @@ More about Intel RDT: https://www.intel.com/content/www/us/en/architecture-and-t
   ## Mandatory if cores aren't set and forbidden if cores are specified.
   ## e.g. ["qemu", "pmd"]
   # processes = ["process"]
+
+  ## Specify if the pqos process should be called with sudo.
+  ## Mandatory if the telegraf process does not run as root.
+  # use_sudo = false
 ```
 
 ### Exposed metrics

--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -45,6 +45,7 @@ type IntelRDT struct {
 	Processes        []string `toml:"processes"`
 	SamplingInterval int32    `toml:"sampling_interval"`
 	ShortenedMetrics bool     `toml:"shortened_metrics"`
+	UseSudo          bool     `toml:"use_sudo"`
 
 	Log              telegraf.Logger  `toml:"-"`
 	Publisher        Publisher        `toml:"-"`
@@ -96,6 +97,10 @@ func (r *IntelRDT) SampleConfig() string {
 	## Mandatory if cores aren't set and forbidden if cores are specified.
 	## e.g. ["qemu", "pmd"]
 	# processes = ["process"]
+
+	## Specify if the pqos process should be called with sudo.
+	## Mandatory if the telegraf process does not run as root.
+	# use_sudo = false
 `
 }
 
@@ -250,8 +255,15 @@ func (r *IntelRDT) createArgsAndStartPQOS(ctx context.Context) {
 func (r *IntelRDT) readData(ctx context.Context, args []string, processesPIDsAssociation map[string]string) {
 	r.wg.Add(1)
 	defer r.wg.Done()
-
-	cmd := exec.Command(r.PqosPath, append(args)...)
+	command := r.PqosPath
+	if r.UseSudo {
+		// Command switched to sh with sudo, note entire command is one string for sudo
+		// must replace ';' with '\;' to allow the shell to pass the command correctly
+		args = []string{"-c", fmt.Sprintf("sudo %s %s", r.PqosPath, strings.Replace(strings.Join(args, " "), ";", "\\;", -1))}
+		command = "/bin/sh"
+		r.Log.Info(fmt.Sprintf("Running pqos with sudo: cmdline=%s %s", command, strings.Join(args, " ")))
+	}
+	cmd := exec.Command(command, args...)
 
 	cmdReader, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9380

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

When running telegraf as a non-root user, this change allows the use
of sudo to run the necessary pqos command for the intel_rdt plugin.
