### PR TITLE
chore: use 4 cores on linux systems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,19 @@ orbs:
 executors:
   go-1_17:
     working_directory: '/go/src/github.com/influxdata/telegraf'
+    resource_class: large
     docker:
       - image: 'quay.io/influxdb/telegraf-ci:1.17.5'
     environment:
-      GOFLAGS: -p=8
+      GOFLAGS: -p=4
   mac:
+    working_directory: '~/go/src/github.com/influxdata/telegraf'
+    resource_class: medium
     macos:
       xcode: 13.2.0
-    working_directory: '~/go/src/github.com/influxdata/telegraf'
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
-      GOFLAGS: -p=8
+      GOFLAGS: -p=4
 
 commands:
   generate-config:


### PR DESCRIPTION
The default medium executor only is 2 cores. With these 2 cores we were
always trying to split tests into 4 parallel runs as well as passing
GOFLAGS of 8.

This ensures the MacOS, Linux (docker), and Windows executors are using
systems with 4 cores and that we pass parallel values of 4.