### PR TITLE
fix: Linter fixes for plugins/serializers/[a-z]*

### DIFF
--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -65,7 +65,7 @@ func (s *Serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	var batch bytes.Buffer
 	for _, metric := range metrics {
-		batch.Write(s.createObject(metric))
+		batch.Write(s.createObject(metric)) //nolint:revive // from buffer.go: "err is always nil"
 	}
 	return batch.Bytes(), nil
 }
@@ -83,31 +83,27 @@ func (s *Serializer) createObject(metric telegraf.Metric) []byte {
 
 		switch metricsFormat {
 		case Carbon2FormatFieldSeparate:
-			m.WriteString(serializeMetricFieldSeparate(
-				name, fieldName,
-			))
+			m.WriteString(serializeMetricFieldSeparate(name, fieldName)) //nolint:revive // from buffer.go: "err is always nil"
 
 		case Carbon2FormatMetricIncludesField:
-			m.WriteString(serializeMetricIncludeField(
-				name, fieldName,
-			))
+			m.WriteString(serializeMetricIncludeField(name, fieldName)) //nolint:revive // from buffer.go: "err is always nil"
 		}
 
 		for _, tag := range metric.TagList() {
-			m.WriteString(strings.Replace(tag.Key, " ", "_", -1))
-			m.WriteString("=")
+			m.WriteString(strings.Replace(tag.Key, " ", "_", -1)) //nolint:revive // from buffer.go: "err is always nil"
+			m.WriteString("=")                                    //nolint:revive // from buffer.go: "err is always nil"
 			value := tag.Value
 			if len(value) == 0 {
 				value = "null"
 			}
-			m.WriteString(strings.Replace(value, " ", "_", -1))
-			m.WriteString(" ")
+			m.WriteString(strings.Replace(value, " ", "_", -1)) //nolint:revive // from buffer.go: "err is always nil"
+			m.WriteString(" ")                                  //nolint:revive // from buffer.go: "err is always nil"
 		}
-		m.WriteString(" ")
-		m.WriteString(formatValue(fieldValue))
-		m.WriteString(" ")
-		m.WriteString(strconv.FormatInt(metric.Time().Unix(), 10))
-		m.WriteString("\n")
+		m.WriteString(" ")                                         //nolint:revive // from buffer.go: "err is always nil"
+		m.WriteString(formatValue(fieldValue))                     //nolint:revive // from buffer.go: "err is always nil"
+		m.WriteString(" ")                                         //nolint:revive // from buffer.go: "err is always nil"
+		m.WriteString(strconv.FormatInt(metric.Time().Unix(), 10)) //nolint:revive // from buffer.go: "err is always nil"
+		m.WriteString("\n")                                        //nolint:revive // from buffer.go: "err is always nil"
 	}
 	return m.Bytes()
 }

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
@@ -44,7 +43,7 @@ func TestSerializeMetricFloat(t *testing.T) {
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, string(buf))
+			require.Equal(t, tc.expected, string(buf))
 		})
 	}
 }
@@ -81,7 +80,7 @@ func TestSerializeMetricWithEmptyStringTag(t *testing.T) {
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, string(buf))
+			require.Equal(t, tc.expected, string(buf))
 		})
 	}
 }
@@ -118,7 +117,7 @@ func TestSerializeWithSpaces(t *testing.T) {
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, string(buf))
+			require.Equal(t, tc.expected, string(buf))
 		})
 	}
 }
@@ -155,7 +154,7 @@ func TestSerializeMetricInt(t *testing.T) {
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, string(buf))
+			require.Equal(t, tc.expected, string(buf))
 		})
 	}
 }
@@ -192,7 +191,7 @@ func TestSerializeMetricString(t *testing.T) {
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, string(buf))
+			require.Equal(t, tc.expected, string(buf))
 		})
 	}
 }
@@ -248,7 +247,7 @@ func TestSerializeMetricBool(t *testing.T) {
 			buf, err := s.Serialize(tc.metric)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, string(buf))
+			require.Equal(t, tc.expected, string(buf))
 		})
 	}
 }
@@ -291,7 +290,7 @@ metric=cpu_value  42 0
 			buf, err := s.SerializeBatch(metrics)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, string(buf))
+			require.Equal(t, tc.expected, string(buf))
 		})
 	}
 }
@@ -400,7 +399,7 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, string(buf))
+			require.Equal(t, tc.expected, string(buf))
 		})
 	}
 }

--- a/plugins/serializers/graphite/graphite_test.go
+++ b/plugins/serializers/graphite/graphite_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
@@ -55,9 +54,9 @@ func TestGraphiteTags(t *testing.T) {
 	tags2 := buildTags(m2.Tags())
 	tags3 := buildTags(m3.Tags())
 
-	assert.Equal(t, "192_168_0_1", tags1)
-	assert.Equal(t, "first.second.192_168_0_1", tags2)
-	assert.Equal(t, "first.second", tags3)
+	require.Equal(t, "192_168_0_1", tags1)
+	require.Equal(t, "first.second.192_168_0_1", tags2)
+	require.Equal(t, "first.second", tags3)
 }
 
 func TestSerializeMetricNoHost(t *testing.T) {
@@ -82,7 +81,7 @@ func TestSerializeMetricNoHost(t *testing.T) {
 	}
 	sort.Strings(mS)
 	sort.Strings(expS)
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricNoHostWithTagSupport(t *testing.T) {
@@ -110,7 +109,7 @@ func TestSerializeMetricNoHostWithTagSupport(t *testing.T) {
 	}
 	sort.Strings(mS)
 	sort.Strings(expS)
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricHost(t *testing.T) {
@@ -136,7 +135,7 @@ func TestSerializeMetricHost(t *testing.T) {
 	}
 	sort.Strings(mS)
 	sort.Strings(expS)
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricHostWithMultipleTemplates(t *testing.T) {
@@ -157,8 +156,8 @@ func TestSerializeMetricHostWithMultipleTemplates(t *testing.T) {
 		"cp* tags.measurement.host.field",
 		"new_cpu tags.host.measurement.field",
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, defaultTemplate, "")
+	require.NoError(t, err)
+	require.Equal(t, defaultTemplate, "")
 
 	s := GraphiteSerializer{
 		Templates: templates,
@@ -170,7 +169,7 @@ func TestSerializeMetricHostWithMultipleTemplates(t *testing.T) {
 	buf = append(buf, buf2...)
 
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := []string{
 		fmt.Sprintf("cpu0.us-west-2.cpu.localhost.usage_idle 91.5 %d", now.Unix()),
@@ -180,7 +179,7 @@ func TestSerializeMetricHostWithMultipleTemplates(t *testing.T) {
 	}
 	sort.Strings(mS)
 	sort.Strings(expS)
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricHostWithMultipleTemplatesWithDefault(t *testing.T) {
@@ -201,8 +200,8 @@ func TestSerializeMetricHostWithMultipleTemplatesWithDefault(t *testing.T) {
 		"cp* tags.measurement.host.field",
 		"tags.host.measurement.field",
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, defaultTemplate, "tags.host.measurement.field")
+	require.NoError(t, err)
+	require.Equal(t, defaultTemplate, "tags.host.measurement.field")
 
 	s := GraphiteSerializer{
 		Templates: templates,
@@ -215,7 +214,7 @@ func TestSerializeMetricHostWithMultipleTemplatesWithDefault(t *testing.T) {
 	buf = append(buf, buf2...)
 
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := []string{
 		fmt.Sprintf("cpu0.us-west-2.cpu.localhost.usage_idle 91.5 %d", now.Unix()),
@@ -225,7 +224,7 @@ func TestSerializeMetricHostWithMultipleTemplatesWithDefault(t *testing.T) {
 	}
 	sort.Strings(mS)
 	sort.Strings(expS)
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricHostWithTagSupport(t *testing.T) {
@@ -254,7 +253,7 @@ func TestSerializeMetricHostWithTagSupport(t *testing.T) {
 	}
 	sort.Strings(mS)
 	sort.Strings(expS)
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 // test that a field named "value" gets ignored.
@@ -277,7 +276,7 @@ func TestSerializeValueField(t *testing.T) {
 	expS := []string{
 		fmt.Sprintf("localhost.cpu0.us-west-2.cpu 91.5 %d", now.Unix()),
 	}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeValueFieldWithTagSupport(t *testing.T) {
@@ -302,7 +301,7 @@ func TestSerializeValueFieldWithTagSupport(t *testing.T) {
 	expS := []string{
 		fmt.Sprintf("cpu;cpu=cpu0;datacenter=us-west-2;host=localhost 91.5 %d", now.Unix()),
 	}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 // test that a field named "value" gets ignored in middle of template.
@@ -327,7 +326,7 @@ func TestSerializeValueField2(t *testing.T) {
 	expS := []string{
 		fmt.Sprintf("localhost.cpu0.us-west-2.cpu 91.5 %d", now.Unix()),
 	}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeValueString(t *testing.T) {
@@ -347,7 +346,7 @@ func TestSerializeValueString(t *testing.T) {
 	}
 	buf, _ := s.Serialize(m)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
-	assert.Equal(t, "", mS[0])
+	require.Equal(t, "", mS[0])
 }
 
 func TestSerializeValueStringWithTagSupport(t *testing.T) {
@@ -368,7 +367,7 @@ func TestSerializeValueStringWithTagSupport(t *testing.T) {
 	}
 	buf, _ := s.Serialize(m)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
-	assert.Equal(t, "", mS[0])
+	require.Equal(t, "", mS[0])
 }
 
 func TestSerializeValueBoolean(t *testing.T) {
@@ -396,7 +395,7 @@ func TestSerializeValueBoolean(t *testing.T) {
 	}
 	sort.Strings(mS)
 	sort.Strings(expS)
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeValueBooleanWithTagSupport(t *testing.T) {
@@ -425,7 +424,7 @@ func TestSerializeValueBooleanWithTagSupport(t *testing.T) {
 	}
 	sort.Strings(mS)
 	sort.Strings(expS)
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeValueUnsigned(t *testing.T) {
@@ -465,7 +464,7 @@ func TestSerializeFieldWithSpaces(t *testing.T) {
 	expS := []string{
 		fmt.Sprintf("localhost.cpu0.us-west-2.cpu.field_with_spaces 91.5 %d", now.Unix()),
 	}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeFieldWithSpacesWithTagSupport(t *testing.T) {
@@ -490,7 +489,7 @@ func TestSerializeFieldWithSpacesWithTagSupport(t *testing.T) {
 	expS := []string{
 		fmt.Sprintf("cpu.field_with_spaces;cpu=cpu0;datacenter=us-west-2;host=localhost 91.5 %d", now.Unix()),
 	}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 // test that tags with spaces get fixed.
@@ -515,7 +514,7 @@ func TestSerializeTagWithSpaces(t *testing.T) {
 	expS := []string{
 		fmt.Sprintf("localhost.cpu_0.us-west-2.cpu.field_with_spaces 91.5 %d", now.Unix()),
 	}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeTagWithSpacesWithTagSupport(t *testing.T) {
@@ -540,7 +539,7 @@ func TestSerializeTagWithSpacesWithTagSupport(t *testing.T) {
 	expS := []string{
 		fmt.Sprintf("cpu.field_with_spaces;cpu=cpu_0;datacenter=us-west-2;host=localhost 91.5 %d", now.Unix()),
 	}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeTagWithSpacesWithTagSupportCompatibleSanitize(t *testing.T) {
@@ -566,7 +565,7 @@ func TestSerializeTagWithSpacesWithTagSupportCompatibleSanitize(t *testing.T) {
 	expS := []string{
 		fmt.Sprintf("cpu.field_with_spaces;cpu=cpu\\ 0;datacenter=us-west-2;host=localhost 91.5 %d", now.Unix()),
 	}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 // test that a field named "value" gets ignored at beginning of template.
@@ -591,7 +590,7 @@ func TestSerializeValueField3(t *testing.T) {
 	expS := []string{
 		fmt.Sprintf("localhost.cpu0.us-west-2.cpu 91.5 %d", now.Unix()),
 	}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 // test that a field named "value" gets ignored at beginning of template.
@@ -616,7 +615,7 @@ func TestSerializeValueField5(t *testing.T) {
 	expS := []string{
 		fmt.Sprintf("localhost.us-west-2.cpu0.cpu 91.5 %d", now.Unix()),
 	}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricPrefix(t *testing.T) {
@@ -642,7 +641,7 @@ func TestSerializeMetricPrefix(t *testing.T) {
 	}
 	sort.Strings(mS)
 	sort.Strings(expS)
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricPrefixWithTagSupport(t *testing.T) {
@@ -672,7 +671,7 @@ func TestSerializeMetricPrefixWithTagSupport(t *testing.T) {
 	}
 	sort.Strings(mS)
 	sort.Strings(expS)
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeBucketNameNoHost(t *testing.T) {
@@ -689,7 +688,7 @@ func TestSerializeBucketNameNoHost(t *testing.T) {
 	mS := SerializeBucketName(m.Name(), m.Tags(), "", "")
 
 	expS := "cpu0.us-west-2.cpu.FIELDNAME"
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeBucketNameHost(t *testing.T) {
@@ -702,7 +701,7 @@ func TestSerializeBucketNameHost(t *testing.T) {
 	mS := SerializeBucketName(m.Name(), m.Tags(), "", "")
 
 	expS := "localhost.cpu0.us-west-2.cpu.FIELDNAME"
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeBucketNamePrefix(t *testing.T) {
@@ -715,7 +714,7 @@ func TestSerializeBucketNamePrefix(t *testing.T) {
 	mS := SerializeBucketName(m.Name(), m.Tags(), "", "prefix")
 
 	expS := "prefix.localhost.cpu0.us-west-2.cpu.FIELDNAME"
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestTemplate1(t *testing.T) {
@@ -728,7 +727,7 @@ func TestTemplate1(t *testing.T) {
 	mS := SerializeBucketName(m.Name(), m.Tags(), template1, "")
 
 	expS := "cpu0.us-west-2.localhost.cpu.FIELDNAME"
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestTemplate2(t *testing.T) {
@@ -741,7 +740,7 @@ func TestTemplate2(t *testing.T) {
 	mS := SerializeBucketName(m.Name(), m.Tags(), template2, "")
 
 	expS := "localhost.cpu.FIELDNAME"
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestTemplate3(t *testing.T) {
@@ -754,7 +753,7 @@ func TestTemplate3(t *testing.T) {
 	mS := SerializeBucketName(m.Name(), m.Tags(), template3, "")
 
 	expS := "localhost.cpu0.us-west-2.FIELDNAME"
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestTemplate4(t *testing.T) {
@@ -767,7 +766,7 @@ func TestTemplate4(t *testing.T) {
 	mS := SerializeBucketName(m.Name(), m.Tags(), template4, "")
 
 	expS := "localhost.cpu0.us-west-2.cpu"
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestTemplate6(t *testing.T) {
@@ -780,7 +779,7 @@ func TestTemplate6(t *testing.T) {
 	mS := SerializeBucketName(m.Name(), m.Tags(), template6, "")
 
 	expS := "localhost.cpu0.us-west-2.cpu.FIELDNAME"
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestClean(t *testing.T) {

--- a/plugins/serializers/influx/influx.go
+++ b/plugins/serializers/influx/influx.go
@@ -80,8 +80,8 @@ func NewSerializer() *Serializer {
 	return serializer
 }
 
-func (s *Serializer) SetMaxLineBytes(bytes int) {
-	s.maxLineBytes = bytes
+func (s *Serializer) SetMaxLineBytes(maxLineBytes int) {
+	s.maxLineBytes = maxLineBytes
 }
 
 func (s *Serializer) SetFieldSortOrder(order FieldSortOrder) {
@@ -135,7 +135,7 @@ func (s *Serializer) writeString(w io.Writer, str string) error {
 	return err
 }
 
-func (s *Serializer) write(w io.Writer, b []byte) error {
+func (s *Serializer) writeBytes(w io.Writer, b []byte) error {
 	n, err := w.Write(b)
 	s.bytesWritten += n
 	return err
@@ -247,7 +247,7 @@ func (s *Serializer) writeMetric(w io.Writer, m telegraf.Metric) error {
 				return s.newMetricError(NeedMoreSpace)
 			}
 
-			err = s.write(w, s.footer)
+			err = s.writeBytes(w, s.footer)
 			if err != nil {
 				return err
 			}
@@ -262,7 +262,7 @@ func (s *Serializer) writeMetric(w io.Writer, m telegraf.Metric) error {
 		}
 
 		if firstField {
-			err = s.write(w, s.header)
+			err = s.writeBytes(w, s.header)
 			if err != nil {
 				return err
 			}
@@ -273,7 +273,7 @@ func (s *Serializer) writeMetric(w io.Writer, m telegraf.Metric) error {
 			}
 		}
 
-		err = s.write(w, s.pair)
+		err = s.writeBytes(w, s.pair)
 		if err != nil {
 			return err
 		}
@@ -286,7 +286,7 @@ func (s *Serializer) writeMetric(w io.Writer, m telegraf.Metric) error {
 		return s.newMetricError(NoFields)
 	}
 
-	return s.write(w, s.footer)
+	return s.writeBytes(w, s.footer)
 }
 
 func (s *Serializer) newMetricError(reason string) *MetricError {

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -61,8 +61,7 @@ func (s *Serializer) createObject(metric telegraf.Metric) map[string]interface{}
 
 	fields := make(map[string]interface{}, len(metric.FieldList()))
 	for _, field := range metric.FieldList() {
-		switch fv := field.Value.(type) {
-		case float64:
+		if fv, ok := field.Value.(float64); ok {
 			// JSON does not support these special values
 			if math.IsNaN(fv) || math.IsInf(fv, 0) {
 				continue

--- a/plugins/serializers/json/json_test.go
+++ b/plugins/serializers/json/json_test.go
@@ -6,19 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func MustMetric(v telegraf.Metric, err error) telegraf.Metric {
-	if err != nil {
-		panic(err)
-	}
-	return v
-}
 
 func TestSerializeMetricFloat(t *testing.T) {
 	now := time.Now()
@@ -33,9 +26,9 @@ func TestSerializeMetricFloat(t *testing.T) {
 	s, _ := NewSerializer(0, "")
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expS := []byte(fmt.Sprintf(`{"fields":{"usage_idle":91.5},"name":"cpu","tags":{"cpu":"cpu0"},"timestamp":%d}`, now.Unix()) + "\n")
-	assert.Equal(t, string(expS), string(buf))
+	require.Equal(t, string(expS), string(buf))
 }
 
 func TestSerialize_TimestampUnits(t *testing.T) {
@@ -112,10 +105,10 @@ func TestSerializeMetricInt(t *testing.T) {
 	s, _ := NewSerializer(0, "")
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := []byte(fmt.Sprintf(`{"fields":{"usage_idle":90},"name":"cpu","tags":{"cpu":"cpu0"},"timestamp":%d}`, now.Unix()) + "\n")
-	assert.Equal(t, string(expS), string(buf))
+	require.Equal(t, string(expS), string(buf))
 }
 
 func TestSerializeMetricString(t *testing.T) {
@@ -131,10 +124,10 @@ func TestSerializeMetricString(t *testing.T) {
 	s, _ := NewSerializer(0, "")
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := []byte(fmt.Sprintf(`{"fields":{"usage_idle":"foobar"},"name":"cpu","tags":{"cpu":"cpu0"},"timestamp":%d}`, now.Unix()) + "\n")
-	assert.Equal(t, string(expS), string(buf))
+	require.Equal(t, string(expS), string(buf))
 }
 
 func TestSerializeMultiFields(t *testing.T) {
@@ -151,10 +144,10 @@ func TestSerializeMultiFields(t *testing.T) {
 	s, _ := NewSerializer(0, "")
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := []byte(fmt.Sprintf(`{"fields":{"usage_idle":90,"usage_total":8559615},"name":"cpu","tags":{"cpu":"cpu0"},"timestamp":%d}`, now.Unix()) + "\n")
-	assert.Equal(t, string(expS), string(buf))
+	require.Equal(t, string(expS), string(buf))
 }
 
 func TestSerializeMetricWithEscapes(t *testing.T) {
@@ -169,10 +162,10 @@ func TestSerializeMetricWithEscapes(t *testing.T) {
 
 	s, _ := NewSerializer(0, "")
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := []byte(fmt.Sprintf(`{"fields":{"U,age=Idle":90},"name":"My CPU","tags":{"cpu tag":"cpu0"},"timestamp":%d}`, now.Unix()) + "\n")
-	assert.Equal(t, string(expS), string(buf))
+	require.Equal(t, string(expS), string(buf))
 }
 
 func TestSerializeBatch(t *testing.T) {

--- a/plugins/serializers/msgpack/metric.go
+++ b/plugins/serializers/msgpack/metric.go
@@ -42,9 +42,9 @@ func (*MessagePackTime) ExtensionType() int8 {
 // 32bits: [1970-01-01 00:00:00 UTC, 2106-02-07 06:28:16 UTC) range. If the nanoseconds part is 0
 // 64bits: [1970-01-01 00:00:00.000000000 UTC, 2514-05-30 01:53:04.000000000 UTC) range.
 // 96bits: [-584554047284-02-23 16:59:44 UTC, 584554051223-11-09 07:00:16.000000000 UTC) range.
-func (t *MessagePackTime) Len() int {
-	sec := t.time.Unix()
-	nsec := t.time.Nanosecond()
+func (z *MessagePackTime) Len() int {
+	sec := z.time.Unix()
+	nsec := z.time.Nanosecond()
 
 	if sec < 0 || sec >= (1<<34) { // 96 bits encoding
 		return 12
@@ -56,21 +56,21 @@ func (t *MessagePackTime) Len() int {
 }
 
 // MarshalBinaryTo implements the Extension interface
-func (t *MessagePackTime) MarshalBinaryTo(buf []byte) error {
-	len := t.Len()
+func (z *MessagePackTime) MarshalBinaryTo(buf []byte) error {
+	length := z.Len()
 
-	if len == 4 {
-		sec := t.time.Unix()
+	if length == 4 {
+		sec := z.time.Unix()
 		binary.BigEndian.PutUint32(buf, uint32(sec))
-	} else if len == 8 {
-		sec := t.time.Unix()
-		nsec := t.time.Nanosecond()
+	} else if length == 8 {
+		sec := z.time.Unix()
+		nsec := z.time.Nanosecond()
 
 		data := uint64(nsec)<<34 | (uint64(sec) & 0x03_ffff_ffff)
 		binary.BigEndian.PutUint64(buf, data)
-	} else if len == 12 {
-		sec := t.time.Unix()
-		nsec := t.time.Nanosecond()
+	} else if length == 12 {
+		sec := z.time.Unix()
+		nsec := z.time.Nanosecond()
 
 		binary.BigEndian.PutUint32(buf, uint32(nsec))
 		binary.BigEndian.PutUint64(buf[4:], uint64(sec))
@@ -80,24 +80,24 @@ func (t *MessagePackTime) MarshalBinaryTo(buf []byte) error {
 }
 
 // UnmarshalBinary implements the Extension interface
-func (t *MessagePackTime) UnmarshalBinary(buf []byte) error {
-	len := len(buf)
+func (z *MessagePackTime) UnmarshalBinary(buf []byte) error {
+	length := len(buf)
 
-	if len == 4 {
+	if length == 4 {
 		sec := binary.BigEndian.Uint32(buf)
-		t.time = time.Unix(int64(sec), 0)
-	} else if len == 8 {
+		z.time = time.Unix(int64(sec), 0)
+	} else if length == 8 {
 		data := binary.BigEndian.Uint64(buf)
 
 		nsec := (data & 0xfffffffc_00000000) >> 34
-		sec := (data & 0x00000003_ffffffff)
+		sec := data & 0x00000003_ffffffff
 
-		t.time = time.Unix(int64(sec), int64(nsec))
-	} else if len == 12 {
+		z.time = time.Unix(int64(sec), int64(nsec))
+	} else if length == 12 {
 		nsec := binary.BigEndian.Uint32(buf)
 		sec := binary.BigEndian.Uint64(buf[4:])
 
-		t.time = time.Unix(int64(sec), int64(nsec))
+		z.time = time.Unix(int64(sec), int64(nsec))
 	}
 
 	return nil

--- a/plugins/serializers/msgpack/metric_test.go
+++ b/plugins/serializers/msgpack/metric_test.go
@@ -6,24 +6,25 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMsgPackTime32(t *testing.T) {
 	// Maximum of 4 bytes encodable time
 	var sec int64 = 0xFFFFFFFF
-	var nsec int64 = 0
+	var nsec int64
 	t1 := MessagePackTime{time: time.Unix(sec, nsec)}
 
-	assert.Equal(t, t1.Len(), 4)
+	require.Equal(t, t1.Len(), 4)
 
 	buf := make([]byte, t1.Len())
-	assert.NoError(t, t1.MarshalBinaryTo(buf))
+	require.NoError(t, t1.MarshalBinaryTo(buf))
 
 	t2 := new(MessagePackTime)
-	t2.UnmarshalBinary(buf)
+	err := t2.UnmarshalBinary(buf)
+	require.NoError(t, err)
 
-	assert.Equal(t, t1.time, t2.time)
+	require.Equal(t, t1.time, t2.time)
 }
 
 func TestMsgPackTime64(t *testing.T) {
@@ -32,15 +33,16 @@ func TestMsgPackTime64(t *testing.T) {
 	var nsec int64 = 999999999
 	t1 := MessagePackTime{time: time.Unix(sec, nsec)}
 
-	assert.Equal(t, t1.Len(), 8)
+	require.Equal(t, t1.Len(), 8)
 
 	buf := make([]byte, t1.Len())
-	assert.NoError(t, t1.MarshalBinaryTo(buf))
+	require.NoError(t, t1.MarshalBinaryTo(buf))
 
 	t2 := new(MessagePackTime)
-	t2.UnmarshalBinary(buf)
+	err := t2.UnmarshalBinary(buf)
+	require.NoError(t, err)
 
-	assert.Equal(t, t1.time, t2.time)
+	require.Equal(t, t1.time, t2.time)
 }
 
 func TestMsgPackTime96(t *testing.T) {
@@ -49,26 +51,28 @@ func TestMsgPackTime96(t *testing.T) {
 	var nsec int64 = 111111111
 	t1 := MessagePackTime{time: time.Unix(sec, nsec)}
 
-	assert.Equal(t, t1.Len(), 12)
+	require.Equal(t, t1.Len(), 12)
 
 	buf := make([]byte, t1.Len())
-	assert.NoError(t, t1.MarshalBinaryTo(buf))
+	require.NoError(t, t1.MarshalBinaryTo(buf))
 
 	t2 := new(MessagePackTime)
-	t2.UnmarshalBinary(buf)
+	err := t2.UnmarshalBinary(buf)
+	require.NoError(t, err)
 
-	assert.True(t, t1.time.Equal(t2.time))
+	require.True(t, t1.time.Equal(t2.time))
 
 	// Testing the default value: 0001-01-01T00:00:00Z
 	t1 = MessagePackTime{}
 
-	assert.Equal(t, t1.Len(), 12)
-	assert.NoError(t, t1.MarshalBinaryTo(buf))
+	require.Equal(t, t1.Len(), 12)
+	require.NoError(t, t1.MarshalBinaryTo(buf))
 
 	t2 = new(MessagePackTime)
-	t2.UnmarshalBinary(buf)
+	err = t2.UnmarshalBinary(buf)
+	require.NoError(t, err)
 
-	assert.True(t, t1.time.Equal(t2.time))
+	require.True(t, t1.time.Equal(t2.time))
 }
 
 func TestMsgPackTimeEdgeCases(t *testing.T) {
@@ -138,6 +142,6 @@ func TestMsgPackTimeEdgeCases(t *testing.T) {
 
 		buf = buf[:0]
 		buf, _ = m.MarshalMsg(buf)
-		assert.Equal(t, expected[i], buf[12:len(buf)-14])
+		require.Equal(t, expected[i], buf[12:len(buf)-14])
 	}
 }

--- a/plugins/serializers/msgpack/msgpack_test.go
+++ b/plugins/serializers/msgpack/msgpack_test.go
@@ -3,10 +3,11 @@ package msgpack
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func toTelegrafMetric(m Metric) telegraf.Metric {
@@ -20,13 +21,13 @@ func TestSerializeMetricInt(t *testing.T) {
 	s := Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	m2 := &Metric{}
 	left, err := m2.UnmarshalMsg(buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, len(left), 0)
+	require.Equal(t, len(left), 0)
 
 	testutil.RequireMetricEqual(t, m, toTelegrafMetric(*m2))
 }
@@ -37,61 +38,61 @@ func TestSerializeMetricString(t *testing.T) {
 	s := Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	m2 := &Metric{}
 	left, err := m2.UnmarshalMsg(buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, len(left), 0)
+	require.Equal(t, len(left), 0)
 
 	testutil.RequireMetricEqual(t, m, toTelegrafMetric(*m2))
 }
 
 func TestSerializeMultiFields(t *testing.T) {
-	m := testutil.TestMetric(int(90))
+	m := testutil.TestMetric(90)
 	m.AddField("value2", 8559615)
 
 	s := Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	m2 := &Metric{}
 	left, err := m2.UnmarshalMsg(buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, len(left), 0)
+	require.Equal(t, len(left), 0)
 
 	testutil.RequireMetricEqual(t, m, toTelegrafMetric(*m2))
 }
 
 func TestSerializeMetricWithEscapes(t *testing.T) {
-	m := testutil.TestMetric(int(90))
+	m := testutil.TestMetric(90)
 	m.AddField("U,age=Idle", int64(90))
 	m.AddTag("cpu tag", "cpu0")
 
 	s := Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	m2 := &Metric{}
 	left, err := m2.UnmarshalMsg(buf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, len(left), 0)
+	require.Equal(t, len(left), 0)
 
 	testutil.RequireMetricEqual(t, m, toTelegrafMetric(*m2))
 }
 
 func TestSerializeMultipleMetric(t *testing.T) {
-	m := testutil.TestMetric(int(90))
+	m := testutil.TestMetric(90)
 
 	s := Serializer{}
 
 	encoded, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Multiple metrics in continous bytes stream
 	var buf []byte
@@ -105,27 +106,27 @@ func TestSerializeMultipleMetric(t *testing.T) {
 		decodeM := &Metric{}
 		left, err = decodeM.UnmarshalMsg(left)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		testutil.RequireMetricEqual(t, m, toTelegrafMetric(*decodeM))
 	}
 }
 
 func TestSerializeBatch(t *testing.T) {
-	m := testutil.TestMetric(int(90))
+	m := testutil.TestMetric(90)
 
 	metrics := []telegraf.Metric{m, m, m, m}
 
 	s := Serializer{}
 
 	buf, err := s.SerializeBatch(metrics)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	left := buf
 	for len(left) > 0 {
 		decodeM := &Metric{}
 		left, err = decodeM.UnmarshalMsg(left)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		testutil.RequireMetricEqual(t, m, toTelegrafMetric(*decodeM))
 	}
 }

--- a/plugins/serializers/nowmetric/nowmetric.go
+++ b/plugins/serializers/nowmetric/nowmetric.go
@@ -46,9 +46,9 @@ func NewSerializer() (*serializer, error) {
 func (s *serializer) Serialize(metric telegraf.Metric) (out []byte, err error) {
 	serialized, err := s.createObject(metric)
 	if err != nil {
-		return []byte{}, nil
+		return []byte{}, err
 	}
-	return serialized, err
+	return serialized, nil
 }
 
 func (s *serializer) SerializeBatch(metrics []telegraf.Metric) (out []byte, err error) {
@@ -56,7 +56,7 @@ func (s *serializer) SerializeBatch(metrics []telegraf.Metric) (out []byte, err 
 	for _, metric := range metrics {
 		m, err := s.createObject(metric)
 		if err != nil {
-			return nil, fmt.Errorf("D! [serializer.nowmetric] Dropping invalid metric: %s", metric.Name())
+			return nil, fmt.Errorf("dropping invalid metric: %s", metric.Name())
 		} else if m != nil {
 			objects = append(objects, m...)
 		}
@@ -97,7 +97,7 @@ func (s *serializer) createObject(metric telegraf.Metric) ([]byte, error) {
 	}
 
 	// Format timestamp to UNIX epoch
-	oimetric.Timestamp = (metric.Time().UnixNano() / int64(time.Millisecond))
+	oimetric.Timestamp = metric.Time().UnixNano() / int64(time.Millisecond)
 
 	// Loop of fields value pair and build datapoint for each of them
 	for _, field := range metric.FieldList() {
@@ -129,9 +129,6 @@ func (s *serializer) createObject(metric telegraf.Metric) ([]byte, error) {
 }
 
 func verifyValue(v interface{}) bool {
-	switch v.(type) {
-	case string:
-		return false
-	}
-	return true
+	_, ok := v.(string)
+	return !ok
 }

--- a/plugins/serializers/nowmetric/nowmetric_test.go
+++ b/plugins/serializers/nowmetric/nowmetric_test.go
@@ -6,18 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func MustMetric(v telegraf.Metric, err error) telegraf.Metric {
-	if err != nil {
-		panic(err)
-	}
-	return v
-}
 
 func TestSerializeMetricFloat(t *testing.T) {
 	now := time.Now()
@@ -32,9 +25,9 @@ func TestSerializeMetricFloat(t *testing.T) {
 	s, _ := NewSerializer()
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
-	expS := []byte(fmt.Sprintf(`[{"metric_type":"usage_idle","resource":"","node":"","value":91.5,"timestamp":%d,"ci2metric_id":null,"source":"Telegraf"}]`, (now.UnixNano() / int64(time.Millisecond))))
-	assert.Equal(t, string(expS), string(buf))
+	require.NoError(t, err)
+	expS := []byte(fmt.Sprintf(`[{"metric_type":"usage_idle","resource":"","node":"","value":91.5,"timestamp":%d,"ci2metric_id":null,"source":"Telegraf"}]`, now.UnixNano()/int64(time.Millisecond)))
+	require.Equal(t, string(expS), string(buf))
 }
 
 func TestSerialize_TimestampUnits(t *testing.T) {
@@ -95,10 +88,10 @@ func TestSerializeMetricInt(t *testing.T) {
 	s, _ := NewSerializer()
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	expS := []byte(fmt.Sprintf(`[{"metric_type":"usage_idle","resource":"","node":"","value":90,"timestamp":%d,"ci2metric_id":null,"source":"Telegraf"}]`, (now.UnixNano() / int64(time.Millisecond))))
-	assert.Equal(t, string(expS), string(buf))
+	expS := []byte(fmt.Sprintf(`[{"metric_type":"usage_idle","resource":"","node":"","value":90,"timestamp":%d,"ci2metric_id":null,"source":"Telegraf"}]`, now.UnixNano()/int64(time.Millisecond)))
+	require.Equal(t, string(expS), string(buf))
 }
 
 func TestSerializeMetricString(t *testing.T) {
@@ -114,9 +107,9 @@ func TestSerializeMetricString(t *testing.T) {
 	s, _ := NewSerializer()
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, "null", string(buf))
+	require.Equal(t, "null", string(buf))
 }
 
 func TestSerializeMultiFields(t *testing.T) {
@@ -138,10 +131,10 @@ func TestSerializeMultiFields(t *testing.T) {
 	s, _ := NewSerializer()
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	expS := []byte(fmt.Sprintf(`[{"metric_type":"usage_idle","resource":"","node":"","value":90,"timestamp":%d,"ci2metric_id":null,"source":"Telegraf"},{"metric_type":"usage_total","resource":"","node":"","value":8559615,"timestamp":%d,"ci2metric_id":null,"source":"Telegraf"}]`, (now.UnixNano() / int64(time.Millisecond)), (now.UnixNano() / int64(time.Millisecond))))
-	assert.Equal(t, string(expS), string(buf))
+	expS := []byte(fmt.Sprintf(`[{"metric_type":"usage_idle","resource":"","node":"","value":90,"timestamp":%d,"ci2metric_id":null,"source":"Telegraf"},{"metric_type":"usage_total","resource":"","node":"","value":8559615,"timestamp":%d,"ci2metric_id":null,"source":"Telegraf"}]`, now.UnixNano()/int64(time.Millisecond), now.UnixNano()/int64(time.Millisecond)))
+	require.Equal(t, string(expS), string(buf))
 }
 
 func TestSerializeMetricWithEscapes(t *testing.T) {
@@ -156,10 +149,10 @@ func TestSerializeMetricWithEscapes(t *testing.T) {
 
 	s, _ := NewSerializer()
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	expS := []byte(fmt.Sprintf(`[{"metric_type":"U,age=Idle","resource":"","node":"","value":90,"timestamp":%d,"ci2metric_id":null,"source":"Telegraf"}]`, (now.UnixNano() / int64(time.Millisecond))))
-	assert.Equal(t, string(expS), string(buf))
+	expS := []byte(fmt.Sprintf(`[{"metric_type":"U,age=Idle","resource":"","node":"","value":90,"timestamp":%d,"ci2metric_id":null,"source":"Telegraf"}]`, now.UnixNano()/int64(time.Millisecond)))
+	require.Equal(t, string(expS), string(buf))
 }
 
 func TestSerializeBatch(t *testing.T) {

--- a/plugins/serializers/prometheus/collection.go
+++ b/plugins/serializers/prometheus/collection.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/telegraf"
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/influxdata/telegraf"
 )
 
 const helpString = "Telegraf collected metric"
@@ -86,10 +87,10 @@ type MetricKey uint64
 func MakeMetricKey(labels []LabelPair) MetricKey {
 	h := fnv.New64a()
 	for _, label := range labels {
-		h.Write([]byte(label.Name))
-		h.Write([]byte("\x00"))
-		h.Write([]byte(label.Value))
-		h.Write([]byte("\x00"))
+		h.Write([]byte(label.Name))  //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte("\x00"))      //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte(label.Value)) //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte("\x00"))      //nolint:revive // from hash.go: "It never returns an error"
 	}
 	return MetricKey(h.Sum64())
 }
@@ -357,8 +358,7 @@ func (c *Collection) GetEntries(order MetricSortOrder) []Entry {
 		entries = append(entries, entry)
 	}
 
-	switch order {
-	case SortMetrics:
+	if order == SortMetrics {
 		sort.Slice(entries, func(i, j int) bool {
 			lhs := entries[i].Family
 			rhs := entries[j].Family
@@ -378,8 +378,7 @@ func (c *Collection) GetMetrics(entry Entry, order MetricSortOrder) []*Metric {
 		metrics = append(metrics, metric)
 	}
 
-	switch order {
-	case SortMetrics:
+	if order == SortMetrics {
 		sort.Slice(metrics, func(i, j int) bool {
 			lhs := metrics[i].Labels
 			rhs := metrics[j].Labels

--- a/plugins/serializers/prometheus/convert.go
+++ b/plugins/serializers/prometheus/convert.go
@@ -4,8 +4,9 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/influxdata/telegraf"
 	dto "github.com/prometheus/client_model/go"
+
+	"github.com/influxdata/telegraf"
 )
 
 type Table struct {
@@ -89,13 +90,13 @@ func sanitize(name string, table Table) (string, bool) {
 		switch {
 		case i == 0:
 			if unicode.In(r, table.First) {
-				b.WriteRune(r)
+				b.WriteRune(r) //nolint:revive // from builder.go: "It returns the length of r and a nil error."
 			}
 		default:
 			if unicode.In(r, table.Rest) {
-				b.WriteRune(r)
+				b.WriteRune(r) //nolint:revive // from builder.go: "It returns the length of r and a nil error."
 			} else {
-				b.WriteString("_")
+				b.WriteString("_") //nolint:revive // from builder.go: "It returns the length of s and a nil error."
 			}
 		}
 	}

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/golang/snappy"
-	"github.com/influxdata/telegraf/plugins/serializers/prometheus"
+	"github.com/prometheus/prometheus/prompb"
 
 	"github.com/influxdata/telegraf"
-	"github.com/prometheus/prometheus/prompb"
+	"github.com/influxdata/telegraf/plugins/serializers/prometheus"
 )
 
 type MetricKey uint64
@@ -210,8 +210,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		i++
 	}
 
-	switch s.config.MetricSortOrder {
-	case SortMetrics:
+	if s.config.MetricSortOrder == SortMetrics {
 		sort.Slice(promTS, func(i, j int) bool {
 			lhs := promTS[i].Labels
 			rhs := promTS[j].Labels
@@ -241,7 +240,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		return nil, fmt.Errorf("unable to marshal protobuf: %v", err)
 	}
 	encoded := snappy.Encode(nil, data)
-	buf.Write(encoded)
+	buf.Write(encoded) //nolint:revive // from buffer.go: "err is always nil"
 	return buf.Bytes(), nil
 }
 
@@ -320,10 +319,10 @@ func (s *Serializer) createLabels(metric telegraf.Metric) []prompb.Label {
 func MakeMetricKey(labels []prompb.Label) MetricKey {
 	h := fnv.New64a()
 	for _, label := range labels {
-		h.Write([]byte(label.Name))
-		h.Write([]byte("\x00"))
-		h.Write([]byte(label.Value))
-		h.Write([]byte("\x00"))
+		h.Write([]byte(label.Name))  //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte("\x00"))      //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte(label.Value)) //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte("\x00"))      //nolint:revive // from hash.go: "It never returns an error"
 	}
 	return MetricKey(h.Sum64())
 }

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -142,7 +142,7 @@ func NewSerializer(config *Config) (Serializer, error) {
 	case "msgpack":
 		serializer, err = NewMsgpackSerializer()
 	default:
-		err = fmt.Errorf("Invalid data format: %s", config.DataFormat)
+		err = fmt.Errorf("invalid data format: %s", config.DataFormat)
 	}
 	return serializer, err
 }

--- a/plugins/serializers/splunkmetric/splunkmetric_test.go
+++ b/plugins/serializers/splunkmetric/splunkmetric_test.go
@@ -4,17 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
-	"github.com/stretchr/testify/assert"
 )
-
-func MustMetric(v telegraf.Metric, err error) telegraf.Metric {
-	if err != nil {
-		panic(err)
-	}
-	return v
-}
 
 func TestSerializeMetricFloat(t *testing.T) {
 	// Test sub-second time
@@ -30,9 +24,9 @@ func TestSerializeMetricFloat(t *testing.T) {
 	s, _ := NewSerializer(false, false)
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expS := `{"_value":91.5,"cpu":"cpu0","metric_name":"cpu.usage_idle","time":1529875740.819}`
-	assert.Equal(t, expS, string(buf))
+	require.Equal(t, expS, string(buf))
 }
 
 func TestSerializeMetricFloatHec(t *testing.T) {
@@ -49,9 +43,9 @@ func TestSerializeMetricFloatHec(t *testing.T) {
 	s, _ := NewSerializer(true, false)
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	expS := `{"time":1529875740.819,"fields":{"_value":91.5,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}`
-	assert.Equal(t, expS, string(buf))
+	require.Equal(t, expS, string(buf))
 }
 
 func TestSerializeMetricInt(t *testing.T) {
@@ -67,10 +61,10 @@ func TestSerializeMetricInt(t *testing.T) {
 	s, _ := NewSerializer(false, false)
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := `{"_value":90,"cpu":"cpu0","metric_name":"cpu.usage_idle","time":0}`
-	assert.Equal(t, expS, string(buf))
+	require.Equal(t, expS, string(buf))
 }
 
 func TestSerializeMetricIntHec(t *testing.T) {
@@ -86,10 +80,10 @@ func TestSerializeMetricIntHec(t *testing.T) {
 	s, _ := NewSerializer(true, false)
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := `{"time":0,"fields":{"_value":90,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}`
-	assert.Equal(t, expS, string(buf))
+	require.Equal(t, expS, string(buf))
 }
 
 func TestSerializeMetricBool(t *testing.T) {
@@ -98,17 +92,17 @@ func TestSerializeMetricBool(t *testing.T) {
 		"container-name": "telegraf-test",
 	}
 	fields := map[string]interface{}{
-		"oomkiller": bool(true),
+		"oomkiller": true,
 	}
 	m := metric.New("docker", tags, fields, now)
 
 	s, _ := NewSerializer(false, false)
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := `{"_value":1,"container-name":"telegraf-test","metric_name":"docker.oomkiller","time":0}`
-	assert.Equal(t, expS, string(buf))
+	require.Equal(t, expS, string(buf))
 }
 
 func TestSerializeMetricBoolHec(t *testing.T) {
@@ -117,17 +111,17 @@ func TestSerializeMetricBoolHec(t *testing.T) {
 		"container-name": "telegraf-test",
 	}
 	fields := map[string]interface{}{
-		"oomkiller": bool(false),
+		"oomkiller": false,
 	}
 	m := metric.New("docker", tags, fields, now)
 
 	s, _ := NewSerializer(true, false)
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := `{"time":0,"fields":{"_value":0,"container-name":"telegraf-test","metric_name":"docker.oomkiller"}}`
-	assert.Equal(t, expS, string(buf))
+	require.Equal(t, expS, string(buf))
 }
 
 func TestSerializeMetricString(t *testing.T) {
@@ -144,11 +138,11 @@ func TestSerializeMetricString(t *testing.T) {
 	s, _ := NewSerializer(false, false)
 	var buf []byte
 	buf, err := s.Serialize(m)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := `{"_value":5,"cpu":"cpu0","metric_name":"cpu.usage_idle","time":0}`
-	assert.Equal(t, expS, string(buf))
-	assert.NoError(t, err)
+	require.Equal(t, expS, string(buf))
+	require.NoError(t, err)
 }
 
 func TestSerializeBatch(t *testing.T) {
@@ -173,10 +167,10 @@ func TestSerializeBatch(t *testing.T) {
 	metrics := []telegraf.Metric{m, n}
 	s, _ := NewSerializer(false, false)
 	buf, err := s.SerializeBatch(metrics)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := `{"_value":42,"metric_name":"cpu.value","time":0}{"_value":92,"metric_name":"cpu.value","time":0}`
-	assert.Equal(t, expS, string(buf))
+	require.Equal(t, expS, string(buf))
 }
 
 func TestSerializeMulti(t *testing.T) {
@@ -193,10 +187,10 @@ func TestSerializeMulti(t *testing.T) {
 	metrics := []telegraf.Metric{m}
 	s, _ := NewSerializer(false, true)
 	buf, err := s.SerializeBatch(metrics)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := `{"metric_name:cpu.system":8,"metric_name:cpu.user":42,"time":0}`
-	assert.Equal(t, expS, string(buf))
+	require.Equal(t, expS, string(buf))
 }
 
 func TestSerializeBatchHec(t *testing.T) {
@@ -219,10 +213,10 @@ func TestSerializeBatchHec(t *testing.T) {
 	metrics := []telegraf.Metric{m, n}
 	s, _ := NewSerializer(true, false)
 	buf, err := s.SerializeBatch(metrics)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := `{"time":0,"fields":{"_value":42,"metric_name":"cpu.value"}}{"time":0,"fields":{"_value":92,"metric_name":"cpu.value"}}`
-	assert.Equal(t, expS, string(buf))
+	require.Equal(t, expS, string(buf))
 }
 
 func TestSerializeMultiHec(t *testing.T) {
@@ -239,8 +233,8 @@ func TestSerializeMultiHec(t *testing.T) {
 	metrics := []telegraf.Metric{m}
 	s, _ := NewSerializer(true, true)
 	buf, err := s.SerializeBatch(metrics)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expS := `{"time":0,"fields":{"metric_name:cpu.system":8,"metric_name:cpu.usage":42}}`
-	assert.Equal(t, expS, string(buf))
+	require.Equal(t, expS, string(buf))
 }

--- a/plugins/serializers/wavefront/wavefront.go
+++ b/plugins/serializers/wavefront/wavefront.go
@@ -49,7 +49,7 @@ func NewSerializer(prefix string, useStrict bool, sourceOverride []string) (*Wav
 	return s, nil
 }
 
-func (s *WavefrontSerializer) serialize(m telegraf.Metric) {
+func (s *WavefrontSerializer) serializeMetric(m telegraf.Metric) {
 	const metricSeparator = "."
 
 	for fieldName, value := range m.Fields() {
@@ -90,7 +90,7 @@ func (s *WavefrontSerializer) serialize(m telegraf.Metric) {
 func (s *WavefrontSerializer) Serialize(m telegraf.Metric) ([]byte, error) {
 	s.mu.Lock()
 	s.scratch.Reset()
-	s.serialize(m)
+	s.serializeMetric(m)
 	out := s.scratch.Copy()
 	s.mu.Unlock()
 	return out, nil
@@ -100,7 +100,7 @@ func (s *WavefrontSerializer) SerializeBatch(metrics []telegraf.Metric) ([]byte,
 	s.mu.Lock()
 	s.scratch.Reset()
 	for _, m := range metrics {
-		s.serialize(m)
+		s.serializeMetric(m)
 	}
 	out := s.scratch.Copy()
 	s.mu.Unlock()
@@ -200,7 +200,7 @@ func (b *buffer) WriteString(s string) {
 	*b = append(*b, s...)
 }
 
-// This is named WriteChar instead of WriteByte because the 'stdmethods' check
+// WriteChar has this name instead of WriteByte because the 'stdmethods' check
 // of 'go vet' wants WriteByte to have the signature:
 //
 // 	func (b *buffer) WriteByte(c byte) error { ... }

--- a/plugins/serializers/wavefront/wavefront_test.go
+++ b/plugins/serializers/wavefront/wavefront_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/outputs/wavefront"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildTags(t *testing.T) {
@@ -185,7 +186,7 @@ func TestSerializeMetricFloat(t *testing.T) {
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{fmt.Sprintf("\"cpu.usage.idle\" 91.500000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricInt(t *testing.T) {
@@ -204,7 +205,7 @@ func TestSerializeMetricInt(t *testing.T) {
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{fmt.Sprintf("\"cpu.usage.idle\" 91.000000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricBoolTrue(t *testing.T) {
@@ -223,7 +224,7 @@ func TestSerializeMetricBoolTrue(t *testing.T) {
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{fmt.Sprintf("\"cpu.usage.idle\" 1.000000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricBoolFalse(t *testing.T) {
@@ -242,7 +243,7 @@ func TestSerializeMetricBoolFalse(t *testing.T) {
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{fmt.Sprintf("\"cpu.usage.idle\" 0.000000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricFieldValue(t *testing.T) {
@@ -257,11 +258,12 @@ func TestSerializeMetricFieldValue(t *testing.T) {
 	m := metric.New("cpu", tags, fields, now)
 
 	s := WavefrontSerializer{}
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{fmt.Sprintf("\"cpu\" 91.000000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func TestSerializeMetricPrefix(t *testing.T) {
@@ -276,11 +278,12 @@ func TestSerializeMetricPrefix(t *testing.T) {
 	m := metric.New("cpu", tags, fields, now)
 
 	s := WavefrontSerializer{Prefix: "telegraf."}
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{fmt.Sprintf("\"telegraf.cpu.usage.idle\" 91.000000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}
-	assert.Equal(t, expS, mS)
+	require.Equal(t, expS, mS)
 }
 
 func benchmarkMetrics(b *testing.B) [4]telegraf.Metric {
@@ -310,7 +313,8 @@ func BenchmarkSerialize(b *testing.B) {
 	metrics := benchmarkMetrics(b)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s.Serialize(metrics[i%len(metrics)])
+		_, err := s.Serialize(metrics[i%len(metrics)])
+		require.NoError(b, err)
 	}
 }
 
@@ -320,6 +324,7 @@ func BenchmarkSerializeBatch(b *testing.B) {
 	metrics := m[:]
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s.SerializeBatch(metrics)
+		_, err := s.SerializeBatch(metrics)
+		require.NoError(b, err)
 	}
 }


### PR DESCRIPTION
Following findings were fixed:
```
plugins/serializers/carbon2/carbon2.go:68:3                                revive       unhandled-error: Unhandled error in call to function batch.Write
plugins/serializers/carbon2/carbon2.go:86:4                                revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/carbon2/carbon2.go:91:4                                revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/carbon2/carbon2.go:97:4                                revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/carbon2/carbon2.go:98:4                                revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/carbon2/carbon2.go:103:4                               revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/carbon2/carbon2.go:104:4                               revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/carbon2/carbon2.go:106:3                               revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/carbon2/carbon2.go:107:3                               revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/carbon2/carbon2.go:108:3                               revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/carbon2/carbon2.go:109:3                               revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/carbon2/carbon2.go:110:3                               revive       unhandled-error: Unhandled error in call to function m.WriteString
plugins/serializers/influx/influx.go:83:38                                 revive       import-shadowing: The name 'bytes' shadows an import name
plugins/serializers/influx/influx.go:138:22                                revive       confusing-naming: Method 'write' differs only by capitalization to method 'Write' in the same source file
plugins/serializers/json/json.go:64:35                                     revive       unnecessary-stmt: switch with only one case can be replaced by an if-then
plugins/serializers/msgpack/metric.go:60:2                                 predeclared  variable len has same name as predeclared identifier
plugins/serializers/msgpack/metric.go:84:2                                 predeclared  variable len has same name as predeclared identifier
plugins/serializers/msgpack/metric_test.go:15:19                           revive       var-declaration: should drop = 0 from declaration of var nsec; it is the zero value
plugins/serializers/msgpack/metric_test.go:24:20                           errcheck     Error return value of `t2.UnmarshalBinary` is not checked
plugins/serializers/msgpack/metric_test.go:41:20                           errcheck     Error return value of `t2.UnmarshalBinary` is not checked
plugins/serializers/msgpack/metric_test.go:58:20                           errcheck     Error return value of `t2.UnmarshalBinary` is not checked
plugins/serializers/msgpack/metric_test.go:69:20                           errcheck     Error return value of `t2.UnmarshalBinary` is not checked
plugins/serializers/nowmetric/nowmetric.go:49:3                            nilerr       error is not nil (line 47) but it returns nil
plugins/serializers/nowmetric/nowmetric.go:132:18                          revive       unnecessary-stmt: switch with only one case can be replaced by an if-then
plugins/serializers/prometheus/collection.go:89:3                          revive       unhandled-error: Unhandled error in call to function h.Write
plugins/serializers/prometheus/collection.go:90:3                          revive       unhandled-error: Unhandled error in call to function h.Write
plugins/serializers/prometheus/collection.go:91:3                          revive       unhandled-error: Unhandled error in call to function h.Write
plugins/serializers/prometheus/collection.go:92:3                          revive       unhandled-error: Unhandled error in call to function h.Write
plugins/serializers/prometheus/collection.go:360:15                        revive       unnecessary-stmt: switch with only one case can be replaced by an if-then
plugins/serializers/prometheus/collection.go:381:15                        revive       unnecessary-stmt: switch with only one case can be replaced by an if-then
plugins/serializers/prometheus/convert.go:92:5                             revive       unhandled-error: Unhandled error in call to function b.WriteRune
plugins/serializers/prometheus/convert.go:96:5                             revive       unhandled-error: Unhandled error in call to function b.WriteRune
plugins/serializers/prometheus/convert.go:98:5                             revive       unhandled-error: Unhandled error in call to function b.WriteString
plugins/serializers/prometheusremotewrite/prometheusremotewrite.go:213:34  revive       unnecessary-stmt: switch with only one case can be replaced by an if-then
plugins/serializers/prometheusremotewrite/prometheusremotewrite.go:244:2   revive       unhandled-error: Unhandled error in call to function buf.Write
plugins/serializers/prometheusremotewrite/prometheusremotewrite.go:323:3   revive       unhandled-error: Unhandled error in call to function h.Write
plugins/serializers/prometheusremotewrite/prometheusremotewrite.go:324:3   revive       unhandled-error: Unhandled error in call to function h.Write
plugins/serializers/prometheusremotewrite/prometheusremotewrite.go:325:3   revive       unhandled-error: Unhandled error in call to function h.Write
plugins/serializers/prometheusremotewrite/prometheusremotewrite.go:326:3   revive       unhandled-error: Unhandled error in call to function h.Write
plugins/serializers/wavefront/wavefront.go:90:31                           revive       confusing-naming: Method 'Serialize' differs only by capitalization to method 'serialize' in the same source file
plugins/serializers/wavefront/wavefront_test.go:313:14                     errcheck     Error return value of `s.Serialize` is not checked
plugins/serializers/wavefront/wavefront_test.go:323:19                     errcheck     Error return value of `s.SerializeBatch` is not checked
```