### PR TITLE
fix: segfault in ingress, persistentvolumeclaim, statefulset

### DIFF
--- a/plugins/inputs/kube_inventory/ingress.go
+++ b/plugins/inputs/kube_inventory/ingress.go
@@ -39,16 +39,22 @@ func (ki *KubernetesInventory) gatherIngress(i netv1.Ingress, acc telegraf.Accum
 		tags["ip"] = ingress.IP
 
 		for _, rule := range i.Spec.Rules {
-			for _, path := range rule.IngressRuleValue.HTTP.Paths {
-				fields["backend_service_port"] = path.Backend.Service.Port.Number
-				fields["tls"] = i.Spec.TLS != nil
+			if rule.IngressRuleValue.HTTP != nil {
+				for _, path := range rule.IngressRuleValue.HTTP.Paths {
+					if path.Backend.Service != nil {
+						tags["backend_service_name"] = path.Backend.Service.Name
+						fields["backend_service_port"] = path.Backend.Service.Port.Number
+					}
 
-				tags["backend_service_name"] = path.Backend.Service.Name
-				tags["path"] = path.Path
-				tags["host"] = rule.Host
+					fields["tls"] = i.Spec.TLS != nil
 
-				acc.AddFields(ingressMeasurement, fields, tags)
+					tags["path"] = path.Path
+					tags["host"] = rule.Host
+
+					acc.AddFields(ingressMeasurement, fields, tags)
+				}
 			}
+
 		}
 	}
 }

--- a/plugins/inputs/kube_inventory/persistentvolumeclaim.go
+++ b/plugins/inputs/kube_inventory/persistentvolumeclaim.go
@@ -34,10 +34,12 @@ func (ki *KubernetesInventory) gatherPersistentVolumeClaim(pvc corev1.Persistent
 		"phase_type": phaseType,
 	}
 	tags := map[string]string{
-		"pvc_name":     pvc.Name,
-		"namespace":    pvc.Namespace,
-		"phase":        string(pvc.Status.Phase),
-		"storageclass": *pvc.Spec.StorageClassName,
+		"pvc_name":  pvc.Name,
+		"namespace": pvc.Namespace,
+		"phase":     string(pvc.Status.Phase),
+	}
+	if pvc.Spec.StorageClassName != nil {
+		tags["storageclass"] = *pvc.Spec.StorageClassName
 	}
 	if pvc.Spec.Selector != nil {
 		for key, val := range pvc.Spec.Selector.MatchLabels {

--- a/plugins/inputs/kube_inventory/persistentvolumeclaim_test.go
+++ b/plugins/inputs/kube_inventory/persistentvolumeclaim_test.go
@@ -134,6 +134,58 @@ func TestPersistentVolumeClaim(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "no storage class name",
+			handler: &mockHandler{
+				responseMap: map[string]interface{}{
+					"/persistentvolumeclaims/": &corev1.PersistentVolumeClaimList{
+						Items: []corev1.PersistentVolumeClaim{
+							{
+								Status: corev1.PersistentVolumeClaimStatus{
+									Phase: "bound",
+								},
+								Spec: corev1.PersistentVolumeClaimSpec{
+									VolumeName:       "pvc-dc870fd6-1e08-11e8-b226-02aa4bc06eb8",
+									StorageClassName: nil,
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"select1": "s1",
+											"select2": "s2",
+										},
+									},
+								},
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "ns1",
+									Name:      "pc1",
+									Labels: map[string]string{
+										"lab1": "v1",
+										"lab2": "v2",
+									},
+									CreationTimestamp: metav1.Time{Time: now},
+								},
+							},
+						},
+					},
+				},
+			},
+			output: []telegraf.Metric{
+				testutil.MustMetric(
+					"kubernetes_persistentvolumeclaim",
+					map[string]string{
+						"pvc_name":         "pc1",
+						"namespace":        "ns1",
+						"phase":            "bound",
+						"selector_select1": "s1",
+						"selector_select2": "s2",
+					},
+					map[string]interface{}{
+						"phase_type": 0,
+					},
+					time.Unix(0, 0),
+				),
+			},
+			hasError: false,
+		},
 	}
 
 	for _, v := range tests {

--- a/plugins/inputs/kube_inventory/statefulset.go
+++ b/plugins/inputs/kube_inventory/statefulset.go
@@ -28,16 +28,20 @@ func (ki *KubernetesInventory) gatherStatefulSet(s v1.StatefulSet, acc telegraf.
 		"replicas_current":    status.CurrentReplicas,
 		"replicas_ready":      status.ReadyReplicas,
 		"replicas_updated":    status.UpdatedReplicas,
-		"spec_replicas":       *s.Spec.Replicas,
 		"observed_generation": s.Status.ObservedGeneration,
+	}
+	if s.Spec.Replicas != nil {
+		fields["spec_replicas"] = *s.Spec.Replicas
 	}
 	tags := map[string]string{
 		"statefulset_name": s.Name,
 		"namespace":        s.Namespace,
 	}
-	for key, val := range s.Spec.Selector.MatchLabels {
-		if ki.selectorFilter.Match(key) {
-			tags["selector_"+key] = val
+	if s.Spec.Selector != nil {
+		for key, val := range s.Spec.Selector.MatchLabels {
+			if ki.selectorFilter.Match(key) {
+				tags["selector_"+key] = val
+			}
 		}
 	}
 


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9537

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Prevent possible segfaults in ingress, persistentvolumeclaim, statefulset in _kube_inventory_ plugin