### PR TITLE
chore: switch HTTP 100 test cases

### DIFF
--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -153,7 +153,7 @@ func TestStatusCode(t *testing.T) {
 			plugin: &HTTP{
 				URL: u.String(),
 			},
-			statusCode: 103,
+			statusCode: http.StatusSwitchingProtocols,
 			errFunc: func(t *testing.T, err error) {
 				require.Error(t, err)
 			},

--- a/plugins/outputs/loki/loki_test.go
+++ b/plugins/outputs/loki/loki_test.go
@@ -87,7 +87,7 @@ func TestStatusCode(t *testing.T) {
 			plugin: &Loki{
 				Domain: u.String(),
 			},
-			statusCode: 103,
+			statusCode: http.StatusSwitchingProtocols,
 			errFunc: func(t *testing.T, err error) {
 				require.Error(t, err)
 			},


### PR DESCRIPTION
The HTTP 103 response code seems to add an artificial delay to tests
while the code waits for further details. As the point of these tests is
to handle any 100 HTTP code, this moves from 103 to 101.