### PR TITLE
fix: directory monitor input plugin when data format is CSV and csv_skip_rows>0 and csv_header_row_count>=1

### DIFF
--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -288,7 +288,7 @@ func (monitor *DirectoryMonitor) parseLine(parser parsers.Parser, line []byte) (
 		m, err := parser.Parse(line)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return []telegraf.Metric{}, nil
+				return nil, nil
 			}
 			return nil, err
 		}

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -261,15 +261,13 @@ func (monitor *DirectoryMonitor) ingestFile(filePath string) error {
 }
 
 func (monitor *DirectoryMonitor) parseFile(parser parsers.Parser, reader io.Reader, fileName string) error {
-	// Read the file line-by-line and parse with the configured parse method.
-	firstLine := true
+
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		metrics, err := monitor.parseLine(parser, scanner.Bytes(), firstLine)
+		metrics, err := monitor.parseLine(parser, scanner.Bytes())
 		if err != nil {
 			return err
 		}
-		firstLine = false
 
 		if monitor.FileTag != "" {
 			for _, m := range metrics {
@@ -285,24 +283,23 @@ func (monitor *DirectoryMonitor) parseFile(parser parsers.Parser, reader io.Read
 	return nil
 }
 
-func (monitor *DirectoryMonitor) parseLine(parser parsers.Parser, line []byte, firstLine bool) ([]telegraf.Metric, error) {
+func (monitor *DirectoryMonitor) parseLine(parser parsers.Parser, line []byte) ([]telegraf.Metric, error) {
 	switch parser.(type) {
 	case *csv.Parser:
-		// The CSV parser parses headers in Parse and skips them in ParseLine.
-		if firstLine {
-			return parser.Parse(line)
-		}
-
-		m, err := parser.ParseLine(string(line))
+		m, err := parser.Parse(line)
 		if err != nil {
-			return nil, err
+			switch err.Error() {
+			case "EOF, [parsers.csv] expecting more skip rows":
+				// Ignore error and continue reading next line
+				return []telegraf.Metric{}, nil
+			case "EOF, [parsers.csv] data columns must be specified":
+				// Ignore error and continue reading next line
+				return []telegraf.Metric{}, nil
+			default:
+				return nil, err
+			}
 		}
-
-		if m != nil {
-			return []telegraf.Metric{m}, nil
-		}
-
-		return []telegraf.Metric{}, nil
+		return m, err
 	default:
 		return parser.Parse(line)
 	}

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -286,10 +286,10 @@ func (monitor *DirectoryMonitor) parseLine(parser parsers.Parser, line []byte) (
 	switch parser.(type) {
 	case *csv.Parser:
 		m, err := parser.Parse(line)
-		if err == io.EOF {
-			return []telegraf.Metric{}, nil
-		}
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return []telegraf.Metric{}, nil
+			}
 			return nil, err
 		}
 		return m, err

--- a/plugins/inputs/directory_monitor/directory_monitor_test.go
+++ b/plugins/inputs/directory_monitor/directory_monitor_test.go
@@ -3,11 +3,10 @@ package directory_monitor
 import (
 	"bytes"
 	"compress/gzip"
+	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/testutil"
@@ -191,5 +190,226 @@ func TestFileTag(t *testing.T) {
 			require.Equal(t, r.FileTag, key)
 			require.Equal(t, filepath.Base(testJSONFile), value)
 		}
+	}
+}
+
+func TestCSVNoSkipRows(t *testing.T) {
+	acc := testutil.Accumulator{}
+	testCsvFile := "test.csv"
+
+	// Establish process directory and finished directory.
+	finishedDirectory, err := os.MkdirTemp("", "finished")
+	require.NoError(t, err)
+	processDirectory, err := os.MkdirTemp("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(processDirectory)
+	defer os.RemoveAll(finishedDirectory)
+
+	// Init plugin.
+	r := DirectoryMonitor{
+		Directory:          processDirectory,
+		FinishedDirectory:  finishedDirectory,
+		MaxBufferedMetrics: 1000,
+		FileQueueSize:      100000,
+	}
+	err = r.Init()
+	require.NoError(t, err)
+
+	parserConfig := parsers.Config{
+		DataFormat:        "csv",
+		CSVHeaderRowCount: 1,
+		CSVSkipRows:       0,
+		CSVTagColumns:     []string{"line1"},
+	}
+	require.NoError(t, err)
+	r.SetParserFunc(func() (parsers.Parser, error) {
+		return parsers.NewParser(&parserConfig)
+	})
+	r.Log = testutil.Logger{}
+
+	testCSV := `line1,line2,line3
+hello,80,test_name2`
+
+	expectedFields := map[string]interface{}{
+		"line2": int64(80),
+		"line3": "test_name2",
+	}
+
+	// Write csv file to process into the 'process' directory.
+	f, err := os.Create(filepath.Join(processDirectory, testCsvFile))
+	require.NoError(t, err)
+	_, err = f.WriteString(testCSV)
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+
+	// Start plugin before adding file.
+	err = r.Start(&acc)
+	require.NoError(t, err)
+	err = r.Gather(&acc)
+	require.NoError(t, err)
+	acc.Wait(1)
+	r.Stop()
+
+	// Verify that we read both files once.
+	require.Equal(t, len(acc.Metrics), 1)
+
+	// File should have gone back to the test directory, as we configured.
+	_, err = os.Stat(filepath.Join(finishedDirectory, testCsvFile))
+	require.NoError(t, err)
+	for _, m := range acc.Metrics {
+		for key, value := range m.Tags {
+			require.Equal(t, "line1", key)
+			require.Equal(t, "hello", value)
+		}
+		require.Equal(t, expectedFields, m.Fields)
+	}
+}
+
+func TestCSVSkipRows(t *testing.T) {
+	acc := testutil.Accumulator{}
+	testCsvFile := "test.csv"
+
+	// Establish process directory and finished directory.
+	finishedDirectory, err := os.MkdirTemp("", "finished")
+	require.NoError(t, err)
+	processDirectory, err := os.MkdirTemp("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(processDirectory)
+	defer os.RemoveAll(finishedDirectory)
+
+	// Init plugin.
+	r := DirectoryMonitor{
+		Directory:          processDirectory,
+		FinishedDirectory:  finishedDirectory,
+		MaxBufferedMetrics: 1000,
+		FileQueueSize:      100000,
+	}
+	err = r.Init()
+	require.NoError(t, err)
+
+	parserConfig := parsers.Config{
+		DataFormat:        "csv",
+		CSVHeaderRowCount: 1,
+		CSVSkipRows:       2,
+		CSVTagColumns:     []string{"line1"},
+	}
+	require.NoError(t, err)
+	r.SetParserFunc(func() (parsers.Parser, error) {
+		return parsers.NewParser(&parserConfig)
+	})
+	r.Log = testutil.Logger{}
+
+	testCSV := `garbage nonsense 1
+garbage,nonsense,2
+line1,line2,line3
+hello,80,test_name2`
+
+	expectedFields := map[string]interface{}{
+		"line2": int64(80),
+		"line3": "test_name2",
+	}
+
+	// Write csv file to process into the 'process' directory.
+	f, err := os.Create(filepath.Join(processDirectory, testCsvFile))
+	require.NoError(t, err)
+	_, err = f.WriteString(testCSV)
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+
+	// Start plugin before adding file.
+	err = r.Start(&acc)
+	require.NoError(t, err)
+	err = r.Gather(&acc)
+	require.NoError(t, err)
+	acc.Wait(1)
+	r.Stop()
+
+	// Verify that we read both files once.
+	require.Equal(t, len(acc.Metrics), 1)
+
+	// File should have gone back to the test directory, as we configured.
+	_, err = os.Stat(filepath.Join(finishedDirectory, testCsvFile))
+	require.NoError(t, err)
+	for _, m := range acc.Metrics {
+		for key, value := range m.Tags {
+			require.Equal(t, "line1", key)
+			require.Equal(t, "hello", value)
+		}
+		require.Equal(t, expectedFields, m.Fields)
+	}
+}
+
+func TestCSVMultiHeader(t *testing.T) {
+	acc := testutil.Accumulator{}
+	testCsvFile := "test.csv"
+
+	// Establish process directory and finished directory.
+	finishedDirectory, err := os.MkdirTemp("", "finished")
+	require.NoError(t, err)
+	processDirectory, err := os.MkdirTemp("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(processDirectory)
+	defer os.RemoveAll(finishedDirectory)
+
+	// Init plugin.
+	r := DirectoryMonitor{
+		Directory:          processDirectory,
+		FinishedDirectory:  finishedDirectory,
+		MaxBufferedMetrics: 1000,
+		FileQueueSize:      100000,
+	}
+	err = r.Init()
+	require.NoError(t, err)
+
+	parserConfig := parsers.Config{
+		DataFormat:        "csv",
+		CSVHeaderRowCount: 2,
+		CSVTagColumns:     []string{"line1"},
+	}
+	require.NoError(t, err)
+	r.SetParserFunc(func() (parsers.Parser, error) {
+		return parsers.NewParser(&parserConfig)
+	})
+	r.Log = testutil.Logger{}
+
+	testCSV := `line,line,line
+1,2,3
+hello,80,test_name2`
+
+	expectedFields := map[string]interface{}{
+		"line2": int64(80),
+		"line3": "test_name2",
+	}
+
+	// Write csv file to process into the 'process' directory.
+	f, err := os.Create(filepath.Join(processDirectory, testCsvFile))
+	require.NoError(t, err)
+	_, err = f.WriteString(testCSV)
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+
+	// Start plugin before adding file.
+	err = r.Start(&acc)
+	require.NoError(t, err)
+	err = r.Gather(&acc)
+	require.NoError(t, err)
+	acc.Wait(1)
+	r.Stop()
+
+	// Verify that we read both files once.
+	require.Equal(t, len(acc.Metrics), 1)
+
+	// File should have gone back to the test directory, as we configured.
+	_, err = os.Stat(filepath.Join(finishedDirectory, testCsvFile))
+	require.NoError(t, err)
+	for _, m := range acc.Metrics {
+		for key, value := range m.Tags {
+			require.Equal(t, "line1", key)
+			require.Equal(t, "hello", value)
+		}
+		require.Equal(t, expectedFields, m.Fields)
 	}
 }

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -294,7 +294,7 @@ func parseLine(parser parsers.Parser, line string) ([]telegraf.Metric, error) {
 		m, err := parser.Parse([]byte(line))
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return []telegraf.Metric{}, nil
+				return nil, nil
 			}
 			return nil, err
 		}

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -292,10 +292,10 @@ func parseLine(parser parsers.Parser, line string) ([]telegraf.Metric, error) {
 	switch parser.(type) {
 	case *csv.Parser:
 		m, err := parser.Parse([]byte(line))
-		if err == io.EOF {
-			return []telegraf.Metric{}, nil
-		}
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return []telegraf.Metric{}, nil
+			}
 			return nil, err
 		}
 		return m, err

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -109,7 +109,8 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 	}
 	if len(metrics) == 1 {
 		return metrics[0], nil
-	} else if len(metrics) > 1 {
+	}
+	if len(metrics) > 1 {
 		return nil, fmt.Errorf("expected 1 metric found %d", len(metrics))
 	}
 	return nil, nil

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -381,10 +381,14 @@ hello,80,test_name2`
 	expectedFields := map[string]interface{}{
 		"line2": int64(80),
 	}
+	expectedTags := map[string]string{
+		"line1": "hello",
+	}
 	metrics, err := p.Parse([]byte(testCSV))
 	require.NoError(t, err)
 	require.Equal(t, "test_name2", metrics[0].Name())
 	require.Equal(t, expectedFields, metrics[0].Fields())
+	require.Equal(t, expectedTags, metrics[0].Tags())
 
 	p, err = NewParser(
 		&Config{
@@ -409,6 +413,7 @@ hello,80,test_name2`
 	require.NoError(t, err)
 	require.Equal(t, "test_name2", m.Name())
 	require.Equal(t, expectedFields, m.Fields())
+	require.Equal(t, expectedTags, m.Tags())
 }
 
 func TestSkipColumns(t *testing.T) {

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -457,10 +457,10 @@ func TestParseStream(t *testing.T) {
 	csvHeader := "a,b,c"
 	csvBody := "1,2,3"
 
-	metrics, err := p.Parse([]byte(csvHeader))
-	require.NoError(t, err)
+	metrics, err1 := p.Parse([]byte(csvHeader))
+	require.NoError(t, err1)
 	require.Len(t, metrics, 0)
-	metric, err := p.ParseLine(csvBody)
+	metric1, err2 := p.ParseLine(csvBody)
 	testutil.RequireMetricEqual(t,
 		testutil.MustMetric(
 			"csv",
@@ -471,7 +471,8 @@ func TestParseStream(t *testing.T) {
 				"c": int64(3),
 			},
 			DefaultTime(),
-		), metric)
+		), metric1)
+	require.NoError(t, err2)
 }
 
 func TestTimestampUnixFloatPrecision(t *testing.T) {


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9898
resolves #9903
resolves #5338

🐛 Fixed an issue with directory monitor input plugin when data format is CSV and csv_skip_rows>0 and csv_header_row_count>=1
✅ Added new test cases that cover these scenarios
