### PR TITLE
fix: empty import tzdata for Windows binaries

### DIFF
--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	_ "time/tzdata" // needed to bundle timezone info into the binary for Windows
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"


### PR DESCRIPTION
The telegraf binary currently does not include any timezone data. While
this data is usually readily available in linux systems it is not
available to a go binary in Windows.

Fixes: #8756
