### PR TITLE
chore: don't trigger share-artifacts if no go files changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,6 +399,8 @@ jobs:
   share-artifacts:
     executor: aws-cli/default
     steps:
+      - checkout
+      - check-changed-files-or-halt
       - run:
           command: |
             PR=${CIRCLE_PULL_REQUEST##*/}


### PR DESCRIPTION
The share-artifacts job wasn't checking what files changed like the other jobs, so the bot was failing to find artifacts when it was triggered this way.