### PR TITLE
docs: Improve language related to the New Relic license key.

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -1481,8 +1481,8 @@
 
 # # Send metrics to New Relic metrics endpoint
 # [[outputs.newrelic]]
-#   ## New Relic Insights API key
-#   insights_key = "insights api key"
+#   ## New Relic License Key
+#   insights_key = "New Relic License Key Here"
 #
 #   ## Prefix to add to add to metric name for easy identification.
 #   # metric_prefix = ""

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -1481,8 +1481,8 @@
 
 # # Send metrics to New Relic metrics endpoint
 # [[outputs.newrelic]]
-#   ## New Relic Insights API key
-#   insights_key = "insights api key"
+#   ## New Relic License Key
+#   insights_key = "New Relic License Key Here"
 #
 #   ## Prefix to add to add to metric name for easy identification.
 #   # metric_prefix = ""

--- a/plugins/outputs/newrelic/README.md
+++ b/plugins/outputs/newrelic/README.md
@@ -10,8 +10,11 @@ Telegraf minimum version: Telegraf 1.15.0
 
 ```toml
 [[outputs.newrelic]]
-  ## New Relic Insights API key
-  insights_key = "insights api key"
+  ## The 'insights_key' parameter requires a NR license key.
+  ## New Relic recommends you create one
+  ## with a convenient name such as TELEGRAF_INSERT_KEY.
+  ## reference: https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key
+  insights_key = "license key here"
 
   ## Prefix to add to add to metric name for easy identification.
   # metric_prefix = ""

--- a/plugins/outputs/newrelic/README.md
+++ b/plugins/outputs/newrelic/README.md
@@ -14,9 +14,10 @@ Telegraf minimum version: Telegraf 1.15.0
   ## New Relic recommends you create one
   ## with a convenient name such as TELEGRAF_INSERT_KEY.
   ## reference: https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key
-  insights_key = "license key here"
+  insights_key = "New Relic License Key Here"
 
   ## Prefix to add to add to metric name for easy identification.
+  ## This is very useful if your metric names are ambiguous.
   # metric_prefix = ""
 
   ## Timeout for writes to the New Relic API.

--- a/plugins/outputs/newrelic/newrelic.go
+++ b/plugins/outputs/newrelic/newrelic.go
@@ -46,6 +46,7 @@ func (nr *NewRelic) SampleConfig() string {
   # insights_key = "New Relic License Key Here"
 
   ## Prefix to add to add to metric name for easy identification.
+  ## This is very useful if your metric names are ambiguous.
   # metric_prefix = ""
 
   ## Timeout for writes to the New Relic API.

--- a/plugins/outputs/newrelic/newrelic.go
+++ b/plugins/outputs/newrelic/newrelic.go
@@ -39,8 +39,11 @@ func (nr *NewRelic) Description() string {
 // SampleConfig : return  default configuration of the Output
 func (nr *NewRelic) SampleConfig() string {
 	return `
-  ## New Relic Insights API key
-  insights_key = "insights api key"
+  ## The 'insights_key' parameter requires a NR license key.
+  ## New Relic recommends you create one
+  ## with a convenient name such as TELEGRAF_INSERT_KEY.
+  ## reference: https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key
+  # insights_key = "New Relic License Key Here"
 
   ## Prefix to add to add to metric name for easy identification.
   # metric_prefix = ""


### PR DESCRIPTION
There has been some confusion about the kind of New Relic key to use in the NR output plugin config.  
This code attempts to clear it up some.  Note that the actual parameter name uses the term "insights_key" which was an older term.  For this PR we have simply updated the phrasing.   I am considering a PR in the near future to actually rename the parameter or preferably use some kind of alias if it's possible.

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format]

