### PR TITLE
doc: warn about logs beeing in UTC+0 timestamp

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -217,7 +217,8 @@ The agent table configures Telegraf and the defaults used across all plugins.
 
 - **logfile**:
   Name of the file to be logged to when using the "file" logtarget.  If set to
-  the empty string then logs are written to stderr.
+  the empty string then logs are written to stderr. Currently, logs are UTC+0
+  only.
 
 - **logfile_rotation_interval**:
   The logfile will be rotated after the time interval specified.  When set to


### PR DESCRIPTION
doc: warn about logs beeing in UTC+0 timestamp

- [N/A] Updated associated README.md.
- [N/A] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This is a simple doc commit to warn users about Telegraf logs being currently only in UTC+0 timestamp and not local timezone.


