### PR TITLE
fix: move "Starting Telegraf" log

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -239,22 +239,17 @@ func runAgent(ctx context.Context,
 		return fmt.Errorf("Agent flush_interval must be positive; found %v", c.Agent.Interval)
 	}
 
-	ag, err := agent.NewAgent(c)
-	if err != nil {
-		return err
-	}
-
 	// Setup logging as configured.
-	telegraf.Debug = ag.Config.Agent.Debug || *fDebug
+	telegraf.Debug = c.Agent.Debug || *fDebug
 	logConfig := logger.LogConfig{
 		Debug:               telegraf.Debug,
-		Quiet:               ag.Config.Agent.Quiet || *fQuiet,
-		LogTarget:           ag.Config.Agent.LogTarget,
-		Logfile:             ag.Config.Agent.Logfile,
-		RotationInterval:    ag.Config.Agent.LogfileRotationInterval,
-		RotationMaxSize:     ag.Config.Agent.LogfileRotationMaxSize,
-		RotationMaxArchives: ag.Config.Agent.LogfileRotationMaxArchives,
-		LogWithTimezone:     ag.Config.Agent.LogWithTimezone,
+		Quiet:               c.Agent.Quiet || *fQuiet,
+		LogTarget:           c.Agent.LogTarget,
+		Logfile:             c.Agent.Logfile,
+		RotationInterval:    c.Agent.LogfileRotationInterval,
+		RotationMaxSize:     c.Agent.LogfileRotationMaxSize,
+		RotationMaxArchives: c.Agent.LogfileRotationMaxArchives,
+		LogWithTimezone:     c.Agent.LogWithTimezone,
 	}
 
 	logger.SetupLogging(logConfig)
@@ -281,6 +276,11 @@ func runAgent(ctx context.Context,
 	}
 	if count, found := c.Deprecations["outputs"]; found && (count[0] > 0 || count[1] > 0) {
 		log.Printf("W! Deprecated outputs: %d and %d options", count[0], count[1])
+	}
+
+	ag, err := agent.NewAgent(c)
+	if err != nil {
+		return err
 	}
 
 	// Notify systemd that telegraf is ready

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -198,8 +198,6 @@ func runAgent(ctx context.Context,
 	inputFilters []string,
 	outputFilters []string,
 ) error {
-	log.Printf("I! Starting Telegraf %s", version)
-
 	// If no other options are specified, load the config file and run.
 	c := config.NewConfig()
 	c.OutputFilters = outputFilters
@@ -261,6 +259,7 @@ func runAgent(ctx context.Context,
 
 	logger.SetupLogging(logConfig)
 
+	log.Printf("I! Starting Telegraf %s", version)
 	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))
 	log.Printf("I! Loaded aggregators: %s", strings.Join(c.AggregatorNames(), " "))
 	log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))


### PR DESCRIPTION
resolve: #9120

As stated in the issue `I! Starting Telegraf <version>` doesn't get written to a logfile if you specify one in the config, in the code this was happening because the logger gets setup after this log call is called so simply moving it after setup resolves this issue.