### PR TITLE
fix: migrate to cloud.google.com/go/monitoring/apiv3/v2

### DIFF
--- a/plugins/inputs/stackdriver/stackdriver.go
+++ b/plugins/inputs/stackdriver/stackdriver.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3"
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	googlepbduration "github.com/golang/protobuf/ptypes/duration"
 	googlepbts "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/influxdata/telegraf"
@@ -397,7 +397,7 @@ func (s *Stackdriver) newTimeSeriesConf(
 		StartTime: &googlepbts.Timestamp{Seconds: startTime.Unix()},
 	}
 	tsReq := &monitoringpb.ListTimeSeriesRequest{
-		Name:     monitoring.MetricProjectPath(s.Project),
+		Name:     fmt.Sprintf("projects/%s", s.Project),
 		Filter:   filter,
 		Interval: interval,
 	}
@@ -533,7 +533,7 @@ func (s *Stackdriver) generatetimeSeriesConfs(
 
 	ret := []*timeSeriesConf{}
 	req := &monitoringpb.ListMetricDescriptorsRequest{
-		Name: monitoring.MetricProjectPath(s.Project),
+		Name: fmt.Sprintf("projects/%s", s.Project),
 	}
 
 	filters := s.newListMetricDescriptorsFilters()

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3" // Imports the Stackdriver Monitoring client package.
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2" // Imports the Stackdriver Monitoring client package.
 	googlepb "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
@@ -218,7 +218,7 @@ func (s *Stackdriver) Write(metrics []telegraf.Metric) error {
 
 		// Prepare time series request.
 		timeSeriesRequest := &monitoringpb.CreateTimeSeriesRequest{
-			Name:       monitoring.MetricProjectPath(s.Project),
+			Name:       fmt.Sprintf("projects/%s", s.Project),
 			TimeSeries: timeSeries,
 		}
 

--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3"
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"github.com/golang/protobuf/proto"
 	emptypb "github.com/golang/protobuf/ptypes/empty"
 	googlepb "github.com/golang/protobuf/ptypes/timestamp"


### PR DESCRIPTION
`cloud.google.com/go/monitoring/apiv3` is deprecated and replaced by `cloud.google.com/go/monitoring/apiv3/v2`, `monitoring.MetricProjectPath` was also deprecated and replaced with `fmt.Sprintf("projects/%s", s.Project)`. Both of these deprecation's were reported by the linter `staticcheck`. 