### PR TITLE
feat(outputs.http): Support configuration of `MaxIdleConns` and `MaxIdleConnsPerHost`

### DIFF
--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -16,8 +16,10 @@ import (
 
 // Common HTTP client struct.
 type HTTPClientConfig struct {
-	Timeout         config.Duration `toml:"timeout"`
-	IdleConnTimeout config.Duration `toml:"idle_conn_timeout"`
+	Timeout             config.Duration `toml:"timeout"`
+	IdleConnTimeout     config.Duration `toml:"idle_conn_timeout"`
+	MaxIdleConns        int             `toml:"max_idle_conn"`
+	MaxIdleConnsPerHost int             `toml:"max_idle_conn_per_host"`
 
 	proxy.HTTPProxy
 	tls.ClientConfig
@@ -37,9 +39,11 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context, log telegraf.Logger
 	}
 
 	transport := &http.Transport{
-		TLSClientConfig: tlsCfg,
-		Proxy:           prox,
-		IdleConnTimeout: time.Duration(h.IdleConnTimeout),
+		TLSClientConfig:     tlsCfg,
+		Proxy:               prox,
+		IdleConnTimeout:     time.Duration(h.IdleConnTimeout),
+		MaxIdleConns:        h.MaxIdleConns,
+		MaxIdleConnsPerHost: h.MaxIdleConnsPerHost,
 	}
 
 	timeout := h.Timeout

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -65,6 +65,15 @@ batch format by default.
   #   # Should be set manually to "application/json" for json data_format
   #   Content-Type = "text/plain; charset=utf-8"
 
+  ## MaxIdleConns controls the maximum number of idle (keep-alive)
+  ## connections across all hosts. Zero means no limit.
+  # max_idle_conn = 0
+
+  ## MaxIdleConnsPerHost, if non-zero, controls the maximum idle
+  ## (keep-alive) connections to keep per-host. If zero,
+  ## DefaultMaxIdleConnsPerHost is used(2).
+  # max_idle_conn_per_host = 2
+
   ## Idle (keep-alive) connection timeout.
   ## Maximum amount of time before idle connection is closed.
   ## Zero means no limit.


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10953 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

## Changes
- Adds inputs for `MaxIdleConns` and `MaxIdleConnsPerHost` in `HTTPClientConfig` to read from toml

## Queries
- Let me know if it's a good idea to keep a default other than 2 for `MaxIdleConnsPerHost`