### PR TITLE
fix(dedup): Modifying slice while iterating is dangerous

### DIFF
--- a/plugins/processors/dedup/dedup.go
+++ b/plugins/processors/dedup/dedup.go
@@ -112,6 +112,9 @@ func (d *Dedup) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 			idx++
 			continue
 		}
+
+		// In any other case remove metric from the output
+		metric.Drop()
 	}
 	metrics = metrics[:idx]
 	d.cleanup()

--- a/plugins/processors/dedup/dedup.go
+++ b/plugins/processors/dedup/dedup.go
@@ -27,12 +27,6 @@ func (d *Dedup) Description() string {
 	return "Filter metrics with repeating field values"
 }
 
-// Remove single item from slice
-func remove(slice []telegraf.Metric, i int) []telegraf.Metric {
-	slice[len(slice)-1], slice[i] = slice[i], slice[len(slice)-1]
-	return slice[:len(slice)-1]
-}
-
 // Remove expired items from cache
 func (d *Dedup) cleanup() {
 	// No need to cleanup cache too often. Lets save some CPU
@@ -57,19 +51,24 @@ func (d *Dedup) save(metric telegraf.Metric, id uint64) {
 
 // main processing method
 func (d *Dedup) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
-	for idx, metric := range metrics {
+	idx := 0
+	for _, metric := range metrics {
 		id := metric.HashID()
 		m, ok := d.Cache[id]
 
 		// If not in cache then just save it
 		if !ok {
 			d.save(metric, id)
+			metrics[idx] = metric
+			idx++
 			continue
 		}
 
 		// If cache item has expired then refresh it
 		if time.Since(m.Time()) >= time.Duration(d.DedupInterval) {
 			d.save(metric, id)
+			metrics[idx] = metric
+			idx++
 			continue
 		}
 
@@ -103,16 +102,18 @@ func (d *Dedup) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 		// If any field value has changed then refresh the cache
 		if changed {
 			d.save(metric, id)
+			metrics[idx] = metric
+			idx++
 			continue
 		}
 
 		if sametime && added {
+			metrics[idx] = metric
+			idx++
 			continue
 		}
-
-		// In any other case remove metric from the output
-		metrics = remove(metrics, idx)
 	}
+	metrics = metrics[:idx]
 	d.cleanup()
 	return metrics
 }

--- a/plugins/processors/dedup/dedup_test.go
+++ b/plugins/processors/dedup/dedup_test.go
@@ -197,3 +197,15 @@ func TestSameTimestamp(t *testing.T) {
 	out = dedup.Apply(in)
 	require.Equal(t, []telegraf.Metric{}, out) // drop
 }
+
+func TestSuppressMultipleRepeatedValue(t *testing.T) {
+	deduplicate := createDedup(time.Now())
+	// Create metric in the past
+	source := createMetric(1, time.Now().Add(-1*time.Second))
+	_ = deduplicate.Apply(source)
+	source = createMetric(1, time.Now())
+	target := deduplicate.Apply(source, source, source, source)
+
+	assertCacheHit(t, &deduplicate, source)
+	assertMetricSuppressed(t, target)
+}


### PR DESCRIPTION
Instead of swapping indexes, use the filter pattern to make sure all
items are properly iterated through.

This manifested with randomly duplicate data, or sometimes weird hangs in processing.

Added a unit test to cover the multiple input metrics test case, as it seems it hadn't been covered yet.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
