### PR TITLE
fix: Linter fixes for plugins/aggregators/[a-z]*

### DIFF
--- a/plugins/aggregators/basicstats/basicstats.go
+++ b/plugins/aggregators/basicstats/basicstats.go
@@ -129,7 +129,7 @@ func (b *BasicStats) Add(in telegraf.Metric) {
 				//variable initialization
 				x := fv
 				mean := tmp.mean
-				M2 := tmp.M2
+				m2 := tmp.M2
 				//counter compute
 				n := tmp.count + 1
 				tmp.count = n
@@ -138,8 +138,8 @@ func (b *BasicStats) Add(in telegraf.Metric) {
 				mean = mean + delta/n
 				tmp.mean = mean
 				//variance/stdev compute
-				M2 = M2 + delta*(x-mean)
-				tmp.M2 = M2
+				m2 = m2 + delta*(x-mean)
+				tmp.M2 = m2
 				//max/min compute
 				if fv < tmp.min {
 					tmp.min = fv

--- a/plugins/aggregators/basicstats/basicstats_test.go
+++ b/plugins/aggregators/basicstats/basicstats_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 )
 
 var m1 = metric.New("m1",
@@ -697,11 +698,11 @@ func TestBasicStatsWithDefaultStats(t *testing.T) {
 	acc := testutil.Accumulator{}
 	aggregator.Push(&acc)
 
-	assert.True(t, acc.HasField("m1", "a_count"))
-	assert.True(t, acc.HasField("m1", "a_min"))
-	assert.True(t, acc.HasField("m1", "a_max"))
-	assert.True(t, acc.HasField("m1", "a_mean"))
-	assert.True(t, acc.HasField("m1", "a_stdev"))
-	assert.True(t, acc.HasField("m1", "a_s2"))
-	assert.False(t, acc.HasField("m1", "a_sum"))
+	require.True(t, acc.HasField("m1", "a_count"))
+	require.True(t, acc.HasField("m1", "a_min"))
+	require.True(t, acc.HasField("m1", "a_max"))
+	require.True(t, acc.HasField("m1", "a_mean"))
+	require.True(t, acc.HasField("m1", "a_stdev"))
+	require.True(t, acc.HasField("m1", "a_s2"))
+	require.False(t, acc.HasField("m1", "a_sum"))
 }

--- a/plugins/aggregators/derivative/derivative_test.go
+++ b/plugins/aggregators/derivative/derivative_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -40,7 +42,8 @@ func TestTwoFullEventsWithParameter(t *testing.T) {
 		cache:    make(map[uint64]*aggregate),
 	}
 	derivative.Log = testutil.Logger{}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	derivative.Add(start)
 	derivative.Add(finish)
@@ -66,7 +69,8 @@ func TestTwoFullEventsWithParameterReverseSequence(t *testing.T) {
 		cache:    make(map[uint64]*aggregate),
 	}
 	derivative.Log = testutil.Logger{}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	derivative.Add(finish)
 	derivative.Add(start)
@@ -88,7 +92,8 @@ func TestTwoFullEventsWithoutParameter(t *testing.T) {
 	acc := testutil.Accumulator{}
 	derivative := NewDerivative()
 	derivative.Log = testutil.Logger{}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	startTime := time.Now()
 	duration, _ := time.ParseDuration("2s")
@@ -130,7 +135,8 @@ func TestTwoFullEventsInSeperatePushes(t *testing.T) {
 		cache:       make(map[uint64]*aggregate),
 	}
 	derivative.Log = testutil.Logger{}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	derivative.Add(start)
 	derivative.Push(&acc)
@@ -163,7 +169,8 @@ func TestTwoFullEventsInSeperatePushesWithSeveralRollOvers(t *testing.T) {
 		cache:       make(map[uint64]*aggregate),
 	}
 	derivative.Log = testutil.Logger{}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	derivative.Add(start)
 	derivative.Push(&acc)
@@ -195,7 +202,8 @@ func TestTwoFullEventsInSeperatePushesWithOutRollOver(t *testing.T) {
 		cache:       make(map[uint64]*aggregate),
 	}
 	derivative.Log = testutil.Logger{}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	derivative.Add(start)
 	// This test relies on RunningAggregator always callining Reset after Push
@@ -220,7 +228,8 @@ func TestIgnoresMissingVariable(t *testing.T) {
 		cache:    make(map[uint64]*aggregate),
 	}
 	derivative.Log = testutil.Logger{}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	noParameter := metric.New("TestMetric",
 		map[string]string{"state": "no_parameter"},
@@ -260,7 +269,8 @@ func TestMergesDifferenMetricsWithSameHash(t *testing.T) {
 	acc := testutil.Accumulator{}
 	derivative := NewDerivative()
 	derivative.Log = testutil.Logger{}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	startTime := time.Now()
 	duration, _ := time.ParseDuration("2s")
@@ -309,7 +319,8 @@ func TestDropsAggregatesOnMaxRollOver(t *testing.T) {
 		cache:       make(map[uint64]*aggregate),
 	}
 	derivative.Log = testutil.Logger{}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	derivative.Add(start)
 	derivative.Push(&acc)
@@ -332,7 +343,8 @@ func TestAddMetricsResetsRollOver(t *testing.T) {
 		cache:       make(map[uint64]*aggregate),
 		Log:         testutil.Logger{},
 	}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	derivative.Add(start)
 	derivative.Push(&acc)
@@ -356,7 +368,8 @@ func TestCalculatesCorrectDerivativeOnTwoConsecutivePeriods(t *testing.T) {
 	period, _ := time.ParseDuration("10s")
 	derivative := NewDerivative()
 	derivative.Log = testutil.Logger{}
-	derivative.Init()
+	err := derivative.Init()
+	require.NoError(t, err)
 
 	startTime := time.Now()
 	first := metric.New("One Field",

--- a/plugins/aggregators/histogram/histogram_test.go
+++ b/plugins/aggregators/histogram/histogram_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 )
 
 type fields map[string]interface{}
@@ -83,7 +84,7 @@ func TestHistogram(t *testing.T) {
 	histogram.Push(acc)
 
 	if len(acc.Metrics) != 6 {
-		assert.Fail(t, "Incorrect number of metrics")
+		require.Fail(t, "Incorrect number of metrics")
 	}
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketRightTag: "0"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketRightTag: "10"})
@@ -107,7 +108,7 @@ func TestHistogramNonCumulative(t *testing.T) {
 	histogram.Push(acc)
 
 	if len(acc.Metrics) != 6 {
-		assert.Fail(t, "Incorrect number of metrics")
+		require.Fail(t, "Incorrect number of metrics")
 	}
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketLeftTag: bucketNegInf, bucketRightTag: "0"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketLeftTag: "0", bucketRightTag: "10"})
@@ -131,7 +132,7 @@ func TestHistogramWithReset(t *testing.T) {
 	histogram.Push(acc)
 
 	if len(acc.Metrics) != 6 {
-		assert.Fail(t, "Incorrect number of metrics")
+		require.Fail(t, "Incorrect number of metrics")
 	}
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketRightTag: "0"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketRightTag: "10"})
@@ -156,7 +157,7 @@ func TestHistogramWithAllFields(t *testing.T) {
 	histogram.Push(acc)
 
 	if len(acc.Metrics) != 12 {
-		assert.Fail(t, "Incorrect number of metrics")
+		require.Fail(t, "Incorrect number of metrics")
 	}
 
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0), "b_bucket": int64(0), "c_bucket": int64(0)}, tags{bucketRightTag: "0"})
@@ -189,7 +190,7 @@ func TestHistogramWithAllFieldsNonCumulative(t *testing.T) {
 	histogram.Push(acc)
 
 	if len(acc.Metrics) != 12 {
-		assert.Fail(t, "Incorrect number of metrics")
+		require.Fail(t, "Incorrect number of metrics")
 	}
 
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0), "b_bucket": int64(0), "c_bucket": int64(0)}, tags{bucketLeftTag: bucketNegInf, bucketRightTag: "0"})
@@ -241,7 +242,7 @@ func TestHistogramWithTwoPeriodsAndAllFields(t *testing.T) {
 func TestWrongBucketsOrder(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
-			assert.Equal(
+			require.Equal(
 				t,
 				"histogram buckets must be in increasing order: 90.00 >= 20.00, metrics: first_metric_name, field: a",
 				fmt.Sprint(r),
@@ -291,12 +292,9 @@ func assertContainsTaggedField(t *testing.T, acc *testutil.Accumulator, metricNa
 		}
 
 		// check fields with their counts
-		if assert.Equal(t, fields, checkedMetric.Fields) {
-			return
-		}
-
-		assert.Fail(t, fmt.Sprintf("incorrect fields %v of metric %s", checkedMetric.Fields, metricName))
+		require.Equal(t, fields, checkedMetric.Fields)
+		return
 	}
 
-	assert.Fail(t, fmt.Sprintf("unknown measurement '%s' with tags: %v, fields: %v", metricName, tags, fields))
+	require.Fail(t, fmt.Sprintf("unknown measurement '%s' with tags: %v, fields: %v", metricName, tags, fields))
 }

--- a/plugins/aggregators/histogram/histogram_test.go
+++ b/plugins/aggregators/histogram/histogram_test.go
@@ -83,9 +83,7 @@ func TestHistogram(t *testing.T) {
 	histogram.Add(firstMetric2)
 	histogram.Push(acc)
 
-	if len(acc.Metrics) != 6 {
-		require.Fail(t, "Incorrect number of metrics")
-	}
+	require.Len(t, acc.Metrics, 6, "Incorrect number of metrics")
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketRightTag: "0"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketRightTag: "10"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(2)}, tags{bucketRightTag: "20"})
@@ -107,9 +105,7 @@ func TestHistogramNonCumulative(t *testing.T) {
 	histogram.Add(firstMetric2)
 	histogram.Push(acc)
 
-	if len(acc.Metrics) != 6 {
-		require.Fail(t, "Incorrect number of metrics")
-	}
+	require.Len(t, acc.Metrics, 6, "Incorrect number of metrics")
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketLeftTag: bucketNegInf, bucketRightTag: "0"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketLeftTag: "0", bucketRightTag: "10"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(2)}, tags{bucketLeftTag: "10", bucketRightTag: "20"})
@@ -131,9 +127,7 @@ func TestHistogramWithReset(t *testing.T) {
 	histogram.Add(firstMetric2)
 	histogram.Push(acc)
 
-	if len(acc.Metrics) != 6 {
-		require.Fail(t, "Incorrect number of metrics")
-	}
+	require.Len(t, acc.Metrics, 6, "Incorrect number of metrics")
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketRightTag: "0"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0)}, tags{bucketRightTag: "10"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(1)}, tags{bucketRightTag: "20"})
@@ -156,10 +150,7 @@ func TestHistogramWithAllFields(t *testing.T) {
 	histogram.Add(secondMetric)
 	histogram.Push(acc)
 
-	if len(acc.Metrics) != 12 {
-		require.Fail(t, "Incorrect number of metrics")
-	}
-
+	require.Len(t, acc.Metrics, 12, "Incorrect number of metrics")
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0), "b_bucket": int64(0), "c_bucket": int64(0)}, tags{bucketRightTag: "0"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(1), "b_bucket": int64(0), "c_bucket": int64(0)}, tags{bucketRightTag: "15.5"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(2), "b_bucket": int64(0), "c_bucket": int64(0)}, tags{bucketRightTag: "20"})
@@ -189,10 +180,7 @@ func TestHistogramWithAllFieldsNonCumulative(t *testing.T) {
 	histogram.Add(secondMetric)
 	histogram.Push(acc)
 
-	if len(acc.Metrics) != 12 {
-		require.Fail(t, "Incorrect number of metrics")
-	}
-
+	require.Len(t, acc.Metrics, 12, "Incorrect number of metrics")
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(0), "b_bucket": int64(0), "c_bucket": int64(0)}, tags{bucketLeftTag: bucketNegInf, bucketRightTag: "0"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(1), "b_bucket": int64(0), "c_bucket": int64(0)}, tags{bucketLeftTag: "0", bucketRightTag: "15.5"})
 	assertContainsTaggedField(t, acc, "first_metric_name", fields{"a_bucket": int64(1), "b_bucket": int64(0), "c_bucket": int64(0)}, tags{bucketLeftTag: "15.5", bucketRightTag: "20"})

--- a/plugins/aggregators/merge/merge_test.go
+++ b/plugins/aggregators/merge/merge_test.go
@@ -229,7 +229,8 @@ var m2 = metric.New(
 
 func BenchmarkMergeOne(b *testing.B) {
 	var merger Merge
-	merger.Init()
+	err := merger.Init()
+	require.NoError(b, err)
 	var acc testutil.NopAccumulator
 
 	for n := 0; n < b.N; n++ {
@@ -241,7 +242,8 @@ func BenchmarkMergeOne(b *testing.B) {
 
 func BenchmarkMergeTwo(b *testing.B) {
 	var merger Merge
-	merger.Init()
+	err := merger.Init()
+	require.NoError(b, err)
 	var acc testutil.NopAccumulator
 
 	for n := 0; n < b.N; n++ {

--- a/plugins/aggregators/quantile/algorithms.go
+++ b/plugins/aggregators/quantile/algorithms.go
@@ -49,8 +49,7 @@ func (e *exactAlgorithmR7) Quantile(q float64) float64 {
 	// Get the quantile index and the fraction to the neighbor
 	// Hyndman & Fan; Sample Quantiles in Statistical Packages; The American Statistician vol 50; pp 361-365; 1996 -- R7
 	// Same as Excel and Numpy.
-	N := float64(size)
-	n := q * (N - 1)
+	n := q * (float64(size) - 1)
 	i, gamma := math.Modf(n)
 	j := int(i)
 	if j < 0 {
@@ -95,8 +94,7 @@ func (e *exactAlgorithmR8) Quantile(q float64) float64 {
 
 	// Get the quantile index and the fraction to the neighbor
 	// Hyndman & Fan; Sample Quantiles in Statistical Packages; The American Statistician vol 50; pp 361-365; 1996 -- R8
-	N := float64(size)
-	n := q*(N+1.0/3.0) - (2.0 / 3.0) // Indices are zero-base here but one-based in the paper
+	n := q*(float64(size)+1.0/3.0) - (2.0 / 3.0) // Indices are zero-base here but one-based in the paper
 	i, gamma := math.Modf(n)
 	j := int(i)
 	if j < 0 {


### PR DESCRIPTION
Following findings were fixed:
```
plugins/aggregators/basicstats/basicstats.go:132:5        revive    unexported-naming: the symbol M2 is local, its name should start with a lowercase letter
plugins/aggregators/derivative/derivative_test.go:43:17   errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/derivative/derivative_test.go:69:17   errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/derivative/derivative_test.go:91:17   errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/derivative/derivative_test.go:133:17  errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/derivative/derivative_test.go:166:17  errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/derivative/derivative_test.go:198:17  errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/derivative/derivative_test.go:223:17  errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/derivative/derivative_test.go:263:17  errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/derivative/derivative_test.go:312:17  errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/derivative/derivative_test.go:335:17  errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/derivative/derivative_test.go:359:17  errcheck  Error return value of `derivative.Init` is not checked
plugins/aggregators/merge/merge_test.go:232:13            errcheck  Error return value of `merger.Init` is not checked
plugins/aggregators/merge/merge_test.go:244:13            errcheck  Error return value of `merger.Init` is not checked
plugins/aggregators/quantile/algorithms.go:52:2           revive    unexported-naming: the symbol N is local, its name should start with a lowercase letter
plugins/aggregators/quantile/algorithms.go:98:2           revive    unexported-naming: the symbol N is local, its name should start with a lowercase letter
```