### PR TITLE
fix: add comment to logparser

### DIFF
--- a/plugins/inputs/logparser/README.md
+++ b/plugins/inputs/logparser/README.md
@@ -14,6 +14,11 @@ Most options can be translated directly to the `tail` plugin:
 - The grok `measurement` option can be replaced using the standard plugin
   `name_override` option.
 
+This plugin also supports [metric filtering](CONFIGURATION.md#metric-filtering)
+and some [additional common options](CONFIGURATION.md#processor-plugins).
+
+## Example
+
 Migration Example:
 
 ```diff


### PR DESCRIPTION
The plugin is deprecated, but resolves a community reported issue that
would improve the docs.

Fixes: #9065
