### PR TITLE
fix: Add error message logging to outputs.http

### DIFF
--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -18,7 +19,8 @@ import (
 )
 
 const (
-	defaultURL = "http://127.0.0.1:8080/telegraf"
+	maxErrMsgLen = 1024
+	defaultURL   = "http://127.0.0.1:8080/telegraf"
 )
 
 var sampleConfig = `
@@ -182,11 +184,18 @@ func (h *HTTP) write(reqBody []byte) error {
 		return err
 	}
 	defer resp.Body.Close()
-	_, err = ioutil.ReadAll(resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("when writing to [%s] received status code: %d", h.URL, resp.StatusCode)
+		errorLine := ""
+		scanner := bufio.NewScanner(io.LimitReader(resp.Body, maxErrMsgLen))
+		if scanner.Scan() {
+			errorLine = scanner.Text()
+		}
+
+		return fmt.Errorf("when writing to [%s] received status code: %d. body: %s", h.URL, resp.StatusCode, errorLine)
 	}
+
+	_, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("when writing to [%s] received error: %v", h.URL, err)
 	}


### PR DESCRIPTION
We run a multitenant system with 1000s of users and some of them use
Telegraf to push to us. The error logs they see look like this:

```
2021-09-06T06:07:34Z E! [agent] Error writing to outputs.http:
when writing to [XXX] received status code: 400
2021-09-06T06:07:34Z D! [outputs.http] Buffer fullness: 2410 / 200000
metrics
2021-09-06T06:07:34Z E! [agent] Error writing to outputs.http: when
writing to [XXX] received status code: 400
2021-09-06T06:07:44Z D! [outputs.http] Buffer fullness: 2415 / 200000
metrics
2021-09-06T06:07:44Z E! [agent] Error writing to outputs.http: when
writing to [XXXX] received status code: 400
```

Our upstream returns actionable messages that make the issue pretty
clear to our users, but those using Telegraf cannot see those messages.
I propose that users should be able to see the error message returned
from upstream.

We're seeing more and more of our users adopting Telegraf and its an
awesome project! This is not the first time our users contacted
regarding this issue and I think this enhancement will be useful to
wider community as well!

This particular piece of code has been inspired by how Prometheus remote
write does the error logging.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
