### PR TITLE
fix: input plugin statsd bug

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -166,7 +166,7 @@ type AgentConfig struct {
 	// valid for the agent config. Leaving them here for now for backwards-
 	// compatibility
 	// Deprecated: 1.0.0 after, has no effect
-	UTC bool `toml:"utc"` // deprecated in 1.0.0; has no effect
+	UTC bool `toml:"utc"`
 
 	// Debug is the option for running in debug mode
 	Debug bool `toml:"debug"`

--- a/config/config.go
+++ b/config/config.go
@@ -165,6 +165,7 @@ type AgentConfig struct {
 	// TODO(cam): Remove UTC and parameter, they are no longer
 	// valid for the agent config. Leaving them here for now for backwards-
 	// compatibility
+	// Deprecated: 1.0.0 after, has no effect
 	UTC bool `toml:"utc"` // deprecated in 1.0.0; has no effect
 
 	// Debug is the option for running in debug mode

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -799,6 +799,12 @@ func parseKeyValue(keyvalue string) (string, string) {
 		val = split[1]
 	} else if len(split) == 1 {
 		val = split[0]
+	} else if len(split) > 2 {
+		// fix: https://github.com/influxdata/telegraf/issues/10113
+		// fix: value has "=" parse error
+		// uri=/service/endpoint?sampleParam={paramValue} parse value key="uri", val="/service/endpoint?sampleParam\={paramValue}"
+		key = split[0]
+		val = strings.Join(split[1:], "=")
 	}
 
 	return key, val

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -1673,3 +1673,30 @@ func TestParse_Ints(t *testing.T) {
 	require.NoError(t, s.Gather(acc))
 	require.Equal(t, s.Percentiles, []Number{90.0})
 }
+
+func TestParse_KeyValue(t *testing.T) {
+	type output struct {
+		key string
+		val string
+	}
+
+	validLines := []struct {
+		input  string
+		output output
+	}{
+		{"", output{"", ""}},
+		{"only value", output{"", "only value"}},
+		{"key=value", output{"key", "value"}},
+		{"url=/api/querystring?key1=val1&key2=value", output{"url", "/api/querystring?key1=val1&key2=value"}},
+	}
+
+	for _, line := range validLines {
+		key, val := parseKeyValue(line.input)
+		if key != line.output.key {
+			t.Errorf("line: %s,  key expected %s, actual %s", line, line.output.key, key)
+		}
+		if val != line.output.val {
+			t.Errorf("line: %s,  val expected %s, actual %s", line, line.output.val, val)
+		}
+	}
+}


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

## fix bug:
  - fix: #10113
     reason: input plugins(statsd), parse metrics line, value has '=' parse error(return empty tag,ignore tag)

     After repair: 
 ```
       line ="uri=/service/endpoint?sampleParam={paramValue}"
       parse result  key="uri", val="/service/endpoint?sampleParam\={paramValue}"
```

### format 
file: config/config.go adjust the deprecated position, some IDE can disply strikethrough, eg: goland


<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
