### PR TITLE
fix: duplicate line_protocol when using object and fields

### DIFF
--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -137,7 +137,7 @@ func (p *Parser) Parse(input []byte) ([]telegraf.Metric, error) {
 		metrics = append(metrics, cartesianProduct(tags, fields)...)
 
 		if len(objects) != 0 && len(metrics) != 0 {
-			metrics = append(metrics, cartesianProduct(objects, metrics)...)
+			metrics = cartesianProduct(objects, metrics)
 		} else {
 			metrics = append(metrics, objects...)
 		}

--- a/plugins/parsers/json_v2/parser_test.go
+++ b/plugins/parsers/json_v2/parser_test.go
@@ -21,6 +21,10 @@ func TestData(t *testing.T) {
 		test string
 	}{
 		{
+			name: "Test when using field and object together",
+			test: "mix_field_and_object",
+		},
+		{
 			name: "Test complex nesting",
 			test: "complex_nesting",
 		},

--- a/plugins/parsers/json_v2/testdata/mix_field_and_object/expected.out
+++ b/plugins/parsers/json_v2/testdata/mix_field_and_object/expected.out
@@ -1,0 +1,1 @@
+openweather,id=2.643743e+06,name=London coord_lat=51.5085,coord_lon=-0.1257,description="few clouds",main_temp=12.54,summary="Clouds",wind_speed=2.11 1628186541000000000

--- a/plugins/parsers/json_v2/testdata/mix_field_and_object/input.json
+++ b/plugins/parsers/json_v2/testdata/mix_field_and_object/input.json
@@ -1,0 +1,44 @@
+{
+    "coord": {
+        "lon": -0.1257,
+        "lat": 51.5085
+    },
+    "weather": [
+        {
+            "id": 801,
+            "main": "Clouds",
+            "description": "few clouds",
+            "icon": "02n"
+        }
+    ],
+    "base": "stations",
+    "main": {
+        "temp": 12.54,
+        "feels_like": 11.86,
+        "temp_min": 10.49,
+        "temp_max": 14.27,
+        "pressure": 1024,
+        "humidity": 77
+    },
+    "visibility": 10000,
+    "wind": {
+        "speed": 2.11,
+        "deg": 254,
+        "gust": 4.63
+    },
+    "clouds": {
+        "all": 21
+    },
+    "dt": 1633545358,
+    "sys": {
+        "type": 2,
+        "id": 2019646,
+        "country": "GB",
+        "sunrise": 1633500560,
+        "sunset": 1633541256
+    },
+    "timezone": 3600,
+    "id": 2643743,
+    "name": "London",
+    "cod": 200
+}

--- a/plugins/parsers/json_v2/testdata/mix_field_and_object/telegraf.conf
+++ b/plugins/parsers/json_v2/testdata/mix_field_and_object/telegraf.conf
@@ -1,0 +1,15 @@
+[[inputs.file]]
+    files = ["./testdata/mix_field_and_object/input.json"]
+    data_format = "json_v2"
+    [[inputs.file.json_v2]]
+        measurement_name = "openweather"
+        [[inputs.file.json_v2.field]]
+            path = "weather.#.main"
+            rename = "summary"
+        [[inputs.file.json_v2.field]]
+            path = "weather.#.description"
+        [[inputs.file.json_v2.object]]
+                path = "@this"
+                included_keys = ["coord_lat", "coord_lon", "main_temp", "wind_speed"] # List of JSON keys (for a nested key, prepend the parent keys with underscores) that should be only included in result
+                tags = ["id", "name"] # List of JSON keys (for a nested key, prepend the parent keys with underscores) to be a tag instead of a field
+


### PR DESCRIPTION
resolves: #9594

The json_v2 parser had a bug when using `field` and `object` together in the config, causing an duplicated metric to be sent. This pr addresses it by only having the cartesian product of object and fields together.