### PR TITLE
fix: openweathermap add feels_like field

### DIFF
--- a/plugins/inputs/openweathermap/README.md
+++ b/plugins/inputs/openweathermap/README.md
@@ -60,6 +60,7 @@ condition ID, icon, and main is at [weather conditions][].
     - sunrise (int, nanoseconds since unix epoch)
     - sunset (int, nanoseconds since unix epoch)
     - temperature (float, degrees)
+    - feels_like (float, degrees)
     - visibility (int, meters, not available on forecast data)
     - wind_degrees (float, wind direction in degrees)
     - wind_speed (float, wind speed in meters/sec or miles/sec)
@@ -69,9 +70,10 @@ condition ID, icon, and main is at [weather conditions][].
 ## Example Output
 
 ```shell
-> weather,city=San\ Francisco,city_id=5391959,condition_id=800,condition_main=Clear,country=US,forecast=* cloudiness=1i,condition_description="clear sky",condition_icon="01d",humidity=35i,pressure=1012,rain=0,sunrise=1570630329000000000i,sunset=1570671689000000000i,temperature=21.52,visibility=16093i,wind_degrees=280,wind_speed=5.7 1570659256000000000
-> weather,city=San\ Francisco,city_id=5391959,condition_id=800,condition_main=Clear,country=US,forecast=3h cloudiness=0i,condition_description="clear sky",condition_icon="01n",humidity=41i,pressure=1010,rain=0,temperature=22.34,wind_degrees=249.393,wind_speed=2.085 1570665600000000000
-> weather,city=San\ Francisco,city_id=5391959,condition_id=800,condition_main=Clear,country=US,forecast=6h cloudiness=0i,condition_description="clear sky",condition_icon="01n",humidity=50i,pressure=1012,rain=0,temperature=17.09,wind_degrees=310.754,wind_speed=3.009 1570676400000000000
+> weather,city=San\ Francisco,city_id=5391959,condition_id=803,condition_main=Clouds,country=US,forecast=114h,host=robot pressure=1027,temperature=10.09,wind_degrees=34,wind_speed=1.24,condition_description="broken clouds",cloudiness=80i,humidity=67i,rain=0,feels_like=8.9,condition_icon="04n" 1645952400000000000
+> weather,city=San\ Francisco,city_id=5391959,condition_id=804,condition_main=Clouds,country=US,forecast=117h,host=robot humidity=65i,rain=0,temperature=10.12,wind_degrees=31,cloudiness=90i,pressure=1026,feels_like=8.88,wind_speed=1.31,condition_description="overcast clouds",condition_icon="04n" 1645963200000000000
+> weather,city=San\ Francisco,city_id=5391959,condition_id=804,condition_main=Clouds,country=US,forecast=120h,host=robot cloudiness=100i,humidity=61i,rain=0,temperature=10.28,wind_speed=1.94,condition_icon="04d",pressure=1027,feels_like=8.96,wind_degrees=16,condition_description="overcast clouds" 1645974000000000000
+
 ```
 
 [api key]: https://openweathermap.org/appid

--- a/plugins/inputs/openweathermap/openweathermap.go
+++ b/plugins/inputs/openweathermap/openweathermap.go
@@ -176,6 +176,7 @@ type WeatherEntry struct {
 		Humidity int64   `json:"humidity"`
 		Pressure float64 `json:"pressure"`
 		Temp     float64 `json:"temp"`
+		Feels    float64 `json:"feels_like"`
 	} `json:"main"`
 	Rain struct {
 		Rain1 float64 `json:"1h"`
@@ -246,6 +247,7 @@ func gatherWeather(acc telegraf.Accumulator, status *Status) {
 			"sunrise":      time.Unix(e.Sys.Sunrise, 0).UnixNano(),
 			"sunset":       time.Unix(e.Sys.Sunset, 0).UnixNano(),
 			"temperature":  e.Main.Temp,
+			"feels_like":   e.Main.Feels,
 			"visibility":   e.Visibility,
 			"wind_degrees": e.Wind.Deg,
 			"wind_speed":   e.Wind.Speed,
@@ -283,6 +285,7 @@ func gatherForecast(acc telegraf.Accumulator, status *Status) {
 			"pressure":     e.Main.Pressure,
 			"rain":         gatherRain(e),
 			"temperature":  e.Main.Temp,
+			"feels_like":   e.Main.Feels,
 			"wind_degrees": e.Wind.Deg,
 			"wind_speed":   e.Wind.Speed,
 		}

--- a/plugins/inputs/openweathermap/openweathermap_test.go
+++ b/plugins/inputs/openweathermap/openweathermap_test.go
@@ -687,7 +687,7 @@ func TestRainMetrics(t *testing.T) {
 				"humidity":              int64(87),
 				"pressure":              1007.0,
 				"temperature":           9.25,
-				"feels_like":            8.25
+				"feels_like":            8.25,
 				"rain":                  0.0,
 				"sunrise":               int64(1544167818000000000),
 				"sunset":                int64(1544198047000000000),

--- a/plugins/inputs/openweathermap/openweathermap_test.go
+++ b/plugins/inputs/openweathermap/openweathermap_test.go
@@ -43,6 +43,7 @@ const sampleStatusResponse = `
                 "pressure": 1018.65,
                 "sea_level": 1030.99,
                 "temp": 6.71,
+                "feels_like": 5.71,
                 "temp_kf": -2.14
             },
             "rain": {
@@ -76,6 +77,7 @@ const sampleStatusResponse = `
                 "pressure": 1032.18,
                 "sea_level": 1044.78,
                 "temp": 6.38,
+                "feels_like": 5.38,
                 "temp_kf": 0
             },
             "rain": {
@@ -118,7 +120,8 @@ const groupWeatherResponse = `
         "main": {
             "humidity": 87,
             "pressure": 1007,
-            "temp": 9.25
+            "temp": 9.25,
+            "feels_like": 8.25
         },
         "name": "Paris",
         "sys": {
@@ -155,7 +158,8 @@ const rainWeatherResponse = `
         "main": {
             "humidity": 87,
             "pressure": 1007,
-            "temp": 9.25
+            "temp": 9.25,
+            "feels_like": 8.25
         },
         "name": "Paris",
         "sys": {
@@ -189,7 +193,8 @@ const rainWeatherResponse = `
         "main": {
             "humidity": 87,
             "pressure": 1007,
-            "temp": 9.25
+            "temp": 9.25,
+            "feels_like": 8.25
         },
         "name": "Paris",
         "sys": {
@@ -223,7 +228,8 @@ const rainWeatherResponse = `
         "main": {
             "humidity": 87,
             "pressure": 1007,
-            "temp": 9.25
+            "temp": 9.25,
+            "feels_like": 8.25
         },
         "name": "Paris",
         "sys": {
@@ -258,7 +264,8 @@ const rainWeatherResponse = `
         "main": {
             "humidity": 87,
             "pressure": 1007,
-            "temp": 9.25
+            "temp": 9.25,
+            "feels_like": 8.25
         },
         "name": "Paris",
         "sys": {
@@ -309,6 +316,7 @@ const batchWeatherResponse = `
 		}],
 		"main": {
 			"temp": 9.57,
+			"feels_like": 8.57,
 			"pressure": 1014,
 			"humidity": 46
 		},
@@ -344,6 +352,7 @@ const batchWeatherResponse = `
 		}],
 		"main": {
 			"temp": 19.29,
+			"feels_like": 18.29,
 			"pressure": 1009,
 			"humidity": 63
 		},
@@ -378,6 +387,7 @@ const batchWeatherResponse = `
 		}],
 		"main": {
 			"temp": 10.62,
+			"feels_like": 9.62,
 			"pressure": 1019,
 			"humidity": 66
 		},
@@ -445,6 +455,7 @@ func TestForecastGeneratesMetrics(t *testing.T) {
 				"humidity":              int64(91),
 				"pressure":              1018.65,
 				"temperature":           6.71,
+				"feels_like":            5.71,
 				"rain":                  0.035,
 				"wind_degrees":          228.501,
 				"wind_speed":            3.76,
@@ -468,6 +479,7 @@ func TestForecastGeneratesMetrics(t *testing.T) {
 				"humidity":              int64(98),
 				"pressure":              1032.18,
 				"temperature":           6.38,
+				"feels_like":            5.38,
 				"rain":                  0.049999999999997,
 				"wind_degrees":          335.005,
 				"wind_speed":            2.66,
@@ -529,6 +541,7 @@ func TestWeatherGeneratesMetrics(t *testing.T) {
 				"humidity":              int64(87),
 				"pressure":              1007.0,
 				"temperature":           9.25,
+				"feels_like":            8.25,
 				"rain":                  0.0,
 				"sunrise":               int64(1544167818000000000),
 				"sunset":                int64(1544198047000000000),
@@ -590,6 +603,7 @@ func TestRainMetrics(t *testing.T) {
 				"humidity":              int64(87),
 				"pressure":              1007.0,
 				"temperature":           9.25,
+				"feels_like":            8.25,
 				"rain":                  1.0,
 				"sunrise":               int64(1544167818000000000),
 				"sunset":                int64(1544198047000000000),
@@ -617,6 +631,7 @@ func TestRainMetrics(t *testing.T) {
 				"humidity":              int64(87),
 				"pressure":              1007.0,
 				"temperature":           9.25,
+				"feels_like":            8.25,
 				"rain":                  3.0,
 				"sunrise":               int64(1544167818000000000),
 				"sunset":                int64(1544198047000000000),
@@ -644,6 +659,7 @@ func TestRainMetrics(t *testing.T) {
 				"humidity":              int64(87),
 				"pressure":              1007.0,
 				"temperature":           9.25,
+				"feels_like":            8.25,
 				"rain":                  1.3,
 				"sunrise":               int64(1544167818000000000),
 				"sunset":                int64(1544198047000000000),
@@ -671,6 +687,7 @@ func TestRainMetrics(t *testing.T) {
 				"humidity":              int64(87),
 				"pressure":              1007.0,
 				"temperature":           9.25,
+				"feels_like":            8.25
 				"rain":                  0.0,
 				"sunrise":               int64(1544167818000000000),
 				"sunset":                int64(1544198047000000000),
@@ -732,6 +749,7 @@ func TestBatchWeatherGeneratesMetrics(t *testing.T) {
 				"humidity":              int64(46),
 				"pressure":              1014.0,
 				"temperature":           9.57,
+				"feels_like":            8.57,
 				"wind_degrees":          60.0,
 				"wind_speed":            5.0,
 				"rain":                  0.0,
@@ -758,6 +776,7 @@ func TestBatchWeatherGeneratesMetrics(t *testing.T) {
 				"humidity":              int64(63),
 				"pressure":              1009.0,
 				"temperature":           19.29,
+				"feels_like":            18.29,
 				"wind_degrees":          0.0,
 				"wind_speed":            1.0,
 				"rain":                  0.0,
@@ -784,6 +803,7 @@ func TestBatchWeatherGeneratesMetrics(t *testing.T) {
 				"humidity":              int64(66),
 				"pressure":              1019.0,
 				"temperature":           10.62,
+				"feels_like":            9.62,
 				"wind_degrees":          290.0,
 				"wind_speed":            6.2,
 				"rain":                  0.072,


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10695 

Added the necessary float data structure to hold the feels_like temperature data. 
Updated the test case to include the data during tests.
Ran locally and updated the README.md to include the actual data from the API.
