### PR TITLE
feat: Add gnmi to use json token based auth for outgoing RPCs.

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -42,6 +42,9 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR (64-
   # [inputs.gnmi.aliases]
   #   ifcounters = "openconfig:/interfaces/interface/state/counters"
 
+  ## Set a gRPC based token for outgoing connections.
+  # webauthtoken = ""
+
   [[inputs.gnmi.subscription]]
     ## Name of the measurement that will be emitted
     name = "ifcounters"

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -71,7 +71,7 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR (64-
 
 ## Example Output
 
-```shell
+```text
 ifcounters,path=openconfig-interfaces:/interfaces/interface/state/counters,host=linux,name=MgmtEth0/RP0/CPU0/0,source=10.49.234.115 in-multicast-pkts=0i,out-multicast-pkts=0i,out-errors=0i,out-discards=0i,in-broadcast-pkts=0i,out-broadcast-pkts=0i,in-discards=0i,in-unknown-protos=0i,in-errors=0i,out-unicast-pkts=0i,in-octets=0i,out-octets=0i,last-clear="2019-05-22T16:53:21Z",in-unicast-pkts=0i 1559145777425000000
 ifcounters,path=openconfig-interfaces:/interfaces/interface/state/counters,host=linux,name=GigabitEthernet0/0/0/0,source=10.49.234.115 out-multicast-pkts=0i,out-broadcast-pkts=0i,in-errors=0i,out-errors=0i,in-discards=0i,out-octets=0i,in-unknown-protos=0i,in-unicast-pkts=0i,in-octets=0i,in-multicast-pkts=0i,in-broadcast-pkts=0i,last-clear="2019-05-22T16:54:50Z",out-unicast-pkts=0i,out-discards=0i 1559145777425000000
 ```

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -3,10 +3,10 @@
 This plugin consumes telemetry data based on the [gNMI](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md) Subscribe method. TLS is supported for authentication and encryption.  This input plugin is vendor-agnostic and is supported on any platform that supports the gNMI spec.
 
 For Cisco devices:
+
 It has been optimized to support gNMI telemetry as produced by Cisco IOS XR (64-bit) version 6.5.1, Cisco NX-OS 9.3 and Cisco IOS XE 16.12 and later.
 
-
-### Configuration
+## Configuration
 
 ```toml
 [[inputs.gnmi]]
@@ -69,8 +69,9 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR (64-
     # heartbeat_interval = "60s"
 ```
 
-### Example Output
-```
+## Example Output
+
+```shell
 ifcounters,path=openconfig-interfaces:/interfaces/interface/state/counters,host=linux,name=MgmtEth0/RP0/CPU0/0,source=10.49.234.115 in-multicast-pkts=0i,out-multicast-pkts=0i,out-errors=0i,out-discards=0i,in-broadcast-pkts=0i,out-broadcast-pkts=0i,in-discards=0i,in-unknown-protos=0i,in-errors=0i,out-unicast-pkts=0i,in-octets=0i,out-octets=0i,last-clear="2019-05-22T16:53:21Z",in-unicast-pkts=0i 1559145777425000000
 ifcounters,path=openconfig-interfaces:/interfaces/interface/state/counters,host=linux,name=GigabitEthernet0/0/0/0,source=10.49.234.115 out-multicast-pkts=0i,out-broadcast-pkts=0i,in-errors=0i,out-errors=0i,in-discards=0i,out-octets=0i,in-unknown-protos=0i,in-unicast-pkts=0i,in-octets=0i,in-multicast-pkts=0i,in-broadcast-pkts=0i,last-clear="2019-05-22T16:54:50Z",out-unicast-pkts=0i,out-discards=0i 1559145777425000000
 ```

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -2,7 +2,7 @@
 
 This plugin consumes telemetry data based on the [gNMI](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md) Subscribe method. TLS is supported for authentication and encryption.  This input plugin is vendor-agnostic and is supported on any platform that supports the gNMI spec.
 
-For Cisco devices: 
+For Cisco devices:
 It has been optimized to support gNMI telemetry as produced by Cisco IOS XR (64-bit) version 6.5.1, Cisco NX-OS 9.3 and Cisco IOS XE 16.12 and later.
 
 
@@ -38,12 +38,12 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR (64-
   # prefix = ""
   # target = ""
 
+  ## Set a gRPC based token for outgoing connections.
+  # webauthtoken = ""
+
   ## Define additional aliases to map telemetry encoding paths to simple measurement names
   # [inputs.gnmi.aliases]
   #   ifcounters = "openconfig:/interfaces/interface/state/counters"
-
-  ## Set a gRPC based token for outgoing connections.
-  # webauthtoken = ""
 
   [[inputs.gnmi.subscription]]
     ## Name of the measurement that will be emitted

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -548,6 +548,10 @@ const sampleConfig = `
  # prefix = ""
  # target = ""
 
+ ## define webauthtoken
+ # webauthtoken = ""
+
+
  ## Define additional aliases to map telemetry encoding paths to simple measurement names
  #[inputs.gnmi.aliases]
  #  ifcounters = "openconfig:/interfaces/interface/state/counters"

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -550,7 +550,7 @@ const sampleConfig = `
  # prefix = ""
  # target = ""
 
- ## define webauthtoken
+ ## Set a gRPC based token for outgoing connections.
  # webauthtoken = ""
 
 

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -46,6 +46,9 @@ type GNMI struct {
 	Username string
 	Password string
 
+	// Web auth token for devices that support it.
+	WebAuthToken string `toml:"webauthtoken"`
+
 	// Redial
 	Redial config.Duration
 
@@ -59,8 +62,7 @@ type GNMI struct {
 	cancel          context.CancelFunc
 	wg              sync.WaitGroup
 
-	Log          telegraf.Logger
-	WebAuthToken string `toml:"webauthtoken"`
+	Log telegraf.Logger
 }
 
 // Subscription for a gNMI client

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -215,19 +215,19 @@ func (c *GNMI) newSubscribeRequest() (*gnmiLib.SubscribeRequest, error) {
 // SubscribeGNMI and extract telemetry data
 func (c *GNMI) subscribeGNMI(ctx context.Context, address string, tlscfg *tls.Config, request *gnmiLib.SubscribeRequest) error {
 	// Create a slice of grpc options for multiple different options.
-	var Options []grpc.DialOption
+	var options []grpc.DialOption
 	if len(c.WebAuthToken) > 0 {
-		Options = append(Options, grpc.WithPerRPCCredentials((oauth.NewOauthAccess(&oauth2.Token{
+		options = append(options, grpc.WithPerRPCCredentials((oauth.NewOauthAccess(&oauth2.Token{
 			AccessToken: c.WebAuthToken,
 		}))))
 	}
 	if tlscfg != nil {
-		Options = append(Options, grpc.WithTransportCredentials(credentials.NewTLS(tlscfg)))
+		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(tlscfg)))
 	}
 	if tlscfg == nil {
-		Options = append(Options, grpc.WithInsecure())
+		options = append(options, grpc.WithInsecure())
 	}
-	client, err := grpc.DialContext(ctx, address, Options...)
+	client, err := grpc.DialContext(ctx, address, options...)
 	if err != nil {
 		return fmt.Errorf("failed to dial: %v", err)
 	}

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -225,8 +225,7 @@ func (c *GNMI) subscribeGNMI(ctx context.Context, address string, tlscfg *tls.Co
 	}
 	if tlscfg != nil {
 		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(tlscfg)))
-	}
-	if tlscfg == nil {
+	} else {
 		options = append(options, grpc.WithInsecure())
 	}
 	client, err := grpc.DialContext(ctx, address, options...)

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -552,7 +552,6 @@ const sampleConfig = `
  ## Set a gRPC based token for outgoing connections.
  # webauthtoken = ""
 
-
  ## Define additional aliases to map telemetry encoding paths to simple measurement names
  #[inputs.gnmi.aliases]
  #  ifcounters = "openconfig:/interfaces/interface/state/counters"

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -47,7 +47,7 @@ type GNMI struct {
 	Password string
 
 	// Web auth token for devices that support it.
-	WebAuthToken string `toml:"webauthtoken"`
+	webauthtoken string `toml:"webauthtoken"`
 
 	// Redial
 	Redial config.Duration
@@ -102,7 +102,7 @@ func (c *GNMI) Start(acc telegraf.Accumulator) error {
 			return err
 		}
 	}
-	if c.WebAuthToken != "" {
+	if c.webauthtoken != "" {
 		tlscfg = &tls.Config{
 			Renegotiation:      tls.RenegotiateNever,
 			InsecureSkipVerify: true,
@@ -218,9 +218,9 @@ func (c *GNMI) newSubscribeRequest() (*gnmiLib.SubscribeRequest, error) {
 func (c *GNMI) subscribeGNMI(ctx context.Context, address string, tlscfg *tls.Config, request *gnmiLib.SubscribeRequest) error {
 	// Create a slice of grpc options for multiple different options.
 	var options []grpc.DialOption
-	if len(c.WebAuthToken) > 0 {
+	if len(c.webauthtoken) > 0 {
 		options = append(options, grpc.WithPerRPCCredentials((oauth.NewOauthAccess(&oauth2.Token{
-			AccessToken: c.WebAuthToken,
+			AccessToken: c.webauthtoken,
 		}))))
 	}
 	if tlscfg != nil {

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -185,7 +185,7 @@ func TestWebAuthToken(t *testing.T) {
 	plugin := &GNMI{
 		Log:          testutil.Logger{},
 		Addresses:    []string{listener.Addr().String()},
-		WebAuthToken: "token123",
+		webauthtoken: "token123",
 		Encoding:     "proto",
 		Redial:       config.Duration(1 * time.Second),
 	}

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -159,7 +159,7 @@ func TestUsernamePassword(t *testing.T) {
 		errors.New("aborted gNMI subscription: rpc error: code = Unknown desc = success"))
 }
 
-func TestWebAuthToken(t *testing.T) {
+func Testwebauthtoken(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
@@ -171,8 +171,8 @@ func TestWebAuthToken(t *testing.T) {
 				return errors.New("failed to get metadata")
 			}
 
-			WebAuthToken := metadata.Get("WebAuthToken")
-			if len(WebAuthToken) != 1 || WebAuthToken[0] != "token123" {
+			webauthtoken := metadata.Get("webauthtoken")
+			if len(webauthtoken) != 1 || webauthtoken[0] != "token123" {
 				return errors.New("wrong token")
 			}
 


### PR DESCRIPTION
### Required for all PRs:

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

[Token-based authentication](https://grpc.io/docs/guides/auth/) with Google: gRPC provides a generic mechanism (described below) to attach metadata based credentials to requests and responses. Additional support for acquiring access tokens (typically OAuth2 tokens) while accessing Google APIs through gRPC is provided for certain auth flows: you can see how this works in our code examples below. In general this mechanism must be used as well as SSL/TLS on the channel - Google will not allow connections without SSL/TLS, and most gRPC language implementations will not let you send credentials on an unencrypted channel.

Some gRPC based applications now require a token to communicate rather than a standard username/password.  So in this event where a gNMI service is running on an application that does not have the availability to use a username/password a token would take its place. 

A good example of such a application is [gNMI gateway](https://github.com/openconfig/gnmi-gateway). 