### PR TITLE
fix: Allow for non x86 macs in Go install script

### DIFF
--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -14,6 +14,7 @@ fi
 
 # This path is cachable. (Saving in /usr/local/ would cause issues restoring the cache.)
 path="/usr/local/Cellar"
+sudo mkdir -p ${path}
 
 # Download Go and verify Go tarball. (Note: we aren't using brew because
 # it is slow to update and we can't pull specific minor versions.)
@@ -27,8 +28,9 @@ setup_go () {
 
     sudo rm -rf ${path}/go
     sudo tar -C $path -xzf go${GO_VERSION}.${GO_ARCH}.tar.gz
-    ln -sf ${path}/go/bin/go /usr/local/bin/go
-    ln -sf ${path}/go/bin/gofmt /usr/local/bin/gofmt
+    sudo mkdir -p /usr/local/bin
+    sudo ln -sf ${path}/go/bin/go /usr/local/bin/go
+    sudo ln -sf ${path}/go/bin/gofmt /usr/local/bin/gofmt
 }
 
 if command -v go >/dev/null 2>&1; then


### PR DESCRIPTION
New macs have arm64 processors. This PR simply modifies the helper script to install the correct architecture build of go on an arm64 (so-called M1/M1 Max/M1 Pro) Apple computer.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)


Resolves #9981

This simply detects the architecture of the machine the script is running on with `uname -m` - which outputs either `arm64` or `x86_64` for M1 or Intel Macs respectively. It then uses the right filename and checksum for the relevant architecture.

I also added some `mkdir` commands because the script assumed `/usr/local/Cellar` and `/usr/local/bin` exists, when on a clean Mac, they don't.

Tested on my daughter's M1 mac ;).

```
alan@Sophies-MacBook-Air telegraf % ./scripts/installgo_mac.sh   
++ uname -m
+ ARCH=arm64
+ GO_VERSION=1.17.2
+ '[' arm64 = arm64 ']'
+ GO_ARCH=darwin-arm64
+ GO_VERSION_SHA=ce8771bd3edfb5b28104084b56bbb532eeb47fbb7769c3e664c6223712c30904
+ path=/usr/local/Cellar
+ sudo mkdir -p /usr/local/Cellar
+ command -v go
+ setup_go
+ echo 'installing go'
installing go
+ curl -L https://golang.org/dl/go1.17.2.darwin-arm64.tar.gz --output go1.17.2.darwin-arm64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    76  100    76    0     0    337      0 --:--:-- --:--:-- --:--:--   336
100  123M  100  123M    0     0  3351k      0  0:00:37  0:00:37 --:--:-- 3737k
+ echo 'ce8771bd3edfb5b28104084b56bbb532eeb47fbb7769c3e664c6223712c30904  go1.17.2.darwin-arm64.tar.gz'
+ shasum --algorithm 256 --check -
go1.17.2.darwin-arm64.tar.gz: OK
+ sudo rm -rf /usr/local/Cellar/go
+ sudo tar -C /usr/local/Cellar -xzf go1.17.2.darwin-arm64.tar.gz
+ sudo mkdir -p /usr/local/bin
+ sudo ln -sf /usr/local/Cellar/go/bin/go /usr/local/bin/go
+ sudo ln -sf /usr/local/Cellar/go/bin/gofmt /usr/local/bin/gofmt
```

Also tested use case where it's already installed

```
alan@Sophies-MacBook-Air telegraf % ./scripts/installgo_mac.sh
++ uname -m
+ ARCH=arm64
+ GO_VERSION=1.17.2
+ '[' arm64 = arm64 ']'
+ GO_ARCH=darwin-arm64
+ GO_VERSION_SHA=ce8771bd3edfb5b28104084b56bbb532eeb47fbb7769c3e664c6223712c30904
+ path=/usr/local/Cellar
+ sudo mkdir -p /usr/local/Cellar
+ command -v go
+ echo 'Go is already installed'
Go is already installed
++ go version
++ read -r _ _ v _
++ echo 1.17.2
+ v=1.17.2
+ echo '1.17.2 is installed, required version is 1.17.2'
1.17.2 is installed, required version is 1.17.2
+ '[' 1.17.2 '!=' 1.17.2 ']'
```

Note: Not tested on a "legacy" x86 Mac. 