### PR TITLE
fix(persers.nagios): nagios parser now uses real error for logging

### DIFF
--- a/plugins/parsers/nagios/parser.go
+++ b/plugins/parsers/nagios/parser.go
@@ -28,7 +28,7 @@ func getExitCode(err error) (int, error) {
 		// If it is not an *exec.ExitError, then it must be
 		// an io error, but docs do not say anything about the
 		// exit code in this case.
-		return 0, errors.New("expected *exec.ExitError")
+		return 0, err
 	}
 
 	ws, ok := ee.Sys().(syscall.WaitStatus)

--- a/plugins/parsers/nagios/parser_test.go
+++ b/plugins/parsers/nagios/parser_test.go
@@ -33,7 +33,7 @@ func TestGetExitCode(t *testing.T) {
 				return errors.New("I am not *exec.ExitError")
 			},
 			expCode: 0,
-			expErr:  errors.New("expected *exec.ExitError"),
+			expErr:  errors.New("I am not *exec.ExitError"),
 		},
 	}
 
@@ -177,7 +177,7 @@ func TestTryAddState(t *testing.T) {
 						n("nagios").
 						f("perfdata", 0).b(),
 				}
-				expErr := "exec: get exit code: expected *exec.ExitError"
+				expErr := "exec: get exit code: non parsable error"
 
 				assertEqual(t, exp, metrics)
 				require.Equal(t, expErr, err.Error())


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10472

The real error will now be returned by the "getExitCode" function instead of an placeholder.
With these changes all real errors message will be written to the log. Problems can be debuged properly.  
