### PR TITLE
feat: Add autorestart and restartdelay flags to Windows service

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -97,6 +97,14 @@ var fServiceDisplayName = flag.String("service-display-name", "Telegraf Data Col
 	"service display name (windows only)")
 
 //nolint:varcheck,unused // False positive - this var is used for non-default build tag: windows
+var fServiceAutoRestart = flag.Bool("service-auto-restart", false,
+	"auto restart service on failure (windows only)")
+
+//nolint:varcheck,unused // False positive - this var is used for non-default build tag: windows
+var fServiceRestartDelay = flag.String("service-restart-delay", "5m",
+	"delay before service auto restart, default is 5m (windows only)")
+
+//nolint:varcheck,unused // False positive - this var is used for non-default build tag: windows
 var fRunAsConsole = flag.Bool("console", false,
 	"run as console application (windows only)")
 var fPlugins = flag.String("plugin-directory", "",

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -94,6 +94,10 @@ func runAsWindowsService(inputFilters, outputFilters []string) {
 		//set servicename to service cmd line, to have a custom name after relaunch as a service
 		svcConfig.Arguments = append(svcConfig.Arguments, "--service-name", *fServiceName)
 
+		if *fServiceAutoRestart {
+			svcConfig.Option = service.KeyValue{"OnFailure": "restart", "OnFailureDelayDuration": *fServiceRestartDelay}
+		}
+
 		err := service.Control(s, *fService)
 		if err != nil {
 			log.Fatal("E! " + err.Error())

--- a/docs/WINDOWS_SERVICE.md
+++ b/docs/WINDOWS_SERVICE.md
@@ -61,6 +61,10 @@ on a single system, you can install the service with the `--service-name` and
 > C:\"Program Files"\Telegraf\telegraf.exe --service install --service-name telegraf-2 --service-display-name "Telegraf 2"
 ```
 
+## Auto restart and restart delay
+
+By default the service will not automatically restart on failure. Providing the `--service-auto-restart` flag during installation will always restart the service with a default delay of 5 minutes. To modify this to for example 3 minutes, provide the additional flag `--service-restart-delay 3m`. The delay can be any valid `time.Duration` string.
+
 ## Troubleshooting
 
 When Telegraf runs as a Windows service, Telegraf logs messages to Windows events log before configuration file with logging settings is loaded.

--- a/internal/usage_windows.go
+++ b/internal/usage_windows.go
@@ -44,6 +44,8 @@ The commands & flags are:
   --service <service>            operate on the service (windows only)
   --service-name                 service name (windows only)
   --service-display-name         service display name (windows only)
+  --service-auto-restart         auto restart service on failure (windows only)
+  --service-restart-delay        delay before service auto restart, default is 5m (windows only)
 
 Examples:
 
@@ -73,4 +75,7 @@ Examples:
 
   # install telegraf service with custom name
   telegraf --service install --service-name=my-telegraf --service-display-name="My Telegraf"
-`
+
+  # install telegraf service with auto restart and restart delay of 3 minutes
+  telegraf --service install --service-auto-retart --service-restart-delay 3m
+  `

--- a/internal/usage_windows.go
+++ b/internal/usage_windows.go
@@ -77,5 +77,5 @@ Examples:
   telegraf --service install --service-name=my-telegraf --service-display-name="My Telegraf"
 
   # install telegraf service with auto restart and restart delay of 3 minutes
-  telegraf --service install --service-auto-retart --service-restart-delay 3m
+  telegraf --service install --service-auto-restart --service-restart-delay 3m
   `


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10522

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

The Windows service library used contains a list of known key value options: https://github.com/kardianos/service/blob/5c08916379a92cb1806764e911af33c55762a753/service.go#L190. I added the `--service-auto-restart` and `--service-restart-delay` flags to make the following options available:
```
//    - OnFailure               string ("restart" )   - Action to perform on service failure. (restart | reboot | noaction)
//    - OnFailureDelayDuration  string ( "1s" )       - Delay before restarting the service, time.Duration string.
```

