### PR TITLE
test: move nats to test-containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,10 +73,6 @@ services:
     image: open62541/open62541
     ports:
       - "4840:4840"
-  nats:
-    image: nats
-    ports:
-      - "4222:4222"
   openldap:
     image: cobaugh/openldap-alpine
     environment:

--- a/plugins/outputs/nats/nats_test.go
+++ b/plugins/outputs/nats/nats_test.go
@@ -17,7 +17,7 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 
 	container := testutil.Container{
 		Image:        "nats",
-		ExposedPorts: []string{"4222", "6222"},
+		ExposedPorts: []string{"4222"},
 		WaitingFor:   wait.ForLog("Server is ready"),
 	}
 	err := container.Start()

--- a/plugins/outputs/nats/nats_test.go
+++ b/plugins/outputs/nats/nats_test.go
@@ -1,11 +1,13 @@
 package nats
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/influxdata/telegraf/plugins/serializers"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func TestConnectAndWriteIntegration(t *testing.T) {
@@ -13,7 +15,18 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	server := []string{"nats://" + testutil.GetLocalHost() + ":4222"}
+	container := testutil.Container{
+		Image:        "nats",
+		ExposedPorts: []string{"4222", "6222"},
+		WaitingFor:   wait.ForLog("Server is ready"),
+	}
+	err := container.Start()
+	require.NoError(t, err, "failed to start container")
+	defer func() {
+		require.NoError(t, container.Terminate(), "terminating container failed")
+	}()
+
+	server := []string{fmt.Sprintf("nats://%s:%s", container.Address, container.Port)}
 	s, _ := serializers.NewInfluxSerializer()
 	n := &NATS{
 		Servers:    server,
@@ -23,7 +36,7 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 	}
 
 	// Verify that we can connect to the NATS daemon
-	err := n.Connect()
+	err = n.Connect()
 	require.NoError(t, err)
 
 	// Verify that we can successfully write data to the NATS daemon


### PR DESCRIPTION
Moves the nats output integration test from expecting the docker-compose infrastructure to use test containers.