### PR TITLE
fix: skip knxlistener when writing the sample config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -560,7 +560,11 @@ func printFilteredInputs(inputFilters []string, commented bool) {
 
 	// Print Inputs
 	for _, pname := range pnames {
+		// Skip inputs that are registered twice for backward compatibility
 		if pname == "cisco_telemetry_gnmi" {
+			continue
+		}
+		if pname == "KNXListener" {
 			continue
 		}
 		creator := inputs.Inputs[pname]


### PR DESCRIPTION
We renamed KNXListener to knx_listener a while back. We registered it under both names for backward compatibility. Since it's registered twice the sample config has two sections, one with each name.

This PR checks for the old name when printing the sample config, and skips the section in that case.