### PR TITLE
feat: add systemd notify support

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/coreos/go-systemd/daemon"
+
 	"github.com/fatih/color"
 
 	"github.com/influxdata/tail/watch"
@@ -280,6 +282,12 @@ func runAgent(ctx context.Context,
 	if count, found := c.Deprecations["outputs"]; found && (count[0] > 0 || count[1] > 0) {
 		log.Printf("W! Deprecated outputs: %d and %d options", count[0], count[1])
 	}
+
+	// Notify systemd that telegraf is ready
+	// SdNotify() only tries to notify if the NOTIFY_SOCKET environment is set, so it's safe to call when systemd isn't present.
+	// Ignore the return values here because they're not valid for platforms that don't use systemd.
+	// For platforms that use systemd, telegraf doesn't log if the notification failed.
+	_, _ = daemon.SdNotify(false, daemon.SdNotifyReady)
 
 	if *fRunOnce {
 		wait := time.Duration(*fTestWait) * time.Second

--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -66,6 +66,7 @@ following works:
 - github.com/cisco-ie/nx-telemetry-proto [Apache License 2.0](https://github.com/cisco-ie/nx-telemetry-proto/blob/master/LICENSE)
 - github.com/containerd/containerd [Apache License 2.0](https://github.com/containerd/containerd/blob/master/LICENSE)
 - github.com/coreos/go-semver [Apache License 2.0](https://github.com/coreos/go-semver/blob/main/LICENSE)
+- github.com/coreos/go-systemd [Apache License 2.0](https://github.com/coreos/go-systemd/blob/main/LICENSE)
 - github.com/couchbase/go-couchbase [MIT License](https://github.com/couchbase/go-couchbase/blob/master/LICENSE)
 - github.com/couchbase/gomemcached [MIT License](https://github.com/couchbase/gomemcached/blob/master/LICENSE)
 - github.com/couchbase/goutils [Apache License 2.0](https://github.com/couchbase/goutils/blob/master/LICENSE.md)

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/caio/go-tdigest v3.1.0+incompatible
 	github.com/cisco-ie/nx-telemetry-proto v0.0.0-20190531143454-82441e232cf6
 	github.com/coreos/go-semver v0.3.0
+	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/couchbase/go-couchbase v0.1.0
 	github.com/denisenkom/go-mssqldb v0.10.0
 	github.com/dimchansky/utfbom v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -600,6 +600,7 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=

--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -4,6 +4,7 @@ Documentation=https://github.com/influxdata/telegraf
 After=network.target
 
 [Service]
+Type=notify
 EnvironmentFile=-/etc/default/telegraf
 User=telegraf
 ExecStart=/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d $TELEGRAF_OPTS


### PR DESCRIPTION
### Required for all PRs:

- [-] Updated associated README.md.
- [-] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #7485

### Summary

Right now telegraf is not specifying Type in [Service] in its systemd service.
When starting telegraf this means that as soon as it's forked systemd
assumes it's running, even though it will stop just milliseconds after.

If Type is changed to Notify the unit will never be marked as Active
since telegraf is not telling systemd it's up.

This patch adds that support and opens up the possibility to convert the
service to a Notify type instead of Simple.

Before:
$ systemd-run --user --service-type=simple  ./telegraf --config /dev/null
Running as unit: run-rdf62c01eb6834b3fa5e96cc8c2816b87.service
$ systemd-run --user --service-type=notify  ./telegraf --config
/dev/null
Job for run-r698ec159a4a54e74a30508ea532fe31a.service failed because the control process exited with error code.
See "systemctl status run-r698ec159a4a54e74a30508ea532fe31a.service" and "journalctl -xe" for details.
$ systemd-run --user --service-type=notify  ./telegraf --config ok.conf
^C # does not complete

After:
$ systemd-run --user --service-type=simple  ./telegraf --config /dev/null
Running as unit: run-rdf62c01eb6834b3fa5e96cc8c2816b87.service
$ systemd-run --user --service-type=notify  ./telegraf --config
/dev/null
Job for run-r3ee32ab984ca4051861a52a903525051.service failed because the service did not take the steps required by its unit configuration.
See "systemctl status run-r3ee32ab984ca4051861a52a903525051.service" and "journalctl -xe" for details.
$ systemd-run --user --service-type=notify  ./telegraf --config ok.conf
Running as unit: run-rdf62c01eb6834b3fa5e96cc8c2816b87.service