### PR TITLE
feat: add count of bonded slaves (for easier alerting)

### DIFF
--- a/plugins/inputs/bond/README.md
+++ b/plugins/inputs/bond/README.md
@@ -27,6 +27,7 @@ The plugin collects these metrics from `/proc/net/bonding/*` files.
 - bond_slave
   - failures
   - status
+  - count
 
 ### Description:
 
@@ -39,6 +40,9 @@ status
 
 failures
   Amount of failures for bond's slave interface.
+
+count
+  Number of slaves attached to bond
 ```
 
 ### Tags:
@@ -79,7 +83,9 @@ Output:
 > bond,bond=bond1,host=local active_slave="eth0",status=1i 1509704525000000000
 > bond_slave,bond=bond1,interface=eth0,host=local status=1i,failures=0i 1509704525000000000
 > bond_slave,host=local,bond=bond1,interface=eth1 status=1i,failures=0i 1509704525000000000
+> bond_slave,host=local,bond=bond1 count=2i 1509704525000000000
 > bond,bond=bond0,host=isvetlov-mac.local status=1i 1509704525000000000
 > bond_slave,bond=bond0,interface=eth1,host=local status=1i,failures=0i 1509704525000000000
 > bond_slave,bond=bond0,interface=eth2,host=local status=1i,failures=0i 1509704525000000000
+> bond_slave,bond=bond0,host=local count=2i 1509704525000000000
 ```

--- a/plugins/inputs/bond/bond.go
+++ b/plugins/inputs/bond/bond.go
@@ -160,10 +160,10 @@ func (bond *Bond) gatherSlavePart(bondName string, rawFile string, acc telegraf.
 		}
 	}
 	fields := map[string]interface{}{
-		"count":   slaveCount,
+		"count": slaveCount,
 	}
 	tags := map[string]string{
-		"bond":      bondName,
+		"bond": bondName,
 	}
 	acc.AddFields("bond_slave", fields, tags)
 

--- a/plugins/inputs/bond/bond.go
+++ b/plugins/inputs/bond/bond.go
@@ -122,6 +122,7 @@ func (bond *Bond) gatherBondPart(bondName string, rawFile string, acc telegraf.A
 func (bond *Bond) gatherSlavePart(bondName string, rawFile string, acc telegraf.Accumulator) error {
 	var slave string
 	var status int
+	var slaveCount int
 
 	scanner := bufio.NewScanner(strings.NewReader(rawFile))
 	for scanner.Scan() {
@@ -155,8 +156,16 @@ func (bond *Bond) gatherSlavePart(bondName string, rawFile string, acc telegraf.
 				"interface": slave,
 			}
 			acc.AddFields("bond_slave", fields, tags)
+			slaveCount++
 		}
 	}
+	fields := map[string]interface{}{
+		"count":   slaveCount,
+	}
+	tags := map[string]string{
+		"bond":      bondName,
+	}
+	acc.AddFields("bond_slave", fields, tags)
 
 	return scanner.Err()
 }

--- a/plugins/inputs/bond/bond_test.go
+++ b/plugins/inputs/bond/bond_test.go
@@ -75,4 +75,5 @@ func TestGatherBondInterface(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "bond", map[string]interface{}{"active_slave": "eth2", "status": 1}, map[string]string{"bond": "bondAB"})
 	acc.AssertContainsTaggedFields(t, "bond_slave", map[string]interface{}{"failures": 2, "status": 0}, map[string]string{"bond": "bondAB", "interface": "eth3"})
 	acc.AssertContainsTaggedFields(t, "bond_slave", map[string]interface{}{"failures": 0, "status": 1}, map[string]string{"bond": "bondAB", "interface": "eth2"})
+	acc.AssertContainsTaggedFields(t, "bond_slave", map[string]interface{}{"count": 2}, map[string]string{"bond": "bondAB"})
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

Collecting the count of slaves to a network bond makes alerting on downed slaves/etc. much easier.