### PR TITLE
Make rabbitmq federation plugin optional

### DIFF
--- a/plugins/inputs/rabbitmq/README.md
+++ b/plugins/inputs/rabbitmq/README.md
@@ -61,7 +61,8 @@ For additional details reference the [RabbitMQ Management HTTP Stats][management
 
   ## Federation upstreams to include and exclude specified as an array of glob
   ## pattern strings.  Federation links can also be limited by the queue and
-  ## exchange filters.
+  ## exchange filters.  If the federation plugin is not enabled these settings
+  ## are ignored.
   # federation_upstream_include = []
   # federation_upstream_exclude = []
 ```

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -720,7 +721,11 @@ func gatherFederationLinks(r *RabbitMQ, acc telegraf.Accumulator) {
 	federationLinks := make([]FederationLink, 0)
 	err := r.requestJSON("/api/federation-links", &federationLinks)
 	if err != nil {
-		acc.AddError(err)
+		// Absence of federation plugin is not an error
+		if !strings.HasSuffix(err.Error(), ": 404 Not Found") {
+			acc.AddError(err)
+		}
+
 		return
 	}
 

--- a/plugins/inputs/rabbitmq/rabbitmq_test.go
+++ b/plugins/inputs/rabbitmq/rabbitmq_test.go
@@ -625,11 +625,10 @@ func TestRabbitMQMetricFilerts(t *testing.T) {
 	defer ts.Close()
 
 	metricErrors := map[string]error{
-		"exchange":   fmt.Errorf("getting \"/api/exchanges\" failed: 404 Not Found"),
-		"federation": fmt.Errorf("getting \"/api/federation-links\" failed: 404 Not Found"),
-		"node":       fmt.Errorf("getting \"/api/nodes\" failed: 404 Not Found"),
-		"overview":   fmt.Errorf("getting \"/api/overview\" failed: 404 Not Found"),
-		"queue":      fmt.Errorf("getting \"/api/queues\" failed: 404 Not Found"),
+		"exchange": fmt.Errorf("getting \"/api/exchanges\" failed: 404 Not Found"),
+		"node":     fmt.Errorf("getting \"/api/nodes\" failed: 404 Not Found"),
+		"overview": fmt.Errorf("getting \"/api/overview\" failed: 404 Not Found"),
+		"queue":    fmt.Errorf("getting \"/api/queues\" failed: 404 Not Found"),
 	}
 
 	// Include test


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9489

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Do not record an error for a 404 return for `api/federation-links`.