### PR TITLE
fix: Revert unintented corruption of the Makefile from #10200.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,18 +150,17 @@ lint-install:
 
 .PHONY: lint
 lint:
-	ifeq (, $(shell which golangci-lint))
-		$(info golangci-lint can't be found, please run: make lint-install)
-		exit 1
-	endif
+	@which golangci-lint >/dev/null 2>&1 || { \
+		echo "golangci-lint not found, please run: make lint-install"; \
+		exit 1; \
+	}
+	golangci-lint run
 
-		golangci-lint run
-
-	ifeq (, $(shell which markdownlint-cli))
-		$(info markdownlint-cli can't be found, please run: make lint-install)
-		exit 1
-	endif
-	markdownlint-cli
+	@which markdownlint >/dev/null 2>&1 || { \
+		echo "markdownlint not found, please run: make lint-install"; \
+		exit 1; \
+	}
+	markdownlint .
 
 .PHONY: lint-branch
 lint-branch:


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

PR #10200 accidentally broke the linter rule in the Makefile by reintroducing old code. This PR fixes the issue and brings back `make lint`.