### PR TITLE
fix: unset host tag whenever omit_hostname is false

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -814,6 +814,9 @@ func (c *Config) LoadConfigData(data []byte) error {
 		}
 
 		c.Tags["host"] = c.Agent.Hostname
+	} else {
+		// we may have already set the host tag in a previously loaded config, no-op if not
+		delete(c.Tags, "host")
 	}
 
 	if len(c.UnusedFields) > 0 {


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>

- [x] Updated associated README.md. (N/A)
- [x] Wrote appropriate unit tests. (it seems a bit heavy to create a test that loads multiple configs to test this, as none are adaptable, there'd have to be new testdata written -- all that when `delete` is an inbuilt safe function)
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10389

The issue occurred whenever multiple configs with an `agent` table were present. If the first had `omit_hostname = false` or unset (default false), then `c.Tags["host"]` would be set. If the next config had `omit_hostname = true`, it wouldn't re-set it, but the "host" tag would remain in the tag map.

I chose to add it as an else, which may seem weird since it's now `if !condition else` instead of `if condition else` but I thought it would be preferable to leave the existing code untouched, for git history among other things.
