### PR TITLE
fix: remove any content type from prometheus accept header

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -24,7 +24,7 @@ import (
 	parserV2 "github.com/influxdata/telegraf/plugins/parsers/prometheus"
 )
 
-const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3,*/*;q=0.1`
+const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3`
 
 type Prometheus struct {
 	// An array of urls to scrape metrics from.


### PR DESCRIPTION
In #6745, the prometheus accept header was changed to accept any media
type. However, our prometheus plugin only accepts text. With the release
of newer versions of prometheus, the OpenMetrics type is now available
and could potentially be set up as the exclusive response type. As this
new content type is not supported, Telegraf should not accept it.

The original issue, #6523, was filed around getting a 406. The issue had
comments from the rabbit-mq maintainers who made changes to their code
to be less rigid, resolving the issue. The change to telegraf was made
afterward anyway.

fixes: #10248