### PR TITLE
fix: remove dotfile artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,9 @@ jobs:
     steps:
       - attach_workspace:
           at: '.'
+      - run:
+          command: |
+            cd dist && find . -type f -name '._*' -delete
       - store_artifacts:
           path: './dist'
           destination: 'build/dist'


### PR DESCRIPTION
When the macOS environment is attached to the package-consolidate
CircleCI job, there are two new files. These dot-underscore files are
hidden files for macOS that store metadata about files. These files are
not required and are not useful for our release process. In fact, they cause
issues when they show up.

This will remove any of these dot-underscore files before artifacts are
uploaded to CircleCI.
