### PR TITLE
fix(mongodb): change command based on server version

### DIFF
--- a/plugins/inputs/mongodb/mongodb_server_test.go
+++ b/plugins/inputs/mongodb/mongodb_server_test.go
@@ -39,3 +39,45 @@ func TestAddDefaultStats(t *testing.T) {
 		assert.True(t, acc.HasInt64Field("mongodb", key))
 	}
 }
+
+func TestPoolStatsVersionCompatibility(t *testing.T) {
+	tests := []struct {
+		name            string
+		version         string
+		expectedCommand string
+		err             bool
+	}{
+		{
+			name:            "mongodb v3",
+			version:         "3.0.0",
+			expectedCommand: "shardConnPoolStats",
+		},
+		{
+			name:            "mongodb v4",
+			version:         "4.0.0",
+			expectedCommand: "shardConnPoolStats",
+		},
+		{
+			name:            "mongodb v5",
+			version:         "5.0.0",
+			expectedCommand: "connPoolStats",
+		},
+		{
+			name:    "invalid version",
+			version: "v4",
+			err:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command, err := poolStatsCommand(test.version)
+			require.Equal(t, test.expectedCommand, command)
+			if test.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

resolves #9622 

Fixes a bug where gathering the pool statistics for a MongoDB server running version 5.0.0 or greater would fail since the command was renamed from `shardConnPoolStats` to `connPoolStats`. This was fixed by changing command run based on the version of the server reported from `serverStatus`.
