### PR TITLE
fix: stop triggering share-artifacts on release/tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,6 +535,9 @@ workflows:
             branches:
               ignore:
                 - master
+                - release.*
+            tags:
+              ignore: /.*/
       - 'release':
           requires:
             - 'test-go-windows'

--- a/scripts/check-file-changes.sh
+++ b/scripts/check-file-changes.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+# CIRCLE-CI SCRIPT: This file is used exclusively for CI
 # To prevent the tests/builds to run for only a doc change, this script checks what files have changed in a pull request.
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 echo $BRANCH
-if [[ "$BRANCH" != "master" ]] && [[ "$BRANCH" != release* ]]; then # This should never skip for master and release branches
+if [[ ${CIRCLE_PULL_REQUEST##*/} != "" ]]; then # Only skip if their is an associated pull request with this job
     # Ask git for all the differences between this branch and master
     # Then use grep to look for changes in the .circleci/ directory, anything named *.go or *.mod or *.sum or *.sh or Makefile
     # If no match is found, then circleci step halt will stop the CI job but mark it successful


### PR DESCRIPTION
- The share-artifacts job wasn't ignoring release branches or tags, this job should only be run when someone makes a pull request. Now the job ignores tags and release branches as well.

- The `scripts/check-file-changes.sh` script would run when a tag was made skipping all the jobs, now the script will check for a pull request number instead. Tags are used during release exclusively. 