### PR TITLE
fix: Fix panic in parsers due to missing Log

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1190,7 +1190,18 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 			return err
 		}
 		t.SetParserFunc(func() (parsers.Parser, error) {
-			return parsers.NewParser(config)
+			parser, err := parsers.NewParser(config)
+			if err != nil {
+				return nil, err
+			}
+			logger := models.NewLogger("parsers", config.DataFormat, name)
+			models.SetLoggerOnPlugin(parser, logger)
+			if initializer, ok := parser.(telegraf.Initializer); ok {
+				if err := initializer.Init(); err != nil {
+					return nil, err
+				}
+			}
+			return parser, nil
 		})
 	}
 


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10285
resolves #10286

Plugins using the SetParserFunc do not initialize the parsers' `Log` field properly (nor do they call `Init()`). This PR fixes the resulting panic by doing the initialization properly.

A quick search shows that `file`, `tail` and `directory_monitor` seem to be hit by this bug.
