### PR TITLE
chore(inputs): add descriptions to config in README.md

### DIFF
--- a/plugins/inputs/conntrack/README.md
+++ b/plugins/inputs/conntrack/README.md
@@ -21,20 +21,20 @@ For more information on conntrack-tools, see the
 ## Configuration
 
 ```toml
- # Collects conntrack stats from the configured directories and files.
- [[inputs.conntrack]]
-   ## The following defaults would work with multiple versions of conntrack.
-   ## Note the nf_ and ip_ filename prefixes are mutually exclusive across
-   ## kernel versions, as are the directory locations.
+# Collects conntrack stats from the configured directories and files.
+[[inputs.conntrack]]
+  ## The following defaults would work with multiple versions of conntrack.
+  ## Note the nf_ and ip_ filename prefixes are mutually exclusive across
+  ## kernel versions, as are the directory locations.
 
-   ## Superset of filenames to look for within the conntrack dirs.
-   ## Missing files will be ignored.
-   files = ["ip_conntrack_count","ip_conntrack_max",
-            "nf_conntrack_count","nf_conntrack_max"]
+  ## Superset of filenames to look for within the conntrack dirs.
+  ## Missing files will be ignored.
+  files = ["ip_conntrack_count","ip_conntrack_max",
+          "nf_conntrack_count","nf_conntrack_max"]
 
-   ## Directories to search within for the conntrack files above.
-   ## Missing directories will be ignored.
-   dirs = ["/proc/sys/net/ipv4/netfilter","/proc/sys/net/netfilter"]
+  ## Directories to search within for the conntrack files above.
+  ## Missing directories will be ignored.
+  dirs = ["/proc/sys/net/ipv4/netfilter","/proc/sys/net/netfilter"]
 ```
 
 ## Measurements & Fields

--- a/plugins/inputs/example/README.md
+++ b/plugins/inputs/example/README.md
@@ -13,6 +13,7 @@ This section contains the default TOML to configure the plugin.  You can
 generate it using `telegraf --usage <plugin-name>`.
 
 ```toml
+# This is an example plugin
 [[inputs.example]]
   example_option = "example_value"
 ```

--- a/plugins/inputs/httpjson/README.md
+++ b/plugins/inputs/httpjson/README.md
@@ -7,6 +7,7 @@ The httpjson plugin collects data from HTTP URLs which respond with JSON.  It fl
 ## Configuration
 
 ```toml
+# Read flattened metrics from one or more JSON HTTP endpoints
 [[inputs.httpjson]]
   ## NOTE This plugin only reads numerical measurements, strings and booleans
   ## will be ignored.

--- a/plugins/inputs/influxdb_listener/README.md
+++ b/plugins/inputs/influxdb_listener/README.md
@@ -21,6 +21,7 @@ submits data to InfluxDB determines the destination database.
 ## Configuration
 
 ```toml
+# Accept metrics over InfluxDB 1.x HTTP API
 [[inputs.influxdb_listener]]
   ## Address and port to host HTTP listener on
   service_address = ":8186"

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -6,6 +6,7 @@ and creates metrics using one of the supported [input data formats][].
 ## Configuration
 
 ```toml
+# Read metrics from MQTT topic(s)
 [[inputs.mqtt_consumer]]
   ## Broker URLs for the MQTT server or cluster.  To connect to multiple
   ## clusters or standalone servers, use a separate plugin instance.
@@ -75,7 +76,7 @@ and creates metrics using one of the supported [input data formats][].
   data_format = "influx"
 
   ## Enable extracting tag values from MQTT topics
-  ## _ denotes an ignored entry in the topic path 
+  ## _ denotes an ignored entry in the topic path
   # [[inputs.mqtt_consumer.topic_parsing]]
   #   topic = ""
   #   measurement = ""

--- a/plugins/inputs/nats_consumer/README.md
+++ b/plugins/inputs/nats_consumer/README.md
@@ -9,6 +9,7 @@ instances of telegraf can read from a NATS cluster in parallel.
 ## Configuration
 
 ```toml
+# Read metrics from NATS subject(s)
 [[inputs.nats_consumer]]
   ## urls of NATS servers
   servers = ["nats://localhost:4222"]

--- a/plugins/inputs/postgresql/README.md
+++ b/plugins/inputs/postgresql/README.md
@@ -33,6 +33,7 @@ More information about the meaning of these metrics can be found in the [Postgre
 ## Configuration
 
 ```toml
+# Read metrics from one or many postgresql servers
 [[inputs.postgresql]]
   ## specify address via a url matching:
   ##   postgres://[pqgotest[:password]]@localhost[/dbname]?sslmode=[disable|verify-ca|verify-full]

--- a/plugins/inputs/ras/README.md
+++ b/plugins/inputs/ras/README.md
@@ -7,6 +7,7 @@ The `RAS` plugin gathers and counts errors provided by [RASDaemon](https://githu
 ## Configuration
 
 ```toml
+# RAS plugin exposes counter metrics for Machine Check Errors provided by RASDaemon (sqlite3 output is required).
 [[inputs.ras]]
   ## Optional path to RASDaemon sqlite3 database.
   ## Default: /var/lib/rasdaemon/ras-mc_event.db

--- a/plugins/inputs/sflow/README.md
+++ b/plugins/inputs/sflow/README.md
@@ -21,6 +21,7 @@ avoid cardinality issues:
 ## Configuration
 
 ```toml
+# SFlow V5 Protocol Listener
 [[inputs.sflow]]
   ## Address to listen for sFlow packets.
   ##   example: service_address = "udp://:6343"

--- a/plugins/inputs/snmp_legacy/README.md
+++ b/plugins/inputs/snmp_legacy/README.md
@@ -11,6 +11,7 @@ In this example, the plugin will gather value of OIDS:
 - `.1.3.6.1.2.1.2.2.1.4.1`
 
 ```toml
+# DEPRECATED! PLEASE USE inputs.snmp INSTEAD.
 [[inputs.snmp_legacy]]
   ## Use 'oids.txt' file to translate oids to names
   ## To generate 'oids.txt' you need to run:

--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -14,6 +14,7 @@ path onto the global path variable
 ## Configuration
 
 ```toml
+# Receive SNMP traps
 [[inputs.snmp_trap]]
   ## Transport, local address, and port to listen on.  Transport must
   ## be "udp://".  Omit local address to listen on all interfaces.

--- a/plugins/inputs/sql/README.md
+++ b/plugins/inputs/sql/README.md
@@ -11,6 +11,7 @@ This section contains the default TOML to configure the plugin.  You can
 generate it using `telegraf --usage <plugin-name>`.
 
 ```toml
+# Read metrics from SQL queries
 [[inputs.sql]]
   ## Database Driver
   ## See https://github.com/influxdata/telegraf/blob/master/docs/SQL_DRIVERS_INPUT.md for

--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -89,10 +89,6 @@ Remove User Id and Password keywords from the connection string in your config f
 ## Configuration
 
 ```toml
-[agent]
-  ## Default data collection interval for all inputs, can be changed as per collection interval needs
-  interval = "10s"
-
 # Read metrics from Microsoft SQL Server
 [[inputs.sqlserver]]
   ## Specify instances to monitor with a list of connection strings.
@@ -122,24 +118,24 @@ Remove User Id and Password keywords from the connection string in your config f
   ## A list of queries to explicitly ignore.
   exclude_query = ["SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates"]
 
-  ## Queries enabled by default for database_type = "SQLServer" are - 
-  ## SQLServerPerformanceCounters, SQLServerWaitStatsCategorized, SQLServerDatabaseIO, SQLServerProperties, SQLServerMemoryClerks, 
+  ## Queries enabled by default for database_type = "SQLServer" are -
+  ## SQLServerPerformanceCounters, SQLServerWaitStatsCategorized, SQLServerDatabaseIO, SQLServerProperties, SQLServerMemoryClerks,
   ## SQLServerSchedulers, SQLServerRequests, SQLServerVolumeSpace, SQLServerCpu, SQLServerAvailabilityReplicaStates, SQLServerDatabaseReplicaStates
 
-  ## Queries enabled by default for database_type = "AzureSQLDB" are - 
-  ## AzureSQLDBResourceStats, AzureSQLDBResourceGovernance, AzureSQLDBWaitStats, AzureSQLDBDatabaseIO, AzureSQLDBServerProperties, 
+  ## Queries enabled by default for database_type = "AzureSQLDB" are -
+  ## AzureSQLDBResourceStats, AzureSQLDBResourceGovernance, AzureSQLDBWaitStats, AzureSQLDBDatabaseIO, AzureSQLDBServerProperties,
   ## AzureSQLDBOsWaitstats, AzureSQLDBMemoryClerks, AzureSQLDBPerformanceCounters, AzureSQLDBRequests, AzureSQLDBSchedulers
 
-  ## Queries enabled by default for database_type = "AzureSQLManagedInstance" are - 
-  ## AzureSQLMIResourceStats, AzureSQLMIResourceGovernance, AzureSQLMIDatabaseIO, AzureSQLMIServerProperties, AzureSQLMIOsWaitstats, 
+  ## Queries enabled by default for database_type = "AzureSQLManagedInstance" are -
+  ## AzureSQLMIResourceStats, AzureSQLMIResourceGovernance, AzureSQLMIDatabaseIO, AzureSQLMIServerProperties, AzureSQLMIOsWaitstats,
   ## AzureSQLMIMemoryClerks, AzureSQLMIPerformanceCounters, AzureSQLMIRequests, AzureSQLMISchedulers
 
-  ## Queries enabled by default for database_type = "AzureSQLPool" are - 
-  ## AzureSQLPoolResourceStats, AzureSQLPoolResourceGovernance, AzureSQLPoolDatabaseIO, AzureSQLPoolWaitStats, 
+  ## Queries enabled by default for database_type = "AzureSQLPool" are -
+  ## AzureSQLPoolResourceStats, AzureSQLPoolResourceGovernance, AzureSQLPoolDatabaseIO, AzureSQLPoolWaitStats,
   ## AzureSQLPoolMemoryClerks, AzureSQLPoolPerformanceCounters, AzureSQLPoolSchedulers
 
   ## Following are old config settings
-  ## You may use them only if you are using the earlier flavor of queries, however it is recommended to use 
+  ## You may use them only if you are using the earlier flavor of queries, however it is recommended to use
   ## the new mechanism of identifying the database_type there by use it's corresponding queries
 
   ## Optional parameter, setting this to 2 will use a new version
@@ -151,18 +147,18 @@ Remove User Id and Password keywords from the connection string in your config f
   ## If you are using AzureDB, setting this to true will gather resource utilization metrics
   # azuredb = false
 
-  ## Toggling this to true will emit an additional metric called "sqlserver_telegraf_health". 
-  ## This metric tracks the count of attempted queries and successful queries for each SQL instance specified in "servers". 
-  ## The purpose of this metric is to assist with identifying and diagnosing any connectivity or query issues. 
+  ## Toggling this to true will emit an additional metric called "sqlserver_telegraf_health".
+  ## This metric tracks the count of attempted queries and successful queries for each SQL instance specified in "servers".
+  ## The purpose of this metric is to assist with identifying and diagnosing any connectivity or query issues.
   ## This setting/metric is optional and is disabled by default.
   # health_metric = false
 
   ## Possible queries accross different versions of the collectors
   ## Queries enabled by default for specific Database Type
-  
+
   ## database_type =  AzureSQLDB  by default collects the following queries
   ## - AzureSQLDBWaitStats
-  ## - AzureSQLDBResourceStats 
+  ## - AzureSQLDBResourceStats
   ## - AzureSQLDBResourceGovernance
   ## - AzureSQLDBDatabaseIO
   ## - AzureSQLDBServerProperties
@@ -173,11 +169,11 @@ Remove User Id and Password keywords from the connection string in your config f
   ## - AzureSQLDBSchedulers
 
   ## database_type =  AzureSQLManagedInstance by default collects the following queries
-  ## - AzureSQLMIResourceStats 
-  ## - AzureSQLMIResourceGovernance 
-  ## - AzureSQLMIDatabaseIO 
-  ## - AzureSQLMIServerProperties 
-  ## - AzureSQLMIOsWaitstats 
+  ## - AzureSQLMIResourceStats
+  ## - AzureSQLMIResourceGovernance
+  ## - AzureSQLMIDatabaseIO
+  ## - AzureSQLMIServerProperties
+  ## - AzureSQLMIOsWaitstats
   ## - AzureSQLMIMemoryClerks
   ## - AzureSQLMIPerformanceCounters
   ## - AzureSQLMIRequests
@@ -187,17 +183,17 @@ Remove User Id and Password keywords from the connection string in your config f
   ## - AzureSQLPoolResourceStats
   ## - AzureSQLPoolResourceGovernance
   ## - AzureSQLPoolDatabaseIO
-  ## - AzureSQLPoolOsWaitStats, 
+  ## - AzureSQLPoolOsWaitStats,
   ## - AzureSQLPoolMemoryClerks
   ## - AzureSQLPoolPerformanceCounters
   ## - AzureSQLPoolSchedulers
 
   ## database_type =  SQLServer by default collects the following queries
-  ## - SQLServerPerformanceCounters 
-  ## - SQLServerWaitStatsCategorized 
-  ## - SQLServerDatabaseIO 
-  ## - SQLServerProperties 
-  ## - SQLServerMemoryClerks 
+  ## - SQLServerPerformanceCounters
+  ## - SQLServerWaitStatsCategorized
+  ## - SQLServerDatabaseIO
+  ## - SQLServerProperties
+  ## - SQLServerMemoryClerks
   ## - SQLServerSchedulers
   ## - SQLServerRequests
   ## - SQLServerVolumeSpace

--- a/plugins/inputs/suricata/README.md
+++ b/plugins/inputs/suricata/README.md
@@ -9,6 +9,7 @@ It can also report for triggered Suricata IDS/IPS alerts.
 ## Configuration
 
 ```toml
+# Suricata stats and alerts plugin
 [[inputs.suricata]]
   ## Data sink for Suricata stats log.
   # This is expected to be a filename of a
@@ -19,7 +20,7 @@ It can also report for triggered Suricata IDS/IPS alerts.
   # becomes "detect_alert" when delimiter is "_".
   delimiter = "_"
 
-  # Detect alert logs 
+  # Detect alert logs
   alerts = false
 ```
 

--- a/plugins/inputs/tail/README.md
+++ b/plugins/inputs/tail/README.md
@@ -22,6 +22,7 @@ The plugin expects messages in one of the
 ## Configuration
 
 ```toml
+# Parse the new lines appended to a file
 [[inputs.tail]]
   ## File names or a pattern to tail.
   ## These accept standard unix glob matching rules, but with the addition of
@@ -81,7 +82,7 @@ The plugin expects messages in one of the
     ## multi-line event.
     #match_which_line = "previous"
 
-    ## The invert_match can be true or false (defaults to false). 
+    ## The invert_match can be true or false (defaults to false).
     ## If true, a message not matching the pattern will constitute a match of the multiline filter and the what will be applied. (vice-versa is also true)
     #invert_match = false
 

--- a/plugins/inputs/webhooks/README.md
+++ b/plugins/inputs/webhooks/README.md
@@ -16,6 +16,7 @@ sudo service telegraf start
 ## Configuration
 
 ```toml
+# A Webhooks Event collector
 [[inputs.webhooks]]
   ## Address and port to host Webhook listener on
   service_address = ":1619"

--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -11,6 +11,7 @@ Telegraf minimum version: Telegraf 1.16.0
 ### Configuration
 
 ```toml
+# Input plugin to collect Windows Event Log messages
 [[inputs.win_eventlog]]
   ## Telegraf should have Administrator permissions to subscribe for some Windows Events channels
   ## (System log, for example)

--- a/plugins/inputs/win_services/README.md
+++ b/plugins/inputs/win_services/README.md
@@ -7,6 +7,7 @@ Monitoring some services may require running Telegraf with administrator privile
 ## Configuration
 
 ```toml
+# Input plugin to report Windows services info.
 [[inputs.win_services]]
   ## Names of the services to monitor. Leave empty to monitor all the available services on the host. Globs accepted. Case sensitive.
   service_names = [


### PR DESCRIPTION
Related to:
* https://github.com/influxdata/telegraf/pull/10924
* https://github.com/influxdata/telegraf/pull/10926

This pull requests adds the first description comment to the configuration section for a handful of plugins that were overlooked in the above two mentioned PRs.