### PR TITLE
fix(opcua): clean client on disconnect so that connect works cleanly

### DIFF
--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -503,6 +503,7 @@ func disconnect(o *OpcUA) error {
 	case "opc.tcp":
 		o.state = Disconnected
 		o.client.Close()
+		o.client = nil
 		return nil
 	default:
 		return fmt.Errorf("invalid controller")


### PR DESCRIPTION
- [-] Updated associated README.md.
- [-] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

resolves #9582 

If the client connection only gets closed, the next invocation of `Connect`
(via `Gather` loop) would try to invoke `CloseSession` on an already-closed
client.

It might be possible to get rid of the nil-check
```
if o.client != nil {
```

in `Connect` but further investigation is needed.
