### PR TITLE
chore: skip longer/integration tests on -short mode

### DIFF
--- a/plugins/inputs/cloud_pubsub/pubsub_test.go
+++ b/plugins/inputs/cloud_pubsub/pubsub_test.go
@@ -197,6 +197,11 @@ func TestRunOverlongMessages(t *testing.T) {
 }
 
 func TestRunErrorInSubscriber(t *testing.T) {
+	// hard-coded retry in seconds
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	subID := "sub-unexpected-error"
 
 	acc := &testutil.Accumulator{}

--- a/plugins/inputs/influxdb_listener/influxdb_listener_test.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener_test.go
@@ -482,6 +482,10 @@ func TestWriteHighTraffic(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip("Skipping due to hang on darwin")
 	}
+	// resource intensive, large test
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
 	listener := newTestListener()
 
 	acc := &testutil.Accumulator{}

--- a/plugins/inputs/leofs/leofs_test.go
+++ b/plugins/inputs/leofs/leofs_test.go
@@ -160,17 +160,33 @@ func testMain(t *testing.T, code string, endpoint string, serverType ServerType)
 }
 
 func TestLeoFSManagerMasterMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	testMain(t, fakeSNMP4Manager, "localhost:4020", ServerTypeManagerMaster)
 }
 
 func TestLeoFSManagerSlaveMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	testMain(t, fakeSNMP4Manager, "localhost:4021", ServerTypeManagerSlave)
 }
 
 func TestLeoFSStorageMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	testMain(t, fakeSNMP4Storage, "localhost:4010", ServerTypeStorage)
 }
 
 func TestLeoFSGatewayMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	testMain(t, fakeSNMP4Gateway, "localhost:4000", ServerTypeGateway)
 }

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -238,6 +238,10 @@ func TestConfigDurationParsing(t *testing.T) {
 }
 
 func TestMaxQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	// Don't run test on 32-bit machines due to bug in simulator.
 	// https://github.com/vmware/govmomi/issues/1330
 	var i int
@@ -295,6 +299,10 @@ func testLookupVM(ctx context.Context, t *testing.T, f *Finder, path string, exp
 }
 
 func TestFinder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	// Don't run test on 32-bit machines due to bug in simulator.
 	// https://github.com/vmware/govmomi/issues/1330
 	var i int
@@ -411,6 +419,10 @@ func TestFinder(t *testing.T) {
 }
 
 func TestFolders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	// Don't run test on 32-bit machines due to bug in simulator.
 	// https://github.com/vmware/govmomi/issues/1330
 	var i int
@@ -452,10 +464,18 @@ func TestFolders(t *testing.T) {
 }
 
 func TestCollectionWithClusterMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	testCollection(t, false)
 }
 
 func TestCollectionNoClusterMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test in short mode")
+	}
+
 	testCollection(t, true)
 }
 


### PR DESCRIPTION
This is a collection of longer-running tests that do not have a clean or
simple solution to shorten their length or reduce their system
utilization. Some cases are due to large memory usage or due to
hard-coded seconds long sleeps.

The leofs tests are integration tests that are actually compiling
in-line code as a go binary.

The vsphere tests make a very long call to create a simulator.

In each case, these can be skipped when running with short.