### PR TITLE
fix: deprecate useless database config option

### DIFF
--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -188,6 +188,7 @@ func makeRequestBodyReader(contentEncoding, body string) (io.ReadCloser, error) 
 		}
 		return rc, nil
 	}
+
 	return io.NopCloser(reader), nil
 }
 

--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -38,6 +38,7 @@ The example below has two queries are specified, with the following parameters:
   ## with pool_mode set to transaction.
   prepared_statements = true
 
+  # Define the toml config where the sql queries are stored
   # The script option can be used to specify the .sql file path.
   # If script and sqlquery options specified at same time, sqlquery will be used
   #

--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -28,8 +28,9 @@ The example below has two queries are specified, with the following parameters:
   # to grab metrics for.
   #
   address = "host=localhost user=postgres sslmode=disable"
-  # A list of databases to pull metrics about. If not specified, metrics for all
-  # databases are gathered.
+
+  ## A list of databases to pull metrics about.
+  ## deprecated in 1.22.3; use the sqlquery option to specify database to use
   # databases = ["app_production", "testing"]
 
   ## Whether to use prepared statements when connecting to the database.

--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -38,21 +38,6 @@ The example below has two queries are specified, with the following parameters:
   ## with pool_mode set to transaction.
   prepared_statements = true
 
-  # Define the toml config where the sql queries are stored
-  # New queries can be added, if the withdbname is set to true and there is no
-  # databases defined in the 'databases field', the sql query is ended by a 'is
-  # not null' in order to make the query succeed.
-  # Be careful that the sqlquery must contain the where clause with a part of
-  # the filtering, the plugin will add a 'IN (dbname list)' clause if the
-  # withdbname is set to true
-  # Example :
-  # The sqlquery : "SELECT * FROM pg_stat_database where datname" become
-  # "SELECT * FROM pg_stat_database where datname IN ('postgres', 'pgbench')"
-  # because the databases variable was set to ['postgres', 'pgbench' ] and the
-  # withdbname was true.
-  # Be careful that if the withdbname is set to false you don't have to define
-  # the where clause (aka with the dbname)
-  #
   # The script option can be used to specify the .sql file path.
   # If script and sqlquery options specified at same time, sqlquery will be used
   #

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -18,7 +18,7 @@ import (
 
 type Postgresql struct {
 	postgresql.Service
-	Databases          []string `deprecated:"1.22.3;use the sqlquery option to specify database to use"`
+	Databases          []string `deprecated:"1.22.4;use the sqlquery option to specify database to use"`
 	AdditionalTags     []string
 	Timestamp          string
 	Query              query
@@ -32,7 +32,7 @@ type query []struct {
 	Sqlquery    string
 	Script      string
 	Version     int
-	Withdbname  bool
+	Withdbname  bool `deprecated:"1.22.4;use the sqlquery option to specify database to use"`
 	Tagvalue    string
 	Measurement string
 	Timestamp   string

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -18,7 +18,7 @@ import (
 
 type Postgresql struct {
 	postgresql.Service
-	Databases          []string
+	Databases          []string `deprecated:"1.22.3;use the sqlquery option to specify database to use"`
 	AdditionalTags     []string
 	Timestamp          string
 	Query              query


### PR DESCRIPTION
This config option makes the configuraiton of this plugin more complex
than it needs to be and the option's docs were not even correct to begin
with.

Fixes: #9735
