### PR TITLE
fix: remove overly verbose info message from cisco mdt

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -356,8 +356,9 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 			}
 		}
 
+		// if the keys and content fields are missing, skip the message as it
+		// does not have parsable data used by Telegraf
 		if keys == nil || content == nil {
-			c.Log.Infof("Message from %s missing keys or content", msg.GetNodeIdStr())
 			continue
 		}
 


### PR DESCRIPTION
When messages are received from Cisco MDT devices the message is scanned
for the `keys` and `content` fields. If these are missing then there is
no parsable data for Telegraf. If lots of messages are coming in, this
message can spam the Telegraf log with lots of unnecessary messages on the
order of hundreds per second.

Fixes: https://github.com/influxdata/EAR/issues/3139