### PR TITLE
fix: remove full access permissions

### DIFF
--- a/plugins/inputs/ceph/ceph_test.go
+++ b/plugins/inputs/ceph/ceph_test.go
@@ -183,7 +183,7 @@ func createTestFiles(dir string, st *SockTest) error {
 	writeFile := func(prefix string, i int) error {
 		f := sockFile(prefix, i)
 		fpath := filepath.Join(dir, f)
-		return os.WriteFile(fpath, []byte(""), 0777)
+		return os.WriteFile(fpath, []byte(""), 0644)
 	}
 	return tstFileApply(st, writeFile)
 }

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -316,7 +316,7 @@ func (monitor *DirectoryMonitor) Init() error {
 
 	// Finished directory can be created if not exists for convenience.
 	if _, err := os.Stat(monitor.FinishedDirectory); os.IsNotExist(err) {
-		err = os.Mkdir(monitor.FinishedDirectory, 0777)
+		err = os.Mkdir(monitor.FinishedDirectory, 0755)
 		if err != nil {
 			return err
 		}
@@ -328,7 +328,7 @@ func (monitor *DirectoryMonitor) Init() error {
 	// If an error directory should be used but has not been configured yet, create one ourselves.
 	if monitor.ErrorDirectory != "" {
 		if _, err := os.Stat(monitor.ErrorDirectory); os.IsNotExist(err) {
-			err := os.Mkdir(monitor.ErrorDirectory, 0777)
+			err := os.Mkdir(monitor.ErrorDirectory, 0755)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
In the directory_monitor and ceph tests, there are a number of places
where directories or test files were created with full permissions. This
is not the right thing to do in these cases. Instead, use the default
file (644) and folder (755) permissions that are commonly used.