### PR TITLE
fix: Implement NaN and inf handling for elasticsearch output

### DIFF
--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -207,7 +207,7 @@ This plugin will format the events in the following way:
   ##    replace -- replace with the value in "float_replacement_value" (default: 0.0)
   ##               NaNs and inf will be replaced with the given number, -inf with the negative of that number
   # float_handling = "none"
-	# float_replacement_value = 0.0
+  # float_replacement_value = 0.0
 ```
 
 ### Permissions

--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -199,6 +199,13 @@ This plugin will format the events in the following way:
   ## If set to true a unique ID hash will be sent as sha256(concat(timestamp,measurement,series-hash)) string
   ## it will enable data resend and update metric points avoiding duplicated metrics with diferent id's
   force_document_id = false
+
+  ## Specifies the handling of NaN and Inf values.
+  ## This option can have the following values:
+  ##    none -- do not modify field-values (default); will produce an error if NaNs or infs are encountered
+  ##    drop -- drop fields containing NaNs or infs
+  ##    <any float> -- Replace NaNs and inf with the given number and -inf with the negative number
+  # nan_handling = "none"
 ```
 
 ### Permissions
@@ -236,6 +243,7 @@ Additionally, you can specify dynamic index names by using tags with the notatio
 * `template_name`: The template name used for telegraf indexes.
 * `overwrite_template`: Set to true if you want telegraf to overwrite an existing template.
 * `force_document_id`: Set to true will compute a unique hash from as sha256(concat(timestamp,measurement,series-hash)),enables resend or update data withoud ES duplicated documents.
+* `nan_handling`: Specifies how to handle `NaN` and infinite field values. `"none"` (default) will do nothing, `"drop"` will drop the field. Any valid float number will replace the field's value with the given value respecting the infinite's sign.
 
 ## Known issues
 

--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -202,10 +202,12 @@ This plugin will format the events in the following way:
 
   ## Specifies the handling of NaN and Inf values.
   ## This option can have the following values:
-  ##    none -- do not modify field-values (default); will produce an error if NaNs or infs are encountered
-  ##    drop -- drop fields containing NaNs or infs
-  ##    <any float> -- Replace NaNs and inf with the given number and -inf with the negative number
+  ##    none    -- do not modify field-values (default); will produce an error if NaNs or infs are encountered
+  ##    drop    -- drop fields containing NaNs or infs
+  ##    replace -- replace with the value in "float_replacement_value" (default: 0.0)
+  ##               NaNs and inf will be replaced with the given number, -inf with the negative of that number
   # float_handling = "none"
+	# float_replacement_value = 0.0
 ```
 
 ### Permissions
@@ -243,7 +245,8 @@ Additionally, you can specify dynamic index names by using tags with the notatio
 * `template_name`: The template name used for telegraf indexes.
 * `overwrite_template`: Set to true if you want telegraf to overwrite an existing template.
 * `force_document_id`: Set to true will compute a unique hash from as sha256(concat(timestamp,measurement,series-hash)),enables resend or update data withoud ES duplicated documents.
-* `float_handling`: Specifies how to handle `NaN` and infinite field values. `"none"` (default) will do nothing, `"drop"` will drop the field. Any valid float number will replace the field's value with the given value respecting the infinite's sign.
+* `float_handling`: Specifies how to handle `NaN` and infinite field values. `"none"` (default) will do nothing, `"drop"` will drop the field and `replace` will replace the field value by the number in `float_replacement_value`
+* `float_replacement_value`: Value (defaulting to `0.0`) to replace `NaN`s and `inf`s if `float_handling` is set to `replace`. Negative `inf` will be replaced by the negative value in this number to respect the sign of the field's original value.
 
 ## Known issues
 

--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -205,7 +205,7 @@ This plugin will format the events in the following way:
   ##    none -- do not modify field-values (default); will produce an error if NaNs or infs are encountered
   ##    drop -- drop fields containing NaNs or infs
   ##    <any float> -- Replace NaNs and inf with the given number and -inf with the negative number
-  # nan_handling = "none"
+  # float_handling = "none"
 ```
 
 ### Permissions
@@ -243,7 +243,7 @@ Additionally, you can specify dynamic index names by using tags with the notatio
 * `template_name`: The template name used for telegraf indexes.
 * `overwrite_template`: Set to true if you want telegraf to overwrite an existing template.
 * `force_document_id`: Set to true will compute a unique hash from as sha256(concat(timestamp,measurement,series-hash)),enables resend or update data withoud ES duplicated documents.
-* `nan_handling`: Specifies how to handle `NaN` and infinite field values. `"none"` (default) will do nothing, `"drop"` will drop the field. Any valid float number will replace the field's value with the given value respecting the infinite's sign.
+* `float_handling`: Specifies how to handle `NaN` and infinite field values. `"none"` (default) will do nothing, `"drop"` will drop the field. Any valid float number will replace the field's value with the given value respecting the infinite's sign.
 
 ## Known issues
 

--- a/plugins/outputs/elasticsearch/elasticsearch.go
+++ b/plugins/outputs/elasticsearch/elasticsearch.go
@@ -106,7 +106,7 @@ var sampleConfig = `
   ##    replace -- replace with the value in "float_replacement_value" (default: 0.0)
   ##               NaNs and inf will be replaced with the given number, -inf with the negative of that number
   # float_handling = "none"
-	# float_replacement_value = 0.0
+  # float_replacement_value = 0.0
 `
 
 const telegrafTemplate = `

--- a/plugins/outputs/elasticsearch/elasticsearch_test.go
+++ b/plugins/outputs/elasticsearch/elasticsearch_test.go
@@ -93,7 +93,7 @@ func TestConnectAndWriteMetricWithNaNValueNone(t *testing.T) {
 		TemplateName:        "telegraf",
 		OverwriteTemplate:   false,
 		HealthCheckInterval: config.Duration(time.Second * 10),
-		NaNHandling:         "none",
+		FloatHandling:       "none",
 		Log:                 testutil.Logger{},
 	}
 
@@ -129,7 +129,7 @@ func TestConnectAndWriteMetricWithNaNValueDrop(t *testing.T) {
 		TemplateName:        "telegraf",
 		OverwriteTemplate:   false,
 		HealthCheckInterval: config.Duration(time.Second * 10),
-		NaNHandling:         "drop",
+		FloatHandling:       "drop",
 		Log:                 testutil.Logger{},
 	}
 
@@ -165,7 +165,7 @@ func TestConnectAndWriteMetricWithNaNValueReplacement(t *testing.T) {
 		TemplateName:        "telegraf",
 		OverwriteTemplate:   false,
 		HealthCheckInterval: config.Duration(time.Second * 10),
-		NaNHandling:         "3.1415",
+		FloatHandling:       "3.1415",
 		Log:                 testutil.Logger{},
 	}
 


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

based on #9221

This fixes an issue with the elasticsearch output when dealing with metrics containing `NaN` or `inf`/`-inf` values. This PR adds an option to handle fields with those values by either do nothing, dropping or replacing the fields and field-values.

The PR is based on the unit-test provided in #9221 by @adrianlzt.