### PR TITLE
fix: run go fmt on inputs.mdstat with Go v1.17

### DIFF
--- a/plugins/inputs/mdstat/mdstat.go
+++ b/plugins/inputs/mdstat/mdstat.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 // Copyright 2018 The Prometheus Authors

--- a/plugins/inputs/mdstat/mdstat_notlinux.go
+++ b/plugins/inputs/mdstat/mdstat_notlinux.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package mdstat

--- a/plugins/inputs/mdstat/mdstat_test.go
+++ b/plugins/inputs/mdstat/mdstat_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package mdstat


### PR DESCRIPTION
#9101 was merged but hadn't run against go v1.17, to fix the CI failing just ran `go fmt` so that it can add the missing updated build flags.

More information on these builds flags can be found in the pr: #9642