### PR TITLE
chore: lint ignore fmt.Printf unhandled error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ linters-settings:
       - name: empty-lines
       - name: error-naming
       - name: error-return
-        arguments: ["fmt.Printf", "fmt.Println"]
       - name: error-strings
       - name: errorf
 #      - name: flag-parameter #disable for now
@@ -76,6 +75,7 @@ linters-settings:
       - name: unconditional-recursion
       - name: unexported-naming
       - name: unhandled-error
+        arguments: ["fmt.Printf", "fmt.Println"]
       - name: unnecessary-stmt
       - name: unreachable-code
       # - name: unused-parameter


### PR DESCRIPTION
Add `fmt.Printf` to the unhandled-error linter ignore list, no need to check every error returned by fmt.Printf (usually for debugging). 

lint docs: https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error