### PR TITLE
fix: update makefile indents to not always run which

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,26 +148,26 @@ lint-install:
 
 .PHONY: lint
 lint:
-ifeq (, $(shell which golangci-lint))
-	$(info golangci-lint can't be found, please run: make lint-install)
-	exit 1
-endif
+	ifeq (, $(shell which golangci-lint))
+		$(info golangci-lint can't be found, please run: make lint-install)
+		exit 1
+	endif
 
 	golangci-lint run
 
-ifeq (, $(shell which markdownlint-cli))
-	$(info markdownlint-cli can't be found, please run: make lint-install)
-	exit 1
-endif
+	ifeq (, $(shell which markdownlint-cli))
+		$(info markdownlint-cli can't be found, please run: make lint-install)
+		exit 1
+	endif
 
 	markdownlint-cli
 
 .PHONY: lint-branch
 lint-branch:
-ifeq (, $(shell which golangci-lint))
-	$(info golangci-lint can't be found, please run: make lint-install)
-	exit 1
-endif
+	ifeq (, $(shell which golangci-lint))
+		$(info golangci-lint can't be found, please run: make lint-install)
+		exit 1
+	endif
 
 	golangci-lint run --new-from-rev master
 

--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,8 @@ lint:
 
 	golangci-lint run
 
-	ifeq (, $(shell which markdownlint-cli))
-		$(info markdownlint-cli can't be found, please run: make lint-install)
+	ifeq (, $(shell which markdownlint))
+		$(info markdownlint can't be found, please run: make lint-install)
 		exit 1
 	endif
 


### PR DESCRIPTION
Currently, any make command will run these three which commands because of how they are indented. It is annoying if you don't happen to have one of the items installed. This moves them back to where they actually need to be run.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
