### PR TITLE
fix: metadata readme description csv parser

### DIFF
--- a/plugins/parsers/csv/README.md
+++ b/plugins/parsers/csv/README.md
@@ -39,8 +39,8 @@ values.
   ## Indicates the number of rows to parse as metadata before looking for header information. 
   ## By default, the parser assumes there are no metadata rows to parse. 
   ## If set, the parser would use the provided separators in the csv_metadata_separators to look for metadata.
-  ## Please note that by default, the (key, value) pairs will be added as fields. 
-  ## Use the csv_tag_columns to convert the metadata into tags.
+  ## Please note that by default, the (key, value) pairs will be added as tags. 
+  ## Use the converter processor to use metadata otherwise.
   csv_metadata_rows = 0
   
   ## A list of metadata separators. If csv_metadata_rows is set,

--- a/plugins/parsers/csv/README.md
+++ b/plugins/parsers/csv/README.md
@@ -36,12 +36,11 @@ values.
   ## Indicates the number of rows to skip before looking for metadata and header information.
   csv_skip_rows = 0
   
-  
   ## Indicates the number of rows to parse as metadata before looking for header information. 
   ## By default, the parser assumes there are no metadata rows to parse. 
   ## If set, the parser would use the provided separators in the csv_metadata_separators to look for metadata.
   ## Please note that by default, the (key, value) pairs will be added as fields. 
-  ## Use the tag_columns to convert the metadata into tags.
+  ## Use the csv_tag_columns to convert the metadata into tags.
   csv_metadata_rows = 0
   
   ## A list of metadata separators. If csv_metadata_rows is set,
@@ -50,7 +49,7 @@ values.
   csv_metadata_separators = [":", "="]
   
   ## A set of metadata trim characters. 
-  ## If csv_metadata_trim_cutset is not set, no trimming is performed.
+  ## If csv_metadata_trim_set is not set, no trimming is performed.
   ## Please note that the trim cutset is case sensitive.
   csv_metadata_trim_set = ""
 

--- a/plugins/parsers/csv/README.md
+++ b/plugins/parsers/csv/README.md
@@ -40,7 +40,7 @@ values.
   ## By default, the parser assumes there are no metadata rows to parse. 
   ## If set, the parser would use the provided separators in the csv_metadata_separators to look for metadata.
   ## Please note that by default, the (key, value) pairs will be added as tags. 
-  ## Use the converter processor to use metadata otherwise.
+  ## If fields are required, use the converter processor.
   csv_metadata_rows = 0
   
   ## A list of metadata separators. If csv_metadata_rows is set,

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -351,9 +351,16 @@ outer:
 		}
 	}
 
-	// add metadata fields
+	// add metadata fields and tags
+outerMetadata:
 	for k, v := range p.metadataTags {
-		tags[k] = v
+		for _, tagName := range p.TagColumns {
+			if k == tagName {
+				tags[k] = v
+				continue outerMetadata
+			}
+		}
+		recordFields[k] = v
 	}
 
 	// add default tags

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -351,16 +351,9 @@ outer:
 		}
 	}
 
-	// add metadata fields and tags
-outerMetadata:
+	// add metadata tags
 	for k, v := range p.metadataTags {
-		for _, tagName := range p.TagColumns {
-			if k == tagName {
-				tags[k] = v
-				continue outerMetadata
-			}
-		}
-		recordFields[k] = v
+		tags[k] = v
 	}
 
 	// add default tags


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Metadata is stored in fields rather than tags by default as is already described in the doc. Metadata can still be used as tag via the `csv_tag_columns` option. Original feat #10083 hasn't been released yet. This will be a breaking change after it is in `v1.22` or `v1.21.5`!
Fixed misspelled optionnames and deleted unnecessary linebreak in the readme.
