### PR TITLE
fix: Revert deprecation of http_listener_v2

### DIFF
--- a/plugins/inputs/deprecations.go
+++ b/plugins/inputs/deprecations.go
@@ -13,10 +13,6 @@ var Deprecations = map[string]telegraf.DeprecationInfo{
 		RemovalIn: "2.0.0",
 		Notice:    "use 'inputs.diskio' instead",
 	},
-	"http_listener_v2": {
-		Since:  "1.9.0",
-		Notice: "has been renamed to 'influxdb_listener', use 'inputs.influxdb_listener' or 'inputs.influxdb_listener_v2' instead",
-	},
 	"httpjson": {
 		Since:  "1.6.0",
 		Notice: "use 'inputs.http' instead",


### PR DESCRIPTION
`plugins/inputs/http_listener_v2` is the recommended plugin for general purpose http listening input. It was added to the deprecated plugins list in df6bf48f8d by mistake. This PR removes it from the list.