### PR TITLE
chore: reference db2 external plugin

### DIFF
--- a/EXTERNAL_PLUGINS.md
+++ b/EXTERNAL_PLUGINS.md
@@ -24,6 +24,7 @@ Pull requests welcome.
 - [net_irtt](https://github.com/iAnatoly/telegraf-input-net_irtt) - Gather information from IRTT network test
 - [dht_sensor](https://github.com/iAnatoly/telegraf-input-dht_sensor) - Gather temperature and humidity from DHTXX sensors
 - [oracle](https://github.com/bonitoo-io/telegraf-input-oracle) - Gather the statistic data from Oracle RDBMS
+- [db2](https://github.com/bonitoo-io/telegraf-input-db2) - Gather the statistic data from DB2 RDBMS
 
 ## Outputs
 - [kinesis](https://github.com/morfien101/telegraf-output-kinesis) - Aggregation and compression of metrics to send Amazon Kinesis.


### PR DESCRIPTION
This PR adds a link to an external plugin.

- [x] Updated associated EXTERNAL_PLUGINS.md.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)
