### PR TITLE
chore: "makefile help" output, but still support building based on arch for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,11 +215,11 @@ jobs:
     steps:
       - package-build:
           type: i386
-  ppc641e-package:
-    executor: go-1_17
+  ppc64le-package:
+    executor: go-1_16
     steps:
       - package-build:
-          type: ppc641e
+          type: ppc64le
   s390x-package:
     executor: go-1_17
     steps:
@@ -391,7 +391,7 @@ workflows:
       - 'i386-package':
           requires:
             - 'test-awaiter'
-      - 'ppc641e-package':
+      - 'ppc64le-package':
           requires:
             - 'test-awaiter'
       - 's390x-package':
@@ -421,7 +421,7 @@ workflows:
       - 'share-artifacts':
           requires:
             - 'i386-package'
-            - 'ppc641e-package'
+            - 'ppc64le-package'
             - 's390x-package'
             - 'armel-package'
             - 'amd64-package'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,11 +123,11 @@ commands:
       - when:
           condition: << parameters.release >>
           steps:
-            - run: 'mips=1 mipsel=1 arm64=1 amd64=1 static=1 armel=1 armhf=1 s390x=1 ppc641e=1 i386=1 windows=1 darwin=1 make package'
+            - run: 'make package'
       - when:
           condition: << parameters.nightly >>
           steps:
-            - run: 'mips=1 mipsel=1 arm64=1 amd64=1 static=1 armel=1 armhf=1 s390x=1 ppc641e=1 i386=1 windows=1 darwin=1 NIGHTLY=1 make package'
+            - run: 'make package'
             - run: 'make upload-nightly'
       - unless:
           condition:
@@ -135,7 +135,7 @@ commands:
               - << parameters.nightly >>
               - << parameters.release >>
           steps:
-            - run: '<< parameters.type >>=1 make package'
+            - run: 'make package << parameters.type >>'
       - store_artifacts:
           path: './build/dist'
           destination: 'build/dist'
@@ -204,62 +204,62 @@ jobs:
     executor: go-1_17
     steps:
       - package-build:
-          type: windows
+          type: zips="windows_i386.zip windows_amd64.zip" debs="" tars="" rpms=""
   darwin-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: darwin
+          type: zips="" debs="" tars="darwin_amd64.tar.gz" rpms=""
   i386-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: i386
+          type: zips="" debs="i386.deb" tars="freebsd_i386.tar.gz linux_i386.tar.gz" rpms="i386.rpm"
   ppc641e-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: ppc641e
+          type: zips="" debs="ppc64el.deb" tars="linux_ppc64le.tar.gz" rpms="ppc64le.rpm"
   s390x-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: s390x
+          type: zips="" debs="s390x.deb" tars="linux_s390x.tar.gz" rpms="s390x.rpm"
   armel-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: armel
+          type: zips="" debs="armel.deb" tars="linux_armel.tar.gz" rpms="armel.rpm"
   amd64-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: amd64
+          type: zips="" debs="x86_64.rpm" tars="freebsd_amd64.tar.gz linux_amd64.tar.gz" rpms="x86_64.rpm"
   arm64-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: arm64
+          type: zips="" debs="arm64.deb" tars="linux_arm64.tar.gz" rpms="aarch64.rpm"
   mipsel-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: mipsel
+          type: zips="" debs="mipsel.deb" tars="linux_mipsel.tar.gz" rpms=""
   mips-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: mips
+          type: zips="" debs="mips.deb" tars="linux_mips.tar.gz" rpms=""
   static-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: static
+          type: zips="" debs="" tars="static_linux_amd64.tar.gz" rpms=""
   armhf-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: armhf
+          type: zips="" debs="armhf.deb" tars="linux_armhf.tar.gz freebsd_armv7.tar.gz" rpms="armv6hl.rpm"
 
   release:
     executor: go-1_17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="x86_64.rpm" tars="freebsd_amd64.tar.gz linux_amd64.tar.gz" rpms="x86_64.rpm"
+          type: zips="" debs="amd64.deb" tars="freebsd_amd64.tar.gz linux_amd64.tar.gz" rpms="x86_64.rpm"
   arm64-package:
     executor: go-1_17
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
     executor: go-1_17
     steps:
       - package-build:
-          type:"linux_armel.tar.gz armel.rpm armel.deb"
+          type: "linux_armel.tar.gz armel.rpm armel.deb"
   amd64-package:
     executor: go-1_17
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ commands:
               - << parameters.nightly >>
               - << parameters.release >>
           steps:
-            - run: 'make package include_packages=<< parameters.type >>'
+            - run: 'make package include_packages="$(make << parameters.type >>)"'
       - store_artifacts:
           path: './build/dist'
           destination: 'build/dist'
@@ -204,62 +204,62 @@ jobs:
     executor: go-1_17
     steps:
       - package-build:
-          type: "windows_i386.zip windows_amd64.zip"
+          type: windows
   darwin-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "darwin_amd64.tar.gz"
+          type: darwin
   i386-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "freebsd_i386.tar.gz i386.deb linux_i386.tar.gzi386.rpm"
+          type: i386
   ppc641e-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "linux_ppc64le.tar.gz ppc64le.rpm ppc64el.deb"
+          type: ppc641e
   s390x-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "linux_s390x.tar.gz s390x.deb s390x.rpm"
+          type: s390x
   armel-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "linux_armel.tar.gz armel.rpm armel.deb"
+          type: armel
   amd64-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "freebsd_amd64.tar.gz linux_amd64.tar.gz amd64.deb x86_64.rpm"
+          type: amd64
   arm64-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "linux_arm64.tar.gz arm64.deb aarch64.rpm"
+          type: arm64
   mipsel-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "mipsel.deb linux_mipsel.tar.gz"
+          type: mipsel
   mips-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "mips.deb linux_mips.tar.gz"
+          type: mips
   static-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "static_linux_amd64.tar.gz"
+          type: static
   armhf-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: "linux_armhf.tar.gz freebsd_armv7.tar.gz armhf.deb armv6hl.rpm"
+          type: armhf
 
   release:
     executor: go-1_17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ commands:
               - << parameters.nightly >>
               - << parameters.release >>
           steps:
-            - run: 'make package << parameters.type >>'
+            - run: 'make package include_packages=<< parameters.type >>'
       - store_artifacts:
           path: './build/dist'
           destination: 'build/dist'
@@ -204,62 +204,62 @@ jobs:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="windows_i386.zip windows_amd64.zip" debs="" tars="" rpms=""
+          type: "windows_i386.zip windows_amd64.zip"
   darwin-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="" tars="darwin_amd64.tar.gz" rpms=""
+          type: "darwin_amd64.tar.gz"
   i386-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="i386.deb" tars="freebsd_i386.tar.gz linux_i386.tar.gz" rpms="i386.rpm"
+          type: "freebsd_i386.tar.gz i386.deb linux_i386.tar.gzi386.rpm"
   ppc641e-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="ppc64el.deb" tars="linux_ppc64le.tar.gz" rpms="ppc64le.rpm"
+          type: "linux_ppc64le.tar.gz ppc64le.rpm ppc64el.deb"
   s390x-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="s390x.deb" tars="linux_s390x.tar.gz" rpms="s390x.rpm"
+          type: "linux_s390x.tar.gz s390x.deb s390x.rpm"
   armel-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="armel.deb" tars="linux_armel.tar.gz" rpms="armel.rpm"
+          type:"linux_armel.tar.gz armel.rpm armel.deb"
   amd64-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="amd64.deb" tars="freebsd_amd64.tar.gz linux_amd64.tar.gz" rpms="x86_64.rpm"
+          type: "freebsd_amd64.tar.gz linux_amd64.tar.gz amd64.deb x86_64.rpm"
   arm64-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="arm64.deb" tars="linux_arm64.tar.gz" rpms="aarch64.rpm"
+          type: "linux_arm64.tar.gz arm64.deb aarch64.rpm"
   mipsel-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="mipsel.deb" tars="linux_mipsel.tar.gz" rpms=""
+          type: "mipsel.deb linux_mipsel.tar.gz"
   mips-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="mips.deb" tars="linux_mips.tar.gz" rpms=""
+          type: "mips.deb linux_mips.tar.gz"
   static-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="" tars="static_linux_amd64.tar.gz" rpms=""
+          type: "static_linux_amd64.tar.gz"
   armhf-package:
     executor: go-1_17
     steps:
       - package-build:
-          type: zips="" debs="armhf.deb" tars="linux_armhf.tar.gz freebsd_armv7.tar.gz" rpms="armv6hl.rpm"
+          type: "linux_armhf.tar.gz freebsd_armv7.tar.gz armhf.deb armv6hl.rpm"
 
   release:
     executor: go-1_17

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ help:
 	@echo '  check-deps   - check docs/LICENSE_OF_DEPENDENCIES.md'
 	@echo '  clean        - delete build artifacts'
 	@echo '  package      - build all supported packages, override include_packages to only build a subset'
-	@echo '                 e.g.: make package include_packages="amd64.deb'
+	@echo '                 e.g.: make package include_packages="amd64.deb"'
 	@echo ''
 	@echo 'Possible values for include_packages variable'
 	@$(foreach package,$(include_packages),echo "  $(package)";)
@@ -226,18 +226,56 @@ $(buildbin):
 	@mkdir -pv $(dir $@)
 	go build -o $(dir $@) -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
-mips += mips.deb linux_mips.tar.gz
+# Define packages Telegraf supports, organized by architecture with a rule to echo the list to limit include_packages
+# e.g. make package include_packages="$(make amd64)"
+mips += linux_mips.tar.gz mips.deb 
+.PHONY: mips
+mips:
+	@ echo $(mips)
 mipsel += mipsel.deb linux_mipsel.tar.gz
+.PHONY: mipsel
+mipsel:
+	@ echo $(mipsel)
 arm64 += linux_arm64.tar.gz arm64.deb aarch64.rpm
+.PHONY: arm64
+arm64:
+	@ echo $(arm64)
 amd64 += freebsd_amd64.tar.gz linux_amd64.tar.gz amd64.deb x86_64.rpm
+.PHONY: amd64
+amd64:
+	@ echo $(amd64)
 static += static_linux_amd64.tar.gz
+.PHONY: static
+static:
+	@ echo $(static)
 armel += linux_armel.tar.gz armel.rpm armel.deb
+.PHONY: armel
+armel:
+	@ echo $(armel)
 armhf += linux_armhf.tar.gz freebsd_armv7.tar.gz armhf.deb armv6hl.rpm
+.PHONY: armhf
+armhf:
+	@ echo $(armhf)
 s390x += linux_s390x.tar.gz s390x.deb s390x.rpm
+.PHONY: s390x
+s390x:
+	@ echo $(s390x)
 ppc641e += linux_ppc64le.tar.gz ppc64le.rpm ppc64el.deb
+.PHONY: ppc641e
+ppc641e:
+	@ echo $(ppc641e)
 i386 += freebsd_i386.tar.gz i386.deb linux_i386.tar.gzi386.rpm
+.PHONY: i386
+i386:
+	@ echo $(i386)
 windows += windows_i386.zip windows_amd64.zip
+.PHONY: windows
+windows:
+	@ echo $(windows)
 darwin += darwin_amd64.tar.gz
+.PHONY: darwin
+darwin:
+	@ echo $(darwin)
 
 include_packages := $(mips) $(mipsel) $(arm64) $(amd64) $(static) $(armel) $(armhf) $(s390x) $(ppc641e) $(i386) $(windows) $(darwin) 
 
@@ -297,7 +335,7 @@ $(include_packages):
 			--package $(pkgdir)/telegraf_$(deb_version)_$@	;\
 	elif [ "$(suffix $@)" = ".zip" ]; then \
 		(cd $(dir $(DESTDIR)) && zip -r - ./*) > $(pkgdir)/telegraf-$(tar_version)_$@ ;\
-	elif [ "$(suffix $@)" = ".tar.gz" ]; then \
+	elif [ "$(suffix $@)" = ".gz" ]; then \
 		tar --owner 0 --group 0 -czvf $(pkgdir)/telegraf-$(tar_version)_$@ -C $(dir $(DESTDIR)) . ;\
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -285,22 +285,13 @@ dists := $(debs) $(rpms) $(tars) $(zips)
 .PHONY: package
 package: $(dists)
 
-rpm_amd64 := amd64
-rpm_386 := i386
-rpm_s390x := s390x
-rpm_ppc64le := ppc64le
-rpm_arm5 := armel
-rpm_arm6 := armv6hl
-rpm_arm647 := aarch64
-rpm_arch = $(rpm_$(GOARCH)$(GOARM))
-
 .PHONY: $(rpms)
 $(rpms):
 	@$(MAKE) install
 	@mkdir -p $(pkgdir)
 	fpm --force \
 		--log info \
-		--architecture $(rpm_arch) \
+		--architecture $(rpm_$(GOARCH)$(GOARM)) \
 		--input-type dir \
 		--output-type rpm \
 		--vendor InfluxData \
@@ -322,24 +313,13 @@ $(rpms):
         --chdir $(DESTDIR) \
 		--package $(pkgdir)/telegraf-$(rpm_version).$@
 
-deb_amd64 := amd64
-deb_386 := i386
-deb_s390x := s390x
-deb_ppc64le := ppc64el
-deb_arm5 := armel
-deb_arm6 := armhf
-deb_arm647 := arm64
-deb_mips := mips
-deb_mipsle := mipsel
-deb_arch = $(deb_$(GOARCH)$(GOARM))
-
 .PHONY: $(debs)
 $(debs):
 	@$(MAKE) install
 	@mkdir -pv $(pkgdir)
 	fpm --force \
 		--log info \
-		--architecture $(deb_arch) \
+		--architecture $(deb_$(GOARCH)$(GOARM)) \
 		--input-type dir \
 		--output-type deb \
 		--vendor InfluxData \

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ $(buildbin):
 
 # Define packages Telegraf supports, organized by architecture with a rule to echo the list to limit include_packages
 # e.g. make package include_packages="$(make amd64)"
-mips += linux_mips.tar.gz mips.deb 
+mips += linux_mips.tar.gz mips.deb
 .PHONY: mips
 mips:
 	@ echo $(mips)
@@ -260,10 +260,10 @@ s390x += linux_s390x.tar.gz s390x.deb s390x.rpm
 .PHONY: s390x
 s390x:
 	@ echo $(s390x)
-ppc641e += linux_ppc64le.tar.gz ppc64le.rpm ppc64el.deb
-.PHONY: ppc641e
-ppc641e:
-	@ echo $(ppc641e)
+ppc64le += linux_ppc64le.tar.gz ppc64le.rpm ppc64el.deb
+.PHONY: ppc64le
+ppc64le:
+	@ echo $(ppc64le)
 i386 += freebsd_i386.tar.gz i386.deb linux_i386.tar.gzi386.rpm
 .PHONY: i386
 i386:
@@ -277,7 +277,7 @@ darwin += darwin_amd64.tar.gz
 darwin:
 	@ echo $(darwin)
 
-include_packages := $(mips) $(mipsel) $(arm64) $(amd64) $(static) $(armel) $(armhf) $(s390x) $(ppc641e) $(i386) $(windows) $(darwin) 
+include_packages := $(mips) $(mipsel) $(arm64) $(amd64) $(static) $(armel) $(armhf) $(s390x) $(ppc64le) $(i386) $(windows) $(darwin)
 
 .PHONY: package
 package: $(include_packages)

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,13 @@ help:
 	@echo ''
 	@echo 'Possible values for include_packages variable'
 	@$(foreach package,$(include_packages),echo "  $(package)";)
+	@echo ''
+	@echo 'Resulting package name format (where arch will be the arch of the package):'
+	@echo '   telegraf_$(deb_version)_arch.deb'
+	@echo '   telegraf-$(rpm_version).arch.rpm'
+	@echo '   telegraf-$(tar_version)_arch.tar.gz'
+	@echo '   telegraf-$(tar_version)_arch.zip'
+
 
 .PHONY: deps
 deps:

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ $(rpms):
 	@mkdir -p $(pkgdir)
 	fpm --force \
 		--log info \
-		--architecture $(rpm_$(GOARCH)$(GOARM)) \
+		--architecture $(basename $@) \
 		--input-type dir \
 		--output-type rpm \
 		--vendor InfluxData \
@@ -319,7 +319,7 @@ $(debs):
 	@mkdir -pv $(pkgdir)
 	fpm --force \
 		--log info \
-		--architecture $(deb_$(GOARCH)$(GOARM)) \
+		--architecture $(basename $@) \
 		--input-type dir \
 		--output-type deb \
 		--vendor InfluxData \

--- a/Makefile
+++ b/Makefile
@@ -224,73 +224,61 @@ $(buildbin):
 	@mkdir -pv $(dir $@)
 	go build -o $(dir $@) -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
-ifdef mips
-debs += telegraf_$(deb_version)_mips.deb
-tars += telegraf-$(tar_version)_linux_mips.tar.gz
-endif
+# mips
+debs += mips.deb
+tars += linux_mips.tar.gz
 
-ifdef mipsel
-debs += telegraf_$(deb_version)_mipsel.deb
-tars += telegraf-$(tar_version)_linux_mipsel.tar.gz
-endif
+# mipsel
+debs += mipsel.deb
+tars += linux_mipsel.tar.gz
 
-ifdef arm64
-tars += telegraf-$(tar_version)_linux_arm64.tar.gz
-debs += telegraf_$(deb_version)_arm64.deb
-rpms += telegraf-$(rpm_version).aarch64.rpm
-endif
+# arm64
+tars += linux_arm64.tar.gz
+debs += arm64.deb
+rpms += aarch64.rpm
 
-ifdef amd64
-tars += telegraf-$(tar_version)_freebsd_amd64.tar.gz
-tars += telegraf-$(tar_version)_linux_amd64.tar.gz
-debs += telegraf_$(deb_version)_amd64.deb
-rpms += telegraf-$(rpm_version).x86_64.rpm
-endif
+# amd64
+tars += freebsd_amd64.tar.gz
+tars += linux_amd64.tar.gz
+debs += amd64.deb
+rpms += x86_64.rpm
 
-ifdef static
-tars += telegraf-$(tar_version)_static_linux_amd64.tar.gz
-endif
+# static
+tars += static_linux_amd64.tar.gz
 
-ifdef armel
-tars += telegraf-$(tar_version)_linux_armel.tar.gz
-rpms += telegraf-$(rpm_version).armel.rpm
-debs += telegraf_$(deb_version)_armel.deb
-endif
+# armel
+tars += linux_armel.tar.gz
+rpms += armel.rpm
+debs += armel.deb
 
-ifdef armhf
-tars += telegraf-$(tar_version)_linux_armhf.tar.gz
-tars += telegraf-$(tar_version)_freebsd_armv7.tar.gz
-debs += telegraf_$(deb_version)_armhf.deb
-rpms += telegraf-$(rpm_version).armv6hl.rpm
-endif
+# armhf
+tars += linux_armhf.tar.gz
+tars += freebsd_armv7.tar.gz
+debs += armhf.deb
+rpms += armv6hl.rpm
 
-ifdef s390x
-tars += telegraf-$(tar_version)_linux_s390x.tar.gz
-debs += telegraf_$(deb_version)_s390x.deb
-rpms += telegraf-$(rpm_version).s390x.rpm
-endif
+# s390x
+tars += linux_s390x.tar.gz
+debs += s390x.deb
+rpms += s390x.rpm
 
-ifdef ppc641e
-tars += telegraf-$(tar_version)_linux_ppc64le.tar.gz
-rpms += telegraf-$(rpm_version).ppc64le.rpm
-debs += telegraf_$(deb_version)_ppc64el.deb
-endif
+# ppc641e
+tars += linux_ppc64le.tar.gz
+rpms += ppc64le.rpm
+debs += ppc64el.deb
 
-ifdef i386
-tars += telegraf-$(tar_version)_freebsd_i386.tar.gz
-debs += telegraf_$(deb_version)_i386.deb
-tars += telegraf-$(tar_version)_linux_i386.tar.gz
-rpms += telegraf-$(rpm_version).i386.rpm
-endif
+# i386
+tars += freebsd_i386.tar.gz
+debs += i386.deb
+tars += linux_i386.tar.gz
+rpms += i386.rpm
 
-ifdef windows
-zips += telegraf-$(tar_version)_windows_i386.zip
-zips += telegraf-$(tar_version)_windows_amd64.zip
-endif
+# windows
+zips += windows_i386.zip
+zips += windows_amd64.zip
 
-ifdef darwin
-tars += telegraf-$(tar_version)_darwin_amd64.tar.gz
-endif
+# darwin
+tars += darwin_amd64.tar.gz
 
 dists := $(debs) $(rpms) $(tars) $(zips)
 
@@ -332,7 +320,7 @@ $(rpms):
 		--version $(version) \
 		--iteration $(rpm_iteration) \
         --chdir $(DESTDIR) \
-		--package $(pkgdir)/$@
+		--package $(pkgdir)/telegraf-$(rpm_version).$@
 
 deb_amd64 := amd64
 deb_386 := i386
@@ -369,19 +357,19 @@ $(debs):
 		--version $(version) \
 		--iteration $(deb_iteration) \
 		--chdir $(DESTDIR) \
-		--package $(pkgdir)/$@
+		--package $(pkgdir)/telegraf_$(deb_version)_$@
 
 .PHONY: $(zips)
 $(zips):
 	@$(MAKE) install
 	@mkdir -p $(pkgdir)
-	(cd $(dir $(DESTDIR)) && zip -r - ./*) > $(pkgdir)/$@
+	(cd $(dir $(DESTDIR)) && zip -r - ./*) > $(pkgdir)/telegraf-$(tar_version)_$@
 
 .PHONY: $(tars)
 $(tars):
 	@$(MAKE) install
 	@mkdir -p $(pkgdir)
-	tar --owner 0 --group 0 -czvf $(pkgdir)/$@ -C $(dir $(DESTDIR)) .
+	tar --owner 0 --group 0 -czvf $(pkgdir)/telegraf-$(tar_version)_$@ -C $(dir $(DESTDIR)) .
 
 .PHONY: upload-nightly
 upload-nightly:
@@ -393,63 +381,63 @@ upload-nightly:
 		--include "*.zip" \
 		--acl public-read
 
-%amd64.deb %x86_64.rpm %linux_amd64.tar.gz: export GOOS := linux
-%amd64.deb %x86_64.rpm %linux_amd64.tar.gz: export GOARCH := amd64
+amd64.deb x86_64.rpm linux_amd64.tar.gz: export GOOS := linux
+amd64.deb x86_64.rpm linux_amd64.tar.gz: export GOARCH := amd64
 
-%static_linux_amd64.tar.gz: export cgo := -nocgo
-%static_linux_amd64.tar.gz: export CGO_ENABLED := 0
+static_linux_amd64.tar.gz: export cgo := -nocgo
+static_linux_amd64.tar.gz: export CGO_ENABLED := 0
 
-%i386.deb %i386.rpm %linux_i386.tar.gz: export GOOS := linux
-%i386.deb %i386.rpm %linux_i386.tar.gz: export GOARCH := 386
+i386.deb i386.rpm linux_i386.tar.gz: export GOOS := linux
+i386.deb i386.rpm linux_i386.tar.gz: export GOARCH := 386
 
-%armel.deb %armel.rpm %linux_armel.tar.gz: export GOOS := linux
-%armel.deb %armel.rpm %linux_armel.tar.gz: export GOARCH := arm
-%armel.deb %armel.rpm %linux_armel.tar.gz: export GOARM := 5
+armel.deb armel.rpm linux_armel.tar.gz: export GOOS := linux
+armel.deb armel.rpm linux_armel.tar.gz: export GOARCH := arm
+armel.deb armel.rpm linux_armel.tar.gz: export GOARM := 5
 
-%armhf.deb %armv6hl.rpm %linux_armhf.tar.gz: export GOOS := linux
-%armhf.deb %armv6hl.rpm %linux_armhf.tar.gz: export GOARCH := arm
-%armhf.deb %armv6hl.rpm %linux_armhf.tar.gz: export GOARM := 6
+armhf.deb armv6hl.rpm linux_armhf.tar.gz: export GOOS := linux
+armhf.deb armv6hl.rpm linux_armhf.tar.gz: export GOARCH := arm
+armhf.deb armv6hl.rpm linux_armhf.tar.gz: export GOARM := 6
 
-%arm64.deb %aarch64.rpm %linux_arm64.tar.gz: export GOOS := linux
-%arm64.deb %aarch64.rpm %linux_arm64.tar.gz: export GOARCH := arm64
-%arm64.deb %aarch64.rpm %linux_arm64.tar.gz: export GOARM := 7
+arm64.deb aarch64.rpm linux_arm64.tar.gz: export GOOS := linux
+arm64.deb aarch64.rpm linux_arm64.tar.gz: export GOARCH := arm64
+arm64.deb aarch64.rpm linux_arm64.tar.gz: export GOARM := 7
 
-%mips.deb %linux_mips.tar.gz: export GOOS := linux
-%mips.deb %linux_mips.tar.gz: export GOARCH := mips
+mips.deb linux_mips.tar.gz: export GOOS := linux
+mips.deb linux_mips.tar.gz: export GOARCH := mips
 
-%mipsel.deb %linux_mipsel.tar.gz: export GOOS := linux
-%mipsel.deb %linux_mipsel.tar.gz: export GOARCH := mipsle
+mipsel.deb linux_mipsel.tar.gz: export GOOS := linux
+mipsel.deb linux_mipsel.tar.gz: export GOARCH := mipsle
 
-%s390x.deb %s390x.rpm %linux_s390x.tar.gz: export GOOS := linux
-%s390x.deb %s390x.rpm %linux_s390x.tar.gz: export GOARCH := s390x
+s390x.deb s390x.rpm linux_s390x.tar.gz: export GOOS := linux
+s390x.deb s390x.rpm linux_s390x.tar.gz: export GOARCH := s390x
 
-%ppc64el.deb %ppc64le.rpm %linux_ppc64le.tar.gz: export GOOS := linux
-%ppc64el.deb %ppc64le.rpm %linux_ppc64le.tar.gz: export GOARCH := ppc64le
+ppc64el.deb ppc64le.rpm linux_ppc64le.tar.gz: export GOOS := linux
+ppc64el.deb ppc64le.rpm linux_ppc64le.tar.gz: export GOARCH := ppc64le
 
-%freebsd_amd64.tar.gz: export GOOS := freebsd
-%freebsd_amd64.tar.gz: export GOARCH := amd64
+freebsd_amd64.tar.gz: export GOOS := freebsd
+freebsd_amd64.tar.gz: export GOARCH := amd64
 
-%freebsd_i386.tar.gz: export GOOS := freebsd
-%freebsd_i386.tar.gz: export GOARCH := 386
+freebsd_i386.tar.gz: export GOOS := freebsd
+freebsd_i386.tar.gz: export GOARCH := 386
 
-%freebsd_armv7.tar.gz: export GOOS := freebsd
-%freebsd_armv7.tar.gz: export GOARCH := arm
-%freebsd_armv7.tar.gz: export GOARM := 7
+freebsd_armv7.tar.gz: export GOOS := freebsd
+freebsd_armv7.tar.gz: export GOARCH := arm
+freebsd_armv7.tar.gz: export GOARM := 7
 
-%windows_amd64.zip: export GOOS := windows
-%windows_amd64.zip: export GOARCH := amd64
+windows_amd64.zip: export GOOS := windows
+windows_amd64.zip: export GOARCH := amd64
 
-%darwin_amd64.tar.gz: export GOOS := darwin
-%darwin_amd64.tar.gz: export GOARCH := amd64
+darwin_amd64.tar.gz: export GOOS := darwin
+darwin_amd64.tar.gz: export GOARCH := amd64
 
-%windows_i386.zip: export GOOS := windows
-%windows_i386.zip: export GOARCH := 386
+windows_i386.zip: export GOOS := windows
+windows_i386.zip: export GOARCH := 386
 
-%windows_i386.zip %windows_amd64.zip: export prefix =
-%windows_i386.zip %windows_amd64.zip: export bindir = $(prefix)
-%windows_i386.zip %windows_amd64.zip: export sysconfdir = $(prefix)
-%windows_i386.zip %windows_amd64.zip: export localstatedir = $(prefix)
-%windows_i386.zip %windows_amd64.zip: export EXEEXT := .exe
+windows_i386.zip windows_amd64.zip: export prefix =
+windows_i386.zip windows_amd64.zip: export bindir = $(prefix)
+windows_i386.zip windows_amd64.zip: export sysconfdir = $(prefix)
+windows_i386.zip windows_amd64.zip: export localstatedir = $(prefix)
+windows_i386.zip windows_amd64.zip: export EXEEXT := .exe
 
 %.deb: export pkg := deb
 %.deb: export prefix := /usr

--- a/docs/developers/PACKAGING.md
+++ b/docs/developers/PACKAGING.md
@@ -1,5 +1,9 @@
 # Packaging
 
+Building the packages for Telegraf is automated using [Make](https://en.wikipedia.org/wiki/Make_(software)). Just running `make` will build a Telegraf binary for the operating system and architecture you are using (if it is supported). If you need to build a different package then you can run `make package` which will build all the supported packages. You will most likely only want a subset, you can define a subset of packages to be built by overriding the `include_packages` variable like so `make package include_packages="amd64.deb"`. You can also build all packages for a specific architecture like so `make package include_packages="$(make amd64)"`.
+
+The packaging steps require certain tools to be setup before hand to work. These dependencies are listed in the ci-1.16.docker file which you can find in the scripts directory. Therefore it is recommended to use Docker to build the artifacts, see more details below.
+
 ## Package using Docker
 
 This packaging method uses the CI images, and is very similar to how the

--- a/docs/developers/PACKAGING.md
+++ b/docs/developers/PACKAGING.md
@@ -18,20 +18,15 @@ docker run -ti quay.io/influxdb/telegraf-ci:1.9.7 /bin/bash
 ```
 
 From within the container:
-```
-go get -d github.com/influxdata/telegraf
-cd /go/src/github.com/influxdata/telegraf
 
-# Use tag of Telegraf version you would like to build
-git checkout release-1.10
-git reset --hard 1.10.2
-make deps
-
-# To build packages run:
-
-```
-make package amd64=1
-```
+1. `go get -d github.com/influxdata/telegraf`
+2. `cd /go/src/github.com/influxdata/telegraf`
+3. `git checkout release-1.10`
+   * Replace tag `release-1.10` with the version of Telegraf you would like to build
+4. `git reset --hard 1.10.2`
+5. `make deps`
+6. `make package include_packages="amd64.deb"`
+    * Change `include_packages` to change what package you want, run `make help` to see possible values
 
 From the host system, copy the build artifacts out of the container:
 ```


### PR DESCRIPTION
resolve: #9261

This change reverts the behavior of `make package` to how it was before #9096 and will build all packages by default. Then to build specific packages you now need to override the variable `include_packages` with the packages you want, such as `make package include_packages="amd64.deb"`. Running `make help` will list the possible values for `include_packages`. To keep the information on what packages are associated with what architecture in the makefile new rules have been added to echo out the lists so that you can build all `amd64` packages for example like so `make package include_packages="$(make amd64)"`.

Example output of `make help`
```
Targets:
  all          - download dependencies and compile telegraf binary
  deps         - download dependencies
  telegraf     - compile telegraf binary
  test         - run short unit tests
  fmt          - format source files
  tidy         - tidy go modules
  lint         - run linter
  lint-branch  - run linter on changes in current branch since master
  lint-install - install linter
  check-deps   - check docs/LICENSE_OF_DEPENDENCIES.md
  clean        - delete build artifacts
  package      - build all supported packages, override include_packages to only build a subset
                 e.g.: make package include_packages="amd64.deb"

Possible values for include_packages variable
  linux_mips.tar.gz
  mips.deb
  mipsel.deb
  linux_mipsel.tar.gz
  linux_arm64.tar.gz
  arm64.deb
  aarch64.rpm
  freebsd_amd64.tar.gz
  linux_amd64.tar.gz
  amd64.deb
  x86_64.rpm
  static_linux_amd64.tar.gz
  linux_armel.tar.gz
  armel.rpm
  armel.deb
  linux_armhf.tar.gz
  freebsd_armv7.tar.gz
  armhf.deb
  armv6hl.rpm
  linux_s390x.tar.gz
  s390x.deb
  s390x.rpm
  linux_ppc64le.tar.gz
  ppc64le.rpm
  ppc64el.deb
  freebsd_i386.tar.gz
  i386.deb
  linux_i386.tar.gzi386.rpm
  windows_i386.zip
  windows_amd64.zip
  darwin_amd64.tar.gz

Resulting package name format (where arch will be the arch of the package):
   telegraf_1.20.0~13f40eeb-0_arch.deb
   telegraf-1.20.0~13f40eeb-0.arch.rpm
   telegraf-1.20.0~13f40eeb_arch.tar.gz
   telegraf-1.20.0~13f40eeb_arch.zip
```