### PR TITLE
feat: add retry to 413 errors with InfluxDB output

### DIFF
--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -226,13 +226,11 @@ func (c *httpClient) splitAndWriteBatch(ctx context.Context, bucket string, metr
 	log.Printf("W! [outputs.influxdb_v2] Retrying write after splitting metric payload in half to reduce batch size")
 	midpoint := len(metrics) / 2
 
-	firstHalf := metrics[:midpoint]
-	if err := c.writeBatch(ctx, bucket, firstHalf); err != nil {
+	if err := c.writeBatch(ctx, bucket, metrics[:midpoint]); err != nil {
 		return err
 	}
 
-	secondHalf := metrics[midpoint:]
-	return c.writeBatch(ctx, bucket, secondHalf)
+	return c.writeBatch(ctx, bucket, metrics[midpoint:])
 }
 
 func (c *httpClient) writeBatch(ctx context.Context, bucket string, metrics []telegraf.Metric) error {

--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -236,8 +236,6 @@ func (c *httpClient) splitAndWriteBatch(ctx context.Context, bucket string, metr
 }
 
 func (c *httpClient) writeBatch(ctx context.Context, bucket string, metrics []telegraf.Metric) error {
-	log.Printf("D! [outputs.influxdb_v2] writting %d metrics", len(metrics))
-
 	loc, err := makeWriteURL(*c.url, c.Organization, bucket)
 	if err != nil {
 		return err

--- a/plugins/outputs/influxdb_v2/http_test.go
+++ b/plugins/outputs/influxdb_v2/http_test.go
@@ -117,7 +117,8 @@ func TestTooLargeWriteRetry(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
 			case "/api/v2/write":
-				r.ParseForm()
+				err := r.ParseForm()
+				require.NoError(t, err)
 
 				body, err := io.ReadAll(r.Body)
 				require.NoError(t, err)

--- a/plugins/outputs/influxdb_v2/http_test.go
+++ b/plugins/outputs/influxdb_v2/http_test.go
@@ -111,3 +111,100 @@ func TestWriteBucketTagWorksOnRetry(t *testing.T) {
 	err = client.Write(ctx, metrics)
 	require.NoError(t, err)
 }
+
+func TestTooLargeWriteRetry(t *testing.T) {
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v2/write":
+				r.ParseForm()
+
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				// Ensure metric body size is small
+				if len(body) > 16 {
+					w.WriteHeader(http.StatusRequestEntityTooLarge)
+				} else {
+					w.WriteHeader(http.StatusNoContent)
+				}
+
+				return
+			default:
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+		}),
+	)
+	defer ts.Close()
+
+	addr := &url.URL{
+		Scheme: "http",
+		Host:   ts.Listener.Addr().String(),
+	}
+
+	config := &influxdb.HTTPConfig{
+		URL:              addr,
+		Bucket:           "telegraf",
+		BucketTag:        "bucket",
+		ExcludeBucketTag: true,
+	}
+
+	client, err := influxdb.NewHTTPClient(config)
+	require.NoError(t, err)
+
+	// Together the metric batch size is too big, split up, we get success
+	metrics := []telegraf.Metric{
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{
+				"bucket": "foo",
+			},
+			map[string]interface{}{
+				"value": 42.0,
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{
+				"bucket": "bar",
+			},
+			map[string]interface{}{
+				"value": 99.0,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	ctx := context.Background()
+	err = client.Write(ctx, metrics)
+	require.NoError(t, err)
+
+	// These metrics are too big, even after splitting in half, expect error
+	hugeMetrics := []telegraf.Metric{
+		testutil.MustMetric(
+			"reallyLargeMetric",
+			map[string]string{
+				"bucket": "foobar",
+			},
+			map[string]interface{}{
+				"value": 123.456,
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric(
+			"evenBiggerMetric",
+			map[string]string{
+				"bucket": "fizzbuzzbang",
+			},
+			map[string]interface{}{
+				"value": 999.999,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	err = client.Write(ctx, hugeMetrics)
+	require.Error(t, err)
+}


### PR DESCRIPTION
The 413 error occurs when the body of a request is too large. In order
to attempt to help avoid these errors, Telegraf can split the metrics
slice in half and retry the request. If there are still errors, then the
write will then fail.

Resolves: #9744