### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/internal/rotate/file_writer_test.go
+++ b/internal/rotate/file_writer_test.go
@@ -11,11 +11,10 @@ import (
 )
 
 func TestFileWriter_NoRotation(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "RotationNo")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test"), 0, 0, 0)
 	require.NoError(t, err)
-	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
 
 	_, err = writer.Write([]byte("Hello World"))
 	require.NoError(t, err)
@@ -26,12 +25,11 @@ func TestFileWriter_NoRotation(t *testing.T) {
 }
 
 func TestFileWriter_TimeRotation(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "RotationTime")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	interval, _ := time.ParseDuration("10ms")
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test"), interval, 0, -1)
 	require.NoError(t, err)
-	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
 
 	_, err = writer.Write([]byte("Hello World"))
 	require.NoError(t, err)
@@ -43,28 +41,26 @@ func TestFileWriter_TimeRotation(t *testing.T) {
 }
 
 func TestFileWriter_ReopenTimeRotation(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "RotationTime")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	interval, _ := time.ParseDuration("10ms")
 	filePath := filepath.Join(tempDir, "test.log")
-	err = os.WriteFile(filePath, []byte("Hello World"), 0644)
+	err := os.WriteFile(filePath, []byte("Hello World"), 0644)
 	time.Sleep(interval)
 	assert.NoError(t, err)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), interval, 0, -1)
 	require.NoError(t, err)
-	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
 
 	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 2, len(files))
 }
 
 func TestFileWriter_SizeRotation(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "RotationSize")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	maxSize := int64(9)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, -1)
 	require.NoError(t, err)
-	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
 
 	_, err = writer.Write([]byte("Hello World"))
 	require.NoError(t, err)
@@ -75,15 +71,14 @@ func TestFileWriter_SizeRotation(t *testing.T) {
 }
 
 func TestFileWriter_ReopenSizeRotation(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "RotationSize")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	maxSize := int64(12)
 	filePath := filepath.Join(tempDir, "test.log")
-	err = os.WriteFile(filePath, []byte("Hello World"), 0644)
+	err := os.WriteFile(filePath, []byte("Hello World"), 0644)
 	assert.NoError(t, err)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, -1)
 	require.NoError(t, err)
-	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
 
 	_, err = writer.Write([]byte("Hello World Again"))
 	require.NoError(t, err)
@@ -96,12 +91,11 @@ func TestFileWriter_DeleteArchives(t *testing.T) {
 		t.Skip("Skipping long test in short mode")
 	}
 
-	tempDir, err := os.MkdirTemp("", "RotationDeleteArchives")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	maxSize := int64(5)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, 2)
 	require.NoError(t, err)
-	defer func() { writer.Close(); os.RemoveAll(tempDir) }()
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
 
 	_, err = writer.Write([]byte("First file"))
 	require.NoError(t, err)
@@ -136,14 +130,11 @@ func TestFileWriter_DeleteArchives(t *testing.T) {
 }
 
 func TestFileWriter_CloseRotates(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "RotationClose")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	maxSize := int64(9)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, -1)
 	require.NoError(t, err)
-
-	writer.Close()
+	require.NoError(t, writer.Close())
 
 	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 1, len(files))

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -96,8 +96,7 @@ func TestWriteToTruncatedFile(t *testing.T) {
 }
 
 func TestWriteToFileInRotation(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "LogRotation")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	cfg := createBasicLogConfig(filepath.Join(tempDir, "test.log"))
 	cfg.LogTarget = LogTargetFile
 	cfg.RotationMaxSize = config.Size(30)
@@ -105,7 +104,7 @@ func TestWriteToFileInRotation(t *testing.T) {
 	// Close the writer here, otherwise the temp folder cannot be deleted because the current log file is in use.
 	closer, isCloser := writer.(io.Closer)
 	assert.True(t, isCloser)
-	defer func() { closer.Close(); os.RemoveAll(tempDir) }()
+	t.Cleanup(func() { require.NoError(t, closer.Close()) })
 
 	log.Printf("I! TEST 1") // Writes 31 bytes, will rotate
 	log.Printf("I! TEST")   // Writes 29 byes, no rotation expected

--- a/plugins/inputs/ceph/ceph_test.go
+++ b/plugins/inputs/ceph/ceph_test.go
@@ -112,12 +112,7 @@ func TestGather(t *testing.T) {
 }
 
 func TestFindSockets(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "socktest")
-	require.NoError(t, err)
-	defer func() {
-		err := os.Remove(tmpdir)
-		require.NoError(t, err)
-	}()
+	tmpdir := t.TempDir()
 	c := &Ceph{
 		CephBinary:             "foo",
 		OsdPrefix:              "ceph-osd",

--- a/plugins/inputs/conntrack/conntrack_test.go
+++ b/plugins/inputs/conntrack/conntrack_test.go
@@ -34,13 +34,11 @@ func TestNoFilesFound(t *testing.T) {
 
 func TestDefaultsUsed(t *testing.T) {
 	defer restoreDflts(dfltFiles, dfltDirs)
-	tmpdir, err := os.MkdirTemp("", "tmp1")
-	require.NoError(t, err)
-	defer os.Remove(tmpdir)
+	tmpdir := t.TempDir()
 
 	tmpFile, err := os.CreateTemp(tmpdir, "ip_conntrack_count")
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
+	t.Cleanup(func() { require.NoError(t, tmpFile.Close()) })
 
 	dfltDirs = []string{tmpdir}
 	fname := path.Base(tmpFile.Name())
@@ -58,16 +56,15 @@ func TestDefaultsUsed(t *testing.T) {
 
 func TestConfigsUsed(t *testing.T) {
 	defer restoreDflts(dfltFiles, dfltDirs)
-	tmpdir, err := os.MkdirTemp("", "tmp1")
-	require.NoError(t, err)
-	defer os.Remove(tmpdir)
+	tmpdir := t.TempDir()
 
 	cntFile, err := os.CreateTemp(tmpdir, "nf_conntrack_count")
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cntFile.Close()) })
+
 	maxFile, err := os.CreateTemp(tmpdir, "nf_conntrack_max")
 	require.NoError(t, err)
-	defer os.Remove(cntFile.Name())
-	defer os.Remove(maxFile.Name())
+	t.Cleanup(func() { require.NoError(t, maxFile.Close()) })
 
 	dfltDirs = []string{tmpdir}
 	cntFname := path.Base(cntFile.Name())

--- a/plugins/inputs/directory_monitor/directory_monitor_test.go
+++ b/plugins/inputs/directory_monitor/directory_monitor_test.go
@@ -3,10 +3,11 @@ package directory_monitor
 import (
 	"bytes"
 	"compress/gzip"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/parsers/csv"
@@ -19,12 +20,8 @@ func TestCSVGZImport(t *testing.T) {
 	testCsvGzFile := "test.csv.gz"
 
 	// Establish process directory and finished directory.
-	finishedDirectory, err := os.MkdirTemp("", "finished")
-	require.NoError(t, err)
-	processDirectory, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(processDirectory)
-	defer os.RemoveAll(finishedDirectory)
+	finishedDirectory := t.TempDir()
+	processDirectory := t.TempDir()
 
 	// Init plugin.
 	r := DirectoryMonitor{
@@ -33,7 +30,7 @@ func TestCSVGZImport(t *testing.T) {
 		MaxBufferedMetrics: 1000,
 		FileQueueSize:      100000,
 	}
-	err = r.Init()
+	err := r.Init()
 	require.NoError(t, err)
 
 	r.SetParserFunc(func() (parsers.Parser, error) {
@@ -87,12 +84,8 @@ func TestMultipleJSONFileImports(t *testing.T) {
 	testJSONFile := "test.json"
 
 	// Establish process directory and finished directory.
-	finishedDirectory, err := os.MkdirTemp("", "finished")
-	require.NoError(t, err)
-	processDirectory, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(processDirectory)
-	defer os.RemoveAll(finishedDirectory)
+	finishedDirectory := t.TempDir()
+	processDirectory := t.TempDir()
 
 	// Init plugin.
 	r := DirectoryMonitor{
@@ -101,7 +94,7 @@ func TestMultipleJSONFileImports(t *testing.T) {
 		MaxBufferedMetrics: 1000,
 		FileQueueSize:      1000,
 	}
-	err = r.Init()
+	err := r.Init()
 	require.NoError(t, err)
 
 	parserConfig := parsers.Config{
@@ -139,12 +132,8 @@ func TestFileTag(t *testing.T) {
 	testJSONFile := "test.json"
 
 	// Establish process directory and finished directory.
-	finishedDirectory, err := os.MkdirTemp("", "finished")
-	require.NoError(t, err)
-	processDirectory, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(processDirectory)
-	defer os.RemoveAll(finishedDirectory)
+	finishedDirectory := t.TempDir()
+	processDirectory := t.TempDir()
 
 	// Init plugin.
 	r := DirectoryMonitor{
@@ -154,7 +143,7 @@ func TestFileTag(t *testing.T) {
 		MaxBufferedMetrics: 1000,
 		FileQueueSize:      1000,
 	}
-	err = r.Init()
+	err := r.Init()
 	require.NoError(t, err)
 
 	parserConfig := parsers.Config{
@@ -198,12 +187,8 @@ func TestCSVNoSkipRows(t *testing.T) {
 	testCsvFile := "test.csv"
 
 	// Establish process directory and finished directory.
-	finishedDirectory, err := os.MkdirTemp("", "finished")
-	require.NoError(t, err)
-	processDirectory, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(processDirectory)
-	defer os.RemoveAll(finishedDirectory)
+	finishedDirectory := t.TempDir()
+	processDirectory := t.TempDir()
 
 	// Init plugin.
 	r := DirectoryMonitor{
@@ -212,7 +197,7 @@ func TestCSVNoSkipRows(t *testing.T) {
 		MaxBufferedMetrics: 1000,
 		FileQueueSize:      100000,
 	}
-	err = r.Init()
+	err := r.Init()
 	require.NoError(t, err)
 
 	r.SetParserFunc(func() (parsers.Parser, error) {
@@ -270,12 +255,8 @@ func TestCSVSkipRows(t *testing.T) {
 	testCsvFile := "test.csv"
 
 	// Establish process directory and finished directory.
-	finishedDirectory, err := os.MkdirTemp("", "finished")
-	require.NoError(t, err)
-	processDirectory, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(processDirectory)
-	defer os.RemoveAll(finishedDirectory)
+	finishedDirectory := t.TempDir()
+	processDirectory := t.TempDir()
 
 	// Init plugin.
 	r := DirectoryMonitor{
@@ -284,7 +265,7 @@ func TestCSVSkipRows(t *testing.T) {
 		MaxBufferedMetrics: 1000,
 		FileQueueSize:      100000,
 	}
-	err = r.Init()
+	err := r.Init()
 	require.NoError(t, err)
 
 	r.SetParserFunc(func() (parsers.Parser, error) {
@@ -344,12 +325,8 @@ func TestCSVMultiHeader(t *testing.T) {
 	testCsvFile := "test.csv"
 
 	// Establish process directory and finished directory.
-	finishedDirectory, err := os.MkdirTemp("", "finished")
-	require.NoError(t, err)
-	processDirectory, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(processDirectory)
-	defer os.RemoveAll(finishedDirectory)
+	finishedDirectory := t.TempDir()
+	processDirectory := t.TempDir()
 
 	// Init plugin.
 	r := DirectoryMonitor{
@@ -358,7 +335,7 @@ func TestCSVMultiHeader(t *testing.T) {
 		MaxBufferedMetrics: 1000,
 		FileQueueSize:      100000,
 	}
-	err = r.Init()
+	err := r.Init()
 	require.NoError(t, err)
 
 	r.SetParserFunc(func() (parsers.Parser, error) {

--- a/plugins/inputs/linux_sysctl_fs/linux_sysctl_fs_test.go
+++ b/plugins/inputs/linux_sysctl_fs/linux_sysctl_fs_test.go
@@ -9,9 +9,7 @@ import (
 )
 
 func TestSysctlFSGather(t *testing.T) {
-	td, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	require.NoError(t, os.WriteFile(td+"/aio-nr", []byte("100\n"), 0644))
 	require.NoError(t, os.WriteFile(td+"/aio-max-nr", []byte("101\n"), 0644))

--- a/plugins/inputs/logparser/logparser_test.go
+++ b/plugins/inputs/logparser/logparser_test.go
@@ -109,7 +109,17 @@ func TestGrokParseLogFiles(t *testing.T) {
 }
 
 func TestGrokParseLogFilesAppearLater(t *testing.T) {
-	emptydir := t.TempDir()
+	// TODO: t.TempDir will fail on Windows because it could not remove
+	//       test.a.log file. This seems like an issue with the tail package, it
+	//       is not closing the os.File properly on Stop.
+	// === RUN   TestGrokParseLogFilesAppearLater
+	//2022/04/16 11:05:13 D! [] Tail added for file: C:\Users\circleci\AppData\Local\Temp\TestGrokParseLogFilesAppearLater3687440534\001\test_a.log
+	//2022/04/16 11:05:13 D! [] Tail dropped for file: C:\Users\circleci\AppData\Local\Temp\TestGrokParseLogFilesAppearLater3687440534\001\test_a.log
+	//    testing.go:1090: TempDir RemoveAll cleanup: CreateFile C:\Users\circleci\AppData\Local\Temp\TestGrokParseLogFilesAppearLater3687440534\001: Access is denied.
+	//--- FAIL: TestGrokParseLogFilesAppearLater (1.68s)
+	emptydir, err := os.MkdirTemp("", "TestGrokParseLogFilesAppearLater")
+	require.NoError(t, err)
+	defer os.RemoveAll(emptydir)
 
 	logparser := &LogParserPlugin{
 		Log:           testutil.Logger{},

--- a/plugins/inputs/logparser/logparser_test.go
+++ b/plugins/inputs/logparser/logparser_test.go
@@ -109,9 +109,7 @@ func TestGrokParseLogFiles(t *testing.T) {
 }
 
 func TestGrokParseLogFilesAppearLater(t *testing.T) {
-	emptydir, err := os.MkdirTemp("", "TestGrokParseLogFilesAppearLater")
-	defer os.RemoveAll(emptydir)
-	require.NoError(t, err)
+	emptydir := t.TempDir()
 
 	logparser := &LogParserPlugin{
 		Log:           testutil.Logger{},

--- a/plugins/inputs/postfix/postfix_test.go
+++ b/plugins/inputs/postfix/postfix_test.go
@@ -14,9 +14,7 @@ import (
 )
 
 func TestGather(t *testing.T) {
-	td, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	for _, q := range []string{"active", "hold", "incoming", "maildrop", "deferred/0/0", "deferred/F/F"} {
 		require.NoError(t, os.MkdirAll(filepath.FromSlash(td+"/"+q), 0755))

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -386,10 +386,8 @@ func TestGather_cgroupPIDs(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("no cgroups in windows")
 	}
-	td, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(td)
-	err = os.WriteFile(filepath.Join(td, "cgroup.procs"), []byte("1234\n5678\n"), 0644)
+	td := t.TempDir()
+	err := os.WriteFile(filepath.Join(td, "cgroup.procs"), []byte("1234\n5678\n"), 0644)
 	require.NoError(t, err)
 
 	p := Procstat{

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -69,8 +68,7 @@ func TestSocketListener_tcp_tls(t *testing.T) {
 }
 
 func TestSocketListener_unix_tls(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 
 	sl := newSocketListener()
 	sl.Log = testutil.Logger{}
@@ -133,8 +131,7 @@ func TestSocketListener_udp(t *testing.T) {
 }
 
 func TestSocketListener_unix(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 
 	testEmptyLog := prepareLog(t)
 	defer testEmptyLog()
@@ -162,8 +159,7 @@ func TestSocketListener_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 
 	testEmptyLog := prepareLog(t)
 	defer testEmptyLog()

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -69,9 +69,7 @@ func TestSocketListener_tcp_tls(t *testing.T) {
 }
 
 func TestSocketListener_unix_tls(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unix_tls.sock")
 
 	sl := newSocketListener()
@@ -80,7 +78,7 @@ func TestSocketListener_unix_tls(t *testing.T) {
 	sl.ServerConfig = *pki.TLSServerConfig()
 
 	acc := &testutil.Accumulator{}
-	err = sl.Start(acc)
+	err := sl.Start(acc)
 	require.NoError(t, err)
 	defer sl.Stop()
 
@@ -135,9 +133,7 @@ func TestSocketListener_udp(t *testing.T) {
 }
 
 func TestSocketListener_unix(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unix.sock")
 
 	testEmptyLog := prepareLog(t)
@@ -151,7 +147,7 @@ func TestSocketListener_unix(t *testing.T) {
 	sl.ReadBufferSize = config.Size(1024)
 
 	acc := &testutil.Accumulator{}
-	err = sl.Start(acc)
+	err := sl.Start(acc)
 	require.NoError(t, err)
 	defer sl.Stop()
 
@@ -166,16 +162,16 @@ func TestSocketListener_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unixgram.sock")
 
 	testEmptyLog := prepareLog(t)
 	defer testEmptyLog()
 
-	_, err = os.Create(sock)
+	f, err := os.Create(sock)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+
 	sl := newSocketListener()
 	sl.Log = testutil.Logger{}
 	sl.ServiceAddress = "unixgram://" + sock

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -70,7 +70,7 @@ func TestSocketListener_tcp_tls(t *testing.T) {
 
 func TestSocketListener_unix_tls(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unix_tls.sock")
+	sock := filepath.Join(tmpdir, "sock")
 
 	sl := newSocketListener()
 	sl.Log = testutil.Logger{}
@@ -134,7 +134,7 @@ func TestSocketListener_udp(t *testing.T) {
 
 func TestSocketListener_unix(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unix.sock")
+	sock := filepath.Join(tmpdir, "sock")
 
 	testEmptyLog := prepareLog(t)
 	defer testEmptyLog()
@@ -163,7 +163,7 @@ func TestSocketListener_unixgram(t *testing.T) {
 	}
 
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sl.TestSocketListener_unixgram.sock")
+	sock := filepath.Join(tmpdir, "sock")
 
 	testEmptyLog := prepareLog(t)
 	defer testEmptyLog()

--- a/plugins/inputs/suricata/suricata_test.go
+++ b/plugins/inputs/suricata/suricata_test.go
@@ -245,7 +245,7 @@ func TestSuricataInvalidPath(t *testing.T) {
 
 func TestSuricataTooLongLine(t *testing.T) {
 	dir := t.TempDir()
-	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
+	tmpfn := filepath.Join(dir, "sock")
 
 	s := Suricata{
 		Source: tmpfn,
@@ -271,7 +271,7 @@ func TestSuricataTooLongLine(t *testing.T) {
 
 func TestSuricataEmptyJSON(t *testing.T) {
 	dir := t.TempDir()
-	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
+	tmpfn := filepath.Join(dir, "sock")
 
 	s := Suricata{
 		Source: tmpfn,
@@ -296,7 +296,7 @@ func TestSuricataEmptyJSON(t *testing.T) {
 
 func TestSuricataDisconnectSocket(t *testing.T) {
 	dir := t.TempDir()
-	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
+	tmpfn := filepath.Join(dir, "sock")
 
 	s := Suricata{
 		Source: tmpfn,
@@ -330,7 +330,7 @@ func TestSuricataDisconnectSocket(t *testing.T) {
 
 func TestSuricataStartStop(t *testing.T) {
 	dir := t.TempDir()
-	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
+	tmpfn := filepath.Join(dir, "sock")
 
 	s := Suricata{
 		Source: tmpfn,

--- a/plugins/inputs/suricata/suricata_test.go
+++ b/plugins/inputs/suricata/suricata_test.go
@@ -21,9 +21,7 @@ var ex2 = `{"timestamp":"2017-03-06T07:43:39.000397+0000","event_type":"stats","
 var ex3 = `{"timestamp":"2017-03-06T07:43:39.000397+0000","event_type":"stats","stats":{"threads": { "W#05-wlp4s0": { "capture":{"kernel_packets":905344474,"kernel_drops":78355440}}}}}`
 
 func TestSuricataLarge(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
 
 	s := Suricata{
@@ -61,9 +59,7 @@ func TestSuricataLarge(t *testing.T) {
 }
 
 func TestSuricataAlerts(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
 
 	s := Suricata{
@@ -116,9 +112,7 @@ func TestSuricataAlerts(t *testing.T) {
 }
 
 func TestSuricata(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
 
 	s := Suricata{
@@ -162,9 +156,7 @@ func TestSuricata(t *testing.T) {
 }
 
 func TestThreadStats(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
 
 	s := Suricata{
@@ -212,9 +204,7 @@ func TestThreadStats(t *testing.T) {
 }
 
 func TestSuricataInvalid(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
 
 	s := Suricata{
@@ -254,9 +244,7 @@ func TestSuricataInvalidPath(t *testing.T) {
 }
 
 func TestSuricataTooLongLine(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
 
 	s := Suricata{
@@ -282,9 +270,7 @@ func TestSuricataTooLongLine(t *testing.T) {
 }
 
 func TestSuricataEmptyJSON(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
 
 	s := Suricata{
@@ -309,9 +295,7 @@ func TestSuricataEmptyJSON(t *testing.T) {
 }
 
 func TestSuricataDisconnectSocket(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
 
 	s := Suricata{
@@ -345,9 +329,7 @@ func TestSuricataDisconnectSocket(t *testing.T) {
 }
 
 func TestSuricataStartStop(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tmpfn := filepath.Join(dir, fmt.Sprintf("t%d", rand.Int63()))
 
 	s := Suricata{

--- a/plugins/inputs/suricata/suricata_test.go
+++ b/plugins/inputs/suricata/suricata_test.go
@@ -244,8 +244,7 @@ func TestSuricataInvalidPath(t *testing.T) {
 }
 
 func TestSuricataTooLongLine(t *testing.T) {
-	dir := t.TempDir()
-	tmpfn := filepath.Join(dir, "sock")
+	tmpfn := testutil.TempSocket(t)
 
 	s := Suricata{
 		Source: tmpfn,
@@ -270,8 +269,7 @@ func TestSuricataTooLongLine(t *testing.T) {
 }
 
 func TestSuricataEmptyJSON(t *testing.T) {
-	dir := t.TempDir()
-	tmpfn := filepath.Join(dir, "sock")
+	tmpfn := testutil.TempSocket(t)
 
 	s := Suricata{
 		Source: tmpfn,
@@ -295,8 +293,7 @@ func TestSuricataEmptyJSON(t *testing.T) {
 }
 
 func TestSuricataDisconnectSocket(t *testing.T) {
-	dir := t.TempDir()
-	tmpfn := filepath.Join(dir, "sock")
+	tmpfn := testutil.TempSocket(t)
 
 	s := Suricata{
 		Source: tmpfn,
@@ -329,8 +326,7 @@ func TestSuricataDisconnectSocket(t *testing.T) {
 }
 
 func TestSuricataStartStop(t *testing.T) {
-	dir := t.TempDir()
-	tmpfn := filepath.Join(dir, "sock")
+	tmpfn := testutil.TempSocket(t)
 
 	s := Suricata{
 		Source: tmpfn,

--- a/plugins/inputs/syslog/nontransparent_test.go
+++ b/plugins/inputs/syslog/nontransparent_test.go
@@ -3,7 +3,6 @@ package syslog
 import (
 	"crypto/tls"
 	"net"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -269,33 +268,25 @@ func TestNonTransparentStrictWithZeroKeepAlive_tcp_tls(t *testing.T) {
 }
 
 func TestNonTransparentStrict_unix(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix.sock")
 	testStrictNonTransparent(t, "unix", sock, false, nil)
 }
 
 func TestNonTransparentBestEffort_unix(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix.sock")
 	testBestEffortNonTransparent(t, "unix", sock, false)
 }
 
 func TestNonTransparentStrict_unix_tls(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix_tls.sock")
 	testStrictNonTransparent(t, "unix", sock, true, nil)
 }
 
 func TestNonTransparentBestEffort_unix_tls(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix_tls.sock")
 	testBestEffortNonTransparent(t, "unix", sock, true)
 }

--- a/plugins/inputs/syslog/nontransparent_test.go
+++ b/plugins/inputs/syslog/nontransparent_test.go
@@ -3,7 +3,6 @@ package syslog
 import (
 	"crypto/tls"
 	"net"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -268,25 +267,21 @@ func TestNonTransparentStrictWithZeroKeepAlive_tcp_tls(t *testing.T) {
 }
 
 func TestNonTransparentStrict_unix(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 	testStrictNonTransparent(t, "unix", sock, false, nil)
 }
 
 func TestNonTransparentBestEffort_unix(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 	testBestEffortNonTransparent(t, "unix", sock, false)
 }
 
 func TestNonTransparentStrict_unix_tls(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 	testStrictNonTransparent(t, "unix", sock, true, nil)
 }
 
 func TestNonTransparentBestEffort_unix_tls(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "s")
+	sock := testutil.TempSocket(t)
 	testBestEffortNonTransparent(t, "unix", sock, true)
 }

--- a/plugins/inputs/syslog/nontransparent_test.go
+++ b/plugins/inputs/syslog/nontransparent_test.go
@@ -269,24 +269,24 @@ func TestNonTransparentStrictWithZeroKeepAlive_tcp_tls(t *testing.T) {
 
 func TestNonTransparentStrict_unix(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix.sock")
+	sock := filepath.Join(tmpdir, "sock")
 	testStrictNonTransparent(t, "unix", sock, false, nil)
 }
 
 func TestNonTransparentBestEffort_unix(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix.sock")
+	sock := filepath.Join(tmpdir, "sock")
 	testBestEffortNonTransparent(t, "unix", sock, false)
 }
 
 func TestNonTransparentStrict_unix_tls(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix_tls.sock")
+	sock := filepath.Join(tmpdir, "sock")
 	testStrictNonTransparent(t, "unix", sock, true, nil)
 }
 
 func TestNonTransparentBestEffort_unix_tls(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix_tls.sock")
+	sock := filepath.Join(tmpdir, "s")
 	testBestEffortNonTransparent(t, "unix", sock, true)
 }

--- a/plugins/inputs/syslog/octetcounting_test.go
+++ b/plugins/inputs/syslog/octetcounting_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -469,33 +468,25 @@ func TestOctetCountingStrictWithZeroKeepAlive_tcp_tls(t *testing.T) {
 }
 
 func TestOctetCountingStrict_unix(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix.sock")
 	testStrictOctetCounting(t, "unix", sock, false, nil)
 }
 
 func TestOctetCountingBestEffort_unix(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix.sock")
 	testBestEffortOctetCounting(t, "unix", sock, false)
 }
 
 func TestOctetCountingStrict_unix_tls(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix_tls.sock")
 	testStrictOctetCounting(t, "unix", sock, true, nil)
 }
 
 func TestOctetCountingBestEffort_unix_tls(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix_tls.sock")
 	testBestEffortOctetCounting(t, "unix", sock, true)
 }

--- a/plugins/inputs/syslog/octetcounting_test.go
+++ b/plugins/inputs/syslog/octetcounting_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -468,25 +467,21 @@ func TestOctetCountingStrictWithZeroKeepAlive_tcp_tls(t *testing.T) {
 }
 
 func TestOctetCountingStrict_unix(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 	testStrictOctetCounting(t, "unix", sock, false, nil)
 }
 
 func TestOctetCountingBestEffort_unix(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 	testBestEffortOctetCounting(t, "unix", sock, false)
 }
 
 func TestOctetCountingStrict_unix_tls(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 	testStrictOctetCounting(t, "unix", sock, true, nil)
 }
 
 func TestOctetCountingBestEffort_unix_tls(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 	testBestEffortOctetCounting(t, "unix", sock, true)
 }

--- a/plugins/inputs/syslog/octetcounting_test.go
+++ b/plugins/inputs/syslog/octetcounting_test.go
@@ -469,24 +469,24 @@ func TestOctetCountingStrictWithZeroKeepAlive_tcp_tls(t *testing.T) {
 
 func TestOctetCountingStrict_unix(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix.sock")
+	sock := filepath.Join(tmpdir, "sock")
 	testStrictOctetCounting(t, "unix", sock, false, nil)
 }
 
 func TestOctetCountingBestEffort_unix(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix.sock")
+	sock := filepath.Join(tmpdir, "sock")
 	testBestEffortOctetCounting(t, "unix", sock, false)
 }
 
 func TestOctetCountingStrict_unix_tls(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "syslog.TestStrict_unix_tls.sock")
+	sock := filepath.Join(tmpdir, "sock")
 	testStrictOctetCounting(t, "unix", sock, true, nil)
 }
 
 func TestOctetCountingBestEffort_unix_tls(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unix_tls.sock")
+	sock := filepath.Join(tmpdir, "sock")
 	testBestEffortOctetCounting(t, "unix", sock, true)
 }

--- a/plugins/inputs/syslog/rfc5426_test.go
+++ b/plugins/inputs/syslog/rfc5426_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"runtime"
 	"sync/atomic"
 	"testing"
@@ -289,8 +288,7 @@ func TestBestEffort_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 	f, err := os.Create(sock)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, f.Close()) })
@@ -303,8 +301,7 @@ func TestStrict_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 	f, err := os.Create(sock)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, f.Close()) })

--- a/plugins/inputs/syslog/rfc5426_test.go
+++ b/plugins/inputs/syslog/rfc5426_test.go
@@ -290,7 +290,7 @@ func TestBestEffort_unixgram(t *testing.T) {
 	}
 
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unixgram.sock")
+	sock := filepath.Join(tmpdir, "sock")
 	f, err := os.Create(sock)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, f.Close()) })
@@ -304,7 +304,7 @@ func TestStrict_unixgram(t *testing.T) {
 	}
 
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "syslog.TestStrict_unixgram.sock")
+	sock := filepath.Join(tmpdir, "sock")
 	f, err := os.Create(sock)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, f.Close()) })

--- a/plugins/inputs/syslog/rfc5426_test.go
+++ b/plugins/inputs/syslog/rfc5426_test.go
@@ -289,12 +289,12 @@ func TestBestEffort_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestBestEffort_unixgram.sock")
-	_, err = os.Create(sock)
+	f, err := os.Create(sock)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+
 	testRFC5426(t, "unixgram", sock, true)
 }
 
@@ -303,12 +303,12 @@ func TestStrict_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestStrict_unixgram.sock")
-	_, err = os.Create(sock)
+	f, err := os.Create(sock)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+
 	testRFC5426(t, "unixgram", sock, false)
 }
 

--- a/plugins/inputs/syslog/syslog_test.go
+++ b/plugins/inputs/syslog/syslog_test.go
@@ -1,7 +1,6 @@
 package syslog
 
 import (
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -45,9 +44,7 @@ func TestAddress(t *testing.T) {
 	require.EqualError(t, err, "unknown protocol 'unsupported' in 'example.com:6514'")
 	require.Error(t, err)
 
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	defer os.RemoveAll(tmpdir)
-	require.NoError(t, err)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "syslog.TestAddress.sock")
 
 	if runtime.GOOS != "windows" {

--- a/plugins/outputs/file/file_test.go
+++ b/plugins/outputs/file/file_test.go
@@ -21,7 +21,6 @@ const (
 
 func TestFileExistingFile(t *testing.T) {
 	fh := createFile(t)
-	defer os.Remove(fh.Name())
 	s, _ := serializers.NewInfluxSerializer()
 	f := File{
 		Files:      []string{fh.Name()},
@@ -43,7 +42,6 @@ func TestFileExistingFile(t *testing.T) {
 func TestFileNewFile(t *testing.T) {
 	s, _ := serializers.NewInfluxSerializer()
 	fh := tmpFile(t)
-	defer os.Remove(fh)
 	f := File{
 		Files:      []string{fh},
 		serializer: s,
@@ -63,11 +61,8 @@ func TestFileNewFile(t *testing.T) {
 
 func TestFileExistingFiles(t *testing.T) {
 	fh1 := createFile(t)
-	defer os.Remove(fh1.Name())
 	fh2 := createFile(t)
-	defer os.Remove(fh2.Name())
 	fh3 := createFile(t)
-	defer os.Remove(fh3.Name())
 
 	s, _ := serializers.NewInfluxSerializer()
 	f := File{
@@ -92,11 +87,8 @@ func TestFileExistingFiles(t *testing.T) {
 func TestFileNewFiles(t *testing.T) {
 	s, _ := serializers.NewInfluxSerializer()
 	fh1 := tmpFile(t)
-	defer os.Remove(fh1)
 	fh2 := tmpFile(t)
-	defer os.Remove(fh2)
 	fh3 := tmpFile(t)
-	defer os.Remove(fh3)
 	f := File{
 		Files:      []string{fh1, fh2, fh3},
 		serializer: s,
@@ -118,9 +110,7 @@ func TestFileNewFiles(t *testing.T) {
 
 func TestFileBoth(t *testing.T) {
 	fh1 := createFile(t)
-	defer os.Remove(fh1.Name())
 	fh2 := tmpFile(t)
-	defer os.Remove(fh2)
 
 	s, _ := serializers.NewInfluxSerializer()
 	f := File{
@@ -185,6 +175,10 @@ func TestFileStdout(t *testing.T) {
 func createFile(t *testing.T) *os.File {
 	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, f.Close())
+		require.NoError(t, os.Remove(f.Name()))
+	})
 
 	_, err = f.WriteString("cpu,cpu=cpu0 value=100 1455312810012459582\n")
 	require.NoError(t, err)
@@ -192,10 +186,7 @@ func createFile(t *testing.T) *os.File {
 }
 
 func tmpFile(t *testing.T) string {
-	d, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-
-	return d + internal.RandomString(10)
+	return t.TempDir() + internal.RandomString(10)
 }
 
 func validateFile(t *testing.T, fileName, expS string) {

--- a/plugins/outputs/file/file_test.go
+++ b/plugins/outputs/file/file_test.go
@@ -173,11 +173,10 @@ func TestFileStdout(t *testing.T) {
 }
 
 func createFile(t *testing.T) *os.File {
-	f, err := os.CreateTemp("", "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, f.Close())
-		require.NoError(t, os.Remove(f.Name()))
 	})
 
 	_, err = f.WriteString("cpu,cpu=cpu0 value=100 1455312810012459582\n")

--- a/plugins/outputs/influxdb/http_test.go
+++ b/plugins/outputs/influxdb/http_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -618,11 +617,7 @@ func TestHTTP_WriteContentEncodingGzip(t *testing.T) {
 }
 
 func TestHTTP_UnixSocket(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf-test")
-	if err != nil {
-		require.NoError(t, err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	sock := path.Join(tmpdir, "test.sock")
 	listener, err := net.Listen("unix", sock)

--- a/plugins/outputs/socket_writer/socket_writer_test.go
+++ b/plugins/outputs/socket_writer/socket_writer_test.go
@@ -3,7 +3,6 @@ package socket_writer
 import (
 	"bufio"
 	"net"
-	"path/filepath"
 	"runtime"
 	"sync"
 	"testing"
@@ -44,8 +43,7 @@ func TestSocketWriter_udp(t *testing.T) {
 }
 
 func TestSocketWriter_unix(t *testing.T) {
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 
 	listener, err := net.Listen("unix", sock)
 	require.NoError(t, err)
@@ -67,8 +65,7 @@ func TestSocketWriter_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sock")
+	sock := testutil.TempSocket(t)
 
 	listener, err := net.ListenPacket("unixgram", sock)
 	require.NoError(t, err)

--- a/plugins/outputs/socket_writer/socket_writer_test.go
+++ b/plugins/outputs/socket_writer/socket_writer_test.go
@@ -3,7 +3,6 @@ package socket_writer
 import (
 	"bufio"
 	"net"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -45,9 +44,7 @@ func TestSocketWriter_udp(t *testing.T) {
 }
 
 func TestSocketWriter_unix(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "sw.TestSocketWriter_unix.sock")
 
 	listener, err := net.Listen("unix", sock)
@@ -70,9 +67,7 @@ func TestSocketWriter_unixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	tmpdir, err := os.MkdirTemp("", "telegraf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	sock := filepath.Join(tmpdir, "sw.TSW_unixgram.sock")
 
 	listener, err := net.ListenPacket("unixgram", sock)

--- a/plugins/outputs/socket_writer/socket_writer_test.go
+++ b/plugins/outputs/socket_writer/socket_writer_test.go
@@ -45,7 +45,7 @@ func TestSocketWriter_udp(t *testing.T) {
 
 func TestSocketWriter_unix(t *testing.T) {
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sw.TestSocketWriter_unix.sock")
+	sock := filepath.Join(tmpdir, "sock")
 
 	listener, err := net.Listen("unix", sock)
 	require.NoError(t, err)
@@ -68,7 +68,7 @@ func TestSocketWriter_unixgram(t *testing.T) {
 	}
 
 	tmpdir := t.TempDir()
-	sock := filepath.Join(tmpdir, "sw.TSW_unixgram.sock")
+	sock := filepath.Join(tmpdir, "sock")
 
 	listener, err := net.ListenPacket("unixgram", sock)
 	require.NoError(t, err)

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -169,9 +169,7 @@ func TestMysqlIntegration(t *testing.T) {
 	const username = "root"
 
 	password := pwgen(32)
-	outDir, err := os.MkdirTemp("", "tg-mysql-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	ctx := context.Background()
 	req := testcontainers.GenericContainerRequest{
@@ -259,9 +257,7 @@ func TestPostgresIntegration(t *testing.T) {
 	const username = "postgres"
 
 	password := pwgen(32)
-	outDir, err := os.MkdirTemp("", "tg-postgres-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	ctx := context.Background()
 	req := testcontainers.GenericContainerRequest{
@@ -361,9 +357,7 @@ func TestClickHouseIntegration(t *testing.T) {
 	// default username for clickhouse is default
 	const username = "default"
 
-	outDir, err := os.MkdirTemp("", "tg-clickhouse-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	ctx := context.Background()
 	req := testcontainers.GenericContainerRequest{

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -7,7 +7,6 @@ package sql
 
 import (
 	gosql "database/sql"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -17,9 +16,7 @@ import (
 )
 
 func TestSqlite(t *testing.T) {
-	outDir, err := os.MkdirTemp("", "tg-sqlite-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(outDir)
+	outDir := t.TempDir()
 
 	dbfile := filepath.Join(outDir, "db")
 

--- a/testutil/socket.go
+++ b/testutil/socket.go
@@ -1,0 +1,32 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TempSocket(tb testing.TB) string {
+	// On MacOS, the maximum path length of Unix domain socket is 104
+	// characters. (https://unix.stackexchange.com/a/367012/376279)
+	//
+	// On MacOS, tb.TempDir() returns e.g.
+	// /var/folders/bl/wbxjgtzx7j5_mjsmfr3ynlc00000gp/T/<the-test-name>/001/socket.sock
+	//
+	// If the name of the test is long, the path length could exceed 104
+	// characters, and this would result in listen unix ...: bind: invalid argument
+	if runtime.GOOS == "darwin" {
+		sock := filepath.Join("/tmp", "sock")
+
+		tb.Cleanup(func() {
+			require.NoError(tb, os.RemoveAll(sock))
+		})
+
+		return sock
+	}
+
+	return filepath.Join(tb.TempDir(), "sock")
+}


### PR DESCRIPTION
### Required for all PRs:

- [x] ~~Updated associated README.md.~~
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer require.NoError(os.RemoveAll(tmpDir))

	// now
	tmpDir := t.TempDir()
}
```