### PR TITLE
fix: Linter fixes for "import-shadowing: The name '...' shadows an import name"

### DIFF
--- a/agent/accumulator.go
+++ b/agent/accumulator.go
@@ -9,7 +9,7 @@ import (
 
 type MetricMaker interface {
 	LogName() string
-	MakeMetric(metric telegraf.Metric) telegraf.Metric
+	MakeMetric(m telegraf.Metric) telegraf.Metric
 	Log() telegraf.Logger
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -23,9 +23,9 @@ type Agent struct {
 }
 
 // NewAgent returns an Agent for the given Config.
-func NewAgent(config *config.Config) (*Agent, error) {
+func NewAgent(cfg *config.Config) (*Agent, error) {
 	a := &Agent{
-		Config: config,
+		Config: cfg,
 	}
 	return a, nil
 }

--- a/internal/http.go
+++ b/internal/http.go
@@ -86,24 +86,24 @@ type ErrorFunc func(rw http.ResponseWriter, code int)
 
 // IPRangeHandler returns a http handler that requires the remote address to be
 // in the specified network.
-func IPRangeHandler(network []*net.IPNet, onError ErrorFunc) func(h http.Handler) http.Handler {
+func IPRangeHandler(networks []*net.IPNet, onError ErrorFunc) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return &ipRangeHandler{
-			network: network,
-			onError: onError,
-			next:    h,
+			networks: networks,
+			onError:  onError,
+			next:     h,
 		}
 	}
 }
 
 type ipRangeHandler struct {
-	network []*net.IPNet
-	onError ErrorFunc
-	next    http.Handler
+	networks []*net.IPNet
+	onError  ErrorFunc
+	next     http.Handler
 }
 
 func (h *ipRangeHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if len(h.network) == 0 {
+	if len(h.networks) == 0 {
 		h.next.ServeHTTP(rw, req)
 		return
 	}
@@ -120,8 +120,8 @@ func (h *ipRangeHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	for _, net := range h.network {
-		if net.Contains(remoteIP) {
+	for _, network := range h.networks {
+		if network.Contains(remoteIP) {
 			h.next.ServeHTTP(rw, req)
 			return
 		}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -18,8 +18,8 @@ func TestWriteLogToFile(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
 
-	config := createBasicLogConfig(tmpfile.Name())
-	SetupLogging(config)
+	cfg := createBasicLogConfig(tmpfile.Name())
+	SetupLogging(cfg)
 	log.Printf("I! TEST")
 	log.Printf("D! TEST") // <- should be ignored
 
@@ -32,9 +32,9 @@ func TestDebugWriteLogToFile(t *testing.T) {
 	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
-	config := createBasicLogConfig(tmpfile.Name())
-	config.Debug = true
-	SetupLogging(config)
+	cfg := createBasicLogConfig(tmpfile.Name())
+	cfg.Debug = true
+	SetupLogging(cfg)
 	log.Printf("D! TEST")
 
 	f, err := os.ReadFile(tmpfile.Name())
@@ -46,9 +46,9 @@ func TestErrorWriteLogToFile(t *testing.T) {
 	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
-	config := createBasicLogConfig(tmpfile.Name())
-	config.Quiet = true
-	SetupLogging(config)
+	cfg := createBasicLogConfig(tmpfile.Name())
+	cfg.Quiet = true
+	SetupLogging(cfg)
 	log.Printf("E! TEST")
 	log.Printf("I! TEST") // <- should be ignored
 
@@ -61,9 +61,9 @@ func TestAddDefaultLogLevel(t *testing.T) {
 	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
-	config := createBasicLogConfig(tmpfile.Name())
-	config.Debug = true
-	SetupLogging(config)
+	cfg := createBasicLogConfig(tmpfile.Name())
+	cfg.Debug = true
+	SetupLogging(cfg)
 	log.Printf("TEST")
 
 	f, err := os.ReadFile(tmpfile.Name())
@@ -75,9 +75,9 @@ func TestWriteToTruncatedFile(t *testing.T) {
 	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer func() { os.Remove(tmpfile.Name()) }()
-	config := createBasicLogConfig(tmpfile.Name())
-	config.Debug = true
-	SetupLogging(config)
+	cfg := createBasicLogConfig(tmpfile.Name())
+	cfg.Debug = true
+	SetupLogging(cfg)
 	log.Printf("TEST")
 
 	f, err := os.ReadFile(tmpfile.Name())
@@ -114,20 +114,20 @@ func TestWriteToFileInRotation(t *testing.T) {
 }
 
 func TestLogTargetSettings(t *testing.T) {
-	config := LogConfig{
+	cfg := LogConfig{
 		LogTarget: "",
 		Quiet:     true,
 	}
-	SetupLogging(config)
+	SetupLogging(cfg)
 	logger, isTelegrafLogger := actualLogger.(*telegrafLog)
 	assert.True(t, isTelegrafLogger)
 	assert.Equal(t, logger.internalWriter, os.Stderr)
 
-	config = LogConfig{
+	cfg = LogConfig{
 		LogTarget: "stderr",
 		Quiet:     true,
 	}
-	SetupLogging(config)
+	SetupLogging(cfg)
 	logger, isTelegrafLogger = actualLogger.(*telegrafLog)
 	assert.True(t, isTelegrafLogger)
 	assert.Equal(t, logger.internalWriter, os.Stderr)

--- a/models/log.go
+++ b/models/log.go
@@ -79,7 +79,7 @@ func logName(pluginType, name, alias string) string {
 	return pluginType + "." + name + "::" + alias
 }
 
-func SetLoggerOnPlugin(i interface{}, log telegraf.Logger) {
+func SetLoggerOnPlugin(i interface{}, logger telegraf.Logger) {
 	valI := reflect.ValueOf(i)
 
 	if valI.Type().Kind() != reflect.Ptr {
@@ -94,10 +94,10 @@ func SetLoggerOnPlugin(i interface{}, log telegraf.Logger) {
 	switch field.Type().String() {
 	case "telegraf.Logger":
 		if field.CanSet() {
-			field.Set(reflect.ValueOf(log))
+			field.Set(reflect.ValueOf(logger))
 		}
 	default:
-		log.Debugf("Plugin %q defines a 'Log' field on its struct of an unexpected type %q. Expected telegraf.Logger",
+		logger.Debugf("Plugin %q defines a 'Log' field on its struct of an unexpected type %q. Expected telegraf.Logger",
 			valI.Type().Name(), field.Type().String())
 	}
 }

--- a/models/running_aggregator.go
+++ b/models/running_aggregator.go
@@ -108,9 +108,9 @@ func (r *RunningAggregator) UpdateWindow(start, until time.Time) {
 	r.log.Debugf("Updated aggregation range [%s, %s]", start, until)
 }
 
-func (r *RunningAggregator) MakeMetric(metric telegraf.Metric) telegraf.Metric {
+func (r *RunningAggregator) MakeMetric(telegrafMetric telegraf.Metric) telegraf.Metric {
 	m := makemetric(
-		metric,
+		telegrafMetric,
 		r.Config.NameOverride,
 		r.Config.MeasurementPrefix,
 		r.Config.MeasurementSuffix,

--- a/plugins/common/shim/example/cmd/main.go
+++ b/plugins/common/shim/example/cmd/main.go
@@ -21,7 +21,7 @@ var err error
 //
 // However, if you want to do all your config in code, you can like so:
 //
-// // initialize your plugin with any settngs you want
+// // initialize your plugin with any settings you want
 // myInput := &mypluginname.MyPlugin{
 // 	DefaultSettingHere: 3,
 // }
@@ -40,20 +40,20 @@ func main() {
 	}
 
 	// create the shim. This is what will run your plugins.
-	shim := shim.New()
+	shimLayer := shim.New()
 
 	// If no config is specified, all imported plugins are loaded.
-	// otherwise follow what the config asks for.
+	// otherwise, follow what the config asks for.
 	// Check for settings from a config toml file,
 	// (or just use whatever plugins were imported above)
-	err = shim.LoadConfig(configFile)
+	err = shimLayer.LoadConfig(configFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Err loading input: %s\n", err)
 		os.Exit(1)
 	}
 
 	// run a single plugin until stdin closes or we receive a termination signal
-	if err := shim.Run(*pollInterval); err != nil {
+	if err := shimLayer.Run(*pollInterval); err != nil {
 		fmt.Fprintf(os.Stderr, "Err: %s\n", err)
 		os.Exit(1)
 	}

--- a/testutil/metric.go
+++ b/testutil/metric.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/metric"
+	telegrafMetric "github.com/influxdata/telegraf/metric"
 )
 
 type metricDiff struct {
@@ -177,7 +177,7 @@ func RequireMetricsEqual(t *testing.T, expected, actual []telegraf.Metric, opts 
 	}
 }
 
-// Metric creates a new metric or panics on error.
+// MustMetric creates a new metric.
 func MustMetric(
 	name string,
 	tags map[string]string,
@@ -185,11 +185,11 @@ func MustMetric(
 	tm time.Time,
 	tp ...telegraf.ValueType,
 ) telegraf.Metric {
-	m := metric.New(name, tags, fields, tm, tp...)
+	m := telegrafMetric.New(name, tags, fields, tm, tp...)
 	return m
 }
 
 func FromTestMetric(met *Metric) telegraf.Metric {
-	m := metric.New(met.Measurement, met.Tags, met.Fields, met.Time, met.Type)
+	m := telegrafMetric.New(met.Measurement, met.Tags, met.Fields, met.Time, met.Type)
 	return m
 }

--- a/testutil/tls.go
+++ b/testutil/tls.go
@@ -10,11 +10,11 @@ import (
 )
 
 type pki struct {
-	path string
+	keyPath string
 }
 
-func NewPKI(path string) *pki {
-	return &pki{path: path}
+func NewPKI(keyPath string) *pki {
+	return &pki{keyPath: keyPath}
 }
 
 func (p *pki) TLSClientConfig() *tls.ClientConfig {
@@ -41,7 +41,7 @@ func (p *pki) ReadCACert() string {
 }
 
 func (p *pki) CACertPath() string {
-	return path.Join(p.path, "cacert.pem")
+	return path.Join(p.keyPath, "cacert.pem")
 }
 
 func (p *pki) CipherSuite() string {
@@ -61,7 +61,7 @@ func (p *pki) ReadClientCert() string {
 }
 
 func (p *pki) ClientCertPath() string {
-	return path.Join(p.path, "clientcert.pem")
+	return path.Join(p.keyPath, "clientcert.pem")
 }
 
 func (p *pki) ReadClientKey() string {
@@ -69,19 +69,19 @@ func (p *pki) ReadClientKey() string {
 }
 
 func (p *pki) ClientKeyPath() string {
-	return path.Join(p.path, "clientkey.pem")
+	return path.Join(p.keyPath, "clientkey.pem")
 }
 
 func (p *pki) ClientCertAndKeyPath() string {
-	return path.Join(p.path, "client.pem")
+	return path.Join(p.keyPath, "client.pem")
 }
 
 func (p *pki) ClientEncKeyPath() string {
-	return path.Join(p.path, "clientkeyenc.pem")
+	return path.Join(p.keyPath, "clientkeyenc.pem")
 }
 
 func (p *pki) ClientCertAndEncKeyPath() string {
-	return path.Join(p.path, "clientenc.pem")
+	return path.Join(p.keyPath, "clientenc.pem")
 }
 
 func (p *pki) ReadServerCert() string {
@@ -89,7 +89,7 @@ func (p *pki) ReadServerCert() string {
 }
 
 func (p *pki) ServerCertPath() string {
-	return path.Join(p.path, "servercert.pem")
+	return path.Join(p.keyPath, "servercert.pem")
 }
 
 func (p *pki) ReadServerKey() string {
@@ -97,11 +97,11 @@ func (p *pki) ReadServerKey() string {
 }
 
 func (p *pki) ServerKeyPath() string {
-	return path.Join(p.path, "serverkey.pem")
+	return path.Join(p.keyPath, "serverkey.pem")
 }
 
 func (p *pki) ServerCertAndKeyPath() string {
-	return path.Join(p.path, "server.pem")
+	return path.Join(p.keyPath, "server.pem")
 }
 
 func readCertificate(filename string) string {


### PR DESCRIPTION
Following findings were fixed:
```
agent/accumulator.go:12:13                                              revive       import-shadowing: The name 'metric' shadows an import name
agent/agent.go:26:15                                                    revive       import-shadowing: The name 'config' shadows an import name
internal/http.go:123:9                                                  revive       import-shadowing: The name 'net' shadows an import name
logger/logger.go:113:19                                                 revive       import-shadowing: The name 'config' shadows an import name
logger/logger.go:120:43                                                 revive       import-shadowing: The name 'config' shadows an import name
logger/logger.go:149:19                                                 revive       import-shadowing: The name 'config' shadows an import name
logger/logger.go:47:15                                                  revive       import-shadowing: The name 'config' shadows an import name
logger/logger_test.go:117:2                                             revive       import-shadowing: The name 'config' shadows an import name
logger/logger_test.go:21:2                                              revive       import-shadowing: The name 'config' shadows an import name
logger/logger_test.go:35:2                                              revive       import-shadowing: The name 'config' shadows an import name
logger/logger_test.go:49:2                                              revive       import-shadowing: The name 'config' shadows an import name
logger/logger_test.go:64:2                                              revive       import-shadowing: The name 'config' shadows an import name
logger/logger_test.go:78:2                                              revive       import-shadowing: The name 'config' shadows an import name
models/log.go:82:39                                                     revive       import-shadowing: The name 'log' shadows an import name
models/running_aggregator.go:111:40                                     revive       import-shadowing: The name 'metric' shadows an import name
plugins/common/shim/example/cmd/main.go:43:2                            revive       import-shadowing: The name 'shim' shadows an import name
testutil/metric.go:94:20                                                revive       import-shadowing: The name 'metric' shadows an import name
testutil/tls.go:16:13                                                   revive       import-shadowing: The name 'path' shadows an import name

```
