### PR TITLE
fix: Set the default value correctly

### DIFF
--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -11,7 +11,7 @@ This plugin uses a query on the [`nvidia-smi`](https://developer.nvidia.com/nvid
   ## We will first try to locate the nvidia-smi binary with the explicitly specified value (or default value), 
   ## if it is not found, we will try to locate it on PATH(exec.LookPath), if it is still not found, an error will be returned
   # bin_path = "/usr/bin/nvidia-smi"
-  
+
   ## Optional: timeout for GPU polling
   # timeout = "5s"
 ```

--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -12,7 +12,7 @@ This plugin uses a query on the [`nvidia-smi`](https://developer.nvidia.com/nvid
   ## if it is not found, we will try to locate it on PATH(exec.LookPath), if it is still not found, an error will be returned
   # bin_path = "/usr/bin/nvidia-smi"
   
-  ## Optional: timeout for GPU polling, defaults "5s"
+  ## Optional: timeout for GPU polling
   # timeout = "5s"
 ```
 

--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -7,11 +7,11 @@ This plugin uses a query on the [`nvidia-smi`](https://developer.nvidia.com/nvid
 ```toml
 # Pulls statistics from nvidia GPUs attached to the host
 [[inputs.nvidia_smi]]
-  ## Optional: path to nvidia-smi binary, if not specified or an empty string is specified, we will search for it on exec.LookPath
-  ## We will use "os.Stat" to check whether the nvidia-smi binary actually exists at the location pointed to by the bin_path, 
-  ## if not, an error will be returned as soon as possible (in Init())
-  # bin_path = ""
-
+  ## Optional: path to nvidia-smi binary, defaults "/usr/bin/nvidia-smi"
+  ## We will first try to locate the nvidia-smi binary with the explicitly specified value (or default value), 
+  ## if it is not found, we will try to locate it on PATH(exec.LookPath), if it is still not found, an error will be returned
+  # bin_path = "/usr/bin/nvidia-smi"
+  
   ## Optional: timeout for GPU polling, defaults "5s"
   # timeout = "5s"
 ```

--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -7,10 +7,12 @@ This plugin uses a query on the [`nvidia-smi`](https://developer.nvidia.com/nvid
 ```toml
 # Pulls statistics from nvidia GPUs attached to the host
 [[inputs.nvidia_smi]]
-  ## Optional: path to nvidia-smi binary, defaults to $PATH via exec.LookPath
-  # bin_path = "/usr/bin/nvidia-smi"
+  ## Optional: path to nvidia-smi binary, if not specified or an empty string is specified, we will search for it on exec.LookPath
+  ## We will use "os.Stat" to check whether the nvidia-smi binary actually exists at the location pointed to by the bin_path, 
+  ## if not, an error will be returned as soon as possible (in Init())
+  # bin_path = ""
 
-  ## Optional: timeout for GPU polling
+  ## Optional: timeout for GPU polling, defaults "5s"
   # timeout = "5s"
 ```
 

--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -16,6 +16,10 @@ This plugin uses a query on the [`nvidia-smi`](https://developer.nvidia.com/nvid
   # timeout = "5s"
 ```
 
+#### Linux
+
+On Linux, `nvidia-smi` is generally located at `/usr/bin/nvidia-smi`
+
 #### Windows
 
 On Windows, `nvidia-smi` is generally located at `C:\Program Files\NVIDIA Corporation\NVSMI\nvidia-smi.exe`

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -3,6 +3,7 @@ package nvidia_smi
 import (
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -51,7 +52,7 @@ func (smi *NvidiaSMI) Init() error {
 	}
 	// fail-fast
 	if _, err := os.Stat(smi.BinPath); os.IsNotExist(err) {
-		return errors.New("nvidia-smi binary not at path " + smi.BinPath)
+		return fmt.Errorf("nvidia-smi binary not at path %w", err)
 	}
 
 	return nil

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -36,7 +36,7 @@ func (smi *NvidiaSMI) SampleConfig() string {
   ## if it is not found, we will try to locate it on PATH(exec.LookPath), if it is still not found, an error will be returned
   # bin_path = "/usr/bin/nvidia-smi"
 
-  ## Optional: timeout for GPU polling, defaults "5s"
+  ## Optional: timeout for GPU polling
   # timeout = "5s"
 `
 }

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -52,7 +52,7 @@ func (smi *NvidiaSMI) Init() error {
 	}
 	// fail-fast
 	if _, err := os.Stat(smi.BinPath); os.IsNotExist(err) {
-		return fmt.Errorf("nvidia-smi binary not at path %w", err)
+		return fmt.Errorf("nvidia-smi binary not at path %s", smi.BinPath)
 	}
 
 	return nil


### PR DESCRIPTION
The smi path exception was thrown in Init() (previously thrown in Gather()), the purpose of this is to find the problem earlier

resolves #9979
