### PR TITLE
fix (inputs/mongodb) readme: correct connection URI

### DIFF
--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -11,7 +11,7 @@ All MongoDB server versions from 2.6 and higher are supported.
   ## For example:
   ##   mongodb://user:auth_key@10.10.3.30:27017,
   ##   mongodb://10.10.3.33:18832,
-  servers = ["mongodb://127.0.0.1:27017"]
+  servers = ["mongodb://127.0.0.1:27017?connect=direct"]  
 
   ## When true, collect cluster status.
   ## Note that the query that counts jumbo chunks triggers a COLLSCAN, which

--- a/plugins/inputs/mongodb/mongodb.go
+++ b/plugins/inputs/mongodb/mongodb.go
@@ -44,7 +44,7 @@ var sampleConfig = `
   ## For example:
   ##   mongodb://user:auth_key@10.10.3.30:27017,
   ##   mongodb://10.10.3.33:18832,
-  servers = ["mongodb://127.0.0.1:27017"]
+  servers = ["mongodb://127.0.0.1:27017?connect=direct"]
 
   ## When true, collect cluster status
   ## Note that the query that counts jumbo chunks triggers a COLLSCAN, which


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Since v1.19.2 telegraf collects PRIMARY MongoDB metrics via SECONDARY servers by default. By that it means you are not able to get SECONDARY server metrics with default configuration. To fix that, `?connection=direct` should be used in conection string URL. Hopefully that README.md fix saves lot of debugging time in future for other users :))

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
