### PR TITLE
feat: add topic parsing with # wild card

### DIFF
--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -290,13 +290,11 @@ func (m *MQTTConsumer) recvMessage(_ mqtt.Client, msg mqtt.Message) {
 
 // compareTopics is used to support the mqtt wild card `+` which allows for one topic of any value
 func compareTopics(expected []string, incoming []string) bool {
-	if len(expected) != len(incoming) {
-		for i := range expected {
-			if strings.Contains(expected[i], "#") {
-				return true
-			}
-		}
+	if len(expected) > len(incoming) {
 		return false
+	}
+	if len(expected) < len(incoming) {
+		return choice.Contains("#", expected)
 	}
 
 	for i, expected := range expected {

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -290,11 +290,13 @@ func (m *MQTTConsumer) recvMessage(_ mqtt.Client, msg mqtt.Message) {
 
 // compareTopics is used to support the mqtt wild card `+` which allows for one topic of any value
 func compareTopics(expected []string, incoming []string) bool {
-	if len(expected) > len(incoming) {
+	if len(expected) != len(incoming) {
+		for i := range expected {
+			if strings.Contains(expected[i], "#") {
+				return true
+			}
+		}
 		return false
-	}
-	if len(expected) < len(incoming) {
-		return choice.Contains("#", expected)
 	}
 
 	for i, expected := range expected {

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -193,18 +193,25 @@ func (m *MQTTConsumer) Init() error {
 		}
 		m.TopicParsing[i].SplitTags = strings.Split(p.Tags, "/")
 		m.TopicParsing[i].SplitFields = strings.Split(p.Fields, "/")
-		m.TopicParsing[i].SplitTopic = strings.Split(p.Topic, "/")
 
-		if len(splitMeasurement) != len(m.TopicParsing[i].SplitTopic) && len(splitMeasurement) != 1 {
-			return fmt.Errorf("config error topic parsing: measurement length does not equal topic length")
+		if strings.Contains(p.Topic, "#") {
+			for x := range m.Topics {
+				m.TopicParsing[i].SplitTopic = strings.Split(m.Topics[x], "/")
+			}
+		} else {
+			m.TopicParsing[i].SplitTopic = strings.Split(p.Topic, "/")
 		}
 
-		if len(m.TopicParsing[i].SplitFields) != len(m.TopicParsing[i].SplitTopic) && p.Fields != "" {
-			return fmt.Errorf("config error topic parsing: fields length does not equal topic length")
+		if len(splitMeasurement) > len(m.TopicParsing[i].SplitTopic) && len(splitMeasurement) != 1 {
+			return fmt.Errorf("config error topic parsing: measurement length is longer than topic length")
 		}
 
-		if len(m.TopicParsing[i].SplitTags) != len(m.TopicParsing[i].SplitTopic) && p.Tags != "" {
-			return fmt.Errorf("config error topic parsing: tags length does not equal topic length")
+		if len(m.TopicParsing[i].SplitFields) > len(m.TopicParsing[i].SplitTopic) && p.Fields != "" {
+			return fmt.Errorf("config error topic parsing: fields length is longer than topic length")
+		}
+
+		if len(m.TopicParsing[i].SplitTags) > len(m.TopicParsing[i].SplitTopic) && p.Tags != "" {
+			return fmt.Errorf("config error topic parsing: tags length is longer than topic length")
 		}
 	}
 

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -195,16 +195,18 @@ func (m *MQTTConsumer) Init() error {
 		m.TopicParsing[i].SplitFields = strings.Split(p.Fields, "/")
 		m.TopicParsing[i].SplitTopic = strings.Split(p.Topic, "/")
 
-		if len(splitMeasurement) > len(m.TopicParsing[i].SplitTopic) && len(splitMeasurement) != 1 && !strings.Contains(p.Topic, "#") {
-			return fmt.Errorf("config error topic parsing: measurement length is longer than topic length")
-		}
+		if !strings.Contains(p.Topic, "#") {
+			if len(splitMeasurement) > len(m.TopicParsing[i].SplitTopic) && len(splitMeasurement) != 1 {
+				return fmt.Errorf("config error topic parsing: measurement length is longer than topic length")
+			}
 
-		if len(m.TopicParsing[i].SplitFields) > len(m.TopicParsing[i].SplitTopic) && p.Fields != "" && !strings.Contains(p.Topic, "#") {
-			return fmt.Errorf("config error topic parsing: fields length is longer than topic length")
-		}
+			if len(m.TopicParsing[i].SplitFields) > len(m.TopicParsing[i].SplitTopic) && p.Fields != "" {
+				return fmt.Errorf("config error topic parsing: fields length is longer than topic length")
+			}
 
-		if len(m.TopicParsing[i].SplitTags) > len(m.TopicParsing[i].SplitTopic) && p.Tags != "" && !strings.Contains(p.Topic, "#") {
-			return fmt.Errorf("config error topic parsing: tags length is longer than topic length")
+			if len(m.TopicParsing[i].SplitTags) > len(m.TopicParsing[i].SplitTopic) && p.Tags != "" {
+				return fmt.Errorf("config error topic parsing: tags length is longer than topic length")
+			}
 		}
 	}
 

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -512,6 +512,30 @@ func TestTopicTag(t *testing.T) {
 				),
 			},
 		},
+		{
+			name:  "topic parsing: found topics with # shorter than given topic",
+			topic: "telegraf/testing",
+			topicTag: func() *string {
+				tag := ""
+				return &tag
+			},
+			expectedErrorAfterInit: fmt.Errorf("config error topic parsing: found topic is shorter than parse topic length"),
+			topicParsing: []TopicParsingConfig{
+				{
+					Topic: "telegraf/testing/#",
+				},
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"45",
+					map[string]string{},
+					map[string]interface{}{
+						"time_idle": 42,
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -323,7 +323,7 @@ func TestTopicTag(t *testing.T) {
 				tag := ""
 				return &tag
 			},
-			expectedError: fmt.Errorf("config error topic parsing: fields length does not equal topic length"),
+			expectedError: fmt.Errorf("config error topic parsing: fields length is longer than topic length"),
 			topicParsing: []TopicParsingConfig{
 				{
 					Topic:       "telegraf/+/test/hello",
@@ -407,6 +407,30 @@ func TestTopicTag(t *testing.T) {
 						"testNumber": 123,
 						"testString": "hello",
 						"time_idle":  42,
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			name:  "topic parsing: topics implemented with #",
+			topic: "telegraf/123/test/hello/45/mqtt/broker",
+			topicTag: func() *string {
+				tag := ""
+				return &tag
+			},
+			topicParsing: []TopicParsingConfig{
+				{
+					Topic:       "telegraf/+/#",
+					Measurement: "_/_/_/_/measurement/_/_",
+				},
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"45",
+					map[string]string{},
+					map[string]interface{}{
+						"time_idle": 42,
 					},
 					time.Unix(0, 0),
 				),

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -436,6 +436,31 @@ func TestTopicTag(t *testing.T) {
 				),
 			},
 		},
+		{
+			name:  "topic parsing: topics with # is shorter than measurement",
+			topic: "telegraf/123",
+			topicTag: func() *string {
+				tag := ""
+				return &tag
+			},
+			expectedError: fmt.Errorf("config error topic parsing: measurement length is longer than topic length"),
+			topicParsing: []TopicParsingConfig{
+				{
+					Topic:       "telegraf/+/#",
+					Measurement: "_/_/_/_/measurement/_/_",
+				},
+			},
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"45",
+					map[string]string{},
+					map[string]interface{}{
+						"time_idle": 42,
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -436,31 +436,30 @@ func TestTopicTag(t *testing.T) {
 				),
 			},
 		},
-		{
-			name:  "topic parsing: topics with # is shorter than measurement",
-			topic: "telegraf/123",
-			topicTag: func() *string {
-				tag := ""
-				return &tag
-			},
-			expectedError: fmt.Errorf("config error topic parsing: measurement length is longer than topic length"),
-			topicParsing: []TopicParsingConfig{
-				{
-					Topic:       "telegraf/+/#",
-					Measurement: "_/_/_/_/measurement/_/_",
-				},
-			},
-			expected: []telegraf.Metric{
-				testutil.MustMetric(
-					"45",
-					map[string]string{},
-					map[string]interface{}{
-						"time_idle": 42,
-					},
-					time.Unix(0, 0),
-				),
-			},
-		},
+		// {
+		// 	name:  "topic parsing: topics with # shorter than measurement",
+		// 	topic: "telegraf/123/test/hello",
+		// 	topicTag: func() *string {
+		// 		tag := ""
+		// 		return &tag
+		// 	},
+		// 	topicParsing: []TopicParsingConfig{
+		// 		{
+		// 			Topic:       "telegraf/#",
+		// 			Measurement: "_/_/_/_/measurement/_/_",
+		// 		},
+		// 	},
+		// 	expected: []telegraf.Metric{
+		// 		testutil.MustMetric(
+		// 			"45",
+		// 			map[string]string{},
+		// 			map[string]interface{}{
+		// 				"time_idle": 42,
+		// 			},
+		// 			time.Unix(0, 0),
+		// 		),
+		// 	},
+		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10476  [community issue](https://influxcommunity.slack.com/archives/CH99HUH8V/p1641323184432000?thread_ts=1641120682.410600&cid=CH99HUH8V)

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
Added topic parsing with # wild card by checking if it is used and then grabbing the length of that topic instead of the given parsed topic. This lessens the rule of topic and measurement, tags, fields, having to be the same length. Now topic can be equal to or longer in the number of elements. 