### PR TITLE
fix: Check return code of zfs command for FreeBSD.

### DIFF
--- a/plugins/inputs/zfs/zfs_freebsd.go
+++ b/plugins/inputs/zfs/zfs_freebsd.go
@@ -174,8 +174,11 @@ func run(command string, args ...string) ([]string, error) {
 	stdout := strings.TrimSpace(outbuf.String())
 	stderr := strings.TrimSpace(errbuf.String())
 
-	if _, ok := err.(*exec.ExitError); ok {
-		return nil, fmt.Errorf("%s error: %s", command, stderr)
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("%s error: %s", command, stderr)
+		}
+		return nil, fmt.Errorf("%s error: %s", command, err)
 	}
 	return strings.Split(stdout, "\n"), nil
 }


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #9946

Currently, errors for execution of the `zfs` command on FreeBSD go unnoticed e.g. if the command is not found. This PR checks the returned errors and return them.