### PR TITLE
fix: Revert "fix: error msg for missing env variables in config (#10681)"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1026,7 +1026,6 @@ func parseConfig(contents []byte) (*ast.Table, error) {
 	contents = trimBOM(contents)
 
 	parameters := envVarRe.FindAllSubmatch(contents, -1)
-	var missingEnvVars []string
 	for _, parameter := range parameters {
 		if len(parameter) != 3 {
 			continue
@@ -1045,19 +1044,7 @@ func parseConfig(contents []byte) (*ast.Table, error) {
 		if ok {
 			envVal = escapeEnv(envVal)
 			contents = bytes.Replace(contents, parameter[0], []byte(envVal), 1)
-		} else {
-			missingEnvVars = append(missingEnvVars, string(envVar))
 		}
-	}
-
-	// Report all missing environment variables to the user
-	if len(missingEnvVars) > 0 {
-		errorMsg := "environment variable(s) not set:"
-		for _, e := range missingEnvVars {
-			errorMsg += e + " "
-		}
-
-		return nil, fmt.Errorf(errorMsg)
 	}
 
 	return toml.Parse(contents)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -264,15 +264,13 @@ func TestConfig_WrongFieldType(t *testing.T) {
 func TestConfig_InlineTables(t *testing.T) {
 	// #4098
 	c := NewConfig()
-	require.NoError(t, os.Setenv("TOKEN", "test"))
 	require.NoError(t, c.LoadConfig("./testdata/inline_table.toml"))
 	require.Len(t, c.Outputs, 2)
 
 	output, ok := c.Outputs[1].Output.(*MockupOuputPlugin)
 	require.True(t, ok)
-	require.Equal(t, map[string]string{"Authorization": "Token test", "Content-Type": "application/json"}, output.Headers)
+	require.Equal(t, map[string]string{"Authorization": "Token $TOKEN", "Content-Type": "application/json"}, output.Headers)
 	require.Equal(t, []string{"org_id"}, c.Outputs[0].Config.Filter.TagInclude)
-	require.NoError(t, os.Unsetenv("TOKEN"))
 }
 
 func TestConfig_SliceComment(t *testing.T) {

--- a/config/testdata/single_plugin_env_vars.toml
+++ b/config/testdata/single_plugin_env_vars.toml
@@ -1,3 +1,18 @@
+# Telegraf Configuration
+#
+# Telegraf is entirely plugin driven. All metrics are gathered from the
+# declared inputs, and sent to the declared outputs.
+#
+# Plugins must be declared in here to be active.
+# To deactivate a plugin, comment out the name and any variables.
+#
+# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
+# file would generate.
+#
+# Environment variables can be used anywhere in this config file, simply surround
+# them with ${}. For strings the variable must be within quotes (ie, "${STR_VAR}"),
+# for numbers and booleans they should be plain (ie, ${INT_VAR}, ${BOOL_VAR})
+
 [[inputs.memcached]]
   servers = ["$MY_TEST_SERVER"]
   namepass = ["metricname1", "ip_${MY_TEST_SERVER}_name"]


### PR DESCRIPTION
Resolve: https://github.com/influxdata/telegraf/issues/10723

As suggested in: https://github.com/influxdata/telegraf/pull/10726#issuecomment-1048921716 better to revert this change for now and create a new PR to address unset environment variables that takes into account comments.
