### PR TITLE
fix: mac signing issue with arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,7 +463,7 @@ workflows:
       # - 'windows-package':
       #     requires:
       #       - 'test-go-windows'
-      #- 'darwin-amd64-package'
+      - 'darwin-amd64-package'
           # requires:
           #   - 'test-go-mac'
       - 'darwin-arm64-package'
@@ -554,7 +554,7 @@ workflows:
       #           only: /.*/
       - 'package-sign-mac':
           requires:
-            #- 'darwin-amd64-package'
+            - 'darwin-amd64-package'
             - 'darwin-arm64-package'
           #    - 'package-sign-windows'
           #  filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,10 +463,10 @@ workflows:
       # - 'windows-package':
       #     requires:
       #       - 'test-go-windows'
-      - 'darwin-amd64-package'
+      #- 'darwin-amd64-package'
           # requires:
           #   - 'test-go-mac'
-      # - 'darwin-arm64-package'
+      - 'darwin-arm64-package'
           # requires:
           #   - 'test-go-mac'
       # - 'i386-package':
@@ -554,8 +554,8 @@ workflows:
       #           only: /.*/
       - 'package-sign-mac':
           requires:
-            - 'darwin-amd64-package'
-            # - 'darwin-arm64-package'
+            #- 'darwin-amd64-package'
+            - 'darwin-arm64-package'
           #    - 'package-sign-windows'
           #  filters:
           #     tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,10 +463,10 @@ workflows:
       # - 'windows-package':
       #     requires:
       #       - 'test-go-windows'
-      # - 'darwin-amd64-package'
+      - 'darwin-amd64-package'
           # requires:
           #   - 'test-go-mac'
-      - 'darwin-arm64-package'
+      # - 'darwin-arm64-package'
           # requires:
           #   - 'test-go-mac'
       # - 'i386-package':
@@ -554,8 +554,8 @@ workflows:
       #           only: /.*/
       - 'package-sign-mac':
           requires:
-            # - 'darwin-amd64-package'
-            - 'darwin-arm64-package'
+            - 'darwin-amd64-package'
+            # - 'darwin-arm64-package'
           #    - 'package-sign-windows'
           #  filters:
           #     tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,7 +463,7 @@ workflows:
       # - 'windows-package':
       #     requires:
       #       - 'test-go-windows'
-      - 'darwin-amd64-package'
+      # - 'darwin-amd64-package'
           # requires:
           #   - 'test-go-mac'
       - 'darwin-arm64-package'
@@ -554,7 +554,7 @@ workflows:
       #           only: /.*/
       - 'package-sign-mac':
           requires:
-            - 'darwin-amd64-package'
+            # - 'darwin-amd64-package'
             - 'darwin-arm64-package'
           #    - 'package-sign-windows'
           #  filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,129 +435,131 @@ workflows:
   version: 2
   check:
     jobs:
-      - 'deps':
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-1_17':
+      # - 'deps':
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'test-go-1_17':
+      #     requires:
+      #       - 'deps'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'test-go-1_17-386':
+      #     requires:
+      #       - 'deps'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'test-go-mac':
+      #     filters:
+      #       tags: # only runs on tags if you specify this filter
+      #         only: /.*/
+      # - 'test-go-windows':
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - *test-awaiter
+      # - 'windows-package':
+      #     requires:
+      #       - 'test-go-windows'
+      - 'darwin-amd64-package'
+          # requires:
+          #   - 'test-go-mac'
+      - 'darwin-arm64-package'
+          # requires:
+          #   - 'test-go-mac'
+      # - 'i386-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'ppc64le-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 's390x-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'armel-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'amd64-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'arm64-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'armhf-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'static-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'mipsel-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'mips-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'generate-config':
+      #     requires:
+      #       - 'amd64-package'
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - 'generate-config-win':
+      #     requires:
+      #       - 'windows-package'
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - 'share-artifacts':
+      #     requires:
+      #       - 'i386-package'
+      #       - 'ppc64le-package'
+      #       - 's390x-package'
+      #       - 'armel-package'
+      #       - 'amd64-package'
+      #       - 'mipsel-package'
+      #       - 'mips-package'
+      #       - 'darwin-amd64-package'
+      #       - 'darwin-arm64-package'
+      #       - 'windows-package'
+      #       - 'static-package'
+      #       - 'arm64-package'
+      #       - 'armhf-package'
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - release.*
+      #       tags:
+      #         ignore: /.*/
+      # - 'release':
+      #     requires:
+      #       - 'test-go-windows'
+      #       - 'test-go-mac'
+      #       - 'test-go-1_17'
+      #       - 'test-go-1_17-386'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #       branches:
+      #         ignore: /.*/
+      # - 'package-sign-windows':
+      #     requires:
+      #       - 'release'
+      #     filters:
+      #         tags:
+      #           only: /.*/
+      - 'package-sign-mac':
           requires:
-            - 'deps'
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-1_17-386':
-          requires:
-            - 'deps'
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-mac':
-          filters:
-            tags: # only runs on tags if you specify this filter
-              only: /.*/
-      - 'test-go-windows':
-          filters:
-            tags:
-              only: /.*/
-      - *test-awaiter
-      - 'windows-package':
-          requires:
-            - 'test-go-windows'
-      - 'darwin-amd64-package':
-          requires:
-            - 'test-go-mac'
-      - 'darwin-arm64-package':
-          requires:
-            - 'test-go-mac'
-      - 'i386-package':
-          requires:
-            - 'test-awaiter'
-      - 'ppc64le-package':
-          requires:
-            - 'test-awaiter'
-      - 's390x-package':
-          requires:
-            - 'test-awaiter'
-      - 'armel-package':
-          requires:
-            - 'test-awaiter'
-      - 'amd64-package':
-          requires:
-            - 'test-awaiter'
-      - 'arm64-package':
-          requires:
-            - 'test-awaiter'
-      - 'armhf-package':
-          requires:
-            - 'test-awaiter'
-      - 'static-package':
-          requires:
-            - 'test-awaiter'
-      - 'mipsel-package':
-          requires:
-            - 'test-awaiter'
-      - 'mips-package':
-          requires:
-            - 'test-awaiter'
-      - 'generate-config':
-          requires:
-            - 'amd64-package'
-          filters:
-            branches:
-              only:
-                - master
-      - 'generate-config-win':
-          requires:
-            - 'windows-package'
-          filters:
-            branches:
-              only:
-                - master
-      - 'share-artifacts':
-          requires:
-            - 'i386-package'
-            - 'ppc64le-package'
-            - 's390x-package'
-            - 'armel-package'
-            - 'amd64-package'
-            - 'mipsel-package'
-            - 'mips-package'
             - 'darwin-amd64-package'
             - 'darwin-arm64-package'
-            - 'windows-package'
-            - 'static-package'
-            - 'arm64-package'
-            - 'armhf-package'
-          filters:
-            branches:
-              ignore:
-                - master
-                - release.*
-            tags:
-              ignore: /.*/
-      - 'release':
-          requires:
-            - 'test-go-windows'
-            - 'test-go-mac'
-            - 'test-go-1_17'
-            - 'test-go-1_17-386'
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
-      - 'package-sign-windows':
-          requires:
-            - 'release'
-          filters:
-              tags:
-                only: /.*/
-      - 'package-sign-mac':
-           requires:
-             - 'package-sign-windows'
-           filters:
-              tags:
-                only: /.*/
+          #    - 'package-sign-windows'
+          #  filters:
+          #     tags:
+          #       only: /.*/
 
   nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,131 +435,129 @@ workflows:
   version: 2
   check:
     jobs:
-      # - 'deps':
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'test-go-1_17':
-      #     requires:
-      #       - 'deps'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'test-go-1_17-386':
-      #     requires:
-      #       - 'deps'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'test-go-mac':
-      #     filters:
-      #       tags: # only runs on tags if you specify this filter
-      #         only: /.*/
-      # - 'test-go-windows':
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - *test-awaiter
-      # - 'windows-package':
-      #     requires:
-      #       - 'test-go-windows'
-      - 'darwin-amd64-package'
-          # requires:
-          #   - 'test-go-mac'
-      - 'darwin-arm64-package'
-          # requires:
-          #   - 'test-go-mac'
-      # - 'i386-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'ppc64le-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 's390x-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'armel-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'amd64-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'arm64-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'armhf-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'static-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'mipsel-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'mips-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'generate-config':
-      #     requires:
-      #       - 'amd64-package'
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - 'generate-config-win':
-      #     requires:
-      #       - 'windows-package'
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - 'share-artifacts':
-      #     requires:
-      #       - 'i386-package'
-      #       - 'ppc64le-package'
-      #       - 's390x-package'
-      #       - 'armel-package'
-      #       - 'amd64-package'
-      #       - 'mipsel-package'
-      #       - 'mips-package'
-      #       - 'darwin-amd64-package'
-      #       - 'darwin-arm64-package'
-      #       - 'windows-package'
-      #       - 'static-package'
-      #       - 'arm64-package'
-      #       - 'armhf-package'
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - release.*
-      #       tags:
-      #         ignore: /.*/
-      # - 'release':
-      #     requires:
-      #       - 'test-go-windows'
-      #       - 'test-go-mac'
-      #       - 'test-go-1_17'
-      #       - 'test-go-1_17-386'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #       branches:
-      #         ignore: /.*/
-      # - 'package-sign-windows':
-      #     requires:
-      #       - 'release'
-      #     filters:
-      #         tags:
-      #           only: /.*/
-      - 'package-sign-mac':
+      - 'deps':
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-1_17':
           requires:
+            - 'deps'
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-1_17-386':
+          requires:
+            - 'deps'
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-mac':
+          filters:
+            tags: # only runs on tags if you specify this filter
+              only: /.*/
+      - 'test-go-windows':
+          filters:
+            tags:
+              only: /.*/
+      - *test-awaiter
+      - 'windows-package':
+          requires:
+            - 'test-go-windows'
+      - 'darwin-amd64-package':
+          requires:
+            - 'test-go-mac'
+      - 'darwin-arm64-package':
+          requires:
+            - 'test-go-mac'
+      - 'i386-package':
+          requires:
+            - 'test-awaiter'
+      - 'ppc64le-package':
+          requires:
+            - 'test-awaiter'
+      - 's390x-package':
+          requires:
+            - 'test-awaiter'
+      - 'armel-package':
+          requires:
+            - 'test-awaiter'
+      - 'amd64-package':
+          requires:
+            - 'test-awaiter'
+      - 'arm64-package':
+          requires:
+            - 'test-awaiter'
+      - 'armhf-package':
+          requires:
+            - 'test-awaiter'
+      - 'static-package':
+          requires:
+            - 'test-awaiter'
+      - 'mipsel-package':
+          requires:
+            - 'test-awaiter'
+      - 'mips-package':
+          requires:
+            - 'test-awaiter'
+      - 'generate-config':
+          requires:
+            - 'amd64-package'
+          filters:
+            branches:
+              only:
+                - master
+      - 'generate-config-win':
+          requires:
+            - 'windows-package'
+          filters:
+            branches:
+              only:
+                - master
+      - 'share-artifacts':
+          requires:
+            - 'i386-package'
+            - 'ppc64le-package'
+            - 's390x-package'
+            - 'armel-package'
+            - 'amd64-package'
+            - 'mipsel-package'
+            - 'mips-package'
             - 'darwin-amd64-package'
             - 'darwin-arm64-package'
-          #    - 'package-sign-windows'
-          #  filters:
-          #     tags:
-          #       only: /.*/
+            - 'windows-package'
+            - 'static-package'
+            - 'arm64-package'
+            - 'armhf-package'
+          filters:
+            branches:
+              ignore:
+                - master
+                - release.*
+            tags:
+              ignore: /.*/
+      - 'release':
+          requires:
+            - 'test-go-windows'
+            - 'test-go-mac'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+      - 'package-sign-windows':
+          requires:
+            - 'release'
+          filters:
+              tags:
+                only: /.*/
+      - 'package-sign-mac':
+           requires:
+             - 'package-sign-windows'
+           filters:
+              tags:
+                only: /.*/
 
   nightly:
     jobs:

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -18,8 +18,8 @@ base64 -D -o AppleSigningAuthorityCertificate.cer <<< "$AppleSigningAuthorityCer
 sudo security import AppleSigningAuthorityCertificate.cer -k '/Library/Keychains/System.keychain' -A
 
 # amdFile=$(find . -name "*darwin_amd64.tar*")
-armFile=$(find "$HOME/project/dist" -name "*darwin_amd64.tar*")
-# armFile=$(find "$HOME/project/dist" -name "*darwin_arm64.tar*")
+# armFile=$(find "$HOME/project/dist" -name "*darwin_amd64.tar*")
+armFile=$(find "$HOME/project/dist" -name "*darwin_arm64.tar*")
 macFiles=("${armFile}")
 
 for tarFile in "${macFiles[@]}";
@@ -38,8 +38,9 @@ do
 
   # Sign telegraf binary and the telegraf_entry_mac script
   tar -xzvf "$tarFile" --strip-components=2 -C "$RootAppDir/Resources"
+  printf "\n"
   TelegrafBinPath="$RootAppDir/Resources/usr/bin/telegraf"
-  codesign -s "$DeveloperID" --timestamp --options=runtime "$TelegrafBinPath"
+  codesign --arch arm64 -s "$DeveloperID" --timestamp --options=runtime "$TelegrafBinPath"
   echo "Verify if $TelegrafBinPath was signed"
   codesign -dvv "$TelegrafBinPath"
 

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -97,5 +97,5 @@ do
 
   mv "$baseName".dmg ~/project/dist
 
-  echo "$tarFile Signed and notarized!"
+  echo "$baseName.dmg signed and notarized!"
 done

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -34,12 +34,14 @@ do
 
   # Sign telegraf binary and the telegraf_entry_mac script
   tar -xzf "$tarFile" --strip-components=2 -C Telegraf.app/Contents/Resources
-  codesign -s "$DeveloperID" --timestamp --options=runtime Telegraf.app/Contents/Resources/usr/bin/telegraf
-  codesign -v telegraf
+  TelegrafBinPath="Telegraf.app/Contents/Resources/usr/bin/telegraf"
+  codesign -s "$DeveloperID" --timestamp --options=runtime "$TelegrafBinPath"
+  codesign -v "$TelegrafBinPath"
 
   cp ~/project/dist/scripts/telegraf_entry_mac Telegraf/Contents/MacOS
-  codesign -s "$DeveloperID" --timestamp --options=runtime Telegraf.app/Contents/MacOS/telegraf_entry_mac
-  codesign -v ../scripts/telegraf_entry_mac
+  EntryMacPath="Telegraf.app/Contents/MacOS/telegraf_entry_mac"
+  codesign -s "$DeveloperID" --timestamp --options=runtime "$EntryMacPath"
+  codesign -v "$EntryMacPath"
 
   cp ~/project/dist/assets/info.plist Telegraf.app/Contents
   cp  ~/project/dist/assets/icon.icns Telegraf.app/Contents/Resources

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -27,26 +27,27 @@ do
 
   # Create the .app bundle directory structure
   mkdir -p Telegraf.app/Contents
-  mkdir -p Telegraf.app/Contents/MacOS
-  mkdir -p Telegraf.app/Contents/Resources
+  RootAppDir="Telegraf.app/Contents"
+  mkdir -p "$RootAppDir/MacOS"
+  mkdir -p "$RootAppDir/Resources"
 
   DeveloperID="Developer ID Application: InfluxData Inc. (M7DN9H35QT)"
 
   # Sign telegraf binary and the telegraf_entry_mac script
-  tar -xzf "$tarFile" --strip-components=2 -C Telegraf.app/Contents/Resources
-  TelegrafBinPath="Telegraf.app/Contents/Resources/usr/bin/telegraf"
+  tar -xzf "$tarFile" --strip-components=2 -C "$RootAppDir/Resources"
+  TelegrafBinPath="$RootAppDir/Resources/usr/bin/telegraf"
   codesign -s "$DeveloperID" --timestamp --options=runtime "$TelegrafBinPath"
   codesign -v "$TelegrafBinPath"
 
-  cp ~/project/dist/scripts/telegraf_entry_mac Telegraf/Contents/MacOS
-  EntryMacPath="Telegraf.app/Contents/MacOS/telegraf_entry_mac"
+  cp ~/project/scripts/telegraf_entry_mac "$RootAppDir"/MacOS
+  EntryMacPath="$RootAppDir/MacOS/telegraf_entry_mac"
   codesign -s "$DeveloperID" --timestamp --options=runtime "$EntryMacPath"
   codesign -v "$EntryMacPath"
 
-  cp ~/project/dist/assets/info.plist Telegraf.app/Contents
-  cp  ~/project/dist/assets/icon.icns Telegraf.app/Contents/Resources
+  cp ~/project/assets/info.plist "$RootAppDir"
+  cp  ~/project/assets/icon.icns "$RootAppDir/Resources"
 
-  chmod +x Telegraf.app/Contents/MacOS/telegraf_entry_mac
+  chmod +x "$RootAppDir/MacOS/telegraf_entry_mac"
 
   # Sign the entire .app bundle, and wrap it in a DMG.
   codesign -s "$DeveloperID" --timestamp --options=runtime --deep --force Telegraf.app

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -7,6 +7,12 @@ function cleanup () {
   rm -rf Telegraf.app
 }
 
+function signBinary () {
+  tarFile=$1
+  arch=$2
+  echo "Processing $tarFile with $arch"
+}
+
 # Acquire the necessary certificates.
 # MacCertificate, MacCertificatePassword, AppleSigningAuthorityCertificate are environment variables, to follow convention they should have been all caps.
 # shellcheck disable=SC2154
@@ -42,15 +48,15 @@ do
   TelegrafBinPath="$RootAppDir/Resources/usr/bin/telegraf"
   codesign --arch arm64 -s "$DeveloperID" --timestamp --options=runtime "$TelegrafBinPath"
   echo "Verify if $TelegrafBinPath was signed"
-  codesign -dvv "$TelegrafBinPath"
+  codesign -v "$TelegrafBinPath"
 
   printf "\n"
 
   cp ~/project/scripts/telegraf_entry_mac "$RootAppDir"/MacOS
   EntryMacPath="$RootAppDir/MacOS/telegraf_entry_mac"
-  codesign -s "$DeveloperID" --timestamp --options=runtime "$EntryMacPath"
+  codesign --arch arm64 -s "$DeveloperID" --timestamp --options=runtime "$EntryMacPath"
   echo "Verify if $EntryMacPath was signed"
-  codesign -dvv "$EntryMacPath"
+  codesign -v "$EntryMacPath"
 
   printf "\n"
 
@@ -60,11 +66,11 @@ do
   chmod +x "$RootAppDir/MacOS/telegraf_entry_mac"
 
   # Sign the entire .app bundle, and wrap it in a DMG.
-  codesign -s "$DeveloperID" --timestamp --options=runtime --deep --force Telegraf.app
+  codesign --arch arm64 -s "$DeveloperID" --timestamp --options=runtime --deep --force Telegraf.app
   baseName=$(basename "$tarFile" .tar.gz)
   echo "$baseName"
   hdiutil create -size 500m -volname Telegraf -srcfolder Telegraf.app "$baseName".dmg
-  codesign -s "$DeveloperID" --timestamp --options=runtime "$baseName".dmg
+  codesign --arch arm64 -s "$DeveloperID" --timestamp --options=runtime "$baseName".dmg
 
   # Send the DMG to be notarized.
   # AppleUsername and ApplePassword are environment variables, to follow convention they should have been all caps.

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -1,67 +1,63 @@
 #!/bin/bash
 
 function cleanup () {
+  echo "Cleaning up any existing Telegraf or Telegraf.app"
   rm -rf Telegraf
   rm -rf Telegraf.app
-  rm -rf "$extractedFolder"
 }
 
 # Acquire the necessary certificates.
+# MacCertificate, MacCertificatePassword, AppleSigningAuthorityCertificate are environment variables, to follow convention they should have been all caps.
 # shellcheck disable=SC2154
 base64 -D -o MacCertificate.p12 <<< "$MacCertificate"
+# shellcheck disable=SC2154
 sudo security import MacCertificate.p12 -k /Library/Keychains/System.keychain -P "$MacCertificatePassword" -A
+# shellcheck disable=SC2154
 base64 -D -o AppleSigningAuthorityCertificate.cer <<< "$AppleSigningAuthorityCertificate"
 sudo security import AppleSigningAuthorityCertificate.cer -k '/Library/Keychains/System.keychain' -A
 
 cd dist || exit
 # amdFile=$(find . -name "*darwin_amd64.tar*")
-armFile=$(find . -name "*darwin_arm64.tar*")
+armFile=$(find . -name "$HOME/project/dist/*darwin_arm64.tar*")
 macFiles=("${armFile}")
 
 
 for tarFile in "${macFiles[@]}";
 do
-  echo "Processing $tarFile"
-  # Extract the built mac binary and sign it.
-  extractedFolder="$(tar -tzf "$tarFile" | head -1 | cut -f1 -d"/")"
   cleanup
-  tar -xzf "$tarFile"
-  echo "$extractedFolder"
-  baseName=$(basename "$tarFile" .tar.gz)
-  echo "$baseName"
-  cd "$extractedFolder" || exit
-  cd usr/bin || exit
-  codesign -s "Developer ID Application: InfluxData Inc. (M7DN9H35QT)" --timestamp --options=runtime telegraf
+  echo "Processing $tarFile"
+
+  # Create the .app bundle directory structure
+  mkdir -p Telegraf.app/Contents
+  mkdir -p Telegraf.app/Contents/MacOS
+  mkdir -p Telegraf.app/Contents/Resources
+
+  DeveloperID="Developer ID Application: InfluxData Inc. (M7DN9H35QT)"
+
+  # Sign telegraf binary and the telegraf_entry_mac script
+  tar -xzf "$tarFile" --strip-components=2 -C Telegraf.app/Contents/Resources telegraf-*
+  codesign -s "$DeveloperID" --timestamp --options=runtime Telegraf.app/Contents/Resources/usr/bin/telegraf
   codesign -v telegraf
 
-  # Reset back out to the main directory.
-  cd ~/project/dist || exit
-
-  # Sign the 'telegraf entry' script, which is required to open Telegraf upon opening the .app bundle.
-  codesign -s "Developer ID Application: InfluxData Inc. (M7DN9H35QT)" --timestamp --options=runtime ../scripts/telegraf_entry_mac
+  cp ~/project/dist/scripts/telegraf_entry_mac Telegraf/Contents/MacOS
+  codesign -s "$DeveloperID" --timestamp --options=runtime Telegraf.app/Contents/MacOS/telegraf_entry_mac
   codesign -v ../scripts/telegraf_entry_mac
 
-  # Create the .app bundle.
-  mkdir Telegraf
-  cd Telegraf || exit
-  mkdir Contents
-  cd Contents || exit
-  mkdir MacOS
-  mkdir Resources
-  cd ../..
-  cp ../info.plist Telegraf/Contents
-  cp -R "$extractedFolder"/ Telegraf/Contents/Resources
-  cp ../scripts/telegraf_entry_mac Telegraf/Contents/MacOS
-  cp ../assets/icon.icns Telegraf/Contents/Resources
-  chmod +x Telegraf/Contents/MacOS/telegraf_entry_mac
-  mv Telegraf Telegraf.app
+  cp ~/project/dist/assets/info.plist Telegraf.app/Contents
+  cp  ~/project/dist/assets/icon.icns Telegraf.app/Contents/Resources
+
+  chmod +x Telegraf.app/Contents/MacOS/telegraf_entry_mac
 
   # Sign the entire .app bundle, and wrap it in a DMG.
-  codesign -s "Developer ID Application: InfluxData Inc. (M7DN9H35QT)" --timestamp --options=runtime --deep --force Telegraf.app
+  codesign -s "$DeveloperID" --timestamp --options=runtime --deep --force Telegraf.app
+  baseName=$(basename "$tarFile" .tar.gz)
+  echo "$baseName"
   hdiutil create -size 500m -volname Telegraf -srcfolder Telegraf.app "$baseName".dmg
-  codesign -s "Developer ID Application: InfluxData Inc. (M7DN9H35QT)" --timestamp --options=runtime "$baseName".dmg
+  codesign -s "$DeveloperID" --timestamp --options=runtime "$baseName".dmg
 
   # Send the DMG to be notarized.
+  # AppleUsername and ApplePassword are environment variables, to follow convention they should have been all caps.
+  # shellcheck disable=SC2154
   uuid=$(xcrun altool --notarize-app --primary-bundle-id "com.influxdata.telegraf" --username "$AppleUsername" --password "$ApplePassword" --file "$baseName".dmg | awk '/RequestUUID/ { print $NF; }')
   echo "$uuid"
   if [[ $uuid == "" ]]; then

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -16,11 +16,9 @@ sudo security import MacCertificate.p12 -k /Library/Keychains/System.keychain -P
 base64 -D -o AppleSigningAuthorityCertificate.cer <<< "$AppleSigningAuthorityCertificate"
 sudo security import AppleSigningAuthorityCertificate.cer -k '/Library/Keychains/System.keychain' -A
 
-cd dist || exit
 # amdFile=$(find . -name "*darwin_amd64.tar*")
-armFile=$(find . -name "$HOME/project/dist/*darwin_arm64.tar*")
+armFile=$(find "$HOME/project/dist" -name "*darwin_arm64.tar*")
 macFiles=("${armFile}")
-
 
 for tarFile in "${macFiles[@]}";
 do
@@ -35,7 +33,7 @@ do
   DeveloperID="Developer ID Application: InfluxData Inc. (M7DN9H35QT)"
 
   # Sign telegraf binary and the telegraf_entry_mac script
-  tar -xzf "$tarFile" --strip-components=2 -C Telegraf.app/Contents/Resources telegraf-*
+  tar -xzf "$tarFile" --strip-components=2 -C Telegraf.app/Contents/Resources
   codesign -s "$DeveloperID" --timestamp --options=runtime Telegraf.app/Contents/Resources/usr/bin/telegraf
   codesign -v telegraf
 

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -7,12 +7,6 @@ function cleanup () {
   rm -rf Telegraf.app
 }
 
-function signBinary () {
-  tarFile=$1
-  arch=$2
-  echo "Processing $tarFile with $arch"
-}
-
 # Acquire the necessary certificates.
 # MacCertificate, MacCertificatePassword, AppleSigningAuthorityCertificate are environment variables, to follow convention they should have been all caps.
 # shellcheck disable=SC2154
@@ -46,17 +40,17 @@ do
   tar -xzvf "$tarFile" --strip-components=2 -C "$RootAppDir/Resources"
   printf "\n"
   TelegrafBinPath="$RootAppDir/Resources/usr/bin/telegraf"
-  codesign --arch arm64 -s "$DeveloperID" --timestamp --options=runtime "$TelegrafBinPath"
+  codesign --force -s "$DeveloperID" --timestamp --options=runtime "$TelegrafBinPath"
   echo "Verify if $TelegrafBinPath was signed"
-  codesign -v "$TelegrafBinPath"
+  codesign -dvv "$TelegrafBinPath"
 
   printf "\n"
 
   cp ~/project/scripts/telegraf_entry_mac "$RootAppDir"/MacOS
   EntryMacPath="$RootAppDir/MacOS/telegraf_entry_mac"
-  codesign --arch arm64 -s "$DeveloperID" --timestamp --options=runtime "$EntryMacPath"
+  codesign -s "$DeveloperID" --timestamp --options=runtime "$EntryMacPath"
   echo "Verify if $EntryMacPath was signed"
-  codesign -v "$EntryMacPath"
+  codesign -dvv "$EntryMacPath"
 
   printf "\n"
 
@@ -66,11 +60,11 @@ do
   chmod +x "$RootAppDir/MacOS/telegraf_entry_mac"
 
   # Sign the entire .app bundle, and wrap it in a DMG.
-  codesign --arch arm64 -s "$DeveloperID" --timestamp --options=runtime --deep --force Telegraf.app
+  codesign -s "$DeveloperID" --timestamp --options=runtime --deep --force Telegraf.app
   baseName=$(basename "$tarFile" .tar.gz)
   echo "$baseName"
   hdiutil create -size 500m -volname Telegraf -srcfolder Telegraf.app "$baseName".dmg
-  codesign --arch arm64 -s "$DeveloperID" --timestamp --options=runtime "$baseName".dmg
+  codesign -s "$DeveloperID" --timestamp --options=runtime "$baseName".dmg
 
   # Send the DMG to be notarized.
   # AppleUsername and ApplePassword are environment variables, to follow convention they should have been all caps.

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -17,16 +17,13 @@ sudo security import MacCertificate.p12 -k /Library/Keychains/System.keychain -P
 base64 -D -o AppleSigningAuthorityCertificate.cer <<< "$AppleSigningAuthorityCertificate"
 sudo security import AppleSigningAuthorityCertificate.cer -k '/Library/Keychains/System.keychain' -A
 
-# amdFile=$(find . -name "*darwin_amd64.tar*")
-# armFile=$(find "$HOME/project/dist" -name "*darwin_amd64.tar*")
+armFile=$(find "$HOME/project/dist" -name "*darwin_amd64.tar*")
 armFile=$(find "$HOME/project/dist" -name "*darwin_arm64.tar*")
 macFiles=("${armFile}")
 
 for tarFile in "${macFiles[@]}";
 do
   cleanup
-  echo "Processing $tarFile"
-  printf "\n"
 
   # Create the .app bundle directory structure
   mkdir -p Telegraf.app/Contents
@@ -37,6 +34,7 @@ do
   DeveloperID="Developer ID Application: InfluxData Inc. (M7DN9H35QT)"
 
   # Sign telegraf binary and the telegraf_entry_mac script
+  echo "Extract $tarFile to $RootAppDir/Resources"
   tar -xzvf "$tarFile" --strip-components=2 -C "$RootAppDir/Resources"
   printf "\n"
   TelegrafBinPath="$RootAppDir/Resources/usr/bin/telegraf"

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -34,14 +34,16 @@ do
   DeveloperID="Developer ID Application: InfluxData Inc. (M7DN9H35QT)"
 
   # Sign telegraf binary and the telegraf_entry_mac script
-  tar -xzfv "$tarFile" --strip-components=2 -C "$RootAppDir/Resources"
+  tar -xzvf "$tarFile" --strip-components=2 -C "$RootAppDir/Resources"
   TelegrafBinPath="$RootAppDir/Resources/usr/bin/telegraf"
   codesign -s "$DeveloperID" --timestamp --options=runtime "$TelegrafBinPath"
+  # Verify if signed
   codesign -v "$TelegrafBinPath"
 
   cp ~/project/scripts/telegraf_entry_mac "$RootAppDir"/MacOS
   EntryMacPath="$RootAppDir/MacOS/telegraf_entry_mac"
   codesign -s "$DeveloperID" --timestamp --options=runtime "$EntryMacPath"
+  # Verify if signed
   codesign -v "$EntryMacPath"
 
   cp ~/project/info.plist "$RootAppDir"

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -23,11 +23,13 @@ for tarFile in "${macFiles[@]}";
 do
   echo "Processing $tarFile"
   # Extract the built mac binary and sign it.
-  extractedFolder="$(tar -txzf "$tarFile" | head -1 | cut -f1 -d"/")"
+  extractedFolder="$(tar -tzf "$tarFile" | head -1 | cut -f1 -d"/")"
+  cleanup
+  tar -xzf "$tarFile"
   echo "$extractedFolder"
   baseName=$(basename "$tarFile" .tar.gz)
   echo "$baseName"
-  cd "$(find . -name "*telegraf-*" -type d)" || exit
+  cd "$extractedFolder" || exit
   cd usr/bin || exit
   codesign -s "Developer ID Application: InfluxData Inc. (M7DN9H35QT)" --timestamp --options=runtime telegraf
   codesign -v telegraf
@@ -40,7 +42,6 @@ do
   codesign -v ../scripts/telegraf_entry_mac
 
   # Create the .app bundle.
-  rm -rf Telegraf
   mkdir Telegraf
   cd Telegraf || exit
   mkdir Contents

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -19,7 +19,7 @@ sudo security import AppleSigningAuthorityCertificate.cer -k '/Library/Keychains
 
 amdFile=$(find "$HOME/project/dist" -name "*darwin_amd64.tar*")
 armFile=$(find "$HOME/project/dist" -name "*darwin_arm64.tar*")
-macFiles=("${amdFile} ${armFile}")
+macFiles=("${amdFile}" "${armFile}")
 
 for tarFile in "${macFiles[@]}";
 do

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -26,8 +26,8 @@ do
   cleanup
 
   # Create the .app bundle directory structure
-  mkdir -p Telegraf.app/Contents
   RootAppDir="Telegraf.app/Contents"
+  mkdir -p "$RootAppDir"
   mkdir -p "$RootAppDir/MacOS"
   mkdir -p "$RootAppDir/Resources"
 

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -10,7 +10,7 @@ sudo security import AppleSigningAuthorityCertificate.cer -k '/Library/Keychains
 cd dist || exit
 # amdFile=$(find . -name "*darwin_amd64.tar*")
 armFile=$(find . -name "*darwin_arm64.tar*")
-macFiles=("${amdFile}" "${armFile}")
+macFiles=("${armFile}")
 
 
 for tarFile in "${macFiles[@]}";

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -17,9 +17,9 @@ sudo security import MacCertificate.p12 -k /Library/Keychains/System.keychain -P
 base64 -D -o AppleSigningAuthorityCertificate.cer <<< "$AppleSigningAuthorityCertificate"
 sudo security import AppleSigningAuthorityCertificate.cer -k '/Library/Keychains/System.keychain' -A
 
-armFile=$(find "$HOME/project/dist" -name "*darwin_amd64.tar*")
+amdFile=$(find "$HOME/project/dist" -name "*darwin_amd64.tar*")
 armFile=$(find "$HOME/project/dist" -name "*darwin_arm64.tar*")
-macFiles=("${armFile}")
+macFiles=("${amdFile} ${armFile}")
 
 for tarFile in "${macFiles[@]}";
 do

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -34,7 +34,7 @@ do
   DeveloperID="Developer ID Application: InfluxData Inc. (M7DN9H35QT)"
 
   # Sign telegraf binary and the telegraf_entry_mac script
-  tar -xzf "$tarFile" --strip-components=2 -C "$RootAppDir/Resources"
+  tar -xzfv "$tarFile" --strip-components=2 -C "$RootAppDir/Resources"
   TelegrafBinPath="$RootAppDir/Resources/usr/bin/telegraf"
   codesign -s "$DeveloperID" --timestamp --options=runtime "$TelegrafBinPath"
   codesign -v "$TelegrafBinPath"
@@ -44,7 +44,7 @@ do
   codesign -s "$DeveloperID" --timestamp --options=runtime "$EntryMacPath"
   codesign -v "$EntryMacPath"
 
-  cp ~/project/assets/info.plist "$RootAppDir"
+  cp ~/project/info.plist "$RootAppDir"
   cp  ~/project/assets/icon.icns "$RootAppDir/Resources"
 
   chmod +x "$RootAppDir/MacOS/telegraf_entry_mac"

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -94,7 +94,8 @@ do
   # Attach the notarization to the DMG.
   xcrun stapler staple "$baseName".dmg
   cleanup
-  ls
+
+  mv "$baseName".dmg ~/project/dist
 
   echo "$tarFile Signed and notarized!"
 done


### PR DESCRIPTION
The arm64 binary failed to get signed during the release because by default Go gives an ad hoc signature to arm64 binaries because Mac requires a signed binary with arm64 otherwise all Go binaries will fail (thread about this here: https://github.com/golang/go/issues/42684). Therefore in order to overwrite the ad hoc sig with our influxdata signature we needed to provide the flag `--force` to the codesign tool. This pull requests adds the required `--force` flag and refactored the mac signing shell script. All linter issues found by shellcheck were addressed, more information is printed out for future debugging, and I updated the script to stop changing directories and instead use absolute paths to make it easier to read.


This was tested by changing the circleci config to only build and sign the mac artifacts, you can see the results here: 
- https://app.circleci.com/pipelines/github/influxdata/telegraf/8166/workflows/f51a71e7-3a9d-4311-b3a0-6c4e9df4071e 

you can find the artifacts that include the signed dmg files here: 
- https://app.circleci.com/pipelines/github/influxdata/telegraf/8166/workflows/f51a71e7-3a9d-4311-b3a0-6c4e9df4071e/jobs/138696/artifacts