### PR TITLE
fix: use predicted time in openweathermap instead of collected time

### DIFF
--- a/plugins/inputs/openweathermap/README.md
+++ b/plugins/inputs/openweathermap/README.md
@@ -42,6 +42,10 @@ condition ID, icon, and main is at [weather conditions][].
   ## Query interval; OpenWeatherMap weather data is updated every 10
   ## minutes.
   interval = "10m"
+
+  ## Type of the timestamp. Default to "issue" which is the collected time.
+  ## Another option is "prediction" which is the predicted time.
+  timestamp = "issue"
 ```
 
 ### Metrics

--- a/plugins/inputs/openweathermap/openweathermap.go
+++ b/plugins/inputs/openweathermap/openweathermap.go
@@ -27,6 +27,7 @@ const (
 	defaultResponseTimeout time.Duration = time.Second * 5
 	defaultUnits           string        = "metric"
 	defaultLang            string        = "en"
+	defaultTimestamp       string        = "issue"
 )
 
 type OpenWeatherMap struct {
@@ -37,6 +38,7 @@ type OpenWeatherMap struct {
 	BaseURL         string          `toml:"base_url"`
 	ResponseTimeout config.Duration `toml:"response_timeout"`
 	Units           string          `toml:"units"`
+	Timestamp       string          `toml:"timestamp"`
 
 	client  *http.Client
 	baseURL *url.URL
@@ -71,6 +73,10 @@ var sampleConfig = `
   ## Query interval; OpenWeatherMap updates their weather data every 10
   ## minutes.
   interval = "10m"
+
+  ## Type of the timestamp. Default to "issue" which is the collected time.
+  ## Another option is "prediction" which is the predicted time.
+  timestamp = "issue"
 `
 
 func (n *OpenWeatherMap) SampleConfig() string {
@@ -335,6 +341,14 @@ func (n *OpenWeatherMap) Init() error {
 		n.Lang = defaultLang
 	default:
 		return fmt.Errorf("unknown language: %s", n.Lang)
+	}
+
+	switch n.Timestamp {
+	case "imperial", "standard", "metric":
+	case "":
+		n.Units = defaultUnits
+	default:
+		return fmt.Errorf("unknown units: %s", n.Units)
 	}
 
 	return nil

--- a/plugins/inputs/openweathermap/openweathermap.go
+++ b/plugins/inputs/openweathermap/openweathermap.go
@@ -293,7 +293,7 @@ func gatherForecast(acc telegraf.Accumulator, status *Status) {
 			tags["condition_main"] = e.Weather[0].Main
 		}
 		tags["forecast"] = fmt.Sprintf("%dh", (i+1)*3)
-		acc.AddFields("weather", fields, tags, tm)
+		acc.AddFields("weather", fields, tags, tm.Add(time.Duration((i+1)*3)*time.Hour))
 	}
 }
 

--- a/plugins/inputs/openweathermap/openweathermap_test.go
+++ b/plugins/inputs/openweathermap/openweathermap_test.go
@@ -541,7 +541,6 @@ func TestForecastGeneratesMetrics(t *testing.T) {
 	testutil.RequireMetricsEqual(t,
 		expected, acc2.GetTelegrafMetrics(),
 		testutil.SortMetrics())
-
 }
 
 func TestWeatherGeneratesMetrics(t *testing.T) {

--- a/plugins/inputs/openweathermap/openweathermap_test.go
+++ b/plugins/inputs/openweathermap/openweathermap_test.go
@@ -451,7 +451,7 @@ func TestForecastGeneratesMetrics(t *testing.T) {
 				"condition_description": "light rain",
 				"condition_icon":        "10n",
 			},
-			time.Unix(1543622400, 0),
+			time.Unix(1543633200, 0),
 		),
 		testutil.MustMetric(
 			"weather",
@@ -474,7 +474,7 @@ func TestForecastGeneratesMetrics(t *testing.T) {
 				"condition_description": "light rain",
 				"condition_icon":        "10n",
 			},
-			time.Unix(1544043600, 0),
+			time.Unix(1544065200, 0),
 		),
 	}
 

--- a/plugins/inputs/openweathermap/openweathermap_test.go
+++ b/plugins/inputs/openweathermap/openweathermap_test.go
@@ -451,6 +451,66 @@ func TestForecastGeneratesMetrics(t *testing.T) {
 				"condition_description": "light rain",
 				"condition_icon":        "10n",
 			},
+			time.Unix(1543622400, 0),
+		),
+		testutil.MustMetric(
+			"weather",
+			map[string]string{
+				"city_id":        "2988507",
+				"forecast":       "6h",
+				"city":           "Paris",
+				"country":        "FR",
+				"condition_id":   "500",
+				"condition_main": "Rain",
+			},
+			map[string]interface{}{
+				"cloudiness":            int64(92),
+				"humidity":              int64(98),
+				"pressure":              1032.18,
+				"temperature":           6.38,
+				"rain":                  0.049999999999997,
+				"wind_degrees":          335.005,
+				"wind_speed":            2.66,
+				"condition_description": "light rain",
+				"condition_icon":        "10n",
+			},
+			time.Unix(1544043600, 0),
+		),
+	}
+
+	testutil.RequireMetricsEqual(t,
+		expected, acc.GetTelegrafMetrics(),
+		testutil.SortMetrics())
+
+	// test timestamp as `prediction`
+	n.Timestamp = "prediction"
+	require.NoError(t, n.Init())
+
+	var acc2 testutil.Accumulator
+	require.NoError(t, n.Gather(&acc2))
+
+	expected = []telegraf.Metric{
+		testutil.MustMetric(
+			"weather",
+			map[string]string{
+				"city_id":        "2988507",
+				"forecast":       "3h",
+				"city":           "Paris",
+				"country":        "FR",
+				"condition_id":   "500",
+				"condition_main": "Rain",
+			},
+			map[string]interface{}{
+				"cloudiness":            int64(88),
+				"humidity":              int64(91),
+				"pressure":              1018.65,
+				"temperature":           6.71,
+				"rain":                  0.035,
+				"wind_degrees":          228.501,
+				"wind_speed":            3.76,
+				"condition_description": "light rain",
+				"condition_icon":        "10n",
+			},
 			time.Unix(1543633200, 0),
 		),
 		testutil.MustMetric(
@@ -479,8 +539,9 @@ func TestForecastGeneratesMetrics(t *testing.T) {
 	}
 
 	testutil.RequireMetricsEqual(t,
-		expected, acc.GetTelegrafMetrics(),
+		expected, acc2.GetTelegrafMetrics(),
 		testutil.SortMetrics())
+
 }
 
 func TestWeatherGeneratesMetrics(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9239

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Fix what's suggested in #9239. I'm not familiar with OpenWeatherMap so maybe reviews are needed if it's correct.
