### PR TITLE
test: update wait for statement for postgres

### DIFF
--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -21,6 +21,8 @@ func launchTestContainer(t *testing.T) *testutil.Container {
 			"POSTGRES_HOST_AUTH_METHOD": "trust",
 		},
 		WaitingFor: wait.ForAll(
+			// the database comes up twice, once right away, then again a second
+			// time after the docker entrypoint starts configuraiton
 			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
 			wait.ForListeningPort(nat.Port(servicePort)),
 		),

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -21,7 +21,7 @@ func launchTestContainer(t *testing.T) *testutil.Container {
 			"POSTGRES_HOST_AUTH_METHOD": "trust",
 		},
 		WaitingFor: wait.ForAll(
-			wait.ForLog("database system is ready to accept connections"),
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
 			wait.ForListeningPort(nat.Port(servicePort)),
 		),
 	}


### PR DESCRIPTION
The postgres docker image will start up and immediately shutdown the
service will the docker entrypoint starts configuration. This results in
the expected ready to accept connections log message to show up twice.
This generally happens within a tenth of a second, but in CI this can
get hit and the test will fail as the database is not yet up.

fixes: #11292