### PR TITLE
fix: datadog count metrics

### DIFF
--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -33,5 +33,11 @@ key with a `.` character.
 Field values are converted to floating point numbers.  Strings and floats that
 cannot be sent over JSON, namely NaN and Inf, are ignored.
 
+We do not send `Rate` types. Counts are sent as `count`, with an
+interval hard-coded to 1. Note that this behavior does *not* play
+super-well if running simultaneously with current Datadog agents; they
+will attempt to change to `Rate` with `interval=10`. We prefer this
+method, however, as it reflects the raw data more accurately.
+
 [metrics]: https://docs.datadoghq.com/api/v1/metrics/#submit-metrics
 [apikey]: https://app.datadoghq.com/account/settings#api

--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -33,12 +33,12 @@ type TimeSeries struct {
 }
 
 type Metric struct {
-	Metric string   `json:"metric"`
-	Points [1]Point `json:"points"`
-	Host   string   `json:"host"`
-	Type   string   `json:"type,omitempty"`
-	Tags   []string `json:"tags,omitempty"`
-	Interval int64  `json:"interval"`
+	Metric   string   `json:"metric"`
+	Points   [1]Point `json:"points"`
+	Host     string   `json:"host"`
+	Type     string   `json:"type,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
+	Interval int64    `json:"interval"`
 }
 
 type Point [2]float64

--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -36,7 +36,9 @@ type Metric struct {
 	Metric string   `json:"metric"`
 	Points [1]Point `json:"points"`
 	Host   string   `json:"host"`
+	Type   string   `json:"type,omitempty"`
 	Tags   []string `json:"tags,omitempty"`
+	Interval int64  `json:"interval"`
 }
 
 type Point [2]float64
@@ -85,10 +87,21 @@ func (d *Datadog) Write(metrics []telegraf.Metric) error {
 				} else {
 					dname = m.Name() + "." + fieldName
 				}
+				var tname string
+				switch m.Type() {
+				case telegraf.Counter:
+					tname = "count"
+				case telegraf.Gauge:
+					tname = "gauge"
+				default:
+					tname = ""
+				}
 				metric := &Metric{
-					Metric: dname,
-					Tags:   metricTags,
-					Host:   host,
+					Metric:   dname,
+					Tags:     metricTags,
+					Host:     host,
+					Type:     tname,
+					Interval: 1,
 				}
 				metric.Points[0] = dogM
 				tempSeries = append(tempSeries, metric)


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests. *
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

*No idea what unit tests would be appropriate. We tested this against a live production system...

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #6822 
resolves #10944 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Added typing to Datadog metrics; forced `interval` to be 1 for `count` typed metrics.