### PR TITLE
fix: allow Makefile to work on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
-next_version :=  $(shell cat build_version.txt)
-tag := $(shell git describe --exact-match --tags 2>git_describe_error.tmp; rm -f git_describe_error.tmp)
+ifeq ($(OS),Windows_NT)
+	next_version := $(shell type build_version.txt)
+	tag := $(shell git describe --exact-match --tags 2> nul)
+else
+	next_version := $(shell cat build_version.txt)
+	tag := $(shell git describe --exact-match --tags 2>/dev/null)
+endif
+
 branch := $(shell git rev-parse --abbrev-ref HEAD)
 commit := $(shell git rev-parse --short=8 HEAD)
 glibc_version := 2.17


### PR DESCRIPTION
The makefile runs some shell commands to collect version information
about the build. The changes currently fail on Windows becuase of some
unix only options and commands. This fixes the two specific lines with
commands to allow the build, testing, etc. to work as expected.

Fixes: #11014