### PR TITLE
Prevent segfault in kube_inventory

### DIFF
--- a/plugins/inputs/kube_inventory/persistentvolumeclaim.go
+++ b/plugins/inputs/kube_inventory/persistentvolumeclaim.go
@@ -39,9 +39,11 @@ func (ki *KubernetesInventory) gatherPersistentVolumeClaim(pvc corev1.Persistent
 		"phase":        string(pvc.Status.Phase),
 		"storageclass": *pvc.Spec.StorageClassName,
 	}
-	for key, val := range pvc.Spec.Selector.MatchLabels {
-		if ki.selectorFilter.Match(key) {
-			tags["selector_"+key] = val
+	if pvc.Spec.Selector != nil {
+		for key, val := range pvc.Spec.Selector.MatchLabels {
+			if ki.selectorFilter.Match(key) {
+				tags["selector_"+key] = val
+			}
 		}
 	}
 

--- a/plugins/inputs/kube_inventory/persistentvolumeclaim_test.go
+++ b/plugins/inputs/kube_inventory/persistentvolumeclaim_test.go
@@ -88,6 +88,52 @@ func TestPersistentVolumeClaim(t *testing.T) {
 			},
 			hasError: false,
 		},
+		{
+			name:     "no label selectors",
+			hasError: false,
+			handler: &mockHandler{
+				responseMap: map[string]interface{}{
+					"/persistentvolumeclaims/": &corev1.PersistentVolumeClaimList{
+						Items: []corev1.PersistentVolumeClaim{
+							{
+								Status: corev1.PersistentVolumeClaimStatus{
+									Phase: "bound",
+								},
+								Spec: corev1.PersistentVolumeClaimSpec{
+									VolumeName:       "pvc-dc870fd6-1e08-11e8-b226-02aa4bc06eb8",
+									StorageClassName: toStrPtr("ebs-1"),
+									Selector:         nil,
+								},
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "ns1",
+									Name:      "pc1",
+									Labels: map[string]string{
+										"lab1": "v1",
+										"lab2": "v2",
+									},
+									CreationTimestamp: metav1.Time{Time: now},
+								},
+							},
+						},
+					},
+				},
+			},
+			output: []telegraf.Metric{
+				testutil.MustMetric(
+					"kubernetes_persistentvolumeclaim",
+					map[string]string{
+						"pvc_name":     "pc1",
+						"namespace":    "ns1",
+						"storageclass": "ebs-1",
+						"phase":        "bound",
+					},
+					map[string]interface{}{
+						"phase_type": 0,
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
 	}
 
 	for _, v := range tests {


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

as mentioned [here](https://github.com/influxdata/telegraf/pull/9456#issuecomment-876720823) and [here](https://github.com/influxdata/telegraf/issues/9537#issuecomment-885877302)

Fixes a segfault in `kube_inventory` when selector labels were not present on a persistent volume claim.
