### PR TITLE
feat: add custom time/date format field for elasticsearch_query

### DIFF
--- a/plugins/inputs/elasticsearch_query/README.md
+++ b/plugins/inputs/elasticsearch_query/README.md
@@ -54,6 +54,13 @@ Currently it is known to break on 7.x or greater versions.
     ## The date/time field in the Elasticsearch index (mandatory).
     date_field = "@timestamp"
 
+    ## If the field used for the date/time field in Elasticsearch is also using
+    ## a custom date/time format it may be required to provide the format to
+    ## correctly parse the field.
+    ##
+    ## If using one of the built in elasticsearch formats this is not required.
+    date_field_custom_format = ""
+
     ## Time window to query (eg. "1m" to query documents from last minute).
     ## Normally should be set to same as collection interval
     query_period = "1m"
@@ -150,6 +157,7 @@ Please note that the `[[inputs.elasticsearch_query]]` is still required for all 
 
 ### Optional parameters
 
+- `date_field_custom_format`: Not needed if using one of the built in date/time formats of Elasticsearch, but may be required if using a custom date/time format.
 - `filter_query`: Lucene query to filter the results (default: "\*")
 - `metric_fields`: The list of fields to perform metric aggregation (these must be indexed as numeric fields)
 - `metric_funcion`: The single-value metric aggregation function to be performed on the `metric_fields` defined. Currently supported aggregations are "avg", "min", "max", "sum". (see [https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics.html)

--- a/plugins/inputs/elasticsearch_query/aggregation_query.go
+++ b/plugins/inputs/elasticsearch_query/aggregation_query.go
@@ -33,7 +33,7 @@ func (e *ElasticsearchQuery) runAggregationQuery(ctx context.Context, aggregatio
 
 	query := elastic5.NewBoolQuery()
 	query = query.Filter(elastic5.NewQueryStringQuery(filterQuery))
-	query = query.Filter(elastic5.NewRangeQuery(aggregation.DateField).From(from).To(now))
+	query = query.Filter(elastic5.NewRangeQuery(aggregation.DateField).From(from).To(now).Format(aggregation.DateFieldFormat))
 
 	src, err := query.Source()
 	if err != nil {

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query.go
@@ -55,6 +55,13 @@ const sampleConfig = `
     ## The date/time field in the Elasticsearch index (mandatory).
     date_field = "@timestamp"
 
+    ## If the field used for the date/time field in Elasticsearch is also using
+    ## a custom date/time format it may be required to provide the format to
+    ## correctly parse the field.
+    ##
+    ## If using one of the built in elasticsearch formats this is not required.
+    date_field_custom_format = ""
+
     ## Time window to query (eg. "1m" to query documents from last minute).
     ## Normally should be set to same as collection interval
     query_period = "1m"
@@ -104,6 +111,7 @@ type esAggregation struct {
 	Index                string          `toml:"index"`
 	MeasurementName      string          `toml:"measurement_name"`
 	DateField            string          `toml:"date_field"`
+	DateFieldFormat      string          `toml:"date_field_custom_format"`
 	QueryPeriod          config.Duration `toml:"query_period"`
 	FilterQuery          string          `toml:"filter_query"`
 	MetricFields         []string        `toml:"metric_fields"`

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -484,6 +484,38 @@ var testEsAggregationData = []esAggregationQueryTest{
 		false,
 		false,
 	},
+	{
+		"query 14 - custom date/time format",
+		esAggregation{
+			Index:           testindex,
+			MeasurementName: "measurement14",
+			MetricFields:    []string{"size"},
+			FilterQuery:     "downloads",
+			MetricFunction:  "max",
+			DateField:       "@timestamp",
+			DateFieldFormat: "yyyy",
+			QueryPeriod:     queryPeriod,
+			Tags:            []string{},
+			mapMetricFields: map[string]string{"size": "long"},
+		},
+		[]aggregationQueryData{
+			{
+				aggKey:   aggKey{measurement: "measurement14", name: "size_max", function: "max", field: "size"},
+				isParent: true,
+			},
+		},
+		[]telegraf.Metric{
+			testutil.MustMetric(
+				"measurement14",
+				map[string]string{},
+				map[string]interface{}{"size_max": float64(3318)},
+				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+			),
+		},
+		false,
+		false,
+		false,
+	},
 }
 
 func setupIntegrationTest() error {


### PR DESCRIPTION
This adds the ability to specify a custom time/date format to
elasticsearch queries. Elasticsearch has a large number of built-in
date/time formats, however, users are also able to add in a custom
date/time format as well. If this is the case, then the query will
always fail as it will be unable to parse the date/time.

This field is generally not required if a user is using a
standard/built-in type.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)
