### PR TITLE
plugins/common/tls/config.go:  Filter client certs by dns names

### DIFF
--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -31,6 +31,12 @@ The server TLS configuration provides support for TLS mutual authentication:
 ## enable mutually authenticated TLS connections.
 # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
 
+## Set one or more allowed DNS name to enable a whitelist
+## to verify incoming client certificates.
+## It will go through all available SAN in the certificate,
+## if of them matches the request is accepted.
+# tls_allowed_dns_names = ["client.example.org"]
+
 ## Add service certificate and key.
 # tls_cert = "/etc/telegraf/cert.pem"
 # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/common/tls/config_test.go
+++ b/plugins/common/tls/config_test.go
@@ -128,12 +128,13 @@ func TestServerConfig(t *testing.T) {
 		{
 			name: "success",
 			server: tls.ServerConfig{
-				TLSCert:           pki.ServerCertPath(),
-				TLSKey:            pki.ServerKeyPath(),
-				TLSAllowedCACerts: []string{pki.CACertPath()},
-				TLSCipherSuites:   []string{pki.CipherSuite()},
-				TLSMinVersion:     pki.TLSMinVersion(),
-				TLSMaxVersion:     pki.TLSMaxVersion(),
+				TLSCert:            pki.ServerCertPath(),
+				TLSKey:             pki.ServerKeyPath(),
+				TLSAllowedCACerts:  []string{pki.CACertPath()},
+				TLSCipherSuites:    []string{pki.CipherSuite()},
+				TLSAllowedDNSNames: []string{"localhost", "127.0.0.1"},
+				TLSMinVersion:      pki.TLSMinVersion(),
+				TLSMaxVersion:      pki.TLSMaxVersion(),
 			},
 		},
 		{
@@ -293,9 +294,10 @@ func TestConnect(t *testing.T) {
 	}
 
 	serverConfig := tls.ServerConfig{
-		TLSCert:           pki.ServerCertPath(),
-		TLSKey:            pki.ServerKeyPath(),
-		TLSAllowedCACerts: []string{pki.CACertPath()},
+		TLSCert:            pki.ServerCertPath(),
+		TLSKey:             pki.ServerKeyPath(),
+		TLSAllowedCACerts:  []string{pki.CACertPath()},
+		TLSAllowedDNSNames: []string{"localhost", "127.0.0.1"},
 	}
 
 	serverTLSConfig, err := serverConfig.TLSConfig()
@@ -322,4 +324,47 @@ func TestConnect(t *testing.T) {
 	resp, err := client.Get(ts.URL)
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
+}
+
+func TestConnectWrongDNS(t *testing.T) {
+	clientConfig := tls.ClientConfig{
+		TLSCA:   pki.CACertPath(),
+		TLSCert: pki.ClientCertPath(),
+		TLSKey:  pki.ClientKeyPath(),
+	}
+
+	serverConfig := tls.ServerConfig{
+		TLSCert:            pki.ServerCertPath(),
+		TLSKey:             pki.ServerKeyPath(),
+		TLSAllowedCACerts:  []string{pki.CACertPath()},
+		TLSAllowedDNSNames: []string{"localhos", "127.0.0.2"},
+	}
+
+	serverTLSConfig, err := serverConfig.TLSConfig()
+	require.NoError(t, err)
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	ts.TLS = serverTLSConfig
+
+	ts.StartTLS()
+	defer ts.Close()
+
+	clientTLSConfig, err := clientConfig.TLSConfig()
+	require.NoError(t, err)
+
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: clientTLSConfig,
+		},
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Get(ts.URL)
+	require.Error(t, err)
+	if resp != nil {
+		err = resp.Body.Close()
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
Makes it possible to filter client certificates by their dns names.

Signed-off-by: Josef Johansson <josef@oderland.se>

### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #9272

plugins/common/tls/config.go:  Filter client certs by dns names