### PR TITLE
feat: Add constant 'algorithm' to the mock plugin

### DIFF
--- a/plugins/inputs/mock/README.md
+++ b/plugins/inputs/mock/README.md
@@ -29,7 +29,7 @@ Below is a sample config to generate one of each of the four types:
   ## One or more mock data fields *must* be defined.
   ##
   ## [[inputs.mock.constant]]
-  ##   name = "rand"
+  ##   name = "constant"
   ##   value = value_of_any_type
   ## [[inputs.mock.random]]
   ##   name = "rand"

--- a/plugins/inputs/mock/README.md
+++ b/plugins/inputs/mock/README.md
@@ -28,6 +28,9 @@ Below is a sample config to generate one of each of the four types:
 
   ## One or more mock data fields *must* be defined.
   ##
+  ## [[inputs.mock.constant]]
+  ##   name = "rand"
+  ##   value = value_of_any_type
   ## [[inputs.mock.random]]
   ##   name = "rand"
   ##   min = 1.0
@@ -50,6 +53,7 @@ Below is a sample config to generate one of each of the four types:
 
 The available algorithms for generating mock data include:
 
+* Constant - generate a field with the given value of type string, float, int or bool
 * Random Float - generate a random float, inclusive of min and max
 * Sine Wave - produce a sine wave with a certain amplitude and period
 * Step - always add the step value, negative values accepted

--- a/plugins/inputs/mock/mock.go
+++ b/plugins/inputs/mock/mock.go
@@ -21,10 +21,16 @@ type Mock struct {
 	MetricName string            `toml:"metric_name"`
 	Tags       map[string]string `toml:"tags"`
 
+	Constant []*constant `toml:"constant"`
 	Random   []*random   `toml:"random"`
 	Step     []*step     `toml:"step"`
 	Stock    []*stock    `toml:"stock"`
 	SineWave []*sineWave `toml:"sine_wave"`
+}
+
+type constant struct {
+	Name  string      `toml:"name"`
+	Value interface{} `toml:"value"`
 }
 
 type random struct {
@@ -70,6 +76,10 @@ func (m *Mock) Gather(acc telegraf.Accumulator) error {
 	m.generateStockPrice(fields)
 	m.generateSineWave(fields)
 	m.generateStep(fields)
+
+	for _, c := range m.Constant {
+		fields[c.Name] = c.Value
+	}
 
 	tags := make(map[string]string)
 	for key, value := range m.Tags {

--- a/plugins/inputs/mock/mock_test.go
+++ b/plugins/inputs/mock/mock_test.go
@@ -8,6 +8,22 @@ import (
 )
 
 func TestGather(t *testing.T) {
+	testConstantString := &constant{
+		Name:  "constant_string",
+		Value: "a string",
+	}
+	testConstantFloat := &constant{
+		Name:  "constant_float",
+		Value: 3.1415,
+	}
+	testConstantInt := &constant{
+		Name:  "constant_int",
+		Value: 42,
+	}
+	testConstantBool := &constant{
+		Name:  "constant_bool",
+		Value: true,
+	}
 	testRandom := &random{
 		Name: "random",
 		Min:  1.0,
@@ -38,6 +54,7 @@ func TestGather(t *testing.T) {
 		MetricName: "test",
 		Tags:       tags,
 
+		Constant: []*constant{testConstantString, testConstantFloat, testConstantInt, testConstantBool},
 		Random:   []*random{testRandom},
 		SineWave: []*sineWave{testSineWave},
 		Step:     []*step{testStep},
@@ -56,6 +73,14 @@ func TestGather(t *testing.T) {
 		switch k {
 		case "abc":
 			require.Equal(t, 50.0, v)
+		case "constant_string":
+			require.Equal(t, testConstantString.Value, v)
+		case "constant_float":
+			require.Equal(t, testConstantFloat.Value, v)
+		case "constant_int":
+			require.Equal(t, testConstantInt.Value, v)
+		case "constant_bool":
+			require.Equal(t, testConstantBool.Value, v)
 		case "random":
 			require.GreaterOrEqual(t, 6.0, v)
 			require.LessOrEqual(t, 1.0, v)

--- a/plugins/inputs/mock/sample.conf
+++ b/plugins/inputs/mock/sample.conf
@@ -9,6 +9,9 @@
 
   ## One or more mock data fields *must* be defined.
   ##
+  ## [[inputs.mock.constant]]
+  ##   name = "rand"
+  ##   value = value_of_any_type
   ## [[inputs.mock.random]]
   ##   name = "rand"
   ##   min = 1.0

--- a/plugins/inputs/mock/sample.conf
+++ b/plugins/inputs/mock/sample.conf
@@ -10,7 +10,7 @@
   ## One or more mock data fields *must* be defined.
   ##
   ## [[inputs.mock.constant]]
-  ##   name = "rand"
+  ##   name = "constant"
   ##   value = value_of_any_type
   ## [[inputs.mock.random]]
   ##   name = "rand"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR adds the possibility to define a field with a constant value (string, float, int, bool) in the `mock` input plugin. This is helpful when testing e.g. processors against known good/known bad values.