### PR TITLE
feat: Add more functionality to template processor

### DIFF
--- a/plugins/processors/template/README.md
+++ b/plugins/processors/template/README.md
@@ -23,9 +23,9 @@ Read the full [Go Template Documentation][].
   template = '{{ .Tag "hostname" }}.{{ .Tag "level" }}'
 ```
 
-## Example
+## Examples
 
-Combine multiple tags to create a single tag:
+### Combine multiple tags to create a single tag
 
 ```toml
 [[processors.template]]
@@ -38,7 +38,7 @@ Combine multiple tags to create a single tag:
 + cpu,level=debug,hostname=localhost,topic=localhost.debug time_idle=42
 ```
 
-Add measurement name as a tag:
+### Add measurement name as a tag
 
 ```toml
 [[processors.template]]
@@ -51,7 +51,7 @@ Add measurement name as a tag:
 + cpu,hostname=localhost,measurement=cpu time_idle=42
 ```
 
-Add the year as a tag, similar to the date processor:
+### Add the year as a tag, similar to the date processor
 
 ```toml
 [[processors.template]]
@@ -59,7 +59,7 @@ Add the year as a tag, similar to the date processor:
   template = '{{.Time.UTC.Year}}'
 ```
 
-Add all fields as a tag:
+### Add all fields as a tag
 
 ```toml
 [[processors.template]]
@@ -74,7 +74,7 @@ Add all fields as a tag:
 + cpu,hostname=localhost,message=Fields:\ map[time_idle:42] time_idle=42
 ```
 
-Just add the current metric as a tag:
+### Just add the current metric as a tag
 
 ```toml
 [[processors.template]]

--- a/plugins/processors/template/README.md
+++ b/plugins/processors/template/README.md
@@ -61,17 +61,33 @@ Read the full [Go Template Documentation][].
 
 ### Add all fields as a tag
 
+Sometimes it is usefull to pass all fields with their values into a single message for sending it to a monitoring system (e.g. Syslog, GroundWork), then you can use `.FieldList` or `.TagList`:
+
 ```toml
 [[processors.template]]
   tag = "message"
-  template = 'Fields: {{ .FieldList }}'
-  # Advanced example:
-  # template 'Fields: {{ range $name, $value := .FieldList }}{{$name}}:{{$value}} {{end}}'
+  template = 'Message about {{.Name}} fields: {{.FieldList}}'
 ```
 
 ```diff
 - cpu,hostname=localhost time_idle=42
-+ cpu,hostname=localhost,message=Fields:\ map[time_idle:42] time_idle=42
++ cpu,hostname=localhost,message=Message\ about\ cpu\ fields:\ map[time_idle:42] time_idle=42
+```
+
+More advanced example, which might make more sense:
+
+```toml
+[[processors.template]]
+  tag = "message"
+  template = '''Message about {{.Name}} fields:
+{{ range $field, $value := .FieldList -}}
+{{$field}}:{{$value}}
+{{ end }}'''
+```
+
+```diff
+- cpu,hostname=localhost time_idle=42
++ cpu,hostname=localhost,message=Message\ about\ cpu\ fields:\ntime_idle:42\n time_idle=42
 ```
 
 ### Just add the current metric as a tag

--- a/plugins/processors/template/README.md
+++ b/plugins/processors/template/README.md
@@ -59,4 +59,32 @@ Add the year as a tag, similar to the date processor:
   template = '{{.Time.UTC.Year}}'
 ```
 
+Add all fields as a tag:
+
+```toml
+[[processors.template]]
+  tag = "message"
+  template = 'Fields: {{ .FieldList }}'
+  # Advanced example:
+  # template 'Fields: {{ range $name, $value := .FieldList }}{{$name}}:{{$value}} {{end}}'
+```
+
+```diff
+- cpu,hostname=localhost time_idle=42
++ cpu,hostname=localhost,message=Fields:\ map[time_idle:42] time_idle=42
+```
+
+Just add the current metric as a tag:
+
+```toml
+[[processors.template]]
+  tag = "metric"
+  template = '{{.}}'
+```
+
+```diff
+- cpu,hostname=localhost time_idle=42
++ cpu,hostname=localhost,metric=cpu\ map[hostname:localhost]\ map[time_idle:42]\ 1257894000000000000 time_idle=42
+```
+
 [Go Template Documentation]: https://golang.org/pkg/text/template/

--- a/plugins/processors/template/template_metric.go
+++ b/plugins/processors/template/template_metric.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -26,4 +27,16 @@ func (m *TemplateMetric) Field(key string) interface{} {
 
 func (m *TemplateMetric) Time() time.Time {
 	return m.metric.Time()
+}
+
+func (m *TemplateMetric) String() string {
+	return fmt.Sprint(m.metric)
+}
+
+func (m *TemplateMetric) TagList() map[string]string {
+	return m.metric.Tags()
+}
+
+func (m *TemplateMetric) FieldList() map[string]interface{} {
+	return m.metric.Fields()
 }

--- a/plugins/processors/template/template_test.go
+++ b/plugins/processors/template/template_test.go
@@ -115,3 +115,48 @@ func TestTagAndFieldConcatenate(t *testing.T) {
 	expected := []telegraf.Metric{testutil.MustMetric("weather", map[string]string{"location": "us-midwest", "LocalTemp": "us-midwest is too warm"}, map[string]interface{}{"temperature": "too warm"}, now)}
 	testutil.RequireMetricsEqual(t, expected, actual)
 }
+
+func TestFieldList(t *testing.T) {
+	// Prepare
+	plugin := TemplateProcessor{Tag: "fields", Template: "{{.FieldList}}"}
+	require.NoError(t, plugin.Init())
+
+	// Run
+	m := testutil.TestMetric(1.23)
+	actual := plugin.Apply(m)
+
+	// Verify
+	expected := m.Copy()
+	expected.AddTag("fields", "map[value:1.23]")
+	testutil.RequireMetricsEqual(t, []telegraf.Metric{expected}, actual)
+}
+
+func TestTagList(t *testing.T) {
+	// Prepare
+	plugin := TemplateProcessor{Tag: "tags", Template: "{{.TagList}}"}
+	require.NoError(t, plugin.Init())
+
+	// Run
+	m := testutil.TestMetric(1.23)
+	actual := plugin.Apply(m)
+
+	// Verify
+	expected := m.Copy()
+	expected.AddTag("tags", "map[tag1:value1]")
+	testutil.RequireMetricsEqual(t, []telegraf.Metric{expected}, actual)
+}
+
+func TestDot(t *testing.T) {
+	// Prepare
+	plugin := TemplateProcessor{Tag: "metric", Template: "{{.}}"}
+	require.NoError(t, plugin.Init())
+
+	// Run
+	m := testutil.TestMetric(1.23)
+	actual := plugin.Apply(m)
+
+	// Verify
+	expected := m.Copy()
+	expected.AddTag("metric", "test1 map[tag1:value1] map[value:1.23] 1257894000000000000")
+	testutil.RequireMetricsEqual(t, []telegraf.Metric{expected}, actual)
+}


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

I was surprised the template processor didn't support `{{.}}` in a usable way.
```diff
- {0xc0000565a0}
+ test1 map[tag1:value1] map[value:1] 1257894000000000000
```

In the meantime, I also added support for `{{ .FieldList }}` and `{{ .TagList }}`.
