### PR TITLE
refactor: use early return pattern

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -78,14 +78,15 @@ func (t *telegrafLog) Write(b []byte) (n int, err error) {
 func (t *telegrafLog) Close() error {
 	stdErrWriter := os.Stderr
 	// avoid closing stderr
-	if t.internalWriter != stdErrWriter {
-		closer, isCloser := t.internalWriter.(io.Closer)
-		if !isCloser {
-			return errors.New("the underlying writer cannot be closed")
-		}
-		return closer.Close()
+	if t.internalWriter == stdErrWriter {
+		return nil
 	}
-	return nil
+
+	closer, isCloser := t.internalWriter.(io.Closer)
+	if !isCloser {
+		return errors.New("the underlying writer cannot be closed")
+	}
+	return closer.Close()
 }
 
 // newTelegrafWriter returns a logging-wrapped writer.


### PR DESCRIPTION
Leverages the early return pattern to simplify the code a bit

- [x] Pull request title or commits are in [conventional commit format]