### PR TITLE
fix: prefix dependabot commits with "fix:"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     ignore:
       # Dependabot isn't able to update this packages that do not match the source, so anything with a version
       - dependency-name: "*.v*"
+    commit-message:
+      prefix: "fix:"


### PR DESCRIPTION
Dependabot is now working again with this merged: https://github.com/influxdata/telegraf/pull/9620 so it made some pr's with the semantic-pullrequest checker failing. To fix this we need to prefix all the commits it makes with `fix:`.

Setting was found in the documentation: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#commit-message

