### PR TITLE
test: force elasticsearch to index batch data

### DIFF
--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -568,8 +568,13 @@ func setupIntegrationTest() error {
 		return err
 	}
 
-	// wait 5s (default) for Elasticsearch to index, so results are consistent
-	time.Sleep(time.Second * 5)
+	// force elastic to refresh indexes to get new batch data
+	ctx := context.Background()
+	_, err = e.esClient.Refresh().Do(ctx)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
On a fast system, 5 seconds is not a long enough sleep to let
elasticsearch index the data used for the test. Instead, use
elasticsearch's own command to force the index to happen of the newly
added data and remove the sleep.

fix: #11124