### PR TITLE
fix: default value for logfile rotation interval

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -404,7 +404,7 @@ var agentConfig = `
   ## The logfile will be rotated after the time interval specified.  When set
   ## to 0 no time based rotation is performed.  Logs are rotated only when
   ## written to, if there is no log activity rotation may be delayed.
-  # logfile_rotation_interval = "0d"
+  # logfile_rotation_interval = "0h"
 
   ## The logfile will be rotated when it becomes larger than the specified
   ## size.  When set to 0 no size based rotation is performed.

--- a/config/types.go
+++ b/config/types.go
@@ -41,6 +41,12 @@ func (d *Duration) UnmarshalTOML(b []byte) error {
 	if durStr == "" {
 		durStr = "0s"
 	}
+	// special case: logging interval had a default of 0d, which silently
+	// failed, but in order to prevent issues with default configs that had
+	// uncommented the option, change it from zero days to zero hours.
+	if durStr == "0d" {
+		durStr = "0h"
+	}
 
 	dur, err := time.ParseDuration(durStr)
 	if err != nil {


### PR DESCRIPTION
The unit of 'd' is not a valid time.Duration unit. Due to the more
strict parsing of durations, this is now correctly failing. Previously
using a value of '1d' would fail silently. If a user wishes to use a
value of days, they need to convert to hours and use '24h' for example
of one day.

Fixes: #10882