### PR TITLE
fix: Change name of snmp translator setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 # Changelog
 
+## v1.22.0
+
+This version introduces an agent setting to select the method of
+translating SNMP objects. The agent setting "snmp_translator" can be
+"netsnmp" which translates by calling external programs snmptranslate
+and snmptable, or "gosmi" which translates using the built-in gosmi
+library.
+
+Before version 1.21.0, Telegraf only used the netsnmp method. Versions
+1.21.0 through 1.21.4 only used the gosmi method. Since the
+translation method is now configurable and "netsnmp" is the default,
+users who wish to continue using "gosmi" must add `snmp_translator =
+"gosmi"` in the agent section of their config file. See
+[#10802](https://github.com/influxdata/telegraf/pull/10802).
+
 ## v1.21.4 [2022-02-16]
 
 ### Bugfixes

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -189,7 +189,7 @@ func (a *Agent) initPlugins() error {
 	for _, input := range a.Config.Inputs {
 		// Share the snmp translator setting with plugins that need it.
 		if tp, ok := input.Input.(snmp.TranslatorPlugin); ok {
-			tp.SetTranslator(a.Config.Agent.Translator)
+			tp.SetTranslator(a.Config.Agent.SnmpTranslator)
 		}
 		err := input.Init()
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -226,7 +226,9 @@ type AgentConfig struct {
 	Hostname     string
 	OmitHostname bool
 
-	Translator string `toml:"translator"`
+	// Method for translating SNMP objects. 'netsnmp' to call external programs,
+	// 'gosmi' to use the built-in library.
+	SnmpTranslator string `toml:"snmp_translator"`
 }
 
 // InputNames returns a list of strings of the configured inputs.
@@ -421,10 +423,10 @@ var agentConfig = `
   ## If set to true, do no set the "host" tag in the telegraf agent.
   omit_hostname = false
 
-  ## Translator for SNMP OIDs
-  ## Valid values are "netsnmp" which runs snmptranslate and snmptable,
-  ## and "gosmi" which uses the gosmi library.
-  # translator = "netsnmp"
+  ## Method of translating SNMP objects. Can be "netsnmp" which
+  ## translates by calling external programs snmptranslate and snmptable,
+  ## or "gosmi" which translates using the built-in gosmi library.
+  # snmp_translator = "netsnmp"
 `
 
 var outputHeader = `
@@ -863,8 +865,8 @@ func (c *Config) LoadConfigData(data []byte) error {
 	}
 
 	// Set snmp agent translator default
-	if c.Agent.Translator == "" {
-		c.Agent.Translator = "netsnmp"
+	if c.Agent.SnmpTranslator == "" {
+		c.Agent.SnmpTranslator = "netsnmp"
 	}
 
 	if len(c.UnusedFields) > 0 {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -242,8 +242,14 @@ The agent table configures Telegraf and the defaults used across all plugins.
 
 - **hostname**:
   Override default hostname, if empty use os.Hostname()
+
 - **omit_hostname**:
   If set to true, do no set the "host" tag in the telegraf agent.
+
+- **snmp_translator**:
+  Method of translating SNMP objects. Can be "netsnmp" which
+  translates by calling external programs snmptranslate and snmptable,
+  or "gosmi" which translates using the built-in gosmi library.
 
 ## Plugins
 


### PR DESCRIPTION
Change the name of snmp translator setting. This change hasn't been released yet so it's still safe to change. "translator" was too generic and "snmp_translator" is more clear.

Update the sample config and add a section in the configuration documentation.

Add a section to the changelog to draw attention to the new setting since it allows users to select one of the two previous defaults, and requires those who want to use gosmi to add the setting manually to their config file.
