### PR TITLE
chore: update slow file rotate tests

### DIFF
--- a/internal/rotate/file_writer_test.go
+++ b/internal/rotate/file_writer_test.go
@@ -28,14 +28,14 @@ func TestFileWriter_NoRotation(t *testing.T) {
 func TestFileWriter_TimeRotation(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "RotationTime")
 	require.NoError(t, err)
-	interval, _ := time.ParseDuration("1s")
+	interval, _ := time.ParseDuration("10ms")
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test"), interval, 0, -1)
 	require.NoError(t, err)
 	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
 
 	_, err = writer.Write([]byte("Hello World"))
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
+	time.Sleep(interval)
 	_, err = writer.Write([]byte("Hello World 2"))
 	require.NoError(t, err)
 	files, _ := os.ReadDir(tempDir)
@@ -45,10 +45,10 @@ func TestFileWriter_TimeRotation(t *testing.T) {
 func TestFileWriter_ReopenTimeRotation(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "RotationTime")
 	require.NoError(t, err)
-	interval, _ := time.ParseDuration("1s")
+	interval, _ := time.ParseDuration("10ms")
 	filePath := filepath.Join(tempDir, "test.log")
 	err = os.WriteFile(filePath, []byte("Hello World"), 0644)
-	time.Sleep(1 * time.Second)
+	time.Sleep(interval)
 	assert.NoError(t, err)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), interval, 0, -1)
 	require.NoError(t, err)
@@ -92,6 +92,10 @@ func TestFileWriter_ReopenSizeRotation(t *testing.T) {
 }
 
 func TestFileWriter_DeleteArchives(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	tempDir, err := os.MkdirTemp("", "RotationDeleteArchives")
 	require.NoError(t, err)
 	maxSize := int64(5)


### PR DESCRIPTION
The tests were hard-coding second-long sleeps. Where these can
safely be reduced down to milliseconds, make that change, otherwise
do not run the test with short.
