### PR TITLE
fix: update starlark 7a1108eaa012->d1966c6b9fcd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -142,7 +142,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.27.0
 	go.opentelemetry.io/otel/metric v0.27.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
-	go.starlark.net v0.0.0-20210406145628-7a1108eaa012
+	go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -2334,6 +2334,8 @@ go.opentelemetry.io/proto/otlp v0.12.0 h1:CMJ/3Wp7iOWES+CYLfnBv+DVmPbB+kmy9PJ92X
 go.opentelemetry.io/proto/otlp v0.12.0/go.mod h1:TsIjwGWIx5VFYv9KGVlOpxoBl5Dy+63SUguV7GGvlSQ=
 go.starlark.net v0.0.0-20210406145628-7a1108eaa012 h1:4RGobP/iq7S22H0Bb92OEt+M8/cfBQnW+T+a2MC0sQo=
 go.starlark.net v0.0.0-20210406145628-7a1108eaa012/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
+go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd h1:Uo/x0Ir5vQJ+683GXB9Ug+4fcjsbp7z7Ul8UaZbhsRM=
+go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/go.sum
+++ b/go.sum
@@ -2332,8 +2332,6 @@ go.opentelemetry.io/otel/trace v1.4.0/go.mod h1:uc3eRsqDfWs9R7b92xbQbU42/eTNz4N+
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.12.0 h1:CMJ/3Wp7iOWES+CYLfnBv+DVmPbB+kmy9PJ92XvlR6c=
 go.opentelemetry.io/proto/otlp v0.12.0/go.mod h1:TsIjwGWIx5VFYv9KGVlOpxoBl5Dy+63SUguV7GGvlSQ=
-go.starlark.net v0.0.0-20210406145628-7a1108eaa012 h1:4RGobP/iq7S22H0Bb92OEt+M8/cfBQnW+T+a2MC0sQo=
-go.starlark.net v0.0.0-20210406145628-7a1108eaa012/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
 go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd h1:Uo/x0Ir5vQJ+683GXB9Ug+4fcjsbp7z7Ul8UaZbhsRM=
 go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/plugins/aggregators/starlark/README.md
+++ b/plugins/aggregators/starlark/README.md
@@ -99,5 +99,5 @@ Refer to the section [Common Questions](plugins/processors/starlark/README.md#co
 
 Open a Pull Request to add any other useful Starlark examples.
 
-[Starlark specification]: https://github.com/google/starlark-go/blob/master/doc/spec.md
+[Starlark specification]: https://github.com/google/starlark-go/blob/d1966c6b9fcd/doc/spec.md
 [dict]: https://github.com/google/starlark-go/blob/master/doc/spec.md#dictionaries

--- a/plugins/aggregators/starlark/README.md
+++ b/plugins/aggregators/starlark/README.md
@@ -100,4 +100,4 @@ Refer to the section [Common Questions](plugins/processors/starlark/README.md#co
 Open a Pull Request to add any other useful Starlark examples.
 
 [Starlark specification]: https://github.com/google/starlark-go/blob/d1966c6b9fcd/doc/spec.md
-[dict]: https://github.com/google/starlark-go/blob/master/doc/spec.md#dictionaries
+[dict]: https://github.com/google/starlark-go/blob/d1966c6b9fcd/doc/spec.md#dictionaries

--- a/plugins/processors/starlark/README.md
+++ b/plugins/processors/starlark/README.md
@@ -250,5 +250,5 @@ def apply(metric):
 Open a Pull Request to add any other useful Starlark examples.
 
 [Starlark specification]: https://github.com/google/starlark-go/blob/d1966c6b9fcd/doc/spec.md
-[string]: https://github.com/google/starlark-go/blob/master/doc/spec.md#strings
-[dict]: https://github.com/google/starlark-go/blob/master/doc/spec.md#dictionaries
+[string]: https://github.com/google/starlark-go/blob/d1966c6b9fcd/doc/spec.md#strings
+[dict]: https://github.com/google/starlark-go/blob/d1966c6b9fcd/doc/spec.md#dictionaries

--- a/plugins/processors/starlark/README.md
+++ b/plugins/processors/starlark/README.md
@@ -249,6 +249,6 @@ def apply(metric):
 
 Open a Pull Request to add any other useful Starlark examples.
 
-[Starlark specification]: https://github.com/google/starlark-go/blob/master/doc/spec.md
+[Starlark specification]: https://github.com/google/starlark-go/blob/d1966c6b9fcd/doc/spec.md
 [string]: https://github.com/google/starlark-go/blob/master/doc/spec.md#strings
 [dict]: https://github.com/google/starlark-go/blob/master/doc/spec.md#dictionaries


### PR DESCRIPTION
resolve: https://github.com/influxdata/telegraf/issues/10828

Updating go.starlark.net to latest version, the project doesn't use official releases but we are using the latest commit. As suggested by @Hipska updated the spec as well to point to the commit instead of master.

@Hipska could you test out this change? thanks!