### PR TITLE
fix: input plugin cisco_telemetry_mdt parse error

### DIFF
--- a/metric/gpbkv_parse.go
+++ b/metric/gpbkv_parse.go
@@ -1,0 +1,330 @@
+package metric
+
+import (
+	"encoding/json"
+	"github.com/influxdata/telegraf"
+	"hash/maphash"
+	"log"
+	"strings"
+	"time"
+)
+
+const (
+	GBPVALUE  = "ValueByType"
+	GBPFIELDS = "fields"
+	GBPNAME = "name"
+)
+
+
+type gbpRow struct {
+	Timestamp float64
+	// 直接解析成 content, keys 可能会出问题，
+	// 可以将 content，keys 包含在 Rows 中比较保险
+	//Rows interface{}
+	Content interface{}
+	Keys interface{}
+}
+
+type SDNMetric struct {
+	Row []gbpRow
+	Telemetry map[string]interface{} `json:Telemetry`
+	Source string `json:Source`
+}
+
+type SDNGrouper struct {
+	metrics map[uint64]telegraf.Metric
+	ordered []telegraf.Metric
+
+	hashSeed maphash.Seed
+}
+
+func NewSDNGrouper() *SDNGrouper {
+	return &SDNGrouper{
+		metrics:  make(map[uint64]telegraf.Metric),
+		ordered:  []telegraf.Metric{},
+		hashSeed: maphash.MakeSeed(),
+	}
+}
+
+func (g *SDNGrouper) Add(
+	measurement string,
+	tm time.Time,
+	field string,
+	fieldValue interface{},
+) error {
+	id := groupID(g.hashSeed, measurement, nil, tm)
+	m := g.metrics[id]
+	if m == nil {
+		m = New(measurement, nil, map[string]interface{}{field: fieldValue}, tm)
+		g.metrics[id] = m
+		g.ordered = append(g.ordered, m)
+		m.AddField(field, fieldValue)
+	} else {
+		m.AddField(field, fieldValue)
+	}
+	return nil
+}
+
+func (g *SDNGrouper) AddMetric(
+	metric telegraf.Metric,
+) {
+	id := groupID(g.hashSeed, metric.Name(), metric.TagList(), metric.Time())
+	m := g.metrics[id]
+	if m == nil {
+		m = metric.Copy()
+		g.metrics[id] = m
+		g.ordered = append(g.ordered, m)
+	} else {
+		for _, f := range metric.FieldList() {
+			m.AddField(f.Key, f.Value)
+		}
+	}
+}
+
+func (g *SDNGrouper) Metrics() []telegraf.Metric {
+	return g.ordered
+}
+
+func GbpkvParse(data []byte, sourceIP string) SDNMetric {
+	var v interface{}
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		log.Println("unmarshal json err: ", err)
+	}
+
+	gpbkv := v.(map[string]interface{})
+
+	var rows []gbpRow
+	telemetry := make(map[string]interface{}, 0)
+
+	for k, v := range gpbkv {
+		if k != "data_gpbkv" {
+			parseTelemetry(telemetry, k, v)
+		}else {
+			rows = parseRow(v)
+		}
+	}
+
+	m := SDNMetric{
+		Telemetry: telemetry,
+		Row: rows,
+		Source: sourceIP,
+	}
+
+	//mtericByte, err := json.Marshal(m)
+	//if err != nil {
+	//	log.Println(err)
+	//}
+
+	return m
+}
+
+func parseTelemetry(telemetry map[string]interface{},key string, value interface{})  {
+	if e, ok := value.(map[string]interface{}); ok {
+		for k, v := range e {
+			k = CamelCaseToUnderscore(k)
+			telemetry[k] = decodeValue(v)
+		}
+	}else {
+		key = CamelCaseToUnderscore(key)
+		telemetry[key] = decodeValue(value)
+	}
+}
+
+func parseRow(value interface{}) []gbpRow {
+	var rowArr []gbpRow
+	for _, arr := range value.([]interface{}){
+		var row gbpRow
+		data := arr.(map[string]interface{})
+		if data[GBPVALUE] == nil && data[GBPFIELDS] != nil {
+			row.Timestamp = data["timestamp"].(float64)
+			field := parseFields(data[GBPFIELDS])
+			if _, ok := field["content"]; ok {
+				row.Content = field["content"]
+			}else {
+				log.Println("No field named content")
+			}
+			if _, ok := field["keys"]; ok {
+				row.Keys = field["keys"]
+			}else {
+				log.Println("No field named keys")
+			}
+			//row.Rows = field
+			rowArr = append(rowArr, row)
+		}
+	}
+	return rowArr
+}
+
+func parseFields(v interface{}) map[string]interface{} {
+	s := make(map[string]interface{})
+	placeInArrayMap := map[string]bool{}
+	for _, arr := range v.([]interface{}) {
+		field := arr.(map[string]interface{})
+		key := field[GBPNAME].(string)
+		var fieldVal interface{}
+		var hint int
+		// 判断值是否已经存在 field 中，如果已经存在，替换值为数组类型，并标识为已经替换
+		existingEntry, exists := s[key]
+		_, placeInArray := placeInArrayMap[key]
+		_, children := field[GBPFIELDS]
+		if !children {
+			fieldVal = field[GBPVALUE]
+			if fieldVal != nil {
+				for _, value := range fieldVal.(map[string]interface{}) {
+					fieldVal = value
+				}
+			}
+			hint = 10
+		}else {
+			fieldVal = parseFields(field[GBPFIELDS])
+			hint = len(field[GBPFIELDS].([]interface{}))
+		}
+
+		if !placeInArray && !exists {
+			// this is the common case by far!
+			s[key] = fieldVal
+		}else {
+			newName := key + GPB_XINQXION_EDIT_SUFFIX
+			if exists {
+				if !placeInArray {
+					// Create list
+					s[newName] = make([]interface{}, 0, hint)
+					// Remember that this field name is arrayified(!?)
+					placeInArrayMap[key] = true
+					// Add existing entry to new array)
+					s[newName] = append(s[newName].([]interface{}),existingEntry)
+					// Delete existing entry from old
+					delete(s, key)
+					placeInArray = true
+				} else {
+					log.Println("GPB KV inconsistency, processing repeated field names")
+				}
+			}
+			if placeInArray && fieldVal != nil {
+				s[newName] = append(s[newName].([]interface{}), fieldVal)
+			}
+		}
+	}
+	return s
+}
+
+func decodeValue(v interface{}) interface{} {
+	switch v := v.(type) {
+	case float64:
+		return v
+	case int64:
+		return v
+	case string:
+		return v
+	case bool:
+		return v
+	case int:
+		return int64(v)
+	case uint:
+		return uint64(v)
+	case uint64:
+		return v
+	case []byte:
+		return string(v)
+	case int32:
+		return int64(v)
+	case int16:
+		return int64(v)
+	case int8:
+		return int64(v)
+	case uint32:
+		return uint64(v)
+	case uint16:
+		return uint64(v)
+	case uint8:
+		return uint64(v)
+	case float32:
+		return float64(v)
+	case *float64:
+		if v != nil {
+			return *v
+		}
+	case *int64:
+		if v != nil {
+			return *v
+		}
+	case *string:
+		if v != nil {
+			return *v
+		}
+	case *bool:
+		if v != nil {
+			return *v
+		}
+	case *int:
+		if v != nil {
+			return int64(*v)
+		}
+	case *uint:
+		if v != nil {
+			return uint64(*v)
+		}
+	case *uint64:
+		if v != nil {
+			return *v
+		}
+	case *[]byte:
+		if v != nil {
+			return string(*v)
+		}
+	case *int32:
+		if v != nil {
+			return int64(*v)
+		}
+	case *int16:
+		if v != nil {
+			return int64(*v)
+		}
+	case *int8:
+		if v != nil {
+			return int64(*v)
+		}
+	case *uint32:
+		if v != nil {
+			return uint64(*v)
+		}
+	case *uint16:
+		if v != nil {
+			return uint64(*v)
+		}
+	case *uint8:
+		if v != nil {
+			return uint64(*v)
+		}
+	case *float32:
+		if v != nil {
+			return float64(*v)
+		}
+	default:
+		return nil
+	}
+	return nil
+}
+
+// 驼峰转下划线
+func CamelCaseToUnderscore(s string) string {
+	data := make([]byte, 0, len(s)*2)
+	j := false
+	num := len(s)
+	for i := 0; i < num; i++ {
+		d := s[i]
+		// or通过ASCII码进行大小写的转化
+		// 65-90（A-Z），97-122（a-z）
+		//判断如果字母为大写的A-Z就在前面拼接一个_
+		if i > 0 && d >= 'A' && d <= 'Z' && j {
+			data = append(data, '_')
+		}
+		if d != '_' {
+			j = true
+		}
+		data = append(data, d)
+	}
+	//ToLower把大写字母统一转小写
+	return strings.ToLower(string(data[:]))
+}

--- a/metric/gpbkv_parse.go
+++ b/metric/gpbkv_parse.go
@@ -13,6 +13,7 @@ const (
 	GBPVALUE  = "ValueByType"
 	GBPFIELDS = "fields"
 	GBPNAME = "name"
+	GPB_XINQXION_EDIT_SUFFIX = ""
 )
 
 

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -273,6 +273,10 @@ func (m *metric) Drop() {
 // Convert field to a supported type or nil if unconvertible
 func convertField(v interface{}) interface{} {
 	switch v := v.(type) {
+	case map[string]interface{}:
+		return v
+	case []gbpRow:
+	    return v
 	case float64:
 		return v
 	case int64:

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
@@ -83,7 +83,7 @@ func TestHandleTelemetryTwoSimple(t *testing.T) {
 	data, err := proto.Marshal(telemetry)
 	require.NoError(t, err)
 
-	c.handleTelemetry(data)
+	c.handleTelemetry(data, "192.168.1.1")
 	require.Empty(t, acc.Errors)
 
 	tags := map[string]string{"path": "type:model/some/path", "name": "str", "uint64": "1234", "source": "hostname", "subscription": "subscription"}
@@ -155,7 +155,7 @@ func TestHandleTelemetrySingleNested(t *testing.T) {
 	data, err := proto.Marshal(telemetry)
 	require.NoError(t, err)
 
-	c.handleTelemetry(data)
+	c.handleTelemetry(data, "192.168.1.1")
 	require.Empty(t, acc.Errors)
 
 	tags := map[string]string{"path": "type:model/nested/path", "level": "3", "source": "hostname", "subscription": "subscription"}
@@ -225,7 +225,7 @@ func TestHandleEmbeddedTags(t *testing.T) {
 	data, err := proto.Marshal(telemetry)
 	require.NoError(t, err)
 
-	c.handleTelemetry(data)
+	c.handleTelemetry(data, "192.168.1.1")
 	require.Empty(t, acc.Errors)
 
 	tags1 := map[string]string{"path": "type:model/extra", "foo": "bar", "source": "hostname", "subscription": "subscription", "list/name": "entry1"}
@@ -314,7 +314,7 @@ func TestHandleNXAPI(t *testing.T) {
 	data, err := proto.Marshal(telemetry)
 	require.NoError(t, err)
 
-	c.handleTelemetry(data)
+	c.handleTelemetry(data, "192.168.1.1")
 	require.Empty(t, acc.Errors)
 
 	tags1 := map[string]string{"path": "show nxapi", "foo": "bar", "TABLE_nxapi": "i1", "row_number": "0", "source": "hostname", "subscription": "subscription"}
@@ -391,7 +391,7 @@ func TestHandleNXAPIXformNXAPI(t *testing.T) {
 	data, err := proto.Marshal(telemetry)
 	require.NoError(t, err)
 
-	c.handleTelemetry(data)
+	c.handleTelemetry(data, "192.168.1.1")
 	require.Empty(t, acc.Errors)
 
 	tags1 := map[string]string{"path": "show processes cpu", "foo": "bar", "TABLE_process_cpu": "i1", "row_number": "0", "source": "hostname", "subscription": "subscription"}
@@ -477,7 +477,7 @@ func TestHandleNXXformMulti(t *testing.T) {
 	data, err := proto.Marshal(telemetry)
 	require.NoError(t, err)
 
-	c.handleTelemetry(data)
+	c.handleTelemetry(data, "192.168.1.1")
 	require.Empty(t, acc.Errors)
 	//validate various transformation scenaarios newly added in the code.
 	fields := map[string]interface{}{"portIdV": "12", "portDesc": "100", "test": int64(281474976710655), "subscriptionId": "2814749767106551"}
@@ -550,7 +550,7 @@ func TestHandleNXDME(t *testing.T) {
 	data, err := proto.Marshal(telemetry)
 	require.NoError(t, err)
 
-	c.handleTelemetry(data)
+	c.handleTelemetry(data, "192.168.1.1")
 	require.Empty(t, acc.Errors)
 
 	tags1 := map[string]string{"path": "sys/dme", "foo": "bar", "fooEntity": "some-rn", "source": "hostname", "subscription": "subscription"}


### PR DESCRIPTION
resolves #9840

The plug-in named cisco-telemetry_mdt has some issues with issue: 9840 and Issue: 10087 as described. Issue: 9840 was raised by me, but it seems to have been closed without a solution. I tried to modify the plug-in's parsing process with as little impact as possible on the rest of the code, and it worked as I expected.
