### PR TITLE
fix: Remove all rebase logic from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,14 +37,6 @@ commands:
   check-changed-files-or-halt:
     steps:
       - run: ./scripts/check-file-changes.sh
-  rebase-on-master:
-    steps:
-      - run: |
-          git config --global user.email "telegraf@influxdb.com"
-          git config --global user.name "telegraf"
-          git remote add upstream https://github.com/influxdata/telegraf
-          git fetch upstream
-          git rebase upstream/master
   test-go:
     parameters:
       os:
@@ -62,7 +54,6 @@ commands:
     steps:
       - checkout
       - check-changed-files-or-halt
-      - rebase-on-master
       - when:
           condition:
             equal: [ linux, << parameters.os >> ]


### PR DESCRIPTION
This rebase is still causing issues with the final release artifacts, removing it entirely in favor to revisit it at another time.
Similar to: https://github.com/influxdata/telegraf/pull/11291