### PR TITLE
fix(inputs.docker): keep field type of tasks_desired the same

### DIFF
--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -314,7 +314,7 @@ func (d *Docker) gatherSwarmInfo(acc telegraf.Accumulator) error {
 		}
 
 		running := map[string]int{}
-		tasksNoShutdown := map[string]int{}
+		tasksNoShutdown := map[string]uint64{}
 
 		activeNodes := make(map[string]struct{})
 		for _, n := range nodes {

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -1104,7 +1104,7 @@ func TestDockerGatherSwarmInfo(t *testing.T) {
 		"docker_swarm",
 		map[string]interface{}{
 			"tasks_running": int(1),
-			"tasks_desired": int(1),
+			"tasks_desired": uint64(1),
 		},
 		map[string]string{
 			"service_id":   "qolkls9g5iasdiuihcyz9rn3",


### PR DESCRIPTION
Resolve: https://github.com/influxdata/telegraf/issues/8570

The field `tasks_desired` could change between int and uint64, which caused the issue `already exists as type` in #8570. Keeping it as uint64 seems like the best option because `tasksNoShutdown` which was an int that only increments up and should never be negative.
