### PR TITLE
style(inputs/disk): Add deprecation notice to legacy mountpoints setting

### DIFF
--- a/plugins/inputs/disk/disk.go
+++ b/plugins/inputs/disk/disk.go
@@ -12,8 +12,7 @@ import (
 type DiskStats struct {
 	ps system.PS
 
-	// Legacy support
-	LegacyMountPoints []string `toml:"mountpoints"`
+	LegacyMountPoints []string `toml:"mountpoints" deprecated:"0.10.2;2.0.0;use 'mount_points' instead"`
 
 	MountPoints []string `toml:"mount_points"`
 	IgnoreFS    []string `toml:"ignore_fs"`


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

I found another deprecated plugin config option that wasn't showing a notice yet.