### PR TITLE
fix(parsers/nagios): metrics will always return a supported status co…

### DIFF
--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -127,9 +127,9 @@ func (e *Exec) ProcessCommand(command string, acc telegraf.Accumulator, wg *sync
 	defer wg.Done()
 	_, isNagios := e.parser.(*nagios.NagiosParser)
 
-	out, errbuf, runErr := e.runner.Run(command, e.Environment, time.Duration(e.Timeout))
+	out, errBuf, runErr := e.runner.Run(command, e.Environment, time.Duration(e.Timeout))
 	if !isNagios && runErr != nil {
-		err := fmt.Errorf("exec: %s for command '%s': %s", runErr, command, string(errbuf))
+		err := fmt.Errorf("exec: %s for command '%s': %s", runErr, command, string(errBuf))
 		acc.AddError(err)
 		return
 	}
@@ -141,10 +141,7 @@ func (e *Exec) ProcessCommand(command string, acc telegraf.Accumulator, wg *sync
 	}
 
 	if isNagios {
-		metrics, err = nagios.TryAddState(runErr, metrics)
-		if err != nil {
-			e.Log.Errorf("Failed to add nagios state: %s", err)
-		}
+		metrics = nagios.AddState(runErr, errBuf, metrics)
 	}
 
 	for _, m := range metrics {

--- a/plugins/parsers/nagios/parser_test.go
+++ b/plugins/parsers/nagios/parser_test.go
@@ -32,7 +32,7 @@ func TestGetExitCode(t *testing.T) {
 			errF: func() error {
 				return errors.New("I am not *exec.ExitError")
 			},
-			expCode: 0,
+			expCode: 3,
 			expErr:  errors.New("I am not *exec.ExitError"),
 		},
 	}
@@ -89,10 +89,11 @@ func assertEqual(t *testing.T, exp, actual []telegraf.Metric) {
 
 func TestTryAddState(t *testing.T) {
 	tests := []struct {
-		name    string
-		runErrF func() error
-		metrics []telegraf.Metric
-		assertF func(*testing.T, []telegraf.Metric, error)
+		name          string
+		runErrF       func() error
+		runErrMessage []byte
+		metrics       []telegraf.Metric
+		assertF       func(*testing.T, []telegraf.Metric)
 	}{
 		{
 			name: "should append state=0 field to existing metric",
@@ -107,7 +108,7 @@ func TestTryAddState(t *testing.T) {
 					n("nagios_state").
 					f("service_output", "OK: system working").b(),
 			},
-			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+			assertF: func(t *testing.T, metrics []telegraf.Metric) {
 				exp := []telegraf.Metric{
 					mb().
 						n("nagios").
@@ -118,7 +119,6 @@ func TestTryAddState(t *testing.T) {
 						f("state", 0).b(),
 				}
 				assertEqual(t, exp, metrics)
-				require.NoError(t, err)
 			},
 		},
 		{
@@ -131,7 +131,7 @@ func TestTryAddState(t *testing.T) {
 					n("nagios").
 					f("perfdata", 0).b(),
 			},
-			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+			assertF: func(t *testing.T, metrics []telegraf.Metric) {
 				exp := []telegraf.Metric{
 					mb().
 						n("nagios").
@@ -141,7 +141,6 @@ func TestTryAddState(t *testing.T) {
 						f("state", 0).b(),
 				}
 				assertEqual(t, exp, metrics)
-				require.NoError(t, err)
 			},
 		},
 		{
@@ -150,7 +149,7 @@ func TestTryAddState(t *testing.T) {
 				return nil
 			},
 			metrics: []telegraf.Metric{},
-			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+			assertF: func(t *testing.T, metrics []telegraf.Metric) {
 				require.Len(t, metrics, 1)
 				m := metrics[0]
 				require.Equal(t, "nagios_state", m.Name())
@@ -158,37 +157,54 @@ func TestTryAddState(t *testing.T) {
 				require.True(t, ok)
 				require.Equal(t, int64(0), s)
 				require.WithinDuration(t, time.Now().UTC(), m.Time(), 10*time.Second)
-				require.NoError(t, err)
 			},
 		},
 		{
-			name: "should return original metrics and an error",
+			name: "should return metrics with state unknown and thrown error is service_output",
 			runErrF: func() error {
 				return errors.New("non parsable error")
 			},
 			metrics: []telegraf.Metric{
 				mb().
-					n("nagios").
-					f("perfdata", 0).b(),
+					n("nagios_state").b(),
 			},
-			assertF: func(t *testing.T, metrics []telegraf.Metric, err error) {
+			assertF: func(t *testing.T, metrics []telegraf.Metric) {
 				exp := []telegraf.Metric{
 					mb().
-						n("nagios").
-						f("perfdata", 0).b(),
+						n("nagios_state").
+						f("state", 3).
+						f("service_output", "non parsable error").b(),
 				}
-				expErr := "exec: get exit code: non parsable error"
 
 				assertEqual(t, exp, metrics)
-				require.Equal(t, expErr, err.Error())
+			},
+		},
+		{
+			name: "should return metrics with state unknown and service_output error from error message parameter",
+			runErrF: func() error {
+				return errors.New("")
+			},
+			runErrMessage: []byte("some error message"),
+			metrics: []telegraf.Metric{
+				mb().
+					n("nagios_state").b(),
+			},
+			assertF: func(t *testing.T, metrics []telegraf.Metric) {
+				exp := []telegraf.Metric{
+					mb().
+						n("nagios_state").
+						f("state", 3).
+						f("service_output", "some error message").b(),
+				}
+				assertEqual(t, exp, metrics)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics, err := TryAddState(tt.runErrF(), tt.metrics)
-			tt.assertF(t, metrics, err)
+			metrics := AddState(tt.runErrF(), tt.runErrMessage, tt.metrics)
+			tt.assertF(t, metrics)
 		})
 	}
 }


### PR DESCRIPTION
…de, error is now in service_output if needed #11061

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #11061

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
 
- The nagios parser will now only return supported status codes. (https://nagios-plugins.org/doc/guidelines.html, Plugin Return Codes)
- All status codes other than 0,1,2,3 will automatically changed to 3 (unknown)
- More errors like the examples in the linked issue will be correct handled now.
- The Human readable error messages will now be added to the 'service_output' metric field. These errors wont be logged to the telegraf error.log anymore because they are useable metrics now and no real errors.
 

 
