### PR TITLE
test: remove restore integration test cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,8 +209,6 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - restore_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: 'make deps'
       - run: 'make test-integration'


### PR DESCRIPTION
The images used between testing (docker image) and integration testing
(ubuntu vm) are very different. The folders, layouts, and versions can
also be different. Therefore, take the small-time hit and not cache
integration tests for now.
