### PR TITLE
chore: allow downgrade of go version in windows script

### DIFF
--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -5,7 +5,7 @@ set -eux
 GO_VERSION="1.17.5"
 
 setup_go () {
-    choco upgrade golang --version=${GO_VERSION}
+    choco upgrade golang --allow-downgrade --version=${GO_VERSION}
     choco install make
     git config --system core.longpaths true
     rm -rf /c/Go


### PR DESCRIPTION
We shouldn't break everyone's CI because the Windows image got updated and has a newer version of Go. This will allow a downgrade to occur.