### PR TITLE
fix: Print loaded plugins and deprecations for once and test

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -256,16 +256,6 @@ func runAgent(ctx context.Context,
 
 	logger.SetupLogging(logConfig)
 
-	if *fRunOnce {
-		wait := time.Duration(*fTestWait) * time.Second
-		return ag.Once(ctx, wait)
-	}
-
-	if *fTest || *fTestWait != 0 {
-		wait := time.Duration(*fTestWait) * time.Second
-		return ag.Test(ctx, wait)
-	}
-
 	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))
 	log.Printf("I! Loaded aggregators: %s", strings.Join(c.AggregatorNames(), " "))
 	log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))
@@ -283,6 +273,16 @@ func runAgent(ctx context.Context,
 	}
 	if count, found := c.Deprecations["outputs"]; found && (count[0] > 0 || count[1] > 0) {
 		log.Printf("W! Deprecated outputs: %d and %d options", count[0], count[1])
+	}
+
+	if *fRunOnce {
+		wait := time.Duration(*fTestWait) * time.Second
+		return ag.Once(ctx, wait)
+	}
+
+	if *fTest || *fTestWait != 0 {
+		wait := time.Duration(*fTestWait) * time.Second
+		return ag.Test(ctx, wait)
 	}
 
 	if *fPidfile != "" {

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -261,7 +261,7 @@ func runAgent(ctx context.Context,
 	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))
 	log.Printf("I! Loaded aggregators: %s", strings.Join(c.AggregatorNames(), " "))
 	log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))
-	if *fTest || *fTestWait != 0 {
+	if !*fRunOnce && (*fTest || *fTestWait != 0) {
 		log.Print(color.RedString("W! Outputs are not used in testing mode!"))
 	} else {
 		log.Printf("I! Loaded outputs: %s", strings.Join(c.OutputNames(), " "))

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fatih/color"
+
 	"github.com/influxdata/tail/watch"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/agent"
@@ -259,7 +261,11 @@ func runAgent(ctx context.Context,
 	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))
 	log.Printf("I! Loaded aggregators: %s", strings.Join(c.AggregatorNames(), " "))
 	log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))
-	log.Printf("I! Loaded outputs: %s", strings.Join(c.OutputNames(), " "))
+	if *fTest || *fTestWait != 0 {
+		log.Print(color.RedString("W! Outputs are not used in testing mode!"))
+	} else {
+		log.Printf("I! Loaded outputs: %s", strings.Join(c.OutputNames(), " "))
+	}
 	log.Printf("I! Tags enabled: %s", c.ListTags())
 
 	if count, found := c.Deprecations["inputs"]; found && (count[0] > 0 || count[1] > 0) {

--- a/docs/COMMANDS_AND_FLAGS.md
+++ b/docs/COMMANDS_AND_FLAGS.md
@@ -36,8 +36,8 @@ telegraf [flags]
 |`--section-filter`               |filter config sections to output, separator is `:`.  Valid values are `agent`, `global_tags`, `outputs`, `processors`, `aggregators` and `inputs`|
 |`--sample-config`                |print out full sample configuration|
 |`--once`                         |enable once mode: gather metrics once, write them, and exit|
-|`--test`                         |enable test mode: gather metrics once and print them|
-|`--test-wait`                    |wait up to this many seconds for service inputs to complete in test or once mode|
+|`--test`                         |enable test mode: gather metrics once and print them.<br>**No outputs are written!**|
+|`--test-wait`                    |wait up to this many seconds for service inputs to complete in test or once mode. <br> **Implies `--test` if not used with `--once`**|
 |`--usage <plugin>`               |print usage for a plugin, ie, `telegraf --usage mysql`|
 |`--version`                      |display the version and exit|
 

--- a/docs/COMMANDS_AND_FLAGS.md
+++ b/docs/COMMANDS_AND_FLAGS.md
@@ -36,8 +36,8 @@ telegraf [flags]
 |`--section-filter`               |filter config sections to output, separator is `:`.  Valid values are `agent`, `global_tags`, `outputs`, `processors`, `aggregators` and `inputs`|
 |`--sample-config`                |print out full sample configuration|
 |`--once`                         |enable once mode: gather metrics once, write them, and exit|
-|`--test`                         |enable test mode: gather metrics once and print them.<br>**No outputs are written!**|
-|`--test-wait`                    |wait up to this many seconds for service inputs to complete in test or once mode. <br> **Implies `--test` if not used with `--once`**|
+|`--test`                         |enable test mode: gather metrics once and print them. **No outputs are executed!**|
+|`--test-wait`                    |wait up to this many seconds for service inputs to complete in test or once mode.  **Implies `--test` if not used with `--once`**|
 |`--usage <plugin>`               |print usage for a plugin, ie, `telegraf --usage mysql`|
 |`--version`                      |display the version and exit|
 

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -39,9 +39,9 @@ The commands & flags are:
   --sample-config                print out full sample configuration
   --once                         enable once mode: gather metrics once, write them, and exit
   --test                         enable test mode: gather metrics once and print them.
-                                 NO OUTPUTS ARE WRITTEN!
+                                 No outputs are executed!
   --test-wait                    wait up to this many seconds for service inputs to complete
-                                 in test or once mode. IMPLIES --test if not used with --once.
+                                 in test or once mode. Implies --test if not used with --once.
   --usage <plugin>               print usage for a plugin, ie, 'telegraf --usage mysql'
   --version                      display the version and exit
 

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -38,9 +38,10 @@ The commands & flags are:
                                  'processors', 'aggregators' and 'inputs'
   --sample-config                print out full sample configuration
   --once                         enable once mode: gather metrics once, write them, and exit
-  --test                         enable test mode: gather metrics once and print them
-  --test-wait                    wait up to this many seconds for service
-                                 inputs to complete in test or once mode
+  --test                         enable test mode: gather metrics once and print them.
+                                 NO OUTPUTS ARE WRITTEN!
+  --test-wait                    wait up to this many seconds for service inputs to complete
+                                 in test or once mode. IMPLIES --test if not used with --once.
   --usage <plugin>               print usage for a plugin, ie, 'telegraf --usage mysql'
   --version                      display the version and exit
 


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10080

In the current state loaded plugin-names will only be shown when running in production mode but **not** when running with `--test` or `--once`. The same holds for the newly added deprecation information.

This PR changes the behavior to _always_ show the loaded plugins as well as the deprecation information even when running in testing mode. Furthermore, it clarifies `--test` behavior and fixes `--test-wait` documentation.