### PR TITLE
doc: Add information on new conventional commit format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ show completion. -->
 
 - [ ] Updated associated README.md.
 - [ ] Wrote appropriate unit tests.
+- [ ] Pull request title is in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)
 
 <!-- Link to issues that describe the need for the change. Issues
 should include context that will help reviewers understand why the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,18 @@
 ### Contributing
 
 1. [Sign the CLA][cla].
-1. Open a [new issue][] to discuss the changes you would like to make.  This is
+2. Open a [new issue][] to discuss the changes you would like to make.  This is
    not strictly required but it may help reduce the amount of rework you need
    to do later.
-1. Make changes or write plugin using the guidelines in the following
+3. Make changes or write plugin using the guidelines in the following
    documents:
    - [Input Plugins][inputs]
    - [Processor Plugins][processors]
    - [Aggregator Plugins][aggregators]
    - [Output Plugins][outputs]
-1. Ensure you have added proper unit tests and documentation.
-1. Open a new [pull request][].
+4. Ensure you have added proper unit tests and documentation.
+5. Open a new [pull request][].
+6. The pull request title needs to follow [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 
 #### Contributing an External Plugin *(new)*
 


### PR DESCRIPTION
The Telegraf project will be using conventional commit messages enforced with this github app: https://github.com/zeke/semantic-pull-requests

This pr updates documentation to highlight this change and requirement for future pull requests.