### PR TITLE
fix(outputs.groundwork): Set NextCheckTime to LastCheckTime 

### DIFF
--- a/plugins/outputs/groundwork/groundwork.go
+++ b/plugins/outputs/groundwork/groundwork.go
@@ -280,6 +280,7 @@ func (g *Groundwork) parseMetric(metric telegraf.Metric) (metricMeta, *transit.M
 		MonitoredInfo: transit.MonitoredInfo{
 			Status:           transit.MonitorStatus(status),
 			LastCheckTime:    lastCheckTime,
+			NextCheckTime:    lastCheckTime, // if not added, GW will make this as LastCheckTime + 5 mins
 			LastPluginOutput: message,
 		},
 		Metrics: nil,


### PR DESCRIPTION
To avoid GroundWork to invent a value like LastCheckTime + 5 minutes

### Required for all PRs:

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

