### PR TITLE
plugins/input/internet_speed : collect and log Sponsor/Provider in new field

### DIFF
--- a/plugins/inputs/internet_speed/README.md
+++ b/plugins/inputs/internet_speed/README.md
@@ -23,9 +23,10 @@ It collects latency, download speed and upload speed
 | Download Speed | download   | float64 | Mbps |
 | Upload Speed   | upload     | float64 | Mbps |
 | Latency        | latency    | float64 | ms   |
+| Sponsor        | provider   | text    | --   |
 
 ## Example Output
 
 ```sh
-internet_speed,host=Sanyam-Ubuntu download=41.791,latency=28.518,upload=59.798 1631031183000000000
+internet_speed,host=Sanyam-Ubuntu download=41.791,latency=28.518,upload=59.798 1631031183000000000,provider=CenturyLink
 ```

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -65,6 +65,7 @@ func (is *InternetSpeed) Gather(acc telegraf.Accumulator) error {
 	fields["download"] = s.DLSpeed
 	fields["upload"] = s.ULSpeed
 	fields["latency"] = timeDurationMillisecondToFloat64(s.Latency)
+	fields["provider"] = s.Sponsor
 
 	tags := make(map[string]string)
 


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Change summary: Adds an additional `provider` field to log the sponsor/provider with the speedtest.net data being collected by the `plugins/inputs/internet_speed` plugin. This PR adds this additional field to the data collection.