### PR TITLE
fix: check index before assignment

### DIFF
--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -148,26 +148,25 @@ func SnmpTranslateCall(oid string) (mibName string, oidNum string, oidText strin
 	if strings.ContainsAny(oid, "::") {
 		// split given oid
 		// for example RFC1213-MIB::sysUpTime.0
-		s := strings.Split(oid, "::")
+		s := strings.SplitN(oid, "::", 2)
 		// node becomes sysUpTime.0
-		if s[1] != "" {
-			node := s[1]
-			if strings.ContainsAny(node, ".") {
-				s = strings.Split(node, ".")
-				// node becomes sysUpTime
-				node = s[0]
-				end = "." + s[1]
-			}
-
-			out, err = gosmi.GetNode(node)
-			if err != nil {
-				return oid, oid, oid, oid, err
-			}
-
-			oidNum = "." + out.RenderNumeric() + end
-		} else {
-			return "", oid, oid, oid, fmt.Errorf("can not parse %v\n", oid)
+		if s[1] == "" {
+			return "", oid, oid, oid, fmt.Errorf("cannot parse %v\n", oid)
 		}
+		node := s[1]
+		if strings.ContainsAny(node, ".") {
+			s = strings.SplitN(node, ".", 2)
+			// node becomes sysUpTime
+			node = s[0]
+			end = "." + s[1]
+		}
+
+		out, err = gosmi.GetNode(node)
+		if err != nil {
+			return oid, oid, oid, oid, err
+		}
+
+		oidNum = "." + out.RenderNumeric() + end
 	} else if strings.ContainsAny(oid, "abcdefghijklnmopqrstuvwxyz") {
 		//handle mixed oid ex. .iso.2.3
 		s := strings.Split(oid, ".")

--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -150,20 +150,24 @@ func SnmpTranslateCall(oid string) (mibName string, oidNum string, oidText strin
 		// for example RFC1213-MIB::sysUpTime.0
 		s := strings.Split(oid, "::")
 		// node becomes sysUpTime.0
-		node := s[1]
-		if strings.ContainsAny(node, ".") {
-			s = strings.Split(node, ".")
-			// node becomes sysUpTime
-			node = s[0]
-			end = "." + s[1]
-		}
+		if s[1] != "" {
+			node := s[1]
+			if strings.ContainsAny(node, ".") {
+				s = strings.Split(node, ".")
+				// node becomes sysUpTime
+				node = s[0]
+				end = "." + s[1]
+			}
 
-		out, err = gosmi.GetNode(node)
-		if err != nil {
-			return oid, oid, oid, oid, err
-		}
+			out, err = gosmi.GetNode(node)
+			if err != nil {
+				return oid, oid, oid, oid, err
+			}
 
-		oidNum = "." + out.RenderNumeric() + end
+			oidNum = "." + out.RenderNumeric() + end
+		} else {
+			return "", oid, oid, oid, fmt.Errorf("can not parse %v\n", oid)
+		}
 	} else if strings.ContainsAny(oid, "abcdefghijklnmopqrstuvwxyz") {
 		//handle mixed oid ex. .iso.2.3
 		s := strings.Split(oid, ".")

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -1304,3 +1304,14 @@ func BenchmarkMibLoading(b *testing.B) {
 		require.NoError(b, err)
 	}
 }
+
+func TestCanNotParse(t *testing.T) {
+	s := &Snmp{
+		Fields: []Field{
+			{Oid: "RFC1213-MIB::"},
+		},
+	}
+
+	err := s.Init()
+	require.Error(t, err)
+}


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10298 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Check the index before looking it up in case there is a floating :: eg. `RFC1213-MIB::` instead of `RFC1213-MIB::sysUpTime`, also added unit test. This will now error instead of panic 