### PR TITLE
fix: error msg for missing env variables in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1051,7 +1051,7 @@ func parseConfig(contents []byte) (*ast.Table, error) {
 
 	// Report all missing environment variables to the user
 	if len(missingEnvVars) > 0 {
-		errorMsg := "failed to find the configured environment variables:"
+		errorMsg := "environment variable(s) not set:"
 		for _, e := range missingEnvVars {
 			errorMsg += e + " "
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -264,13 +264,15 @@ func TestConfig_WrongFieldType(t *testing.T) {
 func TestConfig_InlineTables(t *testing.T) {
 	// #4098
 	c := NewConfig()
+	require.NoError(t, os.Setenv("TOKEN", "test"))
 	require.NoError(t, c.LoadConfig("./testdata/inline_table.toml"))
 	require.Len(t, c.Outputs, 2)
 
 	output, ok := c.Outputs[1].Output.(*MockupOuputPlugin)
 	require.True(t, ok)
-	require.Equal(t, map[string]string{"Authorization": "Token $TOKEN", "Content-Type": "application/json"}, output.Headers)
+	require.Equal(t, map[string]string{"Authorization": "Token test", "Content-Type": "application/json"}, output.Headers)
 	require.Equal(t, []string{"org_id"}, c.Outputs[0].Config.Filter.TagInclude)
+	require.NoError(t, os.Unsetenv("TOKEN"))
 }
 
 func TestConfig_SliceComment(t *testing.T) {


### PR DESCRIPTION
This PR was inspired by: https://community.influxdata.com/t/telegraf-config-failing-to-load/23905/3

Currently, if an environment variable inside a config isn't found it is skipped and not replaced and the user ends up with a misleading error `invalid TOML syntax`. TOML doesn't natively support non quoted environment variables (e.g. just ${INFLUX_SKIP_DATABASE_CREATION}) therefore it can't parse it. I thought it would be more helpful to track all configured environment variables not found and report it to the user like so: 

```sh
2022-02-18T21:55:01Z E! [telegraf] Error running agent: Error loading config file telegraf.conf: Error parsing data: failed to find the configured environment variables:INFLUX_URL INFLUX_SKIP_DATABASE_CREATION INFLUX_PASSWORD 
```