### PR TITLE
feat(inputs/memcached): Support client TLS origination to memcached

### DIFF
--- a/plugins/inputs/memcached/README.md
+++ b/plugins/inputs/memcached/README.md
@@ -12,6 +12,14 @@ This plugin gathers statistics data from a Memcached server.
   servers = ["localhost:11211"]
   # An array of unix memcached sockets to gather stats about.
   # unix_sockets = ["/var/run/memcached.sock"]
+
+  ## Optional TLS Config
+  # enable_tls = true
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## If false, skip chain & host verification
+  # insecure_skip_verify = true
 ```
 
 ## Measurements & Fields

--- a/plugins/inputs/memcached/memcached.go
+++ b/plugins/inputs/memcached/memcached.go
@@ -3,19 +3,24 @@ package memcached
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"strconv"
 	"time"
 
 	"github.com/influxdata/telegraf"
+	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	"golang.org/x/net/proxy"
 )
 
 // Memcached is a memcached plugin
 type Memcached struct {
-	Servers     []string
-	UnixSockets []string
+	Servers     []string `toml:"servers"`
+	UnixSockets []string `toml:"unix_sockets"`
+	EnableTLS   bool     `toml:"enable_tls"`
+	tlsint.ClientConfig
 }
 
 var sampleConfig = `
@@ -23,6 +28,14 @@ var sampleConfig = `
   ## with optional port. ie localhost, 10.0.0.1:11211, etc.
   servers = ["localhost:11211"]
   # unix_sockets = ["/var/run/memcached.sock"]
+
+  ## Optional TLS Config
+  # enable_tls = true
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## If false, skip chain & host verification
+  # insecure_skip_verify = true
 `
 
 var defaultTimeout = 5 * time.Second
@@ -105,8 +118,23 @@ func (m *Memcached) gatherServer(
 ) error {
 	var conn net.Conn
 	var err error
+	var dialer proxy.Dialer
+
+	dialer = &net.Dialer{Timeout: defaultTimeout}
+	if m.EnableTLS {
+		tlsCfg, err := m.ClientConfig.TLSConfig()
+		if err != nil {
+			return err
+		}
+
+		dialer = &tls.Dialer{
+			NetDialer: dialer.(*net.Dialer),
+			Config:    tlsCfg,
+		}
+	}
+
 	if unix {
-		conn, err = net.DialTimeout("unix", address, defaultTimeout)
+		conn, err = dialer.Dial("unix", address)
 		if err != nil {
 			return err
 		}
@@ -117,7 +145,7 @@ func (m *Memcached) gatherServer(
 			address = address + ":11211"
 		}
 
-		conn, err = net.DialTimeout("tcp", address, defaultTimeout)
+		conn, err = dialer.Dial("tcp", address)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This change adds support for client TLS origination to memcached, leveraging the common TLS plugin library in `plugins/common/tls`. I also added `toml` struct tags to make the TOML parsing behavior explicit, which seems to be more in line with other plugins as well.

Test and verification:

Collection with server TLS enabled, using the memcached test fixture certificates in [`t/server_crt.pem` et al.](https://github.com/memcached/memcached/blob/e9b28fe92898dda891bc78fb901ba15f834a24cd/t/server_crt.pem):

```
# telegraf.conf
[[inputs.memcached]]
    enable_tls = true
    tls_ca = "/path/to/memcached/t/cacert.pem"
    tls_cert = "/path/to/memcached/t/client_crt.pem"
    tls_key = "/path/to/memcached/t/client_key.pem"
    tls_server_name = "test.com"
```

```
# Compiled with ./configure --enable-tls
$ ./memcached --enable-ssl --extended ssl_chain_cert=t/server_crt.pem,ssl_key=t/server_key.pem,ssl_ca_cert=t/cacert.pem -vv
slab class   1: chunk size        96 perslab   10922
slab class   2: chunk size       120 perslab    8738
slab class   3: chunk size       152 perslab    6898
slab class   4: chunk size       192 perslab    5461
slab class   5: chunk size       240 perslab    4369
slab class   6: chunk size       304 perslab    3449
slab class   7: chunk size       384 perslab    2730
slab class   8: chunk size       480 perslab    2184
slab class   9: chunk size       600 perslab    1747
slab class  10: chunk size       752 perslab    1394
slab class  11: chunk size       944 perslab    1110
slab class  12: chunk size      1184 perslab     885
slab class  13: chunk size      1480 perslab     708
slab class  14: chunk size      1856 perslab     564
slab class  15: chunk size      2320 perslab     451
slab class  16: chunk size      2904 perslab     361
slab class  17: chunk size      3632 perslab     288
slab class  18: chunk size      4544 perslab     230
slab class  19: chunk size      5680 perslab     184
slab class  20: chunk size      7104 perslab     147
slab class  21: chunk size      8880 perslab     118
slab class  22: chunk size     11104 perslab      94
slab class  23: chunk size     13880 perslab      75
slab class  24: chunk size     17352 perslab      60
slab class  25: chunk size     21696 perslab      48
slab class  26: chunk size     27120 perslab      38
slab class  27: chunk size     33904 perslab      30
slab class  28: chunk size     42384 perslab      24
slab class  29: chunk size     52984 perslab      19
slab class  30: chunk size     66232 perslab      15
slab class  31: chunk size     82792 perslab      12
slab class  32: chunk size    103496 perslab      10
slab class  33: chunk size    129376 perslab       8
slab class  34: chunk size    161720 perslab       6
slab class  35: chunk size    202152 perslab       5
slab class  36: chunk size    252696 perslab       4
slab class  37: chunk size    315872 perslab       3
slab class  38: chunk size    394840 perslab       2
slab class  39: chunk size    524288 perslab       2
<22 server listening (auto-negotiate)
<23 server listening (auto-negotiate)
<24 new auto-negotiating client connection
24: Client using the ascii protocol
<24 stats
<24 connection closed.
```

```
$ ./telegraf --config telegraf.conf --test
...
> memcached,server=:11211 accepting_conns=1i,auth_cmds=0i,auth_errors=0i,bytes=0i,bytes_read=7i,bytes_written=0i,cas_badval=0i,cas_hits=0i,cas_misses=0i,cmd_flush=0i,cmd_get=0i,cmd_set=0i,cmd_touch=0i,conn_yields=0i,connection_structures=3i,curr_connections=2i,curr_items=0i,decr_hits=0i,decr_misses=0i,delete_hits=0i,delete_misses=0i,evicted_unfetched=0i,evictions=0i,expired_unfetched=0i,get_hits=0i,get_misses=0i,hash_bytes=524288i,hash_is_expanding=0i,hash_power_level=16i,incr_hits=0i,incr_misses=0i,limit_maxbytes=67108864i,listen_disabled_num=0i,reclaimed=0i,threads=4i,total_connections=3i,total_items=0i,touch_hits=0i,touch_misses=0i,uptime=21i 1644773022000000000
```

Collection with server TLS disabled, to verify backwards compatibility:

```
# telegraf.conf
[[inputs.memcached]]
```

```
$ ./memcached -vv
slab class   1: chunk size        96 perslab   10922
slab class   2: chunk size       120 perslab    8738
slab class   3: chunk size       152 perslab    6898
slab class   4: chunk size       192 perslab    5461
slab class   5: chunk size       240 perslab    4369
slab class   6: chunk size       304 perslab    3449
slab class   7: chunk size       384 perslab    2730
slab class   8: chunk size       480 perslab    2184
slab class   9: chunk size       600 perslab    1747
slab class  10: chunk size       752 perslab    1394
slab class  11: chunk size       944 perslab    1110
slab class  12: chunk size      1184 perslab     885
slab class  13: chunk size      1480 perslab     708
slab class  14: chunk size      1856 perslab     564
slab class  15: chunk size      2320 perslab     451
slab class  16: chunk size      2904 perslab     361
slab class  17: chunk size      3632 perslab     288
slab class  18: chunk size      4544 perslab     230
slab class  19: chunk size      5680 perslab     184
slab class  20: chunk size      7104 perslab     147
slab class  21: chunk size      8880 perslab     118
slab class  22: chunk size     11104 perslab      94
slab class  23: chunk size     13880 perslab      75
slab class  24: chunk size     17352 perslab      60
slab class  25: chunk size     21696 perslab      48
slab class  26: chunk size     27120 perslab      38
slab class  27: chunk size     33904 perslab      30
slab class  28: chunk size     42384 perslab      24
slab class  29: chunk size     52984 perslab      19
slab class  30: chunk size     66232 perslab      15
slab class  31: chunk size     82792 perslab      12
slab class  32: chunk size    103496 perslab      10
slab class  33: chunk size    129376 perslab       8
slab class  34: chunk size    161720 perslab       6
slab class  35: chunk size    202152 perslab       5
slab class  36: chunk size    252696 perslab       4
slab class  37: chunk size    315872 perslab       3
slab class  38: chunk size    394840 perslab       2
slab class  39: chunk size    524288 perslab       2
<22 server listening (auto-negotiate)
<23 server listening (auto-negotiate)
<24 new auto-negotiating client connection
24: Client using the ascii protocol
<24 stats
<24 connection closed.
```

```
$ ./telegraf --config telegraf.conf --test
...
> memcached,server=:11211 accepting_conns=1i,auth_cmds=0i,auth_errors=0i,bytes=0i,bytes_read=7i,bytes_written=0i,cas_badval=0i,cas_hits=0i,cas_misses=0i,cmd_flush=0i,cmd_get=0i,cmd_set=0i,cmd_touch=0i,conn_yields=0i,connection_structures=3i,curr_connections=2i,curr_items=0i,decr_hits=0i,decr_misses=0i,delete_hits=0i,delete_misses=0i,evicted_unfetched=0i,evictions=0i,expired_unfetched=0i,get_hits=0i,get_misses=0i,hash_bytes=524288i,hash_is_expanding=0i,hash_power_level=16i,incr_hits=0i,incr_misses=0i,limit_maxbytes=67108864i,listen_disabled_num=0i,reclaimed=0i,threads=4i,total_connections=3i,total_items=0i,touch_hits=0i,touch_misses=0i,uptime=11i 1644773145000000000
```