### PR TITLE
fix: Bump golangci-lint from 1.45.2 to 1.46.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.46.2
           only-new-issues: true
   golangci-master:
     if: github.ref == 'refs/heads/master'
@@ -31,6 +31,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.46.2
           only-new-issues: true
           args: --issues-exit-code=0

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli


### PR DESCRIPTION
Bump the golangci linter to a new version to re-enable more checks on go 1.18.