### PR TITLE
feat: add new rtt per op field to nfsclient

### DIFF
--- a/plugins/inputs/nfsclient/README.md
+++ b/plugins/inputs/nfsclient/README.md
@@ -62,7 +62,8 @@ If `fullstat` is set, a great deal of additional metrics are collected, detailed
   - ops (integer, count) - The number of operations of this type executed.
   - retrans (integer, count) - The number of times an operation had to be retried (retrans = OP_trans - OP_ops.  See nfs_ops below)
   - exe (integer, miliseconds) - The number of miliseconds it took to process the operations.
-  - rtt (integer, miliseconds) - The round-trip time for operations.
+  - rtt (integer, miliseconds) - The total round-trip time for all operations.
+  - rtt_per_op (float, miliseconds) - The round-trip time per operation.
 
 In addition enabling `fullstat` will make many more metrics available.
 

--- a/plugins/inputs/nfsclient/README.md
+++ b/plugins/inputs/nfsclient/README.md
@@ -63,7 +63,7 @@ If `fullstat` is set, a great deal of additional metrics are collected, detailed
   - retrans (integer, count) - The number of times an operation had to be retried (retrans = OP_trans - OP_ops.  See nfs_ops below)
   - exe (integer, miliseconds) - The number of miliseconds it took to process the operations.
   - rtt (integer, miliseconds) - The total round-trip time for all operations.
-  - rtt_per_op (float, miliseconds) - The round-trip time per operation.
+  - rtt_per_op (float, miliseconds) - The average round-trip time per operation.
 
 In addition enabling `fullstat` will make many more metrics available.
 

--- a/plugins/inputs/nfsclient/nfsclient.go
+++ b/plugins/inputs/nfsclient/nfsclient.go
@@ -190,6 +190,10 @@ func (n *NFSClient) parseStat(mountpoint string, export string, version string, 
 		fields["bytes"] = nline[3] + nline[4]
 		fields["rtt"] = nline[6]
 		fields["exe"] = nline[7]
+		fields["rtt_per_op"] = 0.0
+		if nline[0] > 0 {
+			fields["rtt_per_op"] = float64(nline[6]) / float64(nline[0])
+		}
 		tags["operation"] = first
 		acc.AddFields("nfsstat", fields, tags)
 	}

--- a/plugins/inputs/nfsclient/nfsclient_test.go
+++ b/plugins/inputs/nfsclient/nfsclient_test.go
@@ -103,11 +103,12 @@ func TestNFSClientProcessStat(t *testing.T) {
 	require.NoError(t, err)
 
 	fieldsReadstat := map[string]interface{}{
-		"ops":     uint64(600),
-		"retrans": uint64(1),
-		"bytes":   uint64(1207),
-		"rtt":     uint64(606),
-		"exe":     uint64(607),
+		"ops":        uint64(600),
+		"retrans":    uint64(1),
+		"bytes":      uint64(1207),
+		"rtt":        uint64(606),
+		"exe":        uint64(607),
+		"rtt_per_op": float64(1.01),
 	}
 
 	readTags := map[string]string{
@@ -119,11 +120,12 @@ func TestNFSClientProcessStat(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "nfsstat", fieldsReadstat, readTags)
 
 	fieldsWritestat := map[string]interface{}{
-		"ops":     uint64(700),
-		"retrans": uint64(1),
-		"bytes":   uint64(1407),
-		"rtt":     uint64(706),
-		"exe":     uint64(707),
+		"ops":        uint64(700),
+		"retrans":    uint64(1),
+		"bytes":      uint64(1407),
+		"rtt":        uint64(706),
+		"exe":        uint64(707),
+		"rtt_per_op": float64(1.0085714285714287),
 	}
 
 	writeTags := map[string]string{


### PR DESCRIPTION
This field will provide the calculation for round-trip time per
operation. The current rtt field is the total number of time taken,
which is not very useful.