### PR TITLE
fix: Don't rebase on master when building packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,6 @@ commands:
     steps:
       - checkout
       - check-changed-files-or-halt
-      - rebase-on-master
       - attach_workspace:
           at: '/go'
       - when:


### PR DESCRIPTION
When creating a tag for release, this rebase causes the wrong `build_version.txt` to be used. Remove this step as it is only needed during testing to verify there are no merge conflicts.