### PR TITLE
fix: check for nil client before closing

### DIFF
--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -259,7 +259,7 @@ func (q *AMQP) Write(metrics []telegraf.Metric) error {
 				if err != nil {
 					return err
 				}
-			} else {
+			} else if q.client != nil {
 				if err := q.client.Close(); err != nil {
 					q.Log.Errorf("Closing connection failed: %v", err)
 				}


### PR DESCRIPTION
Recently added the logic to close the connection, but in some cases it
appears that the connection is already nil.

Fixes: #10634