### PR TITLE
fix: Restore sample configurations broken during initial migration

### DIFF
--- a/plugins/aggregators/derivative/README.md
+++ b/plugins/aggregators/derivative/README.md
@@ -29,9 +29,11 @@ contained in both the first and last metric of the aggregation interval.
 Without further configuration the derivative will be calculated with respect to
 the time difference between these two measurements in seconds.
 The following formula is applied is for every field
-$$
-derivative = {{value}_{last} - {value}_{first} \over {{time}_{last} - {time}_{first}}}
-$$
+
+```text
+derivative = (value_last - value_first) / (time_last - time_first)
+```
+
 The resulting derivative will be named `<fieldname>_rate` if no `suffix` is
 configured.
 
@@ -63,9 +65,9 @@ the period. From these measurements the time difference in seconds is
 calculated. This time difference is than used to divide the difference of each
 field using the following formula:
 
-$$
-derivative = {{value}_{last} - {value}_{first} \over {{time}_{last} - {time}_{first}}}
-$$
+```text
+derivative = (value_last - value_first) / (time_last - time_first)
+```
 
 For each field the derivative is emitted with a naming pattern
 `<fieldname>_rate`.
@@ -76,9 +78,9 @@ The plugin supports to use a field of the aggregated measurements as derivation
 variable in the denominator. This variable is assumed to be a monotonically
 increasing value. In this feature the following formula is used:
 
-$$
-derivative = {{value}_{last} - {value}_{first} \over {{variable}_{last} - {variable}_{first}}}
-$$
+```text
+derivative = (value_last - value_first) / (variable_last - variable_first)
+```
 
 **Make sure the specified variable is not filtered and exists in the metrics
 passed to this aggregator!**

--- a/plugins/aggregators/derivative/README.md
+++ b/plugins/aggregators/derivative/README.md
@@ -153,6 +153,47 @@ with only occasional changes.
 ## Configuration
 
 ```toml @sample.conf
+# Calculates a derivative for every field.
+[[aggregators.derivative]]
+  ## The period in which to flush the aggregator.
+  period = "30s"
+  ##
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+  ##
+  ## This aggregator will estimate a derivative for each field, which is
+  ## contained in both the first and last metric of the aggregation interval.
+  ## Without further configuration the derivative will be calculated with
+  ## respect to the time difference between these two measurements in seconds.
+  ## The formula applied is for every field:
+  ##
+  ##               value_last - value_first
+  ## derivative = --------------------------
+  ##              time_difference_in_seconds
+  ##
+  ## The resulting derivative will be named *fieldname_rate*. The suffix
+  ## "_rate" can be configured by the *suffix* parameter. When using a
+  ## derivation variable you can include its name for more clarity.
+  # suffix = "_rate"
+  ##
+  ## As an abstraction the derivative can be calculated not only by the time
+  ## difference but by the difference of a field, which is contained in the
+  ## measurement. This field is assumed to be monotonously increasing. This
+  ## feature is used by specifying a *variable*.
+  ## Make sure the specified variable is not filtered and exists in the metrics
+  ## passed to this aggregator!
+  # variable = ""
+  ##
+  ## When using a field as the derivation parameter the name of that field will
+  ## be used for the resulting derivative, e.g. *fieldname_by_parameter*.
+  ##
+  ## Note, that the calculation is based on the actual timestamp of the
+  ## measurements. When there is only one measurement during that period, the
+  ## measurement will be rolled over to the next period. The maximum number of
+  ## such roll-overs can be configured with a default of 10.
+  # max_roll_over = 10
+  ##
 ```
 
 To calculate a derivative for every field use

--- a/plugins/aggregators/derivative/README.md
+++ b/plugins/aggregators/derivative/README.md
@@ -153,7 +153,11 @@ with only occasional changes.
 ## Configuration
 
 ```toml @sample.conf
-# Calculates a derivative for every field.
+```
+
+To calculate a derivative for every field use
+
+```toml
 [[aggregators.derivative]]
   ## Specific Derivative Aggregator Arguments:
 

--- a/plugins/aggregators/derivative/sample.conf
+++ b/plugins/aggregators/derivative/sample.conf
@@ -1,17 +1,41 @@
 # Calculates a derivative for every field.
 [[aggregators.derivative]]
-  ## Specific Derivative Aggregator Arguments:
-
-  ## Configure a custom derivation variable. Timestamp is used if none is given.
-  # variable = ""
-
-  ## Suffix to add to the field name for the derivative name.
-  # suffix = "_rate"
-
-  ## Roll-Over last measurement to first measurement of next period
-  # max_roll_over = 10
-
-  ## General Aggregator Arguments:
-
-  ## calculate derivative every 30 seconds
+  ## The period in which to flush the aggregator.
   period = "30s"
+  ##
+  ## If true, the original metric will be dropped by the
+  ## aggregator and will not get sent to the output plugins.
+  drop_original = false
+  ##
+  ## This aggregator will estimate a derivative for each field, which is
+  ## contained in both the first and last metric of the aggregation interval.
+  ## Without further configuration the derivative will be calculated with
+  ## respect to the time difference between these two measurements in seconds.
+  ## The formula applied is for every field:
+  ##
+  ##               value_last - value_first
+  ## derivative = --------------------------
+  ##              time_difference_in_seconds
+  ##
+  ## The resulting derivative will be named *fieldname_rate*. The suffix
+  ## "_rate" can be configured by the *suffix* parameter. When using a
+  ## derivation variable you can include its name for more clarity.
+  # suffix = "_rate"
+  ##
+  ## As an abstraction the derivative can be calculated not only by the time
+  ## difference but by the difference of a field, which is contained in the
+  ## measurement. This field is assumed to be monotonously increasing. This
+  ## feature is used by specifying a *variable*.
+  ## Make sure the specified variable is not filtered and exists in the metrics
+  ## passed to this aggregator!
+  # variable = ""
+  ##
+  ## When using a field as the derivation parameter the name of that field will
+  ## be used for the resulting derivative, e.g. *fieldname_by_parameter*.
+  ##
+  ## Note, that the calculation is based on the actual timestamp of the
+  ## measurements. When there is only one measurement during that period, the
+  ## measurement will be rolled over to the next period. The maximum number of
+  ## such roll-overs can be configured with a default of 10.
+  # max_roll_over = 10
+  ##

--- a/plugins/aggregators/derivative/sample.conf
+++ b/plugins/aggregators/derivative/sample.conf
@@ -3,39 +3,14 @@
   ## The period in which to flush the aggregator.
   period = "30s"
   ##
-  ## If true, the original metric will be dropped by the
-  ## aggregator and will not get sent to the output plugins.
-  drop_original = false
-  ##
-  ## This aggregator will estimate a derivative for each field, which is
-  ## contained in both the first and last metric of the aggregation interval.
-  ## Without further configuration the derivative will be calculated with
-  ## respect to the time difference between these two measurements in seconds.
-  ## The formula applied is for every field:
-  ##
-  ##               value_last - value_first
-  ## derivative = --------------------------
-  ##              time_difference_in_seconds
-  ##
-  ## The resulting derivative will be named *fieldname_rate*. The suffix
-  ## "_rate" can be configured by the *suffix* parameter. When using a
-  ## derivation variable you can include its name for more clarity.
+  ## Suffix to append for the resulting derivative field.
   # suffix = "_rate"
   ##
-  ## As an abstraction the derivative can be calculated not only by the time
-  ## difference but by the difference of a field, which is contained in the
-  ## measurement. This field is assumed to be monotonously increasing. This
-  ## feature is used by specifying a *variable*.
-  ## Make sure the specified variable is not filtered and exists in the metrics
-  ## passed to this aggregator!
-  # variable = ""
-  ##
+  ## Field to use for the quotient when computing the derivative.
   ## When using a field as the derivation parameter the name of that field will
   ## be used for the resulting derivative, e.g. *fieldname_by_parameter*.
+  ## By default the timestamps of the metrics are used and the suffix is omitted.
+  # variable = ""
   ##
-  ## Note, that the calculation is based on the actual timestamp of the
-  ## measurements. When there is only one measurement during that period, the
-  ## measurement will be rolled over to the next period. The maximum number of
-  ## such roll-overs can be configured with a default of 10.
+  ## Maximum number of roll-overs in case only one measurement is found during a period.
   # max_roll_over = 10
-  ##

--- a/plugins/inputs/cassandra/README.md
+++ b/plugins/inputs/cassandra/README.md
@@ -32,11 +32,6 @@ querying table metrics with a wildcard for the keyspace or table name.
 ```toml @sample.conf
 # Read Cassandra metrics through Jolokia
 [[inputs.cassandra]]
-  ## DEPRECATED: The cassandra plugin has been deprecated.  Please use the
-  ## jolokia2 plugin instead.
-  ##
-  ## see https://github.com/influxdata/telegraf/tree/master/plugins/inputs/jolokia2
-
   context = "/jolokia/read"
   ## List of cassandra servers exposing jolokia read service
   servers = ["myuser:mypassword@10.10.10.1:8778","10.10.10.2:8778",":8778"]

--- a/plugins/inputs/cassandra/sample.conf
+++ b/plugins/inputs/cassandra/sample.conf
@@ -1,10 +1,5 @@
 # Read Cassandra metrics through Jolokia
 [[inputs.cassandra]]
-  ## DEPRECATED: The cassandra plugin has been deprecated.  Please use the
-  ## jolokia2 plugin instead.
-  ##
-  ## see https://github.com/influxdata/telegraf/tree/master/plugins/inputs/jolokia2
-
   context = "/jolokia/read"
   ## List of cassandra servers exposing jolokia read service
   servers = ["myuser:mypassword@10.10.10.1:8778","10.10.10.2:8778",":8778"]

--- a/plugins/inputs/kafka_consumer_legacy/README.md
+++ b/plugins/inputs/kafka_consumer_legacy/README.md
@@ -12,7 +12,6 @@ instances of telegraf can read from the same topic in parallel.
 ## Configuration
 
 ```toml @sample.conf
-## DEPRECATED: The 'kafka_consumer_legacy' plugin is deprecated in version 1.4.0, use 'inputs.kafka_consumer' instead, NOTE: 'kafka_consumer' only supports Kafka v0.8+.
 # Read metrics from Kafka topic(s)
 [[inputs.kafka_consumer_legacy]]
   ## topic(s) to consume

--- a/plugins/inputs/kafka_consumer_legacy/sample.conf
+++ b/plugins/inputs/kafka_consumer_legacy/sample.conf
@@ -1,4 +1,3 @@
-## DEPRECATED: The 'kafka_consumer_legacy' plugin is deprecated in version 1.4.0, use 'inputs.kafka_consumer' instead, NOTE: 'kafka_consumer' only supports Kafka v0.8+.
 # Read metrics from Kafka topic(s)
 [[inputs.kafka_consumer_legacy]]
   ## topic(s) to consume

--- a/plugins/inputs/logparser/README.md
+++ b/plugins/inputs/logparser/README.md
@@ -49,7 +49,6 @@ Migration Example:
 ## Configuration
 
 ```toml @sample.conf
-## DEPRECATED: The 'logparser' plugin is deprecated in version 1.15.0, use 'inputs.tail' with 'grok' data format instead.
 # Read metrics off Arista LANZ, via socket
 [[inputs.logparser]]
   ## Log files to parse.

--- a/plugins/inputs/logparser/sample.conf
+++ b/plugins/inputs/logparser/sample.conf
@@ -1,4 +1,3 @@
-## DEPRECATED: The 'logparser' plugin is deprecated in version 1.15.0, use 'inputs.tail' with 'grok' data format instead.
 # Read metrics off Arista LANZ, via socket
 [[inputs.logparser]]
   ## Log files to parse.

--- a/plugins/inputs/riemann_listener/README.md
+++ b/plugins/inputs/riemann_listener/README.md
@@ -7,7 +7,7 @@ client that use riemann clients using riemann-protobuff format.
 
 ```toml @sample.conf
 # Riemann protobuff listener
-[[inputs.rimann_listener]]
+[[inputs.riemann_listener]]
   ## URL to listen on
   ## Default is "tcp://:5555"
   #  service_address = "tcp://:8094"

--- a/plugins/inputs/riemann_listener/sample.conf
+++ b/plugins/inputs/riemann_listener/sample.conf
@@ -1,5 +1,5 @@
 # Riemann protobuff listener
-[[inputs.rimann_listener]]
+[[inputs.riemann_listener]]
   ## URL to listen on
   ## Default is "tcp://:5555"
   #  service_address = "tcp://:8094"

--- a/plugins/inputs/snmp_legacy/README.md
+++ b/plugins/inputs/snmp_legacy/README.md
@@ -7,7 +7,6 @@ The SNMP input plugin gathers metrics from SNMP agents
 ## Configuration
 
 ```toml @sample.conf
-# DEPRECATED! PLEASE USE inputs.snmp INSTEAD.
 [[inputs.snmp_legacy]]
   ## Use 'oids.txt' file to translate oids to names
   ## To generate 'oids.txt' you need to run:

--- a/plugins/inputs/snmp_legacy/sample.conf
+++ b/plugins/inputs/snmp_legacy/sample.conf
@@ -1,4 +1,3 @@
-# DEPRECATED! PLEASE USE inputs.snmp INSTEAD.
 [[inputs.snmp_legacy]]
   ## Use 'oids.txt' file to translate oids to names
   ## To generate 'oids.txt' you need to run:

--- a/plugins/inputs/vsphere/README.md
+++ b/plugins/inputs/vsphere/README.md
@@ -19,10 +19,10 @@ Compatibility information is available from the govmomi project
 
 ## Configuration
 
-```toml
-# Read metrics from one or many vCenters
+```toml @sample.conf
+-# Read metrics from one or many vCenters
 [[inputs.vsphere]]
-    ## List of vCenter URLs to be monitored. These three lines must be uncommented
+  ## List of vCenter URLs to be monitored. These three lines must be uncommented
   ## and edited for the plugin to work.
   vcenters = [ "https://vcenter.local/sdk" ]
   username = "user@corp.local"
@@ -144,7 +144,7 @@ Compatibility information is available from the govmomi project
   # datastore_metric_exclude = [] ## Nothing excluded by default
   # datastore_instances = false ## false by default
 
-    ## Datastores
+  ## Datastores
   # datastore_include = [ "/*/datastore/**"] # Inventory path to datastores to collect (by default all are collected)
   # datastore_exclude = [] # Inventory paths to exclude
   # datastore_metric_include = [] ## if omitted or empty, all metrics are collected
@@ -188,12 +188,6 @@ Compatibility information is available from the govmomi project
   ## preserve the full precision when averaging takes place.
   # use_int_samples = true
 
-  ## The number of vSphere 5 minute metric collection cycles to look back for non-realtime metrics. In 
-  ## some versions (6.7, 7.0 and possible more), certain metrics, such as cluster metrics, may be reported
-  ## with a significant delay (>30min). If this happens, try increasing this number. Please note that increasing
-  ## it too much may cause performance issues.
-  # metric_lookback = 3
-
   ## Custom attributes from vCenter can be very useful for queries in order to slice the
   ## metrics along different dimension and for forming ad-hoc relationships. They are disabled
   ## by default, since they can add a considerable amount of tags to the resulting metrics. To
@@ -205,19 +199,29 @@ Compatibility information is available from the govmomi project
   # custom_attribute_include = []
   # custom_attribute_exclude = ["*"]
 
+  ## The number of vSphere 5 minute metric collection cycles to look back for non-realtime metrics. In
+  ## some versions (6.7, 7.0 and possible more), certain metrics, such as cluster metrics, may be reported
+  ## with a significant delay (>30min). If this happens, try increasing this number. Please note that increasing
+  ## it too much may cause performance issues.
+  # metric_lookback = 3
+
   ## Optional SSL Config
   # ssl_ca = "/path/to/cafile"
   # ssl_cert = "/path/to/certfile"
   # ssl_key = "/path/to/keyfile"
   ## Use SSL but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## The Historical Interval value must match EXACTLY the interval in the daily
+  # "Interval Duration" found on the VCenter server under Configure > General > Statistics > Statistic intervals
+  # historical_interval = "5m"
 ```
 
 NOTE: To disable collection of a specific resource type, simply exclude all
 metrics using the XX_metric_exclude.  For example, to disable collection of VMs,
 add this:
 
-```toml @sample.conf
+```toml
 vm_metric_exclude = [ "*" ]
 ```
 

--- a/plugins/inputs/vsphere/sample.conf
+++ b/plugins/inputs/vsphere/sample.conf
@@ -1,4 +1,4 @@
-# Read metrics from VMware vCenter
+-# Read metrics from one or many vCenters
 [[inputs.vsphere]]
   ## List of vCenter URLs to be monitored. These three lines must be uncommented
   ## and edited for the plugin to work.

--- a/plugins/inputs/vsphere/sample.conf
+++ b/plugins/inputs/vsphere/sample.conf
@@ -1,1 +1,195 @@
-vm_metric_exclude = [ "*" ]
+# Read metrics from VMware vCenter
+[[inputs.vsphere]]
+  ## List of vCenter URLs to be monitored. These three lines must be uncommented
+  ## and edited for the plugin to work.
+  vcenters = [ "https://vcenter.local/sdk" ]
+  username = "user@corp.local"
+  password = "secret"
+
+  ## VMs
+  ## Typical VM metrics (if omitted or empty, all metrics are collected)
+  # vm_include = [ "/*/vm/**"] # Inventory path to VMs to collect (by default all are collected)
+  # vm_exclude = [] # Inventory paths to exclude
+  vm_metric_include = [
+    "cpu.demand.average",
+    "cpu.idle.summation",
+    "cpu.latency.average",
+    "cpu.readiness.average",
+    "cpu.ready.summation",
+    "cpu.run.summation",
+    "cpu.usagemhz.average",
+    "cpu.used.summation",
+    "cpu.wait.summation",
+    "mem.active.average",
+    "mem.granted.average",
+    "mem.latency.average",
+    "mem.swapin.average",
+    "mem.swapinRate.average",
+    "mem.swapout.average",
+    "mem.swapoutRate.average",
+    "mem.usage.average",
+    "mem.vmmemctl.average",
+    "net.bytesRx.average",
+    "net.bytesTx.average",
+    "net.droppedRx.summation",
+    "net.droppedTx.summation",
+    "net.usage.average",
+    "power.power.average",
+    "virtualDisk.numberReadAveraged.average",
+    "virtualDisk.numberWriteAveraged.average",
+    "virtualDisk.read.average",
+    "virtualDisk.readOIO.latest",
+    "virtualDisk.throughput.usage.average",
+    "virtualDisk.totalReadLatency.average",
+    "virtualDisk.totalWriteLatency.average",
+    "virtualDisk.write.average",
+    "virtualDisk.writeOIO.latest",
+    "sys.uptime.latest",
+  ]
+  # vm_metric_exclude = [] ## Nothing is excluded by default
+  # vm_instances = true ## true by default
+
+  ## Hosts
+  ## Typical host metrics (if omitted or empty, all metrics are collected)
+  # host_include = [ "/*/host/**"] # Inventory path to hosts to collect (by default all are collected)
+  # host_exclude [] # Inventory paths to exclude
+  host_metric_include = [
+    "cpu.coreUtilization.average",
+    "cpu.costop.summation",
+    "cpu.demand.average",
+    "cpu.idle.summation",
+    "cpu.latency.average",
+    "cpu.readiness.average",
+    "cpu.ready.summation",
+    "cpu.swapwait.summation",
+    "cpu.usage.average",
+    "cpu.usagemhz.average",
+    "cpu.used.summation",
+    "cpu.utilization.average",
+    "cpu.wait.summation",
+    "disk.deviceReadLatency.average",
+    "disk.deviceWriteLatency.average",
+    "disk.kernelReadLatency.average",
+    "disk.kernelWriteLatency.average",
+    "disk.numberReadAveraged.average",
+    "disk.numberWriteAveraged.average",
+    "disk.read.average",
+    "disk.totalReadLatency.average",
+    "disk.totalWriteLatency.average",
+    "disk.write.average",
+    "mem.active.average",
+    "mem.latency.average",
+    "mem.state.latest",
+    "mem.swapin.average",
+    "mem.swapinRate.average",
+    "mem.swapout.average",
+    "mem.swapoutRate.average",
+    "mem.totalCapacity.average",
+    "mem.usage.average",
+    "mem.vmmemctl.average",
+    "net.bytesRx.average",
+    "net.bytesTx.average",
+    "net.droppedRx.summation",
+    "net.droppedTx.summation",
+    "net.errorsRx.summation",
+    "net.errorsTx.summation",
+    "net.usage.average",
+    "power.power.average",
+    "storageAdapter.numberReadAveraged.average",
+    "storageAdapter.numberWriteAveraged.average",
+    "storageAdapter.read.average",
+    "storageAdapter.write.average",
+    "sys.uptime.latest",
+  ]
+    ## Collect IP addresses? Valid values are "ipv4" and "ipv6"
+  # ip_addresses = ["ipv6", "ipv4" ]
+
+  # host_metric_exclude = [] ## Nothing excluded by default
+  # host_instances = true ## true by default
+
+
+  ## Clusters
+  # cluster_include = [ "/*/host/**"] # Inventory path to clusters to collect (by default all are collected)
+  # cluster_exclude = [] # Inventory paths to exclude
+  # cluster_metric_include = [] ## if omitted or empty, all metrics are collected
+  # cluster_metric_exclude = [] ## Nothing excluded by default
+  # cluster_instances = false ## false by default
+
+  ## Resource Pools
+  # datastore_include = [ "/*/host/**"] # Inventory path to datastores to collect (by default all are collected)
+  # datastore_exclude = [] # Inventory paths to exclude
+  # datastore_metric_include = [] ## if omitted or empty, all metrics are collected
+  # datastore_metric_exclude = [] ## Nothing excluded by default
+  # datastore_instances = false ## false by default
+
+  ## Datastores
+  # datastore_include = [ "/*/datastore/**"] # Inventory path to datastores to collect (by default all are collected)
+  # datastore_exclude = [] # Inventory paths to exclude
+  # datastore_metric_include = [] ## if omitted or empty, all metrics are collected
+  # datastore_metric_exclude = [] ## Nothing excluded by default
+  # datastore_instances = false ## false by default
+
+  ## Datacenters
+  # datacenter_include = [ "/*/host/**"] # Inventory path to clusters to collect (by default all are collected)
+  # datacenter_exclude = [] # Inventory paths to exclude
+  datacenter_metric_include = [] ## if omitted or empty, all metrics are collected
+  datacenter_metric_exclude = [ "*" ] ## Datacenters are not collected by default.
+  # datacenter_instances = false ## false by default
+
+  ## Plugin Settings
+  ## separator character to use for measurement and field names (default: "_")
+  # separator = "_"
+
+  ## number of objects to retrieve per query for realtime resources (vms and hosts)
+  ## set to 64 for vCenter 5.5 and 6.0 (default: 256)
+  # max_query_objects = 256
+
+  ## number of metrics to retrieve per query for non-realtime resources (clusters and datastores)
+  ## set to 64 for vCenter 5.5 and 6.0 (default: 256)
+  # max_query_metrics = 256
+
+  ## number of go routines to use for collection and discovery of objects and metrics
+  # collect_concurrency = 1
+  # discover_concurrency = 1
+
+  ## the interval before (re)discovering objects subject to metrics collection (default: 300s)
+  # object_discovery_interval = "300s"
+
+  ## timeout applies to any of the api request made to vcenter
+  # timeout = "60s"
+
+  ## When set to true, all samples are sent as integers. This makes the output
+  ## data types backwards compatible with Telegraf 1.9 or lower. Normally all
+  ## samples from vCenter, with the exception of percentages, are integer
+  ## values, but under some conditions, some averaging takes place internally in
+  ## the plugin. Setting this flag to "false" will send values as floats to
+  ## preserve the full precision when averaging takes place.
+  # use_int_samples = true
+
+  ## Custom attributes from vCenter can be very useful for queries in order to slice the
+  ## metrics along different dimension and for forming ad-hoc relationships. They are disabled
+  ## by default, since they can add a considerable amount of tags to the resulting metrics. To
+  ## enable, simply set custom_attribute_exclude to [] (empty set) and use custom_attribute_include
+  ## to select the attributes you want to include.
+  ## By default, since they can add a considerable amount of tags to the resulting metrics. To
+  ## enable, simply set custom_attribute_exclude to [] (empty set) and use custom_attribute_include
+  ## to select the attributes you want to include.
+  # custom_attribute_include = []
+  # custom_attribute_exclude = ["*"]
+
+  ## The number of vSphere 5 minute metric collection cycles to look back for non-realtime metrics. In
+  ## some versions (6.7, 7.0 and possible more), certain metrics, such as cluster metrics, may be reported
+  ## with a significant delay (>30min). If this happens, try increasing this number. Please note that increasing
+  ## it too much may cause performance issues.
+  # metric_lookback = 3
+
+  ## Optional SSL Config
+  # ssl_ca = "/path/to/cafile"
+  # ssl_cert = "/path/to/certfile"
+  # ssl_key = "/path/to/keyfile"
+  ## Use SSL but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## The Historical Interval value must match EXACTLY the interval in the daily
+  # "Interval Duration" found on the VCenter server under Configure > General > Statistics > Statistic intervals
+  # historical_interval = "5m"

--- a/plugins/outputs/logzio/README.md
+++ b/plugins/outputs/logzio/README.md
@@ -7,24 +7,16 @@ This plugin sends metrics to Logz.io over HTTPs.
 ```toml @sample.conf
 # A plugin that can send metrics over HTTPs to Logz.io
 [[outputs.logzio]]
-  ## Set to true if Logz.io sender checks the disk space before adding metrics to the disk queue.
-  # check_disk_space = true
+  ## Connection timeout, defaults to "5s" if not set.
+  # timeout = "5s"
 
-  ## The percent of used file system space at which the sender will stop queueing.
-  ## When we will reach that percentage, the file system in which the queue is stored will drop
-  ## all new logs until the percentage of used space drops below that threshold.
-  # disk_threshold = 98
-
-  ## How often Logz.io sender should drain the queue.
-  ## Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-  # drain_duration = "3s"
-
-  ## Where Logz.io sender should store the queue
-  ## queue_dir = Sprintf("%s%s%s%s%d", os.TempDir(), string(os.PathSeparator),
-  ##                     "logzio-buffer", string(os.PathSeparator), time.Now().UnixNano())
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
 
   ## Logz.io account token
-  token = "your Logz.io token" # required
+  token = "your logz.io token" # required
 
   ## Use your listener URL for your Logz.io account region.
   # url = "https://listener.logz.io:8071"

--- a/plugins/outputs/logzio/sample.conf
+++ b/plugins/outputs/logzio/sample.conf
@@ -1,23 +1,15 @@
 # A plugin that can send metrics over HTTPs to Logz.io
 [[outputs.logzio]]
-  ## Set to true if Logz.io sender checks the disk space before adding metrics to the disk queue.
-  # check_disk_space = true
+  ## Connection timeout, defaults to "5s" if not set.
+  # timeout = "5s"
 
-  ## The percent of used file system space at which the sender will stop queueing.
-  ## When we will reach that percentage, the file system in which the queue is stored will drop
-  ## all new logs until the percentage of used space drops below that threshold.
-  # disk_threshold = 98
-
-  ## How often Logz.io sender should drain the queue.
-  ## Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-  # drain_duration = "3s"
-
-  ## Where Logz.io sender should store the queue
-  ## queue_dir = Sprintf("%s%s%s%s%d", os.TempDir(), string(os.PathSeparator),
-  ##                     "logzio-buffer", string(os.PathSeparator), time.Now().UnixNano())
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
 
   ## Logz.io account token
-  token = "your Logz.io token" # required
+  token = "your logz.io token" # required
 
   ## Use your listener URL for your Logz.io account region.
   # url = "https://listener.logz.io:8071"

--- a/tools/readme_config_includer/generator.go
+++ b/tools/readme_config_includer/generator.go
@@ -57,7 +57,7 @@ func insertInclude(buf *bytes.Buffer, include string) error {
 }
 
 func insertIncludes(buf *bytes.Buffer, b includeBlock) error {
-	// Insert all includes in the order they occured
+	// Insert all includes in the order they occurred
 	for _, include := range b.Includes {
 		if err := insertInclude(buf, include); err != nil {
 			return err
@@ -127,7 +127,7 @@ func main() {
 			block.Includes = append(block.Includes, string(inc[1]))
 		}
 
-		// Extract the block boarders
+		// Extract the block borders
 		block.extractBlockBorders(codeNode)
 		blocksToReplace = append(blocksToReplace, block)
 	}
@@ -153,13 +153,13 @@ func main() {
 			log.Fatal(err)
 		}
 	}
-	// Copy the remainings of the original file...
+	// Copy the remaining of the original file...
 	if _, err := output.Write(readme[offset:]); err != nil {
 		log.Fatalf("Writing remaining content failed: %v", err)
 	}
 
 	// Write output with same permission as input
-	file, err := os.OpenFile(inputFilename, os.O_CREATE|os.O_WRONLY, perm)
+	file, err := os.OpenFile(inputFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
 	if err != nil {
 		log.Fatalf("Opening output file failed: %v", err)
 	}


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR fixes a few broken `sample.conf` files that were broken during the initial migration to template-based generation. This concerns

- outputs/logzio           -- fix mismatch between README and in-code options
- inputs/riemann_listener -- fix type in section
- inputs/vsphere          -- restore config due to initial migrating of the wrong TOML section
- removal of superfluous `DEPRECATED` warnings in the `sample.conf`

Furthermore, this fixes an issue in the embedding tool that adds garbage to the README in cases where the sample.config was getting smaller. This is due to missing truncation keeping the "old" content of the README at the end.

