### PR TITLE
test: enable logging with testcontainers

### DIFF
--- a/plugins/inputs/aerospike/aerospike_test.go
+++ b/plugins/inputs/aerospike/aerospike_test.go
@@ -14,7 +14,7 @@ import (
 
 const servicePort = "3000"
 
-func launchTestServer(t *testing.T) testutil.Container {
+func launchTestServer(t *testing.T) *testutil.Container {
 	container := testutil.Container{
 		Image:        "aerospike:ce-6.0.0.1",
 		ExposedPorts: []string{servicePort},
@@ -23,7 +23,7 @@ func launchTestServer(t *testing.T) testutil.Container {
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
 
-	return container
+	return &container
 }
 
 func TestAerospikeStatisticsIntegration(t *testing.T) {

--- a/plugins/outputs/cratedb/cratedb_test.go
+++ b/plugins/outputs/cratedb/cratedb_test.go
@@ -18,7 +18,7 @@ import (
 
 const servicePort = "5432"
 
-func createTestContainer(t *testing.T) testutil.Container {
+func createTestContainer(t *testing.T) *testutil.Container {
 	container := testutil.Container{
 		Image:        "crate",
 		ExposedPorts: []string{servicePort},
@@ -34,7 +34,7 @@ func createTestContainer(t *testing.T) testutil.Container {
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
 
-	return container
+	return &container
 }
 
 func TestConnectAndWriteIntegration(t *testing.T) {


### PR DESCRIPTION
This collects the container logs and prints them if/when a test fails.
Very helpful when trying to debug or understand if a container actually
started.

When running with -race, caught a couple issues when creating containers
in a generic function in aerospike and cratedb plugins.