### PR TITLE
feat: add ConsecutiveNamePrefixLimit option to Aggregator, Input, Output plugins.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -696,7 +696,7 @@ func (c *Config) LoadDirectory(path string) error {
 
 		if info.IsDir() {
 			if strings.HasPrefix(info.Name(), "..") {
-				// skip Kubernetes mounts, prevening loading the same config twice
+				// skip Kubernetes mounts, preventing loading the same config twice
 				return filepath.SkipDir
 			}
 
@@ -1240,6 +1240,7 @@ func (c *Config) buildAggregator(name string, tbl *ast.Table) (*models.Aggregato
 	c.getFieldDuration(tbl, "grace", &conf.Grace)
 	c.getFieldBool(tbl, "drop_original", &conf.DropOriginal)
 	c.getFieldString(tbl, "name_prefix", &conf.MeasurementPrefix)
+	c.getFieldInt(tbl, "consecutive_name_prefix_limit", &conf.ConsecutiveNamePrefixLimit)
 	c.getFieldString(tbl, "name_suffix", &conf.MeasurementSuffix)
 	c.getFieldString(tbl, "name_override", &conf.NameOverride)
 	c.getFieldString(tbl, "alias", &conf.Alias)
@@ -1328,6 +1329,7 @@ func (c *Config) buildInput(name string, tbl *ast.Table) (*models.InputConfig, e
 	c.getFieldDuration(tbl, "precision", &cp.Precision)
 	c.getFieldDuration(tbl, "collection_jitter", &cp.CollectionJitter)
 	c.getFieldString(tbl, "name_prefix", &cp.MeasurementPrefix)
+	c.getFieldInt(tbl, "consecutive_name_prefix_limit", &cp.ConsecutiveNamePrefixLimit)
 	c.getFieldString(tbl, "name_suffix", &cp.MeasurementSuffix)
 	c.getFieldString(tbl, "name_override", &cp.NameOverride)
 	c.getFieldString(tbl, "alias", &cp.Alias)
@@ -1640,6 +1642,7 @@ func (c *Config) buildOutput(name string, tbl *ast.Table) (*models.OutputConfig,
 	c.getFieldString(tbl, "name_override", &oc.NameOverride)
 	c.getFieldString(tbl, "name_suffix", &oc.NameSuffix)
 	c.getFieldString(tbl, "name_prefix", &oc.NamePrefix)
+	c.getFieldInt(tbl, "consecutive_name_prefix_limit", &oc.ConsecutiveNamePrefixLimit)
 
 	if c.hasErrs() {
 		return nil, c.firstErr()
@@ -1652,6 +1655,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 	switch key {
 	case "alias", "carbon2_format", "carbon2_sanitize_replace_char", "collectd_auth_file",
 		"collectd_parse_multivalue", "collectd_security_level", "collectd_typesdb", "collection_jitter",
+		"consecutive_name_prefix_limit",
 		"csv_column_names", "csv_column_types", "csv_comment", "csv_delimiter", "csv_header_row_count",
 		"csv_measurement_column", "csv_skip_columns", "csv_skip_rows", "csv_tag_columns", "csv_skip_errors",
 		"csv_timestamp_column", "csv_timestamp_format", "csv_timezone", "csv_trim_space", "csv_skip_values",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -290,6 +290,15 @@ Parameters that can be used with any input plugin:
 
 - **tags**: A map of tags to apply to a specific input's measurements.
 
+- **consecutive_name_prefix_limit**:
+  If a `name_prefix` is specified, this limit will prevent a prefix from
+  being applied if the metric name already begins with N occurrences
+  of the prefix. This can prevent a prefix loop.
+  Using the prefix `foo_` and a `consecutive_name_prefix_limit` of 2, a metric with
+  the initial name `foo_bar` would translate into `foo_foo_bar`, i.e. the prefix
+  would be applied. A metric with the initial name `foo_foo_bar` would remain
+  `foo_foo_bar`, i.e. the prefix would not be applied.
+
 The [metric filtering][] parameters can be used to limit what metrics are
 emitted from the input plugin.
 
@@ -363,6 +372,14 @@ Parameters that can be used with any output plugin:
 - **name_override**: Override the original name of the measurement.
 - **name_prefix**: Specifies a prefix to attach to the measurement name.
 - **name_suffix**: Specifies a suffix to attach to the measurement name.
+- **consecutive_name_prefix_limit**:
+  If a `name_prefix` is specified, this limit will prevent a prefix from
+  being applied if the metric name already begins with N occurrences
+  of the prefix. This can prevent a prefix loop.
+  Using the prefix `foo_` and a `consecutive_name_prefix_limit` of 2, a metric with
+  the initial name `foo_bar` would translate into `foo_foo_bar`, i.e. the prefix
+  would be applied. A metric with the initial name `foo_foo_bar` would remain
+  `foo_foo_bar`, i.e. the prefix would not be applied.
 
 The [metric filtering][] parameters can be used to limit what metrics are
 emitted from the output plugin.
@@ -451,6 +468,14 @@ Parameters that can be used with any aggregator plugin:
 - **name_prefix**: Specifies a prefix to attach to the measurement name.
 - **name_suffix**: Specifies a suffix to attach to the measurement name.
 - **tags**: A map of tags to apply to the measurement - behavior varies based on aggregator.
+- **consecutive_name_prefix_limit**:
+  If a `name_prefix` is specified, this limit will prevent a prefix from
+  being applied if the metric name already begins with N occurrences
+  of the prefix. This can prevent a prefix loop.
+  Using the prefix `foo_` and a `consecutive_name_prefix_limit` of 2, a metric with
+  the initial name `foo_bar` would translate into `foo_foo_bar`, i.e. the prefix
+  would be applied. A metric with the initial name `foo_foo_bar` would remain
+  `foo_foo_bar`, i.e. the prefix would not be applied.
 
 The [metric filtering][] parameters can be used to limit what metrics are
 handled by the aggregator.  Excluded metrics are passed downstream to the next

--- a/models/helper.go
+++ b/models/helper.go
@@ -1,0 +1,29 @@
+package models
+
+// shouldApplyPrefixToMetric returns whether the prefix should be prepended
+// to the metric name, taking into account a limit of consecutive prefixes that
+// the metric name can contain.
+func shouldApplyPrefixToMetric(name, prefix string, consecutiveNamePrefixLimit int) bool {
+	// not using the limit
+	if consecutiveNamePrefixLimit <= 0 {
+		return true
+	}
+
+	lenName := len(name)
+	lenPrefix := len(prefix)
+	// cannot reach limit of consecutive prefixes
+	if lenName < (lenPrefix * consecutiveNamePrefixLimit) {
+		return true
+	}
+
+	for i := lenPrefix; i < lenName; i += lenPrefix {
+		subst := name[i-lenPrefix : i]
+		// the current prefix length subst of the metric name
+		// does not equal prefix, cannot reach limit
+		if subst != prefix {
+			return true
+		}
+	}
+
+	return false
+}

--- a/models/helper_test.go
+++ b/models/helper_test.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that ShouldApplyPrefixToMetric is applied properly
+// with respect to ConsecutiveNamePrefixLimit option
+func TestRunningOutput_ShouldApplyPrefixToMetric(t *testing.T) {
+	table := []struct {
+		Description       string
+		Name              string
+		Prefix            string
+		Limit             int
+		ShouldApplyPrefix bool
+	}{
+		{
+			Description:       "ConsecutiveNamePrefixLimit unset (default 0)",
+			Name:              "prefix_foo",
+			Prefix:            "prefix_",
+			Limit:             0,
+			ShouldApplyPrefix: true,
+		},
+		{
+			Description:       "ConsecutiveNamePrefixLimit set, metric does not begin with prefix",
+			Name:              "prefix_foo",
+			Prefix:            "notprefix",
+			Limit:             1,
+			ShouldApplyPrefix: true,
+		},
+		{
+			Description:       "ConsecutiveNamePrefixLimit set, metric name shorter than prefix",
+			Name:              "foo",
+			Prefix:            "prefix_",
+			Limit:             1,
+			ShouldApplyPrefix: true,
+		},
+		{
+			Description:       "ConsecutiveNamePrefixLimit set, metric begins with prefix, limit not reached",
+			Name:              "prefix_foo",
+			Prefix:            "prefix_",
+			Limit:             2,
+			ShouldApplyPrefix: true,
+		},
+		{
+			Description:       "ConsecutiveNamePrefixLimit set, metric begins with prefix, limit reached",
+			Name:              "prefix_prefix_foo",
+			Prefix:            "prefix_",
+			Limit:             2,
+			ShouldApplyPrefix: false,
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.Description, func(t *testing.T) {
+			shouldApplyPrefix := shouldApplyPrefixToMetric(test.Name, test.Prefix, test.Limit)
+			assert.Equal(t, shouldApplyPrefix, test.ShouldApplyPrefix)
+		})
+	}
+}

--- a/models/makemetric.go
+++ b/models/makemetric.go
@@ -10,6 +10,7 @@ func makemetric(
 	metric telegraf.Metric,
 	nameOverride string,
 	namePrefix string,
+	consecutiveNamePrefixLimit int,
 	nameSuffix string,
 	tags map[string]string,
 	globalTags map[string]string,
@@ -19,7 +20,9 @@ func makemetric(
 	}
 
 	if len(namePrefix) != 0 {
-		metric.AddPrefix(namePrefix)
+		if shouldApplyPrefixToMetric(metric.Name(), namePrefix, consecutiveNamePrefixLimit) {
+			metric.AddPrefix(namePrefix)
+		}
 	}
 	if len(nameSuffix) != 0 {
 		metric.AddSuffix(nameSuffix)

--- a/models/running_aggregator.go
+++ b/models/running_aggregator.go
@@ -78,6 +78,8 @@ type AggregatorConfig struct {
 	MeasurementSuffix string
 	Tags              map[string]string
 	Filter            Filter
+
+	ConsecutiveNamePrefixLimit int
 }
 
 func (r *RunningAggregator) LogName() string {
@@ -113,6 +115,7 @@ func (r *RunningAggregator) MakeMetric(metric telegraf.Metric) telegraf.Metric {
 		metric,
 		r.Config.NameOverride,
 		r.Config.MeasurementPrefix,
+		r.Config.ConsecutiveNamePrefixLimit,
 		r.Config.MeasurementSuffix,
 		r.Config.Tags,
 		nil)

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -67,6 +67,8 @@ type InputConfig struct {
 	MeasurementSuffix string
 	Tags              map[string]string
 	Filter            Filter
+
+	ConsecutiveNamePrefixLimit int
 }
 
 func (r *RunningInput) metricFiltered(metric telegraf.Metric) {
@@ -97,6 +99,7 @@ func (r *RunningInput) MakeMetric(metric telegraf.Metric) telegraf.Metric {
 		metric,
 		r.Config.NameOverride,
 		r.Config.MeasurementPrefix,
+		r.Config.ConsecutiveNamePrefixLimit,
 		r.Config.MeasurementSuffix,
 		r.Config.Tags,
 		r.defaultTags)

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -31,6 +31,8 @@ type OutputConfig struct {
 	NameOverride string
 	NamePrefix   string
 	NameSuffix   string
+
+	ConsecutiveNamePrefixLimit int
 }
 
 // RunningOutput contains the output configuration
@@ -155,7 +157,9 @@ func (r *RunningOutput) AddMetric(metric telegraf.Metric) {
 	}
 
 	if len(r.Config.NamePrefix) > 0 {
-		metric.AddPrefix(r.Config.NamePrefix)
+		if shouldApplyPrefixToMetric(metric.Name(), r.Config.NamePrefix, r.Config.ConsecutiveNamePrefixLimit) {
+			metric.AddPrefix(r.Config.NamePrefix)
+		}
 	}
 
 	if len(r.Config.NameSuffix) > 0 {


### PR DESCRIPTION
feat: add consecutive_name_prefix_limit to Aggregator, Input, and Output plugins, such that the prefix is not appended if a metric name already begins with N occurrences of the prefix, where N is the defined limit.
	
If the limit is unset, the prefix will always be applied.
	
Using the prefix `foo_` and a limit of 2 consecutive prefixes, a metric with the initial name `foo_bar` would translate into `foo_foo_bar`, i.e. the prefix would be applied. A metric with the initial name `foo_foo_bar` would remain `foo_foo_bar`, i.e. the prefix would not be applied.

Signed-off-by: Conor Evans <coevans@tcd.ie>

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #9227
resolves #9022

I created the helper file since it didn't really seem to fit anywhere else -- it touches 3 of the different plugins, so i wanted to define it as a named function
