### PR TITLE
fix #10027

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -477,7 +477,7 @@ func (c *CloudWatch) getDataQueries(filteredMetrics []filteredMetric) map[string
 					Id:    aws.String("average_" + id),
 					Label: aws.String(snakeCase(*metric.MetricName + "_average")),
 					MetricStat: &types.MetricStat{
-						Metric: &metric,
+						Metric: &filtered.metrics[j],
 						Period: aws.Int32(int32(time.Duration(c.Period).Seconds())),
 						Stat:   aws.String(StatisticAverage),
 					},
@@ -489,7 +489,7 @@ func (c *CloudWatch) getDataQueries(filteredMetrics []filteredMetric) map[string
 					Id:    aws.String("maximum_" + id),
 					Label: aws.String(snakeCase(*metric.MetricName + "_maximum")),
 					MetricStat: &types.MetricStat{
-						Metric: &metric,
+						Metric: &filtered.metrics[j],
 						Period: aws.Int32(int32(time.Duration(c.Period).Seconds())),
 						Stat:   aws.String(StatisticMaximum),
 					},
@@ -501,7 +501,7 @@ func (c *CloudWatch) getDataQueries(filteredMetrics []filteredMetric) map[string
 					Id:    aws.String("minimum_" + id),
 					Label: aws.String(snakeCase(*metric.MetricName + "_minimum")),
 					MetricStat: &types.MetricStat{
-						Metric: &metric,
+						Metric: &filtered.metrics[j],
 						Period: aws.Int32(int32(time.Duration(c.Period).Seconds())),
 						Stat:   aws.String(StatisticMinimum),
 					},
@@ -513,7 +513,7 @@ func (c *CloudWatch) getDataQueries(filteredMetrics []filteredMetric) map[string
 					Id:    aws.String("sum_" + id),
 					Label: aws.String(snakeCase(*metric.MetricName + "_sum")),
 					MetricStat: &types.MetricStat{
-						Metric: &metric,
+						Metric: &filtered.metrics[j],
 						Period: aws.Int32(int32(time.Duration(c.Period).Seconds())),
 						Stat:   aws.String(StatisticSum),
 					},
@@ -525,7 +525,7 @@ func (c *CloudWatch) getDataQueries(filteredMetrics []filteredMetric) map[string
 					Id:    aws.String("sample_count_" + id),
 					Label: aws.String(snakeCase(*metric.MetricName + "_sample_count")),
 					MetricStat: &types.MetricStat{
-						Metric: &metric,
+						Metric: &filtered.metrics[j],
 						Period: aws.Int32(int32(time.Duration(c.Period).Seconds())),
 						Stat:   aws.String(StatisticSampleCount),
 					},


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10027

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.-->

store pointer to metric rather than pointer to range value variable

Copied from #10123:

getDataQueries iterates over all filteredMetrics and takes the address of the metric from that list to store it in the dataQueries map. However since go seems to re-use the same object for every iteration of the loop the pointer that is taken always points to the exact same memory location. Due to this the Metric field will always contain the same pointer (and therefore value) after the for loop is done. The fix is easy and I will provide it as soon as I am done with this issue: the metric struct needs to be copied once to allocate new memory, after that the address can be taken.
