### PR TITLE
fix: search services file in /etc/services and fall back to /usr/etc/…

### DIFF
--- a/plugins/processors/port_name/services_path_notwindows.go
+++ b/plugins/processors/port_name/services_path_notwindows.go
@@ -3,6 +3,23 @@
 
 package port_name
 
+import (
+	"os"
+)
+
+// servicesPath tries to find the `services` file at the common
+// place(s) on most systems and returns its path. If it can't
+// find anything, it returns the common default `/etc/services`
 func servicesPath() string {
-	return "/etc/services"
+	var files = []string{
+		"/etc/services",
+		"/usr/etc/services", // fallback on OpenSuSE
+	}
+
+	for i := range files {
+		if _, err := os.Stat(files[i]); err == nil {
+			return files[i]
+		}
+	}
+	return files[0]
 }


### PR DESCRIPTION
…services (fixes #11178)

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11178

This resolves an issue on systems (e.g. OpenSuSE Tumbleweed) where `/etc/services` doesn't exist and is "replaced" by `/usr/etc/services`.