### PR TITLE
chore: reduce timeouts and sleeps

### DIFF
--- a/plugins/inputs/cloud_pubsub_push/pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push_test.go
@@ -125,7 +125,7 @@ func TestServeHTTP(t *testing.T) {
 			sem:          make(chan struct{}, 1),
 			undelivered:  make(map[telegraf.TrackingID]chan bool),
 			mu:           &sync.Mutex{},
-			WriteTimeout: config.Duration(time.Second * 1),
+			WriteTimeout: config.Duration(time.Millisecond * 10),
 		}
 
 		pubPush.ctx, pubPush.cancel = context.WithCancel(context.Background())

--- a/plugins/inputs/jti_openconfig_telemetry/openconfig_telemetry_test.go
+++ b/plugins/inputs/jti_openconfig_telemetry/openconfig_telemetry_test.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/plugins/inputs/jti_openconfig_telemetry/oc"
+	telemetry "github.com/influxdata/telegraf/plugins/inputs/jti_openconfig_telemetry/oc"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +19,7 @@ import (
 var cfg = &OpenConfigTelemetry{
 	Log:             testutil.Logger{},
 	Servers:         []string{"127.0.0.1:50051"},
-	SampleFrequency: config.Duration(time.Second * 2),
+	SampleFrequency: config.Duration(time.Millisecond * 10),
 }
 
 var data = &telemetry.OpenConfigData{
@@ -108,9 +108,7 @@ func TestOpenConfigTelemetryData(t *testing.T) {
 		"_subcomponent_id": uint32(0),
 	}
 
-	// Give sometime for gRPC channel to be established
-	time.Sleep(2 * time.Second)
-
+	require.Eventually(t, func() bool { return acc.HasMeasurement("/sensor") }, 5*time.Second, 10*time.Millisecond)
 	acc.AssertContainsTaggedFields(t, "/sensor", fields, tags)
 }
 
@@ -134,9 +132,7 @@ func TestOpenConfigTelemetryDataWithPrefix(t *testing.T) {
 		"_subcomponent_id":      uint32(0),
 	}
 
-	// Give sometime for gRPC channel to be established
-	time.Sleep(2 * time.Second)
-
+	require.Eventually(t, func() bool { return acc.HasMeasurement("/sensor_with_prefix") }, 5*time.Second, 10*time.Millisecond)
 	acc.AssertContainsTaggedFields(t, "/sensor_with_prefix", fields, tags)
 }
 
@@ -175,9 +171,7 @@ func TestOpenConfigTelemetryDataWithMultipleTags(t *testing.T) {
 		"_subcomponent_id":      uint32(0),
 	}
 
-	// Give sometime for gRPC channel to be established
-	time.Sleep(2 * time.Second)
-
+	require.Eventually(t, func() bool { return acc.HasMeasurement("/sensor_with_multiple_tags") }, 5*time.Second, 10*time.Millisecond)
 	acc.AssertContainsTaggedFields(t, "/sensor_with_multiple_tags", fields1, tags1)
 	acc.AssertContainsTaggedFields(t, "/sensor_with_multiple_tags", fields2, tags2)
 }
@@ -203,9 +197,7 @@ func TestOpenConfigTelemetryDataWithStringValues(t *testing.T) {
 		"_subcomponent_id":               uint32(0),
 	}
 
-	// Give sometime for gRPC channel to be established
-	time.Sleep(2 * time.Second)
-
+	require.Eventually(t, func() bool { return acc.HasMeasurement("/sensor_with_string_values") }, 5*time.Second, 10*time.Millisecond)
 	acc.AssertContainsTaggedFields(t, "/sensor_with_string_values", fields, tags)
 }
 

--- a/plugins/inputs/uwsgi/uwsgi_test.go
+++ b/plugins/inputs/uwsgi/uwsgi_test.go
@@ -4,7 +4,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs/uwsgi"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
@@ -160,6 +162,7 @@ func TestInvalidJSON(t *testing.T) {
 func TestHttpError(t *testing.T) {
 	plugin := &uwsgi.Uwsgi{
 		Servers: []string{"http://novalidurladress/"},
+		Timeout: config.Duration(10 * time.Millisecond),
 	}
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Gather(&acc))

--- a/plugins/outputs/signalfx/signalfx_test.go
+++ b/plugins/outputs/signalfx/signalfx_test.go
@@ -439,9 +439,8 @@ func TestSignalFx_SignalFx(t *testing.T) {
 
 			err := s.Write(measurements)
 			require.NoError(t, err)
-
-			require.Eventually(t, func() bool { return len(s.client.(*sink).dps) == len(tt.want.datapoints) }, 5*time.Second, 100*time.Millisecond)
-			require.Eventually(t, func() bool { return len(s.client.(*sink).evs) == len(tt.want.events) }, 5*time.Second, 100*time.Millisecond)
+			require.Eventually(t, func() bool { return len(s.client.(*sink).dps) == len(tt.want.datapoints) }, 5*time.Second, 10*time.Millisecond)
+			require.Eventually(t, func() bool { return len(s.client.(*sink).evs) == len(tt.want.events) }, 5*time.Second, 10*time.Millisecond)
 
 			if !reflect.DeepEqual(s.client.(*sink).dps, tt.want.datapoints) {
 				t.Errorf("Collected datapoints do not match desired.  Collected: %v Desired: %v", s.client.(*sink).dps, tt.want.datapoints)

--- a/plugins/processors/topk/topk_test.go
+++ b/plugins/processors/topk/topk_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-var oneSecondDuration = config.Duration(time.Second)
+var tenMillisecondsDuration = config.Duration(10 * time.Millisecond)
 
 // Key, value pair that represents a telegraf.Metric Field
 type field struct {
@@ -139,7 +139,7 @@ func runAndCompare(topk *TopK, metrics []telegraf.Metric, answer []telegraf.Metr
 func TestTopkAggregatorsSmokeTests(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.Fields = []string{"a"}
 	topk.GroupBy = []string{"tag_name"}
 
@@ -160,7 +160,7 @@ func TestTopkAggregatorsSmokeTests(t *testing.T) {
 func TestTopkMeanAddAggregateFields(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "mean"
 	topk.AddAggregateFields = []string{"a"}
 	topk.Fields = []string{"a"}
@@ -188,7 +188,7 @@ func TestTopkMeanAddAggregateFields(t *testing.T) {
 func TestTopkSumAddAggregateFields(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"a"}
 	topk.Fields = []string{"a"}
@@ -216,7 +216,7 @@ func TestTopkSumAddAggregateFields(t *testing.T) {
 func TestTopkMaxAddAggregateFields(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "max"
 	topk.AddAggregateFields = []string{"a"}
 	topk.Fields = []string{"a"}
@@ -244,7 +244,7 @@ func TestTopkMaxAddAggregateFields(t *testing.T) {
 func TestTopkMinAddAggregateFields(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "min"
 	topk.AddAggregateFields = []string{"a"}
 	topk.Fields = []string{"a"}
@@ -272,7 +272,7 @@ func TestTopkMinAddAggregateFields(t *testing.T) {
 func TestTopkGroupby1(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"value"}
@@ -296,7 +296,7 @@ func TestTopkGroupby1(t *testing.T) {
 func TestTopkGroupby2(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "mean"
 	topk.AddAggregateFields = []string{"value"}
@@ -324,7 +324,7 @@ func TestTopkGroupby2(t *testing.T) {
 func TestTopkGroupby3(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 1
 	topk.Aggregation = "min"
 	topk.AddAggregateFields = []string{"value"}
@@ -349,7 +349,7 @@ func TestTopkGroupby3(t *testing.T) {
 func TestTopkGroupbyFields1(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 4 // This settings generate less than 3 groups
 	topk.Aggregation = "mean"
 	topk.AddAggregateFields = []string{"A"}
@@ -375,7 +375,7 @@ func TestTopkGroupbyFields1(t *testing.T) {
 func TestTopkGroupbyFields2(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 2
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"B", "C"}
@@ -402,7 +402,7 @@ func TestTopkGroupbyFields2(t *testing.T) {
 func TestTopkGroupbyMetricName1(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 1
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"value"}
@@ -427,7 +427,7 @@ func TestTopkGroupbyMetricName1(t *testing.T) {
 func TestTopkGroupbyMetricName2(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 2
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"A", "value"}
@@ -454,7 +454,7 @@ func TestTopkGroupbyMetricName2(t *testing.T) {
 func TestTopkBottomk(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "sum"
 	topk.GroupBy = []string{"tag1", "tag3"}
@@ -479,7 +479,7 @@ func TestTopkBottomk(t *testing.T) {
 func TestTopkGroupByKeyTag(t *testing.T) {
 	// Build the processor
 	topk := *New()
-	topk.Period = oneSecondDuration
+	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "sum"
 	topk.GroupBy = []string{"tag1", "tag3"}


### PR DESCRIPTION
There are a number of tests with hard-coded sleep or timeouts that are
larger than they need to be. This reduces those times across the board
so that one test is not sitting and waiting any longer than it needs to
be.