### PR TITLE
fix: add s390x to nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -593,6 +593,7 @@ workflows:
             - 'test-awaiter'
       - 's390x-package':
           name: 's390x-package-nightly'
+          nightly: true
           requires:
             - 'test-awaiter'
       - 'armel-package':


### PR DESCRIPTION
While going through the nightlies URLs I noticed the s390x packages did
not get updated recently. This adds s390x back in.
