### PR TITLE
fix: logging in intel_rdt.go caused service stop timeout even as root (#9844)

### DIFF
--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -278,12 +278,12 @@ func (r *IntelRDT) readData(ctx context.Context, args []string, processesPIDsAss
 	}()
 	err = cmd.Start()
 	if err != nil {
-		r.errorChan <- fmt.Errorf("pqos: %v", err)
+		r.Log.Errorf("pqos: %v", err)
 		return
 	}
 	err = cmd.Wait()
 	if err != nil {
-		r.errorChan <- fmt.Errorf("pqos: %v", err)
+		r.Log.Errorf("pqos: %v", err)
 	}
 }
 


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. feat: or fix:)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9844

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
when intel_rdt plugin enabled, `service stop telegraf` will timeout even when telegraf service is running as root.
This patch fixes it.
