### PR TITLE
fix: have telegraf service wait for network up

### DIFF
--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=The plugin-driven server agent for reporting metrics into InfluxDB
 Documentation=https://github.com/influxdata/telegraf
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
The current behavior for the systemd service file is to wait for the
network.target to activate. This does not mean that the network is
actually up or that a network device has an IP address. The
network-online.target instead waits for a functional network to be up.

A user recently saw issues with this when trying to use a remote config.
On boot, the network.target was hit, but the wireless network was not
ready yet, and telegraf failed to obtain the remote configuration and
never started.