### PR TITLE
fix: add tracefs to ignore, reduce log level

### DIFF
--- a/plugins/inputs/disk/README.md
+++ b/plugins/inputs/disk/README.md
@@ -16,7 +16,7 @@ Note that `used_percent` is calculated by doing `used / (used + free)`, _not_
   # mount_points = ["/"]
 
   ## Ignore mount points by filesystem type.
-  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
+  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "tracefs"]
 ```
 
 ### Docker container

--- a/plugins/inputs/disk/README.md
+++ b/plugins/inputs/disk/README.md
@@ -16,7 +16,7 @@ Note that `used_percent` is calculated by doing `used / (used + free)`, _not_
   # mount_points = ["/"]
 
   ## Ignore mount points by filesystem type.
-  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "tracefs"]
+  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
 ```
 
 ### Docker container

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -154,7 +154,7 @@ func (s *SystemPS) DiskUsage(
 		du, err := s.PSDiskUsage(mountpoint)
 		if err != nil {
 			if s.Log != nil {
-				s.Log.Errorf("[SystemPS] => error getting disk usage (%q): %v", mountpoint, err)
+				s.Log.Warnf("[SystemPS] => unable to get disk usage (%q): %v", mountpoint, err)
 			}
 			continue
 		}

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -154,7 +154,7 @@ func (s *SystemPS) DiskUsage(
 		du, err := s.PSDiskUsage(mountpoint)
 		if err != nil {
 			if s.Log != nil {
-				s.Log.Warnf("[SystemPS] => unable to get disk usage (%q): %v", mountpoint, err)
+				s.Log.Debugf("[SystemPS] => unable to get disk usage (%q): %v", mountpoint, err)
 			}
 			continue
 		}


### PR DESCRIPTION
The tracefs filesystem is showing up more and is not likely something a
user wishes to have enabled by default. This adds it to the ignore in
the config by default.

This also reduces the error message level from error to warning. This
was previously a debug message, but was bumped all the way to an error.
This message does not prevent any messages from getting read by Telegraf
and not an error that halts Telegraf. Users may still wish to address
the messages so reducing to a warning is better than hiding them.

Fixes: #10897