### PR TITLE
test: add install go for linux, use in integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,7 @@ jobs:
     steps:
       - checkout
       - check-changed-files-or-halt
+      - run: 'sh ./scripts/installgo_linux.sh'
       - run: 'make deps'
       - run: 'make test-integration'
   test-go-mac:

--- a/docs/developers/PACKAGING.md
+++ b/docs/developers/PACKAGING.md
@@ -14,7 +14,7 @@ Incrementing the version is maintained by the core Telegraf team because it requ
 
 1. Within the `Makefile` and `.circleci\config.yml` update the Go versions to the new version number
 2. Run `make ci`, this requires quay.io internal permissions
-3. The files `scripts\installgo_mac.sh` and `scripts\installgo_windows.sh` need to be updated as well with the new Go version and SHA
+3. The files `scripts\installgo_linux.sh`, `scripts\installgo_mac.sh`, and `scripts\installgo_windows.sh` need to be updated as well with the new Go version and SHA
 4. Create a pull request with these new changes, and verify the CI passes and uses the new docker image
 
 See the [previous PRs](https://github.com/influxdata/telegraf/search?q=chore+update+go&type=commits) as examples.

--- a/scripts/installgo_linux.sh
+++ b/scripts/installgo_linux.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -eux
+
+ARCH=$(uname -m)
+GO_VERSION="1.18.3"
+GO_ARCH="linux-amd64"
+# from https://golang.org/dl
+GO_VERSION_SHA="956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245"
+
+# Download Go and verify Go tarball
+setup_go () {
+    echo "installing go"
+    curl -L https://golang.org/dl/go${GO_VERSION}.${GO_ARCH}.tar.gz --output go${GO_VERSION}.${GO_ARCH}.tar.gz
+    if ! echo "${GO_VERSION_SHA}  go${GO_VERSION}.${GO_ARCH}.tar.gz" | shasum --algorithm 256 --check -; then
+        echo "Checksum failed" >&2
+        exit 1
+    fi
+
+    sudo tar -C /usr/local -xzf go${GO_VERSION}.${GO_ARCH}.tar.gz
+
+    echo $PATH
+    which go
+    go version
+}
+
+if command -v go >/dev/null 2>&1; then
+    echo "Go is already installed"
+    v=$(go version | { read -r _ _ v _; echo "${v#go}"; })
+    echo "$v is installed, required version is ${GO_VERSION}"
+    if [ "$v" != ${GO_VERSION} ]; then
+        setup_go
+    fi
+else
+    setup_go
+fi

--- a/scripts/installgo_linux.sh
+++ b/scripts/installgo_linux.sh
@@ -2,7 +2,6 @@
 
 set -eux
 
-ARCH=$(uname -m)
 GO_VERSION="1.18.3"
 GO_ARCH="linux-amd64"
 # from https://golang.org/dl
@@ -19,7 +18,7 @@ setup_go () {
 
     sudo tar -C /usr/local -xzf go${GO_VERSION}.${GO_ARCH}.tar.gz
 
-    echo $PATH
+    echo "$PATH"
     which go
     go version
 }


### PR DESCRIPTION
In order to ensure all our testing is using the same version of go
across all tests, add an install go for linux.