### PR TITLE
chore: increase timeout for darwin packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,13 +151,17 @@ commands:
       - when:
           condition: << parameters.nightly >>
           steps:
-            - run: 'NIGHTLY=1 make package include_packages="$(make << parameters.type >>)"'
+            - run:
+                command: 'NIGHTLY=1 make package include_packages="$(make << parameters.type >>)"'
+                no_output_timeout: 30m
       - unless:
           condition:
             or:
               - << parameters.nightly >>
           steps:
-            - run: 'make package include_packages="$(make << parameters.type >>)"'
+            - run:
+                command: 'make package include_packages="$(make << parameters.type >>)"'
+                no_output_timeout: 30m
       - store_artifacts:
           path: './build/dist'
           destination: 'build/dist'


### PR DESCRIPTION
The Darwin packaging step is timing out: https://app.circleci.com/pipelines/github/influxdata/telegraf/10247/workflows/d38aeeeb-f0e0-4678-a59d-20e97593e757/jobs/169092

Restarting the job occasionally fixes it seems, and then it runs in `4m 29s`. So something could actually be hanging but from the logs it seems it was just slow downloading the dependencies. Hopefully just increasing the timeout will help, it seems like a dirty fix open for suggestions if there is a better approach to fixing this.