### PR TITLE
feat(inputs/cpu): add tags with core id or physical id to cpus

### DIFF
--- a/plugins/inputs/cpu/README.md
+++ b/plugins/inputs/cpu/README.md
@@ -15,6 +15,8 @@ The `cpu` plugin gather metrics on the system CPUs.
   collect_cpu_time = false
   ## If true, compute and report the sum of all non-idle CPU states
   report_active = false
+  ## If true and the info is available then add core_id and physical_id tags
+  core_tags = false
 ```
 
 ## Metrics
@@ -52,6 +54,7 @@ On Linux, consult `man proc` for details on the meanings of these values.
 
 On Linux systems the `/proc/stat` file is used to gather CPU times.
 Percentages are based on the last 2 samples.
+Tags core_id and physical_id are read from `/proc/cpuinfo` on Linux systems
 
 ## Example Output
 

--- a/plugins/inputs/cpu/cpu.go
+++ b/plugins/inputs/cpu/cpu.go
@@ -12,13 +12,19 @@ import (
 )
 
 type CPUStats struct {
-	ps        system.PS
-	lastStats map[string]cpuUtil.TimesStat
+	ps         system.PS
+	lastStats  map[string]cpuUtil.TimesStat
+	cpuInfo    map[string]cpuUtil.InfoStat
+	coreID     bool
+	physicalID bool
 
 	PerCPU         bool `toml:"percpu"`
 	TotalCPU       bool `toml:"totalcpu"`
 	CollectCPUTime bool `toml:"collect_cpu_time"`
 	ReportActive   bool `toml:"report_active"`
+	CoreTags       bool `toml:"core_tags"`
+
+	Log telegraf.Logger `toml:"-"`
 }
 
 func NewCPUStats(ps system.PS) *CPUStats {
@@ -39,6 +45,12 @@ func (c *CPUStats) Gather(acc telegraf.Accumulator) error {
 	for _, cts := range times {
 		tags := map[string]string{
 			"cpu": cts.CPU,
+		}
+		if c.coreID {
+			tags["core_id"] = c.cpuInfo[cts.CPU].CoreID
+		}
+		if c.physicalID {
+			tags["physical_id"] = c.cpuInfo[cts.CPU].PhysicalID
 		}
 
 		total := totalCPUTime(cts)
@@ -111,6 +123,25 @@ func (c *CPUStats) Gather(acc telegraf.Accumulator) error {
 	}
 
 	return err
+}
+
+func (c *CPUStats) Init() error {
+	if c.CoreTags {
+		cpuInfo, err := cpuUtil.Info()
+		if err == nil {
+			c.coreID = cpuInfo[0].CoreID != ""
+			c.physicalID = cpuInfo[0].PhysicalID != ""
+
+			c.cpuInfo = make(map[string]cpuUtil.InfoStat)
+			for _, ci := range cpuInfo {
+				c.cpuInfo[fmt.Sprintf("cpu%d", ci.CPU)] = ci
+			}
+		} else {
+			c.Log.Warnf("Failed to gather info about CPUs: %s", err)
+		}
+	}
+
+	return nil
 }
 
 func totalCPUTime(t cpuUtil.TimesStat) float64 {


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

potentially resolves #5949

Adds tags core_id and physical_id which contain information about physical CPU or cores in cases of hyper-threading. This is an opt-in setting to not generate tags for users that will not use them.
These tags are added only if they are available in the already used library github.com/shirou/gopsutil