### PR TITLE
feat: Extend regexp processor do allow renaming of measurements, tags and fields

### DIFF
--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -61,5 +61,5 @@ No tags are applied by this processor.
 
 ### Example Output:
 ```
-nginx_requests,verb=GET,resp_code=2xx request="/api/search/?category=plugins&q=regex&sort=asc",method="/search/",search_category="plugins",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
+nginx_requests,verb=GET,resp_code=2xx request="/api/search/?category=plugins&q=regex&sort=asc",method="/search/",category="plugins",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
 ```

--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -59,8 +59,8 @@ For metrics transforms, `key` denotes the element that should be transformed. Fu
   #   ## Matches of the pattern will be replaced with this string.  Use ${1}
   #   ## notation to use the text of the first submatch.
   #   replacement = "${1}"
-  #   ## If the new tag or field name is already present, you can either
-  #   ## "overwrite" or "keep" the existing tag or field.
+  #   ## If the new tag name is already present, you can either
+  #   ## "overwrite" or "keep" the existing tag.
   #   # result_key = "keep"
 
   # Rename metrics

--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -48,8 +48,8 @@ For metrics transforms, `key` denotes the element that should be transformed. Fu
     ## Matches of the pattern will be replaced with this string.  Use ${1}
     ## notation to use the text of the first submatch.
     replacement = "${1}"
-    ## If the new tag or field name is already present, you can either
-    ## "overwrite" or "keep" the existing tag or field.
+    ## If the new field name is already present, you can either
+    ## "overwrite" or "keep" the existing field.
     # result_key = "keep"
 
   # Rename metric tags

--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -48,8 +48,9 @@ For metrics transforms, `key` denotes the element that should be transformed. Fu
     ## Matches of the pattern will be replaced with this string.  Use ${1}
     ## notation to use the text of the first submatch.
     replacement = "${1}"
-    ## If the new field name is already present, you can either
-    ## "overwrite" or "keep" the existing field.
+    ## If the new field name already exists, you can either "overwrite" the
+    ## existing one with the value of the renamed field OR you can "keep"
+    ## both the existing and source field.
     # result_key = "keep"
 
   # Rename metric tags
@@ -59,8 +60,9 @@ For metrics transforms, `key` denotes the element that should be transformed. Fu
   #   ## Matches of the pattern will be replaced with this string.  Use ${1}
   #   ## notation to use the text of the first submatch.
   #   replacement = "${1}"
-  #   ## If the new tag name is already present, you can either
-  #   ## "overwrite" or "keep" the existing tag.
+  #   ## If the new tag name already exists, you can either "overwrite" the
+  #   ## existing one with the value of the renamed tag OR you can "keep"
+  #   ## both the existing and source tag.
   #   # result_key = "keep"
 
   # Rename metrics

--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -41,11 +41,9 @@ For metrics transforms, `key` denotes the element that should be transformed. Fu
     replacement = "${1}"
     result_key = "search_category"
 
-  # Replace metric element names such as "measurement", "tag" or "field" name
-  [[processors.regex.metrics]]
-    ## Element name to change, can be "measurement", "tags" or "fields"
-    key = "fields"
-    ## Regular expression to match on a element name
+  # Rename metric fields
+  [[processors.regex.field_rename]]
+    ## Regular expression to match on a field name
     pattern = "^search_(\\w+)d$"
     ## Matches of the pattern will be replaced with this string.  Use ${1}
     ## notation to use the text of the first submatch.
@@ -53,6 +51,28 @@ For metrics transforms, `key` denotes the element that should be transformed. Fu
     ## If the new tag or field name is already present, you can either
     ## "overwrite" or "keep" the existing tag or field.
     # result_key = "keep"
+
+  # Rename metric tags
+  # [[processors.regex.tag_rename]]
+  #   ## Regular expression to match on a tag name
+  #   pattern = "^search_(\\w+)d$"
+  #   ## Matches of the pattern will be replaced with this string.  Use ${1}
+  #   ## notation to use the text of the first submatch.
+  #   replacement = "${1}"
+  #   ## If the new tag or field name is already present, you can either
+  #   ## "overwrite" or "keep" the existing tag or field.
+  #   # result_key = "keep"
+
+  # Rename metrics
+  # [[processors.regex.metric_rename]]
+  #   ## Regular expression to match on an metric name
+  #   pattern = "^search_(\\w+)d$"
+  #   ## Matches of the pattern will be replaced with this string.  Use ${1}
+  #   ## notation to use the text of the first submatch.
+  #   replacement = "${1}"
+  #   ## If the new tag or field name is already present, you can either
+  #   ## "overwrite" or "keep" the existing tag or field.
+  #   # result_key = "keep"
 ```
 
 ### Tags:

--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -70,9 +70,6 @@ For metrics transforms, `key` denotes the element that should be transformed. Fu
   #   ## Matches of the pattern will be replaced with this string.  Use ${1}
   #   ## notation to use the text of the first submatch.
   #   replacement = "${1}"
-  #   ## If the new tag or field name is already present, you can either
-  #   ## "overwrite" or "keep" the existing tag or field.
-  #   # result_key = "keep"
 ```
 
 ### Tags:

--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -4,6 +4,8 @@ The `regex` plugin transforms tag and field values with regex pattern. If `resul
 
 For tags transforms, if `append` is set to `true`, it will append the transformation to the existing tag value, instead of overwriting it.
 
+For metrics transforms, `key` denotes the element that should be transformed. Furthermore, `result_key` allows control over the behavior applied in case the resulting `tag` or `field` name already exists.
+
 ### Configuration:
 
 ```toml
@@ -38,6 +40,19 @@ For tags transforms, if `append` is set to `true`, it will append the transforma
     pattern = ".*category=(\\w+).*"
     replacement = "${1}"
     result_key = "search_category"
+
+  # Replace metric element names such as "measurement", "tag" or "field" name
+  [[processors.regex.metrics]]
+    ## Element name to change, can be "measurement", "tags" or "fields"
+    key = "fields"
+    ## Regular expression to match on a element name
+    pattern = "^search_(\\w+)d$"
+    ## Matches of the pattern will be replaced with this string.  Use ${1}
+    ## notation to use the text of the first submatch.
+    replacement = "${1}"
+    ## If the new tag or field name is already present, you can either
+    ## "overwrite" or "keep" the existing tag or field.
+    # result_key = "keep"
 ```
 
 ### Tags:

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -57,7 +57,7 @@ const sampleConfig = `
   #   replacement = "${1}"
   #   result_key = "search_category"
 
-	## Rename metric fields
+  ## Rename metric fields
   # [[processors.regex.field_rename]]
   #   ## Regular expression to match on a field name
   #   pattern = "^search_(\\w+)d$"

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -211,7 +211,7 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 					}
 				}
 			}
-			// We needed to postpone the replacement as we cannot modify the field-list
+			// We needed to postpone the replacement as we cannot modify the tag-list
 			// while iterating it as this will result in invalid memory dereference panic.
 			for oldName, newName := range replacements {
 				value, ok := metric.GetTag(oldName)

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -128,9 +128,8 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 
 		for _, converter := range r.Fields {
 			if value, ok := metric.GetField(converter.Key); ok {
-				switch value := value.(type) {
-				case string:
-					if key, newValue := r.convert(converter, value); newValue != "" {
+				if v, ok := value.(string); ok {
+					if key, newValue := r.convert(converter, v); newValue != "" {
 						metric.AddField(key, newValue)
 					}
 				}
@@ -214,10 +213,9 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	return in
 }
 
-func (r *Regex) convert(c converter, src string) (string, string) {
+func (r *Regex) convert(c converter, src string) (key string, value string) {
 	regex := r.regexCache[c.Pattern]
 
-	value := ""
 	if c.ResultKey == "" || regex.MatchString(src) {
 		value = regex.ReplaceAllString(src, c.Replacement)
 	}

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -146,8 +146,7 @@ func (r *Regex) Init() error {
 		}
 
 		if c.ResultKey != "" {
-			r.Log.Info("'metric_rename' section contains a result_key setting which is ignored during processing")
-			r.Log.Info("'metric_rename' sections will ALWAYS overwrite the name of the metric")
+			r.Log.Info("'metric_rename' section contains a 'result_key' ignored during processing as metrics will ALWAYS the name")
 		}
 
 		if _, compiled := r.regexCache[c.Pattern]; !compiled {
@@ -219,7 +218,6 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 					// Just in case the tag got removed in the meantime
 					continue
 				}
-				metric.RemoveTag(newName)
 				metric.AddTag(newName, value)
 				metric.RemoveTag(oldName)
 			}
@@ -253,7 +251,6 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 					// Just in case the field got removed in the meantime
 					continue
 				}
-				metric.RemoveField(newName)
 				metric.AddField(newName, value)
 				metric.RemoveField(oldName)
 			}

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -216,7 +216,7 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 			for oldName, newName := range replacements {
 				value, ok := metric.GetTag(oldName)
 				if !ok {
-					// Just in case the field got removed in the meantime
+					// Just in case the tag got removed in the meantime
 					continue
 				}
 				metric.RemoveTag(newName)

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -203,6 +203,7 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 					if !metric.HasTag(newName) {
 						// There is no colliding tag, we can just change the name.
 						tag.Key = newName
+						continue
 					}
 
 					if converter.ResultKey == "overwrite" {
@@ -236,6 +237,7 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 					if !metric.HasField(newName) {
 						// There is no colliding field, we can just change the name.
 						field.Key = newName
+						continue
 					}
 
 					if converter.ResultKey == "overwrite" {

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -1,15 +1,18 @@
 package regex
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal/choice"
 	"github.com/influxdata/telegraf/plugins/processors"
 )
 
 type Regex struct {
 	Tags       []converter     `toml:"tags"`
 	Fields     []converter     `toml:"fields"`
+	Metrics    []converter     `toml:"metrics"`
 	Log        telegraf.Logger `toml:"-"`
 	regexCache map[string]*regexp.Regexp
 }
@@ -51,6 +54,19 @@ const sampleConfig = `
   #   pattern = ".*category=(\\w+).*"
   #   replacement = "${1}"
   #   result_key = "search_category"
+
+  ## Replace metric element names such as "measurement", "tag" or "field" name
+  # [[processors.regex.metrics]]
+  #   ## Element name to change, can be "measurement", "tags" or "fields"
+  #   key = "fields"
+  #   ## Regular expression to match on a element name
+  #   pattern = "^value_(\\d)_\\d_\\d$"
+  #   ## Matches of the pattern will be replaced with this string.  Use ${1}
+  #   ## notation to use the text of the first submatch.
+  #   replacement = "${1}"
+  #   ## If the new tag or field name is already present, you can either
+  #   ## "overwrite" or "keep" the existing tag or field.
+  #   # result_key = "keep"
 `
 
 func (r *Regex) Init() error {
@@ -67,6 +83,22 @@ func (r *Regex) Init() error {
 			r.regexCache[c.Pattern] = regexp.MustCompile(c.Pattern)
 		}
 	}
+	for _, c := range r.Metrics {
+		if err := choice.Check(c.Key, []string{"measurement", "fields", "tags"}); err != nil {
+			return fmt.Errorf("invalid metrics key: %v", err)
+		}
+
+		if c.ResultKey == "" {
+			c.ResultKey = "keep"
+		}
+		if err := choice.Check(c.ResultKey, []string{"overwrite", "keep"}); err != nil {
+			return fmt.Errorf("invalid metrics result_key: %v", err)
+		}
+
+		if _, compiled := r.regexCache[c.Pattern]; !compiled {
+			r.regexCache[c.Pattern] = regexp.MustCompile(c.Pattern)
+		}
+	}
 
 	return nil
 }
@@ -76,7 +108,7 @@ func (r *Regex) SampleConfig() string {
 }
 
 func (r *Regex) Description() string {
-	return "Transforms tag and field values with regex pattern"
+	return "Transforms tag and field values as well as measurement, tag and field names with regex pattern"
 }
 
 func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
@@ -101,6 +133,79 @@ func (r *Regex) Apply(in ...telegraf.Metric) []telegraf.Metric {
 					if key, newValue := r.convert(converter, value); newValue != "" {
 						metric.AddField(key, newValue)
 					}
+				}
+			}
+		}
+
+		for _, converter := range r.Metrics {
+			regex := r.regexCache[converter.Pattern]
+
+			switch converter.Key {
+			case "measurement":
+				value := metric.Name()
+				if regex.MatchString(value) {
+					newValue := regex.ReplaceAllString(value, converter.Replacement)
+					metric.SetName(newValue)
+				}
+			case "fields":
+				replacements := make(map[string]string)
+				for _, field := range metric.FieldList() {
+					name := field.Key
+					if regex.MatchString(name) {
+						newName := regex.ReplaceAllString(name, converter.Replacement)
+
+						if !metric.HasField(newName) {
+							// There is no colliding field, we can just change the name.
+							field.Key = newName
+						}
+
+						if converter.ResultKey == "overwrite" {
+							// We got a colliding field, remember the replacement and do it later
+							replacements[name] = newName
+						}
+					}
+				}
+				// We needed to postpone the replacement as we cannot modify the field-list
+				// while iterating it as this will result in invalid memory dereference panic.
+				for oldName, newName := range replacements {
+					value, ok := metric.GetField(oldName)
+					if !ok {
+						// Just in case the field got removed in the meantime
+						continue
+					}
+					metric.RemoveField(newName)
+					metric.AddField(newName, value)
+					metric.RemoveField(oldName)
+				}
+			case "tags":
+				replacements := make(map[string]string)
+				for _, tag := range metric.TagList() {
+					name := tag.Key
+					if regex.MatchString(name) {
+						newName := regex.ReplaceAllString(name, converter.Replacement)
+
+						if !metric.HasTag(newName) {
+							// There is no colliding tag, we can just change the name.
+							tag.Key = newName
+						}
+
+						if converter.ResultKey == "overwrite" {
+							// We got a colliding tag, remember the replacement and do it later
+							replacements[name] = newName
+						}
+					}
+				}
+				// We needed to postpone the replacement as we cannot modify the field-list
+				// while iterating it as this will result in invalid memory dereference panic.
+				for oldName, newName := range replacements {
+					value, ok := metric.GetTag(oldName)
+					if !ok {
+						// Just in case the field got removed in the meantime
+						continue
+					}
+					metric.RemoveTag(newName)
+					metric.AddTag(newName, value)
+					metric.RemoveTag(oldName)
 				}
 			}
 		}

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -159,6 +160,406 @@ func TestTagConversions(t *testing.T) {
 		assert.Equal(t, expectedFields, processed[0].Fields(), test.message, "Should not change fields")
 		assert.Equal(t, test.expectedTags, processed[0].Tags(), test.message)
 		assert.Equal(t, "access_log", processed[0].Name(), "Should not change name")
+	}
+}
+
+func TestMetricConversions(t *testing.T) {
+	inputTemplate := []telegraf.Metric{
+		testutil.MustMetric(
+			"access_log",
+			map[string]string{
+				"verb":      "GET",
+				"resp_code": "200",
+			},
+			map[string]interface{}{
+				"request": "/users/42/",
+			},
+			time.Unix(1627646243, 0),
+		),
+		testutil.MustMetric(
+			"access_log",
+			map[string]string{
+				"verb":      "GET",
+				"resp_code": "200",
+			},
+			map[string]interface{}{
+				"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+				"ignore_number": int64(200),
+				"ignore_bool":   true,
+			},
+			time.Unix(1627646253, 0),
+		),
+		testutil.MustMetric(
+			"error_log",
+			map[string]string{
+				"verb":      "GET",
+				"resp_code": "404",
+			},
+			map[string]interface{}{
+				"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+				"ignore_number": int64(404),
+				"ignore_flag":   true,
+				"error_message": "request too silly",
+			},
+			time.Unix(1627646263, 0),
+		),
+	}
+
+	tests := []struct {
+		name      string
+		converter converter
+		expected  []telegraf.Metric
+	}{
+		{
+			name: "Should change metric name",
+			converter: converter{
+				Key:         "measurement",
+				Pattern:     "^(\\w+)_log$",
+				Replacement: "${1}",
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"access",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "200",
+					},
+					map[string]interface{}{
+						"request": "/users/42/",
+					},
+					time.Unix(1627646243, 0),
+				),
+				testutil.MustMetric(
+					"access",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "200",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(200),
+						"ignore_bool":   true,
+					},
+					time.Unix(1627646253, 0),
+				),
+				testutil.MustMetric(
+					"error",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "404",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(404),
+						"ignore_flag":   true,
+						"error_message": "request too silly",
+					},
+					time.Unix(1627646263, 0),
+				),
+			},
+		},
+		{
+			name: "Should change field name",
+			converter: converter{
+				Key:         "fields",
+				Pattern:     "^(?:ignore|error)_(\\w+)$",
+				Replacement: "result_${1}",
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "200",
+					},
+					map[string]interface{}{
+						"request": "/users/42/",
+					},
+					time.Unix(1627646243, 0),
+				),
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "200",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"result_number": int64(200),
+						"result_bool":   true,
+					},
+					time.Unix(1627646253, 0),
+				),
+				testutil.MustMetric(
+					"error_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "404",
+					},
+					map[string]interface{}{
+						"request":        "/api/search/?category=plugins&q=regex&sort=asc",
+						"result_number":  int64(404),
+						"result_flag":    true,
+						"result_message": "request too silly",
+					},
+					time.Unix(1627646263, 0),
+				),
+			},
+		},
+		{
+			name: "Should change tag name",
+			converter: converter{
+				Key:         "tags",
+				Pattern:     "^resp_(\\w+)$",
+				Replacement: "${1}",
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb": "GET",
+						"code": "200",
+					},
+					map[string]interface{}{
+						"request": "/users/42/",
+					},
+					time.Unix(1627646243, 0),
+				),
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb": "GET",
+						"code": "200",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(200),
+						"ignore_bool":   true,
+					},
+					time.Unix(1627646253, 0),
+				),
+				testutil.MustMetric(
+					"error_log",
+					map[string]string{
+						"verb": "GET",
+						"code": "404",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(404),
+						"ignore_flag":   true,
+						"error_message": "request too silly",
+					},
+					time.Unix(1627646263, 0),
+				),
+			},
+		},
+		{
+			name: "Should keep existing field name",
+			converter: converter{
+				Key:         "fields",
+				Pattern:     "^(?:ignore|error)_(\\w+)$",
+				Replacement: "request",
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "200",
+					},
+					map[string]interface{}{
+						"request": "/users/42/",
+					},
+					time.Unix(1627646243, 0),
+				),
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "200",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(200),
+						"ignore_bool":   true,
+					},
+					time.Unix(1627646253, 0),
+				),
+				testutil.MustMetric(
+					"error_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "404",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(404),
+						"ignore_flag":   true,
+						"error_message": "request too silly",
+					},
+					time.Unix(1627646263, 0),
+				),
+			},
+		},
+		{
+			name: "Should keep existing tag name",
+			converter: converter{
+				Key:         "tags",
+				Pattern:     "^resp_(\\w+)$",
+				Replacement: "verb",
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "200",
+					},
+					map[string]interface{}{
+						"request": "/users/42/",
+					},
+					time.Unix(1627646243, 0),
+				),
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "200",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(200),
+						"ignore_bool":   true,
+					},
+					time.Unix(1627646253, 0),
+				),
+				testutil.MustMetric(
+					"error_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "404",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(404),
+						"ignore_flag":   true,
+						"error_message": "request too silly",
+					},
+					time.Unix(1627646263, 0),
+				),
+			},
+		},
+		{
+			name: "Should overwrite existing field name",
+			converter: converter{
+				Key:         "fields",
+				Pattern:     "^ignore_bool$",
+				Replacement: "request",
+				ResultKey:   "overwrite",
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "200",
+					},
+					map[string]interface{}{
+						"request": "/users/42/",
+					},
+					time.Unix(1627646243, 0),
+				),
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "200",
+					},
+					map[string]interface{}{
+						"ignore_number": int64(200),
+						"request":       true,
+					},
+					time.Unix(1627646253, 0),
+				),
+				testutil.MustMetric(
+					"error_log",
+					map[string]string{
+						"verb":      "GET",
+						"resp_code": "404",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(404),
+						"ignore_flag":   true,
+						"error_message": "request too silly",
+					},
+					time.Unix(1627646263, 0),
+				),
+			},
+		},
+		{
+			name: "Should overwrite existing tag name",
+			converter: converter{
+				Key:         "tags",
+				Pattern:     "^resp_(\\w+)$",
+				Replacement: "verb",
+				ResultKey:   "overwrite",
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb": "200",
+					},
+					map[string]interface{}{
+						"request": "/users/42/",
+					},
+					time.Unix(1627646243, 0),
+				),
+				testutil.MustMetric(
+					"access_log",
+					map[string]string{
+						"verb": "200",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(200),
+						"ignore_bool":   true,
+					},
+					time.Unix(1627646253, 0),
+				),
+				testutil.MustMetric(
+					"error_log",
+					map[string]string{
+						"verb": "404",
+					},
+					map[string]interface{}{
+						"request":       "/api/search/?category=plugins&q=regex&sort=asc",
+						"ignore_number": int64(404),
+						"ignore_flag":   true,
+						"error_message": "request too silly",
+					},
+					time.Unix(1627646263, 0),
+				),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		// Copy the inputs as they will be modified by the processor
+		input := make([]telegraf.Metric, len(inputTemplate))
+		for i, m := range inputTemplate {
+			input[i] = m.Copy()
+		}
+
+		t.Run(test.name, func(t *testing.T) {
+			regex := Regex{Metrics: []converter{test.converter}}
+			require.NoError(t, regex.Init())
+
+			actual := regex.Apply(input...)
+			testutil.RequireMetricsEqual(t, test.expected, actual)
+		})
 	}
 }
 

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -5,15 +5,14 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func newM1() telegraf.Metric {
-	m1 := metric.New("access_log",
+	return testutil.MustMetric(
+		"access_log",
 		map[string]string{
 			"verb":      "GET",
 			"resp_code": "200",
@@ -23,11 +22,11 @@ func newM1() telegraf.Metric {
 		},
 		time.Now(),
 	)
-	return m1
 }
 
 func newM2() telegraf.Metric {
-	m2 := metric.New("access_log",
+	return testutil.MustMetric(
+		"access_log",
 		map[string]string{
 			"verb":      "GET",
 			"resp_code": "200",
@@ -39,7 +38,6 @@ func newM2() telegraf.Metric {
 		},
 		time.Now(),
 	)
-	return m2
 }
 
 func TestFieldConversions(t *testing.T) {
@@ -89,9 +87,9 @@ func TestFieldConversions(t *testing.T) {
 			"resp_code": "200",
 		}
 
-		assert.Equal(t, test.expectedFields, processed[0].Fields(), test.message)
-		assert.Equal(t, expectedTags, processed[0].Tags(), "Should not change tags")
-		assert.Equal(t, "access_log", processed[0].Name(), "Should not change name")
+		require.Equal(t, test.expectedFields, processed[0].Fields(), test.message)
+		require.Equal(t, expectedTags, processed[0].Tags(), "Should not change tags")
+		require.Equal(t, "access_log", processed[0].Name(), "Should not change name")
 	}
 }
 
@@ -157,9 +155,9 @@ func TestTagConversions(t *testing.T) {
 			"request": "/users/42/",
 		}
 
-		assert.Equal(t, expectedFields, processed[0].Fields(), test.message, "Should not change fields")
-		assert.Equal(t, test.expectedTags, processed[0].Tags(), test.message)
-		assert.Equal(t, "access_log", processed[0].Name(), "Should not change name")
+		require.Equal(t, expectedFields, processed[0].Fields(), test.message, "Should not change fields")
+		require.Equal(t, test.expectedTags, processed[0].Tags(), test.message)
+		require.Equal(t, "access_log", processed[0].Name(), "Should not change name")
 	}
 }
 
@@ -612,8 +610,8 @@ func TestMultipleConversions(t *testing.T) {
 		"resp_code_text":  "OK",
 	}
 
-	assert.Equal(t, expectedFields, processed[0].Fields())
-	assert.Equal(t, expectedTags, processed[0].Tags())
+	require.Equal(t, expectedFields, processed[0].Fields())
+	require.Equal(t, expectedTags, processed[0].Tags())
 }
 
 func TestNoMatches(t *testing.T) {
@@ -668,7 +666,7 @@ func TestNoMatches(t *testing.T) {
 
 		processed := regex.Apply(newM1())
 
-		assert.Equal(t, test.expectedFields, processed[0].Fields(), test.message)
+		require.Equal(t, test.expectedFields, processed[0].Fields(), test.message)
 	}
 }
 


### PR DESCRIPTION
- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.

resolves #5159
resolves #9506 
resolves #9557 

related to #6830, #6831

With this PR, the `regexp` processor is able to rename measurements, tags and fields using regular expressions. To do so, the user specifies _what_ to rename using the `key` property. Furthermore, the user has control over the behavior in case the resulting tag or field name already exists by changing the `result_key` value between `overwrite` and `keep`.