### PR TITLE
fix: issues with prometheus kubernetes pod discovery

### DIFF
--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -123,8 +123,8 @@ func (p *Prometheus) watchPod(ctx context.Context, client *kubernetes.Clientset)
 		default:
 			for event := range watcher.ResultChan() {
 				pod, ok := event.Object.(*corev1.Pod)
-    	  if !ok {
-        	return fmt.Errorf("Unexpected object when getting pods")
+				if !ok {
+					return fmt.Errorf("Unexpected object when getting pods")
 				}
 
 				// If the pod is not "ready", there will be no ip associated with it.
@@ -140,9 +140,9 @@ func (p *Prometheus) watchPod(ctx context.Context, client *kubernetes.Clientset)
 						// To avoid multiple actions for each event, unregister on the first event
 						// in the delete sequence, when the containers are still "ready".
 					if pod.GetDeletionTimestamp() != nil {
-				  	unregisterPod(pod, p)
+						unregisterPod(pod, p)
 					} else {
-				  	registerPod(pod, p)
+						registerPod(pod, p)
 					}
 				}
 			}

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -111,35 +111,43 @@ func (p *Prometheus) watchPod(ctx context.Context, client *kubernetes.Clientset)
 		LabelSelector: p.KubernetesLabelSelector,
 		FieldSelector: p.KubernetesFieldSelector,
 	})
+	defer watcher.Stop()
 	if err != nil {
 		return err
 	}
-	pod := &corev1.Pod{}
-	go func() {
-		for event := range watcher.ResultChan() {
-			pod = &corev1.Pod{}
-			// If the pod is not "ready", there will be no ip associated with it.
-			if pod.Annotations["prometheus.io/scrape"] != "true" ||
-				!podReady(pod.Status.ContainerStatuses) {
-				continue
-			}
 
-			switch event.Type {
-			case watch.Added:
-				registerPod(pod, p)
-			case watch.Modified:
-				// To avoid multiple actions for each event, unregister on the first event
-				// in the delete sequence, when the containers are still "ready".
-				if pod.GetDeletionTimestamp() != nil {
-					unregisterPod(pod, p)
-				} else {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			for event := range watcher.ResultChan() {
+				pod, ok := event.Object.(*corev1.Pod)
+    	  if !ok {
+        	return fmt.Errorf("Unexpected object when getting pods")
+				}
+
+				// If the pod is not "ready", there will be no ip associated with it.
+				if pod.Annotations["prometheus.io/scrape"] != "true" ||
+					!podReady(pod.Status.ContainerStatuses) {
+					continue
+				}
+
+				switch event.Type {
+				case watch.Added:
 					registerPod(pod, p)
+				case watch.Modified:
+						// To avoid multiple actions for each event, unregister on the first event
+						// in the delete sequence, when the containers are still "ready".
+					if pod.GetDeletionTimestamp() != nil {
+				  	unregisterPod(pod, p)
+					} else {
+				  	registerPod(pod, p)
+					}
 				}
 			}
 		}
-	}()
-
-	return nil
+	}
 }
 
 func (p *Prometheus) cAdvisor(ctx context.Context, bearerToken string) error {

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -137,8 +137,8 @@ func (p *Prometheus) watchPod(ctx context.Context, client *kubernetes.Clientset)
 				case watch.Added:
 					registerPod(pod, p)
 				case watch.Modified:
-						// To avoid multiple actions for each event, unregister on the first event
-						// in the delete sequence, when the containers are still "ready".
+					// To avoid multiple actions for each event, unregister on the first event
+					// in the delete sequence, when the containers are still "ready".
 					if pod.GetDeletionTimestamp() != nil {
 						unregisterPod(pod, p)
 					} else {


### PR DESCRIPTION
### Required for all PRs:

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

Resolves #9600

- Get the pod info from the event using `event.Object.(*corev1.Pod)` so that the pod isn't an empty struct. This is the equivalent of `watcher.Next(pod)` when the previous client package was used.

- A [go routine](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/prometheus/kubernetes.go#L80) is already running that keeps calling the watchPod() function whenever it returns. Right now with the watchPod() function is calling its own go routine, the function returns and watchPod is called again. This continuously creates new threads and new watchers and re-registers pods instead of having one watcher running each time. Changed back to the [previous functionality](https://github.com/influxdata/telegraf/blob/24a552b90ba06d278cbe0639290a9bee1d7791b6/plugins/inputs/prometheus/kubernetes.go#L95) with a for loop that returns when `ctx.Done()`

- Added `defer watcher.Stop()` which is the equivalent of `defer watcher.Close()` when the previous client package was used.

I'm not sure any unit tests can be added to detect these issues since the function relies on the kubernetes watch api call and discovering kubernetes pods.
