### PR TITLE
fix: CrateDB replace dots in tag keys with underscores

### DIFF
--- a/plugins/outputs/cratedb/README.md
+++ b/plugins/outputs/cratedb/README.md
@@ -35,4 +35,6 @@ config option, see below.
   table = "metrics"
   # If true, and the metrics table does not exist, create it automatically.
   table_create = true
+  # The character(s) to replace any '.' in an object key with
+  key_separator = "_"
 ```

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -77,7 +77,7 @@ func (c *CrateDB) Write(metrics []telegraf.Metric) error {
 		return err
 	}
 
-	_, err := c.DB.ExecContext(ctx, generatedSQL)
+	_, err = c.DB.ExecContext(ctx, generatedSQL)
 	if err != nil {
 		return err
 	}

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -77,7 +77,7 @@ func (c *CrateDB) Write(metrics []telegraf.Metric) error {
 		return err
 	}
 
-	result, err := c.DB.ExecContext(ctx, generatedSQL)
+	_, err := c.DB.ExecContext(ctx, generatedSQL)
 	if err != nil {
 		return err
 	}

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -69,12 +69,12 @@ func (c *CrateDB) Write(metrics []telegraf.Metric) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.Timeout))
 	defer cancel()
 
-	generatedSql, err := insertSQL(c.Table, metrics)
+	generatedSQL, err := insertSQL(c.Table, metrics)
 	if err != nil {
 		return err
 	}
 
-	result, err := c.DB.ExecContext(ctx, generatedSql)
+	result, err := c.DB.ExecContext(ctx, generatedSQL)
 	if err != nil {
 		return err
 	}

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -190,7 +190,7 @@ func escapeObject(m map[string]interface{}, keyReplacement string) (string, erro
 	// Now we build our key = val pairs
 	pairs := make([]string, 0, len(m))
 	for _, k := range keys {
-		key := strings.ReplaceAll(escapeString(k, `"`), ".", keyReplacement)
+		key := escapeString(strings.ReplaceAll(k, ".", keyReplacement), `"`)
 
 		// escape the value of the value at k (potentially recursive)
 		val, err := escapeValue(m[k], keyReplacement)

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -187,12 +187,15 @@ func escapeObject(m map[string]interface{}) (string, error) {
 	// Now we build our key = val pairs
 	pairs := make([]string, 0, len(m))
 	for _, k := range keys {
-		// escape the value of our key k (potentially recursive)
+		key := strings.ReplaceAll(escapeString(k, `"`), ".", "_")
+
+		// escape the value of the value at k (potentially recursive)
 		val, err := escapeValue(m[k])
 		if err != nil {
 			return "", err
 		}
-		pairs = append(pairs, escapeString(k, `"`)+" = "+val)
+
+		pairs = append(pairs, key+" = "+val)
 	}
 	return `{` + strings.Join(pairs, ", ") + `}`, nil
 }

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -82,16 +82,6 @@ func (c *CrateDB) Write(metrics []telegraf.Metric) error {
 		return err
 	}
 
-	if affected, err := result.RowsAffected(); err != nil {
-		return err
-	} else if affected != int64(len(metrics)) {
-		// Unfortunately this is the most we can do to ensure everything was written. CrateDB
-		// does not return an error for a single row when doing bulk inserts, instead it just
-		// decrements the number of affected rows.
-		// https://crate.io/docs/crate/reference/en/latest/general/dml.html#inserting-data
-		return fmt.Errorf("failed to insert %d rows", int64(len(metrics))-affected)
-	}
-
 	return nil
 }
 

--- a/plugins/outputs/cratedb/cratedb_test.go
+++ b/plugins/outputs/cratedb/cratedb_test.go
@@ -48,9 +48,9 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 	// the rows using their primary keys in order to take advantage of
 	// read-after-write consistency in CrateDB.
 	for _, m := range metrics {
-		hashIDVal, err := escapeValue(hashID(m))
+		hashIDVal, err := escapeValue(hashID(m), "_")
 		require.NoError(t, err)
-		timestamp, err := escapeValue(m.Time())
+		timestamp, err := escapeValue(m.Time(), "_")
 		require.NoError(t, err)
 
 		var id int64
@@ -84,7 +84,7 @@ VALUES
 	}
 
 	for _, test := range tests {
-		if got, err := insertSQL("my_table", test.Metrics); err != nil {
+		if got, err := insertSQL("my_table", "_", test.Metrics); err != nil {
 			t.Error(err)
 		} else if got != test.Want {
 			t.Errorf("got:\n%s\n\nwant:\n%s", got, test.Want)
@@ -141,7 +141,7 @@ func Test_escapeValueIntegration(t *testing.T) {
 
 	tests := escapeValueTests()
 	for _, test := range tests {
-		got, err := escapeValue(test.Value)
+		got, err := escapeValue(test.Value, "_")
 		require.NoError(t, err, "value: %#v", test.Value)
 
 		// This is a smoke test that will blow up if our escaping causing a SQL
@@ -155,7 +155,7 @@ func Test_escapeValueIntegration(t *testing.T) {
 func Test_escapeValue(t *testing.T) {
 	tests := escapeValueTests()
 	for _, test := range tests {
-		got, err := escapeValue(test.Value)
+		got, err := escapeValue(test.Value, "_")
 		require.NoError(t, err, "value: %#v", test.Value)
 		require.Equal(t, got, test.Want)
 	}

--- a/plugins/outputs/cratedb/cratedb_test.go
+++ b/plugins/outputs/cratedb/cratedb_test.go
@@ -161,6 +161,12 @@ func Test_escapeValue(t *testing.T) {
 	}
 }
 
+func Test_circumeventingStringEscape(t *testing.T) {
+	value, err := escapeObject(map[string]interface{}{"a.b": "c"}, `_"`)
+	require.NoError(t, err)
+	require.Equal(t, value, `{"a_""b" = 'c'}`)
+}
+
 func Test_hashID(t *testing.T) {
 	tests := []struct {
 		Name   string

--- a/telegraf.conf
+++ b/telegraf.conf
@@ -1,0 +1,1 @@
+/home/alex/Documents/Git/influxdata/issues/7026/telegraf.conf

--- a/telegraf.conf
+++ b/telegraf.conf
@@ -1,1 +1,0 @@
-/home/alex/Documents/Git/influxdata/issues/7026/telegraf.conf


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

resolves #7026 

Fixes a bug in the `cratedb` output where records would fail to insert if any tags contained keys separated by dots by replacing all dots with underscores in the key. Also made insertion errors more explicit since CrateDB does not cause the entire insert command to fail when the one record fails in a batch.
