### PR TITLE
docs: clarify the k and fields topk params

### DIFF
--- a/plugins/processors/topk/README.md
+++ b/plugins/processors/topk/README.md
@@ -22,14 +22,21 @@ Notes:
   ## How many seconds between aggregations
   # period = 10
 
-  ## How many top buckets to return
+  ## How many top buckets to return per field
+  ## Every field specified to aggregate over will return k number of results.
+  ## For example, 1 field with k of 10 will return 10 buckets. While 2 fields
+  ## with k of 3 will return 6 buckets.
   # k = 10
 
   ## Based on which tags should the buckets be computed. Globs can be specified.
   ## If set to an empty list tags are not considered when creating the buckets
   # group_by = ['*']
 
-  ## Over which fields is the aggregation done
+  ## The field(s) to aggregate
+  ## Each field defined is used to create an independent aggregation. Each
+  ## aggregation will return k buckets. If a metric does not have a defined
+  ## field the metric will be dropped from the aggregation. Considering using
+  ## the defaults processor plugin to ensure fields are set if required.
   # fields = ["value"]
 
   ## What aggregation function to use. Options: sum, mean, min, max

--- a/plugins/processors/topk/topk.go
+++ b/plugins/processors/topk/topk.go
@@ -56,7 +56,10 @@ var sampleConfig = `
   ## How many seconds between aggregations
   # period = 10
 
-  ## How many top metrics to return
+  ## How many top buckets to return per field
+  ## Every field specified to aggregate over will return k number of results.
+  ## For example, 1 field with k of 10 will return 10 buckets. While 2 fields
+  ## with k of 3 will return 6 buckets.
   # k = 10
 
   ## Over which tags should the aggregation be done. Globs can be specified, in
@@ -64,7 +67,11 @@ var sampleConfig = `
   ## empty list is no aggregation over tags is done
   # group_by = ['*']
 
-  ## Over which fields are the top k are calculated
+  ## The field(s) to aggregate
+  ## Each field defined is used to create an independent aggregation. Each
+  ## aggregation will return k buckets. If a metric does not have a defined
+  ## field the metric will be dropped from the aggregation. Considering using
+  ## the defaults processor plugin to ensure fields are set if required.
   # fields = ["value"]
 
   ## What aggregation to use. Options: sum, mean, min, max


### PR DESCRIPTION
The k and fields parameters in topk together determine the total number
of results. The current docs were not clear that there was a
relationship between the two that resulted in more than k results from
appearing.

Fixes: #10725