### PR TITLE
fix: Always build README-embedder for host-architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,7 @@ localstatedir ?= $(prefix)/var
 pkgdir ?= build/dist
 
 .PHONY: all
-all: docs
-	@$(MAKE) deps
-	@$(MAKE) telegraf
+all: deps docs telegraf
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ darwin-arm64:
 include_packages := $(mips) $(mipsel) $(arm64) $(amd64) $(static) $(armel) $(armhf) $(riscv64) $(s390x) $(ppc64le) $(i386) $(windows) $(darwin-amd64) $(darwin-arm64)
 
 .PHONY: package
-package: generate $(include_packages)
+package: docs $(include_packages)
 
 .PHONY: $(include_packages)
 $(include_packages):

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,6 @@ versioninfo:
 	go run scripts/generate_versioninfo/main.go; \
 	go generate cmd/telegraf/telegraf_windows.go; \
 
-.PHONY: build_tools
 build_tools:
 	$(HOSTGO) build -o ./tools/readme_config_includer/generator ./tools/readme_config_includer/generator.go
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ help:
 	@echo 'Targets:'
 	@echo '  all          - download dependencies and compile telegraf binary'
 	@echo '  deps         - download dependencies'
-	@echo '  docs         - generate documentation and embed sample-configurations'
+	@echo '  docs         - generate documentation and embed sample-configurations into READMEs'
 	@echo '  telegraf     - compile telegraf binary'
 	@echo '  test         - run short unit tests'
 	@echo '  fmt          - format source files'

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ help:
 	@echo 'Targets:'
 	@echo '  all          - download dependencies and compile telegraf binary'
 	@echo '  deps         - download dependencies'
-	@echo '  docs         - generate documentation and embed sample-configurations into READMEs'
+	@echo '  docs         - embed sample-configurations into READMEs'
 	@echo '  telegraf     - compile telegraf binary'
 	@echo '  test         - run short unit tests'
 	@echo '  fmt          - format source files'

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ localstatedir ?= $(prefix)/var
 pkgdir ?= build/dist
 
 .PHONY: all
-all:
+all: docs
 	@$(MAKE) deps
 	@$(MAKE) telegraf
 
@@ -79,6 +79,7 @@ help:
 	@echo 'Targets:'
 	@echo '  all          - download dependencies and compile telegraf binary'
 	@echo '  deps         - download dependencies'
+	@echo '  docs         - generate documentation and embed sample-configurations'
 	@echo '  telegraf     - compile telegraf binary'
 	@echo '  test         - run short unit tests'
 	@echo '  fmt          - format source files'
@@ -115,22 +116,22 @@ versioninfo:
 	go run scripts/generate_versioninfo/main.go; \
 	go generate cmd/telegraf/telegraf_windows.go; \
 
-.PHONY: build_generator
-build_generator:
-	go build -o ./tools/readme_config_includer/generator ./tools/readme_config_includer/generator.go
+.PHONY: build_tools
+build_tools:
+	$(HOSTGO) build -o ./tools/readme_config_includer/generator ./tools/readme_config_includer/generator.go
 
-embed_readme_%: build_generator
+embed_readme_%:
 	go generate -run="readme_config_includer/generator$$" ./plugins/$*/...
 
-.PHONY: generate
-generate: embed_readme_inputs embed_readme_outputs embed_readme_processors embed_readme_aggregators
+.PHONY: docs
+docs: build_tools embed_readme_inputs embed_readme_outputs embed_readme_processors embed_readme_aggregators
 
 .PHONY: build
 build:
 	go build -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
 .PHONY: telegraf
-telegraf: generate build
+telegraf: build
 
 # Used by dockerfile builds
 .PHONY: go-install


### PR DESCRIPTION
When cross-compiling telegraf, the tool for embedding the `sample.conf` into the READMEs always needs to be built for the host architecture. Furthermore, remove the embedding procedure from building telegraf and document the new `docs` makefile target.