### PR TITLE
fix: Linter fixes for plugins/inputs/[a-o]* (leftovers)

### DIFF
--- a/plugins/inputs/bind/bind_test.go
+++ b/plugins/inputs/bind/bind_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBindJsonStats(t *testing.T) {
@@ -29,7 +30,7 @@ func TestBindJsonStats(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(b.Gather)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Use subtests for counters, since they are similar structure
 	type fieldSet struct {
@@ -179,8 +180,8 @@ func TestBindJsonStats(t *testing.T) {
 
 	// Subtest for per-context memory stats
 	t.Run("memory_context", func(t *testing.T) {
-		assert.True(t, acc.HasInt64Field("bind_memory_context", "total"))
-		assert.True(t, acc.HasInt64Field("bind_memory_context", "in_use"))
+		require.True(t, acc.HasInt64Field("bind_memory_context", "total"))
+		require.True(t, acc.HasInt64Field("bind_memory_context", "in_use"))
 	})
 }
 
@@ -202,7 +203,7 @@ func TestBindXmlStatsV2(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(b.Gather)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Use subtests for counters, since they are similar structure
 	type fieldSet struct {
@@ -384,8 +385,8 @@ func TestBindXmlStatsV2(t *testing.T) {
 
 	// Subtest for per-context memory stats
 	t.Run("memory_context", func(t *testing.T) {
-		assert.True(t, acc.HasInt64Field("bind_memory_context", "total"))
-		assert.True(t, acc.HasInt64Field("bind_memory_context", "in_use"))
+		require.True(t, acc.HasInt64Field("bind_memory_context", "total"))
+		require.True(t, acc.HasInt64Field("bind_memory_context", "in_use"))
 	})
 }
 
@@ -407,7 +408,7 @@ func TestBindXmlStatsV3(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(b.Gather)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Use subtests for counters, since they are similar structure
 	type fieldSet struct {
@@ -611,8 +612,8 @@ func TestBindXmlStatsV3(t *testing.T) {
 
 	// Subtest for per-context memory stats
 	t.Run("memory_context", func(t *testing.T) {
-		assert.True(t, acc.HasInt64Field("bind_memory_context", "total"))
-		assert.True(t, acc.HasInt64Field("bind_memory_context", "in_use"))
+		require.True(t, acc.HasInt64Field("bind_memory_context", "total"))
+		require.True(t, acc.HasInt64Field("bind_memory_context", "in_use"))
 	})
 }
 
@@ -623,5 +624,5 @@ func TestBindUnparseableURL(t *testing.T) {
 
 	var acc testutil.Accumulator
 	err := acc.GatherError(b.Gather)
-	assert.Contains(t, err.Error(), "unable to parse address")
+	require.Contains(t, err.Error(), "unable to parse address")
 }

--- a/plugins/inputs/cassandra/cassandra_test.go
+++ b/plugins/inputs/cassandra/cassandra_test.go
@@ -1,15 +1,14 @@
 package cassandra
 
 import (
-	_ "fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
-	_ "github.com/stretchr/testify/require"
 )
 
 const validJavaMultiValueJSON = `
@@ -138,8 +137,8 @@ func TestHttpJsonJavaMultiValue(t *testing.T) {
 	acc.SetDebug(true)
 	err := acc.GatherError(cassandra.Gather)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(acc.Metrics))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(acc.Metrics))
 
 	fields := map[string]interface{}{
 		"HeapMemoryUsage_init":      67108864.0,
@@ -167,8 +166,8 @@ func TestHttpJsonJavaMultiType(t *testing.T) {
 	acc.SetDebug(true)
 	err := acc.GatherError(cassandra.Gather)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(acc.Metrics))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(acc.Metrics))
 
 	fields := map[string]interface{}{
 		"CollectionCount": 1.0,
@@ -188,9 +187,9 @@ func TestHttp404(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(jolokia.Gather)
 
-	assert.Error(t, err)
-	assert.Equal(t, 0, len(acc.Metrics))
-	assert.Contains(t, err.Error(), "has status code 404")
+	require.Error(t, err)
+	require.Equal(t, 0, len(acc.Metrics))
+	require.Contains(t, err.Error(), "has status code 404")
 }
 
 // Test that the proper values are ignored or collected for class=Cassandra
@@ -200,8 +199,8 @@ func TestHttpJsonCassandraMultiValue(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(cassandra.Gather)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(acc.Metrics))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(acc.Metrics))
 
 	fields := map[string]interface{}{
 		"ReadLatency_999thPercentile": 20.0,
@@ -232,8 +231,8 @@ func TestHttpJsonCassandraNestedMultiValue(t *testing.T) {
 	acc.SetDebug(true)
 	err := acc.GatherError(cassandra.Gather)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(acc.Metrics))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(acc.Metrics))
 
 	fields1 := map[string]interface{}{
 		"ReadLatency_999thPercentile": 1.0,

--- a/plugins/inputs/cloud_pubsub/pubsub_test.go
+++ b/plugins/inputs/cloud_pubsub/pubsub_test.go
@@ -5,9 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -53,7 +54,7 @@ func TestRunParse(t *testing.T) {
 	sub.messages <- msg
 
 	acc.Wait(1)
-	assert.Equal(t, acc.NFields(), 1)
+	require.Equal(t, acc.NFields(), 1)
 	metric := acc.Metrics[0]
 	validateTestInfluxMetric(t, metric)
 }
@@ -98,7 +99,7 @@ func TestRunBase64(t *testing.T) {
 	sub.messages <- msg
 
 	acc.Wait(1)
-	assert.Equal(t, acc.NFields(), 1)
+	require.Equal(t, acc.NFields(), 1)
 	metric := acc.Metrics[0]
 	validateTestInfluxMetric(t, metric)
 }
@@ -145,7 +146,7 @@ func TestRunInvalidMessages(t *testing.T) {
 	// Make sure we acknowledged message so we don't receive it again.
 	testTracker.WaitForAck(1)
 
-	assert.Equal(t, acc.NFields(), 0)
+	require.Equal(t, acc.NFields(), 0)
 }
 
 func TestRunOverlongMessages(t *testing.T) {
@@ -192,7 +193,7 @@ func TestRunOverlongMessages(t *testing.T) {
 	// Make sure we acknowledged message so we don't receive it again.
 	testTracker.WaitForAck(1)
 
-	assert.Equal(t, acc.NFields(), 0)
+	require.Equal(t, acc.NFields(), 0)
 }
 
 func TestRunErrorInSubscriber(t *testing.T) {
@@ -228,12 +229,12 @@ func TestRunErrorInSubscriber(t *testing.T) {
 		t.Fatal("expected plugin subscription to be non-nil")
 	}
 	acc.WaitError(1)
-	assert.Regexp(t, fakeErrStr, acc.Errors[0])
+	require.Regexp(t, fakeErrStr, acc.Errors[0])
 }
 
 func validateTestInfluxMetric(t *testing.T, m *testutil.Metric) {
-	assert.Equal(t, "cpu_load_short", m.Measurement)
-	assert.Equal(t, "server01", m.Tags["host"])
-	assert.Equal(t, 23422.0, m.Fields["value"])
-	assert.Equal(t, int64(1422568543702900257), m.Time.UnixNano())
+	require.Equal(t, "cpu_load_short", m.Measurement)
+	require.Equal(t, "server01", m.Tags["host"])
+	require.Equal(t, 23422.0, m.Fields["value"])
+	require.Equal(t, int64(1422568543702900257), m.Time.UnixNano())
 }

--- a/plugins/inputs/csgo/csgo_test.go
+++ b/plugins/inputs/csgo/csgo_test.go
@@ -1,10 +1,11 @@
 package csgo
 
 import (
-	"github.com/influxdata/telegraf/testutil"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 const testInput = `CPU   NetIn   NetOut    Uptime  Maps   FPS   Players  Svms    +-ms   ~tick
@@ -28,17 +29,17 @@ func TestCPUStats(t *testing.T) {
 		t.Errorf("acc.HasMeasurement: expected csgo")
 	}
 
-	assert.Equal(t, "1.2.3.4:1234", acc.Metrics[0].Tags["host"])
-	assert.Equal(t, expectedOutput.CPU, acc.Metrics[0].Fields["cpu"])
-	assert.Equal(t, expectedOutput.NetIn, acc.Metrics[0].Fields["net_in"])
-	assert.Equal(t, expectedOutput.NetOut, acc.Metrics[0].Fields["net_out"])
-	assert.Equal(t, expectedOutput.UptimeMinutes, acc.Metrics[0].Fields["uptime_minutes"])
-	assert.Equal(t, expectedOutput.Maps, acc.Metrics[0].Fields["maps"])
-	assert.Equal(t, expectedOutput.FPS, acc.Metrics[0].Fields["fps"])
-	assert.Equal(t, expectedOutput.Players, acc.Metrics[0].Fields["players"])
-	assert.Equal(t, expectedOutput.Sim, acc.Metrics[0].Fields["sv_ms"])
-	assert.Equal(t, expectedOutput.Variance, acc.Metrics[0].Fields["variance_ms"])
-	assert.Equal(t, expectedOutput.Tick, acc.Metrics[0].Fields["tick_ms"])
+	require.Equal(t, "1.2.3.4:1234", acc.Metrics[0].Tags["host"])
+	require.Equal(t, expectedOutput.CPU, acc.Metrics[0].Fields["cpu"])
+	require.Equal(t, expectedOutput.NetIn, acc.Metrics[0].Fields["net_in"])
+	require.Equal(t, expectedOutput.NetOut, acc.Metrics[0].Fields["net_out"])
+	require.Equal(t, expectedOutput.UptimeMinutes, acc.Metrics[0].Fields["uptime_minutes"])
+	require.Equal(t, expectedOutput.Maps, acc.Metrics[0].Fields["maps"])
+	require.Equal(t, expectedOutput.FPS, acc.Metrics[0].Fields["fps"])
+	require.Equal(t, expectedOutput.Players, acc.Metrics[0].Fields["players"])
+	require.Equal(t, expectedOutput.Sim, acc.Metrics[0].Fields["sv_ms"])
+	require.Equal(t, expectedOutput.Variance, acc.Metrics[0].Fields["variance_ms"])
+	require.Equal(t, expectedOutput.Tick, acc.Metrics[0].Fields["tick_ms"])
 }
 
 func requestMock(_ string, _ string) (string, error) {

--- a/plugins/inputs/dcos/client.go
+++ b/plugins/inputs/dcos/client.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 const (
@@ -100,7 +100,7 @@ type ClusterClient struct {
 
 type claims struct {
 	UID string `json:"uid"`
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }
 
 func (e APIError) Error() string {
@@ -327,9 +327,9 @@ func (c *ClusterClient) toURL(path string) string {
 func (c *ClusterClient) createLoginToken(sa *ServiceAccount) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims{
 		UID: sa.AccountID,
-		StandardClaims: jwt.StandardClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
 			// How long we have to login with this token
-			ExpiresAt: time.Now().Add(time.Minute * 5).Unix(),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 5)),
 		},
 	})
 	return token.SignedString(sa.PrivateKey)

--- a/plugins/inputs/dcos/dcos.go
+++ b/plugins/inputs/dcos/dcos.go
@@ -237,9 +237,7 @@ func (d *DCOS) createPoints(m *Metrics) []*point {
 			fieldKey = fieldKey + "_bytes"
 		}
 
-		if strings.HasPrefix(fieldKey, "dcos_metrics_module_") {
-			fieldKey = strings.TrimPrefix(fieldKey, "dcos_metrics_module_")
-		}
+		fieldKey = strings.TrimPrefix(fieldKey, "dcos_metrics_module_")
 
 		tagset := make([]string, 0, len(tags))
 		for k, v := range tags {

--- a/plugins/inputs/dcos/dcos.go
+++ b/plugins/inputs/dcos/dcos.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"

--- a/plugins/inputs/dns_query/dns_query_test.go
+++ b/plugins/inputs/dns_query/dns_query_test.go
@@ -4,11 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf/testutil"
-
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 var servers = []string{"8.8.8.8"}
@@ -25,12 +24,12 @@ func TestGathering(t *testing.T) {
 	var acc testutil.Accumulator
 
 	err := acc.GatherError(dnsConfig.Gather)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	metric, ok := acc.Get("dns_query")
 	require.True(t, ok)
 	queryTime, _ := metric.Fields["query_time_ms"].(float64)
 
-	assert.NotEqual(t, 0, queryTime)
+	require.NotEqual(t, 0, queryTime)
 }
 
 func TestGatheringMxRecord(t *testing.T) {
@@ -45,12 +44,12 @@ func TestGatheringMxRecord(t *testing.T) {
 	dnsConfig.RecordType = "MX"
 
 	err := acc.GatherError(dnsConfig.Gather)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	metric, ok := acc.Get("dns_query")
 	require.True(t, ok)
 	queryTime, _ := metric.Fields["query_time_ms"].(float64)
 
-	assert.NotEqual(t, 0, queryTime)
+	require.NotEqual(t, 0, queryTime)
 }
 
 func TestGatheringRootDomain(t *testing.T) {
@@ -76,7 +75,7 @@ func TestGatheringRootDomain(t *testing.T) {
 	}
 
 	err := acc.GatherError(dnsConfig.Gather)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	metric, ok := acc.Get("dns_query")
 	require.True(t, ok)
 	queryTime, _ := metric.Fields["query_time_ms"].(float64)
@@ -107,7 +106,7 @@ func TestMetricContainsServerAndDomainAndRecordTypeTags(t *testing.T) {
 	}
 
 	err := acc.GatherError(dnsConfig.Gather)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	metric, ok := acc.Get("dns_query")
 	require.True(t, ok)
 	queryTime, _ := metric.Fields["query_time_ms"].(float64)
@@ -134,9 +133,9 @@ func TestGatheringTimeout(t *testing.T) {
 	}()
 	select {
 	case err := <-channel:
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	case <-time.After(time.Second * 2):
-		assert.Fail(t, "DNS query did not timeout")
+		require.Fail(t, "DNS query did not timeout")
 	}
 }
 
@@ -145,16 +144,16 @@ func TestSettingDefaultValues(t *testing.T) {
 
 	dnsConfig.setDefaultValues()
 
-	assert.Equal(t, []string{"."}, dnsConfig.Domains, "Default domain not equal \".\"")
-	assert.Equal(t, "NS", dnsConfig.RecordType, "Default record type not equal 'NS'")
-	assert.Equal(t, 53, dnsConfig.Port, "Default port number not equal 53")
-	assert.Equal(t, 2, dnsConfig.Timeout, "Default timeout not equal 2")
+	require.Equal(t, []string{"."}, dnsConfig.Domains, "Default domain not equal \".\"")
+	require.Equal(t, "NS", dnsConfig.RecordType, "Default record type not equal 'NS'")
+	require.Equal(t, 53, dnsConfig.Port, "Default port number not equal 53")
+	require.Equal(t, 2, dnsConfig.Timeout, "Default timeout not equal 2")
 
 	dnsConfig = DNSQuery{Domains: []string{"."}}
 
 	dnsConfig.setDefaultValues()
 
-	assert.Equal(t, "NS", dnsConfig.RecordType, "Default record type not equal 'NS'")
+	require.Equal(t, "NS", dnsConfig.RecordType, "Default record type not equal 'NS'")
 }
 
 func TestRecordTypeParser(t *testing.T) {
@@ -163,47 +162,47 @@ func TestRecordTypeParser(t *testing.T) {
 
 	dnsConfig.RecordType = "A"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypeA, recordType)
+	require.Equal(t, dns.TypeA, recordType)
 
 	dnsConfig.RecordType = "AAAA"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypeAAAA, recordType)
+	require.Equal(t, dns.TypeAAAA, recordType)
 
 	dnsConfig.RecordType = "ANY"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypeANY, recordType)
+	require.Equal(t, dns.TypeANY, recordType)
 
 	dnsConfig.RecordType = "CNAME"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypeCNAME, recordType)
+	require.Equal(t, dns.TypeCNAME, recordType)
 
 	dnsConfig.RecordType = "MX"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypeMX, recordType)
+	require.Equal(t, dns.TypeMX, recordType)
 
 	dnsConfig.RecordType = "NS"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypeNS, recordType)
+	require.Equal(t, dns.TypeNS, recordType)
 
 	dnsConfig.RecordType = "PTR"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypePTR, recordType)
+	require.Equal(t, dns.TypePTR, recordType)
 
 	dnsConfig.RecordType = "SOA"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypeSOA, recordType)
+	require.Equal(t, dns.TypeSOA, recordType)
 
 	dnsConfig.RecordType = "SPF"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypeSPF, recordType)
+	require.Equal(t, dns.TypeSPF, recordType)
 
 	dnsConfig.RecordType = "SRV"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypeSRV, recordType)
+	require.Equal(t, dns.TypeSRV, recordType)
 
 	dnsConfig.RecordType = "TXT"
 	recordType, _ = dnsConfig.parseRecordType()
-	assert.Equal(t, dns.TypeTXT, recordType)
+	require.Equal(t, dns.TypeTXT, recordType)
 }
 
 func TestRecordTypeParserError(t *testing.T) {
@@ -212,5 +211,5 @@ func TestRecordTypeParserError(t *testing.T) {
 
 	dnsConfig.RecordType = "nil"
 	_, err = dnsConfig.parseRecordType()
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/plugins/inputs/dns_query/dns_query_test.go
+++ b/plugins/inputs/dns_query/dns_query_test.go
@@ -70,7 +70,7 @@ func TestGatheringRootDomain(t *testing.T) {
 		"result":      "success",
 	}
 	fields := map[string]interface{}{
-		"rcode_value": int(0),
+		"rcode_value": 0,
 		"result_code": uint64(0),
 	}
 
@@ -101,7 +101,7 @@ func TestMetricContainsServerAndDomainAndRecordTypeTags(t *testing.T) {
 		"result":      "success",
 	}
 	fields := map[string]interface{}{
-		"rcode_value": int(0),
+		"rcode_value": 0,
 		"result_code": uint64(0),
 	}
 

--- a/plugins/inputs/ecs/client_test.go
+++ b/plugins/inputs/ecs/client_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type pollMock struct {
@@ -80,8 +80,8 @@ func TestEcsClient_PollSync(t *testing.T) {
 				t.Errorf("EcsClient.PollSync() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.Equal(t, tt.want, got, "EcsClient.PollSync() got = %v, want %v", got, tt.want)
-			assert.Equal(t, tt.want1, got1, "EcsClient.PollSync() got1 = %v, want %v", got1, tt.want1)
+			require.Equal(t, tt.want, got, "EcsClient.PollSync() got = %v, want %v", got, tt.want)
+			require.Equal(t, tt.want1, got1, "EcsClient.PollSync() got1 = %v, want %v", got1, tt.want1)
 		})
 	}
 }
@@ -160,7 +160,7 @@ func TestEcsClient_Task(t *testing.T) {
 				t.Errorf("EcsClient.Task() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.Equal(t, tt.want, got, "EcsClient.Task() = %v, want %v", got, tt.want)
+			require.Equal(t, tt.want, got, "EcsClient.Task() = %v, want %v", got, tt.want)
 		})
 	}
 }
@@ -234,7 +234,7 @@ func TestEcsClient_ContainerStats(t *testing.T) {
 				t.Errorf("EcsClient.ContainerStats() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.Equal(t, tt.want, got, "EcsClient.ContainerStats() = %v, want %v", got, tt.want)
+			require.Equal(t, tt.want, got, "EcsClient.ContainerStats() = %v, want %v", got, tt.want)
 		})
 	}
 }
@@ -268,10 +268,10 @@ func TestResolveTaskURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			baseURL, err := url.Parse(tt.base)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			act := resolveTaskURL(baseURL, tt.ver)
-			assert.Equal(t, tt.exp, act)
+			require.Equal(t, tt.exp, act)
 		})
 	}
 }
@@ -305,10 +305,10 @@ func TestResolveStatsURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			baseURL, err := url.Parse(tt.base)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			act := resolveStatsURL(baseURL, tt.ver)
-			assert.Equal(t, tt.exp, act)
+			require.Equal(t, tt.exp, act)
 		})
 	}
 }

--- a/plugins/inputs/ethtool/ethtool_test.go
+++ b/plugins/inputs/ethtool/ethtool_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -310,8 +310,8 @@ func TestGather(t *testing.T) {
 	var acc testutil.Accumulator
 
 	err := command.Gather(&acc)
-	assert.NoError(t, err)
-	assert.Len(t, acc.Metrics, 2)
+	require.NoError(t, err)
+	require.Len(t, acc.Metrics, 2)
 
 	expectedFieldsEth1 := toStringMapInterface(interfaceMap["eth1"].Stat)
 	expectedTagsEth1 := map[string]string{
@@ -334,8 +334,8 @@ func TestGatherIncludeInterfaces(t *testing.T) {
 	command.InterfaceInclude = append(command.InterfaceInclude, "eth1")
 
 	err := command.Gather(&acc)
-	assert.NoError(t, err)
-	assert.Len(t, acc.Metrics, 1)
+	require.NoError(t, err)
+	require.Len(t, acc.Metrics, 1)
 
 	// Should contain eth1
 	expectedFieldsEth1 := toStringMapInterface(interfaceMap["eth1"].Stat)
@@ -361,8 +361,8 @@ func TestGatherIgnoreInterfaces(t *testing.T) {
 	command.InterfaceExclude = append(command.InterfaceExclude, "eth1")
 
 	err := command.Gather(&acc)
-	assert.NoError(t, err)
-	assert.Len(t, acc.Metrics, 1)
+	require.NoError(t, err)
+	require.Len(t, acc.Metrics, 1)
 
 	// Should not contain eth1
 	expectedFieldsEth1 := toStringMapInterface(interfaceMap["eth1"].Stat)
@@ -489,8 +489,8 @@ func TestNormalizedKeys(t *testing.T) {
 		var acc testutil.Accumulator
 		err := command.Gather(&acc)
 
-		assert.NoError(t, err)
-		assert.Len(t, acc.Metrics, 1)
+		require.NoError(t, err)
+		require.Len(t, acc.Metrics, 1)
 
 		acc.AssertContainsFields(t, pluginName, toStringMapInterface(c.expectedFields))
 		acc.AssertContainsTaggedFields(t, pluginName, toStringMapInterface(c.expectedFields), expectedTags)

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const validJSON = `
@@ -94,7 +94,7 @@ func TestExec(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(e.Gather)
 	require.NoError(t, err)
-	assert.Equal(t, acc.NFields(), 8, "non-numeric measurements should be ignored")
+	require.Equal(t, acc.NFields(), 8, "non-numeric measurements should be ignored")
 
 	fields := map[string]interface{}{
 		"num_processes": float64(82),
@@ -123,7 +123,7 @@ func TestExecMalformed(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.Error(t, acc.GatherError(e.Gather))
-	assert.Equal(t, acc.NFields(), 0, "No new points should have been added")
+	require.Equal(t, acc.NFields(), 0, "No new points should have been added")
 }
 
 func TestCommandError(t *testing.T) {
@@ -140,7 +140,7 @@ func TestCommandError(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.Error(t, acc.GatherError(e.Gather))
-	assert.Equal(t, acc.NFields(), 0, "No new points should have been added")
+	require.Equal(t, acc.NFields(), 0, "No new points should have been added")
 }
 
 func TestExecCommandWithGlob(t *testing.T) {
@@ -263,14 +263,14 @@ func TestRemoveCarriageReturns(t *testing.T) {
 		for _, test := range crTests {
 			b := bytes.NewBuffer(test.input)
 			out := removeWindowsCarriageReturns(*b)
-			assert.True(t, bytes.Equal(test.output, out.Bytes()))
+			require.True(t, bytes.Equal(test.output, out.Bytes()))
 		}
 	} else {
 		// Test that the buffer is returned unaltered
 		for _, test := range crTests {
 			b := bytes.NewBuffer(test.input)
 			out := removeWindowsCarriageReturns(*b)
-			assert.True(t, bytes.Equal(test.input, out.Bytes()))
+			require.True(t, bytes.Equal(test.input, out.Bytes()))
 		}
 	}
 }

--- a/plugins/inputs/execd/shim/goshim_posix.go
+++ b/plugins/inputs/execd/shim/goshim_posix.go
@@ -15,10 +15,7 @@ func listenForCollectMetricsSignals(ctx context.Context, collectMetricsPrompt ch
 	signal.Notify(collectMetricsPrompt, syscall.SIGHUP, syscall.SIGUSR1, syscall.SIGUSR2)
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			// context done. stop to signals to avoid pushing messages to a closed channel
-			signal.Stop(collectMetricsPrompt)
-		}
+		<-ctx.Done()
+		signal.Stop(collectMetricsPrompt)
 	}()
 }

--- a/plugins/inputs/execd/shim/shim_test.go
+++ b/plugins/inputs/execd/shim/shim_test.go
@@ -121,10 +121,10 @@ func TestLoadConfig(t *testing.T) {
 	})
 
 	c := "./testdata/plugin.conf"
-	inputs, err := LoadConfig(&c)
+	loadedInputs, err := LoadConfig(&c)
 	require.NoError(t, err)
 
-	inp := inputs[0].(*serviceInput)
+	inp := loadedInputs[0].(*serviceInput)
 
 	require.Equal(t, "awesome name", inp.ServiceName)
 	require.Equal(t, "xxxxxxxxxx", inp.SecretToken)

--- a/plugins/inputs/graylog/graylog_test.go
+++ b/plugins/inputs/graylog/graylog_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 const validJSON = `
@@ -172,8 +172,8 @@ func TestHttpJson500(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(graylog[0].Gather)
 
-	assert.Error(t, err)
-	assert.Equal(t, 0, acc.NFields())
+	require.Error(t, err)
+	require.Equal(t, 0, acc.NFields())
 }
 
 // Test response to malformed JSON
@@ -183,8 +183,8 @@ func TestHttpJsonBadJson(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(graylog[0].Gather)
 
-	assert.Error(t, err)
-	assert.Equal(t, 0, acc.NFields())
+	require.Error(t, err)
+	require.Equal(t, 0, acc.NFields())
 }
 
 // Test response to empty string as response objectgT
@@ -194,6 +194,6 @@ func TestHttpJsonEmptyResponse(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(graylog[0].Gather)
 
-	assert.Error(t, err)
-	assert.Equal(t, 0, acc.NFields())
+	require.Error(t, err)
+	require.Equal(t, 0, acc.NFields())
 }

--- a/plugins/inputs/hddtemp/hddtemp_test.go
+++ b/plugins/inputs/hddtemp/hddtemp_test.go
@@ -3,7 +3,6 @@ package hddtemp
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/plugins/inputs/hddtemp/go-hddtemp"
@@ -44,7 +43,7 @@ func TestFetch(t *testing.T) {
 	err := hddTemp.Gather(acc)
 
 	require.NoError(t, err)
-	assert.Equal(t, acc.NFields(), 2)
+	require.Equal(t, acc.NFields(), 2)
 
 	var tests = []struct {
 		fields map[string]interface{}

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -16,12 +16,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Receives a list with fields that are expected to be absent
@@ -168,8 +168,8 @@ func checkOutput(t *testing.T, acc *testutil.Accumulator, presentFields map[stri
 func TestHeaders(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cHeader := r.Header.Get("Content-Type")
-		assert.Equal(t, "Hello", r.Host)
-		assert.Equal(t, "application/json", cHeader)
+		require.Equal(t, "Hello", r.Host)
+		require.Equal(t, "application/json", cHeader)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
@@ -1100,7 +1100,7 @@ func TestRedirect(t *testing.T) {
 func TestBasicAuth(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		aHeader := r.Header.Get("Authorization")
-		assert.Equal(t, "Basic bWU6bXlwYXNzd29yZA==", aHeader)
+		require.Equal(t, "Basic bWU6bXlwYXNzd29yZA==", aHeader)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
@@ -1277,7 +1277,7 @@ func TestStatusCodeAndStringMatchFail(t *testing.T) {
 
 func TestSNI(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "super-special-hostname.example.com", r.TLS.ServerName)
+		require.Equal(t, "super-special-hostname.example.com", r.TLS.ServerName)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()

--- a/plugins/inputs/httpjson/httpjson_test.go
+++ b/plugins/inputs/httpjson/httpjson_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 const validJSON = `
@@ -212,7 +212,7 @@ func TestHttpJson200(t *testing.T) {
 		var acc testutil.Accumulator
 		err := acc.GatherError(service.Gather)
 		require.NoError(t, err)
-		assert.Equal(t, 12, acc.NFields())
+		require.Equal(t, 12, acc.NFields())
 		// Set responsetime
 		for _, p := range acc.Metrics {
 			p.Fields["response_time"] = 1.0
@@ -231,7 +231,7 @@ func TestHttpJson200(t *testing.T) {
 func TestHttpJsonGET_URL(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		key := r.FormValue("api_key")
-		assert.Equal(t, "mykey", key)
+		require.Equal(t, "mykey", key)
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintln(w, validJSON2)
 		require.NoError(t, err)
@@ -304,7 +304,7 @@ func TestHttpJsonGET(t *testing.T) {
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		key := r.FormValue("api_key")
-		assert.Equal(t, "mykey", key)
+		require.Equal(t, "mykey", key)
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintln(w, validJSON2)
 		require.NoError(t, err)
@@ -378,8 +378,8 @@ func TestHttpJsonPOST(t *testing.T) {
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		assert.NoError(t, err)
-		assert.Equal(t, "api_key=mykey", string(body))
+		require.NoError(t, err)
+		require.Equal(t, "api_key=mykey", string(body))
 		w.WriteHeader(http.StatusOK)
 		_, err = fmt.Fprintln(w, validJSON2)
 		require.NoError(t, err)
@@ -453,8 +453,8 @@ func TestHttpJson500(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(httpjson[0].Gather)
 
-	assert.Error(t, err)
-	assert.Equal(t, 0, acc.NFields())
+	require.Error(t, err)
+	require.Equal(t, 0, acc.NFields())
 }
 
 // Test response to HTTP 405
@@ -465,8 +465,8 @@ func TestHttpJsonBadMethod(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(httpjson[0].Gather)
 
-	assert.Error(t, err)
-	assert.Equal(t, 0, acc.NFields())
+	require.Error(t, err)
+	require.Equal(t, 0, acc.NFields())
 }
 
 // Test response to malformed JSON
@@ -476,8 +476,8 @@ func TestHttpJsonBadJson(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(httpjson[0].Gather)
 
-	assert.Error(t, err)
-	assert.Equal(t, 0, acc.NFields())
+	require.Error(t, err)
+	require.Equal(t, 0, acc.NFields())
 }
 
 // Test response to empty string as response object
@@ -486,7 +486,7 @@ func TestHttpJsonEmptyResponse(t *testing.T) {
 
 	var acc testutil.Accumulator
 	err := acc.GatherError(httpjson[0].Gather)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Test that the proper values are ignored or collected
@@ -502,7 +502,7 @@ func TestHttpJson200Tags(t *testing.T) {
 				p.Fields["response_time"] = 1.0
 			}
 			require.NoError(t, err)
-			assert.Equal(t, 4, acc.NFields())
+			require.Equal(t, 4, acc.NFields())
 			for _, srv := range service.Servers {
 				tags := map[string]string{"server": srv, "role": "master", "build": "123"}
 				fields := map[string]interface{}{"value": float64(15), "response_time": float64(1)}
@@ -540,22 +540,22 @@ func TestHttpJsonArray200Tags(t *testing.T) {
 				p.Fields["response_time"] = 1.0
 			}
 			require.NoError(t, err)
-			assert.Equal(t, 8, acc.NFields())
-			assert.Equal(t, uint64(4), acc.NMetrics())
+			require.Equal(t, 8, acc.NFields())
+			require.Equal(t, uint64(4), acc.NMetrics())
 
 			for _, m := range acc.Metrics {
 				if m.Tags["role"] == "master" {
-					assert.Equal(t, "123", m.Tags["build"])
-					assert.Equal(t, float64(15), m.Fields["value"])
-					assert.Equal(t, float64(1), m.Fields["response_time"])
-					assert.Equal(t, "httpjson_"+service.Name, m.Measurement)
+					require.Equal(t, "123", m.Tags["build"])
+					require.Equal(t, float64(15), m.Fields["value"])
+					require.Equal(t, float64(1), m.Fields["response_time"])
+					require.Equal(t, "httpjson_"+service.Name, m.Measurement)
 				} else if m.Tags["role"] == "slave" {
-					assert.Equal(t, "456", m.Tags["build"])
-					assert.Equal(t, float64(17), m.Fields["value"])
-					assert.Equal(t, float64(1), m.Fields["response_time"])
-					assert.Equal(t, "httpjson_"+service.Name, m.Measurement)
+					require.Equal(t, "456", m.Tags["build"])
+					require.Equal(t, float64(17), m.Fields["value"])
+					require.Equal(t, float64(1), m.Fields["response_time"])
+					require.Equal(t, "httpjson_"+service.Name, m.Measurement)
 				} else {
-					assert.FailNow(t, "unknown metric")
+					require.FailNow(t, "unknown metric")
 				}
 			}
 		}

--- a/plugins/inputs/jolokia/jolokia_test.go
+++ b/plugins/inputs/jolokia/jolokia_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
-	_ "github.com/stretchr/testify/require"
 )
 
 const validThreeLevelMultiValueJSON = `
@@ -143,8 +143,8 @@ func TestHttpJsonMultiValue(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(jolokia.Gather)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(acc.Metrics))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(acc.Metrics))
 
 	fields := map[string]interface{}{
 		"heap_memory_usage_init":      67108864.0,
@@ -167,8 +167,8 @@ func TestHttpJsonBulkResponse(t *testing.T) {
 	var acc testutil.Accumulator
 	err := jolokia.Gather(&acc)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(acc.Metrics))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(acc.Metrics))
 
 	fields := map[string]interface{}{
 		"heap_memory_usage_init":          67108864.0,
@@ -195,8 +195,8 @@ func TestHttpJsonThreeLevelMultiValue(t *testing.T) {
 	var acc testutil.Accumulator
 	err := acc.GatherError(jolokia.Gather)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(acc.Metrics))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(acc.Metrics))
 
 	fields := map[string]interface{}{
 		"heap_memory_usage_java.lang:type=Memory_ObjectPendingFinalizationCount": 0.0,
@@ -228,9 +228,9 @@ func TestHttp404(t *testing.T) {
 	acc.SetDebug(true)
 	err := acc.GatherError(jolokia.Gather)
 
-	assert.Error(t, err)
-	assert.Equal(t, 0, len(acc.Metrics))
-	assert.Contains(t, err.Error(), "has status code 404")
+	require.Error(t, err)
+	require.Equal(t, 0, len(acc.Metrics))
+	require.Contains(t, err.Error(), "has status code 404")
 }
 
 // Test that the proper values are ignored or collected
@@ -241,7 +241,7 @@ func TestHttpInvalidJson(t *testing.T) {
 	acc.SetDebug(true)
 	err := acc.GatherError(jolokia.Gather)
 
-	assert.Error(t, err)
-	assert.Equal(t, 0, len(acc.Metrics))
-	assert.Contains(t, err.Error(), "error decoding JSON response")
+	require.Error(t, err)
+	require.Equal(t, 0, len(acc.Metrics))
+	require.Contains(t, err.Error(), "error decoding JSON response")
 }

--- a/plugins/inputs/jolokia2/gatherer_test.go
+++ b/plugins/inputs/jolokia2/gatherer_test.go
@@ -3,7 +3,7 @@ package jolokia2
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJolokia2_makeReadRequests(t *testing.T) {
@@ -96,9 +96,9 @@ func TestJolokia2_makeReadRequests(t *testing.T) {
 	for _, c := range cases {
 		payload := makeReadRequests([]Metric{c.metric})
 
-		assert.Equal(t, len(c.expected), len(payload), "Failing case: "+c.metric.Name)
+		require.Equal(t, len(c.expected), len(payload), "Failing case: "+c.metric.Name)
 		for _, actual := range payload {
-			assert.Contains(t, c.expected, actual, "Failing case: "+c.metric.Name)
+			require.Contains(t, c.expected, actual, "Failing case: "+c.metric.Name)
 		}
 	}
 }

--- a/plugins/inputs/jolokia2/jolokia_test.go
+++ b/plugins/inputs/jolokia2/jolokia_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
@@ -80,7 +80,7 @@ func TestJolokia2_ScalarValues(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(&acc))
 
 	acc.AssertContainsTaggedFields(t, "scalar_without_attribute", map[string]interface{}{
 		"value": 123.0,
@@ -240,7 +240,7 @@ func TestJolokia2_ObjectValues(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(&acc))
 
 	acc.AssertContainsTaggedFields(t, "object_without_attribute", map[string]interface{}{
 		"biz": 123.0,
@@ -328,7 +328,7 @@ func TestJolokia2_StatusCodes(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(&acc))
 
 	acc.AssertContainsTaggedFields(t, "ok", map[string]interface{}{
 		"value": 1.0,
@@ -378,7 +378,7 @@ func TestJolokia2_TagRenaming(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(&acc))
 
 	acc.AssertContainsTaggedFields(t, "default_tag_prefix", map[string]interface{}{
 		"value": 123.0,
@@ -471,7 +471,7 @@ func TestJolokia2_FieldRenaming(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(&acc))
 
 	acc.AssertContainsTaggedFields(t, "default_field_modifiers", map[string]interface{}{
 		"DEFAULT_PREFIX_hello_DEFAULT_SEPARATOR_world": 123.0,
@@ -579,7 +579,7 @@ func TestJolokia2_MetricMbeanMatching(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(&acc))
 
 	acc.AssertContainsTaggedFields(t, "mbean_name_and_object_keys", map[string]interface{}{
 		"value": 123.0,
@@ -672,7 +672,7 @@ func TestJolokia2_MetricCompaction(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(&acc))
 
 	acc.AssertContainsTaggedFields(t, "compact_metric", map[string]interface{}{
 		"value": 123.0,
@@ -733,7 +733,7 @@ func TestJolokia2_ProxyTargets(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(&acc))
 
 	acc.AssertContainsTaggedFields(t, "hello", map[string]interface{}{
 		"value": 123.0,
@@ -755,11 +755,11 @@ func TestFillFields(t *testing.T) {
 
 	results := map[string]interface{}{}
 	newPointBuilder(Metric{Name: "test", Mbean: "complex"}, []string{"this", "that"}, "/").fillFields("", complexPoint, results)
-	assert.Equal(t, map[string]interface{}{}, results)
+	require.Equal(t, map[string]interface{}{}, results)
 
 	results = map[string]interface{}{}
 	newPointBuilder(Metric{Name: "test", Mbean: "scalar"}, []string{"this", "that"}, "/").fillFields("", scalarPoint, results)
-	assert.Equal(t, map[string]interface{}{}, results)
+	require.Equal(t, map[string]interface{}{}, results)
 }
 
 func setupServer(resp string) *httptest.Server {

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -159,13 +159,13 @@ type ConsumerGroup interface {
 }
 
 type ConsumerGroupCreator interface {
-	Create(brokers []string, group string, config *sarama.Config) (ConsumerGroup, error)
+	Create(brokers []string, group string, cfg *sarama.Config) (ConsumerGroup, error)
 }
 
 type SaramaCreator struct{}
 
-func (*SaramaCreator) Create(brokers []string, group string, config *sarama.Config) (ConsumerGroup, error) {
-	return sarama.NewConsumerGroup(brokers, group, config)
+func (*SaramaCreator) Create(brokers []string, group string, cfg *sarama.Config) (ConsumerGroup, error) {
+	return sarama.NewConsumerGroup(brokers, group, cfg)
 }
 
 func (k *KafkaConsumer) SampleConfig() string {
@@ -191,31 +191,31 @@ func (k *KafkaConsumer) Init() error {
 		k.ConsumerGroup = defaultConsumerGroup
 	}
 
-	config := sarama.NewConfig()
+	cfg := sarama.NewConfig()
 
 	// Kafka version 0.10.2.0 is required for consumer groups.
-	config.Version = sarama.V0_10_2_0
+	cfg.Version = sarama.V0_10_2_0
 
-	if err := k.SetConfig(config); err != nil {
+	if err := k.SetConfig(cfg); err != nil {
 		return err
 	}
 
 	switch strings.ToLower(k.Offset) {
 	case "oldest", "":
-		config.Consumer.Offsets.Initial = sarama.OffsetOldest
+		cfg.Consumer.Offsets.Initial = sarama.OffsetOldest
 	case "newest":
-		config.Consumer.Offsets.Initial = sarama.OffsetNewest
+		cfg.Consumer.Offsets.Initial = sarama.OffsetNewest
 	default:
 		return fmt.Errorf("invalid offset %q", k.Offset)
 	}
 
 	switch strings.ToLower(k.BalanceStrategy) {
 	case "range", "":
-		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
+		cfg.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
 	case "roundrobin":
-		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
+		cfg.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
 	case "sticky":
-		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategySticky
+		cfg.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategySticky
 	default:
 		return fmt.Errorf("invalid balance strategy %q", k.BalanceStrategy)
 	}
@@ -224,9 +224,9 @@ func (k *KafkaConsumer) Init() error {
 		k.ConsumerCreator = &SaramaCreator{}
 	}
 
-	config.Consumer.MaxProcessingTime = time.Duration(k.MaxProcessingTime)
+	cfg.Consumer.MaxProcessingTime = time.Duration(k.MaxProcessingTime)
 
-	k.config = config
+	k.config = cfg
 	return nil
 }
 

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -43,10 +43,10 @@ type FakeCreator struct {
 	ConsumerGroup *FakeConsumerGroup
 }
 
-func (c *FakeCreator) Create(brokers []string, group string, config *sarama.Config) (ConsumerGroup, error) {
+func (c *FakeCreator) Create(brokers []string, group string, cfg *sarama.Config) (ConsumerGroup, error) {
 	c.ConsumerGroup.brokers = brokers
 	c.ConsumerGroup.group = group
-	c.ConsumerGroup.config = config
+	c.ConsumerGroup.config = cfg
 	return c.ConsumerGroup, nil
 }
 

--- a/plugins/inputs/minecraft/internal/rcon/rcon.go
+++ b/plugins/inputs/minecraft/internal/rcon/rcon.go
@@ -67,17 +67,17 @@ func (p Packet) Compile() (payload []byte, err error) {
 	var padding [PacketPaddingSize]byte
 
 	if err = binary.Write(&buffer, binary.LittleEndian, &size); nil != err {
-		return
+		return nil, err
 	} else if err = binary.Write(&buffer, binary.LittleEndian, &p.Header.Challenge); nil != err {
-		return
+		return nil, err
 	} else if err = binary.Write(&buffer, binary.LittleEndian, &p.Header.Type); nil != err {
-		return
-	}
-
-	if _, err := buffer.WriteString(p.Body); err != nil {
 		return nil, err
 	}
-	if _, err := buffer.Write(padding[:]); err != nil {
+
+	if _, err = buffer.WriteString(p.Body); err != nil {
+		return nil, err
+	}
+	if _, err = buffer.Write(padding[:]); err != nil {
 		return nil, err
 	}
 
@@ -95,16 +95,13 @@ func NewPacket(challenge, typ int32, body string) (packet *Packet) {
 // or a potential error.
 func (c *Client) Authorize(password string) (response *Packet, err error) {
 	if response, err = c.Send(Auth, password); nil == err {
-		if response.Header.Type == AuthResponse {
-			c.Authorized = true
-		} else {
-			err = ErrFailedAuthorization
-			response = nil
-			return
+		if response.Header.Type != AuthResponse {
+			return nil, ErrFailedAuthorization
 		}
+		c.Authorized = true
 	}
 
-	return
+	return response, err
 }
 
 // Execute calls Send with the appropriate command type and the provided
@@ -213,5 +210,5 @@ func NewClient(host string, port int) (client *Client, err error) {
 	client.Host = host
 	client.Port = port
 	client.Connection, err = net.Dial("tcp", fmt.Sprintf("%v:%v", client.Host, client.Port))
-	return
+	return client, err
 }

--- a/plugins/inputs/minecraft/internal/rcon/rcon.go
+++ b/plugins/inputs/minecraft/internal/rcon/rcon.go
@@ -111,7 +111,7 @@ func (c *Client) Execute(command string) (response *Packet, err error) {
 	return c.Send(Exec, command)
 }
 
-// Sends accepts the commands type and its string to execute to the clients server,
+// Send accepts the commands type and its string to execute to the clients server,
 // creating a packet with a random challenge id for the server to mirror,
 // and compiling its payload bytes in the appropriate order. The response is
 // decompiled from its bytes into a Packet type for return. An error is returned

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -475,7 +475,7 @@ func (o *OpcUA) setupOptions() error {
 		}
 	}
 
-	o.opts, err = o.generateClientOpts(endpoints, o.Certificate, o.PrivateKey, o.SecurityPolicy, o.SecurityMode, o.AuthMethod, o.Username, o.Password, time.Duration(o.RequestTimeout))
+	o.opts, err = o.generateClientOpts(endpoints)
 
 	return err
 }

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -52,7 +52,6 @@ type OpcUA struct {
 	opts   []opcua.Option
 }
 
-// OPCTag type
 type NodeSettings struct {
 	FieldName      string     `toml:"name"`
 	Namespace      string     `toml:"namespace"`

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -476,7 +476,7 @@ func (o *OpcUA) setupOptions() error {
 		}
 	}
 
-	o.opts, err = generateClientOpts(endpoints, o.Certificate, o.PrivateKey, o.SecurityPolicy, o.SecurityMode, o.AuthMethod, o.Username, o.Password, time.Duration(o.RequestTimeout))
+	o.opts, err = o.generateClientOpts(endpoints, o.Certificate, o.PrivateKey, o.SecurityPolicy, o.SecurityMode, o.AuthMethod, o.Username, o.Password, time.Duration(o.RequestTimeout))
 
 	return err
 }

--- a/plugins/inputs/opcua/opcua_util.go
+++ b/plugins/inputs/opcua/opcua_util.go
@@ -145,7 +145,7 @@ func pemBlockForKey(priv interface{}) (*pem.Block, error) {
 }
 
 //revive:disable-next-line
-func (o *OpcUA) generateClientOpts(endpoints []*ua.EndpointDescription, certFile, keyFile, policy, mode, auth, username, password string, requestTimeout time.Duration) ([]opcua.Option, error) {
+func (o *OpcUA) generateClientOpts(endpoints []*ua.EndpointDescription) ([]opcua.Option, error) {
 	opts := []opcua.Option{}
 	appuri := "urn:telegraf:gopcua:client"
 	appname := "Telegraf"
@@ -153,9 +153,12 @@ func (o *OpcUA) generateClientOpts(endpoints []*ua.EndpointDescription, certFile
 	// ApplicationURI is automatically read from the cert so is not required if a cert if provided
 	opts = append(opts, opcua.ApplicationURI(appuri))
 	opts = append(opts, opcua.ApplicationName(appname))
+	opts = append(opts, opcua.RequestTimeout(time.Duration(o.RequestTimeout)))
 
-	opts = append(opts, opcua.RequestTimeout(requestTimeout))
-
+	certFile := o.Certificate
+	keyFile := o.PrivateKey
+	policy := o.SecurityPolicy
+	mode := o.SecurityMode
 	var err error
 	if certFile == "" && keyFile == "" {
 		if policy != "None" || mode != "None" {
@@ -197,7 +200,7 @@ func (o *OpcUA) generateClientOpts(endpoints []*ua.EndpointDescription, certFile
 	}
 
 	// Select the most appropriate authentication mode from server capabilities and user input
-	authMode, authOption, err := o.generateAuth(auth, cert, username, password)
+	authMode, authOption, err := o.generateAuth(o.AuthMethod, cert, o.Username, o.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/opcua/opcua_util.go
+++ b/plugins/inputs/opcua/opcua_util.go
@@ -159,7 +159,7 @@ func (o *OpcUA) generateClientOpts(endpoints []*ua.EndpointDescription, certFile
 	var err error
 	if certFile == "" && keyFile == "" {
 		if policy != "None" || mode != "None" {
-			certFile, keyFile, err = generateCert(appuri, 2048, certFile, keyFile, (365 * 24 * time.Hour))
+			certFile, keyFile, err = generateCert(appuri, 2048, certFile, keyFile, 365*24*time.Hour)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Following findings were fixed:
```
plugins/inputs/dcos/client.go:330:19                                       staticcheck  SA1019: jwt.StandardClaims is deprecated: Use RegisteredClaims instead for a forward-compatible way to access registered claims in a struct. 
plugins/inputs/dcos/dcos.go:240:3                                          gosimple     S1017: should replace this `if` statement with an unconditional `strings.TrimPrefix`
plugins/inputs/execd/shim/goshim_posix.go:18:3                             gosimple     S1000: should use a simple channel send/receive instead of `select` with a single case
plugins/inputs/execd/shim/shim_test.go:124:2                               revive       import-shadowing: The name 'inputs' shadows an import name
plugins/inputs/kafka_consumer/kafka_consumer.go:162:41                     revive       import-shadowing: The name 'config' shadows an import name
plugins/inputs/kafka_consumer/kafka_consumer.go:167:62                     revive       import-shadowing: The name 'config' shadows an import name
plugins/inputs/kafka_consumer/kafka_consumer.go:194:2                      revive       import-shadowing: The name 'config' shadows an import name
plugins/inputs/kafka_consumer/kafka_consumer_test.go:46:62                 revive       import-shadowing: The name 'config' shadows an import name
plugins/inputs/minecraft/internal/rcon/rcon.go:103:4                       revive       bare-return: avoid using bare returns, please add return expressions
plugins/inputs/minecraft/internal/rcon/rcon.go:107:2                       nakedret     naked return in func `Authorize` with 12 lines of code
plugins/inputs/minecraft/internal/rcon/rcon.go:216:2                       nakedret     naked return in func `NewClient` with 6 lines of code
plugins/inputs/minecraft/internal/rcon/rcon.go:70:3                        revive       bare-return: avoid using bare returns, please add return expressions
plugins/inputs/minecraft/internal/rcon/rcon.go:72:3                        revive       bare-return: avoid using bare returns, please add return expressions
plugins/inputs/minecraft/internal/rcon/rcon.go:74:3                        revive       bare-return: avoid using bare returns, please add return expressions
plugins/inputs/minecraft/internal/rcon/rcon.go:98:3                        revive       early-return: if c {...} else {... return } can be simplified to if !c { ... return } ...
plugins/inputs/opcua/opcua_util.go:12:2                                    revive       imports-blacklist: should not use the following blacklisted import: "log"
```

Also all `assert.` for these plugins were replaced by `require.`