### PR TITLE
fix: remove npm/markdown lint tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,9 +143,6 @@ lint-install:
 	@echo "Installing golangci-lint"
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
 
-	@echo "Installing markdownlint"
-	npm install -g markdownlint-cli
-
 .PHONY: lint
 lint:
 ifeq (, $(shell which golangci-lint))
@@ -154,13 +151,6 @@ ifeq (, $(shell which golangci-lint))
 endif
 
 	golangci-lint run
-
-ifeq (, $(shell which markdownlint-cli))
-	$(info markdownlint-cli can't be found, please run: make lint-install)
-	exit 1
-endif
-
-	markdownlint-cli
 
 .PHONY: lint-branch
 lint-branch:


### PR DESCRIPTION
After we removed the uber/super linter we did not remove the markdown
related items from here either.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
