### PR TITLE
fix: correctly read ntpq long poll output

### DIFF
--- a/plugins/inputs/ntpq/ntpq.go
+++ b/plugins/inputs/ntpq/ntpq.go
@@ -122,13 +122,13 @@ func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
 					continue
 				}
 
-				if key == "when" {
+				if key == "when" || key == "poll" {
 					when := fields[index]
 					switch {
 					case strings.HasSuffix(when, "h"):
 						m, err := strconv.Atoi(strings.TrimSuffix(fields[index], "h"))
 						if err != nil {
-							acc.AddError(fmt.Errorf("error ntpq: parsing int: %s", fields[index]))
+							acc.AddError(fmt.Errorf("error ntpq: parsing %s as int: %s", key, fields[index]))
 							continue
 						}
 						// seconds in an hour
@@ -137,7 +137,7 @@ func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
 					case strings.HasSuffix(when, "d"):
 						m, err := strconv.Atoi(strings.TrimSuffix(fields[index], "d"))
 						if err != nil {
-							acc.AddError(fmt.Errorf("error ntpq: parsing int: %s", fields[index]))
+							acc.AddError(fmt.Errorf("error ntpq: parsing %s as int: %s", key, fields[index]))
 							continue
 						}
 						// seconds in a day
@@ -146,7 +146,7 @@ func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
 					case strings.HasSuffix(when, "m"):
 						m, err := strconv.Atoi(strings.TrimSuffix(fields[index], "m"))
 						if err != nil {
-							acc.AddError(fmt.Errorf("error ntpq: parsing int: %s", fields[index]))
+							acc.AddError(fmt.Errorf("error ntpq: parsing %s as int: %s", key, fields[index]))
 							continue
 						}
 						// seconds in a day
@@ -157,7 +157,7 @@ func (n *NTPQ) Gather(acc telegraf.Accumulator) error {
 
 				m, err := strconv.Atoi(fields[index])
 				if err != nil {
-					acc.AddError(fmt.Errorf("error ntpq: parsing int: %s", fields[index]))
+					acc.AddError(fmt.Errorf("error ntpq: parsing %s as int: %s", key, fields[index]))
 					continue
 				}
 				mFields[key] = int64(m)

--- a/plugins/inputs/ntpq/ntpq_test.go
+++ b/plugins/inputs/ntpq/ntpq_test.go
@@ -375,6 +375,36 @@ func TestMissingDelayColumnNTPQ(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "ntpq", fields, tags)
 }
 
+func TestLongPoll(t *testing.T) {
+	tt := tester{
+		ret: []byte(longPollTime),
+		err: nil,
+	}
+	n := newNTPQ()
+	n.runQ = tt.runqTest
+
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(n.Gather))
+
+	fields := map[string]interface{}{
+		"when":   int64(617),
+		"poll":   int64(4080),
+		"reach":  int64(377),
+		"offset": float64(2.849),
+		"jitter": float64(1.192),
+		"delay":  float64(9.145),
+	}
+	tags := map[string]string{
+		"remote":       "uschi5-ntp-002.",
+		"state_prefix": "-",
+		"refid":        "10.177.80.46",
+		"type":         "u",
+		"stratum":      "3",
+	}
+
+	acc.AssertContainsTaggedFields(t, "ntpq", fields, tags)
+}
+
 func TestFailedNTPQ(t *testing.T) {
 	tt := tester{
 		ret: []byte(singleNTPQ),
@@ -519,4 +549,9 @@ var noRefID = `     remote           refid      st t when poll reach   delay   o
  83.137.98.96    10.177.80.37     2 u  740 1024  377   54.033  243.426 449514.
  91.189.94.4                      2 u  673 1024  377  143.047  274.726 449445.
  131.188.3.221   10.177.80.37     2 u  783 1024  377  111.820  261.921 449528.
+`
+
+var longPollTime = `     remote           refid      st t when poll reach   delay   offset  jitter
+==============================================================================
+-uschi5-ntp-002. 10.177.80.46     3 u  617 68m 377 9.145 +2.849 1.192
 `


### PR DESCRIPTION
At a certain point, the poll value will go from seconds to a value plus a
suffix (e.g. 68m). This re-uses the when login to parse the value
correctly if it has a suffix or continues on and assume it is in seconds.

Fixes: #10747