### PR TITLE
Update Go to v1.16.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
   go-1_16:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.16.5'
+      - image: 'quay.io/influxdb/telegraf-ci:1.16.6'
     environment:
       GOFLAGS: -p=8
   mac:
@@ -150,7 +150,7 @@ jobs:
     steps:
       - checkout
       - check-changed-files-or-halt-windows
-      - run: choco upgrade golang --version=1.16.5
+      - run: choco upgrade golang --version=1.16.6
       - run: choco install make
       - run: git config --system core.longpaths true
       - run: make test-windows

--- a/Makefile
+++ b/Makefile
@@ -201,8 +201,8 @@ ci-1.15:
 
 .PHONY: ci-1.16
 ci-1.16:
-	docker build -t quay.io/influxdb/telegraf-ci:1.16.5 - < scripts/ci-1.16.docker
-	docker push quay.io/influxdb/telegraf-ci:1.16.5
+	docker build -t quay.io/influxdb/telegraf-ci:1.16.6 - < scripts/ci-1.16.docker
+	docker push quay.io/influxdb/telegraf-ci:1.16.6
 
 .PHONY: install
 install: $(buildbin)

--- a/scripts/alpine.docker
+++ b/scripts/alpine.docker
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 as builder
+FROM golang:1.16.6 as builder
 WORKDIR /go/src/github.com/influxdata/telegraf
 
 COPY . /go/src/github.com/influxdata/telegraf

--- a/scripts/buster.docker
+++ b/scripts/buster.docker
@@ -1,4 +1,4 @@
-FROM golang:1.16.5-buster as builder
+FROM golang:1.16.6-buster as builder
 WORKDIR /go/src/github.com/influxdata/telegraf
 
 COPY . /go/src/github.com/influxdata/telegraf

--- a/scripts/ci-1.16.docker
+++ b/scripts/ci-1.16.docker
@@ -1,4 +1,4 @@
-FROM golang:1.16.5
+FROM golang:1.16.6
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/mac_installgo.sh
+++ b/scripts/mac_installgo.sh
@@ -4,7 +4,7 @@ set -eux
 
 GO_ARCH="darwin-amd64"
 GO_VERSION="1.16.6"
-GO_VERSION_SHA="be761716d5bfc958a5367440f68ba6563509da2f539ad1e1864bd42fe553f277" # from https://golang.org/dl
+GO_VERSION_SHA="0b49b6cbe50b30aa0a5bb9f8ccdbb43f9cd3d9a3c36a769b8e46777d694539b5" # from https://golang.org/dl
 
 # This path is cachable. (Saving in /usr/local/ would cause issues restoring the cache.)
 path="/usr/local/Cellar"

--- a/scripts/mac_installgo.sh
+++ b/scripts/mac_installgo.sh
@@ -3,7 +3,7 @@
 set -eux
 
 GO_ARCH="darwin-amd64"
-GO_VERSION="1.16.5"
+GO_VERSION="1.16.6"
 GO_VERSION_SHA="be761716d5bfc958a5367440f68ba6563509da2f539ad1e1864bd42fe553f277" # from https://golang.org/dl
 
 # This path is cachable. (Saving in /usr/local/ would cause issues restoring the cache.)

--- a/scripts/mac_installgo.sh
+++ b/scripts/mac_installgo.sh
@@ -4,7 +4,7 @@ set -eux
 
 GO_ARCH="darwin-amd64"
 GO_VERSION="1.16.6"
-GO_VERSION_SHA="0b49b6cbe50b30aa0a5bb9f8ccdbb43f9cd3d9a3c36a769b8e46777d694539b5" # from https://golang.org/dl
+GO_VERSION_SHA="e4e83e7c6891baa00062ed37273ce95835f0be77ad8203a29ec56dbf3d87508a" # from https://golang.org/dl
 
 # This path is cachable. (Saving in /usr/local/ would cause issues restoring the cache.)
 path="/usr/local/Cellar"


### PR DESCRIPTION
Release notes: https://golang.org/doc/devel/release#go1.16

Updating the CI to use 1.16.6