### PR TITLE
feat(exec, execd): add an option to pass a custom environment to their child process

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"sync"
 	"sync/atomic"
@@ -26,13 +27,14 @@ type Process struct {
 
 	name       string
 	args       []string
+	envs       []string
 	pid        int32
 	cancel     context.CancelFunc
 	mainLoopWg sync.WaitGroup
 }
 
 // New creates a new process wrapper
-func New(command []string) (*Process, error) {
+func New(command []string, envs []string) (*Process, error) {
 	if len(command) == 0 {
 		return nil, errors.New("no command")
 	}
@@ -41,6 +43,7 @@ func New(command []string) (*Process, error) {
 		RestartDelay: 5 * time.Second,
 		name:         command[0],
 		args:         []string{},
+		envs:         envs,
 	}
 
 	if len(command) > 1 {
@@ -84,6 +87,10 @@ func (p *Process) Stop() {
 
 func (p *Process) cmdStart() error {
 	p.Cmd = exec.Command(p.name, p.args...)
+
+	if len(p.envs) > 0 {
+		p.Cmd.Env = append(os.Environ(), p.envs...)
+	}
 
 	var err error
 	p.Stdin, err = p.Cmd.StdinPipe()

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -27,7 +27,7 @@ func TestRestartingRebindsPipes(t *testing.T) {
 	exe, err := os.Executable()
 	require.NoError(t, err)
 
-	p, err := New([]string{exe, "-external"})
+	p, err := New([]string{exe, "-external"}, []string{"INTERNAL_PROCESS_MODE=application"})
 	p.RestartDelay = 100 * time.Nanosecond
 	p.Log = testutil.Logger{}
 	require.NoError(t, err)
@@ -62,7 +62,8 @@ var external = flag.Bool("external", false,
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	if *external {
+	runMode := os.Getenv("INTERNAL_PROCESS_MODE")
+	if *external && runMode == "application" {
 		externalProcess()
 		os.Exit(0)
 	}

--- a/plugins/inputs/exec/README.md
+++ b/plugins/inputs/exec/README.md
@@ -18,8 +18,10 @@ This plugin can be used to poll for custom metrics from any source.
   ]
 
   ## Environment variables
-  ## eg: environment = ["LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs", "USERNAME=John Doe"]
-  environment = ["LD_LIBRARY_PATH=/opt/custom/lib64"]
+  ## Array of "key=value" pairs to pass as environment variables
+  ## e.g. "KEY=value", "USERNAME=John Doe",
+  ## "LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs"
+  # environment = []
 
   ## Timeout for each command to complete.
   timeout = "5s"

--- a/plugins/inputs/exec/README.md
+++ b/plugins/inputs/exec/README.md
@@ -17,6 +17,10 @@ This plugin can be used to poll for custom metrics from any source.
     "/tmp/collect_*.sh"
   ]
 
+  ## Environment variables
+  ## eg: environment = ["LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs", "USERNAME=John Doe"]
+  environment = ["LD_LIBRARY_PATH=/opt/custom/lib64"]
+
   ## Timeout for each command to complete.
   timeout = "5s"
 
@@ -55,7 +59,7 @@ It can be paired with the following configuration and will be run at the `interv
 
 ### My script works when I run it by hand, but not when Telegraf is running as a service
 
-This may be related to the Telegraf service running as a different user.  The
+This may be related to the Telegraf service running as a different user. The
 official packages run Telegraf as the `telegraf` user and group on Linux
 systems.
 

--- a/plugins/inputs/execd/README.md
+++ b/plugins/inputs/execd/README.md
@@ -23,8 +23,10 @@ STDERR from the process will be relayed to Telegraf as errors in the logs.
   command = ["telegraf-smartctl", "-d", "/dev/sda"]
 
   ## Environment variables
-  ## eg: environment = ["LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs", "USERNAME=John Doe"]
-  environment = ["LD_LIBRARY_PATH=/opt/custom/lib64"]
+  ## Array of "key=value" pairs to pass as environment variables
+  ## e.g. "KEY=value", "USERNAME=John Doe",
+  ## "LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs"
+  # environment = []
 
   ## Define how the process is signaled on each collection interval.
   ## Valid values are:

--- a/plugins/inputs/execd/README.md
+++ b/plugins/inputs/execd/README.md
@@ -22,6 +22,10 @@ STDERR from the process will be relayed to Telegraf as errors in the logs.
   ## NOTE: process and each argument should each be their own string
   command = ["telegraf-smartctl", "-d", "/dev/sda"]
 
+  ## Environment variables
+  ## eg: environment = ["LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs", "USERNAME=John Doe"]
+  environment = ["LD_LIBRARY_PATH=/opt/custom/lib64"]
+
   ## Define how the process is signaled on each collection interval.
   ## Valid values are:
   ##   "none"    : Do not signal anything. (Recommended for service inputs)

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -19,6 +19,7 @@ import (
 
 type Execd struct {
 	Command      []string        `toml:"command"`
+	Environment  []string        `toml:"environment"`
 	Signal       string          `toml:"signal"`
 	RestartDelay config.Duration `toml:"restart_delay"`
 	Log          telegraf.Logger `toml:"-"`
@@ -35,7 +36,7 @@ func (e *Execd) SetParser(parser parsers.Parser) {
 func (e *Execd) Start(acc telegraf.Accumulator) error {
 	e.acc = acc
 	var err error
-	e.process, err = process.New(e.Command)
+	e.process, err = process.New(e.Command, e.Environment)
 	if err != nil {
 		return fmt.Errorf("error creating new process: %w", err)
 	}

--- a/plugins/outputs/exec/README.md
+++ b/plugins/outputs/exec/README.md
@@ -21,8 +21,10 @@ For better performance, consider execd, which runs continuously.
   command = ["tee", "-a", "/dev/null"]
 
   ## Environment variables
-  ## eg: environment = ["LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs", "USERNAME=John Doe"]
-  # environment = ["LD_LIBRARY_PATH=/opt/custom/lib64"]
+  ## Array of "key=value" pairs to pass as environment variables
+  ## e.g. "KEY=value", "USERNAME=John Doe",
+  ## "LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs"
+  # environment = []
 
   ## Timeout for command to complete.
   # timeout = "5s"

--- a/plugins/outputs/exec/README.md
+++ b/plugins/outputs/exec/README.md
@@ -20,6 +20,10 @@ For better performance, consider execd, which runs continuously.
   ## Command to ingest metrics via stdin.
   command = ["tee", "-a", "/dev/null"]
 
+  ## Environment variables
+  ## eg: environment = ["LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs", "USERNAME=John Doe"]
+  # environment = ["LD_LIBRARY_PATH=/opt/custom/lib64"]
+
   ## Timeout for command to complete.
   # timeout = "5s"
 

--- a/plugins/outputs/execd/README.md
+++ b/plugins/outputs/execd/README.md
@@ -13,6 +13,10 @@ Telegraf minimum version: Telegraf 1.15.0
   ## NOTE: process and each argument should each be their own string
   command = ["my-telegraf-output", "--some-flag", "value"]
 
+  ## Environment variables
+  ## eg: environment = ["LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs", "USERNAME=John Doe"]
+  environment = ["LD_LIBRARY_PATH=/opt/custom/lib64"]
+
   ## Delay before the process is restarted after an unexpected termination
   restart_delay = "10s"
 

--- a/plugins/outputs/execd/README.md
+++ b/plugins/outputs/execd/README.md
@@ -14,8 +14,10 @@ Telegraf minimum version: Telegraf 1.15.0
   command = ["my-telegraf-output", "--some-flag", "value"]
 
   ## Environment variables
-  ## eg: environment = ["LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs", "USERNAME=John Doe"]
-  environment = ["LD_LIBRARY_PATH=/opt/custom/lib64"]
+  ## Array of "key=value" pairs to pass as environment variables
+  ## e.g. "KEY=value", "USERNAME=John Doe",
+  ## "LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs"
+  # environment = []
 
   ## Delay before the process is restarted after an unexpected termination
   restart_delay = "10s"

--- a/plugins/outputs/execd/execd.go
+++ b/plugins/outputs/execd/execd.go
@@ -16,6 +16,7 @@ import (
 
 type Execd struct {
 	Command      []string        `toml:"command"`
+	Environment  []string        `toml:"environment"`
 	RestartDelay config.Duration `toml:"restart_delay"`
 	Log          telegraf.Logger
 
@@ -34,7 +35,7 @@ func (e *Execd) Init() error {
 
 	var err error
 
-	e.process, err = process.New(e.Command)
+	e.process, err = process.New(e.Command, e.Environment)
 	if err != nil {
 		return fmt.Errorf("error creating process %s: %w", e.Command, err)
 	}

--- a/plugins/processors/execd/README.md
+++ b/plugins/processors/execd/README.md
@@ -30,6 +30,10 @@ Telegraf minimum version: Telegraf 1.15.0
   ## eg: command = ["/path/to/your_program", "arg1", "arg2"]
   command = ["cat"]
 
+  ## Environment variables
+  ## eg: environment = ["LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs", "USERNAME=John Doe"]
+  # environment = ["LD_LIBRARY_PATH=/opt/custom/lib64"]
+
   ## Delay before the process is restarted after an unexpected termination
   # restart_delay = "10s"
 ```

--- a/plugins/processors/execd/README.md
+++ b/plugins/processors/execd/README.md
@@ -31,8 +31,10 @@ Telegraf minimum version: Telegraf 1.15.0
   command = ["cat"]
 
   ## Environment variables
-  ## eg: environment = ["LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs", "USERNAME=John Doe"]
-  # environment = ["LD_LIBRARY_PATH=/opt/custom/lib64"]
+  ## Array of "key=value" pairs to pass as environment variables
+  ## e.g. "KEY=value", "USERNAME=John Doe",
+  ## "LD_LIBRARY_PATH=/opt/custom/lib64:/usr/local/libs"
+  # environment = []
 
   ## Delay before the process is restarted after an unexpected termination
   # restart_delay = "10s"

--- a/plugins/processors/execd/execd.go
+++ b/plugins/processors/execd/execd.go
@@ -19,6 +19,7 @@ import (
 
 type Execd struct {
 	Command      []string        `toml:"command"`
+	Environment  []string        `toml:"environment"`
 	RestartDelay config.Duration `toml:"restart_delay"`
 	Log          telegraf.Logger
 
@@ -54,7 +55,7 @@ func (e *Execd) Start(acc telegraf.Accumulator) error {
 	}
 	e.acc = acc
 
-	e.process, err = process.New(e.Command)
+	e.process, err = process.New(e.Command, e.Environment)
 	if err != nil {
 		return fmt.Errorf("error creating new process: %w", err)
 	}


### PR DESCRIPTION
resolves #9281

adds support for environment variables for **execd** and **exec** plugins

example usage:
```toml
[[inputs.execd]]
  command = [
    "/opt/custom-plugins/my-custom-plugin",
    "-config", "/opt/custom-plugins/my-custom-plugin.conf",
    "-interval", "30s",
  ]
  environment = ["LD_LIBRARY_PATH=/opt/app/lib64"]
```