### PR TITLE
fix: Refactor ec2 init for config-api

### DIFF
--- a/plugins/processors/aws/ec2/ec2.go
+++ b/plugins/processors/aws/ec2/ec2.go
@@ -125,11 +125,10 @@ func (r *AwsEc2Processor) Init() error {
 	}
 
 	for _, tag := range r.ImdsTags {
-		if len(tag) > 0 && isImdsTagAllowed(tag) {
-			r.imdsTags[tag] = struct{}{}
-		} else {
+		if len(tag) == 0 && !isImdsTagAllowed(tag) {
 			return fmt.Errorf("not allowed metadata tag specified in configuration: %s", tag)
 		}
+		r.imdsTags[tag] = struct{}{}
 	}
 	if len(r.imdsTags) == 0 && len(r.EC2Tags) == 0 {
 		return errors.New("no allowed metadata tags specified in configuration")

--- a/plugins/processors/aws/ec2/ec2.go
+++ b/plugins/processors/aws/ec2/ec2.go
@@ -176,6 +176,12 @@ func (r *AwsEc2Processor) Start(acc telegraf.Accumulator) error {
 		}
 	}
 
+	if r.Ordered {
+		r.parallel = parallel.NewOrdered(acc, r.asyncAdd, DefaultMaxOrderedQueueSize, r.MaxParallelCalls)
+	} else {
+		r.parallel = parallel.NewUnordered(acc, r.asyncAdd, r.MaxParallelCalls)
+	}
+
 	return nil
 }
 

--- a/plugins/processors/aws/ec2/ec2.go
+++ b/plugins/processors/aws/ec2/ec2.go
@@ -125,7 +125,7 @@ func (r *AwsEc2Processor) Init() error {
 	}
 
 	for _, tag := range r.ImdsTags {
-		if len(tag) == 0 && !isImdsTagAllowed(tag) {
+		if len(tag) == 0 || !isImdsTagAllowed(tag) {
 			return fmt.Errorf("not allowed metadata tag specified in configuration: %s", tag)
 		}
 		r.imdsTags[tag] = struct{}{}

--- a/plugins/processors/aws/ec2/ec2_test.go
+++ b/plugins/processors/aws/ec2/ec2_test.go
@@ -13,8 +13,7 @@ func TestBasicStartup(t *testing.T) {
 	p.Log = &testutil.Logger{}
 	p.ImdsTags = []string{"accountId", "instanceId"}
 	acc := &testutil.Accumulator{}
-	require.NoError(t, p.Start(acc))
-	require.NoError(t, p.Stop())
+	require.NoError(t, p.Init())
 
 	require.Len(t, acc.GetTelegrafMetrics(), 0)
 	require.Len(t, acc.Errors, 0)
@@ -26,8 +25,7 @@ func TestBasicStartupWithEC2Tags(t *testing.T) {
 	p.ImdsTags = []string{"accountId", "instanceId"}
 	p.EC2Tags = []string{"Name"}
 	acc := &testutil.Accumulator{}
-	require.NoError(t, p.Start(acc))
-	require.NoError(t, p.Stop())
+	require.NoError(t, p.Init())
 
 	require.Len(t, acc.GetTelegrafMetrics(), 0)
 	require.Len(t, acc.Errors, 0)


### PR DESCRIPTION
To help with the config-api work, the init functions should no longer be responsible with connecting to external services. Moved this change from the config-api pull request: https://github.com/influxdata/telegraf/pull/9546 because it shouldn't be a breaking change created a separate pr for it to help reduce the number of files changed in #9546 