### PR TITLE
Feat: SQL Server - sqlServerRequestsV2- added s.[login_name]

### DIFF
--- a/plugins/inputs/sqlserver/sqlqueriesV2.go
+++ b/plugins/inputs/sqlserver/sqlqueriesV2.go
@@ -1284,6 +1284,7 @@ N' , COALESCE(r.status,s.status) AS status
 , r.blocking_session_id
 , s.program_name
 , s.host_name
+, s.login_name
 , s.nt_user_name '
 + @Columns + 
 N', LEFT (CASE COALESCE(r.transaction_isolation_level, s.transaction_isolation_level)


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
This PR is an extension to #8351. Currently `sqlServerRequestsV2` in `sqlqueriesV2.go` doesn't give SQL login name and only `nt_user_name`. 
resolves #
This PR will add `s.login_name` in the output which will be helpful in logging the SQL server login name.
<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
