### PR TITLE
makefile: fix indenting, use corret markdownlint binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ lint:
 		exit 1; \
 	}
 
-	markdownlint
+	markdownlint .
 
 .PHONY: lint-branch
 lint-branch:

--- a/Makefile
+++ b/Makefile
@@ -149,14 +149,14 @@ lint-install:
 .PHONY: lint
 lint:
 	@which golangci-lint >/dev/null 2>&1 || { \
-		{ echo "golangci-lint not found, please run: make lint-install"; \
+		echo "golangci-lint not found, please run: make lint-install"; \
 		exit 1; \
 	}
 
 	golangci-lint run
 
 	@which markdownlint >/dev/null 2>&1 || { \
-		{ echo "markdownlint not found, please run: make lint-install"; \
+		echo "markdownlint not found, please run: make lint-install"; \
 		exit 1; \
 	}
 

--- a/Makefile
+++ b/Makefile
@@ -148,26 +148,26 @@ lint-install:
 
 .PHONY: lint
 lint:
-	ifeq (, $(shell which golangci-lint))
-		$(info golangci-lint can't be found, please run: make lint-install)
-		exit 1
-	endif
+	@which golangci-lint >/dev/null 2>&1 || { \
+		{ echo "golangci-lint not found, please run: make lint-install"; \
+		exit 1; \
+	}
 
 	golangci-lint run
 
-	ifeq (, $(shell which markdownlint))
-		$(info markdownlint can't be found, please run: make lint-install)
-		exit 1
-	endif
+	@which markdownlint >/dev/null 2>&1 || { \
+		{ echo "markdownlint not found, please run: make lint-install"; \
+		exit 1; \
+	}
 
-	markdownlint-cli
+	markdownlint
 
 .PHONY: lint-branch
 lint-branch:
-	ifeq (, $(shell which golangci-lint))
-		$(info golangci-lint can't be found, please run: make lint-install)
-		exit 1
-	endif
+	@which golangci-lint >/dev/null 2>&1 || { \
+		echo "golangci-lint not found, please run: make lint-install"; \
+		exit 1; \
+	}
 
 	golangci-lint run --new-from-rev master
 


### PR DESCRIPTION
This correctly indents and fixes the various checks for binaries that are used in the Makefile. It also corrects the markdown link binary name when it is run.