### PR TITLE
fix: Set log as text block in but reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -20,6 +20,7 @@ body:
     attributes:
       label: Logs from Telegraf
       description: Please include the Telegraf logs, ideally with `--debug` used.
+      render: text
     validations:
       required: true
   - type: input


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

It's usually more readable when done so as user don't take into account the special characters in the logs will be converted to markup.