### PR TITLE
fix: use sha256 for RPM digest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,7 @@ $(include_packages):
 			--description "Plugin-driven server agent for reporting metrics into InfluxDB." \
 			--depends coreutils \
 			--depends shadow-utils \
+			--rpm-digest sha256 \
 			--rpm-posttrans scripts/rpm/post-install.sh \
 			--name telegraf \
 			--version $(version) \


### PR DESCRIPTION
The md5 algorithm is known to be unsafe and FIPS enabled systems do not
allow its use for file manifests. The `fpm` tool used to produce rpm
and deb packages uses md5 by default. This updates the algorithm to
sha256.

Resolves: #10270