### PR TITLE
chore: add readme linter to CI

### DIFF
--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -1,0 +1,23 @@
+name: Lint plugin readmes
+on:
+  push:
+    branches-ignore: master
+#  pull_request:
+#    branches: master
+jobs:
+  run-readme-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v18.7
+#        with:
+#          files: plugins/*/*/README.md
+      - name: List changed files
+# go run tools/readme-linter
+        run: |
+          echo ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -19,7 +19,5 @@ jobs:
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           files: plugins/**/README.md
-      - name: List changed files
-# go run tools/readme-linter
-        run: |
-          echo ${{ steps.changed-files.outputs.all_changed_files }}
+      - name: Run readme linter on changed files
+        run: go run ./tools/readme_linter ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -1,9 +1,10 @@
 name: Lint plugin readmes
 on:
-  push:
-    branches-ignore: master
-#  pull_request:
-#    branches: master
+#  push:
+#    branches-ignore: master
+  pull_request:
+    branches: # Names of target branches, not source branches
+      - master
 jobs:
   run-readme-linter:
     runs-on: ubuntu-latest
@@ -15,8 +16,9 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v18.7
-#        with:
-#          files: plugins/*/*/README.md
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          files: plugins/**/README.md
       - name: List changed files
 # go run tools/readme-linter
         run: |

--- a/tools/readme_linter/assert.go
+++ b/tools/readme_linter/assert.go
@@ -140,3 +140,7 @@ func (t *T) assertHeadingLevel(expected int, n ast.Node) {
 
 	t.printFailedAssertf(n, "expected header level %d, have %d", expected, h.Level)
 }
+
+func (t *T) pass() bool {
+	return t.fails == 0
+}


### PR DESCRIPTION
Add a github actions workflow to run the readme linter.

The action finds plugin readme files changed in the PR and runs the linter on them.

The linter itself is built during the action (using "go run"). It is a small program with very few dependencies that doesn't take much time to build. The entire action takes about 20 seconds, including getting code, building, and running the linter.

In order for the workflow to know when the linter failed, I also changed the linter to exit with nonzero status if it finds anything.

Here is output of a failed job as an example:

```
go: downloading github.com/yuin/goldmark v1.4.1
plugins/inputs/file/README.md:3: long line in paragraph
plugins/inputs/file/README.md:1: missing required section 'Example Output'
plugins/inputs/file/README.md:1: missing required section 'Metrics'
Fail plugins/inputs/file/README.md, 3 failed assertions
plugins/inputs/tail/README.md:20: long line in paragraph
plugins/inputs/tail/README.md:19: in-repo link must be relative: https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
plugins/inputs/tail/README.md:1: missing required section 'Example Output'
Fail plugins/inputs/tail/README.md, 3 failed assertions
exit status 1
```