### PR TITLE
fix(prometheusremotewrite): use wrong timestamp unit

### DIFF
--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -195,7 +195,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 			// sample then we can skip over it.
 			m, ok := entries[metrickey]
 			if ok {
-				if metric.Time().Before(time.Unix(m.Samples[0].Timestamp, 0)) {
+				if metric.Time().Before(time.Unix(0, m.Samples[0].Timestamp*1_000_000)) {
 					continue
 				}
 			}


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Promethues sample timestamp is in milliseconds, and `time.Unit()` first param receive time in seconds.