### PR TITLE
feat: add mount option filtering to disk plugin

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -3166,9 +3166,6 @@
   ## Ignore mount points by filesystem type.
   ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
 
-  ## Ignore mount points by mount options.
-  ignore_mount_opts = ["bind"]
-
 
 # Read metrics about disk IO by device
 [[inputs.diskio]]

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -3166,6 +3166,9 @@
   ## Ignore mount points by filesystem type.
   ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
 
+  ## Ignore mount points by mount options.
+  ignore_mount_opts = ["bind"]
+
 
 # Read metrics about disk IO by device
 [[inputs.diskio]]

--- a/plugins/inputs/disk/README.md
+++ b/plugins/inputs/disk/README.md
@@ -19,8 +19,8 @@ Note that `used_percent` is calculated by doing `used / (used + free)`, _not_
   ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
 
   ## Ignore mount points by mount options.
-  ## The `mount` command reports options of all mounts in parathesis.
-  ## Bind mounts can be ignored with the special `bind` option.
+  ## The 'mount' command reports options of all mounts in parathesis.
+  ## Bind mounts can be ignored with the special 'bind' option.
   # ignore_mount_opts = []
 ```
 

--- a/plugins/inputs/disk/README.md
+++ b/plugins/inputs/disk/README.md
@@ -19,7 +19,9 @@ Note that `used_percent` is calculated by doing `used / (used + free)`, _not_
   ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
 
   ## Ignore mount points by mount options.
-  ignore_mount_opts = ["bind"]
+  ## The `mount` command reports options of all mounts in parathesis.
+  ## Bind mounts can be ignored with the special `bind` option.
+  # ignore_mount_opts = []
 ```
 
 ### Docker container

--- a/plugins/inputs/disk/README.md
+++ b/plugins/inputs/disk/README.md
@@ -17,6 +17,9 @@ Note that `used_percent` is calculated by doing `used / (used + free)`, _not_
 
   ## Ignore mount points by filesystem type.
   ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
+
+  ## Ignore mount points by mount options.
+  ignore_mount_opts = ["bind"]
 ```
 
 ### Docker container

--- a/plugins/inputs/disk/disk.go
+++ b/plugins/inputs/disk/disk.go
@@ -15,8 +15,9 @@ type DiskStats struct {
 	// Legacy support
 	LegacyMountPoints []string `toml:"mountpoints"`
 
-	MountPoints []string `toml:"mount_points"`
-	IgnoreFS    []string `toml:"ignore_fs"`
+	MountPoints     []string `toml:"mount_points"`
+	IgnoreFS        []string `toml:"ignore_fs"`
+	IgnoreMountOpts []string `toml:"ignore_mount_opts"`
 
 	Log telegraf.Logger `toml:"-"`
 }
@@ -35,7 +36,7 @@ func (ds *DiskStats) Init() error {
 }
 
 func (ds *DiskStats) Gather(acc telegraf.Accumulator) error {
-	disks, partitions, err := ds.ps.DiskUsage(ds.MountPoints, ds.IgnoreFS)
+	disks, partitions, err := ds.ps.DiskUsage(ds.MountPoints, ds.IgnoreMountOpts, ds.IgnoreFS)
 	if err != nil {
 		return fmt.Errorf("error getting disk usage info: %s", err)
 	}

--- a/plugins/inputs/system/mock_PS.go
+++ b/plugins/inputs/system/mock_PS.go
@@ -46,8 +46,8 @@ func (m *MockPS) CPUTimes(_, _ bool) ([]cpu.TimesStat, error) {
 	return r0, r1
 }
 
-func (m *MockPS) DiskUsage(mountPointFilter []string, fstypeExclude []string) ([]*disk.UsageStat, []*disk.PartitionStat, error) {
-	ret := m.Called(mountPointFilter, fstypeExclude)
+func (m *MockPS) DiskUsage(mountPointFilter []string, mountOptsExclude []string, fstypeExclude []string) ([]*disk.UsageStat, []*disk.PartitionStat, error) {
+	ret := m.Called(mountPointFilter, mountOptsExclude, fstypeExclude)
 
 	r0 := ret.Get(0).([]*disk.UsageStat)
 	r1 := ret.Get(1).([]*disk.PartitionStat)

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -17,7 +17,7 @@ import (
 
 type PS interface {
 	CPUTimes(perCPU, totalCPU bool) ([]cpu.TimesStat, error)
-	DiskUsage(mountPointFilter []string, fstypeExclude []string) ([]*disk.UsageStat, []*disk.PartitionStat, error)
+	DiskUsage(mountPointFilter []string, mountOptsExclude []string, fstypeExclude []string) ([]*disk.UsageStat, []*disk.PartitionStat, error)
 	NetIO() ([]net.IOCountersStat, error)
 	NetProto() ([]net.ProtoCountersStat, error)
 	DiskIO(names []string) (map[string]disk.IOCountersStat, error)
@@ -91,6 +91,7 @@ func newSet() *set {
 
 func (s *SystemPS) DiskUsage(
 	mountPointFilter []string,
+	mountOptsExclude []string,
 	fstypeExclude []string,
 ) ([]*disk.UsageStat, []*disk.PartitionStat, error) {
 	parts, err := s.Partitions(true)
@@ -101,6 +102,10 @@ func (s *SystemPS) DiskUsage(
 	mountPointFilterSet := newSet()
 	for _, filter := range mountPointFilter {
 		mountPointFilterSet.add(filter)
+	}
+	mountOptFilterSet := newSet()
+	for _, filter := range mountOptsExclude {
+		mountOptFilterSet.add(filter)
 	}
 	fstypeExcludeSet := newSet()
 	for _, filter := range fstypeExclude {
@@ -120,9 +125,15 @@ func (s *SystemPS) DiskUsage(
 	var partitions []*disk.PartitionStat
 	hostMountPrefix := s.OSGetenv("HOST_MOUNT_PREFIX")
 
+partitionRange:
 	for i := range parts {
 		p := parts[i]
 
+		for _, o := range p.Opts {
+			if !mountOptFilterSet.empty() && mountOptFilterSet.has(o) {
+				continue partitionRange
+			}
+		}
 		// If there is a filter set and if the mount point is not a
 		// member of the filter set, don't gather info on it.
 		if !mountPointFilterSet.empty() && !mountPointFilterSet.has(p.Mountpoint) {


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10986 and #10897

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Nomad (and possibly other software) will create bind mounts in locations that Telegraf running as a non-root user cannot inspect. This creates an `ignore_mount_opts` option to the disk plugin that can ignore these mounts, which are unlikely to generate useful metrics anyway.
