### PR TITLE
fix cloudwatch-input query generation

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -471,13 +471,14 @@ func (c *CloudWatch) getDataQueries(filteredMetrics []filteredMetric) map[string
 		for j, metric := range filtered.metrics {
 			id := strconv.Itoa(j) + "_" + strconv.Itoa(i)
 			dimension := ctod(metric.Dimensions)
+			m := metric // Needed to avoid pointing to the same memory address in the loop see issue #10122
 			if filtered.statFilter.Match("average") {
 				c.queryDimensions["average_"+id] = dimension
 				dataQueries[*metric.Namespace] = append(dataQueries[*metric.Namespace], types.MetricDataQuery{
 					Id:    aws.String("average_" + id),
 					Label: aws.String(snakeCase(*metric.MetricName + "_average")),
 					MetricStat: &types.MetricStat{
-						Metric: &metric,
+						Metric: &m,
 						Period: aws.Int32(int32(time.Duration(c.Period).Seconds())),
 						Stat:   aws.String(StatisticAverage),
 					},
@@ -489,7 +490,7 @@ func (c *CloudWatch) getDataQueries(filteredMetrics []filteredMetric) map[string
 					Id:    aws.String("maximum_" + id),
 					Label: aws.String(snakeCase(*metric.MetricName + "_maximum")),
 					MetricStat: &types.MetricStat{
-						Metric: &metric,
+						Metric: &m,
 						Period: aws.Int32(int32(time.Duration(c.Period).Seconds())),
 						Stat:   aws.String(StatisticMaximum),
 					},
@@ -501,7 +502,7 @@ func (c *CloudWatch) getDataQueries(filteredMetrics []filteredMetric) map[string
 					Id:    aws.String("minimum_" + id),
 					Label: aws.String(snakeCase(*metric.MetricName + "_minimum")),
 					MetricStat: &types.MetricStat{
-						Metric: &metric,
+						Metric: &m,
 						Period: aws.Int32(int32(time.Duration(c.Period).Seconds())),
 						Stat:   aws.String(StatisticMinimum),
 					},
@@ -513,7 +514,7 @@ func (c *CloudWatch) getDataQueries(filteredMetrics []filteredMetric) map[string
 					Id:    aws.String("sum_" + id),
 					Label: aws.String(snakeCase(*metric.MetricName + "_sum")),
 					MetricStat: &types.MetricStat{
-						Metric: &metric,
+						Metric: &m,
 						Period: aws.Int32(int32(time.Duration(c.Period).Seconds())),
 						Stat:   aws.String(StatisticSum),
 					},
@@ -525,7 +526,7 @@ func (c *CloudWatch) getDataQueries(filteredMetrics []filteredMetric) map[string
 					Id:    aws.String("sample_count_" + id),
 					Label: aws.String(snakeCase(*metric.MetricName + "_sample_count")),
 					MetricStat: &types.MetricStat{
-						Metric: &metric,
+						Metric: &m,
 						Period: aws.Int32(int32(time.Duration(c.Period).Seconds())),
 						Stat:   aws.String(StatisticSampleCount),
 					},


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md. (not applicable, or?)
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Resolves: #10122

`getDataQueries` iterates over all `filteredMetrics` and takes the address of the metric from that list to store it in the `dataQueries` map. However since go seems to re-use the same object for every iteration of the loop the pointer that is taken always points to the exact same memory location. Due to this the `Metric` field will always contain the same pointer (and therefore value) after the for loop is done. The fix is easy and I will provide it as soon as I am done with this issue: the metric struct needs to be copied once to allocate new memory, after that the address can be taken.