### PR TITLE
feat: Add ability to check every tag for regex replace

### DIFF
--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -14,7 +14,7 @@ For metrics transforms, `key` denotes the element that should be transformed. Fu
 
   # Tag and field conversions defined in a separate sub-tables
   [[processors.regex.tags]]
-    ## Tag to change
+    ## Tag to change, "*" will change every tag
     key = "resp_code"
     ## Regular expression to match on a tag value
     pattern = "^(\\d)\\d\\d$"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Added the ability to check every tag for a regex to replace.  This came up as a need for us to scrub UUIDs out of tags defined by service owners.  Unit test reflects this use case.