### PR TITLE
feat: add Vault input plugin

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -196,6 +196,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/unbound"
 	_ "github.com/influxdata/telegraf/plugins/inputs/uwsgi"
 	_ "github.com/influxdata/telegraf/plugins/inputs/varnish"
+	_ "github.com/influxdata/telegraf/plugins/inputs/vault"
 	_ "github.com/influxdata/telegraf/plugins/inputs/vsphere"
 	_ "github.com/influxdata/telegraf/plugins/inputs/webhooks"
 	_ "github.com/influxdata/telegraf/plugins/inputs/win_eventlog"

--- a/plugins/inputs/vault/README.md
+++ b/plugins/inputs/vault/README.md
@@ -11,12 +11,12 @@ The Vault plugin could grab metrics from every Vault agent of the cluster. Teleg
   ## URL for the vault agent
   # url = "http://127.0.0.1:8200"
 
-  ## Use auth token for authorization.
+  ## Use Vault token for authorization.
   ## Vault token configuration is mandatory.
   ## If both are empty or both are set, an error is thrown.
-  # token = "/path/to/auth/token"
+  # token_file = "/path/to/auth/token"
   ## OR
-  token_string = "s.CDDrgg5zPv5ssI0Z2P4qxJj2"
+  token = "s.CDDrgg5zPv5ssI0Z2P4qxJj2"
 
   ## Set response_timeout (default 5 seconds)
   # response_timeout = "5s"

--- a/plugins/inputs/vault/README.md
+++ b/plugins/inputs/vault/README.md
@@ -1,0 +1,35 @@
+# Hashicorp Vault Input Plugin
+
+The Vault plugin could grab metrics from every Vault agent of the cluster. Telegraf may be present in every node and connect to the agent locally. In this case should be something like `http://127.0.0.1:8200`.
+
+> Tested on vault 1.8.5
+
+## Configuration
+
+```toml
+[[inputs.vault]]
+  ## URL for the vault agent
+  # url = "http://127.0.0.1:8200"
+
+  ## Use auth token for authorization.
+  ## Vault token configuration is mandatory.
+  ## If both are empty or both are set, an error is thrown.
+  # vault_token = "/path/to/auth/token"
+  ## OR
+  vault_token_string = "s.CDDrgg5zPv5ssI0Z2P4qxJj2"
+
+  ## Set response_timeout (default 5 seconds)
+  # response_timeout = "5s"
+
+  ## Optional TLS Config
+  # tls_ca = /path/to/cafile
+  # tls_cert = /path/to/certfile
+  # tls_key = /path/to/keyfile
+```
+
+## Metrics
+
+For a more deep understanding of Vault monitoring, please have a look at the following Vault documentation:
+
+- [https://www.vaultproject.io/docs/internals/telemetry](https://www.vaultproject.io/docs/internals/telemetry)
+- [https://learn.hashicorp.com/tutorials/vault/monitor-telemetry-audit-splunk?in=vault/monitoring](https://learn.hashicorp.com/tutorials/vault/monitor-telemetry-audit-splunk?in=vault/monitoring)

--- a/plugins/inputs/vault/README.md
+++ b/plugins/inputs/vault/README.md
@@ -14,9 +14,9 @@ The Vault plugin could grab metrics from every Vault agent of the cluster. Teleg
   ## Use auth token for authorization.
   ## Vault token configuration is mandatory.
   ## If both are empty or both are set, an error is thrown.
-  # vault_token = "/path/to/auth/token"
+  # token = "/path/to/auth/token"
   ## OR
-  vault_token_string = "s.CDDrgg5zPv5ssI0Z2P4qxJj2"
+  token_string = "s.CDDrgg5zPv5ssI0Z2P4qxJj2"
 
   ## Set response_timeout (default 5 seconds)
   # response_timeout = "5s"

--- a/plugins/inputs/vault/testdata/response_key_metrics.json
+++ b/plugins/inputs/vault/testdata/response_key_metrics.json
@@ -1,0 +1,40 @@
+{
+	"Gauges": [
+		{
+			"Name": "vault.core.unsealed",
+			"Value": 1,
+			"Labels": {
+				"cluster": "vault-cluster-23b671c7"
+			}
+		}
+	],
+	"Counters": [
+		{
+			"Name": "vault.raft.replication.appendEntries.logs",
+			"Count": 130,
+			"Rate": 0.2,
+			"Sum": 2,
+			"Min": 0,
+			"Max": 1,
+			"Mean": 0.015384615384615385,
+			"Stddev": 0.12355304447984486,
+			"Labels": {
+				"peer_id": "clustnode-02"
+			}
+		}
+	],
+	"Samples": [
+		{
+			"Name": "vault.token.lookup",
+			"Count": 5135,
+			"Rate": 87.21228296905755,
+			"Sum": 872.1228296905756,
+			"Min": 0.06690400093793869,
+			"Max": 16.22449493408203,
+			"Mean": 0.1698389152269865,
+			"Stddev": 0.24637634000854705,
+			"Labels": {}
+		}
+	],
+	"Timestamp": "2021-11-30 15:49:00 +0000 UTC"
+}

--- a/plugins/inputs/vault/vault.go
+++ b/plugins/inputs/vault/vault.go
@@ -38,7 +38,7 @@ var sampleConfig = `
   ## Only one of the options can be set. Leave empty to not use any token.
   # vault_token = "/path/to/auth/token"
   ## OR
-  # vault_token_string = "a1234567-40c7-9048-7bae-378687048181"
+  vault_token_string = "a1234567-40c7-9048-7bae-378687048181"
 
   ## Set response_timeout (default 5 seconds)
   # response_timeout = "5s"
@@ -72,8 +72,12 @@ func (n *Vault) Init() error {
 		n.URL = "http://127.0.0.1:8200"
 	}
 
+	if n.VaultToken == "" && n.VaultTokenString == "" {
+		return fmt.Errorf("Vault token missing")
+	}
+
 	if n.VaultToken != "" && n.VaultTokenString != "" {
-		return fmt.Errorf("config error: both auth_token and auth_token_string are set")
+		return fmt.Errorf("config error: both vault_token and vault_token_string are set")
 	}
 
 	if n.VaultToken != "" {

--- a/plugins/inputs/vault/vault.go
+++ b/plugins/inputs/vault/vault.go
@@ -111,12 +111,7 @@ func (n *Vault) Gather(acc telegraf.Accumulator) error {
 		return err
 	}
 
-	err = buildVaultMetrics(acc, sysMetrics)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return buildVaultMetrics(acc, sysMetrics)
 }
 
 func (n *Vault) loadJSON(url string) (*SysMetrics, error) {

--- a/plugins/inputs/vault/vault.go
+++ b/plugins/inputs/vault/vault.go
@@ -1,0 +1,200 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/common/tls"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+// Nomad configuration object
+type Vault struct {
+	URL string `toml:"url"`
+
+	VaultToken       string `toml:"vault_token"`
+	VaultTokenString string `toml:"vault_token_string"`
+
+	ResponseTimeout config.Duration `toml:"response_timeout"`
+
+	tls.ClientConfig
+
+	roundTripper http.RoundTripper
+}
+
+const timeLayout = "2006-01-02 15:04:05 -0700 MST"
+
+var sampleConfig = `
+  ## URL for the Vault agent
+  # url = "http://127.0.0.1:8200"
+
+  ## Use vault token for authorization. 
+  ## Only one of the options can be set. Leave empty to not use any token.
+  # vault_token = "/path/to/auth/token"
+  ## OR
+  # vault_token_string = "a1234567-40c7-9048-7bae-378687048181"
+
+  ## Set response_timeout (default 5 seconds)
+  # response_timeout = "5s"
+
+  ## Optional TLS Config
+  # tls_ca = /path/to/cafile
+  # tls_cert = /path/to/certfile
+  # tls_key = /path/to/keyfile
+`
+
+func init() {
+	inputs.Add("vault", func() telegraf.Input {
+		return &Vault{
+			ResponseTimeout: config.Duration(5 * time.Second),
+		}
+	})
+}
+
+// SampleConfig returns a sample config
+func (n *Vault) SampleConfig() string {
+	return sampleConfig
+}
+
+// Description returns a description of the plugin
+func (n *Vault) Description() string {
+	return "Read metrics from the Vault API"
+}
+
+func (n *Vault) Init() error {
+	if n.URL == "" {
+		n.URL = "http://127.0.0.1:8200"
+	}
+
+	if n.VaultToken != "" && n.VaultTokenString != "" {
+		return fmt.Errorf("config error: both auth_token and auth_token_string are set")
+	}
+
+	if n.VaultToken != "" {
+		token, err := os.ReadFile(n.VaultToken)
+		if err != nil {
+			return fmt.Errorf("reading file failed: %v", err)
+		}
+		n.VaultTokenString = strings.TrimSpace(string(token))
+	}
+
+	tlsCfg, err := n.ClientConfig.TLSConfig()
+	if err != nil {
+		return fmt.Errorf("setting up TLS configuration failed: %v", err)
+	}
+
+	n.roundTripper = &http.Transport{
+		TLSHandshakeTimeout:   5 * time.Second,
+		TLSClientConfig:       tlsCfg,
+		ResponseHeaderTimeout: time.Duration(n.ResponseTimeout),
+	}
+
+	return nil
+}
+
+// Gather, collects metrics from Vault endpoint
+func (n *Vault) Gather(acc telegraf.Accumulator) error {
+	sysMetrics := &SysMetrics{}
+	err := n.loadJSON(n.URL+"/v1/sys/metrics", sysMetrics)
+	if err != nil {
+		return err
+	}
+
+	err = buildVaultMetrics(acc, sysMetrics)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (n *Vault) loadJSON(url string, v interface{}) error {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", "X-Vault-Token "+n.VaultTokenString)
+	req.Header.Add("Accept", "application/json")
+
+	resp, err := n.roundTripper.RoundTrip(req)
+	if err != nil {
+		return fmt.Errorf("error making HTTP request to %s: %s", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s returned HTTP status %s", url, resp.Status)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(v)
+	if err != nil {
+		return fmt.Errorf("error parsing json response: %s", err)
+	}
+
+	return nil
+}
+
+// buildVaultMetrics, it builds all the metrics and adds them to the accumulator)
+func buildVaultMetrics(acc telegraf.Accumulator, sysMetrics *SysMetrics) error {
+	t, err := time.Parse(timeLayout, sysMetrics.Timestamp)
+	if err != nil {
+		return fmt.Errorf("error parsing time: %s", err)
+	}
+
+	for _, counters := range sysMetrics.Counters {
+		tags := make(map[string]string)
+		for key, val := range counters.baseInfo.Labels {
+			tags[key] = val.(string)
+		}
+
+		fields := map[string]interface{}{
+			"count": counters.Count,
+			"rate":  counters.Rate,
+			"sum":   counters.Sum,
+			"min":   counters.Min,
+			"max":   counters.Max,
+			"mean":  counters.Mean,
+		}
+		acc.AddCounter(counters.baseInfo.Name, fields, tags, t)
+	}
+
+	for _, gauges := range sysMetrics.Gauges {
+		tags := make(map[string]string)
+		for key, val := range gauges.baseInfo.Labels {
+			tags[key] = val.(string)
+		}
+
+		fields := map[string]interface{}{
+			"value": gauges.Value,
+		}
+
+		acc.AddGauge(gauges.Name, fields, tags, t)
+	}
+
+	for _, summaries := range sysMetrics.Summaries {
+		tags := make(map[string]string)
+		for key, val := range summaries.baseInfo.Labels {
+			tags[key] = val.(string)
+		}
+
+		fields := map[string]interface{}{
+			"count":  summaries.Count,
+			"rate":   summaries.Rate,
+			"sum":    summaries.Sum,
+			"stddev": summaries.Stddev,
+			"min":    summaries.Min,
+			"max":    summaries.Max,
+			"mean":   summaries.Mean,
+		}
+		acc.AddCounter(summaries.Name, fields, tags, t)
+	}
+
+	return nil
+}

--- a/plugins/inputs/vault/vault.go
+++ b/plugins/inputs/vault/vault.go
@@ -31,7 +31,7 @@ type Vault struct {
 
 const timeLayout = "2006-01-02 15:04:05 -0700 MST"
 
-var sampleConfig = `
+const sampleConfig = `
   ## URL for the Vault agent
   # url = "http://127.0.0.1:8200"
 
@@ -122,7 +122,7 @@ func (n *Vault) Gather(acc telegraf.Accumulator) error {
 func (n *Vault) loadJSON(url string) (*SysMetrics, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return &SysMetrics{}, err
+		return nil, err
 	}
 
 	req.Header.Set("X-Vault-Token", n.Token)
@@ -130,18 +130,18 @@ func (n *Vault) loadJSON(url string) (*SysMetrics, error) {
 
 	resp, err := n.roundTripper.RoundTrip(req)
 	if err != nil {
-		return &SysMetrics{}, fmt.Errorf("error making HTTP request to %s: %s", url, err)
+		return nil, fmt.Errorf("error making HTTP request to %s: %s", url, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return &SysMetrics{}, fmt.Errorf("%s returned HTTP status %s", url, resp.Status)
+		return nil, fmt.Errorf("%s returned HTTP status %s", url, resp.Status)
 	}
 
 	var metrics SysMetrics
 	err = json.NewDecoder(resp.Body).Decode(&metrics)
 	if err != nil {
-		return &SysMetrics{}, fmt.Errorf("error parsing json response: %s", err)
+		return nil, fmt.Errorf("error parsing json response: %s", err)
 	}
 
 	return &metrics, nil

--- a/plugins/inputs/vault/vault.go
+++ b/plugins/inputs/vault/vault.go
@@ -124,7 +124,7 @@ func (n *Vault) loadJSON(url string, v interface{}) error {
 		return err
 	}
 
-	req.Header.Set("Authorization", "X-Vault-Token "+n.VaultTokenString)
+	req.Header.Set("X-Vault-Token", n.VaultTokenString)
 	req.Header.Add("Accept", "application/json")
 
 	resp, err := n.roundTripper.RoundTrip(req)

--- a/plugins/inputs/vault/vault_metrics.go
+++ b/plugins/inputs/vault/vault_metrics.go
@@ -1,0 +1,40 @@
+package vault
+
+type SysMetrics struct {
+	Timestamp string    `json:"timestamp"`
+	Gauges    []gauge   `json:"Gauges"`
+	Counters  []counter `json:"Counters"`
+	Summaries []summary `json:"Samples"`
+}
+
+type baseInfo struct {
+	Name   string                 `json:"Name"`
+	Labels map[string]interface{} `json:"Labels"`
+}
+
+type gauge struct {
+	baseInfo
+	Value int `json:"Value"`
+}
+
+type counter struct {
+	baseInfo
+	Count  int     `json:"Count"`
+	Rate   float64 `json:"Rate"`
+	Sum    int     `json:"Sum"`
+	Min    int     `json:"Min"`
+	Max    int     `json:"Max"`
+	Mean   float64 `json:"Mean"`
+	Stddev float64 `json:"Stddev"`
+}
+
+type summary struct {
+	baseInfo
+	Count  int     `json:"Count"`
+	Rate   float64 `json:"Rate"`
+	Sum    float64 `json:"Sum"`
+	Min    float64 `json:"Min"`
+	Max    float64 `json:"Max"`
+	Mean   float64 `json:"Mean"`
+	Stddev float64 `json:"Stddev"`
+}

--- a/plugins/inputs/vault/vault_test.go
+++ b/plugins/inputs/vault/vault_test.go
@@ -81,8 +81,8 @@ func TestVaultStats(t *testing.T) {
 			defer ts.Close()
 
 			plugin := &Vault{
-				URL:         ts.URL,
-				TokenString: "s.CDDrgg5zPv5ssI0Z2P4qxJj2",
+				URL:   ts.URL,
+				Token: "s.CDDrgg5zPv5ssI0Z2P4qxJj2",
 			}
 			err := plugin.Init()
 			require.NoError(t, err)

--- a/plugins/inputs/vault/vault_test.go
+++ b/plugins/inputs/vault/vault_test.go
@@ -1,0 +1,97 @@
+package vault
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVaultStats(t *testing.T) {
+	var applyTests = []struct {
+		name     string
+		expected []telegraf.Metric
+	}{
+		{
+			name: "Metrics",
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"vault.raft.replication.appendEntries.logs",
+					map[string]string{
+						"peer_id": "clustnode-02",
+					},
+					map[string]interface{}{
+						"count":  int(130),
+						"rate":   float64(0.2),
+						"sum":    int(2),
+						"min":    int(0),
+						"max":    int(1),
+						"mean":   float64(0.015384615384615385),
+						"stddev": float64(0.12355304447984486),
+					},
+					time.Unix(1638287340, 0),
+					1,
+				),
+				testutil.MustMetric(
+					"vault.core.unsealed",
+					map[string]string{
+						"cluster": "vault-cluster-23b671c7",
+					},
+					map[string]interface{}{
+						"value": int(1),
+					},
+					time.Unix(1638287340, 0),
+					2,
+				),
+				testutil.MustMetric(
+					"vault.token.lookup",
+					map[string]string{},
+					map[string]interface{}{
+						"count":  int(5135),
+						"max":    float64(16.22449493408203),
+						"mean":   float64(0.1698389152269865),
+						"min":    float64(0.06690400093793869),
+						"rate":   float64(87.21228296905755),
+						"stddev": float64(0.24637634000854705),
+						"sum":    float64(872.1228296905756),
+					},
+					time.Unix(1638287340, 0),
+					1,
+				),
+			},
+		},
+	}
+
+	for _, tt := range applyTests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.RequestURI == "/v1/sys/metrics" {
+					w.WriteHeader(http.StatusOK)
+					responseKeyMetrics, _ := ioutil.ReadFile("testdata/response_key_metrics.json")
+					_, err := fmt.Fprintln(w, string(responseKeyMetrics))
+					require.NoError(t, err)
+				}
+			}))
+			defer ts.Close()
+
+			plugin := &Vault{
+				URL:              ts.URL,
+				VaultTokenString: "s.CDDrgg5zPv5ssI0Z2P4qxJj2",
+			}
+			err := plugin.Init()
+			require.NoError(t, err)
+
+			acc := testutil.Accumulator{}
+			err = plugin.Gather(&acc)
+			require.NoError(t, err)
+
+			testutil.RequireMetricsEqual(t, tt.expected, acc.GetTelegrafMetrics())
+		})
+	}
+}

--- a/plugins/inputs/vault/vault_test.go
+++ b/plugins/inputs/vault/vault_test.go
@@ -81,8 +81,8 @@ func TestVaultStats(t *testing.T) {
 			defer ts.Close()
 
 			plugin := &Vault{
-				URL:              ts.URL,
-				VaultTokenString: "s.CDDrgg5zPv5ssI0Z2P4qxJj2",
+				URL:         ts.URL,
+				TokenString: "s.CDDrgg5zPv5ssI0Z2P4qxJj2",
 			}
 			err := plugin.Init()
 			require.NoError(t, err)


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

This PR adds Hashicorp Vault input plugin. It is not so much different from Nomad input plugin here:
https://github.com/influxdata/telegraf/pull/10106

There are a couple of things that differs. An authentication/authorization through a token is mandatory and some structs have different fields.
 