### PR TITLE
fix(json_v2): remove dead code

### DIFF
--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -268,7 +268,7 @@ func (p *Parser) expandArray(result MetricNode) ([]telegraf.Metric, error) {
 
 	if result.IsArray() {
 		var err error
-		if result.IncludeCollection == nil && (len(p.currentSettings.FieldPaths) > 0 || len(p.currentSettings.TagPaths) > 0) {
+		if result.IncludeCollection == nil && (len(p.objectConfig.FieldPaths) > 0 || len(p.objectConfig.TagPaths) > 0) {
 			result.IncludeCollection = p.existsInpathResults(result.Index)
 		}
 		result.ForEach(func(_, val gjson.Result) bool {
@@ -375,7 +375,7 @@ func (p *Parser) expandArray(result MetricNode) ([]telegraf.Metric, error) {
 }
 
 func (p *Parser) existsInpathResults(index int) *PathResult {
-	for _, f := range p.pathResults {
+	for _, f := range p.subPathResults {
 		if f.result.Index == index {
 			return &f
 		}


### PR DESCRIPTION
Removed a few lines of code in the json_v2 parser that don't seem to be getting used, tests still pass and weren't changed. The function `existsInpathResults` even had a parameter it wasn't using, surprised the linter didn't catch this. The parser could use more refactoring, this is a start in cleaning it up.