### PR TITLE
fix: use os-agnositc systemd detection, remove sysv in RPM packaging

### DIFF
--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -5,25 +5,6 @@ LOG_DIR=/var/log/telegraf
 SCRIPT_DIR=/usr/lib/telegraf/scripts
 LOGROTATE_DIR=/etc/logrotate.d
 
-function install_init {
-    cp -f $SCRIPT_DIR/init.sh /etc/init.d/telegraf
-    chmod +x /etc/init.d/telegraf
-}
-
-function install_systemd {
-    cp -f $SCRIPT_DIR/telegraf.service $1
-    systemctl enable telegraf || true
-    systemctl daemon-reload || true
-}
-
-function install_update_rcd {
-    update-rc.d telegraf defaults
-}
-
-function install_chkconfig {
-    chkconfig --add telegraf
-}
-
 # Remove legacy symlink, if it exists
 if [[ -L /etc/init.d/telegraf ]]; then
     rm -f /etc/init.d/telegraf
@@ -48,41 +29,14 @@ if [[ ! -f /etc/telegraf/telegraf.conf ]] && [[ -f /etc/telegraf/telegraf.conf.s
    cp /etc/telegraf/telegraf.conf.sample /etc/telegraf/telegraf.conf
 fi
 
+# Set up log directories
 test -d $LOG_DIR || mkdir -p $LOG_DIR
 chown -R -L telegraf:telegraf $LOG_DIR
 chmod 755 $LOG_DIR
 
-# Distribution-specific logic
-if [[ -f /etc/redhat-release ]] || [[ -f /etc/SuSE-release ]]; then
-    # RHEL-variant logic
-    if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
-        install_systemd /usr/lib/systemd/system/telegraf.service
-    else
-        # Assuming SysVinit
-        install_init
-        # Run update-rc.d or fallback to chkconfig if not available
-        if which update-rc.d &>/dev/null; then
-            install_update_rcd
-        else
-            install_chkconfig
-        fi
-    fi
-elif [[ -f /etc/os-release ]]; then
-    source /etc/os-release
-    if [[ "$NAME" = "Amazon Linux" ]]; then
-        # Amazon Linux 2+ logic
-        install_systemd /usr/lib/systemd/system/telegraf.service
-    elif [[ "$NAME" = "Amazon Linux AMI" ]]; then
-        # Amazon Linux logic
-        install_init
-        # Run update-rc.d or fallback to chkconfig if not available
-        if which update-rc.d &>/dev/null; then
-            install_update_rcd
-        else
-            install_chkconfig
-        fi
-    elif [[ "$NAME" = "Solus" ]]; then
-        # Solus logic
-        install_systemd /usr/lib/systemd/system/telegraf.service
-    fi
+# Set up systemd service
+if [[ -d /run/systemd/system ]]; then
+    cp -f $SCRIPT_DIR/telegraf.service /usr/lib/systemd/system/telegraf.service
+    systemctl enable telegraf || true
+    systemctl daemon-reload || true
 fi

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -30,9 +30,10 @@ test -d $LOG_DIR || mkdir -p $LOG_DIR
 chown -R -L telegraf:telegraf $LOG_DIR
 chmod 755 $LOG_DIR
 
-# Set up systemd service
+# Set up systemd service - check if the systemd directory exists per:
+# https://www.freedesktop.org/software/systemd/man/sd_booted.html
 if [[ -d /run/systemd/system ]]; then
     cp -f /usr/lib/telegraf/scripts/telegraf.service /usr/lib/systemd/system/telegraf.service
-    systemctl enable telegraf || true
-    systemctl daemon-reload || true
+    systemctl enable telegraf
+    systemctl daemon-reload
 fi

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-BIN_DIR=/usr/bin
-LOG_DIR=/var/log/telegraf
-SCRIPT_DIR=/usr/lib/telegraf/scripts
-LOGROTATE_DIR=/etc/logrotate.d
-
 # Remove legacy symlink, if it exists
 if [[ -L /etc/init.d/telegraf ]]; then
     rm -f /etc/init.d/telegraf
@@ -30,13 +25,14 @@ if [[ ! -f /etc/telegraf/telegraf.conf ]] && [[ -f /etc/telegraf/telegraf.conf.s
 fi
 
 # Set up log directories
+LOG_DIR=/var/log/telegraf
 test -d $LOG_DIR || mkdir -p $LOG_DIR
 chown -R -L telegraf:telegraf $LOG_DIR
 chmod 755 $LOG_DIR
 
 # Set up systemd service
 if [[ -d /run/systemd/system ]]; then
-    cp -f $SCRIPT_DIR/telegraf.service /usr/lib/systemd/system/telegraf.service
+    cp -f /usr/lib/telegraf/scripts/telegraf.service /usr/lib/systemd/system/telegraf.service
     systemctl enable telegraf || true
     systemctl daemon-reload || true
 fi

--- a/scripts/rpm/post-remove.sh
+++ b/scripts/rpm/post-remove.sh
@@ -7,6 +7,7 @@ if [[ "$1" = "0" ]]; then
     if [[ -d /run/systemd/system ]]; then
         systemctl disable telegraf
         rm -f /usr/lib/systemd/system/telegraf.service
+        systemctl daemon-reload
     fi
 fi
 

--- a/scripts/rpm/post-remove.sh
+++ b/scripts/rpm/post-remove.sh
@@ -1,55 +1,18 @@
 #!/bin/bash
 
-function disable_systemd {
-    systemctl disable telegraf
-    rm -f $1
-}
+# Telegraf is no longer installed, remove from systemd
+if [[ "$1" = "0" ]]; then
+    rm -f /etc/default/telegraf
 
-function disable_update_rcd {
-    update-rc.d -f telegraf remove
-    rm -f /etc/init.d/telegraf
-}
-
-function disable_chkconfig {
-    chkconfig --del telegraf
-    rm -f /etc/init.d/telegraf
-}
-
-if [[ -f /etc/redhat-release ]] || [[ -f /etc/SuSE-release ]]; then
-    # RHEL-variant logic
-    if [[ "$1" = "0" ]]; then
-        # InfluxDB is no longer installed, remove from init system
-        rm -f /etc/default/telegraf
-
-        if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
-            disable_systemd /usr/lib/systemd/system/telegraf.service
-        else
-            # Assuming sysv
-            disable_chkconfig
-        fi
+    if [[ -d /run/systemd/system ]]; then
+        systemctl disable telegraf
+        rm -f /usr/lib/systemd/system/telegraf.service
     fi
-    if [[ $1 -ge 1 ]]; then
-        # Package upgrade, not uninstall
+fi
 
-        if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
-            systemctl try-restart telegraf.service >/dev/null 2>&1 || :
-        fi
-    fi
-elif [[ -f /etc/os-release ]]; then
-    source /etc/os-release
-    if [[ "$ID" = "amzn" ]] && [[ "$1" = "0" ]]; then
-        # InfluxDB is no longer installed, remove from init system
-        rm -f /etc/default/telegraf
-
-        if [[ "$NAME" = "Amazon Linux" ]]; then
-            # Amazon Linux 2+ logic
-            disable_systemd /usr/lib/systemd/system/telegraf.service
-        elif [[ "$NAME" = "Amazon Linux AMI" ]]; then
-            # Amazon Linux logic
-            disable_chkconfig
-        fi
-    elif [[ "$NAME" = "Solus" ]]; then
-        rm -f /etc/default/telegraf
-        disable_systemd /usr/lib/systemd/system/telegraf.service
+# Telegraf upgrade, restart service
+if [[ $1 -ge 1 ]]; then
+    if [[ -d /run/systemd/system ]]; then
+        systemctl try-restart telegraf.service >/dev/null 2>&1 || :
     fi
 fi


### PR DESCRIPTION
Instead of having an ever growing list of distros and releases, this
collapses the logic to switch based on whether systemd is detected or
not.
    
This also removes the sysv logic as all supported Fedora and RHEL
distros are only systemd at this point. This does leave the check for
systemd in place to ensure installs in containers work without errors.

Fixes: #4507
