### PR TITLE
Fix(inputs/mongodb): better handling of conn errors

### DIFF
--- a/plugins/inputs/mongodb/mongodb_server.go
+++ b/plugins/inputs/mongodb/mongodb_server.go
@@ -19,6 +19,7 @@ type Server struct {
 	client     *mongo.Client
 	hostname   string
 	lastResult *MongoStatus
+	reachable  bool
 
 	Log telegraf.Logger
 }


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10078 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Here is a draft for improvements in the MongoDB input plugin.
The current issue is described and tracked in #10078.
For now, Telegraf exits if a conn to a configured MongoDB server failed on startup.
This PR tries to add a more reliable "retry after" mechanism.

