### PR TITLE
fix: typo in openstack neutron input plugin (newtron)

### DIFF
--- a/plugins/inputs/openstack/README.md
+++ b/plugins/inputs/openstack/README.md
@@ -182,7 +182,7 @@ Also, consider polling OpenStack services at different intervals depending on yo
   * subnet_id  [string]
   * subnets  [integer]
   * updated_at  [string]
-* openstack_newtron_agent
+* openstack_neutron_agent
   * agent_host
   * agent_type
   * availability_zone
@@ -344,7 +344,7 @@ Also, consider polling OpenStack services at different intervals depending on yo
 ### Example Output
 
 ```text
-> openstack_newtron_agent,agent_host=vim2,agent_type=DHCP\ agent,availability_zone=nova,binary=neutron-dhcp-agent,host=telegraf_host,topic=dhcp_agent admin_state_up=true,alive=true,created_at="2021-01-07T03:40:53Z",heartbeat_timestamp="2021-10-14T07:46:40Z",id="17e1e446-d7da-4656-9e32-67d3690a306f",resources_synced=false,started_at="2021-07-02T21:47:42Z" 1634197616000000000
+> openstack_neutron_agent,agent_host=vim2,agent_type=DHCP\ agent,availability_zone=nova,binary=neutron-dhcp-agent,host=telegraf_host,topic=dhcp_agent admin_state_up=true,alive=true,created_at="2021-01-07T03:40:53Z",heartbeat_timestamp="2021-10-14T07:46:40Z",id="17e1e446-d7da-4656-9e32-67d3690a306f",resources_synced=false,started_at="2021-07-02T21:47:42Z" 1634197616000000000
 > openstack_aggregate,host=telegraf_host,name=non-dpdk aggregate_host="vim3",aggregate_hosts=2i,created_at="2021-02-01T18:28:00Z",deleted=false,deleted_at="0001-01-01T00:00:00Z",id=3i,updated_at="0001-01-01T00:00:00Z" 1634197617000000000
 > openstack_flavor,host=telegraf_host,is_public=true,name=hwflavor disk=20i,ephemeral=0i,id="f89785c0-6b9f-47f5-a02e-f0fcbb223163",ram=8192i,rxtx_factor=1,swap=0i,vcpus=8i 1634197617000000000
 > openstack_hypervisor,cpu_arch=x86_64,cpu_feature_3dnowprefetch=true,cpu_feature_abm=true,cpu_feature_acpi=true,cpu_feature_adx=true,cpu_feature_aes=true,cpu_feature_apic=true,cpu_feature_xtpr=true,cpu_model=C-Server,cpu_vendor=xyz,host=telegraf_host,hypervisor_hostname=vim3,hypervisor_type=QEMU,hypervisor_version=4002000,service_host=vim3,service_id=192,state=up,status=enabled cpu_topology_cores=28i,cpu_topology_sockets=1i,cpu_topology_threads=2i,current_workload=0i,disk_available_least=2596i,free_disk_gb=2744i,free_ram_mb=374092i,host_ip="xx:xx:xx:x::xxx",id="12",local_gb=3366i,local_gb_used=622i,memory_mb=515404i,memory_mb_used=141312i,running_vms=15i,vcpus=0i,vcpus_used=72i 1634197618000000000

--- a/plugins/inputs/openstack/openstack.go
+++ b/plugins/inputs/openstack/openstack.go
@@ -514,11 +514,11 @@ func (o *OpenStack) gatherNetworks(acc telegraf.Accumulator) error {
 func (o *OpenStack) gatherAgents(acc telegraf.Accumulator) error {
 	page, err := agents.List(o.network, &agents.ListOpts{}).AllPages()
 	if err != nil {
-		return fmt.Errorf("unable to list newtron agents %v", err)
+		return fmt.Errorf("unable to list neutron agents %v", err)
 	}
 	extractedAgents, err := agents.ExtractAgents(page)
 	if err != nil {
-		return fmt.Errorf("unable to extract newtron agents %v", err)
+		return fmt.Errorf("unable to extract neutron agents %v", err)
 	}
 	for _, agent := range extractedAgents {
 		tags := map[string]string{
@@ -538,7 +538,7 @@ func (o *OpenStack) gatherAgents(acc telegraf.Accumulator) error {
 			"started_at":          o.convertTimeFormat(agent.StartedAt),
 			"heartbeat_timestamp": o.convertTimeFormat(agent.HeartbeatTimestamp),
 		}
-		acc.AddFields("openstack_newtron_agent", fields, tags)
+		acc.AddFields("openstack_neutron_agent", fields, tags)
 	}
 	return nil
 }


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [N/A] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10282

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Renamed Ne**u**tron metrics openstack_ne**u**tron_agent, instead of openstack_ne**w**tron_agent.
Updated code comments and README accordingly.