### PR TITLE
fix: sort logs by timestamp before writing to Loki

### DIFF
--- a/plugins/outputs/loki/README.md
+++ b/plugins/outputs/loki/README.md
@@ -3,6 +3,8 @@
 This plugin sends logs to Loki, using tags as labels, 
 log line will content all fields in `key="value"` format which is easily parsable with `logfmt` parser in Loki.
 
+Logs within each stream are sorted by timestamp before being sent to Loki.
+
 ### Configuration:
 
 ```toml

--- a/plugins/outputs/loki/loki.go
+++ b/plugins/outputs/loki/loki.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -146,6 +147,10 @@ func (l *Loki) Write(metrics []telegraf.Metric) error {
 		}
 
 		s.insertLog(tags, Log{fmt.Sprintf("%d", m.Time().UnixNano()), line})
+	}
+
+	for _, stream := range s {
+		sort.SliceStable(stream.Logs, func(i, j int) bool { return stream.Logs[i][0] < stream.Logs[j][0] })
 	}
 
 	return l.write(s)

--- a/plugins/outputs/loki/loki.go
+++ b/plugins/outputs/loki/loki.go
@@ -138,6 +138,10 @@ func (l *Loki) Close() error {
 func (l *Loki) Write(metrics []telegraf.Metric) error {
 	s := Streams{}
 
+	sort.SliceStable(metrics, func(i, j int) bool {
+		return metrics[i].Time().Before(metrics[j].Time())
+	})
+
 	for _, m := range metrics {
 		tags := m.TagList()
 		var line string
@@ -147,10 +151,6 @@ func (l *Loki) Write(metrics []telegraf.Metric) error {
 		}
 
 		s.insertLog(tags, Log{fmt.Sprintf("%d", m.Time().UnixNano()), line})
-	}
-
-	for _, stream := range s {
-		sort.SliceStable(stream.Logs, func(i, j int) bool { return stream.Logs[i][0] < stream.Logs[j][0] })
 	}
 
 	return l.write(s)

--- a/plugins/outputs/loki/loki_test.go
+++ b/plugins/outputs/loki/loki_test.go
@@ -42,7 +42,7 @@ func getOutOfOrderMetrics() []telegraf.Metric {
 				"line":  "newer log",
 				"field": 3.14,
 			},
-			time.Unix(456, 0),
+			time.Unix(1230, 0),
 		),
 		testutil.MustMetric(
 			"log",
@@ -53,7 +53,7 @@ func getOutOfOrderMetrics() []telegraf.Metric {
 				"line":  "older log",
 				"field": 3.14,
 			},
-			time.Unix(123, 0),
+			time.Unix(456, 0),
 		),
 	}
 }
@@ -404,10 +404,10 @@ func TestMetricSorting(t *testing.T) {
 			require.Len(t, s.Streams[0].Logs, 2)
 			require.Len(t, s.Streams[0].Logs[0], 2)
 			require.Equal(t, map[string]string{"key1": "value1"}, s.Streams[0].Labels)
-			require.Equal(t, "123000000000", s.Streams[0].Logs[0][0])
+			require.Equal(t, "456000000000", s.Streams[0].Logs[0][0])
 			require.Contains(t, s.Streams[0].Logs[0][1], "line=\"older log\"")
 			require.Contains(t, s.Streams[0].Logs[0][1], "field=\"3.14\"")
-			require.Equal(t, "456000000000", s.Streams[0].Logs[1][0])
+			require.Equal(t, "1230000000000", s.Streams[0].Logs[1][0])
 			require.Contains(t, s.Streams[0].Logs[1][1], "line=\"newer log\"")
 			require.Contains(t, s.Streams[0].Logs[1][1], "field=\"3.14\"")
 

--- a/plugins/outputs/loki/loki_test.go
+++ b/plugins/outputs/loki/loki_test.go
@@ -31,6 +31,33 @@ func getMetric() telegraf.Metric {
 	)
 }
 
+func getOutOfOrderMetrics() []telegraf.Metric {
+	return []telegraf.Metric{
+		testutil.MustMetric(
+			"log",
+			map[string]string{
+				"key1": "value1",
+			},
+			map[string]interface{}{
+				"line":  "newer log",
+				"field": 3.14,
+			},
+			time.Unix(456, 0),
+		),
+		testutil.MustMetric(
+			"log",
+			map[string]string{
+				"key1": "value1",
+			},
+			map[string]interface{}{
+				"line":  "older log",
+				"field": 3.14,
+			},
+			time.Unix(123, 0),
+		),
+	}
+}
+
 func TestStatusCode(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()
@@ -351,6 +378,50 @@ func TestDefaultUserAgent(t *testing.T) {
 		require.NoError(t, err)
 
 		err = client.Write([]telegraf.Metric{getMetric()})
+		require.NoError(t, err)
+	})
+}
+
+func TestMetricSorting(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	u, err := url.Parse(fmt.Sprintf("http://%s", ts.Listener.Addr().String()))
+	require.NoError(t, err)
+
+	t.Run("out of order metrics", func(t *testing.T) {
+		ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body := r.Body
+			var err error
+
+			payload, err := ioutil.ReadAll(body)
+			require.NoError(t, err)
+
+			var s Request
+			err = json.Unmarshal(payload, &s)
+			require.NoError(t, err)
+			require.Len(t, s.Streams, 1)
+			require.Len(t, s.Streams[0].Logs, 2)
+			require.Len(t, s.Streams[0].Logs[0], 2)
+			require.Equal(t, map[string]string{"key1": "value1"}, s.Streams[0].Labels)
+			require.Equal(t, "123000000000", s.Streams[0].Logs[0][0])
+			require.Contains(t, s.Streams[0].Logs[0][1], "line=\"older log\"")
+			require.Contains(t, s.Streams[0].Logs[0][1], "field=\"3.14\"")
+			require.Equal(t, "456000000000", s.Streams[0].Logs[1][0])
+			require.Contains(t, s.Streams[0].Logs[1][1], "line=\"newer log\"")
+			require.Contains(t, s.Streams[0].Logs[1][1], "field=\"3.14\"")
+
+			w.WriteHeader(http.StatusNoContent)
+		})
+
+		client := &Loki{
+			Domain: u.String(),
+		}
+
+		err = client.Connect()
+		require.NoError(t, err)
+
+		err = client.Write(getOutOfOrderMetrics())
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.

Related to https://github.com/influxdata/telegraf/pull/9114

Loki has very strict ordering requirements. You cannot submit a log line with a timestamp older than what already exists (for a matching label set). One way around the issue is to overwrite the timestamp using a processor, as discussed in the related PR. However this is not ideal when we want to send our logs with the timestamp of the input source, not the time telegraf processed the metric.

This PR adds an additional step in the Loki plugin to sort the ~~log data by timestamp in each log stream~~ batch of metrics by timestamp before they are serialised and written to Loki.

@Eraac - looping you in as the author of the original Loki plugin.
@loganmc10 - may be of interest to you