### PR TITLE
fix: outputs.opentelemetry use attributes setting

### DIFF
--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -160,6 +160,14 @@ func (o *OpenTelemetry) Write(metrics []telegraf.Metric) error {
 		return nil
 	}
 
+	if len(o.Attributes) > 0 {
+		for i := 0; i < md.ResourceMetrics().Len(); i++ {
+			for k, v := range o.Attributes {
+				md.ResourceMetrics().At(i).Resource().Attributes().UpsertString(k, v)
+			}
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout))
 
 	if len(o.Headers) > 0 {

--- a/plugins/outputs/opentelemetry/opentelemetry_test.go
+++ b/plugins/outputs/opentelemetry/opentelemetry_test.go
@@ -26,6 +26,7 @@ func TestOpenTelemetry(t *testing.T) {
 	{
 		rm := expect.ResourceMetrics().AppendEmpty()
 		rm.Resource().Attributes().InsertString("host.name", "potato")
+		rm.Resource().Attributes().InsertString("attr-key", "attr-val")
 		ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
 		ilm.InstrumentationLibrary().SetName("My Library Name")
 		m := ilm.Metrics().AppendEmpty()
@@ -45,6 +46,7 @@ func TestOpenTelemetry(t *testing.T) {
 		ServiceAddress:       m.Address(),
 		Timeout:              config.Duration(time.Second),
 		Headers:              map[string]string{"test": "header1"},
+		Attributes:           map[string]string{"attr-key": "attr-val"},
 		metricsConverter:     metricsConverter,
 		grpcClientConn:       m.GrpcClient(),
 		metricsServiceClient: otlpgrpc.NewMetricsClient(m.GrpcClient()),


### PR DESCRIPTION
### Required for all PRs:

- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

Following the discussion [here](https://github.com/influxdata/telegraf/pull/9228#issuecomment-892942452), the attributes setting was not being utilized in the opentelemetry output plugin. This PR fixes that by upserting the attributes configured into the resource before emitting it.

This is a followup to https://github.com/influxdata/telegraf/pull/9587