### PR TITLE
fix: add missing build constraints for sqlite

### DIFF
--- a/plugins/inputs/sql/drivers_sqlite.go
+++ b/plugins/inputs/sql/drivers_sqlite.go
@@ -1,5 +1,11 @@
-//go:build !arm && !mips && !mipsle && !mips64 && !mips64le
-// +build !arm,!mips,!mipsle,!mips64,!mips64le
+//go:build !arm && !mips && !mipsle && !mips64 && !mips64le && !ppc64 && !(freebsd && arm64)
+// +build !arm
+// +build !mips
+// +build !mipsle
+// +build !mips64
+// +build !mips64le
+// +build !ppc64
+// +build !freebsd !arm64
 
 package sql
 

--- a/plugins/inputs/sql/drivers_sqlite_other.go
+++ b/plugins/inputs/sql/drivers_sqlite_other.go
@@ -1,4 +1,4 @@
-//go:build arm || mips || mipsle || mips64 || mips64le
-// +build arm mips mipsle mips64 mips64le
+//go:build arm || mips || mipsle || mips64 || mips64le || ppc64 || (freebsd && arm64)
+// +build arm mips mipsle mips64 mips64le ppc64 freebsd,arm64
 
 package sql

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -19,6 +19,7 @@ for target in ${targets}; do
 		*) continue;;
 	esac
 
+	echo "${target%%/*}/${target##*/}"
 	GOOS=${target%%/*} GOARCH=${target##*/} \
 		go list -deps -f '{{with .Module}}{{.Path}}{{end}}' ./cmd/telegraf/ >> "${tmpdir}/golist"
 done

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -24,7 +24,7 @@ for target in ${targets}; do
 		go list -deps -f '{{with .Module}}{{.Path}}{{end}}' ./cmd/telegraf/ >> "${tmpdir}/golist"
 done
 
-for dep in $(LC_ALL=C sort -u "${tmpdir}/golist"); do
+LC_ALL=C sort -u < "${tmpdir}/golist" | while IFS= read -r dep; do
 	case "${dep}" in
 		# ignore ourselves
 		github.com/influxdata/telegraf) continue;;


### PR DESCRIPTION
There were a couple of additional combinations of distro/arch that were
missing. These were discovered with running the `make check-deps`
command.

To make it easier to know which combination of distro/arch is failing
this also adds a printout of which is combination is currently
evaluated.
