### PR TITLE
feat: add field key option to set event partition key

### DIFF
--- a/plugins/outputs/event_hubs/README.md
+++ b/plugins/outputs/event_hubs/README.md
@@ -21,8 +21,15 @@ JSON is probably the easiest to integrate with downstream components.
   ## The full connection string to the Event Hub (required)
   ## The shared access key must have "Send" permissions on the target Event Hub.
   connection_string = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName"
+
   ## Client timeout (defaults to 30s)
   # timeout = "30s"
+
+  ## Partition key field
+  ## Metric field name to use for the event partition key. The value of this
+  ## field is set as the key for events if it exists.
+  # partition_key_field = ""
+
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/event_hubs/README.md
+++ b/plugins/outputs/event_hubs/README.md
@@ -25,10 +25,10 @@ JSON is probably the easiest to integrate with downstream components.
   ## Client timeout (defaults to 30s)
   # timeout = "30s"
 
-  ## Partition key field
-  ## Metric field name to use for the event partition key. The value of this
-  ## field is set as the key for events if it exists.
-  # partition_key_field = ""
+  ## Partition key
+  ## Metric tag or field name to use for the event partition key. The value of
+  ## this tag or field is set as the key for events if it exists.
+  # partition_key = ""
 
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/outputs/event_hubs/README.md
+++ b/plugins/outputs/event_hubs/README.md
@@ -27,7 +27,8 @@ JSON is probably the easiest to integrate with downstream components.
 
   ## Partition key
   ## Metric tag or field name to use for the event partition key. The value of
-  ## this tag or field is set as the key for events if it exists.
+  ## this tag or field is set as the key for events if it exists. If both, tag
+  ## and field, exist the tag is preferred.
   # partition_key = ""
 
   ## Data format to output.

--- a/plugins/outputs/event_hubs/event_hubs.go
+++ b/plugins/outputs/event_hubs/event_hubs.go
@@ -48,10 +48,10 @@ func (eh *eventHub) SendBatch(ctx context.Context, iterator eventhub.BatchIterat
 /* End wrapper interface */
 
 type EventHubs struct {
-	Log               telegraf.Logger `toml:"-"`
-	ConnectionString  string          `toml:"connection_string"`
-	Timeout           config.Duration `toml:"timeout"`
-	PartitionKeyField string          `toml:"partition_key_field"`
+	Log              telegraf.Logger `toml:"-"`
+	ConnectionString string          `toml:"connection_string"`
+	Timeout          config.Duration `toml:"timeout"`
+	PartitionKey     string          `toml:"partition_key"`
 
 	Hub        EventHubInterface
 	serializer serializers.Serializer
@@ -104,13 +104,16 @@ func (e *EventHubs) Write(metrics []telegraf.Metric) error {
 		}
 
 		event := eventhub.NewEvent(payload)
-		if e.PartitionKeyField != "" {
-			if key, ok := metric.GetField(e.PartitionKeyField); ok {
+		if e.PartitionKey != "" {
+			if key, ok := metric.GetTag(e.PartitionKey); ok {
+				event.PartitionKey = &key
+			} else if key, ok := metric.GetField(e.PartitionKey); ok {
 				if strKey, ok := key.(string); ok {
 					event.PartitionKey = &strKey
 				}
 			}
 		}
+
 		events = append(events, event)
 	}
 


### PR DESCRIPTION
This allows users to set the partition key value in data set to Azure.
This value gets hashed and that hash determines which of the available
partitions the event will get sent to. The hash values get split evenly
over the available partitions that exist in Azure.

Fixes: #10762