### PR TITLE
fix: sync on init to run it once for safety

### DIFF
--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -15,11 +15,12 @@ import (
 // must init, append path for each directory, load module for every file
 // or gosmi will fail without saying why
 var m sync.Mutex
+var once sync.Once
 
 func LoadMibsFromPath(paths []string, log telegraf.Logger) error {
 	m.Lock()
 	defer m.Unlock()
-	gosmi.Init()
+	once.Do(gosmi.Init)
 	var folders []string
 	for _, mibPath := range paths {
 		gosmi.AppendPath(mibPath)


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
added once.Do on init as it is getting called multiple times and only needs to be called once