### PR TITLE
fix: removed snmptranslate from readme and fix default path

### DIFF
--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -6,21 +6,8 @@ notifications (traps and inform requests).
 Notifications are received on plain UDP. The port to listen is
 configurable.
 
-### Prerequisites
+## Configuration
 
-This plugin uses the `snmptranslate` programs from the
-[net-snmp][] project.  These tools will need to be installed into the `PATH` in
-order to be located.  Other utilities from the net-snmp project may be useful
-for troubleshooting, but are not directly used by the plugin.
-
-These programs will load available MIBs on the system.  Typically the default
-directory for MIBs is `/usr/share/snmp/mibs`, but if your MIBs are in a
-different location you may need to make the paths known to net-snmp.  The
-location of these files can be configured in the `snmp.conf` or via the
-`MIBDIRS` environment variable. See [`man 1 snmpcmd`][man snmpcmd] for more
-information.
-
-### Configuration
 ```toml
 [[inputs.snmp_trap]]
   ## Transport, local address, and port to listen on.  Transport must
@@ -55,7 +42,7 @@ information.
   # priv_password = ""
 ```
 
-#### Using a Privileged Port
+### Using a Privileged Port
 
 On many operating systems, listening on a privileged port (a port
 number less than 1024) requires extra permission.  Since the default
@@ -73,7 +60,7 @@ the privileged port.
 To use a privileged port on Linux, you can use setcap to enable the
 CAP_NET_BIND_SERVICE capability on the telegraf binary:
 
-```
+```shell
 setcap cap_net_bind_service=+ep /usr/bin/telegraf
 ```
 
@@ -84,21 +71,22 @@ On Mac OS, listening on privileged ports is unrestricted on versions
 
 - snmp_trap
   - tags:
-	- source (string, IP address of trap source)
-	- name (string, value from SNMPv2-MIB::snmpTrapOID.0 PDU)
-	- mib (string, MIB from SNMPv2-MIB::snmpTrapOID.0 PDU)
-	- oid (string, OID string from SNMPv2-MIB::snmpTrapOID.0 PDU)
-	- version (string, "1" or "2c" or "3")
-	- context_name (string, value from v3 trap)
-	- engine_id (string, value from v3 trap)
-	- community (string, value from 1 or 2c trap)
+    - source (string, IP address of trap source)
+    - name (string, value from SNMPv2-MIB::snmpTrapOID.0 PDU)
+    - mib (string, MIB from SNMPv2-MIB::snmpTrapOID.0 PDU)
+    - oid (string, OID string from SNMPv2-MIB::snmpTrapOID.0 PDU)
+    - version (string, "1" or "2c" or "3")
+    - context_name (string, value from v3 trap)
+    - engine_id (string, value from v3 trap)
+    - community (string, value from 1 or 2c trap)
   - fields:
-	- Fields are mapped from variables in the trap. Field names are
+    - Fields are mapped from variables in the trap. Field names are
       the trap variable names after MIB lookup. Field values are trap
       variable values.
 
 ### Example Output
-```
+
+```shell
 snmp_trap,mib=SNMPv2-MIB,name=coldStart,oid=.1.3.6.1.6.3.1.1.5.1,source=192.168.122.102,version=2c,community=public snmpTrapEnterprise.0="linux",sysUpTimeInstance=1i 1574109187723429814
 snmp_trap,mib=NET-SNMP-AGENT-MIB,name=nsNotifyShutdown,oid=.1.3.6.1.4.1.8072.4.0.2,source=192.168.122.102,version=2c,community=public sysUpTimeInstance=5803i,snmpTrapEnterprise.0="netSnmpNotificationPrefix" 1574109186555115459
 ```

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -105,6 +105,7 @@ func init() {
 			lookupFunc:     lookup,
 			ServiceAddress: "udp://:162",
 			Timeout:        defaultTimeout,
+			Path:           []string{"/usr/share/snmp/mibs"},
 			Version:        "2c",
 		}
 	})


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
`snmp_trap` was reworked to use `gosmi` for mib look up but the readme still stated `snmptranslate`. Removed the `snmptranslate` section from the readme.

Also fix default path to use the suggested path from the readme if none is specified.