### PR TITLE
fix: Check for error from glob.Match in tail input plugin 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,3 +177,5 @@ replace github.com/mdlayher/apcupsd => github.com/influxdata/apcupsd v0.0.0-2021
 //https://github.com/WireGuard/wgctrl-go/blob/e35592f146e40ce8057113d14aafcc3da231fbac/go.mod#L12 ) was not working when using GOPROXY=direct.
 //Replacing with the pseudo-version works around this.
 replace golang.zx2c4.com/wireguard v0.0.20200121 => golang.zx2c4.com/wireguard v0.0.0-20200121152719-05b03c675090
+
+replace github.com/bmatcuk/doublestar/v3 v3.0.0 => github.com/sspaink/doublestar/v3 v3.0.1-0.20210820140701-f956defdd203

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,6 @@ github.com/bitly/go-hostpool v0.1.0/go.mod h1:4gOCgp6+NZnVqlKyZ/iBZFTAJKembaVENU
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmatcuk/doublestar/v3 v3.0.0 h1:TQtVPlDnAYwcrVNB2JiGuMc++H5qzWZd9PhkNo5WyHI=
-github.com/bmatcuk/doublestar/v3 v3.0.0/go.mod h1:6PcTVMw80pCY1RVuoqu3V++99uQB3vsSYKPTd8AWA0k=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
@@ -1436,6 +1434,8 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/sspaink/doublestar/v3 v3.0.1-0.20210820140701-f956defdd203 h1:jGeD93VVTxn4X483xLvWg6ZtRyfZfvzgIRWi5dnfG+8=
+github.com/sspaink/doublestar/v3 v3.0.1-0.20210820140701-f956defdd203/go.mod h1:6PcTVMw80pCY1RVuoqu3V++99uQB3vsSYKPTd8AWA0k=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271 h1:WhxRHzgeVGETMlmVfqhRn8RIeeNoPr2Czh33I4Zdccw=

--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -44,14 +44,17 @@ func Compile(path string) (*GlobPath, error) {
 // Match returns all files matching the expression.
 // If it's a static path, returns path.
 // All returned path will have the host platform separator.
-func (g *GlobPath) Match() []string {
+func (g *GlobPath) Match() ([]string, error) {
 	// This string replacement is for backwards compatibility support
 	// The original implemention allowed **.txt but the double star package requires **/**.txt
 	g.path = strings.ReplaceAll(g.path, "**/**", "**")
 	g.path = strings.ReplaceAll(g.path, "**", "**/**")
 
-	files, _ := doublestar.Glob(g.path)
-	return files
+	files, err := doublestar.Glob(g.path)
+	if err != nil {
+		return nil, err
+	}
+	return files, err
 }
 
 // MatchString tests the path string against the glob.  The path should contain

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // TODO: Windows - should be enabled for Windows when super asterisk is fixed on Windows
@@ -50,7 +51,7 @@ func TestCompileAndMatch(t *testing.T) {
 	for _, tc := range tests {
 		g, err := Compile(tc.path)
 		require.Nil(t, err)
-		matches := g.Match()
+		matches, _ := g.Match()
 		require.Len(t, matches, tc.matches)
 	}
 }
@@ -77,7 +78,7 @@ func TestFindNestedTextFile(t *testing.T) {
 	g1, err := Compile(filepath.Join(testdataDir, "**.txt"))
 	require.NoError(t, err)
 
-	matches := g1.Match()
+	matches, _ := g1.Match()
 	require.Len(t, matches, 1)
 }
 
@@ -97,7 +98,7 @@ func TestMatch_ErrPermission(t *testing.T) {
 	for _, test := range tests {
 		glob, err := Compile(test.input)
 		require.NoError(t, err)
-		actual := glob.Match()
+		actual, _ := glob.Match()
 		require.Equal(t, test.expected, actual)
 	}
 }

--- a/plugins/inputs/file/file.go
+++ b/plugins/inputs/file/file.go
@@ -96,7 +96,7 @@ func (f *File) refreshFilePaths() error {
 		if err != nil {
 			return fmt.Errorf("could not compile glob %v: %v", file, err)
 		}
-		files := g.Match()
+		files, _ := g.Match()
 		if len(files) <= 0 {
 			return fmt.Errorf("could not find file: %v", file)
 		}

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -70,7 +70,7 @@ func (f *FileStat) Gather(acc telegraf.Accumulator) error {
 			f.globs[filepath] = g
 		}
 
-		files := g.Match()
+		files, _ := g.Match()
 		if len(files) == 0 {
 			acc.AddFields("filestat",
 				map[string]interface{}{

--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -1,3 +1,4 @@
+//go:build !solaris
 // +build !solaris
 
 package logparser
@@ -214,7 +215,7 @@ func (l *LogParserPlugin) tailNewfiles(fromBeginning bool) error {
 			l.Log.Errorf("Glob %q failed to compile: %s", filepath, err)
 			continue
 		}
-		files := g.Match()
+		files, _ := g.Match()
 
 		for _, file := range files {
 			if _, ok := l.tailers[file]; ok {

--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -296,7 +296,7 @@ func globUnixSocket(url string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not compile glob %q: %v", pattern, err)
 	}
-	paths := glob.Match()
+	paths, _ := glob.Match()
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("socket doesn't exist %q", pattern)
 	}

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -1,3 +1,4 @@
+//go:build !solaris
 // +build !solaris
 
 package tail
@@ -215,8 +216,14 @@ func (t *Tail) tailNewFiles(fromBeginning bool) error {
 		g, err := globpath.Compile(filepath)
 		if err != nil {
 			t.Log.Errorf("Glob %q failed to compile: %s", filepath, err.Error())
+			continue
 		}
-		for _, file := range g.Match() {
+		files, err := g.Match()
+		if err != nil {
+			t.Log.Errorf("Failed to match for filepath %q: %s", filepath, err.Error())
+			continue
+		}
+		for _, file := range files {
 			if _, ok := t.tailers[file]; ok {
 				// we're already tailing this file
 				continue

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -7,13 +7,14 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/pion/dtls/v2"
 	"io/ioutil"
 	"net"
 	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/pion/dtls/v2"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
@@ -265,7 +266,7 @@ func (c *X509Cert) collectCertURLs() ([]*url.URL, error) {
 	var urls []*url.URL
 
 	for _, path := range c.globpaths {
-		files := path.Match()
+		files, _ := path.Match()
 		if len(files) <= 0 {
 			c.Log.Errorf("could not find file: %v", path)
 			continue


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

resolve: #9129

```
2021-08-20T14:27:48Z I! Starting Telegraf 
2021-08-20T14:27:48Z W! Telegraf is not permitted to read /etc/telegraf/telegraf.d
2021-08-20T14:27:48Z D! [agent] Initializing plugins
2021-08-20T14:27:48Z D! [agent] Starting service inputs
2021-08-20T14:27:48Z E! [inputs.tail] Failed to match for filepath "/var/log/apache2/error_log": open /var/log/apache2: permission denied
2021-08-20T14:27:48Z E! [inputs.tail] Failed to match for filepath "/var/log/apache2/error_log": open /var/log/apache2: permission denied
2021-08-20T14:27:58Z D! [agent] Stopping service inputs
2021-08-20T14:27:58Z D! [agent] Input channel closed
2021-08-20T14:27:58Z D! [agent] Stopped Successfully
2021-08-20T14:27:58Z E! [telegraf] Error running agent: input plugins recorded 2 errors
```