### PR TITLE
chore: Embed sample configurations into README for outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ generate_plugins_%: build_generator
 	go generate -run="plugindata/main.go$$" ./plugins/$*/...
 
 .PHONY: generate
-generate: insert_config_to_readme_inputs insert_config_to_readme_inputs generate_plugins_processors generate_plugins_aggregators
+generate: insert_config_to_readme_inputs insert_config_to_readme_outputs generate_plugins_processors generate_plugins_aggregators
 
 .PHONY: generate-clean
 generate-clean:

--- a/Makefile
+++ b/Makefile
@@ -126,11 +126,11 @@ generate_plugins_%: build_generator
 	go generate -run="plugindata/main.go$$" ./plugins/$*/...
 
 .PHONY: generate
-generate: insert_config_to_readme_inputs generate_plugins_outputs generate_plugins_processors generate_plugins_aggregators
+generate: insert_config_to_readme_inputs insert_config_to_readme_inputs generate_plugins_processors generate_plugins_aggregators
 
 .PHONY: generate-clean
 generate-clean:
-	go generate -run="plugindata/main.go --clean" ./plugins/outputs/... ./plugins/processors/... ./plugins/aggregators/...
+	go generate -run="plugindata/main.go --clean" ./plugins/processors/... ./plugins/aggregators/...
 
 .PHONY: build
 build:

--- a/plugins/outputs/amon/README.md
+++ b/plugins/outputs/amon/README.md
@@ -11,7 +11,7 @@ Metrics are grouped by converting any `_` characters to `.` in the Point Name.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for Amon Server to send metrics to.
 [[outputs.amon]]
   ## Amon Server Key

--- a/plugins/outputs/amon/amon.go
+++ b/plugins/outputs/amon/amon.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package amon
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,6 +14,10 @@ import (
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type Amon struct {
 	ServerKey    string          `toml:"server_key"`
@@ -32,6 +38,10 @@ type Metric struct {
 }
 
 type Point [2]float64
+
+func (*Amon) SampleConfig() string {
+	return sampleConfig
+}
 
 func (a *Amon) Connect() error {
 	if a.ServerKey == "" || a.AmonInstance == "" {

--- a/plugins/outputs/amon/amon_sample_config.go
+++ b/plugins/outputs/amon/amon_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package amon
-
-func (a *Amon) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/amqp/README.md
+++ b/plugins/outputs/amqp/README.md
@@ -12,7 +12,7 @@ For an introduction to AMQP see:
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Publishes metrics to an AMQP broker
 [[outputs.amqp]]
   ## Broker to publish to.

--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package amqp
 
 import (
 	"bytes"
+	_ "embed"
 	"strings"
 	"time"
 
@@ -14,6 +16,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	DefaultURL             = "amqp://localhost:5672/influxdb"
@@ -69,6 +75,10 @@ type AMQP struct {
 type Client interface {
 	Publish(key string, body []byte) error
 	Close() error
+}
+
+func (*AMQP) SampleConfig() string {
+	return sampleConfig
 }
 
 func (q *AMQP) SetSerializer(serializer serializers.Serializer) {

--- a/plugins/outputs/amqp/amqp_sample_config.go
+++ b/plugins/outputs/amqp/amqp_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package amqp
-
-func (q *AMQP) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/application_insights/README.md
+++ b/plugins/outputs/application_insights/README.md
@@ -5,7 +5,7 @@ Insights](https://azure.microsoft.com/en-us/services/application-insights/).
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send metrics to Azure Application Insights
 [[outputs.application_insights]]
   ## Instrumentation key of the Application Insights resource.

--- a/plugins/outputs/application_insights/application_insights.go
+++ b/plugins/outputs/application_insights/application_insights.go
@@ -1,16 +1,23 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package application_insights
 
 import (
+	_ "embed"
 	"fmt"
 	"math"
 	"time"
 	"unsafe"
 
+	"github.com/microsoft/ApplicationInsights-Go/appinsights"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/outputs"
-	"github.com/microsoft/ApplicationInsights-Go/appinsights"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type TelemetryTransmitter interface {
 	Track(appinsights.Telemetry)
@@ -38,6 +45,10 @@ var (
 	is32Bit        bool
 	is32BitChecked bool
 )
+
+func (*ApplicationInsights) SampleConfig() string {
+	return sampleConfig
+}
 
 func (a *ApplicationInsights) Connect() error {
 	if a.InstrumentationKey == "" {

--- a/plugins/outputs/application_insights/application_insights_sample_config.go
+++ b/plugins/outputs/application_insights/application_insights_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package application_insights
-
-func (a *ApplicationInsights) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/azure_data_explorer/README.md
+++ b/plugins/outputs/azure_data_explorer/README.md
@@ -15,7 +15,7 @@ of logs, metrics and time series data.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Sends metrics to Azure Data Explorer
 [[outputs.azure_data_explorer]]
   ## The URI property of the Azure Data Explorer resource on Azure

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer.go
@@ -1,8 +1,10 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package azure_data_explorer
 
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
@@ -13,12 +15,17 @@ import (
 	"github.com/Azure/azure-kusto-go/kusto/ingest"
 	"github.com/Azure/azure-kusto-go/kusto/unsafe"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
 	"github.com/influxdata/telegraf/plugins/serializers/json"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type AzureDataExplorer struct {
 	Endpoint        string          `toml:"endpoint_url"`
@@ -54,6 +61,10 @@ type ingestorFactory func(localClient, string, string) (localIngestor, error)
 
 const createTableCommand = `.create-merge table ['%s']  (['fields']:dynamic, ['name']:string, ['tags']:dynamic, ['timestamp']:datetime);`
 const createTableMappingCommand = `.create-or-alter table ['%s'] ingestion json mapping '%s_mapping' '[{"column":"fields", "Properties":{"Path":"$[\'fields\']"}},{"column":"name", "Properties":{"Path":"$[\'name\']"}},{"column":"tags", "Properties":{"Path":"$[\'tags\']"}},{"column":"timestamp", "Properties":{"Path":"$[\'timestamp\']"}}]'`
+
+func (*AzureDataExplorer) SampleConfig() string {
+	return sampleConfig
+}
 
 func (adx *AzureDataExplorer) Connect() error {
 	authorizer, err := auth.NewAuthorizerFromEnvironmentWithResource(adx.Endpoint)

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer_sample_config.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package azure_data_explorer
-
-func (adx *AzureDataExplorer) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/azure_monitor/README.md
+++ b/plugins/outputs/azure_monitor/README.md
@@ -16,7 +16,7 @@ dimension on each Azure Monitor metric.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send aggregate metrics to Azure Monitor
 [[outputs.azure_monitor]]
   ## Timeout for HTTP writes.

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -1,9 +1,11 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package azure_monitor
 
 import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	_ "embed"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -24,6 +26,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/selfstat"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 // AzureMonitor allows publishing of metrics to the Azure Monitor custom metrics
 // service
@@ -102,6 +108,10 @@ const (
 	urlOverrideTemplate        = "%s%s/metrics"
 	maxRequestBodySize         = 4000000
 )
+
+func (*AzureMonitor) SampleConfig() string {
+	return sampleConfig
+}
 
 // Connect initializes the plugin and validates connectivity
 func (a *AzureMonitor) Connect() error {

--- a/plugins/outputs/azure_monitor/azure_monitor_sample_config.go
+++ b/plugins/outputs/azure_monitor/azure_monitor_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package azure_monitor
-
-func (a *AzureMonitor) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/bigquery/README.md
+++ b/plugins/outputs/bigquery/README.md
@@ -10,7 +10,7 @@ Be aware that this plugin accesses APIs that are
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for Google Cloud BigQuery to send entries
 [[outputs.bigquery]]
   ## Credentials File

--- a/plugins/outputs/bigquery/bigquery.go
+++ b/plugins/outputs/bigquery/bigquery.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package bigquery
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"reflect"
 	"strings"
@@ -16,6 +18,10 @@ import (
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const timeStampFieldName = "timestamp"
 
@@ -34,6 +40,10 @@ type BigQuery struct {
 	client *bigquery.Client
 
 	warnedOnHyphens map[string]bool
+}
+
+func (*BigQuery) SampleConfig() string {
+	return sampleConfig
 }
 
 func (s *BigQuery) Connect() error {

--- a/plugins/outputs/bigquery/bigquery_sample_config.go
+++ b/plugins/outputs/bigquery/bigquery_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package bigquery
-
-func (s *BigQuery) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/cloud_pubsub/README.md
+++ b/plugins/outputs/cloud_pubsub/README.md
@@ -5,7 +5,7 @@ as one of the supported [output data formats][].
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Publish Telegraf metrics to a Google Cloud PubSub topic
 [[outputs.cloud_pubsub]]
   ## Required. Name of Google Cloud Platform (GCP) Project that owns

--- a/plugins/outputs/cloud_pubsub/cloud_pubsub.go
+++ b/plugins/outputs/cloud_pubsub/cloud_pubsub.go
@@ -1,21 +1,28 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package cloud_pubsub
 
 import (
 	"context"
+	_ "embed"
 	"encoding/base64"
 	"fmt"
 	"sync"
 	"time"
 
 	"cloud.google.com/go/pubsub"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
-	"golang.org/x/oauth2/google"
-	"google.golang.org/api/option"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type PubSub struct {
 	CredentialsFile string            `toml:"credentials_file"`
@@ -39,6 +46,10 @@ type PubSub struct {
 
 	serializer     serializers.Serializer
 	publishResults []publishResult
+}
+
+func (*PubSub) SampleConfig() string {
+	return sampleConfig
 }
 
 func (ps *PubSub) SetSerializer(serializer serializers.Serializer) {

--- a/plugins/outputs/cloud_pubsub/cloud_pubsub_sample_config.go
+++ b/plugins/outputs/cloud_pubsub/cloud_pubsub_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package cloud_pubsub
-
-func (ps *PubSub) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/cloudwatch/README.md
+++ b/plugins/outputs/cloudwatch/README.md
@@ -29,7 +29,7 @@ The IAM user needs only the `cloudwatch:PutMetricData` permission.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for AWS CloudWatch output.
 [[outputs.cloudwatch]]
   ## Amazon REGION

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package cloudwatch
 
 import (
 	"context"
+	_ "embed"
 	"math"
 	"sort"
 	"strings"
@@ -15,6 +17,10 @@ import (
 	internalaws "github.com/influxdata/telegraf/config/aws"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type CloudWatch struct {
 	Namespace             string `toml:"namespace"` // CloudWatch Metrics Namespace
@@ -146,6 +152,10 @@ func (f *valueField) buildDatum() []types.MetricDatum {
 			StorageResolution: aws.Int32(int32(f.storageResolution)),
 		},
 	}
+}
+
+func (*CloudWatch) SampleConfig() string {
+	return sampleConfig
 }
 
 func (c *CloudWatch) Connect() error {

--- a/plugins/outputs/cloudwatch/cloudwatch_sample_config.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package cloudwatch
-
-func (c *CloudWatch) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/cloudwatch_logs/README.md
+++ b/plugins/outputs/cloudwatch_logs/README.md
@@ -33,7 +33,7 @@ The IAM user needs the following permissions (see this [reference][4] for more):
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for AWS CloudWatchLogs output.
 [[outputs.cloudwatch_logs]]
   ## The region is the Amazon region that you wish to connect to.

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package cloudwatch_logs
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"sort"
 	"strings"
@@ -9,10 +11,15 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+
 	"github.com/influxdata/telegraf"
 	internalaws "github.com/influxdata/telegraf/config/aws"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type messageBatch struct {
 	logEvents    []types.InputLogEvent
@@ -72,6 +79,10 @@ const (
 	//maxTimeSpanInBatch = time.Hour * 24 // A batch of log events in a single request cannot span more than 24 hours.
 	// Otherwise, the operation fails.
 )
+
+func (*CloudWatchLogs) SampleConfig() string {
+	return sampleConfig
+}
 
 // Init initialize plugin with checking configuration parameters
 func (c *CloudWatchLogs) Init() error {

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs_sample_config.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package cloudwatch_logs
-
-func (c *CloudWatchLogs) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/cratedb/README.md
+++ b/plugins/outputs/cratedb/README.md
@@ -23,7 +23,7 @@ config option, see below.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for CrateDB to send metrics to.
 [[outputs.cratedb]]
   # A github.com/jackc/pgx/v4 connection string.

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -1,9 +1,11 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package cratedb
 
 import (
 	"context"
 	"crypto/sha512"
 	"database/sql"
+	_ "embed"
 	"encoding/binary"
 	"fmt"
 	"sort"
@@ -11,12 +13,16 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/jackc/pgx/v4/stdlib" //to register stdlib from PostgreSQL Driver and Toolkit
+	_ "github.com/jackc/pgx/v4/stdlib"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const MaxInt64 = int64(^uint64(0) >> 1)
 
@@ -27,6 +33,10 @@ type CrateDB struct {
 	TableCreate  bool   `toml:"table_create"`
 	KeySeparator string `toml:"key_separator"`
 	DB           *sql.DB
+}
+
+func (*CrateDB) SampleConfig() string {
+	return sampleConfig
 }
 
 func (c *CrateDB) Connect() error {

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/jackc/pgx/v4/stdlib"
+	_ "github.com/jackc/pgx/v4/stdlib" //to register stdlib from PostgreSQL Driver and Toolkit
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"

--- a/plugins/outputs/cratedb/cratedb_sample_config.go
+++ b/plugins/outputs/cratedb/cratedb_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package cratedb
-
-func (c *CrateDB) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -5,7 +5,7 @@ This plugin writes to the [Datadog Metrics API][metrics] and requires an
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for DataDog API to send metrics to.
 [[outputs.datadog]]
   ## Datadog API key

--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package datadog
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -16,6 +18,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/proxy"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type Datadog struct {
 	Apikey      string          `toml:"apikey"`
@@ -44,6 +50,10 @@ type Metric struct {
 type Point [2]float64
 
 const datadogAPI = "https://app.datadoghq.com/api/v1/series"
+
+func (*Datadog) SampleConfig() string {
+	return sampleConfig
+}
 
 func (d *Datadog) Connect() error {
 	if d.Apikey == "" {

--- a/plugins/outputs/datadog/datadog_sample_config.go
+++ b/plugins/outputs/datadog/datadog_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package datadog
-
-func (d *Datadog) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/discard/README.md
+++ b/plugins/outputs/discard/README.md
@@ -5,7 +5,7 @@ meant to be used for testing purposes.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send metrics to nowhere at all
 [[outputs.discard]]
   # no configuration

--- a/plugins/outputs/discard/discard.go
+++ b/plugins/outputs/discard/discard.go
@@ -1,11 +1,22 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package discard
 
 import (
+	_ "embed"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
+
 type Discard struct{}
+
+func (*Discard) SampleConfig() string {
+	return sampleConfig
+}
 
 func (d *Discard) Connect() error { return nil }
 func (d *Discard) Close() error   { return nil }

--- a/plugins/outputs/discard/discard_sample_config.go
+++ b/plugins/outputs/discard/discard_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package discard
-
-func (d *Discard) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -50,7 +50,7 @@ Note: The name and identifier of the host running Telegraf will be added as a
 dimension to every metric. If this is undesirable, then the output plugin may be
 used in standalone mode using the directions below.
 
-```toml @sample.conf
+```toml
 [[outputs.dynatrace]]
   ## No options are required. By default, metrics will be exported via the OneAgent on the local host.
 ```
@@ -93,7 +93,7 @@ You can learn more about how to use the Dynatrace API
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send telegraf metrics to a Dynatrace environment
 [[outputs.dynatrace]]
   ## For usage with the Dynatrace OneAgent you can omit any configuration,

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -50,7 +50,7 @@ Note: The name and identifier of the host running Telegraf will be added as a
 dimension to every metric. If this is undesirable, then the output plugin may be
 used in standalone mode using the directions below.
 
-```toml
+```toml @sample.conf
 [[outputs.dynatrace]]
   ## No options are required. By default, metrics will be exported via the OneAgent on the local host.
 ```

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -1,22 +1,28 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package dynatrace
 
 import (
 	"bytes"
+	_ "embed"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
 
+	dtMetric "github.com/dynatrace-oss/dynatrace-metric-utils-go/metric"
+	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/apiconstants"
+	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/dimensions"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
-
-	dtMetric "github.com/dynatrace-oss/dynatrace-metric-utils-go/metric"
-	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/apiconstants"
-	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/dimensions"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 // Dynatrace Configuration for the Dynatrace output plugin
 type Dynatrace struct {
@@ -36,6 +42,10 @@ type Dynatrace struct {
 	client *http.Client
 
 	loggedMetrics map[string]bool // New empty set
+}
+
+func (*Dynatrace) SampleConfig() string {
+	return sampleConfig
 }
 
 // Connect Connects the Dynatrace output plugin to the Telegraf stream

--- a/plugins/outputs/dynatrace/dynatrace_sample_config.go
+++ b/plugins/outputs/dynatrace/dynatrace_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package dynatrace
-
-func (d *Dynatrace) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -197,7 +197,7 @@ POST https://es.us-east-1.amazonaws.com/2021-01-01/opensearch/upgradeDomain
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for Elasticsearch to send metrics to.
 [[outputs.elasticsearch]]
   ## The full HTTP endpoint URL for your Elasticsearch instance

--- a/plugins/outputs/elasticsearch/elasticsearch.go
+++ b/plugins/outputs/elasticsearch/elasticsearch.go
@@ -1,8 +1,11 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package elasticsearch
 
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	_ "embed"
 	"fmt"
 	"math"
 	"net/http"
@@ -12,8 +15,6 @@ import (
 	"text/template"
 	"time"
 
-	"crypto/sha256"
-
 	"github.com/olivere/elastic"
 
 	"github.com/influxdata/telegraf"
@@ -21,6 +22,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type Elasticsearch struct {
 	AuthBearerToken     string          `toml:"auth_bearer_token"`
@@ -125,6 +130,10 @@ const telegrafTemplate = `
 type templatePart struct {
 	TemplatePattern string
 	Version         int
+}
+
+func (*Elasticsearch) SampleConfig() string {
+	return sampleConfig
 }
 
 func (a *Elasticsearch) Connect() error {

--- a/plugins/outputs/elasticsearch/elasticsearch_sample_config.go
+++ b/plugins/outputs/elasticsearch/elasticsearch_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package elasticsearch
-
-func (a *Elasticsearch) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/event_hubs/README.md
+++ b/plugins/outputs/event_hubs/README.md
@@ -15,7 +15,7 @@ JSON is probably the easiest to integrate with downstream components.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for Event Hubs output plugin
 [[outputs.event_hubs]]
   ## The full connection string to the Event Hub (required)

--- a/plugins/outputs/event_hubs/event_hubs.go
+++ b/plugins/outputs/event_hubs/event_hubs.go
@@ -1,15 +1,22 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package event_hubs
 
 import (
 	"context"
+	_ "embed"
 	"time"
 
 	eventhub "github.com/Azure/azure-event-hubs-go/v3"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 /*
 ** Wrapper interface for eventhub.Hub
@@ -60,6 +67,10 @@ type EventHubs struct {
 const (
 	defaultRequestTimeout = time.Second * 30
 )
+
+func (*EventHubs) SampleConfig() string {
+	return sampleConfig
+}
 
 func (e *EventHubs) Init() error {
 	err := e.Hub.GetHub(e.ConnectionString)

--- a/plugins/outputs/event_hubs/event_hubs_sample_config.go
+++ b/plugins/outputs/event_hubs/event_hubs_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package event_hubs
-
-func (e *EventHubs) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/event_hubs/sample.conf
+++ b/plugins/outputs/event_hubs/sample.conf
@@ -3,8 +3,16 @@
   ## The full connection string to the Event Hub (required)
   ## The shared access key must have "Send" permissions on the target Event Hub.
   connection_string = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName"
+
   ## Client timeout (defaults to 30s)
   # timeout = "30s"
+
+  ## Partition key
+  ## Metric tag or field name to use for the event partition key. The value of
+  ## this tag or field is set as the key for events if it exists. If both, tag
+  ## and field, exist the tag is preferred.
+  # partition_key = ""
+
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/exec/README.md
+++ b/plugins/outputs/exec/README.md
@@ -14,7 +14,7 @@ For better performance, consider execd, which runs continuously.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send metrics to command as input over stdin
 [[outputs.exec]]
   ## Command to ingest metrics via stdin.

--- a/plugins/outputs/exec/exec.go
+++ b/plugins/outputs/exec/exec.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package exec
 
 import (
 	"bytes"
+	_ "embed"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +18,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
+
 const maxStderrBytes = 512
 
 // Exec defines the exec output plugin.
@@ -27,6 +33,10 @@ type Exec struct {
 
 	runner     Runner
 	serializer serializers.Serializer
+}
+
+func (*Exec) SampleConfig() string {
+	return sampleConfig
 }
 
 func (e *Exec) Init() error {

--- a/plugins/outputs/exec/exec_sample_config.go
+++ b/plugins/outputs/exec/exec_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package exec
-
-func (e *Exec) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/execd/README.md
+++ b/plugins/outputs/execd/README.md
@@ -6,7 +6,7 @@ Telegraf minimum version: Telegraf 1.15.0
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Run executable as long-running output plugin
 [[outputs.execd]]
   ## One program to run as daemon.

--- a/plugins/outputs/execd/execd.go
+++ b/plugins/outputs/execd/execd.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package execd
 
 import (
 	"bufio"
+	_ "embed"
 	"fmt"
 	"io"
 	"strings"
@@ -14,6 +16,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
+
 type Execd struct {
 	Command      []string        `toml:"command"`
 	Environment  []string        `toml:"environment"`
@@ -22,6 +28,10 @@ type Execd struct {
 
 	process    *process.Process
 	serializer serializers.Serializer
+}
+
+func (*Execd) SampleConfig() string {
+	return sampleConfig
 }
 
 func (e *Execd) SetSerializer(s serializers.Serializer) {

--- a/plugins/outputs/execd/execd_sample_config.go
+++ b/plugins/outputs/execd/execd_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package execd
-
-func (e *Execd) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/file/README.md
+++ b/plugins/outputs/file/README.md
@@ -4,7 +4,7 @@ This plugin writes telegraf metrics to files
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send telegraf metrics to file(s)
 [[outputs.file]]
   ## Files to write to, "stdout" is a specially handled file.

--- a/plugins/outputs/file/file.go
+++ b/plugins/outputs/file/file.go
@@ -1,6 +1,8 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package file
 
 import (
+	_ "embed"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +15,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
+
 type File struct {
 	Files               []string        `toml:"files"`
 	RotationInterval    config.Duration `toml:"rotation_interval"`
@@ -24,6 +30,10 @@ type File struct {
 	writer     io.Writer
 	closers    []io.Closer
 	serializer serializers.Serializer
+}
+
+func (*File) SampleConfig() string {
+	return sampleConfig
 }
 
 func (f *File) SetSerializer(serializer serializers.Serializer) {

--- a/plugins/outputs/file/file_sample_config.go
+++ b/plugins/outputs/file/file_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package file
-
-func (f *File) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/graphite/README.md
+++ b/plugins/outputs/graphite/README.md
@@ -11,7 +11,7 @@ see the [Graphite Data Format][2].
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for Graphite server to send metrics to
 [[outputs.graphite]]
   ## TCP endpoint for your graphite instance.

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package graphite
 
 import (
 	"crypto/tls"
+	_ "embed"
 	"errors"
 	"io"
 	"math/rand"
@@ -13,6 +15,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type Graphite struct {
 	GraphiteTagSupport      bool   `toml:"graphite_tag_support"`
@@ -28,6 +34,10 @@ type Graphite struct {
 
 	conns []net.Conn
 	tlsint.ClientConfig
+}
+
+func (*Graphite) SampleConfig() string {
+	return sampleConfig
 }
 
 func (g *Graphite) Connect() error {

--- a/plugins/outputs/graphite/graphite_sample_config.go
+++ b/plugins/outputs/graphite/graphite_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package graphite
-
-func (g *Graphite) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/graylog/README.md
+++ b/plugins/outputs/graylog/README.md
@@ -23,7 +23,7 @@ the field name.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send telegraf metrics to graylog
 [[outputs.graylog]]
   ## Endpoints for your graylog instances.

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package graylog
 
 import (
@@ -5,6 +6,7 @@ import (
 	"compress/zlib"
 	"crypto/rand"
 	"crypto/tls"
+	_ "embed"
 	"encoding/binary"
 	ejson "encoding/json"
 	"fmt"
@@ -20,6 +22,10 @@ import (
 	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	defaultEndpoint        = "127.0.0.1:12201"
@@ -315,6 +321,10 @@ type Graylog struct {
 
 	writer  io.Writer
 	closers []io.WriteCloser
+}
+
+func (*Graylog) SampleConfig() string {
+	return sampleConfig
 }
 
 func (g *Graylog) Connect() error {

--- a/plugins/outputs/graylog/graylog_sample_config.go
+++ b/plugins/outputs/graylog/graylog_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package graylog
-
-func (g *Graylog) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/groundwork/README.md
+++ b/plugins/outputs/groundwork/README.md
@@ -7,7 +7,7 @@ GW8+
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send telegraf metrics to GroundWork Monitor
 [[outputs.groundwork]]
   ## URL of your groundwork instance.

--- a/plugins/outputs/groundwork/groundwork.go
+++ b/plugins/outputs/groundwork/groundwork.go
@@ -1,8 +1,10 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package groundwork
 
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +18,10 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type metricMeta struct {
 	group    string
@@ -33,6 +39,10 @@ type Groundwork struct {
 	ResourceTag         string          `toml:"resource_tag"`
 	Log                 telegraf.Logger `toml:"-"`
 	client              clients.GWClient
+}
+
+func (*Groundwork) SampleConfig() string {
+	return sampleConfig
 }
 
 func (g *Groundwork) Init() error {

--- a/plugins/outputs/groundwork/groundwork_sample_config.go
+++ b/plugins/outputs/groundwork/groundwork_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package groundwork
-
-func (g *Groundwork) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/health/README.md
+++ b/plugins/outputs/health/README.md
@@ -9,7 +9,7 @@ must fail in order for the resource to enter the failed state.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configurable HTTP health check resource based on metrics
 [[outputs.health]]
   ## Address and port to listen on.

--- a/plugins/outputs/health/health.go
+++ b/plugins/outputs/health/health.go
@@ -1,8 +1,10 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package health
 
 import (
 	"context"
 	"crypto/tls"
+	_ "embed"
 	"errors"
 	"net"
 	"net/http"
@@ -16,6 +18,10 @@ import (
 	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	defaultServiceAddress = "tcp://:8080"
@@ -50,6 +56,10 @@ type Health struct {
 
 	mu      sync.Mutex
 	healthy bool
+}
+
+func (*Health) SampleConfig() string {
+	return sampleConfig
 }
 
 func (h *Health) Init() error {

--- a/plugins/outputs/health/health_sample_config.go
+++ b/plugins/outputs/health/health_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package health
-
-func (h *Health) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -6,7 +6,7 @@ format by default.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # A plugin that can transmit metrics over HTTP
 [[outputs.http]]
   ## URL is the address to send metrics to

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package http
 
 import (
@@ -5,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	_ "embed"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +15,7 @@ import (
 
 	awsV2 "github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+
 	"github.com/influxdata/telegraf"
 	internalaws "github.com/influxdata/telegraf/config/aws"
 	"github.com/influxdata/telegraf/internal"
@@ -22,6 +25,10 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/api/idtoken"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	maxErrMsgLen = 1024
@@ -56,6 +63,10 @@ type HTTP struct {
 	// Google API Auth
 	CredentialsFile string `toml:"google_application_credentials"`
 	oauth2Token     *oauth2.Token
+}
+
+func (*HTTP) SampleConfig() string {
+	return sampleConfig
 }
 
 func (h *HTTP) SetSerializer(serializer serializers.Serializer) {

--- a/plugins/outputs/http/http_sample_config.go
+++ b/plugins/outputs/http/http_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package http
-
-func (h *HTTP) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/http/sample.conf
+++ b/plugins/outputs/http/sample.conf
@@ -19,6 +19,9 @@
   # token_url = "https://indentityprovider/oauth2/v1/token"
   # scopes = ["urn:opc:idm:__myscopes__"]
 
+  ## Goole API Auth
+  # google_application_credentials = "/etc/telegraf/example_secret.json"
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"

--- a/plugins/outputs/influxdb/README.md
+++ b/plugins/outputs/influxdb/README.md
@@ -5,7 +5,7 @@ service.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for sending metrics to InfluxDB
 [[outputs.influxdb]]
   ## The full HTTP or UDP URL for your InfluxDB instance.

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -1,8 +1,10 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //nolint
 package influxdb
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -15,6 +17,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 var (
 	defaultURL = "http://localhost:8086"
@@ -61,6 +67,10 @@ type InfluxDB struct {
 	CreateUDPClientF  func(config *UDPConfig) (Client, error)
 
 	Log telegraf.Logger
+}
+
+func (*InfluxDB) SampleConfig() string {
+	return sampleConfig
 }
 
 func (i *InfluxDB) Connect() error {

--- a/plugins/outputs/influxdb/influxdb_sample_config.go
+++ b/plugins/outputs/influxdb/influxdb_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package influxdb
-
-func (i *InfluxDB) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/influxdb_v2/README.md
+++ b/plugins/outputs/influxdb_v2/README.md
@@ -4,7 +4,7 @@ The InfluxDB output plugin writes metrics to the [InfluxDB v2.x] HTTP service.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for sending metrics to InfluxDB 2.0
 [[outputs.influxdb_v2]]
   ## The URLs of the InfluxDB cluster nodes.

--- a/plugins/outputs/influxdb_v2/influxdb_v2.go
+++ b/plugins/outputs/influxdb_v2/influxdb_v2.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package influxdb_v2
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -14,6 +16,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 var (
 	defaultURL = "http://localhost:8086"
@@ -46,6 +52,10 @@ type InfluxDB struct {
 	Log telegraf.Logger `toml:"-"`
 
 	clients []Client
+}
+
+func (*InfluxDB) SampleConfig() string {
+	return sampleConfig
 }
 
 func (i *InfluxDB) Connect() error {

--- a/plugins/outputs/influxdb_v2/influxdb_v2_sample_config.go
+++ b/plugins/outputs/influxdb_v2/influxdb_v2_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package influxdb_v2
-
-func (i *InfluxDB) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/instrumental/README.md
+++ b/plugins/outputs/instrumental/README.md
@@ -11,7 +11,7 @@ used if the metric comes in as a counter through `[[input.statsd]]`.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for sending metrics to an Instrumental project
 [[outputs.instrumental]]
   ## Project API Token (required)

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package instrumental
 
 import (
 	"bytes"
+	_ "embed"
 	"fmt"
 	"io"
 	"net"
@@ -15,6 +17,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 var (
 	ValueIncludesBadChar = regexp.MustCompile("[^[:digit:].]")
@@ -42,6 +48,10 @@ const (
 	AuthFormat      = "authenticate %s\n"
 	HandshakeFormat = HelloMessage + AuthFormat
 )
+
+func (*Instrumental) SampleConfig() string {
+	return sampleConfig
+}
 
 func (i *Instrumental) Connect() error {
 	connection, err := net.DialTimeout("tcp", i.Host+":8000", time.Duration(i.Timeout))

--- a/plugins/outputs/instrumental/instrumental_sample_config.go
+++ b/plugins/outputs/instrumental/instrumental_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package instrumental
-
-func (i *Instrumental) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -5,7 +5,7 @@ Broker](http://kafka.apache.org/07/quickstart.html) acting a Kafka Producer.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for the Kafka server to send metrics to
 [[outputs.kafka]]
   ## URLs of kafka brokers

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -1,6 +1,8 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package kafka
 
 import (
+	_ "embed"
 	"fmt"
 	"log"
 	"strings"
@@ -15,6 +17,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 var ValidTopicSuffixMethods = []string{
 	"",
@@ -87,6 +93,10 @@ func ValidateTopicSuffixMethod(method string) error {
 		}
 	}
 	return fmt.Errorf("unknown topic suffix method provided: %s", method)
+}
+
+func (*Kafka) SampleConfig() string {
+	return sampleConfig
 }
 
 func (k *Kafka) GetTopicName(metric telegraf.Metric) (telegraf.Metric, string) {

--- a/plugins/outputs/kafka/kafka_sample_config.go
+++ b/plugins/outputs/kafka/kafka_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package kafka
-
-func (k *Kafka) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/kinesis/README.md
+++ b/plugins/outputs/kinesis/README.md
@@ -36,7 +36,7 @@ will be used.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for the AWS Kinesis output.
 [[outputs.kinesis]]
   ## Amazon REGION of kinesis endpoint.

--- a/plugins/outputs/kinesis/kinesis.go
+++ b/plugins/outputs/kinesis/kinesis.go
@@ -1,18 +1,25 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package kinesis
 
 import (
 	"context"
+	_ "embed"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 	"github.com/gofrs/uuid"
+
 	"github.com/influxdata/telegraf"
 	internalaws "github.com/influxdata/telegraf/config/aws"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 // Limit set by AWS (https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html)
 const maxRecordsPerRequest uint32 = 500
@@ -41,6 +48,10 @@ type (
 
 type kinesisClient interface {
 	PutRecords(context.Context, *kinesis.PutRecordsInput, ...func(*kinesis.Options)) (*kinesis.PutRecordsOutput, error)
+}
+
+func (*KinesisOutput) SampleConfig() string {
+	return sampleConfig
 }
 
 func (k *KinesisOutput) Connect() error {

--- a/plugins/outputs/kinesis/kinesis_sample_config.go
+++ b/plugins/outputs/kinesis/kinesis_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package kinesis
-
-func (k *KinesisOutput) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/librato/README.md
+++ b/plugins/outputs/librato/README.md
@@ -17,7 +17,7 @@ Currently, the plugin does not send any associated Point Tags.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for Librato API to send metrics to.
 [[outputs.librato]]
   ## Librato API Docs

--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package librato
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +16,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 // Librato structure for configuration and client
 type Librato struct {
@@ -53,6 +59,10 @@ func NewLibrato(apiURL string) *Librato {
 		APIUrl:   apiURL,
 		Template: "host",
 	}
+}
+
+func (*Librato) SampleConfig() string {
+	return sampleConfig
 }
 
 // Connect is the default output plugin connection function who make sure it

--- a/plugins/outputs/librato/librato_sample_config.go
+++ b/plugins/outputs/librato/librato_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package librato
-
-func (l *Librato) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/logzio/README.md
+++ b/plugins/outputs/logzio/README.md
@@ -4,7 +4,7 @@ This plugin sends metrics to Logz.io over HTTPs.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # A plugin that can send metrics over HTTPs to Logz.io
 [[outputs.logzio]]
   ## Set to true if Logz.io sender checks the disk space before adding metrics to the disk queue.

--- a/plugins/outputs/logzio/logzio.go
+++ b/plugins/outputs/logzio/logzio.go
@@ -1,11 +1,12 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package logzio
 
 import (
 	"bytes"
 	"compress/gzip"
+	_ "embed"
 	"encoding/json"
 	"fmt"
-
 	"net/http"
 	"time"
 
@@ -14,6 +15,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	defaultLogzioURL = "https://listener.logz.io:8071"
@@ -41,6 +46,10 @@ type Metric struct {
 	Dimensions map[string]string      `json:"dimensions"`
 	Time       time.Time              `json:"@timestamp"`
 	Type       string                 `json:"type"`
+}
+
+func (*Logzio) SampleConfig() string {
+	return sampleConfig
 }
 
 // Connect to the Output

--- a/plugins/outputs/logzio/logzio_sample_config.go
+++ b/plugins/outputs/logzio/logzio_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package logzio
-
-func (l *Logzio) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/loki/README.md
+++ b/plugins/outputs/loki/README.md
@@ -8,7 +8,7 @@ Logs within each stream are sorted by timestamp before being sent to Loki.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # A plugin that can transmit logs to Loki
 [[outputs.loki]]
   ## The domain of Loki

--- a/plugins/outputs/loki/loki.go
+++ b/plugins/outputs/loki/loki.go
@@ -1,8 +1,10 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package loki
 
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,6 +22,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	defaultEndpoint      = "/loki/api/v1/push"
@@ -70,6 +76,10 @@ func (l *Loki) createClient(ctx context.Context) (*http.Client, error) {
 	}
 
 	return client, nil
+}
+
+func (*Loki) SampleConfig() string {
+	return sampleConfig
 }
 
 func (l *Loki) Connect() (err error) {

--- a/plugins/outputs/loki/loki_sample_config.go
+++ b/plugins/outputs/loki/loki_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package loki
-
-func (l *Loki) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/mongodb/README.md
+++ b/plugins/outputs/mongodb/README.md
@@ -6,7 +6,7 @@ Requires MongoDB 5.0+ for Time Series Collections
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # A plugin that can transmit logs to mongodb
 [[outputs.mongodb]]
   # connection string examples for mongodb

--- a/plugins/outputs/mongodb/mongodb.go
+++ b/plugins/outputs/mongodb/mongodb.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package mongodb
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -18,6 +20,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 func (s *MongoDB) getCollections(ctx context.Context) error {
 	s.collections = map[string]bson.M{}
@@ -59,6 +65,10 @@ type MongoDB struct {
 	clientOptions       *options.ClientOptions
 	collections         map[string]bson.M
 	tls.ClientConfig
+}
+
+func (*MongoDB) SampleConfig() string {
+	return sampleConfig
 }
 
 func (s *MongoDB) Init() error {

--- a/plugins/outputs/mongodb/mongodb_sample_config.go
+++ b/plugins/outputs/mongodb/mongodb_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package mongodb
-
-func (s *MongoDB) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -14,7 +14,7 @@ As a reference `eclipse/paho.mqtt.golang` sets the `keep_alive` to 30.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for MQTT server to send metrics to
 [[outputs.mqtt]]
   ## MQTT Brokers

--- a/plugins/outputs/mqtt/mqtt.go
+++ b/plugins/outputs/mqtt/mqtt.go
@@ -1,6 +1,8 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package mqtt
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 	"sync"
@@ -15,6 +17,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	defaultKeepAlive = 0
@@ -41,6 +47,10 @@ type MQTT struct {
 	serializer serializers.Serializer
 
 	sync.Mutex
+}
+
+func (*MQTT) SampleConfig() string {
+	return sampleConfig
 }
 
 func (m *MQTT) Connect() error {

--- a/plugins/outputs/mqtt/mqtt_sample_config.go
+++ b/plugins/outputs/mqtt/mqtt_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package mqtt
-
-func (m *MQTT) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -4,7 +4,7 @@ This plugin writes to a (list of) specified NATS instance(s).
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send telegraf measurements to NATS
 [[outputs.nats]]
   ## URLs of NATS servers

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -1,6 +1,8 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package nats
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -11,6 +13,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type NATS struct {
 	Servers     []string `toml:"servers"`
@@ -27,6 +33,10 @@ type NATS struct {
 
 	conn       *nats.Conn
 	serializer serializers.Serializer
+}
+
+func (*NATS) SampleConfig() string {
+	return sampleConfig
 }
 
 func (n *NATS) SetSerializer(serializer serializers.Serializer) {

--- a/plugins/outputs/nats/nats_sample_config.go
+++ b/plugins/outputs/nats/nats_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package nats
-
-func (n *NATS) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/newrelic/README.md
+++ b/plugins/outputs/newrelic/README.md
@@ -8,7 +8,7 @@ Telegraf minimum version: Telegraf 1.15.0
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send metrics to New Relic metrics endpoint
 [[outputs.newrelic]]
   ## The 'insights_key' parameter requires a NR license key.

--- a/plugins/outputs/newrelic/newrelic.go
+++ b/plugins/outputs/newrelic/newrelic.go
@@ -1,8 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package newrelic
 
-// newrelic.go
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,6 +16,10 @@ import (
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 // NewRelic nr structure
 type NewRelic struct {
@@ -29,6 +34,10 @@ type NewRelic struct {
 	savedErrors map[int]interface{}
 	errorCount  int
 	client      http.Client
+}
+
+func (*NewRelic) SampleConfig() string {
+	return sampleConfig
 }
 
 // Connect to the Output

--- a/plugins/outputs/newrelic/newrelic_sample_config.go
+++ b/plugins/outputs/newrelic/newrelic_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package newrelic
-
-func (nr *NewRelic) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/nsq/README.md
+++ b/plugins/outputs/nsq/README.md
@@ -5,7 +5,7 @@ producer. It requires a `server` name and a `topic` name.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send telegraf measurements to NSQD
 [[outputs.nsq]]
   ## Location of nsqd instance listening on TCP

--- a/plugins/outputs/nsq/nsq.go
+++ b/plugins/outputs/nsq/nsq.go
@@ -1,6 +1,8 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package nsq
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/nsqio/go-nsq"
@@ -10,6 +12,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
+
 type NSQ struct {
 	Server string
 	Topic  string
@@ -17,6 +23,10 @@ type NSQ struct {
 
 	producer   *nsq.Producer
 	serializer serializers.Serializer
+}
+
+func (*NSQ) SampleConfig() string {
+	return sampleConfig
 }
 
 func (n *NSQ) SetSerializer(serializer serializers.Serializer) {

--- a/plugins/outputs/nsq/nsq_sample_config.go
+++ b/plugins/outputs/nsq/nsq_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package nsq
-
-func (n *NSQ) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/opentelemetry/README.md
+++ b/plugins/outputs/opentelemetry/README.md
@@ -5,7 +5,7 @@ and agents via gRPC.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send OpenTelemetry metrics over gRPC
 [[outputs.opentelemetry]]
   ## Override the default (localhost:4317) OpenTelemetry gRPC service

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -1,24 +1,29 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package opentelemetry
 
 import (
 	"context"
-	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
-	"google.golang.org/grpc/credentials/insecure"
+	_ "embed"
 	"time"
 
 	"github.com/influxdata/influxdb-observability/common"
 	"github.com/influxdata/influxdb-observability/influx2otel"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	_ "google.golang.org/grpc/encoding/gzip"
+	"google.golang.org/grpc/metadata"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
-	// This causes the gRPC library to register gzip compression.
-	_ "google.golang.org/grpc/encoding/gzip"
-	"google.golang.org/grpc/metadata"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type OpenTelemetry struct {
 	ServiceAddress string `toml:"service_address"`
@@ -35,6 +40,10 @@ type OpenTelemetry struct {
 	grpcClientConn       *grpc.ClientConn
 	metricsServiceClient pmetricotlp.Client
 	callOptions          []grpc.CallOption
+}
+
+func (*OpenTelemetry) SampleConfig() string {
+	return sampleConfig
 }
 
 func (o *OpenTelemetry) Connect() error {

--- a/plugins/outputs/opentelemetry/opentelemetry_sample_config.go
+++ b/plugins/outputs/opentelemetry/opentelemetry_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package opentelemetry
-
-func (o *OpenTelemetry) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/opentsdb/README.md
+++ b/plugins/outputs/opentsdb/README.md
@@ -12,7 +12,7 @@ details.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for OpenTSDB server to send metrics to
 [[outputs.opentsdb]]
   ## prefix for metrics keys

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -1,6 +1,8 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package opentsdb
 
 import (
+	_ "embed"
 	"fmt"
 	"math"
 	"net"
@@ -13,6 +15,10 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 var (
 	allowedChars = regexp.MustCompile(`[^a-zA-Z0-9-_./\p{L}]`)
@@ -51,6 +57,10 @@ func ToLineFormat(tags map[string]string) string {
 	}
 	sort.Strings(tagsArray)
 	return strings.Join(tagsArray, " ")
+}
+
+func (*OpenTSDB) SampleConfig() string {
+	return sampleConfig
 }
 
 func (o *OpenTSDB) Connect() error {

--- a/plugins/outputs/opentsdb/opentsdb_sample_config.go
+++ b/plugins/outputs/opentsdb/opentsdb_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package opentsdb
-
-func (o *OpenTSDB) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -5,7 +5,7 @@ metrics on `/metrics` (default) to be polled by a Prometheus server.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for the Prometheus client to spawn
 [[outputs.prometheus_client]]
   ## Address to listen on.

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -1,8 +1,10 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package prometheus_client
 
 import (
 	"context"
 	"crypto/tls"
+	_ "embed"
 	"fmt"
 	"net"
 	"net/http"
@@ -22,6 +24,10 @@ import (
 	v1 "github.com/influxdata/telegraf/plugins/outputs/prometheus_client/v1"
 	v2 "github.com/influxdata/telegraf/plugins/outputs/prometheus_client/v2"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 var (
 	defaultListen             = ":9273"
@@ -54,6 +60,10 @@ type PrometheusClient struct {
 	url       *url.URL
 	collector Collector
 	wg        sync.WaitGroup
+}
+
+func (*PrometheusClient) SampleConfig() string {
+	return sampleConfig
 }
 
 func (p *PrometheusClient) Init() error {

--- a/plugins/outputs/prometheus_client/prometheus_client_sample_config.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package prometheus_client
-
-func (p *PrometheusClient) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/riemann/README.md
+++ b/plugins/outputs/riemann/README.md
@@ -4,7 +4,7 @@ This plugin writes to [Riemann](http://riemann.io/) via TCP or UDP.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for Riemann to send metrics to
 [[outputs.riemann]]
   ## The full TCP or UDP URL of the Riemann server

--- a/plugins/outputs/riemann/riemann.go
+++ b/plugins/outputs/riemann/riemann.go
@@ -1,6 +1,8 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package riemann
 
 import (
+	_ "embed"
 	"fmt"
 	"net/url"
 	"os"
@@ -15,6 +17,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
+
 type Riemann struct {
 	URL                    string          `toml:"url"`
 	TTL                    float32         `toml:"ttl"`
@@ -28,6 +34,10 @@ type Riemann struct {
 	Log                    telegraf.Logger `toml:"-"`
 
 	client *raidman.Client
+}
+
+func (*Riemann) SampleConfig() string {
+	return sampleConfig
 }
 
 func (r *Riemann) Connect() error {

--- a/plugins/outputs/riemann/riemann_sample_config.go
+++ b/plugins/outputs/riemann/riemann_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package riemann
-
-func (r *Riemann) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/riemann_legacy/README.md
+++ b/plugins/outputs/riemann_legacy/README.md
@@ -7,7 +7,7 @@ instead.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for the Riemann server to send metrics to
 [[outputs.riemann_legacy]]
   ## URL of server

--- a/plugins/outputs/riemann_legacy/riemann_legacy.go
+++ b/plugins/outputs/riemann_legacy/riemann_legacy.go
@@ -1,6 +1,8 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package riemann_legacy
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
 	"sort"
@@ -12,6 +14,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
+
 const deprecationMsg = "Error: this Riemann output plugin will be deprecated in a future release, see https://github.com/influxdata/telegraf/issues/1878 for more details & discussion."
 
 type Riemann struct {
@@ -21,6 +27,10 @@ type Riemann struct {
 	Log       telegraf.Logger `toml:"-"`
 
 	client *raidman.Client
+}
+
+func (*Riemann) SampleConfig() string {
+	return sampleConfig
 }
 
 func (r *Riemann) Connect() error {

--- a/plugins/outputs/riemann_legacy/riemann_legacy_sample_config.go
+++ b/plugins/outputs/riemann_legacy/riemann_legacy_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package riemann_legacy
-
-func (r *Riemann) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/sensu/README.md
+++ b/plugins/outputs/sensu/README.md
@@ -5,7 +5,7 @@ HTTP events API.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send aggregate metrics to Sensu Monitor
 [[outputs.sensu]]
   ## BACKEND API URL is the Sensu Backend API root URL to send metrics to

--- a/plugins/outputs/sensu/sensu.go
+++ b/plugins/outputs/sensu/sensu.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package sensu
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,6 +22,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	defaultURL           = "http://127.0.0.1:3031"
@@ -115,6 +121,10 @@ func (s *Sensu) createClient() (*http.Client, error) {
 	}
 
 	return client, nil
+}
+
+func (*Sensu) SampleConfig() string {
+	return sampleConfig
 }
 
 func (s *Sensu) Connect() error {

--- a/plugins/outputs/sensu/sensu_sample_config.go
+++ b/plugins/outputs/sensu/sensu_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package sensu
-
-func (s *Sensu) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/signalfx/README.md
+++ b/plugins/outputs/signalfx/README.md
@@ -6,7 +6,7 @@ The SignalFx output plugin sends metrics to [SignalFx][docs].
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send metrics and events to SignalFx
 [[outputs.signalfx]]
   ## SignalFx Org Access Token

--- a/plugins/outputs/signalfx/signalfx.go
+++ b/plugins/outputs/signalfx/signalfx.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package signalfx
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"strings"
@@ -14,6 +16,10 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 //init initializes the plugin context
 func init() {
@@ -69,6 +75,10 @@ func NewSignalFx() *SignalFx {
 		cancel:             cancel,
 		client:             sfxclient.NewHTTPSink(),
 	}
+}
+
+func (*SignalFx) SampleConfig() string {
+	return sampleConfig
 }
 
 // Connect establishes a connection to SignalFx

--- a/plugins/outputs/signalfx/signalfx_sample_config.go
+++ b/plugins/outputs/signalfx/signalfx_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package signalfx
-
-func (s *SignalFx) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/socket_writer/README.md
+++ b/plugins/outputs/socket_writer/README.md
@@ -8,7 +8,7 @@ It can output data in any of the [supported output formats][formats].
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Generic socket writer capable of handling multiple socket types.
 [[outputs.socket_writer]]
   ## URL to connect to

--- a/plugins/outputs/socket_writer/socket_writer.go
+++ b/plugins/outputs/socket_writer/socket_writer.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package socket_writer
 
 import (
 	"crypto/tls"
+	_ "embed"
 	"fmt"
 	"net"
 	"strings"
@@ -15,6 +17,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
+
 type SocketWriter struct {
 	ContentEncoding string `toml:"content_encoding"`
 	Address         string
@@ -27,6 +33,10 @@ type SocketWriter struct {
 	encoder internal.ContentEncoder
 
 	net.Conn
+}
+
+func (*SocketWriter) SampleConfig() string {
+	return sampleConfig
 }
 
 func (sw *SocketWriter) SetSerializer(s serializers.Serializer) {

--- a/plugins/outputs/socket_writer/socket_writer_sample_config.go
+++ b/plugins/outputs/socket_writer/socket_writer_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package socket_writer
-
-func (sw *SocketWriter) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -60,7 +60,7 @@ convert settings.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Save metrics to an SQL Database
 [[outputs.sql]]
   ## Database driver

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"strings"
 
-	_ "github.com/ClickHouse/clickhouse-go"
-	_ "github.com/denisenkom/go-mssqldb"
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/jackc/pgx/v4/stdlib"
-	_ "github.com/snowflakedb/gosnowflake"
+	//Register sql drivers
+	_ "github.com/ClickHouse/clickhouse-go" // clickhouse
+	_ "github.com/denisenkom/go-mssqldb"    // mssql (sql server)
+	_ "github.com/go-sql-driver/mysql"      // mysql
+	_ "github.com/jackc/pgx/v4/stdlib"      // pgx (postgres)
+	_ "github.com/snowflakedb/gosnowflake"  // snowflake
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -1,20 +1,25 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package sql
 
 import (
 	gosql "database/sql"
+	_ "embed"
 	"fmt"
 	"strings"
 
-	//Register sql drivers
-	_ "github.com/ClickHouse/clickhouse-go" // clickhouse
-	_ "github.com/denisenkom/go-mssqldb"    // mssql (sql server)
-	_ "github.com/go-sql-driver/mysql"      // mysql
-	_ "github.com/jackc/pgx/v4/stdlib"      // pgx (postgres)
-	_ "github.com/snowflakedb/gosnowflake"  // snowflake
+	_ "github.com/ClickHouse/clickhouse-go"
+	_ "github.com/denisenkom/go-mssqldb"
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/jackc/pgx/v4/stdlib"
+	_ "github.com/snowflakedb/gosnowflake"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type ConvertStruct struct {
 	Integer         string
@@ -39,6 +44,10 @@ type SQL struct {
 	db     *gosql.DB
 	Log    telegraf.Logger `toml:"-"`
 	tables map[string]bool
+}
+
+func (*SQL) SampleConfig() string {
+	return sampleConfig
 }
 
 func (p *SQL) Connect() error {

--- a/plugins/outputs/sql/sql_sample_config.go
+++ b/plugins/outputs/sql/sql_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package sql
-
-func (p *SQL) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -20,7 +20,7 @@ the required `project_id` label is always set to the `project` variable.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for Google Cloud Stackdriver to send metrics to
 [[outputs.stackdriver]]
   ## GCP Project

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -1,14 +1,16 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package stackdriver
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"hash/fnv"
 	"path"
 	"sort"
 	"strings"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3/v2" // Imports the Stackdriver Monitoring client package.
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"google.golang.org/api/option"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
@@ -19,6 +21,10 @@ import (
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 // Stackdriver is the Google Stackdriver config info.
 type Stackdriver struct {
@@ -50,6 +56,10 @@ const (
 	errStringPointsTooOld      = "data points cannot be written more than 24h in the past"
 	errStringPointsTooFrequent = "one or more points were written more frequently than the maximum sampling period configured for the metric"
 )
+
+func (*Stackdriver) SampleConfig() string {
+	return sampleConfig
+}
 
 // Connect initiates the primary connection to the GCP project.
 func (s *Stackdriver) Connect() error {

--- a/plugins/outputs/stackdriver/stackdriver_sample_config.go
+++ b/plugins/outputs/stackdriver/stackdriver_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package stackdriver
-
-func (s *Stackdriver) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/sumologic/README.md
+++ b/plugins/outputs/sumologic/README.md
@@ -16,7 +16,7 @@ by Sumologic HTTP Source:
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # A plugin that can send metrics to Sumo Logic HTTP metric collector.
 [[outputs.sumologic]]
   ## Unique URL generated for your HTTP Metrics Source.

--- a/plugins/outputs/sumologic/sumologic.go
+++ b/plugins/outputs/sumologic/sumologic.go
@@ -1,8 +1,10 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package sumologic
 
 import (
 	"bytes"
 	"compress/gzip"
+	_ "embed"
 	"net/http"
 	"time"
 
@@ -17,6 +19,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 	"github.com/influxdata/telegraf/plugins/serializers/prometheus"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	defaultClientTimeout      = 5 * time.Second
@@ -55,6 +61,10 @@ type SumoLogic struct {
 
 	err     error
 	headers map[string]string
+}
+
+func (*SumoLogic) SampleConfig() string {
+	return sampleConfig
 }
 
 func (s *SumoLogic) SetSerializer(serializer serializers.Serializer) {

--- a/plugins/outputs/sumologic/sumologic_sample_config.go
+++ b/plugins/outputs/sumologic/sumologic_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package sumologic
-
-func (s *SumoLogic) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/syslog/README.md
+++ b/plugins/outputs/syslog/README.md
@@ -11,7 +11,7 @@ Syslog messages are formatted according to [RFC
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for Syslog server to send metrics to
 [[outputs.syslog]]
   ## URL to connect to

--- a/plugins/outputs/syslog/syslog.go
+++ b/plugins/outputs/syslog/syslog.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package syslog
 
 import (
 	"crypto/tls"
+	_ "embed"
 	"fmt"
 	"net"
 	"strconv"
@@ -18,6 +20,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
+
 type Syslog struct {
 	Address             string
 	KeepAlivePeriod     *config.Duration
@@ -33,6 +39,10 @@ type Syslog struct {
 	net.Conn
 	tlsint.ClientConfig
 	mapper *SyslogMapper
+}
+
+func (*Syslog) SampleConfig() string {
+	return sampleConfig
 }
 
 func (s *Syslog) Connect() error {

--- a/plugins/outputs/syslog/syslog_sample_config.go
+++ b/plugins/outputs/syslog/syslog_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package syslog
-
-func (s *Syslog) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -4,7 +4,7 @@ The Timestream output plugin writes metrics to the [Amazon Timestream] service.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for sending metrics to Amazon Timestream.
 [[outputs.timestream]]
   ## Amazon Region

--- a/plugins/outputs/timestream/timestream.go
+++ b/plugins/outputs/timestream/timestream.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package timestream
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"reflect"
@@ -18,6 +20,10 @@ import (
 	internalaws "github.com/influxdata/telegraf/config/aws"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 type (
 	Timestream struct {
@@ -68,6 +74,10 @@ var WriteFactory = func(credentialConfig *internalaws.CredentialConfig) (WriteCl
 		return &timestreamwrite.Client{}, err
 	}
 	return timestreamwrite.NewFromConfig(cfg), nil
+}
+
+func (*Timestream) SampleConfig() string {
+	return sampleConfig
 }
 
 func (t *Timestream) Connect() error {

--- a/plugins/outputs/timestream/timestream_sample_config.go
+++ b/plugins/outputs/timestream/timestream_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package timestream
-
-func (t *Timestream) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/warp10/README.md
+++ b/plugins/outputs/warp10/README.md
@@ -4,7 +4,7 @@ The `warp10` output plugin writes metrics to [Warp 10][].
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Write metrics to Warp 10
 [[outputs.warp10]]
   # Prefix to add to the measurement.

--- a/plugins/outputs/warp10/warp10.go
+++ b/plugins/outputs/warp10/warp10.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package warp10
 
 import (
 	"bytes"
+	_ "embed"
 	"fmt"
 	"io"
 	"math"
@@ -17,6 +19,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	defaultClientTimeout = 15 * time.Second
@@ -62,6 +68,10 @@ func (w *Warp10) createClient() (*http.Client, error) {
 	}
 
 	return client, nil
+}
+
+func (*Warp10) SampleConfig() string {
+	return sampleConfig
 }
 
 // Connect to warp10

--- a/plugins/outputs/warp10/warp10_sample_config.go
+++ b/plugins/outputs/warp10/warp10_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package warp10
-
-func (w *Warp10) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -5,7 +5,7 @@ Wavefront data format over TCP.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Configuration for Wavefront server to send metrics to
 [[outputs.wavefront]]
   ## Url for Wavefront Direct Ingestion. For Wavefront Proxy Ingestion, see

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -1,6 +1,8 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package wavefront
 
 import (
+	_ "embed"
 	"fmt"
 	"regexp"
 	"strings"
@@ -10,6 +12,10 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const maxTagLength = 254
 
@@ -64,6 +70,10 @@ type MetricPoint struct {
 	Timestamp int64
 	Source    string
 	Tags      map[string]string
+}
+
+func (*Wavefront) SampleConfig() string {
+	return sampleConfig
 }
 
 func (w *Wavefront) Connect() error {

--- a/plugins/outputs/wavefront/wavefront_sample_config.go
+++ b/plugins/outputs/wavefront/wavefront_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package wavefront
-
-func (w *Wavefront) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/websocket/README.md
+++ b/plugins/outputs/websocket/README.md
@@ -8,7 +8,7 @@ It can output data in any of the [supported output formats][formats].
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # A plugin that can transmit metrics over WebSocket.
 [[outputs.websocket]]
   ## URL is the address to send metrics to. Make sure ws or wss scheme is used.

--- a/plugins/outputs/websocket/websocket.go
+++ b/plugins/outputs/websocket/websocket.go
@@ -1,11 +1,15 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package websocket
 
 import (
+	_ "embed"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"time"
+
+	ws "github.com/gorilla/websocket"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
@@ -13,9 +17,11 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers"
-
-	ws "github.com/gorilla/websocket"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 const (
 	defaultConnectTimeout = 30 * time.Second
@@ -38,6 +44,10 @@ type WebSocket struct {
 
 	conn       *ws.Conn
 	serializer serializers.Serializer
+}
+
+func (*WebSocket) SampleConfig() string {
+	return sampleConfig
 }
 
 // SetSerializer implements serializers.SerializerOutput.

--- a/plugins/outputs/websocket/websocket_sample_config.go
+++ b/plugins/outputs/websocket/websocket_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package websocket
-
-func (w *WebSocket) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}

--- a/plugins/outputs/yandex_cloud_monitoring/README.md
+++ b/plugins/outputs/yandex_cloud_monitoring/README.md
@@ -5,7 +5,7 @@ Monitoring](https://cloud.yandex.com/services/monitoring).
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Send aggregated metrics to Yandex.Cloud Monitoring
 [[outputs.yandex_cloud_monitoring]]
   ## Timeout for HTTP writes.

--- a/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring.go
+++ b/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring.go
@@ -1,7 +1,9 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package yandex_cloud_monitoring
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,6 +15,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/selfstat"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embedd the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 // YandexCloudMonitoring allows publishing of metrics to the Yandex Cloud Monitoring custom metrics
 // service
@@ -62,6 +68,10 @@ const (
 	defaultMetadataTokenURL  = "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token"
 	defaultMetadataFolderURL = "http://169.254.169.254/computeMetadata/v1/yandex/folder-id"
 )
+
+func (*YandexCloudMonitoring) SampleConfig() string {
+	return sampleConfig
+}
 
 // Connect initializes the plugin and validates connectivity
 func (a *YandexCloudMonitoring) Connect() error {

--- a/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring_sample_config.go
+++ b/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring_sample_config.go
@@ -1,8 +1,0 @@
-//go:generate go run ../../../tools/generate_plugindata/main.go
-//go:generate go run ../../../tools/generate_plugindata/main.go --clean
-// DON'T EDIT; This file is used as a template by tools/generate_plugindata
-package yandex_cloud_monitoring
-
-func (a *YandexCloudMonitoring) SampleConfig() string {
-	return `{{ .SampleConfig }}`
-}


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 
This PR uses the newly created sample.conf files as a single source of truth for output plugins. To do so, the sample.conf is embedded into the plugin package at build time using [Golang's embed package](https://pkg.go.dev/embed). Furthermore, the sample.conf file is inserted into the REAME.md markdown file by using a custom @<file to input> pattern then used by the new readme_config_includer/generator tool to do the heavy lifting.
This new approach will remove the current stateful build (for outputs) and improves build times.

For validating the approach, the generated telegraf sample-configuration was compared before and after the PR and is binary equal. Furthermore, the current README.md files can be reproduced. You can test this by removing the content of a toml @sample.conf section in a README.md and run make.