### PR TITLE
chore: run release signing jobs at the same time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,16 +342,6 @@ jobs:
               --include "*.rpm" \
               --include "*.zip" \
               --acl public-read
-  package-consolidate:
-    executor:
-        name: win/default
-        shell: powershell.exe
-    steps:
-      - attach_workspace:
-          at: '/build'
-      - store_artifacts:
-          path: './build/dist'
-          destination: 'build/dist'
   package-sign-windows:
     executor:
         name: win/default
@@ -389,13 +379,14 @@ jobs:
           root: './build'
           paths:
             - 'dist'
-  all-artifacts:
-    executor: go-1_17
+  package-consolidate:
+    docker:
+     - image: alpine
     steps:
       - attach_workspace:
           at: '.'
       - store_artifacts:
-          path: './build/dist'
+          path: './dist'
           destination: 'build/dist'
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ commands:
       - persist_to_workspace:
           root: './build'
           paths:
-            - 'dist'
+            - 'build/dist'
 jobs:
   deps:
     executor: go-1_17
@@ -369,7 +369,7 @@ jobs:
       - persist_to_workspace:
           root: './build'
           paths:
-            - 'dist'
+            - 'build/dist'
       - store_artifacts:
           path: './build/dist'
           destination: 'build/dist'
@@ -389,11 +389,16 @@ jobs:
           command: |
             sh ./scripts/mac-signing.sh
       - store_artifacts:
-          path: './dist'
+          path: './build/dist'
           destination: 'build/dist'
   all-artifacts:
     executor: go-1_17
     steps:
+      - attach_workspace:
+          at: '.'
+      - store_artifacts:
+          path: './build/dist'
+          destination: 'build/dist'
       - run:
           command: |
             echo "This job contains all the final artifacts."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -579,8 +579,8 @@ workflows:
           filters:
               tags:
                 only: /.*/
-              # branches:
-              #   ignore: /.*/
+              branches:
+                ignore: /.*/
       - 'package-sign-mac':
            requires:
             - 'darwin-amd64-package'
@@ -608,8 +608,8 @@ workflows:
            filters:
               tags:
                 only: /.*/
-              # branches:
-              #   ignore: /.*/
+              branches:
+                ignore: /.*/
 
   nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,28 +588,28 @@ workflows:
            filters:
               tags:
                 only: /.*/
-              # branches:
-              #   ignore: /.*/
-      - 'all-artifacts':
-            requires:
-             - 'i386-package'
-             - 'ppc64le-package'
-             - 's390x-package'
-             - 'armel-package'
-             - 'amd64-package'
-             - 'mipsel-package'
-             - 'mips-package'
-             - 'static-package'
-             - 'arm64-package'
-             - 'armhf-package'
-             - 'riscv64-package'
-             - 'package-sign-mac'
-             - 'package-sign-windows'
-           filters:
-              tags:
-                only: /.*/
               branches:
                 ignore: /.*/
+      - 'package-consolidate':
+           requires:
+            - 'i386-package'
+            - 'ppc64le-package'
+            - 's390x-package'
+            - 'armel-package'
+            - 'amd64-package'
+            - 'mipsel-package'
+            - 'mips-package'
+            - 'static-package'
+            - 'arm64-package'
+            - 'armhf-package'
+            - 'riscv64-package'
+            - 'package-sign-mac'
+            - 'package-sign-windows'
+           filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
 
   nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,12 +391,12 @@ jobs:
       - store_artifacts:
           path: './dist'
           destination: 'build/dist'
-  test-awaiter:
+  all-artifacts:
     executor: go-1_17
     steps:
       - run:
           command: |
-            echo "Go tests complete."
+            echo "This job contains all the final artifacts."
   share-artifacts:
     executor: aws-cli/default
     steps:
@@ -418,16 +418,6 @@ jobs:
     steps:
       - generate-config:
           os: windows
-
-commonjobs:
-  - &test-awaiter
-    'test-awaiter':
-      requires:
-        - 'test-go-1_17'
-        - 'test-go-1_17-386'
-      filters:
-        tags:
-          only: /.*/
 
 workflows:
   version: 2
@@ -478,67 +468,78 @@ workflows:
               only: /.*/
       - 'i386-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
       - 'ppc64le-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
       - 'riscv64-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
       - 's390x-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
       - 'armel-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
       - 'amd64-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
       - 'arm64-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
       - 'armhf-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
       - 'static-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
       - 'mipsel-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
       - 'mips-package':
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
           filters:
             tags:
               only: /.*/
@@ -581,32 +582,41 @@ workflows:
               ignore: /.*/
       - 'package-sign-windows':
           requires:
-            - 'i386-package'
-            - 'ppc64le-package'
-            - 's390x-package'
-            - 'armel-package'
-            - 'amd64-package'
-            - 'mipsel-package'
-            - 'mips-package'
-            - 'darwin-amd64-package'
-            - 'darwin-arm64-package'
             - 'windows-package'
-            - 'static-package'
-            - 'arm64-package'
-            - 'armhf-package'
           filters:
               tags:
                 only: /.*/
-              branches:
-                ignore: /.*/
+              # branches:
+              #   ignore: /.*/
       - 'package-sign-mac':
            requires:
+            - 'darwin-amd64-package'
+            - 'darwin-arm64-package'
+           filters:
+              tags:
+                only: /.*/
+              # branches:
+              #   ignore: /.*/
+      - 'all-artifacts':
+            requires:
+             - 'i386-package'
+             - 'ppc64le-package'
+             - 's390x-package'
+             - 'armel-package'
+             - 'amd64-package'
+             - 'mipsel-package'
+             - 'mips-package'
+             - 'static-package'
+             - 'arm64-package'
+             - 'armhf-package'
+             - 'riscv64-package'
+             - 'package-sign-mac'
              - 'package-sign-windows'
            filters:
               tags:
                 only: /.*/
-              branches:
-                ignore: /.*/
+              # branches:
+              #   ignore: /.*/
 
   nightly:
     jobs:
@@ -619,7 +629,6 @@ workflows:
             - 'deps'
       - 'test-go-mac'
       - 'test-go-windows'
-      - *test-awaiter
       - 'windows-package':
           name: 'windows-package-nightly'
           nightly: true
@@ -639,57 +648,68 @@ workflows:
           name: 'i386-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - 'ppc64le-package':
           name: 'ppc64le-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - 'riscv64-package':
           name: 'riscv64-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - 's390x-package':
           name: 's390x-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - 'armel-package':
           name: 'armel-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - 'amd64-package':
           name: 'amd64-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - 'arm64-package':
           name: 'arm64-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - 'armhf-package':
           name: 'armhf-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - 'static-package':
           name: 'static-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - 'mipsel-package':
           name: 'mipsel-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - 'mips-package':
           name: 'mips-package-nightly'
           nightly: true
           requires:
-            - 'test-awaiter'
+            - 'test-go-1_17'
+            - 'test-go-1_17-386'
       - nightly:
           requires:
             - 'i386-package-nightly'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ commands:
       - persist_to_workspace:
           root: './build'
           paths:
-            - 'build/dist'
+            - 'dist'
 jobs:
   deps:
     executor: go-1_17
@@ -369,10 +369,7 @@ jobs:
       - persist_to_workspace:
           root: './build'
           paths:
-            - 'build/dist'
-      - store_artifacts:
-          path: './build/dist'
-          destination: 'build/dist'
+            - 'dist'
   package-sign-mac:
     executor: mac
     working_directory: /Users/distiller/project
@@ -388,9 +385,10 @@ jobs:
       - run:
           command: |
             sh ./scripts/mac-signing.sh
-      - store_artifacts:
-          path: './build/dist'
-          destination: 'build/dist'
+      - persist_to_workspace:
+          root: './build'
+          paths:
+            - 'dist'
   all-artifacts:
     executor: go-1_17
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - *test-awaiter
       - 'windows-package':
           requires:
             - 'test-go-windows'

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -95,7 +95,7 @@ do
   xcrun stapler staple "$baseName".dmg
   cleanup
 
-  mv "$baseName".dmg ~/project/dist
+  mv "$baseName".dmg ~/project/build/dist
 
   echo "$baseName.dmg signed and notarized!"
 done

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -95,6 +95,7 @@ do
   xcrun stapler staple "$baseName".dmg
   cleanup
 
+  mkdir -p ~/project/build/dist
   mv "$baseName".dmg ~/project/build/dist
 
   echo "$baseName.dmg signed and notarized!"


### PR DESCRIPTION
New release time: `25m 40s`

Tested here: [app.circleci.com/pipelines/github/influxdata/telegraf/8324/workflows/7f088f3d-670c-44fb-8821-73f097dfbc32](https://app.circleci.com/pipelines/github/influxdata/telegraf/8324/workflows/7f088f3d-670c-44fb-8821-73f097dfbc32) 

The new job package-consolidate now will contain all the artifacts for a release: [app.circleci.com/pipelines/github/influxdata/telegraf/8324/workflows/7f088f3d-670c-44fb-8821-73f097dfbc32/jobs/141206/artifacts](https://app.circleci.com/pipelines/github/influxdata/telegraf/8324/workflows/7f088f3d-670c-44fb-8821-73f097dfbc32/jobs/141206/artifacts) 

This pull requests updates the circle-ci config so that the mac and windows signing job run at the same time and only depend on the relevant packages instead of everything. This saves about 15 minutes! Evidently there was an unused job called `package-consolidate` already so I re-used it so that during the release you still just need to grab one job ID. Also removed `test-awaiter` because now that we only have two linux test jobs it doesn't really reduce the config size. Also made all the artifact paths the same, there was some inconsistency with the mac signing job.

![image](https://user-images.githubusercontent.com/3441183/147158633-7d5ac817-c6e3-4056-9eab-40708c927376.png)
