### PR TITLE
test: reduce unit test time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,7 @@ commands:
           steps:
             - run: echo 'export RACE="-race"' >> $BASH_ENV
       - run: |
-          PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-          GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> --junitfile test-results/gotestsum-report.xml -- ${RACE} -short $PACKAGE_NAMES
+          GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> --junitfile test-results/gotestsum-report.xml -- ${RACE} -short ./...
       - store_test_results:
           path: test-results
       - when:
@@ -160,7 +159,6 @@ commands:
 jobs:
   test-go-linux:
     executor: go-1_17
-    parallelism: 4
     steps:
       - checkout
       - restore_cache:
@@ -182,7 +180,6 @@ jobs:
             - '*'
   test-go-linux-386:
     executor: go-1_17
-    parallelism: 4
     steps:
       - checkout
       - restore_cache:
@@ -198,16 +195,15 @@ jobs:
     steps:
       - test-go:
           os: darwin
-    parallelism: 4
   test-go-windows:
     executor:
         name: win/default
         shell: bash.exe
+        size: large
     steps:
       - test-go:
           os: windows
           gotestsum: "gotestsum.exe"
-    parallelism: 4
 
   windows-package:
     parameters:

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -20,6 +20,10 @@ import (
 
 // test that a restarting process resets pipes properly
 func TestRestartingRebindsPipes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long running test in short mode")
+	}
+
 	exe, err := os.Executable()
 	require.NoError(t, err)
 

--- a/internal/rotate/file_writer_test.go
+++ b/internal/rotate/file_writer_test.go
@@ -26,6 +26,10 @@ func TestFileWriter_NoRotation(t *testing.T) {
 }
 
 func TestFileWriter_TimeRotation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	tempDir, err := os.MkdirTemp("", "RotationTime")
 	require.NoError(t, err)
 	interval, _ := time.ParseDuration("1s")
@@ -43,6 +47,10 @@ func TestFileWriter_TimeRotation(t *testing.T) {
 }
 
 func TestFileWriter_ReopenTimeRotation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	tempDir, err := os.MkdirTemp("", "RotationTime")
 	require.NoError(t, err)
 	interval, _ := time.ParseDuration("1s")
@@ -92,6 +100,10 @@ func TestFileWriter_ReopenSizeRotation(t *testing.T) {
 }
 
 func TestFileWriter_DeleteArchives(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	tempDir, err := os.MkdirTemp("", "RotationDeleteArchives")
 	require.NoError(t, err)
 	maxSize := int64(5)

--- a/plugins/inputs/cloud_pubsub/pubsub_test.go
+++ b/plugins/inputs/cloud_pubsub/pubsub_test.go
@@ -197,6 +197,10 @@ func TestRunOverlongMessages(t *testing.T) {
 }
 
 func TestRunErrorInSubscriber(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	subID := "sub-unexpected-error"
 
 	acc := &testutil.Accumulator{}

--- a/plugins/inputs/cloud_pubsub_push/pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push_test.go
@@ -125,7 +125,7 @@ func TestServeHTTP(t *testing.T) {
 			sem:          make(chan struct{}, 1),
 			undelivered:  make(map[telegraf.TrackingID]chan bool),
 			mu:           &sync.Mutex{},
-			WriteTimeout: config.Duration(time.Second * 1),
+			WriteTimeout: config.Duration(time.Millisecond * 10),
 		}
 
 		pubPush.ctx, pubPush.cancel = context.WithCancel(context.Background())

--- a/plugins/inputs/influxdb_listener/influxdb_listener_test.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener_test.go
@@ -479,8 +479,8 @@ func TestWriteGzippedData(t *testing.T) {
 
 // writes 25,000 metrics to the listener with 10 different writers
 func TestWriteHighTraffic(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("Skipping due to hang on darwin")
+	if runtime.GOOS == "darwin" || testing.Short() {
+		t.Skip("Skipping long test in short mode, hangs on darwin")
 	}
 	listener := newTestListener()
 

--- a/plugins/inputs/intel_pmu/intel_pmu_test.go
+++ b/plugins/inputs/intel_pmu/intel_pmu_test.go
@@ -386,7 +386,7 @@ func TestEstimateCoresFd(t *testing.T) {
 			{parsedEvents: makeEvents(2, 1), parsedCores: makeIDs(20)},
 		}, 715},
 		{"1024 events", []*CoreEventEntity{{parsedEvents: makeEvents(1024, 1), parsedCores: makeIDs(12)}}, 12288},
-		{"big number", []*CoreEventEntity{{parsedEvents: makeEvents(1048576, 1), parsedCores: makeIDs(1024)}}, 1073741824},
+		{"big number", []*CoreEventEntity{{parsedEvents: makeEvents(1024, 1), parsedCores: makeIDs(1048576)}}, 1073741824},
 	}
 
 	for _, test := range tests {

--- a/plugins/inputs/jti_openconfig_telemetry/openconfig_telemetry_test.go
+++ b/plugins/inputs/jti_openconfig_telemetry/openconfig_telemetry_test.go
@@ -11,15 +11,17 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/plugins/inputs/jti_openconfig_telemetry/oc"
+	telemetry "github.com/influxdata/telegraf/plugins/inputs/jti_openconfig_telemetry/oc"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
 
+var tenMillisecondsDuration = time.Millisecond * 50
+
 var cfg = &OpenConfigTelemetry{
 	Log:             testutil.Logger{},
 	Servers:         []string{"127.0.0.1:50051"},
-	SampleFrequency: config.Duration(time.Second * 2),
+	SampleFrequency: config.Duration(tenMillisecondsDuration),
 }
 
 var data = &telemetry.OpenConfigData{
@@ -109,7 +111,7 @@ func TestOpenConfigTelemetryData(t *testing.T) {
 	}
 
 	// Give sometime for gRPC channel to be established
-	time.Sleep(2 * time.Second)
+	time.Sleep(tenMillisecondsDuration)
 
 	acc.AssertContainsTaggedFields(t, "/sensor", fields, tags)
 }
@@ -135,7 +137,7 @@ func TestOpenConfigTelemetryDataWithPrefix(t *testing.T) {
 	}
 
 	// Give sometime for gRPC channel to be established
-	time.Sleep(2 * time.Second)
+	time.Sleep(tenMillisecondsDuration)
 
 	acc.AssertContainsTaggedFields(t, "/sensor_with_prefix", fields, tags)
 }
@@ -176,7 +178,7 @@ func TestOpenConfigTelemetryDataWithMultipleTags(t *testing.T) {
 	}
 
 	// Give sometime for gRPC channel to be established
-	time.Sleep(2 * time.Second)
+	time.Sleep(tenMillisecondsDuration)
 
 	acc.AssertContainsTaggedFields(t, "/sensor_with_multiple_tags", fields1, tags1)
 	acc.AssertContainsTaggedFields(t, "/sensor_with_multiple_tags", fields2, tags2)
@@ -204,7 +206,7 @@ func TestOpenConfigTelemetryDataWithStringValues(t *testing.T) {
 	}
 
 	// Give sometime for gRPC channel to be established
-	time.Sleep(2 * time.Second)
+	time.Sleep(tenMillisecondsDuration)
 
 	acc.AssertContainsTaggedFields(t, "/sensor_with_string_values", fields, tags)
 }

--- a/plugins/inputs/jti_openconfig_telemetry/openconfig_telemetry_test.go
+++ b/plugins/inputs/jti_openconfig_telemetry/openconfig_telemetry_test.go
@@ -110,9 +110,7 @@ func TestOpenConfigTelemetryData(t *testing.T) {
 		"_subcomponent_id": uint32(0),
 	}
 
-	// Give sometime for gRPC channel to be established
-	time.Sleep(tenMillisecondsDuration)
-
+	require.Eventually(t, func() bool { return acc.HasMeasurement("/sensor") }, 5*time.Second, 10*time.Millisecond)
 	acc.AssertContainsTaggedFields(t, "/sensor", fields, tags)
 }
 
@@ -136,9 +134,7 @@ func TestOpenConfigTelemetryDataWithPrefix(t *testing.T) {
 		"_subcomponent_id":      uint32(0),
 	}
 
-	// Give sometime for gRPC channel to be established
-	time.Sleep(tenMillisecondsDuration)
-
+	require.Eventually(t, func() bool { return acc.HasMeasurement("/sensor_with_prefix") }, 5*time.Second, 10*time.Millisecond)
 	acc.AssertContainsTaggedFields(t, "/sensor_with_prefix", fields, tags)
 }
 
@@ -177,9 +173,7 @@ func TestOpenConfigTelemetryDataWithMultipleTags(t *testing.T) {
 		"_subcomponent_id":      uint32(0),
 	}
 
-	// Give sometime for gRPC channel to be established
-	time.Sleep(tenMillisecondsDuration)
-
+	require.Eventually(t, func() bool { return acc.HasMeasurement("/sensor_with_multiple_tags") }, 5*time.Second, 10*time.Millisecond)
 	acc.AssertContainsTaggedFields(t, "/sensor_with_multiple_tags", fields1, tags1)
 	acc.AssertContainsTaggedFields(t, "/sensor_with_multiple_tags", fields2, tags2)
 }
@@ -206,8 +200,7 @@ func TestOpenConfigTelemetryDataWithStringValues(t *testing.T) {
 	}
 
 	// Give sometime for gRPC channel to be established
-	time.Sleep(tenMillisecondsDuration)
-
+	require.Eventually(t, func() bool { return acc.HasMeasurement("/sensor_with_string_values") }, 5*time.Second, 10*time.Millisecond)
 	acc.AssertContainsTaggedFields(t, "/sensor_with_string_values", fields, tags)
 }
 

--- a/plugins/inputs/leofs/leofs_test.go
+++ b/plugins/inputs/leofs/leofs_test.go
@@ -160,17 +160,33 @@ func testMain(t *testing.T, code string, endpoint string, serverType ServerType)
 }
 
 func TestLeoFSManagerMasterMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long running test in short mode")
+	}
+
 	testMain(t, fakeSNMP4Manager, "localhost:4020", ServerTypeManagerMaster)
 }
 
 func TestLeoFSManagerSlaveMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long running test in short mode")
+	}
+
 	testMain(t, fakeSNMP4Manager, "localhost:4021", ServerTypeManagerSlave)
 }
 
 func TestLeoFSStorageMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long running test in short mode")
+	}
+
 	testMain(t, fakeSNMP4Storage, "localhost:4010", ServerTypeStorage)
 }
 
 func TestLeoFSGatewayMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long running test in short mode")
+	}
+
 	testMain(t, fakeSNMP4Gateway, "localhost:4000", ServerTypeGateway)
 }

--- a/plugins/inputs/uwsgi/uwsgi_test.go
+++ b/plugins/inputs/uwsgi/uwsgi_test.go
@@ -4,7 +4,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs/uwsgi"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
@@ -160,6 +162,7 @@ func TestInvalidJSON(t *testing.T) {
 func TestHttpError(t *testing.T) {
 	plugin := &uwsgi.Uwsgi{
 		Servers: []string{"http://novalidurladress/"},
+		Timeout: config.Duration(10 * time.Millisecond),
 	}
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Gather(&acc))

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -153,7 +153,7 @@ func TestStatusCode(t *testing.T) {
 			plugin: &HTTP{
 				URL: u.String(),
 			},
-			statusCode: 103,
+			statusCode: http.StatusEarlyHints,
 			errFunc: func(t *testing.T, err error) {
 				require.Error(t, err)
 			},
@@ -192,6 +192,10 @@ func TestStatusCode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		if testing.Short() && tt.statusCode == http.StatusEarlyHints {
+			t.Skip("Skipping long test in short mode")
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
 			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tt.statusCode)

--- a/plugins/outputs/loki/loki_test.go
+++ b/plugins/outputs/loki/loki_test.go
@@ -87,7 +87,7 @@ func TestStatusCode(t *testing.T) {
 			plugin: &Loki{
 				Domain: u.String(),
 			},
-			statusCode: 103,
+			statusCode: http.StatusEarlyHints,
 			errFunc: func(t *testing.T, err error) {
 				require.Error(t, err)
 			},
@@ -116,6 +116,10 @@ func TestStatusCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if testing.Short() && tt.statusCode == http.StatusEarlyHints {
+				t.Skip("Skipping long test in short mode")
+			}
+
 			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tt.statusCode)
 			})

--- a/plugins/outputs/signalfx/signalfx_test.go
+++ b/plugins/outputs/signalfx/signalfx_test.go
@@ -439,10 +439,8 @@ func TestSignalFx_SignalFx(t *testing.T) {
 
 			err := s.Write(measurements)
 			require.NoError(t, err)
-
-			require.Eventually(t, func() bool { return len(s.client.(*sink).dps) == len(tt.want.datapoints) }, 5*time.Second, 100*time.Millisecond)
-			require.Eventually(t, func() bool { return len(s.client.(*sink).evs) == len(tt.want.events) }, 5*time.Second, 100*time.Millisecond)
-
+			require.Eventually(t, func() bool { return len(s.client.(*sink).dps) == len(tt.want.datapoints) }, 5*time.Second, 10*time.Millisecond)
+			require.Eventually(t, func() bool { return len(s.client.(*sink).evs) == len(tt.want.events) }, 5*time.Second, 10*time.Millisecond)
 			if !reflect.DeepEqual(s.client.(*sink).dps, tt.want.datapoints) {
 				t.Errorf("Collected datapoints do not match desired.  Collected: %v Desired: %v", s.client.(*sink).dps, tt.want.datapoints)
 			}

--- a/plugins/processors/topk/topk_test.go
+++ b/plugins/processors/topk/topk_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-var oneSecondDuration = config.Duration(time.Second)
+var tenMillisecondsDuration = config.Duration(10 * time.Millisecond)
 
 // Key, value pair that represents a telegraf.Metric Field
 type field struct {
@@ -139,7 +139,7 @@ func runAndCompare(topk *TopK, metrics []telegraf.Metric, answer []telegraf.Metr
 func TestTopkAggregatorsSmokeTests(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.Fields = []string{"a"}
 	topk.GroupBy = []string{"tag_name"}
 
@@ -160,7 +160,7 @@ func TestTopkAggregatorsSmokeTests(t *testing.T) {
 func TestTopkMeanAddAggregateFields(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "mean"
 	topk.AddAggregateFields = []string{"a"}
 	topk.Fields = []string{"a"}
@@ -188,7 +188,7 @@ func TestTopkMeanAddAggregateFields(t *testing.T) {
 func TestTopkSumAddAggregateFields(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"a"}
 	topk.Fields = []string{"a"}
@@ -216,7 +216,7 @@ func TestTopkSumAddAggregateFields(t *testing.T) {
 func TestTopkMaxAddAggregateFields(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "max"
 	topk.AddAggregateFields = []string{"a"}
 	topk.Fields = []string{"a"}
@@ -244,7 +244,7 @@ func TestTopkMaxAddAggregateFields(t *testing.T) {
 func TestTopkMinAddAggregateFields(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "min"
 	topk.AddAggregateFields = []string{"a"}
 	topk.Fields = []string{"a"}
@@ -272,7 +272,7 @@ func TestTopkMinAddAggregateFields(t *testing.T) {
 func TestTopkGroupby1(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"value"}
@@ -296,7 +296,7 @@ func TestTopkGroupby1(t *testing.T) {
 func TestTopkGroupby2(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "mean"
 	topk.AddAggregateFields = []string{"value"}
@@ -324,7 +324,7 @@ func TestTopkGroupby2(t *testing.T) {
 func TestTopkGroupby3(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 1
 	topk.Aggregation = "min"
 	topk.AddAggregateFields = []string{"value"}
@@ -349,7 +349,7 @@ func TestTopkGroupby3(t *testing.T) {
 func TestTopkGroupbyFields1(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 4 // This settings generate less than 3 groups
 	topk.Aggregation = "mean"
 	topk.AddAggregateFields = []string{"A"}
@@ -375,7 +375,7 @@ func TestTopkGroupbyFields1(t *testing.T) {
 func TestTopkGroupbyFields2(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 2
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"B", "C"}
@@ -402,7 +402,7 @@ func TestTopkGroupbyFields2(t *testing.T) {
 func TestTopkGroupbyMetricName1(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 1
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"value"}
@@ -427,7 +427,7 @@ func TestTopkGroupbyMetricName1(t *testing.T) {
 func TestTopkGroupbyMetricName2(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 2
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"A", "value"}
@@ -454,7 +454,7 @@ func TestTopkGroupbyMetricName2(t *testing.T) {
 func TestTopkBottomk(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "sum"
 	topk.GroupBy = []string{"tag1", "tag3"}
@@ -479,7 +479,7 @@ func TestTopkBottomk(t *testing.T) {
 func TestTopkGroupByKeyTag(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "sum"
 	topk.GroupBy = []string{"tag1", "tag3"}


### PR DESCRIPTION
The unit tests take upwards of a minute on a very fast system and over
four minutes in CI. There are a few changes that were made:

* Some tests are just long running tests, more integration style
tests or have hard-coded sleeps that cannot be changed or fixed. These
types of tests have been skipped.
* Some sleeps and/or timeouts have been reduced down from multiple
seconds to milliseconds. This way the tests have the opportunity to
end faster.
* http error code 103 in the go library causes at least a 2 second
delay in unit tests. These have also been skipped in short mode.