### PR TITLE
chore: update nightly workflow to match per-commit workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,9 +109,6 @@ commands:
       release:
         type: boolean
         default: false
-      nightly:
-        type: boolean
-        default: false
       type:
         type: string
         default: ""
@@ -124,15 +121,9 @@ commands:
           condition: << parameters.release >>
           steps:
             - run: 'make package'
-      - when:
-          condition: << parameters.nightly >>
-          steps:
-            - run: 'make package'
-            - run: 'make upload-nightly'
       - unless:
           condition:
             or:
-              - << parameters.nightly >>
               - << parameters.release >>
           steps:
             - run: 'make package include_packages="$(make << parameters.type >>)"'
@@ -269,8 +260,17 @@ jobs:
   nightly:
     executor: go-1_17
     steps:
-      - package-build:
-          nightly: true
+      - attach_workspace:
+          at: '/build'
+      - run:
+          command: |
+            aws s3 sync /build/dist s3://dl.influxdata.com/telegraf/nightlies/ \
+              --exclude "*" \
+              --include "*.tar.gz" \
+              --include "*.deb" \
+              --include "*.rpm" \
+              --include "*.zip" \
+              --acl public-read
   package-consolidate:
     executor:
         name: win/default
@@ -336,6 +336,63 @@ jobs:
             printf -v payload '{ "pullRequestNumber": "%s" }' "$PR"
             curl -X POST "https://182c7jdgog.execute-api.us-east-1.amazonaws.com/prod/shareArtifacts" --data "$payload"
 
+commonjobs:
+  - &test-awaiter
+    'test-awaiter':
+      requires:
+        - 'test-go-1_16'
+        - 'test-go-1_16-386'
+        - 'test-go-1_17'
+        - 'test-go-1_17-386'
+  - &windows-package
+    'windows-package':
+      requires:
+        - 'test-go-windows'
+  - &darwin-package
+    'darwin-package':
+      requires:
+        - 'test-go-mac'
+  - &i386-package
+    'i386-package':
+      requires:
+        - 'test-awaiter'
+  - &ppc64le-package
+    'ppc64le-package':
+      requires:
+        - 'test-awaiter'
+  - &s390x-package
+    's390x-package':
+      requires:
+        - 'test-awaiter'
+  - &armel-package
+    'armel-package':
+      requires:
+        - 'test-awaiter'
+  - &amd64-package
+    'amd64-package':
+      requires:
+        - 'test-awaiter'
+  - &arm64-package
+    'arm64-package':
+      requires:
+        - 'test-awaiter'
+  - &armhf-package
+    'armhf-package':
+      requires:
+        - 'test-awaiter'
+  - &static-package
+    'static-package':
+      requires:
+        - 'test-awaiter'
+  - &mipsel-package
+    'mipsel-package':
+      requires:
+        - 'test-awaiter'
+  - &mips-package
+    'mips-package':
+      requires:
+        - 'test-awaiter'
+
 workflows:
   version: 2
   check:
@@ -376,48 +433,19 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - 'test-awaiter':
-          requires:
-            - 'test-go-1_16'
-            - 'test-go-1_16-386'
-            - 'test-go-1_17'
-            - 'test-go-1_17-386'
-      - 'windows-package':
-          requires:
-            - 'test-go-windows'
-      - 'darwin-package':
-          requires:
-            - 'test-go-mac'
-      - 'i386-package':
-          requires:
-            - 'test-awaiter'
-      - 'ppc64le-package':
-          requires:
-            - 'test-awaiter'
-      - 's390x-package':
-          requires:
-            - 'test-awaiter'
-      - 'armel-package':
-          requires:
-            - 'test-awaiter'
-      - 'amd64-package':
-          requires:
-            - 'test-awaiter'
-      - 'arm64-package':
-          requires:
-            - 'test-awaiter'
-      - 'armhf-package':
-          requires:
-            - 'test-awaiter'
-      - 'static-package':
-          requires:
-            - 'test-awaiter'
-      - 'mipsel-package':
-          requires:
-            - 'test-awaiter'
-      - 'mips-package':
-          requires:
-            - 'test-awaiter'
+      - *test-awaiter
+      - *windows-package
+      - *darwin-package
+      - *i386-package
+      - *ppc64le-package
+      - *s390x-package
+      - *armel-package
+      - *amd64-package
+      - *arm64-package
+      - *armhf-package
+      - *static-package
+      - *mipsel-package
+      - *mips-package
       - 'share-artifacts':
           requires:
             - 'i386-package'
@@ -479,14 +507,20 @@ workflows:
             - 'deps'
       - 'test-go-mac'
       - 'test-go-windows'
-      - 'nightly':
-          requires:
-            - 'test-go-windows'
-            - 'test-go-mac'
-            - 'test-go-1_16'
-            - 'test-go-1_16-386'
-            - 'test-go-1_17'
-            - 'test-go-1_17-386'
+      - *test-awaiter
+      - *windows-package
+      - *darwin-package
+      - *i386-package
+      - *ppc64le-package
+      - *s390x-package
+      - *armel-package
+      - *amd64-package
+      - *arm64-package
+      - *armhf-package
+      - *static-package
+      - *mipsel-package
+      - *mips-package
+      - nightly
     triggers:
       - schedule:
           cron: "0 7 * * *"

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ plugin-%:
 ci-1.16:
 	docker build -t quay.io/influxdb/telegraf-ci:1.16.7 - < scripts/ci-1.16.docker
 	docker push quay.io/influxdb/telegraf-ci:1.16.7
-	
+
 .PHONY: ci-1.17
 ci-1.17:
 	docker build -t quay.io/influxdb/telegraf-ci:1.17.0 - < scripts/ci-1.17.docker
@@ -345,16 +345,6 @@ $(include_packages):
 	elif [ "$(suffix $@)" = ".gz" ]; then \
 		tar --owner 0 --group 0 -czvf $(pkgdir)/telegraf-$(tar_version)_$@ -C $(dir $(DESTDIR)) . ;\
 	fi
-
-.PHONY: upload-nightly
-upload-nightly:
-	aws s3 sync $(pkgdir) s3://dl.influxdata.com/telegraf/nightlies/ \
-		--exclude "*" \
-		--include "*.tar.gz" \
-		--include "*.deb" \
-		--include "*.rpm" \
-		--include "*.zip" \
-		--acl public-read
 
 amd64.deb x86_64.rpm linux_amd64.tar.gz: export GOOS := linux
 amd64.deb x86_64.rpm linux_amd64.tar.gz: export GOARCH := amd64


### PR DESCRIPTION
Updated the nightly workflow to be the same as the per-commit workflow so that is packages everything in parallel. Also removed `make upload-nightly` and moved the logic in the the CI config. All it was doing was an aws call which is only used in the CI process and won't be used by users so it doesn't seem appropriate to live in the makefile.

Used YAML anchors to make the nightly and per-commit workflow a little bit more DRY, but seems this is the limit with YAML. Bit more context in this stack-overflow question: https://stackoverflow.com/questions/4948933/is-there-a-way-to-alias-anchor-an-array-in-yaml

:warning: I don't know how to the test the nightly workflow without running the nightly workflow. 