### PR TITLE
chore: rename circleci executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   aws-cli: circleci/aws-cli@1.4.0
 
 executors:
-  go-1_17:
+  telegraf-ci:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     resource_class: large
     docker:
@@ -171,7 +171,7 @@ commands:
             - 'dist'
 jobs:
   test-go-linux:
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - checkout
       - restore_cache:
@@ -192,7 +192,7 @@ jobs:
           paths:
             - '*'
   test-go-linux-386:
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - checkout
       - restore_cache:
@@ -222,7 +222,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: windows
@@ -232,7 +232,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: darwin-amd64
@@ -242,7 +242,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: darwin-arm64
@@ -252,7 +252,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: i386
@@ -262,7 +262,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: ppc64le
@@ -272,7 +272,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: riscv64
@@ -282,7 +282,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: s390x
@@ -292,7 +292,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: armel
@@ -302,7 +302,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: amd64
@@ -312,7 +312,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: arm64
@@ -322,7 +322,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: mipsel
@@ -332,7 +332,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: mips
@@ -342,7 +342,7 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: static
@@ -352,13 +352,13 @@ jobs:
       nightly:
         type: boolean
         default: false
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - package-build:
           type: armhf
           nightly: << parameters.nightly >>
   nightly:
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - attach_workspace:
           at: '/build'
@@ -460,7 +460,7 @@ jobs:
             printf -v payload '{ "pullRequestNumber": "%s" }' "$PR"
             curl -X POST "https://182c7jdgog.execute-api.us-east-1.amazonaws.com/prod/shareArtifacts" --data "$payload"
   generate-config:
-    executor: go-1_17
+    executor: telegraf-ci
     steps:
       - generate-config
   generate-config-win:


### PR DESCRIPTION
We are on go1.18 and I would like to not have to update the executor
name after every go release. This calls it the same as the container
name itself.