### PR TITLE
chore: remove go generate from CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,6 @@ commands:
                 key: windows-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
-      - run: 'make generate'
       - run: mkdir -p test-results
       - run: ./scripts/install_gotestsum.sh << parameters.os >> << parameters.gotestsum >>
       - unless:
@@ -121,7 +120,6 @@ commands:
                 paths:
                   - 'C:\Go'
                   - 'C:\Users\circleci\project\gotestsum.exe'
-      - run: 'make generate-clean'
   package-build:
     parameters:
       type:

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -5,13 +5,11 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
 	"unsafe"
 
-	"github.com/influxdata/toml"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator"
@@ -220,16 +218,6 @@ func TestAlignMetrics(t *testing.T) {
 	for _, v := range newValues {
 		require.Equal(t, 2.0, v, "Aligned value should be 2")
 	}
-}
-
-func TestParseConfig(t *testing.T) {
-	v := VSphere{}
-	c := v.SampleConfig()
-	p := regexp.MustCompile("\n#")
-	c = configHeader + "\n[[inputs.vsphere]]\n" + p.ReplaceAllLiteralString(c, "\n")
-	tab, err := toml.Parse([]byte(c))
-	require.NoError(t, err)
-	require.NotNil(t, tab)
 }
 
 func TestConfigDurationParsing(t *testing.T) {


### PR DESCRIPTION
go generate command is unfortunately a single-threaded, one at a time
command. There are no flags to change this. As a result it takes a long
time in our project due to the large number of plugins.

We run this command in CI twice, once during tests and again during
package build. The tests do not need this to be run and this removes it
to save some time on the overall CI process.