### PR TITLE
test: switch internet speed to enable file download

### DIFF
--- a/plugins/inputs/internet_speed/internet_speed_test.go
+++ b/plugins/inputs/internet_speed/internet_speed_test.go
@@ -12,7 +12,7 @@ func TestGathering(t *testing.T) {
 		t.Skip("Skipping network-dependent test in short mode.")
 	}
 	internetSpeed := &InternetSpeed{
-		EnableFileDownload: false,
+		EnableFileDownload: true,
 		Log:                testutil.Logger{},
 	}
 
@@ -26,7 +26,7 @@ func TestDataGen(t *testing.T) {
 		t.Skip("Skipping network-dependent test in short mode.")
 	}
 	internetSpeed := &InternetSpeed{
-		EnableFileDownload: false,
+		EnableFileDownload: true,
 		Log:                testutil.Logger{},
 	}
 


### PR DESCRIPTION
The file download test when enabled is significantly faster in terms of
total test time (45 sec vs 4 sec). In CI when running all these tests
in parallel we could hit limits or timeouts, so we want to limit our
need for external networking.

Running with the previous setting, while running other integration tests
can lead to timeouts and other networking hiccups, which cause this test
to fail.

fixes: #11123