### PR TITLE
chore: remove slow process test

### DIFF
--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -20,6 +20,10 @@ import (
 
 // test that a restarting process resets pipes properly
 func TestRestartingRebindsPipes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long running test in short mode")
+	}
+
 	exe, err := os.Executable()
 	require.NoError(t, err)
 
@@ -49,6 +53,7 @@ func TestRestartingRebindsPipes(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 
+	// the mainLoopWg.Wait() call p.Stop() makes takes multiple seconds to complete
 	p.Stop()
 }
 


### PR DESCRIPTION
This test takes multiple seconds to wait for the process group to stop.
This adds the skip if short flag given the length this test takes.