### PR TITLE
Change the line 73 where "Dead" property is defined string instead of…

### DIFF
--- a/plugins/inputs/fibaro/fibaro.go
+++ b/plugins/inputs/fibaro/fibaro.go
@@ -70,7 +70,7 @@ type Devices struct {
 	Enabled    bool   `json:"enabled"`
 	Properties struct {
 		BatteryLevel *string     `json:"batteryLevel"`
-		Dead         string      `json:"dead"`
+		Dead         bool      `json:"dead"`
 		Energy       *string     `json:"energy"`
 		Power        *string     `json:"power"`
 		Value        interface{} `json:"value"`


### PR DESCRIPTION
… bool

Makes the Fibaro telegraf fail upload to influxdc when fething data from Fibaro HC-3

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.


Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #
https://github.com/influxdata/telegraf/issues/10128

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
