### PR TITLE
fix: pagination broken if multiple namespaces

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -434,7 +434,8 @@ func (c *CloudWatch) fetchNamespaceMetrics() ([]types.Metric, error) {
 			}
 
 			metrics = append(metrics, resp.Metrics...)
-			if resp.NextToken == nil {
+			if resp.NextToken == nil || len(*resp.NextToken) == 0 {
+				params.NextToken = token
 				break
 			}
 


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Added a check for missing criteria empty string and reset the params.NextToken (pagination) variable when there is none.
