### PR TITLE
fix: update the precision parameter default value

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -381,7 +381,7 @@ var agentConfig = `
   ##
   ## Precision will NOT be used for service inputs. It is up to each individual
   ## service input to set the timestamp at the appropriate precision.
-  precision = ""
+  precision = "0s"
 
   ## Log at debug level.
   # debug = false

--- a/config/types.go
+++ b/config/types.go
@@ -38,6 +38,10 @@ func (d *Duration) UnmarshalTOML(b []byte) error {
 	// Finally, try value is a TOML string (e.g. "3s", 3s) or literal (e.g. '3s')
 	durStr = strings.ReplaceAll(durStr, "'", "")
 	durStr = strings.ReplaceAll(durStr, "\"", "")
+	if durStr == "" {
+		durStr = "0s"
+	}
+
 	dur, err := time.ParseDuration(durStr)
 	if err != nil {
 		return err

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -52,6 +52,14 @@ func TestDuration(t *testing.T) {
 	require.NoError(t, d.UnmarshalTOML([]byte(`1.5`)))
 	require.Equal(t, time.Second, time.Duration(d))
 
+	d = config.Duration(0)
+	require.NoError(t, d.UnmarshalTOML([]byte(``)))
+	require.Equal(t, 0*time.Second, time.Duration(d))
+
+	d = config.Duration(0)
+	require.NoError(t, d.UnmarshalTOML([]byte(`""`)))
+	require.Equal(t, 0*time.Second, time.Duration(d))
+
 	require.Error(t, d.UnmarshalTOML([]byte(`"1"`)))  // string missing unit
 	require.Error(t, d.UnmarshalTOML([]byte(`'2'`)))  // string missing unit
 	require.Error(t, d.UnmarshalTOML([]byte(`'ns'`))) // string missing time


### PR DESCRIPTION
In #10803, precision parsing was made more strict so that incorrect
values would be caught. The default precision value however is not
correct as an empty string.

fixes: #10813