### PR TITLE
fix: SNMP MIBs: use the correct path when evaluating symlink

### DIFF
--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -67,7 +67,7 @@ func LoadMibsFromPath(paths []string, log telegraf.Logger, loader MibLoader) err
 				symlink := filepath.Join(path, info.Name())
 				target, err := filepath.EvalSymlinks(symlink)
 				if err != nil {
-					log.Warnf("Couldn't evaluate symbolic links for %v: %v", info.Name(), err)
+					log.Warnf("Couldn't evaluate symbolic links for %v: %v", symlink, err)
 					continue
 				}
 				//replace symlink's info with the target's info
@@ -118,7 +118,7 @@ func walkPaths(paths []string, log telegraf.Logger) ([]string, error) {
 			if info.Mode()&os.ModeSymlink != 0 {
 				target, err := filepath.EvalSymlinks(path)
 				if err != nil {
-					log.Warnf("Couldn't evaluate symbolic links for %v: %v", target, err)
+					log.Warnf("Couldn't evaluate symbolic links for %v: %v", path, err)
 				}
 				info, err = os.Lstat(target)
 				if err != nil {

--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -20,8 +20,12 @@ var once sync.Once
 var cache = make(map[string]bool)
 
 type MibLoader interface {
-	loadModule(path string) error
+	// appendPath takes the path of a directory
 	appendPath(path string)
+
+	// loadModule takes the name of a file in one of the
+	// directories. Basename only, no relative or absolute path
+	loadModule(path string) error
 }
 
 type GosmiMibLoader struct{}
@@ -60,17 +64,18 @@ func LoadMibsFromPath(paths []string, log telegraf.Logger, loader MibLoader) err
 
 		for _, info := range modules {
 			if info.Mode()&os.ModeSymlink != 0 {
-				target, err := filepath.EvalSymlinks(path)
+				symlink := filepath.Join(path, info.Name())
+				target, err := filepath.EvalSymlinks(symlink)
 				if err != nil {
-					log.Warnf("Couldn't evaluate symbolic links for %v: %v", target, err)
+					log.Warnf("Couldn't evaluate symbolic links for %v: %v", info.Name(), err)
 					continue
 				}
-				info, err = os.Lstat(filepath.Join(path, target))
+				//replace symlink's info with the target's info
+				info, err = os.Lstat(target)
 				if err != nil {
 					log.Warnf("Couldn't stat target %v: %v", target, err)
 					continue
 				}
-				path = target
 			}
 			if info.Mode().IsRegular() {
 				err := loader.loadModule(info.Name())

--- a/internal/snmp/translate_test.go
+++ b/internal/snmp/translate_test.go
@@ -107,8 +107,6 @@ func TestFolderLookup(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on windows")
 	}
-	var folders []string
-	var givenPath []string
 
 	tests := []struct {
 		name    string
@@ -132,17 +130,23 @@ func TestFolderLookup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			loader := TestingMibLoader{}
+
+			var givenPath []string
 			for _, paths := range tt.mibPath {
 				rootPath := filepath.Join(paths...)
 				givenPath = append(givenPath, rootPath)
 			}
+
 			err := LoadMibsFromPath(givenPath, testutil.Logger{}, &loader)
 			require.NoError(t, err)
+
+			var folders []string
 			for _, pathSlice := range tt.paths {
 				path := filepath.Join(pathSlice...)
 				folders = append(folders, path)
 			}
 			require.Equal(t, folders, loader.folders)
+
 			require.Equal(t, tt.files, loader.files)
 		})
 	}


### PR DESCRIPTION
related #10674

This PR changes handling of symlinks to files when loading MIBs. Previously it would try to evaluate the parent directory's path as a symlink instead of the symlink's path.

This change should remove many "Couldn't stat target" warnings in logs like the following:

```
2022-02-17T18:06:33Z W! [inputs.snmp] Couldn't stat target /usr/share/snmp/mibs
```
