### PR TITLE
chore: update CI go to 1.17.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     resource_class: large
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.17.5'
+      - image: 'quay.io/influxdb/telegraf-ci:1.17.6'
     environment:
       GOFLAGS: -p=4
   mac:

--- a/Makefile
+++ b/Makefile
@@ -221,8 +221,8 @@ plugin-%:
 
 .PHONY: ci-1.17
 ci-1.17:
-	docker build -t quay.io/influxdb/telegraf-ci:1.17.5 - < scripts/ci-1.17.docker
-	docker push quay.io/influxdb/telegraf-ci:1.17.5
+	docker build -t quay.io/influxdb/telegraf-ci:1.17.6 - < scripts/ci-1.17.docker
+	docker push quay.io/influxdb/telegraf-ci:1.17.6
 
 .PHONY: install
 install: $(buildbin)

--- a/scripts/ci-1.17.docker
+++ b/scripts/ci-1.17.docker
@@ -1,4 +1,4 @@
-FROM golang:1.17.5
+FROM golang:1.17.6
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -9,7 +9,7 @@ if [ "$ARCH" = 'arm64' ]; then
     GO_VERSION_SHA="dc54f3f4099e2be9e9c33bf926a7dc3ad64f34717142f7abcaff9ae44bc03d0c" # from https://golang.org/dl
 elif [ "$ARCH" = 'x86_64' ]; then
     GO_ARCH="darwin-amd64"
-    GO_VERSION_SHA="231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2" # from https://golang.org/dl
+    GO_VERSION_SHA="874bc6f95e07697380069a394a21e05576a18d60f4ba178646e1ebed8f8b1f89" # from https://golang.org/dl
 fi
 
 # This path is cachable. (Saving in /usr/local/ would cause issues restoring the cache.)

--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -3,13 +3,13 @@
 set -eux
 
 ARCH=$(uname -m)
-GO_VERSION="1.17.5"
+GO_VERSION="1.17.6"
 if [ "$ARCH" = 'arm64' ]; then
     GO_ARCH="darwin-arm64"
-    GO_VERSION_SHA="111f71166de0cb8089bb3e8f9f5b02d76e1bf1309256824d4062a47b0e5f98e0" # from https://golang.org/dl
+    GO_VERSION_SHA="dc54f3f4099e2be9e9c33bf926a7dc3ad64f34717142f7abcaff9ae44bc03d0c" # from https://golang.org/dl
 elif [ "$ARCH" = 'x86_64' ]; then
     GO_ARCH="darwin-amd64"
-    GO_VERSION_SHA="2db6a5d25815b56072465a2cacc8ed426c18f1d5fc26c1fc8c4f5a7188658264" # from https://golang.org/dl
+    GO_VERSION_SHA="231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2" # from https://golang.org/dl
 fi
 
 # This path is cachable. (Saving in /usr/local/ would cause issues restoring the cache.)

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION="1.17.5"
+GO_VERSION="1.17.6"
 
 setup_go () {
     choco upgrade golang --version=${GO_VERSION}


### PR DESCRIPTION
Release notes: https://go.dev/doc/devel/release