### PR TITLE
Read the complete body to allow the request to be reusued.

### DIFF
--- a/plugins/inputs/couchbase/couchbase.go
+++ b/plugins/inputs/couchbase/couchbase.go
@@ -2,6 +2,8 @@ package couchbase
 
 import (
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"regexp"
 	"sync"
@@ -373,8 +375,10 @@ func (cb *Couchbase) queryDetailedBucketStats(server, bucket string, bucketStats
 	if err != nil {
 		return err
 	}
-
 	defer r.Body.Close()
+
+	//nolint:errcheck  // We discard the body anyway
+	defer io.Copy(ioutil.Discard, r.Body)
 
 	return json.NewDecoder(r.Body).Decode(bucketStats)
 }


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

resolves #9495

This PR tries to tackle the memory leak observed in #9495 by reading the complete request body in order to allow reusing this body. Presumable the memory is drained due not allocating new requests in a high frequency.