### PR TITLE
Fix handling bool in sql input plugin

### DIFF
--- a/internal/type_conversions.go
+++ b/internal/type_conversions.go
@@ -191,6 +191,8 @@ func ToBool(value interface{}) (bool, error) {
 		return v > 0, nil
 	case float64:
 		return v > 0, nil
+	case bool:
+		return v, nil
 	case nil:
 		return false, nil
 	}


### PR DESCRIPTION
### Required for all PRs:

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

Resolves #9517 

The `ToBool` type conversion didn't check whether the value already was a boolean value (identity check). This adds the check so that bool values will be handled.