### PR TITLE
fix: Fix panic for non-existing metric names

### DIFF
--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -395,7 +395,7 @@ func NewXPathParserConfigs(metricName string, cfgs []XPathConfig) []xpath.Config
 	configs := make([]xpath.Config, 0, len(cfgs))
 	for _, cfg := range cfgs {
 		config := xpath.Config(cfg)
-		config.MetricName = metricName
+		config.MetricDefaultName = metricName
 		configs = append(configs, config)
 	}
 	return configs

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -168,6 +168,9 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 		}
 		var ok bool
 		if metricname, ok = v.(string); !ok {
+			if v == nil {
+				p.Log.Infof("Hint: Empty metric-name-node. If you wanted to set a constant please use `metric_name = \"'name'\"`.")
+			}
 			return nil, fmt.Errorf("failed to query metric name: query result is of type %T not 'string'", v)
 		}
 	}

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -148,8 +148,8 @@ func TestInvalidTypeQueriesFail(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					FieldsInt: map[string]string{
 						"a": "/Device_1/value_string",
 					},
@@ -185,8 +185,8 @@ func TestInvalidTypeQueries(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"a": "number(/Device_1/value_string)",
 					},
@@ -207,8 +207,8 @@ func TestInvalidTypeQueries(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"a": "boolean(/Device_1/value_string)",
 					},
@@ -252,8 +252,8 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -269,9 +269,9 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName:   "test",
-					Timestamp:    "/Device_1/Timestamp_unix",
-					TimestampFmt: "unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
+					TimestampFmt:      "unix",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -287,9 +287,9 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName:   "test",
-					Timestamp:    "/Device_1/Timestamp_unix_ms",
-					TimestampFmt: "unix_ms",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix_ms",
+					TimestampFmt:      "unix_ms",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -305,9 +305,9 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName:   "test",
-					Timestamp:    "/Device_1/Timestamp_unix_us",
-					TimestampFmt: "unix_us",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix_us",
+					TimestampFmt:      "unix_us",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -323,9 +323,9 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName:   "test",
-					Timestamp:    "/Device_1/Timestamp_unix_ns",
-					TimestampFmt: "unix_ns",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix_ns",
+					TimestampFmt:      "unix_ns",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -341,9 +341,9 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName:   "test",
-					Timestamp:    "/Device_1/Timestamp_iso",
-					TimestampFmt: "2006-01-02T15:04:05Z",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_iso",
+					TimestampFmt:      "2006-01-02T15:04:05Z",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -382,8 +382,8 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"a": "/Device_1/value_int",
 						"b": "/Device_1/value_float",
@@ -410,8 +410,8 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"a": "number(Device_1/value_int)",
 						"b": "number(/Device_1/value_float)",
@@ -438,8 +438,8 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"b": "number(/Device_1/value_float)",
 						"c": "boolean(/Device_1/value_bool)",
@@ -468,8 +468,8 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"x": "substring-before(/Device_1/value_position, ';')",
 						"y": "substring-after(/Device_1/value_position, ';')",
@@ -492,8 +492,8 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"x": "number(substring-before(/Device_1/value_position, ';'))",
 						"y": "number(substring-after(/Device_1/value_position, ';'))",
@@ -516,8 +516,8 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					FieldsInt: map[string]string{
 						"x": "substring-before(/Device_1/value_position, ';')",
 						"y": "substring-after(/Device_1/value_position, ';')",
@@ -540,8 +540,8 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					Tags: map[string]string{
 						"state": "/Device_1/State",
 						"name":  "substring-after(/Device_1/Name, ' ')",
@@ -587,8 +587,8 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix/@value",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix/@value",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -604,9 +604,9 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricName:   "test",
-					Timestamp:    "/Device_1/Timestamp_iso/@value",
-					TimestampFmt: "2006-01-02T15:04:05Z",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_iso/@value",
+					TimestampFmt:      "2006-01-02T15:04:05Z",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -622,8 +622,8 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix/@value",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix/@value",
 					Fields: map[string]string{
 						"a": "/Device_1/attr_int/@_",
 						"b": "/Device_1/attr_float/@_",
@@ -650,8 +650,8 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix/@value",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix/@value",
 					Fields: map[string]string{
 						"a": "number(/Device_1/attr_int/@_)",
 						"b": "number(/Device_1/attr_float/@_)",
@@ -678,8 +678,8 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix/@value",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix/@value",
 					Fields: map[string]string{
 						"b": "number(/Device_1/attr_float/@_)",
 						"c": "boolean(/Device_1/attr_bool/@_)",
@@ -708,8 +708,8 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix/@value",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix/@value",
 					Fields: map[string]string{
 						"name": "substring-after(/Device_1/Name/@value, ' ')",
 					},
@@ -730,8 +730,8 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix/@value",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix/@value",
 					Tags: map[string]string{
 						"state": "/Device_1/State/@_",
 						"name":  "substring-after(/Device_1/Name/@value, ' ')",
@@ -754,8 +754,8 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Device_1/Timestamp_unix/@value",
+					MetricDefaultName: "test",
+					Timestamp:         "/Device_1/Timestamp_unix/@value",
 					Fields: map[string]string{
 						"a": "/Device_1/attr_bool_numeric/@_ = 1",
 					},
@@ -799,8 +799,8 @@ func TestParseMultiValues(t *testing.T) {
 			input: singleMetricMultiValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Timestamp/@value",
+					MetricDefaultName: "test",
+					Timestamp:         "/Timestamp/@value",
 					Fields: map[string]string{
 						"a": "number(/Device/Value[1])",
 						"b": "number(/Device/Value[2])",
@@ -831,8 +831,8 @@ func TestParseMultiValues(t *testing.T) {
 			input: singleMetricMultiValuesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Timestamp:  "/Timestamp/@value",
+					MetricDefaultName: "test",
+					Timestamp:         "/Timestamp/@value",
 					FieldsInt: map[string]string{
 						"a": "/Device/Value[1]",
 						"b": "/Device/Value[2]",
@@ -886,9 +886,9 @@ func TestParseMultiNodes(t *testing.T) {
 			input: multipleNodesXML,
 			configs: []Config{
 				{
-					MetricName: "test",
-					Selection:  "/Device",
-					Timestamp:  "/Timestamp/@value",
+					MetricDefaultName: "test",
+					Selection:         "/Device",
+					Timestamp:         "/Timestamp/@value",
 					Fields: map[string]string{
 						"value":  "number(Value)",
 						"active": "Active = 1",
@@ -999,9 +999,9 @@ func TestParseMetricQuery(t *testing.T) {
 			input: metricNameQueryXML,
 			configs: []Config{
 				{
-					MetricName:  "test",
-					MetricQuery: "name(/Device_1/Metric/@*[1])",
-					Timestamp:   "/Device_1/Timestamp_unix",
+					MetricDefaultName: "test",
+					MetricQuery:       "name(/Device_1/Metric/@*[1])",
+					Timestamp:         "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"value": "/Device_1/Metric/@*[1]",
 					},
@@ -1010,6 +1010,29 @@ func TestParseMetricQuery(t *testing.T) {
 			defaultTags: map[string]string{},
 			expected: testutil.MustMetric(
 				"state",
+				map[string]string{},
+				map[string]interface{}{
+					"value": "ok",
+				},
+				time.Unix(1577923199, 0),
+			),
+		},
+		{
+			name:  "parse metric name constant",
+			input: metricNameQueryXML,
+			configs: []Config{
+				{
+					MetricDefaultName: "test",
+					MetricQuery:       "string('the_metric')",
+					Timestamp:         "/Device_1/Timestamp_unix",
+					Fields: map[string]string{
+						"value": "/Device_1/Metric/@*[1]",
+					},
+				},
+			},
+			defaultTags: map[string]string{},
+			expected: testutil.MustMetric(
+				"the_metric",
 				map[string]string{},
 				map[string]interface{}{
 					"value": "ok",
@@ -1028,6 +1051,42 @@ func TestParseMetricQuery(t *testing.T) {
 			require.NoError(t, err)
 
 			testutil.RequireMetricEqual(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestParseErrors(t *testing.T) {
+	var tests = []struct {
+		name     string
+		input    string
+		configs  []Config
+		expected string
+	}{
+		{
+			name:  "string metric name query",
+			input: metricNameQueryXML,
+			configs: []Config{
+				{
+					MetricDefaultName: "test",
+					MetricQuery:       "arbitrary",
+					Timestamp:         "/Device_1/Timestamp_unix",
+					Fields: map[string]string{
+						"value": "/Device_1/Metric/@*[1]",
+					},
+				},
+			},
+			expected: "failed to query metric name: query result is of type <nil> not 'string'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &Parser{Configs: tt.configs, DefaultTags: map[string]string{}, Log: testutil.Logger{Name: "parsers.xml"}}
+			require.NoError(t, parser.Init())
+
+			_, err := parser.ParseLine(tt.input)
+			require.Error(t, err)
+			require.Equal(t, tt.expected, err.Error())
 		})
 	}
 }
@@ -1146,7 +1205,7 @@ func TestTestCases(t *testing.T) {
 			filename := filepath.FromSlash(tt.filename)
 			cfg, header, err := loadTestConfiguration(filename)
 			require.NoError(t, err)
-			cfg.MetricName = "xml"
+			cfg.MetricDefaultName = "xml"
 
 			// Load the xml-content
 			input, err := testutil.ParseRawLinesFrom(header, "File:")

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -1023,7 +1023,7 @@ func TestParseMetricQuery(t *testing.T) {
 			configs: []Config{
 				{
 					MetricDefaultName: "test",
-					MetricQuery:       "string('the_metric')",
+					MetricQuery:       "'the_metric'",
 					Timestamp:         "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"value": "/Device_1/Metric/@*[1]",


### PR DESCRIPTION
### Required for all PRs:
- [ ] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

related to #9756 

In case you specify a `metric_name` within a parser configuration section you will actually set a _query_ to fill the metric name. If this query references a non-existing node the code will panic as the resulting `nil` value cannot be converted to `string` (see #9756). However, this might also happen in case you try to specify a constant metric name but omit the `string('...')` around that name.

Catch the panic before it occurs and add test cases to test it works correctly.

