### PR TITLE
fix: filter quantiles with NaN in prometheus parser

### DIFF
--- a/plugins/parsers/prometheus/parser.go
+++ b/plugins/parsers/prometheus/parser.go
@@ -124,6 +124,9 @@ func makeQuantiles(m *dto.Metric, tags map[string]string, metricName string, met
 	metrics = append(metrics, met)
 
 	for _, q := range m.GetSummary().Quantile {
+		if math.IsNaN(q.GetValue()) {
+			continue
+		}
 		newTags := tags
 		fields = make(map[string]interface{})
 


### PR DESCRIPTION
This bugfix filters out summary quantiles with NaN values from being
emitted as fields when using prometheus parser v2. This behavior is
consistent with both how the legacy parser behaves, and how the v2
parser handles other prometheus metric types.

Prometheus summary data often contains NaN values, for example:
```
request_duration_seconds{method="GET",path="/directory",status="200",quantile="0.5"} NaN
request_duration_seconds{method="GET",path="/directory",status="200",quantile="0.9"} NaN
request_duration_seconds{method="GET",path="/directory",status="200",quantile="0.99"} NaN
request_duration_seconds_sum{method="GET",path="/directory",status="200"} 0.242569642
request_duration_seconds_count{method="GET",path="/directory",status="200"} 1
```

In `metric_version` 1 of the prometheus parser, this would result in the
following metric:
```
{
  "fields": {
    "count": 1,
    "sum": 0.242569642
  },
  "name": "request_duration_seconds",
  "tags": {
    "method": "GET",
    "path": "/directory",
    "status": "200",
    "url": "http://localhost:11000/metrics"
  },
  "timestamp": 1633553140
}
```

In `metric_version` 2, the same input prom data will lead to multiple
metrics, some of which will have empty fields when serialized to JSON:
```
{
  "fields": {},
  "name": "prometheus",
  "tags": {
    "method": "GET",
    "path": "/directory",
    "quantile": "0.5",
    "status": "200",
    "url": "http://localhost:11000/metrics"
  },
  "timestamp": 1633553240
}
```

The existing codebase already refrains from emitting NaN values for
other prometheus metric types. This commit merely extends this to
summaries.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
