### PR TITLE
feat: Add trace_filters option to disk plugin

### DIFF
--- a/plugins/inputs/disk/README.md
+++ b/plugins/inputs/disk/README.md
@@ -22,6 +22,11 @@ Note that `used_percent` is calculated by doing `used / (used + free)`, _not_
   ## The 'mount' command reports options of all mounts in parathesis.
   ## Bind mounts can be ignored with the special 'bind' option.
   # ignore_mount_opts = []
+
+  ## Trace why mount-points are ignored.
+  ## This option is useful when debugging why mount-points are getting dropped.
+  ## ONLY WORKS WITH DEBUG ENABLED!
+  # trace_filters = false
 ```
 
 ### Docker container

--- a/plugins/inputs/disk/disk.go
+++ b/plugins/inputs/disk/disk.go
@@ -23,6 +23,7 @@ type DiskStats struct {
 	MountPoints     []string `toml:"mount_points"`
 	IgnoreFS        []string `toml:"ignore_fs"`
 	IgnoreMountOpts []string `toml:"ignore_mount_opts"`
+	TraceFilters    bool     `toml:"trace_filters"`
 
 	Log telegraf.Logger `toml:"-"`
 }
@@ -39,6 +40,7 @@ func (ds *DiskStats) Init() error {
 
 	ps := system.NewSystemPS()
 	ps.Log = ds.Log
+	ps.Trace = ds.TraceFilters
 	ds.ps = ps
 
 	return nil

--- a/plugins/inputs/disk/sample.conf
+++ b/plugins/inputs/disk/sample.conf
@@ -11,3 +11,8 @@
   ## The 'mount' command reports options of all mounts in parathesis.
   ## Bind mounts can be ignored with the special 'bind' option.
   # ignore_mount_opts = []
+
+  ## Trace why mount-points are ignored.
+  ## This option is useful when debugging why mount-points are getting dropped.
+  ## ONLY WORKS WITH DEBUG ENABLED!
+  # trace_filters = false

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -171,6 +171,9 @@ partitionRange:
 				continue
 			}
 		}
+		if s.Trace && s.Log != nil {
+			s.Log.Debugf("[SystemPS] => kept %q (%q)", p.Mountpoint, mountpoint)
+		}
 
 		du, err := s.PSDiskUsage(mountpoint)
 		if err != nil {

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -133,7 +133,7 @@ partitionRange:
 		for _, o := range p.Opts {
 			if !mountOptFilterSet.empty() && mountOptFilterSet.has(o) {
 				if s.Trace && s.Log != nil {
-					s.Log.Debugf("[SystemPS] => dropped by mount option: %q", o)
+					s.Log.Debugf("[SystemPS] => dropped %q by mount option: %q", p.Mountpoint, o)
 				}
 				continue partitionRange
 			}
@@ -142,7 +142,7 @@ partitionRange:
 		// member of the filter set, don't gather info on it.
 		if !mountPointFilterSet.empty() && !mountPointFilterSet.has(p.Mountpoint) {
 			if s.Trace && s.Log != nil {
-				s.Log.Debugf("[SystemPS] => dropped by mount point: %q", p.Mountpoint)
+				s.Log.Debugf("[SystemPS] => dropped %q by mount point", p.Mountpoint)
 			}
 			continue
 		}
@@ -151,7 +151,7 @@ partitionRange:
 		// don't gather info on it.
 		if fstypeExcludeSet.has(p.Fstype) {
 			if s.Trace && s.Log != nil {
-				s.Log.Debugf("[SystemPS] => dropped by fs type: %q", p.Fstype)
+				s.Log.Debugf("[SystemPS] => dropped %q by fs type: %q", p.Mountpoint, p.Fstype)
 			}
 			continue
 		}
@@ -166,7 +166,7 @@ partitionRange:
 			// Exclude conflicting paths
 			if paths.has(mountpoint) {
 				if s.Log != nil {
-					s.Log.Debugf("[SystemPS] => dropped by mount prefix (%q): %q", mountpoint, hostMountPrefix)
+					s.Log.Debugf("[SystemPS] => dropped %q by mount prefix (%q): %q", p.Mountpoint, mountpoint, hostMountPrefix)
 				}
 				continue
 			}

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -40,7 +40,8 @@ func NewSystemPS() *SystemPS {
 
 type SystemPS struct {
 	PSDiskDeps
-	Log telegraf.Logger `toml:"-"`
+	Log   telegraf.Logger `toml:"-"`
+	Trace bool            `toml:"-"`
 }
 
 type SystemPSDisk struct{}
@@ -131,18 +132,27 @@ partitionRange:
 
 		for _, o := range p.Opts {
 			if !mountOptFilterSet.empty() && mountOptFilterSet.has(o) {
+				if s.Trace && s.Log != nil {
+					s.Log.Debugf("[SystemPS] => dropped by mount option: %q", o)
+				}
 				continue partitionRange
 			}
 		}
 		// If there is a filter set and if the mount point is not a
 		// member of the filter set, don't gather info on it.
 		if !mountPointFilterSet.empty() && !mountPointFilterSet.has(p.Mountpoint) {
+			if s.Trace && s.Log != nil {
+				s.Log.Debugf("[SystemPS] => dropped by mount point: %q", p.Mountpoint)
+			}
 			continue
 		}
 
 		// If the mount point is a member of the exclude set,
 		// don't gather info on it.
 		if fstypeExcludeSet.has(p.Fstype) {
+			if s.Trace && s.Log != nil {
+				s.Log.Debugf("[SystemPS] => dropped by fs type: %q", p.Fstype)
+			}
 			continue
 		}
 


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR adds a `trace_filters` option to the `disk` input plugin in order to trace why a mount-point was dropped. Lately we more often observed missing metrics with the disk plugin especially in container environments. Often it is unclear why certain mount-points are dropped, so we add this option to get a log-message for mount-point drops if both `--debug` and the new `trace_filters` options are enabled.