### PR TITLE
fix: pagination error on cloudwatch plugin

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -410,6 +410,7 @@ func (c *CloudWatch) fetchNamespaceMetrics() ([]*cwClient.Metric, error) {
 	default:
 		recentlyActive = nil
 	}
+	
 	for _, namespace := range c.Namespaces {
 
 		params = &cwClient.ListMetricsInput{
@@ -417,24 +418,23 @@ func (c *CloudWatch) fetchNamespaceMetrics() ([]*cwClient.Metric, error) {
 			NextToken:      token,
 			MetricName:     nil,
 			RecentlyActive: recentlyActive,
-	    	}
-	    	params.Namespace = aws.String(namespace)
-		
+			Namespace:      aws.String(namespace),
+		}
+
 		for {
-				resp, err := c.client.ListMetrics(params)
-				if err != nil {
-					return nil, err
-				}
-
-				metrics = append(metrics, resp.Metrics...)
-				if resp.NextToken == nil {
-					break
-				}
-
-				params.NextToken = resp.NextToken
+			resp, err := c.client.ListMetrics(params)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list metrics with params per namespace: %v", err)
 			}
-	}
 
+			metrics = append(metrics, resp.Metrics...)
+			if resp.NextToken == nil {
+				break
+			}
+
+			params.NextToken = resp.NextToken
+		}
+	}
 	return metrics, nil
 }
 

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -410,7 +410,7 @@ func (c *CloudWatch) fetchNamespaceMetrics() ([]*cwClient.Metric, error) {
 	default:
 		recentlyActive = nil
 	}
-	
+
 	for _, namespace := range c.Namespaces {
 
 		params = &cwClient.ListMetricsInput{

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -410,27 +410,29 @@ func (c *CloudWatch) fetchNamespaceMetrics() ([]*cwClient.Metric, error) {
 	default:
 		recentlyActive = nil
 	}
-	params = &cwClient.ListMetricsInput{
-		Dimensions:     []*cwClient.DimensionFilter{},
-		NextToken:      token,
-		MetricName:     nil,
-		RecentlyActive: recentlyActive,
-	}
 	for _, namespace := range c.Namespaces {
-		params.Namespace = aws.String(namespace)
+
+		params = &cwClient.ListMetricsInput{
+			Dimensions:     []*cwClient.DimensionFilter{},
+			NextToken:      token,
+			MetricName:     nil,
+			RecentlyActive: recentlyActive,
+	    	}
+	    	params.Namespace = aws.String(namespace)
+		
 		for {
-			resp, err := c.client.ListMetrics(params)
-			if err != nil {
-				return nil, err
-			}
+				resp, err := c.client.ListMetrics(params)
+				if err != nil {
+					return nil, err
+				}
 
-			metrics = append(metrics, resp.Metrics...)
-			if resp.NextToken == nil {
-				break
-			}
+				metrics = append(metrics, resp.Metrics...)
+				if resp.NextToken == nil {
+					break
+				}
 
-			params.NextToken = resp.NextToken
-		}
+				params.NextToken = resp.NextToken
+			}
 	}
 
 	return metrics, nil


### PR DESCRIPTION
Fix the error of InvalidParameterValue: Parameters do not match original request parameters as the current code dont use correctly the return token from aws client

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [X] Updated associated README.md. 
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)


Following the discussion on PR #9386  (the update to support multiple namespaces in cloudwatch input plugin ) the latest change keep the token pagination to the next namespace which result in an error of InvalidParameterValue: Parameters do not match original request parameters. This change is to fix this error.


I moved the namespace loop and the aws param initialization to be outside the loop of the pagination

