### PR TITLE
fix: ensure aliyuncms metrics accept array, fix discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/Shopify/sarama v1.32.0
 	github.com/aerospike/aerospike-client-go/v5 v5.7.0
 	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15
-	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1483
+	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1529
 	github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9
 	github.com/antchfx/jsonquery v1.1.5
 	github.com/antchfx/xmlquery v1.3.9

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:C
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
-github.com/aliyun/alibaba-cloud-sdk-go v1.61.1483 h1:J8HaD+Zpfi1gcel3HCKpoHHEsrcuRrZlSnx7R9SCf5I=
-github.com/aliyun/alibaba-cloud-sdk-go v1.61.1483/go.mod h1:RcDobYh8k5VP6TNybz9m++gL3ijVI5wueVr0EM10VsU=
+github.com/aliyun/alibaba-cloud-sdk-go v1.61.1529 h1:qAt5MZ3Ukwx/JMAiaagQhNQMBZLcmJbnweBoK3EeHxI=
+github.com/aliyun/alibaba-cloud-sdk-go v1.61.1529/go.mod h1:RcDobYh8k5VP6TNybz9m++gL3ijVI5wueVr0EM10VsU=
 github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9 h1:FXrPTd8Rdlc94dKccl7KPmdmIbVh/OjelJ8/vgMRzcQ=
 github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9/go.mod h1:eliMa/PW+RDr2QLWRmLH1R1ZA4RInpmvOzDDXtaIZkc=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/plugins/inputs/aliyuncms/aliyuncms.go
+++ b/plugins/inputs/aliyuncms/aliyuncms.go
@@ -442,7 +442,6 @@ L:
 					metric.requestDimensions,
 					map[string]string{s.dimensionKey: instanceID})
 			}
-
 		}
 
 		//add dimensions filter from config file

--- a/plugins/inputs/aliyuncms/aliyuncms.go
+++ b/plugins/inputs/aliyuncms/aliyuncms.go
@@ -436,14 +436,16 @@ L:
 				metric.discoveryTags[instanceID][tagKey] = tagValue
 			}
 
-			//Preparing dimensions (first adding dimensions that comes from discovery data)
-			metric.requestDimensions = append(
-				metric.requestDimensions,
-				map[string]string{s.dimensionKey: instanceID})
+			//if no dimension configured in config file, use discovery data
+			if len(metric.dimensionsUdArr) == 0 && len(metric.dimensionsUdObj) == 0 {
+				metric.requestDimensions = append(
+					metric.requestDimensions,
+					map[string]string{s.dimensionKey: instanceID})
+			}
+
 		}
 
-		//Get final dimension (need to get full lis of
-		//what was provided in config + what comes from discovery
+		//add dimensions filter from config file
 		if len(metric.dimensionsUdArr) != 0 {
 			metric.requestDimensions = append(metric.requestDimensions, metric.dimensionsUdArr...)
 		}

--- a/plugins/inputs/aliyuncms/aliyuncms.go
+++ b/plugins/inputs/aliyuncms/aliyuncms.go
@@ -144,10 +144,16 @@ func (s *AliyunCMS) Init() error {
 		if metric.Dimensions != "" {
 			metric.dimensionsUdObj = map[string]string{}
 			metric.dimensionsUdArr = []map[string]string{}
+
+			// first try to unmarshal as an object
 			err := json.Unmarshal([]byte(metric.Dimensions), &metric.dimensionsUdObj)
 			if err != nil {
+				// then try to unmarshal as an array
 				err := json.Unmarshal([]byte(metric.Dimensions), &metric.dimensionsUdArr)
-				return errors.Errorf("Can't parse dimensions (it is neither obj, nor array) %q :%v", metric.Dimensions, err)
+
+				if err != nil {
+					return errors.Errorf("cannot parse dimensions (neither obj, nor array) %q :%v", metric.Dimensions, err)
+				}
 			}
 		}
 	}

--- a/plugins/inputs/aliyuncms/aliyuncms_test.go
+++ b/plugins/inputs/aliyuncms/aliyuncms_test.go
@@ -296,7 +296,6 @@ func TestPluginMetricsInitialize(t *testing.T) {
 			} else {
 				require.Equal(t, nil, plugin.Init())
 			}
-
 		})
 	}
 }

--- a/plugins/inputs/aliyuncms/aliyuncms_test.go
+++ b/plugins/inputs/aliyuncms/aliyuncms_test.go
@@ -199,6 +199,108 @@ func TestPluginInitialize(t *testing.T) {
 	}
 }
 
+func TestPluginMetricsInitialize(t *testing.T) {
+	var err error
+
+	plugin := new(AliyunCMS)
+	plugin.Log = testutil.Logger{Name: inputTitle}
+	plugin.Regions = []string{"cn-shanghai"}
+	plugin.dt, err = getDiscoveryTool("acs_slb_dashboard", plugin.Regions)
+	if err != nil {
+		t.Fatalf("Can't create discovery tool object: %v", err)
+	}
+
+	httpResp := &http.Response{
+		StatusCode: 200,
+		Body: io.NopCloser(bytes.NewBufferString(
+			`{
+				"LoadBalancers":
+					{
+						"LoadBalancer": [
+ 							{"LoadBalancerId":"bla"}
+                        ]
+                    },
+				"TotalCount": 1,
+				"PageSize": 1,
+				"PageNumber": 1
+			}`)),
+	}
+	mockCli, err := getMockSdkCli(httpResp)
+	if err != nil {
+		t.Fatalf("Can't create mock sdk cli: %v", err)
+	}
+	plugin.dt.cli = map[string]aliyunSdkClient{plugin.Regions[0]: &mockCli}
+
+	tests := []struct {
+		name                string
+		project             string
+		accessKeyID         string
+		accessKeySecret     string
+		expectedErrorString string
+		regions             []string
+		discoveryRegions    []string
+		metrics             []*Metric
+	}{
+		{
+			name:            "Valid project",
+			project:         "acs_slb_dashboard",
+			regions:         []string{"cn-shanghai"},
+			accessKeyID:     "dummy",
+			accessKeySecret: "dummy",
+			metrics: []*Metric{
+				{
+					MetricNames: []string{},
+					Dimensions:  `{"instanceId": "i-abcdefgh123456"}`,
+				},
+			},
+		},
+		{
+			name:            "Valid project",
+			project:         "acs_slb_dashboard",
+			regions:         []string{"cn-shanghai"},
+			accessKeyID:     "dummy",
+			accessKeySecret: "dummy",
+			metrics: []*Metric{
+				{
+					MetricNames: []string{},
+					Dimensions:  `[{"instanceId": "p-example"},{"instanceId": "q-example"}]`,
+				},
+			},
+		},
+		{
+			name:                "Valid project",
+			project:             "acs_slb_dashboard",
+			regions:             []string{"cn-shanghai"},
+			accessKeyID:         "dummy",
+			accessKeySecret:     "dummy",
+			expectedErrorString: `cannot parse dimensions (neither obj, nor array) "[" :unexpected end of JSON input`,
+			metrics: []*Metric{
+				{
+					MetricNames: []string{},
+					Dimensions:  `[`,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin.Project = tt.project
+			plugin.AccessKeyID = tt.accessKeyID
+			plugin.AccessKeySecret = tt.accessKeySecret
+			plugin.Regions = tt.regions
+			plugin.Metrics = tt.metrics
+
+			if tt.expectedErrorString != "" {
+				require.EqualError(t, plugin.Init(), tt.expectedErrorString)
+			} else {
+				require.Equal(t, nil, plugin.Init())
+			}
+
+		})
+	}
+}
+
 func TestUpdateWindow(t *testing.T) {
 	duration, _ := time.ParseDuration("1m")
 	internalDuration := config.Duration(duration)


### PR DESCRIPTION
First, the aliyuncms plugin was not correctly parsing metrics with multiple dimensions. This was due to some bad if/else logic. Once fixed users can do the following in their config:

```
    dimensions = '[{"instanceId": "rm-bp1zureya4l415lus"},{"instanceId": "rm-bp161628eanrceqz2"}]'
```

Second, the plugin can do some auto-discovery of the JSON response that is received and then determine how to parse the response. However, it appears that aliyun/alibaba has updated some of the responses. This adds a `responseRootKey` rather than trying to determine that as the logic was not correct and no longer consistent across services. We already have a hard-coded `responseObjectIDKey` that is used as part of that root key.

Finally, this updates the aliyun SDK.

Fixes: #10848
