### PR TITLE
feat: Migrate xpath parser to new style

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1842,9 +1842,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 		"prefix", "prometheus_export_timestamp", "prometheus_ignore_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label",
 		"separator", "splunkmetric_hec_routing", "splunkmetric_multimetric", "tag_keys",
 		"tagdrop", "tagexclude", "taginclude", "tagpass", "tags", "template", "templates",
-		"value_field_name", "wavefront_source_override", "wavefront_use_strict", "wavefront_disable_prefix_conversion",
-		"xml", "xpath", "xpath_json", "xpath_msgpack", "xpath_protobuf", "xpath_print_document",
-		"xpath_protobuf_file", "xpath_protobuf_type", "xpath_protobuf_import_paths":
+		"value_field_name", "wavefront_source_override", "wavefront_use_strict", "wavefront_disable_prefix_conversion":
 
 		// ignore fields that are common to all plugins.
 	default:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -406,7 +406,6 @@ func TestConfig_ParserInterfaceNewFormat(t *testing.T) {
 	}
 
 	override := map[string]struct {
-		cfg   *parsers.Config
 		param map[string]interface{}
 		mask  []string
 	}{
@@ -420,11 +419,6 @@ func TestConfig_ParserInterfaceNewFormat(t *testing.T) {
 			mask: []string{"Now"},
 		},
 		"xpath_protobuf": {
-			cfg: &parsers.Config{
-				MetricName:        "parser_test_new",
-				XPathProtobufFile: "testdata/addressbook.proto",
-				XPathProtobufType: "addressbook.AddressBook",
-			},
 			param: map[string]interface{}{
 				"ProtobufMessageDef":  "testdata/addressbook.proto",
 				"ProtobufMessageType": "addressbook.AddressBook",
@@ -435,10 +429,6 @@ func TestConfig_ParserInterfaceNewFormat(t *testing.T) {
 	expected := make([]telegraf.Parser, 0, len(formats))
 	for _, format := range formats {
 		formatCfg := &cfg
-		settings, hasOverride := override[format]
-		if hasOverride && settings.cfg != nil {
-			formatCfg = settings.cfg
-		}
 		formatCfg.DataFormat = format
 
 		logger := models.NewLogger("parsers", format, cfg.MetricName)
@@ -555,7 +545,6 @@ func TestConfig_ParserInterfaceOldFormat(t *testing.T) {
 	}
 
 	override := map[string]struct {
-		cfg   *parsers.Config
 		param map[string]interface{}
 		mask  []string
 	}{
@@ -569,11 +558,6 @@ func TestConfig_ParserInterfaceOldFormat(t *testing.T) {
 			mask: []string{"Now"},
 		},
 		"xpath_protobuf": {
-			cfg: &parsers.Config{
-				MetricName:        "parser_test_new",
-				XPathProtobufFile: "testdata/addressbook.proto",
-				XPathProtobufType: "addressbook.AddressBook",
-			},
 			param: map[string]interface{}{
 				"ProtobufMessageDef":  "testdata/addressbook.proto",
 				"ProtobufMessageType": "addressbook.AddressBook",
@@ -584,10 +568,6 @@ func TestConfig_ParserInterfaceOldFormat(t *testing.T) {
 	expected := make([]telegraf.Parser, 0, len(formats))
 	for _, format := range formats {
 		formatCfg := &cfg
-		settings, hasOverride := override[format]
-		if hasOverride && settings.cfg != nil {
-			formatCfg = settings.cfg
-		}
 		formatCfg.DataFormat = format
 
 		logger := models.NewLogger("parsers", format, cfg.MetricName)

--- a/plugins/parsers/all/all.go
+++ b/plugins/parsers/all/all.go
@@ -3,4 +3,5 @@ package all
 import (
 	//Blank imports for plugins to register themselves
 	_ "github.com/influxdata/telegraf/plugins/parsers/csv"
+	_ "github.com/influxdata/telegraf/plugins/parsers/xpath"
 )

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -19,7 +19,6 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers/prometheusremotewrite"
 	"github.com/influxdata/telegraf/plugins/parsers/value"
 	"github.com/influxdata/telegraf/plugins/parsers/wavefront"
-	"github.com/influxdata/telegraf/plugins/parsers/xpath"
 )
 
 // Creator is the function to create a new parser
@@ -184,12 +183,12 @@ type Config struct {
 	ValueFieldName string `toml:"value_field_name"`
 
 	// XPath configuration
-	XPathPrintDocument       bool     `toml:"xpath_print_document"`
-	XPathProtobufFile        string   `toml:"xpath_protobuf_file"`
-	XPathProtobufType        string   `toml:"xpath_protobuf_type"`
-	XPathProtobufImportPaths []string `toml:"xpath_protobuf_import_paths"`
-	XPathAllowEmptySelection bool     `toml:"xpath_allow_empty_selection"`
-	XPathConfig              []XPathConfig
+	XPathPrintDocument       bool          `toml:"xpath_print_document"`
+	XPathProtobufFile        string        `toml:"xpath_protobuf_file"`
+	XPathProtobufType        string        `toml:"xpath_protobuf_type"`
+	XPathProtobufImportPaths []string      `toml:"xpath_protobuf_import_paths"`
+	XPathAllowEmptySelection bool          `toml:"xpath_allow_empty_selection"`
+	XPathConfig              []XPathConfig `toml:"xpath"`
 
 	// JSONPath configuration
 	JSONV2Config []JSONV2Config `toml:"json_v2"`
@@ -201,7 +200,29 @@ type Config struct {
 	LogFmtTagKeys []string `toml:"logfmt_tag_keys"`
 }
 
-type XPathConfig xpath.Config
+// XPathConfig definition for backward compatibitlity ONLY.
+// We need this here to avoid cyclic dependencies. However, we need
+// to move this to plugins/parsers/xpath once we deprecate parser
+// construction via `NewParser()`.
+type XPathConfig struct {
+	MetricQuery  string            `toml:"metric_name"`
+	Selection    string            `toml:"metric_selection"`
+	Timestamp    string            `toml:"timestamp"`
+	TimestampFmt string            `toml:"timestamp_format"`
+	Tags         map[string]string `toml:"tags"`
+	Fields       map[string]string `toml:"fields"`
+	FieldsInt    map[string]string `toml:"fields_int"`
+
+	FieldSelection  string `toml:"field_selection"`
+	FieldNameQuery  string `toml:"field_name"`
+	FieldValueQuery string `toml:"field_value"`
+	FieldNameExpand bool   `toml:"field_name_expansion"`
+
+	TagSelection  string `toml:"tag_selection"`
+	TagNameQuery  string `toml:"tag_name"`
+	TagValueQuery string `toml:"tag_value"`
+	TagNameExpand bool   `toml:"tag_name_expansion"`
+}
 
 type JSONV2Config struct {
 	json_v2.Config
@@ -280,17 +301,6 @@ func NewParser(config *Config) (Parser, error) {
 		)
 	case "prometheusremotewrite":
 		parser, err = NewPrometheusRemoteWriteParser(config.DefaultTags)
-	case "xml", "xpath_json", "xpath_msgpack", "xpath_protobuf":
-		parser = &xpath.Parser{
-			Format:              config.DataFormat,
-			ProtobufMessageDef:  config.XPathProtobufFile,
-			ProtobufMessageType: config.XPathProtobufType,
-			ProtobufImportPaths: config.XPathProtobufImportPaths,
-			PrintDocument:       config.XPathPrintDocument,
-			DefaultTags:         config.DefaultTags,
-			AllowEmptySelection: config.XPathAllowEmptySelection,
-			Configs:             NewXPathParserConfigs(config.MetricName, config.XPathConfig),
-		}
 	case "json_v2":
 		parser, err = NewJSONPathParser(config.JSONV2Config)
 	default:
@@ -427,17 +437,6 @@ func NewPrometheusRemoteWriteParser(defaultTags map[string]string) (Parser, erro
 	return &prometheusremotewrite.Parser{
 		DefaultTags: defaultTags,
 	}, nil
-}
-
-func NewXPathParserConfigs(metricName string, cfgs []XPathConfig) []xpath.Config {
-	// Convert the config formats which is a one-to-one copy
-	configs := make([]xpath.Config, 0, len(cfgs))
-	for _, cfg := range cfgs {
-		config := xpath.Config(cfg)
-		config.MetricDefaultName = metricName
-		configs = append(configs, config)
-	}
-	return configs
 }
 
 func NewJSONPathParser(jsonv2config []JSONV2Config) (Parser, error) {

--- a/plugins/parsers/registry_test.go
+++ b/plugins/parsers/registry_test.go
@@ -2,8 +2,11 @@ package parsers_test
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
@@ -15,6 +18,8 @@ func TestRegistry_BackwardCompatibility(t *testing.T) {
 	cfg := &parsers.Config{
 		MetricName:        "parser_compatibility_test",
 		CSVHeaderRowCount: 42,
+		XPathProtobufFile: "xpath/testcases/protos/addressbook.proto",
+		XPathProtobufType: "addressbook.AddressBook",
 	}
 
 	// Some parsers need certain settings to not error. Furthermore, we
@@ -28,6 +33,12 @@ func TestRegistry_BackwardCompatibility(t *testing.T) {
 				"HeaderRowCount": cfg.CSVHeaderRowCount,
 			},
 			mask: []string{"TimeFunc"},
+		},
+		"xpath_protobuf": {
+			param: map[string]interface{}{
+				"ProtobufMessageDef":  cfg.XPathProtobufFile,
+				"ProtobufMessageType": cfg.XPathProtobufType,
+			},
 		},
 	}
 
@@ -52,19 +63,23 @@ func TestRegistry_BackwardCompatibility(t *testing.T) {
 		actual, err := parsers.NewParser(cfg)
 		require.NoError(t, err)
 
-		// Compare with mask
-		if settings, found := override[name]; found {
-			a := reflect.Indirect(reflect.ValueOf(actual))
-			e := reflect.Indirect(reflect.ValueOf(expected))
-			for _, key := range settings.mask {
-				af := a.FieldByName(key)
-				ef := e.FieldByName(key)
-
-				v := reflect.Zero(ef.Type())
-				af.Set(v)
-				ef.Set(v)
-			}
+		// Determine the underlying type of the parser
+		stype := reflect.Indirect(reflect.ValueOf(expected)).Interface()
+		// Ignore all unexported fields and fields not relevant for functionality
+		options := []cmp.Option{
+			cmpopts.IgnoreUnexported(stype),
+			cmpopts.IgnoreTypes(sync.Mutex{}),
+			cmpopts.IgnoreInterfaces(struct{ telegraf.Logger }{}),
 		}
-		require.EqualValuesf(t, expected, actual, "format %q", name)
+
+		// Add overrides and masks to compare options
+		if settings, found := override[name]; found {
+			options = append(options, cmpopts.IgnoreFields(stype, settings.mask...))
+		}
+
+		// Do a manual comparision as require.EqualValues will also work on unexported fields
+		// that cannot be cleared or ignored.
+		diff := cmp.Diff(expected, actual, options...)
+		require.Emptyf(t, diff, "Difference for %q", name)
 	}
 }

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -1,6 +1,7 @@
 package xpath
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -70,10 +71,7 @@ func (p *Parser) Init() error {
 
 	// Make sure we do have a metric name
 	if p.DefaultMetricName == "" {
-		p.DefaultMetricName = p.Format
-		if p.Format == "" {
-			p.DefaultMetricName = "xml"
-		}
+		return errors.New("missing default metric name")
 	}
 
 	return nil

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -149,8 +149,7 @@ func TestInvalidTypeQueriesFail(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 					FieldsInt: map[string]string{
 						"a": "/Device_1/value_string",
 					},
@@ -186,8 +185,7 @@ func TestInvalidTypeQueries(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"a": "number(/Device_1/value_string)",
 					},
@@ -208,8 +206,7 @@ func TestInvalidTypeQueries(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"a": "boolean(/Device_1/value_string)",
 					},
@@ -229,7 +226,12 @@ func TestInvalidTypeQueries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: tt.defaultTags, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "test",
+				Configs:           tt.configs,
+				DefaultTags:       tt.defaultTags,
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			actual, err := parser.ParseLine(tt.input)
@@ -253,8 +255,7 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -270,9 +271,8 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
-					TimestampFmt:      "unix",
+					Timestamp:    "/Device_1/Timestamp_unix",
+					TimestampFmt: "unix",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -288,9 +288,8 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix_ms",
-					TimestampFmt:      "unix_ms",
+					Timestamp:    "/Device_1/Timestamp_unix_ms",
+					TimestampFmt: "unix_ms",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -306,9 +305,8 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix_us",
-					TimestampFmt:      "unix_us",
+					Timestamp:    "/Device_1/Timestamp_unix_us",
+					TimestampFmt: "unix_us",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -324,9 +322,8 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix_ns",
-					TimestampFmt:      "unix_ns",
+					Timestamp:    "/Device_1/Timestamp_unix_ns",
+					TimestampFmt: "unix_ns",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -342,9 +339,8 @@ func TestParseTimestamps(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_iso",
-					TimestampFmt:      "2006-01-02T15:04:05Z",
+					Timestamp:    "/Device_1/Timestamp_iso",
+					TimestampFmt: "2006-01-02T15:04:05Z",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -359,7 +355,12 @@ func TestParseTimestamps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: tt.defaultTags, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "test",
+				Configs:           tt.configs,
+				DefaultTags:       tt.defaultTags,
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			actual, err := parser.ParseLine(tt.input)
@@ -383,8 +384,7 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"a": "/Device_1/value_int",
 						"b": "/Device_1/value_float",
@@ -411,8 +411,7 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"a": "number(Device_1/value_int)",
 						"b": "number(/Device_1/value_float)",
@@ -439,8 +438,7 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"b": "number(/Device_1/value_float)",
 						"c": "boolean(/Device_1/value_bool)",
@@ -469,8 +467,7 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"x": "substring-before(/Device_1/value_position, ';')",
 						"y": "substring-after(/Device_1/value_position, ';')",
@@ -493,8 +490,7 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"x": "number(substring-before(/Device_1/value_position, ';'))",
 						"y": "number(substring-after(/Device_1/value_position, ';'))",
@@ -517,8 +513,7 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 					FieldsInt: map[string]string{
 						"x": "substring-before(/Device_1/value_position, ';')",
 						"y": "substring-after(/Device_1/value_position, ';')",
@@ -541,8 +536,7 @@ func TestParseSingleValues(t *testing.T) {
 			input: singleMetricValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					Timestamp: "/Device_1/Timestamp_unix",
 					Tags: map[string]string{
 						"state": "/Device_1/State",
 						"name":  "substring-after(/Device_1/Name, ' ')",
@@ -564,7 +558,12 @@ func TestParseSingleValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: tt.defaultTags, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "test",
+				Configs:           tt.configs,
+				DefaultTags:       tt.defaultTags,
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			actual, err := parser.ParseLine(tt.input)
@@ -588,8 +587,7 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix/@value",
+					Timestamp: "/Device_1/Timestamp_unix/@value",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -605,9 +603,8 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_iso/@value",
-					TimestampFmt:      "2006-01-02T15:04:05Z",
+					Timestamp:    "/Device_1/Timestamp_iso/@value",
+					TimestampFmt: "2006-01-02T15:04:05Z",
 				},
 			},
 			defaultTags: map[string]string{},
@@ -623,8 +620,7 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix/@value",
+					Timestamp: "/Device_1/Timestamp_unix/@value",
 					Fields: map[string]string{
 						"a": "/Device_1/attr_int/@_",
 						"b": "/Device_1/attr_float/@_",
@@ -651,8 +647,7 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix/@value",
+					Timestamp: "/Device_1/Timestamp_unix/@value",
 					Fields: map[string]string{
 						"a": "number(/Device_1/attr_int/@_)",
 						"b": "number(/Device_1/attr_float/@_)",
@@ -679,8 +674,7 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix/@value",
+					Timestamp: "/Device_1/Timestamp_unix/@value",
 					Fields: map[string]string{
 						"b": "number(/Device_1/attr_float/@_)",
 						"c": "boolean(/Device_1/attr_bool/@_)",
@@ -709,8 +703,7 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix/@value",
+					Timestamp: "/Device_1/Timestamp_unix/@value",
 					Fields: map[string]string{
 						"name": "substring-after(/Device_1/Name/@value, ' ')",
 					},
@@ -731,8 +724,7 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix/@value",
+					Timestamp: "/Device_1/Timestamp_unix/@value",
 					Tags: map[string]string{
 						"state": "/Device_1/State/@_",
 						"name":  "substring-after(/Device_1/Name/@value, ' ')",
@@ -755,8 +747,7 @@ func TestParseSingleAttributes(t *testing.T) {
 			input: singleMetricAttributesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Device_1/Timestamp_unix/@value",
+					Timestamp: "/Device_1/Timestamp_unix/@value",
 					Fields: map[string]string{
 						"a": "/Device_1/attr_bool_numeric/@_ = 1",
 					},
@@ -776,7 +767,12 @@ func TestParseSingleAttributes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: tt.defaultTags, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "test",
+				Configs:           tt.configs,
+				DefaultTags:       tt.defaultTags,
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			actual, err := parser.ParseLine(tt.input)
@@ -800,8 +796,7 @@ func TestParseMultiValues(t *testing.T) {
 			input: singleMetricMultiValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Timestamp/@value",
+					Timestamp: "/Timestamp/@value",
 					Fields: map[string]string{
 						"a": "number(/Device/Value[1])",
 						"b": "number(/Device/Value[2])",
@@ -832,8 +827,7 @@ func TestParseMultiValues(t *testing.T) {
 			input: singleMetricMultiValuesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Timestamp:         "/Timestamp/@value",
+					Timestamp: "/Timestamp/@value",
 					FieldsInt: map[string]string{
 						"a": "/Device/Value[1]",
 						"b": "/Device/Value[2]",
@@ -863,7 +857,12 @@ func TestParseMultiValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: tt.defaultTags, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "test",
+				Configs:           tt.configs,
+				DefaultTags:       tt.defaultTags,
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			actual, err := parser.ParseLine(tt.input)
@@ -887,9 +886,8 @@ func TestParseMultiNodes(t *testing.T) {
 			input: multipleNodesXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					Selection:         "/Device",
-					Timestamp:         "/Timestamp/@value",
+					Selection: "/Device",
+					Timestamp: "/Timestamp/@value",
 					Fields: map[string]string{
 						"value":  "number(Value)",
 						"active": "Active = 1",
@@ -976,7 +974,12 @@ func TestParseMultiNodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: tt.defaultTags, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "test",
+				Configs:           tt.configs,
+				DefaultTags:       tt.defaultTags,
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			actual, err := parser.Parse([]byte(tt.input))
@@ -1000,9 +1003,8 @@ func TestParseMetricQuery(t *testing.T) {
 			input: metricNameQueryXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					MetricQuery:       "name(/Device_1/Metric/@*[1])",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					MetricQuery: "name(/Device_1/Metric/@*[1])",
+					Timestamp:   "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"value": "/Device_1/Metric/@*[1]",
 					},
@@ -1023,9 +1025,8 @@ func TestParseMetricQuery(t *testing.T) {
 			input: metricNameQueryXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					MetricQuery:       "'the_metric'",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					MetricQuery: "'the_metric'",
+					Timestamp:   "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"value": "/Device_1/Metric/@*[1]",
 					},
@@ -1045,7 +1046,12 @@ func TestParseMetricQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: tt.defaultTags, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "test",
+				Configs:           tt.configs,
+				DefaultTags:       tt.defaultTags,
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			actual, err := parser.ParseLine(tt.input)
@@ -1068,9 +1074,8 @@ func TestParseErrors(t *testing.T) {
 			input: metricNameQueryXML,
 			configs: []Config{
 				{
-					MetricDefaultName: "test",
-					MetricQuery:       "arbitrary",
-					Timestamp:         "/Device_1/Timestamp_unix",
+					MetricQuery: "arbitrary",
+					Timestamp:   "/Device_1/Timestamp_unix",
 					Fields: map[string]string{
 						"value": "/Device_1/Metric/@*[1]",
 					},
@@ -1082,7 +1087,12 @@ func TestParseErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: map[string]string{}, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "test",
+				Configs:           tt.configs,
+				DefaultTags:       map[string]string{},
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			_, err := parser.ParseLine(tt.input)
@@ -1150,79 +1160,17 @@ func TestEmptySelection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: map[string]string{}, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "test",
+				Configs:           tt.configs,
+				DefaultTags:       map[string]string{},
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			_, err := parser.Parse([]byte(tt.input))
 			require.Error(t, err)
-			require.Equal(t, "cannot parse with empty selection node", err.Error())
-		})
-	}
-}
-
-func TestEmptySelectionAllowed(t *testing.T) {
-	var tests = []struct {
-		name    string
-		input   string
-		configs []Config
-	}{
-		{
-			name:  "empty path",
-			input: multipleNodesXML,
-			configs: []Config{
-				{
-					Selection: "/Device/NonExisting",
-					Fields:    map[string]string{"value": "number(Value)"},
-					FieldsInt: map[string]string{"mode": "Value/@mode"},
-					Tags:      map[string]string{},
-				},
-			},
-		},
-		{
-			name:  "empty pattern",
-			input: multipleNodesXML,
-			configs: []Config{
-				{
-					Selection: "//NonExisting",
-					Fields:    map[string]string{"value": "number(Value)"},
-					FieldsInt: map[string]string{"mode": "Value/@mode"},
-					Tags:      map[string]string{},
-				},
-			},
-		},
-		{
-			name:  "empty axis",
-			input: multipleNodesXML,
-			configs: []Config{
-				{
-					Selection: "/Device/child::NonExisting",
-					Fields:    map[string]string{"value": "number(Value)"},
-					FieldsInt: map[string]string{"mode": "Value/@mode"},
-					Tags:      map[string]string{},
-				},
-			},
-		},
-		{
-			name:  "empty predicate",
-			input: multipleNodesXML,
-			configs: []Config{
-				{
-					Selection: "/Device[@NonExisting=true]",
-					Fields:    map[string]string{"value": "number(Value)"},
-					FieldsInt: map[string]string{"mode": "Value/@mode"},
-					Tags:      map[string]string{},
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, AllowEmptySelection: true, DefaultTags: map[string]string{}, Log: testutil.Logger{Name: "parsers.xml"}}
-			require.NoError(t, parser.Init())
-
-			_, err := parser.Parse([]byte(tt.input))
-			require.NoError(t, err)
+			require.Equal(t, err.Error(), "cannot parse with empty selection node")
 		})
 	}
 }
@@ -1277,7 +1225,6 @@ func TestTestCases(t *testing.T) {
 			filename := filepath.FromSlash(tt.filename)
 			cfg, header, err := loadTestConfiguration(filename)
 			require.NoError(t, err)
-			cfg.MetricDefaultName = "xml"
 
 			// Load the xml-content
 			input, err := testutil.ParseRawLinesFrom(header, "File:")

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -126,7 +126,12 @@ func TestParseInvalidXML(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: tt.defaultTags, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "xml",
+				Configs:           tt.configs,
+				DefaultTags:       tt.defaultTags,
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			_, err := parser.ParseLine(tt.input)
@@ -162,7 +167,12 @@ func TestInvalidTypeQueriesFail(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := &Parser{Configs: tt.configs, DefaultTags: tt.defaultTags, Log: testutil.Logger{Name: "parsers.xml"}}
+			parser := &Parser{
+				DefaultMetricName: "xml",
+				Configs:           tt.configs,
+				DefaultTags:       tt.defaultTags,
+				Log:               testutil.Logger{Name: "parsers.xml"},
+			}
 			require.NoError(t, parser.Init())
 
 			_, err := parser.ParseLine(tt.input)
@@ -1234,6 +1244,7 @@ func TestEmptySelectionAllowed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := &Parser{
+				DefaultMetricName:   "xml",
 				Configs:             tt.configs,
 				AllowEmptySelection: true,
 				DefaultTags:         map[string]string{},
@@ -1334,7 +1345,12 @@ func TestTestCases(t *testing.T) {
 			expectedErrors, _ := testutil.ParseRawLinesFrom(header, "Expected Error:")
 
 			// Setup the parser and run it.
+			metricName := "xml"
+			if fileformat != "" {
+				metricName = fileformat
+			}
 			parser := &Parser{
+				DefaultMetricName:   metricName,
 				Format:              fileformat,
 				ProtobufMessageDef:  pbmsgdef,
 				ProtobufMessageType: pbmsgtype,
@@ -1359,6 +1375,7 @@ func TestTestCases(t *testing.T) {
 func TestProtobufImporting(t *testing.T) {
 	// Setup the parser and run it.
 	parser := &Parser{
+		DefaultMetricName:   "xpath_protobuf",
 		Format:              "xpath_protobuf",
 		ProtobufMessageDef:  "person.proto",
 		ProtobufMessageType: "importtest.Person",

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -1175,6 +1175,78 @@ func TestEmptySelection(t *testing.T) {
 	}
 }
 
+func TestEmptySelectionAllowed(t *testing.T) {
+	var tests = []struct {
+		name    string
+		input   string
+		configs []Config
+	}{
+		{
+			name:  "empty path",
+			input: multipleNodesXML,
+			configs: []Config{
+				{
+					Selection: "/Device/NonExisting",
+					Fields:    map[string]string{"value": "number(Value)"},
+					FieldsInt: map[string]string{"mode": "Value/@mode"},
+					Tags:      map[string]string{},
+				},
+			},
+		},
+		{
+			name:  "empty pattern",
+			input: multipleNodesXML,
+			configs: []Config{
+				{
+					Selection: "//NonExisting",
+					Fields:    map[string]string{"value": "number(Value)"},
+					FieldsInt: map[string]string{"mode": "Value/@mode"},
+					Tags:      map[string]string{},
+				},
+			},
+		},
+		{
+			name:  "empty axis",
+			input: multipleNodesXML,
+			configs: []Config{
+				{
+					Selection: "/Device/child::NonExisting",
+					Fields:    map[string]string{"value": "number(Value)"},
+					FieldsInt: map[string]string{"mode": "Value/@mode"},
+					Tags:      map[string]string{},
+				},
+			},
+		},
+		{
+			name:  "empty predicate",
+			input: multipleNodesXML,
+			configs: []Config{
+				{
+					Selection: "/Device[@NonExisting=true]",
+					Fields:    map[string]string{"value": "number(Value)"},
+					FieldsInt: map[string]string{"mode": "Value/@mode"},
+					Tags:      map[string]string{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &Parser{
+				Configs:             tt.configs,
+				AllowEmptySelection: true,
+				DefaultTags:         map[string]string{},
+				Log:                 testutil.Logger{Name: "parsers.xml"},
+			}
+			require.NoError(t, parser.Init())
+
+			_, err := parser.Parse([]byte(tt.input))
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestTestCases(t *testing.T) {
 	var tests = []struct {
 		name     string


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR migrates the `xpath` parser family to the new-style parser structure. The change is backward compatible.