### PR TITLE
feat: Sematext output plugin

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1403,7 +1403,8 @@
 
 # ## Sematext output config
 # [[outputs.sematext]]
-#   ## Docs at https://sematext.com/docs/monitoring
+#   ## Docs at https://sematext.com/docs/monitoring provide info about getting
+#   ## started with Sematext monitoring.
 #
 #   ## URL of your Sematext metrics receiver. US-region metrics receiver is used
 #   ## in this example (it is also the default when receiver_url value is empty),
@@ -1416,12 +1417,12 @@
 #   ## here.
 #   token = ""
 #
-#   ## Optional TLS Config
+#   ## Optional TLS Config.
 #   # tls_ca = "/etc/telegraf/ca.pem"
 #   # tls_cert = "/etc/telegraf/cert.pem"
 #   # tls_key = "/etc/telegraf/key.pem"
 #
-#   ## Optional flag for ignoring tls certificate check
+#   ## Optional flag for ignoring tls certificate check.
 #   # insecure_skip_verify = false
 
 

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1401,6 +1401,30 @@
 #   separator = " "
 
 
+# ## Sematext output config
+# [[outputs.sematext]]
+#   ## Docs at https://sematext.com/docs/monitoring
+#
+#   ## URL of your Sematext metrics receiver. US-region metrics receiver is used
+#   ## in this example (it is also the default when receiver_url value is empty),
+#   ## but address of e.g. on-premises Sematext metrics receiver can be used
+#   ## instead.
+#   receiver_url = "https://spm-receiver.sematext.com"
+#
+#   ## Token of the App to which the data is sent. Create an App of appropriate
+#   ## type in Sematext UI, instructions will show its token which can be used
+#   ## here.
+#   token = ""
+#
+#   ## Optional TLS Config
+#   # tls_ca = "/etc/telegraf/ca.pem"
+#   # tls_cert = "/etc/telegraf/cert.pem"
+#   # tls_key = "/etc/telegraf/key.pem"
+#
+#   ## Optional flag for ignoring tls certificate check
+#   # insecure_skip_verify = false
+
+
 # # Send aggregate metrics to Sensu Monitor
 # [[outputs.sensu]]
 #   ## BACKEND API URL is the Sensu Backend API root URL to send metrics to

--- a/plugins/outputs/all/all.go
+++ b/plugins/outputs/all/all.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/outputs/prometheus_client"
 	_ "github.com/influxdata/telegraf/plugins/outputs/riemann"
 	_ "github.com/influxdata/telegraf/plugins/outputs/riemann_legacy"
+	_ "github.com/influxdata/telegraf/plugins/outputs/sematext"
 	_ "github.com/influxdata/telegraf/plugins/outputs/sensu"
 	_ "github.com/influxdata/telegraf/plugins/outputs/signalfx"
 	_ "github.com/influxdata/telegraf/plugins/outputs/socket_writer"

--- a/plugins/outputs/sematext/README.md
+++ b/plugins/outputs/sematext/README.md
@@ -8,24 +8,25 @@ Check the [docs](https://sematext.com/docs/monitoring) for more info.
 ```toml
 # Sematext output config
 [[outputs.sematext]]
-   ## Docs at https://sematext.com/docs/monitoring
+  ## Docs at https://sematext.com/docs/monitoring provide info about getting
+  ## started with Sematext monitoring.
 
-   ## URL of your Sematext metrics receiver. US-region metrics receiver is used
-   ## in this example (it is also the default when receiver_url value is empty),
-   ## but address of e.g. Sematext EU-region metrics receiver can be used
-   ## instead.
-   receiver_url = "https://spm-receiver.sematext.com"
+  ## URL of your Sematext metrics receiver. US-region metrics receiver is used
+  ## in this example (it is also the default when receiver_url value is empty),
+  ## but address of e.g. Sematext EU-region metrics receiver can be used
+  ## instead.
+  receiver_url = "https://spm-receiver.sematext.com"
 
-   ## Token of the App to which the data is sent. Create an App of appropriate
-   ## type in Sematext UI, instructions will show its token which can be used
-   ## here.
-   token = ""
+  ## Token of the App to which the data is sent. Create an App of appropriate
+  ## type in Sematext UI, instructions will show its token which can be used
+  ## here.
+  token = ""
 
-   ## Optional TLS Config
-   # tls_ca = "/etc/telegraf/ca.pem"
-   # tls_cert = "/etc/telegraf/cert.pem"
-   # tls_key = "/etc/telegraf/key.pem"
+  ## Optional TLS Config.
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
 
-   ## Optional flag for ignoring tls certificate check
-   # insecure_skip_verify = false
+  ## Optional flag for ignoring tls certificate check.
+  # insecure_skip_verify = false
 ```

--- a/plugins/outputs/sematext/README.md
+++ b/plugins/outputs/sematext/README.md
@@ -1,0 +1,31 @@
+# Sematext Output Plugin
+
+The Sematext output plugin writes metrics to [Sematext](https://sematext.com/spm/).
+Check the [docs](https://sematext.com/docs/monitoring) for more info.
+
+### Configuration:
+
+```toml
+# Sematext output config
+[[outputs.sematext]]
+   ## Docs at https://sematext.com/docs/monitoring
+
+   ## URL of your Sematext metrics receiver. US-region metrics receiver is used
+   ## in this example (it is also the default when receiver_url value is empty),
+   ## but address of e.g. Sematext EU-region metrics receiver can be used
+   ## instead.
+   receiver_url = "https://spm-receiver.sematext.com"
+
+   ## Token of the App to which the data is sent. Create an App of appropriate
+   ## type in Sematext UI, instructions will show its token which can be used
+   ## here.
+   token = ""
+
+   ## Optional TLS Config
+   # tls_ca = "/etc/telegraf/ca.pem"
+   # tls_cert = "/etc/telegraf/cert.pem"
+   # tls_key = "/etc/telegraf/key.pem"
+
+   ## Optional flag for ignoring tls certificate check
+   # insecure_skip_verify = false
+```

--- a/plugins/outputs/sematext/processors/container.go
+++ b/plugins/outputs/sematext/processors/container.go
@@ -1,0 +1,74 @@
+package processors
+
+import (
+	"os"
+
+	"github.com/influxdata/telegraf"
+)
+
+const (
+	containerNameEnvName        = "SEMATEXT_CONTAINER_NAME"
+	containerIDEnvName          = "SEMATEXT_CONTAINER_ID"
+	containerImageNameEnvName   = "SEMATEXT_CONTAINER_IMAGE_NAME"
+	containerImageTagEnvName    = "SEMATEXT_CONTAINER_IMAGE_TAG"
+	containerImageDigestEnvName = "SEMATEXT_CONTAINER_IMAGE_DIGEST"
+	k8sPodEnvName               = "SEMATEXT_K8S_POD_NAME"
+	k8sNamespaceEnvName         = "SEMATEXT_K8S_NAMESPACE"
+	k8sClusterEnvName           = "SEMATEXT_K8S_CLUSTER"
+
+	containerImageTag       = "container.name"
+	containerHostnameTag    = "container.hostname"
+	containerIDTag          = "container.id"
+	containerImageNameTag   = "container.image.name"
+	containerImageTagTag    = "container.image.tag"
+	containerImageDigestTag = "container.image.digest"
+	k8sPodNameTag           = "kubernetes.pod.name"
+	k8sNamespaceIDTag       = "kubernetes.namespace"
+	k8sClusterTag           = "kubernetes.cluster.name"
+)
+
+// ContainerTags is a metric processor that injects container tags read from env variables
+type ContainerTags struct {
+	tags map[string]string
+}
+
+// NewContainerTags creates new instance of container MetricProcessor
+func NewContainerTags() MetricProcessor {
+	tags := make(map[string]string)
+	tags[containerImageTag] = os.Getenv(containerNameEnvName)
+	tags[containerIDTag] = os.Getenv(containerIDEnvName)
+	tags[containerImageNameTag] = os.Getenv(containerImageNameEnvName)
+	tags[containerImageTagTag] = os.Getenv(containerImageTagEnvName)
+	tags[containerImageDigestTag] = os.Getenv(containerImageDigestEnvName)
+
+	tags[k8sPodNameTag] = os.Getenv(k8sPodEnvName)
+	tags[k8sNamespaceIDTag] = os.Getenv(k8sNamespaceEnvName)
+	tags[k8sClusterTag] = os.Getenv(k8sClusterEnvName)
+
+	// fill container.hostname only when running in a container env
+	if tags[containerIDTag] != "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			// use container id value for container.hostname when the hostname can't be read
+			hostname = tags[containerIDTag]
+		}
+		tags[containerHostnameTag] = hostname
+	}
+
+	return &ContainerTags{
+		tags: tags,
+	}
+}
+
+// Process is a method where ContainerTags processor injects container tags from env variables to metric
+func (c *ContainerTags) Process(metric telegraf.Metric) error {
+	for tag, value := range c.tags {
+		if value != "" {
+			metric.AddTag(tag, value)
+		}
+	}
+	return nil
+}
+
+// Close clears the resources processor used, no-op in this case
+func (c *ContainerTags) Close() {}

--- a/plugins/outputs/sematext/processors/counter.go
+++ b/plugins/outputs/sematext/processors/counter.go
@@ -1,0 +1,139 @@
+package processors
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/outputs/sematext/tags"
+	"math"
+	"sync"
+	"time"
+)
+
+// HandleCounter keeps track of previous values of counter-type metrics and converts their value into delta between
+// current and previous measurement.
+type HandleCounter struct {
+	lock          sync.Mutex
+	countersCache map[string]*counterCacheEntry
+	lastCleared   time.Time
+}
+
+type counterCacheEntry struct {
+	lastValue    interface{}
+	lastRecorded time.Time
+}
+
+// NewHandleCounter creates a new HandleCounter processor
+func NewHandleCounter() MetricProcessor {
+	return &HandleCounter{
+		lastCleared:   time.Now(),
+		countersCache: make(map[string]*counterCacheEntry),
+	}
+}
+
+func (h *HandleCounter) Process(metric telegraf.Metric) error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	// if metric is a counter, keep track of its last recording, change the current value to be delta
+	if getSematextMetricType(metric.Type()) == Counter {
+		for _, field := range metric.FieldList() {
+			key := metric.Name() + "." + field.Key + "-" + tags.GetTagsKey(metric.Tags())
+			prevValueEntry := h.countersCache[key]
+			currValue := field.Value
+
+			var delta interface{}
+			if prevValueEntry == nil {
+				delta = getZeroValue(currValue)
+
+				h.countersCache[key] = &counterCacheEntry{
+					lastValue:    currValue,
+					lastRecorded: metric.Time(),
+				}
+			} else {
+				delta = calculateDelta(prevValueEntry.lastValue, currValue)
+
+				prevValueEntry.lastValue = currValue
+				prevValueEntry.lastRecorded = metric.Time()
+			}
+
+			field.Value = delta
+		}
+	}
+
+	h.clearCounterCache()
+
+	return nil
+}
+
+// clearCounterCache once a day goes through all entries in the cache map and removes all that were not used for the
+// past 24 hours
+func (h *HandleCounter) clearCounterCache() {
+	var now = time.Now()
+	if hoursSince(now, h.lastCleared) >= 24 {
+		newCountersCache := make(map[string]*counterCacheEntry)
+
+		for k, v := range h.countersCache {
+			if hoursSince(now, h.countersCache[k].lastRecorded) < 24 {
+				newCountersCache[k] = v
+			}
+		}
+
+		h.countersCache = newCountersCache
+		h.lastCleared = time.Now()
+	}
+}
+
+func hoursSince(end time.Time, start time.Time) float64 {
+	return (end.Sub(start)).Hours()
+}
+
+func getZeroValue(value interface{}) interface{} {
+	switch value.(type) {
+	case string:
+		return ""
+	case bool:
+		return false
+	case float64:
+		return 0.0
+	case uint64:
+		return 0
+	case int64:
+		return 0
+	default:
+		return 0
+	}
+}
+
+func calculateDelta(prevValue interface{}, currValue interface{}) interface{} {
+	switch v := prevValue.(type) {
+	case string:
+		return currValue
+	case bool:
+		return currValue
+	case float64:
+		if !math.IsNaN(v) && !math.IsInf(v, 0) && !math.IsNaN(currValue.(float64)) && !math.IsInf(currValue.(float64), 0) {
+			delta := currValue.(float64) - prevValue.(float64)
+			if delta < 0 {
+				delta = 0
+			}
+			return delta
+		}
+
+		return 0.0
+	case uint64:
+		if currValue.(uint64) < prevValue.(uint64) {
+			return 0
+		}
+		return currValue.(uint64) - prevValue.(uint64)
+	case int64:
+		delta := currValue.(int64) - prevValue.(int64)
+		if delta < 0 {
+			delta = 0
+		}
+		return delta
+	default:
+		return 0
+	}
+}
+
+func (h *HandleCounter) Close() {
+}

--- a/plugins/outputs/sematext/processors/counter_test.go
+++ b/plugins/outputs/sematext/processors/counter_test.go
@@ -1,0 +1,68 @@
+package processors
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestClearCounterCache(t *testing.T) {
+	now := time.Now()
+
+	lastCleared := time.Now().Add(-1 * time.Hour)
+	p := &HandleCounter{
+		lastCleared:   lastCleared,
+		countersCache: make(map[string]*counterCacheEntry),
+	}
+
+	p.countersCache["new"] = &counterCacheEntry{
+		lastValue:    123,
+		lastRecorded: time.Now().Add(-1 * time.Hour),
+	}
+	p.countersCache["old"] = &counterCacheEntry{
+		lastValue:    234,
+		lastRecorded: time.Now().Add(-30 * time.Hour),
+	}
+
+	p.clearCounterCache()
+
+	// nothing should have changed
+	assert.Equal(t, lastCleared.Unix(), p.lastCleared.Unix())
+	assert.Equal(t, 2, len(p.countersCache))
+	_, exists := p.countersCache["new"]
+	assert.Equal(t, true, exists)
+	_, exists = p.countersCache["old"]
+	assert.Equal(t, true, exists)
+
+	p.lastCleared = time.Now().Add(-25 * time.Hour)
+	p.clearCounterCache()
+
+	assert.True(t, p.lastCleared.Unix() >= now.Unix())
+	assert.Equal(t, 1, len(p.countersCache))
+	_, exists = p.countersCache["new"]
+	assert.Equal(t, true, exists)
+	_, exists = p.countersCache["old"]
+	assert.Equal(t, false, exists)
+}
+
+func TestHoursSince(t *testing.T) {
+	time1 := time.Date(2021, 04, 06, 10, 0, 0, 0, time.UTC)
+	time2 := time.Date(2021, 04, 06, 11, 0, 0, 0, time.UTC)
+
+	assert.Equal(t, 1, int(hoursSince(time2, time1)))
+}
+
+func TestGetZeroValue(t *testing.T) {
+	assert.Equal(t, "", getZeroValue("string"))
+	assert.Equal(t, false, getZeroValue(true))
+	assert.Equal(t, false, getZeroValue(false))
+	assert.Equal(t, 0.0, getZeroValue(float64(0)))
+	assert.Equal(t, 0, getZeroValue(uint64(0)))
+	assert.Equal(t, 0, getZeroValue(int64(0)))
+}
+
+func TestCalculateDelta(t *testing.T) {
+	assert.Equal(t, int64(10), calculateDelta(int64(10), int64(20)))
+	assert.Equal(t, float64(10), calculateDelta(float64(10), float64(20)))
+	assert.Equal(t, "def", calculateDelta("abc", "def"))
+}

--- a/plugins/outputs/sematext/processors/heartbeat.go
+++ b/plugins/outputs/sematext/processors/heartbeat.go
@@ -1,0 +1,110 @@
+package processors
+
+import (
+	"sync"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+)
+
+const (
+	oneMinuteSeconds = int64(60)
+	oneHourMinutes   = int64(60)
+	oneDaySeconds    = 24 * oneHourMinutes * oneMinuteSeconds
+	oneDayMinutes    = 24 * oneHourMinutes
+)
+
+// Heartbeat is a batch processor that injects heartbeat metric as necessary (once per minute). It stores info about
+// already injected heartbeats (one per minute) into injectedMinutes field. It will clear this map once a day to avoid
+// it to grow too big (field mapResetDay keeps the record of the "day" for which injectedMinutes contains the data)
+type Heartbeat struct {
+	injectedMinutes map[int64]bool
+	mapResetDay     int64
+	lock            sync.Mutex
+}
+
+func NewHeartbeat() BatchProcessor {
+	return &Heartbeat{
+		injectedMinutes: make(map[int64]bool),
+	}
+}
+
+// Process is a method where Heartbeat processor checks whether a heartbeat metric is needed and injects it if so
+func (h *Heartbeat) Process(metrics []telegraf.Metric) ([]telegraf.Metric, error) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	h.resetMap()
+
+	minutes := findMetricMinutes(metrics)
+
+	for minute, timeSeconds := range minutes {
+		if h.heartbeatNeeded(minute) {
+			newMetrics := h.addHeartbeat(metrics, minute, timeSeconds)
+			metrics = newMetrics
+		}
+	}
+
+	return metrics, nil
+}
+
+// Close clears the resources processor used, no-op in this case
+func (h *Heartbeat) Close() {}
+
+func findMetricMinutes(metrics []telegraf.Metric) map[int64]int64 {
+	// holds a mapping between a minute and the "biggest" timestamp (in seconds) found for that minute
+	minMap := make(map[int64]int64)
+
+	for _, m := range metrics {
+		min := getEpochMinute(m.Time())
+		seconds := m.Time().Unix()
+
+		if seconds > minMap[min] {
+			minMap[min] = seconds
+		}
+	}
+
+	return minMap
+}
+
+func (h *Heartbeat) addHeartbeat(metrics []telegraf.Metric, minute int64, timeSeconds int64) []telegraf.Metric {
+	hb := buildHeartbeatMetric(time.Unix(timeSeconds, 0))
+
+	metrics = append(metrics, hb)
+	h.injectedMinutes[minute] = true
+
+	return metrics
+}
+
+func buildHeartbeatMetric(timestamp time.Time) telegraf.Metric {
+	// no need to inject any Sematext specific tags since MetricProcessors will be run afterwards and will take care
+	// of such things
+	hb := metric.New("heartbeat",
+		make(map[string]string),
+		map[string]interface{}{"alive": int64(1)},
+		timestamp, telegraf.Gauge)
+
+	return hb
+}
+
+func (h *Heartbeat) heartbeatNeeded(minute int64) bool {
+	return !h.injectedMinutes[minute]
+}
+
+func (h *Heartbeat) resetMap() {
+	day := getEpochDay(time.Now())
+
+	if day > h.mapResetDay {
+		h.injectedMinutes = make(map[int64]bool, oneDayMinutes)
+		h.mapResetDay = day
+	}
+}
+
+func getEpochDay(t time.Time) int64 {
+	return t.Unix() / oneDaySeconds
+}
+
+func getEpochMinute(t time.Time) int64 {
+	return t.Unix() / oneMinuteSeconds
+}

--- a/plugins/outputs/sematext/processors/heartbeat_test.go
+++ b/plugins/outputs/sematext/processors/heartbeat_test.go
@@ -1,0 +1,110 @@
+package processors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildHeartbeatMetric(t *testing.T) {
+	now := time.Now()
+	m := buildHeartbeatMetric(now)
+
+	assert.Equal(t, "heartbeat", m.Name())
+	assert.Equal(t, 1, len(m.Fields()))
+	val, set := m.GetField("alive")
+	assert.Equal(t, true, set)
+	assert.Equal(t, int64(1), val)
+	assert.Equal(t, 0, len(m.Tags()))
+}
+
+func TestHeartbeatNeeded(t *testing.T) {
+	minute := int64(11)
+	bp := NewHeartbeat()
+	h := bp.(*Heartbeat)
+	assert.Equal(t, true, h.heartbeatNeeded(minute))
+
+	h.injectedMinutes[minute] = true
+	assert.Equal(t, false, h.heartbeatNeeded(minute))
+
+	minute++
+	assert.Equal(t, true, h.heartbeatNeeded(minute))
+}
+
+func TestAddHeartbeat(t *testing.T) {
+	bp := NewHeartbeat()
+	h := bp.(*Heartbeat)
+	now := time.Now()
+	currentMinute := getEpochMinute(now)
+
+	assert.Equal(t, false, h.injectedMinutes[currentMinute])
+	metrics := make([]telegraf.Metric, 0, 1)
+	var err error
+	metrics = h.addHeartbeat(metrics, currentMinute, now.Unix())
+
+	assert.Nil(t, err)
+	assert.Equal(t, true, h.injectedMinutes[currentMinute])
+	assert.Equal(t, 1, len(metrics))
+	assert.Equal(t, now.Unix(), metrics[0].Time().Unix())
+}
+
+func TestProcess(t *testing.T) {
+	bp := NewHeartbeat()
+	h := bp.(*Heartbeat)
+	metrics := make([]telegraf.Metric, 0, 2)
+
+	var err error
+	metrics, err = h.Process(metrics)
+
+	// no metrics, so no heartbeat metric should be injected
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(metrics))
+
+	now := time.Now()
+	currentMinute := getEpochMinute(now)
+	cpuMetric := metric.New("os",
+		make(map[string]string),
+		map[string]interface{}{"cpu.user": 99.9},
+		now, telegraf.Gauge)
+
+	assert.Nil(t, err)
+
+	metrics = append(metrics, cpuMetric)
+
+	metrics, err = h.Process(metrics)
+	assert.Nil(t, err)
+	assert.Equal(t, true, h.injectedMinutes[currentMinute])
+	// cpu.user and a heartbeat metric:
+	assert.Equal(t, 2, len(metrics))
+}
+
+func TestFindMetricMinutes(t *testing.T) {
+	metrics := make([]telegraf.Metric, 0, 1)
+
+	now := time.Now()
+	currentMinute := getEpochMinute(now)
+	cpuMetric := metric.New("os",
+		make(map[string]string),
+		map[string]interface{}{"cpu.user": 99.9},
+		now, telegraf.Gauge)
+
+	metrics = append(metrics, cpuMetric)
+
+	minMap := findMetricMinutes(metrics)
+	assert.Equal(t, now.Unix(), minMap[currentMinute])
+}
+
+func TestResetMap(t *testing.T) {
+	bp := NewHeartbeat()
+	h := bp.(*Heartbeat)
+	h.injectedMinutes[123] = true
+	h.mapResetDay = 123
+
+	h.resetMap()
+
+	assert.Equal(t, 0, len(h.injectedMinutes))
+	assert.NotEqual(t, 123, h.mapResetDay)
+}

--- a/plugins/outputs/sematext/processors/host.go
+++ b/plugins/outputs/sematext/processors/host.go
@@ -1,0 +1,142 @@
+package processors
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/influxdata/telegraf"
+)
+
+const (
+	sematextHostTag  = "os.host"
+	telegrafHostTag  = "host"
+	hostnameFileName = ".resolved-hostname"
+
+	containerHostHostnameEnvName = "SEMATEXT_CONTAINER_HOST_HOSTNAME"
+)
+
+type Host struct {
+	hostname     string
+	lock         sync.RWMutex
+	reloadTicker *time.Ticker
+	stopReload   chan bool
+	Log          telegraf.Logger
+}
+
+// NewHost creates and initializes an instance of Host processor. It also starts periodic host reload goroutine.
+func NewHost(log telegraf.Logger) MetricProcessor {
+	// do the initial load before spawning a goroutine which will periodically reload the hostname
+	var host string
+	var err error
+
+	// in container envs, check if specific env var is present, use it as a hostname if it is
+	containerHostHostname := os.Getenv(containerHostHostnameEnvName)
+	if containerHostHostname != "" {
+		host = containerHostHostname
+	} else {
+		// otherwise try to read from the hostname file
+		hostnameFileName := getHostnameFileName()
+
+		if hostnameFileName != "" {
+			host, err = loadHostname(hostnameFileName)
+			if err != nil {
+				log.Warnf("can't load the hostname from the file %s, error: %v, falling back to os.Hostname()",
+					hostnameFileName, err)
+			}
+		}
+		if host == "" {
+			host, err = os.Hostname()
+			if err != nil {
+				log.Warnf("os.Hostname() resulted in error: %v")
+			}
+		}
+	}
+
+	h := &Host{
+		hostname: host,
+		Log:      log,
+	}
+
+	// start only if hostname will be read from the file (env var not present) and if the Sematext dir (which might
+	// hold the hostname file) exists, no point in starting the ticker otherwise
+	if containerHostHostname == "" && hostnameFileName != "" {
+		h.reloadTicker = time.NewTicker(5 * time.Minute)
+		h.stopReload = make(chan bool, 1)
+
+		go func() {
+			for {
+				select {
+				case <-h.stopReload:
+					return
+				case <-h.reloadTicker.C:
+					host, err = loadHostname(hostnameFileName)
+					if err != nil {
+						log.Warnf("can't load the hostname from the file %s, error: %v", hostnameFileName, err)
+					}
+
+					if host != "" {
+						h.lock.Lock()
+						h.hostname = host
+						h.lock.Unlock()
+					}
+				}
+			}
+		}()
+	}
+
+	return h
+}
+
+// Process adjusts the host tag to be compliant with Sematext backend
+func (h *Host) Process(metric telegraf.Metric) error {
+	// locking because of h.hostname which might be written to by a separate goroutine
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+
+	adjustHostname(metric, h.hostname)
+
+	return nil
+}
+
+// Close clears the resources processor used
+func (h *Host) Close() {
+	if h.stopReload != nil {
+		h.stopReload <- true
+	}
+	h.reloadTicker.Stop()
+}
+
+func adjustHostname(metric telegraf.Metric, loadedHostname string) {
+	if loadedHostname != "" {
+		metric.RemoveTag(telegrafHostTag)
+		metric.AddTag(sematextHostTag, loadedHostname)
+	} else {
+		h, set := metric.GetTag(telegrafHostTag)
+		if set {
+			metric.RemoveTag(telegrafHostTag)
+			metric.AddTag(sematextHostTag, h)
+		}
+	}
+}
+
+// getHostnameFileName returns the full path of the hostname
+func getHostnameFileName() string {
+	if root := GetRootDir(); root != "" {
+		return path.Join(root, hostnameFileName)
+	}
+	return ""
+}
+
+func loadHostname(hostnameFileName string) (string, error) {
+	data, err := ioutil.ReadFile(hostnameFileName)
+	if err != nil {
+		return "", err
+	}
+
+	fullStr := string(data)
+	return strings.Split(fullStr, "\n")[0], nil
+}

--- a/plugins/outputs/sematext/processors/host_test.go
+++ b/plugins/outputs/sematext/processors/host_test.go
@@ -1,0 +1,59 @@
+package processors
+
+import (
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestAdjustHostname(t *testing.T) {
+	now := time.Now()
+
+	m := metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	adjustHostname(m, "abc")
+
+	newVal, set := m.GetTag(sematextHostTag)
+
+	assert.Equal(t, true, set)
+	assert.Equal(t, "abc", newVal)
+}
+
+func TestLoadHostname(t *testing.T) {
+	assert.Equal(t, "somehost001", onlyHost(loadHostname("./testdata/resolved-hostname")))
+	assert.Equal(t, "", onlyHost(loadHostname("./testdata/doesnt-exist")))
+	assert.Equal(t, "", onlyHost(loadHostname("/baddir")))
+	assert.Equal(t, "somehost001", onlyHost(loadHostname("./testdata/resolved-hostname-multiline")))
+	assert.Equal(t, "somehost001", onlyHost(loadHostname("./testdata/resolved-hostname-multiline2")))
+}
+
+func onlyHost(host string, _ error) string {
+	return host
+}
+
+func TestHostProcess(t *testing.T) {
+	h := &Host{
+		hostname: "abc",
+	}
+
+	now := time.Now()
+
+	m := metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	err := h.Process(m)
+	assert.Nil(t, err)
+
+	newVal, set := m.GetTag(sematextHostTag)
+
+	assert.Equal(t, true, set)
+	assert.Equal(t, "abc", newVal)
+}

--- a/plugins/outputs/sematext/processors/metainfo.go
+++ b/plugins/outputs/sematext/processors/metainfo.go
@@ -1,0 +1,247 @@
+package processors
+
+import (
+	"fmt"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/outputs/sematext/sender"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+const (
+	metainfoRetryIntervalSeconds = 60
+	maxMetainfoRetries           = 10
+)
+
+// MetricMetainfo contains metainfo about a single metric
+type MetricMetainfo struct {
+	token       string
+	name        string
+	namespace   string
+	semType     SematextMetricType
+	numericType NumericType
+	label       string
+	description string
+	host        string
+}
+
+// SematextMetricType is an enumeration of metric types expected by Sematext backend
+type SematextMetricType int
+
+// Possible values for the ValueType enum.
+const (
+	_ SematextMetricType = iota
+	Counter
+	Gauge
+)
+
+func (s SematextMetricType) String() string {
+	return [...]string{"", "Counter", "Gauge"}[s]
+}
+
+// NumericType represents metric's data type
+type NumericType int
+
+const (
+	UnsupportedNumericType NumericType = iota
+	Long
+	Double
+	Bool
+)
+
+func (s NumericType) String() string {
+	return [...]string{"", "Long", "Double", "Bool"}[s]
+}
+
+// Metainfo is a processor that extracts metainfo from telegraf metrics and sends it to Sematext backend
+type Metainfo struct {
+	log         telegraf.Logger
+	token       string
+	sentMetrics map[string]*MetricMetainfo
+	lock        sync.Mutex
+	sendChannel chan bool
+	serializer  *MetainfoSerializer
+
+	metainfoURL  string
+	senderConfig *sender.Config
+	sender       *sender.Sender
+}
+
+// NewMetainfo creates a new Metainfo processor
+func NewMetainfo(log telegraf.Logger, token string, receiverURL string, senderConfig *sender.Config) BatchProcessor {
+	sentMetricsMap := make(map[string]*MetricMetainfo)
+	return &Metainfo{
+		log:          log,
+		token:        token,
+		sentMetrics:  sentMetricsMap,
+		sendChannel:  make(chan bool, 1),
+		metainfoURL:  receiverURL + "/write?db=metainfo",
+		senderConfig: senderConfig,
+		sender:       sender.NewSender(senderConfig),
+		serializer:   NewMetainfoSerializer(log),
+	}
+}
+
+// Process contains core logic of Metainfo processor
+func (m *Metainfo) Process(metrics []telegraf.Metric) ([]telegraf.Metric, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	newMetrics := make(map[string]*MetricMetainfo)
+
+	for _, metric := range metrics {
+		for _, field := range metric.FieldList() {
+			mInfo, mKey := processMetric(m.token, metric, field, m.sentMetrics)
+			if mInfo != nil {
+				newMetrics[mKey] = mInfo
+			}
+		}
+	}
+
+	if len(newMetrics) > 0 {
+		go m.sendMetainfo(newMetrics)
+
+		// add newMetrics to sentMetrics so they are not sent again from other goroutines
+		for k, v := range newMetrics {
+			m.sentMetrics[k] = v
+		}
+	}
+
+	return metrics, nil
+}
+
+func (m *Metainfo) sendMetainfo(newMetrics map[string]*MetricMetainfo) {
+	reqCounter := 0
+
+	mInfoSlice := make([]*MetricMetainfo, 0, len(newMetrics))
+	for _, mInfo := range newMetrics {
+		mInfoSlice = append(mInfoSlice, mInfo)
+	}
+	body := m.serializer.Write(mInfoSlice)
+
+	for {
+		select {
+		case <-m.sendChannel:
+			return
+		default:
+			m.log.Infof("sending metainfo to Sematext endpoint %s", m.metainfoURL)
+			res, err := m.sender.Request("POST", m.metainfoURL, "text/plain; charset=utf-8", body)
+			reqCounter++
+			if err != nil {
+				// possibly non-recoverable, return without retrying
+				m.log.Errorf("can't send metainfo to Sematext endpoint %s, error: %v",
+					m.metainfoURL, err)
+				return
+			}
+			responseContent := response(res)
+			res.Body.Close()
+
+			success := res.StatusCode >= 200 && res.StatusCode < 300
+
+			if success {
+				m.log.Infof("successfully sent metainfo to Sematext endpoint %s, batch size : %d",
+					m.metainfoURL, len(newMetrics))
+				return
+			}
+
+			m.log.Errorf("can't send the metainfo to Sematext endpoint %s, response code: %d, response: %s",
+				m.metainfoURL, res.StatusCode, responseContent)
+
+			badRequest := res.StatusCode >= 400 && res.StatusCode < 500
+			if badRequest {
+				m.log.Infof("no retry for bad requests, response code was %d", res.StatusCode)
+				return
+			}
+
+			if reqCounter >= maxMetainfoRetries {
+				m.log.Warnf("max retries (%d) exceeded, cancelling the request permanently",
+					maxMetainfoRetries)
+				return
+			}
+
+			nextSleepIntervalSec := int32(reqCounter * metainfoRetryIntervalSeconds)
+			m.log.Infof("metainfo sending retry in %d seconds", nextSleepIntervalSec)
+			time.Sleep(time.Second * time.Duration(rand.Int31n(nextSleepIntervalSec)))
+		}
+	}
+}
+
+func processMetric(token string, metric telegraf.Metric, field *telegraf.Field,
+	sentMetrics map[string]*MetricMetainfo) (*MetricMetainfo, string) {
+	host, set := metric.GetTag(telegrafHostTag)
+	// skip if no host tag
+	if set {
+		key := buildMetricKey(host, metric.Name(), field.Key)
+
+		_, set := sentMetrics[key]
+		if !set {
+			return buildMetainfo(token, host, metric, field), key
+		}
+	}
+
+	return nil, ""
+}
+
+func buildMetainfo(token string, host string, metric telegraf.Metric, field *telegraf.Field) *MetricMetainfo {
+	semType := getSematextMetricType(metric.Type())
+	numericType := getSematextNumericType(field)
+
+	if numericType == UnsupportedNumericType || numericType == Bool {
+		return nil
+	}
+
+	label := fmt.Sprintf("%s.%s", metric.Name(), field.Key)
+
+	return &MetricMetainfo{
+		token:       token,
+		name:        field.Key,
+		namespace:   metric.Name(),
+		semType:     semType,
+		numericType: numericType,
+		label:       label,
+		description: "",
+		host:        host,
+	}
+}
+
+// Close clears the resources used by Metainfo processor
+func (m *Metainfo) Close() {
+	// close the channel to metainfo sender goroutines + close the sender
+	close(m.sendChannel)
+	m.sender.Close()
+}
+
+func getSematextMetricType(metricType telegraf.ValueType) SematextMetricType {
+	var semType SematextMetricType
+	switch metricType {
+	case telegraf.Counter:
+		semType = Counter
+	default:
+		semType = Gauge
+	}
+
+	return semType
+}
+
+func getSematextNumericType(field *telegraf.Field) NumericType {
+	var numType NumericType
+	switch field.Value.(type) {
+	case float64:
+		numType = Double
+	case uint64:
+		numType = Long
+	case int64:
+		numType = Long
+	case bool:
+		numType = Bool
+	default:
+		numType = UnsupportedNumericType
+	}
+
+	return numType
+}
+
+func buildMetricKey(host string, namespace string, name string) string {
+	return fmt.Sprintf("%s-%s.%s", host, namespace, name)
+}

--- a/plugins/outputs/sematext/processors/metainfo_serializer.go
+++ b/plugins/outputs/sematext/processors/metainfo_serializer.go
@@ -1,0 +1,48 @@
+package processors
+
+import (
+	"bytes"
+	"github.com/influxdata/telegraf"
+	"strings"
+)
+
+type MetainfoSerializer struct {
+	log telegraf.Logger
+}
+
+func (m *MetainfoSerializer) Write(mList []*MetricMetainfo) []byte {
+	var output bytes.Buffer
+
+	for _, meta := range mList {
+		_, _ = output.Write(serializeMetainfo(meta))
+		_, _ = output.WriteString("\n")
+	}
+
+	return output.Bytes()
+}
+
+func serializeMetainfo(metainfo *MetricMetainfo) []byte {
+	var output bytes.Buffer
+
+	_, _ = output.WriteString((*metainfo).namespace)
+	_, _ = output.WriteString(",label=")
+	_, _ = output.WriteString((*metainfo).label)
+	_, _ = output.WriteString(",numericType=")
+	_, _ = output.WriteString(strings.ToLower((*metainfo).numericType.String()))
+	_, _ = output.WriteString(",os.host=")
+	_, _ = output.WriteString((*metainfo).host)
+	_, _ = output.WriteString(",token=")
+	_, _ = output.WriteString((*metainfo).token)
+	_, _ = output.WriteString(",type=")
+	_, _ = output.WriteString(strings.ToLower((*metainfo).semType.String()))
+	_, _ = output.WriteString(" ")
+	_, _ = output.WriteString((*metainfo).name)
+
+	return output.Bytes()
+}
+
+func NewMetainfoSerializer(log telegraf.Logger) *MetainfoSerializer {
+	return &MetainfoSerializer{
+		log: log,
+	}
+}

--- a/plugins/outputs/sematext/processors/metainfo_serializer_test.go
+++ b/plugins/outputs/sematext/processors/metainfo_serializer_test.go
@@ -1,0 +1,22 @@
+package processors
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSerializeMetainfo(t *testing.T) {
+	mInfo := &MetricMetainfo{
+		name:        "cpu.user",
+		namespace:   "os",
+		label:       "os.cpu.user",
+		semType:     Gauge,
+		numericType: Long,
+		token:       "token",
+		host:        "host001",
+	}
+
+	body := string(serializeMetainfo(mInfo))
+
+	assert.Equal(t, "os,label=os.cpu.user,numericType=long,os.host=host001,token=token,type=gauge cpu.user", body)
+}

--- a/plugins/outputs/sematext/processors/metainfo_test.go
+++ b/plugins/outputs/sematext/processors/metainfo_test.go
@@ -1,0 +1,114 @@
+package processors
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestProcessMetric(t *testing.T) {
+	now := time.Now()
+	m := metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	sentMetrics := make(map[string]*MetricMetainfo)
+
+	mInfo, mKey := processMetric("aaa", m, getField(m, "disk.used"), sentMetrics)
+	assert.NotNil(t, mInfo)
+
+	sentMetrics[mKey] = mInfo
+	// once it is in sentMetrics, it shouldn't be created again
+	mInfo, mKey = processMetric("aaa", m, getField(m, "disk.used"), sentMetrics)
+	assert.Nil(t, mInfo)
+
+	sentMetrics[mKey] = nil
+	m.RemoveTag(telegrafHostTag)
+	mInfo, _ = processMetric("aaa", m, getField(m, "disk.used"), sentMetrics)
+	assert.Nil(t, mInfo)
+}
+
+func TestBuildMetainfo(t *testing.T) {
+	now := time.Now()
+	m := metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	mInfo := buildMetainfo("aaa", "host", m, getField(m, "disk.used"))
+
+	assert.Equal(t, "aaa", mInfo.token)
+	assert.Equal(t, "host", mInfo.host)
+	assert.Equal(t, "os", mInfo.namespace)
+	assert.Equal(t, "disk.used", mInfo.name)
+	assert.Equal(t, Gauge, mInfo.semType)
+	assert.Equal(t, Double, mInfo.numericType)
+	assert.Equal(t, "os.disk.used", mInfo.label)
+	assert.Equal(t, "", mInfo.description)
+
+	m = metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now, telegraf.Counter)
+	mInfo = buildMetainfo("aaa", "host", m, getField(m, "disk.used"))
+
+	assert.Equal(t, Counter, mInfo.semType)
+
+	m = metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.state": "active"},
+		now, telegraf.Counter)
+	mInfo = buildMetainfo("aaa", "host", m, getField(m, "disk.state"))
+	assert.Nil(t, mInfo)
+}
+
+func getField(m telegraf.Metric, name string) *telegraf.Field {
+	for _, f := range m.FieldList() {
+		if f.Key == name {
+			return f
+		}
+	}
+	return nil
+}
+
+func TestGetSematextMetricType(t *testing.T) {
+	assert.Equal(t, Gauge, getSematextMetricType(telegraf.Gauge))
+	assert.Equal(t, Counter, getSematextMetricType(telegraf.Counter))
+	assert.Equal(t, Gauge, getSematextMetricType(telegraf.Histogram))
+	assert.Equal(t, Gauge, getSematextMetricType(telegraf.Summary))
+	assert.Equal(t, Gauge, getSematextMetricType(telegraf.Untyped))
+}
+
+func TestGetSematextNumericType(t *testing.T) {
+	assert.Equal(t, Double, getSematextNumericType(&telegraf.Field{
+		Key:   "abc",
+		Value: 1.23,
+	}))
+	assert.Equal(t, Long, getSematextNumericType(&telegraf.Field{
+		Key:   "abc",
+		Value: int64(11),
+	}))
+	assert.Equal(t, Long, getSematextNumericType(&telegraf.Field{
+		Key:   "abc",
+		Value: uint64(11),
+	}))
+	assert.Equal(t, Bool, getSematextNumericType(&telegraf.Field{
+		Key:   "abc",
+		Value: true,
+	}))
+	assert.Equal(t, UnsupportedNumericType, getSematextNumericType(&telegraf.Field{
+		Key:   "abc",
+		Value: "abc",
+	}))
+}
+
+func TestBuildMetricKey(t *testing.T) {
+	assert.Equal(t, "host-os.cpu.user", buildMetricKey("host", "os", "cpu.user"))
+}

--- a/plugins/outputs/sematext/processors/metric_type.go
+++ b/plugins/outputs/sematext/processors/metric_type.go
@@ -1,0 +1,34 @@
+package processors
+
+import (
+	"fmt"
+	"github.com/influxdata/telegraf"
+)
+
+const (
+	metricTypeTagName = "metric_type"
+)
+
+// MetricType processor removes metric_type tag if it is present and appends it to metric name as a suffix
+type MetricType struct {
+}
+
+// Process implements the core of MetricType processor logic
+func (m *MetricType) Process(metric telegraf.Metric) error {
+	if tagValue, set := metric.GetTag(metricTypeTagName); set {
+		metric.RemoveTag(metricTypeTagName)
+
+		for _, f := range metric.FieldList() {
+			f.Key = fmt.Sprintf("%s.%s", f.Key, tagValue)
+		}
+	}
+	return nil
+}
+
+// Close clears the resources processor used, no-op in this case
+func (m *MetricType) Close() {}
+
+// NewMetricType creates a new MetricType processor
+func NewMetricType() MetricProcessor {
+	return &MetricType{}
+}

--- a/plugins/outputs/sematext/processors/metric_type_test.go
+++ b/plugins/outputs/sematext/processors/metric_type_test.go
@@ -1,0 +1,30 @@
+package processors
+
+import (
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMetricType(t *testing.T) {
+	mt := NewMetricType()
+
+	now := time.Now()
+	m := metric.New(
+		"os",
+		map[string]string{telegrafHostTag: "somehost", "os.disk": "sda1", metricTypeTagName: "counter"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	err := mt.Process(m)
+
+	assert.Nil(t, err)
+
+	_, set := m.GetTag(metricTypeTagName)
+	assert.Equal(t, false, set)
+	assert.True(t, strings.HasSuffix(m.FieldList()[0].Key, ".counter"))
+	assert.True(t, strings.HasSuffix(m.FieldList()[1].Key, ".counter"))
+	assert.True(t, strings.HasSuffix(m.FieldList()[2].Key, ".counter"))
+}

--- a/plugins/outputs/sematext/processors/processor.go
+++ b/plugins/outputs/sematext/processors/processor.go
@@ -1,0 +1,22 @@
+package processors
+
+import "github.com/influxdata/telegraf"
+
+// MetricProcessor is interface that should be implemented by modules which adjust Telegraf metrics to match Sematext
+// format.
+type MetricProcessor interface {
+	// Process makes adjustments to a single metric instance to be compliant with Sematext backend
+	Process(metric telegraf.Metric) error
+
+	Close()
+}
+
+// BatchProcessor is used to execute actions on the level of a whole batch of metrics. Batch processors are run before
+// any Metric processors kick in, so metrics produced by a batch processor can count on further being decorated by
+// metric processors. Also, metrics batch processors work on are "original" Telegraf metrics without any Sematext
+// specific adjustments.
+type BatchProcessor interface {
+	Process(metrics []telegraf.Metric) ([]telegraf.Metric, error)
+
+	Close()
+}

--- a/plugins/outputs/sematext/processors/rename.go
+++ b/plugins/outputs/sematext/processors/rename.go
@@ -1,0 +1,149 @@
+package processors
+
+import (
+	"github.com/influxdata/telegraf"
+)
+
+var (
+	measurementReplaces = map[string]string{
+		"phpfpm":              "php",
+		"mongodb":             "mongo",
+		"mongodb_db_stats":    "mongo",
+		"mongodb_col_stats":   "mongo",
+		"mongodb_shard_stats": "mongo",
+		"apache":              "apache",
+		"nginx":               "nginx",
+	}
+	fieldReplaces = map[string]string{
+		// apache
+		"apache.BusyWorkers":          "workers.busy",
+		"apache.BytesPerReq":          "bytes",
+		"apache.ReqPerSec":            "requests",
+		"apache.ConnsAsyncClosing":    "connections.async.closing",
+		"apache.ConnsAsyncKeepAlive":  "connections.async.keepAlive",
+		"apache.ConnsAsyncWriting":    "connections.async.writing",
+		"apache.ConnsTotal":           "connections",
+		"apache.IdleWorkers":          "workers.idle",
+		"apache.scboard_closing":      "workers.closing",
+		"apache.scboard_dnslookup":    "workers.dns",
+		"apache.scboard_finishing":    "workers.finishing",
+		"apache.scboard_idle_cleanup": "workers.cleanup",
+		"apache.scboard_keepalive":    "workers.keepalive",
+		"apache.scboard_logging":      "workers.logging",
+		"apache.scboard_open":         "workers.open",
+		"apache.scboard_reading":      "workers.reading",
+		"apache.scboard_sending":      "workers.sending",
+		"apache.scboard_starting":     "workers.starting",
+		"apache.scboard_waiting":      "workers.waiting",
+		"phpfpm.accepted_conn":        "fpm.requests.accepted.conns",
+		"phpfpm.listen_queue":         "fpm.queue.listen",
+		"phpfpm.max_listen_queue":     "fpm.queue.listen.max",
+		"phpfpm.listen_queue_len":     "fpm.queue.listen.len",
+		"phpfpm.idle_processes":       "fpm.process.idle",
+		"phpfpm.active_processes":     "fpm.process.active",
+		"phpfpm.total_processes":      "fpm.process.total",
+		"phpfpm.max_active_processes": "fpm.process.active.max",
+		"phpfpm.max_children_reached": "fpm.process.childrenReached.max",
+		"phpfpm.slow_requests":        "fpm.requests.slow",
+		// nginx
+		"nginx.accepts":  "requests.connections.accepted",
+		"nginx.handled":  "requests.connections.handled",
+		"nginx.active":   "requests.connections.active",
+		"nginx.reading":  "requests.connections.reading",
+		"nginx.writing":  "requests.connections.writing",
+		"nginx.waiting":  "requests.connections.waiting",
+		"nginx.requests": "request.count",
+		// mongodb
+		"mongodb.flushes":                 "flushes",
+		"mongodb.flushes_total_time_ns":   "flushes.time",
+		"mongodb.document_inserted":       "documents.inserted",
+		"mongodb.document_updated":        "documents.updated",
+		"mongodb.document_deleted":        "documents.deleted",
+		"mongodb.document_returned":       "documents.returned",
+		"mongodb.resident_megabytes":      "memory.resident",
+		"mongodb.vsize_megabytes":         "memory.virtual",
+		"mongodb.mapped_megabytes":        "memory.mapped",
+		"mongodb.inserts":                 "ops.insert",
+		"mongodb.queries":                 "ops.query",
+		"mongodb.updates":                 "ops.update",
+		"mongodb.getmores":                "ops.getmore",
+		"mongodb.commands":                "ops.command",
+		"mongodb.repl_inserts":            "replica.ops.insert",
+		"mongodb.repl_queries":            "replica.ops.query",
+		"mongodb.repl_updates":            "replica.ops.update",
+		"mongodb.repl_deletes":            "replica.ops.delete",
+		"mongodb.repl_getmores":           "replica.ops.getmore",
+		"mongodb.repl_commands":           "replica.ops.command",
+		"mongodb.count_command_failed":    "commands.failed",
+		"mongodb.count_command_total":     "commands.total",
+		"mongodb_db_stats.data_size":      "database.data.size",
+		"mongodb_db_stats.storage_size":   "database.storage.size",
+		"mongodb_db_stats.index_size":     "database.index.size",
+		"mongodb_db_stats.collections":    "database.collections",
+		"mongodb_db_stats.objects":        "database.objects",
+		"mongodb_db_stats.avg_obj_size":   "database.avg_obj_size",
+		"mongodb_db_stats.indexes":        "database.indexes",
+		"mongodb_db_stats.num_extents":    "database.num_extents",
+		"mongodb_db_stats.ok":             "database.ok",
+		"mongo.connections_current":       "network.connections",
+		"mongo.connections_total_created": "network.connections.total",
+		"mongo.net_in_bytes":              "network.transfer.rx.rate",
+		"mongo.net_out_bytes":             "network.transfer.tx.rate",
+		// mongodb_col_stats -> these appear like they map to the same thing, but "from" side is actually
+		// "name.metricName" and "to" side is just the new "metricName"
+		"mongodb_col_stats.avg_obj_size":     "mongodb_col_stats.avg_obj_size",
+		"mongodb_col_stats.count":            "mongodb_col_stats.count",
+		"mongodb_col_stats.ok":               "mongodb_col_stats.ok",
+		"mongodb_col_stats.size":             "mongodb_col_stats.size",
+		"mongodb_col_stats.storage_size":     "mongodb_col_stats.storage_size",
+		"mongodb_col_stats.total_index_size": "mongodb_col_stats.total_index_size",
+		// mongodb_shard_stats -> same logic as for mongodb_col_stats
+		"mongodb_shard_stats.in_use":     "mongodb_shard_stats.in_use",
+		"mongodb_shard_stats.available":  "mongodb_shard_stats.available",
+		"mongodb_shard_stats.created":    "mongodb_shard_stats.created",
+		"mongodb_shard_stats.refreshing": "mongodb_shard_stats.refreshing",
+	}
+)
+
+// Rename processor renames the measurement (metric) names
+// to match the existing metric names sent by Node.js agents
+type Rename struct{}
+
+// NewRename builds a new rename processor.
+func NewRename() BatchProcessor { return &Rename{} }
+
+// Process performs a lookup in the local maps of metric/field names
+// and replaces the metric name with the new name.
+func (r *Rename) Process(points []telegraf.Metric) ([]telegraf.Metric, error) {
+	for _, point := range points {
+		originalName := point.Name()
+		replace, ok := measurementReplaces[originalName]
+		if !ok {
+			continue
+		}
+		point.SetName(replace)
+		removedFields := make([]string, 0)
+		for _, field := range point.FieldList() {
+			key := originalName + "." + field.Key
+			replace, ok := fieldReplaces[key]
+			if !ok {
+				continue
+			}
+			// we can't remove the fields
+			// while iterating because it
+			// produces unwanted effects
+			// e.g. metrics that have the
+			// mapping are not renamed.
+			// That's why we have to remove
+			// them in a separate loop
+			removedFields = append(removedFields, field.Key)
+			point.AddField(replace, field.Value)
+		}
+		for _, f := range removedFields {
+			point.RemoveField(f)
+		}
+	}
+	return points, nil
+}
+
+func (Rename) Close() {}

--- a/plugins/outputs/sematext/processors/rename_test.go
+++ b/plugins/outputs/sematext/processors/rename_test.go
@@ -1,0 +1,42 @@
+package processors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRename(t *testing.T) {
+	r := Rename{}
+	m1 := newMetric("apache", nil, nil)
+	m2 := newMetric("phpfpm", nil, nil)
+	m3 := newMetric("apache", nil, map[string]interface{}{"scboard_dnslookup": 120})
+	m4 := newMetric("etcd", nil, map[string]interface{}{"slow_requests": 10})
+	m5 := newMetric("phpfpm", nil, map[string]interface{}{"slow_requests": 10})
+	m6 := newMetric("mongodb_col_stats", nil, map[string]interface{}{"ok": 10})
+
+	results, err := r.Process([]telegraf.Metric{m1, m2, m3, m4, m5, m6})
+	require.NoError(t, err)
+	assert.Equal(t, "apache", results[0].Name())
+	assert.Equal(t, "php", results[1].Name())
+	assert.Equal(t, "workers.dns", results[2].FieldList()[0].Key)
+	assert.Equal(t, "slow_requests", results[3].FieldList()[0].Key)
+	assert.Equal(t, "fpm.requests.slow", results[4].FieldList()[0].Key)
+	assert.Equal(t, "mongo", results[5].Name())
+	assert.Equal(t, "mongodb_col_stats.ok", results[5].FieldList()[0].Key)
+}
+
+func newMetric(name string, tags map[string]string, fields map[string]interface{}) telegraf.Metric {
+	if tags == nil {
+		tags = map[string]string{}
+	}
+	if fields == nil {
+		fields = map[string]interface{}{}
+	}
+	m := metric.New(name, tags, fields, time.Now())
+	return m
+}

--- a/plugins/outputs/sematext/processors/testdata/resolved-hostname
+++ b/plugins/outputs/sematext/processors/testdata/resolved-hostname
@@ -1,0 +1,1 @@
+somehost001

--- a/plugins/outputs/sematext/processors/testdata/resolved-hostname-multiline
+++ b/plugins/outputs/sematext/processors/testdata/resolved-hostname-multiline
@@ -1,0 +1,1 @@
+somehost001

--- a/plugins/outputs/sematext/processors/testdata/resolved-hostname-multiline2
+++ b/plugins/outputs/sematext/processors/testdata/resolved-hostname-multiline2
@@ -1,0 +1,2 @@
+somehost001
+someotherhost002

--- a/plugins/outputs/sematext/processors/token.go
+++ b/plugins/outputs/sematext/processors/token.go
@@ -1,0 +1,24 @@
+package processors
+
+import "github.com/influxdata/telegraf"
+
+// Token is processor which injects Sematext App token into each metric
+type Token struct {
+	Token string
+}
+
+// Process is a method where Token processor logic is implemented
+func (t *Token) Process(metric telegraf.Metric) error {
+	metric.AddTag("token", t.Token)
+	return nil
+}
+
+// Close clears the resources processor used, no-op in this case
+func (t *Token) Close() {}
+
+// NewToken creates a new token processor
+func NewToken(token string) MetricProcessor {
+	return &Token{
+		Token: token,
+	}
+}

--- a/plugins/outputs/sematext/processors/utils.go
+++ b/plugins/outputs/sematext/processors/utils.go
@@ -1,0 +1,43 @@
+package processors
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+const (
+	RootEnvVar     = "SPM_ROOT"
+	DefaultRootDir = "/opt/spm/"
+)
+
+// GetRootDir returns the root dir of Sematext Agent installation, if it is present. Otherwise empty string.
+func GetRootDir() string {
+	if dir := os.Getenv(RootEnvVar); dir != "" {
+		if exists(dir) {
+			return dir
+		}
+	}
+
+	if exists(DefaultRootDir) {
+		return DefaultRootDir
+	}
+
+	return ""
+}
+
+func exists(dir string) bool {
+	if _, err := os.Stat(dir); err != nil {
+		return false
+	}
+	return true
+}
+
+// response reads the response from the HTTP body.
+func response(r *http.Response) string {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return ""
+	}
+	return string(body)
+}

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -1,0 +1,292 @@
+package sematext
+
+import (
+	"fmt"
+	"github.com/influxdata/telegraf/plugins/common/tls"
+	"net/http"
+	"net/url"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/outputs"
+	"github.com/influxdata/telegraf/plugins/outputs/sematext/processors"
+	"github.com/influxdata/telegraf/plugins/outputs/sematext/sender"
+	"github.com/influxdata/telegraf/plugins/outputs/sematext/serializer"
+	"github.com/influxdata/telegraf/plugins/outputs/sematext/tags"
+)
+
+const (
+	defaultSematextMetricsReceiverURL = "https://spm-receiver.sematext.com"
+)
+
+// Sematext struct contains configuration read from Telegraf config and a few runtime objects.
+// We'll use one separate instance of Telegraf for each monitored service. Therefore, token for particular service
+// will be configured on Sematext output level
+type Sematext struct {
+	ReceiverURL string          `toml:"receiver_url"`
+	Token       string          `toml:"token"`
+	ProxyServer string          `toml:"proxy_server"`
+	Username    string          `toml:"username"`
+	Password    string          `toml:"password"`
+	Log         telegraf.Logger `toml:"-"`
+	tls.ClientConfig
+
+	metricsURL       string
+	sender           *sender.Sender
+	senderConfig     *sender.Config
+	serializer       serializer.MetricSerializer
+	metricProcessors []processors.MetricProcessor
+	batchProcessors  []processors.BatchProcessor
+}
+
+const sampleConfig = `
+  ## Docs at https://sematext.com/docs/monitoring
+
+  ## URL of your Sematext metrics receiver. US-region metrics receiver is used
+  ## in this example (it is also the default when receiver_url value is empty),
+  ## but address of e.g. Sematext EU-region metrics receiver can be used
+  ## instead.
+  receiver_url = "https://spm-receiver.sematext.com"
+
+  ## Token of the App to which the data is sent. Create an App of appropriate
+  ## type in Sematext UI, instructions will show its token which can be used
+  ## here.
+  token = ""
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## Optional flag for ignoring tls certificate check
+  # insecure_skip_verify = false
+`
+
+// Connect is no-op for Sematext output plugin, everything was set up before in Init() method
+func (s *Sematext) Connect() error {
+	return nil
+}
+
+// Close Closes the Sematext output
+func (s *Sematext) Close() error {
+	s.sender.Close()
+
+	for _, mp := range s.metricProcessors {
+		mp.Close()
+	}
+
+	for _, bp := range s.batchProcessors {
+		bp.Close()
+	}
+
+	return nil
+}
+
+// SampleConfig Returns a sample configuration for the Sematext output
+func (s *Sematext) SampleConfig() string {
+	return sampleConfig
+}
+
+// Description returns the description for the Sematext output
+func (s *Sematext) Description() string {
+	return "Use telegraf to send metrics to Sematext"
+}
+
+// Init performs full initialization of Sematext output
+func (s *Sematext) Init() error {
+	if len(s.Token) == 0 {
+		return fmt.Errorf("'token' is a required field for Sematext output")
+	}
+	if len(s.ReceiverURL) == 0 {
+		s.ReceiverURL = defaultSematextMetricsReceiverURL
+	}
+
+	var proxyURL *url.URL
+
+	if s.ProxyServer != "" {
+		var err error
+		proxyURL, err = url.Parse(s.ProxyServer)
+		if err != nil {
+			return fmt.Errorf("invalid url %s for the proxy server: %v", s.ProxyServer, err)
+		}
+	}
+
+	tlsConfig, err := s.ClientConfig.TLSConfig()
+	if err != nil {
+		return err
+	}
+
+	s.senderConfig = &sender.Config{
+		ProxyURL:  proxyURL,
+		Username:  s.Username,
+		Password:  s.Password,
+		TLSConfig: tlsConfig,
+	}
+	s.sender = sender.NewSender(s.senderConfig)
+	s.metricsURL = s.ReceiverURL + "/write?db=metrics"
+
+	s.initProcessors()
+
+	s.serializer = serializer.NewMetricSerializer(s.Log)
+
+	s.Log.Infof("Sematext output started with Token=%s, ReceiverUrl=%s, ProxyServer=%s", s.Token, s.ReceiverURL,
+		s.ProxyServer)
+
+	return nil
+}
+
+// initProcessors instantiates all metric processors that will be used to prepare metrics/tags for sending to Sematext
+func (s *Sematext) initProcessors() {
+	// add more processors as they are implemented
+	s.metricProcessors = []processors.MetricProcessor{
+		processors.NewToken(s.Token),
+		processors.NewHost(s.Log),
+		processors.NewHandleCounter(),
+		processors.NewContainerTags(),
+	}
+	s.batchProcessors = []processors.BatchProcessor{
+		// rename processor has to run before metainfo processor to ensure metainfo processor uses final metric names
+		processors.NewRename(),
+		processors.NewHeartbeat(),
+		processors.NewMetainfo(s.Log, s.Token, s.ReceiverURL, s.senderConfig),
+	}
+}
+
+// Write sends metrics to Sematext backend and handles the response
+func (s *Sematext) Write(metrics []telegraf.Metric) error {
+	s.Log.Debugf("Sematext.Write() called with %d metrics in the slice", len(metrics))
+	processedMetrics, err := s.processMetrics(metrics)
+
+	if err != nil {
+		// error means the whole batch should be discarded without sending it. To achieve that, we have to return nil
+		s.Log.Errorf("error while preparing to send metrics to Sematext, the batch will be dropped: %v", err)
+		return nil
+	}
+
+	s.Log.Debugf("Preparing to send %d processed metrics", len(processedMetrics))
+
+	if len(processedMetrics) > 0 {
+		body := s.serializer.Write(processedMetrics)
+
+		s.Log.Debugf("Sending metrics to %s : %s", s.metricsURL, body)
+
+		res, err := s.sender.Request("POST", s.metricsURL, "text/plain; charset=utf-8", body)
+		if err != nil {
+			// error will happen in case of e.g. network connectivity issues; it is unrelated to response code and
+			// therefore it is OK to retry it
+			s.Log.Errorf("error while sending to %s : %s", s.metricsURL, err.Error())
+			return err
+		}
+		defer res.Body.Close()
+
+		s.Log.Debugf("Sending metrics to %s, response status code: %d", s.metricsURL, res.StatusCode)
+
+		return s.handleResponse(res)
+	}
+
+	return nil
+}
+
+func (s *Sematext) handleResponse(res *http.Response) error {
+	success, badRequest := checkResponseStatus(res)
+
+	if !success {
+		errorMsg := fmt.Sprintf("received %d status code, message = %q while sending to %s",
+			res.StatusCode, res.Status, s.metricsURL)
+
+		if badRequest {
+			// shouldn't be re-sent as bad request will continue to be a bad request
+			s.Log.Errorf("%s - request will be dropped", errorMsg)
+			return nil
+		}
+
+		// otherwise it is some temporary error from the backend and we should retry
+		return fmt.Errorf(errorMsg)
+	}
+
+	return nil
+}
+
+func checkResponseStatus(res *http.Response) (success bool, badRequest bool) {
+	success = res.StatusCode >= 200 && res.StatusCode < 300
+	badRequest = res.StatusCode >= 400 && res.StatusCode < 500
+
+	return success, badRequest
+}
+
+// processMetrics returns an error only when the whole batch of metrics should be discarded
+// batchProcessors run first, metricProcessors follow later
+func (s *Sematext) processMetrics(metrics []telegraf.Metric) ([]telegraf.Metric, error) {
+	s.Log.Debugf("Starting processing of slice of %d metrics", len(metrics))
+
+	if metricsAlreadyProcessed(metrics) {
+		// in case some batch was fully processed before, we don't want to process it once again
+		s.Log.Debugf("Skipping processing of already processed slice of %d metrics", len(metrics))
+		return metrics, nil
+	}
+
+	for _, p := range s.batchProcessors {
+		var err error
+		metrics, err = p.Process(metrics)
+
+		if err != nil {
+			s.Log.Errorf("error while running batch processors in Sematext output: %v", err)
+			return metrics, err
+		}
+	}
+
+	processedMetrics := make([]telegraf.Metric, 0, len(metrics))
+
+	for _, metric := range metrics {
+		metricOk := true
+
+		// don't process the metrics that were already processed before
+		if !metricAlreadyProcessed(metric) {
+			for _, p := range s.metricProcessors {
+				err := p.Process(metric)
+
+				if err != nil {
+					// log the message, mark the metric to be skipped, skip other processors
+					s.Log.Warnf("can't process metric: %s in Sematext output, error : %s", metric, err.Error())
+					metricOk = false
+					break
+				}
+			}
+		}
+
+		if metricOk {
+			processedMetrics = append(processedMetrics, metric)
+		}
+	}
+
+	markMetricsProcessed(processedMetrics)
+
+	return processedMetrics, nil
+}
+
+func metricsAlreadyProcessed(metrics []telegraf.Metric) bool {
+	// return that batch hasn't been processed yet if any of its metrics hasn't been processed
+	for _, m := range metrics {
+		if !metricAlreadyProcessed(m) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func metricAlreadyProcessed(metric telegraf.Metric) bool {
+	_, processed := metric.GetTag(tags.SematextProcessedTag)
+	return processed
+}
+
+func markMetricsProcessed(metrics []telegraf.Metric) {
+	for _, m := range metrics {
+		m.AddTag(tags.SematextProcessedTag, tags.SematextProcessedTag)
+	}
+}
+
+func init() {
+	outputs.Add("sematext", func() telegraf.Output {
+		return &Sematext{}
+	})
+}

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -143,6 +143,7 @@ func (s *Sematext) initProcessors() {
 		processors.NewHost(s.Log),
 		processors.NewHandleCounter(),
 		processors.NewContainerTags(),
+		processors.NewMetricType(),
 	}
 	s.batchProcessors = []processors.BatchProcessor{
 		// rename processor has to run before metainfo processor to ensure metainfo processor uses final metric names

--- a/plugins/outputs/sematext/sematext.go
+++ b/plugins/outputs/sematext/sematext.go
@@ -39,7 +39,8 @@ type Sematext struct {
 }
 
 const sampleConfig = `
-  ## Docs at https://sematext.com/docs/monitoring
+  ## Docs at https://sematext.com/docs/monitoring provide info about getting
+  ## started with Sematext monitoring.
 
   ## URL of your Sematext metrics receiver. US-region metrics receiver is used
   ## in this example (it is also the default when receiver_url value is empty),
@@ -52,12 +53,12 @@ const sampleConfig = `
   ## here.
   token = ""
 
-  ## Optional TLS Config
+  ## Optional TLS Config.
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
 
-  ## Optional flag for ignoring tls certificate check
+  ## Optional flag for ignoring tls certificate check.
   # insecure_skip_verify = false
 `
 

--- a/plugins/outputs/sematext/sematext_test.go
+++ b/plugins/outputs/sematext/sematext_test.go
@@ -1,0 +1,96 @@
+package sematext
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestCheckResponseStatus(t *testing.T) {
+	res := &http.Response{
+		StatusCode: 200,
+	}
+	success, badRequest := checkResponseStatus(res)
+	assert.Equal(t, true, success)
+	assert.Equal(t, false, badRequest)
+
+	res.StatusCode = 301
+	success, badRequest = checkResponseStatus(res)
+	assert.Equal(t, false, success)
+	assert.Equal(t, false, badRequest)
+
+	res.StatusCode = 404
+	success, badRequest = checkResponseStatus(res)
+	assert.Equal(t, false, success)
+	assert.Equal(t, true, badRequest)
+
+	res.StatusCode = 500
+	success, badRequest = checkResponseStatus(res)
+	assert.Equal(t, false, success)
+	assert.Equal(t, false, badRequest)
+}
+
+func TestHandleResponse(t *testing.T) {
+	sem := &Sematext{
+		Log: testutil.Logger{},
+	}
+	res := &http.Response{
+		StatusCode: 200,
+	}
+	assert.Nil(t, sem.handleResponse(res))
+
+	res.StatusCode = 301
+	assert.NotNil(t, sem.handleResponse(res))
+
+	res.StatusCode = 404
+	assert.Nil(t, sem.handleResponse(res))
+
+	res.StatusCode = 500
+	assert.NotNil(t, sem.handleResponse(res))
+}
+
+func TestMetricAlreadyProcessed(t *testing.T) {
+	now := time.Now()
+	m := metric.New(
+		"os",
+		map[string]string{"os.host": "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34)},
+		now)
+
+	assert.False(t, metricAlreadyProcessed(m))
+
+	metrics := make([]telegraf.Metric, 0)
+	metrics = append(metrics, m)
+
+	markMetricsProcessed(metrics)
+
+	assert.True(t, metricAlreadyProcessed(m))
+}
+
+func TestMetricsAlreadyProcessed(t *testing.T) {
+	now := time.Now()
+	m1 := metric.New(
+		"os",
+		map[string]string{"os.host": "somehost", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34)},
+		now)
+
+	m2 := metric.New(
+		"os",
+		map[string]string{"os.host": "somehost", "os.disk": "sda2"},
+		map[string]interface{}{"disk.used": float64(23.45)},
+		now)
+
+	metrics := make([]telegraf.Metric, 0)
+	metrics = append(metrics, m1, m2)
+
+	assert.False(t, metricsAlreadyProcessed(metrics))
+
+	markMetricsProcessed(metrics)
+
+	assert.True(t, metricsAlreadyProcessed(metrics))
+}

--- a/plugins/outputs/sematext/sender/sender.go
+++ b/plugins/outputs/sematext/sender/sender.go
@@ -1,0 +1,112 @@
+package sender
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	// defaultConnectTimeout is the maximum amount of time a dial will wait for a connect to complete.
+	defaultConnectTimeout = time.Second * 3
+
+	// defaultTimeout specifies a time limit for requests made by this client
+	defaultTimeout = time.Second * 10
+
+	headerAgent       = "User-Agent"
+	headerContentType = "Content-Type"
+	headerProxyAuth   = "Proxy-Authorization"
+)
+
+// Config contains sender configuration
+type Config struct {
+	ProxyURL  *url.URL
+	Username  string
+	Password  string
+	TLSConfig *tls.Config
+}
+
+// Sender is a simple wrapper around standard HTTP client
+type Sender struct {
+	client    *http.Client
+	proxyAuth string
+}
+
+// NewSender constructs a new HTTP sender that should be used to send requests to Sematext
+func NewSender(config *Config) *Sender {
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: defaultConnectTimeout,
+		}).DialContext,
+		TLSHandshakeTimeout: defaultConnectTimeout,
+	}
+
+	if config.ProxyURL != nil {
+		transport.Proxy = http.ProxyURL(config.ProxyURL)
+	}
+	if config.TLSConfig != nil {
+		transport.TLSClientConfig = config.TLSConfig
+	}
+
+	c := &http.Client{
+		Timeout:   defaultTimeout,
+		Transport: transport,
+	}
+
+	return &Sender{client: c, proxyAuth: getProxyHeader(config)}
+}
+
+// getProxyHeader creates proxy authentication header based on config settings
+func getProxyHeader(config *Config) string {
+	var proxyAuth string
+	if len(config.Username) > 0 && len(config.Password) > 0 {
+		auth := fmt.Sprintf("%s:%s", config.Username, config.Password)
+		proxyAuth = fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(auth)))
+	}
+	return proxyAuth
+}
+
+// Request emits an HTTP request targeting given HTTP method and URL.
+func (s *Sender) Request(method, requestURL, contentType string, body []byte) (*http.Response, error) {
+	req, err := s.createRequest(method, requestURL, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	res, err := s.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// createRequest forms the request object based on method, url, content type and body which should be sent
+func (s *Sender) createRequest(method, requestURL, contentType string, body []byte) (*http.Request, error) {
+	req, err := http.NewRequest(method, requestURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set(headerContentType, contentType)
+	req.Header.Set(headerAgent, "telegraf")
+
+	if len(s.proxyAuth) > 0 {
+		req.Header.Add(headerProxyAuth, s.proxyAuth)
+	}
+
+	return req, nil
+}
+
+// Close is a method which clears resources used by the Sender, should be invoked once the Sender is not needed anymore
+func (s *Sender) Close() {
+	s.client = nil
+}

--- a/plugins/outputs/sematext/sender/sender_test.go
+++ b/plugins/outputs/sematext/sender/sender_test.go
@@ -1,0 +1,69 @@
+package sender
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestGetProxyHeaderNone(t *testing.T) {
+	config := &Config{}
+	assert.Equal(t, "", getProxyHeader(config))
+}
+
+func TestGetProxyHeaderNoUsernameOrPassword(t *testing.T) {
+	proxyURL, _ := url.Parse("https://proxy.sematext.com:1234")
+	config := &Config{
+		ProxyURL: proxyURL,
+	}
+	assert.Equal(t, "", getProxyHeader(config))
+}
+
+func TestGetProxyHeaderWithAuth(t *testing.T) {
+	proxyURL, _ := url.Parse("https://proxy.sematext.com:1234")
+	config := &Config{
+		ProxyURL: proxyURL,
+		Username: "user",
+		Password: "password",
+	}
+	assert.Equal(t, fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("user:password"))),
+		getProxyHeader(config))
+}
+
+func TestCreateRequestNoProxy(t *testing.T) {
+	config := &Config{}
+	sender := NewSender(config)
+	req, err := sender.createRequest("POST", "www.sematext.com", "text/plain; charset=utf-8",
+		[]byte("metrics"))
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, len(req.Header), 2)
+	assert.Equal(t, req.Header.Get(headerContentType), "text/plain; charset=utf-8")
+	assert.Equal(t, req.Header.Get(headerAgent), "telegraf")
+}
+
+func TestCreateRequestWithProxy(t *testing.T) {
+	proxyURL, _ := url.Parse("https://proxy.sematext.com:1234")
+	config := &Config{
+		ProxyURL: proxyURL,
+		Username: "username",
+		Password: "password",
+	}
+	sender := NewSender(config)
+
+	assert.NotNil(t, sender.client.Transport.(*http.Transport).Proxy)
+
+	req, err := sender.createRequest("POST", "www.sematext.com", "text/plain; charset=utf-8",
+		[]byte("metrics"))
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, len(req.Header), 3)
+	assert.Equal(t, req.Header.Get(headerContentType), "text/plain; charset=utf-8")
+	assert.Equal(t, req.Header.Get(headerAgent), "telegraf")
+	assert.Equal(t, req.Header.Get(headerProxyAuth), getProxyHeader(config))
+}

--- a/plugins/outputs/sematext/serializer/escape.go
+++ b/plugins/outputs/sematext/serializer/escape.go
@@ -1,0 +1,46 @@
+// logic copied from plugins/serializers/influx/escape.go
+package serializer
+
+import "strings"
+
+const (
+	escapes     = "\t\n\f\r ,="
+	nameEscapes = "\t\n\f\r ,"
+)
+
+var (
+	escaper = strings.NewReplacer(
+		"\t", `\t`,
+		"\n", `\n`,
+		"\f", `\f`,
+		"\r", `\r`,
+		`,`, `\,`,
+		` `, `\ `,
+		`=`, `\=`,
+	)
+
+	nameEscaper = strings.NewReplacer(
+		"\t", `\t`,
+		"\n", `\n`,
+		"\f", `\f`,
+		"\r", `\r`,
+		`,`, `\,`,
+		` `, `\ `,
+	)
+)
+
+// Escape a tagkey, tagvalue, or fieldkey
+func escape(s string) string {
+	if strings.ContainsAny(s, escapes) {
+		return escaper.Replace(s)
+	}
+	return s
+}
+
+// Escape a measurement name
+func nameEscape(s string) string {
+	if strings.ContainsAny(s, nameEscapes) {
+		return nameEscaper.Replace(s)
+	}
+	return s
+}

--- a/plugins/outputs/sematext/serializer/serializer.go
+++ b/plugins/outputs/sematext/serializer/serializer.go
@@ -1,0 +1,259 @@
+package serializer
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/outputs/sematext/tags"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type SerializationConfig struct {
+	notSerializable map[string]bool
+}
+
+func NewSerializationConfig() *SerializationConfig {
+	return &SerializationConfig{
+		notSerializable: map[string]bool{tags.SematextProcessedTag: true},
+	}
+}
+
+// MetricSerializer is an interface implemented by different metric serialization implementations.
+type MetricSerializer interface {
+	// Write serializes metrics from metrics parameter and returns the result in []byte
+	Write(metrics []telegraf.Metric) []byte
+}
+
+// LinePerMetricSerializer provides simple implementation which writes each metric into a new line. The logic is simpler
+// and lighter, but the resulting output will be bigger.
+type LinePerMetricSerializer struct {
+	log    telegraf.Logger
+	config *SerializationConfig
+}
+
+// NewLinePerMetricSerializer creates an instance of LinePerMetricSerializer
+func NewLinePerMetricSerializer(log telegraf.Logger) *LinePerMetricSerializer {
+	return &LinePerMetricSerializer{
+		log:    log,
+		config: NewSerializationConfig(),
+	}
+}
+
+// NewMetricSerializer creates and instance serializer which should be used to produce Sematext metrics format
+func NewMetricSerializer(log telegraf.Logger) MetricSerializer {
+	return NewCompactMetricSerializer(log)
+}
+
+// Write serializes input metrics array according to Sematext variant of influx line protocol. The output is returned
+// as []byte which can be empty if there were no metrics or metrics couldn't be serialized.
+func (s *LinePerMetricSerializer) Write(metrics []telegraf.Metric) []byte {
+	var output bytes.Buffer
+
+	// sematext format is based on influx line protocol: namespace,tags metrics timestamp
+	for _, metric := range metrics {
+		if len(metric.Fields()) == 0 {
+			s.log.Debugf("Skipping the serialization of metric %s without fields ", metric.Name())
+			continue
+		}
+
+		serializedTags := serializeTags(metric.Tags(), s.config.notSerializable)
+		serializedMetrics := serializeMetric(metric)
+		serializedTimestamp := strconv.FormatInt(metric.Time().UnixNano(), 10)
+
+		if serializedMetrics == "" {
+			continue
+		}
+
+		_, _ = output.WriteString(nameEscape(metric.Name()))
+		if serializedTags != "" {
+			_, _ = output.WriteString(",")
+			_, _ = output.WriteString(serializedTags)
+		}
+		_, _ = output.WriteString(" ")
+		_, _ = output.WriteString(serializedMetrics)
+		_, _ = output.WriteString(" ")
+		_, _ = output.WriteString(serializedTimestamp)
+		// has to end with a newline
+		_, _ = output.WriteString("\n")
+	}
+
+	return output.Bytes()
+}
+
+func serializeTags(tagsMap map[string]string, notSerializable map[string]bool) string {
+	var serializedTags strings.Builder
+
+	// make tag order sorted
+	sortedTagKeys := make([]string, 0, len(tagsMap))
+	for t := range tagsMap {
+		sortedTagKeys = append(sortedTagKeys, t)
+	}
+	sort.Strings(sortedTagKeys)
+
+	for _, tagKey := range sortedTagKeys {
+		if _, set := notSerializable[tagKey]; set {
+			continue
+		}
+
+		tagValue := tagsMap[tagKey]
+		if serializedTags.Len() > 0 {
+			_, _ = serializedTags.WriteString(",")
+		}
+
+		_, _ = serializedTags.WriteString(escape(tagKey))
+		_, _ = serializedTags.WriteString("=")
+		_, _ = serializedTags.WriteString(escape(tagValue))
+	}
+	return serializedTags.String()
+}
+
+func serializeMetric(metric telegraf.Metric) string {
+	var serializedMetrics strings.Builder
+
+	// make the field order sorted
+	sort.Slice(metric.FieldList(), func(i, j int) bool {
+		return metric.FieldList()[i].Key < metric.FieldList()[j].Key
+	})
+
+	var countAdded = 0
+	for _, field := range metric.FieldList() {
+		var serializedMetric = serializeMetricField(field.Key, field.Value)
+
+		if serializedMetric == "" {
+			continue
+		}
+
+		if countAdded > 0 {
+			_, _ = serializedMetrics.WriteString(",")
+		}
+		_, _ = serializedMetrics.WriteString(serializedMetric)
+		countAdded++
+	}
+
+	return serializedMetrics.String()
+}
+
+func serializeMetricField(key string, value interface{}) string {
+	var metricValue string
+	switch v := value.(type) {
+	case string:
+		// temporarily made string values ignorable (until Sematext backend starts supporting them)
+		// metricValue = fmt.Sprintf("\"%s\"", stringFieldEscape(v))
+		return ""
+	case bool:
+		metricValue = strconv.FormatBool(v)
+	case float64:
+		if !math.IsNaN(v) && !math.IsInf(v, 0) {
+			metricValue = strconv.FormatFloat(v, 'f', -1, 64)
+		}
+	case uint64:
+		metricValue = strconv.FormatUint(v, 10) + "i"
+	case int64:
+		metricValue = strconv.FormatInt(v, 10) + "i"
+	default:
+		return ""
+	}
+
+	return fmt.Sprint(key, "=", metricValue)
+}
+
+// CompactMetricSerializer can be used to output metrics in compact format. Compact format squeezes as many metrics
+// as possible in a single output line, based on tags and timestamp of each metric. When multiple metrics share the
+// same tags and the same timestamp, we can write them in a single line to reduce the total bulk size by not
+// repeating the same tags+timestamp multiple times.
+type CompactMetricSerializer struct {
+	log    telegraf.Logger
+	config *SerializationConfig
+}
+
+// NewCompactMetricSerializer creates an instance of CompactMetricSerializer
+func NewCompactMetricSerializer(log telegraf.Logger) *CompactMetricSerializer {
+	return &CompactMetricSerializer{
+		log:    log,
+		config: NewSerializationConfig(),
+	}
+}
+
+// Write serializes input metrics array according to Sematext variant of influx line protocol. The output is returned
+// as []byte which can be empty if there were no metrics or metrics couldn't be serialized.
+func (s *CompactMetricSerializer) Write(metrics []telegraf.Metric) []byte {
+	var output bytes.Buffer
+	idToMetrics := make(map[string][]telegraf.Metric)
+
+	// first group the metrics that share the same identification
+	for _, m := range metrics {
+		id := buildID(m)
+		idToMetrics[id] = append(idToMetrics[id], m)
+	}
+
+	// sort the keys to keep the order fixed
+	sortedIds := make([]string, 0, len(idToMetrics))
+	for i := range idToMetrics {
+		sortedIds = append(sortedIds, i)
+	}
+	sort.Strings(sortedIds)
+
+	// then create 1 metrics line for each of created groups
+	for _, groupID := range sortedIds {
+		metrics := idToMetrics[groupID]
+		serializedTags := serializeTags(metrics[0].Tags(), s.config.notSerializable)
+		serializedMetrics := serializeMetrics(metrics)
+		serializedTimestamp := strconv.FormatInt(metrics[0].Time().UnixNano(), 10)
+
+		if serializedMetrics == "" {
+			continue
+		}
+
+		_, _ = output.WriteString(nameEscape(metrics[0].Name()))
+		if serializedTags != "" {
+			_, _ = output.WriteString(",")
+			_, _ = output.WriteString(serializedTags)
+		}
+		_, _ = output.WriteString(" ")
+		_, _ = output.WriteString(serializedMetrics)
+		_, _ = output.WriteString(" ")
+		_, _ = output.WriteString(serializedTimestamp)
+		// has to end with a newline
+		_, _ = output.WriteString("\n")
+	}
+
+	return output.Bytes()
+}
+
+func serializeMetrics(metrics []telegraf.Metric) string {
+	var serializedMetrics strings.Builder
+	fieldList := make([]*telegraf.Field, 0)
+
+	for _, metric := range metrics {
+		fieldList = append(fieldList, metric.FieldList()...)
+	}
+
+	// make the field order sorted
+	sort.Slice(fieldList, func(i, j int) bool {
+		return fieldList[i].Key < fieldList[j].Key
+	})
+
+	countAdded := 0
+	for _, field := range fieldList {
+		var serializedMetric = serializeMetricField(field.Key, field.Value)
+
+		if serializedMetric == "" {
+			continue
+		}
+
+		if countAdded > 0 {
+			_, _ = serializedMetrics.WriteString(",")
+		}
+		_, _ = serializedMetrics.WriteString(serializedMetric)
+		countAdded++
+	}
+
+	return serializedMetrics.String()
+}
+
+func buildID(metric telegraf.Metric) string {
+	return strconv.FormatInt(metric.Time().UnixNano(), 10) + "-" + metric.Name() + "-" + tags.GetTagsKey(metric.Tags())
+}

--- a/plugins/outputs/sematext/serializer/serializer_test.go
+++ b/plugins/outputs/sematext/serializer/serializer_test.go
@@ -1,0 +1,277 @@
+package serializer
+
+import (
+	"fmt"
+	"github.com/influxdata/telegraf/testutil"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+)
+
+func TestLinePerMetricSerializerWrite(t *testing.T) {
+	serializer := NewLinePerMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname"},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.host=hostname disk.size=777i %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+
+	m = metric.New(
+		"system",
+		map[string]string{"os.host": "hostname", "token": "token"},
+		map[string]interface{}{"uptime_format": "18 days, 22:37"},
+		now)
+
+	metrics = []telegraf.Metric{m}
+	assert.Equal(t,
+		// strings are temporarily filtered out (until Sematext backend gets support)
+		// fmt.Sprintf("system,os.host=hostname,token=token uptime_format=\"18 days, 22:37\" %d\n", now.UnixNano()),
+		"",
+		string(serializer.Write(metrics)))
+}
+
+func TestLinePerMetricSerializerWriteNoTags(t *testing.T) {
+	serializer := NewLinePerMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m := metric.New(
+		"os",
+		map[string]string{},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t,
+		fmt.Sprintf("os disk.size=777i %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestLinePerMetricSerializerWriteNoMetrics(t *testing.T) {
+	serializer := NewLinePerMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname"},
+		map[string]interface{}{},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t, "", string(serializer.Write(metrics)))
+}
+
+func TestLinePerMetricSerializerWriteMultipleTagsAndMetrics(t *testing.T) {
+	serializer := NewLinePerMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.disk=sda1,os.host=hostname disk.free=55i,disk.size=777i,disk.used=12.34 %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWrite(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname"},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.host=hostname disk.size=777i %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+
+	m = metric.New(
+		"system",
+		map[string]string{"os.host": "hostname", "token": "token"},
+		map[string]interface{}{"uptime_format": "18 days, 22:37"},
+		now)
+
+	metrics = []telegraf.Metric{m}
+	assert.Equal(t,
+		// strings are temporarily filtered out (until Sematext backend gets support)
+		// fmt.Sprintf("system,os.host=hostname,token=token uptime_format=\"18 days, 22:37\" %d\n", now.UnixNano()),
+		"",
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteNoTags(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m := metric.New(
+		"os",
+		map[string]string{},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t,
+		fmt.Sprintf("os disk.size=777i %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteNoMetrics(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname"},
+		map[string]interface{}{},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t, "", string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteMultipleTagsAndMetrics(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34), "disk.free": int64(55), "disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.disk=sda1,os.host=hostname disk.free=55i,disk.size=777i,disk.used=12.34 %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteMultipleMetricsSingleLine(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m1 := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34)},
+		now)
+
+	m2 := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.free": int64(55)},
+		now)
+
+	m3 := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m1, m2, m3}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.disk=sda1,os.host=hostname disk.free=55i,disk.size=777i,disk.used=12.34 %d\n", now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteMultipleMetricsMultipleLines(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m1 := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34)},
+		now)
+
+	m2 := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.free": int64(55)},
+		now)
+
+	m3 := metric.New(
+		"somethingelse",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now)
+
+	metrics := []telegraf.Metric{m1, m2, m3}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.disk=sda1,os.host=hostname disk.free=55i,disk.used=12.34 %d\n"+
+			"somethingelse,os.disk=sda1,os.host=hostname disk.size=777i %d\n", now.UnixNano(), now.UnixNano()),
+		string(serializer.Write(metrics)))
+}
+
+func TestCompactMetricSerializerWriteMultipleMetricsDifferentTimestamp(t *testing.T) {
+	serializer := NewCompactMetricSerializer(testutil.Logger{})
+
+	now := time.Now()
+
+	m1 := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.used": float64(12.34)},
+		now)
+
+	now2 := time.Now().AddDate(0, 0, 1)
+
+	m2 := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.free": int64(55)},
+		now2)
+
+	now3 := time.Now().AddDate(0, 0, 2)
+
+	m3 := metric.New(
+		"os",
+		map[string]string{"os.host": "hostname", "os.disk": "sda1"},
+		map[string]interface{}{"disk.size": uint64(777)},
+		now3)
+
+	metrics := []telegraf.Metric{m1, m2, m3}
+
+	assert.Equal(t,
+		fmt.Sprintf("os,os.disk=sda1,os.host=hostname disk.used=12.34 %d\n"+
+			"os,os.disk=sda1,os.host=hostname disk.free=55i %d\n"+
+			"os,os.disk=sda1,os.host=hostname disk.size=777i %d\n",
+			now.UnixNano(), now2.UnixNano(), now3.UnixNano()),
+		string(serializer.Write(metrics)))
+}

--- a/plugins/outputs/sematext/tags/tags.go
+++ b/plugins/outputs/sematext/tags/tags.go
@@ -1,0 +1,30 @@
+package tags
+
+import (
+	"bytes"
+	"sort"
+)
+
+const (
+	SematextProcessedTag = "sematext.processed"
+)
+
+func GetTagsKey(tags map[string]string) string {
+	var output bytes.Buffer
+
+	// sort tags to ensure the order
+	sortedTagKeys := make([]string, 0, len(tags))
+	for t := range tags {
+		sortedTagKeys = append(sortedTagKeys, t)
+	}
+	sort.Strings(sortedTagKeys)
+
+	for _, tagKey := range sortedTagKeys {
+		_, _ = output.WriteString(tagKey)
+		_, _ = output.WriteString("=")
+		_, _ = output.WriteString(tags[tagKey])
+		_, _ = output.WriteString(",")
+	}
+
+	return output.String()
+}

--- a/plugins/outputs/sematext/tags/tags_test.go
+++ b/plugins/outputs/sematext/tags/tags_test.go
@@ -1,0 +1,10 @@
+package tags
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetTagsKey(t *testing.T) {
+	assert.Equal(t, "tag1=a,tag2=b,", GetTagsKey(map[string]string{"tag1": "a", "tag2": "b"}))
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format]

This PR adds output plugin for [Sematext](https://sematext.com). The format in which metrics are sent is similar to Influx line protocol, but Sematext platform has specific expectations from metrics data, so a fair amount of processing logic was needed to produce the right data. This logic was split into separate processors.
There are two types of processors, each represented as an interface:
- metric processors - those that process each metric in isolation
- batch processors - those that have to examine the whole batch of metrics

There are 8 processors implementing these interfaces:
- ContainerTags - injects Sematext-specific container tags (read from environment variables)
- HandleCounter - Sematext platform expects counter-type metric to be sent as delta between current and previous measurement. This processor keeps track of previous measurement and replaces original cumulative value with calculated delta.
- Heartbeat - periodically injects Sematext-specific heartbeat metric
- Host - checks Sematext-specific file on the local file-system and Sematext-specific environment variable which can override the hostname resolved by Telegraf. Sematext platform also expects a tag with name "os.host" to represent the hostname. This processor contains the logic to take care of all this.
- MetricMetainfo - Sematext platform expects metric metainfo (info about the metric name, type etc) to be sent to separate endpoint. This processor extracts the metainfo from metrics generated by Telegraf, ensures that metainfo for some metric isn't sent multiple times, and sends the metainfo batches in a separate goroutine.
- MetricType - checks for the presence of metric_type tag and removes it
- Rename - some Telegraf input integrations (nginx, mongodb, apache) are already supported by Sematext platform. There are out-of-the-box reports that expect specific names of metrics and tags. This processor renames the metrics/tags generated by Telegraf to match the expectations of Sematext platform.
- Token - injects Sematext token (specified in Telegraf config) as a tag to all metrics

A few of these transformations could have been done via config using Telegraf processors, however, that would require from user to not only enable the Sematext output plugin, but also add additional pieces of config (which may not suit other output plugins, in case the user decides to switch away from Sematext). Having all the logic encapsulated in a single output plugin seems more user-friendly and less error-prone.

I am submitting this PR on behalf of [Sematext Group](sematext.com). I signed the CLA and our CEO (Otis Gospodnetic) separately emailed the Corporate CLA.