### PR TITLE
fix: consul_metrics input plugin docs

### DIFF
--- a/plugins/inputs/consul_metrics/README.md
+++ b/plugins/inputs/consul_metrics/README.md
@@ -7,7 +7,7 @@ This plugin grabs metrics from a Consul agent. Telegraf may be present in every 
 ## Configuration
 
 ```toml
-[[inputs.consul]]
+[[inputs.consul_metrics]]
   ## URL for the Consul agent
   # url = "http://127.0.0.1:8500"
 

--- a/plugins/inputs/consul_metrics/README.md
+++ b/plugins/inputs/consul_metrics/README.md
@@ -2,7 +2,7 @@
 
 This plugin grabs metrics from a Consul agent. Telegraf may be present in every node and connect to the agent locally. In this case should be something like `http://127.0.0.1:8500`.
 
-> Tested on Consul 1.10.4
+> Tested on Consul 1.10.4 .
 
 ## Configuration
 


### PR DESCRIPTION
Wrong input pointing in toml configuration in README file.

Fixes https://github.com/influxdata/telegraf/issues/10870.