### PR TITLE
fix: Markdown linter fixes for LICENSE_OF_DEPENDENCIES.md

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -283,5 +283,7 @@ following works:
 - modernc.org/sqlite [BSD 3-Clause "New" or "Revised" License](https://gitlab.com/cznic/sqlite/-/blob/master/LICENSE)
 - sigs.k8s.io/structured-merge-diff [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)
 - sigs.k8s.io/yaml [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)
-## telegraf used and modified code from these projects
+
+## Telegraf used and modified code from these projects
+
 - github.com/DataDog/datadog-agent [Apache License 2.0](https://github.com/DataDog/datadog-agent/LICENSE)


### PR DESCRIPTION
Markdown linter fixes for LICENSE_OF_DEPENDENCIES.md

resolves https://github.com/influxdata/telegraf/issues/10064