### PR TITLE
feat: Add starlark benchmark for tag-concatenation

### DIFF
--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -3183,6 +3183,68 @@ def apply(metric):
 				),
 			},
 		},
+		{
+			name: "concatenate 2 tags",
+			source: `
+def apply(metric):
+	metric.tags["result"] = '_'.join(metric.tags.values())
+	return metric
+`,
+			input: []telegraf.Metric{
+				testutil.MustMetric("cpu",
+					map[string]string{
+						"tag_1": "a",
+						"tag_2": "b",
+					},
+					map[string]interface{}{"value": 42},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			name: "concatenate 4 tags",
+			source: `
+def apply(metric):
+	metric.tags["result"] = '_'.join(metric.tags.values())
+	return metric
+`,
+			input: []telegraf.Metric{
+				testutil.MustMetric("cpu",
+					map[string]string{
+						"tag_1": "a",
+						"tag_2": "b",
+						"tag_3": "c",
+						"tag_4": "d",
+					},
+					map[string]interface{}{"value": 42},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			name: "concatenate 8 tags",
+			source: `
+def apply(metric):
+	metric.tags["result"] = '_'.join(metric.tags.values())
+	return metric
+`,
+			input: []telegraf.Metric{
+				testutil.MustMetric("cpu",
+					map[string]string{
+						"tag_1": "a",
+						"tag_2": "b",
+						"tag_3": "c",
+						"tag_4": "d",
+						"tag_5": "e",
+						"tag_6": "f",
+						"tag_7": "g",
+						"tag_8": "h",
+					},
+					map[string]interface{}{"value": 42},
+					time.Unix(0, 0),
+				),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/testutil/metric.go
+++ b/testutil/metric.go
@@ -20,6 +20,10 @@ type metricDiff struct {
 	Time        time.Time
 }
 
+type helper interface {
+	Helper()
+}
+
 func lessFunc(lhs, rhs *metricDiff) bool {
 	if lhs.Measurement != rhs.Measurement {
 		return lhs.Measurement < rhs.Measurement
@@ -140,8 +144,10 @@ func MetricEqual(expected, actual telegraf.Metric, opts ...cmp.Option) bool {
 
 // RequireMetricEqual halts the test with an error if the metrics are not
 // equal.
-func RequireMetricEqual(t *testing.T, expected, actual telegraf.Metric, opts ...cmp.Option) {
-	t.Helper()
+func RequireMetricEqual(t testing.TB, expected, actual telegraf.Metric, opts ...cmp.Option) {
+	if x, ok := t.(helper); ok {
+		x.Helper()
+	}
 
 	var lhs, rhs *metricDiff
 	if expected != nil {
@@ -159,8 +165,10 @@ func RequireMetricEqual(t *testing.T, expected, actual telegraf.Metric, opts ...
 
 // RequireMetricsEqual halts the test with an error if the array of metrics
 // are not equal.
-func RequireMetricsEqual(t *testing.T, expected, actual []telegraf.Metric, opts ...cmp.Option) {
-	t.Helper()
+func RequireMetricsEqual(t testing.TB, expected, actual []telegraf.Metric, opts ...cmp.Option) {
+	if x, ok := t.(helper); ok {
+		x.Helper()
+	}
 
 	lhs := make([]*metricDiff, 0, len(expected))
 	for _, m := range expected {


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR adds a benchmark for concatenating tags in the `starlark` processor. Furthermore, it adds the possibility to compare metrics in benchmark runs.