### PR TITLE
chore(aggregators): migrate sample configs into separate files

### DIFF
--- a/plugins/aggregators/basicstats/sample.conf
+++ b/plugins/aggregators/basicstats/sample.conf
@@ -1,0 +1,11 @@
+# Keep the aggregate basicstats of each metric passing through.
+[[aggregators.basicstats]]
+  ## The period on which to flush & clear the aggregator.
+  period = "30s"
+
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+
+  ## Configures which basic stats to push as fields
+  # stats = ["count","diff","rate","min","max","mean","non_negative_diff","non_negative_rate","stdev","s2","sum","interval"]

--- a/plugins/aggregators/derivative/sample.conf
+++ b/plugins/aggregators/derivative/sample.conf
@@ -1,0 +1,17 @@
+# Calculates a derivative for every field.
+[[aggregators.derivative]]
+  ## Specific Derivative Aggregator Arguments:
+
+  ## Configure a custom derivation variable. Timestamp is used if none is given.
+  # variable = ""
+
+  ## Suffix to add to the field name for the derivative name.
+  # suffix = "_rate"
+
+  ## Roll-Over last measurement to first measurement of next period
+  # max_roll_over = 10
+
+  ## General Aggregator Arguments:
+
+  ## calculate derivative every 30 seconds
+  period = "30s"

--- a/plugins/aggregators/final/sample.conf
+++ b/plugins/aggregators/final/sample.conf
@@ -1,0 +1,10 @@
+# Report the final metric of a series
+[[aggregators.final]]
+  ## The period on which to flush & clear the aggregator.
+  period = "30s"
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+
+  ## The time that a series is not updated until considering it final.
+  series_timeout = "5m"

--- a/plugins/aggregators/histogram/sample.conf
+++ b/plugins/aggregators/histogram/sample.conf
@@ -1,0 +1,40 @@
+# Configuration for aggregate histogram metrics
+[[aggregators.histogram]]
+  ## The period in which to flush the aggregator.
+  period = "30s"
+
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+
+  ## If true, the histogram will be reset on flush instead
+  ## of accumulating the results.
+  reset = false
+
+  ## Whether bucket values should be accumulated. If set to false, "gt" tag will be added.
+  ## Defaults to true.
+  cumulative = true
+
+  ## Expiration interval for each histogram. The histogram will be expired if
+  ## there are no changes in any buckets for this time interval. 0 == no expiration.
+  # expiration_interval = "0m"
+
+  ## If true, aggregated histogram are pushed to output only if it was updated since
+  ## previous push. Defaults to false.
+  # push_only_on_update = false
+
+  ## Example config that aggregates all fields of the metric.
+  # [[aggregators.histogram.config]]
+  #   ## Right borders of buckets (with +Inf implicitly added).
+  #   buckets = [0.0, 15.6, 34.5, 49.1, 71.5, 80.5, 94.5, 100.0]
+  #   ## The name of metric.
+  #   measurement_name = "cpu"
+
+  ## Example config that aggregates only specific fields of the metric.
+  # [[aggregators.histogram.config]]
+  #   ## Right borders of buckets (with +Inf implicitly added).
+  #   buckets = [0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0]
+  #   ## The name of metric.
+  #   measurement_name = "diskio"
+  #   ## The concrete fields of metric
+  #   fields = ["io_time", "read_time", "write_time"]

--- a/plugins/aggregators/merge/sample.conf
+++ b/plugins/aggregators/merge/sample.conf
@@ -1,0 +1,5 @@
+# Merge metrics into multifield metrics by series key
+[[aggregators.merge]]
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = true

--- a/plugins/aggregators/minmax/sample.conf
+++ b/plugins/aggregators/minmax/sample.conf
@@ -1,0 +1,8 @@
+# Keep the aggregate min/max of each metric passing through.
+[[aggregators.minmax]]
+  ## General Aggregator Arguments:
+  ## The period on which to flush & clear the aggregator.
+  period = "30s"
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false

--- a/plugins/aggregators/quantile/sample.conf
+++ b/plugins/aggregators/quantile/sample.conf
@@ -1,0 +1,26 @@
+# Keep the aggregate quantiles of each metric passing through.
+[[aggregators.quantile]]
+  ## General Aggregator Arguments:
+  ## The period on which to flush & clear the aggregator.
+  period = "30s"
+
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+
+  ## Quantiles to output in the range [0,1]
+  # quantiles = [0.25, 0.5, 0.75]
+
+  ## Type of aggregation algorithm
+  ## Supported are:
+  ##  "t-digest" -- approximation using centroids, can cope with large number of samples
+  ##  "exact R7" -- exact computation also used by Excel or NumPy (Hyndman & Fan 1996 R7)
+  ##  "exact R8" -- exact computation (Hyndman & Fan 1996 R8)
+  ## NOTE: Do not use "exact" algorithms with large number of samples
+  ##       to not impair performance or memory consumption!
+  # algorithm = "t-digest"
+
+  ## Compression for approximation (t-digest). The value needs to be
+  ## greater or equal to 1.0. Smaller values will result in more
+  ## performance but less accuracy.
+  # compression = 100.0

--- a/plugins/aggregators/starlark/sample.conf
+++ b/plugins/aggregators/starlark/sample.conf
@@ -1,0 +1,29 @@
+# Aggregate metrics using a Starlark script
+[[aggregators.starlark]]
+  ## The Starlark source can be set as a string in this configuration file, or
+  ## by referencing a file containing the script.  Only one source or script
+  ## should be set at once.
+  ##
+  ## Source of the Starlark script.
+  source = '''
+state = {}
+
+def add(metric):
+  state["last"] = metric
+
+def push():
+  return state.get("last")
+
+def reset():
+  state.clear()
+'''
+
+  ## File containing a Starlark script.
+  # script = "/usr/local/bin/myscript.star"
+
+  ## The constants of the Starlark script.
+  # [aggregators.starlark.constants]
+  #   max_size = 10
+  #   threshold = 0.75
+  #   default_name = "Julia"
+  #   debug_mode = true

--- a/plugins/aggregators/valuecounter/sample.conf
+++ b/plugins/aggregators/valuecounter/sample.conf
@@ -1,0 +1,10 @@
+# Count the occurrence of values in fields.
+[[aggregators.valuecounter]]
+  ## General Aggregator Arguments:
+  ## The period on which to flush & clear the aggregator.
+  period = "30s"
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+  ## The fields for which the values will be counted
+  fields = ["status"]


### PR DESCRIPTION
To prepare for the new way to generate sample configurations, moving all of the sample configs to a separate file. This PR handles all the aggregator plugins migration.