### PR TITLE
fix: re-add event to splunk serializer

### DIFF
--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -22,6 +22,7 @@ type CommonTags struct {
 
 type HECTimeSeries struct {
 	Time   float64                `json:"time"`
+	Event  string                 `json:"event"`
 	Host   string                 `json:"host,omitempty"`
 	Index  string                 `json:"index,omitempty"`
 	Source string                 `json:"source,omitempty"`
@@ -65,6 +66,7 @@ func (s *serializer) createMulti(metric telegraf.Metric, dataGroup HECTimeSeries
 	var metricJSON []byte
 
 	// Set the event data from the commonTags above.
+	dataGroup.Event = "metric"
 	dataGroup.Time = commonTags.Time
 	dataGroup.Host = commonTags.Host
 	dataGroup.Index = commonTags.Index
@@ -121,6 +123,7 @@ func (s *serializer) createSingle(metric telegraf.Metric, dataGroup HECTimeSerie
 		dataGroup.Time = commonTags.Time
 
 		// Apply the common tags from above to every record.
+		dataGroup.Event = "metric"
 		dataGroup.Host = commonTags.Host
 		dataGroup.Index = commonTags.Index
 		dataGroup.Source = commonTags.Source

--- a/plugins/serializers/splunkmetric/splunkmetric_test.go
+++ b/plugins/serializers/splunkmetric/splunkmetric_test.go
@@ -44,7 +44,7 @@ func TestSerializeMetricFloatHec(t *testing.T) {
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
-	expS := `{"time":1529875740.819,"fields":{"_value":91.5,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}`
+	expS := `{"time":1529875740.819,"event":"metric","fields":{"_value":91.5,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}`
 	require.Equal(t, expS, string(buf))
 }
 
@@ -82,7 +82,7 @@ func TestSerializeMetricIntHec(t *testing.T) {
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
 
-	expS := `{"time":0,"fields":{"_value":90,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}`
+	expS := `{"time":0,"event":"metric","fields":{"_value":90,"cpu":"cpu0","metric_name":"cpu.usage_idle"}}`
 	require.Equal(t, expS, string(buf))
 }
 
@@ -120,7 +120,7 @@ func TestSerializeMetricBoolHec(t *testing.T) {
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
 
-	expS := `{"time":0,"fields":{"_value":0,"container-name":"telegraf-test","metric_name":"docker.oomkiller"}}`
+	expS := `{"time":0,"event":"metric","fields":{"_value":0,"container-name":"telegraf-test","metric_name":"docker.oomkiller"}}`
 	require.Equal(t, expS, string(buf))
 }
 
@@ -215,7 +215,7 @@ func TestSerializeBatchHec(t *testing.T) {
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
 
-	expS := `{"time":0,"fields":{"_value":42,"metric_name":"cpu.value"}}{"time":0,"fields":{"_value":92,"metric_name":"cpu.value"}}`
+	expS := `{"time":0,"event":"metric","fields":{"_value":42,"metric_name":"cpu.value"}}{"time":0,"event":"metric","fields":{"_value":92,"metric_name":"cpu.value"}}`
 	require.Equal(t, expS, string(buf))
 }
 
@@ -235,6 +235,6 @@ func TestSerializeMultiHec(t *testing.T) {
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
 
-	expS := `{"time":0,"fields":{"metric_name:cpu.system":8,"metric_name:cpu.usage":42}}`
+	expS := `{"time":0,"event":"metric","fields":{"metric_name:cpu.system":8,"metric_name:cpu.usage":42}}`
 	require.Equal(t, expS, string(buf))
 }


### PR DESCRIPTION
Contrary to #8039, splunk documentation does require the event tag with
metric value. This reverts that previous change.

fixes: #8761