### PR TITLE
fix(inputs.prometheus): moved from watcher to informer

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -63,6 +63,10 @@ in Prometheus format.
   # eg. To scrape pods on a specific node
   # kubernetes_field_selector = "spec.nodeName=$HOSTNAME"
 
+  # cache refresh interval to set the interval for getting notified about addition / deletion of pods. 
+  # Default is 60 minutes.
+  # cache_refresh_interval = 60
+
   ## Scrape Services available in Consul Catalog
   # [inputs.prometheus.consul]
   #   enabled = true

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -63,7 +63,7 @@ in Prometheus format.
   # eg. To scrape pods on a specific node
   # kubernetes_field_selector = "spec.nodeName=$HOSTNAME"
 
-  # cache refresh interval to set the interval for getting notified about addition / deletion of pods. 
+  # cache refresh interval to set the interval for re-sync of pods list. 
   # Default is 60 minutes.
   # cache_refresh_interval = 60
 

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -421,11 +421,10 @@ func unregisterPod(pod *corev1.Pod, p *Prometheus) {
 		return
 	}
 
-	p.Log.Debugf("registered a delete request for %q in namespace %q", pod.Name, pod.Namespace)
-
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	if _, ok := p.kubernetesPods[targetURL.String()]; ok {
+		p.Log.Debugf("registered a delete request for %q in namespace %q", pod.Name, pod.Namespace)
 		delete(p.kubernetesPods, targetURL.String())
 		p.Log.Debugf("will stop scraping for %q", targetURL.String())
 	}

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -130,7 +130,11 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 
 			pod, _ := clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 
-			if pod.Annotations["prometheus.io/scrape"] == "true" && podReady(pod.Status.ContainerStatuses) {
+			if pod.Annotations["prometheus.io/scrape"] == "true" &&
+				podReady(pod.Status.ContainerStatuses) &&
+				podHasMatchingNamespace(pod, p) &&
+				podHasMatchingLabelSelector(pod, p.podLabelSelector) &&
+				podHasMatchingFieldSelector(pod, p.podFieldSelector) {
 				registerPod(pod, p)
 			}
 		},
@@ -147,7 +151,11 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 
 			newPod, _ := clientset.CoreV1().Pods(newNamespace).Get(ctx, newName, metav1.GetOptions{})
 
-			if newPod.Annotations["prometheus.io/scrape"] == "true" && podReady(newPod.Status.ContainerStatuses) {
+			if newPod.Annotations["prometheus.io/scrape"] == "true" &&
+				podReady(newPod.Status.ContainerStatuses) &&
+				podHasMatchingNamespace(newPod, p) &&
+				podHasMatchingLabelSelector(newPod, p.podLabelSelector) &&
+				podHasMatchingFieldSelector(newPod, p.podFieldSelector) {
 				if newPod.GetDeletionTimestamp() == nil {
 					registerPod(newPod, p)
 				}
@@ -165,7 +173,11 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 
 			oldPod, _ := clientset.CoreV1().Pods(oldNamespace).Get(ctx, oldName, metav1.GetOptions{})
 
-			if oldPod.Annotations["prometheus.io/scrape"] == "true" && podReady(oldPod.Status.ContainerStatuses) {
+			if oldPod.Annotations["prometheus.io/scrape"] == "true" &&
+				podReady(oldPod.Status.ContainerStatuses) &&
+				podHasMatchingNamespace(oldPod, p) &&
+				podHasMatchingLabelSelector(oldPod, p.podLabelSelector) &&
+				podHasMatchingFieldSelector(oldPod, p.podFieldSelector) {
 				if oldPod.GetDeletionTimestamp() != nil {
 					unregisterPod(oldPod, p)
 				}
@@ -184,7 +196,11 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 
 			pod, _ := clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 
-			if pod.Annotations["prometheus.io/scrape"] == "true" && podReady(pod.Status.ContainerStatuses) {
+			if pod.Annotations["prometheus.io/scrape"] == "true" &&
+				podReady(pod.Status.ContainerStatuses) &&
+				podHasMatchingNamespace(pod, p) &&
+				podHasMatchingLabelSelector(pod, p.podLabelSelector) &&
+				podHasMatchingFieldSelector(pod, p.podFieldSelector) {
 				if pod.GetDeletionTimestamp() != nil {
 					unregisterPod(pod, p)
 				}

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -117,7 +117,7 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 
 	podinformer := informerfactory.Core().V1().Pods()
 	podinformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(newObj interface{}){
+		AddFunc: func(newObj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(newObj)
 			if err != nil {
 				p.Log.Errorf("getting key from cache %s\n", err.Error())
@@ -134,7 +134,7 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 				registerPod(pod, p)
 			}
 		},
-		UpdateFunc: func(oldObj, newObj interface{}){
+		UpdateFunc: func(oldObj, newObj interface{}) {
 			newKey, err := cache.MetaNamespaceKeyFunc(newObj)
 			if err != nil {
 				p.Log.Errorf("getting key from cache %s\n", err.Error())
@@ -171,7 +171,7 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 				}
 			}
 		},
-		DeleteFunc: func(oldObj interface{}){
+		DeleteFunc: func(oldObj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(oldObj)
 			if err != nil {
 				p.Log.Errorf("getting key from cache %s", err.Error())

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -117,8 +117,8 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 
 	podinformer := informerfactory.Core().V1().Pods()
 	podinformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(new_obj interface{}){
-			key, err := cache.MetaNamespaceKeyFunc(new_obj)
+		AddFunc: func(newObj interface{}){
+			key, err := cache.MetaNamespaceKeyFunc(newObj)
 			if err != nil {
 				p.Log.Errorf("getting key from cache %s\n", err.Error())
 			}
@@ -134,45 +134,45 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 				registerPod(pod, p)
 			}
 		},
-		UpdateFunc: func(old_obj, new_obj interface{}){
-			new_key, err := cache.MetaNamespaceKeyFunc(new_obj)
+		UpdateFunc: func(oldObj, newObj interface{}){
+			newKey, err := cache.MetaNamespaceKeyFunc(newObj)
 			if err != nil {
 				p.Log.Errorf("getting key from cache %s\n", err.Error())
 			}
 
-			new_namespace, new_name, err := cache.SplitMetaNamespaceKey(new_key)
+			newNamespace, newName, err := cache.SplitMetaNamespaceKey(newKey)
 			if err != nil {
 				p.Log.Errorf("splitting key into namespace and name %s\n", err.Error())
 			}
 
-			new_pod, _ := clientset.CoreV1().Pods(new_namespace).Get(ctx, new_name, metav1.GetOptions{})
+			newPod, _ := clientset.CoreV1().Pods(newNamespace).Get(ctx, newName, metav1.GetOptions{})
 
-			if new_pod.Annotations["prometheus.io/scrape"] == "true" && podReady(new_pod.Status.ContainerStatuses) {
-				if new_pod.GetDeletionTimestamp() == nil {
-					registerPod(new_pod, p)
+			if newPod.Annotations["prometheus.io/scrape"] == "true" && podReady(newPod.Status.ContainerStatuses) {
+				if newPod.GetDeletionTimestamp() == nil {
+					registerPod(newPod, p)
 				}
 			}
 
-			old_key, err := cache.MetaNamespaceKeyFunc(old_obj)
+			oldKey, err := cache.MetaNamespaceKeyFunc(oldObj)
 			if err != nil {
 				p.Log.Errorf("getting key from cache %s\n", err.Error())
 			}
 
-			old_namespace, old_name, err := cache.SplitMetaNamespaceKey(old_key)
+			oldNamespace, oldName, err := cache.SplitMetaNamespaceKey(oldKey)
 			if err != nil {
 				p.Log.Errorf("splitting key into namespace and name %s\n", err.Error())
 			}
 
-			old_pod, _ := clientset.CoreV1().Pods(old_namespace).Get(ctx, old_name, metav1.GetOptions{})
+			oldPod, _ := clientset.CoreV1().Pods(oldNamespace).Get(ctx, oldName, metav1.GetOptions{})
 
-			if old_pod.Annotations["prometheus.io/scrape"] == "true" && podReady(old_pod.Status.ContainerStatuses) {
-				if old_pod.GetDeletionTimestamp() != nil {
-					unregisterPod(old_pod, p)
+			if oldPod.Annotations["prometheus.io/scrape"] == "true" && podReady(oldPod.Status.ContainerStatuses) {
+				if oldPod.GetDeletionTimestamp() != nil {
+					unregisterPod(oldPod, p)
 				}
 			}
 		},
-		DeleteFunc: func(old_obj interface{}){
-			key, err := cache.MetaNamespaceKeyFunc(old_obj)
+		DeleteFunc: func(oldObj interface{}){
+			key, err := cache.MetaNamespaceKeyFunc(oldObj)
 			if err != nil {
 				p.Log.Errorf("getting key from cache %s", err.Error())
 			}

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -84,6 +84,9 @@ type Prometheus struct {
 	podFieldSelector  fields.Selector
 	isNodeScrapeScope bool
 
+	// Only for monitor_kubernetes_pods=true 
+	CacheRefreshInterval int `toml:"cache_refresh_interval"`
+
 	// List of consul services to scrape
 	consulServices map[string]URLAndAddress
 }
@@ -139,6 +142,10 @@ var sampleConfig = `
   # field selector to target pods
   # eg. To scrape pods on a specific node
   # kubernetes_field_selector = "spec.nodeName=$HOSTNAME"
+
+  # cache refresh interval to set the interval for getting notified about addition / deletion of pods. 
+  # Default is 60 minutes.
+  # cache_refresh_interval = 60
 
   ## Scrape Services available in Consul Catalog
   # [inputs.prometheus.consul]

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -143,7 +143,7 @@ var sampleConfig = `
   # eg. To scrape pods on a specific node
   # kubernetes_field_selector = "spec.nodeName=$HOSTNAME"
 
-  # cache refresh interval to set the interval for getting notified about addition / deletion of pods. 
+  # cache refresh interval to set the interval for re-sync of pods list. 
   # Default is 60 minutes.
   # cache_refresh_interval = 60
 

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -84,7 +84,7 @@ type Prometheus struct {
 	podFieldSelector  fields.Selector
 	isNodeScrapeScope bool
 
-	// Only for monitor_kubernetes_pods=true 
+	// Only for monitor_kubernetes_pods=true
 	CacheRefreshInterval int `toml:"cache_refresh_interval"`
 
 	// List of consul services to scrape


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Resolves:
#10148, #10878 and #10928

Issues:
- telegraf stops monitoring pods after 30 minutes 
- high CPU utilization

watcher has a default timeout of 30 minutes, leading to the above mentioned problems.

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Fix:
- Replaced watcher with informer. Actions that are triggered for "add", "update/modify" and "delete" events remain same.
- Added a new config cache_refresh_interval that is used by informer to rebase its cache.
