### PR TITLE
feat: add bool datatype for sql output plugin

### DIFF
--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -104,6 +104,7 @@ through the convert settings.
   #  timestamp            = "TIMESTAMP"
   #  defaultvalue         = "TEXT"
   #  unsigned             = "UNSIGNED"
+  #  bool                 = "BOOL"
 ```
 
 ## Driver-specific information

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -22,6 +22,7 @@ type ConvertStruct struct {
 	Timestamp    string
 	Defaultvalue string
 	Unsigned     string
+	Bool         string
 }
 
 type SQL struct {
@@ -103,6 +104,8 @@ func (p *SQL) deriveDatatype(value interface{}) string {
 		datatype = p.Convert.Real
 	case string:
 		datatype = p.Convert.Text
+	case bool:
+		datatype = p.Convert.Bool
 	default:
 		datatype = p.Convert.Defaultvalue
 		p.Log.Errorf("Unknown datatype: '%T' %v", value, value)
@@ -272,6 +275,7 @@ func newSQL() *SQL {
 			Timestamp:    "TIMESTAMP",
 			Defaultvalue: "TEXT",
 			Unsigned:     "UNSIGNED",
+			Bool:         "BOOL",
 		},
 	}
 }

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -100,6 +100,14 @@ var (
 					Key:   "int64_two",
 					Value: int64(2345),
 				},
+				{
+					Key:   "bool_one",
+					Value: true,
+				},
+				{
+					Key:   "bool_two",
+					Value: false,
+				},
 			},
 			ts,
 		),

--- a/plugins/outputs/sql/testdata/mariadb/expected.sql
+++ b/plugins/outputs/sql/testdata/mariadb/expected.sql
@@ -21,10 +21,12 @@ CREATE TABLE `metric_one` (
   `tag_one` text DEFAULT NULL,
   `tag_two` text DEFAULT NULL,
   `int64_one` int(11) DEFAULT NULL,
-  `int64_two` int(11) DEFAULT NULL
+  `int64_two` int(11) DEFAULT NULL,
+  `bool_one` tinyint(1) DEFAULT NULL,
+  `bool_two` tinyint(1) DEFAULT NULL
 );
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO `metric_one` VALUES ('2021-05-17 22:04:45','tag1','tag2',1234,2345);
+INSERT INTO `metric_one` VALUES ('2021-05-17 22:04:45','tag1','tag2',1234,2345,1,0);
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `metric_two` (

--- a/plugins/outputs/sql/testdata/postgres/expected.sql
+++ b/plugins/outputs/sql/testdata/postgres/expected.sql
@@ -21,7 +21,9 @@ CREATE TABLE public.metric_one (
     tag_one text,
     tag_two text,
     int64_one integer,
-    int64_two integer
+    int64_two integer,
+    bool_one boolean,
+    bool_two boolean
 );
 ALTER TABLE public.metric_one OWNER TO postgres;
 CREATE TABLE public.metric_two (
@@ -33,8 +35,8 @@ ALTER TABLE public.metric_two OWNER TO postgres;
 COPY public."metric three" ("timestamp", "tag four", "string two") FROM stdin;
 2021-05-17 22:04:45	tag4	string2
 \.
-COPY public.metric_one ("timestamp", tag_one, tag_two, int64_one, int64_two) FROM stdin;
-2021-05-17 22:04:45	tag1	tag2	1234	2345
+COPY public.metric_one ("timestamp", tag_one, tag_two, int64_one, int64_two, bool_one, bool_two) FROM stdin;
+2021-05-17 22:04:45	tag1	tag2	1234	2345	t	f
 \.
 COPY public.metric_two ("timestamp", tag_three, string_one) FROM stdin;
 2021-05-17 22:04:45	tag3	string1


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

resolves #9597 

Add `Bool` to the datatypes that can be configured and allow for bool values to be mapped to this datatype.
