### PR TITLE
feat: Collection offset implementation

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -298,11 +298,17 @@ func (a *Agent) runInputs(
 			jitter = input.Config.CollectionJitter
 		}
 
+		// Overwrite agent collection_offset if this plugin has its own.
+		offset := time.Duration(a.Config.Agent.CollectionOffset)
+		if input.Config.CollectionOffset != 0 {
+			offset = input.Config.CollectionOffset
+		}
+
 		var ticker Ticker
 		if a.Config.Agent.RoundInterval {
-			ticker = NewAlignedTicker(startTime, interval, jitter)
+			ticker = NewAlignedTicker(startTime, interval, jitter, offset)
 		} else {
-			ticker = NewUnalignedTicker(interval, jitter)
+			ticker = NewUnalignedTicker(interval, jitter, offset)
 		}
 		defer ticker.Stop()
 

--- a/agent/tick.go
+++ b/agent/tick.go
@@ -128,18 +128,19 @@ type UnalignedTicker struct {
 }
 
 func NewUnalignedTicker(interval, jitter, offset time.Duration) *UnalignedTicker {
-	return newUnalignedTicker(interval, jitter, offset, clock.New())
-}
-
-func newUnalignedTicker(interval, jitter, offset time.Duration, clk clock.Clock) *UnalignedTicker {
-	ctx, cancel := context.WithCancel(context.Background())
 	t := &UnalignedTicker{
 		interval: interval,
 		jitter:   jitter,
 		offset:   offset,
-		ch:       make(chan time.Time, 1),
-		cancel:   cancel,
 	}
+	t.start(clock.New())
+	return t
+}
+
+func (t *UnalignedTicker) start(clk clock.Clock) *UnalignedTicker {
+	t.ch = make(chan time.Time, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.cancel = cancel
 
 	ticker := clk.Ticker(t.interval)
 	if t.offset == 0 {

--- a/agent/tick.go
+++ b/agent/tick.go
@@ -226,17 +226,19 @@ type RollingTicker struct {
 }
 
 func NewRollingTicker(interval, jitter time.Duration) *RollingTicker {
-	return newRollingTicker(interval, jitter, clock.New())
-}
-
-func newRollingTicker(interval, jitter time.Duration, clk clock.Clock) *RollingTicker {
-	ctx, cancel := context.WithCancel(context.Background())
 	t := &RollingTicker{
 		interval: interval,
 		jitter:   jitter,
-		ch:       make(chan time.Time, 1),
-		cancel:   cancel,
 	}
+	t.start(clock.New())
+	return t
+}
+
+func (t *RollingTicker) start(clk clock.Clock) *RollingTicker {
+	t.ch = make(chan time.Time, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.cancel = cancel
 
 	d := t.next()
 	timer := clk.Timer(d)

--- a/agent/tick.go
+++ b/agent/tick.go
@@ -141,9 +141,6 @@ func newUnalignedTicker(interval, jitter, offset time.Duration, clock clock.Cloc
 		cancel:   cancel,
 	}
 
-	// Initially wait for the given offset to phase-shift the period
-	_ = sleep(ctx, t.offset, clock)
-
 	ticker := clock.Ticker(t.interval)
 	t.ch <- clock.Now()
 
@@ -179,7 +176,7 @@ func (t *UnalignedTicker) run(ctx context.Context, ticker *clock.Ticker, clock c
 			return
 		case <-ticker.C:
 			jitter := internal.RandomDuration(t.jitter)
-			err := sleep(ctx, jitter, clock)
+			err := sleep(ctx, jitter+t.offset, clock)
 			if err != nil {
 				ticker.Stop()
 				return

--- a/agent/tick.go
+++ b/agent/tick.go
@@ -142,7 +142,10 @@ func newUnalignedTicker(interval, jitter, offset time.Duration, clock clock.Cloc
 	}
 
 	ticker := clock.Ticker(t.interval)
-	t.ch <- clock.Now()
+	if t.offset == 0 {
+		// Perform initial trigger to stay backward compatible
+		t.ch <- clock.Now()
+	}
 
 	t.wg.Add(1)
 	go func() {

--- a/agent/tick.go
+++ b/agent/tick.go
@@ -76,8 +76,8 @@ func (t *AlignedTicker) next(now time.Time) time.Duration {
 	if d == 0 {
 		d = t.interval
 	}
-	d += internal.RandomDuration(t.jitter)
 	d += t.offset
+	d += internal.RandomDuration(t.jitter)
 	return d
 }
 
@@ -180,7 +180,7 @@ func (t *UnalignedTicker) run(ctx context.Context, ticker *clock.Ticker, clk clo
 			return
 		case <-ticker.C:
 			jitter := internal.RandomDuration(t.jitter)
-			err := sleep(ctx, jitter+t.offset, clk)
+			err := sleep(ctx, t.offset+jitter, clk)
 			if err != nil {
 				ticker.Stop()
 				return

--- a/agent/tick_test.go
+++ b/agent/tick_test.go
@@ -114,10 +114,8 @@ func TestAlignedTickerOffset(t *testing.T) {
 
 	clk.Add(10*time.Second + offset)
 	for !clk.Now().After(until) {
-		select {
-		case tm := <-ticker.Elapsed():
-			actual = append(actual, tm.UTC())
-		}
+		tm := <-ticker.Elapsed()
+		actual = append(actual, tm.UTC())
 		clk.Add(10 * time.Second)
 	}
 

--- a/agent/tick_test.go
+++ b/agent/tick_test.go
@@ -159,7 +159,12 @@ func TestUnalignedTicker(t *testing.T) {
 	since := clk.Now()
 	until := since.Add(60 * time.Second)
 
-	ticker := newUnalignedTicker(interval, jitter, offset, clk)
+	ticker := &UnalignedTicker{
+		interval: interval,
+		jitter:   jitter,
+		offset:   offset,
+	}
+	ticker.start(clk)
 	defer ticker.Stop()
 
 	expected := []time.Time{
@@ -195,7 +200,12 @@ func TestRollingTicker(t *testing.T) {
 	since := clk.Now()
 	until := since.Add(60 * time.Second)
 
-	ticker := newUnalignedTicker(interval, jitter, offset, clk)
+	ticker := &UnalignedTicker{
+		interval: interval,
+		jitter:   jitter,
+		offset:   offset,
+	}
+	ticker.start(clk)
 	defer ticker.Stop()
 
 	expected := []time.Time{
@@ -288,7 +298,12 @@ func TestUnalignedTickerDistribution(t *testing.T) {
 
 	clk := clock.NewMock()
 
-	ticker := newUnalignedTicker(interval, jitter, offset, clk)
+	ticker := &UnalignedTicker{
+		interval: interval,
+		jitter:   jitter,
+		offset:   offset,
+	}
+	ticker.start(clk)
 	defer ticker.Stop()
 	dist := simulatedDist(ticker, clk)
 	printDist(dist)
@@ -307,7 +322,12 @@ func TestUnalignedTickerDistributionWithOffset(t *testing.T) {
 
 	clk := clock.NewMock()
 
-	ticker := newUnalignedTicker(interval, jitter, offset, clk)
+	ticker := &UnalignedTicker{
+		interval: interval,
+		jitter:   jitter,
+		offset:   offset,
+	}
+	ticker.start(clk)
 	defer ticker.Stop()
 	dist := simulatedDist(ticker, clk)
 	printDist(dist)

--- a/agent/tick_test.go
+++ b/agent/tick_test.go
@@ -347,7 +347,11 @@ func TestRollingTickerDistribution(t *testing.T) {
 
 	clk := clock.NewMock()
 
-	ticker := newRollingTicker(interval, jitter, clk)
+	ticker := &RollingTicker{
+		interval: interval,
+		jitter:   jitter,
+	}
+	ticker.start(clk)
 	defer ticker.Stop()
 	dist := simulatedDist(ticker, clk)
 	printDist(dist)

--- a/config/config.go
+++ b/config/config.go
@@ -153,6 +153,11 @@ type AgentConfig struct {
 	// same time, which can have a measurable effect on the system.
 	CollectionJitter Duration
 
+	// CollectionOffset is used to shift the collection by the given amount.
+	// This can be be used to avoid many plugins querying constraint devices
+	// at the same time by manually scheduling them in time.
+	CollectionOffset Duration
+
 	// FlushInterval is the Interval at which to flush data
 	FlushInterval Duration
 
@@ -322,6 +327,7 @@ var globalTagsConfig = `
   # user = "$USER"
 
 `
+
 var agentConfig = `
 # Configuration for telegraf agent
 [agent]
@@ -346,6 +352,11 @@ var agentConfig = `
   ## This can be used to avoid many plugins querying things like sysfs at the
   ## same time, which can have a measurable effect on the system.
   collection_jitter = "0s"
+
+  ## Collection offset is used to shift the collection by the given amount.
+  ## This can be be used to avoid many plugins querying constraint devices
+  ## at the same time by manually scheduling them in time.
+  # collection_offset = "0s"
 
   ## Default flushing interval for all outputs. Maximum flush_interval will be
   ## flush_interval + flush_jitter
@@ -1488,6 +1499,7 @@ func (c *Config) buildInput(name string, tbl *ast.Table) (*models.InputConfig, e
 	c.getFieldDuration(tbl, "interval", &cp.Interval)
 	c.getFieldDuration(tbl, "precision", &cp.Precision)
 	c.getFieldDuration(tbl, "collection_jitter", &cp.CollectionJitter)
+	c.getFieldDuration(tbl, "collection_offset", &cp.CollectionOffset)
 	c.getFieldString(tbl, "name_prefix", &cp.MeasurementPrefix)
 	c.getFieldString(tbl, "name_suffix", &cp.MeasurementSuffix)
 	c.getFieldString(tbl, "name_override", &cp.NameOverride)
@@ -1792,6 +1804,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 	switch key {
 	case "alias", "carbon2_format", "carbon2_sanitize_replace_char", "collectd_auth_file",
 		"collectd_parse_multivalue", "collectd_security_level", "collectd_typesdb", "collection_jitter",
+		"collection_offset",
 		"data_format", "data_type", "delay", "drop", "drop_original", "dropwizard_metric_registry_path",
 		"dropwizard_tag_paths", "dropwizard_tags_path", "dropwizard_time_format", "dropwizard_time_path",
 		"fielddrop", "fieldpass", "flush_interval", "flush_jitter", "form_urlencoded_tag_keys",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -188,6 +188,11 @@ The agent table configures Telegraf and the defaults used across all plugins.
   This can be used to avoid many plugins querying things like sysfs at the
   same time, which can have a measurable effect on the system.
 
+- **collection_offset**:
+  Collection offset is used to shift the collection by the given [interval][].
+  This can be be used to avoid many plugins querying constraint devices
+  at the same time by manually scheduling them in time.
+
 - **flush_interval**:
   Default flushing [interval][] for all outputs. Maximum flush_interval will be
   flush_interval + flush_jitter.
@@ -279,6 +284,11 @@ Parameters that can be used with any input plugin:
 - **collection_jitter**:
   Overrides the `collection_jitter` setting of the [agent][Agent] for the
   plugin.  Collection jitter is used to jitter the collection by a random
+  [interval][].
+
+- **collection_offset**:
+  Overrides the `collection_offset` setting of the [agent][Agent] for the
+  plugin. Collection offset is used to shift the collection by the given
   [interval][].
 
 - **name_override**: Override the base name of the measurement.  (Default is

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -60,6 +60,7 @@ type InputConfig struct {
 	Alias            string
 	Interval         time.Duration
 	CollectionJitter time.Duration
+	CollectionOffset time.Duration
 	Precision        time.Duration
 
 	NameOverride      string


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #1319
resolves #10406 

related to #10530

This PR addresses a long standing feature-request to be able to define an offset from the collection interval. This can be helpful in order to manually schedule data collection between agents, if the global option is used with multiple agents, or, if the plugin option is used, between plugins. The new `collection_offset` allows to define a time offset from the (rounded and unaligned) collection time. The option is valid in either the agent section or in any input-plugin section (as other interval parameters).