### PR TITLE
chore: update dependabot commit from fix to chore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
       # Dependabot isn't able to update this packages that do not match the source, so anything with a version
       - dependency-name: "*.v*"
     commit-message:
-      prefix: "fix:"
+      prefix: "chore:"


### PR DESCRIPTION
I think updating dependencies probably make more sense to be labelled as "chore" then "fix", thoughts?