### PR TITLE
feat: add syslog-ng input plugin

### DIFF
--- a/plugins/inputs/syslog-ng/README.md
+++ b/plugins/inputs/syslog-ng/README.md
@@ -1,0 +1,74 @@
+# syslog-ng Input Plugin
+
+This plugin gathers stats from [syslog-ng](https://www.syslog-ng.com/) -
+an enhanced log daemon.
+
+## Configuration
+
+```toml
+# A plugin to collect stats from the syslog-ng daemon
+[[inputs.syslog-ng]]
+  ## If running as a restricted user you can prepend sudo for additional access:
+  # use_sudo = false
+
+  ## The default location of the syslog-ng-ctl binary can be overridden with:
+  # binary = "/usr/local/sbin/syslog-ng-ctl"
+
+  ## The default timeout of 1s can be overridden with:
+  # timeout = "1s"
+```
+
+### Permissions
+
+It's important to note that this plugin references syslog-ng-ctl, which
+may require additional permissions to execute successfully.  Depending
+on the user/group permissions of the telegraf user executing this
+plugin, you may need to alter the group membership, set facls, or use
+sudo.
+
+**Group membership**:
+
+```bash
+$ groups telegraf
+telegraf : telegraf
+
+$ usermod -a -G syslog-ng telegraf
+
+$ groups telegraf
+telegraf : telegraf syslog-ng
+```
+
+**Sudo privileges (Recommended)**:
+If you use this method, you will need the following in your telegraf config:
+
+```toml
+[[inputs.syslog-ng]]
+  use_sudo = true
+```
+
+You will also need to update your sudoers file:
+
+```bash
+$ visudo
+# Add the following line:
+Cmnd_Alias SYSLOGNGCTL = /usr/local/sbin/syslog-ng-ctl
+telegraf  ALL=(ALL) NOPASSWD: SYSLOGNGCTL
+Defaults!SYSLOGNGCTL !logfile, !syslog, !pam_session
+```
+
+Please use the solution you see as most appropriate.
+
+## Metrics
+
+This is the full list of stats provided by syslog-ng. In the output, the
+pascal-case in the syslog-ng-ctl stat name are replaced by snake case
+(see
+<https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.16/administration-guide/80>
+for details).
+
+- syslog-ng
+  - tags:
+    - type
+    - source_name
+  - fields:
+    - number

--- a/plugins/inputs/syslog-ng/syslogng.go
+++ b/plugins/inputs/syslog-ng/syslogng.go
@@ -1,0 +1,136 @@
+package syslogng
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+type runner func(cmdName string, timeout config.Duration, useSudo bool) (*bytes.Buffer, error)
+
+type SyslogNg struct {
+	Binary  string
+	Timeout config.Duration
+	UseSudo bool
+
+	run runner
+}
+
+var defaultBinary = "/usr/local/sbin/syslog-ng-ctl"
+var defaultTimeout = config.Duration(time.Second)
+
+var sampleConfig = `
+  ## If running as a restricted user you can prepend sudo for additional access:
+  # use_sudo = false
+
+  ## The default location of the syslog-ng-ctl binary can be overridden with:
+  # binary = "/usr/local/sbin/syslog-ng-ctl"
+
+  ## The default timeout of 1s can be overridden with:
+  # timeout = "1s"
+`
+
+func SyslogNgCtlRunner(cmdName string, timeout config.Duration, useSudo bool) (*bytes.Buffer, error) {
+	var out bytes.Buffer
+	cmdArgs := []string{"stats"}
+
+	cmd := exec.Command(cmdName, cmdArgs...)
+	if useSudo {
+		cmdArgs = append([]string{cmdName}, cmdArgs...)
+		cmd = exec.Command("sudo", cmdArgs...)
+	}
+	cmd.Stdout = &out
+	err := internal.RunTimeout(cmd, time.Duration(timeout))
+
+	if err != nil {
+		return &out, fmt.Errorf("error running syslog-ng-ctl: %w (%s, %v)", err, cmdName, cmdArgs)
+	}
+
+	return &out, nil
+}
+
+// Description displays what this plugin is about
+func (s *SyslogNg) Description() string {
+	return "A plugin to collect stats from the syslog-ng log daemon"
+}
+
+// SampleConfig displays configuration instructions
+func (s *SyslogNg) SampleConfig() string {
+	return sampleConfig
+}
+
+// Gather collects stats from syslog-ng-ctl and adds them to the Accumulator
+func (s *SyslogNg) Gather(acc telegraf.Accumulator) error {
+	out, err := s.run(s.Binary, s.Timeout, s.UseSudo)
+	if err != nil {
+		return fmt.Errorf("error gathering metrics: %w", err)
+	}
+
+	reader := csv.NewReader(out)
+	reader.Comma = ';'
+
+	rows := []map[string]string{}
+	header := []string{}
+
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return fmt.Errorf("cannot read metrics: %w", err)
+		}
+
+		if len(header) == 0 {
+			header = record
+		} else {
+			row := map[string]string{}
+			for i := range header {
+				row[header[i]] = record[i]
+			}
+			rows = append(rows, row)
+		}
+	}
+
+	for _, row := range rows {
+		number, _ := strconv.Atoi(row["Number"])
+
+		switch row["Type"] {
+		case "processed", "dropped", "queued", "suppressed", "discarded", "memory_usage", "matched", "not_matched", "written":
+			tags := map[string]string{
+				"type":        row["Type"],
+				"source_name": row["SourceName"],
+			}
+			fields := map[string]interface{}{
+				"number": number,
+			}
+
+			acc.AddFields("syslog-ng", fields, tags)
+		default:
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	inputs.Add("syslog-ng", func() telegraf.Input {
+		return &SyslogNg{
+			Binary:  defaultBinary,
+			Timeout: defaultTimeout,
+			UseSudo: false,
+
+			run: SyslogNgCtlRunner,
+		}
+	})
+}

--- a/plugins/inputs/syslog-ng/syslogng_test.go
+++ b/plugins/inputs/syslog-ng/syslogng_test.go
@@ -1,0 +1,66 @@
+package syslogng
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func SyslogNgCtlRunnerTest(output string) func(string, config.Duration, bool) (*bytes.Buffer, error) {
+	return func(string, config.Duration, bool) (*bytes.Buffer, error) {
+		return bytes.NewBuffer([]byte(output)), nil
+	}
+}
+
+func TestParseFullOutput(t *testing.T) {
+	acc := &testutil.Accumulator{}
+	v := &SyslogNg{
+		run: SyslogNgCtlRunnerTest(fullOutput),
+	}
+	err := v.Gather(acc)
+
+	require.NoError(t, err)
+	require.True(t, acc.HasMeasurement("syslog-ng"))
+
+	require.Len(t, acc.Metrics, 26)
+	require.Equal(t, 26, acc.NFields())
+
+	acc.AssertContainsFields(t, "syslog-ng", parsedFullOutput)
+}
+
+var parsedFullOutput = map[string]interface{}{
+	"number": 0,
+}
+
+var fullOutput = `SourceName;SourceId;SourceInstance;State;Type;Number
+destination;xferlog;;a;processed;0
+destination;security;;a;processed;0
+src.internal;src#4;;a;processed;23
+src.internal;src#4;;a;stamp;1648129533
+destination;debuglog;;a;processed;82
+global;msg_clones;;a;processed;3
+destination;cron;;a;processed;64
+global;internal_source;;a;dropped;0
+global;internal_source;;a;queued;0
+global;sdata_updates;;a;processed;1530016
+destination;d_foo2;;a;processed;1530016
+destination;authlog;;a;processed;3
+destination;messages;;a;processed;22
+global;scratch_buffers_count;;a;queued;9
+destination;console;;a;processed;0
+center;;queued;a;processed;1530187
+src.syslog;s_foo;afsocket_sd.(stream,AF_INET(127.0.0.1:6514));a;connections;0
+destination;slip;;a;processed;0
+global;payload_reallocs;;a;processed;43
+destination;ppp;;a;processed;0
+destination;lpd-errs;;a;processed;0
+destination;allusers;;a;processed;0
+center;;received;a;processed;1530280
+destination;maillog;;a;processed;0
+global;internal_queue_length;;a;processed;0
+source;src;;a;processed;264
+source;s_foo;;a;processed;1530016
+global;scratch_buffers_bytes;;a;queued;512`


### PR DESCRIPTION
syslog-ng is a popular log daemon to replace the system default Syslog. Syslog-ng expose metrics. It would be great to have telegraf plugin to collect them.
