### PR TITLE
docs: Adding links to net_irtt and dht_sensor external plugins

### DIFF
--- a/EXTERNAL_PLUGINS.md
+++ b/EXTERNAL_PLUGINS.md
@@ -21,6 +21,7 @@ Pull requests welcome.
 - [x509_crl](https://github.com/jcgonnard/telegraf-input-x590crl) - Gather information from your X509 CRL files
 - [s7comm](https://github.com/nicolasme/s7comm) - Gather information from Siemens PLC
 - [net_irtt](https://github.com/iAnatoly/telegraf-input-net_irtt) - Gather information from IRTT network test
+- [dht_sensor](https://github.com/iAnatoly/telegraf-input-dht_sensor) - Gather temperature and humidity from DHTXX sensors
 
 ## Outputs
 - [kinesis](https://github.com/morfien101/telegraf-output-kinesis) - Aggregation and compression of metrics to send Amazon Kinesis.

--- a/EXTERNAL_PLUGINS.md
+++ b/EXTERNAL_PLUGINS.md
@@ -20,6 +20,7 @@ Pull requests welcome.
 - [ldap_org and ds389](https://github.com/falon/CSI-telegraf-plugins) - Gather statistics from 389ds and from LDAP trees.
 - [x509_crl](https://github.com/jcgonnard/telegraf-input-x590crl) - Gather information from your X509 CRL files
 - [s7comm](https://github.com/nicolasme/s7comm) - Gather information from Siemens PLC
+- [net_irtt](https://github.com/iAnatoly/telegraf-input-net_irtt) - Gather information from IRTT network test
 
 ## Outputs
 - [kinesis](https://github.com/morfien101/telegraf-output-kinesis) - Aggregation and compression of metrics to send Amazon Kinesis.


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [ n/a ] Wrote appropriate unit tests.

Summary: adding a link to net_irtt external plugin, as per https://github.com/influxdata/telegraf/tree/master/plugins/common/shim