### PR TITLE
fix:Update Readme.MD, missing keyword in sql command creating SID (Service Identity)

### DIFF
--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -71,7 +71,7 @@ To create the login for the telegraf service run the following script:
 ```sql
 USE master;
 GO
-CREATE LOGIN [NT SERVICE\telegraf];
+CREATE LOGIN [NT SERVICE\telegraf] FROM WINDOWS;
 GO
 GRANT VIEW SERVER STATE TO [NT SERVICE\telegraf];
 GO


### PR DESCRIPTION
Tested today, without the clause "FROM WINDOWS", the comand returns an error.
Worked seamlessly with this change.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ x ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #

Tested today, without the clause "FROM WINDOWS", the comand returns an error.
Worked seamlessly with this change.
