### PR TITLE
fix: Correct conversion of int with specific bit size

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -474,7 +474,7 @@ func (p *Procstat) simpleSystemdUnitPIDs() ([]PID, error) {
 		if len(kv[1]) == 0 || bytes.Equal(kv[1], []byte("0")) {
 			return nil, nil
 		}
-		pid, err := strconv.Atoi(string(kv[1]))
+		pid, err := strconv.ParseInt(string(kv[1]), 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid pid '%s'", kv[1])
 		}


### PR DESCRIPTION
More info here: https://codeql.github.com/codeql-query-help/go/go-incorrect-integer-conversion/ 

Using `strconv.Atoi` without checking bounds and then converting to int32 can produce unexpected results. Using `ParseInt` solves this by specifying the base.