### PR TITLE
feat: InfluxDB Protobuf Data Protocol serializer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1517,15 +1517,19 @@ func (c *Config) buildSerializer(tbl *ast.Table) (serializers.Serializer, error)
 	c.getFieldString(tbl, "prefix", &sc.Prefix)
 	c.getFieldString(tbl, "template", &sc.Template)
 	c.getFieldStringSlice(tbl, "templates", &sc.Templates)
+
 	c.getFieldString(tbl, "carbon2_format", &sc.Carbon2Format)
 	c.getFieldString(tbl, "carbon2_sanitize_replace_char", &sc.Carbon2SanitizeReplaceChar)
-	c.getFieldInt(tbl, "influx_max_line_bytes", &sc.InfluxMaxLineBytes)
 
+	c.getFieldInt(tbl, "influx_max_line_bytes", &sc.InfluxMaxLineBytes)
 	c.getFieldBool(tbl, "influx_sort_fields", &sc.InfluxSortFields)
 	c.getFieldBool(tbl, "influx_uint_support", &sc.InfluxUintSupport)
+
+	c.getFieldString(tbl, "influx_protobuf_database", &sc.InfluxProtobufDatabase)
+	c.getFieldBool(tbl, "influx_protobuf_iox", &sc.InfluxProtobufIOx)
+
 	c.getFieldBool(tbl, "graphite_tag_support", &sc.GraphiteTagSupport)
 	c.getFieldString(tbl, "graphite_tag_sanitize_mode", &sc.GraphiteTagSanitizeMode)
-
 	c.getFieldString(tbl, "graphite_separator", &sc.GraphiteSeparator)
 
 	c.getFieldDuration(tbl, "json_timestamp_units", &sc.TimestampUnits)
@@ -1594,7 +1598,8 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 		"grace", "graphite_separator", "graphite_tag_sanitize_mode", "graphite_tag_support",
 		"grok_custom_pattern_files", "grok_custom_patterns", "grok_named_patterns", "grok_patterns",
 		"grok_timezone", "grok_unique_timestamp", "influx_max_line_bytes", "influx_sort_fields",
-		"influx_uint_support", "interval", "json_name_key", "json_query", "json_strict",
+		"influx_uint_support", "influx_protobuf_database", "influx_protobuf_iox", "interval",
+		"json_name_key", "json_query", "json_strict",
 		"json_string_fields", "json_time_format", "json_time_key", "json_timestamp_format", "json_timestamp_units", "json_timezone", "json_v2",
 		"lvm", "metric_batch_size", "metric_buffer_limit", "name_override", "name_prefix",
 		"name_suffix", "namedrop", "namepass", "order", "pass", "period", "precision",

--- a/docs/DATA_FORMATS_OUTPUT.md
+++ b/docs/DATA_FORMATS_OUTPUT.md
@@ -5,6 +5,7 @@ standard data formats that may be selected from when configuring many output
 plugins.
 
 1. [InfluxDB Line Protocol](/plugins/serializers/influx)
+1. [InfluxDB Protobuf Data Protocol](/plugins/serializers/influx_protobuf)
 1. [Carbon2](/plugins/serializers/carbon2)
 1. [Graphite](/plugins/serializers/graphite)
 1. [JSON](/plugins/serializers/json)

--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -129,6 +129,7 @@ following works:
 - github.com/influxdata/influxdb-observability/common [MIT License](https://github.com/influxdata/influxdb-observability/blob/main/LICENSE)
 - github.com/influxdata/influxdb-observability/influx2otel [MIT License](https://github.com/influxdata/influxdb-observability/blob/main/LICENSE)
 - github.com/influxdata/influxdb-observability/otel2influx [MIT License](https://github.com/influxdata/influxdb-observability/blob/main/LICENSE)
+- github.com/influxdata/influxdb-pb-data-protocol/golang [Apache License 2.0](https://github.com/influxdata/influxdb-pb-data-protocol/blob/main/LICENSE-APACHE)
 - github.com/influxdata/tail [MIT License](https://github.com/influxdata/tail/blob/master/LICENSE.txt)
 - github.com/influxdata/toml [MIT License](https://github.com/influxdata/toml/blob/master/LICENSE)
 - github.com/influxdata/wlog [MIT License](https://github.com/influxdata/wlog/blob/master/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -339,6 +339,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/influxdata/influxdb-pb-data-protocol/golang v0.0.0-20210927183324-097bc42f9e1b // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,7 @@ github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmU
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/RoaringBitmap/roaring v0.9.4/go.mod h1:icnadbWcNyfEHlYdr+tDlOTih1Bf/h+rzPpv4sbomAA=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/sarama v1.22.2-0.20190604114437-cd910a683f9f/go.mod h1:XLH1GYJnLVE0XCr6KdJGVJRTwY30moWNJ4sERjXX6fs=
@@ -479,6 +480,7 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/clarkduvall/hyperloglog v0.0.0-20171127014514-a0107a5d8004/go.mod h1:drodPoQNro6QBO6TJ/MpMZbz8Bn2eSDtRN6jpG4VGw8=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -1236,6 +1238,8 @@ github.com/influxdata/influxdb-observability/influx2otel v0.2.8 h1:XlVo4WLIFByOA
 github.com/influxdata/influxdb-observability/influx2otel v0.2.8/go.mod h1:t9LeYL1mBiVRZBt5TfIj+4MBkJ/1POBxUlKSxEA+uj8=
 github.com/influxdata/influxdb-observability/otel2influx v0.2.8 h1:vTamg9mKUXHaXPtydrR1ejpqj/OKAGc56MiedXjlsnA=
 github.com/influxdata/influxdb-observability/otel2influx v0.2.8/go.mod h1:xKTR9GLOtkSekysDKhAFNrPYpeiFV31Sy6zDqF54axA=
+github.com/influxdata/influxdb-pb-data-protocol/golang v0.0.0-20210927183324-097bc42f9e1b h1:H5UUe13Z4daYCWymKUrMO2t2Glza9jSdbBWFEiN20hw=
+github.com/influxdata/influxdb-pb-data-protocol/golang v0.0.0-20210927183324-097bc42f9e1b/go.mod h1:dfG6+Q4U5tTV+8BMWzQUodOuYTW5lqOZa/JSJrtbUTg=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/influxql v1.1.1-0.20200828144457-65d3ef77d385/go.mod h1:gHp9y86a/pxhjJ+zMjNXiQAA197Xk9wLxaz+fGG+kWk=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
@@ -1566,6 +1570,7 @@ github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:
 github.com/mozilla/tls-observatory v0.0.0-20201209171846-0547674fceff/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
+github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/multiplay/go-ts3 v1.0.0 h1:loxtEFqvYtpoGh1jOqEt6aDzctYuQsi3vb3dMpvWiWw=
 github.com/multiplay/go-ts3 v1.0.0/go.mod h1:14S6cS3fLNT3xOytrA/DkRyAFNuQLMLEqOYAsf87IbQ=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/plugins/serializers/influx_protobuf/README.md
+++ b/plugins/serializers/influx_protobuf/README.md
@@ -1,0 +1,52 @@
+# Influx protocol-buffer serializer
+
+This serializer outputs metrics in the binary
+[InfluxDB Protobuf Data Protocol][1]. This protocol is optimized for efficient
+ingestion into IOx, and is also a good choice for transporting timeseries data
+in general. The protocol-buffer definition can be found [here][2].
+
+Please also read the [optimization notes][3] if you intent to parse the
+serialized data yourself.
+
+## Example
+
+This is the most simple usage example for this serializer.
+```toml
+[[outputs.file]]
+  ## Files to write to, "stdout" is a specially handled file.
+  files = ["/tmp/metrics.out"]
+
+  ## Data format to output.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "influx_protobuf"
+
+  ## Database name to use in DatabaseBatch.
+  # influx_protobuf_database = ""
+
+  ## Serialize to line-protocol-like representation if `false` and to IOx representation otherwise.
+  ## Please note: IOx representation will loose information on tag-field separation.
+  # influx_protobuf_iox = false
+```
+The shown configuration will serialize metrics to the line-protocol-like binary
+format preserving tag and field separation with an empty _database name_.
+For a more sophisticated use-case check the configuration options below.
+
+## Options
+### `influx_protobuf_database` (string)
+With this option you can set the `DatabaseName` in `DatabaseBatch`. This can
+be handy in case you want to directly push the serialized data to an InfluxDB
+or IOx instance. By default, the database-name will be empty.
+
+### `influx_protobuf_iox` (bool)
+If set to true, the `IOx` [semantic type][4] will be used for all columns.
+Please note, that this type will drop information on whether a column is a tag
+or a field and is most suited to be ingested by IOx itself. By default,
+`Tag` and `Field` [semantic types][4] will be used corresponding to the
+traditional line-protocol elements.
+
+[1]: https://github.com/influxdata/influxdb-pb-data-protocol
+[2]: https://github.com/influxdata/influxdb-pb-data-protocol/blob/main/influxdb-pb-data-protocol.proto
+[3]: https://github.com/influxdata/influxdb-pb-data-protocol#optimizations
+[4]: https://github.com/influxdata/influxdb-pb-data-protocol#semantic-type

--- a/plugins/serializers/influx_protobuf/influx_protobuf.go
+++ b/plugins/serializers/influx_protobuf/influx_protobuf.go
@@ -48,14 +48,12 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 			Columns:   make([]*influx.Column, 0, len(tbl.Tags)+len(tbl.Fields)+1),
 			RowCount:  tbl.rows,
 		}
-		table.Columns = append(table.Columns, &tbl.Time)
-		for i := range tbl.Tags {
-			col := tbl.Tags[i]
-			table.Columns = append(table.Columns, &col)
+		table.Columns = append(table.Columns, tbl.Time)
+		for _, col := range tbl.Tags {
+			table.Columns = append(table.Columns, col)
 		}
-		for i := range tbl.Fields {
-			col := tbl.Fields[i]
-			table.Columns = append(table.Columns, &col)
+		for _, col := range tbl.Fields {
+			table.Columns = append(table.Columns, col)
 		}
 		tables = append(tables, &table)
 	}

--- a/plugins/serializers/influx_protobuf/influx_protobuf.go
+++ b/plugins/serializers/influx_protobuf/influx_protobuf.go
@@ -1,0 +1,68 @@
+package influx_protobuf
+
+import (
+	"fmt"
+
+	influx "github.com/influxdata/influxdb-pb-data-protocol/golang"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/influxdata/telegraf"
+)
+
+// Serializer encodes metrics in the InfluxData protocol-buffer format
+type Serializer struct {
+	DatabaseName string
+	IsIox        bool
+}
+
+// Serialize implements serializers.Serializer.Serialize
+// github.com/influxdata/telegraf/plugins/serializers/Serializer
+func (s *Serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
+	return s.SerializeBatch([]telegraf.Metric{metric})
+}
+
+// SerializeBatch implements serializers.Serializer.SerializeBatch
+// github.com/influxdata/telegraf/plugins/serializers/Serializer
+func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
+	// Collect the metrics into tables and columns in those tables
+	collection := make(map[string]table)
+	for _, m := range metrics {
+		name := m.Name()
+
+		// Create a new table if it doesn't exist yet
+		if _, found := collection[name]; !found {
+			collection[name] = newTable()
+		}
+		c := collection[name]
+		if err := c.addMetric(m, s.IsIox); err != nil {
+			return nil, fmt.Errorf("adding metric %q failed: %v", name, err)
+		}
+		collection[name] = c
+	}
+
+	// Convert the data into the protocol-buffer format
+	tables := make([]*influx.TableBatch, 0, len(collection))
+	for name, tbl := range collection {
+		table := influx.TableBatch{
+			TableName: name,
+			Columns:   make([]*influx.Column, 0, len(tbl.Tags)+len(tbl.Fields)+1),
+			RowCount:  tbl.rows,
+		}
+		table.Columns = append(table.Columns, &tbl.Time)
+		for i := range tbl.Tags {
+			col := tbl.Tags[i]
+			table.Columns = append(table.Columns, &col)
+		}
+		for i := range tbl.Fields {
+			col := tbl.Fields[i]
+			table.Columns = append(table.Columns, &col)
+		}
+		tables = append(tables, &table)
+	}
+
+	db := influx.DatabaseBatch{
+		DatabaseName: s.DatabaseName,
+		TableBatches: tables,
+	}
+	return proto.Marshal(&db)
+}

--- a/plugins/serializers/influx_protobuf/influx_protobuf_test.go
+++ b/plugins/serializers/influx_protobuf/influx_protobuf_test.go
@@ -1,0 +1,438 @@
+package influx_protobuf
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	influx "github.com/influxdata/influxdb-pb-data-protocol/golang"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/testutil"
+)
+
+func isNull(mask []byte, idx int) bool {
+	offset, bit := (idx / 8), (idx % 8)
+
+	if len(mask) < offset+1 {
+		return false
+	}
+
+	return (mask[offset] & (1 << bit)) != 0
+}
+
+func getValue(values *influx.Column_Values, idx int) (interface{}, error) {
+	length := map[string]int{
+		"i64":    len(values.I64Values),
+		"u64":    len(values.U64Values),
+		"f64":    len(values.F64Values),
+		"string": len(values.StringValues),
+		"bool":   len(values.BoolValues),
+		"byte":   len(values.BytesValues),
+	}
+
+	// Check if only one value
+	var valid []string
+	for k, l := range length {
+		if l > 0 {
+			valid = append(valid, k)
+		}
+	}
+	if len(valid) == 0 {
+		return nil, fmt.Errorf("no values")
+	}
+	if len(valid) > 1 {
+		return nil, fmt.Errorf("mixture of value types %v", valid)
+	}
+
+	switch valid[0] {
+	case "i64":
+		v := values.I64Values
+		if len(v) < idx {
+			return v[len(v)-1], nil
+		}
+		return v[idx], nil
+	case "u64":
+		v := values.U64Values
+		if len(v) < idx {
+			return v[len(v)-1], nil
+		}
+		return v[idx], nil
+	case "f64":
+		v := values.F64Values
+		if len(v) < idx {
+			return v[len(v)-1], nil
+		}
+		return v[idx], nil
+	case "string":
+		v := values.StringValues
+		if len(v) < idx {
+			return v[len(v)-1], nil
+		}
+		return v[idx], nil
+	case "bool":
+		v := values.BoolValues
+		if len(v) < idx {
+			return v[len(v)-1], nil
+		}
+		return v[idx], nil
+	case "byte":
+		v := values.BytesValues
+		if len(v) < idx {
+			return v[len(v)-1], nil
+		}
+		return v[idx], nil
+	}
+
+	return nil, fmt.Errorf("unhandled value type %q", valid[0])
+}
+
+func getRow(columns []*influx.Column, idx int) (telegraf.Metric, error) {
+	var tset bool
+	var t time.Time
+
+	tags := make(map[string]string)
+	fields := make(map[string]interface{})
+
+	for _, col := range columns {
+		name := col.ColumnName
+		if isNull(col.NullMask, idx) {
+			// This column has no valid data in this row
+			continue
+		}
+		value, err := getValue(col.Values, idx)
+		if err != nil {
+			return nil, fmt.Errorf("get value of column %q failed: %v", name, err)
+		}
+		switch col.SemanticType {
+		case influx.Column_SEMANTIC_TYPE_IOX, influx.Column_SEMANTIC_TYPE_FIELD:
+			fields[name] = value
+		case influx.Column_SEMANTIC_TYPE_TAG:
+			v, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("tag in column %q is not a string but %T", name, value)
+			}
+			tags[name] = v
+		case influx.Column_SEMANTIC_TYPE_TIME:
+			if tset {
+				return nil, fmt.Errorf("time previously set but set again in column %q", name)
+			}
+			v, ok := value.(int64)
+			if !ok {
+				return nil, fmt.Errorf("time in column %q is not int64 but %T", name, value)
+			}
+			t, tset = time.Unix(0, v).UTC(), true
+		default:
+			return nil, fmt.Errorf("unknown column type %v", col.SemanticType)
+		}
+	}
+
+	return testutil.MustMetric("", tags, fields, t), nil
+}
+
+func toMetrics(tables []*influx.TableBatch) ([]telegraf.Metric, error) {
+	var metrics []telegraf.Metric
+
+	for _, table := range tables {
+		name := table.TableName
+		for i := 0; i < int(table.RowCount); i++ {
+			m, err := getRow(table.Columns, i)
+			if err != nil {
+				return nil, fmt.Errorf("getting row %d in table %q failed: %v", i, name, err)
+			}
+			m.SetName(name)
+			metrics = append(metrics, m)
+		}
+	}
+
+	return metrics, nil
+}
+
+func TestSerializeMetricSingleNonIOx(t *testing.T) {
+	m := testutil.MustMetric(
+		"protobuf_test",
+		map[string]string{
+			"foo":  "42",
+			"bar":  "abc",
+			"pi":   "3.14",
+			"test": "true",
+		},
+		map[string]interface{}{
+			"speed":      float64(42.23),
+			"rpm":        uint64(3500),
+			"gear":       int64(3),
+			"status":     "ok",
+			"autonomous": true,
+		},
+		time.Now().UTC(),
+	)
+
+	s := Serializer{DatabaseName: "wunderbar"}
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
+
+	var db influx.DatabaseBatch
+	require.NoError(t, proto.Unmarshal(buf, &db))
+	require.Equal(t, db.DatabaseName, "wunderbar")
+
+	actual, err := toMetrics(db.TableBatches)
+	require.NoError(t, err)
+	require.Len(t, actual, 1)
+	testutil.RequireMetricEqual(t, m, actual[0])
+}
+
+func TestSerializeMetricSingleBatchNonIOx(t *testing.T) {
+	m := []telegraf.Metric{
+		testutil.MustMetric(
+			"protobuf_test",
+			map[string]string{
+				"foo":  "42",
+				"bar":  "abc",
+				"pi":   "3.14",
+				"test": "true",
+			},
+			map[string]interface{}{
+				"speed":      float64(42.23),
+				"rpm":        uint64(3500),
+				"gear":       int64(3),
+				"status":     "ok",
+				"autonomous": true,
+			},
+			time.Now().UTC(),
+		),
+	}
+
+	s := Serializer{DatabaseName: "wunderbar"}
+	buf, err := s.SerializeBatch(m)
+	require.NoError(t, err)
+
+	var db influx.DatabaseBatch
+	require.NoError(t, proto.Unmarshal(buf, &db))
+	require.Equal(t, db.DatabaseName, "wunderbar")
+
+	actual, err := toMetrics(db.TableBatches)
+	require.NoError(t, err)
+	testutil.RequireMetricsEqual(t, m, actual, testutil.SortMetrics())
+}
+
+func TestSerializeMultipleNonIOx(t *testing.T) {
+	input := []telegraf.Metric{
+		testutil.TestMetric(float64(42.1), "a"),
+		testutil.TestMetric(float32(42.2), "b"),
+		testutil.TestMetric(uint64(3500), "c"),
+		testutil.TestMetric(uint32(3500), "d"),
+		testutil.TestMetric(uint16(35), "e"),
+		testutil.TestMetric(uint8(35), "f"),
+		testutil.TestMetric(uint(35), "g"),
+		testutil.TestMetric(int64(23), "h"),
+		testutil.TestMetric(int32(23), "i"),
+		testutil.TestMetric(int16(23), "j"),
+		testutil.TestMetric(int8(23), "k"),
+		testutil.TestMetric(int(23), "l"),
+		testutil.TestMetric("ok", "m"),
+		testutil.TestMetric("", "n"),
+		testutil.TestMetric(true, "o"),
+		testutil.TestMetric(false, "p"),
+	}
+	expected := []telegraf.Metric{
+		testutil.TestMetric(float64(42.1), "a"),
+		testutil.TestMetric(float64(float32(42.2)), "b"),
+		testutil.TestMetric(uint64(3500), "c"),
+		testutil.TestMetric(uint64(3500), "d"),
+		testutil.TestMetric(uint64(35), "e"),
+		testutil.TestMetric(uint64(35), "f"),
+		testutil.TestMetric(uint64(35), "g"),
+		testutil.TestMetric(int64(23), "h"),
+		testutil.TestMetric(int64(23), "i"),
+		testutil.TestMetric(int64(23), "j"),
+		testutil.TestMetric(int64(23), "k"),
+		testutil.TestMetric(int64(23), "l"),
+		testutil.TestMetric("ok", "m"),
+		testutil.TestMetric("", "n"),
+		testutil.TestMetric(true, "o"),
+		testutil.TestMetric(false, "p"),
+	}
+
+	s := Serializer{DatabaseName: "wunderbar"}
+	buf, err := s.SerializeBatch(input)
+	require.NoError(t, err)
+
+	var db influx.DatabaseBatch
+	require.NoError(t, proto.Unmarshal(buf, &db))
+	require.Equal(t, db.DatabaseName, "wunderbar")
+
+	actual, err := toMetrics(db.TableBatches)
+	require.NoError(t, err)
+	testutil.RequireMetricsEqual(t, expected, actual, testutil.SortMetrics())
+}
+
+func TestSerializeMetricSingleIOx(t *testing.T) {
+	input := testutil.MustMetric(
+		"protobuf_test",
+		map[string]string{
+			"foo":  "42",
+			"bar":  "abc",
+			"pi":   "3.14",
+			"test": "true",
+		},
+		map[string]interface{}{
+			"speed":      float64(42.23),
+			"rpm":        uint64(3500),
+			"gear":       int64(3),
+			"status":     "ok",
+			"autonomous": true,
+		},
+		time.Now().UTC(),
+	)
+
+	expected := testutil.MustMetric(
+		"protobuf_test",
+		map[string]string{},
+		map[string]interface{}{
+			"speed":      float64(42.23),
+			"rpm":        uint64(3500),
+			"gear":       int64(3),
+			"status":     "ok",
+			"autonomous": true,
+			"foo":        "42",
+			"bar":        "abc",
+			"pi":         "3.14",
+			"test":       "true",
+		},
+		input.Time(),
+	)
+
+	s := Serializer{
+		DatabaseName: "wunderbar",
+		IsIox:        true,
+	}
+	buf, err := s.Serialize(input)
+	require.NoError(t, err)
+
+	var db influx.DatabaseBatch
+	require.NoError(t, proto.Unmarshal(buf, &db))
+	require.Equal(t, db.DatabaseName, "wunderbar")
+
+	actual, err := toMetrics(db.TableBatches)
+	require.NoError(t, err)
+	require.Len(t, actual, 1)
+	testutil.RequireMetricEqual(t, expected, actual[0])
+}
+
+func TestSerializeMetricSingleBatchIOx(t *testing.T) {
+	input := []telegraf.Metric{
+		testutil.MustMetric(
+			"protobuf_test",
+			map[string]string{
+				"foo":  "42",
+				"bar":  "abc",
+				"pi":   "3.14",
+				"test": "true",
+			},
+			map[string]interface{}{
+				"speed":      float64(42.23),
+				"rpm":        uint64(3500),
+				"gear":       int64(3),
+				"status":     "ok",
+				"autonomous": true,
+			},
+			time.Now().UTC(),
+		),
+	}
+
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"protobuf_test",
+			map[string]string{},
+			map[string]interface{}{
+				"speed":      float64(42.23),
+				"rpm":        uint64(3500),
+				"gear":       int64(3),
+				"status":     "ok",
+				"autonomous": true,
+				"foo":        "42",
+				"bar":        "abc",
+				"pi":         "3.14",
+				"test":       "true",
+			},
+			input[0].Time(),
+		),
+	}
+	s := Serializer{
+		DatabaseName: "wunderbar",
+		IsIox:        true,
+	}
+	buf, err := s.SerializeBatch(input)
+	require.NoError(t, err)
+
+	var db influx.DatabaseBatch
+	require.NoError(t, proto.Unmarshal(buf, &db))
+	require.Equal(t, db.DatabaseName, "wunderbar")
+
+	actual, err := toMetrics(db.TableBatches)
+	require.NoError(t, err)
+	testutil.RequireMetricsEqual(t, expected, actual, testutil.SortMetrics())
+}
+
+func TestSerializeMultipleIOx(t *testing.T) {
+	input := []telegraf.Metric{
+		testutil.TestMetric(float64(42.1), "a"),
+		testutil.TestMetric(float32(42.2), "b"),
+		testutil.TestMetric(uint64(3500), "c"),
+		testutil.TestMetric(uint32(3500), "d"),
+		testutil.TestMetric(uint16(35), "e"),
+		testutil.TestMetric(uint8(35), "f"),
+		testutil.TestMetric(uint(35), "g"),
+		testutil.TestMetric(int64(23), "h"),
+		testutil.TestMetric(int32(23), "i"),
+		testutil.TestMetric(int16(23), "j"),
+		testutil.TestMetric(int8(23), "k"),
+		testutil.TestMetric(int(23), "l"),
+		testutil.TestMetric("ok", "m"),
+		testutil.TestMetric("", "n"),
+		testutil.TestMetric(true, "o"),
+		testutil.TestMetric(false, "p"),
+	}
+
+	expected := make([]telegraf.Metric, 0, len(input))
+	for _, m := range input {
+		e := m.Copy()
+		for key, value := range e.Fields() {
+			switch x := value.(type) {
+			case int, int8, int16, int32:
+				v, err := internal.ToInt64(value)
+				require.NoError(t, err)
+				e.AddField(key, v)
+			case uint, uint8, uint16, uint32:
+				v, err := internal.ToUint64(value)
+				require.NoError(t, err)
+				e.AddField(key, v)
+			case float32:
+				e.AddField(key, float64(x))
+			}
+		}
+		for key, value := range e.Tags() {
+			e.AddField(key, value)
+			e.RemoveTag(key)
+		}
+		expected = append(expected, e)
+	}
+
+	s := Serializer{
+		DatabaseName: "wunderbar",
+		IsIox:        true,
+	}
+	buf, err := s.SerializeBatch(input)
+	require.NoError(t, err)
+
+	var db influx.DatabaseBatch
+	require.NoError(t, proto.Unmarshal(buf, &db))
+	require.Equal(t, db.DatabaseName, "wunderbar")
+
+	actual, err := toMetrics(db.TableBatches)
+	require.NoError(t, err)
+	testutil.RequireMetricsEqual(t, expected, actual, testutil.SortMetrics())
+}

--- a/plugins/serializers/influx_protobuf/table.go
+++ b/plugins/serializers/influx_protobuf/table.go
@@ -1,0 +1,158 @@
+package influx_protobuf
+
+import (
+	"fmt"
+
+	influx "github.com/influxdata/influxdb-pb-data-protocol/golang"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+)
+
+type table struct {
+	Time   influx.Column
+	Tags   map[string]influx.Column
+	Fields map[string]influx.Column
+	rows   uint32
+}
+
+func newTable() table {
+	return table{
+		Time: influx.Column{
+			ColumnName:   "time",
+			SemanticType: influx.Column_SEMANTIC_TYPE_TIME,
+			Values:       &influx.Column_Values{},
+		},
+		Tags:   make(map[string]influx.Column),
+		Fields: make(map[string]influx.Column),
+	}
+}
+
+func (t *table) addMetric(metric telegraf.Metric, isiox bool) error {
+	// Compute the byte and bit-offset for null-value handling
+	offset, bit := (t.rows / 8), (t.rows % 8)
+
+	// Add time (we leave out null-mask as all values are set)
+	t.Time.Values.I64Values = append(t.Time.Values.I64Values, metric.Time().UnixNano())
+
+	// Add tag columns
+	for _, tag := range metric.TagList() {
+		if _, found := t.Tags[tag.Key]; !found {
+			// We get a new tag column, so create a new column and mark
+			// all previous entries as null-values
+			col := influx.Column{
+				ColumnName:   tag.Key,
+				SemanticType: influx.Column_SEMANTIC_TYPE_TAG,
+				Values:       &influx.Column_Values{StringValues: make([]string, t.rows)},
+				NullMask:     make([]byte, offset+1),
+			}
+			if isiox {
+				col.SemanticType = influx.Column_SEMANTIC_TYPE_IOX
+			}
+			// Set all null-bits for the previous entries
+			for i := uint32(0); i < offset; i++ {
+				col.NullMask[i] = ^byte(0)
+			}
+			col.NullMask[offset] = byte(1<<bit+1) - 1
+			t.Tags[tag.Key] = col
+		}
+
+		col := t.Tags[tag.Key]
+		missing := int(offset+1) - len(t.Tags[tag.Key].NullMask)
+		if missing > 0 {
+			col.NullMask = append(col.NullMask, make([]byte, missing)...)
+		}
+
+		// Add the tag
+		col.Values.StringValues = append(col.Values.StringValues, tag.Value)
+		col.NullMask[offset] = col.NullMask[offset] & ^byte(1<<bit)
+		t.Tags[tag.Key] = col
+	}
+
+	// Add field columns
+	for _, field := range metric.FieldList() {
+		if _, found := t.Fields[field.Key]; !found {
+			// We get a new tag column, so create a new column and mark
+			// all previous entries as null-values
+			col := influx.Column{
+				ColumnName:   field.Key,
+				SemanticType: influx.Column_SEMANTIC_TYPE_FIELD,
+				Values:       &influx.Column_Values{},
+				NullMask:     make([]byte, offset+1),
+			}
+			if isiox {
+				col.SemanticType = influx.Column_SEMANTIC_TYPE_IOX
+			}
+			// Set all null-bits for the previous entries
+			for i := uint32(0); i < offset; i++ {
+				col.NullMask[i] = ^byte(0)
+			}
+			col.NullMask[offset] = byte(1<<bit+1) - 1
+			t.Fields[field.Key] = col
+		}
+
+		col := t.Fields[field.Key]
+		missing := int(offset+1) - len(col.NullMask)
+		if missing > 0 {
+			col.NullMask = append(col.NullMask, make([]byte, missing)...)
+		}
+		// Add the field
+		switch v := field.Value.(type) {
+		case int, int8, int16, int32, int64:
+			n := len(col.Values.I64Values)
+			if uint32(n) != t.rows {
+				return fmt.Errorf("field %q of type %T has insufficient length (%d != %d)", field.Key, v, n, t.rows)
+			}
+			x, err := internal.ToInt64(field.Value)
+			if err != nil {
+				return fmt.Errorf("converting field %q of type %T failed: %v", field.Key, v, err)
+			}
+			col.Values.I64Values = append(col.Values.I64Values, x)
+		case uint, uint8, uint16, uint32, uint64:
+			n := len(col.Values.U64Values)
+			if uint32(n) != t.rows {
+				return fmt.Errorf("field %q of type %T has insufficient length (%d != %d)", field.Key, v, n, t.rows)
+			}
+			x, err := internal.ToUint64(field.Value)
+			if err != nil {
+				return fmt.Errorf("converting field %q of type %T failed: %v", field.Key, v, err)
+			}
+			col.Values.U64Values = append(col.Values.U64Values, x)
+		case float32, float64:
+			n := len(col.Values.F64Values)
+			if uint32(n) != t.rows {
+				return fmt.Errorf("field %q of type %T has insufficient length (%d != %d)", field.Key, v, n, t.rows)
+			}
+			x, err := internal.ToFloat64(field.Value)
+			if err != nil {
+				return fmt.Errorf("converting field %q of type %T failed: %v", field.Key, v, err)
+			}
+			col.Values.F64Values = append(col.Values.F64Values, x)
+		case string:
+			n := len(col.Values.StringValues)
+			if uint32(n) != t.rows {
+				return fmt.Errorf("field %q of type %T has insufficient length (%d != %d)", field.Key, v, n, t.rows)
+			}
+			col.Values.StringValues = append(col.Values.StringValues, v)
+		case bool:
+			n := len(col.Values.BoolValues)
+			if uint32(n) != t.rows {
+				return fmt.Errorf("field %q of type %T has insufficient length (%d != %d)", field.Key, v, n, t.rows)
+			}
+			col.Values.BoolValues = append(col.Values.BoolValues, v)
+		case []byte:
+			n := len(col.Values.BytesValues)
+			if uint32(n) != t.rows {
+				return fmt.Errorf("field %q of type %T has insufficient length (%d != %d)", field.Key, v, n, t.rows)
+			}
+			col.Values.BytesValues = append(col.Values.BytesValues, v)
+		default:
+			return fmt.Errorf("field %q contains unknown type %t", field.Key, v)
+		}
+		col.NullMask[offset] = col.NullMask[offset] & ^byte(1<<bit)
+		t.Fields[field.Key] = col
+	}
+	t.rows++
+
+	return nil
+}

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers/carbon2"
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
+	"github.com/influxdata/telegraf/plugins/serializers/influx_protobuf"
 	"github.com/influxdata/telegraf/plugins/serializers/json"
 	"github.com/influxdata/telegraf/plugins/serializers/msgpack"
 	"github.com/influxdata/telegraf/plugins/serializers/nowmetric"
@@ -75,6 +76,12 @@ type Config struct {
 	// Support unsigned integer output; influx format only
 	InfluxUintSupport bool `toml:"influx_uint_support"`
 
+	// Database name for binary protocol
+	InfluxProtobufDatabase string `toml:"influx_protobuf_database"`
+
+	// Use IOx format
+	InfluxProtobufIOx bool `toml:"influx_protobuf_iox"`
+
 	// Prefix to add to all measurements, only supports Graphite
 	Prefix string `toml:"prefix"`
 
@@ -123,6 +130,8 @@ func NewSerializer(config *Config) (Serializer, error) {
 	switch config.DataFormat {
 	case "influx":
 		serializer, err = NewInfluxSerializerConfig(config)
+	case "influx_protobuf":
+		serializer, err = NewInfluxProtobufSerializer(config.InfluxProtobufDatabase, config.InfluxProtobufIOx)
 	case "graphite":
 		serializer, err = NewGraphiteSerializer(config.Prefix, config.Template, config.GraphiteTagSupport, config.GraphiteTagSanitizeMode, config.GraphiteSeparator, config.Templates)
 	case "json":
@@ -227,6 +236,14 @@ func NewInfluxSerializerConfig(config *Config) (Serializer, error) {
 
 func NewInfluxSerializer() (Serializer, error) {
 	return influx.NewSerializer(), nil
+}
+
+func NewInfluxProtobufSerializer(db string, iox bool) (Serializer, error) {
+	s := influx_protobuf.Serializer{
+		DatabaseName: db,
+		IsIox:        iox,
+	}
+	return &s, nil
 }
 
 func NewGraphiteSerializer(prefix, template string, tagSupport bool, tagSanitizeMode string, separator string, templates []string) (Serializer, error) {


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #9492

This PR adds a serializer for the [InfluxDB Protobuf Data Protocol](https://github.com/influxdata/influxdb-pb-data-protocol) format; a binary format to represent timeseries data. The serializer can handle both, the binary version of the line-protocol as well as the new IOx format.