### PR TITLE
fix: do not save cache on i386 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,15 +182,6 @@ jobs:
       - run: 'GOARCH=386 make check'
       - test-go:
           arch: "386"
-      - save_cache:
-          name: 'go module cache'
-          key: go-mod-v1-{{ checksum "go.sum" }}
-          paths:
-            - '/go/pkg/mod'
-      - persist_to_workspace:
-          root: '/go'
-          paths:
-            - '*'
   test-go-mac:
     executor: mac
     steps:


### PR DESCRIPTION
Possibly fix to prevent workspace attach issues on nightlies
