### PR TITLE
feat(mongodb): add FsTotalSize and FsUsedSize informations

### DIFF
--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -248,6 +248,8 @@ by running Telegraf with the `--debug` argument.
     - ok (integer)
     - storage_size (integer)
     - type (string)
+    - fs_used_size (integer)
+    - fs_total_size (integer)
 
 - mongodb_col_stats
   - tags:

--- a/plugins/inputs/mongodb/mongodb_data.go
+++ b/plugins/inputs/mongodb/mongodb_data.go
@@ -245,15 +245,17 @@ var defaultStorageStats = map[string]string{
 }
 
 var dbDataStats = map[string]string{
-	"collections":  "Collections",
-	"objects":      "Objects",
-	"avg_obj_size": "AvgObjSize",
-	"data_size":    "DataSize",
-	"storage_size": "StorageSize",
-	"num_extents":  "NumExtents",
-	"indexes":      "Indexes",
-	"index_size":   "IndexSize",
-	"ok":           "Ok",
+	"collections":   "Collections",
+	"objects":       "Objects",
+	"avg_obj_size":  "AvgObjSize",
+	"data_size":     "DataSize",
+	"storage_size":  "StorageSize",
+	"num_extents":   "NumExtents",
+	"indexes":       "Indexes",
+	"index_size":    "IndexSize",
+	"ok":            "Ok",
+	"fs_used_size":  "FsUsedSize",
+	"fs_total_size": "FsTotalSize",
 }
 
 var colDataStats = map[string]string{

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -96,6 +96,8 @@ type DbStatsData struct {
 	IndexSize   int64       `bson:"indexSize"`
 	Ok          int64       `bson:"ok"`
 	GleStats    interface{} `bson:"gleStats"`
+	FsUsedSize  int64       `bson:"fsUsedSize"`
+	FsTotalSize int64       `bson:"fsTotalSize"`
 }
 
 type ColStats struct {
@@ -837,6 +839,8 @@ type DbStatLine struct {
 	Indexes     int64
 	IndexSize   int64
 	Ok          int64
+	FsUsedSize  int64
+	FsTotalSize int64
 }
 type ColStatLine struct {
 	Name           string
@@ -1361,6 +1365,8 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 				Indexes:     dbStatsData.Indexes,
 				IndexSize:   dbStatsData.IndexSize,
 				Ok:          dbStatsData.Ok,
+				FsTotalSize: dbStatsData.FsTotalSize,
+				FsUsedSize:  dbStatsData.FsUsedSize,
 			}
 			returnVal.DbStatsLines = append(returnVal.DbStatsLines, *dbStatLine)
 		}


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10624

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Allow to retrieve informations about fs size for mongo server.
I try to implement test in `mongostat_test.go` and `mongodb_data_test.go` but no success
