### PR TITLE
feat: Add option to disable Wavefront prefix conversion

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1590,6 +1590,7 @@ func (c *Config) buildSerializer(tbl *ast.Table) (serializers.Serializer, error)
 
 	c.getFieldStringSlice(tbl, "wavefront_source_override", &sc.WavefrontSourceOverride)
 	c.getFieldBool(tbl, "wavefront_use_strict", &sc.WavefrontUseStrict)
+	c.getFieldBool(tbl, "wavefront_disable_prefix_conversion", &sc.WavefrontDisablePrefixConversion)
 
 	c.getFieldBool(tbl, "prometheus_export_timestamp", &sc.PrometheusExportTimestamp)
 	c.getFieldBool(tbl, "prometheus_sort_metrics", &sc.PrometheusSortMetrics)

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -104,6 +104,9 @@ type Config struct {
 	// When enabled forward slash (/) and comma (,) will be accepted
 	WavefrontUseStrict bool `toml:"wavefront_use_strict"`
 
+	// Convert "_" in prefixes to "." for Wavefront
+	WavefrontDisablePrefixConversion bool `toml:"wavefront_disable_prefix_conversion"`
+
 	// Include the metric timestamp on each sample.
 	PrometheusExportTimestamp bool `toml:"prometheus_export_timestamp"`
 
@@ -134,7 +137,7 @@ func NewSerializer(config *Config) (Serializer, error) {
 	case "carbon2":
 		serializer, err = NewCarbon2Serializer(config.Carbon2Format, config.Carbon2SanitizeReplaceChar)
 	case "wavefront":
-		serializer, err = NewWavefrontSerializer(config.Prefix, config.WavefrontUseStrict, config.WavefrontSourceOverride)
+		serializer, err = NewWavefrontSerializer(config.Prefix, config.WavefrontUseStrict, config.WavefrontSourceOverride, config.WavefrontDisablePrefixConversion)
 	case "prometheus":
 		serializer, err = NewPrometheusSerializer(config)
 	case "prometheusremotewrite":
@@ -187,8 +190,8 @@ func NewPrometheusSerializer(config *Config) (Serializer, error) {
 	})
 }
 
-func NewWavefrontSerializer(prefix string, useStrict bool, sourceOverride []string) (Serializer, error) {
-	return wavefront.NewSerializer(prefix, useStrict, sourceOverride)
+func NewWavefrontSerializer(prefix string, useStrict bool, sourceOverride []string, disablePrefixConversions bool) (Serializer, error) {
+	return wavefront.NewSerializer(prefix, useStrict, sourceOverride, disablePrefixConversions)
 }
 
 func NewJSONSerializer(timestampUnits time.Duration, timestampFormat string) (Serializer, error) {

--- a/plugins/serializers/wavefront/README.md
+++ b/plugins/serializers/wavefront/README.md
@@ -20,6 +20,10 @@ The `wavefront` serializer translates the Telegraf metric format to the [Wavefro
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "wavefront"
+  ## Users who wish their prefix paths to not be converted may set the following:
+  ## default behavior (enabled prefix/path conversion):       prod.prefix.name.metric.name
+  ## configurable behavior (disabled prefix/path conversion): prod.prefix_name.metric_name
+  # wavefront_disable_prefix_conversion = true
 ```
 
 ## Metrics

--- a/plugins/serializers/wavefront/wavefront.go
+++ b/plugins/serializers/wavefront/wavefront.go
@@ -69,7 +69,7 @@ func (s *WavefrontSerializer) serializeMetric(m telegraf.Metric) {
 			name = sanitizedChars.Replace(name)
 		}
 
-		if s.DisablePrefixConversions == false {
+		if !s.DisablePrefixConversions {
 			name = pathReplacer.Replace(name)
 		}
 


### PR DESCRIPTION
Maintaining the default behavior for backwards compatibility, while adding the option of preserving original metric prefixes.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #7913

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Users who use the Wavefront serializer who don't wish to have their metric prefixes modified may configure their output plugin in a similar way as the [Wavefront Output Plugin](https://github.com/influxdata/telegraf/blob/release-1.20/plugins/outputs/wavefront/README.md#convert-path--metric-separator).

Users may set the following configuration option: `wavefront_disable_prefix_conversion = true`

Default behavior (enabled prefix/path conversion): `prod.prefix.name.metric.name`

Configurable behavior (disabled prefix/path conversion): `prod.prefix_name.metric_name`
