### PR TITLE
feat: Unify graphics SMI implementations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9
 	github.com/antchfx/jsonquery v1.1.4
 	github.com/antchfx/xmlquery v1.3.6
-	github.com/antchfx/xpath v1.1.11
+	github.com/antchfx/xpath v1.2.1-0.20210925030449-696d1234f878
 	github.com/apache/arrow/go/arrow v0.0.0-20211006091945-a69884db78f4 // indirect
 	github.com/apache/thrift v0.14.2
 	github.com/aristanetworks/glog v0.0.0-20191112221043-67e8567f59f3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/antchfx/xmlquery v1.3.6 h1:kaEVzH1mNo/2AJZrhZjAaAUTy2Nn2zxGfYYU8jWfXO
 github.com/antchfx/xmlquery v1.3.6/go.mod h1:64w0Xesg2sTaawIdNqMB+7qaW/bSqkQm+ssPaCMWNnc=
 github.com/antchfx/xpath v1.1.7/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/antchfx/xpath v1.1.10/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
-github.com/antchfx/xpath v1.1.11 h1:WOFtK8TVAjLm3lbgqeP0arlHpvCEeTANeWZ/csPpJkQ=
-github.com/antchfx/xpath v1.1.11/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
+github.com/antchfx/xpath v1.2.1-0.20210925030449-696d1234f878 h1:mf/bAiWauE9qZ6I+lHzDaj7DdPPiSRlL5SeczHp+xls=
+github.com/antchfx/xpath v1.2.1-0.20210925030449-696d1234f878/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antonmedv/expr v1.8.9/go.mod h1:5qsM3oLGDND7sDmQGDXHkYfkjYMUX14qsgqmHhwGEk8=

--- a/plugins/common/receive_parse/receive_parse.go
+++ b/plugins/common/receive_parse/receive_parse.go
@@ -1,0 +1,99 @@
+package receive_parse
+
+import (
+	"fmt"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/models"
+	"github.com/influxdata/telegraf/plugins/common/transport"
+
+	"github.com/influxdata/telegraf/plugins/parsers"
+)
+
+// PostProcessor allows to perform arbitrary post-processing (e.g. type conversion or formatting) on the parsed metrics.
+type PostProcessor struct {
+	Name    string
+	Process func(m telegraf.Metric) error
+}
+
+// ReceiveAndParse is a general plugin implementation for plugins that receive some data over a transport
+// (e.g. exec, or http) and parse this data into metrics.
+// Individual plugins then only need to specify the transport and to configure the parser.
+type ReceiveAndParse struct {
+	// Receiver will also contain all configurable parameters for the plugin
+	transport.Receiver
+	// Parser to process the raw data received by the transport
+	Parser parsers.Parser `toml:"-"`
+	// PostProcessors allow to post-process the parsed metrics in an arbitrary manner
+	PostProcessors []PostProcessor `toml:"-"`
+
+	// Description for the plugin
+	DescriptionText string `toml:"-"`
+
+	// Log is the logging facility automatically filled by telegraf
+	Log telegraf.Logger `toml:"-"`
+}
+
+// Description returns the description of the GraphicsSMI plugin
+func (r *ReceiveAndParse) Description() string {
+	return r.DescriptionText
+}
+
+// SampleConfig returns the sample configuration for the GraphicsSMI plugin
+func (r *ReceiveAndParse) SampleConfig() string {
+	return r.Receiver.SampleConfig()
+}
+
+// Init implements the initializer interface
+func (r *ReceiveAndParse) Init() error {
+	// Try to push the logger to the receiver and parser
+	models.SetLoggerOnPlugin(r.Receiver, r.Log)
+	models.SetLoggerOnPlugin(r.Parser, r.Log)
+
+	// Try to initialize the transport
+	if t, ok := r.Receiver.(telegraf.Initializer); ok {
+		if err := t.Init(); err != nil {
+			return fmt.Errorf("initializing receiver failed: %v", err)
+		}
+	}
+
+	// Try to initialize the parser
+	if p, ok := r.Parser.(telegraf.Initializer); ok {
+		if err := p.Init(); err != nil {
+			return fmt.Errorf("initializing parser failed: %v", err)
+		}
+	}
+
+	fmt.Printf("got: %v\n", r)
+
+	return nil
+}
+
+// Gather implements the telegraf interface
+func (r *ReceiveAndParse) Gather(acc telegraf.Accumulator) error {
+	data, err := r.Receiver.Receive()
+	if err != nil {
+		return fmt.Errorf("receiving data failed: %v", err)
+	}
+
+	return r.Parse(acc, data)
+}
+
+func (r *ReceiveAndParse) Parse(acc telegraf.Accumulator, data []byte) error {
+	metrics, err := r.Parser.Parse(data)
+	if err != nil {
+		return fmt.Errorf("parsing data failed: %v", err)
+	}
+
+	for _, metric := range metrics {
+		for _, proc := range r.PostProcessors {
+			r.Log.Debugf("Running post-processors %q on metric %q...", proc.Name, metric.Name())
+			if err := proc.Process(metric); err != nil {
+				acc.AddError(fmt.Errorf("post-processor %q failed: %v", proc.Name, err))
+				continue
+			}
+		}
+		acc.AddMetric(metric)
+	}
+	return nil
+}

--- a/plugins/common/receive_parse/receive_parse.go
+++ b/plugins/common/receive_parse/receive_parse.go
@@ -50,7 +50,7 @@ func (r *ReceiveAndParse) Init() error {
 	models.SetLoggerOnPlugin(r.Receiver, r.Log)
 	models.SetLoggerOnPlugin(r.Parser, r.Log)
 
-	// Try to initialize the transport
+	// Try to initialize the receiver
 	if t, ok := r.Receiver.(telegraf.Initializer); ok {
 		if err := t.Init(); err != nil {
 			return fmt.Errorf("initializing receiver failed: %v", err)

--- a/plugins/common/receive_parse/receive_parse.go
+++ b/plugins/common/receive_parse/receive_parse.go
@@ -64,8 +64,6 @@ func (r *ReceiveAndParse) Init() error {
 		}
 	}
 
-	fmt.Printf("got: %v\n", r)
-
 	return nil
 }
 

--- a/plugins/common/transport/exec.go
+++ b/plugins/common/transport/exec.go
@@ -1,0 +1,54 @@
+package transport
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
+)
+
+// Exec is a transport implementation for locally executing a program
+type Exec struct {
+	BinPath string          `toml:"bin_path"`
+	Timeout config.Duration `toml:"timeout"`
+	BinArgs []string        `toml:"-"`
+
+	cmd *exec.Cmd
+}
+
+func (e *Exec) SampleConfig() string {
+	return `
+  ## Optional: path to executable, defaults to $PATH via exec.LookPath
+  # bin_path = "/usr/bin/nvidia-smi"
+
+  ## Optional: timeout for execution
+  # timeout = "5s"
+`
+}
+
+// Init performs all preparation work such as argument checks, default value handling etc. It should always
+// be called before Receive().
+func (e *Exec) Init() error {
+	if _, err := os.Stat(e.BinPath); errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("binary not at path %s", e.BinPath)
+	}
+
+	e.cmd = exec.Command(e.BinPath, e.BinArgs...)
+
+	return nil
+}
+
+// Receive calls the given command and returns the raw data received from its output.
+func (e *Exec) Receive() ([]byte, error) {
+	data, err := internal.CombinedOutputTimeout(e.cmd, time.Duration(e.Timeout))
+	if err != nil {
+		return nil, fmt.Errorf("executing %q failed: %v", strings.Join(append([]string{e.BinPath}, e.BinArgs...), " "), err)
+	}
+	return data, nil
+}

--- a/plugins/common/transport/transport.go
+++ b/plugins/common/transport/transport.go
@@ -1,0 +1,18 @@
+package transport
+
+import (
+	"github.com/influxdata/telegraf"
+)
+
+// Transport interface for general transport functions
+type Transport interface {
+	SampleConfig() string
+	telegraf.Initializer
+}
+
+// Receiver interface to get data that can be parsed in a later step
+type Receiver interface {
+	// Receive data from the endpoint(s)
+	Receive() ([]byte, error)
+	Transport
+}

--- a/plugins/inputs/amd_rocm_smi/amd_rocm_smi.go
+++ b/plugins/inputs/amd_rocm_smi/amd_rocm_smi.go
@@ -62,12 +62,12 @@ func NewAMDSMI() *generic.ReceiveAndParse {
 				"--json"},
 		},
 		Parser: &xpath.Parser{
-			Format:    "xpath_json",
-			IgnoreNaN: true,
+			Format: "xpath_json",
 			// PrintDocument: true,
 			Configs: []xpath.Config{
 				{
 					MetricDefaultName: "amd_rocm_smi",
+					IgnoreNaN:         true,
 					Selection:         "//*[starts-with(name(.), 'card')]",
 					Tags: map[string]string{
 						"name":          "name()",

--- a/plugins/inputs/amd_rocm_smi/amd_rocm_smi.go
+++ b/plugins/inputs/amd_rocm_smi/amd_rocm_smi.go
@@ -1,294 +1,157 @@
 package amd_rocm_smi
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/common/transport"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/parsers/xpath"
+
+	generic "github.com/influxdata/telegraf/plugins/common/receive_parse"
 )
 
-const measurement = "amd_rocm_smi"
-
-type ROCmSMI struct {
-	BinPath string
-	Timeout config.Duration
+func NewAMDSMI() *generic.ReceiveAndParse {
+	return &generic.ReceiveAndParse{
+		DescriptionText: "Query statistics from AMD Graphics cards using rocm-smi binary",
+		Receiver: &transport.Exec{
+			BinPath: "/opt/rocm/bin/rocm-smi",
+			Timeout: config.Duration(5 * time.Second),
+			BinArgs: []string{
+				"-o",
+				"-l",
+				"-m",
+				"-M",
+				"-g",
+				"-c",
+				"-t",
+				"-u",
+				"-i",
+				"-f",
+				"-p",
+				"-P",
+				"-s",
+				"-S",
+				"-v",
+				"--showreplaycount",
+				"--showpids",
+				"--showdriverversion",
+				"--showmemvendor",
+				"--showfwinfo",
+				"--showproductname",
+				"--showserial",
+				"--showuniqueid",
+				"--showbus",
+				"--showpendingpages",
+				"--showpagesinfo",
+				"--showmeminfo",
+				"all",
+				"--showretiredpages",
+				"--showunreservablepages",
+				"--showmemuse",
+				"--showvoltage",
+				"--showtopo",
+				"--showtopoweight",
+				"--showtopohops",
+				"--showtopotype",
+				"--showtoponuma",
+				"--json"},
+		},
+		Parser: &xpath.Parser{
+			Format:    "xpath_json",
+			IgnoreNaN: true,
+			// PrintDocument: true,
+			Configs: []xpath.Config{
+				{
+					MetricDefaultName: "amd_rocm_smi",
+					Selection:         "//*[starts-with(name(.), 'card')]",
+					Tags: map[string]string{
+						"name":          "name()",
+						"gpu_id":        "child::*[name() = 'GPU ID']",
+						"gpu_unique_id": "child::*[name() = 'Unique ID']",
+					},
+					Fields: map[string]string{
+						"temperature_sensor_edge":     "number(child::*[name() = 'Temperature (Sensor edge) (C)'])",
+						"temperature_sensor_junction": "number(child::*[name() = 'Temperature (Sensor junction) (C)'])",
+						"temperature_sensor_memory":   "number(child::*[name() = 'Temperature (Sensor memory) (C)'])",
+						"power_draw":                  "number(child::*[name() = 'Average Graphics Package Power (W)'])",
+						"driver_version":              "/system/child::*[name() = 'Driver version']",
+					},
+					FieldsInt: map[string]string{
+						"fan_speed":             "child::*[name() = 'Fan speed (%)']",
+						"memory_total":          "child::*[name() = 'VRAM Total Memory (B)']",
+						"memory_used":           "child::*[name() = 'VRAM Total Used Memory (B)']",
+						"utilization_gpu":       "child::*[name() = 'GPU use (%)']",
+						"utilization_memory":    "child::*[name() = 'GPU memory use (%)']",
+						"clocks_current_sm":     "substring(child::*[name() = 'sclk clock speed:'], 2, string-length(.)-5)",
+						"clocks_current_memory": "substring(child::*[name() = 'mclk clock speed:'], 2, string-length(.)-5)",
+					},
+				},
+			},
+		},
+		PostProcessors: []generic.PostProcessor{
+			{
+				Name:    "memory_free computation",
+				Process: postProcessMemoryFree,
+			},
+			{
+				Name:    "driver_version conversion",
+				Process: postProcessDriverVersion,
+			},
+		},
+	}
 }
 
-// Description returns the description of the ROCmSMI plugin
-func (rsmi *ROCmSMI) Description() string {
-	return "Query statistics from AMD Graphics cards using rocm-smi binary"
-}
+func postProcessMemoryFree(m telegraf.Metric) error {
+	fields := m.Fields()
 
-var ROCmSMIConfig = `
-## Optional: path to rocm-smi binary, defaults to $PATH via exec.LookPath
-# bin_path = "/opt/rocm/bin/rocm-smi"
-
-## Optional: timeout for GPU polling
-# timeout = "5s"
-`
-
-// SampleConfig returns the sample configuration for the ROCmSMI plugin
-func (rsmi *ROCmSMI) SampleConfig() string {
-	return ROCmSMIConfig
-}
-
-// Gather implements the telegraf interface
-func (rsmi *ROCmSMI) Gather(acc telegraf.Accumulator) error {
-	if _, err := os.Stat(rsmi.BinPath); os.IsNotExist(err) {
-		return fmt.Errorf("rocm-smi binary not found in path %s, cannot query GPUs statistics", rsmi.BinPath)
+	iTotal, found := fields["memory_total"]
+	if !found {
+		return fmt.Errorf("memory_total missing")
+	}
+	total, ok := iTotal.(int64)
+	if !ok {
+		return fmt.Errorf("memory_total is not int64 but %T", iTotal)
 	}
 
-	data, err := rsmi.pollROCmSMI()
+	iUsed, found := fields["memory_used"]
+	if !found {
+		return fmt.Errorf("memory_used missing")
+	}
+	used, ok := iUsed.(int64)
+	if !ok {
+		return fmt.Errorf("memory_used is not int64 but %T", iUsed)
+	}
+
+	m.AddField("memory_free", total-used)
+	return nil
+}
+
+func postProcessDriverVersion(m telegraf.Metric) error {
+	iVersion, found := m.GetField("driver_version")
+	if !found {
+		return nil
+	}
+
+	sVersion, ok := iVersion.(string)
+	if !ok {
+		return fmt.Errorf("driver_version is not string but %T", iVersion)
+	}
+
+	sVersion = strings.Replace(sVersion, ".", "", -1)
+	version, err := strconv.ParseInt(sVersion, 10, 64)
 	if err != nil {
 		return err
 	}
 
-	err = gatherROCmSMI(data, acc)
-	if err != nil {
-		return err
-	}
-
+	m.AddField("driver_version", version)
 	return nil
 }
 
 func init() {
-	inputs.Add("amd_rocm_smi", func() telegraf.Input {
-		return &ROCmSMI{
-			BinPath: "/opt/rocm/bin/rocm-smi",
-			Timeout: config.Duration(5 * time.Second),
-		}
-	})
-}
-
-func (rsmi *ROCmSMI) pollROCmSMI() ([]byte, error) {
-	// Construct and execute metrics query, there currently exist (ROCm v4.3.x) a "-a" option
-	// that does not provide all the information, so each needed parameter is set manually
-	cmd := exec.Command(rsmi.BinPath,
-		"-o",
-		"-l",
-		"-m",
-		"-M",
-		"-g",
-		"-c",
-		"-t",
-		"-u",
-		"-i",
-		"-f",
-		"-p",
-		"-P",
-		"-s",
-		"-S",
-		"-v",
-		"--showreplaycount",
-		"--showpids",
-		"--showdriverversion",
-		"--showmemvendor",
-		"--showfwinfo",
-		"--showproductname",
-		"--showserial",
-		"--showuniqueid",
-		"--showbus",
-		"--showpendingpages",
-		"--showpagesinfo",
-		"--showmeminfo",
-		"all",
-		"--showretiredpages",
-		"--showunreservablepages",
-		"--showmemuse",
-		"--showvoltage",
-		"--showtopo",
-		"--showtopoweight",
-		"--showtopohops",
-		"--showtopotype",
-		"--showtoponuma",
-		"--json")
-
-	ret, _ := internal.StdOutputTimeout(cmd,
-		time.Duration(rsmi.Timeout))
-	return ret, nil
-}
-
-func gatherROCmSMI(ret []byte, acc telegraf.Accumulator) error {
-	var gpus map[string]GPU
-	var sys map[string]sysInfo
-
-	err1 := json.Unmarshal(ret, &gpus)
-	if err1 != nil {
-		return err1
-	}
-
-	err2 := json.Unmarshal(ret, &sys)
-	if err2 != nil {
-		return err2
-	}
-
-	metrics := genTagsFields(gpus, sys)
-	for _, metric := range metrics {
-		acc.AddFields(measurement, metric.fields, metric.tags)
-	}
-
-	return nil
-}
-
-type metric struct {
-	tags   map[string]string
-	fields map[string]interface{}
-}
-
-func genTagsFields(gpus map[string]GPU, system map[string]sysInfo) []metric {
-	metrics := []metric{}
-	for cardID, payload := range gpus {
-		if strings.Contains(cardID, "card") {
-			tags := map[string]string{
-				"name": cardID,
-			}
-			fields := map[string]interface{}{}
-
-			totVRAM, _ := strconv.ParseInt(payload.GpuVRAMTotalMemory, 10, 64)
-			usdVRAM, _ := strconv.ParseInt(payload.GpuVRAMTotalUsedMemory, 10, 64)
-			strFree := strconv.FormatInt(totVRAM-usdVRAM, 10)
-
-			setTagIfUsed(tags, "gpu_id", payload.GpuID)
-			setTagIfUsed(tags, "gpu_unique_id", payload.GpuUniqueID)
-
-			setIfUsed("int", fields, "driver_version", strings.Replace(system["system"].DriverVersion, ".", "", -1))
-			setIfUsed("int", fields, "fan_speed", payload.GpuFanSpeedPercentage)
-			setIfUsed("int64", fields, "memory_total", payload.GpuVRAMTotalMemory)
-			setIfUsed("int64", fields, "memory_used", payload.GpuVRAMTotalUsedMemory)
-			setIfUsed("int64", fields, "memory_free", strFree)
-			setIfUsed("float", fields, "temperature_sensor_edge", payload.GpuTemperatureSensorEdge)
-			setIfUsed("float", fields, "temperature_sensor_junction", payload.GpuTemperatureSensorJunction)
-			setIfUsed("float", fields, "temperature_sensor_memory", payload.GpuTemperatureSensorMemory)
-			setIfUsed("int", fields, "utilization_gpu", payload.GpuUsePercentage)
-			setIfUsed("int", fields, "utilization_memory", payload.GpuMemoryUsePercentage)
-			setIfUsed("int", fields, "clocks_current_sm", strings.Trim(payload.GpuSclkClockSpeed, "(Mhz)"))
-			setIfUsed("int", fields, "clocks_current_memory", strings.Trim(payload.GpuMclkClockSpeed, "(Mhz)"))
-			setIfUsed("float", fields, "power_draw", payload.GpuAveragePower)
-
-			metrics = append(metrics, metric{tags, fields})
-		}
-	}
-	return metrics
-}
-
-func setTagIfUsed(m map[string]string, k, v string) {
-	if v != "" {
-		m[k] = v
-	}
-}
-
-func setIfUsed(t string, m map[string]interface{}, k, v string) {
-	vals := strings.Fields(v)
-	if len(vals) < 1 {
-		return
-	}
-
-	val := vals[0]
-
-	switch t {
-	case "float":
-		if val != "" {
-			f, err := strconv.ParseFloat(val, 64)
-			if err == nil {
-				m[k] = f
-			}
-		}
-	case "int":
-		if val != "" {
-			i, err := strconv.Atoi(val)
-			if err == nil {
-				m[k] = i
-			}
-		}
-	case "int64":
-		if val != "" {
-			i, err := strconv.ParseInt(val, 10, 64)
-			if err == nil {
-				m[k] = i
-			}
-		}
-	case "str":
-		if val != "" {
-			m[k] = val
-		}
-	}
-}
-
-type sysInfo struct {
-	DriverVersion string `json:"Driver version"`
-}
-
-type GPU struct {
-	GpuID                        string `json:"GPU ID"`
-	GpuUniqueID                  string `json:"Unique ID"`
-	GpuVBIOSVersion              string `json:"VBIOS version"`
-	GpuTemperatureSensorEdge     string `json:"Temperature (Sensor edge) (C)"`
-	GpuTemperatureSensorJunction string `json:"Temperature (Sensor junction) (C)"`
-	GpuTemperatureSensorMemory   string `json:"Temperature (Sensor memory) (C)"`
-	GpuDcefClkClockSpeed         string `json:"dcefclk clock speed"`
-	GpuDcefClkClockLevel         string `json:"dcefclk clock level"`
-	GpuFclkClockSpeed            string `json:"fclk clock speed"`
-	GpuFclkClockLevel            string `json:"fclk clock level"`
-	GpuMclkClockSpeed            string `json:"mclk clock speed:"`
-	GpuMclkClockLevel            string `json:"mclk clock level:"`
-	GpuSclkClockSpeed            string `json:"sclk clock speed:"`
-	GpuSclkClockLevel            string `json:"sclk clock level:"`
-	GpuSocclkClockSpeed          string `json:"socclk clock speed"`
-	GpuSocclkClockLevel          string `json:"socclk clock level"`
-	GpuPcieClock                 string `json:"pcie clock level"`
-	GpuFanSpeedLevel             string `json:"Fan speed (level)"`
-	GpuFanSpeedPercentage        string `json:"Fan speed (%)"`
-	GpuFanRPM                    string `json:"Fan RPM"`
-	GpuPerformanceLevel          string `json:"Performance Level"`
-	GpuOverdrive                 string `json:"GPU OverDrive value (%)"`
-	GpuMaxPower                  string `json:"Max Graphics Package Power (W)"`
-	GpuAveragePower              string `json:"Average Graphics Package Power (W)"`
-	GpuUsePercentage             string `json:"GPU use (%)"`
-	GpuMemoryUsePercentage       string `json:"GPU memory use (%)"`
-	GpuMemoryVendor              string `json:"GPU memory vendor"`
-	GpuPCIeReplay                string `json:"PCIe Replay Count"`
-	GpuSerialNumber              string `json:"Serial Number"`
-	GpuVoltagemV                 string `json:"Voltage (mV)"`
-	GpuPCIBus                    string `json:"PCI Bus"`
-	GpuASDDirmware               string `json:"ASD firmware version"`
-	GpuCEFirmware                string `json:"CE firmware version"`
-	GpuDMCUFirmware              string `json:"DMCU firmware version"`
-	GpuMCFirmware                string `json:"MC firmware version"`
-	GpuMEFirmware                string `json:"ME firmware version"`
-	GpuMECFirmware               string `json:"MEC firmware version"`
-	GpuMEC2Firmware              string `json:"MEC2 firmware version"`
-	GpuPFPFirmware               string `json:"PFP firmware version"`
-	GpuRLCFirmware               string `json:"RLC firmware version"`
-	GpuRLCSRLC                   string `json:"RLC SRLC firmware version"`
-	GpuRLCSRLG                   string `json:"RLC SRLG firmware version"`
-	GpuRLCSRLS                   string `json:"RLC SRLS firmware version"`
-	GpuSDMAFirmware              string `json:"SDMA firmware version"`
-	GpuSDMA2Firmware             string `json:"SDMA2 firmware version"`
-	GpuSMCFirmware               string `json:"SMC firmware version"`
-	GpuSOSFirmware               string `json:"SOS firmware version"`
-	GpuTARAS                     string `json:"TA RAS firmware version"`
-	GpuTAXGMI                    string `json:"TA XGMI firmware version"`
-	GpuUVDFirmware               string `json:"UVD firmware version"`
-	GpuVCEFirmware               string `json:"VCE firmware version"`
-	GpuVCNFirmware               string `json:"VCN firmware version"`
-	GpuCardSeries                string `json:"Card series"`
-	GpuCardModel                 string `json:"Card model"`
-	GpuCardVendor                string `json:"Card vendor"`
-	GpuCardSKU                   string `json:"Card SKU"`
-	GpuNUMANode                  string `json:"(Topology) Numa Node"`
-	GpuNUMAAffinity              string `json:"(Topology) Numa Affinity"`
-	GpuVisVRAMTotalMemory        string `json:"VIS_VRAM Total Memory (B)"`
-	GpuVisVRAMTotalUsedMemory    string `json:"VIS_VRAM Total Used Memory (B)"`
-	GpuVRAMTotalMemory           string `json:"VRAM Total Memory (B)"`
-	GpuVRAMTotalUsedMemory       string `json:"VRAM Total Used Memory (B)"`
-	GpuGTTTotalMemory            string `json:"GTT Total Memory (B)"`
-	GpuGTTTotalUsedMemory        string `json:"GTT Total Used Memory (B)"`
+	inputs.Add("amd_rocm_smi", func() telegraf.Input { return NewAMDSMI() })
 }

--- a/plugins/inputs/amd_rocm_smi/amd_rocm_smi_parser.conf
+++ b/plugins/inputs/amd_rocm_smi/amd_rocm_smi_parser.conf
@@ -1,3 +1,7 @@
+# See https://github.com/influxdata/telegraf/tree/master/plugins/parsers/xpath for details
+# on the parser settings and syntax.
+# Please note: We have to use the special 'xpath_config' section to allow setting up the parser.
+
 data_format = "xpath_json"
 metric_name = "amd_rocm_smi"
 

--- a/plugins/inputs/amd_rocm_smi/amd_rocm_smi_parser.conf
+++ b/plugins/inputs/amd_rocm_smi/amd_rocm_smi_parser.conf
@@ -1,0 +1,27 @@
+data_format = "xpath_json"
+metric_name = "amd_rocm_smi"
+
+[[xpath_config]]
+  metric_selection = "//*[starts-with(name(.), 'card')]"
+  ignore_nan = true
+
+  [xpath_config.tags]
+    name = "name()"
+    gpu_id = "child::*[name() = 'GPU ID']"
+    gpu_unique_id = "child::*[name() = 'Unique ID']"
+
+  [xpath_config.fields]
+    temperature_sensor_edge = "number(child::*[name() = 'Temperature (Sensor edge) (C)'])"
+    temperature_sensor_junction = "number(child::*[name() = 'Temperature (Sensor junction) (C)'])"
+    temperature_sensor_memory = "number(child::*[name() = 'Temperature (Sensor memory) (C)'])"
+    power_draw = "number(child::*[name() = 'Average Graphics Package Power (W)'])"
+    driver_version = "/system/child::*[name() = 'Driver version']"
+
+  [xpath_config.fields_int]
+    fan_speed = "child::*[name() = 'Fan speed (%)']"
+    memory_total = "child::*[name() = 'VRAM Total Memory (B)']"
+    memory_used = "child::*[name() = 'VRAM Total Used Memory (B)']"
+    utilization_gpu = "child::*[name() = 'GPU use (%)']"
+    utilization_memory = "child::*[name() = 'GPU memory use (%)']"
+    clocks_current_sm = "substring(child::*[name() = 'sclk clock speed:'], 2, string-length(.)-5)"
+    clocks_current_memory = "substring(child::*[name() = 'mclk clock speed:'], 2, string-length(.)-5)"

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -1,18 +1,34 @@
 package nvidia_smi
 
 import (
+	_ "embed" // Required for embedding the parser config file
+	"fmt"
 	"time"
+
+	"github.com/influxdata/toml"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/transport"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/parsers/xpath"
+	"github.com/influxdata/telegraf/plugins/parsers"
 
 	generic "github.com/influxdata/telegraf/plugins/common/receive_parse"
 )
 
+//go:embed nvidia_smi_parser.conf
+var cfgfile []byte
+
 func NewNvidiaSMI() *generic.ReceiveAndParse {
+	var cfg parsers.Config
+	if err := toml.Unmarshal(cfgfile, &cfg); err != nil {
+		panic(fmt.Errorf("cannot unmarshal 'nvidia_smi_parser.conf': %v", err))
+	}
+	parser, err := parsers.NewParser(&cfg)
+	if err != nil {
+		panic(fmt.Errorf("cannot instantiate parser for 'nvidia_smi': %v", err))
+	}
+
 	return &generic.ReceiveAndParse{
 		DescriptionText: "Pulls statistics from nvidia GPUs attached to the host",
 		Receiver: &transport.Exec{
@@ -20,51 +36,7 @@ func NewNvidiaSMI() *generic.ReceiveAndParse {
 			Timeout: config.Duration(5 * time.Second),
 			BinArgs: []string{"-q", "-x"},
 		},
-		Parser: &xpath.Parser{
-			Format: "xml",
-			Configs: []xpath.Config{
-				{
-					MetricDefaultName: "nvidia_smi",
-					IgnoreNaN:         true,
-					Selection:         "//gpu",
-					Tags: map[string]string{
-						"index":        "count(./preceding-sibling::gpu)",
-						"pstate":       "performance_state",
-						"name":         "product_name",
-						"uuid":         "uuid",
-						"compute_mode": "compute_mode",
-					},
-					Fields: map[string]string{
-						"driver_version": "../driver_version",
-						"cuda_version":   "../cuda_version",
-						"power_draw":     "number(substring-before(power_readings/power_draw, ' '))",
-					},
-					FieldsInt: map[string]string{
-						"fan_speed":                     "substring-before(fan_speed, ' ')",
-						"memory_total":                  "substring-before(fb_memory_usage/total, ' ')",
-						"memory_used":                   "substring-before(fb_memory_usage/used, ' ')",
-						"memory_free":                   "substring-before(fb_memory_usage/free, ' ')",
-						"temperature_gpu":               "substring-before(temperature/gpu_temp, ' ')",
-						"utilization_gpu":               "substring-before(utilization/gpu_util, ' ')",
-						"utilization_memory":            "substring-before(utilization/memory_util, ' ')",
-						"utilization_encoder":           "substring-before(utilization/encoder_util, ' ')",
-						"utilization_decoder":           "substring-before(utilization/decoder_util, ' ')",
-						"pcie_link_gen_current":         "pci/pci_gpu_link_info/pcie_gen/current_link_gen",
-						"pcie_link_width_current":       "substring-before(pci/pci_gpu_link_info/link_widths/current_link_width, 'x')",
-						"encoder_stats_session_count":   "encoder_stats/session_count",
-						"encoder_stats_average_fps":     "encoder_stats/average_fps",
-						"encoder_stats_average_latency": "encoder_stats/average_latency",
-						"fbc_stats_session_count":       "fbc_stats/session_count",
-						"fbc_stats_average_fps":         "fbc_stats/average_fps",
-						"fbc_stats_average_latency":     "fbc_stats/average_latency",
-						"clocks_current_graphics":       "substring-before(clocks/graphics_clock, ' ')",
-						"clocks_current_sm":             "substring-before(clocks/sm_clock, ' ')",
-						"clocks_current_memory":         "substring-before(clocks/mem_clock, ' ')",
-						"clocks_current_video":          "substring-before(clocks/video_clock, ' ')",
-					},
-				},
-			},
-		},
+		Parser: parser,
 	}
 }
 

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -21,11 +21,11 @@ func NewNvidiaSMI() *generic.ReceiveAndParse {
 			BinArgs: []string{"-q", "-x"},
 		},
 		Parser: &xpath.Parser{
-			Format:    "xml",
-			IgnoreNaN: true,
+			Format: "xml",
 			Configs: []xpath.Config{
 				{
 					MetricDefaultName: "nvidia_smi",
+					IgnoreNaN:         true,
 					Selection:         "//gpu",
 					Tags: map[string]string{
 						"index":        "count(./preceding-sibling::gpu)",

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -1,263 +1,73 @@
 package nvidia_smi
 
 import (
-	"encoding/xml"
-	"fmt"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/common/transport"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/parsers/xpath"
+
+	generic "github.com/influxdata/telegraf/plugins/common/receive_parse"
 )
 
-const measurement = "nvidia_smi"
-
-// NvidiaSMI holds the methods for this plugin
-type NvidiaSMI struct {
-	BinPath string
-	Timeout config.Duration
-}
-
-// Description returns the description of the NvidiaSMI plugin
-func (smi *NvidiaSMI) Description() string {
-	return "Pulls statistics from nvidia GPUs attached to the host"
-}
-
-// SampleConfig returns the sample configuration for the NvidiaSMI plugin
-func (smi *NvidiaSMI) SampleConfig() string {
-	return `
-  ## Optional: path to nvidia-smi binary, defaults to $PATH via exec.LookPath
-  # bin_path = "/usr/bin/nvidia-smi"
-
-  ## Optional: timeout for GPU polling
-  # timeout = "5s"
-`
-}
-
-// Gather implements the telegraf interface
-func (smi *NvidiaSMI) Gather(acc telegraf.Accumulator) error {
-	if _, err := os.Stat(smi.BinPath); os.IsNotExist(err) {
-		return fmt.Errorf("nvidia-smi binary not at path %s, cannot gather GPU data", smi.BinPath)
+func NewNvidiaSMI() *generic.ReceiveAndParse {
+	return &generic.ReceiveAndParse{
+		DescriptionText: "Pulls statistics from nvidia GPUs attached to the host",
+		Receiver: &transport.Exec{
+			BinPath: "/usr/bin/nvidia-smi",
+			Timeout: config.Duration(5 * time.Second),
+			BinArgs: []string{"-q", "-x"},
+		},
+		Parser: &xpath.Parser{
+			Format:    "xml",
+			IgnoreNaN: true,
+			Configs: []xpath.Config{
+				{
+					MetricDefaultName: "nvidia_smi",
+					Selection:         "//gpu",
+					Tags: map[string]string{
+						"index":        "count(./preceding-sibling::gpu)",
+						"pstate":       "performance_state",
+						"name":         "product_name",
+						"uuid":         "uuid",
+						"compute_mode": "compute_mode",
+					},
+					Fields: map[string]string{
+						"driver_version": "../driver_version",
+						"cuda_version":   "../cuda_version",
+						"power_draw":     "number(substring-before(power_readings/power_draw, ' '))",
+					},
+					FieldsInt: map[string]string{
+						"fan_speed":                     "substring-before(fan_speed, ' ')",
+						"memory_total":                  "substring-before(fb_memory_usage/total, ' ')",
+						"memory_used":                   "substring-before(fb_memory_usage/used, ' ')",
+						"memory_free":                   "substring-before(fb_memory_usage/free, ' ')",
+						"temperature_gpu":               "substring-before(temperature/gpu_temp, ' ')",
+						"utilization_gpu":               "substring-before(utilization/gpu_util, ' ')",
+						"utilization_memory":            "substring-before(utilization/memory_util, ' ')",
+						"utilization_encoder":           "substring-before(utilization/encoder_util, ' ')",
+						"utilization_decoder":           "substring-before(utilization/decoder_util, ' ')",
+						"pcie_link_gen_current":         "pci/pci_gpu_link_info/pcie_gen/current_link_gen",
+						"pcie_link_width_current":       "substring-before(pci/pci_gpu_link_info/link_widths/current_link_width, 'x')",
+						"encoder_stats_session_count":   "encoder_stats/session_count",
+						"encoder_stats_average_fps":     "encoder_stats/average_fps",
+						"encoder_stats_average_latency": "encoder_stats/average_latency",
+						"fbc_stats_session_count":       "fbc_stats/session_count",
+						"fbc_stats_average_fps":         "fbc_stats/average_fps",
+						"fbc_stats_average_latency":     "fbc_stats/average_latency",
+						"clocks_current_graphics":       "substring-before(clocks/graphics_clock, ' ')",
+						"clocks_current_sm":             "substring-before(clocks/sm_clock, ' ')",
+						"clocks_current_memory":         "substring-before(clocks/mem_clock, ' ')",
+						"clocks_current_video":          "substring-before(clocks/video_clock, ' ')",
+					},
+				},
+			},
+		},
 	}
-
-	data, err := smi.pollSMI()
-	if err != nil {
-		return err
-	}
-
-	err = gatherNvidiaSMI(data, acc)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func init() {
-	inputs.Add("nvidia_smi", func() telegraf.Input {
-		return &NvidiaSMI{
-			BinPath: "/usr/bin/nvidia-smi",
-			Timeout: config.Duration(5 * time.Second),
-		}
-	})
-}
-
-func (smi *NvidiaSMI) pollSMI() ([]byte, error) {
-	// Construct and execute metrics query
-	ret, err := internal.CombinedOutputTimeout(exec.Command(smi.BinPath, "-q", "-x"), time.Duration(smi.Timeout))
-	if err != nil {
-		return nil, err
-	}
-	return ret, nil
-}
-
-func gatherNvidiaSMI(ret []byte, acc telegraf.Accumulator) error {
-	smi := &SMI{}
-	err := xml.Unmarshal(ret, smi)
-	if err != nil {
-		return err
-	}
-
-	metrics := smi.genTagsFields()
-
-	for _, metric := range metrics {
-		acc.AddFields(measurement, metric.fields, metric.tags)
-	}
-
-	return nil
-}
-
-type metric struct {
-	tags   map[string]string
-	fields map[string]interface{}
-}
-
-func (s *SMI) genTagsFields() []metric {
-	metrics := []metric{}
-	for i, gpu := range s.GPU {
-		tags := map[string]string{
-			"index": strconv.Itoa(i),
-		}
-		fields := map[string]interface{}{}
-
-		setTagIfUsed(tags, "pstate", gpu.PState)
-		setTagIfUsed(tags, "name", gpu.ProdName)
-		setTagIfUsed(tags, "uuid", gpu.UUID)
-		setTagIfUsed(tags, "compute_mode", gpu.ComputeMode)
-
-		setIfUsed("str", fields, "driver_version", s.DriverVersion)
-		setIfUsed("str", fields, "cuda_version", s.CUDAVersion)
-		setIfUsed("int", fields, "fan_speed", gpu.FanSpeed)
-		setIfUsed("int", fields, "memory_total", gpu.Memory.Total)
-		setIfUsed("int", fields, "memory_used", gpu.Memory.Used)
-		setIfUsed("int", fields, "memory_free", gpu.Memory.Free)
-		setIfUsed("int", fields, "temperature_gpu", gpu.Temp.GPUTemp)
-		setIfUsed("int", fields, "utilization_gpu", gpu.Utilization.GPU)
-		setIfUsed("int", fields, "utilization_memory", gpu.Utilization.Memory)
-		setIfUsed("int", fields, "utilization_encoder", gpu.Utilization.Encoder)
-		setIfUsed("int", fields, "utilization_decoder", gpu.Utilization.Decoder)
-		setIfUsed("int", fields, "pcie_link_gen_current", gpu.PCI.LinkInfo.PCIEGen.CurrentLinkGen)
-		setIfUsed("int", fields, "pcie_link_width_current", gpu.PCI.LinkInfo.LinkWidth.CurrentLinkWidth)
-		setIfUsed("int", fields, "encoder_stats_session_count", gpu.Encoder.SessionCount)
-		setIfUsed("int", fields, "encoder_stats_average_fps", gpu.Encoder.AverageFPS)
-		setIfUsed("int", fields, "encoder_stats_average_latency", gpu.Encoder.AverageLatency)
-		setIfUsed("int", fields, "fbc_stats_session_count", gpu.FBC.SessionCount)
-		setIfUsed("int", fields, "fbc_stats_average_fps", gpu.FBC.AverageFPS)
-		setIfUsed("int", fields, "fbc_stats_average_latency", gpu.FBC.AverageLatency)
-		setIfUsed("int", fields, "clocks_current_graphics", gpu.Clocks.Graphics)
-		setIfUsed("int", fields, "clocks_current_sm", gpu.Clocks.SM)
-		setIfUsed("int", fields, "clocks_current_memory", gpu.Clocks.Memory)
-		setIfUsed("int", fields, "clocks_current_video", gpu.Clocks.Video)
-
-		setIfUsed("float", fields, "power_draw", gpu.Power.PowerDraw)
-		metrics = append(metrics, metric{tags, fields})
-	}
-	return metrics
-}
-
-func setTagIfUsed(m map[string]string, k, v string) {
-	if v != "" {
-		m[k] = v
-	}
-}
-
-func setIfUsed(t string, m map[string]interface{}, k, v string) {
-	vals := strings.Fields(v)
-	if len(vals) < 1 {
-		return
-	}
-
-	val := vals[0]
-	if k == "pcie_link_width_current" {
-		val = strings.TrimSuffix(vals[0], "x")
-	}
-
-	switch t {
-	case "float":
-		if val != "" {
-			f, err := strconv.ParseFloat(val, 64)
-			if err == nil {
-				m[k] = f
-			}
-		}
-	case "int":
-		if val != "" {
-			i, err := strconv.Atoi(val)
-			if err == nil {
-				m[k] = i
-			}
-		}
-	case "str":
-		if val != "" {
-			m[k] = val
-		}
-	}
-}
-
-// SMI defines the structure for the output of _nvidia-smi -q -x_.
-type SMI struct {
-	GPU           GPU    `xml:"gpu"`
-	DriverVersion string `xml:"driver_version"`
-	CUDAVersion   string `xml:"cuda_version"`
-}
-
-// GPU defines the structure of the GPU portion of the smi output.
-type GPU []struct {
-	FanSpeed    string           `xml:"fan_speed"` // int
-	Memory      MemoryStats      `xml:"fb_memory_usage"`
-	PState      string           `xml:"performance_state"`
-	Temp        TempStats        `xml:"temperature"`
-	ProdName    string           `xml:"product_name"`
-	UUID        string           `xml:"uuid"`
-	ComputeMode string           `xml:"compute_mode"`
-	Utilization UtilizationStats `xml:"utilization"`
-	Power       PowerReadings    `xml:"power_readings"`
-	PCI         PCI              `xml:"pci"`
-	Encoder     EncoderStats     `xml:"encoder_stats"`
-	FBC         FBCStats         `xml:"fbc_stats"`
-	Clocks      ClockStats       `xml:"clocks"`
-}
-
-// MemoryStats defines the structure of the memory portions in the smi output.
-type MemoryStats struct {
-	Total string `xml:"total"` // int
-	Used  string `xml:"used"`  // int
-	Free  string `xml:"free"`  // int
-}
-
-// TempStats defines the structure of the temperature portion of the smi output.
-type TempStats struct {
-	GPUTemp string `xml:"gpu_temp"` // int
-}
-
-// UtilizationStats defines the structure of the utilization portion of the smi output.
-type UtilizationStats struct {
-	GPU     string `xml:"gpu_util"`     // int
-	Memory  string `xml:"memory_util"`  // int
-	Encoder string `xml:"encoder_util"` // int
-	Decoder string `xml:"decoder_util"` // int
-}
-
-// PowerReadings defines the structure of the power_readings portion of the smi output.
-type PowerReadings struct {
-	PowerDraw string `xml:"power_draw"` // float
-}
-
-// PCI defines the structure of the pci portion of the smi output.
-type PCI struct {
-	LinkInfo struct {
-		PCIEGen struct {
-			CurrentLinkGen string `xml:"current_link_gen"` // int
-		} `xml:"pcie_gen"`
-		LinkWidth struct {
-			CurrentLinkWidth string `xml:"current_link_width"` // int
-		} `xml:"link_widths"`
-	} `xml:"pci_gpu_link_info"`
-}
-
-// EncoderStats defines the structure of the encoder_stats portion of the smi output.
-type EncoderStats struct {
-	SessionCount   string `xml:"session_count"`   // int
-	AverageFPS     string `xml:"average_fps"`     // int
-	AverageLatency string `xml:"average_latency"` // int
-}
-
-// FBCStats defines the structure of the fbc_stats portion of the smi output.
-type FBCStats struct {
-	SessionCount   string `xml:"session_count"`   // int
-	AverageFPS     string `xml:"average_fps"`     // int
-	AverageLatency string `xml:"average_latency"` // int
-}
-
-// ClockStats defines the structure of the clocks portion of the smi output.
-type ClockStats struct {
-	Graphics string `xml:"graphics_clock"` // int
-	SM       string `xml:"sm_clock"`       // int
-	Memory   string `xml:"mem_clock"`      // int
-	Video    string `xml:"video_clock"`    // int
+	inputs.Add("nvidia_smi", func() telegraf.Input { return NewNvidiaSMI() })
 }

--- a/plugins/inputs/nvidia_smi/nvidia_smi_parser.conf
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_parser.conf
@@ -1,3 +1,7 @@
+# See https://github.com/influxdata/telegraf/tree/master/plugins/parsers/xpath for details
+# on the parser settings and syntax.
+# Please note: We have to use the special 'xpath_config' section to allow setting up the parser.
+
 data_format = "xpath_xml"
 metric_name = "nvidia_smi"
 

--- a/plugins/inputs/nvidia_smi/nvidia_smi_parser.conf
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_parser.conf
@@ -1,0 +1,41 @@
+data_format = "xpath_xml"
+metric_name = "nvidia_smi"
+
+[[xpath_config]]
+  metric_selection = "//gpu"
+  ignore_nan = true
+
+  [xpath_config.tags]
+    index = "count(./preceding-sibling::gpu)"
+    pstate = "performance_state"
+    name = "product_name"
+    uuid = "uuid"
+    compute_mode = "compute_mode"
+
+  [xpath_config.fields]
+    driver_version = "../driver_version"
+    cuda_version = "../cuda_version"
+    power_draw = "number(substring-before(power_readings/power_draw, ' '))"
+
+  [xpath_config.fields_int]
+    fan_speed = "substring-before(fan_speed, ' ')"
+    memory_total = "substring-before(fb_memory_usage/total, ' ')"
+    memory_used = "substring-before(fb_memory_usage/used, ' ')"
+    memory_free = "substring-before(fb_memory_usage/free, ' ')"
+    temperature_gpu = "substring-before(temperature/gpu_temp, ' ')"
+    utilization_gpu = "substring-before(utilization/gpu_util, ' ')"
+    utilization_memory = "substring-before(utilization/memory_util, ' ')"
+    utilization_encoder = "substring-before(utilization/encoder_util, ' ')"
+    utilization_decoder = "substring-before(utilization/decoder_util, ' ')"
+    pcie_link_gen_current = "pci/pci_gpu_link_info/pcie_gen/current_link_gen"
+    pcie_link_width_current = "substring-before(pci/pci_gpu_link_info/link_widths/current_link_width, 'x')"
+    encoder_stats_session_count = "encoder_stats/session_count"
+    encoder_stats_average_fps = "encoder_stats/average_fps"
+    encoder_stats_average_latency = "encoder_stats/average_latency"
+    fbc_stats_session_count = "fbc_stats/session_count"
+    fbc_stats_average_fps = "fbc_stats/average_fps"
+    fbc_stats_average_latency = "fbc_stats/average_latency"
+    clocks_current_graphics = "substring-before(clocks/graphics_clock, ' ')"
+    clocks_current_sm = "substring-before(clocks/sm_clock, ' ')"
+    clocks_current_memory = "substring-before(clocks/mem_clock, ' ')"
+    clocks_current_video = "substring-before(clocks/video_clock, ' ')"

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -18,6 +18,46 @@ func TestGatherValidXML(t *testing.T) {
 		expected []telegraf.Metric
 	}{
 		{
+			name:     "GeForce GT 1030",
+			filename: "gt-1030.xml",
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"nvidia_smi",
+					map[string]string{
+						"name":         "NVIDIA GeForce GT 1030",
+						"compute_mode": "Default",
+						"index":        "0",
+						"pstate":       "P0",
+						"uuid":         "GPU-857c6374-f681-cf3a-f99f-9063a87b8ac0",
+					},
+					map[string]interface{}{
+						"clocks_current_graphics":       1265,
+						"clocks_current_memory":         3003,
+						"clocks_current_sm":             1265,
+						"clocks_current_video":          1126,
+						"encoder_stats_average_fps":     0,
+						"encoder_stats_average_latency": 0,
+						"encoder_stats_session_count":   0,
+						"fan_speed":                     35,
+						"memory_free":                   1123,
+						"memory_total":                  1998,
+						"memory_used":                   875,
+						"pcie_link_gen_current":         3,
+						"pcie_link_width_current":       4,
+						"temperature_gpu":               36,
+						"utilization_gpu":               0,
+						"utilization_memory":            3,
+						"utilization_decoder":           0,
+						"cuda_version":                  "11.4",
+						"driver_version":                "470.74",
+						"fbc_stats_average_fps":         0,
+						"fbc_stats_average_latency":     0,
+						"fbc_stats_session_count":       0,
+					},
+					time.Unix(0, 0)),
+			},
+		},
+		{
 			name:     "GeForce GTX 1070 Ti",
 			filename: "gtx-1070-ti.xml",
 			expected: []telegraf.Metric{

--- a/plugins/inputs/nvidia_smi/testdata/gt-1030.xml
+++ b/plugins/inputs/nvidia_smi/testdata/gt-1030.xml
@@ -1,0 +1,652 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v11.dtd">
+<nvidia_smi_log>
+	<timestamp>Thu Sep 23 17:44:07 2021</timestamp>
+	<driver_version>470.74</driver_version>
+	<cuda_version>11.4</cuda_version>
+	<attached_gpus>1</attached_gpus>
+	<gpu id="00000000:2D:00.0">
+		<product_name>NVIDIA GeForce GT 1030</product_name>
+		<product_brand>GeForce</product_brand>
+		<display_mode>Enabled</display_mode>
+		<display_active>Enabled</display_active>
+		<persistence_mode>Disabled</persistence_mode>
+		<mig_mode>
+			<current_mig>N/A</current_mig>
+			<pending_mig>N/A</pending_mig>
+		</mig_mode>
+		<mig_devices>
+			None
+		</mig_devices>
+		<accounting_mode>Disabled</accounting_mode>
+		<accounting_mode_buffer_size>4000</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>N/A</serial>
+		<uuid>GPU-857c6374-f681-cf3a-f99f-9063a87b8ac0</uuid>
+		<minor_number>0</minor_number>
+		<vbios_version>86.08.24.00.23</vbios_version>
+		<multigpu_board>No</multigpu_board>
+		<board_id>0x2d00</board_id>
+		<gpu_part_number>N/A</gpu_part_number>
+		<gpu_module_id>0</gpu_module_id>
+		<inforom_version>
+			<img_version>G001.0000.01.04</img_version>
+			<oem_object>1.1</oem_object>
+			<ecc_object>N/A</ecc_object>
+			<pwr_object>N/A</pwr_object>
+		</inforom_version>
+		<gpu_operation_mode>
+			<current_gom>N/A</current_gom>
+			<pending_gom>N/A</pending_gom>
+		</gpu_operation_mode>
+		<gsp_firmware_version>N/A</gsp_firmware_version>
+		<gpu_virtualization_mode>
+			<virtualization_mode>None</virtualization_mode>
+			<host_vgpu_mode>N/A</host_vgpu_mode>
+		</gpu_virtualization_mode>
+		<ibmnpu>
+			<relaxed_ordering_mode>N/A</relaxed_ordering_mode>
+		</ibmnpu>
+		<pci>
+			<pci_bus>2D</pci_bus>
+			<pci_device>00</pci_device>
+			<pci_domain>0000</pci_domain>
+			<pci_device_id>1D0110DE</pci_device_id>
+			<pci_bus_id>00000000:2D:00.0</pci_bus_id>
+			<pci_sub_system_id>8C981462</pci_sub_system_id>
+			<pci_gpu_link_info>
+				<pcie_gen>
+					<max_link_gen>3</max_link_gen>
+					<current_link_gen>3</current_link_gen>
+				</pcie_gen>
+				<link_widths>
+					<max_link_width>4x</max_link_width>
+					<current_link_width>4x</current_link_width>
+				</link_widths>
+			</pci_gpu_link_info>
+			<pci_bridge_chip>
+				<bridge_chip_type>N/A</bridge_chip_type>
+				<bridge_chip_fw>N/A</bridge_chip_fw>
+			</pci_bridge_chip>
+			<replay_counter>0</replay_counter>
+			<replay_rollover_counter>0</replay_rollover_counter>
+			<tx_util>53000 KB/s</tx_util>
+			<rx_util>1000 KB/s</rx_util>
+		</pci>
+		<fan_speed>35 %</fan_speed>
+		<performance_state>P0</performance_state>
+		<clocks_throttle_reasons>
+			<clocks_throttle_reason_gpu_idle>Active</clocks_throttle_reason_gpu_idle>
+			<clocks_throttle_reason_applications_clocks_setting>Not Active</clocks_throttle_reason_applications_clocks_setting>
+			<clocks_throttle_reason_sw_power_cap>Not Active</clocks_throttle_reason_sw_power_cap>
+			<clocks_throttle_reason_hw_slowdown>Not Active</clocks_throttle_reason_hw_slowdown>
+			<clocks_throttle_reason_hw_thermal_slowdown>Not Active</clocks_throttle_reason_hw_thermal_slowdown>
+			<clocks_throttle_reason_hw_power_brake_slowdown>Not Active</clocks_throttle_reason_hw_power_brake_slowdown>
+			<clocks_throttle_reason_sync_boost>Not Active</clocks_throttle_reason_sync_boost>
+			<clocks_throttle_reason_sw_thermal_slowdown>Not Active</clocks_throttle_reason_sw_thermal_slowdown>
+			<clocks_throttle_reason_display_clocks_setting>Not Active</clocks_throttle_reason_display_clocks_setting>
+		</clocks_throttle_reasons>
+		<fb_memory_usage>
+			<total>1998 MiB</total>
+			<used>875 MiB</used>
+			<free>1123 MiB</free>
+		</fb_memory_usage>
+		<bar1_memory_usage>
+			<total>256 MiB</total>
+			<used>6 MiB</used>
+			<free>250 MiB</free>
+		</bar1_memory_usage>
+		<compute_mode>Default</compute_mode>
+		<utilization>
+			<gpu_util>0 %</gpu_util>
+			<memory_util>3 %</memory_util>
+			<encoder_util>N/A</encoder_util>
+			<decoder_util>0 %</decoder_util>
+		</utilization>
+		<encoder_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</encoder_stats>
+		<fbc_stats>
+			<session_count>0</session_count>
+			<average_fps>0</average_fps>
+			<average_latency>0</average_latency>
+		</fbc_stats>
+		<ecc_mode>
+			<current_ecc>N/A</current_ecc>
+			<pending_ecc>N/A</pending_ecc>
+		</ecc_mode>
+		<ecc_errors>
+			<volatile>
+				<single_bit>
+					<device_memory>N/A</device_memory>
+					<register_file>N/A</register_file>
+					<l1_cache>N/A</l1_cache>
+					<l2_cache>N/A</l2_cache>
+					<texture_memory>N/A</texture_memory>
+					<texture_shm>N/A</texture_shm>
+					<cbu>N/A</cbu>
+					<total>N/A</total>
+				</single_bit>
+				<double_bit>
+					<device_memory>N/A</device_memory>
+					<register_file>N/A</register_file>
+					<l1_cache>N/A</l1_cache>
+					<l2_cache>N/A</l2_cache>
+					<texture_memory>N/A</texture_memory>
+					<texture_shm>N/A</texture_shm>
+					<cbu>N/A</cbu>
+					<total>N/A</total>
+				</double_bit>
+			</volatile>
+			<aggregate>
+				<single_bit>
+					<device_memory>N/A</device_memory>
+					<register_file>N/A</register_file>
+					<l1_cache>N/A</l1_cache>
+					<l2_cache>N/A</l2_cache>
+					<texture_memory>N/A</texture_memory>
+					<texture_shm>N/A</texture_shm>
+					<cbu>N/A</cbu>
+					<total>N/A</total>
+				</single_bit>
+				<double_bit>
+					<device_memory>N/A</device_memory>
+					<register_file>N/A</register_file>
+					<l1_cache>N/A</l1_cache>
+					<l2_cache>N/A</l2_cache>
+					<texture_memory>N/A</texture_memory>
+					<texture_shm>N/A</texture_shm>
+					<cbu>N/A</cbu>
+					<total>N/A</total>
+				</double_bit>
+			</aggregate>
+		</ecc_errors>
+		<retired_pages>
+			<multiple_single_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</multiple_single_bit_retirement>
+			<double_bit_retirement>
+				<retired_count>N/A</retired_count>
+				<retired_pagelist>N/A</retired_pagelist>
+			</double_bit_retirement>
+			<pending_blacklist>N/A</pending_blacklist>
+			<pending_retirement>N/A</pending_retirement>
+		</retired_pages>
+		<remapped_rows>N/A</remapped_rows>
+		<temperature>
+			<gpu_temp>36 C</gpu_temp>
+			<gpu_temp_max_threshold>102 C</gpu_temp_max_threshold>
+			<gpu_temp_slow_threshold>99 C</gpu_temp_slow_threshold>
+			<gpu_temp_max_gpu_threshold>N/A</gpu_temp_max_gpu_threshold>
+			<gpu_target_temperature>83 C</gpu_target_temperature>
+			<memory_temp>N/A</memory_temp>
+			<gpu_temp_max_mem_threshold>N/A</gpu_temp_max_mem_threshold>
+		</temperature>
+		<supported_gpu_target_temp>
+			<gpu_target_temp_min>65 C</gpu_target_temp_min>
+			<gpu_target_temp_max>97 C</gpu_target_temp_max>
+		</supported_gpu_target_temp>
+		<power_readings>
+			<power_state>P0</power_state>
+			<power_management>Supported</power_management>
+			<power_draw>N/A</power_draw>
+			<power_limit>30.00 W</power_limit>
+			<default_power_limit>30.00 W</default_power_limit>
+			<enforced_power_limit>30.00 W</enforced_power_limit>
+			<min_power_limit>25.50 W</min_power_limit>
+			<max_power_limit>30.00 W</max_power_limit>
+		</power_readings>
+		<clocks>
+			<graphics_clock>1265 MHz</graphics_clock>
+			<sm_clock>1265 MHz</sm_clock>
+			<mem_clock>3003 MHz</mem_clock>
+			<video_clock>1126 MHz</video_clock>
+		</clocks>
+		<applications_clocks>
+			<graphics_clock>N/A</graphics_clock>
+			<mem_clock>N/A</mem_clock>
+		</applications_clocks>
+		<default_applications_clocks>
+			<graphics_clock>N/A</graphics_clock>
+			<mem_clock>N/A</mem_clock>
+		</default_applications_clocks>
+		<max_clocks>
+			<graphics_clock>1949 MHz</graphics_clock>
+			<sm_clock>1949 MHz</sm_clock>
+			<mem_clock>3004 MHz</mem_clock>
+			<video_clock>1708 MHz</video_clock>
+		</max_clocks>
+		<max_customer_boost_clocks>
+			<graphics_clock>N/A</graphics_clock>
+		</max_customer_boost_clocks>
+		<clock_policy>
+			<auto_boost>N/A</auto_boost>
+			<auto_boost_default>N/A</auto_boost_default>
+		</clock_policy>
+		<voltage>
+			<graphics_volt>N/A</graphics_volt>
+		</voltage>
+		<supported_clocks>
+			<supported_mem_clock>
+				<value>3004 MHz</value>
+				<supported_graphics_clock>1949 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1936 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1923 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1911 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1898 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1873 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1835 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1809 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1797 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1784 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1771 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1759 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1746 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1733 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1721 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1708 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1683 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1670 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1632 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1594 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1569 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1556 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1544 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1531 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1518 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1506 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1493 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1468 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1430 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1404 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1392 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1379 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1366 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1354 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1341 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1328 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1316 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1303 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1278 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1265 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1227 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1189 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1164 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1151 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1139 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1126 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1113 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1101 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1088 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1075 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1063 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1037 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>999 MHz</supported_graphics_clock>
+				<supported_graphics_clock>987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>974 MHz</supported_graphics_clock>
+				<supported_graphics_clock>961 MHz</supported_graphics_clock>
+				<supported_graphics_clock>949 MHz</supported_graphics_clock>
+				<supported_graphics_clock>936 MHz</supported_graphics_clock>
+				<supported_graphics_clock>923 MHz</supported_graphics_clock>
+				<supported_graphics_clock>911 MHz</supported_graphics_clock>
+				<supported_graphics_clock>898 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>873 MHz</supported_graphics_clock>
+				<supported_graphics_clock>860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>835 MHz</supported_graphics_clock>
+				<supported_graphics_clock>822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>797 MHz</supported_graphics_clock>
+				<supported_graphics_clock>784 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>759 MHz</supported_graphics_clock>
+				<supported_graphics_clock>746 MHz</supported_graphics_clock>
+				<supported_graphics_clock>734 MHz</supported_graphics_clock>
+				<supported_graphics_clock>721 MHz</supported_graphics_clock>
+				<supported_graphics_clock>708 MHz</supported_graphics_clock>
+				<supported_graphics_clock>696 MHz</supported_graphics_clock>
+				<supported_graphics_clock>683 MHz</supported_graphics_clock>
+				<supported_graphics_clock>670 MHz</supported_graphics_clock>
+				<supported_graphics_clock>658 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>632 MHz</supported_graphics_clock>
+				<supported_graphics_clock>620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>594 MHz</supported_graphics_clock>
+				<supported_graphics_clock>582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>569 MHz</supported_graphics_clock>
+				<supported_graphics_clock>556 MHz</supported_graphics_clock>
+				<supported_graphics_clock>544 MHz</supported_graphics_clock>
+				<supported_graphics_clock>531 MHz</supported_graphics_clock>
+				<supported_graphics_clock>518 MHz</supported_graphics_clock>
+				<supported_graphics_clock>506 MHz</supported_graphics_clock>
+				<supported_graphics_clock>493 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>468 MHz</supported_graphics_clock>
+				<supported_graphics_clock>455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>430 MHz</supported_graphics_clock>
+				<supported_graphics_clock>417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>392 MHz</supported_graphics_clock>
+				<supported_graphics_clock>379 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>354 MHz</supported_graphics_clock>
+				<supported_graphics_clock>341 MHz</supported_graphics_clock>
+				<supported_graphics_clock>329 MHz</supported_graphics_clock>
+				<supported_graphics_clock>316 MHz</supported_graphics_clock>
+				<supported_graphics_clock>303 MHz</supported_graphics_clock>
+				<supported_graphics_clock>291 MHz</supported_graphics_clock>
+				<supported_graphics_clock>278 MHz</supported_graphics_clock>
+				<supported_graphics_clock>265 MHz</supported_graphics_clock>
+				<supported_graphics_clock>253 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>227 MHz</supported_graphics_clock>
+				<supported_graphics_clock>215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>189 MHz</supported_graphics_clock>
+				<supported_graphics_clock>177 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>810 MHz</value>
+				<supported_graphics_clock>1911 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1898 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1873 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1835 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1809 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1797 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1784 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1771 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1759 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1746 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1733 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1721 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1708 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1695 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1683 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1670 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1657 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1632 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1594 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1569 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1556 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1544 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1531 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1518 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1506 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1493 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1468 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1430 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1404 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1392 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1379 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1366 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1354 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1341 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1328 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1316 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1303 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1290 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1278 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1265 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1252 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1227 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1189 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1164 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1151 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1139 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1126 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1113 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1101 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1088 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1075 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1063 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1050 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1037 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1025 MHz</supported_graphics_clock>
+				<supported_graphics_clock>1012 MHz</supported_graphics_clock>
+				<supported_graphics_clock>999 MHz</supported_graphics_clock>
+				<supported_graphics_clock>987 MHz</supported_graphics_clock>
+				<supported_graphics_clock>974 MHz</supported_graphics_clock>
+				<supported_graphics_clock>961 MHz</supported_graphics_clock>
+				<supported_graphics_clock>949 MHz</supported_graphics_clock>
+				<supported_graphics_clock>936 MHz</supported_graphics_clock>
+				<supported_graphics_clock>923 MHz</supported_graphics_clock>
+				<supported_graphics_clock>911 MHz</supported_graphics_clock>
+				<supported_graphics_clock>898 MHz</supported_graphics_clock>
+				<supported_graphics_clock>885 MHz</supported_graphics_clock>
+				<supported_graphics_clock>873 MHz</supported_graphics_clock>
+				<supported_graphics_clock>860 MHz</supported_graphics_clock>
+				<supported_graphics_clock>847 MHz</supported_graphics_clock>
+				<supported_graphics_clock>835 MHz</supported_graphics_clock>
+				<supported_graphics_clock>822 MHz</supported_graphics_clock>
+				<supported_graphics_clock>810 MHz</supported_graphics_clock>
+				<supported_graphics_clock>797 MHz</supported_graphics_clock>
+				<supported_graphics_clock>784 MHz</supported_graphics_clock>
+				<supported_graphics_clock>772 MHz</supported_graphics_clock>
+				<supported_graphics_clock>759 MHz</supported_graphics_clock>
+				<supported_graphics_clock>746 MHz</supported_graphics_clock>
+				<supported_graphics_clock>734 MHz</supported_graphics_clock>
+				<supported_graphics_clock>721 MHz</supported_graphics_clock>
+				<supported_graphics_clock>708 MHz</supported_graphics_clock>
+				<supported_graphics_clock>696 MHz</supported_graphics_clock>
+				<supported_graphics_clock>683 MHz</supported_graphics_clock>
+				<supported_graphics_clock>670 MHz</supported_graphics_clock>
+				<supported_graphics_clock>658 MHz</supported_graphics_clock>
+				<supported_graphics_clock>645 MHz</supported_graphics_clock>
+				<supported_graphics_clock>632 MHz</supported_graphics_clock>
+				<supported_graphics_clock>620 MHz</supported_graphics_clock>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>594 MHz</supported_graphics_clock>
+				<supported_graphics_clock>582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>569 MHz</supported_graphics_clock>
+				<supported_graphics_clock>556 MHz</supported_graphics_clock>
+				<supported_graphics_clock>544 MHz</supported_graphics_clock>
+				<supported_graphics_clock>531 MHz</supported_graphics_clock>
+				<supported_graphics_clock>518 MHz</supported_graphics_clock>
+				<supported_graphics_clock>506 MHz</supported_graphics_clock>
+				<supported_graphics_clock>493 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>468 MHz</supported_graphics_clock>
+				<supported_graphics_clock>455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>430 MHz</supported_graphics_clock>
+				<supported_graphics_clock>417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>392 MHz</supported_graphics_clock>
+				<supported_graphics_clock>379 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>354 MHz</supported_graphics_clock>
+				<supported_graphics_clock>341 MHz</supported_graphics_clock>
+				<supported_graphics_clock>329 MHz</supported_graphics_clock>
+				<supported_graphics_clock>316 MHz</supported_graphics_clock>
+				<supported_graphics_clock>303 MHz</supported_graphics_clock>
+				<supported_graphics_clock>291 MHz</supported_graphics_clock>
+				<supported_graphics_clock>278 MHz</supported_graphics_clock>
+				<supported_graphics_clock>265 MHz</supported_graphics_clock>
+				<supported_graphics_clock>253 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>227 MHz</supported_graphics_clock>
+				<supported_graphics_clock>215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>189 MHz</supported_graphics_clock>
+				<supported_graphics_clock>177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>164 MHz</supported_graphics_clock>
+				<supported_graphics_clock>151 MHz</supported_graphics_clock>
+				<supported_graphics_clock>139 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+			<supported_mem_clock>
+				<value>405 MHz</value>
+				<supported_graphics_clock>607 MHz</supported_graphics_clock>
+				<supported_graphics_clock>594 MHz</supported_graphics_clock>
+				<supported_graphics_clock>582 MHz</supported_graphics_clock>
+				<supported_graphics_clock>569 MHz</supported_graphics_clock>
+				<supported_graphics_clock>556 MHz</supported_graphics_clock>
+				<supported_graphics_clock>544 MHz</supported_graphics_clock>
+				<supported_graphics_clock>531 MHz</supported_graphics_clock>
+				<supported_graphics_clock>518 MHz</supported_graphics_clock>
+				<supported_graphics_clock>506 MHz</supported_graphics_clock>
+				<supported_graphics_clock>493 MHz</supported_graphics_clock>
+				<supported_graphics_clock>480 MHz</supported_graphics_clock>
+				<supported_graphics_clock>468 MHz</supported_graphics_clock>
+				<supported_graphics_clock>455 MHz</supported_graphics_clock>
+				<supported_graphics_clock>442 MHz</supported_graphics_clock>
+				<supported_graphics_clock>430 MHz</supported_graphics_clock>
+				<supported_graphics_clock>417 MHz</supported_graphics_clock>
+				<supported_graphics_clock>405 MHz</supported_graphics_clock>
+				<supported_graphics_clock>392 MHz</supported_graphics_clock>
+				<supported_graphics_clock>379 MHz</supported_graphics_clock>
+				<supported_graphics_clock>367 MHz</supported_graphics_clock>
+				<supported_graphics_clock>354 MHz</supported_graphics_clock>
+				<supported_graphics_clock>341 MHz</supported_graphics_clock>
+				<supported_graphics_clock>329 MHz</supported_graphics_clock>
+				<supported_graphics_clock>316 MHz</supported_graphics_clock>
+				<supported_graphics_clock>303 MHz</supported_graphics_clock>
+				<supported_graphics_clock>291 MHz</supported_graphics_clock>
+				<supported_graphics_clock>278 MHz</supported_graphics_clock>
+				<supported_graphics_clock>265 MHz</supported_graphics_clock>
+				<supported_graphics_clock>253 MHz</supported_graphics_clock>
+				<supported_graphics_clock>240 MHz</supported_graphics_clock>
+				<supported_graphics_clock>227 MHz</supported_graphics_clock>
+				<supported_graphics_clock>215 MHz</supported_graphics_clock>
+				<supported_graphics_clock>202 MHz</supported_graphics_clock>
+				<supported_graphics_clock>189 MHz</supported_graphics_clock>
+				<supported_graphics_clock>177 MHz</supported_graphics_clock>
+				<supported_graphics_clock>164 MHz</supported_graphics_clock>
+				<supported_graphics_clock>151 MHz</supported_graphics_clock>
+				<supported_graphics_clock>139 MHz</supported_graphics_clock>
+			</supported_mem_clock>
+		</supported_clocks>
+		<processes>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>607</pid>
+				<type>G</type>
+				<process_name>/usr/lib/Xorg</process_name>
+				<used_memory>547 MiB</used_memory>
+			</process_info>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>746</pid>
+				<type>G</type>
+				<process_name>/usr/bin/kded5</process_name>
+				<used_memory>0 MiB</used_memory>
+			</process_info>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>750</pid>
+				<type>G</type>
+				<process_name>/usr/bin/kwin_x11</process_name>
+				<used_memory>67 MiB</used_memory>
+			</process_info>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>816</pid>
+				<type>G</type>
+				<process_name>/usr/bin/plasmashell</process_name>
+				<used_memory>51 MiB</used_memory>
+			</process_info>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>992</pid>
+				<type>G</type>
+				<process_name>/usr/bin/akonadi_archivemail_agent</process_name>
+				<used_memory>1 MiB</used_memory>
+			</process_info>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>1000</pid>
+				<type>G</type>
+				<process_name>/usr/bin/akonadi_mailfilter_agent</process_name>
+				<used_memory>1 MiB</used_memory>
+			</process_info>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>1005</pid>
+				<type>G</type>
+				<process_name>/usr/bin/akonadi_sendlater_agent</process_name>
+				<used_memory>1 MiB</used_memory>
+			</process_info>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>1006</pid>
+				<type>G</type>
+				<process_name>/usr/bin/akonadi_unifiedmailbox_agent</process_name>
+				<used_memory>1 MiB</used_memory>
+			</process_info>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>1264</pid>
+				<type>G</type>
+				<process_name>/usr/lib/chromium/chromium --type=gpu-process --field-trial-handle=1880224456256751497,10415613957372836837,131072 --enable-crashpad --crashpad-handler-pid=1233 --enable-crash-reporter=,Arch Linux --gpu-preferences=UAAAAAAAAAAgAAAQAAAAAAAAAAAAAAAAAABgAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAGAAAAAAAAAAIAAAAAAAAAAgAAAAAAAAACAAAAAAAAAA= --shared-files</process_name>
+				<used_memory>130 MiB</used_memory>
+			</process_info>
+			<process_info>
+				<gpu_instance_id>N/A</gpu_instance_id>
+				<compute_instance_id>N/A</compute_instance_id>
+				<pid>2028</pid>
+				<type>G</type>
+				<process_name>/usr/lib/electron9/electron --type=gpu-process --field-trial-handle=10946030397795380993,13110588606608672251,131072 --enable-features=WebComponentsV0Enabled --disable-features=SpareRendererForSitePerProcess --gpu-preferences=MAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAQAAAAAAAAAAAAAAAAAAAACAAAAAAAAAA= --shared-files</process_name>
+				<used_memory>65 MiB</used_memory>
+			</process_info>
+		</processes>
+		<accounted_processes>
+		</accounted_processes>
+	</gpu>
+
+</nvidia_smi_log>

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -268,7 +268,7 @@ func NewParser(config *Config) (Parser, error) {
 		)
 	case "prometheusremotewrite":
 		parser, err = NewPrometheusRemoteWriteParser(config.DefaultTags)
-	case "xml", "xpath_json", "xpath_msgpack", "xpath_protobuf":
+	case "xml", "xpath_xml", "xpath_json", "xpath_msgpack", "xpath_protobuf":
 		parser = &xpath.Parser{
 			Format:              config.DataFormat,
 			ProtobufMessageDef:  config.XPathProtobufFile,

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -31,12 +31,12 @@ type Parser struct {
 	Configs             []Config
 	DefaultTags         map[string]string
 	Log                 telegraf.Logger
-	IgnoreNaN           bool
 	document            dataDocument
 }
 
 type Config struct {
 	MetricDefaultName string            `toml:"-"`
+	IgnoreNaN         bool              `toml:"ignore_nan"`
 	MetricQuery       string            `toml:"metric_name"`
 	Selection         string            `toml:"metric_selection"`
 	Timestamp         string            `toml:"timestamp"`
@@ -260,7 +260,7 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 		case string:
 			fv, err := strconv.ParseInt(v, 10, 54)
 			if err != nil {
-				if p.IgnoreNaN {
+				if config.IgnoreNaN {
 					continue
 				}
 				return nil, fmt.Errorf("failed to parse field (int) '%s': %v", name, err)
@@ -286,7 +286,7 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 		if err != nil {
 			return nil, fmt.Errorf("failed to query field '%s': %v", name, err)
 		}
-		if fpv, ok := v.(float64); ok && p.IgnoreNaN && math.IsNaN(fpv) {
+		if fpv, ok := v.(float64); ok && config.IgnoreNaN && math.IsNaN(fpv) {
 			continue
 		}
 		fields[name] = v

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -53,7 +53,7 @@ type Config struct {
 
 func (p *Parser) Init() error {
 	switch p.Format {
-	case "", "xml":
+	case "", "xml", "xpath_xml":
 		p.document = &xmlDocument{}
 	case "xpath_json":
 		p.document = &jsonDocument{}

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -150,6 +150,7 @@ func TestInvalidNumbericTypeQueriesIgnore(t *testing.T) {
 			configs: []Config{
 				{
 					MetricDefaultName: "test",
+					IgnoreNaN:         true,
 					Timestamp:         "/Device_1/Timestamp_unix",
 					FieldsInt: map[string]string{
 						"a": "/Device_1/value_string",
@@ -164,7 +165,6 @@ func TestInvalidNumbericTypeQueriesIgnore(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := &Parser{
-				IgnoreNaN:   true,
 				Configs:     tt.configs,
 				DefaultTags: tt.defaultTags,
 				Log:         testutil.Logger{Name: "parsers.xml"},
@@ -222,18 +222,17 @@ func TestInvalidTypeQueries(t *testing.T) {
 	var tests = []struct {
 		name        string
 		input       string
-		ignoreNaN   bool
 		configs     []Config
 		defaultTags map[string]string
 		expected    telegraf.Metric
 	}{
 		{
-			name:      "invalid field type (number, ignore-NaN)",
-			input:     singleMetricValuesXML,
-			ignoreNaN: true,
+			name:  "invalid field type (number, ignore-NaN)",
+			input: singleMetricValuesXML,
 			configs: []Config{
 				{
 					MetricDefaultName: "test",
+					IgnoreNaN:         true,
 					Timestamp:         "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"a": "number(/Device_1/value_string)",
@@ -297,7 +296,6 @@ func TestInvalidTypeQueries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := &Parser{
-				IgnoreNaN:   tt.ignoreNaN,
 				Configs:     tt.configs,
 				DefaultTags: tt.defaultTags,
 				Log:         testutil.Logger{Name: "parsers.xml"},


### PR DESCRIPTION
### Required for all PRs:
- [ ] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

Both SMI implementations, `nvidia_smi` as well as `amd_rocm_smi`, share a common code structure: Try first execute a binary that produces the data and then parse the data into metrics using a kind of mapping definition. The present PR unifies this common structure and merges both plugins into a new generic `ReceiveAndParse` plugin. This new plugin provides a common infrastructure allowing to split the processing into a `transport` which receives the raw data and a `parser` transforming this raw data to metrics. Additional post-processing capabilities are provided to allow further metric transformation impossible in the parser. The whole change by this PR is transparent to the user.

To generalize more, a `common/transport` package is introduced that abstracts the way of receiving the data. For now only an `Exec` receiver is provided sufficient to unify the two graphics plugins. However, in the future we might want to extend this to e.g. HTTP transports or similar.
For the parsing part, we uses telegraf's plugin power to instantiate a suitable parser. We configure this parser with a config **file** embedded into the telegraf binary.

Please note that more such common structures exist in telegraf e.g. for web-plugins that do a HTTP request and then parse the response (usually JSON) to metrics. Those plugins might also be unified in a similar way.