### PR TITLE
fix: procstat tags were not getting generated correctly

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -154,11 +154,16 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 		}
 	}
 
-	tags := make(map[string]string)
 	p.procs = newProcs
 	for _, proc := range p.procs {
-		tags = proc.Tags()
 		p.addMetric(proc, acc, now)
+	}
+
+	tags := make(map[string]string)
+	for _, pidTag := range pidTags {
+		for key, value := range pidTag.Tags {
+			tags[key] = value
+		}
 	}
 
 	fields := map[string]interface{}{


### PR DESCRIPTION
Correctly create the tags for procstat measurements. This creates the tags based on all, not just one of the pidTags.

Fixes: #9961

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
