### PR TITLE
fix(parser/csv): resolve linter issues

### DIFF
--- a/plugins/parsers/csv/README.md
+++ b/plugins/parsers/csv/README.md
@@ -3,7 +3,7 @@
 The `csv` parser creates metrics from a document containing comma separated
 values.
 
-### Configuration
+## Configuration
 
 ```toml
 [[inputs.file]]
@@ -78,7 +78,8 @@ values.
   ## The field will be skipped entirely where it matches any values inserted here.
   csv_skip_values = []
   ```
-#### csv_timestamp_column, csv_timestamp_format
+
+### csv_timestamp_column, csv_timestamp_format
 
 By default the current time will be used for all created metrics, to set the
 time using the JSON document you can use the `csv_timestamp_column` and
@@ -104,6 +105,7 @@ columns and rows.
 ### Examples
 
 Config:
+
 ```toml
 [[inputs.file]]
   files = ["example"]
@@ -114,13 +116,15 @@ Config:
 ```
 
 Input:
-```
+
+```shell
 measurement,cpu,time_user,time_system,time_idle,time
 cpu,cpu0,42,42,42,2018-09-13T13:03:28Z
 ```
 
 Output:
-```
+
+```shell
 cpu cpu=cpu0,time_user=42,time_system=42,time_idle=42 1536869008000000000
 ```
 


### PR DESCRIPTION
This pull request resolves some minor markdown linter issues in the parser/csv readme.

The linter complained about them in pr #10083 