### PR TITLE
test: remove unused riemann from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     ports:
       - "3306:3306"
-    # removes warning "mbind operation not permitted" enables you to see the docker logs 
+    # removes warning "mbind operation not permitted" enables you to see the docker logs
     cap_add:
     - SYS_NICE  # CAP_SYS_NICE
   memcached:
@@ -82,10 +82,6 @@ services:
     image: open62541/open62541
     ports:
       - "4840:4840"
-  riemann:
-    image: stealthly/docker-riemann
-    ports:
-      - "5555:5555"
   nats:
     image: nats
     ports:

--- a/plugins/outputs/riemann_legacy/riemann_legacy_test.go
+++ b/plugins/outputs/riemann_legacy/riemann_legacy_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestConnectAndWrite(t *testing.T) {
+	// if this needs to run use: `docker run stealthly/docker-riemann`
 	t.Skip("Skipping legacy integration test")
 
 	url := testutil.GetLocalHost() + ":5555"
@@ -15,6 +16,7 @@ func TestConnectAndWrite(t *testing.T) {
 	r := &Riemann{
 		URL:       url,
 		Transport: "tcp",
+		Log:       testutil.Logger{},
 	}
 
 	err := r.Connect()


### PR DESCRIPTION
fixes: #11117