### PR TITLE
feat: Bump github.com/aerospike/aerospike-client-go from 1.27.0 to 5.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/ClickHouse/clickhouse-go v1.5.1
 	github.com/Mellanox/rdmamap v0.0.0-20191106181932-7c3c4763a6ee
 	github.com/Shopify/sarama v1.29.1
-	github.com/aerospike/aerospike-client-go v1.27.0
+	github.com/aerospike/aerospike-client-go/v5 v5.7.0
 	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1004
 	github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9
@@ -320,7 +320,7 @@ require (
 	github.com/xdg-go/stringprep v1.0.2 // indirect
 	github.com/xdg/stringprep v1.0.3 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
-	github.com/yuin/gopher-lua v0.0.0-20200603152657-dc2b0ca8b37e // indirect
+	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.0 // indirect
 	go.opencensus.io v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
-github.com/aerospike/aerospike-client-go v1.27.0 h1:VC6/Wqqm3Qlp4/utM7Zts3cv4A2HPn8rVFp/XZKTWgE=
-github.com/aerospike/aerospike-client-go v1.27.0/go.mod h1:zj8LBEnWBDOVEIJt8LvaRvDG5ARAoa5dBeHaB472NRc=
+github.com/aerospike/aerospike-client-go/v5 v5.7.0 h1:Olgq011scnhKlGxo4AcGSXI8JRLF0aSEdl1PhjmKTUo=
+github.com/aerospike/aerospike-client-go/v5 v5.7.0/go.mod h1:rJ/KpmClE7kiBPfvAPrGw9WuNOiz8v2uKbQaUyYPXtI=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -926,6 +926,7 @@ github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=
 github.com/go-toolsmith/astcopy v1.0.0/go.mod h1:vrgyG+5Bxrnz4MZWPF+pI4R8h3qKRjjyvV/DSez4WVQ=
 github.com/go-toolsmith/astequal v1.0.0/go.mod h1:H+xSiq0+LtiDC11+h1G32h7Of5O3CYFJ99GVbS5lDKY=
@@ -1671,8 +1672,9 @@ github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt
 github.com/nishanths/predeclared v0.2.1/go.mod h1:HvkGJcA3naj4lOwnFXFDkFxVtSqQMB9sbB1usJ+xjQE=
 github.com/nsqio/go-nsq v1.1.0 h1:PQg+xxiUjA7V+TLdXw7nVrJ5Jbl3sN86EhGCQj4+FYE=
 github.com/nsqio/go-nsq v1.1.0/go.mod h1:vKq36oyeVXgsS5Q8YEO7WghqidAVXQlcFxzQbQTuDEY=
-github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
@@ -1695,8 +1697,9 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo v1.14.2 h1:8mVmC9kjFFmA8H4pKMUhcblgifdkOIXPvbhN1T36q1M=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
+github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1706,8 +1709,9 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
-github.com/onsi/gomega v1.10.4 h1:NiTx7EEvBzu9sFOD1zORteLSt3o8gnlvZZwSE9TnY9U=
 github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
+github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
+github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/openconfig/gnmi v0.0.0-20180912164834-33a1865c3029 h1:lXQqyLroROhwR2Yq/kXbLzVecgmVeZh2TFLg6OxCd+w=
 github.com/openconfig/gnmi v0.0.0-20180912164834-33a1865c3029/go.mod h1:t+O9It+LKzfOAhKTT5O0ehDix+MTqbtT0T9t+7zzOvc=
@@ -2190,8 +2194,9 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/gopher-lua v0.0.0-20200603152657-dc2b0ca8b37e h1:oIpIX9VKxSCFrfjsKpluGbNPBGq9iNnT9crH781j9wY=
 github.com/yuin/gopher-lua v0.0.0-20200603152657-dc2b0ca8b37e/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
+github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da h1:NimzV1aGyq29m5ukMK0AMWEhFaL/lrEOaephfuoiARg=
+github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
@@ -2459,6 +2464,7 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/net v0.0.0-20210427231257-85d9c07bbe3a/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
+golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -2620,6 +2626,7 @@ golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201218084310-7d0127a74742/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210123111255-9b0068b26619/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -2802,6 +2809,7 @@ golang.org/x/tools v0.0.0-20201118003311-bd56c0adb394/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201124115921-2c860bdd6e78/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201230224404-63754364767c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210102185154-773b96fafca2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/plugins/inputs/aerospike/README.md
+++ b/plugins/inputs/aerospike/README.md
@@ -27,6 +27,7 @@ All metrics are attempted to be cast to integers, then booleans, then strings.
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
+  # tls_name = "tlsname"
   ## If false, skip chain & host verification
   # insecure_skip_verify = true
 

--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -160,7 +160,7 @@ func (a *Aerospike) gatherServer(acc telegraf.Accumulator, hostPort string) erro
 
 	nodes := c.GetNodes()
 	for _, n := range nodes {
-		nodeHost := fmt.Sprintf("%s", n.GetHost())
+		nodeHost := n.GetHost().String()
 		stats, err := a.getNodeInfo(n, asInfoPolicy)
 		if err != nil {
 			return err

--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -23,6 +23,7 @@ type Aerospike struct {
 	Password string `toml:"password"`
 
 	EnableTLS bool   `toml:"enable_tls"`
+	EnableSSL bool   `toml:"enable_ssl"` // deprecated in 1.7; use enable_tls
 	TLSName   string `toml:"tls_name"`
 	tlsint.ClientConfig
 
@@ -105,7 +106,7 @@ func (a *Aerospike) Gather(acc telegraf.Accumulator) error {
 		if err != nil {
 			return err
 		}
-		if tlsConfig == nil && a.EnableTLS {
+		if tlsConfig == nil && (a.EnableTLS || a.EnableSSL) {
 			tlsConfig = &tls.Config{}
 		}
 		a.tlsConfig = tlsConfig
@@ -146,7 +147,7 @@ func (a *Aerospike) gatherServer(acc telegraf.Accumulator, hostPort string) erro
 	if err != nil {
 		return err
 	}
-	if a.TLSName != "" && a.EnableTLS {
+	if a.TLSName != "" && (a.EnableTLS || a.EnableSSL) {
 		for _, asHost := range asHosts {
 			asHost.TLSName = a.TLSName
 		}

--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -22,8 +22,8 @@ type Aerospike struct {
 	Username string `toml:"username"`
 	Password string `toml:"password"`
 
-	EnableTLS bool `toml:"enable_tls"`
-	TLSName string `toml:"tls_name"`
+	EnableTLS bool   `toml:"enable_tls"`
+	TLSName   string `toml:"tls_name"`
 	tlsint.ClientConfig
 
 	initialized bool
@@ -160,7 +160,7 @@ func (a *Aerospike) gatherServer(acc telegraf.Accumulator, hostPort string) erro
 
 	nodes := c.GetNodes()
 	for _, n := range nodes {
-		nodeHost := fmt.Sprintf("%s",n.GetHost())
+		nodeHost := fmt.Sprintf("%s", n.GetHost())
 		stats, err := a.getNodeInfo(n, asInfoPolicy)
 		if err != nil {
 			return err
@@ -466,8 +466,8 @@ func parseAerospikeValue(key string, v string) interface{} {
 	} else if parsed, err := strconv.ParseBool(v); err == nil {
 		return parsed
 	} else if parsed, err := strconv.ParseFloat(v, 32); err == nil {
-                return parsed
-        } else {
+		return parsed
+	} else {
 		// leave as string
 		return v
 	}

--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -4,13 +4,12 @@ import (
 	"crypto/tls"
 	"fmt"
 	"math"
-	"net"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	as "github.com/aerospike/aerospike-client-go"
+	as "github.com/aerospike/aerospike-client-go/v5"
 
 	"github.com/influxdata/telegraf"
 	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
@@ -24,7 +23,7 @@ type Aerospike struct {
 	Password string `toml:"password"`
 
 	EnableTLS bool `toml:"enable_tls"`
-	EnableSSL bool `toml:"enable_ssl"` // deprecated in 1.7; use enable_tls
+	TLSName string `toml:"tls_name"`
 	tlsint.ClientConfig
 
 	initialized bool
@@ -56,6 +55,7 @@ var sampleConfig = `
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
+  # tls_name = "tlsname"
   ## If false, skip chain & host verification
   # insecure_skip_verify = true
 
@@ -78,7 +78,7 @@ var sampleConfig = `
   # by default, aerospike produces a 100 bucket histogram
   # this is not great for most graphing tools, this will allow
   # the ability to squash this to a smaller number of buckets
-  # To have a balanced histogram, the number of buckets chosen 
+  # To have a balanced histogram, the number of buckets chosen
   # should divide evenly into 100.
   # num_histogram_buckets = 100 # default: 10
 `
@@ -105,7 +105,7 @@ func (a *Aerospike) Gather(acc telegraf.Accumulator) error {
 		if err != nil {
 			return err
 		}
-		if tlsConfig == nil && (a.EnableTLS || a.EnableSSL) {
+		if tlsConfig == nil && a.EnableTLS {
 			tlsConfig = &tls.Config{}
 		}
 		a.tlsConfig = tlsConfig
@@ -138,35 +138,36 @@ func (a *Aerospike) Gather(acc telegraf.Accumulator) error {
 }
 
 func (a *Aerospike) gatherServer(acc telegraf.Accumulator, hostPort string) error {
-	host, port, err := net.SplitHostPort(hostPort)
-	if err != nil {
-		return err
-	}
-
-	iport, err := strconv.Atoi(port)
-	if err != nil {
-		iport = 3000
-	}
-
 	policy := as.NewClientPolicy()
 	policy.User = a.Username
 	policy.Password = a.Password
 	policy.TlsConfig = a.tlsConfig
-	c, err := as.NewClientWithPolicy(policy, host, iport)
+	asHosts, err := as.NewHosts(hostPort)
 	if err != nil {
 		return err
 	}
+	if a.TLSName != "" && a.EnableTLS {
+		for _, asHost := range asHosts {
+			asHost.TLSName = a.TLSName
+		}
+	}
+	c, err := as.NewClientWithPolicyAndHost(policy, asHosts...)
+	if err != nil {
+		return err
+	}
+	asInfoPolicy := as.NewInfoPolicy()
 	defer c.Close()
 
 	nodes := c.GetNodes()
 	for _, n := range nodes {
-		stats, err := a.getNodeInfo(n)
+		nodeHost := fmt.Sprintf("%s",n.GetHost())
+		stats, err := a.getNodeInfo(n, asInfoPolicy)
 		if err != nil {
 			return err
 		}
-		a.parseNodeInfo(acc, stats, hostPort, n.GetName())
+		a.parseNodeInfo(acc, stats, nodeHost, n.GetName())
 
-		namespaces, err := a.getNamespaces(n)
+		namespaces, err := a.getNamespaces(n, asInfoPolicy)
 		if err != nil {
 			return err
 		}
@@ -174,21 +175,21 @@ func (a *Aerospike) gatherServer(acc telegraf.Accumulator, hostPort string) erro
 		if !a.DisableQueryNamespaces {
 			// Query Namespaces
 			for _, namespace := range namespaces {
-				stats, err = a.getNamespaceInfo(namespace, n)
+				stats, err = a.getNamespaceInfo(namespace, n, asInfoPolicy)
 
 				if err != nil {
 					continue
 				}
-				a.parseNamespaceInfo(acc, stats, hostPort, namespace, n.GetName())
+				a.parseNamespaceInfo(acc, stats, nodeHost, namespace, n.GetName())
 
 				if a.EnableTTLHistogram {
-					err = a.getTTLHistogram(acc, hostPort, namespace, "", n)
+					err = a.getTTLHistogram(acc, nodeHost, namespace, "", n, asInfoPolicy)
 					if err != nil {
 						continue
 					}
 				}
 				if a.EnableObjectSizeLinearHistogram {
-					err = a.getObjectSizeLinearHistogram(acc, hostPort, namespace, "", n)
+					err = a.getObjectSizeLinearHistogram(acc, nodeHost, namespace, "", n, asInfoPolicy)
 					if err != nil {
 						continue
 					}
@@ -197,26 +198,26 @@ func (a *Aerospike) gatherServer(acc telegraf.Accumulator, hostPort string) erro
 		}
 
 		if a.QuerySets {
-			namespaceSets, err := a.getSets(n)
+			namespaceSets, err := a.getSets(n, asInfoPolicy)
 			if err == nil {
 				for _, namespaceSet := range namespaceSets {
 					namespace, set := splitNamespaceSet(namespaceSet)
-					stats, err := a.getSetInfo(namespaceSet, n)
+					stats, err := a.getSetInfo(namespaceSet, n, asInfoPolicy)
 
 					if err != nil {
 						continue
 					}
-					a.parseSetInfo(acc, stats, hostPort, namespaceSet, n.GetName())
+					a.parseSetInfo(acc, stats, nodeHost, namespaceSet, n.GetName())
 
 					if a.EnableTTLHistogram {
-						err = a.getTTLHistogram(acc, hostPort, namespace, set, n)
+						err = a.getTTLHistogram(acc, nodeHost, namespace, set, n, asInfoPolicy)
 						if err != nil {
 							continue
 						}
 					}
 
 					if a.EnableObjectSizeLinearHistogram {
-						err = a.getObjectSizeLinearHistogram(acc, hostPort, namespace, set, n)
+						err = a.getObjectSizeLinearHistogram(acc, nodeHost, namespace, set, n, asInfoPolicy)
 						if err != nil {
 							continue
 						}
@@ -228,8 +229,8 @@ func (a *Aerospike) gatherServer(acc telegraf.Accumulator, hostPort string) erro
 	return nil
 }
 
-func (a *Aerospike) getNodeInfo(n *as.Node) (map[string]string, error) {
-	stats, err := as.RequestNodeStats(n)
+func (a *Aerospike) getNodeInfo(n *as.Node, infoPolicy *as.InfoPolicy) (map[string]string, error) {
+	stats, err := n.RequestInfo(infoPolicy)
 	if err != nil {
 		return nil, err
 	}
@@ -251,10 +252,10 @@ func (a *Aerospike) parseNodeInfo(acc telegraf.Accumulator, stats map[string]str
 	acc.AddFields("aerospike_node", fields, tags, time.Now())
 }
 
-func (a *Aerospike) getNamespaces(n *as.Node) ([]string, error) {
+func (a *Aerospike) getNamespaces(n *as.Node, infoPolicy *as.InfoPolicy) ([]string, error) {
 	var namespaces []string
 	if len(a.Namespaces) <= 0 {
-		info, err := as.RequestNodeInfo(n, "namespaces")
+		info, err := n.RequestInfo(infoPolicy, "namespaces")
 		if err != nil {
 			return namespaces, err
 		}
@@ -266,8 +267,8 @@ func (a *Aerospike) getNamespaces(n *as.Node) ([]string, error) {
 	return namespaces, nil
 }
 
-func (a *Aerospike) getNamespaceInfo(namespace string, n *as.Node) (map[string]string, error) {
-	stats, err := as.RequestNodeInfo(n, "namespace/"+namespace)
+func (a *Aerospike) getNamespaceInfo(namespace string, n *as.Node, infoPolicy *as.InfoPolicy) (map[string]string, error) {
+	stats, err := n.RequestInfo(infoPolicy, "namespace/"+namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -294,15 +295,14 @@ func (a *Aerospike) parseNamespaceInfo(acc telegraf.Accumulator, stats map[strin
 	acc.AddFields("aerospike_namespace", nFields, nTags, time.Now())
 }
 
-func (a *Aerospike) getSets(n *as.Node) ([]string, error) {
+func (a *Aerospike) getSets(n *as.Node, infoPolicy *as.InfoPolicy) ([]string, error) {
 	var namespaceSets []string
 	// Gather all sets
 	if len(a.Sets) <= 0 {
-		stats, err := as.RequestNodeInfo(n, "sets")
+		stats, err := n.RequestInfo(infoPolicy, "sets")
 		if err != nil {
 			return namespaceSets, err
 		}
-
 		stat := strings.Split(stats["sets"], ";")
 		for _, setStats := range stat {
 			// setInfo is "ns=test:set=foo:objects=1:tombstones=0"
@@ -332,8 +332,8 @@ func (a *Aerospike) getSets(n *as.Node) ([]string, error) {
 	return namespaceSets, nil
 }
 
-func (a *Aerospike) getSetInfo(namespaceSet string, n *as.Node) (map[string]string, error) {
-	stats, err := as.RequestNodeInfo(n, "sets/"+namespaceSet)
+func (a *Aerospike) getSetInfo(namespaceSet string, n *as.Node, infoPolicy *as.InfoPolicy) (map[string]string, error) {
+	stats, err := n.RequestInfo(infoPolicy, "sets/"+namespaceSet)
 	if err != nil {
 		return nil, err
 	}
@@ -362,8 +362,8 @@ func (a *Aerospike) parseSetInfo(acc telegraf.Accumulator, stats map[string]stri
 	acc.AddFields("aerospike_set", nFields, nTags, time.Now())
 }
 
-func (a *Aerospike) getTTLHistogram(acc telegraf.Accumulator, hostPort string, namespace string, set string, n *as.Node) error {
-	stats, err := a.getHistogram(namespace, set, "ttl", n)
+func (a *Aerospike) getTTLHistogram(acc telegraf.Accumulator, hostPort string, namespace string, set string, n *as.Node, infoPolicy *as.InfoPolicy) error {
+	stats, err := a.getHistogram(namespace, set, "ttl", n, infoPolicy)
 	if err != nil {
 		return err
 	}
@@ -374,8 +374,8 @@ func (a *Aerospike) getTTLHistogram(acc telegraf.Accumulator, hostPort string, n
 	return nil
 }
 
-func (a *Aerospike) getObjectSizeLinearHistogram(acc telegraf.Accumulator, hostPort string, namespace string, set string, n *as.Node) error {
-	stats, err := a.getHistogram(namespace, set, "object-size-linear", n)
+func (a *Aerospike) getObjectSizeLinearHistogram(acc telegraf.Accumulator, hostPort string, namespace string, set string, n *as.Node, infoPolicy *as.InfoPolicy) error {
+	stats, err := a.getHistogram(namespace, set, "object-size-linear", n, infoPolicy)
 	if err != nil {
 		return err
 	}
@@ -386,7 +386,7 @@ func (a *Aerospike) getObjectSizeLinearHistogram(acc telegraf.Accumulator, hostP
 	return nil
 }
 
-func (a *Aerospike) getHistogram(namespace string, set string, histogramType string, n *as.Node) (map[string]string, error) {
+func (a *Aerospike) getHistogram(namespace string, set string, histogramType string, n *as.Node, infoPolicy *as.InfoPolicy) (map[string]string, error) {
 	var queryArg string
 	if len(set) > 0 {
 		queryArg = fmt.Sprintf("histogram:type=%s;namespace=%v;set=%v", histogramType, namespace, set)
@@ -394,7 +394,7 @@ func (a *Aerospike) getHistogram(namespace string, set string, histogramType str
 		queryArg = fmt.Sprintf("histogram:type=%s;namespace=%v", histogramType, namespace)
 	}
 
-	stats, err := as.RequestNodeInfo(n, queryArg)
+	stats, err := n.RequestInfo(infoPolicy, queryArg)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +465,9 @@ func parseAerospikeValue(key string, v string) interface{} {
 		return parsed
 	} else if parsed, err := strconv.ParseBool(v); err == nil {
 		return parsed
-	} else {
+	} else if parsed, err := strconv.ParseFloat(v, 32); err == nil {
+                return parsed
+        } else {
 		// leave as string
 		return v
 	}

--- a/plugins/inputs/aerospike/aerospike_test.go
+++ b/plugins/inputs/aerospike/aerospike_test.go
@@ -156,8 +156,8 @@ func TestQuerySetsIntegration(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err = acc.GatherError(a.Gather)
-	require.NoError(t, err)
+	errAs := acc.GatherError(a.Gather)
+	require.NoError(t, errAs)
 
 	require.True(t, FindTagValue(&acc, "aerospike_set", "set", "test/foo"))
 	require.True(t, FindTagValue(&acc, "aerospike_set", "set", "test/bar"))
@@ -206,8 +206,8 @@ func TestSelectQuerySetsIntegration(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err = acc.GatherError(a.Gather)
-	require.NoError(t, err)
+	errAs := acc.GatherError(a.Gather)
+	require.NoError(t, errAs)
 
 	require.True(t, FindTagValue(&acc, "aerospike_set", "set", "test/foo"))
 	require.False(t, FindTagValue(&acc, "aerospike_set", "set", "test/bar"))

--- a/plugins/inputs/aerospike/aerospike_test.go
+++ b/plugins/inputs/aerospike/aerospike_test.go
@@ -3,7 +3,7 @@ package aerospike
 import (
 	"testing"
 
-	as "github.com/aerospike/aerospike-client-go"
+	as "github.com/aerospike/aerospike-client-go/v5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"

--- a/plugins/inputs/aerospike/aerospike_test.go
+++ b/plugins/inputs/aerospike/aerospike_test.go
@@ -126,26 +126,26 @@ func TestQuerySetsIntegration(t *testing.T) {
 	// create a set
 	// test is the default namespace from aerospike
 	policy := as.NewClientPolicy()
-	client, err := as.NewClientWithPolicy(policy, testutil.GetLocalHost(), 3000)
-	require.NoError(t, err)
+	client, errAs := as.NewClientWithPolicy(policy, testutil.GetLocalHost(), 3000)
+	require.NoError(t, errAs)
 
-	key, err := as.NewKey("test", "foo", 123)
-	require.NoError(t, err)
+	key, errAs := as.NewKey("test", "foo", 123)
+	require.NoError(t, errAs)
 	bins := as.BinMap{
 		"e":  2,
 		"pi": 3,
 	}
-	err = client.Add(nil, key, bins)
-	require.NoError(t, err)
+	errAs = client.Add(nil, key, bins)
+	require.NoError(t, errAs)
 
-	key, err = as.NewKey("test", "bar", 1234)
-	require.NoError(t, err)
+	key, errAs = as.NewKey("test", "bar", 1234)
+	require.NoError(t, errAs)
 	bins = as.BinMap{
 		"e":  2,
 		"pi": 3,
 	}
-	err = client.Add(nil, key, bins)
-	require.NoError(t, err)
+	errAs = client.Add(nil, key, bins)
+	require.NoError(t, errAs)
 
 	a := &Aerospike{
 		Servers: []string{
@@ -156,8 +156,8 @@ func TestQuerySetsIntegration(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	errAs := acc.GatherError(a.Gather)
-	require.NoError(t, errAs)
+	err := acc.GatherError(a.Gather)
+	require.NoError(t, err)
 
 	require.True(t, FindTagValue(&acc, "aerospike_set", "set", "test/foo"))
 	require.True(t, FindTagValue(&acc, "aerospike_set", "set", "test/bar"))
@@ -175,26 +175,26 @@ func TestSelectQuerySetsIntegration(t *testing.T) {
 	// create a set
 	// test is the default namespace from aerospike
 	policy := as.NewClientPolicy()
-	client, err := as.NewClientWithPolicy(policy, testutil.GetLocalHost(), 3000)
-	require.NoError(t, err)
+	client, errAs := as.NewClientWithPolicy(policy, testutil.GetLocalHost(), 3000)
+	require.NoError(t, errAs)
 
-	key, err := as.NewKey("test", "foo", 123)
-	require.NoError(t, err)
+	key, errAs := as.NewKey("test", "foo", 123)
+	require.NoError(t, errAs)
 	bins := as.BinMap{
 		"e":  2,
 		"pi": 3,
 	}
-	err = client.Add(nil, key, bins)
-	require.NoError(t, err)
+	errAs = client.Add(nil, key, bins)
+	require.NoError(t, errAs)
 
-	key, err = as.NewKey("test", "bar", 1234)
-	require.NoError(t, err)
+	key, errAs = as.NewKey("test", "bar", 1234)
+	require.NoError(t, errAs)
 	bins = as.BinMap{
 		"e":  2,
 		"pi": 3,
 	}
-	err = client.Add(nil, key, bins)
-	require.NoError(t, err)
+	errAs = client.Add(nil, key, bins)
+	require.NoError(t, errAs)
 
 	a := &Aerospike{
 		Servers: []string{
@@ -206,8 +206,8 @@ func TestSelectQuerySetsIntegration(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	errAs := acc.GatherError(a.Gather)
-	require.NoError(t, errAs)
+	err := acc.GatherError(a.Gather)
+	require.NoError(t, err)
 
 	require.True(t, FindTagValue(&acc, "aerospike_set", "set", "test/foo"))
 	require.False(t, FindTagValue(&acc, "aerospike_set", "set", "test/bar"))


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format]

resolves #10315 

The changes are listed below:

- Upgrading aerospike go client to 5.7.0.
- Removing SSL support from the aerospike telegraf plugin. `enable_ssl` option would no longer be available.
- Added an option in the aerospike input plugin config as `tls_name`, which should be set to the value of [`tls-name`](https://docs.aerospike.com/reference/configuration#tls-name) under `tls{}` stanza in the aerospike.conf if present.
- Fixed the value of `node_name` tag to return [Node.GetName()](https://pkg.go.dev/github.com/aerospike/aerospike-client-go/v5#Node.GetName) which now correctly returns node name, instead of the host:port which was incorrect.