### PR TITLE
chore: support windows and mac for Go linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17.7]
-        os: [macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint-pr-changes
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,6 +12,10 @@ on:
 jobs:
   golangci-pr:
     if: github.ref != 'refs/heads/master'
+    strategy:
+      matrix:
+        go-version: [1.17.7]
+        os: [macos-latest, windows-latest]
     name: lint-pr-changes
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,6 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.42.1
+          args: --timeout=30m
           only-new-issues: true
   golangci-master:
     if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Taken from the golangci-lint github action documentation: https://github.com/golangci/golangci-lint-action#multiple-os-support