### PR TITLE
fix: race condition in cookie test

### DIFF
--- a/plugins/common/cookie/cookie.go
+++ b/plugins/common/cookie/cookie.go
@@ -39,6 +39,7 @@ func (c *CookieAuthConfig) Start(client *http.Client, log telegraf.Logger, clock
 	// continual auth renewal if set
 	if c.Renewal > 0 {
 		ticker := clock.Ticker(time.Duration(c.Renewal))
+		// this context is used in the tests only, it is to cancel the goroutine
 		go c.authRenewal(context.Background(), ticker, log)
 	}
 

--- a/plugins/common/cookie/cookie.go
+++ b/plugins/common/cookie/cookie.go
@@ -1,12 +1,14 @@
 package cookie
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"strings"
+	"sync"
 	"time"
 
 	clockutil "github.com/benbjohnson/clock"
@@ -26,9 +28,24 @@ type CookieAuthConfig struct {
 	Renewal config.Duration `toml:"cookie_auth_renewal"`
 
 	client *http.Client
+	wg     sync.WaitGroup
 }
 
 func (c *CookieAuthConfig) Start(client *http.Client, log telegraf.Logger, clock clockutil.Clock) (err error) {
+	if err = c.initializeClient(client); err != nil {
+		return err
+	}
+
+	// continual auth renewal if set
+	if c.Renewal > 0 {
+		ticker := clock.Ticker(time.Duration(c.Renewal))
+		go c.authRenewal(context.Background(), ticker, log)
+	}
+
+	return nil
+}
+
+func (c *CookieAuthConfig) initializeClient(client *http.Client) (err error) {
 	c.client = client
 
 	if c.Method == "" {
@@ -40,23 +57,21 @@ func (c *CookieAuthConfig) Start(client *http.Client, log telegraf.Logger, clock
 		return err
 	}
 
-	if err = c.auth(); err != nil {
-		return err
-	}
+	return c.auth()
+}
 
-	// continual auth renewal if set
-	if c.Renewal > 0 {
-		ticker := clock.Ticker(time.Duration(c.Renewal))
-		go func() {
-			for range ticker.C {
-				if err := c.auth(); err != nil && log != nil {
-					log.Errorf("renewal failed for %q: %v", c.URL, err)
-				}
+func (c *CookieAuthConfig) authRenewal(ctx context.Context, ticker *clockutil.Ticker, log telegraf.Logger) {
+	for {
+		select {
+		case <-ctx.Done():
+			c.wg.Done()
+			return
+		case <-ticker.C:
+			if err := c.auth(); err != nil && log != nil {
+				log.Errorf("renewal failed for %q: %v", c.URL, err)
 			}
-		}()
+		}
 	}
-
-	return nil
 }
 
 func (c *CookieAuthConfig) auth() error {


### PR DESCRIPTION
The tests in `cookie_test.go` are still failing randomly ([link to circleci failed Mac build on master](https://app.circleci.com/pipelines/github/influxdata/telegraf/6062/workflows/6c41cd80-9c03-47c5-902e-85593ef791cd/jobs/107660)), I thought I had resolved this issue in this pr #9608. I believe the problem is due to a race condition, where the go-routine running the ticker loop to authenticate again isn't guaranteed to be called before checking the count.

This pr adds a `sync.WaitGroup` and a `context.Context` with cancel, to guarantee that the ticker loop has finished running before checking the count. Also moved the authentication renewal loop to a separate function so that the tests can pass ticker and then call `ticker.Close()`. Refactored the tests away from using the assert function as well to reduce repeated code.