### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -933,7 +933,7 @@ func loadConfig(config string) ([]byte, error) {
 	}
 
 	// If it isn't a https scheme, try it as a file
-	return ioutil.ReadFile(config)
+	return os.ReadFile(config)
 }
 
 func fetchConfig(u *url.URL) ([]byte, error) {
@@ -964,7 +964,7 @@ func fetchConfig(u *url.URL) ([]byte, error) {
 			return nil, fmt.Errorf("Retry %d of %d failed to retrieve remote config: %s", i, retries, resp.Status)
 		}
 		defer resp.Body.Close()
-		return ioutil.ReadAll(resp.Body)
+		return io.ReadAll(resp.Body)
 	}
 
 	return nil, nil

--- a/internal/content_coding_test.go
+++ b/internal/content_coding_test.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -68,7 +68,7 @@ func TestStreamIdentityDecode(t *testing.T) {
 	dec, err := NewStreamContentDecoder("identity", &r)
 	require.NoError(t, err)
 
-	data, err := ioutil.ReadAll(dec)
+	data, err := io.ReadAll(dec)
 	require.NoError(t, err)
 
 	require.Equal(t, []byte("howdy"), data)

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"log"
 	"os/exec"
 	"regexp"
@@ -182,7 +181,7 @@ func TestCompressWithGzip(t *testing.T) {
 	assert.NoError(t, err)
 	defer gzipReader.Close()
 
-	output, err := ioutil.ReadAll(gzipReader)
+	output, err := io.ReadAll(gzipReader)
 	assert.NoError(t, err)
 
 	assert.Equal(t, testData, string(output))
@@ -203,7 +202,7 @@ func TestCompressWithGzipEarlyClose(t *testing.T) {
 	rc, err := CompressWithGzip(mr)
 	assert.NoError(t, err)
 
-	n, err := io.CopyN(ioutil.Discard, rc, 10000)
+	n, err := io.CopyN(io.Discard, rc, 10000)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(10000), n)
 
@@ -211,7 +210,7 @@ func TestCompressWithGzipEarlyClose(t *testing.T) {
 	err = rc.Close()
 	assert.NoError(t, err)
 
-	n, err = io.CopyN(ioutil.Discard, rc, 10000)
+	n, err = io.CopyN(io.Discard, rc, 10000)
 	assert.Error(t, io.EOF, err)
 	assert.Equal(t, int64(0), n)
 

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"sync"
 	"sync/atomic"
@@ -187,5 +186,5 @@ func isQuitting(ctx context.Context) bool {
 }
 
 func defaultReadPipe(r io.Reader) {
-	io.Copy(ioutil.Discard, r)
+	_, _ = io.Copy(io.Discard, r)
 }

--- a/internal/rotate/file_writer_test.go
+++ b/internal/rotate/file_writer_test.go
@@ -1,7 +1,6 @@
 package rotate
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestFileWriter_NoRotation(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "RotationNo")
+	tempDir, err := os.MkdirTemp("", "RotationNo")
 	require.NoError(t, err)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test"), 0, 0, 0)
 	require.NoError(t, err)
@@ -22,12 +21,12 @@ func TestFileWriter_NoRotation(t *testing.T) {
 	require.NoError(t, err)
 	_, err = writer.Write([]byte("Hello World 2"))
 	require.NoError(t, err)
-	files, _ := ioutil.ReadDir(tempDir)
+	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 1, len(files))
 }
 
 func TestFileWriter_TimeRotation(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "RotationTime")
+	tempDir, err := os.MkdirTemp("", "RotationTime")
 	require.NoError(t, err)
 	interval, _ := time.ParseDuration("1s")
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test"), interval, 0, -1)
@@ -39,28 +38,28 @@ func TestFileWriter_TimeRotation(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	_, err = writer.Write([]byte("Hello World 2"))
 	require.NoError(t, err)
-	files, _ := ioutil.ReadDir(tempDir)
+	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 2, len(files))
 }
 
 func TestFileWriter_ReopenTimeRotation(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "RotationTime")
+	tempDir, err := os.MkdirTemp("", "RotationTime")
 	require.NoError(t, err)
 	interval, _ := time.ParseDuration("1s")
 	filePath := filepath.Join(tempDir, "test.log")
-	err = ioutil.WriteFile(filePath, []byte("Hello World"), 0644)
+	err = os.WriteFile(filePath, []byte("Hello World"), 0644)
 	time.Sleep(1 * time.Second)
 	assert.NoError(t, err)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), interval, 0, -1)
 	require.NoError(t, err)
 	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
 
-	files, _ := ioutil.ReadDir(tempDir)
+	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 2, len(files))
 }
 
 func TestFileWriter_SizeRotation(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "RotationSize")
+	tempDir, err := os.MkdirTemp("", "RotationSize")
 	require.NoError(t, err)
 	maxSize := int64(9)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, -1)
@@ -71,16 +70,16 @@ func TestFileWriter_SizeRotation(t *testing.T) {
 	require.NoError(t, err)
 	_, err = writer.Write([]byte("World 2"))
 	require.NoError(t, err)
-	files, _ := ioutil.ReadDir(tempDir)
+	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 2, len(files))
 }
 
 func TestFileWriter_ReopenSizeRotation(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "RotationSize")
+	tempDir, err := os.MkdirTemp("", "RotationSize")
 	require.NoError(t, err)
 	maxSize := int64(12)
 	filePath := filepath.Join(tempDir, "test.log")
-	err = ioutil.WriteFile(filePath, []byte("Hello World"), 0644)
+	err = os.WriteFile(filePath, []byte("Hello World"), 0644)
 	assert.NoError(t, err)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, -1)
 	require.NoError(t, err)
@@ -88,12 +87,12 @@ func TestFileWriter_ReopenSizeRotation(t *testing.T) {
 
 	_, err = writer.Write([]byte("Hello World Again"))
 	require.NoError(t, err)
-	files, _ := ioutil.ReadDir(tempDir)
+	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 2, len(files))
 }
 
 func TestFileWriter_DeleteArchives(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "RotationDeleteArchives")
+	tempDir, err := os.MkdirTemp("", "RotationDeleteArchives")
 	require.NoError(t, err)
 	maxSize := int64(5)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, 2)
@@ -112,14 +111,14 @@ func TestFileWriter_DeleteArchives(t *testing.T) {
 	_, err = writer.Write([]byte("Third file"))
 	require.NoError(t, err)
 
-	files, _ := ioutil.ReadDir(tempDir)
+	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 3, len(files))
 
 	for _, tempFile := range files {
 		var bytes []byte
 		var err error
 		path := filepath.Join(tempDir, tempFile.Name())
-		if bytes, err = ioutil.ReadFile(path); err != nil {
+		if bytes, err = os.ReadFile(path); err != nil {
 			t.Error(err.Error())
 			return
 		}
@@ -133,7 +132,7 @@ func TestFileWriter_DeleteArchives(t *testing.T) {
 }
 
 func TestFileWriter_CloseRotates(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "RotationClose")
+	tempDir, err := os.MkdirTemp("", "RotationClose")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 	maxSize := int64(9)
@@ -142,7 +141,7 @@ func TestFileWriter_CloseRotates(t *testing.T) {
 
 	writer.Close()
 
-	files, _ := ioutil.ReadDir(tempDir)
+	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 1, len(files))
 	assert.Regexp(t, "^test\\.[^\\.]+\\.log$", files[0].Name())
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -3,7 +3,6 @@ package logger
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestWriteLogToFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 
@@ -24,13 +23,13 @@ func TestWriteLogToFile(t *testing.T) {
 	log.Printf("I! TEST")
 	log.Printf("D! TEST") // <- should be ignored
 
-	f, err := ioutil.ReadFile(tmpfile.Name())
+	f, err := os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z I! TEST\n"))
 }
 
 func TestDebugWriteLogToFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 	config := createBasicLogConfig(tmpfile.Name())
@@ -38,13 +37,13 @@ func TestDebugWriteLogToFile(t *testing.T) {
 	SetupLogging(config)
 	log.Printf("D! TEST")
 
-	f, err := ioutil.ReadFile(tmpfile.Name())
+	f, err := os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z D! TEST\n"))
 }
 
 func TestErrorWriteLogToFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 	config := createBasicLogConfig(tmpfile.Name())
@@ -53,13 +52,13 @@ func TestErrorWriteLogToFile(t *testing.T) {
 	log.Printf("E! TEST")
 	log.Printf("I! TEST") // <- should be ignored
 
-	f, err := ioutil.ReadFile(tmpfile.Name())
+	f, err := os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z E! TEST\n"))
 }
 
 func TestAddDefaultLogLevel(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 	config := createBasicLogConfig(tmpfile.Name())
@@ -67,13 +66,13 @@ func TestAddDefaultLogLevel(t *testing.T) {
 	SetupLogging(config)
 	log.Printf("TEST")
 
-	f, err := ioutil.ReadFile(tmpfile.Name())
+	f, err := os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z I! TEST\n"))
 }
 
 func TestWriteToTruncatedFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 	config := createBasicLogConfig(tmpfile.Name())
@@ -81,7 +80,7 @@ func TestWriteToTruncatedFile(t *testing.T) {
 	SetupLogging(config)
 	log.Printf("TEST")
 
-	f, err := ioutil.ReadFile(tmpfile.Name())
+	f, err := os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z I! TEST\n"))
 
@@ -91,13 +90,13 @@ func TestWriteToTruncatedFile(t *testing.T) {
 
 	log.Printf("SHOULD BE FIRST")
 
-	f, err = ioutil.ReadFile(tmpfile.Name())
+	f, err = os.ReadFile(tmpfile.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, f[19:], []byte("Z I! SHOULD BE FIRST\n"))
 }
 
 func TestWriteToFileInRotation(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "LogRotation")
+	tempDir, err := os.MkdirTemp("", "LogRotation")
 	require.NoError(t, err)
 	cfg := createBasicLogConfig(filepath.Join(tempDir, "test.log"))
 	cfg.LogTarget = LogTargetFile
@@ -110,7 +109,7 @@ func TestWriteToFileInRotation(t *testing.T) {
 
 	log.Printf("I! TEST 1") // Writes 31 bytes, will rotate
 	log.Printf("I! TEST")   // Writes 29 byes, no rotation expected
-	files, _ := ioutil.ReadDir(tempDir)
+	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 2, len(files))
 }
 

--- a/plugins/common/cookie/cookie.go
+++ b/plugins/common/cookie/cookie.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"strings"
@@ -78,7 +77,7 @@ func (c *CookieAuthConfig) authRenewal(ctx context.Context, ticker *clockutil.Ti
 func (c *CookieAuthConfig) auth() error {
 	var body io.ReadCloser
 	if c.Body != "" {
-		body = ioutil.NopCloser(strings.NewReader(c.Body))
+		body = io.NopCloser(strings.NewReader(c.Body))
 		defer body.Close()
 	}
 
@@ -97,7 +96,7 @@ func (c *CookieAuthConfig) auth() error {
 	}
 	defer resp.Body.Close()
 
-	if _, err = io.Copy(ioutil.Discard, resp.Body); err != nil {
+	if _, err = io.Copy(io.Discard, resp.Body); err != nil {
 		return err
 	}
 

--- a/plugins/common/cookie/cookie_test.go
+++ b/plugins/common/cookie/cookie_test.go
@@ -3,7 +3,7 @@ package cookie
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -50,7 +50,7 @@ func newFakeServer(t *testing.T) fakeServer {
 			case authEndpointNoCreds:
 				authed()
 			case authEndpointWithBody:
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				if !cmp.Equal([]byte(reqBody), body) {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/plugins/common/encoding/decoder_test.go
+++ b/plugins/common/encoding/decoder_test.go
@@ -2,7 +2,7 @@ package encoding
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -66,7 +66,7 @@ func TestDecoder(t *testing.T) {
 			require.NoError(t, err)
 			buf := bytes.NewBuffer(tt.input)
 			r := decoder.Reader(buf)
-			actual, err := ioutil.ReadAll(r)
+			actual, err := io.ReadAll(r)
 			if tt.expectedErr {
 				require.Error(t, err)
 				return

--- a/plugins/common/logrus/hook.go
+++ b/plugins/common/logrus/hook.go
@@ -1,7 +1,7 @@
 package logrus
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"strings"
 	"sync"
@@ -19,7 +19,7 @@ type LogHook struct {
 // that directly log to the logrus system without providing an override method.
 func InstallHook() {
 	once.Do(func() {
-		logrus.SetOutput(ioutil.Discard)
+		logrus.SetOutput(io.Discard)
 		logrus.AddHook(&LogHook{})
 	})
 }

--- a/plugins/common/shim/config.go
+++ b/plugins/common/shim/config.go
@@ -3,7 +3,6 @@ package shim
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -53,7 +52,7 @@ func LoadConfig(filePath *string) (loaded loadedConfig, err error) {
 	var data string
 	conf := config{}
 	if filePath != nil && *filePath != "" {
-		b, err := ioutil.ReadFile(*filePath)
+		b, err := os.ReadFile(*filePath)
 		if err != nil {
 			return loadedConfig{}, err
 		}

--- a/plugins/common/shim/input_test.go
+++ b/plugins/common/shim/input_test.go
@@ -3,7 +3,6 @@ package shim
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -45,7 +44,9 @@ func TestInputShimStdinSignalingWorks(t *testing.T) {
 	require.Equal(t, "measurement,tag=tag field=1i 1234000005678\n", out)
 
 	stdinWriter.Close()
-	go ioutil.ReadAll(r)
+	go func() {
+		_, _ = io.ReadAll(r)
+	}()
 	// check that it exits cleanly
 	<-exited
 }

--- a/plugins/common/shim/processor_test.go
+++ b/plugins/common/shim/processor_test.go
@@ -3,7 +3,6 @@ package shim
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"sync"
 	"testing"
@@ -84,7 +83,9 @@ func testSendAndRecieve(t *testing.T, fieldKey string, fieldValue string) {
 	val2, ok := mOut.Fields()[fieldKey]
 	require.True(t, ok)
 	require.Equal(t, fieldValue, val2)
-	go ioutil.ReadAll(r)
+	go func() {
+		_, _ = io.ReadAll(r)
+	}()
 	wg.Wait()
 }
 

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -147,7 +147,7 @@ func (c *ServerConfig) TLSConfig() (*tls.Config, error) {
 func makeCertPool(certFiles []string) (*x509.CertPool, error) {
 	pool := x509.NewCertPool()
 	for _, certFile := range certFiles {
-		pem, err := ioutil.ReadFile(certFile)
+		pem, err := os.ReadFile(certFile)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"could not read certificate %q: %v", certFile, err)

--- a/plugins/inputs/activemq/activemq.go
+++ b/plugins/inputs/activemq/activemq.go
@@ -3,7 +3,7 @@ package activemq
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -184,7 +184,7 @@ func (a *ActiveMQ) GetMetrics(u string) ([]byte, error) {
 		return nil, fmt.Errorf("GET %s returned status %q", u, resp.Status)
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (a *ActiveMQ) GatherQueuesMetrics(acc telegraf.Accumulator, queues Queues) {

--- a/plugins/inputs/aliyuncms/aliyuncms_test.go
+++ b/plugins/inputs/aliyuncms/aliyuncms_test.go
@@ -2,7 +2,7 @@ package aliyuncms
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -132,7 +132,7 @@ func TestPluginInitialize(t *testing.T) {
 
 	httpResp := &http.Response{
 		StatusCode: 200,
-		Body: ioutil.NopCloser(bytes.NewBufferString(
+		Body: io.NopCloser(bytes.NewBufferString(
 			`{
 						"LoadBalancers":
 						 {
@@ -359,7 +359,7 @@ func TestGetDiscoveryDataAcrossRegions(t *testing.T) {
 			region:  "cn-hongkong",
 			httpResp: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`{}`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
 			},
 			totalCount:          0,
 			pageSize:            0,
@@ -372,7 +372,7 @@ func TestGetDiscoveryDataAcrossRegions(t *testing.T) {
 			region:  "cn-hongkong",
 			httpResp: &http.Response{
 				StatusCode: 200,
-				Body: ioutil.NopCloser(bytes.NewBufferString(
+				Body: io.NopCloser(bytes.NewBufferString(
 					`{
 						"LoadBalancers":
 						 {

--- a/plugins/inputs/amd_rocm_smi/amd_rocm_smi_test.go
+++ b/plugins/inputs/amd_rocm_smi/amd_rocm_smi_test.go
@@ -1,7 +1,7 @@
 package amd_rocm_smi
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -78,7 +78,7 @@ func TestGatherValidJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var acc testutil.Accumulator
-			octets, err := ioutil.ReadFile(filepath.Join("testdata", tt.filename))
+			octets, err := os.ReadFile(filepath.Join("testdata", tt.filename))
 			require.NoError(t, err)
 
 			err = gatherROCmSMI(octets, &acc)

--- a/plugins/inputs/bcache/bcache.go
+++ b/plugins/inputs/bcache/bcache.go
@@ -8,7 +8,6 @@ package bcache
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -85,7 +84,7 @@ func (b *Bcache) gatherBcache(bdev string, acc telegraf.Accumulator) error {
 	if len(metrics) == 0 {
 		return errors.New("can't read any stats file")
 	}
-	file, err := ioutil.ReadFile(bdev + "/dirty_data")
+	file, err := os.ReadFile(bdev + "/dirty_data")
 	if err != nil {
 		return err
 	}
@@ -97,7 +96,7 @@ func (b *Bcache) gatherBcache(bdev string, acc telegraf.Accumulator) error {
 
 	for _, path := range metrics {
 		key := filepath.Base(path)
-		file, err := ioutil.ReadFile(path)
+		file, err := os.ReadFile(path)
 		rawValue := strings.TrimSpace(string(file))
 		if err != nil {
 			return err

--- a/plugins/inputs/bcache/bcache_test.go
+++ b/plugins/inputs/bcache/bcache_test.go
@@ -4,7 +4,6 @@
 package bcache
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -50,39 +49,39 @@ func TestBcacheGeneratesMetrics(t *testing.T) {
 	err = os.MkdirAll(testBcacheUUIDPath+"/bdev0/stats_total", 0755)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testBcacheUUIDPath+"/bdev0/dirty_data",
+	err = os.WriteFile(testBcacheUUIDPath+"/bdev0/dirty_data",
 		[]byte(dirtyData), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/bypassed",
+	err = os.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/bypassed",
 		[]byte(bypassed), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_bypass_hits",
+	err = os.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_bypass_hits",
 		[]byte(cacheBypassHits), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_bypass_misses",
+	err = os.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_bypass_misses",
 		[]byte(cacheBypassMisses), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_hit_ratio",
+	err = os.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_hit_ratio",
 		[]byte(cacheHitRatio), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_hits",
+	err = os.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_hits",
 		[]byte(cacheHits), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_miss_collisions",
+	err = os.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_miss_collisions",
 		[]byte(cacheMissCollisions), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_misses",
+	err = os.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_misses",
 		[]byte(cacheMisses), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_readaheads",
+	err = os.WriteFile(testBcacheUUIDPath+"/bdev0/stats_total/cache_readaheads",
 		[]byte(cacheReadaheads), 0644)
 	require.NoError(t, err)
 

--- a/plugins/inputs/beat/beat_test.go
+++ b/plugins/inputs/beat/beat_test.go
@@ -2,11 +2,11 @@ package beat
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
@@ -31,7 +31,7 @@ func Test_BeatStats(t *testing.T) {
 			require.FailNow(t, "cannot handle request")
 		}
 
-		data, err := ioutil.ReadFile(jsonFilePath)
+		data, err := os.ReadFile(jsonFilePath)
 		require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
 		_, err = w.Write(data)
 		require.NoError(t, err, "could not write data")
@@ -175,7 +175,7 @@ func Test_BeatRequest(t *testing.T) {
 			require.FailNow(t, "cannot handle request")
 		}
 
-		data, err := ioutil.ReadFile(jsonFilePath)
+		data, err := os.ReadFile(jsonFilePath)
 		require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
 		require.Equal(t, request.Host, "beat.test.local")
 		require.Equal(t, request.Method, "POST")

--- a/plugins/inputs/bond/bond.go
+++ b/plugins/inputs/bond/bond.go
@@ -3,7 +3,6 @@ package bond
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -53,7 +52,7 @@ func (bond *Bond) Gather(acc telegraf.Accumulator) error {
 	}
 	for _, bondName := range bondNames {
 		bondAbsPath := bond.HostProc + "/net/bonding/" + bondName
-		file, err := ioutil.ReadFile(bondAbsPath)
+		file, err := os.ReadFile(bondAbsPath)
 		if err != nil {
 			acc.AddError(fmt.Errorf("error inspecting '%s' interface: %v", bondAbsPath, err))
 			continue

--- a/plugins/inputs/burrow/burrow_test.go
+++ b/plugins/inputs/burrow/burrow_test.go
@@ -2,7 +2,6 @@ package burrow
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -28,7 +27,7 @@ func getResponseJSON(requestURI string) ([]byte, int) {
 	}
 
 	// respond with file
-	b, _ := ioutil.ReadFile(jsonFile)
+	b, _ := os.ReadFile(jsonFile)
 	return b, code
 }
 

--- a/plugins/inputs/cassandra/cassandra.go
+++ b/plugins/inputs/cassandra/cassandra.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -217,7 +217,7 @@ func (c *Cassandra) getAttr(requestURL *url.URL) (map[string]interface{}, error)
 	}
 
 	// read body
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/cassandra/cassandra_test.go
+++ b/plugins/inputs/cassandra/cassandra_test.go
@@ -2,7 +2,7 @@ package cassandra
 
 import (
 	_ "fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -109,7 +109,7 @@ type jolokiaClientStub struct {
 func (c jolokiaClientStub) MakeRequest(_ *http.Request) (*http.Response, error) {
 	resp := http.Response{}
 	resp.StatusCode = c.statusCode
-	resp.Body = ioutil.NopCloser(strings.NewReader(c.responseBody))
+	resp.Body = io.NopCloser(strings.NewReader(c.responseBody))
 	return &resp, nil
 }
 

--- a/plugins/inputs/ceph/ceph.go
+++ b/plugins/inputs/ceph/ceph.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -206,7 +206,7 @@ var perfDump = func(binary string, socket *socket) (string, error) {
 }
 
 var findSockets = func(c *Ceph) ([]*socket, error) {
-	listing, err := ioutil.ReadDir(c.SocketDir)
+	listing, err := os.ReadDir(c.SocketDir)
 	if err != nil {
 		return []*socket{}, fmt.Errorf("Failed to read socket directory '%s': %v", c.SocketDir, err)
 	}

--- a/plugins/inputs/ceph/ceph_test.go
+++ b/plugins/inputs/ceph/ceph_test.go
@@ -2,7 +2,6 @@ package ceph
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -113,7 +112,7 @@ func TestGather(t *testing.T) {
 }
 
 func TestFindSockets(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "socktest")
+	tmpdir, err := os.MkdirTemp("", "socktest")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(tmpdir)
@@ -189,7 +188,7 @@ func createTestFiles(dir string, st *SockTest) error {
 	writeFile := func(prefix string, i int) error {
 		f := sockFile(prefix, i)
 		fpath := filepath.Join(dir, f)
-		return ioutil.WriteFile(fpath, []byte(""), 0777)
+		return os.WriteFile(fpath, []byte(""), 0777)
 	}
 	return tstFileApply(st, writeFile)
 }

--- a/plugins/inputs/cgroup/cgroup_linux.go
+++ b/plugins/inputs/cgroup/cgroup_linux.go
@@ -5,7 +5,6 @@ package cgroup
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -46,7 +45,7 @@ func (g *CGroup) gatherDir(acc telegraf.Accumulator, dir string) error {
 			return file.err
 		}
 
-		raw, err := ioutil.ReadFile(file.path)
+		raw, err := os.ReadFile(file.path)
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/clickhouse/clickhouse.go
+++ b/plugins/inputs/clickhouse/clickhouse.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -590,7 +589,7 @@ func (ch *ClickHouse) execQuery(address *url.URL, query string, i interface{}) e
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
-		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
 		return &clickhouseError{
 			StatusCode: resp.StatusCode,
 			body:       body,
@@ -606,7 +605,7 @@ func (ch *ClickHouse) execQuery(address *url.URL, query string, i interface{}) e
 		return err
 	}
 
-	if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 		return err
 	}
 	return nil

--- a/plugins/inputs/cloud_pubsub_push/pubsub_push.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push.go
@@ -5,7 +5,7 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -222,7 +222,7 @@ func (p *PubSubPush) serveWrite(res http.ResponseWriter, req *http.Request) {
 	}
 
 	body := http.MaxBytesReader(res, req.Body, int64(p.MaxBodySize))
-	bytes, err := ioutil.ReadAll(body)
+	bytes, err := io.ReadAll(body)
 	if err != nil {
 		res.WriteHeader(http.StatusRequestEntityTooLarge)
 		return

--- a/plugins/inputs/conntrack/conntrack.go
+++ b/plugins/inputs/conntrack/conntrack.go
@@ -5,14 +5,14 @@ package conntrack
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
 
+	"path/filepath"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"path/filepath"
 )
 
 type Conntrack struct {
@@ -91,7 +91,7 @@ func (c *Conntrack) Gather(acc telegraf.Accumulator) error {
 				continue
 			}
 
-			contents, err := ioutil.ReadFile(fName)
+			contents, err := os.ReadFile(fName)
 			if err != nil {
 				acc.AddError(fmt.Errorf("E! failed to read file '%s': %v", fName, err))
 				continue

--- a/plugins/inputs/conntrack/conntrack_test.go
+++ b/plugins/inputs/conntrack/conntrack_test.go
@@ -4,7 +4,6 @@
 package conntrack
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -35,11 +34,11 @@ func TestNoFilesFound(t *testing.T) {
 
 func TestDefaultsUsed(t *testing.T) {
 	defer restoreDflts(dfltFiles, dfltDirs)
-	tmpdir, err := ioutil.TempDir("", "tmp1")
+	tmpdir, err := os.MkdirTemp("", "tmp1")
 	require.NoError(t, err)
 	defer os.Remove(tmpdir)
 
-	tmpFile, err := ioutil.TempFile(tmpdir, "ip_conntrack_count")
+	tmpFile, err := os.CreateTemp(tmpdir, "ip_conntrack_count")
 	require.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
 
@@ -48,7 +47,7 @@ func TestDefaultsUsed(t *testing.T) {
 	dfltFiles = []string{fname}
 
 	count := 1234321
-	require.NoError(t, ioutil.WriteFile(tmpFile.Name(), []byte(strconv.Itoa(count)), 0660))
+	require.NoError(t, os.WriteFile(tmpFile.Name(), []byte(strconv.Itoa(count)), 0660))
 	c := &Conntrack{}
 	acc := &testutil.Accumulator{}
 
@@ -59,13 +58,13 @@ func TestDefaultsUsed(t *testing.T) {
 
 func TestConfigsUsed(t *testing.T) {
 	defer restoreDflts(dfltFiles, dfltDirs)
-	tmpdir, err := ioutil.TempDir("", "tmp1")
+	tmpdir, err := os.MkdirTemp("", "tmp1")
 	require.NoError(t, err)
 	defer os.Remove(tmpdir)
 
-	cntFile, err := ioutil.TempFile(tmpdir, "nf_conntrack_count")
+	cntFile, err := os.CreateTemp(tmpdir, "nf_conntrack_count")
 	require.NoError(t, err)
-	maxFile, err := ioutil.TempFile(tmpdir, "nf_conntrack_max")
+	maxFile, err := os.CreateTemp(tmpdir, "nf_conntrack_max")
 	require.NoError(t, err)
 	defer os.Remove(cntFile.Name())
 	defer os.Remove(maxFile.Name())
@@ -77,8 +76,8 @@ func TestConfigsUsed(t *testing.T) {
 
 	count := 1234321
 	max := 9999999
-	require.NoError(t, ioutil.WriteFile(cntFile.Name(), []byte(strconv.Itoa(count)), 0660))
-	require.NoError(t, ioutil.WriteFile(maxFile.Name(), []byte(strconv.Itoa(max)), 0660))
+	require.NoError(t, os.WriteFile(cntFile.Name(), []byte(strconv.Itoa(count)), 0660))
+	require.NoError(t, os.WriteFile(maxFile.Name(), []byte(strconv.Itoa(max)), 0660))
 	c := &Conntrack{}
 	acc := &testutil.Accumulator{}
 

--- a/plugins/inputs/dcos/creds.go
+++ b/plugins/inputs/dcos/creds.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -48,7 +48,7 @@ func (c *ServiceAccount) IsExpired() bool {
 }
 
 func (c *TokenCreds) Token(_ context.Context, _ Client) (string, error) {
-	octets, err := ioutil.ReadFile(c.Path)
+	octets, err := os.ReadFile(c.Path)
 	if err != nil {
 		return "", fmt.Errorf("error reading token file %q: %s", c.Path, err)
 	}

--- a/plugins/inputs/dcos/dcos.go
+++ b/plugins/inputs/dcos/dcos.go
@@ -2,8 +2,8 @@ package dcos
 
 import (
 	"context"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -370,7 +370,7 @@ func (d *DCOS) createClient() (Client, error) {
 
 func (d *DCOS) createCredentials() (Credentials, error) {
 	if d.ServiceAccountID != "" && d.ServiceAccountPrivateKey != "" {
-		bs, err := ioutil.ReadFile(d.ServiceAccountPrivateKey)
+		bs, err := os.ReadFile(d.ServiceAccountPrivateKey)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -108,7 +107,7 @@ func (monitor *DirectoryMonitor) Description() string {
 
 func (monitor *DirectoryMonitor) Gather(_ telegraf.Accumulator) error {
 	// Get all files sitting in the directory.
-	files, err := ioutil.ReadDir(monitor.Directory)
+	files, err := os.ReadDir(monitor.Directory)
 	if err != nil {
 		return fmt.Errorf("unable to monitor the targeted directory: %w", err)
 	}
@@ -183,7 +182,7 @@ func (monitor *DirectoryMonitor) Monitor() {
 	}
 }
 
-func (monitor *DirectoryMonitor) processFile(file os.FileInfo) {
+func (monitor *DirectoryMonitor) processFile(file os.DirEntry) {
 	if file.IsDir() {
 		return
 	}

--- a/plugins/inputs/directory_monitor/directory_monitor_test.go
+++ b/plugins/inputs/directory_monitor/directory_monitor_test.go
@@ -3,7 +3,6 @@ package directory_monitor
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,9 +19,9 @@ func TestCSVGZImport(t *testing.T) {
 	testCsvGzFile := "test.csv.gz"
 
 	// Establish process directory and finished directory.
-	finishedDirectory, err := ioutil.TempDir("", "finished")
+	finishedDirectory, err := os.MkdirTemp("", "finished")
 	require.NoError(t, err)
-	processDirectory, err := ioutil.TempDir("", "test")
+	processDirectory, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(processDirectory)
 	defer os.RemoveAll(finishedDirectory)
@@ -62,7 +61,7 @@ func TestCSVGZImport(t *testing.T) {
 	require.NoError(t, err)
 	err = w.Close()
 	require.NoError(t, err)
-	err = ioutil.WriteFile(filepath.Join(processDirectory, testCsvGzFile), b.Bytes(), 0666)
+	err = os.WriteFile(filepath.Join(processDirectory, testCsvGzFile), b.Bytes(), 0666)
 	require.NoError(t, err)
 
 	// Start plugin before adding file.
@@ -89,9 +88,9 @@ func TestMultipleJSONFileImports(t *testing.T) {
 	testJSONFile := "test.json"
 
 	// Establish process directory and finished directory.
-	finishedDirectory, err := ioutil.TempDir("", "finished")
+	finishedDirectory, err := os.MkdirTemp("", "finished")
 	require.NoError(t, err)
-	processDirectory, err := ioutil.TempDir("", "test")
+	processDirectory, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(processDirectory)
 	defer os.RemoveAll(finishedDirectory)

--- a/plugins/inputs/diskio/diskio_linux_test.go
+++ b/plugins/inputs/diskio/diskio_linux_test.go
@@ -4,7 +4,6 @@
 package diskio
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -20,7 +19,7 @@ S:foo/bar/devlink1
 
 // setupNullDisk sets up fake udev info as if /dev/null were a disk.
 func setupNullDisk(t *testing.T, s *DiskIO, devName string) func() {
-	td, err := ioutil.TempFile("", ".telegraf.DiskInfoTest")
+	td, err := os.CreateTemp("", ".telegraf.DiskInfoTest")
 	require.NoError(t, err)
 
 	if s.infoCache == nil {

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -3,7 +3,7 @@ package docker
 import (
 	"context"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"sort"
 	"strings"
@@ -1060,7 +1060,7 @@ func TestContainerName(t *testing.T) {
 				}
 				client.ContainerStatsF = func(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error) {
 					return types.ContainerStats{
-						Body: ioutil.NopCloser(strings.NewReader(`{"name": "logspout"}`)),
+						Body: io.NopCloser(strings.NewReader(`{"name": "logspout"}`)),
 					}, nil
 				}
 				return &client, nil
@@ -1080,7 +1080,7 @@ func TestContainerName(t *testing.T) {
 				}
 				client.ContainerStatsF = func(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error) {
 					return types.ContainerStats{
-						Body: ioutil.NopCloser(strings.NewReader(`{}`)),
+						Body: io.NopCloser(strings.NewReader(`{}`)),
 					}, nil
 				}
 				return &client, nil

--- a/plugins/inputs/docker/docker_testdata.go
+++ b/plugins/inputs/docker/docker_testdata.go
@@ -2,7 +2,7 @@ package docker
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -344,7 +344,7 @@ func containerStats(s string) types.ContainerStats {
     },
     "read": "2016-02-24T11:42:27.472459608-05:00"
 }`, name)
-	stat.Body = ioutil.NopCloser(strings.NewReader(jsonStat))
+	stat.Body = io.NopCloser(strings.NewReader(jsonStat))
 	return stat
 }
 
@@ -488,7 +488,7 @@ func containerStatsWindows() types.ContainerStats {
 	},
 	"name":"/gt_test_iis",
 }`
-	stat.Body = ioutil.NopCloser(strings.NewReader(jsonStat))
+	stat.Body = io.NopCloser(strings.NewReader(jsonStat))
 	return stat
 }
 

--- a/plugins/inputs/ecs/client.go
+++ b/plugins/inputs/ecs/client.go
@@ -3,7 +3,6 @@ package ecs
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -113,7 +112,7 @@ func (c *EcsClient) Task() (*Task, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		// ignore the err here; LimitReader returns io.EOF and we're not interested in read errors.
-		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
 		return nil, fmt.Errorf("%s returned HTTP status %s: %q", c.taskURL, resp.Status, body)
 	}
 
@@ -137,7 +136,7 @@ func (c *EcsClient) ContainerStats() (map[string]types.StatsJSON, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		// ignore the err here; LimitReader returns io.EOF and we're not interested in read errors.
-		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
 		return nil, fmt.Errorf("%s returned HTTP status %s: %q", c.statsURL, resp.Status, body)
 	}
 

--- a/plugins/inputs/ecs/client_test.go
+++ b/plugins/inputs/ecs/client_test.go
@@ -3,7 +3,7 @@ package ecs
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -108,7 +108,7 @@ func TestEcsClient_Task(t *testing.T) {
 				do: func(req *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(rc),
+						Body:       io.NopCloser(rc),
 					}, nil
 				},
 			},
@@ -129,7 +129,7 @@ func TestEcsClient_Task(t *testing.T) {
 				do: func(req *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusInternalServerError,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
+						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
 					}, nil
 				},
 			},
@@ -141,7 +141,7 @@ func TestEcsClient_Task(t *testing.T) {
 				do: func(req *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
+						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
 					}, nil
 				},
 			},
@@ -179,7 +179,7 @@ func TestEcsClient_ContainerStats(t *testing.T) {
 				do: func(req *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(rc),
+						Body:       io.NopCloser(rc),
 					}, nil
 				},
 			},
@@ -201,7 +201,7 @@ func TestEcsClient_ContainerStats(t *testing.T) {
 				do: func(req *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
+						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
 					}, nil
 				},
 			},
@@ -214,7 +214,7 @@ func TestEcsClient_ContainerStats(t *testing.T) {
 				do: func(req *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusInternalServerError,
-						Body:       ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
+						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
 					}, nil
 				},
 			},

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -3,7 +3,7 @@ package elasticsearch
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"sort"
@@ -702,7 +702,7 @@ func (e *Elasticsearch) getCatMaster(url string) (string, error) {
 		// future calls.
 		return "", fmt.Errorf("elasticsearch: Unable to retrieve master node information. API responded with status-code %d, expected %d", r.StatusCode, http.StatusOK)
 	}
-	response, err := ioutil.ReadAll(r.Body)
+	response, err := io.ReadAll(r.Body)
 
 	if err != nil {
 		return "", err

--- a/plugins/inputs/elasticsearch/elasticsearch_test.go
+++ b/plugins/inputs/elasticsearch/elasticsearch_test.go
@@ -1,7 +1,7 @@
 package elasticsearch
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -44,7 +44,7 @@ func (t *transportMock) RoundTrip(r *http.Request) (*http.Response, error) {
 		StatusCode: t.statusCode,
 	}
 	res.Header.Set("Content-Type", "application/json")
-	res.Body = ioutil.NopCloser(strings.NewReader(t.body))
+	res.Body = io.NopCloser(strings.NewReader(t.body))
 	return res, nil
 }
 

--- a/plugins/inputs/execd/shim/goshim.go
+++ b/plugins/inputs/execd/shim/goshim.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"strings"
@@ -274,7 +273,7 @@ func LoadConfig(filePath *string) ([]telegraf.Input, error) {
 		return DefaultImportedPlugins()
 	}
 
-	b, err := ioutil.ReadFile(*filePath)
+	b, err := os.ReadFile(*filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/file/file.go
+++ b/plugins/inputs/file/file.go
@@ -2,7 +2,7 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -115,7 +115,7 @@ func (f *File) readMetric(filename string) ([]telegraf.Metric, error) {
 	defer file.Close()
 
 	r, _ := utfbom.Skip(f.decoder.Reader(file))
-	fileContents, err := ioutil.ReadAll(r)
+	fileContents, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("E! Error file: %v could not be read, %s", filename, err)
 	}

--- a/plugins/inputs/fluentd/fluentd.go
+++ b/plugins/inputs/fluentd/fluentd.go
@@ -3,7 +3,7 @@ package fluentd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -104,7 +104,7 @@ func (h *Fluentd) Gather(acc telegraf.Accumulator) error {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return fmt.Errorf("unable to read the HTTP body \"%s\": %v", string(body), err)

--- a/plugins/inputs/graylog/graylog.go
+++ b/plugins/inputs/graylog/graylog.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -264,7 +264,7 @@ func (h *GrayLog) sendRequest(serverURL string) (string, float64, error) {
 	defer resp.Body.Close()
 	responseTime := time.Since(start).Seconds()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return string(body), responseTime, err
 	}

--- a/plugins/inputs/graylog/graylog_test.go
+++ b/plugins/inputs/graylog/graylog_test.go
@@ -1,7 +1,7 @@
 package graylog
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -115,7 +115,7 @@ func (c *mockHTTPClient) MakeRequest(req *http.Request) (*http.Response, error) 
 		resp.StatusCode = 405 // Method not allowed
 	}
 
-	resp.Body = ioutil.NopCloser(strings.NewReader(c.responseBody))
+	resp.Body = io.NopCloser(strings.NewReader(c.responseBody))
 	return &resp, nil
 }
 

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 
@@ -180,7 +180,7 @@ func (h *HTTP) gatherURL(
 	}
 
 	if h.BearerToken != "" {
-		token, err := ioutil.ReadFile(h.BearerToken)
+		token, err := os.ReadFile(h.BearerToken)
 		if err != nil {
 			return err
 		}
@@ -225,7 +225,7 @@ func (h *HTTP) gatherURL(
 			h.SuccessStatusCodes)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -254,7 +254,7 @@ func makeRequestBodyReader(contentEncoding, body string) (io.ReadCloser, error) 
 		}
 		return rc, nil
 	}
-	return ioutil.NopCloser(reader), nil
+	return io.NopCloser(reader), nil
 }
 
 func init() {

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -3,7 +3,7 @@ package http_test
 import (
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -183,7 +183,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 				URLs:   []string{url},
 			},
 			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Equal(t, []byte(""), body)
 				w.WriteHeader(http.StatusOK)
@@ -197,7 +197,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 				Body:   "test",
 			},
 			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Equal(t, []byte("test"), body)
 				w.WriteHeader(http.StatusOK)
@@ -211,7 +211,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 				Body:   "test",
 			},
 			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Equal(t, []byte("test"), body)
 				w.WriteHeader(http.StatusOK)
@@ -230,7 +230,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 
 				gr, err := gzip.NewReader(r.Body)
 				require.NoError(t, err)
-				body, err := ioutil.ReadAll(gr)
+				body, err := io.ReadAll(gr)
 				require.NoError(t, err)
 				require.Equal(t, []byte("test"), body)
 				w.WriteHeader(http.StatusOK)

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -4,7 +4,7 @@ import (
 	"compress/gzip"
 	"crypto/subtle"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -292,7 +292,7 @@ func (h *HTTPListenerV2) collectBody(res http.ResponseWriter, req *http.Request)
 		}
 		defer r.Close()
 		maxReader := http.MaxBytesReader(res, r, int64(h.MaxBodySize))
-		bytes, err := ioutil.ReadAll(maxReader)
+		bytes, err := io.ReadAll(maxReader)
 		if err != nil {
 			if err := tooLarge(res); err != nil {
 				h.Log.Debugf("error in too-large: %v", err)
@@ -302,7 +302,7 @@ func (h *HTTPListenerV2) collectBody(res http.ResponseWriter, req *http.Request)
 		return bytes, true
 	case "snappy":
 		defer req.Body.Close()
-		bytes, err := ioutil.ReadAll(req.Body)
+		bytes, err := io.ReadAll(req.Body)
 		if err != nil {
 			h.Log.Debug(err.Error())
 			if err := badRequest(res); err != nil {
@@ -322,7 +322,7 @@ func (h *HTTPListenerV2) collectBody(res http.ResponseWriter, req *http.Request)
 		return bytes, true
 	default:
 		defer req.Body.Close()
-		bytes, err := ioutil.ReadAll(req.Body)
+		bytes, err := io.ReadAll(req.Body)
 		if err != nil {
 			h.Log.Debug(err.Error())
 			if err := badRequest(res); err != nil {

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -361,7 +361,7 @@ func TestWriteHTTPGzippedData(t *testing.T) {
 	require.NoError(t, listener.Start(acc))
 	defer listener.Stop()
 
-	data, err := ioutil.ReadFile("./testdata/testmsgs.gz")
+	data, err := os.ReadFile("./testdata/testmsgs.gz")
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("POST", createURL(listener, "http", "/write", ""), bytes.NewBuffer(data))

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -277,7 +277,7 @@ func (h *HTTPResponse) httpGather(u string) (map[string]interface{}, map[string]
 	}
 
 	if h.BearerToken != "" {
-		token, err := ioutil.ReadFile(h.BearerToken)
+		token, err := os.ReadFile(h.BearerToken)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -339,7 +339,7 @@ func (h *HTTPResponse) httpGather(u string) (map[string]interface{}, map[string]
 	if h.ResponseBodyMaxSize == 0 {
 		h.ResponseBodyMaxSize = config.Size(defaultResponseBodyMaxSize)
 	}
-	bodyBytes, err := ioutil.ReadAll(io.LimitReader(resp.Body, int64(h.ResponseBodyMaxSize)+1))
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, int64(h.ResponseBodyMaxSize)+1))
 	// Check first if the response body size exceeds the limit.
 	if err == nil && int64(len(bodyBytes)) > int64(h.ResponseBodyMaxSize) {
 		h.setBodyReadError("The body of the HTTP Response is too large", bodyBytes, fields, tags)

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -8,7 +8,7 @@ package http_response
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -123,7 +123,7 @@ func setUpTestMux() http.Handler {
 		fmt.Fprintf(w, "used post correctly!")
 	})
 	mux.HandleFunc("/musthaveabody", func(w http.ResponseWriter, req *http.Request) {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		//nolint:errcheck,revive
 		req.Body.Close()
 		if err != nil {

--- a/plugins/inputs/httpjson/httpjson.go
+++ b/plugins/inputs/httpjson/httpjson.go
@@ -3,7 +3,7 @@ package httpjson
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -263,7 +263,7 @@ func (h *HTTPJSON) sendRequest(serverURL string) (string, float64, error) {
 	defer resp.Body.Close()
 	responseTime := time.Since(start).Seconds()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return string(body), responseTime, err
 	}

--- a/plugins/inputs/httpjson/httpjson_test.go
+++ b/plugins/inputs/httpjson/httpjson_test.go
@@ -2,7 +2,7 @@ package httpjson
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -143,7 +143,7 @@ func (c *mockHTTPClient) MakeRequest(req *http.Request) (*http.Response, error) 
 		resp.StatusCode = 405 // Method not allowed
 	}
 
-	resp.Body = ioutil.NopCloser(strings.NewReader(c.responseBody))
+	resp.Body = io.NopCloser(strings.NewReader(c.responseBody))
 	return &resp, nil
 }
 
@@ -377,7 +377,7 @@ func TestHttpJsonPOST(t *testing.T) {
 		"api_key": "mykey",
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, "api_key=mykey", string(body))
 		w.WriteHeader(http.StatusOK)

--- a/plugins/inputs/influxdb_listener/influxdb_listener_test.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -406,7 +406,7 @@ func TestWriteGzippedData(t *testing.T) {
 	require.NoError(t, listener.Start(acc))
 	defer listener.Stop()
 
-	data, err := ioutil.ReadFile("./testdata/testmsgs.gz")
+	data, err := os.ReadFile("./testdata/testmsgs.gz")
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("POST", createURL(listener, "http", "/write", ""), bytes.NewBuffer(data))

--- a/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go
+++ b/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -256,7 +256,7 @@ func (h *InfluxDBV2Listener) handleWrite() http.HandlerFunc {
 		var readErr error
 		var bytes []byte
 		//body = http.MaxBytesReader(res, req.Body, 1000000) //p.MaxBodySize.Size)
-		bytes, readErr = ioutil.ReadAll(body)
+		bytes, readErr = io.ReadAll(body)
 		if readErr != nil {
 			h.Log.Debugf("Error parsing the request body: %v", readErr.Error())
 			if err := badRequest(res, InternalError, readErr.Error()); err != nil {

--- a/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener_test.go
+++ b/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener_test.go
@@ -5,9 +5,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -363,7 +364,7 @@ func TestWriteGzippedData(t *testing.T) {
 	require.NoError(t, listener.Start(acc))
 	defer listener.Stop()
 
-	data, err := ioutil.ReadFile("./testdata/testmsgs.gz")
+	data, err := os.ReadFile("./testdata/testmsgs.gz")
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("POST", createURL(listener, "http", "/api/v2/write", "bucket=mybucket"), bytes.NewBuffer(data))
@@ -485,7 +486,7 @@ func TestReady(t *testing.T) {
 	resp, err := http.Get(createURL(listener, "http", "/api/v2/ready", ""))
 	require.NoError(t, err)
 	require.Equal(t, "application/json", resp.Header["Content-Type"][0])
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Contains(t, string(bodyBytes), "\"status\":\"ready\"")
 	require.NoError(t, resp.Body.Close())

--- a/plugins/inputs/intel_powerstat/file.go
+++ b/plugins/inputs/intel_powerstat/file.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -107,7 +106,7 @@ func (fs *fileServiceImpl) getStringsMatchingPatternOnPath(path string) ([]strin
 
 // readFile reads file on path and return string content.
 func (fs *fileServiceImpl) readFile(path string) ([]byte, error) {
-	out, err := ioutil.ReadFile(path)
+	out, err := os.ReadFile(path)
 	if err != nil {
 		return make([]byte, 0), err
 	}
@@ -116,7 +115,7 @@ func (fs *fileServiceImpl) readFile(path string) ([]byte, error) {
 
 // readFileToFloat64 reads file on path and tries to parse content to float64.
 func (fs *fileServiceImpl) readFileToFloat64(reader io.Reader) (float64, int64, error) {
-	read, err := ioutil.ReadAll(reader)
+	read, err := io.ReadAll(reader)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/plugins/inputs/jolokia/jolokia.go
+++ b/plugins/inputs/jolokia/jolokia.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -153,7 +153,7 @@ func (j *Jolokia) doRequest(req *http.Request) ([]map[string]interface{}, error)
 	}
 
 	// read body
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/jolokia/jolokia_test.go
+++ b/plugins/inputs/jolokia/jolokia_test.go
@@ -2,7 +2,7 @@ package jolokia
 
 import (
 	_ "fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -116,7 +116,7 @@ type jolokiaClientStub struct {
 func (c jolokiaClientStub) MakeRequest(_ *http.Request) (*http.Response, error) {
 	resp := http.Response{}
 	resp.StatusCode = c.statusCode
-	resp.Body = ioutil.NopCloser(strings.NewReader(c.responseBody))
+	resp.Body = io.NopCloser(strings.NewReader(c.responseBody))
 	return &resp, nil
 }
 

--- a/plugins/inputs/jolokia2/client.go
+++ b/plugins/inputs/jolokia2/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -149,7 +149,7 @@ func (c *Client) read(requests []ReadRequest) ([]ReadResponse, error) {
 			c.URL, resp.StatusCode, http.StatusText(resp.StatusCode), http.StatusOK, http.StatusText(http.StatusOK))
 	}
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/jolokia2/client_test.go
+++ b/plugins/inputs/jolokia2/client_test.go
@@ -3,7 +3,7 @@ package jolokia2
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +20,7 @@ func TestJolokia2_ClientAuthRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		username, password, _ = r.BasicAuth()
 
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		require.NoError(t, json.Unmarshal(body, &requests))
 
 		w.WriteHeader(http.StatusOK)
@@ -56,7 +56,7 @@ func TestJolokia2_ClientProxyAuthRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		username, password, _ = r.BasicAuth()
 
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		require.NoError(t, json.Unmarshal(body, &requests))
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintf(w, "[]")

--- a/plugins/inputs/kernel/kernel.go
+++ b/plugins/inputs/kernel/kernel.go
@@ -6,7 +6,6 @@ package kernel
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -41,7 +40,7 @@ func (k *Kernel) Gather(acc telegraf.Accumulator) error {
 		return err
 	}
 
-	entropyData, err := ioutil.ReadFile(k.entropyStatFile)
+	entropyData, err := os.ReadFile(k.entropyStatFile)
 	if err != nil {
 		return err
 	}
@@ -109,7 +108,7 @@ func (k *Kernel) getProcStat() ([]byte, error) {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadFile(k.statFile)
+	data, err := os.ReadFile(k.statFile)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/kernel/kernel_test.go
+++ b/plugins/inputs/kernel/kernel_test.go
@@ -4,7 +4,6 @@
 package kernel
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -169,7 +168,7 @@ const entropyStatFilePartial = `1024`
 const entropyStatFileInvalid = ``
 
 func makeFakeStatFile(t *testing.T, content []byte) string {
-	tmpfile, err := ioutil.TempFile("", "kernel_test")
+	tmpfile, err := os.CreateTemp("", "kernel_test")
 	require.NoError(t, err)
 
 	_, err = tmpfile.Write(content)

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat.go
@@ -6,7 +6,6 @@ package kernel_vmstat
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -61,7 +60,7 @@ func (k *KernelVmstat) getProcVmstat() ([]byte, error) {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadFile(k.statFile)
+	data, err := os.ReadFile(k.statFile)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat_test.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat_test.go
@@ -4,7 +4,6 @@
 package kernel_vmstat
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -300,7 +299,7 @@ thp_collapse_alloc_failed 102214
 thp_split abcd`
 
 func makeFakeVMStatFile(t *testing.T, content []byte) string {
-	tmpfile, err := ioutil.TempFile("", "kernel_vmstat_test")
+	tmpfile, err := os.CreateTemp("", "kernel_vmstat_test")
 	require.NoError(t, err)
 
 	_, err = tmpfile.Write(content)

--- a/plugins/inputs/kibana/kibana.go
+++ b/plugins/inputs/kibana/kibana.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -253,7 +252,7 @@ func (k *Kibana) gatherJSONData(url string, v interface{}) (host string, err err
 
 	if response.StatusCode != http.StatusOK {
 		// ignore the err here; LimitReader returns io.EOF and we're not interested in read errors.
-		body, _ := ioutil.ReadAll(io.LimitReader(response.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 200))
 		return request.Host, fmt.Errorf("%s returned HTTP status %s: %q", url, response.Status, body)
 	}
 

--- a/plugins/inputs/kibana/kibana_test.go
+++ b/plugins/inputs/kibana/kibana_test.go
@@ -1,7 +1,7 @@
 package kibana
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -46,7 +46,7 @@ func (t *transportMock) RoundTrip(r *http.Request) (*http.Response, error) {
 		StatusCode: t.statusCode,
 	}
 	res.Header.Set("Content-Type", "application/json")
-	res.Body = ioutil.NopCloser(strings.NewReader(t.body))
+	res.Body = io.NopCloser(strings.NewReader(t.body))
 	return res, nil
 }
 

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -6,7 +6,7 @@ import (
 	"compress/zlib"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"strings"
 	"sync"
@@ -349,7 +349,7 @@ func processGzip(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	defer zipData.Close()
-	return ioutil.ReadAll(zipData)
+	return io.ReadAll(zipData)
 }
 
 func processZlib(data []byte) ([]byte, error) {
@@ -358,7 +358,7 @@ func processZlib(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	defer zlibData.Close()
-	return ioutil.ReadAll(zlibData)
+	return io.ReadAll(zlibData)
 }
 
 func processNoOp(data []byte) ([]byte, error) {

--- a/plugins/inputs/kube_inventory/kube_state.go
+++ b/plugins/inputs/kube_inventory/kube_state.go
@@ -3,8 +3,8 @@ package kube_inventory
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -101,7 +101,7 @@ func (ki *KubernetesInventory) Init() error {
 	}
 
 	if ki.BearerToken != "" {
-		token, err := ioutil.ReadFile(ki.BearerToken)
+		token, err := os.ReadFile(ki.BearerToken)
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -3,8 +3,8 @@ package kubernetes
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -93,7 +93,7 @@ func (k *Kubernetes) Init() error {
 	}
 
 	if k.BearerToken != "" {
-		token, err := ioutil.ReadFile(k.BearerToken)
+		token, err := os.ReadFile(k.BearerToken)
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/leofs/leofs_test.go
+++ b/plugins/inputs/leofs/leofs_test.go
@@ -1,7 +1,6 @@
 package leofs
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -132,7 +131,7 @@ func testMain(t *testing.T, code string, endpoint string, serverType ServerType)
 
 	// Build the fake snmpwalk for test
 	src := os.TempDir() + "/test.go"
-	require.NoError(t, ioutil.WriteFile(src, []byte(code), 0600))
+	require.NoError(t, os.WriteFile(src, []byte(code), 0600))
 	defer os.Remove(src)
 
 	require.NoError(t, exec.Command("go", "build", "-o", executable, src).Run())

--- a/plugins/inputs/linux_sysctl_fs/linux_sysctl_fs.go
+++ b/plugins/inputs/linux_sysctl_fs/linux_sysctl_fs.go
@@ -3,7 +3,6 @@ package linux_sysctl_fs
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -29,7 +28,7 @@ func (sfs SysctlFS) SampleConfig() string {
 }
 
 func (sfs *SysctlFS) gatherList(file string, fields map[string]interface{}, fieldNames ...string) error {
-	bs, err := ioutil.ReadFile(sfs.path + "/" + file)
+	bs, err := os.ReadFile(sfs.path + "/" + file)
 	if err != nil {
 		// Ignore non-existing entries
 		if errors.Is(err, os.ErrNotExist) {
@@ -58,7 +57,7 @@ func (sfs *SysctlFS) gatherList(file string, fields map[string]interface{}, fiel
 }
 
 func (sfs *SysctlFS) gatherOne(name string, fields map[string]interface{}) error {
-	bs, err := ioutil.ReadFile(sfs.path + "/" + name)
+	bs, err := os.ReadFile(sfs.path + "/" + name)
 	if err != nil {
 		// Ignore non-existing entries
 		if errors.Is(err, os.ErrNotExist) {

--- a/plugins/inputs/linux_sysctl_fs/linux_sysctl_fs_test.go
+++ b/plugins/inputs/linux_sysctl_fs/linux_sysctl_fs_test.go
@@ -1,7 +1,6 @@
 package linux_sysctl_fs
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -10,16 +9,16 @@ import (
 )
 
 func TestSysctlFSGather(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
+	td, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(td)
 
-	require.NoError(t, ioutil.WriteFile(td+"/aio-nr", []byte("100\n"), 0644))
-	require.NoError(t, ioutil.WriteFile(td+"/aio-max-nr", []byte("101\n"), 0644))
-	require.NoError(t, ioutil.WriteFile(td+"/super-nr", []byte("102\n"), 0644))
-	require.NoError(t, ioutil.WriteFile(td+"/super-max", []byte("103\n"), 0644))
-	require.NoError(t, ioutil.WriteFile(td+"/file-nr", []byte("104\t0\t106\n"), 0644))
-	require.NoError(t, ioutil.WriteFile(td+"/inode-state", []byte("107\t108\t109\t0\t0\t0\t0\n"), 0644))
+	require.NoError(t, os.WriteFile(td+"/aio-nr", []byte("100\n"), 0644))
+	require.NoError(t, os.WriteFile(td+"/aio-max-nr", []byte("101\n"), 0644))
+	require.NoError(t, os.WriteFile(td+"/super-nr", []byte("102\n"), 0644))
+	require.NoError(t, os.WriteFile(td+"/super-max", []byte("103\n"), 0644))
+	require.NoError(t, os.WriteFile(td+"/file-nr", []byte("104\t0\t106\n"), 0644))
+	require.NoError(t, os.WriteFile(td+"/inode-state", []byte("107\t108\t109\t0\t0\t0\t0\n"), 0644))
 
 	sfs := &SysctlFS{
 		path: td,

--- a/plugins/inputs/logparser/logparser_test.go
+++ b/plugins/inputs/logparser/logparser_test.go
@@ -1,7 +1,6 @@
 package logparser
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -111,7 +110,7 @@ func TestGrokParseLogFiles(t *testing.T) {
 }
 
 func TestGrokParseLogFilesAppearLater(t *testing.T) {
-	emptydir, err := ioutil.TempDir("", "TestGrokParseLogFilesAppearLater")
+	emptydir, err := os.MkdirTemp("", "TestGrokParseLogFilesAppearLater")
 	defer os.RemoveAll(emptydir)
 	assert.NoError(t, err)
 
@@ -131,10 +130,10 @@ func TestGrokParseLogFilesAppearLater(t *testing.T) {
 
 	assert.Equal(t, acc.NFields(), 0)
 
-	input, err := ioutil.ReadFile(filepath.Join(testdataDir, "test_a.log"))
+	input, err := os.ReadFile(filepath.Join(testdataDir, "test_a.log"))
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(emptydir, "test_a.log"), input, 0644)
+	err = os.WriteFile(filepath.Join(emptydir, "test_a.log"), input, 0644)
 	assert.NoError(t, err)
 
 	assert.NoError(t, acc.GatherError(logparser.Gather))

--- a/plugins/inputs/logstash/logstash.go
+++ b/plugins/inputs/logstash/logstash.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -206,7 +205,7 @@ func (logstash *Logstash) gatherJSONData(url string, value interface{}) error {
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		// ignore the err here; LimitReader returns io.EOF and we're not interested in read errors.
-		body, _ := ioutil.ReadAll(io.LimitReader(response.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 200))
 		return fmt.Errorf("%s returned HTTP status %s: %q", url, response.Status, body)
 	}
 

--- a/plugins/inputs/lustre2/lustre2.go
+++ b/plugins/inputs/lustre2/lustre2.go
@@ -8,7 +8,7 @@
 package lustre2
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -374,7 +374,7 @@ func (l *Lustre2) GetLustreProcStats(fileglob string, wantedFields []*mapping) e
 		name := path[len(path)-2]
 
 		//lines, err := internal.ReadLines(file)
-		wholeFile, err := ioutil.ReadFile(file)
+		wholeFile, err := os.ReadFile(file)
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -4,7 +4,6 @@
 package lustre2
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -149,13 +148,13 @@ func TestLustre2GeneratesMetrics(t *testing.T) {
 	err = os.MkdirAll(obddir+"/"+ostName, 0755)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(mdtdir+"/"+ostName+"/md_stats", []byte(mdtProcContents), 0644)
+	err = os.WriteFile(mdtdir+"/"+ostName+"/md_stats", []byte(mdtProcContents), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(osddir+"/"+ostName+"/stats", []byte(osdldiskfsProcContents), 0644)
+	err = os.WriteFile(osddir+"/"+ostName+"/stats", []byte(osdldiskfsProcContents), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(obddir+"/"+ostName+"/stats", []byte(obdfilterProcContents), 0644)
+	err = os.WriteFile(obddir+"/"+ostName+"/stats", []byte(obdfilterProcContents), 0644)
 	require.NoError(t, err)
 
 	// Begin by testing standard Lustre stats
@@ -218,10 +217,10 @@ func TestLustre2GeneratesJobstatsMetrics(t *testing.T) {
 	err = os.MkdirAll(obddir+"/"+ostName, 0755)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(mdtdir+"/"+ostName+"/job_stats", []byte(mdtJobStatsContents), 0644)
+	err = os.WriteFile(mdtdir+"/"+ostName+"/job_stats", []byte(mdtJobStatsContents), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(obddir+"/"+ostName+"/job_stats", []byte(obdfilterJobStatsContents), 0644)
+	err = os.WriteFile(obddir+"/"+ostName+"/job_stats", []byte(obdfilterJobStatsContents), 0644)
 	require.NoError(t, err)
 
 	// Test Lustre Jobstats

--- a/plugins/inputs/mailchimp/chimp_api.go
+++ b/plugins/inputs/mailchimp/chimp_api.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -148,11 +147,11 @@ func runChimp(api *ChimpAPI, params ReportsParams) ([]byte, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		// ignore the err here; LimitReader returns io.EOF and we're not interested in read errors.
-		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
 		return nil, fmt.Errorf("%s returned HTTP status %s: %q", api.url.String(), resp.Status, body)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/mdstat/mdstat.go
+++ b/plugins/inputs/mdstat/mdstat.go
@@ -20,7 +20,6 @@ package mdstat
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"
@@ -291,7 +290,7 @@ func (k *MdstatConf) getProcMdstat() ([]byte, error) {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadFile(mdStatFile)
+	data, err := os.ReadFile(mdStatFile)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/mdstat/mdstat_test.go
+++ b/plugins/inputs/mdstat/mdstat_test.go
@@ -4,7 +4,6 @@
 package mdstat
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -134,7 +133,7 @@ unused devices: <none>
 `
 
 func makeFakeMDStatFile(content []byte) (filename string) {
-	fileobj, err := ioutil.TempFile("", "mdstat")
+	fileobj, err := os.CreateTemp("", "mdstat")
 	if err != nil {
 		panic(err)
 	}

--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -3,7 +3,7 @@ package mesos
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -558,7 +558,7 @@ func (m *Mesos) gatherMainMetrics(u *url.URL, role Role, acc telegraf.Accumulato
 		return err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	// Ignore the returned error to not shadow the initial one
 	//nolint:errcheck,revive
 	resp.Body.Close()

--- a/plugins/inputs/multifile/multifile.go
+++ b/plugins/inputs/multifile/multifile.go
@@ -3,8 +3,8 @@ package multifile
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"path"
 	"strconv"
 	"time"
@@ -84,7 +84,7 @@ func (m *MultiFile) Gather(acc telegraf.Accumulator) error {
 	tags := make(map[string]string)
 
 	for _, file := range m.Files {
-		fileContents, err := ioutil.ReadFile(file.Name)
+		fileContents, err := os.ReadFile(file.Name)
 
 		if err != nil {
 			if m.FailEarly {

--- a/plugins/inputs/nats/nats.go
+++ b/plugins/inputs/nats/nats.go
@@ -5,7 +5,7 @@ package nats
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -56,7 +56,7 @@ func (n *Nats) Gather(acc telegraf.Accumulator) error {
 	}
 	defer resp.Body.Close()
 
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/neptune_apex/neptune_apex.go
+++ b/plugins/inputs/neptune_apex/neptune_apex.go
@@ -5,7 +5,7 @@ package neptuneapex
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"strconv"
@@ -276,7 +276,7 @@ func (n *NeptuneApex) sendRequest(server string) ([]byte, error) {
 			url, resp.StatusCode, http.StatusText(resp.StatusCode),
 			http.StatusOK, http.StatusText(http.StatusOK))
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read output from %q: %v", url, err)
 	}

--- a/plugins/inputs/nginx_plus_api/nginx_plus_api_metrics.go
+++ b/plugins/inputs/nginx_plus_api/nginx_plus_api_metrics.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -70,7 +70,7 @@ func (n *NginxPlusAPI) gatherURL(addr *url.URL, path string) ([]byte, error) {
 	contentType := strings.Split(resp.Header.Get("Content-Type"), ";")[0]
 	switch contentType {
 	case "application/json":
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/inputs/nginx_upstream_check/nginx_upstream_check.go
+++ b/plugins/inputs/nginx_upstream_check/nginx_upstream_check.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -153,7 +152,7 @@ func (check *NginxUpstreamCheck) gatherJSONData(url string, value interface{}) e
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		// ignore the err here; LimitReader returns io.EOF and we're not interested in read errors.
-		body, _ := ioutil.ReadAll(io.LimitReader(response.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 200))
 		return fmt.Errorf("%s returned HTTP status %s: %q", url, response.Status, body)
 	}
 

--- a/plugins/inputs/nsq/nsq.go
+++ b/plugins/inputs/nsq/nsq.go
@@ -25,7 +25,7 @@ package nsq
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -131,7 +131,7 @@ func (n *NSQ) gatherEndpoint(e string, acc telegraf.Accumulator) error {
 		return fmt.Errorf("%s returned HTTP status %s", u.String(), r.Status)
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return fmt.Errorf(`error reading body: %s`, err)
 	}

--- a/plugins/inputs/nstat/nstat.go
+++ b/plugins/inputs/nstat/nstat.go
@@ -2,7 +2,6 @@ package nstat
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -62,7 +61,7 @@ func (ns *Nstat) Gather(acc telegraf.Accumulator) error {
 	// load paths, get from env if config values are empty
 	ns.loadPaths()
 
-	netstat, err := ioutil.ReadFile(ns.ProcNetNetstat)
+	netstat, err := os.ReadFile(ns.ProcNetNetstat)
 	if err != nil {
 		return err
 	}
@@ -71,14 +70,14 @@ func (ns *Nstat) Gather(acc telegraf.Accumulator) error {
 	ns.gatherNetstat(netstat, acc)
 
 	// collect SNMP data
-	snmp, err := ioutil.ReadFile(ns.ProcNetSNMP)
+	snmp, err := os.ReadFile(ns.ProcNetSNMP)
 	if err != nil {
 		return err
 	}
 	ns.gatherSNMP(snmp, acc)
 
 	// collect SNMP6 data, if SNMP6 directory exists (IPv6 enabled)
-	snmp6, err := ioutil.ReadFile(ns.ProcNetSNMP6)
+	snmp6, err := os.ReadFile(ns.ProcNetSNMP6)
 	if err == nil {
 		ns.gatherSNMP6(snmp6, acc)
 	} else if !os.IsNotExist(err) {

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -1,7 +1,7 @@
 package nvidia_smi
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -139,7 +139,7 @@ func TestGatherValidXML(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var acc testutil.Accumulator
 
-			octets, err := ioutil.ReadFile(filepath.Join("testdata", tt.filename))
+			octets, err := os.ReadFile(filepath.Join("testdata", tt.filename))
 			require.NoError(t, err)
 
 			err = gatherNvidiaSMI(octets, &acc)

--- a/plugins/inputs/opcua/opcua_util.go
+++ b/plugins/inputs/opcua/opcua_util.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"net"
@@ -27,7 +26,7 @@ import (
 // SELF SIGNED CERT FUNCTIONS
 
 func newTempDir() (string, error) {
-	dir, err := ioutil.TempDir("", "ssc")
+	dir, err := os.MkdirTemp("", "ssc")
 	return dir, err
 }
 

--- a/plugins/inputs/passenger/passenger_test.go
+++ b/plugins/inputs/passenger/passenger_test.go
@@ -2,7 +2,6 @@ package passenger
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -28,7 +27,7 @@ func fakePassengerStatus(stat string) (string, error) {
 	}
 
 	tempFilePath := filepath.Join(os.TempDir(), "passenger-status"+fileExtension)
-	if err := ioutil.WriteFile(tempFilePath, []byte(content), 0700); err != nil {
+	if err := os.WriteFile(tempFilePath, []byte(content), 0700); err != nil {
 		return "", err
 	}
 

--- a/plugins/inputs/phpfpm/child.go
+++ b/plugins/inputs/phpfpm/child.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/cgi"
@@ -161,7 +160,7 @@ func (c *child) serve() {
 
 var errCloseConn = errors.New("fcgi: connection should be closed")
 
-var emptyBody = ioutil.NopCloser(strings.NewReader(""))
+var emptyBody = io.NopCloser(strings.NewReader(""))
 
 // ErrRequestAborted is returned by Read when a handler attempts to read the
 // body of a request that has been aborted by the web server.
@@ -295,7 +294,7 @@ func (c *child) serveRequest(req *request, body io.ReadCloser) {
 	// can properly cut off the client sending all the data.
 	// For now just bound it a little and
 	//nolint:errcheck,revive
-	io.CopyN(ioutil.Discard, body, 100<<20)
+	io.CopyN(io.Discard, body, 100<<20)
 	//nolint:errcheck,revive
 	body.Close()
 

--- a/plugins/inputs/phpfpm/fcgi_test.go
+++ b/plugins/inputs/phpfpm/fcgi_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 )
@@ -242,7 +241,7 @@ func TestChildServeCleansUp(t *testing.T) {
 			r *http.Request,
 		) {
 			// block on reading body of request
-			_, err := io.Copy(ioutil.Discard, r.Body)
+			_, err := io.Copy(io.Discard, r.Body)
 			if err != tt.err {
 				t.Errorf("Expected %#v, got %#v", tt.err, err)
 			}
@@ -274,7 +273,7 @@ func TestMalformedParams(_ *testing.T) {
 		// end of params
 		1, 4, 0, 1, 0, 0, 0, 0,
 	}
-	rw := rwNopCloser{bytes.NewReader(input), ioutil.Discard}
+	rw := rwNopCloser{bytes.NewReader(input), io.Discard}
 	c := newChild(rw, http.DefaultServeMux)
 	c.serve()
 }

--- a/plugins/inputs/postfix/postfix_test.go
+++ b/plugins/inputs/postfix/postfix_test.go
@@ -4,7 +4,6 @@
 package postfix
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestGather(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
+	td, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(td)
 
@@ -23,12 +22,12 @@ func TestGather(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.FromSlash(td+"/"+q), 0755))
 	}
 
-	require.NoError(t, ioutil.WriteFile(filepath.FromSlash(td+"/active/01"), []byte("abc"), 0644))
-	require.NoError(t, ioutil.WriteFile(filepath.FromSlash(td+"/active/02"), []byte("defg"), 0644))
-	require.NoError(t, ioutil.WriteFile(filepath.FromSlash(td+"/hold/01"), []byte("abc"), 0644))
-	require.NoError(t, ioutil.WriteFile(filepath.FromSlash(td+"/incoming/01"), []byte("abcd"), 0644))
-	require.NoError(t, ioutil.WriteFile(filepath.FromSlash(td+"/deferred/0/0/01"), []byte("abc"), 0644))
-	require.NoError(t, ioutil.WriteFile(filepath.FromSlash(td+"/deferred/F/F/F1"), []byte("abc"), 0644))
+	require.NoError(t, os.WriteFile(filepath.FromSlash(td+"/active/01"), []byte("abc"), 0644))
+	require.NoError(t, os.WriteFile(filepath.FromSlash(td+"/active/02"), []byte("defg"), 0644))
+	require.NoError(t, os.WriteFile(filepath.FromSlash(td+"/hold/01"), []byte("abc"), 0644))
+	require.NoError(t, os.WriteFile(filepath.FromSlash(td+"/incoming/01"), []byte("abcd"), 0644))
+	require.NoError(t, os.WriteFile(filepath.FromSlash(td+"/deferred/0/0/01"), []byte("abc"), 0644))
+	require.NoError(t, os.WriteFile(filepath.FromSlash(td+"/deferred/F/F/F1"), []byte("abc"), 0644))
 
 	p := Postfix{
 		QueueDirectory: td,

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -3,7 +3,7 @@ package postgresql_extensible
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -147,7 +147,7 @@ func ReadQueryFromFile(filePath string) (string, error) {
 	}
 	defer file.Close()
 
-	query, err := ioutil.ReadAll(file)
+	query, err := io.ReadAll(file)
 	if err != nil {
 		return "", err
 	}

--- a/plugins/inputs/processes/processes_notwindows.go
+++ b/plugins/inputs/processes/processes_notwindows.go
@@ -6,7 +6,6 @@ package processes
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -192,7 +191,7 @@ func (p *Processes) gatherFromProc(fields map[string]interface{}) error {
 }
 
 func readProcFile(filename string) ([]byte, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/plugins/inputs/procstat/native_finder.go
+++ b/plugins/inputs/procstat/native_finder.go
@@ -2,7 +2,7 @@ package procstat
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -43,7 +43,7 @@ func (pg *NativeFinder) UID(user string) ([]PID, error) {
 //PidFile returns the pid from the pid file given.
 func (pg *NativeFinder) PidFile(path string) ([]PID, error) {
 	var pids []PID
-	pidString, err := ioutil.ReadFile(path)
+	pidString, err := os.ReadFile(path)
 	if err != nil {
 		return pids, fmt.Errorf("Failed to read pidfile '%s'. Error: '%s'",
 			path, err)

--- a/plugins/inputs/procstat/pgrep.go
+++ b/plugins/inputs/procstat/pgrep.go
@@ -2,7 +2,7 @@ package procstat
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -25,7 +25,7 @@ func NewPgrep() (PIDFinder, error) {
 
 func (pg *Pgrep) PidFile(path string) ([]PID, error) {
 	var pids []PID
-	pidString, err := ioutil.ReadFile(path)
+	pidString, err := os.ReadFile(path)
 	if err != nil {
 		return pids, fmt.Errorf("Failed to read pidfile '%s'. Error: '%s'",
 			path, err)

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -3,7 +3,6 @@ package procstat
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -516,7 +515,7 @@ func (p *Procstat) singleCgroupPIDs(path string) ([]PID, error) {
 		return nil, fmt.Errorf("not a directory %s", path)
 	}
 	procsPath := filepath.Join(path, "cgroup.procs")
-	out, err := ioutil.ReadFile(procsPath)
+	out, err := os.ReadFile(procsPath)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -2,7 +2,6 @@ package procstat
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -385,10 +384,10 @@ func TestGather_cgroupPIDs(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("no cgroups in windows")
 	}
-	td, err := ioutil.TempDir("", "")
+	td, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(td)
-	err = ioutil.WriteFile(filepath.Join(td, "cgroup.procs"), []byte("1234\n5678\n"), 0644)
+	err = os.WriteFile(filepath.Join(td, "cgroup.procs"), []byte("1234\n5678\n"), 0644)
 	require.NoError(t, err)
 
 	p := Procstat{

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -5,11 +5,11 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/user"
 	"path/filepath"
 	"time"
@@ -41,7 +41,7 @@ const cAdvisorPodListDefaultInterval = 60
 // loadClient parses a kubeconfig from a file and returns a Kubernetes
 // client. It does not support extensions or client auth providers.
 func loadClient(kubeconfigPath string) (*kubernetes.Clientset, error) {
-	data, err := ioutil.ReadFile(kubeconfigPath)
+	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading '%s': %v", kubeconfigPath, err)
 	}

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -382,7 +382,7 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) error 
 	p.addHeaders(req)
 
 	if p.BearerToken != "" {
-		token, err := ioutil.ReadFile(p.BearerToken)
+		token, err := os.ReadFile(p.BearerToken)
 		if err != nil {
 			return err
 		}
@@ -408,7 +408,7 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) error 
 		return fmt.Errorf("%s returned HTTP status %s", u.URL, resp.Status)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("error reading body: %s", err)
 	}

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -3,7 +3,7 @@ package proxmox
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -115,7 +115,7 @@ func performRequest(px *Proxmox, apiURL string, method string, data url.Values) 
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/puppetagent/puppetagent.go
+++ b/plugins/inputs/puppetagent/puppetagent.go
@@ -2,11 +2,11 @@ package puppetagent
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -102,7 +102,7 @@ func (pa *PuppetAgent) Gather(acc telegraf.Accumulator) error {
 		return fmt.Errorf("%s", err)
 	}
 
-	fh, err := ioutil.ReadFile(pa.Location)
+	fh, err := os.ReadFile(pa.Location)
 	if err != nil {
 		return fmt.Errorf("%s", err)
 	}

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -3,7 +3,7 @@ package rabbitmq
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"sync"
@@ -431,7 +431,7 @@ func (r *RabbitMQ) requestEndpoint(u string) ([]byte, error) {
 		return nil, fmt.Errorf("getting %q failed: %v %v", u, resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (r *RabbitMQ) requestJSON(u string, target interface{}) error {

--- a/plugins/inputs/rabbitmq/rabbitmq_test.go
+++ b/plugins/inputs/rabbitmq/rabbitmq_test.go
@@ -2,9 +2,9 @@ package rabbitmq
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"time"
 
 	"testing"
@@ -37,7 +37,7 @@ func TestRabbitMQGeneratesMetricsSet1(t *testing.T) {
 			return
 		}
 
-		data, err := ioutil.ReadFile(jsonFilePath)
+		data, err := os.ReadFile(jsonFilePath)
 		require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
 
 		_, err = w.Write(data)
@@ -247,7 +247,7 @@ func TestRabbitMQGeneratesMetricsSet2(t *testing.T) {
 			return
 		}
 
-		data, err := ioutil.ReadFile(jsonFilePath)
+		data, err := os.ReadFile(jsonFilePath)
 		require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
 
 		_, err = w.Write(data)

--- a/plugins/inputs/ravendb/ravendb_test.go
+++ b/plugins/inputs/ravendb/ravendb_test.go
@@ -1,9 +1,9 @@
 package ravendb
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -30,7 +30,7 @@ func TestRavenDBGeneratesMetricsFull(t *testing.T) {
 			require.Failf(t, "Cannot handle request for uri %s", r.URL.Path)
 		}
 
-		data, err := ioutil.ReadFile(jsonFilePath)
+		data, err := os.ReadFile(jsonFilePath)
 		require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
 
 		_, err = w.Write(data)
@@ -225,7 +225,7 @@ func TestRavenDBGeneratesMetricsMin(t *testing.T) {
 			require.Failf(t, "Cannot handle request for uri %s", r.URL.Path)
 		}
 
-		data, err := ioutil.ReadFile(jsonFilePath)
+		data, err := os.ReadFile(jsonFilePath)
 		require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
 
 		_, err = w.Write(data)

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -3,7 +3,7 @@ package redfish
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -199,7 +199,7 @@ func (r *Redfish) getData(url string, payload interface{}) error {
 			r.Address)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/salesforce/salesforce.go
+++ b/plugins/inputs/salesforce/salesforce.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -203,11 +202,11 @@ func (s *Salesforce) login() error {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		// ignore the err here; LimitReader returns io.EOF and we're not interested in read errors.
-		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
 		return fmt.Errorf("%s returned HTTP status %s: %q", loginEndpoint, resp.Status, body)
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/snmp_legacy/snmp_legacy.go
+++ b/plugins/inputs/snmp_legacy/snmp_legacy.go
@@ -1,9 +1,9 @@
 package snmp_legacy
 
 import (
-	"io/ioutil"
 	"log"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -296,7 +296,7 @@ func (s *Snmp) Gather(acc telegraf.Accumulator) error {
 			subnodes: make(map[string]Node),
 		}
 
-		data, err := ioutil.ReadFile(s.SnmptranslateFile)
+		data, err := os.ReadFile(s.SnmptranslateFile)
 		if err != nil {
 			s.Log.Errorf("Reading SNMPtranslate file error: %s", err.Error())
 			return err

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -69,7 +68,7 @@ func TestSocketListener_tcp_tls(t *testing.T) {
 }
 
 func TestSocketListener_unix_tls(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unix_tls.sock")
@@ -133,7 +132,7 @@ func TestSocketListener_udp(t *testing.T) {
 }
 
 func TestSocketListener_unix(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unix.sock")
@@ -163,7 +162,7 @@ func TestSocketListener_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unixgram.sock")

--- a/plugins/inputs/sql/sql.go
+++ b/plugins/inputs/sql/sql.go
@@ -5,7 +5,7 @@ import (
 	dbsql "database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -326,7 +326,7 @@ func (s *SQL) Init() error {
 
 		// In case we got a script, we should read the query now.
 		if q.Script != "" {
-			query, err := ioutil.ReadFile(q.Script)
+			query, err := os.ReadFile(q.Script)
 			if err != nil {
 				return fmt.Errorf("reading script %q failed: %v", q.Script, err)
 			}

--- a/plugins/inputs/suricata/suricata_test.go
+++ b/plugins/inputs/suricata/suricata_test.go
@@ -2,7 +2,6 @@ package suricata
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -21,7 +20,7 @@ var ex2 = `{"timestamp":"2017-03-06T07:43:39.000397+0000","event_type":"stats","
 var ex3 = `{"timestamp":"2017-03-06T07:43:39.000397+0000","event_type":"stats","stats":{"threads": { "W#05-wlp4s0": { "capture":{"kernel_packets":905344474,"kernel_drops":78355440}}}}}`
 
 func TestSuricataLarge(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
@@ -38,7 +37,7 @@ func TestSuricataLarge(t *testing.T) {
 	require.NoError(t, s.Start(&acc))
 	defer s.Stop()
 
-	data, err := ioutil.ReadFile("testdata/test1.json")
+	data, err := os.ReadFile("testdata/test1.json")
 	require.NoError(t, err)
 
 	c, err := net.Dial("unix", tmpfn)
@@ -49,7 +48,7 @@ func TestSuricataLarge(t *testing.T) {
 	require.NoError(t, err)
 
 	//test suricata alerts
-	data2, err := ioutil.ReadFile("testdata/test2.json")
+	data2, err := os.ReadFile("testdata/test2.json")
 	require.NoError(t, err)
 	_, err = c.Write(data2)
 	require.NoError(t, err)
@@ -61,7 +60,7 @@ func TestSuricataLarge(t *testing.T) {
 }
 
 func TestSuricataAlerts(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
@@ -78,7 +77,7 @@ func TestSuricataAlerts(t *testing.T) {
 	require.NoError(t, s.Start(&acc))
 	defer s.Stop()
 
-	data, err := ioutil.ReadFile("testdata/test3.json")
+	data, err := os.ReadFile("testdata/test3.json")
 	require.NoError(t, err)
 
 	c, err := net.Dial("unix", tmpfn)
@@ -116,7 +115,7 @@ func TestSuricataAlerts(t *testing.T) {
 }
 
 func TestSuricata(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
@@ -162,7 +161,7 @@ func TestSuricata(t *testing.T) {
 }
 
 func TestThreadStats(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
@@ -212,7 +211,7 @@ func TestThreadStats(t *testing.T) {
 }
 
 func TestSuricataInvalid(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
@@ -254,7 +253,7 @@ func TestSuricataInvalidPath(t *testing.T) {
 }
 
 func TestSuricataTooLongLine(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
@@ -282,7 +281,7 @@ func TestSuricataTooLongLine(t *testing.T) {
 }
 
 func TestSuricataEmptyJSON(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
@@ -309,7 +308,7 @@ func TestSuricataEmptyJSON(t *testing.T) {
 }
 
 func TestSuricataDisconnectSocket(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
@@ -345,7 +344,7 @@ func TestSuricataDisconnectSocket(t *testing.T) {
 }
 
 func TestSuricataStartStop(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.MkdirTemp("", "test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
@@ -387,7 +386,7 @@ func TestSuricataParse(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		data, err := ioutil.ReadFile("testdata/" + tc.filename)
+		data, err := os.ReadFile("testdata/" + tc.filename)
 		require.NoError(t, err)
 		s := Suricata{
 			Delimiter: "_",

--- a/plugins/inputs/synproxy/synproxy_test.go
+++ b/plugins/inputs/synproxy/synproxy_test.go
@@ -4,7 +4,6 @@
 package synproxy
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -156,7 +155,7 @@ func testSynproxyFileData(t *testing.T, fileData string, telegrafData map[string
 }
 
 func makeFakeSynproxyFile(content []byte) string {
-	tmpfile, err := ioutil.TempFile("", "synproxy_test")
+	tmpfile, err := os.CreateTemp("", "synproxy_test")
 	if err != nil {
 		panic(err)
 	}

--- a/plugins/inputs/syslog/nontransparent_test.go
+++ b/plugins/inputs/syslog/nontransparent_test.go
@@ -2,7 +2,6 @@ package syslog
 
 import (
 	"crypto/tls"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -270,7 +269,7 @@ func TestNonTransparentStrictWithZeroKeepAlive_tcp_tls(t *testing.T) {
 }
 
 func TestNonTransparentStrict_unix(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix.sock")
@@ -278,7 +277,7 @@ func TestNonTransparentStrict_unix(t *testing.T) {
 }
 
 func TestNonTransparentBestEffort_unix(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix.sock")
@@ -286,7 +285,7 @@ func TestNonTransparentBestEffort_unix(t *testing.T) {
 }
 
 func TestNonTransparentStrict_unix_tls(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix_tls.sock")
@@ -294,7 +293,7 @@ func TestNonTransparentStrict_unix_tls(t *testing.T) {
 }
 
 func TestNonTransparentBestEffort_unix_tls(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix_tls.sock")

--- a/plugins/inputs/syslog/octetcounting_test.go
+++ b/plugins/inputs/syslog/octetcounting_test.go
@@ -3,7 +3,6 @@ package syslog
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -470,7 +469,7 @@ func TestOctetCountingStrictWithZeroKeepAlive_tcp_tls(t *testing.T) {
 }
 
 func TestOctetCountingStrict_unix(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix.sock")
@@ -478,7 +477,7 @@ func TestOctetCountingStrict_unix(t *testing.T) {
 }
 
 func TestOctetCountingBestEffort_unix(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix.sock")
@@ -486,7 +485,7 @@ func TestOctetCountingBestEffort_unix(t *testing.T) {
 }
 
 func TestOctetCountingStrict_unix_tls(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix_tls.sock")
@@ -494,7 +493,7 @@ func TestOctetCountingStrict_unix_tls(t *testing.T) {
 }
 
 func TestOctetCountingBestEffort_unix_tls(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix_tls.sock")

--- a/plugins/inputs/syslog/rfc5426_test.go
+++ b/plugins/inputs/syslog/rfc5426_test.go
@@ -2,7 +2,6 @@ package syslog
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -290,7 +289,7 @@ func TestBestEffort_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unixgram.sock")
@@ -304,7 +303,7 @@ func TestStrict_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "syslog.TestStrict_unixgram.sock")

--- a/plugins/inputs/syslog/syslog_test.go
+++ b/plugins/inputs/syslog/syslog_test.go
@@ -1,7 +1,6 @@
 package syslog
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -46,7 +45,7 @@ func TestAddress(t *testing.T) {
 	require.EqualError(t, err, "unknown protocol 'unsupported' in 'example.com:6514'")
 	require.Error(t, err)
 
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	defer os.RemoveAll(tmpdir)
 	require.NoError(t, err)
 	sock := filepath.Join(tmpdir, "syslog.TestAddress.sock")

--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -2,7 +2,6 @@ package tail
 
 import (
 	"bytes"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -49,7 +48,7 @@ func NewTestTail() *Tail {
 }
 
 func TestTailBadLine(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -86,7 +85,7 @@ func TestTailBadLine(t *testing.T) {
 }
 
 func TestTailDosLineEndings(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 	_, err = tmpfile.WriteString("cpu usage_idle=100\r\ncpu2 usage_idle=200\r\n")
@@ -173,7 +172,7 @@ func TestGrokParseLogFilesWithMultiline(t *testing.T) {
 }
 
 func TestGrokParseLogFilesWithMultilineTimeout(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -286,7 +285,7 @@ func createGrokParser() (parsers.Parser, error) {
 
 // The csv parser should only parse the header line once per file.
 func TestCSVHeadersParsedOnce(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -345,7 +344,7 @@ cpu,42
 
 // Ensure that the first line can produce multiple metrics (#6138)
 func TestMultipleMetricsOnFirstLine(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -542,7 +541,7 @@ func TestCharacterEncoding(t *testing.T) {
 }
 
 func TestTailEOF(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 	_, err = tmpfile.WriteString("cpu usage_idle=100\r\n")

--- a/plugins/inputs/twemproxy/twemproxy.go
+++ b/plugins/inputs/twemproxy/twemproxy.go
@@ -3,7 +3,7 @@ package twemproxy
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net"
 	"time"
 
@@ -37,7 +37,7 @@ func (t *Twemproxy) Gather(acc telegraf.Accumulator) error {
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(conn)
+	body, err := io.ReadAll(conn)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/udp_listener/udp_listener_test.go
+++ b/plugins/inputs/udp_listener/udp_listener_test.go
@@ -104,7 +104,7 @@ package udp_listener
 // }
 
 // func TestRunParser(t *testing.T) {
-// 	log.SetOutput(ioutil.Discard)
+// 	log.SetOutput(io.Discard)
 // 	var testmsg = []byte("cpu_load_short,host=server01 value=12.0 1422568543702900257\n")
 
 // 	listener, in := newTestUDPListener()
@@ -127,7 +127,7 @@ package udp_listener
 // }
 
 // func TestRunParserInvalidMsg(_ *testing.T) {
-// 	log.SetOutput(ioutil.Discard)
+// 	log.SetOutput(io.Discard)
 // 	var testmsg = []byte("cpu_load_short")
 
 // 	listener, in := newTestUDPListener()
@@ -153,7 +153,7 @@ package udp_listener
 // }
 
 // func TestRunParserGraphiteMsg(t *testing.T) {
-// 	log.SetOutput(ioutil.Discard)
+// 	log.SetOutput(io.Discard)
 // 	var testmsg = []byte("cpu.load.graphite 12 1454780029")
 
 // 	listener, in := newTestUDPListener()
@@ -174,7 +174,7 @@ package udp_listener
 // }
 
 // func TestRunParserJSONMsg(t *testing.T) {
-// 	log.SetOutput(ioutil.Discard)
+// 	log.SetOutput(io.Discard)
 // 	var testmsg = []byte("{\"a\": 5, \"b\": {\"c\": 6}}\n")
 
 // 	listener, in := newTestUDPListener()

--- a/plugins/inputs/webhooks/filestack/filestack_webhooks.go
+++ b/plugins/inputs/webhooks/filestack/filestack_webhooks.go
@@ -2,7 +2,7 @@ package filestack
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -25,7 +25,7 @@ func (fs *FilestackWebhook) Register(router *mux.Router, acc telegraf.Accumulato
 
 func (fs *FilestackWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/plugins/inputs/webhooks/github/github_webhooks.go
+++ b/plugins/inputs/webhooks/github/github_webhooks.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -28,7 +28,7 @@ func (gh *GithubWebhook) Register(router *mux.Router, acc telegraf.Accumulator) 
 func (gh *GithubWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	eventType := r.Header.Get("X-Github-Event")
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks.go
@@ -2,7 +2,7 @@ package mandrill
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -31,7 +31,7 @@ func (md *MandrillWebhook) returnOK(w http.ResponseWriter, _ *http.Request) {
 
 func (md *MandrillWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks.go
@@ -3,7 +3,7 @@ package rollbar
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -25,7 +25,7 @@ func (rb *RollbarWebhook) Register(router *mux.Router, acc telegraf.Accumulator)
 
 func (rb *RollbarWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/plugins/inputs/wireless/wireless_linux.go
+++ b/plugins/inputs/wireless/wireless_linux.go
@@ -5,7 +5,6 @@ package wireless
 
 import (
 	"bytes"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -47,7 +46,7 @@ func (w *Wireless) Gather(acc telegraf.Accumulator) error {
 	w.loadPath()
 
 	wirelessPath := path.Join(w.HostProc, "net", "wireless")
-	table, err := ioutil.ReadFile(wirelessPath)
+	table, err := os.ReadFile(wirelessPath)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -7,13 +7,14 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/pion/dtls/v2"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/pion/dtls/v2"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
@@ -176,7 +177,7 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 
 		return certs, nil
 	case "file":
-		content, err := ioutil.ReadFile(u.Path)
+		content, err := os.ReadFile(u.Path)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -4,8 +4,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"github.com/pion/dtls/v2"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/url"
@@ -14,6 +12,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/pion/dtls/v2"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +32,7 @@ var _ telegraf.Input = &X509Cert{}
 func TestGatherRemoteIntegration(t *testing.T) {
 	t.Skip("Skipping network-dependent test due to race condition when test-all")
 
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	require.NoError(t, err)
 
 	defer os.Remove(tmpfile.Name())
@@ -149,7 +149,7 @@ func TestGatherLocal(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			f, err := ioutil.TempFile("", "x509_cert")
+			f, err := os.CreateTemp("", "x509_cert")
 			require.NoError(t, err)
 
 			_, err = f.Write([]byte(test.content))
@@ -181,7 +181,7 @@ func TestGatherLocal(t *testing.T) {
 func TestTags(t *testing.T) {
 	cert := fmt.Sprintf("%s\n%s", pki.ReadServerCert(), pki.ReadCACert())
 
-	f, err := ioutil.TempFile("", "x509_cert")
+	f, err := os.CreateTemp("", "x509_cert")
 	require.NoError(t, err)
 
 	_, err = f.Write([]byte(cert))
@@ -238,7 +238,7 @@ func TestGatherChain(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			f, err := ioutil.TempFile("", "x509_cert")
+			f, err := os.CreateTemp("", "x509_cert")
 			require.NoError(t, err)
 
 			_, err = f.Write([]byte(test.content))

--- a/plugins/inputs/zfs/zfs_linux_test.go
+++ b/plugins/inputs/zfs/zfs_linux_test.go
@@ -4,7 +4,6 @@
 package zfs
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -192,10 +191,10 @@ func TestZfsPoolMetrics(t *testing.T) {
 	err = os.MkdirAll(testKstatPath+"/HOME", 0755)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testKstatPath+"/HOME/io", []byte(poolIoContents), 0644)
+	err = os.WriteFile(testKstatPath+"/HOME/io", []byte(poolIoContents), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testKstatPath+"/arcstats", []byte(arcstatsContents), 0644)
+	err = os.WriteFile(testKstatPath+"/arcstats", []byte(arcstatsContents), 0644)
 	require.NoError(t, err)
 
 	poolMetrics := getPoolMetrics()
@@ -231,25 +230,25 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 	err = os.MkdirAll(testKstatPath+"/HOME", 0755)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testKstatPath+"/HOME/io", []byte(""), 0644)
+	err = os.WriteFile(testKstatPath+"/HOME/io", []byte(""), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testKstatPath+"/arcstats", []byte(arcstatsContents), 0644)
+	err = os.WriteFile(testKstatPath+"/arcstats", []byte(arcstatsContents), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testKstatPath+"/zfetchstats", []byte(zfetchstatsContents), 0644)
+	err = os.WriteFile(testKstatPath+"/zfetchstats", []byte(zfetchstatsContents), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testKstatPath+"/zil", []byte(zilContents), 0644)
+	err = os.WriteFile(testKstatPath+"/zil", []byte(zilContents), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testKstatPath+"/fm", []byte(fmContents), 0644)
+	err = os.WriteFile(testKstatPath+"/fm", []byte(fmContents), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testKstatPath+"/dmu_tx", []byte(dmuTxContents), 0644)
+	err = os.WriteFile(testKstatPath+"/dmu_tx", []byte(dmuTxContents), 0644)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testKstatPath+"/abdstats", []byte(abdstatsContents), 0644)
+	err = os.WriteFile(testKstatPath+"/abdstats", []byte(abdstatsContents), 0644)
 	require.NoError(t, err)
 
 	intMetrics := getKstatMetricsAll()
@@ -272,7 +271,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 	err = os.MkdirAll(testKstatPath+"/STORAGE", 0755)
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(testKstatPath+"/STORAGE/io", []byte(""), 0644)
+	err = os.WriteFile(testKstatPath+"/STORAGE/io", []byte(""), 0644)
 	require.NoError(t, err)
 
 	tags = map[string]string{

--- a/plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go
+++ b/plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go
@@ -29,8 +29,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/influxdata/telegraf/plugins/inputs/zipkin/codec/thrift/gen-go/zipkincore"
@@ -52,7 +52,7 @@ func init() {
 
 func main() {
 	flag.Parse()
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := os.ReadFile(filename)
 	if err != nil {
 		log.Fatalf("Error reading file: %v\n", err)
 	}
@@ -63,7 +63,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("%v\n", err)
 		}
-		if err := ioutil.WriteFile(outFileName, raw, 0644); err != nil {
+		if err := os.WriteFile(outFileName, raw, 0644); err != nil {
 			log.Fatalf("%v", err)
 		}
 	case "thrift":
@@ -71,7 +71,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("%v\n", err)
 		}
-		if err := ioutil.WriteFile(outFileName, raw, 0644); err != nil {
+		if err := os.WriteFile(outFileName, raw, 0644); err != nil {
 			log.Fatalf("%v", err)
 		}
 	default:

--- a/plugins/inputs/zipkin/codec/thrift/thrift_test.go
+++ b/plugins/inputs/zipkin/codec/thrift/thrift_test.go
@@ -1,7 +1,7 @@
 package thrift
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -193,7 +193,7 @@ func TestUnmarshalThrift(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dat, err := ioutil.ReadFile(tt.filename)
+			dat, err := os.ReadFile(tt.filename)
 			if err != nil {
 				t.Fatalf("Could not find file %s\n", tt.filename)
 			}

--- a/plugins/inputs/zipkin/handler.go
+++ b/plugins/inputs/zipkin/handler.go
@@ -3,7 +3,7 @@ package zipkin
 import (
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 	"strings"
@@ -88,7 +88,7 @@ func (s *SpanHandler) Spans(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnsupportedMediaType)
 	}
 
-	octets, err := ioutil.ReadAll(body)
+	octets, err := io.ReadAll(body)
 	if err != nil {
 		s.recorder.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/plugins/inputs/zipkin/handler_test.go
+++ b/plugins/inputs/zipkin/handler_test.go
@@ -2,9 +2,10 @@ package zipkin
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func (m *MockRecorder) Error(err error) {
 }
 
 func TestSpanHandler(t *testing.T) {
-	dat, err := ioutil.ReadFile("testdata/threespans.dat")
+	dat, err := os.ReadFile("testdata/threespans.dat")
 	if err != nil {
 		t.Fatalf("Could not find file %s\n", "testdata/threespans.dat")
 	}
@@ -37,7 +38,7 @@ func TestSpanHandler(t *testing.T) {
 	r := httptest.NewRequest(
 		"POST",
 		"http://server.local/api/v1/spans",
-		ioutil.NopCloser(
+		io.NopCloser(
 			bytes.NewReader(dat)))
 
 	r.Header.Set("Content-Type", "application/x-thrift")

--- a/plugins/inputs/zipkin/zipkin_test.go
+++ b/plugins/inputs/zipkin/zipkin_test.go
@@ -3,8 +3,8 @@ package zipkin
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -637,7 +637,7 @@ func TestZipkinPlugin(t *testing.T) {
 }
 
 func postThriftData(datafile, address, contentType string) error {
-	dat, err := ioutil.ReadFile(datafile)
+	dat, err := os.ReadFile(datafile)
 	if err != nil {
 		return fmt.Errorf("could not read from data file %s", datafile)
 	}

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -221,7 +221,7 @@ func vmInstanceMetadata(c *http.Client) (string, string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", err
 	}
@@ -356,7 +356,7 @@ func (a *AzureMonitor) send(body []byte) error {
 	}
 	defer resp.Body.Close()
 
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil || resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return fmt.Errorf("failed to write batch: [%v] %s", resp.StatusCode, resp.Status)
 	}

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -3,7 +3,7 @@ package dynatrace
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -209,7 +209,7 @@ func (d *Dynatrace) send(msg string) error {
 	}
 
 	// print metric line results as info log
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		d.Log.Errorf("Dynatrace error reading response")
 	}

--- a/plugins/outputs/dynatrace/dynatrace_test.go
+++ b/plugins/outputs/dynatrace/dynatrace_test.go
@@ -3,7 +3,7 @@ package dynatrace
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -130,7 +130,7 @@ func TestSendMetrics(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// check the encoded result
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		bodyString := string(bodyBytes)
 
@@ -209,7 +209,7 @@ func TestSendMetrics(t *testing.T) {
 func TestSendSingleMetricWithUnorderedTags(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// check the encoded result
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		bodyString := string(bodyBytes)
 		// use regex because dimension order isn't guaranteed
@@ -255,7 +255,7 @@ func TestSendMetricWithoutTags(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		// check the encoded result
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		bodyString := string(bodyBytes)
 		expected := "mymeasurement.myfield,dt.metrics.source=telegraf gauge,3.14 1289430000000"
@@ -296,7 +296,7 @@ func TestSendMetricWithUpperCaseTagKeys(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		// check the encoded result
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		bodyString := string(bodyBytes)
 
@@ -343,7 +343,7 @@ func TestSendBooleanMetricWithoutTags(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		// check the encoded result
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		bodyString := string(bodyBytes)
 		// use regex because field order isn't guaranteed
@@ -384,7 +384,7 @@ func TestSendMetricWithDefaultDimensions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		// check the encoded result
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		bodyString := string(bodyBytes)
 		// use regex because field order isn't guaranteed
@@ -427,7 +427,7 @@ func TestMetricDimensionsOverrideDefault(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		// check the encoded result
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		bodyString := string(bodyBytes)
 		// use regex because field order isn't guaranteed
@@ -470,7 +470,7 @@ func TestStaticDimensionsOverrideMetric(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		// check the encoded result
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		bodyString := string(bodyBytes)
 		// use regex because field order isn't guaranteed

--- a/plugins/outputs/file/file_test.go
+++ b/plugins/outputs/file/file_test.go
@@ -3,7 +3,6 @@ package file
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -181,7 +180,7 @@ func TestFileStdout(t *testing.T) {
 }
 
 func createFile() *os.File {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -190,7 +189,7 @@ func createFile() *os.File {
 }
 
 func tmpFile() string {
-	d, err := ioutil.TempDir("", "")
+	d, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -198,7 +197,7 @@ func tmpFile() string {
 }
 
 func validateFile(fname, expS string, t *testing.T) {
-	buf, err := ioutil.ReadFile(fname)
+	buf, err := os.ReadFile(fname)
 	if err != nil {
 		panic(err)
 	}

--- a/plugins/outputs/health/health_test.go
+++ b/plugins/outputs/health/health_test.go
@@ -1,7 +1,7 @@
 package health_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -121,7 +121,7 @@ func TestHealth(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedCode, resp.StatusCode)
 
-			_, err = ioutil.ReadAll(resp.Body)
+			_, err = io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			err = output.Close()

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -195,7 +194,7 @@ func (h *HTTP) write(reqBody []byte) error {
 		return fmt.Errorf("when writing to [%s] received status code: %d. body: %s", h.URL, resp.StatusCode, errorLine)
 	}
 
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("when writing to [%s] received error: %v", h.URL, err)
 	}

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -3,7 +3,7 @@ package http
 import (
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -272,7 +272,7 @@ func TestContentEncodingGzip(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				payload, err := ioutil.ReadAll(body)
+				payload, err := io.ReadAll(body)
 				require.NoError(t, err)
 				require.Contains(t, string(payload), "cpu value=42")
 

--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -489,7 +488,7 @@ func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) (io.ReadCloser
 		return rc, nil
 	}
 
-	return ioutil.NopCloser(reader), nil
+	return io.NopCloser(reader), nil
 }
 
 func (c *httpClient) addHeaders(req *http.Request) {
@@ -503,13 +502,13 @@ func (c *httpClient) addHeaders(req *http.Request) {
 }
 
 func (c *httpClient) validateResponse(response io.ReadCloser) (io.ReadCloser, error) {
-	bodyBytes, err := ioutil.ReadAll(response)
+	bodyBytes, err := io.ReadAll(response)
 	if err != nil {
 		return nil, err
 	}
 	defer response.Close()
 
-	originalResponse := ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+	originalResponse := io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	// Empty response is valid.
 	if response == http.NoBody || len(bodyBytes) == 0 || bodyBytes == nil {

--- a/plugins/outputs/influxdb/http_test.go
+++ b/plugins/outputs/influxdb/http_test.go
@@ -6,7 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -284,7 +284,7 @@ func TestHTTP_Write(t *testing.T) {
 			},
 			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, r.FormValue("db"), "telegraf")
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Contains(t, string(body), "cpu value=42")
 				w.WriteHeader(http.StatusNoContent)
@@ -573,7 +573,7 @@ func TestHTTP_WriteContentEncodingGzip(t *testing.T) {
 
 				gr, err := gzip.NewReader(r.Body)
 				require.NoError(t, err)
-				body, err := ioutil.ReadAll(gr)
+				body, err := io.ReadAll(gr)
 				require.NoError(t, err)
 
 				require.Contains(t, string(body), "cpu value=42")
@@ -618,7 +618,7 @@ func TestHTTP_WriteContentEncodingGzip(t *testing.T) {
 }
 
 func TestHTTP_UnixSocket(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf-test")
+	tmpdir, err := os.MkdirTemp("", "telegraf-test")
 	if err != nil {
 		require.NoError(t, err)
 	}
@@ -700,7 +700,7 @@ func TestHTTP_WriteDatabaseTagWorksOnRetry(t *testing.T) {
 				r.ParseForm()
 				require.Equal(t, r.Form["db"], []string{"foo"})
 
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Contains(t, string(body), "cpu value=42")
 
@@ -835,7 +835,7 @@ func TestDBRPTags(t *testing.T) {
 			handlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, r.FormValue("db"), "telegraf")
 				require.Equal(t, r.FormValue("rp"), "foo")
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Contains(t, string(body), "cpu,rp=foo value=42")
 				w.WriteHeader(http.StatusNoContent)
@@ -917,7 +917,7 @@ func TestDBRPTags(t *testing.T) {
 			handlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, r.FormValue("db"), "telegraf")
 				require.Equal(t, r.FormValue("rp"), "foo")
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Contains(t, string(body), "cpu value=42")
 				w.WriteHeader(http.StatusNoContent)
@@ -948,7 +948,7 @@ func TestDBRPTags(t *testing.T) {
 			handlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, r.FormValue("db"), "telegraf")
 				require.Equal(t, r.FormValue("rp"), "foo")
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Contains(t, string(body), "cpu,rp=foo value=42")
 				w.WriteHeader(http.StatusNoContent)

--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"net"
@@ -361,7 +360,7 @@ func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) (io.ReadCloser
 		return rc, nil
 	}
 
-	return ioutil.NopCloser(reader), nil
+	return io.NopCloser(reader), nil
 }
 
 func (c *httpClient) addHeaders(req *http.Request) {

--- a/plugins/outputs/influxdb_v2/http_test.go
+++ b/plugins/outputs/influxdb_v2/http_test.go
@@ -2,7 +2,7 @@ package influxdb_v2_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -63,7 +63,7 @@ func TestWriteBucketTagWorksOnRetry(t *testing.T) {
 				r.ParseForm()
 				require.Equal(t, r.Form["bucket"], []string{"foo"})
 
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				require.Contains(t, string(body), "cpu value=42")
 

--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"time"
@@ -151,7 +151,7 @@ func (l *Librato) Write(metrics []telegraf.Metric) error {
 		defer resp.Body.Close()
 
 		if resp.StatusCode != 200 || l.Debug {
-			htmlData, err := ioutil.ReadAll(resp.Body)
+			htmlData, err := io.ReadAll(resp.Body)
 			if err != nil {
 				l.Log.Debugf("Couldn't get response! (%v)", err)
 			}

--- a/plugins/outputs/loki/loki_test.go
+++ b/plugins/outputs/loki/loki_test.go
@@ -4,13 +4,14 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"github.com/influxdata/telegraf/testutil"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/influxdata/telegraf/testutil"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
@@ -215,7 +216,7 @@ func TestContentEncodingGzip(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				payload, err := ioutil.ReadAll(body)
+				payload, err := io.ReadAll(body)
 				require.NoError(t, err)
 
 				var s Request
@@ -394,7 +395,7 @@ func TestMetricSorting(t *testing.T) {
 			body := r.Body
 			var err error
 
-			payload, err := ioutil.ReadAll(body)
+			payload, err := io.ReadAll(body)
 			require.NoError(t, err)
 
 			var s Request

--- a/plugins/outputs/opentsdb/opentsdb_http.go
+++ b/plugins/outputs/opentsdb/opentsdb_http.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -163,7 +162,7 @@ func (o *openTSDBHttp) flush() error {
 		fmt.Printf("Received response\n%s\n\n", dump)
 	} else {
 		// Important so http client reuse connection for next request if need be.
-		io.Copy(ioutil.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 	}
 
 	if resp.StatusCode/100 != 2 {

--- a/plugins/outputs/prometheus_client/prometheus_client_v1_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v1_test.go
@@ -2,7 +2,7 @@ package prometheus
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -261,7 +261,7 @@ rpc_duration_seconds_count 2693
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			require.Equal(t,
@@ -392,7 +392,7 @@ rpc_duration_seconds_count 2693
 			resp, err := http.Get(output.URL())
 			require.NoError(t, err)
 
-			actual, err := ioutil.ReadAll(resp.Body)
+			actual, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			require.Equal(t,
@@ -422,7 +422,7 @@ func TestLandingPage(t *testing.T) {
 	resp, err := http.Get(u.String())
 	require.NoError(t, err)
 
-	actual, err := ioutil.ReadAll(resp.Body)
+	actual, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	require.Equal(t, expected, strings.TrimSpace(string(actual)))

--- a/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
@@ -2,7 +2,7 @@ package prometheus
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -321,7 +321,7 @@ cpu_usage_idle_count{cpu="cpu1"} 20
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			require.Equal(t,
@@ -452,7 +452,7 @@ rpc_duration_seconds_count 2693
 			resp, err := http.Get(output.URL())
 			require.NoError(t, err)
 
-			actual, err := ioutil.ReadAll(resp.Body)
+			actual, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			require.Equal(t,

--- a/plugins/outputs/sensu/sensu.go
+++ b/plugins/outputs/sensu/sensu.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -336,7 +335,7 @@ func (s *Sensu) write(reqBody []byte) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		bodyData, err := ioutil.ReadAll(resp.Body)
+		bodyData, err := io.ReadAll(resp.Body)
 		if err != nil {
 			s.Log.Debugf("Couldn't read response body: %v", err)
 		}

--- a/plugins/outputs/sensu/sensu_test.go
+++ b/plugins/outputs/sensu/sensu_test.go
@@ -3,7 +3,7 @@ package sensu
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -118,7 +118,7 @@ func TestConnectAndWrite(t *testing.T) {
 			require.Equal(t, expectedURL, r.URL.String())
 			require.Equal(t, expectedAuthHeader, r.Header.Get("Authorization"))
 			// let's make sure what we received is a valid Sensu event that contains all of the expected data
-			body, err := ioutil.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			receivedEvent := &corev2.Event{}
 			err = json.Unmarshal(body, receivedEvent)

--- a/plugins/outputs/socket_writer/socket_writer_test.go
+++ b/plugins/outputs/socket_writer/socket_writer_test.go
@@ -2,7 +2,6 @@ package socket_writer
 
 import (
 	"bufio"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -46,7 +45,7 @@ func TestSocketWriter_udp(t *testing.T) {
 }
 
 func TestSocketWriter_unix(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "sw.TestSocketWriter_unix.sock")
@@ -71,7 +70,7 @@ func TestSocketWriter_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir, err := ioutil.TempDir("", "telegraf")
+	tmpdir, err := os.MkdirTemp("", "telegraf")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	sock := filepath.Join(tmpdir, "sw.TSW_unixgram.sock")

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -3,7 +3,6 @@ package sql
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -162,7 +161,7 @@ func TestMysqlIntegration(t *testing.T) {
 	const username = "root"
 
 	password := pwgen(32)
-	outDir, err := ioutil.TempDir("", "tg-mysql-*")
+	outDir, err := os.MkdirTemp("", "tg-mysql-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 
@@ -230,9 +229,9 @@ func TestMysqlIntegration(t *testing.T) {
 	require.FileExists(t, dumpfile)
 
 	//compare the dump to what we expected
-	expected, err := ioutil.ReadFile("testdata/mariadb/expected.sql")
+	expected, err := os.ReadFile("testdata/mariadb/expected.sql")
 	require.NoError(t, err)
-	actual, err := ioutil.ReadFile(dumpfile)
+	actual, err := os.ReadFile(dumpfile)
 	require.NoError(t, err)
 	require.Equal(t, string(expected), string(actual))
 }
@@ -252,7 +251,7 @@ func TestPostgresIntegration(t *testing.T) {
 	const username = "postgres"
 
 	password := pwgen(32)
-	outDir, err := ioutil.TempDir("", "tg-postgres-*")
+	outDir, err := os.MkdirTemp("", "tg-postgres-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 
@@ -329,9 +328,9 @@ func TestPostgresIntegration(t *testing.T) {
 	require.FileExists(t, dumpfile)
 
 	//compare the dump to what we expected
-	expected, err := ioutil.ReadFile("testdata/postgres/expected.sql")
+	expected, err := os.ReadFile("testdata/postgres/expected.sql")
 	require.NoError(t, err)
-	actual, err := ioutil.ReadFile(dumpfile)
+	actual, err := os.ReadFile(dumpfile)
 	require.NoError(t, err)
 	require.Equal(t, string(expected), string(actual))
 }

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -7,7 +7,6 @@ package sql
 
 import (
 	gosql "database/sql"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestSqlite(t *testing.T) {
-	outDir, err := ioutil.TempDir("", "tg-sqlite-*")
+	outDir, err := os.MkdirTemp("", "tg-sqlite-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 

--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -300,7 +299,7 @@ func TestContentEncodingGzip(t *testing.T) {
 				body, err := gzip.NewReader(r.Body)
 				require.NoError(t, err)
 
-				payload, err := ioutil.ReadAll(body)
+				payload, err := io.ReadAll(body)
 				require.NoError(t, err)
 
 				assert.Equal(t, string(payload), "metric=cpu field=value  42 0\n")

--- a/plugins/outputs/warp10/warp10.go
+++ b/plugins/outputs/warp10/warp10.go
@@ -3,7 +3,7 @@ package warp10
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math"
 	"net/http"
@@ -154,7 +154,7 @@ func (w *Warp10) Write(metrics []telegraf.Metric) error {
 
 	if resp.StatusCode != http.StatusOK {
 		if w.PrintErrorBody {
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			return fmt.Errorf(w.WarpURL + ": " + w.HandleError(string(body), w.MaxStringErrorSize))
 		}
 

--- a/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring.go
+++ b/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -172,7 +172,7 @@ func getResponseFromMetadata(c *http.Client, metadataURL string) ([]byte, error)
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (a *YandexCloudMonitoring) send(body []byte) error {
 	}
 	defer resp.Body.Close()
 
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil || resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return fmt.Errorf("failed to write batch: [%v] %s", resp.StatusCode, resp.Status)
 	}

--- a/plugins/parsers/json_v2/parser_test.go
+++ b/plugins/parsers/json_v2/parser_test.go
@@ -3,7 +3,6 @@ package json_v2_test
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -90,7 +89,7 @@ func TestData(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Process the telegraf config file for the test
-			buf, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s/telegraf.conf", tc.test))
+			buf, err := os.ReadFile(fmt.Sprintf("testdata/%s/telegraf.conf", tc.test))
 			require.NoError(t, err)
 			inputs.Add("file", func() telegraf.Input {
 				return &file.File{}

--- a/plugins/parsers/prometheus/parser_test.go
+++ b/plugins/parsers/prometheus/parser_test.go
@@ -2,7 +2,7 @@ package prometheus
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -435,7 +435,7 @@ func TestParserProtobufHeader(t *testing.T) {
 		t.Fatalf("error making HTTP request to %s: %s", ts.URL, err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("error reading body: %s", err)
 	}

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -1,7 +1,7 @@
 package xpath
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1233,7 +1233,7 @@ func TestTestCases(t *testing.T) {
 				pbmsgtype = protofields[1]
 			}
 
-			content, err := ioutil.ReadFile(datafile)
+			content, err := os.ReadFile(datafile)
 			require.NoError(t, err)
 
 			// Get the expectations
@@ -1266,7 +1266,7 @@ func TestTestCases(t *testing.T) {
 }
 
 func loadTestConfiguration(filename string) (*Config, []string, error) {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -3,7 +3,6 @@ package starlark
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -3194,7 +3193,7 @@ func TestAllScriptTestData(t *testing.T) {
 			}
 			fn := path
 			t.Run(fn, func(t *testing.T) {
-				b, err := ioutil.ReadFile(fn)
+				b, err := os.ReadFile(fn)
 				require.NoError(t, err)
 				lines := strings.Split(string(b), "\n")
 				inputMetrics := parseMetricsFrom(t, lines, "Example Input:")

--- a/testutil/tls.go
+++ b/testutil/tls.go
@@ -2,7 +2,7 @@ package testutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 
@@ -93,7 +93,7 @@ func readCertificate(filename string) string {
 	if err != nil {
 		panic(fmt.Sprintf("opening %q: %v", filename, err))
 	}
-	octets, err := ioutil.ReadAll(file)
+	octets, err := io.ReadAll(file)
 	if err != nil {
 		panic(fmt.Sprintf("reading %q: %v", filename, err))
 	}


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Partly related to #9642 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Hi! The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

#### Special notes for reviewers
No breaking changes.