### PR TITLE
fix: inputs.snmp to respect number of retries configured

### DIFF
--- a/internal/snmp/wrapper.go
+++ b/internal/snmp/wrapper.go
@@ -25,9 +25,8 @@ func (gs GosnmpWrapper) Host() string {
 func (gs GosnmpWrapper) Walk(oid string, fn gosnmp.WalkFunc) error {
 	if gs.Version == gosnmp.Version1 {
 		return gs.GoSNMP.Walk(oid, fn)
-	} else {
-		return gs.GoSNMP.BulkWalk(oid, fn)
 	}
+	return gs.GoSNMP.BulkWalk(oid, fn)
 }
 
 func NewWrapper(s ClientConfig) (GosnmpWrapper, error) {

--- a/internal/snmp/wrapper.go
+++ b/internal/snmp/wrapper.go
@@ -22,42 +22,12 @@ func (gs GosnmpWrapper) Host() string {
 
 // Walk wraps GoSNMP.Walk() or GoSNMP.BulkWalk(), depending on whether the
 // connection is using SNMPv1 or newer.
-// Also, if any error is encountered, it will just once reconnect and try again.
 func (gs GosnmpWrapper) Walk(oid string, fn gosnmp.WalkFunc) error {
-	var err error
-	// On error, retry once.
-	// Unfortunately we can't distinguish between an error returned by gosnmp, and one returned by the walk function.
-	for i := 0; i < 2; i++ {
-		if gs.Version == gosnmp.Version1 {
-			err = gs.GoSNMP.Walk(oid, fn)
-		} else {
-			err = gs.GoSNMP.BulkWalk(oid, fn)
-		}
-		if err == nil {
-			return nil
-		}
-		if err := gs.GoSNMP.Connect(); err != nil {
-			return fmt.Errorf("reconnecting: %w", err)
-		}
+	if gs.Version == gosnmp.Version1 {
+		return gs.GoSNMP.Walk(oid, fn)
+	} else {
+		return gs.GoSNMP.BulkWalk(oid, fn)
 	}
-	return err
-}
-
-// Get wraps GoSNMP.GET().
-// If any error is encountered, it will just once reconnect and try again.
-func (gs GosnmpWrapper) Get(oids []string) (*gosnmp.SnmpPacket, error) {
-	var err error
-	var pkt *gosnmp.SnmpPacket
-	for i := 0; i < 2; i++ {
-		pkt, err = gs.GoSNMP.Get(oids)
-		if err == nil {
-			return pkt, nil
-		}
-		if err := gs.GoSNMP.Connect(); err != nil {
-			return nil, fmt.Errorf("reconnecting: %w", err)
-		}
-	}
-	return nil, err
 }
 
 func NewWrapper(s ClientConfig) (GosnmpWrapper, error) {


### PR DESCRIPTION
### Required for all PRs:

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #7300, resolves #4683

The snmp input always doubled the number of configured retries. Since the underlaying library handles this correctly, the reconnect in telegraf code can be removed.