### PR TITLE
fix: windows service - graceful shutdown of telegraf

### DIFF
--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -50,7 +50,7 @@ func (p *program) run() {
 func (p *program) Stop(s service.Service) error {
 	var empty struct{}
 	stop <- empty // signal reloadLoop to finish (context cancel)
-	<-stop        // wait for reloadLoop to finish and channel to close
+	<-stop        // wait for reloadLoop to finish and close channel
 	return nil
 }
 

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -45,9 +45,12 @@ func (p *program) run() {
 		p.inputFilters,
 		p.outputFilters,
 	)
+	close(stop)
 }
 func (p *program) Stop(s service.Service) error {
-	close(stop)
+	var empty struct{}
+	stop <- empty // signal reloadLoop to finish (context cancel)
+	<-stop        // wait for reloadLoop to finish and channel to close
 	return nil
 }
 


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md. (I don't think there's any relevant readme to update here)
- [ ] Wrote appropriate unit tests. (not sure this is relevant either)
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

Resolves #7876, however the issue affects telegraf agent behaviour across all plugins when telegraf runs as service, not just the execd plugin.

The current telegraf service implementation does not appear to wait for the main telegraf agent loop to gracefully finish before the main thread exits. This causes an abrupt exit and plugins do not have a chance to shut down / clean up properly (ie. outputs are not flushed, inputs with external dependencies are not closed properly).

I'm submitting this PR initially as a review - I am not sure this is the right solution to cover all scenarios. However from testing, it does work as intended under ideal scenarios - the main goroutine thread is blocked until the agent thread runs to completion.

The code changes are fairly simple. When the service stop control signal is triggered in Windows, the service interface `Stop` is called (see https://github.com/kardianos/service/blob/v1.0.0/service_windows.go#L282). The `Stop` interface sends a struct to the `stop` channel so that the `reloadLoop` runs the context cancel function to commence agent shutdown. While shutdown is in progress, the `Stop` interface is blocked waiting for the `stop` channel to be closed. Once `reloadLoop` completes, we close the `stop` channel to allow the main thread to complete.

My hesitancy with this PR being a full fix is that I do not fully understand the windows service specific concurrency implementation, so I'm unsure if this PR opens up telegraf to other potential race condition or deadlocks.

@ssoroka 