### PR TITLE
fix: ignore env vars in comments

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,8 +49,7 @@ var (
 	outputDefaults = []string{"influxdb"}
 
 	// envVarRe is a regex to find environment variables in the config file
-	envVarLineRe = regexp.MustCompile(`^#.*(\$\{(\w+)\}|\$(\w+)).*$`)
-	envVarRe     = regexp.MustCompile(`\$\{(\w+)\}|\$(\w+)`)
+	envVarRe = regexp.MustCompile(`\$\{(\w+)\}|\$(\w+)`)
 
 	envVarEscaper = strings.NewReplacer(
 		`"`, `\"`,

--- a/config/config.go
+++ b/config/config.go
@@ -1032,7 +1032,7 @@ func parseConfig(contents []byte) (*ast.Table, error) {
 	for scanner.Scan() {
 		// Get Bytes and display the byte.
 		b := scanner.Bytes()
-		if strings.HasPrefix(string(b), "#") {
+		if strings.HasPrefix(strings.TrimLeft(string(b), " "), "#") {
 			continue
 		}
 		parameters := envVarRe.FindAllSubmatch(b, -1)

--- a/config/testdata/single_plugin_env_vars.toml
+++ b/config/testdata/single_plugin_env_vars.toml
@@ -1,3 +1,18 @@
+# Telegraf Configuration
+#
+# Telegraf is entirely plugin driven. All metrics are gathered from the
+# declared inputs, and sent to the declared outputs.
+#
+# Plugins must be declared in here to be active.
+# To deactivate a plugin, comment out the name and any variables.
+#
+# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
+# file would generate.
+#
+# Environment variables can be used anywhere in this config file, simply surround
+# them with ${}. For strings the variable must be within quotes (ie, "${STR_VAR}"),
+# for numbers and booleans they should be plain (ie, ${INT_VAR}, ${BOOL_VAR})
+
 [[inputs.memcached]]
   servers = ["$MY_TEST_SERVER"]
   namepass = ["metricname1", "ip_${MY_TEST_SERVER}_name"]


### PR DESCRIPTION
resolve: https://github.com/influxdata/telegraf/issues/10723

This PR introduced a bug: https://github.com/influxdata/telegraf/pull/10681 causing Telegraf to error when an env variables is mentioned in a comment. This PR resolves it by going through each line and ignoring if the line starts with a `#` indicating it is a comment.