### PR TITLE
feat(plugins/inputs/systemd_units): add pattern support

### DIFF
--- a/plugins/inputs/systemd_units/README.md
+++ b/plugins/inputs/systemd_units/README.md
@@ -1,7 +1,7 @@
 # systemd Units Input Plugin
 
 The systemd_units plugin gathers systemd unit status on Linux. It relies on
-`systemctl list-units --all --plain --type=service` to collect data on service status.
+`systemctl list-units [PATTERN] --all --plain --type=service` to collect data on service status.
 
 The results are tagged with the unit name and provide enumerated fields for
 loaded, active and running fields, indicating the unit health.
@@ -22,6 +22,13 @@ see `systemctl list-units --all --type help` for possible options.
   ## values are "socket", "target", "device", "mount", "automount", "swap",
   ## "timer", "path", "slice" and "scope ":
   # unittype = "service"
+  #
+  ## Filter for a specific pattern, default is "" (i.e. all), other possible
+  ## values are valid pattern for systemctl, e.g. "a*" for all units with
+  ## names starting with "a"
+  # pattern = ""
+  ## pattern = "telegraf* influxdb*"
+  ## pattern = "a*"
 ```
 
 ### Metrics

--- a/plugins/inputs/systemd_units/systemd_units_linux_test.go
+++ b/plugins/inputs/systemd_units/systemd_units_linux_test.go
@@ -74,7 +74,7 @@ func TestSystemdUnits(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			systemdUnits := &SystemdUnits{
-				systemctl: func(timeout config.Duration, unitType string) (*bytes.Buffer, error) {
+				systemctl: func(timeout config.Duration, unitType string, pattern string) (*bytes.Buffer, error) {
 					return bytes.NewBufferString(tt.line), nil
 				},
 			}


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [-] Wrote appropriate unit tests:
       - Existing tests replace Linux systemctl with dummy function. Changes only affect behavior of Linux systemctl.
       - Tests would need dummy implementation of systemctl filter functionality -> suggest to keep tests as is. 
- [x] Pull request title or commits are in [conventional commit format]

resolves #9664

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

This code change extends the existing `systemd_units` inputs plugin to also support Linux `systemctl list-units PATTERN` filters. 
It adds a respective option for the conf file and parses/forwards it to the `os.exec.Command` to `systemctl`

CCLA has been signed and exchanged with @timhallinflux, ICLA has been submitted. 

Thank you for feedback/suggestions/acceptance for/of the pull request. 
Cheers,
David