### PR TITLE
feat(outputs/wavefront): make maximum http batch size configurable

### DIFF
--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -15,8 +15,8 @@ Wavefront data format over TCP.
   ## Authentication Token for Wavefront. Only required if using Direct Ingestion
   #token = "DUMMY_TOKEN"
 
-  ## Number of metrics to send per batch for Direct Ingestion. Ignored unless 'url' is set. Default is 10,000. Values higher than 40,000 are not recommended.
-  # http_batch_size = 10000
+  ## Maximum number of metrics to send per batch for Direct Ingestion. Ignored unless 'url' is set. This value should be higher than the `metric_batch_size`. Default is 10,000. Values higher than 40,000 are not recommended.
+  # http_maximum_batch_size = 10000
 
   ## DNS name of the wavefront proxy server. Do not use if url is specified
   #host = "wavefront.example.com"

--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -15,6 +15,9 @@ Wavefront data format over TCP.
   ## Authentication Token for Wavefront. Only required if using Direct Ingestion
   #token = "DUMMY_TOKEN"
 
+  ## Number of metrics to send per batch for Direct Ingestion. Ignored unless 'url' is set. Default is 10,000. Values higher than 40,000 are not recommended.
+  # http_batch_size = 10000
+
   ## DNS name of the wavefront proxy server. Do not use if url is specified
   #host = "wavefront.example.com"
 

--- a/plugins/outputs/wavefront/sample.conf
+++ b/plugins/outputs/wavefront/sample.conf
@@ -7,8 +7,8 @@
   ## Authentication Token for Wavefront. Only required if using Direct Ingestion
   #token = "DUMMY_TOKEN"
 
-  ## Number of metrics to send per batch for Direct Ingestion. Ignored unless 'url' is set. Default is 10,000. Values higher than 40,000 are not recommended.
-  # http_batch_size = 10000
+  ## Maximum number of metrics to send per batch for Direct Ingestion. Ignored unless 'url' is set. This value should be higher than the `metric_batch_size`. Default is 10,000. Values higher than 40,000 are not recommended.
+  # http_maximum_batch_size = 10000
 
   ## DNS name of the wavefront proxy server. Do not use if url is specified
   #host = "wavefront.example.com"

--- a/plugins/outputs/wavefront/sample.conf
+++ b/plugins/outputs/wavefront/sample.conf
@@ -7,6 +7,9 @@
   ## Authentication Token for Wavefront. Only required if using Direct Ingestion
   #token = "DUMMY_TOKEN"
 
+  ## Number of metrics to send per batch for Direct Ingestion. Ignored unless 'url' is set. Default is 10,000. Values higher than 40,000 are not recommended.
+  # http_batch_size = 10000
+
   ## DNS name of the wavefront proxy server. Do not use if url is specified
   #host = "wavefront.example.com"
 

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -29,6 +29,7 @@ type Wavefront struct {
 	MetricSeparator string                          `toml:"metric_separator"`
 	ConvertPaths    bool                            `toml:"convert_paths"`
 	ConvertBool     bool                            `toml:"convert_bool"`
+	HTTPBatchSize   int                             `toml:"http_batch_size"`
 	UseRegex        bool                            `toml:"use_regex"`
 	UseStrict       bool                            `toml:"use_strict"`
 	TruncateTags    bool                            `toml:"truncate_tags"`
@@ -87,6 +88,7 @@ func (w *Wavefront) Connect() error {
 			Server:               w.URL,
 			Token:                w.Token,
 			FlushIntervalSeconds: flushSeconds,
+			BatchSize:            w.HTTPBatchSize,
 		})
 		if err != nil {
 			return fmt.Errorf("could not create Wavefront Sender for Url: %s", w.URL)
@@ -298,6 +300,7 @@ func init() {
 			ConvertBool:     true,
 			TruncateTags:    false,
 			ImmediateFlush:  true,
+			HTTPBatchSize:   10000,
 		}
 	})
 }

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -20,22 +20,22 @@ var sampleConfig string
 const maxTagLength = 254
 
 type Wavefront struct {
-	URL             string                          `toml:"url"`
-	Token           string                          `toml:"token"`
-	Host            string                          `toml:"host"`
-	Port            int                             `toml:"port"`
-	Prefix          string                          `toml:"prefix"`
-	SimpleFields    bool                            `toml:"simple_fields"`
-	MetricSeparator string                          `toml:"metric_separator"`
-	ConvertPaths    bool                            `toml:"convert_paths"`
-	ConvertBool     bool                            `toml:"convert_bool"`
-	HTTPBatchSize   int                             `toml:"http_batch_size"`
-	UseRegex        bool                            `toml:"use_regex"`
-	UseStrict       bool                            `toml:"use_strict"`
-	TruncateTags    bool                            `toml:"truncate_tags"`
-	ImmediateFlush  bool                            `toml:"immediate_flush"`
-	SourceOverride  []string                        `toml:"source_override"`
-	StringToNumber  map[string][]map[string]float64 `toml:"string_to_number" deprecated:"1.9.0;use the enum processor instead"`
+	URL                  string                          `toml:"url"`
+	Token                string                          `toml:"token"`
+	Host                 string                          `toml:"host"`
+	Port                 int                             `toml:"port"`
+	Prefix               string                          `toml:"prefix"`
+	SimpleFields         bool                            `toml:"simple_fields"`
+	MetricSeparator      string                          `toml:"metric_separator"`
+	ConvertPaths         bool                            `toml:"convert_paths"`
+	ConvertBool          bool                            `toml:"convert_bool"`
+	HTTPMaximumBatchSize int                             `toml:"http_maximum_batch_size"`
+	UseRegex             bool                            `toml:"use_regex"`
+	UseStrict            bool                            `toml:"use_strict"`
+	TruncateTags         bool                            `toml:"truncate_tags"`
+	ImmediateFlush       bool                            `toml:"immediate_flush"`
+	SourceOverride       []string                        `toml:"source_override"`
+	StringToNumber       map[string][]map[string]float64 `toml:"string_to_number" deprecated:"1.9.0;use the enum processor instead"`
 
 	sender wavefront.Sender
 	Log    telegraf.Logger `toml:"-"`
@@ -88,7 +88,7 @@ func (w *Wavefront) Connect() error {
 			Server:               w.URL,
 			Token:                w.Token,
 			FlushIntervalSeconds: flushSeconds,
-			BatchSize:            w.HTTPBatchSize,
+			BatchSize:            w.HTTPMaximumBatchSize,
 		})
 		if err != nil {
 			return fmt.Errorf("could not create Wavefront Sender for Url: %s", w.URL)
@@ -294,13 +294,13 @@ func (w *Wavefront) Close() error {
 func init() {
 	outputs.Add("wavefront", func() telegraf.Output {
 		return &Wavefront{
-			Token:           "DUMMY_TOKEN",
-			MetricSeparator: ".",
-			ConvertPaths:    true,
-			ConvertBool:     true,
-			TruncateTags:    false,
-			ImmediateFlush:  true,
-			HTTPBatchSize:   10000,
+			Token:                "DUMMY_TOKEN",
+			MetricSeparator:      ".",
+			ConvertPaths:         true,
+			ConvertBool:          true,
+			TruncateTags:         false,
+			ImmediateFlush:       true,
+			HTTPMaximumBatchSize: 10000,
 		}
 	})
 }

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -352,6 +353,11 @@ func TestTagLimits(t *testing.T) {
 	_, tags = w.buildTags(template)
 	require.Contains(t, tags, longKey, "Should contain non truncated long key")
 	require.Equal(t, longKey, tags[longKey])
+}
+
+func TestDefaults(t *testing.T) {
+	defaultWavefront := outputs.Outputs["wavefront"]().(*Wavefront)
+	require.Equal(t, 10000, defaultWavefront.HTTPBatchSize)
 }
 
 // Benchmarks to test performance of string replacement via Regex and Replacer

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -357,7 +357,7 @@ func TestTagLimits(t *testing.T) {
 
 func TestDefaults(t *testing.T) {
 	defaultWavefront := outputs.Outputs["wavefront"]().(*Wavefront)
-	require.Equal(t, 10000, defaultWavefront.HTTPBatchSize)
+	require.Equal(t, 10000, defaultWavefront.HTTPMaximumBatchSize)
 }
 
 // Benchmarks to test performance of string replacement via Regex and Replacer


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

The Wavefront golang SDK can send metrics via http(s) or tcp. In the case of http, the Wavefront SDK batches metrics internally, flushing them periodically or when they reach a maximum batch size. At present, configuring this batch size is not possible from the wavefront plugin output, so the sdk default value (10,000) is always used. In some cases smaller or larger batch sizes might be preferred, or users might want to match the wavefront client's batch size to the batch size configured for the telegraf output.

This pr exposes the wavefront internal batch size for configuration as `http_batch_size`.

I added a unit test validating that the intended default is set, although the `outputs.Outputs` map doesn't necessarily seem like an interface that wants to be used for this purpose.