### PR TITLE
feat: enrich AWS CW metrics with additional tags

### DIFF
--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -1,8 +1,9 @@
 package all
 
 import (
-	//Blank imports for plugins to register themselves
+	// Blank imports for plugins to register themselves
 	_ "github.com/influxdata/telegraf/plugins/processors/aws/ec2"
+	_ "github.com/influxdata/telegraf/plugins/processors/aws/tags"
 	_ "github.com/influxdata/telegraf/plugins/processors/clone"
 	_ "github.com/influxdata/telegraf/plugins/processors/converter"
 	_ "github.com/influxdata/telegraf/plugins/processors/date"

--- a/plugins/processors/aws/tags/cache.go
+++ b/plugins/processors/aws/tags/cache.go
@@ -1,0 +1,155 @@
+package tags
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/influxdata/telegraf"
+)
+
+// Tags is a read only map. Since it could be returned to multiple go routines simultaneously
+// we have to make sure no one writes to it to avoid race conditions.
+type Tags struct {
+	t time.Time
+	m map[string]string
+}
+
+func (t *Tags) Keys() (keys []string) {
+	for key := range t.m {
+		keys = append(keys, key)
+	}
+	return
+}
+
+func (t *Tags) Value(key string) (value string) {
+	value = t.m[key]
+	return
+}
+
+func (t *Tags) age() time.Duration {
+	return time.Now().Sub(t.t)
+}
+
+type TagCache struct {
+	maxAge         time.Duration
+	requestTimeout time.Duration
+	ec2Client      *ec2.Client
+	log            telegraf.Logger
+	// cache maps instance ids to a set of tags
+	// TODO: one optimization that could be done, if memory is a concern, is to only save the tags that are requested
+	cache     map[string]*Tags
+	cacheLock sync.RWMutex
+	// requests holds all ongoing requests so that calls can check for already ongoing requests
+	// and simply wait on them instead of duplicating calls.
+	requests     map[string]*sync.WaitGroup
+	requestsLock sync.Mutex
+	// requestsQueue is used to limit the amount of parallel requests
+	// TODO: since we already limit parallelism through the use of the parallel package
+	//       we could think about removing this. However, it would make more sense to increase
+	//       the number of workers to a fixed, reasonable amount and only use this request limiting
+	//       since the workers (most of the time) won't need to hit the network anyways.
+	requestsQueue chan bool
+}
+
+// Get simplifies the access to tags by always choosing the quickest option to
+// obtain the needed tags and automatically renewing outdated cache entries.
+func (c *TagCache) Get(id string) *Tags {
+	c.cacheLock.RLock()
+	tags, ok := c.cache[id]
+	c.cacheLock.RUnlock()
+	if ok {
+		c.log.Debugf("serving tags from cache for %s", id)
+		if tags.age() > c.maxAge {
+			c.log.Debugf("cache expired for %s, refreshing", id)
+			go c.fetch(id)
+		}
+		return tags
+	}
+
+	c.fetch(id)
+
+	c.cacheLock.RLock()
+	tags = c.cache[id]
+	c.cacheLock.RUnlock()
+	return tags
+}
+
+// fetch either waits for the existing request to complete or triggers a new one and waits
+// for it to complete.
+// TODO: this can result in duplicate requests if someone is waiting at the top of the function while
+//       we delete the WaitGroup at the bottom. However, that should generally not happen since we
+//       wrote the value already to the cache which prevents anyone from calling fetch on this id.
+func (c *TagCache) fetch(id string) {
+	c.log.Debugf("fetching tags for %s", id)
+	c.requestsLock.Lock()
+	if req, ok := c.requests[id]; ok {
+		c.requestsLock.Unlock()
+		c.log.Debugf("request to fetch tags for %s already running, waiting", id)
+		req.Wait()
+		return
+	}
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	c.requests[id] = wg
+	c.requestsLock.Unlock()
+
+	tags := c.getTags(id)
+	c.cacheLock.Lock()
+	c.cache[id] = &Tags{m: tags, t: time.Now()}
+	c.cacheLock.Unlock()
+
+	wg.Done()
+	c.requestsLock.Lock()
+	delete(c.requests, id)
+	c.requestsLock.Unlock()
+}
+
+// getTags is the actual call to the AWS API to retrieve tags for a given
+// instance id. Parallelism is limited by the requestsQueue
+func (c *TagCache) getTags(id string) map[string]string {
+	c.log.Debugf("calling aws API for %s, %d requests currently in flight", id, len(c.requestsQueue))
+	// this will block if we already have maxParallel requests in flight
+	c.requestsQueue <- true
+
+	ctx := context.Background()
+	context.WithTimeout(context.Background(), c.requestTimeout)
+	describeTags, err := c.ec2Client.DescribeTags(ctx, &ec2.DescribeTagsInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("resource-id"),
+				Values: []string{id},
+			},
+		},
+	})
+
+	tags := make(map[string]string)
+	if err != nil {
+		c.log.Errorf("unable to describe tags for instance id %s; reason: %s", id, err.Error())
+	} else {
+		for _, tag := range describeTags.Tags {
+			tags[*tag.Key] = *tag.Value
+		}
+	}
+
+	<-c.requestsQueue
+	return tags
+}
+
+func NewTagCache(maxAge, requestTimeout time.Duration, maxParallel int, ec2Client *ec2.Client, log telegraf.Logger) *TagCache {
+	c := &TagCache{
+		maxAge:         maxAge,
+		requestTimeout: requestTimeout,
+		ec2Client:      ec2Client,
+		log:            log,
+		cache:          make(map[string]*Tags),
+		cacheLock:      sync.RWMutex{},
+		requests:       make(map[string]*sync.WaitGroup),
+		requestsLock:   sync.Mutex{},
+		requestsQueue:  make(chan bool, maxParallel),
+	}
+	return c
+}

--- a/plugins/processors/aws/tags/tags.go
+++ b/plugins/processors/aws/tags/tags.go
@@ -1,0 +1,213 @@
+package tags
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/smithy-go"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	internalAWS "github.com/influxdata/telegraf/config/aws"
+	"github.com/influxdata/telegraf/plugins/common/parallel"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+type AwsTagsProcessor struct {
+	Tags             []string        `toml:"tags"`
+	Timeout          config.Duration `toml:"timeout"`
+	MaxCacheAge      config.Duration `toml:"max_cache_age"`
+	Ordered          bool            `toml:"ordered"`
+	MaxParallelCalls int             `toml:"max_parallel_calls"`
+
+	internalAWS.CredentialConfig
+
+	Log telegraf.Logger `toml:"-"`
+
+	tagCache  *TagCache
+	ec2Client *ec2.Client
+	parallel  parallel.Parallel
+}
+
+const sampleConfig = `
+  ## Amazon Region
+  region = "eu-central-1"
+
+  ## Amazon Credentials
+  ## Credentials are loaded in the following order
+  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 2) Assumed credentials via STS if role_arn is specified
+  ## 3) explicit credentials from 'access_key' and 'secret_key'
+  ## 4) shared profile from 'profile'
+  ## 5) environment variables
+  ## 6) shared credentials file
+  ## 7) EC2 Instance Profile
+  # access_key = ""
+  # secret_key = ""
+  # token = ""
+  # role_arn = ""
+  # web_identity_token_file = ""
+  # role_session_name = ""
+  # profile = ""
+  # shared_credential_file = ""
+
+  ## EC2 instance tags retrieved with DescribeTags action.
+  ## In case tag is empty upon retrieval it's omitted when tagging metrics.
+  ## Note that in order for this to work, role attached to EC2 instance or AWS
+  ## credentials available from the environment must have a policy attached, that
+  ## allows ec2:DescribeTags.
+  ##
+  ## For more information see:
+  ## https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTags.html
+  tags = []
+
+  ## Timeout for http requests made against aws ec2 metadata endpoint.
+  timeout = "10s"
+
+  ## Maximum age of cached data after which it will be refreshed. Please note that refreshing
+  ## the data takes an additional metrics run since it is done asynchronously to not delay metrics.
+  ## e.g. the first request after the age expired will still use the cached data but the refresh
+  ## will start in the background.
+  ## It is recommended to keep this value high to avoid charges for API requests.
+  max_cache_age = "1h"
+
+  ## ordered controls whether or not the metrics need to stay in the same order
+  ## this plugin received them in. If false, this plugin will change the order
+  ## with requests hitting cached results moving through immediately and not
+  ## waiting on slower lookups. This may cause issues for you if you are
+  ## depending on the order of metrics staying the same. If so, set this to true.
+  ## Keeping the metrics ordered may be slightly slower.
+  ordered = false
+
+  ## max_parallel_calls is the maximum number of AWS API calls to be in flight
+  ## at the same time.
+  max_parallel_calls = 10
+`
+
+const (
+	DefaultMaxOrderedQueueSize = 10_000
+	DefaultMaxParallelCalls    = 10
+	DefaultTimeout             = 10 * time.Second
+)
+
+func (r *AwsTagsProcessor) SampleConfig() string {
+	return sampleConfig
+}
+
+func (r *AwsTagsProcessor) Description() string {
+	return "Attach AWS EC2 metadata to metrics"
+}
+
+func (r *AwsTagsProcessor) Add(metric telegraf.Metric, _ telegraf.Accumulator) error {
+	r.parallel.Enqueue(metric)
+	return nil
+}
+
+func (r *AwsTagsProcessor) Init() error {
+	r.Log.Debug("Initializing AWS Tags Processor")
+	if len(r.Tags) == 0 {
+		return errors.New("no tags specified in configuration")
+	}
+	r.tagCache = NewTagCache(time.Duration(r.MaxCacheAge), time.Duration(r.Timeout), r.MaxParallelCalls, nil, r.Log)
+	return nil
+}
+
+func (r *AwsTagsProcessor) Start(acc telegraf.Accumulator) error {
+	ctx := context.Background()
+	cfg, err := r.CredentialConfig.Credentials()
+	if err != nil {
+		return fmt.Errorf("failed loading default AWS config: %w", err)
+	}
+
+	ec2Client := ec2.NewFromConfig(cfg)
+
+	_, err = ec2Client.DescribeTags(ctx, &ec2.DescribeTagsInput{
+		DryRun: true,
+	})
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		if ae.ErrorCode() != "DryRunOperation" {
+			return fmt.Errorf("instance doesn't have permissions to call DescribeTags: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("error calling DescribeTags: %w", err)
+	}
+
+	r.tagCache.ec2Client = ec2Client
+
+	if r.Ordered {
+		r.parallel = parallel.NewOrdered(acc, r.asyncAdd, DefaultMaxOrderedQueueSize, r.MaxParallelCalls)
+	} else {
+		r.parallel = parallel.NewUnordered(acc, r.asyncAdd, r.MaxParallelCalls)
+	}
+
+	return nil
+}
+
+func (r *AwsTagsProcessor) Stop() error {
+	if r.parallel == nil {
+		return errors.New("trying to stop un-started AWS EC2 Processor")
+	}
+	r.parallel.Stop()
+	return nil
+}
+
+func (r *AwsTagsProcessor) asyncAdd(metric telegraf.Metric) []telegraf.Metric {
+	instanceId := getInstanceId(metric)
+	if instanceId == "" {
+		r.Log.Errorf("unable to determine instance id, unknown metric name %s", metric.Name())
+		return []telegraf.Metric{metric}
+	}
+
+	tags := r.tagCache.Get(instanceId)
+	tagKeys := tags.Keys()
+	if len(tagKeys) == 0 {
+		r.Log.Warnf("received empty list of tags for %s", instanceId)
+	}
+
+	for _, tag := range tagKeys {
+		if r.wantedTag(tag) {
+			value := tags.Value(tag)
+			if value != "" {
+				metric.AddTag(tag, tags.Value(tag))
+			}
+		}
+	}
+
+	return []telegraf.Metric{metric}
+}
+
+func (r *AwsTagsProcessor) wantedTag(tag string) bool {
+	for _, wantedTag := range r.Tags {
+		if wantedTag == tag {
+			return true
+		}
+	}
+	return false
+}
+
+func getInstanceId(metric telegraf.Metric) string {
+	// TODO: add other metric names
+	switch metric.Name() {
+	case "cloudwatch_aws_nat_gateway":
+		return metric.Tags()["nat_gateway_id"]
+	default:
+		return ""
+	}
+}
+
+func init() {
+	processors.AddStreaming("aws_tags", func() telegraf.StreamingProcessor {
+		return newAwsTagsProcessor()
+	})
+}
+
+func newAwsTagsProcessor() *AwsTagsProcessor {
+	return &AwsTagsProcessor{
+		MaxParallelCalls: DefaultMaxParallelCalls,
+		Timeout:          config.Duration(DefaultTimeout),
+	}
+}


### PR DESCRIPTION
new plugin `aws_tags` copied from the existing `aws_ec2` plugins,
excluding the instance identity logic. It includes a tag cache which
contains the majority of the logic so it can easily be moved around.

### Required for all PRs:

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10639

Most of the details are in the issue. Since I didn't get feedback there I'm opening this PR to start a discussion around this.

My main question is whether this functionality should be a standalone plugin or integrated into the CloudWatch plugin?