### PR TITLE
fix: internet_speed input plugin not collecting/reporting latency

### DIFF
--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -69,7 +69,7 @@ func (is *InternetSpeed) Gather(acc telegraf.Accumulator) error {
 	fields := make(map[string]interface{})
 	fields["download"] = s.DLSpeed
 	fields["upload"] = s.ULSpeed
-	fields["latency"] = timeDurationToFloat64(s.Latency)
+	fields["latency"] = timeDurationMillisecondToFloat64(s.Latency)
 
 	tags := make(map[string]string)
 
@@ -82,6 +82,6 @@ func init() {
 	})
 }
 
-func timeDurationToFloat64(d time.Duration) float64 {
+func timeDurationMillisecondToFloat64(d time.Duration) float64 {
 	return float64(d) / float64(time.Millisecond)
 }


### PR DESCRIPTION

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format]

The`internet_speed` should report latency as described in the[ plugin README](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/internet_speed)

[resolves #9931](https://github.com/influxdata/telegraf/issues/9931)

As described in the [showwin/speedtest-go](https://github.com/showwin/speedtest-go) library the `Latency` has a type of `time.Duration`, that is why it was not reported by the plugin as a field.
I converted that to `float64`
