### PR TITLE
fix(inputs.opcua): add more data to error log

### DIFF
--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -529,7 +529,9 @@ func (o *OpcUA) getData() error {
 	for i, d := range resp.Results {
 		o.nodeData[i].Quality = d.Status
 		if !o.checkStatusCode(d.Status) {
-			o.Log.Errorf("status not OK for node %v: %v", o.nodes[i].tag.FieldName, d.Status)
+			mp := newMP(&o.nodes[i])
+			o.Log.Errorf("status not OK for node '%s'(metric name '%s', tags '%s')",
+				mp.fieldName, mp.metricName, mp.tags)
 			continue
 		}
 		o.nodeData[i].TagName = o.nodes[i].tag.FieldName


### PR DESCRIPTION
resolve: [#2932](https://github.com/influxdata/EAR/issues/2932) (this is an internal issue)

This pull request adds metric name and tags to the "status no OK" error logs. Copied the same output format as  validateOPCTags is using https://github.com/influxdata/telegraf/blob/opcuaimprovedlog/plugins/inputs/opcua/opcua_client.go#L394-L395.