### PR TITLE
fix: Output timestamp with fractional seconds

### DIFF
--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -214,7 +214,7 @@ func (g *Graylog) serialize(metric telegraf.Metric) ([]string, error) {
 
 	m := make(map[string]interface{})
 	m["version"] = "1.1"
-	m["timestamp"] = metric.Time().UnixNano() / 1000000000
+	m["timestamp"] = float64(metric.Time().UnixNano()) / 1_000_000_000
 	m["short_message"] = "telegraf"
 	m["name"] = metric.Name()
 


### PR DESCRIPTION
The graylog output plugin previously output the timestamp in whole seconds with no fractional part. This PR adds the fractionalpart. I'm not sure why it wasn't there before. The gelf format specification says it is optional but is clear that fractional seconds are allowed.

https://docs.graylog.org/en/3.3/pages/gelf.html#gelf-payload-specification