### PR TITLE
 fix: duplicate influxdb listener writes

### DIFF
--- a/plugins/inputs/influxdb_listener/influxdb_listener.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener.go
@@ -213,9 +213,9 @@ func (h *InfluxDBListener) handleWrite() http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		if h.ParserType == "upstream" {
 			h.handleWriteUpstreamParser(res, req)
+		} else {
+			h.handleWriteInternalParser(res, req)
 		}
-
-		h.handleWriteInternalParser(res, req)
 	}
 }
 


### PR DESCRIPTION
The influxdb_listener input plugin, when using the upstream parser had
bad logic that would write first using the new upstream parser and then
attempt to parse the data again with the internal parser right after.
This was leading to EOF errors on the internal parser because the data
had already been read.
    
Fixes: #10900
