### PR TITLE
fix: use now as ecs timestamp

### DIFF
--- a/plugins/inputs/ecs/ecs.go
+++ b/plugins/inputs/ecs/ecs.go
@@ -172,7 +172,7 @@ func (ecs *Ecs) accTask(task *Task, tags map[string]string, acc telegraf.Accumul
 		"limit_mem":      task.Limits["Memory"],
 	}
 
-	acc.AddFields("ecs_task", taskFields, tags, task.PullStoppedAt)
+	acc.AddFields("ecs_task", taskFields, tags)
 }
 
 func (ecs *Ecs) accContainers(task *Task, taskTags map[string]string, acc telegraf.Accumulator) {


### PR DESCRIPTION
The current ecs timestamp option will use the timestamp when an image
was last pulled down. Because the tags are not changing for a specific
ecs container this means that the metric never actually updates.

By changing the timestamp to be the current time, which is more standard
for metrics, users will get updated information for their fields.

Fixes: #8375