### PR TITLE
chore: add actions/setup-go@v2 to linter config

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,11 +15,12 @@ jobs:
     name: lint-pr-changes
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1
+          version: v1.45.2
           only-new-issues: true
   golangci-master:
     if: github.ref == 'refs/heads/master'
@@ -30,6 +31,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42.1
+          version: v1.45.2
           only-new-issues: true
           args: --issues-exit-code=0

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli


### PR DESCRIPTION
The golanci-lint action recently updated to require an additional step: `actions/setup-go@v2`, documented in the main README.md: https://github.com/golangci/golangci-lint-action. This seems like it might have been a breaking change because the linter is behaving strangely (reporting issues were there aren't any, or ignoring issues) not obvious if this is directly related, but seems like the reason.

This PR adds this missing step to our github configuration, updates the version of golangci-lint to v1.45.2 as well. 