### PR TITLE
feat: add Transmission input plugin

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -189,6 +189,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/temp"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tengine"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tomcat"
+	_ "github.com/influxdata/telegraf/plugins/inputs/transmission"
 	_ "github.com/influxdata/telegraf/plugins/inputs/trig"
 	_ "github.com/influxdata/telegraf/plugins/inputs/twemproxy"
 	_ "github.com/influxdata/telegraf/plugins/inputs/udp_listener"

--- a/plugins/inputs/transmission/README.md
+++ b/plugins/inputs/transmission/README.md
@@ -1,0 +1,58 @@
+# Transmission Input Plugin
+
+This plugin uses the [Transmission RPC API](https://github.com/transmission/transmission/blob/master/extras/rpc-spec.txt) (>= RPC Version 16 / Transmission 3.00) to gather information about the BitTorrent client and the status of it’s added torrents.
+
+For this plugin to work the RPC API has to be enabled, and the `rpc-whitelist` has to be set accordingly if a remote connection is used. Further information can be found [here](https://github.com/transmission/transmission/wiki/Editing-Configuration-Files#rpc).
+
+### Configuration:
+
+```toml
+# Collect Transmission client statistics about bandwidth usage and torrent status
+[[inputs.transmission]]
+  ## An URL where the Transmission RPC API is available
+  url = "http://127.0.0.1:9091/transmission/rpc"
+  
+  ## Timeout for HTTP requests
+  # timeout = "5s"
+  
+  ## Optional HTTP Basic Auth credentials
+  # username = "username"
+  # password = "pa$$word"
+  
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+```
+
+### Metrics
+
+- transmission
+  - tags
+    - url
+    - rpc_host
+    - rpc_port
+    - peer_port
+  - fields
+    - torrents_active (integer)
+    - torrents_stopped (integer)
+    - torrents_queued_checking (integer)
+    - torrents_checking (integer)
+    - torrents_queued_downloading (integer)
+    - torrents_downloading (integer)
+    - torrents_queued_seeding (integer)
+    - torrents_seeding (integer)
+    - torrents_size (integer, total file size in bytes)
+    - peers_connected (integer)
+    - peers_getting_from_us (integer)
+    - peers_sending_to_us (integer)
+    - download_speed (integer, in B/s)
+    - upload_speed (integer, in B/s)
+
+### Example output:
+
+```
+transmission,peer_port=6881,rpc_host=127.0.0.1,rpc_port=9091,url=http://127.0.0.1:9091/transmission/rpc torrents_queued_checking=0i,torrents_checking=0i,torrents_size=834402528251i,peers_connected=63i,torrents_queued_seeding=0i,torrents_seeding=582i,peers_getting_from_us=16i,download_speed=0i,peers_sending_to_us=0i,torrents_active=1i,upload_speed=1577000i,torrents_stopped=30i,torrents_queued_downloading=0i,torrents_downloading=0i 1633606320000000000
+```

--- a/plugins/inputs/transmission/transmission.go
+++ b/plugins/inputs/transmission/transmission.go
@@ -1,0 +1,321 @@
+package transmission
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/common/tls"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const sampleConfig = `
+  ## An URL where the Transmission RPC API is available
+  url = "http://127.0.0.1:9091/transmission/rpc"
+
+  ## Timeout for HTTP requests
+  # timeout = "5s"
+
+  ## Optional HTTP Basic Auth credentials
+  # username = "username"
+  # password = "pa$$word"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+`
+
+const description = "Collect Transmission client statistics about bandwidth usage and torrent status"
+
+// Transmission is an input that collects client statistics
+// about bandwidth usage and torrent status of the Transmission BitTorrent client.
+type Transmission struct {
+	URL      string `toml:"url"`
+	Username string `toml:"username"`
+	Password string `toml:"password"`
+
+	Timeout config.Duration `toml:"timeout"`
+
+	// Used as tags
+	rpcHost string
+	rpcPort string
+
+	tls.ClientConfig
+	client     *http.Client
+	csrfHeader string
+}
+
+type requestPayload struct {
+	Method    string      `json:"method"`
+	Arguments interface{} `json:"arguments,omitempty"`
+	Tag       int         `json:"tag,omitempty"`
+}
+
+type responsePayload struct {
+	Arguments interface{} `json:"arguments"`
+	Result    string      `json:"result"`
+	Tag       *int        `json:"tag"`
+}
+
+type sessionInformation struct {
+	PeerPort int64 `json:"peer-port"`
+}
+
+type torrentStats struct {
+	Active             int64
+	Stopped            int64
+	QueuedChecking     int64
+	Checking           int64
+	QueuedDownloading  int64
+	Downloading        int64
+	QueuedSeeding      int64
+	Seeding            int64
+	Size               int64
+	PeersConnected     int64
+	PeersGettingFromUs int64
+	PeersSendingToUs   int64
+	TotalDownloadSpeed int64
+	TotalUploadSpeed   int64
+}
+
+func (t *Transmission) Description() string {
+	return description
+}
+
+func (t *Transmission) SampleConfig() string {
+	return sampleConfig
+}
+
+// Init is for setup, and validating config.
+func (t *Transmission) Init() error {
+	if t.client == nil {
+		client, err := t.createHTTPClient()
+
+		if err != nil {
+			return err
+		}
+		t.client = client
+	}
+
+	u, err := url.Parse(t.URL)
+	if err != nil {
+		return err
+	}
+
+	t.rpcHost, t.rpcPort, err = net.SplitHostPort(u.Host)
+	if err != nil {
+		t.rpcHost = u.Host
+		if u.Scheme == "http" {
+			t.rpcPort = "80"
+		} else if u.Scheme == "https" {
+			t.rpcPort = "443"
+		} else {
+			t.rpcPort = ""
+		}
+	}
+
+	return nil
+}
+
+// createHTTPClient creates an HTTP client to access the RPC API.
+func (t *Transmission) createHTTPClient() (*http.Client, error) {
+	tlsConfig, err := t.ClientConfig.TLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	timeout := t.Timeout
+	if timeout == 0 {
+		timeout = config.Duration(time.Second * 5)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+		Timeout: time.Duration(timeout),
+	}
+
+	return client, nil
+}
+
+// doRPC executes the RPC using the given method and optional arguments for that method.
+// It tries to unmarshal the specific RPC response for that method using the given result interface.
+// If retry is true it will retry the call once, using a new X-Transmission-Session-Id in case of a http.StatusConflict.
+func (t *Transmission) doRPC(method string, arguments interface{}, result interface{}, retry bool) error {
+	// Random number used by clients to track responses
+	tag := rand.Int()
+
+	reqPayload, err := json.Marshal(requestPayload{
+		Method:    method,
+		Arguments: arguments,
+		Tag:       tag,
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", t.URL, bytes.NewBuffer(reqPayload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Transmission-Session-Id", t.csrfHeader)
+	if t.Username != "" && t.Password != "" {
+		req.SetBasicAuth(t.Username, t.Password)
+	}
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusConflict {
+		t.csrfHeader = resp.Header.Get("X-Transmission-Session-Id")
+		if retry {
+			return t.doRPC(method, arguments, result, retry)
+		}
+		return errors.New("CSRF header invalid twice in a row, aborting")
+	} else if resp.StatusCode != http.StatusOK {
+		return errors.New("HTTP status code is not 200 OK")
+	}
+
+	defer resp.Body.Close()
+	respPayload := responsePayload{Arguments: result}
+	if err = json.NewDecoder(resp.Body).Decode(&respPayload); err != nil {
+		return errors.New("can not decode JSON response")
+	}
+
+	if respPayload.Tag == nil || *respPayload.Tag != tag {
+		return errors.New("tag mismatch")
+	}
+
+	if respPayload.Result != "success" {
+		return errors.New("RPC unsuccessful")
+	}
+
+	return nil
+}
+
+// getSessionInformation calls the session-get method to gather information about the Transmission client itself.
+func (t *Transmission) getSessionInformation() (*sessionInformation, error) {
+	arguments := map[string]interface{}{
+		"fields": []string{"peer-port"},
+	}
+
+	si := &sessionInformation{}
+	err := t.doRPC("session-get", arguments, si, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return si, nil
+}
+
+// getTorrentStats calls the torrent-get method to gather information about individual torrents.
+func (t *Transmission) getTorrentStats() (*torrentStats, error) {
+	arguments := map[string]interface{}{
+		"format": "table",
+		"fields": []string{"status", "totalSize", "peersConnected", "peersGettingFromUs", "peersSendingToUs", "rateDownload", "rateUpload"},
+	}
+
+	type torrentResponse struct {
+		Torrents []json.RawMessage `json:"torrents"`
+	}
+	tr := &torrentResponse{}
+
+	err := t.doRPC("torrent-get", arguments, tr, true)
+	if err != nil {
+		return nil, err
+	}
+
+	row := [7]int64{}
+	ts := &torrentStats{}
+	for _, v := range tr.Torrents[1:] {
+		err := json.Unmarshal(v, &row)
+		if err != nil {
+			continue
+		}
+		switch row[0] {
+		case 0:
+			ts.Stopped++
+		case 1:
+			ts.QueuedChecking++
+		case 2:
+			ts.Checking++
+		case 3:
+			ts.QueuedDownloading++
+		case 4:
+			ts.Downloading++
+		case 5:
+			ts.QueuedSeeding++
+		case 6:
+			ts.Seeding++
+		}
+		ts.Size += row[1]
+		ts.PeersConnected += row[2]
+		ts.PeersGettingFromUs += row[3]
+		ts.PeersSendingToUs += row[4]
+		if row[5] > 0 || row[6] > 0 {
+			ts.Active++
+		}
+		ts.TotalDownloadSpeed += row[5]
+		ts.TotalUploadSpeed += row[6]
+	}
+
+	return ts, nil
+}
+
+func (t *Transmission) Gather(acc telegraf.Accumulator) error {
+	si, err := t.getSessionInformation()
+	if err != nil {
+		return err
+	}
+
+	ts, err := t.getTorrentStats()
+	if err != nil {
+		return err
+	}
+
+	tags := map[string]string{
+		"url":       t.URL,
+		"rpc_host":  t.rpcHost,
+		"rpc_port":  t.rpcPort,
+		"peer_port": strconv.FormatInt(si.PeerPort, 10),
+	}
+
+	fields := map[string]interface{}{
+		"torrents_active":             ts.Active,
+		"torrents_stopped":            ts.Stopped,
+		"torrents_queued_checking":    ts.QueuedChecking,
+		"torrents_checking":           ts.Checking,
+		"torrents_queued_downloading": ts.QueuedDownloading,
+		"torrents_downloading":        ts.Downloading,
+		"torrents_queued_seeding":     ts.QueuedSeeding,
+		"torrents_seeding":            ts.Seeding,
+		"torrents_size":               ts.Size,
+		"peers_connected":             ts.PeersConnected,
+		"peers_getting_from_us":       ts.PeersGettingFromUs,
+		"peers_sending_to_us":         ts.PeersSendingToUs,
+		"download_speed":              ts.TotalDownloadSpeed,
+		"upload_speed":                ts.TotalUploadSpeed,
+	}
+
+	acc.AddFields("transmission", fields, tags)
+
+	return nil
+}
+
+func init() {
+	inputs.Add("transmission", func() telegraf.Input { return &Transmission{} })
+}

--- a/plugins/inputs/transmission/transmission_test.go
+++ b/plugins/inputs/transmission/transmission_test.go
@@ -1,0 +1,208 @@
+package transmission
+
+import (
+	"encoding/json"
+	"github.com/influxdata/telegraf/testutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testJSONTorrent = `{"arguments":{"torrents":[["status","totalSize","peersConnected","peersGettingFromUs","peersSendingToUs","rateDownload","rateUpload"],[6,33345888,0,0,0,0,0],[0,371033238,0,0,0,0,0],[6,1682767645,2,1,0,0,16000],[4,135178626499,50,15,10,20,3013000]]},"result":"success","tag":TAG}`
+const testJSONSession = `{"arguments":{"peer-port":6881},"result":"success","tag":TAG}`
+
+func TestTransmissionGather(t *testing.T) {
+	var acc testutil.Accumulator
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		reqPayload := &requestPayload{}
+		err := json.NewDecoder(r.Body).Decode(&reqPayload)
+		require.NoError(t, err)
+
+		w.Header().Add("Content-Type", "application/json")
+		if reqPayload.Method == "torrent-get" {
+			_, err := w.Write([]byte(strings.Replace(testJSONTorrent, "TAG", strconv.FormatInt(int64(reqPayload.Tag), 10), 1)))
+			require.NoError(t, err)
+		}
+		if reqPayload.Method == "session-get" {
+			_, err = w.Write([]byte(strings.Replace(testJSONSession, "TAG", strconv.FormatInt(int64(reqPayload.Tag), 10), 1)))
+			require.NoError(t, err)
+		}
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		host = u.Host
+		if u.Scheme == "http" {
+			port = "80"
+		} else if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = ""
+		}
+	}
+
+	trans := Transmission{
+		URL: ts.URL,
+	}
+	err = trans.Init()
+	require.NoError(t, err)
+
+	err = trans.Gather(&acc)
+	require.NoError(t, err)
+
+	expectFields := map[string]interface{}{
+		"torrents_stopped":            int64(1),
+		"torrents_queued_checking":    int64(0),
+		"torrents_checking":           int64(0),
+		"torrents_queued_downloading": int64(0),
+		"torrents_downloading":        int64(1),
+		"torrents_queued_seeding":     int64(0),
+		"torrents_seeding":            int64(2),
+		"torrents_size":               int64(137265773270),
+		"peers_connected":             int64(52),
+		"peers_getting_from_us":       int64(16),
+		"peers_sending_to_us":         int64(10),
+		"torrents_active":             int64(2),
+		"download_speed":              int64(20),
+		"upload_speed":                int64(3029000),
+	}
+
+	expectTags := map[string]string{
+		"url":       ts.URL,
+		"rpc_host":  host,
+		"rpc_port":  port,
+		"peer_port": "6881",
+	}
+
+	acc.AssertContainsTaggedFields(t, "transmission", expectFields, expectTags)
+}
+
+func TestTransmissionGatherTagError(t *testing.T) {
+	var acc testutil.Accumulator
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		reqPayload := &requestPayload{}
+		err := json.NewDecoder(r.Body).Decode(&reqPayload)
+		require.NoError(t, err)
+
+		w.Header().Add("Content-Type", "application/json")
+		if reqPayload.Method == "torrent-get" {
+			_, err := w.Write([]byte(strings.Replace(testJSONTorrent, "TAG", strconv.FormatInt(int64(reqPayload.Tag)+1, 10), 1)))
+			require.NoError(t, err)
+		}
+		if reqPayload.Method == "session-get" {
+			_, err = w.Write([]byte(strings.Replace(testJSONSession, "TAG", strconv.FormatInt(int64(reqPayload.Tag)+1, 10), 1)))
+			require.NoError(t, err)
+		}
+	}))
+	defer ts.Close()
+
+	trans := Transmission{
+		URL: ts.URL,
+	}
+	err := trans.Init()
+	require.NoError(t, err)
+
+	err = trans.Gather(&acc)
+	require.EqualError(t, err, "tag mismatch")
+}
+
+func TestTransmissionGatherInvalidJSON(t *testing.T) {
+	var acc testutil.Accumulator
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		reqPayload := &requestPayload{}
+		err := json.NewDecoder(r.Body).Decode(&reqPayload)
+		require.NoError(t, err)
+
+		w.Header().Add("Content-Type", "application/json")
+		if reqPayload.Method == "torrent-get" {
+			_, err := w.Write([]byte(testJSONTorrent))
+			require.NoError(t, err)
+		}
+		if reqPayload.Method == "session-get" {
+			_, err = w.Write([]byte(testJSONSession))
+			require.NoError(t, err)
+		}
+	}))
+	defer ts.Close()
+
+	trans := Transmission{
+		URL: ts.URL,
+	}
+	err := trans.Init()
+	require.NoError(t, err)
+
+	err = trans.Gather(&acc)
+	require.EqualError(t, err, "can not decode JSON response")
+}
+
+func TestTransmissionGatherUsingBasicAuth(t *testing.T) {
+	var acc testutil.Accumulator
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		reqPayload := &requestPayload{}
+		err := json.NewDecoder(r.Body).Decode(&reqPayload)
+		require.NoError(t, err)
+
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "testUser" || pass != "testPass" {
+			w.WriteHeader(401)
+			_, err := w.Write([]byte("Unauthorised.\n"))
+			require.NoError(t, err)
+			return
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		if reqPayload.Method == "torrent-get" {
+			_, err := w.Write([]byte(strings.Replace(testJSONTorrent, "TAG", strconv.FormatInt(int64(reqPayload.Tag), 10), 1)))
+			require.NoError(t, err)
+		}
+		if reqPayload.Method == "session-get" {
+			_, err = w.Write([]byte(strings.Replace(testJSONSession, "TAG", strconv.FormatInt(int64(reqPayload.Tag), 10), 1)))
+			require.NoError(t, err)
+		}
+	}))
+	defer ts.Close()
+
+	transOK := Transmission{
+		URL:      ts.URL,
+		Username: "testUser",
+		Password: "testPass",
+	}
+	err := transOK.Init()
+	require.NoError(t, err)
+
+	err = transOK.Gather(&acc)
+	require.NoError(t, err)
+
+	transErr := Transmission{
+		URL:      ts.URL,
+		Username: "invalid",
+		Password: "invalid",
+	}
+	err = transErr.Init()
+	require.NoError(t, err)
+
+	err = transErr.Gather(&acc)
+	require.EqualError(t, err, "HTTP status code is not 200 OK")
+}


### PR DESCRIPTION
This PR adds a telegraf input plugin to gather metrics from the [Transmission](https://transmissionbt.com/) BitTorrent client.

It does so by querying the [RPC API](https://github.com/transmission/transmission/blob/master/extras/rpc-spec.txt) of Transmission. It supports Transmission 3.00 and above.

Closes #9889 

### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)




