### PR TITLE
feat: add debug query output to elasticsearch_query

### DIFF
--- a/plugins/inputs/elasticsearch_query/aggregation_query.go
+++ b/plugins/inputs/elasticsearch_query/aggregation_query.go
@@ -2,6 +2,7 @@ package elasticsearch_query
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -33,6 +34,16 @@ func (e *ElasticsearchQuery) runAggregationQuery(ctx context.Context, aggregatio
 	query := elastic5.NewBoolQuery()
 	query = query.Filter(elastic5.NewQueryStringQuery(filterQuery))
 	query = query.Filter(elastic5.NewRangeQuery(aggregation.DateField).From(from).To(now))
+
+	src, err := query.Source()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get query soruce - %v", err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response - %v", err)
+	}
+	e.Log.Debugf("{\"query\": %s}", string(data))
 
 	search := e.esClient.Search().Index(aggregation.Index).Query(query).Size(0)
 

--- a/plugins/inputs/elasticsearch_query/aggregation_query.go
+++ b/plugins/inputs/elasticsearch_query/aggregation_query.go
@@ -37,7 +37,7 @@ func (e *ElasticsearchQuery) runAggregationQuery(ctx context.Context, aggregatio
 
 	src, err := query.Source()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get query soruce - %v", err)
+		return nil, fmt.Errorf("failed to get query source - %v", err)
 	}
 	data, err := json.Marshal(src)
 	if err != nil {


### PR DESCRIPTION
This will print out the elasticsearch query itself if debug logging is
turned on. This is incredibly helpful when trying to put together a new
query or debugging what might be going on. The output string can then be
used directly with Elasticsearch via something like:

$ curl -H 'Content-Type: application/json' -XPOST "http://localhost:9200/_search" -d'<output>'

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
