### PR TITLE
fix: outputs.opentelemetry use headers config in grpc requests

### DIFF
--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/model/otlpgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 )
 
 type OpenTelemetry struct {
@@ -160,6 +161,10 @@ func (o *OpenTelemetry) Write(metrics []telegraf.Metric) error {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout))
+
+	if len(o.Headers) > 0 {
+		ctx = metadata.NewOutgoingContext(ctx, metadata.New(o.Headers))
+	}
 	defer cancel()
 	_, err := o.metricsServiceClient.Export(ctx, md, o.callOptions...)
 	return err


### PR DESCRIPTION
### Required for all PRs:

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

resolves issue mentioned in this [comment](https://github.com/influxdata/telegraf/pull/9228#issuecomment-892942452)

Updating the OpenTelemetry output plugin to pass `headers` configuration as metadata into grpc requests.