### PR TITLE
fix(cmd): Also allow 0 outputs when using test-wait parameter

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -232,7 +232,7 @@ func runAgent(ctx context.Context,
 		}
 	}
 
-	if !*fTest && len(c.Outputs) == 0 {
+	if !(*fTest || *fTestWait != 0) && len(c.Outputs) == 0 {
 		return errors.New("Error: no outputs found, did you provide a valid config file?")
 	}
 	if *fPlugins == "" && len(c.Inputs) == 0 {


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

The command help functions state that `--test-wait` does imply `--test` but behaviour is still different. Adding this extra check will make behaviour consistent. Maybe even better would be to set `fTest` to `true` if `fTestWait` is more than 0?