### PR TITLE
fix: ensure graylog spec fields not prefixed with '_'

### DIFF
--- a/plugins/outputs/graylog/graylog_test.go
+++ b/plugins/outputs/graylog/graylog_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/zlib"
 	"crypto/tls"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -46,7 +45,6 @@ func TestSerializer(t *testing.T) {
 		var obj GelfObject
 		err = json.Unmarshal([]byte(r), &obj)
 		require.NoError(t, err)
-		fmt.Println(r)
 
 		require.Equal(t, obj["version"], "1.1")
 		require.Equal(t, obj["_name"], "testing")


### PR DESCRIPTION
The Graylog GELF spec[1] there are a number of fields that are part of
the spec and should *not* be prefixed by a '_'. The only fields that get
the underscore per the spec are additional fields not part of the spec.

[1] https://docs.graylog.org/docs/gelf

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
