### PR TITLE
fix: update golang-ci package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.38.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
On go1.17.1 make lint is failing due to some errors around a constant
overflow error. Upgrading the golang-ci package resolves this.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
