### PR TITLE
fix: Fix panic in logparser due to missing Log.

### DIFF
--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/tail"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/globpath"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
 )
@@ -184,6 +185,7 @@ func (l *LogParserPlugin) Start(acc telegraf.Accumulator) error {
 	if err != nil {
 		return err
 	}
+	models.SetLoggerOnPlugin(l.GrokParser, l.Log)
 
 	l.wg.Add(1)
 	go l.parser()


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10286

The `logparser` plugins sets-up the `grok` parser manually without initializing the logger. This leads to the panic reported in #10286. This PR fixes the resulting panic by doing the initialization properly.