### PR TITLE
fix: update golanci-lint to v1.42.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.38
+          version: v1.42.1
           only-new-issues: true
   golangci-master:
     if: github.ref == 'refs/heads/master'
@@ -30,6 +30,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.38
+          version: v1.42.1
           only-new-issues: true
           args: --issues-exit-code=0


### PR DESCRIPTION
We could also set this to "latest", but maybe keeping it to a specific version is better. This matches the version used in `make lint-install` 