### PR TITLE
fix(parsers/xpath): Reduce debug messages when empty selection is allowed

### DIFF
--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -100,11 +100,9 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(selectedNodes) < 1 || selectedNodes[0] == nil {
+		if (len(selectedNodes) < 1 || selectedNodes[0] == nil) && !p.AllowEmptySelection {
 			p.debugEmptyQuery("metric selection", doc, config.Selection)
-			if !p.AllowEmptySelection {
-				return metrics, fmt.Errorf("cannot parse with empty selection node")
-			}
+			return metrics, fmt.Errorf("cannot parse with empty selection node")
 		}
 		p.Log.Debugf("Number of selected metric nodes: %d", len(selectedNodes))
 


### PR DESCRIPTION

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Option introduced in #11102 does produce a lot of debug messages when we are in a valid state. This PR aims to reduce this.