### PR TITLE
feat(prometheus): filter pod annotations and labels from metric tags

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -50,6 +50,16 @@ in Prometheus format.
   ## Default is 60 seconds.
   # pod_scrape_interval = 60
   
+  ## Exclude subset of annotations from being used as metric tags.
+  ## An empty include list will accept all annotations and an empty exclude list will not exclude any annotation.
+  # tag_pod_annotations_include = []
+  # tag_pod_annotations_exclude = ["prometheus.io/*"]
+
+  ## Exclude subset of labels from being used as metric tags.
+  ## An empty include list will accept all labels and an empty exclude list will not exclude any labels.
+  # tag_pod_labels_include = []
+  # tag_pod_labels_exclude = []
+
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"
   # monitor_kubernetes_pods_namespace = ""

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -303,15 +303,20 @@ func registerPod(pod *corev1.Pod, p *Prometheus) {
 
 	log.Printf("D! [inputs.prometheus] will scrape metrics from %q", *targetURL)
 	// add annotation as metrics tags
-	tags := pod.Annotations
-	if tags == nil {
-		tags = map[string]string{}
+	tags := map[string]string{}
+	for k, v := range pod.Annotations {
+		if p.tagPodAnnotationsFilter == nil || p.tagPodAnnotationsFilter.Match(k) {
+			tags[k] = v
+		}
 	}
+
 	tags["pod_name"] = pod.Name
 	tags["namespace"] = pod.Namespace
 	// add labels as metrics tags
 	for k, v := range pod.Labels {
-		tags[k] = v
+		if p.tagPodLabelsFilter == nil || p.tagPodLabelsFilter.Match(k) {
+			tags[k] = v
+		}
 	}
 	URL, err := url.Parse(*targetURL)
 	if err != nil {


### PR DESCRIPTION
This commit allows a user to configure a filter to control what pod
annotations and labels to use as metric tags. The primary use case is to
restrain cardinality, since Kubernetes promotes many uses for labels and
annotations which are not relevant for the purposes of analyzing time
series data.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
