### PR TITLE
fix: Do not return on disconnect to avoid breaking reconnect

### DIFF
--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -407,7 +407,9 @@ func Connect(o *OpcUA) error {
 
 		if o.client != nil {
 			if err := o.client.CloseSession(); err != nil {
-				return err
+				// Only log the error but to not bail-out here as this prevents
+				// reconnections for multiple parties (see e.g. #9523).
+				o.Log.Errorf("Closing session failed: %v", err)
 			}
 		}
 

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +45,6 @@ func TestClient1Integration(t *testing.T) {
 	o.SecurityPolicy = "None"
 	o.SecurityMode = "None"
 	o.Log = testutil.Logger{}
-
 	for _, tags := range testopctags {
 		o.RootNodes = append(o.RootNodes, MapOPCTag(tags))
 	}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

resolves #9523 

The underlying OPCUA library seems to error out often when disconnecting sessions. In turn, with the recent linter-fixes (#8992) applied, reconnection fails due to the newly introduced error check in disconnect.
This PR changes the bailing-out with an error into logging the error only but allows to continue reconnection.