### PR TITLE
chore: update mac signing job to use latest xcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,12 +462,8 @@ workflows:
       # - 'windows-package':
       #     requires:
       #       - 'test-go-windows'
-      - 'darwin-amd64-package':
-          requires:
-            - 'test-go-mac'
-      - 'darwin-arm64-package':
-          requires:
-            - 'test-go-mac'
+      - 'darwin-amd64-package'
+      - 'darwin-arm64-package'
       # - 'i386-package':
       #     requires:
       #       - 'test-awaiter'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,10 +462,10 @@ workflows:
       - 'windows-package':
           requires:
             - 'test-go-windows'
-      - 'darwin-amd64-package'
+      - 'darwin-amd64-package':
           requires:
             - 'test-go-mac'
-      - 'darwin-arm64-package'
+      - 'darwin-arm64-package':
           requires:
             - 'test-go-mac'
       - 'i386-package':
@@ -553,7 +553,7 @@ workflows:
                 only: /.*/
       - 'package-sign-mac':
            requires:
-            - 'package-sign-windows'
+             - 'package-sign-windows'
            filters:
               tags:
                 only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,127 +434,129 @@ workflows:
   version: 2
   check:
     jobs:
-      # - 'deps':
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'test-go-1_17':
-      #     requires:
-      #       - 'deps'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'test-go-1_17-386':
-      #     requires:
-      #       - 'deps'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'test-go-mac':
-      #     filters:
-      #       tags: # only runs on tags if you specify this filter
-      #         only: /.*/
-      # - 'test-go-windows':
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - *test-awaiter
-      # - 'windows-package':
-      #     requires:
-      #       - 'test-go-windows'
+      - 'deps':
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-1_17':
+          requires:
+            - 'deps'
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-1_17-386':
+          requires:
+            - 'deps'
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-mac':
+          filters:
+            tags: # only runs on tags if you specify this filter
+              only: /.*/
+      - 'test-go-windows':
+          filters:
+            tags:
+              only: /.*/
+      - *test-awaiter
+      - 'windows-package':
+          requires:
+            - 'test-go-windows'
       - 'darwin-amd64-package'
+          requires:
+            - 'test-go-mac'
       - 'darwin-arm64-package'
-      # - 'i386-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'ppc64le-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 's390x-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'armel-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'amd64-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'arm64-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'armhf-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'static-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'mipsel-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'mips-package':
-      #     requires:
-      #       - 'test-awaiter'
-      # - 'generate-config':
-      #     requires:
-      #       - 'amd64-package'
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - 'generate-config-win':
-      #     requires:
-      #       - 'windows-package'
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - 'share-artifacts':
-      #     requires:
-      #       - 'i386-package'
-      #       - 'ppc64le-package'
-      #       - 's390x-package'
-      #       - 'armel-package'
-      #       - 'amd64-package'
-      #       - 'mipsel-package'
-      #       - 'mips-package'
-      #       - 'darwin-amd64-package'
-      #       - 'darwin-arm64-package'
-      #       - 'windows-package'
-      #       - 'static-package'
-      #       - 'arm64-package'
-      #       - 'armhf-package'
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - release.*
-      #       tags:
-      #         ignore: /.*/
-      # - 'release':
-      #     requires:
-      #       - 'test-go-windows'
-      #       - 'test-go-mac'
-      #       - 'test-go-1_17'
-      #       - 'test-go-1_17-386'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #       branches:
-      #         ignore: /.*/
-      # - 'package-sign-windows':
-      #     requires:
-      #       - 'release'
-      #     filters:
-      #         tags:
-      #           only: /.*/
+          requires:
+            - 'test-go-mac'
+      - 'i386-package':
+          requires:
+            - 'test-awaiter'
+      - 'ppc64le-package':
+          requires:
+            - 'test-awaiter'
+      - 's390x-package':
+          requires:
+            - 'test-awaiter'
+      - 'armel-package':
+          requires:
+            - 'test-awaiter'
+      - 'amd64-package':
+          requires:
+            - 'test-awaiter'
+      - 'arm64-package':
+          requires:
+            - 'test-awaiter'
+      - 'armhf-package':
+          requires:
+            - 'test-awaiter'
+      - 'static-package':
+          requires:
+            - 'test-awaiter'
+      - 'mipsel-package':
+          requires:
+            - 'test-awaiter'
+      - 'mips-package':
+          requires:
+            - 'test-awaiter'
+      - 'generate-config':
+          requires:
+            - 'amd64-package'
+          filters:
+            branches:
+              only:
+                - master
+      - 'generate-config-win':
+          requires:
+            - 'windows-package'
+          filters:
+            branches:
+              only:
+                - master
+      - 'share-artifacts':
+          requires:
+            - 'i386-package'
+            - 'ppc64le-package'
+            - 's390x-package'
+            - 'armel-package'
+            - 'amd64-package'
+            - 'mipsel-package'
+            - 'mips-package'
+            - 'darwin-amd64-package'
+            - 'darwin-arm64-package'
+            - 'windows-package'
+            - 'static-package'
+            - 'arm64-package'
+            - 'armhf-package'
+          filters:
+            branches:
+              ignore:
+                - master
+                - release.*
+            tags:
+              ignore: /.*/
+      - 'release':
+          requires:
+            - 'test-go-windows'
+            - 'test-go-mac'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+      - 'package-sign-windows':
+          requires:
+            - 'release'
+          filters:
+              tags:
+                only: /.*/
       - 'package-sign-mac':
            requires:
-            - 'darwin-arm64-package'
-            - 'darwin-amd64-package'
-            #  - 'package-sign-windows'
-          #  filters:
-          #     tags:
-          #       only: /.*/
+            - 'package-sign-windows'
+           filters:
+              tags:
+                only: /.*/
 
   nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       GOFLAGS: -p=8
   mac:
     macos:
-      xcode: 12.4.0
+      xcode: 13.2.0
     working_directory: '~/go/src/github.com/influxdata/telegraf'
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -378,8 +378,7 @@ jobs:
           path: './build/dist'
           destination: 'build/dist'
   package-sign-mac:
-    macos:
-      xcode: "11.3"
+    executor: mac
     working_directory: /Users/distiller/project
     environment:
       FL_OUTPUT_DIR: output
@@ -435,129 +434,131 @@ workflows:
   version: 2
   check:
     jobs:
-      - 'deps':
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-1_17':
-          requires:
-            - 'deps'
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-1_17-386':
-          requires:
-            - 'deps'
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-mac':
-          filters:
-            tags: # only runs on tags if you specify this filter
-              only: /.*/
-      - 'test-go-windows':
-          filters:
-            tags:
-              only: /.*/
-      - *test-awaiter
-      - 'windows-package':
-          requires:
-            - 'test-go-windows'
+      # - 'deps':
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'test-go-1_17':
+      #     requires:
+      #       - 'deps'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'test-go-1_17-386':
+      #     requires:
+      #       - 'deps'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'test-go-mac':
+      #     filters:
+      #       tags: # only runs on tags if you specify this filter
+      #         only: /.*/
+      # - 'test-go-windows':
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - *test-awaiter
+      # - 'windows-package':
+      #     requires:
+      #       - 'test-go-windows'
       - 'darwin-amd64-package':
           requires:
             - 'test-go-mac'
       - 'darwin-arm64-package':
           requires:
             - 'test-go-mac'
-      - 'i386-package':
-          requires:
-            - 'test-awaiter'
-      - 'ppc64le-package':
-          requires:
-            - 'test-awaiter'
-      - 's390x-package':
-          requires:
-            - 'test-awaiter'
-      - 'armel-package':
-          requires:
-            - 'test-awaiter'
-      - 'amd64-package':
-          requires:
-            - 'test-awaiter'
-      - 'arm64-package':
-          requires:
-            - 'test-awaiter'
-      - 'armhf-package':
-          requires:
-            - 'test-awaiter'
-      - 'static-package':
-          requires:
-            - 'test-awaiter'
-      - 'mipsel-package':
-          requires:
-            - 'test-awaiter'
-      - 'mips-package':
-          requires:
-            - 'test-awaiter'
-      - 'generate-config':
-          requires:
-            - 'amd64-package'
-          filters:
-            branches:
-              only:
-                - master
-      - 'generate-config-win':
-          requires:
-            - 'windows-package'
-          filters:
-            branches:
-              only:
-                - master
-      - 'share-artifacts':
-          requires:
-            - 'i386-package'
-            - 'ppc64le-package'
-            - 's390x-package'
-            - 'armel-package'
-            - 'amd64-package'
-            - 'mipsel-package'
-            - 'mips-package'
-            - 'darwin-amd64-package'
-            - 'darwin-arm64-package'
-            - 'windows-package'
-            - 'static-package'
-            - 'arm64-package'
-            - 'armhf-package'
-          filters:
-            branches:
-              ignore:
-                - master
-                - release.*
-            tags:
-              ignore: /.*/
-      - 'release':
-          requires:
-            - 'test-go-windows'
-            - 'test-go-mac'
-            - 'test-go-1_17'
-            - 'test-go-1_17-386'
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
-      - 'package-sign-windows':
-          requires:
-            - 'release'
-          filters:
-              tags:
-                only: /.*/
+      # - 'i386-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'ppc64le-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 's390x-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'armel-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'amd64-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'arm64-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'armhf-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'static-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'mipsel-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'mips-package':
+      #     requires:
+      #       - 'test-awaiter'
+      # - 'generate-config':
+      #     requires:
+      #       - 'amd64-package'
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - 'generate-config-win':
+      #     requires:
+      #       - 'windows-package'
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - 'share-artifacts':
+      #     requires:
+      #       - 'i386-package'
+      #       - 'ppc64le-package'
+      #       - 's390x-package'
+      #       - 'armel-package'
+      #       - 'amd64-package'
+      #       - 'mipsel-package'
+      #       - 'mips-package'
+      #       - 'darwin-amd64-package'
+      #       - 'darwin-arm64-package'
+      #       - 'windows-package'
+      #       - 'static-package'
+      #       - 'arm64-package'
+      #       - 'armhf-package'
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - release.*
+      #       tags:
+      #         ignore: /.*/
+      # - 'release':
+      #     requires:
+      #       - 'test-go-windows'
+      #       - 'test-go-mac'
+      #       - 'test-go-1_17'
+      #       - 'test-go-1_17-386'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #       branches:
+      #         ignore: /.*/
+      # - 'package-sign-windows':
+      #     requires:
+      #       - 'release'
+      #     filters:
+      #         tags:
+      #           only: /.*/
       - 'package-sign-mac':
            requires:
-             - 'package-sign-windows'
-           filters:
-              tags:
-                only: /.*/
+            - 'darwin-arm64-package'
+            - 'darwin-amd64-package'
+            #  - 'package-sign-windows'
+          #  filters:
+          #     tags:
+          #       only: /.*/
 
   nightly:
     jobs:


### PR DESCRIPTION
The circle-ci job `package-sign-mac` is using an older version of xcode that will be deprecated next year, I got an email from circle-ci giving me the heads up that in the last 4 weeks we were using a soon to be deprecated version. This pull request updates the `package-sign-mac` job to use the same executor as the test mac jobs and then also update the xcode to be the latest available. More info here: https://circleci.com/docs/2.0/testing-ios/?mkt_tok=NDg1LVpNSC02MjYAAAGBeOzfiKOY9HazYFRauJhXC2JKwmQWafZS9Xg4Us_YocgMYgZElmdRcFtqqCOkYSuPh5aP7wd4wFCG5vYxooLRzF8cDV0WagYftENvIYg4G6kd