### PR TITLE
fix (inputs/mongodb): Add direct connection to mongod plugin

### DIFF
--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -31,6 +31,11 @@ All MongoDB server versions from 2.6 and higher are supported.
   ## List of db where collections stats are collected
   ## If empty, all db are concerned
   # col_stats_dbs = ["local"]
+  
+  ## Direct connect to mongod node that included in replcaset and collect stats exactly from this node.
+  ## If you disable this option, telegraf will collect stats only from primary node, even if you specify secondary node in "servers" section.
+  ## Default value true, if you want to disable direct_connect option, you have to set this option to false
+  # direct_connect = true
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Since 1.19.2 version, telegraf collect statistics from primary node, even if secondary node was specified. It can be fixed with connection=direct with connection string in config file, but I think this MR better way to fix this problem, no any action from users required.

resolves #9555 
