### PR TITLE
fix: do not error when closing statsd network connection

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -456,7 +456,7 @@ func (s *Statsd) udpListen(conn *net.UDPConn) error {
 					s.Log.Errorf("Error reading: %s", err.Error())
 					continue
 				}
-				return err
+				return nil
 			}
 			s.UDPPacketsRecv.Incr(1)
 			s.UDPBytesRecv.Incr(int64(n))


### PR DESCRIPTION
Errors from the UDPListen function were previously not checked. In a
recent minor release we started checking them, which introduced more
visible errors to users. However, when statsd is run with the `--test`
option or when a user kills Telegraf with a ctrl-c, an error now shows
up as the read is still trying after a close has occurred.

The ReadFromUDP call blocks until something is received, so I don't
believe there is anything else for us to check to prevent. All other
non-connection-related errors are logged and we continue on (see
the above lines). This also does not hide issues when starting or
stopping the connection.

Fixes: #9867