### PR TITLE
fix: Fix warning output when running with --test

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -262,7 +262,7 @@ func runAgent(ctx context.Context,
 	log.Printf("I! Loaded aggregators: %s", strings.Join(c.AggregatorNames(), " "))
 	log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))
 	if !*fRunOnce && (*fTest || *fTestWait != 0) {
-		log.Print(color.RedString("W! Outputs are not used in testing mode!"))
+		log.Print("W! " + color.RedString("Outputs are not used in testing mode!"))
 	} else {
 		log.Printf("I! Loaded outputs: %s", strings.Join(c.OutputNames(), " "))
 	}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

When running with `--test` you see the output
```shell
2021-12-22T12:34:09Z I! Starting Telegraf 1.22.0-f239ac32
2021-12-22T12:34:09Z I! Loaded inputs: disk
2021-12-22T12:34:09Z I! Loaded aggregators: 
2021-12-22T12:34:09Z I! Loaded processors: 
2021-12-22T12:34:09Z I! W! Outputs are not used in testing mode!
```
Please note the `I! W!` for the last line. This is due to the coloring of the output including `W!` which breaks the log detection of the type. This PR fixes the issue by not coloring the `W!`.