### PR TITLE
docs: address documentation gap when running telegraf in k8s 

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -137,7 +137,7 @@ If using node level scrape scope, `pod_scrape_interval` specifies how often (in 
 
 The pod running telegraf will need to have the proper rbac configuration in order to be allowed to call the k8s api to discover and watch pods in the cluster.
 A typical configuration will create a service account, a cluster role with the appropriate rules and a cluster role binding to tie the cluster role to the service account.
-Example of configuration:
+Example of configuration for cluster level discovery:
 
 ```yaml
 ---

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -175,7 +175,6 @@ metadata:
   name: telegraf-k8s-{{ .Release.Name }}
 ```
 
-
 ### Consul Service Discovery
 
 Enabling this option and configuring consul `agent` url will allow the plugin to query


### PR DESCRIPTION
### Required for all PRs:


- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests (read me change only)
- [x] Pull request title or commits are in [conventional commit format]

resolves #10085 

Address documentation gap when running telegraf in a k8s pod (required for k8s 1.20 and higher).
