### PR TITLE
build: move `stackdriver` plugin to new protobuf library

### DIFF
--- a/plugins/inputs/stackdriver/stackdriver.go
+++ b/plugins/inputs/stackdriver/stackdriver.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
-	googlepbduration "github.com/golang/protobuf/ptypes/duration"
-	googlepbts "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal/limiter"
@@ -22,6 +20,8 @@ import (
 	distributionpb "google.golang.org/genproto/googleapis/api/distribution"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -393,8 +393,8 @@ func (s *Stackdriver) newTimeSeriesConf(
 ) *timeSeriesConf {
 	filter := s.newListTimeSeriesFilter(metricType)
 	interval := &monitoringpb.TimeInterval{
-		EndTime:   &googlepbts.Timestamp{Seconds: endTime.Unix()},
-		StartTime: &googlepbts.Timestamp{Seconds: startTime.Unix()},
+		EndTime:   &timestamppb.Timestamp{Seconds: endTime.Unix()},
+		StartTime: &timestamppb.Timestamp{Seconds: startTime.Unix()},
 	}
 	tsReq := &monitoringpb.ListTimeSeriesRequest{
 		Name:     fmt.Sprintf("projects/%s", s.Project),
@@ -432,7 +432,7 @@ func (t *timeSeriesConf) initForAggregate(alignerStr string) {
 	}
 	aligner := monitoringpb.Aggregation_Aligner(alignerInt)
 	agg := &monitoringpb.Aggregation{
-		AlignmentPeriod:  &googlepbduration.Duration{Seconds: 60},
+		AlignmentPeriod:  &durationpb.Duration{Seconds: 60},
 		PerSeriesAligner: aligner,
 	}
 	t.fieldKey = t.fieldKey + "_" + strings.ToLower(alignerStr)
@@ -522,8 +522,8 @@ func (s *Stackdriver) generatetimeSeriesConfs(
 	if s.timeSeriesConfCache != nil && s.timeSeriesConfCache.IsValid() {
 		// Update interval for timeseries requests in timeseries cache
 		interval := &monitoringpb.TimeInterval{
-			EndTime:   &googlepbts.Timestamp{Seconds: endTime.Unix()},
-			StartTime: &googlepbts.Timestamp{Seconds: startTime.Unix()},
+			EndTime:   &timestamppb.Timestamp{Seconds: endTime.Unix()},
+			StartTime: &timestamppb.Timestamp{Seconds: startTime.Unix()},
 		}
 		for _, timeSeriesConf := range s.timeSeriesConfCache.TimeSeriesConfs {
 			timeSeriesConf.listTimeSeriesRequest.Interval = interval

--- a/plugins/inputs/stackdriver/stackdriver_test.go
+++ b/plugins/inputs/stackdriver/stackdriver_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/testutil"
@@ -15,6 +14,7 @@ import (
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type Call struct {
@@ -105,7 +105,7 @@ func TestGather(t *testing.T) {
 			timeseries: createTimeSeries(
 				&monitoringpb.Point{
 					Interval: &monitoringpb.TimeInterval{
-						EndTime: &timestamp.Timestamp{
+						EndTime: &timestamppb.Timestamp{
 							Seconds: now.Unix(),
 						},
 					},
@@ -138,7 +138,7 @@ func TestGather(t *testing.T) {
 			timeseries: createTimeSeries(
 				&monitoringpb.Point{
 					Interval: &monitoringpb.TimeInterval{
-						EndTime: &timestamp.Timestamp{
+						EndTime: &timestamppb.Timestamp{
 							Seconds: now.Unix(),
 						},
 					},
@@ -171,7 +171,7 @@ func TestGather(t *testing.T) {
 			timeseries: createTimeSeries(
 				&monitoringpb.Point{
 					Interval: &monitoringpb.TimeInterval{
-						EndTime: &timestamp.Timestamp{
+						EndTime: &timestamppb.Timestamp{
 							Seconds: now.Unix(),
 						},
 					},
@@ -204,7 +204,7 @@ func TestGather(t *testing.T) {
 			timeseries: createTimeSeries(
 				&monitoringpb.Point{
 					Interval: &monitoringpb.TimeInterval{
-						EndTime: &timestamp.Timestamp{
+						EndTime: &timestamppb.Timestamp{
 							Seconds: now.Unix(),
 						},
 					},
@@ -249,7 +249,7 @@ func TestGather(t *testing.T) {
 				Points: []*monitoringpb.Point{
 					{
 						Interval: &monitoringpb.TimeInterval{
-							EndTime: &timestamp.Timestamp{
+							EndTime: &timestamppb.Timestamp{
 								Seconds: now.Unix(),
 							},
 						},
@@ -283,7 +283,7 @@ func TestGather(t *testing.T) {
 			timeseries: createTimeSeries(
 				&monitoringpb.Point{
 					Interval: &monitoringpb.TimeInterval{
-						EndTime: &timestamp.Timestamp{
+						EndTime: &timestamppb.Timestamp{
 							Seconds: now.Unix(),
 						},
 					},
@@ -378,7 +378,7 @@ func TestGather(t *testing.T) {
 			timeseries: createTimeSeries(
 				&monitoringpb.Point{
 					Interval: &monitoringpb.TimeInterval{
-						EndTime: &timestamp.Timestamp{
+						EndTime: &timestamppb.Timestamp{
 							Seconds: now.Unix(),
 						},
 					},
@@ -473,7 +473,7 @@ func TestGather(t *testing.T) {
 			timeseries: createTimeSeries(
 				&monitoringpb.Point{
 					Interval: &monitoringpb.TimeInterval{
-						EndTime: &timestamp.Timestamp{
+						EndTime: &timestamppb.Timestamp{
 							Seconds: now.Unix(),
 						},
 					},
@@ -556,7 +556,7 @@ func TestGather(t *testing.T) {
 			timeseries: createTimeSeries(
 				&monitoringpb.Point{
 					Interval: &monitoringpb.TimeInterval{
-						EndTime: &timestamp.Timestamp{
+						EndTime: &timestamppb.Timestamp{
 							Seconds: now.Unix(),
 						},
 					},
@@ -702,7 +702,7 @@ func TestGatherAlign(t *testing.T) {
 				createTimeSeries(
 					&monitoringpb.Point{
 						Interval: &monitoringpb.TimeInterval{
-							EndTime: &timestamp.Timestamp{
+							EndTime: &timestamppb.Timestamp{
 								Seconds: now.Unix(),
 							},
 						},
@@ -717,7 +717,7 @@ func TestGatherAlign(t *testing.T) {
 				createTimeSeries(
 					&monitoringpb.Point{
 						Interval: &monitoringpb.TimeInterval{
-							EndTime: &timestamp.Timestamp{
+							EndTime: &timestamppb.Timestamp{
 								Seconds: now.Unix(),
 							},
 						},
@@ -732,7 +732,7 @@ func TestGatherAlign(t *testing.T) {
 				createTimeSeries(
 					&monitoringpb.Point{
 						Interval: &monitoringpb.TimeInterval{
-							EndTime: &timestamp.Timestamp{
+							EndTime: &timestamppb.Timestamp{
 								Seconds: now.Unix(),
 							},
 						},
@@ -1081,7 +1081,7 @@ func TestListMetricDescriptorFilter(t *testing.T) {
 					ch <- createTimeSeries(
 						&monitoringpb.Point{
 							Interval: &monitoringpb.TimeInterval{
-								EndTime: &timestamp.Timestamp{
+								EndTime: &timestamppb.Timestamp{
 									Seconds: now.Unix(),
 								},
 							},

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2" // Imports the Stackdriver Monitoring client package.
-	googlepb "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/outputs"
@@ -18,6 +17,7 @@ import (
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Stackdriver is the Google Stackdriver config info.
@@ -247,16 +247,16 @@ func getStackdriverTimeInterval(
 	switch m {
 	case metricpb.MetricDescriptor_GAUGE:
 		return &monitoringpb.TimeInterval{
-			EndTime: &googlepb.Timestamp{
+			EndTime: &timestamppb.Timestamp{
 				Seconds: end,
 			},
 		}, nil
 	case metricpb.MetricDescriptor_CUMULATIVE:
 		return &monitoringpb.TimeInterval{
-			StartTime: &googlepb.Timestamp{
+			StartTime: &timestamppb.Timestamp{
 				Seconds: start,
 			},
-			EndTime: &googlepb.Timestamp{
+			EndTime: &timestamppb.Timestamp{
 				Seconds: end,
 			},
 		}, nil

--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -12,9 +12,6 @@ import (
 	"time"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
-	"github.com/golang/protobuf/proto"
-	emptypb "github.com/golang/protobuf/ptypes/empty"
-	googlepb "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
@@ -22,6 +19,9 @@ import (
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // clientOpt is the option tests should use to connect to the test server.
@@ -181,7 +181,7 @@ func TestWriteAscendingTime(t *testing.T) {
 	ts := request.TimeSeries[0]
 	require.Len(t, ts.Points, 1)
 	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
-		EndTime: &googlepb.Timestamp{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 1,
 		},
 	})
@@ -196,7 +196,7 @@ func TestWriteAscendingTime(t *testing.T) {
 	ts = request.TimeSeries[0]
 	require.Len(t, ts.Points, 1)
 	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
-		EndTime: &googlepb.Timestamp{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 2,
 		},
 	})
@@ -311,7 +311,7 @@ func TestWriteBatchable(t *testing.T) {
 	ts := request.TimeSeries[0]
 	require.Len(t, ts.Points, 1)
 	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
-		EndTime: &googlepb.Timestamp{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 3,
 		},
 	})
@@ -324,7 +324,7 @@ func TestWriteBatchable(t *testing.T) {
 	ts = request.TimeSeries[1]
 	require.Len(t, ts.Points, 1)
 	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
-		EndTime: &googlepb.Timestamp{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 1,
 		},
 	})
@@ -337,7 +337,7 @@ func TestWriteBatchable(t *testing.T) {
 	ts = request.TimeSeries[2]
 	require.Len(t, ts.Points, 1)
 	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
-		EndTime: &googlepb.Timestamp{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 3,
 		},
 	})
@@ -350,7 +350,7 @@ func TestWriteBatchable(t *testing.T) {
 	ts = request.TimeSeries[4]
 	require.Len(t, ts.Points, 1)
 	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
-		EndTime: &googlepb.Timestamp{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 5,
 		},
 	})


### PR DESCRIPTION
Moves the `stackdriver` plugin to using the newer `google.golang.org/protobuf` library over the deprecated `github.com/golang/protobuf`.

- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)