### PR TITLE
fix: bump thrift and zipkin-go-opentracing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/antchfx/xmlquery v1.3.5
 	github.com/antchfx/xpath v1.1.11
 	github.com/apache/arrow/go/arrow v0.0.0-20200601151325-b2287a20f230 // indirect
-	github.com/apache/thrift v0.13.0
+	github.com/apache/thrift v0.14.2
 	github.com/aristanetworks/glog v0.0.0-20191112221043-67e8567f59f3 // indirect
 	github.com/aristanetworks/goarista v0.0.0-20190325233358-a123909ec740
 	github.com/armon/go-metrics v0.3.3 // indirect
@@ -206,7 +206,7 @@ require (
 	github.com/opencontainers/runc v1.0.0-rc93 // indirect
 	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/openzipkin/zipkin-go-opentracing v0.3.4
+	github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5
 	github.com/philhofer/fwd v1.1.1 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pion/dtls/v2 v2.0.9

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/apache/arrow/go/arrow v0.0.0-20200601151325-b2287a20f230/go.mod h1:QN
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.14.2 h1:hY4rAyg7Eqbb27GB6gkhUKrRAuc8xRjlNtJq+LseKeY=
+github.com/apache/thrift v0.14.2/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/aristanetworks/glog v0.0.0-20191112221043-67e8567f59f3 h1:Bmjk+DjIi3tTAU0wxGaFbfjGUqlxxSXARq9A96Kgoos=
 github.com/aristanetworks/glog v0.0.0-20191112221043-67e8567f59f3/go.mod h1:KASm+qXFKs/xjSoWn30NrWBBvdTTQq+UjkhjEJHfSFA=
 github.com/aristanetworks/goarista v0.0.0-20190325233358-a123909ec740 h1:FD4/ikKOFxwP8muWDypbmBWc634+YcAs3eBrYAmRdZY=

--- a/plugins/inputs/zipkin/cmd/stress_test_write/stress_test_write.go
+++ b/plugins/inputs/zipkin/cmd/stress_test_write/stress_test_write.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"time"
 
-	zipkin "github.com/openzipkin/zipkin-go-opentracing"
+	zipkin "github.com/openzipkin-contrib/zipkin-go-opentracing"
 )
 
 var (

--- a/plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go
+++ b/plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go
@@ -32,7 +32,7 @@ import (
 	"log"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/openzipkin/zipkin-go-opentracing/thrift/gen-go/zipkincore"
+	"github.com/openzipkin-contrib/zipkin-go-opentracing/thrift/gen-go/zipkincore"
 )
 
 var (

--- a/plugins/inputs/zipkin/codec/codec.go
+++ b/plugins/inputs/zipkin/codec/codec.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf/plugins/inputs/zipkin/trace"
-	"github.com/openzipkin/zipkin-go-opentracing/thrift/gen-go/zipkincore"
+	"github.com/openzipkin-contrib/zipkin-go-opentracing/thrift/gen-go/zipkincore"
 )
 
 //now is a mockable time for now

--- a/plugins/inputs/zipkin/codec/jsonV1/jsonV1.go
+++ b/plugins/inputs/zipkin/codec/jsonV1/jsonV1.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf/plugins/inputs/zipkin/codec"
-	"github.com/openzipkin/zipkin-go-opentracing/thrift/gen-go/zipkincore"
+	"github.com/openzipkin-contrib/zipkin-go-opentracing/thrift/gen-go/zipkincore"
 )
 
 // JSON decodes spans from  bodies `POST`ed to the spans endpoint

--- a/plugins/inputs/zipkin/codec/thrift/thrift.go
+++ b/plugins/inputs/zipkin/codec/thrift/thrift.go
@@ -10,7 +10,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs/zipkin/codec"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/openzipkin/zipkin-go-opentracing/thrift/gen-go/zipkincore"
+	"github.com/openzipkin-contrib/zipkin-go-opentracing/thrift/gen-go/zipkincore"
 )
 
 // UnmarshalThrift converts raw bytes in thrift format to a slice of spans

--- a/plugins/inputs/zipkin/codec/thrift/thrift_test.go
+++ b/plugins/inputs/zipkin/codec/thrift/thrift_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/openzipkin/zipkin-go-opentracing/thrift/gen-go/zipkincore"
+	"github.com/openzipkin-contrib/zipkin-go-opentracing/thrift/gen-go/zipkincore"
 )
 
 func Test_endpointHost(t *testing.T) {


### PR DESCRIPTION
Update thrift version to address #9657

This isn't a trivial version bump. Thrift v0.14.2 requires openzipkin/zipkin-go-opentracing to bump to v0.4.5. That module moved to openzipkin-contrib and changed. Simply changing telegraf references to openzipkin-contrib doesn't work. For example, plugins/inputs/zipkin/codec/codec.go is broken because it references constants that no longer exist in the module.