### PR TITLE
style: align plugin renaming

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -613,10 +613,8 @@ func printFilteredInputs(inputFilters []string, commented bool) {
 	// Print Inputs
 	for _, pname := range pnames {
 		// Skip inputs that are registered twice for backward compatibility
-		if pname == "cisco_telemetry_gnmi" {
-			continue
-		}
-		if pname == "KNXListener" {
+		switch pname {
+		case "cisco_telemetry_gnmi", "io", "KNXListener":
 			continue
 		}
 		creator := inputs.Inputs[pname]
@@ -1241,14 +1239,6 @@ func (c *Config) addOutput(name string, table *ast.Table) error {
 func (c *Config) addInput(name string, table *ast.Table) error {
 	if len(c.InputFilters) > 0 && !sliceContains(name, c.InputFilters) {
 		return nil
-	}
-
-	// Legacy support renaming io input to diskio
-	if name == "io" {
-		if err := c.printUserDeprecation("inputs", name, nil); err != nil {
-			return err
-		}
-		name = "diskio"
 	}
 
 	// For inputs with parsers we need to compute the set of

--- a/plugins/inputs/diskio/diskio.go
+++ b/plugins/inputs/diskio/diskio.go
@@ -220,4 +220,8 @@ func init() {
 	inputs.Add("diskio", func() telegraf.Input {
 		return &DiskIO{ps: ps, SkipSerialNumber: true}
 	})
+	// Backwards compatible alias
+	inputs.Add("io", func() telegraf.Input {
+		return &DiskIO{ps: ps, SkipSerialNumber: true}
+	})
 }


### PR DESCRIPTION
The `io` input plugin was renamed differently compared to `cisco_telemetry_gnmi` and `KNXListener`. This PR aims to streamline this..

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)
