### PR TITLE
fix: do not build modbus on openbsd

### DIFF
--- a/plugins/inputs/modbus/configuration.go
+++ b/plugins/inputs/modbus/configuration.go
@@ -1,3 +1,5 @@
+//go:build !openbsd
+
 package modbus
 
 import "fmt"

--- a/plugins/inputs/modbus/configuration_original.go
+++ b/plugins/inputs/modbus/configuration_original.go
@@ -1,3 +1,5 @@
+//go:build !openbsd
+
 package modbus
 
 import (

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -1,3 +1,5 @@
+//go:build !openbsd
+
 package modbus
 
 import (

--- a/plugins/inputs/modbus/modbus_openbsd.go
+++ b/plugins/inputs/modbus/modbus_openbsd.go
@@ -1,0 +1,3 @@
+//go:build openbsd
+
+package modbus

--- a/plugins/inputs/modbus/modbus_test.go
+++ b/plugins/inputs/modbus/modbus_test.go
@@ -1,3 +1,5 @@
+//go:build !openbsd
+
 package modbus
 
 import (

--- a/plugins/inputs/modbus/request.go
+++ b/plugins/inputs/modbus/request.go
@@ -1,3 +1,5 @@
+//go:build !openbsd
+
 package modbus
 
 import "sort"

--- a/plugins/inputs/modbus/type_conversions.go
+++ b/plugins/inputs/modbus/type_conversions.go
@@ -1,3 +1,5 @@
+//go:build !openbsd
+
 package modbus
 
 import "fmt"

--- a/plugins/inputs/modbus/type_conversions16.go
+++ b/plugins/inputs/modbus/type_conversions16.go
@@ -1,3 +1,5 @@
+//go:build !openbsd
+
 package modbus
 
 import (

--- a/plugins/inputs/modbus/type_conversions32.go
+++ b/plugins/inputs/modbus/type_conversions32.go
@@ -1,3 +1,5 @@
+//go:build !openbsd
+
 package modbus
 
 import (

--- a/plugins/inputs/modbus/type_conversions64.go
+++ b/plugins/inputs/modbus/type_conversions64.go
@@ -1,3 +1,5 @@
+//go:build !openbsd
+
 package modbus
 
 import (


### PR DESCRIPTION
This is the remaining plugin that is blocking builds on OpenBSD. The issue is the github.com/grid-x/serial library does not build on OpenBSD. That library is an indirect import, due to github.com/grid-x/modbus. Upgrading modbus does not help the situation as it does not pull in a newer version of the grid-x/serial.

Because this is the only one, I figured it is simpler to stop building this on openbsd until someone comes by with a better solution.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10034

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
