### PR TITLE
fix: update influxdb_v2 error message

### DIFF
--- a/plugins/outputs/influxdb_v2/influxdb_v2.go
+++ b/plugins/outputs/influxdb_v2/influxdb_v2.go
@@ -107,7 +107,7 @@ func (i *InfluxDB) Write(metrics []telegraf.Metric) error {
 		i.Log.Errorf("When writing to [%s]: %v", client.URL(), err)
 	}
 
-	return fmt.Errorf("failed to send metrics to all configured servers")
+	return fmt.Errorf("failed to send metrics to any configured server(s)")
 }
 
 func (i *InfluxDB) getHTTPClient(address *url.URL, proxy *url.URL) (Client, error) {

--- a/plugins/outputs/influxdb_v2/influxdb_v2.go
+++ b/plugins/outputs/influxdb_v2/influxdb_v2.go
@@ -107,7 +107,7 @@ func (i *InfluxDB) Write(metrics []telegraf.Metric) error {
 		i.Log.Errorf("When writing to [%s]: %v", client.URL(), err)
 	}
 
-	return err
+	return fmt.Errorf("failed to send metrics to all configured servers")
 }
 
 func (i *InfluxDB) getHTTPClient(address *url.URL, proxy *url.URL) (Client, error) {


### PR DESCRIPTION
When sending metrics to all servers fails the last error message is also
sent to the agent to report. This results in duplicate error messages.
Instead of printing the last error message a second time, report that
sending to all configured servers failed.

Fixes: #10956