### PR TITLE
fix(outputs/stackdriver): cumulative interval start times

### DIFF
--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -50,7 +50,16 @@ Points collected with greater than 1 minute precision may need to be
 aggregated before then can be written.  Consider using the [basicstats][]
 aggregator to do this.
 
+Histogram / distribution and delta metrics are not yet supported. These will
+be dropped silently unless debugging is on.
+
+Note that the plugin keeps an in-memory cache of the start times and last
+observed values of all COUNTER metrics in order to comply with the
+requirements of the stackdriver API.  This cache is not GCed: if you remove
+a large number of counters from the input side, you may wish to restart
+telegraf to clear it.
+
 [basicstats]: /plugins/aggregators/basicstats/README.md
 [stackdriver]: https://cloud.google.com/monitoring/api/v3/
 [authentication]: https://cloud.google.com/docs/authentication/getting-started
-[pricing]: https://cloud.google.com/stackdriver/pricing#stackdriver_monitoring_services
+[pricing]: https://cloud.google.com/stackdriver/pricing#google-clouds-operations-suite-pricing

--- a/plugins/outputs/stackdriver/counter_cache.go
+++ b/plugins/outputs/stackdriver/counter_cache.go
@@ -38,8 +38,8 @@ func (cc *counterCache) get(key string) (*counterCacheEntry, bool) {
 
 func (cc *counterCache) set(key string, value *counterCacheEntry) {
 	cc.Lock()
+	defer cc.Unlock()
 	cc.cache[key] = value
-	cc.Unlock()
 }
 
 func (cc *counterCache) GetStartTime(key string, value *monpb.TypedValue, endTime *tspb.Timestamp) *tspb.Timestamp {

--- a/plugins/outputs/stackdriver/counter_cache.go
+++ b/plugins/outputs/stackdriver/counter_cache.go
@@ -1,0 +1,96 @@
+package stackdriver
+
+import (
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/influxdata/telegraf"
+
+	monpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type CounterCache struct {
+	sync.RWMutex
+	cache map[string]*CounterCacheEntry
+	log   telegraf.Logger
+}
+
+type CounterCacheEntry struct {
+	LastValue *monpb.TypedValue
+	StartTime *tspb.Timestamp
+}
+
+func (cce *CounterCacheEntry) Reset(ts *tspb.Timestamp) {
+	// always backdate a reset by -1ms, otherwise stackdriver's API will hate us
+	cce.StartTime = tspb.New(ts.AsTime().Add(time.Millisecond * -1))
+}
+
+func (cc *CounterCache) get(key string) (*CounterCacheEntry, bool) {
+	cc.RLock()
+	value, ok := cc.cache[key]
+	cc.RUnlock()
+	return value, ok
+}
+
+func (cc *CounterCache) set(key string, value *CounterCacheEntry) {
+	cc.Lock()
+	cc.cache[key] = value
+	cc.Unlock()
+}
+
+func (cc *CounterCache) GetStartTime(key string, value *monpb.TypedValue, endTime *tspb.Timestamp) *tspb.Timestamp {
+	lastObserved, ok := cc.get(key)
+
+	// init: create a new key, backdate the state time to 1ms before the end time
+	if !ok {
+		newEntry := NewCounterCacheEntry(value, endTime)
+		cc.set(key, newEntry)
+		return newEntry.StartTime
+	}
+
+	// update of existing entry
+	if value.GetDoubleValue() < lastObserved.LastValue.GetDoubleValue() || value.GetInt64Value() < lastObserved.LastValue.GetInt64Value() {
+		// counter reset
+		lastObserved.Reset(endTime)
+	} else {
+		// counter increment
+		//
+		// ...but...
+		// start times cannot be over 25 hours old; reset after 1 day to be safe
+		age := endTime.GetSeconds() - lastObserved.StartTime.GetSeconds()
+		cc.log.Debugf("age: %d", age)
+		if age > 86400 {
+			lastObserved.Reset(endTime)
+		}
+	}
+	// update last observed value
+	lastObserved.LastValue = value
+	return lastObserved.StartTime
+}
+
+func NewCounterCache(log telegraf.Logger) *CounterCache {
+	return &CounterCache{
+		cache: make(map[string]*CounterCacheEntry),
+		log:   log}
+}
+
+func NewCounterCacheEntry(value *monpb.TypedValue, ts *tspb.Timestamp) *CounterCacheEntry {
+	// Start times must be _before_ the end time, so backdate our original start time
+	// to 1ms before the observed time.
+	backDatedStart := ts.AsTime().Add(time.Millisecond * -1)
+	return &CounterCacheEntry{LastValue: value, StartTime: tspb.New(backDatedStart)}
+}
+
+func GetCounterCacheKey(m telegraf.Metric, f *telegraf.Field) string {
+	// normalize tag list to form a predictable key
+	var tags []string
+	for _, t := range m.TagList() {
+		tags = append(tags, strings.Join([]string{t.Key, t.Value}, "="))
+	}
+	sort.Strings(tags)
+	return path.Join(m.Name(), strings.Join(tags, "/"), f.Key)
+}

--- a/plugins/outputs/stackdriver/counter_cache_test.go
+++ b/plugins/outputs/stackdriver/counter_cache_test.go
@@ -1,0 +1,166 @@
+package stackdriver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf/models"
+
+	monpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestCreateCounterCacheEntry(t *testing.T) {
+	cc := NewCounterCache(models.NewLogger("outputs", "stackdriver", "TestCreateCounterCacheEntry"))
+	value := &monpb.TypedValue{
+		Value: &monpb.TypedValue_Int64Value{
+			Int64Value: int64(1),
+		},
+	}
+	endTime := tspb.Now()
+	startTime := cc.GetStartTime("key", value, endTime)
+	if endTime.AsTime().Add(time.Millisecond*-1) != startTime.AsTime() {
+		t.Fatal("Start time on a new entry should be 1ms behind the end time")
+	}
+}
+
+func TestUpdateCounterCacheEntry(t *testing.T) {
+	cc := NewCounterCache(models.NewLogger("outputs", "stackdriver", "TestUpdateCounterCacheEntry"))
+	now := time.Now().UTC()
+	value := &monpb.TypedValue{
+		Value: &monpb.TypedValue_Int64Value{
+			Int64Value: int64(1),
+		},
+	}
+	endTime := tspb.New(now)
+	startTime := cc.GetStartTime("key", value, endTime)
+	if endTime.AsTime().Add(time.Millisecond*-1) != startTime.AsTime() {
+		t.Fatal("Start time on a new entry should be 1ms behind the end time")
+	}
+
+	// next observation, 1m later
+	value = &monpb.TypedValue{
+		Value: &monpb.TypedValue_Int64Value{
+			Int64Value: int64(2),
+		},
+	}
+	endTime = tspb.New(now.Add(time.Second * 60))
+	startTime = cc.GetStartTime("key", value, endTime)
+	// startTime is unchanged
+	if startTime.GetSeconds() != now.Unix() {
+		t.Fatal("Returned start time on an updated counter on the same day should not change")
+	}
+	obs, ok := cc.get("key")
+	if !ok {
+		t.Fatal("GetStartTime should create a fetchable k/v")
+	}
+	if obs.StartTime != startTime {
+		t.Fatal("Start time on fetched observation should match output from GetStartTime()")
+	}
+	if obs.LastValue != value {
+		t.Fatal("Stored value on fetched observation should have been updated.")
+	}
+}
+
+func TestCounterCounterCacheEntryReset(t *testing.T) {
+	cc := NewCounterCache(models.NewLogger("outputs", "stackdriver", "TestCounterCounterCacheEntryReset"))
+	now := time.Now().UTC()
+	backdatedNow := now.Add(time.Millisecond * -1)
+	value := &monpb.TypedValue{
+		Value: &monpb.TypedValue_Int64Value{
+			Int64Value: int64(2),
+		},
+	}
+	endTime := tspb.New(now)
+	startTime := cc.GetStartTime("key", value, endTime)
+	if startTime.AsTime() != backdatedNow {
+		t.Fatal("Start time on a new entry should be 1ms behind the end time")
+	}
+
+	// next observation, 1m later, but a lower value
+	value = &monpb.TypedValue{
+		Value: &monpb.TypedValue_Int64Value{
+			Int64Value: int64(1),
+		},
+	}
+	later := now.Add(time.Second * 60)
+	endTime = tspb.New(later)
+	startTime = cc.GetStartTime("key", value, endTime)
+	// startTime should now be the new endTime -1ms
+	if startTime.AsTime() != later.Add(time.Millisecond*-1) {
+		t.Fatal("Returned start time after a counter reset should equal the end time minus 1ms")
+	}
+	obs, ok := cc.get("key")
+	if !ok {
+		t.Fatal("GetStartTime should create a fetchable k/v")
+	}
+	if obs.StartTime.AsTime() != endTime.AsTime().Add(time.Millisecond*-1) {
+		t.Fatal("Start time on fetched observation after a counter reset should equal the end time minus 1ms")
+	}
+	if obs.LastValue != value {
+		t.Fatal("Stored value on fetched observation should have been updated.")
+	}
+}
+
+func TestCounterCacheDayRollover(t *testing.T) {
+	cc := NewCounterCache(models.NewLogger("outputs", "stackdriver", "TestCounterCacheDayRollover"))
+	now := time.Now().UTC()
+	backdatedNow := now.Add(time.Millisecond * -1)
+	value := &monpb.TypedValue{
+		Value: &monpb.TypedValue_Int64Value{
+			Int64Value: int64(1),
+		},
+	}
+	endTime := tspb.New(now)
+	startTime := cc.GetStartTime("key", value, endTime)
+	if startTime.AsTime() != backdatedNow {
+		t.Fatal("Start time on a new entry should be 1ms behind the end time")
+	}
+
+	// next observation, 24h later
+	value = &monpb.TypedValue{
+		Value: &monpb.TypedValue_Int64Value{
+			Int64Value: int64(2),
+		},
+	}
+	later := now.Add(time.Hour * 24)
+	endTime = tspb.New(later)
+	startTime = cc.GetStartTime("key", value, endTime)
+	if startTime.AsTime() != backdatedNow {
+		t.Fatalf("Returned start time %d 1s before a day rollover should equal the end time %d", startTime.GetSeconds(), now.Unix())
+	}
+	obs, ok := cc.get("key")
+	if !ok {
+		t.Fatal("GetStartTime should create a fetchable k/v")
+	}
+	if obs.StartTime.AsTime() != backdatedNow {
+		t.Fatal("Start time on an updated counter 1s before a day rollover should be unchanged")
+	}
+	if obs.LastValue != value {
+		t.Fatal("Stored value on an updated counter should have been updated.")
+	}
+
+	// next observation, 24h 1s later
+	value = &monpb.TypedValue{
+		Value: &monpb.TypedValue_Int64Value{
+			Int64Value: int64(3),
+		},
+	}
+	tomorrow := later.Add(time.Second * 1)
+	endTime = tspb.New(tomorrow)
+	startTime = cc.GetStartTime("key", value, endTime)
+	// startTime should now be the new endTime
+	if startTime.GetSeconds() != tomorrow.Unix() {
+		t.Fatalf("Returned start time %d after a day rollover should equal the end time %d", startTime.GetSeconds(), tomorrow.Unix())
+	}
+	obs, ok = cc.get("key")
+	if !ok {
+		t.Fatal("GetStartTime should create a fetchable k/v")
+	}
+	if obs.StartTime.AsTime() != endTime.AsTime().Add(time.Millisecond*-1) {
+		t.Fatal("Start time on fetched observation after a day rollover should equal the new end time -1ms")
+	}
+	if obs.LastValue != value {
+		t.Fatal("Stored value on fetched observation should have been updated.")
+	}
+}

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -163,13 +163,7 @@ func (s *Stackdriver) Write(metrics []telegraf.Metric) error {
 				continue
 			}
 
-			startTime, endTime := getStackdriverIntervalEndpoints(
-				metricKind,
-				value,
-				m,
-				f,
-				s.counterCache,
-			)
+			startTime, endTime := getStackdriverIntervalEndpoints(metricKind, value, m, f, s.counterCache)
 
 			timeInterval, err := getStackdriverTimeInterval(metricKind, startTime, endTime)
 			if err != nil {

--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -11,18 +11,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/testutil"
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
+	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
-	mon "cloud.google.com/go/monitoring/apiv3/v2"
-	monpb "google.golang.org/genproto/googleapis/monitoring/v3"
-	tspb "google.golang.org/protobuf/types/known/timestamppb"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 // clientOpt is the option tests should use to connect to the test server.
@@ -35,7 +35,7 @@ type mockMetricServer struct {
 	// Embed for forward compatibility.
 	// Tests will keep working if more methods are added
 	// in the future.
-	monpb.MetricServiceServer
+	monitoringpb.MetricServiceServer
 
 	reqs []proto.Message
 
@@ -46,7 +46,7 @@ type mockMetricServer struct {
 	resps []proto.Message
 }
 
-func (s *mockMetricServer) CreateTimeSeries(ctx context.Context, req *monpb.CreateTimeSeriesRequest) (*emptypb.Empty, error) {
+func (s *mockMetricServer) CreateTimeSeries(ctx context.Context, req *monitoringpb.CreateTimeSeriesRequest) (*emptypb.Empty, error) {
 	md, _ := metadata.FromIncomingContext(ctx)
 	if xg := md["x-goog-api-client"]; len(xg) == 0 || !strings.Contains(xg[0], "gl-go/") {
 		return nil, fmt.Errorf("x-goog-api-client = %v, expected gl-go key", xg)
@@ -60,7 +60,7 @@ func (s *mockMetricServer) CreateTimeSeries(ctx context.Context, req *monpb.Crea
 
 func TestMain(m *testing.M) {
 	serv := grpc.NewServer()
-	monpb.RegisterMetricServiceServer(serv, &mockMetric)
+	monitoringpb.RegisterMetricServiceServer(serv, &mockMetric)
 
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -86,7 +86,7 @@ func TestWrite(t *testing.T) {
 	mockMetric.reqs = nil
 	mockMetric.resps = append(mockMetric.resps[:0], expectedResponse)
 
-	c, err := mon.NewMetricClient(context.Background(), clientOpt)
+	c, err := monitoring.NewMetricClient(context.Background(), clientOpt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func TestWrite(t *testing.T) {
 	err = s.Write(testutil.MockMetrics())
 	require.NoError(t, err)
 
-	request := mockMetric.reqs[0].(*monpb.CreateTimeSeriesRequest)
+	request := mockMetric.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
 	require.Equal(t, request.TimeSeries[0].Resource.Type, "global")
 	require.Equal(t, request.TimeSeries[0].Resource.Labels["project_id"], "projects/[PROJECT]")
 }
@@ -114,7 +114,7 @@ func TestWriteResourceTypeAndLabels(t *testing.T) {
 	mockMetric.reqs = nil
 	mockMetric.resps = append(mockMetric.resps[:0], expectedResponse)
 
-	c, err := mon.NewMetricClient(context.Background(), clientOpt)
+	c, err := monitoring.NewMetricClient(context.Background(), clientOpt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestWriteResourceTypeAndLabels(t *testing.T) {
 	err = s.Write(testutil.MockMetrics())
 	require.NoError(t, err)
 
-	request := mockMetric.reqs[0].(*monpb.CreateTimeSeriesRequest)
+	request := mockMetric.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
 	require.Equal(t, request.TimeSeries[0].Resource.Type, "foo")
 	require.Equal(t, request.TimeSeries[0].Resource.Labels["project_id"], "projects/[PROJECT]")
 	require.Equal(t, request.TimeSeries[0].Resource.Labels["mylabel"], "myvalue")
@@ -147,7 +147,7 @@ func TestWriteAscendingTime(t *testing.T) {
 	mockMetric.reqs = nil
 	mockMetric.resps = append(mockMetric.resps[:0], expectedResponse)
 
-	c, err := mon.NewMetricClient(context.Background(), clientOpt)
+	c, err := monitoring.NewMetricClient(context.Background(), clientOpt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,32 +183,32 @@ func TestWriteAscendingTime(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, mockMetric.reqs, 2)
-	request := mockMetric.reqs[0].(*monpb.CreateTimeSeriesRequest)
+	request := mockMetric.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
 	require.Len(t, request.TimeSeries, 1)
 	ts := request.TimeSeries[0]
 	require.Len(t, ts.Points, 1)
-	require.Equal(t, ts.Points[0].Interval, &monpb.TimeInterval{
-		EndTime: &tspb.Timestamp{
+	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 1,
 		},
 	})
-	require.Equal(t, ts.Points[0].Value, &monpb.TypedValue{
-		Value: &monpb.TypedValue_Int64Value{
+	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
+		Value: &monitoringpb.TypedValue_Int64Value{
 			Int64Value: int64(43),
 		},
 	})
 
-	request = mockMetric.reqs[1].(*monpb.CreateTimeSeriesRequest)
+	request = mockMetric.reqs[1].(*monitoringpb.CreateTimeSeriesRequest)
 	require.Len(t, request.TimeSeries, 1)
 	ts = request.TimeSeries[0]
 	require.Len(t, ts.Points, 1)
-	require.Equal(t, ts.Points[0].Interval, &monpb.TimeInterval{
-		EndTime: &tspb.Timestamp{
+	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 2,
 		},
 	})
-	require.Equal(t, ts.Points[0].Value, &monpb.TypedValue{
-		Value: &monpb.TypedValue_Int64Value{
+	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
+		Value: &monitoringpb.TypedValue_Int64Value{
 			Int64Value: int64(42),
 		},
 	})
@@ -220,7 +220,7 @@ func TestWriteBatchable(t *testing.T) {
 	mockMetric.reqs = nil
 	mockMetric.resps = append(mockMetric.resps[:0], expectedResponse)
 
-	c, err := mon.NewMetricClient(context.Background(), clientOpt)
+	c, err := monitoring.NewMetricClient(context.Background(), clientOpt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,56 +314,56 @@ func TestWriteBatchable(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, mockMetric.reqs, 2)
-	request := mockMetric.reqs[0].(*monpb.CreateTimeSeriesRequest)
+	request := mockMetric.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
 	require.Len(t, request.TimeSeries, 6)
 	ts := request.TimeSeries[0]
 	require.Len(t, ts.Points, 1)
-	require.Equal(t, ts.Points[0].Interval, &monpb.TimeInterval{
-		EndTime: &tspb.Timestamp{
+	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 3,
 		},
 	})
-	require.Equal(t, ts.Points[0].Value, &monpb.TypedValue{
-		Value: &monpb.TypedValue_Int64Value{
+	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
+		Value: &monitoringpb.TypedValue_Int64Value{
 			Int64Value: int64(43),
 		},
 	})
 
 	ts = request.TimeSeries[1]
 	require.Len(t, ts.Points, 1)
-	require.Equal(t, ts.Points[0].Interval, &monpb.TimeInterval{
-		EndTime: &tspb.Timestamp{
+	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 1,
 		},
 	})
-	require.Equal(t, ts.Points[0].Value, &monpb.TypedValue{
-		Value: &monpb.TypedValue_Int64Value{
+	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
+		Value: &monitoringpb.TypedValue_Int64Value{
 			Int64Value: int64(43),
 		},
 	})
 
 	ts = request.TimeSeries[2]
 	require.Len(t, ts.Points, 1)
-	require.Equal(t, ts.Points[0].Interval, &monpb.TimeInterval{
-		EndTime: &tspb.Timestamp{
+	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 3,
 		},
 	})
-	require.Equal(t, ts.Points[0].Value, &monpb.TypedValue{
-		Value: &monpb.TypedValue_Int64Value{
+	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
+		Value: &monitoringpb.TypedValue_Int64Value{
 			Int64Value: int64(43),
 		},
 	})
 
 	ts = request.TimeSeries[4]
 	require.Len(t, ts.Points, 1)
-	require.Equal(t, ts.Points[0].Interval, &monpb.TimeInterval{
-		EndTime: &tspb.Timestamp{
+	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+		EndTime: &timestamppb.Timestamp{
 			Seconds: 5,
 		},
 	})
-	require.Equal(t, ts.Points[0].Value, &monpb.TypedValue{
-		Value: &monpb.TypedValue_Int64Value{
+	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
+		Value: &monitoringpb.TypedValue_Int64Value{
 			Int64Value: int64(43),
 		},
 	})
@@ -398,7 +398,7 @@ func TestWriteIgnoredErrors(t *testing.T) {
 			mockMetric.err = tt.err
 			mockMetric.reqs = nil
 
-			c, err := mon.NewMetricClient(context.Background(), clientOpt)
+			c, err := monitoring.NewMetricClient(context.Background(), clientOpt)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #7758 

Cumulative metrics, when posted to google cloud monitoring (nee
Stackdriver), require a TimeInterval with a start time that corresponds
to the last time at which the counter/cumulative metric was reset to
zero, cannot overlap previous intervals, and cannot be more than 25
hours in the past:

https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TimeInterval

The stackdriver output plugin had been creating StartTimes of
`Thu Jan 1 00:00:01 UTC 1970` leading to bizarre behavior: stackdriver graphs
would reflect flatlined fractional values no matter what data telegraf
was sending, and direct queries to the projects.timeSeries.list API
would initially return the last handful of posted values but then
eventually return only `{"unit": "not_a_unit"}` for the same query,
presumably due to stackdriver having GC'ed the invalid intervals on the
backend.

So, herein:

- create a cache of start times and observed last values for all counter metrics (keyed by name, tags and field)
- reset the start time of a cache entry if the newest value is less than the previous observed value (counter reset)
- reset the start time of a cache entry if it is greater than 24 hours old
- while we're at it, use the telegraf logger rather than the base golang logger