### PR TITLE
fix: add newline in execd for prometheus parsing

### DIFF
--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
+	"github.com/influxdata/telegraf/plugins/parsers/prometheus"
 )
 
 const sampleConfig = `
@@ -100,10 +101,17 @@ func (e *Execd) cmdReadOut(out io.Reader) {
 		return
 	}
 
+	_, isPrometheus := e.parser.(*prometheus.Parser)
+
 	scanner := bufio.NewScanner(out)
 
 	for scanner.Scan() {
-		metrics, err := e.parser.Parse(scanner.Bytes())
+		data := scanner.Bytes()
+		if isPrometheus {
+			data = append(data, []byte("\n")...)
+		}
+
+		metrics, err := e.parser.Parse(data)
 		if err != nil {
 			e.acc.AddError(fmt.Errorf("parse error: %w", err))
 		}


### PR DESCRIPTION
The Prometheus parser currently will return a text format parsing error
due to an unexpected end of input stream. This is due to there not being
a new line (e.g. \n) at the end of the string. Once added, the execd
works as expected.

Fixes: #10460