### PR TITLE
chore: add -race flag to go tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ commands:
             - restore_cache:
                 key: windows-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
+            - run: choco install mingw
       - run: mkdir -p test-results
       - run: ./scripts/install_gotestsum.sh << parameters.os >> << parameters.gotestsum >>
       - when:
@@ -445,180 +446,180 @@ workflows:
   version: 2
   check:
     jobs:
-      - 'test-go-linux':
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-linux-386':
-          filters:
-            tags:
-              only: /.*/
-      - 'test-go-mac':
-          filters:
-            tags: # only runs on tags if you specify this filter
-              only: /.*/
+      # - 'test-go-linux':
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'test-go-linux-386':
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'test-go-mac':
+      #     filters:
+      #       tags: # only runs on tags if you specify this filter
+      #         only: /.*/
       - 'test-go-windows':
           filters:
             tags:
               only: /.*/
-      - 'windows-package':
-          requires:
-            - 'test-go-windows'
-          filters:
-            tags:
-              only: /.*/
-      - 'darwin-amd64-package':
-          requires:
-            - 'test-go-mac'
-          filters:
-            tags:
-              only: /.*/
-      - 'darwin-arm64-package':
-          requires:
-            - 'test-go-mac'
-          filters:
-            tags:
-              only: /.*/
-      - 'i386-package':
-          requires:
-            - 'test-go-linux-386'
-          filters:
-            tags:
-              only: /.*/
-      - 'ppc64le-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
-      - 'riscv64-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
-      - 's390x-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
-      - 'armel-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
-      - 'amd64-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
-      - 'arm64-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
-      - 'armhf-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
-      - 'static-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
-      - 'mipsel-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
-      - 'mips-package':
-          requires:
-            - 'test-go-linux'
-          filters:
-            tags:
-              only: /.*/
-      - 'generate-config':
-          requires:
-            - 'amd64-package'
-          filters:
-            branches:
-              only:
-                - master
-      - 'generate-config-win':
-          requires:
-            - 'windows-package'
-          filters:
-            branches:
-              only:
-                - master
-      - 'share-artifacts':
-          requires:
-            - 'i386-package'
-            - 'ppc64le-package'
-            - 'riscv64-package'
-            - 's390x-package'
-            - 'armel-package'
-            - 'amd64-package'
-            - 'mipsel-package'
-            - 'mips-package'
-            - 'darwin-amd64-package'
-            - 'darwin-arm64-package'
-            - 'windows-package'
-            - 'static-package'
-            - 'arm64-package'
-            - 'armhf-package'
-          filters:
-            branches:
-              ignore:
-                - master
-                - release.*
-            tags:
-              ignore: /.*/
-      - 'package-sign-windows':
-          requires:
-            - 'windows-package'
-          filters:
-              tags:
-                only: /.*/
-              branches:
-                ignore: /.*/
-      - 'package-sign-mac':
-           requires:
-            - 'darwin-amd64-package'
-            - 'darwin-arm64-package'
-           filters:
-              tags:
-                only: /.*/
-              branches:
-                ignore: /.*/
-      - 'package-consolidate':
-           requires:
-            - 'i386-package'
-            - 'ppc64le-package'
-            - 's390x-package'
-            - 'armel-package'
-            - 'amd64-package'
-            - 'mipsel-package'
-            - 'mips-package'
-            - 'static-package'
-            - 'arm64-package'
-            - 'armhf-package'
-            - 'riscv64-package'
-            - 'package-sign-mac'
-            - 'package-sign-windows'
-           filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+      # - 'windows-package':
+      #     requires:
+      #       - 'test-go-windows'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'darwin-amd64-package':
+      #     requires:
+      #       - 'test-go-mac'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'darwin-arm64-package':
+      #     requires:
+      #       - 'test-go-mac'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'i386-package':
+      #     requires:
+      #       - 'test-go-linux-386'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'ppc64le-package':
+      #     requires:
+      #       - 'test-go-linux'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'riscv64-package':
+      #     requires:
+      #       - 'test-go-linux'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 's390x-package':
+      #     requires:
+      #       - 'test-go-linux'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'armel-package':
+      #     requires:
+      #       - 'test-go-linux'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'amd64-package':
+      #     requires:
+      #       - 'test-go-linux'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'arm64-package':
+      #     requires:
+      #       - 'test-go-linux'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'armhf-package':
+      #     requires:
+      #       - 'test-go-linux'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'static-package':
+      #     requires:
+      #       - 'test-go-linux'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'mipsel-package':
+      #     requires:
+      #       - 'test-go-linux'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'mips-package':
+      #     requires:
+      #       - 'test-go-linux'
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      # - 'generate-config':
+      #     requires:
+      #       - 'amd64-package'
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - 'generate-config-win':
+      #     requires:
+      #       - 'windows-package'
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - 'share-artifacts':
+      #     requires:
+      #       - 'i386-package'
+      #       - 'ppc64le-package'
+      #       - 'riscv64-package'
+      #       - 's390x-package'
+      #       - 'armel-package'
+      #       - 'amd64-package'
+      #       - 'mipsel-package'
+      #       - 'mips-package'
+      #       - 'darwin-amd64-package'
+      #       - 'darwin-arm64-package'
+      #       - 'windows-package'
+      #       - 'static-package'
+      #       - 'arm64-package'
+      #       - 'armhf-package'
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - release.*
+      #       tags:
+      #         ignore: /.*/
+      # - 'package-sign-windows':
+      #     requires:
+      #       - 'windows-package'
+      #     filters:
+      #         tags:
+      #           only: /.*/
+      #         branches:
+      #           ignore: /.*/
+      # - 'package-sign-mac':
+      #      requires:
+      #       - 'darwin-amd64-package'
+      #       - 'darwin-arm64-package'
+      #      filters:
+      #         tags:
+      #           only: /.*/
+      #         branches:
+      #           ignore: /.*/
+      # - 'package-consolidate':
+      #      requires:
+      #       - 'i386-package'
+      #       - 'ppc64le-package'
+      #       - 's390x-package'
+      #       - 'armel-package'
+      #       - 'amd64-package'
+      #       - 'mipsel-package'
+      #       - 'mips-package'
+      #       - 'static-package'
+      #       - 'arm64-package'
+      #       - 'armhf-package'
+      #       - 'riscv64-package'
+      #       - 'package-sign-mac'
+      #       - 'package-sign-windows'
+      #      filters:
+      #       tags:
+      #         only: /.*/
+      #       branches:
+      #         ignore: /.*/
 
   nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,9 +79,19 @@ commands:
             - run: 'sh ./scripts/installgo_windows.sh'
       - run: mkdir -p test-results
       - run: ./scripts/install_gotestsum.sh << parameters.os >> << parameters.gotestsum >>
+      - when:
+          condition:
+            equal: [ "386", << parameters.arch >> ]
+          steps:
+            - run: echo 'export RACE=""' >> $BASH_ENV
+      - unless:
+          condition:
+            equal: [ "386", << parameters.arch >> ]
+          steps:
+            - run: echo 'export RACE="-race"' >> $BASH_ENV
       - run: |
           PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-          GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> --junitfile test-results/gotestsum-report.xml -- -short $PACKAGE_NAMES
+          GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> --junitfile test-results/gotestsum-report.xml -- ${RACE} -short $PACKAGE_NAMES
       - store_test_results:
           path: test-results
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,11 +80,6 @@ commands:
             - run: choco install mingw
       - run: mkdir -p test-results
       - run: ./scripts/install_gotestsum.sh << parameters.os >> << parameters.gotestsum >>
-      - when:
-          condition:
-            equal: [ "386", << parameters.arch >> ]
-          steps:
-            - run: echo 'export RACE=""' >> $BASH_ENV
       - unless:
           condition:
             equal: [ "386", << parameters.arch >> ]
@@ -446,180 +441,180 @@ workflows:
   version: 2
   check:
     jobs:
-      # - 'test-go-linux':
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'test-go-linux-386':
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'test-go-mac':
-      #     filters:
-      #       tags: # only runs on tags if you specify this filter
-      #         only: /.*/
+      - 'test-go-linux':
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-linux-386':
+          filters:
+            tags:
+              only: /.*/
+      - 'test-go-mac':
+          filters:
+            tags: # only runs on tags if you specify this filter
+              only: /.*/
       - 'test-go-windows':
           filters:
             tags:
               only: /.*/
-      # - 'windows-package':
-      #     requires:
-      #       - 'test-go-windows'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'darwin-amd64-package':
-      #     requires:
-      #       - 'test-go-mac'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'darwin-arm64-package':
-      #     requires:
-      #       - 'test-go-mac'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'i386-package':
-      #     requires:
-      #       - 'test-go-linux-386'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'ppc64le-package':
-      #     requires:
-      #       - 'test-go-linux'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'riscv64-package':
-      #     requires:
-      #       - 'test-go-linux'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 's390x-package':
-      #     requires:
-      #       - 'test-go-linux'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'armel-package':
-      #     requires:
-      #       - 'test-go-linux'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'amd64-package':
-      #     requires:
-      #       - 'test-go-linux'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'arm64-package':
-      #     requires:
-      #       - 'test-go-linux'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'armhf-package':
-      #     requires:
-      #       - 'test-go-linux'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'static-package':
-      #     requires:
-      #       - 'test-go-linux'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'mipsel-package':
-      #     requires:
-      #       - 'test-go-linux'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'mips-package':
-      #     requires:
-      #       - 'test-go-linux'
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      # - 'generate-config':
-      #     requires:
-      #       - 'amd64-package'
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - 'generate-config-win':
-      #     requires:
-      #       - 'windows-package'
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - 'share-artifacts':
-      #     requires:
-      #       - 'i386-package'
-      #       - 'ppc64le-package'
-      #       - 'riscv64-package'
-      #       - 's390x-package'
-      #       - 'armel-package'
-      #       - 'amd64-package'
-      #       - 'mipsel-package'
-      #       - 'mips-package'
-      #       - 'darwin-amd64-package'
-      #       - 'darwin-arm64-package'
-      #       - 'windows-package'
-      #       - 'static-package'
-      #       - 'arm64-package'
-      #       - 'armhf-package'
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - release.*
-      #       tags:
-      #         ignore: /.*/
-      # - 'package-sign-windows':
-      #     requires:
-      #       - 'windows-package'
-      #     filters:
-      #         tags:
-      #           only: /.*/
-      #         branches:
-      #           ignore: /.*/
-      # - 'package-sign-mac':
-      #      requires:
-      #       - 'darwin-amd64-package'
-      #       - 'darwin-arm64-package'
-      #      filters:
-      #         tags:
-      #           only: /.*/
-      #         branches:
-      #           ignore: /.*/
-      # - 'package-consolidate':
-      #      requires:
-      #       - 'i386-package'
-      #       - 'ppc64le-package'
-      #       - 's390x-package'
-      #       - 'armel-package'
-      #       - 'amd64-package'
-      #       - 'mipsel-package'
-      #       - 'mips-package'
-      #       - 'static-package'
-      #       - 'arm64-package'
-      #       - 'armhf-package'
-      #       - 'riscv64-package'
-      #       - 'package-sign-mac'
-      #       - 'package-sign-windows'
-      #      filters:
-      #       tags:
-      #         only: /.*/
-      #       branches:
-      #         ignore: /.*/
+      - 'windows-package':
+          requires:
+            - 'test-go-windows'
+          filters:
+            tags:
+              only: /.*/
+      - 'darwin-amd64-package':
+          requires:
+            - 'test-go-mac'
+          filters:
+            tags:
+              only: /.*/
+      - 'darwin-arm64-package':
+          requires:
+            - 'test-go-mac'
+          filters:
+            tags:
+              only: /.*/
+      - 'i386-package':
+          requires:
+            - 'test-go-linux-386'
+          filters:
+            tags:
+              only: /.*/
+      - 'ppc64le-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            tags:
+              only: /.*/
+      - 'riscv64-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            tags:
+              only: /.*/
+      - 's390x-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            tags:
+              only: /.*/
+      - 'armel-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            tags:
+              only: /.*/
+      - 'amd64-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            tags:
+              only: /.*/
+      - 'arm64-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            tags:
+              only: /.*/
+      - 'armhf-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            tags:
+              only: /.*/
+      - 'static-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            tags:
+              only: /.*/
+      - 'mipsel-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            tags:
+              only: /.*/
+      - 'mips-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            tags:
+              only: /.*/
+      - 'generate-config':
+          requires:
+            - 'amd64-package'
+          filters:
+            branches:
+              only:
+                - master
+      - 'generate-config-win':
+          requires:
+            - 'windows-package'
+          filters:
+            branches:
+              only:
+                - master
+      - 'share-artifacts':
+          requires:
+            - 'i386-package'
+            - 'ppc64le-package'
+            - 'riscv64-package'
+            - 's390x-package'
+            - 'armel-package'
+            - 'amd64-package'
+            - 'mipsel-package'
+            - 'mips-package'
+            - 'darwin-amd64-package'
+            - 'darwin-arm64-package'
+            - 'windows-package'
+            - 'static-package'
+            - 'arm64-package'
+            - 'armhf-package'
+          filters:
+            branches:
+              ignore:
+                - master
+                - release.*
+            tags:
+              ignore: /.*/
+      - 'package-sign-windows':
+          requires:
+            - 'windows-package'
+          filters:
+              tags:
+                only: /.*/
+              branches:
+                ignore: /.*/
+      - 'package-sign-mac':
+           requires:
+            - 'darwin-amd64-package'
+            - 'darwin-arm64-package'
+           filters:
+              tags:
+                only: /.*/
+              branches:
+                ignore: /.*/
+      - 'package-consolidate':
+           requires:
+            - 'i386-package'
+            - 'ppc64le-package'
+            - 's390x-package'
+            - 'armel-package'
+            - 'amd64-package'
+            - 'mipsel-package'
+            - 'mips-package'
+            - 'static-package'
+            - 'arm64-package'
+            - 'armhf-package'
+            - 'riscv64-package'
+            - 'package-sign-mac'
+            - 'package-sign-windows'
+           filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
 
   nightly:
     jobs:


### PR DESCRIPTION
resolve: #8459

The `-race` flag wasn't working on the Windows CI job because GCC was missing, so I've updated the circle-ci config to install mingw. Also when migrating to use gotestsum to parallelize the builds the `-race` was accidentally dropped from the linux tests as well, now its been added back.