### PR TITLE
style: Add deprecation notice to renamed plugins

### DIFF
--- a/plugins/inputs/deprecations.go
+++ b/plugins/inputs/deprecations.go
@@ -8,6 +8,10 @@ var Deprecations = map[string]telegraf.DeprecationInfo{
 		Since:  "1.7.0",
 		Notice: "use 'inputs.jolokia2' with the 'cassandra.conf' example configuration instead",
 	},
+	"cisco_telemetry_gnmi": {
+		Since:  "1.15.0",
+		Notice: "has been renamed to 'gnmi'",
+	},
 	"http_listener": {
 		Since:  "1.9.0",
 		Notice: "has been renamed to 'influxdb_listener', use 'inputs.influxdb_listener' or 'inputs.http_listener_v2' instead",

--- a/plugins/inputs/deprecations.go
+++ b/plugins/inputs/deprecations.go
@@ -33,6 +33,10 @@ var Deprecations = map[string]telegraf.DeprecationInfo{
 		Since:  "1.4.0",
 		Notice: "use 'inputs.kafka_consumer' instead, NOTE: 'kafka_consumer' only supports Kafka v0.8+",
 	},
+	"KNXListener": {
+		Since:  "1.20.1",
+		Notice: "has been renamed to 'knx_listener'",
+	},
 	"logparser": {
 		Since:  "1.15.0",
 		Notice: "use 'inputs.tail' with 'grok' data format instead",


### PR DESCRIPTION
There were a few cases that didn't get a deprecation notice yet.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)
