### PR TITLE
fix: update aws orb to fix share-artifacts job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   win: circleci/windows@2.4.0
-  aws-cli: circleci/aws-cli@1.4.0
+  aws-cli: circleci/aws-cli@2.0.6
 
 executors:
   go-1_17:


### PR DESCRIPTION
The share-artifacts job is failing (https://app.circleci.com/pipelines/github/influxdata/telegraf/8205/workflows/6f8ba0ae-d19a-4763-a44f-b6aa92c6fe09/jobs/139335) because it can't get the docker image, I assume it might be because we are using an older version. Updating it to the latest. 

Info on the aws orb here: https://circleci.com/developer/orbs/orb/circleci/aws-cli