### PR TITLE
fix: avoid calling sadc with invalid 0 interval

### DIFF
--- a/plugins/inputs/sysstat/sysstat.go
+++ b/plugins/inputs/sysstat/sysstat.go
@@ -122,7 +122,7 @@ func (s *Sysstat) collect(tempfile string) error {
 	collectInterval := s.interval - parseInterval
 
 	// If true, interval is not defined yet and Gather is run for the first time.
-	if collectInterval < 0 {
+	if collectInterval <= 0 {
 		collectInterval = 1 // In that case we only collect for 1 second.
 	}
 


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11135

Avoids the sysstat input plugin becoming "stuck" continuously using an invalid interval argument of 0 to sadc. https://github.com/sysstat/sysstat/blob/c5bb321b4e910b704b7ba4a600c7edfbd477b2cf/sadc.c#L1315

No changes to README.md , and as only able to reproduce with code injection, no unit tests added.