### PR TITLE
fix: update BurntSushi/toml for hex config support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/BurntSushi/toml v0.3.1
+	github.com/BurntSushi/toml v0.4.1
 	github.com/Mellanox/rdmamap v0.0.0-20191106181932-7c3c4763a6ee
 	github.com/Microsoft/go-winio v0.4.17 // indirect
 	github.com/Microsoft/hcsshim v0.8.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=

--- a/plugins/common/shim/config_test.go
+++ b/plugins/common/shim/config_test.go
@@ -54,6 +54,7 @@ func TestLoadingSpecialTypes(t *testing.T) {
 
 	require.EqualValues(t, 3*time.Second, inp.Duration)
 	require.EqualValues(t, 3*1000*1000, inp.Size)
+	require.EqualValues(t, 52, inp.Hex)
 }
 
 func TestLoadingProcessorWithConfig(t *testing.T) {
@@ -72,6 +73,7 @@ func TestLoadingProcessorWithConfig(t *testing.T) {
 type testDurationInput struct {
 	Duration tgConfig.Duration `toml:"duration"`
 	Size     tgConfig.Size     `toml:"size"`
+	Hex      int64             `toml:"hex"`
 }
 
 func (i *testDurationInput) SampleConfig() string {

--- a/plugins/common/shim/testdata/special.conf
+++ b/plugins/common/shim/testdata/special.conf
@@ -2,3 +2,4 @@
 [[inputs.test]]
 	duration = "3s"
   size = "3MB"
+  hex = 0x34


### PR DESCRIPTION
- [x] Updated associated README.md. - Not necessary
- [x] Wrote appropriate unit tests. - Added to `plugins/common/shim/config_test.go` 
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10088 

Bump up version of BurntSushi/toml to v0.4.1

Local tests: 
* `make check` and `make test` run successfully
* Starting the docker containers and running `make test-integration` runs with two failures, which locally on my machine also fail with the current master (i.e. same behavior for `BurntSushi/toml v0.3.1` and `v0.4.1`: 
  * `FAIL    github.com/influxdata/telegraf/plugins/inputs/ping      10.169s`
  * `FAIL    github.com/influxdata/telegraf/plugins/outputs/mongodb  65.052s `
