### PR TITLE
chore: remove CircleCI parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,7 @@ commands:
           steps:
             - run: echo 'export RACE="-race"' >> $BASH_ENV
       - run: |
-          PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-          GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> --junitfile test-results/gotestsum-report.xml -- ${RACE} -short $PACKAGE_NAMES
+          GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> --junitfile test-results/gotestsum-report.xml -- ${RACE} -short ./...
       - store_test_results:
           path: test-results
       - when:
@@ -160,7 +159,6 @@ commands:
 jobs:
   test-go-linux:
     executor: go-1_17
-    parallelism: 4
     steps:
       - checkout
       - restore_cache:
@@ -182,7 +180,6 @@ jobs:
             - '*'
   test-go-linux-386:
     executor: go-1_17
-    parallelism: 4
     steps:
       - checkout
       - restore_cache:
@@ -198,7 +195,6 @@ jobs:
     steps:
       - test-go:
           os: darwin
-    parallelism: 4
   test-go-windows:
     executor:
         name: win/default
@@ -207,7 +203,6 @@ jobs:
       - test-go:
           os: windows
           gotestsum: "gotestsum.exe"
-    parallelism: 4
 
   windows-package:
     parameters:


### PR DESCRIPTION
The parallelism option will launch N systems and split the unit tests
across them. However, the entire test process involves a number of other
items: downloading go deps, make check, launching the VM/container
itself. These other items generally take longer than running the
tests themselves and as a result, other than spending more money on
CircleCI we are not getting a benefit from this option.

Furthermore, in order to start collecting coverage information it is
easier to not have this all split up.