### PR TITLE
fix: add keep alive config option for identifier rejected error

### DIFF
--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -40,6 +40,12 @@ This plugin writes to a [MQTT Broker](http://http://mqtt.org/) acting as a mqtt 
   ## When true, messages will have RETAIN flag set.
   # retain = false
 
+  ## Defines the maximum length of time that the broker and client may not communicate. 
+  ## Defaults to 0 which turns the feature off. For version v2.0.12 mosquitto there is a 
+  ## [bug](https://github.com/eclipse/mosquitto/issues/2117) which requires keep_alive to be set.
+  ## As a reference eclipse/paho.mqtt.golang v1.3.0 defaults to 30.
+  # keep_alive = 0
+
   ## Data format to output.
   # data_format = "influx"
 ```
@@ -62,3 +68,4 @@ This plugin writes to a [MQTT Broker](http://http://mqtt.org/) acting as a mqtt 
 * `batch`: When true, metrics will be sent in one MQTT message per flush. Otherwise, metrics are written one metric per MQTT message.
 * `retain`: Set `retain` flag when publishing
 * `data_format`: [About Telegraf data formats](https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md)
+* `keep_alive`: Defines the maximum length of time that the broker and client may not communicate with each other. Defaults to 0 which deactivates this feature. 

--- a/plugins/outputs/mqtt/mqtt_test.go
+++ b/plugins/outputs/mqtt/mqtt_test.go
@@ -19,6 +19,7 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 	m := &MQTT{
 		Servers:    []string{url},
 		serializer: s,
+		KeepAlive:  30,
 	}
 
 	// Verify that we can connect to the MQTT broker


### PR DESCRIPTION
resolves #9763

Users were getting a identifier rejected error when using the plugin with mosquitto v2.0.12

eclipse/mosquitto v2.0.12 has a [bug](https://github.com/eclipse/mosquitto/issues/2117) where you cannot set keep_alive to 0. This is now a known bug which will be fixed in the next release v2.0.13.

I've added a config option for keep_alive so that users can decide themselves what they want to set this to, and so users of v2.0.12 are still able to use this plugin.

Defaults to 0 (turning the keep alive feature off) as this has been the behavior of this plugin for the last 4 years. The library github.com/eclipse/paho.mqtt.golang we are using defaults keep_alive to 30.

Added documentation around the purpose of the config option and updated the integration test so if you are running any version of mosquitto it still passes.
