### PR TITLE
fix: align the default value for msg size

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/README.md
+++ b/plugins/inputs/cisco_telemetry_mdt/README.md
@@ -21,7 +21,7 @@ The TCP dialout transport is supported on IOS XR (32-bit and 64-bit) 6.1.x and l
  service_address = ":57000"
 
  ## Grpc Maximum Message Size, default is 4MB, increase the size.
- max_msg_size = 20000000
+ max_msg_size = 4000000
 
  ## Enable TLS; grpc transport only.
  # tls_cert = "/etc/telegraf/cert.pem"


### PR DESCRIPTION
The comment and the grpc library use 4,000,000 as a default. Our README
had a much larger value for an unknown reason. This aligns the default
message size.