### PR TITLE
feat: In Lustre input plugin, support collecting per-client stats.

### DIFF
--- a/plugins/inputs/lustre2/README.md
+++ b/plugins/inputs/lustre2/README.md
@@ -17,10 +17,12 @@ This plugin monitors the Lustre file system using its entries in the proc filesy
   #   "/proc/fs/lustre/obdfilter/*/stats",
   #   "/proc/fs/lustre/osd-ldiskfs/*/stats",
   #   "/proc/fs/lustre/obdfilter/*/job_stats",
+  #   "/proc/fs/lustre/obdfilter/*/exports/*/stats",
   # ]
   # mds_procfiles = [
   #   "/proc/fs/lustre/mdt/*/md_stats",
   #   "/proc/fs/lustre/mdt/*/job_stats",
+  #   "/proc/fs/lustre/mdt/*/exports/*/stats",
   # ]
 ```
 
@@ -39,6 +41,18 @@ From `/proc/fs/lustre/obdfilter/*/stats` and `/proc/fs/lustre/osd-ldiskfs/*/stat
     - cache_hit
     - cache_miss
     - cache_access
+
+From `/proc/fs/lustre/obdfilter/*/exports/*/stats`:
+
+- lustre2
+  - tags:
+    - name
+    - client
+  - fields:
+    - write_bytes
+    - write_calls
+    - read_bytes
+    - read_calls
 
 From `/proc/fs/lustre/obdfilter/*/job_stats`:
 
@@ -71,6 +85,30 @@ From `/proc/fs/lustre/mdt/*/md_stats`:
 - lustre2
   - tags:
     - name
+  - fields:
+    - open
+    - close
+    - mknod
+    - link
+    - unlink
+    - mkdir
+    - rmdir
+    - rename
+    - getattr
+    - setattr
+    - getxattr
+    - setxattr
+    - statfs
+    - sync
+    - samedir_rename
+    - crossdir_rename
+
+From `/proc/fs/lustre/mdt/*/exports/*/stats`:
+
+- lustre2
+  - tags:
+    - name
+    - client
   - fields:
     - open
     - close

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -204,6 +204,69 @@ func TestLustre2GeneratesMetrics(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestLustre2GeneratesClientMetrics(t *testing.T) {
+	tempdir := os.TempDir() + "/telegraf/proc/fs/lustre/"
+	ostName := "OST0001"
+	clientName := "10.2.4.27@o2ib1"
+	mdtdir := tempdir + "/mdt/"
+	err := os.MkdirAll(mdtdir+"/"+ostName+"/exports/"+clientName, 0755)
+	require.NoError(t, err)
+
+	obddir := tempdir + "/obdfilter/"
+	err = os.MkdirAll(obddir+"/"+ostName+"/exports/"+clientName, 0755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(mdtdir+"/"+ostName+"/exports/"+clientName+"/stats", []byte(mdtProcContents), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(obddir+"/"+ostName+"/exports/"+clientName+"/stats", []byte(obdfilterProcContents), 0644)
+	require.NoError(t, err)
+
+	// Begin by testing standard Lustre stats
+	m := &Lustre2{
+		OstProcfiles: []string{obddir + "/*/exports/*/stats"},
+		MdsProcfiles: []string{mdtdir + "/*/exports/*/stats"},
+	}
+
+	var acc testutil.Accumulator
+
+	err = m.Gather(&acc)
+	require.NoError(t, err)
+
+	tags := map[string]string{
+		"name":   ostName,
+		"client": clientName,
+	}
+
+	fields := map[string]interface{}{
+		"close":           uint64(873243496),
+		"crossdir_rename": uint64(369571),
+		"getattr":         uint64(1503663097),
+		"getxattr":        uint64(6145349681),
+		"link":            uint64(445),
+		"mkdir":           uint64(705499),
+		"mknod":           uint64(349042),
+		"open":            uint64(1024577037),
+		"read_bytes":      uint64(78026117632000),
+		"read_calls":      uint64(203238095),
+		"rename":          uint64(629196),
+		"rmdir":           uint64(227434),
+		"samedir_rename":  uint64(259625),
+		"setattr":         uint64(1898364),
+		"setxattr":        uint64(83969),
+		"statfs":          uint64(2916320),
+		"sync":            uint64(434081),
+		"unlink":          uint64(3549417),
+		"write_bytes":     uint64(15201500833981),
+		"write_calls":     uint64(71893382),
+	}
+
+	acc.AssertContainsTaggedFields(t, "lustre2", fields, tags)
+
+	err = os.RemoveAll(os.TempDir() + "/telegraf")
+	require.NoError(t, err)
+}
+
 func TestLustre2GeneratesJobstatsMetrics(t *testing.T) {
 	tempdir := os.TempDir() + "/telegraf/proc/fs/lustre/"
 	ostName := "OST0001"


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

When reading stats from files /proc/fs/lustre/<target_type>/<target_name>/exports/<client_nid>/stats
previously the target was not tagged, but  the client NID was tagged as 'name' and the metrics
from multiple targets were also 'mixed up' (not aggregated).
With this fix, the target name will be tagged as 'name' and the client NID will be tagged as 'client'.

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

The code detects whether there is an '/exports/' directory in the stat file path, 
and will create the tags correctly in that case.