### PR TITLE
fix: redundant zfs pool tag

### DIFF
--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -69,11 +69,11 @@ func getPools(kstatPath string) ([]poolInfo, error) {
 
 func getTags(pools []poolInfo) map[string]string {
 	poolNames := ""
-	knownPools := make(map[string]bool)
+	knownPools := make(map[string]struct{})
 	for _, entry := range pools {
 		name := entry.name
 		if _, value := knownPools[name]; !value {
-			knownPools[name] = true
+			knownPools[name] = struct{}{}
 			if poolNames != "" {
 				poolNames += "::"
 			}

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -68,13 +68,17 @@ func getPools(kstatPath string) ([]poolInfo, error) {
 }
 
 func getTags(pools []poolInfo) map[string]string {
-	var poolNames string
-
-	for _, pool := range pools {
-		if len(poolNames) != 0 {
-			poolNames += "::"
+	poolNames := ""
+	knownPools := make(map[string]bool)
+	for _, entry := range pools {
+		name := entry.name
+		if _, value := knownPools[name]; !value {
+			knownPools[name] = true
+			if poolNames != "" {
+				poolNames += "::"
+			}
+			poolNames += name
 		}
-		poolNames += pool.name
 	}
 
 	return map[string]string{"pools": poolNames}

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -72,7 +72,7 @@ func getTags(pools []poolInfo) map[string]string {
 	knownPools := make(map[string]struct{})
 	for _, entry := range pools {
 		name := entry.name
-		if _, value := knownPools[name]; !value {
+		if _, ok := knownPools[name]; !ok {
 			knownPools[name] = struct{}{}
 			if poolNames != "" {
 				poolNames += "::"


### PR DESCRIPTION
If a ZFS pool has multiple datasets it will show up in the ZFS pool list
that Telegraf maintains. When trying to produce the ZFS pools tag this
will result in a pool name showing up more than once. This creates a
unique set of pool names for the tag.

Fixes: #10837