### PR TITLE
feat: Add SMART plugin concurrency configuration option, nvme-cli v1.14+ support and lint fixes.

### DIFF
--- a/plugins/inputs/smart/README.md
+++ b/plugins/inputs/smart/README.md
@@ -112,6 +112,14 @@ smartctl --scan -d nvme
   
     ## Timeout for the cli command to complete.
     # timeout = "30s"
+    
+    ## Optionally call smartctl and nvme-cli with a specific concurrency policy.
+    ## By default, smartctl and nvme-cli are called in separate threads (goroutines) to gather disk attributes.
+    ## Some devices (e.g. disks in RAID arrays) may have access limitations that require sequential reading of
+    ## SMART data - one individual array drive at the time. In such case please set this configuration option
+    ## to "sequential" to get readings for all drives.
+    ## valid options: concurrent, sequential
+    # read_method = "concurrent"
 ```
 
 ## Permissions
@@ -235,11 +243,25 @@ the DEVICE (name of the device could be taken from the previous command):
 smartctl --info --health --attributes --tolerance=verypermissive --nocheck NOCHECK --format=brief -d DEVICE
 ```
 
-If you try to gather vendor specific metrics, please provide this commad
+If you try to gather vendor specific metrics, please provide this command
 and replace vendor and device to match your case:
 
 ```sh
 nvme VENDOR smart-log-add DEVICE
+```
+
+If you have specified devices array in configuration file, and Telegraf only shows data from one device, you should
+change the plugin configuration to sequentially gather disk attributes instead of collecting it in separate threads
+(goroutines). To do this find in plugin configuration read_method and change it to sequential:
+
+```toml
+    ## Optionally call smartctl and nvme-cli with a specific concurrency policy.
+    ## By default, smartctl and nvme-cli are called in separate threads (goroutines) to gather disk attributes.
+    ## Some devices (e.g. disks in RAID arrays) may have access limitations that require sequential reading of
+    ## SMART data - one individual array drive at the time. In such case please set this configuration option
+    ## to "sequential" to get readings for all drives.
+    ## valid options: concurrent, sequential
+    read_method = "sequential"
 ```
 
 ## Example SMART Plugin Outputs

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -43,8 +43,8 @@ var (
 	// PASSED, FAILED, UNKNOWN
 	smartOverallHealth = regexp.MustCompile(`^(SMART overall-health self-assessment test result|SMART Health Status):\s+(\w+).*$`)
 
-	// sasNvmeAttr is a SAS or NVME SMART attribute
-	sasNvmeAttr = regexp.MustCompile(`^([^:]+):\s+(.+)$`)
+	// sasNVMeAttr is a SAS or NVMe SMART attribute
+	sasNVMeAttr = regexp.MustCompile(`^([^:]+):\s+(.+)$`)
 
 	// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
 	//   1 Raw_Read_Error_Rate     -O-RC-   200   200   000    -    0
@@ -53,13 +53,25 @@ var (
 	attribute = regexp.MustCompile(`^\s*([0-9]+)\s(\S+)\s+([-P][-O][-S][-R][-C][-K])\s+([0-9]+)\s+([0-9]+)\s+([0-9-]+)\s+([-\w]+)\s+([\w\+\.]+).*$`)
 
 	//  Additional Smart Log for NVME device:nvme0 namespace-id:ffffffff
+	// nvme version 1.14+ metrics:
+	// ID             KEY                                 Normalized     Raw
+	// 0xab    program_fail_count                             100         0
+
+	// nvme deprecated metric format:
 	//	key                               normalized raw
 	//	program_fail_count              : 100%       0
-	intelExpressionPattern = regexp.MustCompile(`^([\w\s]+):([\w\s]+)%(.+)`)
+
+	// REGEX patter supports deprecated metrics (nvme-cli version below 1.14) and metrics from nvme-cli 1.14 (and above).
+	intelExpressionPattern = regexp.MustCompile(`^([A-Za-z0-9_\s]+)[:|\s]+(\d+)[%|\s]+(.+)`)
 
 	//	vid     : 0x8086
 	//	sn      : CFGT53260XSP8011P
 	nvmeIDCtrlExpressionPattern = regexp.MustCompile(`^([\w\s]+):([\s\w]+)`)
+
+	// Format from nvme-cli 1.14 (and above) gives ID and KEY, this regex is for separating id from key.
+	//  ID			  KEY
+	// 0xab    program_fail_count
+	nvmeIDSeparatePattern = regexp.MustCompile(`^([A-Za-z0-9_]+)(.+)`)
 
 	deviceFieldIds = map[string]string{
 		"1":   "read_error_rate",
@@ -70,7 +82,7 @@ var (
 	}
 
 	// to obtain metrics from smartctl
-	sasNvmeAttributes = map[string]struct {
+	sasNVMeAttributes = map[string]struct {
 		ID    string
 		Name  string
 		Parse func(fields, deviceFields map[string]interface{}, str string) error
@@ -213,9 +225,48 @@ var (
 			Parse: parseTemperatureSensor,
 		},
 	}
-
-	// to obtain Intel specific metrics from nvme-cli
+	// To obtain Intel specific metrics from nvme-cli version 1.14 and above.
 	intelAttributes = map[string]struct {
+		ID    string
+		Name  string
+		Parse func(acc telegraf.Accumulator, fields map[string]interface{}, tags map[string]string, str string) error
+	}{
+		"program_fail_count": {
+			Name: "Program_Fail_Count",
+		},
+		"erase_fail_count": {
+			Name: "Erase_Fail_Count",
+		},
+		"wear_leveling_count": { // previously: "wear_leveling"
+			Name: "Wear_Leveling_Count",
+		},
+		"e2e_error_detect_count": { // previously: "end_to_end_error_detection_count"
+			Name: "End_To_End_Error_Detection_Count",
+		},
+		"crc_error_count": {
+			Name: "Crc_Error_Count",
+		},
+		"media_wear_percentage": { // previously: "timed_workload_media_wear"
+			Name: "Media_Wear_Percentage",
+		},
+		"host_reads": {
+			Name: "Host_Reads",
+		},
+		"timed_work_load": { // previously: "timed_workload_timer"
+			Name: "Timed_Workload_Timer",
+		},
+		"thermal_throttle_status": {
+			Name: "Thermal_Throttle_Status",
+		},
+		"retry_buff_overflow_count": { // previously: "retry_buffer_overflow_count"
+			Name: "Retry_Buffer_Overflow_Count",
+		},
+		"pll_lock_loss_counter": { // previously: "pll_lock_loss_count"
+			Name: "Pll_Lock_Loss_Count",
+		},
+	}
+	// to obtain Intel specific metrics from nvme-cli
+	intelAttributesDeprecatedFormat = map[string]struct {
 		ID    string
 		Name  string
 		Parse func(acc telegraf.Accumulator, fields map[string]interface{}, tags map[string]string, str string) error
@@ -269,6 +320,8 @@ var (
 			Parse: parseBytesWritten,
 		},
 	}
+
+	knownReadMethods = []string{"concurrent", "sequential"}
 )
 
 // Smart plugin reads metrics from storage devices supporting S.M.A.R.T.
@@ -283,6 +336,7 @@ type Smart struct {
 	Devices          []string        `toml:"devices"`
 	UseSudo          bool            `toml:"use_sudo"`
 	Timeout          config.Duration `toml:"timeout"`
+	ReadMethod       string          `toml:"read_method"`
 	Log              telegraf.Logger `toml:"-"`
 }
 
@@ -333,11 +387,20 @@ var sampleConfig = `
 
   ## Timeout for the cli command to complete.
   # timeout = "30s"
+
+  ## Optionally call smartctl and nvme-cli with a specific concurrency policy.
+  ## By default, smartctl and nvme-cli are called in separate threads (goroutines) to gather disk attributes.
+  ## Some devices (e.g. disks in RAID arrays) may have access limitations that require sequential reading of
+  ## SMART data - one individual array drive at the time. In such case please set this configuration option
+  ## to "sequential" to get readings for all drives.
+  ## valid options: concurrent, sequential
+  # read_method = "concurrent"
 `
 
 func newSmart() *Smart {
 	return &Smart{
-		Timeout: config.Duration(time.Second * 30),
+		Timeout:    config.Duration(time.Second * 30),
+		ReadMethod: "concurrent",
 	}
 }
 
@@ -366,6 +429,10 @@ func (m *Smart) Init() error {
 	//if `path_nvme` is not provided in config, try to find nvme binary in PATH
 	if len(m.PathNVMe) == 0 {
 		m.PathNVMe, _ = exec.LookPath("nvme")
+	}
+
+	if !contains(knownReadMethods, m.ReadMethod) {
+		return fmt.Errorf("provided read method `%s` is not valid", m.ReadMethod)
 	}
 
 	err := validatePath(m.PathSmartctl)
@@ -404,9 +471,9 @@ func (m *Smart) Gather(acc telegraf.Accumulator) error {
 			if err != nil {
 				return err
 			}
-			NVMeDevices := distinguishNVMeDevices(devicesFromConfig, scannedNVMeDevices)
+			nvmeDevices := distinguishNVMeDevices(devicesFromConfig, scannedNVMeDevices)
 
-			m.getVendorNVMeAttributes(acc, NVMeDevices)
+			m.getVendorNVMeAttributes(acc, nvmeDevices)
 		}
 		return nil
 	}
@@ -434,28 +501,28 @@ func (m *Smart) scanAllDevices(ignoreExcludes bool) ([]string, []string, error) 
 	}
 
 	// this will return only NVMe devices
-	NVMeDevices, err := m.scanDevices(ignoreExcludes, "--scan", "--device=nvme")
+	nvmeDevices, err := m.scanDevices(ignoreExcludes, "--scan", "--device=nvme")
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// to handle all versions of smartctl this will return only non NVMe devices
-	nonNVMeDevices := difference(devices, NVMeDevices)
-	return NVMeDevices, nonNVMeDevices, nil
+	nonNVMeDevices := difference(devices, nvmeDevices)
+	return nvmeDevices, nonNVMeDevices, nil
 }
 
 func distinguishNVMeDevices(userDevices []string, availableNVMeDevices []string) []string {
-	var NVMeDevices []string
+	var nvmeDevices []string
 
 	for _, userDevice := range userDevices {
-		for _, NVMeDevice := range availableNVMeDevices {
+		for _, availableNVMeDevice := range availableNVMeDevices {
 			// double check. E.g. in case when nvme0 is equal nvme0n1, will check if "nvme0" part is present.
-			if strings.Contains(NVMeDevice, userDevice) || strings.Contains(userDevice, NVMeDevice) {
-				NVMeDevices = append(NVMeDevices, userDevice)
+			if strings.Contains(availableNVMeDevice, userDevice) || strings.Contains(userDevice, availableNVMeDevice) {
+				nvmeDevices = append(nvmeDevices, userDevice)
 			}
 		}
 	}
-	return NVMeDevices
+	return nvmeDevices
 }
 
 // Scan for S.M.A.R.T. devices from smartctl
@@ -506,69 +573,86 @@ func excludedDev(excludes []string, deviceLine string) bool {
 func (m *Smart) getAttributes(acc telegraf.Accumulator, devices []string) {
 	var wg sync.WaitGroup
 	wg.Add(len(devices))
-
 	for _, device := range devices {
-		go gatherDisk(acc, m.Timeout, m.UseSudo, m.Attributes, m.PathSmartctl, m.Nocheck, device, &wg)
+		switch m.ReadMethod {
+		case "concurrent":
+			go m.gatherDisk(acc, device, &wg)
+		case "sequential":
+			m.gatherDisk(acc, device, &wg)
+		default:
+			wg.Done()
+		}
 	}
 
 	wg.Wait()
 }
 
 func (m *Smart) getVendorNVMeAttributes(acc telegraf.Accumulator, devices []string) {
-	NVMeDevices := getDeviceInfoForNVMeDisks(acc, devices, m.PathNVMe, m.Timeout, m.UseSudo)
+	nvmeDevices := getDeviceInfoForNVMeDisks(acc, devices, m.PathNVMe, m.Timeout, m.UseSudo)
 
 	var wg sync.WaitGroup
 
-	for _, device := range NVMeDevices {
+	for _, device := range nvmeDevices {
 		if contains(m.EnableExtensions, "auto-on") {
+			// nolint:revive // one case switch on purpose to demonstrate potential extensions
 			switch device.vendorID {
 			case intelVID:
 				wg.Add(1)
-				go gatherIntelNVMeDisk(acc, m.Timeout, m.UseSudo, m.PathNVMe, device, &wg)
+				switch m.ReadMethod {
+				case "concurrent":
+					go gatherIntelNVMeDisk(acc, m.Timeout, m.UseSudo, m.PathNVMe, device, &wg)
+				case "sequential":
+					gatherIntelNVMeDisk(acc, m.Timeout, m.UseSudo, m.PathNVMe, device, &wg)
+				default:
+					wg.Done()
+				}
 			}
 		} else if contains(m.EnableExtensions, "Intel") && device.vendorID == intelVID {
 			wg.Add(1)
-			go gatherIntelNVMeDisk(acc, m.Timeout, m.UseSudo, m.PathNVMe, device, &wg)
+			switch m.ReadMethod {
+			case "concurrent":
+				go gatherIntelNVMeDisk(acc, m.Timeout, m.UseSudo, m.PathNVMe, device, &wg)
+			case "sequential":
+				gatherIntelNVMeDisk(acc, m.Timeout, m.UseSudo, m.PathNVMe, device, &wg)
+			default:
+				wg.Done()
+			}
 		}
 	}
 	wg.Wait()
 }
 
 func getDeviceInfoForNVMeDisks(acc telegraf.Accumulator, devices []string, nvme string, timeout config.Duration, useSudo bool) []nvmeDevice {
-	var NVMeDevices []nvmeDevice
+	var nvmeDevices []nvmeDevice
 
 	for _, device := range devices {
-		vid, sn, mn, err := gatherNVMeDeviceInfo(nvme, device, timeout, useSudo)
+		newDevice, err := gatherNVMeDeviceInfo(nvme, device, timeout, useSudo)
 		if err != nil {
 			acc.AddError(fmt.Errorf("cannot find device info for %s device", device))
 			continue
 		}
-		newDevice := nvmeDevice{
-			name:         device,
-			vendorID:     vid,
-			model:        mn,
-			serialNumber: sn,
-		}
-		NVMeDevices = append(NVMeDevices, newDevice)
+		nvmeDevices = append(nvmeDevices, newDevice)
 	}
-	return NVMeDevices
+	return nvmeDevices
 }
 
-func gatherNVMeDeviceInfo(nvme, device string, timeout config.Duration, useSudo bool) (string, string, string, error) {
+func gatherNVMeDeviceInfo(nvme, deviceName string, timeout config.Duration, useSudo bool) (device nvmeDevice, err error) {
 	args := []string{"id-ctrl"}
-	args = append(args, strings.Split(device, " ")...)
+	args = append(args, strings.Split(deviceName, " ")...)
 	out, err := runCmd(timeout, useSudo, nvme, args...)
 	if err != nil {
-		return "", "", "", err
+		return device, err
 	}
 	outStr := string(out)
-
-	vid, sn, mn, err := findNVMeDeviceInfo(outStr)
-
-	return vid, sn, mn, err
+	device, err = findNVMeDeviceInfo(outStr)
+	if err != nil {
+		return device, err
+	}
+	device.name = deviceName
+	return device, nil
 }
 
-func findNVMeDeviceInfo(output string) (string, string, string, error) {
+func findNVMeDeviceInfo(output string) (nvmeDevice, error) {
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	var vid, sn, mn string
 
@@ -580,7 +664,7 @@ func findNVMeDeviceInfo(output string) (string, string, string, error) {
 			matches[2] = strings.TrimSpace(matches[2])
 			if matches[1] == "vid" {
 				if _, err := fmt.Sscanf(matches[2], "%s", &vid); err != nil {
-					return "", "", "", err
+					return nvmeDevice{}, err
 				}
 			}
 			if matches[1] == "sn" {
@@ -591,7 +675,13 @@ func findNVMeDeviceInfo(output string) (string, string, string, error) {
 			}
 		}
 	}
-	return vid, sn, mn, nil
+
+	newDevice := nvmeDevice{
+		vendorID:     vid,
+		model:        mn,
+		serialNumber: sn,
+	}
+	return newDevice, nil
 }
 
 func gatherIntelNVMeDisk(acc telegraf.Accumulator, timeout config.Duration, usesudo bool, nvme string, device nvmeDevice, wg *sync.WaitGroup) {
@@ -619,10 +709,31 @@ func gatherIntelNVMeDisk(acc telegraf.Accumulator, timeout config.Duration, uses
 		tags["model"] = device.model
 		tags["serial_no"] = device.serialNumber
 
-		if matches := intelExpressionPattern.FindStringSubmatch(line); len(matches) > 3 {
-			matches[1] = strings.TrimSpace(matches[1])
+		// Create struct to initialize later with intel attributes.
+		var (
+			attr = struct {
+				ID    string
+				Name  string
+				Parse func(acc telegraf.Accumulator, fields map[string]interface{}, tags map[string]string, str string) error
+			}{}
+			attrExists bool
+		)
+
+		if matches := intelExpressionPattern.FindStringSubmatch(line); len(matches) > 3 && len(matches[1]) > 1 {
+			// Check if nvme shows metrics in deprecated format or in format with ID.
+			// Based on that, an attribute map with metrics is chosen.
+			// If string has more than one character it means it has KEY there, otherwise it's empty string ("").
+			if separatedIDAndKey := nvmeIDSeparatePattern.FindStringSubmatch(matches[1]); len(strings.TrimSpace(separatedIDAndKey[2])) > 1 {
+				matches[1] = strings.TrimSpace(separatedIDAndKey[2])
+				attr, attrExists = intelAttributes[matches[1]]
+			} else {
+				matches[1] = strings.TrimSpace(matches[1])
+				attr, attrExists = intelAttributesDeprecatedFormat[matches[1]]
+			}
+
 			matches[3] = strings.TrimSpace(matches[3])
-			if attr, ok := intelAttributes[matches[1]]; ok {
+
+			if attrExists {
 				tags["name"] = attr.Name
 				if attr.ID != "" {
 					tags["id"] = attr.ID
@@ -641,18 +752,18 @@ func gatherIntelNVMeDisk(acc telegraf.Accumulator, timeout config.Duration, uses
 	}
 }
 
-func gatherDisk(acc telegraf.Accumulator, timeout config.Duration, usesudo, collectAttributes bool, smartctl, nocheck, device string, wg *sync.WaitGroup) {
+func (m *Smart) gatherDisk(acc telegraf.Accumulator, device string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	// smartctl 5.41 & 5.42 have are broken regarding handling of --nocheck/-n
-	args := []string{"--info", "--health", "--attributes", "--tolerance=verypermissive", "-n", nocheck, "--format=brief"}
+	args := []string{"--info", "--health", "--attributes", "--tolerance=verypermissive", "-n", m.Nocheck, "--format=brief"}
 	args = append(args, strings.Split(device, " ")...)
-	out, e := runCmd(timeout, usesudo, smartctl, args...)
+	out, e := runCmd(m.Timeout, m.UseSudo, m.PathSmartctl, args...)
 	outStr := string(out)
 
 	// Ignore all exit statuses except if it is a command line parse error
 	exitStatus, er := exitStatus(e)
 	if er != nil {
-		acc.AddError(fmt.Errorf("failed to run command '%s %s': %s - %s", smartctl, strings.Join(args, " "), e, outStr))
+		acc.AddError(fmt.Errorf("failed to run command '%s %s': %s - %s", m.PathSmartctl, strings.Join(args, " "), e, outStr))
 		return
 	}
 
@@ -712,7 +823,7 @@ func gatherDisk(acc telegraf.Accumulator, timeout config.Duration, usesudo, coll
 		tags := map[string]string{}
 		fields := make(map[string]interface{})
 
-		if collectAttributes {
+		if m.Attributes {
 			//add power mode
 			keys := [...]string{"device", "model", "serial_no", "wwn", "capacity", "enabled", "power"}
 			for _, key := range keys {
@@ -724,8 +835,8 @@ func gatherDisk(acc telegraf.Accumulator, timeout config.Duration, usesudo, coll
 
 		attr := attribute.FindStringSubmatch(line)
 		if len(attr) > 1 {
-			// attribute has been found, add it only if collectAttributes is true
-			if collectAttributes {
+			// attribute has been found, add it only if m.Attributes is true
+			if m.Attributes {
 				tags["id"] = attr[1]
 				tags["name"] = attr[2]
 				tags["flags"] = attr[3]
@@ -758,8 +869,8 @@ func gatherDisk(acc telegraf.Accumulator, timeout config.Duration, usesudo, coll
 			}
 		} else {
 			// what was found is not a vendor attribute
-			if matches := sasNvmeAttr.FindStringSubmatch(line); len(matches) > 2 {
-				if attr, ok := sasNvmeAttributes[matches[1]]; ok {
+			if matches := sasNVMeAttr.FindStringSubmatch(line); len(matches) > 2 {
+				if attr, ok := sasNVMeAttributes[matches[1]]; ok {
 					tags["name"] = attr.Name
 					if attr.ID != "" {
 						tags["id"] = attr.ID
@@ -774,8 +885,8 @@ func gatherDisk(acc telegraf.Accumulator, timeout config.Duration, usesudo, coll
 						continue
 					}
 					// if the field is classified as an attribute, only add it
-					// if collectAttributes is true
-					if collectAttributes {
+					// if m.Attributes is true
+					if m.Attributes {
 						acc.AddFields("smart_attribute", fields, tags)
 					}
 				}
@@ -972,13 +1083,13 @@ func parseTemperatureSensor(fields, _ map[string]interface{}, str string) error 
 	return nil
 }
 
-func validatePath(path string) error {
-	pathInfo, err := os.Stat(path)
+func validatePath(filePath string) error {
+	pathInfo, err := os.Stat(filePath)
 	if os.IsNotExist(err) {
-		return fmt.Errorf("provided path does not exist: [%s]", path)
+		return fmt.Errorf("provided path does not exist: [%s]", filePath)
 	}
 	if mode := pathInfo.Mode(); !mode.IsRegular() {
-		return fmt.Errorf("provided path does not point to a regular file: [%s]", path)
+		return fmt.Errorf("provided path does not point to a regular file: [%s]", filePath)
 	}
 	return nil
 }


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Resolves #10149.
Resolves #8684.
Resolves #9417.


This PR fixes a two issues and provides some code clean-up:

* Updated SMART plugin input parsing to support nvme-cli v1.14+ version (output format has changed). Compatibility with older versions is preserved.
* Added concurrency configuration option to plugin config: read_method -  optionally call smartctl and nvme-cli sequentially to gather disks attributes. The reason for this change can be found here: https://github.com/influxdata/telegraf/issues/8684#issuecomment-772392280
* Linter issues fixed.
