### PR TITLE
docs: update caddy server instructions

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -158,7 +158,7 @@ Authorization header.
 
 ### Usage for Caddy HTTP server
 
-If you want to monitor Caddy, you need to use Caddy with its Prometheus plugin:
+Steps to monitor Caddy with Telegraf's Prometheus input plugin:
 
 * Download [Caddy](https://caddyserver.com/download)
 * Download Prometheus and set up [monitoring Caddy with Prometheus metrics](https://caddyserver.com/docs/metrics#monitoring-caddy-with-prometheus-metrics)
@@ -171,7 +171,7 @@ If you want to monitor Caddy, you need to use Caddy with its Prometheus plugin:
   urls = ["http://localhost:2019/metrics"]
 ```
 
-> This is the default URL where Caddy Prometheus plugin will send data.
+> This is the default URL where Caddy will send data.
 > For more details, please read the [Caddy Prometheus documentation](https://github.com/miekg/caddy-prometheus/blob/master/README.md).
 
 ### Metrics:

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -160,15 +160,15 @@ Authorization header.
 
 If you want to monitor Caddy, you need to use Caddy with its Prometheus plugin:
 
-* Download Caddy+Prometheus plugin [here](https://caddyserver.com/download/linux/amd64?plugins=http.prometheus)
-* Add the `prometheus` directive in your `CaddyFile`
+* Download [Caddy](https://caddyserver.com/download)
+* Download Prometheus and set up [monitoring Caddy with Prometheus metrics](https://caddyserver.com/docs/metrics#monitoring-caddy-with-prometheus-metrics)
 * Restart Caddy
 * Configure Telegraf to fetch metrics on it:
 
 ```toml
 [[inputs.prometheus]]
 #   ## An array of urls to scrape metrics from.
-  urls = ["http://localhost:9180/metrics"]
+  urls = ["http://localhost:2019/metrics"]
 ```
 
 > This is the default URL where Caddy Prometheus plugin will send data.


### PR DESCRIPTION
Existing Prometheus plugin docs for "Usage for Caddy Server" is for Caddy v1 and out of date as now Caddy no longer has a prometheus plugin and metrics are built in. 

Updating readme to include new instructions and links