### PR TITLE
fix: re-init azure monitor http client on context deadline error

### DIFF
--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -3,12 +3,14 @@ package azure_monitor
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -109,12 +111,7 @@ func (a *AzureMonitor) Connect() error {
 		a.Timeout = config.Duration(defaultRequestTimeout)
 	}
 
-	a.client = &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-		},
-		Timeout: time.Duration(a.Timeout),
-	}
+	a.initHTTPClient()
 
 	var err error
 	var region string
@@ -166,6 +163,15 @@ func (a *AzureMonitor) Connect() error {
 	a.MetricOutsideWindow = selfstat.Register("azure_monitor", "metric_outside_window", tags)
 
 	return nil
+}
+
+func (a *AzureMonitor) initHTTPClient() {
+	a.client = &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
+		Timeout: time.Duration(a.Timeout),
+	}
 }
 
 // vmMetadata retrieves metadata about the current Azure VM
@@ -313,6 +319,10 @@ func (a *AzureMonitor) send(body []byte) error {
 
 	resp, err := a.client.Do(req)
 	if err != nil {
+		if err.(*url.Error).Unwrap() == context.DeadlineExceeded {
+			a.initHTTPClient()
+		}
+
 		return err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
The context deadline exceeded error most commonly indicates that a
network related issues has occurred preventing the client from getting to
the server. Usually this means that there is something the user needs to
address. However, there appears to be a case where a network issue (e.g.
a down proxy) can occur and telegraf never recovers from the down
service.

This checks for the context deadline error and will re-create the HTTP
client if it is hit.

Fixes: #10950