### PR TITLE
fix: super-linter use v4.8.1, issue with latest

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,7 +48,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v4.8.1
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master


### PR DESCRIPTION
The markdown linter is failing due to an issue with the latest version (v4.8.3), in the meantime updating the linter configuration to use an older version known to still work (v4.8.1).

Relevant issue: https://github.com/github/super-linter/issues/2128