### PR TITLE
feat: add option to disable prepared statements for PostgreSQL

### DIFF
--- a/plugins/inputs/postgresql/README.md
+++ b/plugins/inputs/postgresql/README.md
@@ -63,8 +63,7 @@ host=localhost user=pgotest dbname=app_production sslmode=require sslkey=/etc/te
 ```toml
 [[inputs.postgresql]]
   ## specify address via a url matching:
-  ##   postgres://[pqgotest[:password]]@localhost[/dbname]\
-  ##       ?sslmode=[disable|verify-ca|verify-full]
+  ##   postgres://[pqgotest[:password]]@localhost[/dbname]?sslmode=[disable|verify-ca|verify-full]
   ## or a simple string:
   ##   host=localhost user=pqgotest password=... sslmode=... dbname=app_production
   ##
@@ -84,7 +83,7 @@ host=localhost user=pgotest dbname=app_production sslmode=require sslkey=/etc/te
   ## connection configuration.
   ## maxlifetime - specify the maximum lifetime of a connection.
   ## default is forever (0s)
-  max_lifetime = "0s"
+  # max_lifetime = "0s"
 
   ## A  list of databases to explicitly ignore.  If not specified, metrics for all
   ## databases are gathered.  Do NOT use with the 'databases' option.

--- a/plugins/inputs/postgresql/README.md
+++ b/plugins/inputs/postgresql/README.md
@@ -62,6 +62,40 @@ host=localhost user=pgotest dbname=app_production sslmode=require sslkey=/etc/te
 
 ```toml
 [[inputs.postgresql]]
-  address = "postgres://telegraf@localhost/someDB"
-  ignored_databases = ["template0", "template1"]
+  ## specify address via a url matching:
+  ##   postgres://[pqgotest[:password]]@localhost[/dbname]\
+  ##       ?sslmode=[disable|verify-ca|verify-full]
+  ## or a simple string:
+  ##   host=localhost user=pqgotest password=... sslmode=... dbname=app_production
+  ##
+  ## All connection parameters are optional.
+  ##
+  ## Without the dbname parameter, the driver will default to a database
+  ## with the same name as the user. This dbname is just for instantiating a
+  ## connection with the server and doesn't restrict the databases we are trying
+  ## to grab metrics for.
+  ##
+  address = "host=localhost user=postgres sslmode=disable"
+  ## A custom name for the database that will be used as the "server" tag in the
+  ## measurement output. If not specified, a default one generated from
+  ## the connection address is used.
+  # outputaddress = "db01"
+
+  ## connection configuration.
+  ## maxlifetime - specify the maximum lifetime of a connection.
+  ## default is forever (0s)
+  max_lifetime = "0s"
+
+  ## A  list of databases to explicitly ignore.  If not specified, metrics for all
+  ## databases are gathered.  Do NOT use with the 'databases' option.
+  # ignored_databases = ["postgres", "template0", "template1"]
+
+  ## A list of databases to pull metrics about. If not specified, metrics for all
+  ## databases are gathered.  Do NOT use with the 'ignored_databases' option.
+  # databases = ["app_production", "testing"]
+
+  ## Whether to use prepared statements when connecting to the database.
+  ## This should be set to false when connecting through a PgBouncer instance
+  ## with pool_mode set to transaction.
+  prepared_statements = true
 ```

--- a/plugins/inputs/postgresql/postgresql.go
+++ b/plugins/inputs/postgresql/postgresql.go
@@ -17,7 +17,7 @@ type Postgresql struct {
 	Service
 	Databases          []string
 	IgnoredDatabases   []string
-	PreparedStatements bool `toml:"prepared-statements"`
+	PreparedStatements bool `toml:"prepared_statements"`
 }
 
 var ignoredColumns = map[string]bool{"stats_reset": true}

--- a/plugins/inputs/postgresql/postgresql.go
+++ b/plugins/inputs/postgresql/postgresql.go
@@ -17,7 +17,7 @@ type Postgresql struct {
 	Service
 	Databases          []string `toml:"databases"`
 	IgnoredDatabases   []string `toml:"ignored_databases"`
-	PreparedStatements bool `toml:"prepared_statements"`
+	PreparedStatements bool     `toml:"prepared_statements"`
 }
 
 var ignoredColumns = map[string]bool{"stats_reset": true}

--- a/plugins/inputs/postgresql/postgresql.go
+++ b/plugins/inputs/postgresql/postgresql.go
@@ -15,8 +15,8 @@ import (
 
 type Postgresql struct {
 	Service
-	Databases          []string
-	IgnoredDatabases   []string
+	Databases          []string `toml:"databases"`
+	IgnoredDatabases   []string `toml:"ignored_databases"`
 	PreparedStatements bool `toml:"prepared_statements"`
 }
 

--- a/plugins/inputs/postgresql/postgresql.go
+++ b/plugins/inputs/postgresql/postgresql.go
@@ -17,7 +17,7 @@ type Postgresql struct {
 	Service
 	Databases          []string
 	IgnoredDatabases   []string
-	PreparedStatements bool `toml:"prepared_statements"`
+	PreparedStatements bool `toml:"prepared-statements"`
 }
 
 var ignoredColumns = map[string]bool{"stats_reset": true}
@@ -58,7 +58,7 @@ var sampleConfig = `
   ## Whether to use prepared statements when connecting to the database.
   ## This should be set to false when connecting through a PgBouncer instance
   ## with pool_mode set to transaction.
-  prepared_statements = true
+  # prepared-statements = true
 `
 
 func (p *Postgresql) SampleConfig() string {

--- a/plugins/inputs/postgresql/postgresql.go
+++ b/plugins/inputs/postgresql/postgresql.go
@@ -15,8 +15,9 @@ import (
 
 type Postgresql struct {
 	Service
-	Databases        []string
-	IgnoredDatabases []string
+	Databases          []string
+	IgnoredDatabases   []string
+	PreparedStatements bool `toml:"prepared-statements"`
 }
 
 var ignoredColumns = map[string]bool{"stats_reset": true}
@@ -53,6 +54,11 @@ var sampleConfig = `
   ## A list of databases to pull metrics about. If not specified, metrics for all
   ## databases are gathered.  Do NOT use with the 'ignored_databases' option.
   # databases = ["app_production", "testing"]
+
+  ## Whether to use prepared statements when connecting to the database.
+  ## This should be set to false when connecting through a PgBouncer instance
+  ## with pool_mode set to transaction.
+  prepared_statements = true
 `
 
 func (p *Postgresql) SampleConfig() string {
@@ -65,6 +71,11 @@ func (p *Postgresql) Description() string {
 
 func (p *Postgresql) IgnoredColumns() map[string]bool {
 	return ignoredColumns
+}
+
+func (p *Postgresql) Init() error {
+	p.Service.IsPgBouncer = !p.PreparedStatements
+	return nil
 }
 
 func (p *Postgresql) Gather(acc telegraf.Accumulator) error {
@@ -198,8 +209,8 @@ func init() {
 				MaxIdle:     1,
 				MaxOpen:     1,
 				MaxLifetime: config.Duration(0),
-				IsPgBouncer: false,
 			},
+			PreparedStatements: true,
 		}
 	})
 }

--- a/plugins/inputs/postgresql/postgresql.go
+++ b/plugins/inputs/postgresql/postgresql.go
@@ -17,7 +17,7 @@ type Postgresql struct {
 	Service
 	Databases          []string
 	IgnoredDatabases   []string
-	PreparedStatements bool `toml:"prepared-statements"`
+	PreparedStatements bool `toml:"prepared_statements"`
 }
 
 var ignoredColumns = map[string]bool{"stats_reset": true}
@@ -58,7 +58,7 @@ var sampleConfig = `
   ## Whether to use prepared statements when connecting to the database.
   ## This should be set to false when connecting through a PgBouncer instance
   ## with pool_mode set to transaction.
-  # prepared-statements = true
+  # prepared_statements = true
 `
 
 func (p *Postgresql) SampleConfig() string {

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -94,7 +94,7 @@ type Service struct {
 	MaxOpen       int
 	MaxLifetime   config.Duration
 	DB            *sql.DB
-	IsPgBouncer   bool
+	IsPgBouncer   bool `toml:"-"`
 }
 
 var socketRegexp = regexp.MustCompile(`/\.s\.PGSQL\.\d+$`)

--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -28,7 +28,12 @@ The example below has two queries are specified, with the following parameters:
   # A list of databases to pull metrics about. If not specified, metrics for all
   # databases are gathered.
   # databases = ["app_production", "testing"]
-  #
+
+  ## Whether to use prepared statements when connecting to the database.
+  ## This should be set to false when connecting through a PgBouncer instance
+  ## with pool_mode set to transaction.
+  prepared_statements = true
+
   # Define the toml config where the sql queries are stored
   # New queries can be added, if the withdbname is set to true and there is no
   # databases defined in the 'databases field', the sql query is ended by a 'is

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -23,7 +23,7 @@ type Postgresql struct {
 	Timestamp          string
 	Query              query
 	Debug              bool
-	PreparedStatements bool `toml:"prepared-statements"`
+	PreparedStatements bool `toml:"prepared_statements"`
 
 	Log telegraf.Logger
 }
@@ -63,7 +63,7 @@ var sampleConfig = `
   ## Whether to use prepared statements when connecting to the database.
   ## This should be set to false when connecting through a PgBouncer instance
   ## with pool_mode set to transaction.
-  # prepared-statements = true
+  # prepared_statements = true
 
   ## A list of databases to pull metrics about. If not specified, metrics for all
   ## databases are gathered.

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -63,7 +63,7 @@ var sampleConfig = `
   ## Whether to use prepared statements when connecting to the database.
   ## This should be set to false when connecting through a PgBouncer instance
   ## with pool_mode set to transaction.
-  prepared_statements = true
+  # prepared-statements = true
 
   ## A list of databases to pull metrics about. If not specified, metrics for all
   ## databases are gathered.

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -18,11 +18,12 @@ import (
 
 type Postgresql struct {
 	postgresql.Service
-	Databases      []string
-	AdditionalTags []string
-	Timestamp      string
-	Query          query
-	Debug          bool
+	Databases          []string
+	AdditionalTags     []string
+	Timestamp          string
+	Query              query
+	Debug              bool
+	PreparedStatements bool `toml:"prepared-statements"`
 
 	Log telegraf.Logger
 }
@@ -58,6 +59,11 @@ var sampleConfig = `
   ## maxlifetime - specify the maximum lifetime of a connection.
   ## default is forever (0s)
   max_lifetime = "0s"
+
+  ## Whether to use prepared statements when connecting to the database.
+  ## This should be set to false when connecting through a PgBouncer instance
+  ## with pool_mode set to transaction.
+  prepared_statements = true
 
   ## A list of databases to pull metrics about. If not specified, metrics for all
   ## databases are gathered.
@@ -125,6 +131,7 @@ func (p *Postgresql) Init() error {
 			}
 		}
 	}
+	p.Service.IsPgBouncer = !p.PreparedStatements
 	return nil
 }
 

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -355,6 +355,7 @@ func init() {
 				MaxLifetime: config.Duration(0),
 				IsPgBouncer: false,
 			},
+			PreparedStatements: true,
 		}
 	})
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

resolves #9630 

This adds an option for disabling the use of prepared statements in the `postgresql` and `postgresql_extensible` inputs. It also prevents changing the `IsPgBouncer` flag from the configuration which was previously possible.
