### PR TITLE
fix: Timestream plugin to work with customer provided endpoint_url

### DIFF
--- a/plugins/outputs/cloudwatch_logs/README.md
+++ b/plugins/outputs/cloudwatch_logs/README.md
@@ -8,7 +8,7 @@ This plugin uses a credential chain for Authentication with the CloudWatch Logs
 API endpoint. In the following order the plugin will attempt to authenticate.
 
 1. Web identity provider credentials via STS if `role_arn` and `web_identity_token_file` are specified
-1. Assumed credentials via STS if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules)
+1. Assumed credentials via STS if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules). The `endpoint_url` attribute is used only for Cloudwatch Logs service. When fetching credentials, STS global endpoint will be used.
 1. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
 1. Shared profile from `profile` attribute
 1. [Environment Variables](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#environment-variables)

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/influxdata/telegraf"
@@ -189,10 +191,31 @@ func (c *CloudWatchLogs) Connect() error {
 	var logGroupsOutput = &cloudwatchlogs.DescribeLogGroupsOutput{NextToken: &dummyToken}
 	var err error
 
-	cfg, err := c.CredentialConfig.Credentials()
+	awsCreds, awsErr := c.CredentialConfig.Credentials()
+	if awsErr != nil {
+		return awsErr
+	}
+
+	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		return err
 	}
+	if c.CredentialConfig.EndpointURL != "" && c.CredentialConfig.Region != "" {
+		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+			return aws.Endpoint{
+				PartitionID:   "aws",
+				URL:           c.CredentialConfig.EndpointURL,
+				SigningRegion: c.CredentialConfig.Region,
+			}, nil
+		})
+
+		cfg, err = config.LoadDefaultConfig(context.TODO(), config.WithEndpointResolverWithOptions(customResolver))
+		if err != nil {
+			return err
+		}
+	}
+
+	cfg.Credentials = awsCreds.Credentials
 	c.svc = cloudwatchlogs.NewFromConfig(cfg)
 
 	//Find log group with name 'c.LogGroup'

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs_test.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs_test.go
@@ -207,6 +207,24 @@ func TestInit(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "valid config with EndpointURL",
+			plugin: &CloudWatchLogs{
+				CredentialConfig: internalaws.CredentialConfig{
+					Region:      "eu-central-1",
+					AccessKey:   "dummy",
+					SecretKey:   "dummy",
+					EndpointURL: "https://test.com",
+				},
+				LogGroup:     "TestLogGroup",
+				LogStream:    "tag:source",
+				LDMetricName: "docker_log",
+				LDSource:     "tag:location",
+				Log: testutil.Logger{
+					Name: "outputs.cloudwatch_logs",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -2,6 +2,19 @@
 
 The Timestream output plugin writes metrics to the [Amazon Timestream] service.
 
+## Authentication
+
+This plugin uses a credential chain for Authentication with Timestream
+API endpoint. In the following order the plugin will attempt to authenticate.
+
+1. Web identity provider credentials via STS if `role_arn` and `web_identity_token_file` are specified
+1. [Assumed credentials via STS] if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules). The `endpoint_url` attribute is used only for Timestream service. When fetching credentials, STS global endpoint will be used.
+1. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
+1. Shared profile from `profile` attribute
+1. [Environment Variables]
+1. [Shared Credentials]
+1. [EC2 Instance Profile]
+
 ## Configuration
 
 ```toml
@@ -154,3 +167,7 @@ go test -v ./plugins/outputs/timestream/...
 ```
 
 [Amazon Timestream]: https://aws.amazon.com/timestream/
+[Assumed credentials via STS]: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/credentials/stscreds
+[Environment Variables]: https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#environment-variables
+[Shared Credentials]: https://github.com/aws/aws-sdk-go/wiki/configuring-sdk#shared-credentials-file
+[EC2 Instance Profile]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html

--- a/plugins/outputs/timestream/timestream.go
+++ b/plugins/outputs/timestream/timestream.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/timestreamwrite"
 	"github.com/aws/aws-sdk-go-v2/service/timestreamwrite/types"
 	"github.com/aws/smithy-go"
@@ -181,11 +182,45 @@ var sampleConfig = `
 
 // WriteFactory function provides a way to mock the client instantiation for testing purposes.
 var WriteFactory = func(credentialConfig *internalaws.CredentialConfig) (WriteClient, error) {
-	cfg, err := credentialConfig.Credentials()
-	if err != nil {
-		return &timestreamwrite.Client{}, err
+
+	awsCreds, awsErr := credentialConfig.Credentials()
+	if awsErr != nil {
+		panic("Unable to load credentials config " + awsErr.Error())
 	}
-	return timestreamwrite.NewFromConfig(cfg), nil
+
+	cfg, cfgErr := config.LoadDefaultConfig(context.TODO())
+	if cfgErr != nil {
+		panic("Unable to load SDK config for Timestream " + cfgErr.Error())
+	}
+
+	if credentialConfig.EndpointURL != "" && credentialConfig.Region != "" {
+		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+			return aws.Endpoint{
+				PartitionID:   "aws",
+				URL:           credentialConfig.EndpointURL,
+				SigningRegion: credentialConfig.Region,
+			}, nil
+		})
+
+		cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithEndpointResolverWithOptions(customResolver))
+
+		if err != nil {
+			panic("unable to load SDK config for Timestream " + err.Error())
+		}
+
+		cfg.Credentials = awsCreds.Credentials
+
+		return timestreamwrite.NewFromConfig(cfg, func(o *timestreamwrite.Options) {
+			o.Region = credentialConfig.Region
+			o.EndpointDiscovery.EnableEndpointDiscovery = aws.EndpointDiscoveryDisabled
+		}), nil
+	}
+
+	cfg.Credentials = awsCreds.Credentials
+
+	return timestreamwrite.NewFromConfig(cfg, func(o *timestreamwrite.Options) {
+		o.Region = credentialConfig.Region
+	}), nil
 }
 
 func (t *Timestream) Connect() error {

--- a/plugins/outputs/timestream/timestream_test.go
+++ b/plugins/outputs/timestream/timestream_test.go
@@ -693,6 +693,22 @@ func TestTransformMetricsUnsupportedFieldsAreSkipped(t *testing.T) {
 		[]*timestreamwrite.WriteRecordsInput{expectedResultMultiTable})
 }
 
+func TestCustomEndpoint(t *testing.T) {
+	customEndpoint := "http://test.custom.endpoint.com"
+	plugin := Timestream{
+		MappingMode:      MappingModeMultiTable,
+		DatabaseName:     tsDbName,
+		Log:              testutil.Logger{},
+		CredentialConfig: internalaws.CredentialConfig{EndpointURL: customEndpoint},
+	}
+
+	// validate config correctness
+	err := plugin.Connect()
+	require.Nil(t, err, "Invalid configuration")
+	// Check customURL is used
+	require.Equal(t, plugin.EndpointURL, customEndpoint)
+}
+
 func comparisonTest(t *testing.T,
 	mappingMode string,
 	telegrafMetrics []telegraf.Metric,


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Updating credentials file to not use endpoint_url parameter, and letting timestream client to use endpoint_url


### Context
- AWS Telegraf plugin fails to start, when trying to fetch AssumeRole credentials from STS, with the error 
```
2022-03-10T02:03:00Z E! [agent] Failed to connect to [outputs.timestream], retrying in 15s, error was 'operation error Timestream Write: DescribeDatabase, failed to sign request: failed to retrieve credentials: operation error STS: AssumeRole, https response error StatusCode: 404, RequestID: OAZPKXHJS7QXUVFPAMG2OB6MAU, api error UnknownError: UnknownError'
```
- This happens when we specify `endpoint_url` option in config file

- When the Telegraf plugin is executed inside a VPC setting, a customer may wish to specify Timestream endpoint. See https://aws.amazon.com/blogs/database/use-vpc-endpoints-with-amazon-timestream/ 

The above failure is blocking customers to use Telegraf and Timesteam inside a VPC setup

### Issue
- The `endpoint_url` parameter is being incorrectly used when fetching STS credentials, during Timestream client initialization - https://github.com/influxdata/telegraf/blob/master/config/aws/credentials.go
- The supplied `endpoint_url` is for a specific AWS service like Timestream, Cloudwatch, etc.. But in the current code, it  is being used to initialize STS to fetch AssumeRole credentials, which causes a 404 error. 
- STS supports global and regionalized endpoints. AWS recommends that the IAM  policy should control access to resources by region.
 - see https://github.com/boto/botocore/issues/2124
 - also see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials
- As per the AWS Go SDK docs, endpoint is **NOT** specified for STS, when using [AssumeRoleOptions and CredentialCache](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/credentials/stscreds#hdr-Assume_Role)
  - See doc  - https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials

### Changes
- Updated the credentials.go file to NOT use endpoint_url parameter
- Modified the [initial endpoint_url changes](https://code.amazon.com/reviews/CR-64783519) to re-use credentials and override endpoints for timestream service 
- Added Unit test for timestream
- Updated Readme to specify use of STS global endpoints
- Updated Timestream and Cloudwatch_log to use EndpointResolver for client creation

### Testing
- Telegraf plugin is able to start with these changes
- Verified that Timestream Endpoint has access control via Security Policy for VPC Endpoint

```
2022-03-15T21:48:26Z I! [outputs.timestream] Constructing Timestream client for 'multi-table' mode
2022-03-15T21:48:26Z I! [outputs.timestream] Describing database 'telegraf-dev3' in region 'us-east-1'
2022-03-15T21:50:07Z I! Starting Telegraf 1.22.0-4fcff21c
2022-03-15T21:50:07Z I! Loaded inputs: http_listener
2022-03-15T21:50:07Z I! Loaded aggregators: 
2022-03-15T21:50:07Z I! Loaded processors: 
2022-03-15T21:50:07Z I! Loaded outputs: timestream (2x)
2022-03-15T21:50:07Z I! Tags enabled: availability_zone=$AZ environment=dev1 host=ip-172-31-50-238.us-west-2.compute.internal pod=1 region=us-west-2 regpod=uw2-1 role=telegraf
2022-03-15T21:50:07Z W! Deprecated inputs: 1 and 0 options
2022-03-15T21:50:07Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"ip-172-31-50-238.us-west-2.compute.internal", Flush Interval:10s
2022-03-15T21:50:07Z I! [outputs.timestream] Constructing Timestream client for 'multi-table' mode
2022-03-15T21:50:07Z I! [outputs.timestream] Describing database 'telegraf-dev2' in region 'us-east-1'
2022-03-15T21:50:08Z I! [outputs.timestream] Describe database 'telegraf-dev2' returned: '&{%!s(*types.Database=&{0xc0008c2260 0xc0008cc0c0 0xc0008c2270 0xc0008c2280 0xc0008cc0d8 159 {}}) {map[{}:%!s(time.Duration=-1191305013) {}:%!s(*http.Response=&{0xc000ff2630}) {}:EAOPLDQQYFWAHVJKBPONQUX2WA {}:{%!s(uint64=13872318735012271413) %!s(int64=1011682118) %!s(*time.Location=&{ [] []  0 0 <nil>})} {}:{%!s(uint64=0) %!s(int64=63782977807) %!s(*time.Location=<nil>)} {}:{[{<nil> %!s(bool=false) %!s(bool=false) {map[{}:%!s(time.Duration=-1191305013) {}:%!s(*http.Response=&{0xc000ff2630}) {}:EAOPLDQQYFWAHVJKBPONQUX2WA {}:{%!s(uint64=13872318735012271413) %!s(int64=1011682118) %!s(*time.Location=&{ [] []  0 0 <nil>})} {}:{%!s(uint64=0) %!s(int64=63782977807) %!s(*time.Location=<nil>)}]}}]}]} {}}'.

```
