### PR TITLE
Fix metrics reported as written but not actually written 

### DIFF
--- a/plugins/outputs/influxdb/http_test.go
+++ b/plugins/outputs/influxdb/http_test.go
@@ -1091,7 +1091,6 @@ func TestDBRPTagsCreateDatabaseCalledOnDatabaseNotFound(t *testing.T) {
 				}
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				fmt.Println("one:", r.URL.Path, r.FormValue("q"))
 				switch r.URL.Path {
 				case "/write":
 					w.WriteHeader(http.StatusNotFound)
@@ -1101,7 +1100,6 @@ func TestDBRPTagsCreateDatabaseCalledOnDatabaseNotFound(t *testing.T) {
 				}
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				fmt.Println("two:", r.URL.Path, r.FormValue("q"))
 				switch r.URL.Path {
 				case "/query":
 					if r.FormValue("q") != `CREATE DATABASE "telegraf"` {
@@ -1114,7 +1112,6 @@ func TestDBRPTagsCreateDatabaseCalledOnDatabaseNotFound(t *testing.T) {
 				}
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				fmt.Println("three:", r.URL.Path)
 				switch r.URL.Path {
 				case "/write":
 					w.WriteHeader(http.StatusNoContent)

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -224,17 +224,19 @@ func (i *InfluxDB) Write(metrics []telegraf.Metric) error {
 
 		switch apiError := err.(type) {
 		case *DatabaseNotFoundError:
-			if !i.SkipDatabaseCreation {
-				allErrorsAreDatabaseNotFoundErrors = false
-				err := client.CreateDatabase(ctx, apiError.Database)
-				if err != nil {
-					i.Log.Errorf("When writing to [%s]: database %q not found and failed to recreate",
-						client.URL(), apiError.Database)
-				} else {
-					// try another client, if all clients fail with this error, do not return error
-					continue
-				}
+			if i.SkipDatabaseCreation {
+				continue
 			}
+
+			err := client.CreateDatabase(ctx, apiError.Database)
+			if err != nil {
+				i.Log.Errorf("When writing to [%s]: database %q not found and failed to recreate",
+					client.URL(), apiError.Database)
+			} else {
+				return errors.New("database created; retry write")
+			}
+		default:
+			allErrorsAreDatabaseNotFoundErrors = false
 		}
 	}
 
@@ -295,6 +297,7 @@ func (i *InfluxDB) httpClient(ctx context.Context, url *url.URL, proxy *url.URL)
 	}
 
 	if !i.SkipDatabaseCreation {
+		fmt.Println("I am the request in http client")
 		err = c.CreateDatabase(ctx, c.Database())
 		if err != nil {
 			i.Log.Warnf("When writing to [%s]: database %q creation failed: %v",

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -1,3 +1,4 @@
+//nolint
 package influxdb
 
 import (
@@ -227,7 +228,8 @@ func (i *InfluxDB) Write(metrics []telegraf.Metric) error {
 			if i.SkipDatabaseCreation {
 				continue
 			}
-
+			// retry control
+			// error so the write is retried
 			err := client.CreateDatabase(ctx, apiError.Database)
 			if err != nil {
 				i.Log.Errorf("When writing to [%s]: database %q not found and failed to recreate",
@@ -297,7 +299,6 @@ func (i *InfluxDB) httpClient(ctx context.Context, url *url.URL, proxy *url.URL)
 	}
 
 	if !i.SkipDatabaseCreation {
-		fmt.Println("I am the request in http client")
 		err = c.CreateDatabase(ctx, c.Database())
 		if err != nil {
 			i.Log.Warnf("When writing to [%s]: database %q creation failed: %v",


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9514 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
Reworked code to handle more than database not found errors so it will not say metrics are getting pushed when the database goes down. Also updated test