### PR TITLE
fix: use Sprint to cast to strings (#11007)

### DIFF
--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -326,7 +326,7 @@ func (c *GNMI) handleSubscribeResponseUpdate(address string, response *gnmiLib.S
 		for subscriptionName, values := range c.lookup {
 			if annotations, ok := values[subscriptionKey]; ok {
 				for k, v := range annotations {
-					tags[subscriptionName+"/"+k] = v.(string)
+					tags[subscriptionName+"/"+k] = fmt.Sprint(v)
 				}
 			}
 		}


### PR DESCRIPTION
When writing gNMI `tag_only` tags, use fmt.Sprint to convert the
value interface to a string.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)


resolves #11007 

