### PR TITLE
fix: Improve parser tests by using go-cmp/cmp

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,9 +8,12 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
@@ -411,33 +414,16 @@ func TestConfig_ParserInterfaceNewFormat(t *testing.T) {
 			param: map[string]interface{}{
 				"HeaderRowCount": cfg.CSVHeaderRowCount,
 			},
-			mask: []string{"TimeFunc", "Log"},
-		},
-		"json_v2": {
-			mask: []string{"Log"},
+			mask: []string{"TimeFunc"},
 		},
 		"logfmt": {
 			mask: []string{"Now"},
 		},
-		"xml": {
-			mask: []string{"Log"},
-		},
-		"xpath_json": {
-			mask: []string{"Log"},
-		},
-		"xpath_msgpack": {
-			mask: []string{"Log"},
-		},
 		"xpath_protobuf": {
-			cfg: &parsers.Config{
-				XPathProtobufFile: "testdata/addressbook.proto",
-				XPathProtobufType: "addressbook.AddressBook",
-			},
 			param: map[string]interface{}{
 				"ProtobufMessageDef":  "testdata/addressbook.proto",
 				"ProtobufMessageType": "addressbook.AddressBook",
 			},
-			mask: []string{"Log"},
 		},
 	}
 
@@ -510,33 +496,24 @@ func TestConfig_ParserInterfaceNewFormat(t *testing.T) {
 	require.Len(t, actual, len(formats))
 
 	for i, format := range formats {
+		// Determine the underlying type of the parser
+		stype := reflect.Indirect(reflect.ValueOf(expected[i])).Interface()
+		// Ignore all unexported fields and fields not relevant for functionality
+		options := []cmp.Option{
+			cmpopts.IgnoreUnexported(stype),
+			cmpopts.IgnoreTypes(sync.Mutex{}),
+			cmpopts.IgnoreInterfaces(struct{ telegraf.Logger }{}),
+		}
 		if settings, found := override[format]; found {
-			a := reflect.Indirect(reflect.ValueOf(actual[i]))
-			e := reflect.Indirect(reflect.ValueOf(expected[i]))
-			g := reflect.Indirect(reflect.ValueOf(generated[i]))
-			for _, key := range settings.mask {
-				af := a.FieldByName(key)
-				ef := e.FieldByName(key)
-				gf := g.FieldByName(key)
-
-				v := reflect.Zero(ef.Type())
-				af.Set(v)
-				ef.Set(v)
-				gf.Set(v)
-			}
+			options = append(options, cmpopts.IgnoreFields(stype, settings.mask...))
 		}
 
-		// We need special handling for same parsers as they internally contain pointers
-		// to other structs that inherently differ between instances
-		switch format {
-		case "dropwizard", "grok", "influx", "wavefront":
-			// At least check if we have the same type
-			require.IsType(t, expected[i], actual[i])
-			require.IsType(t, expected[i], generated[i])
-			continue
-		}
-		require.EqualValuesf(t, expected[i], actual[i], "in SetParser() for %q", format)
-		require.EqualValuesf(t, expected[i], generated[i], "in SetParserFunc() for %q", format)
+		// Do a manual comparision as require.EqualValues will also work on unexported fields
+		// that cannot be cleared or ignored.
+		diff := cmp.Diff(expected[i], actual[i], options...)
+		require.Emptyf(t, diff, "Difference in SetParser() for %q", format)
+		diff = cmp.Diff(expected[i], generated[i], options...)
+		require.Emptyf(t, diff, "Difference in SetParserFunc() for %q", format)
 	}
 }
 
@@ -581,33 +558,16 @@ func TestConfig_ParserInterfaceOldFormat(t *testing.T) {
 			param: map[string]interface{}{
 				"HeaderRowCount": cfg.CSVHeaderRowCount,
 			},
-			mask: []string{"TimeFunc", "Log"},
-		},
-		"json_v2": {
-			mask: []string{"Log"},
+			mask: []string{"TimeFunc"},
 		},
 		"logfmt": {
 			mask: []string{"Now"},
 		},
-		"xml": {
-			mask: []string{"Log"},
-		},
-		"xpath_json": {
-			mask: []string{"Log"},
-		},
-		"xpath_msgpack": {
-			mask: []string{"Log"},
-		},
 		"xpath_protobuf": {
-			cfg: &parsers.Config{
-				XPathProtobufFile: "testdata/addressbook.proto",
-				XPathProtobufType: "addressbook.AddressBook",
-			},
 			param: map[string]interface{}{
 				"ProtobufMessageDef":  "testdata/addressbook.proto",
 				"ProtobufMessageType": "addressbook.AddressBook",
 			},
-			mask: []string{"Log"},
 		},
 	}
 
@@ -680,33 +640,24 @@ func TestConfig_ParserInterfaceOldFormat(t *testing.T) {
 	require.Len(t, actual, len(formats))
 
 	for i, format := range formats {
+		// Determine the underlying type of the parser
+		stype := reflect.Indirect(reflect.ValueOf(expected[i])).Interface()
+		// Ignore all unexported fields and fields not relevant for functionality
+		options := []cmp.Option{
+			cmpopts.IgnoreUnexported(stype),
+			cmpopts.IgnoreTypes(sync.Mutex{}),
+			cmpopts.IgnoreInterfaces(struct{ telegraf.Logger }{}),
+		}
 		if settings, found := override[format]; found {
-			a := reflect.Indirect(reflect.ValueOf(actual[i]))
-			e := reflect.Indirect(reflect.ValueOf(expected[i]))
-			g := reflect.Indirect(reflect.ValueOf(generated[i]))
-			for _, key := range settings.mask {
-				af := a.FieldByName(key)
-				ef := e.FieldByName(key)
-				gf := g.FieldByName(key)
-
-				v := reflect.Zero(ef.Type())
-				af.Set(v)
-				ef.Set(v)
-				gf.Set(v)
-			}
+			options = append(options, cmpopts.IgnoreFields(stype, settings.mask...))
 		}
 
-		// We need special handling for same parsers as they internally contain pointers
-		// to other structs that inherently differ between instances
-		switch format {
-		case "dropwizard", "grok", "influx", "wavefront":
-			// At least check if we have the same type
-			require.IsType(t, expected[i], actual[i])
-			require.IsType(t, expected[i], generated[i])
-			continue
-		}
-		require.EqualValuesf(t, expected[i], actual[i], "in SetParser() for %q", format)
-		require.EqualValuesf(t, expected[i], generated[i], "in SetParserFunc() for %q", format)
+		// Do a manual comparision as require.EqualValues will also work on unexported fields
+		// that cannot be cleared or ignored.
+		diff := cmp.Diff(expected[i], actual[i], options...)
+		require.Emptyf(t, diff, "Difference in SetParser() for %q", format)
+		diff = cmp.Diff(expected[i], generated[i], options...)
+		require.Emptyf(t, diff, "Difference in SetParserFunc() for %q", format)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -420,6 +420,11 @@ func TestConfig_ParserInterfaceNewFormat(t *testing.T) {
 			mask: []string{"Now"},
 		},
 		"xpath_protobuf": {
+			cfg: &parsers.Config{
+				MetricName:        "parser_test_new",
+				XPathProtobufFile: "testdata/addressbook.proto",
+				XPathProtobufType: "addressbook.AddressBook",
+			},
 			param: map[string]interface{}{
 				"ProtobufMessageDef":  "testdata/addressbook.proto",
 				"ProtobufMessageType": "addressbook.AddressBook",
@@ -564,6 +569,11 @@ func TestConfig_ParserInterfaceOldFormat(t *testing.T) {
 			mask: []string{"Now"},
 		},
 		"xpath_protobuf": {
+			cfg: &parsers.Config{
+				MetricName:        "parser_test_new",
+				XPathProtobufFile: "testdata/addressbook.proto",
+				XPathProtobufType: "addressbook.AddressBook",
+			},
 			param: map[string]interface{}{
 				"ProtobufMessageDef":  "testdata/addressbook.proto",
 				"ProtobufMessageType": "addressbook.AddressBook",


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Will fix CI error in #10083.

The current parser tests in `config/config_test` is using `require.EqualValues()` which also checks on unexported fields of the parser to test. This leads to problems due to internal states (see [CI error in #10083](https://app.circleci.com/pipelines/github/influxdata/telegraf/8694/workflows/3f4b1bdd-64ff-4ced-956a-be6ebe4aa439/jobs/146415) or `xpath_*`) which cannot be ignored with the mentioned function.

As we do not want to check internal states anyway (but only check if the parsers are equally configured) we change the comparision in this PR to use `github.com/google/go-cmp/cmp`. By this we can flexibly ignore certain fields. By default, both unexported fields and `telegraf.Logger` are ignored. Additional fields can be specified by name in the `override` structure.

As a side effect, the testing code becomes more compact and readable.