### PR TITLE
test: add coveralls coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,6 @@ commands:
                 key: windows-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
-      - run: mkdir -p test-results
       - run: ./scripts/install_gotestsum.sh << parameters.os >> << parameters.gotestsum >>
       - unless:
           condition:
@@ -86,9 +85,23 @@ commands:
           steps:
             - run: echo 'export RACE="-race"' >> $BASH_ENV
       - run: |
-          GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> --junitfile test-results/gotestsum-report.xml -- ${RACE} -short ./...
-      - store_test_results:
-          path: test-results
+          GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> -- ${RACE} -short -cover -coverprofile=coverage.out ./...
+      - when:
+          condition:
+            and:
+              - equal: [ "master", << pipeline.git.branch >> ]
+              - equal: [ "linux", << parameters.os >> ]
+              - equal: [ "amd64", << parameters.arch >> ]
+          steps:
+            - run:
+                name: "Installing goveralls"
+                command: go install github.com/mattn/goveralls@latest
+            - run:
+                name: "Remove plugins/parsers/influx/machine.go from coverage"
+                command: sed -i '/github.com\/influxdata\/telegraf\/plugins\/parsers\/influx\/machine.go/d' coverage.out
+            - run:
+                name: "Create report"
+                command: /go/bin/goveralls -coverprofile=coverage.out -service=circle-ci -repotoken=${COVERALLS_TOKEN}
       - when:
           condition:
             equal: [ linux, << parameters.os >> ]


### PR DESCRIPTION
On amd64, linux unit test runs, code coverage will be collected and
uploaded to the coveralls coverage service on runs with the master
branch. This does not include forks or PRs from community members.

Currently, the coveralls service requires a token to be used to upload
all coverage reports. However, there is no safe/secure way with circle
ci to hide this with our current processes that we have in place.

This also removes the coverage for the parsers/influx/machine.go file as
it contains many "//line" comments which currently break reports. See
https://github.com/golang/go/issues/35781 for more details.

fixes: https://github.com/influxdata/telegraf/issues/10733