### PR TITLE
fix: procstat missing tags in procstat_lookup metric

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -155,9 +155,10 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 		}
 	}
 
+	tags := make(map[string]string)
 	p.procs = newProcs
-
 	for _, proc := range p.procs {
+		tags = proc.Tags()
 		p.addMetric(proc, acc, now)
 	}
 
@@ -166,7 +167,7 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 		"running":     len(p.procs),
 		"result_code": 0,
 	}
-	tags := make(map[string]string)
+
 	tags["pid_finder"] = p.PidFinder
 	tags["result"] = "success"
 	acc.AddFields("procstat_lookup", fields, tags, now)


### PR DESCRIPTION
In #9488 the way that tags were built for procstat_lookup was changed
and it was only including the pid_finder and result tags. This is not
consistent with the documentation and is a regression from how they were
previously constructed.

Because of the large change to how procstat metrics are gathered, this
will use one of the process metric's tags as a basis for the tags for
procstat_lookup.

Resolves: #9793

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)