### PR TITLE
feat(inputs.win_services): add exclude filter

### DIFF
--- a/plugins/inputs/win_services/README.md
+++ b/plugins/inputs/win_services/README.md
@@ -4,7 +4,7 @@ Reports information about Windows service status.
 
 Monitoring some services may require running Telegraf with administrator privileges.
 
-### Configuration:
+## Configuration
 
 ```toml
 [[inputs.win_services]]
@@ -14,16 +14,17 @@ Monitoring some services may require running Telegraf with administrator privile
     "TermService",
     "Win*",
   ]
-  ignored_names = ['WinRM'] # Names of service to exclude - usefull when using globs.
+  excluded_service_names = ['WinRM'] # optional, list of service names to exclude
 ```
 
-### Measurements & Fields:
+### Measurements & Fields
 
 - win_services
-    - state : integer
-    - startup_mode : integer
+  - state : integer
+  - startup_mode : integer
 
 The `state` field can have the following values:
+
 - 1 - stopped
 - 2 - start pending
 - 3 - stop pending
@@ -33,30 +34,33 @@ The `state` field can have the following values:
 - 7 - paused
 
 The `startup_mode` field can have the following values:
+
 - 0 - boot start
 - 1 - system start
 - 2 - auto start
 - 3 - demand start
 - 4 - disabled
 
-### Tags:
+### Tags
 
 - All measurements have the following tags:
-    - service_name
-    - display_name
+  - service_name
+  - display_name
 
-### Example Output:
-```
+### Example Output
+
+```shell
 win_services,host=WIN2008R2H401,display_name=Server,service_name=LanmanServer state=4i,startup_mode=2i 1500040669000000000
 win_services,display_name=Remote\ Desktop\ Services,service_name=TermService,host=WIN2008R2H401 state=1i,startup_mode=3i 1500040669000000000
 ```
+
 ### TICK Scripts
 
 A sample TICK script for a notification about a not running service.
 It sends a notification whenever any service changes its state to be not _running_ and when it changes that state back to _running_.
 The notification is sent via an HTTP POST call.
 
-```
+```shell
 stream
     |from()
         .database('telegraf')

--- a/plugins/inputs/win_services/README.md
+++ b/plugins/inputs/win_services/README.md
@@ -8,12 +8,13 @@ Monitoring some services may require running Telegraf with administrator privile
 
 ```toml
 [[inputs.win_services]]
-  ## Names of the services to monitor. Leave empty to monitor all the available services on the host. Globs accepted.
+  ## Names of the services to monitor. Leave empty to monitor all the available services on the host. Globs accepted. Case sensitive.
   service_names = [
     "LanmanServer",
     "TermService",
     "Win*",
   ]
+  ignored_names = ['WinRM'] # Names of service to exclude - usefull when using globs.
 ```
 
 ### Measurements & Fields:

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -86,7 +86,7 @@ var sampleConfig = `
 	"TermService",
 	"Win*",
   ]
-  #ignored_names = [] ## optional, list of service names to exclude
+  #excluded_service_names = [] ## optional, list of service names to exclude
 `
 
 var description = "Input plugin to report Windows services info."
@@ -96,7 +96,7 @@ type WinServices struct {
 	Log telegraf.Logger
 
 	ServiceNames []string `toml:"service_names"`
-	IgnoredNames []string `toml:"ignored_names"`
+	ServiceNamesExcluded []string `toml:"excluded_service_names"`
 	mgrProvider  ManagerProvider
 
 	servicesFilter filter.Filter
@@ -111,7 +111,7 @@ type ServiceInfo struct {
 
 func (m *WinServices) Init() error {
 	var err error
-	m.servicesFilter, err = filter.NewIncludeExcludeFilter(m.ServiceNames, m.IgnoredNames)
+	m.servicesFilter, err = filter.NewIncludeExcludeFilter(m.ServiceNames, m.ServiceNamesExcluded)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -86,7 +86,7 @@ var sampleConfig = `
 	"TermService",
 	"Win*",
   ]
-  #excluded_service_names = [] ## optional, list of service names to exclude
+  #excluded_service_names = [] # optional, list of service names to exclude
 `
 
 var description = "Input plugin to report Windows services info."

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -95,9 +95,9 @@ var description = "Input plugin to report Windows services info."
 type WinServices struct {
 	Log telegraf.Logger
 
-	ServiceNames []string `toml:"service_names"`
+	ServiceNames         []string `toml:"service_names"`
 	ServiceNamesExcluded []string `toml:"excluded_service_names"`
-	mgrProvider  ManagerProvider
+	mgrProvider          ManagerProvider
 
 	servicesFilter filter.Filter
 }

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -86,6 +86,7 @@ var sampleConfig = `
 	"TermService",
 	"Win*",
   ]
+  #ignored_names = [] ## optional, list of service names to exclude
 `
 
 var description = "Input plugin to report Windows services info."
@@ -95,6 +96,7 @@ type WinServices struct {
 	Log telegraf.Logger
 
 	ServiceNames []string `toml:"service_names"`
+	IgnoredNames []string `toml:"ignored_names"`
 	mgrProvider  ManagerProvider
 
 	servicesFilter filter.Filter
@@ -109,7 +111,7 @@ type ServiceInfo struct {
 
 func (m *WinServices) Init() error {
 	var err error
-	m.servicesFilter, err = filter.NewIncludeExcludeFilter(m.ServiceNames, nil)
+	m.servicesFilter, err = filter.NewIncludeExcludeFilter(m.ServiceNames, m.IgnoredNames)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -201,7 +201,6 @@ var testSimpleData = []testData{
 	{[]string{"Service 1", "Service 2"}, nil, nil, []serviceTestInfo{
 		{nil, nil, nil, "Service 1", "Fake service 1", 1, 2},
 		{nil, nil, nil, "Service 2", "Fake service 2", 1, 2},
-		//{nil, nil, nil, "NoService 3", "Fake service 3", 1, 2},
 	}},
 }
 
@@ -230,7 +229,6 @@ func TestGatherContainsTag(t *testing.T) {
 func TestExcludingNamesTag(t *testing.T) {
 	winServices := &WinServices{
 		Log:                  testutil.Logger{},
-		ServiceNames:         []string{"*"}, // '*' == default, all included
 		ServiceNamesExcluded: []string{"Service*"},
 		mgrProvider:          &FakeMgProvider{testSimpleData[0]},
 	}

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -237,7 +237,6 @@ func TestExcludingNamesTag(t *testing.T) {
 	winServices.Init()
 	var acc1 testutil.Accumulator
 	require.NoError(t, winServices.Gather(&acc1))
-	assert.Len(t, acc1.Errors, 0, "There should be no errors after gather")
 
 	for _, s := range testSimpleData[0].services {
 		fields := make(map[string]interface{})

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -229,10 +229,10 @@ func TestGatherContainsTag(t *testing.T) {
 
 func TestExcludingNamesTag(t *testing.T) {
 	winServices := &WinServices{
-		Log:          testutil.Logger{},
-		ServiceNames: []string{"*"}, // '*' == default, all included
+		Log:                  testutil.Logger{},
+		ServiceNames:         []string{"*"}, // '*' == default, all included
 		ServiceNamesExcluded: []string{"Service*"},
-		mgrProvider:  &FakeMgProvider{testSimpleData[0]},
+		mgrProvider:          &FakeMgProvider{testSimpleData[0]},
 	}
 	winServices.Init()
 	var acc1 testutil.Accumulator
@@ -246,6 +246,6 @@ func TestExcludingNamesTag(t *testing.T) {
 		fields["startup_mode"] = int(s.startUpMode)
 		tags["service_name"] = s.serviceName
 		tags["display_name"] = s.displayName
-		acc1.AssertDoesNotContainsTaggedFields(t, "win_services", fields, tags) 
+		acc1.AssertDoesNotContainsTaggedFields(t, "win_services", fields, tags)
 	}
 }

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -203,10 +203,6 @@ var testSimpleData = []testData{
 		{nil, nil, nil, "Service 2", "Fake service 2", 1, 2},
 		//{nil, nil, nil, "NoService 3", "Fake service 3", 1, 2},
 	}},
-	{[]string{"Service 1", "Service 2", "OtherSrvc"}, nil, nil, []serviceTestInfo{
-		{nil, nil, nil, "Service 1", "Fake service 21", 1, 2},
-		{nil, nil, nil, "Service 2", "Fake service 22", 1, 2},
-	}},
 }
 
 func TestGatherContainsTag(t *testing.T) {
@@ -234,7 +230,7 @@ func TestGatherContainsTag(t *testing.T) {
 func TestExcludingNamesTag(t *testing.T) {
 	winServices := &WinServices{
 		Log:          testutil.Logger{},
-		//ServiceNames: []string{"*"},
+		ServiceNames: []string{"*"}, // '*' == default, all included
 		ServiceNamesExcluded: []string{"Service*"},
 		mgrProvider:  &FakeMgProvider{testSimpleData[0]},
 	}
@@ -243,14 +239,13 @@ func TestExcludingNamesTag(t *testing.T) {
 	require.NoError(t, winServices.Gather(&acc1))
 	assert.Len(t, acc1.Errors, 0, "There should be no errors after gather")
 
-	for _, s := range testSimpleData[1].services {
+	for _, s := range testSimpleData[0].services {
 		fields := make(map[string]interface{})
 		tags := make(map[string]string)
 		fields["state"] = int(s.state)
 		fields["startup_mode"] = int(s.startUpMode)
 		tags["service_name"] = s.serviceName
 		tags["display_name"] = s.displayName
-		fmt.Print("service:", s.serviceName, " s.serviceName.\n")
 		acc1.AssertDoesNotContainsTaggedFields(t, "win_services", fields, tags) 
 	}
 }


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #8733

This pull request updates the input plugin `win_services` and adds a new configuration feature named `excluded_service_names` that will allow users to list what services to ignore. This plugin was already using the internal utility `NewIncludeExcludeFilter` which accepts an exclude list, so now it gets list from the user and passes it along.

Background info:

This duplicates and replaces the pull request: #8901, my intention is to just clean it up slightly to help get the feature merged. All the credit should go to @let-thomas thank you for working on this! I just had to run `gofmt`, match the sample config with the readme, and fix some minor markdown linter issues.