### PR TITLE
feat: #9725 add shift property to modify register value in modbus input plugin

### DIFF
--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -1,3 +1,4 @@
+useless push to reopen PR closed by mistake
 # Modbus Input Plugin
 
 The Modbus plugin collects Discrete Inputs, Coils, Input Registers and Holding


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

adds new 'shift' property to add a constant to the register value see issue #9725 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

Minor changes:
* remove unused functions (type conversions without scale)
* reorder some checks (name was called in error message before checking it existed)
* adds new 'shift' property to add a constant to the register value see issue #9725 
