### PR TITLE
fix: Accept non-standard OPC UA OK status by implementing a configurable workaround

### DIFF
--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -92,8 +92,8 @@ Plugin minimum tested version: 1.16
   
   ## Enable workarounds required by some devices to work correctly
   # [inputs.opcua.workarounds]
-    ## Set valid status codes
-    # valid_status_codes = ["0x0"]
+    ## Set additional valid status codes, StatusOK (0x0) is always considered valid
+    # additional_valid_status_codes = ["0xC0"]
 ```
 
 ## Node Configuration

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -89,6 +89,11 @@ Plugin minimum tested version: 1.16
   #  {name="", namespace="", identifier_type="", identifier=""},
   #  {name="", namespace="", identifier_type="", identifier=""},
   #]
+  
+  ## Enable workarounds required by some devices to work correctly
+  # [inputs.opcua.workarounds]
+  ## Set valid status codes
+  # valid_status_codes = ["0x0", "0xC0"]
 ```
 
 ## Node Configuration

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -92,8 +92,8 @@ Plugin minimum tested version: 1.16
   
   ## Enable workarounds required by some devices to work correctly
   # [inputs.opcua.workarounds]
-  ## Set valid status codes
-  # valid_status_codes = ["0x0", "0xC0"]
+    ## Set valid status codes
+    # valid_status_codes = ["0x0"]
 ```
 
 ## Node Configuration

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -190,8 +190,8 @@ const sampleConfig = `
 
   ## Enable workarounds required by some devices to work correctly
   # [inputs.opcua.workarounds]
-  ## Set valid status codes
-  # valid_status_codes = ["0x0", "0xC0"]
+    ## Set valid status codes
+    # valid_status_codes = ["0x0"]
 `
 
 // Description will appear directly above the plugin definition in the config file
@@ -499,18 +499,13 @@ func (o *OpcUA) setupOptions() error {
 
 func (o *OpcUA) setupWorkarounds() error {
 	if len(o.Workarounds.ValidStatusCodes) != 0 {
-		o.codes = []ua.StatusCode{} // clear default codes
-
 		for _, c := range o.Workarounds.ValidStatusCodes {
 			val, err := strconv.ParseInt(c, 0, 32) // setting 32 bits to allow for safe conversion
-
 			if err != nil {
 				return err
 			}
-
 			o.codes = append(o.codes, ua.StatusCode(uint32(val)))
 		}
-		return nil
 	}
 	return nil
 }

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -511,9 +511,8 @@ func (o *OpcUA) setupWorkarounds() error {
 			o.codes = append(o.codes, ua.StatusCode(uint32(val)))
 		}
 		return nil
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (o *OpcUA) checkStatusCode(code ua.StatusCode) bool {

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,23 +19,28 @@ import (
 	"github.com/influxdata/telegraf/selfstat"
 )
 
+type OpcuaWorkarounds struct {
+	ValidStatusCodes []string `toml:"valid_status_codes"`
+}
+
 // OpcUA type
 type OpcUA struct {
-	MetricName     string          `toml:"name"`
-	Endpoint       string          `toml:"endpoint"`
-	SecurityPolicy string          `toml:"security_policy"`
-	SecurityMode   string          `toml:"security_mode"`
-	Certificate    string          `toml:"certificate"`
-	PrivateKey     string          `toml:"private_key"`
-	Username       string          `toml:"username"`
-	Password       string          `toml:"password"`
-	Timestamp      string          `toml:"timestamp"`
-	AuthMethod     string          `toml:"auth_method"`
-	ConnectTimeout config.Duration `toml:"connect_timeout"`
-	RequestTimeout config.Duration `toml:"request_timeout"`
-	RootNodes      []NodeSettings  `toml:"nodes"`
-	Groups         []GroupSettings `toml:"group"`
-	Log            telegraf.Logger `toml:"-"`
+	MetricName     string           `toml:"name"`
+	Endpoint       string           `toml:"endpoint"`
+	SecurityPolicy string           `toml:"security_policy"`
+	SecurityMode   string           `toml:"security_mode"`
+	Certificate    string           `toml:"certificate"`
+	PrivateKey     string           `toml:"private_key"`
+	Username       string           `toml:"username"`
+	Password       string           `toml:"password"`
+	Timestamp      string           `toml:"timestamp"`
+	AuthMethod     string           `toml:"auth_method"`
+	ConnectTimeout config.Duration  `toml:"connect_timeout"`
+	RequestTimeout config.Duration  `toml:"request_timeout"`
+	RootNodes      []NodeSettings   `toml:"nodes"`
+	Groups         []GroupSettings  `toml:"group"`
+	Workarounds    OpcuaWorkarounds `toml:"workarounds"`
+	Log            telegraf.Logger  `toml:"-"`
 
 	nodes       []Node
 	nodeData    []OPCData
@@ -50,6 +56,7 @@ type OpcUA struct {
 	client *opcua.Client
 	req    *ua.ReadRequest
 	opts   []opcua.Option
+	codes  []ua.StatusCode
 }
 
 type NodeSettings struct {
@@ -180,6 +187,11 @@ const sampleConfig = `
   #  {name="", namespace="", identifier_type="", identifier=""},
   #  {name="", namespace="", identifier_type="", identifier=""},
   #]
+
+  ## Enable workarounds required by some devices to work correctly
+  # [inputs.opcua.workarounds]
+  ## Set valid status codes
+  # valid_status_codes = ["0x0", "0xC0"]
 `
 
 // Description will appear directly above the plugin definition in the config file
@@ -212,6 +224,11 @@ func (o *OpcUA) Init() error {
 	}
 
 	err = o.setupOptions()
+	if err != nil {
+		return err
+	}
+
+	err = o.setupWorkarounds()
 	if err != nil {
 		return err
 	}
@@ -480,6 +497,34 @@ func (o *OpcUA) setupOptions() error {
 	return err
 }
 
+func (o *OpcUA) setupWorkarounds() error {
+	if len(o.Workarounds.ValidStatusCodes) != 0 {
+		o.codes = []ua.StatusCode{} // clear default codes
+
+		for _, c := range o.Workarounds.ValidStatusCodes {
+			val, err := strconv.ParseInt(c, 0, 32) // setting 32 bits to allow for safe conversion
+
+			if err != nil {
+				return err
+			}
+
+			o.codes = append(o.codes, ua.StatusCode(uint32(val)))
+		}
+		return nil
+	} else {
+		return nil
+	}
+}
+
+func (o *OpcUA) checkStatusCode(code ua.StatusCode) bool {
+	for _, val := range o.codes {
+		if val == code {
+			return true
+		}
+	}
+	return false
+}
+
 func (o *OpcUA) getData() error {
 	resp, err := o.client.Read(o.req)
 	if err != nil {
@@ -489,7 +534,7 @@ func (o *OpcUA) getData() error {
 	o.ReadSuccess.Incr(1)
 	for i, d := range resp.Results {
 		o.nodeData[i].Quality = d.Status
-		if d.Status != ua.StatusOK {
+		if !o.checkStatusCode(d.Status) {
 			o.Log.Errorf("status not OK for node %v: %v", o.nodes[i].tag.FieldName, d.Status)
 			continue
 		}
@@ -593,6 +638,7 @@ func init() {
 			Certificate:    "/etc/telegraf/cert.pem",
 			PrivateKey:     "/etc/telegraf/key.pem",
 			AuthMethod:     "Anonymous",
+			codes:          []ua.StatusCode{ua.StatusOK},
 		}
 	})
 }

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -20,7 +20,7 @@ import (
 )
 
 type OpcuaWorkarounds struct {
-	ValidStatusCodes []string `toml:"valid_status_codes"`
+	AdditionalValidStatusCodes []string `toml:"additional_valid_status_codes"`
 }
 
 // OpcUA type
@@ -190,8 +190,8 @@ const sampleConfig = `
 
   ## Enable workarounds required by some devices to work correctly
   # [inputs.opcua.workarounds]
-    ## Set valid status codes
-    # valid_status_codes = ["0x0"]
+    ## Set additional valid status codes, StatusOK (0x0) is always considered valid
+    # additional_valid_status_codes = ["0xC0"]
 `
 
 // Description will appear directly above the plugin definition in the config file
@@ -498,8 +498,8 @@ func (o *OpcUA) setupOptions() error {
 }
 
 func (o *OpcUA) setupWorkarounds() error {
-	if len(o.Workarounds.ValidStatusCodes) != 0 {
-		for _, c := range o.Workarounds.ValidStatusCodes {
+	if len(o.Workarounds.AdditionalValidStatusCodes) != 0 {
+		for _, c := range o.Workarounds.AdditionalValidStatusCodes {
 			val, err := strconv.ParseInt(c, 0, 32) // setting 32 bits to allow for safe conversion
 			if err != nil {
 				return err

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -597,7 +597,7 @@ func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
 	}
 
 	for i, n := range o.nodes {
-		if o.nodeData[i].Quality == ua.StatusOK {
+		if o.checkStatusCode(o.nodeData[i].Quality) {
 			fields := make(map[string]interface{})
 			tags := map[string]string{
 				"id": n.idStr,

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -112,7 +112,7 @@ tags = [["tag1", "val1"], ["tag2", "val2"]]
 nodes = [{name="name4", identifier="4000", tags=[["tag1", "override"]]}]
 
 [inputs.opcua.workarounds]
-valid_status_codes = ["0x00", "0xC0"]
+additional_valid_status_codes = ["0xC0"]
 `
 
 	c := config.NewConfig()
@@ -138,9 +138,8 @@ valid_status_codes = ["0x00", "0xC0"]
 	require.Len(t, o.nodes[2].metricTags, 3)
 	require.Len(t, o.nodes[3].metricTags, 2)
 
-	require.Len(t, o.Workarounds.ValidStatusCodes, 2)
-	require.Equal(t, o.Workarounds.ValidStatusCodes[0], "0x00")
-	require.Equal(t, o.Workarounds.ValidStatusCodes[1], "0xC0")
+	require.Len(t, o.Workarounds.AdditionalValidStatusCodes, 1)
+	require.Equal(t, o.Workarounds.AdditionalValidStatusCodes[0], "0xC0")
 }
 
 func TestTagsSliceToMap(t *testing.T) {
@@ -272,7 +271,9 @@ func TestValidateOPCTags(t *testing.T) {
 
 func TestSetupWorkarounds(t *testing.T) {
 	var o OpcUA
-	o.Workarounds.ValidStatusCodes = []string{"0x00", "0xC0", "0x00AA0000"}
+	o.codes = []ua.StatusCode{ua.StatusOK}
+
+	o.Workarounds.AdditionalValidStatusCodes = []string{"0xC0", "0x00AA0000"}
 
 	err := o.setupWorkarounds()
 	require.NoError(t, err)

--- a/plugins/inputs/opcua/opcua_client_test.go
+++ b/plugins/inputs/opcua/opcua_client_test.go
@@ -273,7 +273,9 @@ func TestValidateOPCTags(t *testing.T) {
 func TestSetupWorkarounds(t *testing.T) {
 	var o OpcUA
 	o.Workarounds.ValidStatusCodes = []string{"0x00", "0xC0", "0x00AA0000"}
-	o.setupWorkarounds()
+
+	err := o.setupWorkarounds()
+	require.NoError(t, err)
 
 	require.Len(t, o.codes, 3)
 	require.Equal(t, o.codes[0], ua.StatusCode(0))


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #8826

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Added `[inputs.opcua.workarounds]` similar to the modbus plugin.
