### PR TITLE
fix: mark TestGatherUDPCert as an integration test

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -259,6 +259,9 @@ func TestGatherChain(t *testing.T) {
 }
 
 func TestGatherUDPCert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	pair, err := tls.X509KeyPair([]byte(pki.ReadServerCert()), []byte(pki.ReadServerKey()))
 	require.NoError(t, err)
 


### PR DESCRIPTION
This unit test has been flaky and occasionally times out: https://app.circleci.com/pipelines/github/influxdata/telegraf/8090/workflows/c8943f70-7ba8-4ae7-84c2-888371146352/jobs/137793/tests#failed-test-0

From the panic stack trace, I think the issue is that it hangs during the client creation because its documentation does state it can hang `Connection handshake will timeout`: https://github.com/influxdata/telegraf/blob/146fff31832e74e0db31ed6405400a3b18e9ccdd/plugins/inputs/x509_cert/x509_cert.go#L128 but it isn't obvious why it hangs. It looks like it only fails in the Mac CI job so it could just be an issue with the Mac environment.