### PR TITLE
feat: always disable cgo support (static builds)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,16 +323,6 @@ jobs:
       - package-build:
           type: mips
           nightly: << parameters.nightly >>
-  static-package:
-    parameters:
-      nightly:
-        type: boolean
-        default: false
-    executor: go-1_17
-    steps:
-      - package-build:
-          type: static
-          nightly: << parameters.nightly >>
   armhf-package:
     parameters:
       nightly:
@@ -514,12 +504,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - 'static-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
       - 'mipsel-package':
           requires:
             - 'test-go-linux'
@@ -559,7 +543,6 @@ workflows:
             - 'darwin-amd64-package'
             - 'darwin-arm64-package'
             - 'windows-package'
-            - 'static-package'
             - 'arm64-package'
             - 'armhf-package'
           filters:
@@ -595,7 +578,6 @@ workflows:
             - 'amd64-package'
             - 'mipsel-package'
             - 'mips-package'
-            - 'static-package'
             - 'arm64-package'
             - 'armhf-package'
             - 'riscv64-package'
@@ -668,11 +650,6 @@ workflows:
           nightly: true
           requires:
             - 'test-go-linux'
-      - 'static-package':
-          name: 'static-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
       - 'mipsel-package':
           name: 'mipsel-package-nightly'
           nightly: true
@@ -696,7 +673,6 @@ workflows:
             - 'darwin-amd64-package-nightly'
             - 'darwin-arm64-package-nightly'
             - 'windows-package-nightly'
-            - 'static-package-nightly'
             - 'arm64-package-nightly'
             - 'armhf-package-nightly'
     triggers:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-export CGO_ENABLED := 0
-
 next_version :=  $(shell cat build_version.txt)
 tag := $(shell git describe --exact-match --tags 2>git_describe_error.tmp; rm -f git_describe_error.tmp)
 branch := $(shell git rev-parse --abbrev-ref HEAD)
@@ -112,7 +110,11 @@ versioninfo:
 
 .PHONY: telegraf
 telegraf:
-	go build -ldflags "$(LDFLAGS)" ./cmd/telegraf
+	@if [ "$(GOOS)" == "linux" ]; then \
+		CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" ./cmd/telegraf; \
+	else \
+		go build -ldflags "$(LDFLAGS)" ./cmd/telegraf; \
+	fi
 
 # Used by dockerfile builds
 .PHONY: go-install


### PR DESCRIPTION
This ensures that cgo is always disabled with builds using
the Makefile. Telegraf does not support importing C libraries
or depending on any of them in the first place. This is to
ensure cross-platform and cross-OS support.

Because Telegraf does not need to depend on dynamic libraries,
we can ensure Telegraf builds statically.

MacOS and Windows do not have official static build support and
by default builds on those systems are already as static as they
can be. This primarily affects the Linux/*BSD builds.

Finally, this removes the no longer necessary static specific
build.
