### PR TITLE
fix: check for ipset command during init

### DIFF
--- a/plugins/inputs/ipset/ipset.go
+++ b/plugins/inputs/ipset/ipset.go
@@ -47,6 +47,15 @@ func (i *Ipset) SampleConfig() string {
 `
 }
 
+func (i *Ipset) Init() error {
+	_, err := exec.LookPath("ipset")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (i *Ipset) Gather(acc telegraf.Accumulator) error {
 	out, e := i.lister(i.Timeout, i.UseSudo)
 	if e != nil {


### PR DESCRIPTION
During init check for the ipset command before running. Prevents a panic from occurring after start.

Resolves: #7228