### PR TITLE
fix(outputs/graylog): fix failing test due to port already in use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -333,6 +333,8 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
+require github.com/libp2p/go-reuseport v0.1.0
+
 require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1420,6 +1420,8 @@ github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.7.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.9.0 h1:L8nSXQQzAYByakOFMTwpjRoHsMJklur4Gi59b6VivR8=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/libp2p/go-reuseport v0.1.0 h1:0ooKOx2iwyIkf339WCZ2HN3ujTDbkK0PjC7JVoP1AiM=
+github.com/libp2p/go-reuseport v0.1.0/go.mod h1:bQVn9hmfcTaoo0c9v5pBhOarsU1eNOBZdaAd2hzXRKU=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
@@ -2418,6 +2420,7 @@ golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/plugins/outputs/graylog/graylog_test.go
+++ b/plugins/outputs/graylog/graylog_test.go
@@ -13,6 +13,7 @@ import (
 
 	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/testutil"
+	reuse "github.com/libp2p/go-reuseport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -161,9 +162,7 @@ func TestWriteTCP(t *testing.T) {
 type GelfObject map[string]interface{}
 
 func UDPServer(t *testing.T, wg *sync.WaitGroup, wg2 *sync.WaitGroup, config *Graylog) {
-	serverAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:12201")
-	require.NoError(t, err)
-	udpServer, err := net.ListenUDP("udp", serverAddr)
+	udpServer, err := reuse.ListenPacket("udp", "127.0.0.1:12201")
 	require.NoError(t, err)
 	defer udpServer.Close()
 	defer wg.Done()
@@ -171,7 +170,7 @@ func UDPServer(t *testing.T, wg *sync.WaitGroup, wg2 *sync.WaitGroup, config *Gr
 
 	recv := func() {
 		bufR := make([]byte, 1024)
-		n, _, err := udpServer.ReadFromUDP(bufR)
+		n, _, err := udpServer.ReadFrom(bufR)
 		require.NoError(t, err)
 
 		b := bytes.NewReader(bufR[0:n])
@@ -203,7 +202,7 @@ func UDPServer(t *testing.T, wg *sync.WaitGroup, wg2 *sync.WaitGroup, config *Gr
 }
 
 func TCPServer(t *testing.T, wg *sync.WaitGroup, wg2 *sync.WaitGroup, wg3 *sync.WaitGroup, tlsConfig *tls.Config) {
-	tcpServer, err := net.Listen("tcp", "127.0.0.1:12201")
+	tcpServer, err := reuse.Listen("tcp", "127.0.0.1:12201")
 	require.NoError(t, err)
 	defer tcpServer.Close()
 	defer wg.Done()


### PR DESCRIPTION
**The error message from the CI:**

```
graylog_test.go:167: 
     Error Trace:	graylog_test.go:167
      	            		asm_amd64.s:1581
     Error:      	Received unexpected error:
      	           listen udp 127.0.0.1:12201: bind: address already in use
     Test:       	TestWriteUDP/UDP
```

**Description:**

The output plugin graylog tests are failing due to trying to bind to a port already in use, because the previous test didn't fully unbind yet. I found this package: https://github.com/libp2p/go-reuseport that makes it easy to call a syscall  `SO_REUSEPORT` so that the bind can be reused even if some else was already bound to it. Originally I was hoping to just use `bytes.Buffer` instead to avoid having to start a UDP and TCP server in a test, but it doesn't cover the connection logic. This approach introduces the fewest changes, so decided this would be better.