### PR TITLE
chore: document deprecation of timeout

### DIFF
--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -27,6 +27,7 @@ path onto the global path variable
   ## Path to mib files
   # path = ["/usr/share/snmp/mibs"]
   ##
+  ## Deprecated in 1.20.0; no longer running snmptranslate
   ## Timeout running snmptranslate command
   # timeout = "5s"
   ## Snmp version

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -58,6 +58,7 @@ var sampleConfig = `
   ## Path to mib files
   # path = ["/usr/share/snmp/mibs"]
   ##
+  ## Deprecated in 1.20.0; no longer running snmptranslate
   ## Timeout running snmptranslate command
   # timeout = "5s"
   ## Snmp version, defaults to 2c


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
Timeout was deprecated in 1.20.0 as we now call `gosmi` instead of `snmptranslate` but it was not documented. 