### PR TITLE
change uri scheme for default RavenDB configuration (#10765)

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -6399,8 +6399,11 @@
 
 # # Reads metrics from RavenDB servers via the Monitoring Endpoints
 # [[inputs.ravendb]]
-#   ## Node URL and port that RavenDB is listening on
-#   url = "http://localhost:8080"
+#   ## Node URL and port that RavenDB is listening on. By default,
+#   ## attempts to connect securely over HTTPS, however, if the user
+#   ## is running a local unsecure development cluster users can use
+#   ## HTTP via a URL like "http://localhost:8080"
+#   url = "https://localhost:4433"
 #
 #   ## RavenDB X509 client certificate setup
 #   # tls_cert = "/etc/telegraf/raven.crt"

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -6400,7 +6400,7 @@
 # # Reads metrics from RavenDB servers via the Monitoring Endpoints
 # [[inputs.ravendb]]
 #   ## Node URL and port that RavenDB is listening on
-#   url = "https://localhost:8080"
+#   url = "http://localhost:8080"
 #
 #   ## RavenDB X509 client certificate setup
 #   # tls_cert = "/etc/telegraf/raven.crt"

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -6267,7 +6267,7 @@
 # # Reads metrics from RavenDB servers via the Monitoring Endpoints
 # [[inputs.ravendb]]
 #   ## Node URL and port that RavenDB is listening on
-#   url = "https://localhost:8080"
+#   url = "http://localhost:8080"
 #
 #   ## RavenDB X509 client certificate setup
 #   # tls_cert = "/etc/telegraf/raven.crt"

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -6266,8 +6266,11 @@
 
 # # Reads metrics from RavenDB servers via the Monitoring Endpoints
 # [[inputs.ravendb]]
-#   ## Node URL and port that RavenDB is listening on
-#   url = "http://localhost:8080"
+#   ## Node URL and port that RavenDB is listening on. By default,
+#   ## attempts to connect securely over HTTPS, however, if the user
+#   ## is running a local unsecure development cluster users can use
+#   ## HTTP via a URL like "http://localhost:8080"
+#   url = "https://localhost:4433"
 #
 #   ## RavenDB X509 client certificate setup
 #   # tls_cert = "/etc/telegraf/raven.crt"

--- a/plugins/inputs/ravendb/README.md
+++ b/plugins/inputs/ravendb/README.md
@@ -10,8 +10,11 @@ The following is an example config for RavenDB. **Note:** The client certificate
 
 ```toml
 [[inputs.ravendb]]
-  ## Node URL and port that RavenDB is listening on
-  url = "http://localhost:8080"
+  ## Node URL and port that RavenDB is listening on. By default,
+  ## attempts to connect securely over HTTPS, however, if the user
+  ## is running a local unsecure development cluster users can use
+  ## HTTP via a URL like "http://localhost:8080"
+  url = "https://localhost:4433"
 
   ## RavenDB X509 client certificate setup
   tls_cert = "/etc/telegraf/raven.crt"

--- a/plugins/inputs/ravendb/README.md
+++ b/plugins/inputs/ravendb/README.md
@@ -11,7 +11,7 @@ The following is an example config for RavenDB. **Note:** The client certificate
 ```toml
 [[inputs.ravendb]]
   ## Node URL and port that RavenDB is listening on
-  url = "https://localhost:8080"
+  url = "http://localhost:8080"
 
   ## RavenDB X509 client certificate setup
   tls_cert = "/etc/telegraf/raven.crt"

--- a/plugins/inputs/ravendb/ravendb.go
+++ b/plugins/inputs/ravendb/ravendb.go
@@ -47,8 +47,11 @@ type RavenDB struct {
 }
 
 var sampleConfig = `
-  ## Node URL and port that RavenDB is listening on
-  url = "http://localhost:8080"
+  ## Node URL and port that RavenDB is listening on. By default,
+  ## attempts to connect securely over HTTPS, however, if the user
+  ## is running a local unsecure development cluster users can use
+  ## HTTP via a URL like "http://localhost:8080"
+  url = "https://localhost:4433"
 
   ## RavenDB X509 client certificate setup
   # tls_cert = "/etc/telegraf/raven.crt"

--- a/plugins/inputs/ravendb/ravendb.go
+++ b/plugins/inputs/ravendb/ravendb.go
@@ -48,7 +48,7 @@ type RavenDB struct {
 
 var sampleConfig = `
   ## Node URL and port that RavenDB is listening on
-  url = "https://localhost:8080"
+  url = "http://localhost:8080"
 
   ## RavenDB X509 client certificate setup
   # tls_cert = "/etc/telegraf/raven.crt"


### PR DESCRIPTION
Minor: Change default URI scheme from https to http. As default server uses http, not https. 

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
