### PR TITLE
fix: nightly upload requires package steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,7 +577,20 @@ workflows:
       - *static-package
       - *mipsel-package
       - *mips-package
-      - nightly
+      - nightly:
+          requires:
+            - 'i386-package'
+            - 'ppc64le-package'
+            - 's390x-package'
+            - 'armel-package'
+            - 'amd64-package'
+            - 'mipsel-package'
+            - 'mips-package'
+            - 'darwin-package'
+            - 'windows-package'
+            - 'static-package'
+            - 'arm64-package'
+            - 'armhf-package'
     triggers:
       - schedule:
           cron: "0 7 * * *"


### PR DESCRIPTION
There was a mistake in the refactor in this pull request: #9781 the nightly step uploads all the artifacts and requires to wait for the package steps. The nightly job was running before them without this change.