### PR TITLE
fix: set location on failing time tests

### DIFF
--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -514,6 +514,7 @@ func TestParseTimestamp(t *testing.T) {
 			format:    "UnixDate",
 			timestamp: "Mon Jan 2 15:04:05 MST 2006",
 			expected:  unixdate("Mon Jan 2 15:04:05 MST 2006"),
+			location:  "Local",
 		},
 
 		{
@@ -521,6 +522,7 @@ func TestParseTimestamp(t *testing.T) {
 			format:    "RubyDate",
 			timestamp: "Mon Jan 02 15:04:05 -0700 2006",
 			expected:  rubydate("Mon Jan 02 15:04:05 -0700 2006"),
+			location:  "Local",
 		},
 
 		{
@@ -528,6 +530,7 @@ func TestParseTimestamp(t *testing.T) {
 			format:    "RFC822",
 			timestamp: "02 Jan 06 15:04 MST",
 			expected:  rfc822("02 Jan 06 15:04 MST"),
+			location:  "Local",
 		},
 
 		{
@@ -535,6 +538,7 @@ func TestParseTimestamp(t *testing.T) {
 			format:    "RFC822Z",
 			timestamp: "02 Jan 06 15:04 -0700",
 			expected:  rfc822z("02 Jan 06 15:04 -0700"),
+			location:  "Local",
 		},
 
 		{
@@ -542,6 +546,7 @@ func TestParseTimestamp(t *testing.T) {
 			format:    "RFC850",
 			timestamp: "Monday, 02-Jan-06 15:04:05 MST",
 			expected:  rfc850("Monday, 02-Jan-06 15:04:05 MST"),
+			location:  "Local",
 		},
 
 		{
@@ -549,6 +554,7 @@ func TestParseTimestamp(t *testing.T) {
 			format:    "RFC1123",
 			timestamp: "Mon, 02 Jan 2006 15:04:05 MST",
 			expected:  rfc1123("Mon, 02 Jan 2006 15:04:05 MST"),
+			location:  "Local",
 		},
 
 		{
@@ -556,6 +562,7 @@ func TestParseTimestamp(t *testing.T) {
 			format:    "RFC1123Z",
 			timestamp: "Mon, 02 Jan 2006 15:04:05 -0700",
 			expected:  rfc1123z("Mon, 02 Jan 2006 15:04:05 -0700"),
+			location:  "Local",
 		},
 
 		{
@@ -563,6 +570,7 @@ func TestParseTimestamp(t *testing.T) {
 			format:    "RFC3339Nano",
 			timestamp: "2006-01-02T15:04:05.999999999-07:00",
 			expected:  rfc3339nano("2006-01-02T15:04:05.999999999-07:00"),
+			location:  "Local",
 		},
 
 		{


### PR DESCRIPTION
On some systems, these time tests were failing. These tests are unique in that they are setting the time zone as a part of the test, while the other time tests do not. As the location is not set in any of these time tests there was a mismatch between the passed in "MST" and the returned "UTC" value. Setting the location to "Local" should give a consistent result and resolve these failures.

Resolves: #9874

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
