### PR TITLE
fix(inputs/snmp): switch new Reconnect method to be a value receiver

### DIFF
--- a/internal/snmp/wrapper.go
+++ b/internal/snmp/wrapper.go
@@ -168,7 +168,7 @@ func (gs *GosnmpWrapper) SetAgent(agent string) error {
 	return nil
 }
 
-func (gs *GosnmpWrapper) Reconnect() error {
+func (gs GosnmpWrapper) Reconnect() error {
 	if gs.Conn == nil {
 		return gs.Connect()
 	}

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -590,13 +590,13 @@ func (s *Snmp) getConnection(idx int) (snmpConnection, error) {
 		return nil, err
 	}
 
-	s.connectionCache[idx] = &gs
+	s.connectionCache[idx] = gs
 
 	if err := gs.Connect(); err != nil {
 		return nil, fmt.Errorf("setting up connection: %w", err)
 	}
 
-	return &gs, nil
+	return gs, nil
 }
 
 // fieldConvert converts from any type according to the conv specification

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -264,7 +264,7 @@ func TestGetSNMPConnection_v2(t *testing.T) {
 
 	gsc, err := s.getConnection(0)
 	require.NoError(t, err)
-	gs := gsc.(*snmp.GosnmpWrapper)
+	gs := gsc.(snmp.GosnmpWrapper)
 	assert.Equal(t, "1.2.3.4", gs.Target)
 	assert.EqualValues(t, 567, gs.Port)
 	assert.Equal(t, gosnmp.Version2c, gs.Version)
@@ -273,14 +273,14 @@ func TestGetSNMPConnection_v2(t *testing.T) {
 
 	gsc, err = s.getConnection(1)
 	require.NoError(t, err)
-	gs = gsc.(*snmp.GosnmpWrapper)
+	gs = gsc.(snmp.GosnmpWrapper)
 	assert.Equal(t, "1.2.3.4", gs.Target)
 	assert.EqualValues(t, 161, gs.Port)
 	assert.Equal(t, "udp", gs.Transport)
 
 	gsc, err = s.getConnection(2)
 	require.NoError(t, err)
-	gs = gsc.(*snmp.GosnmpWrapper)
+	gs = gsc.(snmp.GosnmpWrapper)
 	assert.Equal(t, "127.0.0.1", gs.Target)
 	assert.EqualValues(t, 161, gs.Port)
 	assert.Equal(t, "udp", gs.Transport)
@@ -304,7 +304,7 @@ func TestGetSNMPConnectionTCP(t *testing.T) {
 	wg.Add(1)
 	gsc, err := s.getConnection(0)
 	require.NoError(t, err)
-	gs := gsc.(*snmp.GosnmpWrapper)
+	gs := gsc.(snmp.GosnmpWrapper)
 	assert.Equal(t, "127.0.0.1", gs.Target)
 	assert.EqualValues(t, 56789, gs.Port)
 	assert.Equal(t, "tcp", gs.Transport)
@@ -351,7 +351,7 @@ func TestGetSNMPConnection_v3(t *testing.T) {
 
 	gsc, err := s.getConnection(0)
 	require.NoError(t, err)
-	gs := gsc.(*snmp.GosnmpWrapper)
+	gs := gsc.(snmp.GosnmpWrapper)
 	assert.Equal(t, gs.Version, gosnmp.Version3)
 	sp := gs.SecurityParameters.(*gosnmp.UsmSecurityParameters)
 	assert.Equal(t, "1.2.3.4", gsc.Host())
@@ -472,7 +472,7 @@ func TestGetSNMPConnection_v3_blumenthal(t *testing.T) {
 
 			gsc, err := s.getConnection(0)
 			require.NoError(t, err)
-			gs := gsc.(*snmp.GosnmpWrapper)
+			gs := gsc.(snmp.GosnmpWrapper)
 			assert.Equal(t, gs.Version, gosnmp.Version3)
 			sp := gs.SecurityParameters.(*gosnmp.UsmSecurityParameters)
 			assert.Equal(t, "1.2.3.4", gsc.Host())

--- a/plugins/processors/ifname/ifname.go
+++ b/plugins/processors/ifname/ifname.go
@@ -258,11 +258,11 @@ func (d *IfName) getMapRemoteNoMock(agent string) (nameMap, error) {
 	//try ifXtable and ifName first.  if that fails, fall back to
 	//ifTable and ifDescr
 	var m nameMap
-	if m, err = d.buildMap(&gs, d.ifXTable); err == nil {
+	if m, err = d.buildMap(gs, d.ifXTable); err == nil {
 		return m, nil
 	}
 
-	if m, err = d.buildMap(&gs, d.ifTable); err == nil {
+	if m, err = d.buildMap(gs, d.ifTable); err == nil {
 		return m, nil
 	}
 
@@ -308,7 +308,7 @@ func (d *IfName) makeTableNoMock(oid string) (*si.Table, error) {
 	return &tab, nil
 }
 
-func (d *IfName) buildMap(gs *snmp.GosnmpWrapper, tab *si.Table) (nameMap, error) {
+func (d *IfName) buildMap(gs snmp.GosnmpWrapper, tab *si.Table) (nameMap, error) {
 	var err error
 
 	rtab, err := tab.Build(gs, true, d.translator)

--- a/plugins/processors/ifname/ifname_test.go
+++ b/plugins/processors/ifname/ifname_test.go
@@ -36,7 +36,7 @@ func TestTable(t *testing.T) {
 	require.NoError(t, err)
 
 	// Could use ifIndex but oid index is always the same
-	m, err := d.buildMap(&gs, tab)
+	m, err := d.buildMap(gs, tab)
 	require.NoError(t, err)
 	require.NotEmpty(t, m)
 }


### PR DESCRIPTION
#11163 added TCP reconnection but also made some unneccesary changes. It changed the connection cache and many places in tests to expect a pointer to Gosnmpwrapper instead of a Gosnmpwrapper value.

The other Gosnmpwrapper methods that implement the snmpConnection interface use value receivers. This PR switches Reconnect to use a value receiver and undoes the changes to connection cache and tests.