### PR TITLE
Restart service if it is already running and upgraded via RPM

### DIFF
--- a/scripts/rpm/post-remove.sh
+++ b/scripts/rpm/post-remove.sh
@@ -28,6 +28,13 @@ if [[ -f /etc/redhat-release ]] || [[ -f /etc/SuSE-release ]]; then
             disable_chkconfig
         fi
     fi
+    if [[ $1 -ge 1 ]]; then
+        # Package upgrade, not uninstall
+
+        if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
+            systemctl try-restart telegraf.service >/dev/null 2>&1 || :
+        fi
+    fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
     if [[ "$ID" = "amzn" ]] && [[ "$1" = "0" ]]; then


### PR DESCRIPTION
Restart service if it is already running and upgraded via RPM. Other services do that and Fedora guidelines suggests it - https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#Systemd :
```
On upgrade, a package may only restart a service if it is running; it may not start it if it is off. Also, the service may not enable itself if it is currently disabled.
```
Fixes #3516.