### PR TITLE
Fix procstat plugin README to match sample config

### DIFF
--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -28,7 +28,7 @@ Processes can be selected for monitoring using one of several methods:
   # user = "nginx"
   ## Systemd unit name, supports globs when include_systemd_children is set to true
   # systemd_unit = "nginx.service"
-  # systemd_all = true
+  # include_systemd_children = false
   ## CGroup name or path
   # cgroup = "systemd/system.slice/nginx.service"
 


### PR DESCRIPTION
Related to #9488, the README wasn't updated correctly and forgot to change ` systemd_all` to `include_systemd_children`.