### PR TITLE
fix: use readers over closers in http input

### DIFF
--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -1,9 +1,11 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -95,9 +97,6 @@ func (h *HTTP) gatherURL(
 	if err != nil {
 		return err
 	}
-	if body != nil {
-		defer body.Close()
-	}
 
 	request, err := http.NewRequest(h.Method, url, body)
 	if err != nil {
@@ -175,7 +174,7 @@ func (h *HTTP) gatherURL(
 	return nil
 }
 
-func makeRequestBodyReader(contentEncoding, body string) (io.ReadCloser, error) {
+func makeRequestBodyReader(contentEncoding, body string) (io.Reader, error) {
 	if body == "" {
 		return nil, nil
 	}
@@ -186,10 +185,14 @@ func makeRequestBodyReader(contentEncoding, body string) (io.ReadCloser, error) 
 		if err != nil {
 			return nil, err
 		}
-		return rc, nil
+		data, err := ioutil.ReadAll(rc)
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewReader(data), nil
 	}
 
-	return io.NopCloser(reader), nil
+	return reader, nil
 }
 
 func init() {


### PR DESCRIPTION
The current http input plugin, when a body is specified, will produce
a NopCloser. I believe this is because the gzip compression function
returns a closer. However, this means that the HTTP request will not
include the content-length. For that to happen, the request body must
either be a string or bytes reader or bytes buffer.

The primary reason to use a closer over those readers is in the event of
a lot of data and trying to stay memory efficient. However, as the input
plugin sends little data over http, the size should generally be
small. Therefore, switch to bytes and string readers so that the http
requests will always include the content length.

fixes: #11034