### PR TITLE
fix: send actual empty http body when no body is set

### DIFF
--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -172,7 +172,9 @@ func (h *HTTP) gatherURL(
 	if err != nil {
 		return err
 	}
-	defer body.Close()
+	if body != nil {
+		defer body.Close()
+	}
 
 	request, err := http.NewRequest(h.Method, url, body)
 	if err != nil {
@@ -246,6 +248,10 @@ func (h *HTTP) gatherURL(
 }
 
 func makeRequestBodyReader(contentEncoding, body string) (io.ReadCloser, error) {
+	if body == "" {
+		return nil, nil
+	}
+
 	var reader io.Reader = strings.NewReader(body)
 	if contentEncoding == "gzip" {
 		rc, err := internal.CompressWithGzip(reader)

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -31,6 +31,7 @@ func TestHTTPWithJSONFormat(t *testing.T) {
 	address := fakeServer.URL + "/endpoint"
 	plugin := &httpplugin.HTTP{
 		URLs: []string{address},
+		Log:  testutil.Logger{},
 	}
 	metricName := "metricName"
 
@@ -74,6 +75,7 @@ func TestHTTPHeaders(t *testing.T) {
 	plugin := &httpplugin.HTTP{
 		URLs:    []string{address},
 		Headers: map[string]string{header: headerValue},
+		Log:     testutil.Logger{},
 	}
 
 	p, _ := parsers.NewParser(&parsers.Config{
@@ -96,6 +98,7 @@ func TestInvalidStatusCode(t *testing.T) {
 	address := fakeServer.URL + "/endpoint"
 	plugin := &httpplugin.HTTP{
 		URLs: []string{address},
+		Log:  testutil.Logger{},
 	}
 
 	metricName := "metricName"
@@ -120,6 +123,7 @@ func TestSuccessStatusCodes(t *testing.T) {
 	plugin := &httpplugin.HTTP{
 		URLs:               []string{address},
 		SuccessStatusCodes: []int{200, 202},
+		Log:                testutil.Logger{},
 	}
 
 	metricName := "metricName"
@@ -147,6 +151,7 @@ func TestMethod(t *testing.T) {
 	plugin := &httpplugin.HTTP{
 		URLs:   []string{fakeServer.URL},
 		Method: "POST",
+		Log:    testutil.Logger{},
 	}
 
 	p, _ := parsers.NewParser(&parsers.Config{
@@ -182,6 +187,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 			plugin: &httpplugin.HTTP{
 				Method: "POST",
 				URLs:   []string{address},
+				Log:    testutil.Logger{},
 			},
 			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				body, err := io.ReadAll(r.Body)
@@ -196,6 +202,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 				URLs:   []string{address},
 				Method: "POST",
 				Body:   "test",
+				Log:    testutil.Logger{},
 			},
 			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				body, err := io.ReadAll(r.Body)
@@ -210,6 +217,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 				URLs:   []string{address},
 				Method: "GET",
 				Body:   "test",
+				Log:    testutil.Logger{},
 			},
 			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				body, err := io.ReadAll(r.Body)
@@ -225,6 +233,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 				Method:          "GET",
 				Body:            "test",
 				ContentEncoding: "gzip",
+				Log:             testutil.Logger{},
 			},
 			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, r.Header.Get("Content-Encoding"), "gzip")
@@ -278,6 +287,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 			name: "no credentials",
 			plugin: &httpplugin.HTTP{
 				URLs: []string{u.String()},
+				Log:  testutil.Logger{},
 			},
 			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				require.Len(t, r.Header["Authorization"], 0)
@@ -296,6 +306,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 						Scopes:       []string{"urn:opc:idm:__myscopes__"},
 					},
 				},
+				Log: testutil.Logger{},
 			},
 			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Even if the http body was empty, the current method will create an
io.ReadCloser and send that to the http request. This was causing a 502
error from a service. Ensuring that the empty body is actually empty
prevents the server side error message.

Add log fixture to tests to aid in debugging.

Fixes: #10386