### PR TITLE
fix: mute graylog UDP/TCP tests by marking them as integration

### DIFF
--- a/plugins/outputs/graylog/graylog_test.go
+++ b/plugins/outputs/graylog/graylog_test.go
@@ -15,14 +15,26 @@ import (
 )
 
 func TestWriteDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	scenarioUDP(t, "127.0.0.1:12201")
 }
 
 func TestWriteUDP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	scenarioUDP(t, "udp://127.0.0.1:12201")
 }
 
 func TestWriteTCP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	scenarioTCP(t, "tcp://127.0.0.1:12201")
 }
 


### PR DESCRIPTION
The graylog plugins UDP/TCP support was a recent addition (https://github.com/influxdata/telegraf/pull/9644), and now the graylog tests are failing randomly: https://app.circleci.com/pipelines/github/influxdata/telegraf/6802/workflows/614bcc62-e1d8-4d6c-8eb8-34667650f615/jobs/118647 They rely on setting up a TCP and UDP server, this is the easiest solution to just mark them as integration tests and not run them. We don't currently run integration tests in our CI at all, so maybe there is a better way to refactor these tests so they don't rely on tcp/udp servers but it isn't obvious to me how.