### PR TITLE
feat: add exclude_root_certs option to x509_cert plugin

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -37,6 +37,9 @@ const sampleConfig = `
   ##   example: server_name = "myhost.example.org"
   # server_name = ""
 
+  ## Don't include root or intermediate certificates in output
+  # exclude_root_certs = false
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
@@ -49,6 +52,7 @@ type X509Cert struct {
 	Sources    []string        `toml:"sources"`
 	Timeout    config.Duration `toml:"timeout"`
 	ServerName string          `toml:"server_name"`
+	ExcludeRootCerts bool      `toml:"exclude_root_certs"`
 	tlsCfg     *tls.Config
 	_tls.ClientConfig
 	locations []*url.URL
@@ -334,6 +338,9 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 			}
 
 			acc.AddFields("x509_cert", fields, tags)
+			if c.ExcludeRootCerts {
+				break;
+			}
 		}
 	}
 

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -49,11 +49,11 @@ const description = "Reads metrics from a SSL certificate"
 
 // X509Cert holds the configuration of the plugin.
 type X509Cert struct {
-	Sources    []string        `toml:"sources"`
-	Timeout    config.Duration `toml:"timeout"`
-	ServerName string          `toml:"server_name"`
-	ExcludeRootCerts bool      `toml:"exclude_root_certs"`
-	tlsCfg     *tls.Config
+	Sources          []string        `toml:"sources"`
+	Timeout          config.Duration `toml:"timeout"`
+	ServerName       string          `toml:"server_name"`
+	ExcludeRootCerts bool            `toml:"exclude_root_certs"`
+	tlsCfg           *tls.Config
 	_tls.ClientConfig
 	locations []*url.URL
 	globpaths []*globpath.GlobPath
@@ -339,7 +339,7 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 
 			acc.AddFields("x509_cert", fields, tags)
 			if c.ExcludeRootCerts {
-				break;
+				break
 			}
 		}
 	}

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -221,13 +221,13 @@ func TestTags(t *testing.T) {
 	require.Equal(t, big.NewInt(1), serialNumber)
 
 	// expect root/intermediate certs (more than one cert)
-	assert.Greater(t, acc.NMetrics(), uint64(1))
+	require.Greater(t, acc.NMetrics(), uint64(1))
 }
 
 func TestGatherExcludeRootCerts(t *testing.T) {
 	cert := fmt.Sprintf("%s\n%s", pki.ReadServerCert(), pki.ReadCACert())
 
-	f, err := ioutil.TempFile("", "x509_cert")
+	f, err := os.CreateTemp("", "x509_cert")
 	require.NoError(t, err)
 
 	_, err = f.Write([]byte(cert))
@@ -246,8 +246,8 @@ func TestGatherExcludeRootCerts(t *testing.T) {
 	acc := testutil.Accumulator{}
 	require.NoError(t, sc.Gather(&acc))
 
-	assert.True(t, acc.HasMeasurement("x509_cert"))
-	assert.Equal(t, acc.NMetrics(), uint64(1))
+	require.True(t, acc.HasMeasurement("x509_cert"))
+	require.Equal(t, acc.NMetrics(), uint64(1))
 }
 
 func TestGatherChain(t *testing.T) {

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -219,6 +219,35 @@ func TestTags(t *testing.T) {
 	_, validSerialNumber := serialNumber.SetString(acc.TagValue("x509_cert", "serial_number"), 16)
 	require.Truef(t, validSerialNumber, "Expected a valid Hex serial number but got %s", acc.TagValue("x509_cert", "serial_number"))
 	require.Equal(t, big.NewInt(1), serialNumber)
+
+	// expect root/intermediate certs (more than one cert)
+	assert.Greater(t, acc.NMetrics(), uint64(1))
+}
+
+func TestGatherExcludeRootCerts(t *testing.T) {
+	cert := fmt.Sprintf("%s\n%s", pki.ReadServerCert(), pki.ReadCACert())
+
+	f, err := ioutil.TempFile("", "x509_cert")
+	require.NoError(t, err)
+
+	_, err = f.Write([]byte(cert))
+	require.NoError(t, err)
+
+	require.NoError(t, f.Close())
+
+	defer os.Remove(f.Name())
+
+	sc := X509Cert{
+		Sources:          []string{f.Name()},
+		ExcludeRootCerts: true,
+	}
+	require.NoError(t, sc.Init())
+
+	acc := testutil.Accumulator{}
+	require.NoError(t, sc.Gather(&acc))
+
+	assert.True(t, acc.HasMeasurement("x509_cert"))
+	assert.Equal(t, acc.NMetrics(), uint64(1))
 }
 
 func TestGatherChain(t *testing.T) {


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9427

This PR adds `exclude_root_certs` configuration option(defaults to false) to  x509_cert plugin. When `exclude_root_certs` is true then x509_cert doesn't add metrics for root (and intermediate) certs.

```
[[inputs.x509_cert]]
  sources = [ "https://www.influxdata.com:443" ]
  exclude_root_certs = false
```
outputs:
```
> x509_cert,common_name=sni.cloudflaressl.com,country=US,host=hidden,issuer_common_name=Cloudflare\ Inc\ ECC\ CA-3,locality=San\ Francisco,organization=Cloudflare\,\ Inc.,province=California,public_key_algorithm=ECDSA,san=www.influxdata.com\,sni.cloudflaressl.com,serial_number=f0e13e9cfe14710ee2e23d4f7255351,signature_algorithm=ECDSA-SHA256,source=https://www.influxdata.com:443,verification=valid age=13523310i,enddate=1650671999i,expiry=18012688i,startdate=1619136000i,verification_code=0i 1632659310000000000
> x509_cert,common_name=Cloudflare\ Inc\ ECC\ CA-3,country=US,host=hidden,issuer_common_name=Baltimore\ CyberTrust\ Root,organization=Cloudflare\,\ Inc.,public_key_algorithm=ECDSA,serial_number=a3787645e5fb48c224efd1bed140c3c,signature_algorithm=SHA256-RSA,source=https://www.influxdata.com:443,verification=valid age=52530022i,enddate=1735689599i,expiry=103030288i,startdate=1580129288i,verification_code=0i 1632659310000000000
```
and with `exclude_root_certs = true`:
```
> x509_cert,common_name=sni.cloudflaressl.com,country=US,host=hidden,issuer_common_name=Cloudflare\ Inc\ ECC\ CA-3,locality=San\ Francisco,organization=Cloudflare\,\ Inc.,province=California,public_key_algorithm=ECDSA,san=www.influxdata.com\,sni.cloudflaressl.com,serial_number=f0e13e9cfe14710ee2e23d4f7255351,signature_algorithm=ECDSA-SHA256,source=https://www.influxdata.com:443,verification=valid age=13523402i,enddate=1650671999i,expiry=18012596i,startdate=1619136000i,verification_code=0i 1632659402000000000
```

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
