### PR TITLE
fix: migrate aws/credentials.go to use NewSession, same functionality but now supports error

### DIFF
--- a/config/aws/credentials.go
+++ b/config/aws/credentials.go
@@ -21,7 +21,7 @@ type CredentialConfig struct {
 	WebIdentityTokenFile string `toml:"web_identity_token_file"`
 }
 
-func (c *CredentialConfig) Credentials() client.ConfigProvider {
+func (c *CredentialConfig) Credentials() (client.ConfigProvider, error) {
 	if c.RoleARN != "" {
 		return c.assumeCredentials()
 	}
@@ -29,7 +29,7 @@ func (c *CredentialConfig) Credentials() client.ConfigProvider {
 	return c.rootCredentials()
 }
 
-func (c *CredentialConfig) rootCredentials() client.ConfigProvider {
+func (c *CredentialConfig) rootCredentials() (client.ConfigProvider, error) {
 	config := &aws.Config{
 		Region: aws.String(c.Region),
 	}
@@ -42,11 +42,14 @@ func (c *CredentialConfig) rootCredentials() client.ConfigProvider {
 		config.Credentials = credentials.NewSharedCredentials(c.Filename, c.Profile)
 	}
 
-	return session.New(config)
+	return session.NewSession(config)
 }
 
-func (c *CredentialConfig) assumeCredentials() client.ConfigProvider {
-	rootCredentials := c.rootCredentials()
+func (c *CredentialConfig) assumeCredentials() (client.ConfigProvider, error) {
+	rootCredentials, err := c.rootCredentials()
+	if err != nil {
+		return nil, err
+	}
 	config := &aws.Config{
 		Region:   aws.String(c.Region),
 		Endpoint: &c.EndpointURL,
@@ -58,5 +61,5 @@ func (c *CredentialConfig) assumeCredentials() client.ConfigProvider {
 		config.Credentials = stscreds.NewCredentials(rootCredentials, c.RoleARN)
 	}
 
-	return session.New(config)
+	return session.NewSession(config)
 }

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -288,7 +288,11 @@ func (c *CloudWatch) initializeCloudWatch() error {
 	}
 
 	loglevel := aws.LogOff
-	c.client = cwClient.New(c.CredentialConfig.Credentials(), cfg.WithLogLevel(loglevel))
+	p, err := c.CredentialConfig.Credentials()
+	if err != nil {
+		return err
+	}
+	c.client = cwClient.New(p, cfg.WithLogLevel(loglevel))
 
 	// Initialize regex matchers for each Dimension value.
 	for _, m := range c.Metrics {

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -177,12 +177,12 @@ var sampleConfig = `
   ## Namespace for the CloudWatch MetricDatums
   namespace = "InfluxData/Telegraf"
 
-  ## If you have a large amount of metrics, you should consider to send statistic 
-  ## values instead of raw metrics which could not only improve performance but 
-  ## also save AWS API cost. If enable this flag, this plugin would parse the required 
-  ## CloudWatch statistic fields (count, min, max, and sum) and send them to CloudWatch. 
-  ## You could use basicstats aggregator to calculate those fields. If not all statistic 
-  ## fields are available, all fields would still be sent as raw metrics. 
+  ## If you have a large amount of metrics, you should consider to send statistic
+  ## values instead of raw metrics which could not only improve performance but
+  ## also save AWS API cost. If enable this flag, this plugin would parse the required
+  ## CloudWatch statistic fields (count, min, max, and sum) and send them to CloudWatch.
+  ## You could use basicstats aggregator to calculate those fields. If not all statistic
+  ## fields are available, all fields would still be sent as raw metrics.
   # write_statistics = false
 
   ## Enable high resolution metrics of 1 second (if not enabled, standard resolution are of 60 seconds precision)
@@ -198,7 +198,11 @@ func (c *CloudWatch) Description() string {
 }
 
 func (c *CloudWatch) Connect() error {
-	c.svc = cloudwatch.New(c.CredentialConfig.Credentials())
+	p, err := c.CredentialConfig.Credentials()
+	if err != nil {
+		return err
+	}
+	c.svc = cloudwatch.New(p)
 	return nil
 }
 

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
@@ -108,12 +108,12 @@ region = "us-east-1"
 
 ## Cloud watch log group. Must be created in AWS cloudwatch logs upfront!
 ## For example, you can specify the name of the k8s cluster here to group logs from all cluster in oine place
-log_group = "my-group-name" 
+log_group = "my-group-name"
 
 ## Log stream in log group
 ## Either log group name or reference to metric attribute, from which it can be parsed:
 ## tag:<TAG_NAME> or field:<FIELD_NAME>. If log stream is not exist, it will be created.
-## Since AWS is not automatically delete logs streams with expired logs entries (i.e. empty log stream) 
+## Since AWS is not automatically delete logs streams with expired logs entries (i.e. empty log stream)
 ## you need to put in place appropriate house-keeping (https://forums.aws.amazon.com/thread.jspa?threadID=178855)
 log_stream = "tag:location"
 
@@ -126,7 +126,7 @@ log_data_metric_name  = "docker_log"
 ## Specify from which metric attribute the log data should be retrieved:
 ## tag:<TAG_NAME> or field:<FIELD_NAME>.
 ## I.e., if you  are using docker_log plugin to stream logs from container, then
-## specify log_data_source  = "field:message" 
+## specify log_data_source  = "field:message"
 log_data_source  = "field:message"
 `
 
@@ -187,7 +187,11 @@ func (c *CloudWatchLogs) Connect() error {
 	var logGroupsOutput = &cloudwatchlogs.DescribeLogGroupsOutput{NextToken: &dummyToken}
 	var err error
 
-	c.svc = cloudwatchlogs.New(c.CredentialConfig.Credentials())
+	p, err := c.CredentialConfig.Credentials()
+	if err != nil {
+		return err
+	}
+	c.svc = cloudwatchlogs.New(p)
 	if c.svc == nil {
 		return fmt.Errorf("can't create cloudwatch logs service endpoint")
 	}

--- a/plugins/outputs/kinesis/kinesis.go
+++ b/plugins/outputs/kinesis/kinesis.go
@@ -126,9 +126,13 @@ func (k *KinesisOutput) Connect() error {
 		k.Log.Infof("Establishing a connection to Kinesis in %s", k.Region)
 	}
 
-	svc := kinesis.New(k.CredentialConfig.Credentials())
+	p, err := k.CredentialConfig.Credentials()
+	if err != nil {
+		return err
+	}
+	svc := kinesis.New(p)
 
-	_, err := svc.DescribeStreamSummary(&kinesis.DescribeStreamSummaryInput{
+	_, err = svc.DescribeStreamSummary(&kinesis.DescribeStreamSummaryInput{
 		StreamName: aws.String(k.StreamName),
 	})
 	k.svc = svc


### PR DESCRIPTION
```session.New is deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.```

The above is the exact message from the linter, noticed it was reporting that `session.New` was deprecated. Easy resolution is to replace it with `NewSession` and propagate the newly returned error. Found a little bit more info here: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/sessions.html, but it just re-iterates the linter message that they deprecated `New` for better error handling.
