### PR TITLE
fix(prometheus): move watcher error check

### DIFF
--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -110,10 +110,10 @@ func (p *Prometheus) watchPod(ctx context.Context, client *kubernetes.Clientset)
 		LabelSelector: p.KubernetesLabelSelector,
 		FieldSelector: p.KubernetesFieldSelector,
 	})
-	defer watcher.Stop()
 	if err != nil {
 		return err
 	}
+	defer watcher.Stop()
 
 	for {
 		select {


### PR DESCRIPTION
If the telegraf role had insufficient permissions to perform pod watching it would cause a panic, because the watcher would be called before the error was checked. Moving the error to the correct place will resolve this.

Kudos to Noam Levy in the Slack community channel for pointing out this mistake.