### PR TITLE
fix: use read-only permissions for win_services plugin

### DIFF
--- a/plugins/inputs/win_services/README.md
+++ b/plugins/inputs/win_services/README.md
@@ -4,7 +4,9 @@ Reports information about Windows service status.
 
 Monitoring some services may require running Telegraf with administrator privileges.
 
-### Configuration:
+### Configuration
+
+Configuration requires a list of service names or wild cards to monitor:
 
 ```toml
 [[inputs.win_services]]
@@ -14,15 +16,22 @@ Monitoring some services may require running Telegraf with administrator privile
     "TermService",
     "Win*",
   ]
+
+  ## By default, the monitoring services plugin will use elevated permissions to
+  ## obtain the status of services. Some services do require higher level of
+  ## permissions to be monitored. However, if the user wishes to limit the
+  ## permission access to a lower level, uncomment the following.
+  # access_level = "read-only"
 ```
 
-### Measurements & Fields:
+### Measurements & Fields
 
 - win_services
-    - state : integer
-    - startup_mode : integer
+  - state : integer
+  - startup_mode : integer
 
 The `state` field can have the following values:
+
 - 1 - stopped
 - 2 - start pending
 - 3 - stop pending
@@ -32,23 +41,26 @@ The `state` field can have the following values:
 - 7 - paused
 
 The `startup_mode` field can have the following values:
+
 - 0 - boot start
 - 1 - system start
 - 2 - auto start
 - 3 - demand start
 - 4 - disabled
 
-### Tags:
+### Tags
 
 - All measurements have the following tags:
     - service_name
     - display_name
 
-### Example Output:
+### Example Output
+
 ```
 win_services,host=WIN2008R2H401,display_name=Server,service_name=LanmanServer state=4i,startup_mode=2i 1500040669000000000
 win_services,display_name=Remote\ Desktop\ Services,service_name=TermService,host=WIN2008R2H401 state=1i,startup_mode=3i 1500040669000000000
 ```
+
 ### TICK Scripts
 
 A sample TICK script for a notification about a not running service.

--- a/plugins/inputs/win_services/svc/mgr/config.go
+++ b/plugins/inputs/win_services/svc/mgr/config.go
@@ -1,0 +1,22 @@
+//go:build windows
+// +build windows
+
+// https://github.com/golang/sys/blob/master/windows/svc/mgr/config.go
+
+package mgr
+
+type Config struct {
+	ServiceType      uint32
+	StartType        uint32
+	ErrorControl     uint32
+	BinaryPathName   string // fully qualified path to the service binary file, can also include arguments for an auto-start service
+	LoadOrderGroup   string
+	TagId            uint32
+	Dependencies     []string
+	ServiceStartName string // name of the account under which the service should run
+	DisplayName      string
+	Password         string
+	Description      string
+	SidType          uint32 // one of SERVICE_SID_TYPE, the type of sid to use for the service
+	DelayedAutoStart bool   // the service is started after other auto-start services are started plus a short delay
+}

--- a/plugins/inputs/win_services/svc/mgr/mgr.go
+++ b/plugins/inputs/win_services/svc/mgr/mgr.go
@@ -1,0 +1,106 @@
+//go:build windows
+// +build windows
+
+// https://github.com/golang/sys/blob/master/windows/svc/mgr/mgr.go
+
+package mgr
+
+import (
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+
+	"github.com/influxdata/telegraf/plugins/inputs/win_services/unsafeheader"
+	"golang.org/x/sys/windows"
+)
+
+type Mgr struct {
+	Handle windows.Handle
+}
+
+// Connect establishes a connection to the service control manager.
+func Connect(accessMask uint32) (*Mgr, error) {
+	var s *uint16
+	h, err := windows.OpenSCManager(s, nil, accessMask)
+	if err != nil {
+		return nil, err
+	}
+	return &Mgr{Handle: h}, nil
+}
+
+// Disconnect closes connection to the service control manager m.
+func (m *Mgr) Disconnect() error {
+	return windows.CloseServiceHandle(m.Handle)
+}
+
+// ListServices enumerates services in the specified
+// service control manager database m.
+// If the caller does not have the SERVICE_QUERY_STATUS
+// access right to a service, the service is silently
+// omitted from the list of services returned.
+func (m *Mgr) ListServices() ([]string, error) {
+	var err error
+	var bytesNeeded, servicesReturned uint32
+	var buf []byte
+	for {
+		var p *byte
+		if len(buf) > 0 {
+			p = &buf[0]
+		}
+		err = windows.EnumServicesStatusEx(m.Handle, windows.SC_ENUM_PROCESS_INFO,
+			windows.SERVICE_WIN32, windows.SERVICE_STATE_ALL,
+			p, uint32(len(buf)), &bytesNeeded, &servicesReturned, nil, nil)
+		if err == nil {
+			break
+		}
+		if err != syscall.ERROR_MORE_DATA {
+			return nil, err
+		}
+		if bytesNeeded <= uint32(len(buf)) {
+			return nil, err
+		}
+		buf = make([]byte, bytesNeeded)
+	}
+	if servicesReturned == 0 {
+		return nil, nil
+	}
+
+	var services []windows.ENUM_SERVICE_STATUS_PROCESS
+	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&services))
+	hdr.Data = unsafe.Pointer(&buf[0])
+	hdr.Len = int(servicesReturned)
+	hdr.Cap = int(servicesReturned)
+
+	var names []string
+	for _, s := range services {
+		name := windows.UTF16PtrToString(s.ServiceName)
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// OpenService retrieves access to service name, so it can
+// be interrogated and controlled.
+func (m *Mgr) OpenService(name string, accessMask uint32) (*Service, error) {
+	namePtr, err := UTF16FromString(name)
+	if err != nil {
+		return nil, err
+	}
+	h, err := windows.OpenService(m.Handle, &namePtr[0], accessMask)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{Name: name, Handle: h}, nil
+}
+
+// UTF16FromString returns the UTF-16 encoding of the UTF-8 string
+// s, with a terminating NUL added. If s contains a NUL byte at any
+// location, it returns (nil, syscall.EINVAL).
+func UTF16FromString(s string) ([]uint16, error) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0 {
+			return nil, syscall.EINVAL
+		}
+	}
+	return utf16.Encode([]rune(s + "\x00")), nil
+}

--- a/plugins/inputs/win_services/svc/mgr/service.go
+++ b/plugins/inputs/win_services/svc/mgr/service.go
@@ -1,0 +1,135 @@
+//go:build windows
+// +build windows
+
+// https://github.com/golang/sys/blob/master/windows/svc/mgr/service.go
+
+package mgr
+
+import (
+	"syscall"
+	"unsafe"
+
+	"github.com/influxdata/telegraf/plugins/inputs/win_services/svc"
+	"golang.org/x/sys/windows"
+)
+
+// Service is used to access Windows service.
+type Service struct {
+	Name   string
+	Handle windows.Handle
+}
+
+// Query returns current status of service s.
+func (s *Service) Query() (svc.Status, error) {
+	var t windows.SERVICE_STATUS_PROCESS
+	var needed uint32
+	err := windows.QueryServiceStatusEx(s.Handle, windows.SC_STATUS_PROCESS_INFO, (*byte)(unsafe.Pointer(&t)), uint32(unsafe.Sizeof(t)), &needed)
+	if err != nil {
+		return svc.Status{}, err
+	}
+	return svc.Status{
+		State:                   svc.State(t.CurrentState),
+		Accepts:                 svc.Accepted(t.ControlsAccepted),
+		ProcessId:               t.ProcessId,
+		Win32ExitCode:           t.Win32ExitCode,
+		ServiceSpecificExitCode: t.ServiceSpecificExitCode,
+	}, nil
+}
+
+// Close relinquish access to the service s.
+func (s *Service) Close() error {
+	return windows.CloseServiceHandle(s.Handle)
+}
+
+// Config retrieves service s configuration paramteres.
+func (s *Service) Config() (Config, error) {
+	var p *windows.QUERY_SERVICE_CONFIG
+	n := uint32(1024)
+	for {
+		b := make([]byte, n)
+		p = (*windows.QUERY_SERVICE_CONFIG)(unsafe.Pointer(&b[0]))
+		err := windows.QueryServiceConfig(s.Handle, p, n, &n)
+		if err == nil {
+			break
+		}
+		if err.(syscall.Errno) != syscall.ERROR_INSUFFICIENT_BUFFER {
+			return Config{}, err
+		}
+		if n <= uint32(len(b)) {
+			return Config{}, err
+		}
+	}
+
+	b, err := s.queryServiceConfig2(windows.SERVICE_CONFIG_DESCRIPTION)
+	if err != nil {
+		return Config{}, err
+	}
+	p2 := (*windows.SERVICE_DESCRIPTION)(unsafe.Pointer(&b[0]))
+
+	b, err = s.queryServiceConfig2(windows.SERVICE_CONFIG_DELAYED_AUTO_START_INFO)
+	if err != nil {
+		return Config{}, err
+	}
+	p3 := (*windows.SERVICE_DELAYED_AUTO_START_INFO)(unsafe.Pointer(&b[0]))
+	delayedStart := false
+	if p3.IsDelayedAutoStartUp != 0 {
+		delayedStart = true
+	}
+
+	b, err = s.queryServiceConfig2(windows.SERVICE_CONFIG_SERVICE_SID_INFO)
+	if err != nil {
+		return Config{}, err
+	}
+	sidType := *(*uint32)(unsafe.Pointer(&b[0]))
+
+	return Config{
+		ServiceType:      p.ServiceType,
+		StartType:        p.StartType,
+		ErrorControl:     p.ErrorControl,
+		BinaryPathName:   windows.UTF16PtrToString(p.BinaryPathName),
+		LoadOrderGroup:   windows.UTF16PtrToString(p.LoadOrderGroup),
+		TagId:            p.TagId,
+		Dependencies:     toStringSlice(p.Dependencies),
+		ServiceStartName: windows.UTF16PtrToString(p.ServiceStartName),
+		DisplayName:      windows.UTF16PtrToString(p.DisplayName),
+		Description:      windows.UTF16PtrToString(p2.Description),
+		DelayedAutoStart: delayedStart,
+		SidType:          sidType,
+	}, nil
+}
+
+// queryServiceConfig2 calls Windows QueryServiceConfig2 with infoLevel parameter and returns retrieved service configuration information.
+func (s *Service) queryServiceConfig2(infoLevel uint32) ([]byte, error) {
+	n := uint32(1024)
+	for {
+		b := make([]byte, n)
+		err := windows.QueryServiceConfig2(s.Handle, infoLevel, &b[0], n, &n)
+		if err == nil {
+			return b, nil
+		}
+		if err.(syscall.Errno) != syscall.ERROR_INSUFFICIENT_BUFFER {
+			return nil, err
+		}
+		if n <= uint32(len(b)) {
+			return nil, err
+		}
+	}
+}
+
+func toStringSlice(ps *uint16) []string {
+	r := make([]string, 0)
+	p := unsafe.Pointer(ps)
+
+	for {
+		s := windows.UTF16PtrToString((*uint16)(p))
+		if len(s) == 0 {
+			break
+		}
+
+		r = append(r, s)
+		offset := unsafe.Sizeof(uint16(0)) * (uintptr)(len(s)+1)
+		p = unsafe.Pointer(uintptr(p) + offset)
+	}
+
+	return r
+}

--- a/plugins/inputs/win_services/svc/service.go
+++ b/plugins/inputs/win_services/svc/service.go
@@ -1,0 +1,19 @@
+package svc
+
+// State describes service execution state (Stopped, Running and so on).
+type State uint32
+
+// Accepted is used to describe commands accepted by the service.
+// Note that Interrogate is always accepted.
+type Accepted uint32
+
+// Status combines State and Accepted commands to fully describe running service.
+type Status struct {
+	State                   State
+	Accepts                 Accepted
+	CheckPoint              uint32 // used to report progress during a lengthy operation
+	WaitHint                uint32 // estimated time required for a pending operation, in milliseconds
+	ProcessId               uint32 //nolint:revive // if the service is running, the process identifier of it, and otherwise zero
+	Win32ExitCode           uint32 // set if the service has exited with a win32 exit code
+	ServiceSpecificExitCode uint32 // set if the service has exited with a service-specific exit code
+}

--- a/plugins/inputs/win_services/unsafeheader/unsafe.go
+++ b/plugins/inputs/win_services/unsafeheader/unsafe.go
@@ -1,0 +1,18 @@
+//go:build windows
+// +build windows
+
+// https://github.com/golang/sys/blob/master/internal/unsafeheader/unsafeheader.go
+
+package unsafeheader
+
+import (
+	"unsafe"
+)
+
+// Slice is the runtime representation of a slice.
+// It cannot be used safely or portably and its representation may change in a later release.
+type Slice struct {
+	Data unsafe.Pointer
+	Len  int
+	Cap  int
+}

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -10,11 +10,11 @@ import (
 	"log"
 	"testing"
 
+	"github.com/influxdata/telegraf/plugins/inputs/win_services/svc"
+	"github.com/influxdata/telegraf/plugins/inputs/win_services/svc/mgr"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/windows/svc"
-	"golang.org/x/sys/windows/svc/mgr"
 )
 
 //testData is DD wrapper for unit testing of WinServices
@@ -44,7 +44,7 @@ func (m *FakeSvcMgr) Disconnect() error {
 	return nil
 }
 
-func (m *FakeSvcMgr) OpenService(name string) (WinService, error) {
+func (m *FakeSvcMgr) OpenService(name string, accessMask uint32) (WinService, error) {
 	for _, s := range m.testData.services {
 		if s.serviceName == name {
 			if s.serviceOpenError != nil {
@@ -69,7 +69,7 @@ type FakeMgProvider struct {
 	testData testData
 }
 
-func (m *FakeMgProvider) Connect() (WinServiceManager, error) {
+func (m *FakeMgProvider) Connect(accessMask uint32) (WinServiceManager, error) {
 	if m.testData.mgrConnectError != nil {
 		return nil, m.testData.mgrConnectError
 	} else {


### PR DESCRIPTION
Instead of using all-access permissions, this limits the windows services plugin to only use read-only permissions. As the plugin only obtains a list of services and then queries the status of each service, restrict access makes sense.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
