### PR TITLE
feat: Optimize locking for SNMP MIBs loading.

### DIFF
--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -44,10 +44,13 @@ func LoadMibsFromPath(paths []string, log telegraf.Logger) error {
 		folders := []string{}
 
 		// Check if we loaded that path already and skip it if so
-		if cache[mibPath] {
+		m.Lock()
+		cached := cache[mibPath]
+		cache[mibPath] = true
+		m.Unlock()
+		if cached {
 			continue
 		}
-		cache[mibPath] = true
 
 		appendPath(mibPath)
 		folders = append(folders, mibPath)

--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -77,7 +77,7 @@ func LoadMibsFromPath(paths []string, log telegraf.Logger) error {
 					appendPath(path)
 				} else if info.Mode()&os.ModeSymlink == 0 {
 					if err := loadModule(info.Name()); err != nil {
-						log.Warnf("Module could not be loaded %v", err)
+						log.Warn(err)
 					}
 				}
 				return nil

--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -83,7 +83,7 @@ func LoadMibsFromPath(paths []string, log telegraf.Logger) error {
 				return nil
 			})
 			if err != nil {
-				return fmt.Errorf("Filepath could not be walked %v", err)
+				return fmt.Errorf("Filepath could not be walked: %v", err)
 			}
 		}
 	}

--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -67,7 +67,7 @@ func LoadMibsFromPath(paths []string, log telegraf.Logger) error {
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("Filepath could not be walked %v", err)
+			return fmt.Errorf("Filepath could not be walked: %v", err)
 		}
 
 		for _, folder := range folders {

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -1295,3 +1295,12 @@ func TestTableJoinNoIndexAsTag_walk(t *testing.T) {
 	require.Contains(t, tb.Rows, rtr2)
 	require.Contains(t, tb.Rows, rtr3)
 }
+
+func BenchmarkMibLoading(b *testing.B) {
+	log := testutil.Logger{}
+	path := []string{"testdata"}
+	for i := 0; i < b.N; i++ {
+		err := snmp.LoadMibsFromPath(path, log)
+		require.NoError(b, err)
+	}
+}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR optimizes locking for the SNMP MIBs loading. This is necessary as the current loading of those files is completely serial. With large setups with dozends or hundreds of SNMP plugins this might take long...

@Hipska will provide measurements... :-)