### PR TITLE
chore: add logs section for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking time to fill out this bug report! We reserve Telegraf issues for bugs for reproducible problems.  
+        Thanks for taking time to fill out this bug report! We reserve Telegraf issues for bugs for reproducible problems.
         Please redirect any questions about Telegraf usage to our [Community Slack](https://influxdata.com/slack) or [Community Page](https://community.influxdata.com/) we have a lot of talented community members there who could help answer your question more quickly.
   - type: textarea
     id: config
@@ -13,6 +13,13 @@ body:
       label: Relevent telegraf.conf
       description: Place config in the toml code section. This will be automatically formatted into toml, so no need for backticks.
       render: toml
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Logs from Telegraf
+      description: Please include the Telegraf logs, ideally with `--debug` used.
     validations:
       required: true
   - type: input
@@ -63,4 +70,4 @@ body:
       description: Include gist of relevant config, logs, etc.
     validations:
       required: false
-  
+


### PR DESCRIPTION
I have seen or needed to request logs from a number of bug reports. I
would like to add an explicit required section for Telegraf logs in our
bug report template.
