### PR TITLE
docs: add apt and knot to EXTERNAL_PLUGINS.md

### DIFF
--- a/EXTERNAL_PLUGINS.md
+++ b/EXTERNAL_PLUGINS.md
@@ -26,6 +26,8 @@ Pull requests welcome.
 - [dht_sensor](https://github.com/iAnatoly/telegraf-input-dht_sensor) - Gather temperature and humidity from DHTXX sensors
 - [oracle](https://github.com/bonitoo-io/telegraf-input-oracle) - Gather the statistic data from Oracle RDBMS
 - [db2](https://github.com/bonitoo-io/telegraf-input-db2) - Gather the statistic data from DB2 RDBMS
+- [apt](https://github.com/x70b1/telegraf-apt) - Check Debian for package updates.
+- [knot](https://github.com/x70b1/telegraf-knot) - Collect stats from Knot DNS.
 
 ## Outputs
 


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

As suggested by @sspaink in https://github.com/influxdata/telegraf/issues/5785 I added two of my plugins to the list.

But this leads me to a question. At [docs/EXTERNAL_PLUGINS.md](https://github.com/influxdata/telegraf/blob/master/docs/EXTERNAL_PLUGINS.md) is a description what an external plugin should be. An important thing seems to be that it uses `execd`. This would mean that scripts in `bash`, `python`, `..` which depend on `exec` and a predefined interval are out of scope and not called as an `external plugin`. It seems like [EXTERNAL_PLUGINS.md](https://github.com/influxdata/telegraf/blob/master/EXTERNAL_PLUGINS.md) was created to link plugins that are working with `execd` and are mostly binary files. Even if there are some other scripts the definition ​feels a bit wrong there. 

The question is how to handle this. For me it would absolutely no problem to be mentioned between the others. 
But maybe it makes sense to explain the terms better or introduce a sub section. I could open a new PR for this.

Another thing related to this: All in all I can recommend the maintenance of a link list very much. With [polybar-scripts](https://github.com/polybar/polybar-scripts#see-also-these-other-user-repositories) I have written many plugins for polybar. At the bttom you will find also a list with links to other repositories. A link list makes it easier for the community to contribute their own ideas and improves the whole environment.