### PR TITLE
test: refactor testcontainer port lookup

### DIFF
--- a/plugins/inputs/aerospike/aerospike_test.go
+++ b/plugins/inputs/aerospike/aerospike_test.go
@@ -12,10 +12,12 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
+const servicePort = "3000"
+
 func launchTestServer(t *testing.T) testutil.Container {
 	container := testutil.Container{
 		Image:        "aerospike:ce-6.0.0.1",
-		ExposedPorts: []string{"3000"},
+		ExposedPorts: []string{servicePort},
 		WaitingFor:   wait.ForLog("migrations: complete"),
 	}
 	err := container.Start()
@@ -35,7 +37,7 @@ func TestAerospikeStatisticsIntegration(t *testing.T) {
 	}()
 
 	a := &Aerospike{
-		Servers: []string{fmt.Sprintf("%s:%s", container.Address, container.Port)},
+		Servers: []string{fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort])},
 	}
 
 	var acc testutil.Accumulator
@@ -65,7 +67,7 @@ func TestAerospikeStatisticsPartialErrIntegration(t *testing.T) {
 
 	a := &Aerospike{
 		Servers: []string{
-			fmt.Sprintf("%s:%s", container.Address, container.Port),
+			fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort]),
 			testutil.GetLocalHost() + ":9999",
 		},
 	}
@@ -94,7 +96,7 @@ func TestSelectNamespacesIntegration(t *testing.T) {
 
 	// Select nonexistent namespace
 	a := &Aerospike{
-		Servers:    []string{fmt.Sprintf("%s:%s", container.Address, container.Port)},
+		Servers:    []string{fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort])},
 		Namespaces: []string{"notTest"},
 	}
 
@@ -133,7 +135,7 @@ func TestDisableQueryNamespacesIntegration(t *testing.T) {
 
 	a := &Aerospike{
 		Servers: []string{
-			fmt.Sprintf("%s:%s", container.Address, container.Port),
+			fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort]),
 		},
 		DisableQueryNamespaces: true,
 	}
@@ -163,7 +165,7 @@ func TestQuerySetsIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	portInt, err := strconv.Atoi(container.Port)
+	portInt, err := strconv.Atoi(container.Ports[servicePort])
 	require.NoError(t, err)
 
 	// create a set
@@ -192,7 +194,7 @@ func TestQuerySetsIntegration(t *testing.T) {
 
 	a := &Aerospike{
 		Servers: []string{
-			fmt.Sprintf("%s:%s", container.Address, container.Port),
+			fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort]),
 		},
 		QuerySets:              true,
 		DisableQueryNamespaces: true,
@@ -220,7 +222,7 @@ func TestSelectQuerySetsIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	portInt, err := strconv.Atoi(container.Port)
+	portInt, err := strconv.Atoi(container.Ports[servicePort])
 	require.NoError(t, err)
 
 	// create a set
@@ -249,7 +251,7 @@ func TestSelectQuerySetsIntegration(t *testing.T) {
 
 	a := &Aerospike{
 		Servers: []string{
-			fmt.Sprintf("%s:%s", container.Address, container.Port),
+			fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort]),
 		},
 		QuerySets:              true,
 		Sets:                   []string{"test/foo"},
@@ -280,7 +282,7 @@ func TestDisableTTLHistogramIntegration(t *testing.T) {
 
 	a := &Aerospike{
 		Servers: []string{
-			fmt.Sprintf("%s:%s", container.Address, container.Port),
+			fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort]),
 		},
 		QuerySets:          true,
 		EnableTTLHistogram: false,
@@ -307,7 +309,7 @@ func TestDisableObjectSizeLinearHistogramIntegration(t *testing.T) {
 
 	a := &Aerospike{
 		Servers: []string{
-			fmt.Sprintf("%s:%s", container.Address, container.Port),
+			fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort]),
 		},
 		QuerySets:                       true,
 		EnableObjectSizeLinearHistogram: false,

--- a/plugins/inputs/memcached/memcached_test.go
+++ b/plugins/inputs/memcached/memcached_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -17,10 +18,11 @@ func TestMemcachedGeneratesMetricsIntegration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	servicePort := "11211"
 	container := testutil.Container{
 		Image:        "memcached",
-		ExposedPorts: []string{"11211"},
-		WaitingFor:   wait.ForListeningPort("11211/tcp"),
+		ExposedPorts: []string{servicePort},
+		WaitingFor:   wait.ForListeningPort(nat.Port(servicePort)),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -29,7 +31,7 @@ func TestMemcachedGeneratesMetricsIntegration(t *testing.T) {
 	}()
 
 	m := &Memcached{
-		Servers: []string{fmt.Sprintf("%s:%s", container.Address, container.Port)},
+		Servers: []string{fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort])},
 	}
 
 	var acc testutil.Accumulator

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -22,6 +23,8 @@ type OPCTags struct {
 	Want           interface{}
 }
 
+const servicePort = "4840"
+
 func TestGetDataBadNodeContainerIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -29,8 +32,8 @@ func TestGetDataBadNodeContainerIntegration(t *testing.T) {
 
 	container := testutil.Container{
 		Image:        "open62541/open62541",
-		ExposedPorts: []string{"4840"},
-		WaitingFor:   wait.ForListeningPort("4840/tcp"),
+		ExposedPorts: []string{servicePort},
+		WaitingFor:   wait.ForListeningPort(nat.Port(servicePort)),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -46,7 +49,7 @@ func TestGetDataBadNodeContainerIntegration(t *testing.T) {
 
 	var o OpcUA
 	o.MetricName = "testing"
-	o.Endpoint = fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Port)
+	o.Endpoint = fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort])
 	fmt.Println(o.Endpoint)
 	o.AuthMethod = "Anonymous"
 	o.ConnectTimeout = config.Duration(10 * time.Second)
@@ -82,8 +85,8 @@ func TestClient1Integration(t *testing.T) {
 
 	container := testutil.Container{
 		Image:        "open62541/open62541",
-		ExposedPorts: []string{"4840"},
-		WaitingFor:   wait.ForListeningPort("4840/tcp"),
+		ExposedPorts: []string{servicePort},
+		WaitingFor:   wait.ForListeningPort(nat.Port(servicePort)),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -101,7 +104,7 @@ func TestClient1Integration(t *testing.T) {
 
 	var o OpcUA
 	o.MetricName = "testing"
-	o.Endpoint = fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Port)
+	o.Endpoint = fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort])
 	o.AuthMethod = "Anonymous"
 	o.ConnectTimeout = config.Duration(10 * time.Second)
 	o.RequestTimeout = config.Duration(1 * time.Second)

--- a/plugins/inputs/openldap/openldap_test.go
+++ b/plugins/inputs/openldap/openldap_test.go
@@ -5,11 +5,17 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/go-ldap/ldap/v3"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/influxdata/telegraf/testutil"
+)
+
+const (
+	servicePort       = "1389"
+	servicePortSecure = "1636"
 )
 
 func TestOpenldapMockResult(t *testing.T) {
@@ -59,12 +65,15 @@ func TestOpenldapGeneratesMetricsIntegration(t *testing.T) {
 
 	container := testutil.Container{
 		Image:        "bitnami/openldap",
-		ExposedPorts: []string{"1389"},
+		ExposedPorts: []string{servicePort},
 		Env: map[string]string{
 			"LDAP_ADMIN_USERNAME": "manager",
 			"LDAP_ADMIN_PASSWORD": "secret",
 		},
-		WaitingFor: wait.ForLog("Starting slapd"),
+		WaitingFor: wait.ForAll(
+			wait.ForLog("Starting slapd"),
+			wait.ForListeningPort(nat.Port(servicePort)),
+		),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -72,7 +81,7 @@ func TestOpenldapGeneratesMetricsIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	port, err := strconv.Atoi(container.Port)
+	port, err := strconv.Atoi(container.Ports[servicePort])
 	require.NoError(t, err)
 
 	o := &Openldap{
@@ -104,7 +113,7 @@ func TestOpenldapStartTLSIntegration(t *testing.T) {
 
 	container := testutil.Container{
 		Image:        "bitnami/openldap",
-		ExposedPorts: []string{"1389", "1636"},
+		ExposedPorts: []string{servicePort},
 		Env: map[string]string{
 			"LDAP_ADMIN_USERNAME": "manager",
 			"LDAP_ADMIN_PASSWORD": "secret",
@@ -118,7 +127,10 @@ func TestOpenldapStartTLSIntegration(t *testing.T) {
 			"/server.crt": tlsCert,
 			"/server.key": tlsKey,
 		},
-		WaitingFor: wait.ForListeningPort("1389/tcp"),
+		WaitingFor: wait.ForAll(
+			wait.ForLog("Starting slapd"),
+			wait.ForListeningPort(nat.Port(servicePort)),
+		),
 	}
 	err = container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -126,7 +138,7 @@ func TestOpenldapStartTLSIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	port, err := strconv.Atoi(container.Port)
+	port, err := strconv.Atoi(container.Ports[servicePort])
 	require.NoError(t, err)
 
 	cert, err := filepath.Abs(pki.ClientCertPath())
@@ -164,7 +176,7 @@ func TestOpenldapLDAPSIntegration(t *testing.T) {
 
 	container := testutil.Container{
 		Image:        "bitnami/openldap",
-		ExposedPorts: []string{"1636"},
+		ExposedPorts: []string{servicePortSecure},
 		Env: map[string]string{
 			"LDAP_ADMIN_USERNAME": "manager",
 			"LDAP_ADMIN_PASSWORD": "secret",
@@ -178,7 +190,10 @@ func TestOpenldapLDAPSIntegration(t *testing.T) {
 			"/server.crt": tlsCert,
 			"/server.key": tlsKey,
 		},
-		WaitingFor: wait.ForListeningPort("1636/tcp"),
+		WaitingFor: wait.ForAll(
+			wait.ForLog("Starting slapd"),
+			wait.ForListeningPort(nat.Port(servicePortSecure)),
+		),
 	}
 	err = container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -186,7 +201,7 @@ func TestOpenldapLDAPSIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	port, err := strconv.Atoi(container.Port)
+	port, err := strconv.Atoi(container.Ports[servicePortSecure])
 	require.NoError(t, err)
 
 	o := &Openldap{
@@ -219,7 +234,7 @@ func TestOpenldapInvalidSSLIntegration(t *testing.T) {
 
 	container := testutil.Container{
 		Image:        "bitnami/openldap",
-		ExposedPorts: []string{"1636"},
+		ExposedPorts: []string{servicePortSecure},
 		Env: map[string]string{
 			"LDAP_ADMIN_USERNAME": "manager",
 			"LDAP_ADMIN_PASSWORD": "secret",
@@ -233,7 +248,10 @@ func TestOpenldapInvalidSSLIntegration(t *testing.T) {
 			"/server.crt": tlsCert,
 			"/server.key": tlsKey,
 		},
-		WaitingFor: wait.ForListeningPort("1636/tcp"),
+		WaitingFor: wait.ForAll(
+			wait.ForLog("Starting slapd"),
+			wait.ForListeningPort(nat.Port(servicePortSecure)),
+		),
 	}
 	err = container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -241,7 +259,7 @@ func TestOpenldapInvalidSSLIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	port, err := strconv.Atoi(container.Port)
+	port, err := strconv.Atoi(container.Ports[servicePortSecure])
 	require.NoError(t, err)
 
 	o := &Openldap{
@@ -265,12 +283,15 @@ func TestOpenldapBindIntegration(t *testing.T) {
 
 	container := testutil.Container{
 		Image:        "bitnami/openldap",
-		ExposedPorts: []string{"1389"},
+		ExposedPorts: []string{servicePort},
 		Env: map[string]string{
 			"LDAP_ADMIN_USERNAME": "manager",
 			"LDAP_ADMIN_PASSWORD": "secret",
 		},
-		WaitingFor: wait.ForListeningPort("1389/tcp"),
+		WaitingFor: wait.ForAll(
+			wait.ForLog("Starting slapd"),
+			wait.ForListeningPort(nat.Port(servicePort)),
+		),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -278,7 +299,7 @@ func TestOpenldapBindIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	port, err := strconv.Atoi(container.Port)
+	port, err := strconv.Atoi(container.Ports[servicePort])
 	require.NoError(t, err)
 
 	o := &Openldap{
@@ -314,12 +335,15 @@ func TestOpenldapReverseMetricsIntegration(t *testing.T) {
 
 	container := testutil.Container{
 		Image:        "bitnami/openldap",
-		ExposedPorts: []string{"1389"},
+		ExposedPorts: []string{servicePort},
 		Env: map[string]string{
 			"LDAP_ADMIN_USERNAME": "manager",
 			"LDAP_ADMIN_PASSWORD": "secret",
 		},
-		WaitingFor: wait.ForListeningPort("1389/tcp"),
+		WaitingFor: wait.ForAll(
+			wait.ForLog("Starting slapd"),
+			wait.ForListeningPort(nat.Port(servicePort)),
+		),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -327,7 +351,7 @@ func TestOpenldapReverseMetricsIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	port, err := strconv.Atoi(container.Port)
+	port, err := strconv.Atoi(container.Ports[servicePort])
 	require.NoError(t, err)
 
 	o := &Openldap{

--- a/plugins/inputs/redis/redis_test.go
+++ b/plugins/inputs/redis/redis_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -38,10 +39,11 @@ func TestRedisConnectIntegration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	servicePort := "6379"
 	container := testutil.Container{
 		Image:        "redis:alpine",
-		ExposedPorts: []string{"6379"},
-		WaitingFor:   wait.ForListeningPort("6379/tcp"),
+		ExposedPorts: []string{servicePort},
+		WaitingFor:   wait.ForListeningPort(nat.Port(servicePort)),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -49,7 +51,7 @@ func TestRedisConnectIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	addr := fmt.Sprintf("%s:%s", container.Address, container.Port)
+	addr := fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort])
 
 	r := &Redis{
 		Log:     testutil.Logger{},

--- a/plugins/inputs/redis_sentinel/redis_sentinel_test.go
+++ b/plugins/inputs/redis_sentinel/redis_sentinel_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -22,10 +23,11 @@ func TestRedisSentinelConnect(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	servicePort := "6379"
 	container := testutil.Container{
 		Image:        "redis:alpine",
-		ExposedPorts: []string{"6379"},
-		WaitingFor:   wait.ForListeningPort("6379/tcp"),
+		ExposedPorts: []string{servicePort},
+		WaitingFor:   wait.ForListeningPort(nat.Port(servicePort)),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -33,7 +35,7 @@ func TestRedisSentinelConnect(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	addr := fmt.Sprintf("tcp://%s:%s", container.Address, container.Port)
+	addr := fmt.Sprintf("tcp://%s:%s", container.Address, container.Ports[servicePort])
 
 	r := &RedisSentinel{
 		Servers: []string{addr},

--- a/plugins/inputs/zookeeper/zookeeper_test.go
+++ b/plugins/inputs/zookeeper/zookeeper_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -15,13 +16,14 @@ func TestZookeeperGeneratesMetricsIntegration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	servicePort := "2181"
 	container := testutil.Container{
 		Image:        "zookeeper",
-		ExposedPorts: []string{"2181"},
+		ExposedPorts: []string{servicePort},
 		Env: map[string]string{
 			"ZOO_4LW_COMMANDS_WHITELIST": "mntr",
 		},
-		WaitingFor: wait.ForListeningPort("2181"),
+		WaitingFor: wait.ForListeningPort(nat.Port(servicePort)),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -31,7 +33,7 @@ func TestZookeeperGeneratesMetricsIntegration(t *testing.T) {
 
 	z := &Zookeeper{
 		Servers: []string{
-			fmt.Sprintf("%s:%s", container.Address, container.Port),
+			fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort]),
 		},
 	}
 

--- a/plugins/outputs/cratedb/cratedb_test.go
+++ b/plugins/outputs/cratedb/cratedb_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/metric"
@@ -15,15 +16,20 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+const servicePort = "5432"
+
 func createTestContainer(t *testing.T) testutil.Container {
 	container := testutil.Container{
 		Image:        "crate",
-		ExposedPorts: []string{"5432"},
+		ExposedPorts: []string{servicePort},
 		Entrypoint: []string{
 			"/docker-entrypoint.sh",
 			"-Cdiscovery.type=single-node",
 		},
-		WaitingFor: wait.ForListeningPort("5432/tcp"),
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(nat.Port(servicePort)),
+			wait.ForLog("recovered [0] indices into cluster_state"),
+		),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -40,8 +46,9 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 	defer func() {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
-	url := fmt.Sprintf("postgres://crate@%s:%s/test", container.Address, container.Port)
+	url := fmt.Sprintf("postgres://crate@%s:%s/test", container.Address, container.Ports[servicePort])
 
+	fmt.Println(url)
 	table := "testing"
 	db, err := sql.Open("pgx", url)
 	require.NoError(t, err)
@@ -151,7 +158,7 @@ func Test_escapeValueIntegration(t *testing.T) {
 	defer func() {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
-	url := fmt.Sprintf("postgres://crate@%s:%s/test", container.Address, container.Port)
+	url := fmt.Sprintf("postgres://crate@%s:%s/test", container.Address, container.Ports[servicePort])
 
 	db, err := sql.Open("pgx", url)
 	require.NoError(t, err)

--- a/plugins/outputs/nats/nats_test.go
+++ b/plugins/outputs/nats/nats_test.go
@@ -15,9 +15,10 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	servicePort := "4222"
 	container := testutil.Container{
 		Image:        "nats",
-		ExposedPorts: []string{"4222"},
+		ExposedPorts: []string{servicePort},
 		WaitingFor:   wait.ForLog("Server is ready"),
 	}
 	err := container.Start()
@@ -26,7 +27,7 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 		require.NoError(t, container.Terminate(), "terminating container failed")
 	}()
 
-	server := []string{fmt.Sprintf("nats://%s:%s", container.Address, container.Port)}
+	server := []string{fmt.Sprintf("nats://%s:%s", container.Address, container.Ports[servicePort])}
 	s, _ := serializers.NewInfluxSerializer()
 	n := &NATS{
 		Servers:    server,

--- a/testutil/container.go
+++ b/testutil/container.go
@@ -6,22 +6,34 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/docker/go-connections/nat"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+type LogConsumer struct {
+	Msgs []string
+}
+
+func (g *LogConsumer) Accept(l testcontainers.Log) {
+	g.Msgs = append(g.Msgs, string(l.Content))
+}
+
 type Container struct {
-	Image        string
+	BindMounts   map[string]string
 	Entrypoint   []string
 	Env          map[string]string
 	ExposedPorts []string
-	BindMounts   map[string]string
+	Image        string
+	Name         string
+	Networks     []string
 	WaitingFor   wait.Strategy
 
 	Address string
-	Port    string
+	Ports   map[string]string
+	Logs    LogConsumer
 
 	container testcontainers.Container
 	ctx       context.Context
@@ -32,11 +44,13 @@ func (c *Container) Start() error {
 
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        c.Image,
-			Env:          c.Env,
-			ExposedPorts: c.ExposedPorts,
 			BindMounts:   c.BindMounts,
 			Entrypoint:   c.Entrypoint,
+			Env:          c.Env,
+			ExposedPorts: c.ExposedPorts,
+			Image:        c.Image,
+			Name:         c.Name,
+			Networks:     c.Networks,
 			WaitingFor:   c.WaitingFor,
 		},
 		Started: true,
@@ -48,26 +62,78 @@ func (c *Container) Start() error {
 	}
 	c.container = container
 
+	err = c.container.StartLogProducer(c.ctx)
+	if err != nil {
+		_ = c.Terminate()
+		return fmt.Errorf("log producer failed to start: %s", err)
+	}
+	c.Logs = LogConsumer{}
+	c.container.FollowOutput(&c.Logs)
+
 	c.Address, err = c.container.Host(c.ctx)
 	if err != nil {
-		return fmt.Errorf("container host address failed: %s", err)
+		_ = c.Terminate()
+		return fmt.Errorf("address lookup failed: %s", err)
 	}
 
-	// assume the first port is the one the test will connect to
-	// additional ports can be used for the waiting for section
-	if len(c.ExposedPorts) > 0 {
-		p, err := c.container.MappedPort(c.ctx, nat.Port(c.ExposedPorts[0]))
-		if err != nil {
-			return fmt.Errorf("container host port failed: %s", err)
-		}
-		c.Port = p.Port()
+	err = c.LookupMappedPorts()
+	if err != nil {
+		_ = c.Terminate()
+		return fmt.Errorf("port lookup failed: %s", err)
 	}
 
 	return nil
 }
 
+// create a lookup table of exposed ports to mapped ports
+func (c *Container) LookupMappedPorts() error {
+	if len(c.ExposedPorts) == 0 {
+		return nil
+	}
+
+	if len(c.Ports) == 0 {
+		c.Ports = make(map[string]string)
+	}
+
+	for _, port := range c.ExposedPorts {
+		// strip off leading host port: 80:8080 -> 8080
+		if strings.Contains(port, ":") {
+			port = strings.Split(port, ":")[1]
+		}
+
+		// strip off the transport: 80/tcp -> 80
+		if strings.Contains(port, "/") {
+			port = strings.Split(port, "/")[0]
+		}
+
+		p, err := c.container.MappedPort(c.ctx, nat.Port(port))
+		if err != nil {
+			return fmt.Errorf("failed to find '%s' - %s", port, err)
+		}
+		fmt.Printf("mapped container port '%s' to host port '%s'\n", port, p.Port())
+		c.Ports[port] = p.Port()
+	}
+
+	return nil
+}
+
+func (c *Container) PrintLogs() {
+	fmt.Println("--- container logs start ---")
+	for _, line := range c.Logs.Msgs {
+		fmt.Print(line)
+	}
+	fmt.Println("--- container logs end ---")
+}
+
 func (c *Container) Terminate() error {
-	err := c.container.Terminate(c.ctx)
+	err := c.container.StopLogProducer()
+	if err != nil {
+		fmt.Printf("failed to stop log producer: %s\n", err)
+	}
+
+	c.PrintLogs()
+
+	err = c.container.Terminate(c.ctx)
 	if err != nil {
 		return fmt.Errorf("failed to terminate the container: %s", err)
 	}

--- a/testutil/container_test.go
+++ b/testutil/container_test.go
@@ -23,6 +23,10 @@ func TestEmptyContainer(t *testing.T) {
 }
 
 func TestMappedPortLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	cases := []struct {
 		name     string
 		port     string

--- a/testutil/container_test.go
+++ b/testutil/container_test.go
@@ -22,6 +22,39 @@ func TestEmptyContainer(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestMappedPortLookup(t *testing.T) {
+	cases := []struct {
+		name     string
+		port     string
+		expected string
+	}{
+		{"random", "80", "80"},
+		{"only 80", "80:80", "80"},
+		{"only 80", "80:80/tcp", "80"},
+		{"only 8080", "8080:80", "8080"},
+		{"only 8080", "8080:80/tcp", "8080"},
+	}
+
+	for _, tc := range cases {
+		container := Container{
+			Image:        "nginx:stable-alpine",
+			ExposedPorts: []string{tc.port},
+		}
+
+		err := container.Start()
+		require.NoError(t, err)
+
+		if tc.name == "random" {
+			require.NotEqual(t, tc.expected, container.Ports["80"])
+		} else {
+			require.Equal(t, tc.expected, container.Ports["80"])
+		}
+
+		err = container.Terminate()
+		require.NoError(t, err)
+	}
+}
+
 func TestBadImageName(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
Containers have at least three options when it comes to specifying the
port a container uses: 80, 80:80, 80/[tcp|udp]. The original logic was
naive and assumed only the first option would ever be used and only one
port was ever cared about.

The new mechanism creates a lookup table for easy use in tests while
also allowing for all the formats above.