### PR TITLE
fix(inputs/aerospike): Statistics query bug

### DIFF
--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -255,7 +255,6 @@ func (a *Aerospike) parseNodeInfo(acc telegraf.Accumulator, stats map[string]str
 		nFields[key] = parseAerospikeValue(key, parts[1])
 	}
 	acc.AddFields("aerospike_node", nFields, nTags, time.Now())
-
 }
 
 func (a *Aerospike) getNamespaces(n *as.Node, infoPolicy *as.InfoPolicy) ([]string, error) {

--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -231,7 +231,7 @@ func (a *Aerospike) gatherServer(acc telegraf.Accumulator, hostPort string) erro
 }
 
 func (a *Aerospike) getNodeInfo(n *as.Node, infoPolicy *as.InfoPolicy) (map[string]string, error) {
-	stats, err := n.RequestInfo(infoPolicy)
+	stats, err := n.RequestInfo(infoPolicy, "statistics")
 	if err != nil {
 		return nil, err
 	}
@@ -240,17 +240,22 @@ func (a *Aerospike) getNodeInfo(n *as.Node, infoPolicy *as.InfoPolicy) (map[stri
 }
 
 func (a *Aerospike) parseNodeInfo(acc telegraf.Accumulator, stats map[string]string, hostPort string, nodeName string) {
-	tags := map[string]string{
+	nTags := map[string]string{
 		"aerospike_host": hostPort,
 		"node_name":      nodeName,
 	}
-	fields := make(map[string]interface{})
-
-	for k, v := range stats {
-		key := strings.Replace(k, "-", "_", -1)
-		fields[key] = parseAerospikeValue(key, v)
+	nFields := make(map[string]interface{})
+	stat := strings.Split(stats["statistics"], ";")
+	for _, pair := range stat {
+		parts := strings.Split(pair, "=")
+		if len(parts) < 2 {
+			continue
+		}
+		key := strings.Replace(parts[0], "-", "_", -1)
+		nFields[key] = parseAerospikeValue(key, parts[1])
 	}
-	acc.AddFields("aerospike_node", fields, tags, time.Now())
+	acc.AddFields("aerospike_node", nFields, nTags, time.Now())
+
 }
 
 func (a *Aerospike) getNamespaces(n *as.Node, infoPolicy *as.InfoPolicy) ([]string, error) {

--- a/plugins/inputs/aerospike/aerospike_test.go
+++ b/plugins/inputs/aerospike/aerospike_test.go
@@ -316,9 +316,7 @@ func TestParseNodeInfo(t *testing.T) {
 	var acc testutil.Accumulator
 
 	stats := map[string]string{
-		"early_tsvc_from_proxy_error": "0",
-		"cluster_principal":           "BB9020012AC4202",
-		"cluster_is_member":           "true",
+		"statistics": "early_tsvc_from_proxy_error=0;cluster_principal=BB9020012AC4202;cluster_is_member=true",
 	}
 
 	expectedFields := map[string]interface{}{


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10929

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

In the aerospike go client v5 onwards they moved RequestNodeStats to RequestInfo
https://github.com/influxdata/telegraf/pull/10604
During this PR, the "statistics" command wasn't passed [here](https://github.com/influxdata/telegraf/pull/10604/files/d3b2aefd0124e2edc73bdaa765464fa64acef577#diff-a8caf4914634b15870431f7a18f3c09854fe2da6fab7b3a3d40b28bac4119b64R234)

The same has been corrected in this PR.
