### PR TITLE
test: move opcua to test-containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,10 +57,6 @@ services:
     ports:
       - "4150:4150"
     command: "/nsqd"
-  opcua:
-    image: open62541/open62541
-    ports:
-      - "4840:4840"
   openldap:
     image: cobaugh/openldap-alpine
     environment:


### PR DESCRIPTION
One integration test was already using test containers, so this moved it to use our generic code for it and added it to the second integration test.