### PR TITLE
fix: Add setting to win_perf_counters input to ignore localization

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -46,6 +46,18 @@ instance indexes will not be returned in the instance names.
 Example:
 `UseWildcardsExpansion=true`
 
+#### LocalizeWildcardsExpansion
+
+When running on a localized version of Windows and with
+UseWildcardsExpansion = true, Windows will localize object and counter
+names. When LocalizeWildcardsExpansion = false, use the names in
+object.Counters instead of the localized names. Only Instances can
+have wildcards in this case. ObjectName and Counters must not have
+wildcards when this setting is false.
+
+Example:
+`LocalizeWildcardsExpansion = true`
+
 #### CountersRefreshInterval
 
 Configured counters are matched against available counters at the interval

--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -75,7 +75,7 @@ Example:
 
 #### PreVistaSupport
 
-_Deprecated. Necessary features on Windows Vista and newer are checked dynamically_
+(Deprecated. Necessary features on Windows Vista and newer are checked dynamically)
 
 Bool, if set to `true`, the plugin will use the localized PerfCounter interface that has been present since before Vista for backwards compatibility.
 
@@ -86,7 +86,7 @@ Example for Windows Server 2003, this would be set to true:
 
 #### UsePerfCounterTime
 
-Bool, if set to `true` will request a timestamp along with the PerfCounter data. 
+Bool, if set to `true` will request a timestamp along with the PerfCounter data.
 If se to `false`, current time will be used.
 
 Supported on Windows Vista/Windows Server 2008 and newer
@@ -98,6 +98,7 @@ Example:
 See Entry below.
 
 ### Entry
+
 A new configuration entry consists of the TOML header starting with,
 `[[inputs.win_perf_counters.object]]`.
 This must follow before other plugin configurations,
@@ -106,14 +107,16 @@ beneath the main win_perf_counters entry, `[[inputs.win_perf_counters]]`.
 Following this are 3 required key/value pairs and three optional parameters and their usage.
 
 #### ObjectName
-**Required**
+
+(Required)
 
 ObjectName is the Object to query for, like Processor, DirectoryServices, LogicalDisk or similar.
 
 Example: `ObjectName = "LogicalDisk"`
 
 #### Instances
-**Required**
+
+(Required)
 
 The instances key (this is an array) declares the instances of a counter you would like returned,
 it can be one or more values.
@@ -133,7 +136,8 @@ Here only one option is valid if you want data back,
 and that is to specify `Instances = ["------"]`.
 
 #### Counters
-**Required**
+
+(Required)
 
 The Counters key (this is an array) declares the counters of the ObjectName
 you would like returned, it can also be one or more values.
@@ -145,7 +149,8 @@ This must be specified for every counter you want the results of, or use
 is set to `true`.
 
 #### Measurement
-*Optional*
+
+(Optional)
 
 This key is optional. If it is not set it will be `win_perf_counters`.
 In InfluxDB this is the key underneath which the returned data is stored.
@@ -156,7 +161,8 @@ separately from Processor results.
 Example: `Measurement = "win_disk"``
 
 #### IncludeTotal
-*Optional*
+
+(Optional)
 
 This key is optional. It is a simple bool.
 If it is not set to true or included it is treated as false.
@@ -166,7 +172,8 @@ like `_Total`, `0,_Total` and so on where applicable
 (Processor Information is one example).
 
 #### WarnOnMissing
-*Optional*
+
+(Optional)
 
 This key is optional. It is a simple bool.
 If it is not set to true or included it is treated as false.
@@ -175,7 +182,8 @@ It will print out any ObjectName/Instance/Counter combinations
 asked for that do not match. Useful when debugging new configurations.
 
 #### FailOnMissing
-*Internal*
+
+(Internal)
 
 This key should not be used. It is for testing purposes only.
 It is a simple bool. If it is not set to true or included this is treated as false.
@@ -185,6 +193,7 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
 ## Examples
 
 ### Generic Queries
+
 ```toml
 [[inputs.win_perf_counters]]
   [[inputs.win_perf_counters.object]]
@@ -229,6 +238,7 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
 ```
 
 ### Active Directory Domain Controller
+
 ```toml
 [[inputs.win_perf_counters]]
   [inputs.win_perf_counters.tags]
@@ -257,6 +267,7 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
 ```
 
 ### DFS Namespace + Domain Controllers
+
 ```toml
 [[inputs.win_perf_counters]]
   [[inputs.win_perf_counters.object]]
@@ -270,6 +281,7 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
 ```
 
 ### DFS Replication + Domain Controllers
+
 ```toml
 [[inputs.win_perf_counters]]
   [[inputs.win_perf_counters.object]]
@@ -283,6 +295,7 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
 ```
 
 ### DNS Server + Domain Controllers
+
 ```toml
 [[inputs.win_perf_counters]]
   [[inputs.win_perf_counters.object]]
@@ -294,6 +307,7 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
 ```
 
 ### IIS / ASP.NET
+
 ```toml
 [[inputs.win_perf_counters]]
   [[inputs.win_perf_counters.object]]
@@ -338,6 +352,7 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
 ```
 
 ### Process
+
 ```toml
 [[inputs.win_perf_counters]]
   [[inputs.win_perf_counters.object]]
@@ -350,6 +365,7 @@ if any of the combinations of ObjectName/Instances/Counters are invalid.
 ```
 
 ### .NET Monitoring
+
 ```toml
 [[inputs.win_perf_counters]]
   [[inputs.win_perf_counters.object]]
@@ -414,6 +430,7 @@ your performance counters.
 1. Drop into the C:\WINDOWS\System32 directory by typing `C:` then `cd \Windows\System32`
 1. Rebuild your counter values, which may take a few moments so please be
    patient, by running:
-   ```
-   lodctr /r
-   ```
+
+```batchfile
+lodctr /r
+```

--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -20,6 +20,10 @@ as counters used when performance monitoring
  This file is likely to be updated in the future with more examples for
  useful configurations for separate scenarios.
 
+For more information on concepts and terminology including object,
+counter, and instance names, see the help in the Windows Performance
+Monitor app.
+
 ### Plugin wide
 
 Plugin wide entries are underneath `[[inputs.win_perf_counters]]`.
@@ -33,30 +37,38 @@ Example:
 
 #### UseWildcardsExpansion
 
-If `UseWildcardsExpansion` is set to true, wildcards can be used in the
-instance name and the counter name.  When using localized Windows, counters
-will be also be localized.  Instance indexes will also be returned in the
-instance name.
+If `UseWildcardsExpansion` is true, wildcards can be used in the
+instance name and the counter name. Instance indexes will also be
+returned in the instance name.
 
-Partial wildcards (e.g. `chrome*`) are supported only in the instance name on Windows Vista and newer.
+Partial wildcards (e.g. `chrome*`) are supported only in the instance
+name on Windows Vista and newer.
 
-If disabled, wildcards (not partial) in instance names can still be used, but
-instance indexes will not be returned in the instance names.
+If disabled, wildcards (not partial) in instance names can still be
+used, but instance indexes will not be returned in the instance names.
 
 Example:
 `UseWildcardsExpansion=true`
 
 #### LocalizeWildcardsExpansion
 
-When running on a localized version of Windows and with
-UseWildcardsExpansion = true, Windows will localize object and counter
-names. When LocalizeWildcardsExpansion = false, use the names in
-object.Counters instead of the localized names. Only Instances can
-have wildcards in this case. ObjectName and Counters must not have
-wildcards when this setting is false.
+`LocalizeWildcardsExpansion` selects whether object and counter names
+are localized when `UseWildcardsExpansion` is true and Telegraf is
+running on a localized installation of Windows.
+
+When `LocalizeWildcardsExpansion` is true, Telegraf produces metrics
+with localized tags and fields even when object and counter names are
+in English.
+
+When `LocalizeWildcardsExpansion` is false, Telegraf expects object
+and counter names to be in English and produces metrics with English
+tags and fields.
+
+When `LocalizeWildcardsExpansion` is false, wildcards can only be used
+in instances. Object and counter names must not have wildcards.
 
 Example:
-`LocalizeWildcardsExpansion = true`
+`LocalizeWildcardsExpansion=true`
 
 #### CountersRefreshInterval
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -252,8 +252,8 @@ func (m *Win_PerfCounters) SampleConfig() string {
 }
 
 //objectName string, counter string, instance string, measurement string, include_total bool
-func (m *Win_PerfCounters) AddItem(origCounterPath string, objectName string, instance string, counterName string, measurement string, includeTotal bool) error {
-	counterPath := origCounterPath
+func (m *Win_PerfCounters) AddItem(counterPath string, objectName string, instance string, counterName string, measurement string, includeTotal bool) error {
+	origCounterPath := counterPath
 	var err error
 	var counterHandle PDH_HCOUNTER
 	if !m.query.IsVistaOrNewer() {

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -28,7 +28,7 @@ var sampleConfig = `
   # and in case of localized Windows, counter paths will be also localized. It also returns instance indexes in instance names.
   # If false, wildcards (not partial) in instance names will still be expanded, but instance indexes will not be returned in instance names.
   #UseWildcardsExpansion = false
-  # When running on a localized version of Windows and UseWildcardsExpansion = true, Windows will
+  # When running on a localized version of Windows and with UseWildcardsExpansion = true, Windows will
   # localize object and counter names. When LocalizeWildcardsExpansion = false, use the names in object.Counters instead
   # of the localized names. Only Instances can have wildcards in this case. ObjectName and Counters must not have wildcards when this
   # setting is false.
@@ -522,8 +522,6 @@ func isKnownCounterDataError(err error) bool {
 	}
 	return false
 }
-
-const wildcardError = "Counter wildcards can't be used with fix_2463"
 
 func (m *Win_PerfCounters) Init() error {
 	if m.UseWildcardsExpansion && !m.LocalizeWildcardsExpansion {

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -453,7 +453,12 @@ func TestWinPerfcountersConfigError1Integration(t *testing.T) {
 
 	perfobjects[0] = PerfObject
 
-	m := Win_PerfCounters{PrintValid: false, Object: perfobjects, query: &PerformanceQueryImpl{}}
+	m := Win_PerfCounters{
+		PrintValid: false,
+		Object:     perfobjects,
+		query:      &PerformanceQueryImpl{},
+		Log:        testutil.Logger{},
+	}
 	m.query.Open()
 
 	err := m.ParseConfig()
@@ -487,7 +492,12 @@ func TestWinPerfcountersConfigError2Integration(t *testing.T) {
 
 	perfobjects[0] = PerfObject
 
-	m := Win_PerfCounters{PrintValid: false, Object: perfobjects, query: &PerformanceQueryImpl{}}
+	m := Win_PerfCounters{
+		PrintValid: false,
+		Object:     perfobjects,
+		query:      &PerformanceQueryImpl{},
+		Log:        testutil.Logger{},
+	}
 	m.query.Open()
 
 	err := m.ParseConfig()
@@ -523,7 +533,12 @@ func TestWinPerfcountersConfigError3Integration(t *testing.T) {
 
 	perfobjects[0] = PerfObject
 
-	m := Win_PerfCounters{PrintValid: false, Object: perfobjects, query: &PerformanceQueryImpl{}}
+	m := Win_PerfCounters{
+		PrintValid: false,
+		Object:     perfobjects,
+		query:      &PerformanceQueryImpl{},
+		Log:        testutil.Logger{},
+	}
 	m.query.Open()
 
 	err := m.ParseConfig()
@@ -558,7 +573,12 @@ func TestWinPerfcountersCollect1Integration(t *testing.T) {
 
 	perfobjects[0] = PerfObject
 
-	m := Win_PerfCounters{PrintValid: false, Object: perfobjects, query: &PerformanceQueryImpl{}}
+	m := Win_PerfCounters{
+		PrintValid: false,
+		Object:     perfobjects,
+		query:      &PerformanceQueryImpl{},
+		Log:        testutil.Logger{},
+	}
 	var acc testutil.Accumulator
 	err := m.Gather(&acc)
 	require.NoError(t, err)
@@ -604,7 +624,14 @@ func TestWinPerfcountersCollect2Integration(t *testing.T) {
 
 	perfobjects[0] = PerfObject
 
-	m := Win_PerfCounters{PrintValid: false, UsePerfCounterTime: true, Object: perfobjects, query: &PerformanceQueryImpl{}, UseWildcardsExpansion: true}
+	m := Win_PerfCounters{
+		PrintValid:            false,
+		UsePerfCounterTime:    true,
+		Object:                perfobjects,
+		query:                 &PerformanceQueryImpl{},
+		UseWildcardsExpansion: true,
+		Log:                   testutil.Logger{},
+	}
 	var acc testutil.Accumulator
 	err := m.Gather(&acc)
 	require.NoError(t, err)

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -1027,14 +1027,22 @@ func TestUTF16ToStringArray(t *testing.T) {
 
 func TestNoWildcards(t *testing.T) {
 	m := Win_PerfCounters{
-		Object:  createPerfObject("measurement", "object", []string{"instance"}, []string{"counter*"}, false, false),
-		Fix2463: true,
-		Log:     testutil.Logger{},
+		Object:                     createPerfObject("measurement", "object", []string{"instance"}, []string{"counter*"}, false, false),
+		UseWildcardsExpansion:      true,
+		LocalizeWildcardsExpansion: false,
+		Log:                        testutil.Logger{},
+	}
+	require.Error(t, m.Init())
+	m = Win_PerfCounters{
+		Object:                     createPerfObject("measurement", "object?", []string{"instance"}, []string{"counter"}, false, false),
+		UseWildcardsExpansion:      true,
+		LocalizeWildcardsExpansion: false,
+		Log:                        testutil.Logger{},
 	}
 	require.Error(t, m.Init())
 }
 
-func TestFix2463(t *testing.T) {
+func TestLocalizeWildcardsExpansion(t *testing.T) {
 	// this test is valid only on localized windows
 	if testing.Short() {
 		t.Skip("Skipping long taking test in short mode")
@@ -1046,9 +1054,9 @@ func TestFix2463(t *testing.T) {
 		CountersRefreshInterval: config.Duration(time.Second * 60),
 		Object: createPerfObject("measurement", "Processor Information",
 			[]string{"_Total"}, []string{counter}, false, false),
-		Fix2463:               true,
-		UseWildcardsExpansion: true,
-		Log:                   testutil.Logger{},
+		LocalizeWildcardsExpansion: false,
+		UseWildcardsExpansion:      true,
+		Log:                        testutil.Logger{},
 	}
 	require.NoError(t, m.Init())
 	var acc testutil.Accumulator
@@ -1056,7 +1064,7 @@ func TestFix2463(t *testing.T) {
 	require.Len(t, acc.Metrics, 1)
 
 	//running on localized windows with UseWildcardsExpansion and
-	//without Fix2463, this will be localized. Using Fix2463 it will
+	//with LocalizeWildcardsExpansion, this will be localized. Using LocalizeWildcardsExpansion=false it will
 	//be English.
 	require.Contains(t, acc.Metrics[0].Fields, sanitizedChars.Replace(counter))
 }


### PR DESCRIPTION
Add a setting to undo the localization that windows does when expanding wildcards.

Many users of this plugin want to gather English metrics from all windows machines, even those that have non-English UI. This is possible when not using wildcards, but before this PR it was not possible when using wildcards on non-English machines because windows localizes counters in the ExpandWildCardPath call.

There are three parts to a counter: object name, counter name, and instance. Object name and counter name are well defined but instance is machine dependent.

This PR is a workaround that lets you use wildcards in the instance name without localizing metrics. It ignores the localized names returned from ExapandWildCardPath and always uses the object and counter names in the plugin config. Users of this new setting still won't be able to use wildcards in instance or counter names.

I checked on a German localized windows installation and didn't find any instance names that were localized. There are numeric indexes, disk/filesystem non-localized identifiers like drive name/path/volume name (c:,HarddiskVolume5), process ID/names, etc. There are also special non-localized English magic strings like "_Total". These are all the same as English windows.