### PR TITLE
Add OCSP verification to X.509 Certificate Input Plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,6 +140,7 @@ require (
 	go.opentelemetry.io/otel/metric v0.24.0
 	go.opentelemetry.io/otel/sdk/metric v0.24.0
 	go.starlark.net v0.0.0-20210406145628-7a1108eaa012
+	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
 	golang.org/x/net v0.0.0-20211208012354-db4efeb81f4b
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -333,7 +334,6 @@ require (
 	go.opentelemetry.io/proto/otlp v0.9.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
 	golang.org/x/exp v0.0.0-20200513190911-00229845015e // indirect
 	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect

--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -1,6 +1,6 @@
-# x509 Certificate Input Plugin
+# X.509 Certificate Input Plugin
 
-This plugin provides information about X509 certificate accessible via local
+This plugin provides information about X.509 certificate accessible via local
 file or network connection.
 
 When using a UDP address as a certificate source, the server must support [DTLS](https://en.wikipedia.org/wiki/Datagram_Transport_Layer_Security).
@@ -24,6 +24,12 @@ When using a UDP address as a certificate source, the server must support [DTLS]
   ## options may be specified at one time.
   ##   example: server_name = "myhost.example.org"
   # server_name = "myhost.example.org"
+
+  ## Don't include root or intermediate certificates in output
+  # exclude_root_certs = false
+
+  ## Skip OCSP revocation check
+  # skip_ocsp_check = false
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/x509_cert/dev/telegraf.conf
+++ b/plugins/inputs/x509_cert/dev/telegraf.conf
@@ -1,4 +1,4 @@
 [[inputs.x509_cert]]
-  sources = ["https://expired.badssl.com:443", "https://wrong.host.badssl.com:443"]
+  sources = ["https://expired.badssl.com:443", "https://wrong.host.badssl.com:443", "https://revoked.badssl.com:443/"]
 
 [[outputs.file]]

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -343,6 +343,24 @@ func TestStrings(t *testing.T) {
 	}
 }
 
+func TestCheckOCSPRevocation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	m := &X509Cert{
+		Sources: []string{"https://revoked.badssl.com:443"},
+	}
+	require.NoError(t, m.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, m.Gather(&acc))
+	require.True(t, acc.HasMeasurement("x509_cert"))
+
+	status, found := acc.IntField("x509_cert", "verification_code")
+	require.True(t, found)
+	require.Equal(t, 2, status)
+}
+
 func TestGatherCertIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
First time contributing to the project -- please let me know if anything isn't up to standard.

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

The current X.509 implementation incorrectly reports certificates as valid when they have, in fact, been revoked. This means that web browsers or other software which performs OCSP checking will see validation errors despite the `inputs.x509_cert` plugin reporting such certificates as healthy. If merged, this PR would introduce enabled-by-default OCSP checking.

The background to this is that [LetsEncrypt recently had to revoke a bunch of mis-issued certificates](https://community.letsencrypt.org/t/2022-01-25-issue-with-tls-alpn-01-validation-method/170450). I discovered that in this situation telegraf can't identify that the certs have been revoked by the CA. The same would be true if an end-user revoked their cert, rather than the CA.

Signed-off-by: Charlie Jonas <charlie@charliejonas.co.uk>