### PR TITLE
fix: Rename KNXListener to knx_listener

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -5539,7 +5539,7 @@
 #   # timeout = "5ms"
 
 
-# # A plugin to collect stats from Opensmtpd - a validating, recursive, and caching DNS resolver 
+# # A plugin to collect stats from Opensmtpd - a validating, recursive, and caching DNS resolver
 # [[inputs.opensmtpd]]
 #   ## If running as a restricted user you can prepend sudo for additional access:
 #   #use_sudo = false
@@ -6795,7 +6795,7 @@
 
 
 # # Listener capable of handling KNX bus messages provided through a KNX-IP Interface.
-# [[inputs.KNXListener]]
+# [[inputs.knx_listener]]
 #   ## Type of KNX-IP interface.
 #   ## Can be either "tunnel" or "router".
 #   # service_type = "tunnel"
@@ -6804,7 +6804,7 @@
 #   service_address = "localhost:3671"
 #
 #   ## Measurement definition(s)
-#   # [[inputs.KNXListener.measurement]]
+#   # [[inputs.knx_listener.measurement]]
 #   #   ## Name of the measurement
 #   #   name = "temperature"
 #   #   ## Datapoint-Type (DPT) of the KNX messages
@@ -6812,7 +6812,7 @@
 #   #   ## List of Group-Addresses (GAs) assigned to the measurement
 #   #   addresses = ["5/5/1"]
 #
-#   # [[inputs.KNXListener.measurement]]
+#   # [[inputs.knx_listener.measurement]]
 #   #   name = "illumination"
 #   #   dpt = "9.004"
 #   #   addresses = ["5/5/3"]
@@ -7660,7 +7660,7 @@
 # 	## This value is propagated to pqos tool. Interval format is defined by pqos itself.
 # 	## If not provided or provided 0, will be set to 10 = 10x100ms = 1s.
 # 	# sampling_interval = "10"
-# 	
+#
 # 	## Optionally specify the path to pqos executable.
 # 	## If not provided, auto discovery will be performed.
 # 	# pqos_path = "/usr/local/bin/pqos"
@@ -7668,12 +7668,12 @@
 # 	## Optionally specify if IPC and LLC_Misses metrics shouldn't be propagated.
 # 	## If not provided, default value is false.
 # 	# shortened_metrics = false
-# 	
+#
 # 	## Specify the list of groups of CPU core(s) to be provided as pqos input.
 # 	## Mandatory if processes aren't set and forbidden if processes are specified.
 # 	## e.g. ["0-3", "4,5,6"] or ["1-3,4"]
 # 	# cores = ["0-3"]
-# 	
+#
 # 	## Specify the list of processes for which Metrics will be collected.
 # 	## Mandatory if cores aren't set and forbidden if cores are specified.
 # 	## e.g. ["qemu", "pmd"]
@@ -9092,4 +9092,3 @@
 # [[inputs.zipkin]]
 #   # path = "/api/v1/spans" # URL path for span data
 #   # port = 9411            # Port on which Telegraf listens
-

--- a/plugins/inputs/knx_listener/README.md
+++ b/plugins/inputs/knx_listener/README.md
@@ -11,7 +11,7 @@ This is a sample config for the plugin.
 
 ```toml
 # Listener capable of handling KNX bus messages provided through a KNX-IP Interface.
-[[inputs.KNXListener]]
+[[inputs.knx_listener]]
   ## Type of KNX-IP interface.
   ## Can be either "tunnel" or "router".
   # service_type = "tunnel"
@@ -20,7 +20,7 @@ This is a sample config for the plugin.
   service_address = "localhost:3671"
 
   ## Measurement definition(s)
-  # [[inputs.KNXListener.measurement]]
+  # [[inputs.knx_listener.measurement]]
   #   ## Name of the measurement
   #   name = "temperature"
   #   ## Datapoint-Type (DPT) of the KNX messages
@@ -28,7 +28,7 @@ This is a sample config for the plugin.
   #   ## List of Group-Addresses (GAs) assigned to the measurement
   #   addresses = ["5/5/1"]
 
-  # [[inputs.KNXListener.measurement]]
+  # [[inputs.knx_listener.measurement]]
   #   name = "illumination"
   #   dpt = "9.004"
   #   addresses = ["5/5/3"]

--- a/plugins/inputs/knx_listener/knx_listener.go
+++ b/plugins/inputs/knx_listener/knx_listener.go
@@ -196,4 +196,6 @@ func (kl *KNXListener) listen() {
 
 func init() {
 	inputs.Add("knx_listener", func() telegraf.Input { return &KNXListener{ServiceType: "tunnel"} })
+	// Register for backward compatibility
+	inputs.Add("KNXListener", func() telegraf.Input { return &KNXListener{ServiceType: "tunnel"} })
 }

--- a/plugins/inputs/knx_listener/knx_listener.go
+++ b/plugins/inputs/knx_listener/knx_listener.go
@@ -56,7 +56,7 @@ func (kl *KNXListener) SampleConfig() string {
   service_address = "localhost:3671"
 
   ## Measurement definition(s)
-  # [[inputs.KNXListener.measurement]]
+  # [[inputs.knx_listener.measurement]]
   #   ## Name of the measurement
   #   name = "temperature"
   #   ## Datapoint-Type (DPT) of the KNX messages
@@ -64,7 +64,7 @@ func (kl *KNXListener) SampleConfig() string {
   #   ## List of Group-Addresses (GAs) assigned to the measurement
   #   addresses = ["5/5/1"]
 
-  # [[inputs.KNXListener.measurement]]
+  # [[inputs.knx_listener.measurement]]
   #   name = "illumination"
   #   dpt = "9.004"
   #   addresses = ["5/5/3"]
@@ -195,5 +195,5 @@ func (kl *KNXListener) listen() {
 }
 
 func init() {
-	inputs.Add("KNXListener", func() telegraf.Input { return &KNXListener{ServiceType: "tunnel"} })
+	inputs.Add("knx_listener", func() telegraf.Input { return &KNXListener{ServiceType: "tunnel"} })
 }


### PR DESCRIPTION
### Required for all PRs:

- [X] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

resolves #9709 

Rename `KNXListener` input plugin to `knx_listener` to follow the convention.