### PR TITLE
chore:  release packaging run in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,42 +449,81 @@ workflows:
       - 'windows-package':
           requires:
             - 'test-go-windows'
+          filters:
+            tags:
+              only: /.*/
       - 'darwin-amd64-package':
           requires:
             - 'test-go-mac'
+          filters:
+            tags:
+              only: /.*/
       - 'darwin-arm64-package':
           requires:
             - 'test-go-mac'
+          filters:
+            tags:
+              only: /.*/
       - 'i386-package':
           requires:
             - 'test-awaiter'
+          filters:
+            tags:
+              only: /.*/
       - 'ppc64le-package':
           requires:
             - 'test-awaiter'
+          filters:
+            tags:
+              only: /.*/
       - 's390x-package':
           requires:
             - 'test-awaiter'
+          filters:
+            tags:
+              only: /.*/
       - 'armel-package':
           requires:
             - 'test-awaiter'
+          filters:
+            tags:
+              only: /.*/
       - 'amd64-package':
           requires:
             - 'test-awaiter'
+          filters:
+            tags:
+              only: /.*/
       - 'arm64-package':
           requires:
             - 'test-awaiter'
+          filters:
+            tags:
+              only: /.*/
       - 'armhf-package':
           requires:
             - 'test-awaiter'
+          filters:
+            tags:
+              only: /.*/
       - 'static-package':
           requires:
             - 'test-awaiter'
+          filters:
+            tags:
+              only: /.*/
       - 'mipsel-package':
           requires:
             - 'test-awaiter'
+          filters:
+            tags:
+              only: /.*/
       - 'mips-package':
           requires:
             - 'test-awaiter'
+          filters:
+            tags:
+              only: /.*/
       - 'generate-config':
           requires:
             - 'amd64-package'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,9 +113,6 @@ commands:
 
   package-build:
     parameters:
-      release:
-        type: boolean
-        default: false
       type:
         type: string
         default: ""
@@ -128,10 +125,6 @@ commands:
       - attach_workspace:
           at: '/go'
       - when:
-          condition: << parameters.release >>
-          steps:
-            - run: 'make package'
-      - when:
           condition: << parameters.nightly >>
           steps:
             - run: 'NIGHTLY=1 make package include_packages="$(make << parameters.type >>)"'
@@ -139,7 +132,6 @@ commands:
           condition:
             or:
               - << parameters.nightly >>
-              - << parameters.release >>
           steps:
             - run: 'make package include_packages="$(make << parameters.type >>)"'
       - store_artifacts:
@@ -326,12 +318,6 @@ jobs:
       - package-build:
           type: armhf
           nightly: << parameters.nightly >>
-
-  release:
-    executor: go-1_17
-    steps:
-      - package-build:
-          release: true
   nightly:
     executor: go-1_17
     steps:
@@ -535,20 +521,21 @@ workflows:
                 - release.*
             tags:
               ignore: /.*/
-      - 'release':
-          requires:
-            - 'test-go-windows'
-            - 'test-go-mac'
-            - 'test-go-1_17'
-            - 'test-go-1_17-386'
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
       - 'package-sign-windows':
           requires:
-            - 'release'
+            - 'i386-package'
+            - 'ppc64le-package'
+            - 's390x-package'
+            - 'armel-package'
+            - 'amd64-package'
+            - 'mipsel-package'
+            - 'mips-package'
+            - 'darwin-amd64-package'
+            - 'darwin-arm64-package'
+            - 'windows-package'
+            - 'static-package'
+            - 'arm64-package'
+            - 'armhf-package'
           filters:
               tags:
                 only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,6 +416,9 @@ commonjobs:
       requires:
         - 'test-go-1_17'
         - 'test-go-1_17-386'
+      filters:
+        tags:
+          only: /.*/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,12 +539,16 @@ workflows:
           filters:
               tags:
                 only: /.*/
+              branches:
+                ignore: /.*/
       - 'package-sign-mac':
            requires:
              - 'package-sign-windows'
            filters:
               tags:
                 only: /.*/
+              branches:
+                ignore: /.*/
 
   nightly:
     jobs:


### PR DESCRIPTION
When a new tag is created for a release, the artifacts get created by running the `release` job. This job didn't make use of the parallel packaging builds based on arch, so it was slow, this PR removes the `release` job so that when a tag is created the same parallel packaging that happens for each pull request is used instead. The signing jobs were dependent on the `release` job, I just had them only trigger when a tag is created just like the `release` job was.