### PR TITLE
fix: Output erroneous namespace and continue instead of error out

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -328,7 +328,8 @@ func (c *CloudWatch) fetchNamespaceMetrics() ([]types.Metric, error) {
 		for {
 			resp, err := c.client.ListMetrics(context.Background(), params)
 			if err != nil {
-				return nil, fmt.Errorf("failed to list metrics with params per namespace: %v", err)
+				fmt.Printf("failed to list metrics with namespace %s: %v", namespace, err)
+				break
 			}
 
 			metrics = append(metrics, resp.Metrics...)

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -328,7 +328,8 @@ func (c *CloudWatch) fetchNamespaceMetrics() ([]types.Metric, error) {
 		for {
 			resp, err := c.client.ListMetrics(context.Background(), params)
 			if err != nil {
-				fmt.Printf("failed to list metrics with namespace %s: %v", namespace, err)
+				c.Log.Errorf("failed to list metrics with namespace %s: %v", namespace, err)
+				// skip problem namespace on error and continue to next namespace
 				break
 			}
 


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR resolve two problems:
1. Error message did not include the namespace causing trouble, making it difficult to figure out the issue with multiple namespaces queried.
2. A single erroneous namespace from AWS API will stop in-take of all subsequent metrics, so just log the error and skip over to the next namespace getting as much metrics as we can.