### PR TITLE
fix: flaky cookie test and failing to close fake server between tests

### DIFF
--- a/plugins/common/cookie/cookie.go
+++ b/plugins/common/cookie/cookie.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	clockutil "github.com/benbjohnson/clock"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 )
@@ -27,7 +28,7 @@ type CookieAuthConfig struct {
 	client *http.Client
 }
 
-func (c *CookieAuthConfig) Start(client *http.Client, log telegraf.Logger) (err error) {
+func (c *CookieAuthConfig) Start(client *http.Client, log telegraf.Logger, clock clockutil.Clock) (err error) {
 	c.client = client
 
 	if c.Method == "" {
@@ -45,7 +46,7 @@ func (c *CookieAuthConfig) Start(client *http.Client, log telegraf.Logger) (err 
 
 	// continual auth renewal if set
 	if c.Renewal > 0 {
-		ticker := time.NewTicker(time.Duration(c.Renewal))
+		ticker := clock.Ticker(time.Duration(c.Renewal))
 		go func() {
 			for range ticker.C {
 				if err := c.auth(); err != nil && log != nil {

--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/cookie"
@@ -54,7 +55,7 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context, log telegraf.Logger
 	client = h.OAuth2Config.CreateOauth2Client(ctx, client)
 
 	if h.CookieAuthConfig.URL != "" {
-		if err := h.CookieAuthConfig.Start(client, log); err != nil {
+		if err := h.CookieAuthConfig.Start(client, log, clock.New()); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
- [x] Wrote appropriate unit tests.

The tests for `cookie.go` were failing randomly, when checking for the expected number of time it should have authenticated sometimes the number would be less then expected and throw the error `"2" is not greater than or equal to "3"` [link to example of a failing test](https://app.circleci.com/pipelines/github/influxdata/telegraf/5898/workflows/cc103580-69df-493e-8842-ca3085ce4d3a/jobs/105376).

This pr fixes the tests by removing the reliance on sleep, also closes each fake http server before the next test to avoid `socket: too many open files` error.