### PR TITLE
chore: upgrade windows circleci size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,7 @@ jobs:
     executor:
         name: win/default
         shell: bash.exe
+        size: xlarge
     steps:
       - test-go:
           os: windows


### PR DESCRIPTION
The Windows tests are the long poll in the test by far. Bump up the size
to speed up runs.