### PR TITLE
Do not skip good quality nodes after a bad quality node is encountered

### DIFF
--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -31,6 +31,7 @@ type OpcUA struct {
 	RequestTimeout config.Duration `toml:"request_timeout"`
 	RootNodes      []NodeSettings  `toml:"nodes"`
 	Groups         []GroupSettings `toml:"group"`
+	Log            telegraf.Logger `toml:"-"`
 
 	nodes       []Node
 	nodeData    []OPCData
@@ -46,9 +47,6 @@ type OpcUA struct {
 	client *opcua.Client
 	req    *ua.ReadRequest
 	opts   []opcua.Option
-
-	// Logger
-	Log telegraf.Logger `toml:"-"`
 }
 
 // OPCTag type

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -255,6 +255,7 @@ func TestValidateOPCTags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			o := OpcUA{
 				nodes: tt.nodes,
+				Log:   testutil.Logger{},
 			}
 			require.Equal(t, tt.err, o.validateOPCTags())
 		})


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Resolves #8871, relates to #9523 and #9524

Properly handles nodes with a bad quality. Instead of returning the error, it is now only passed to the logger. Any following good quality nodes are no longer skipped.

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
