### PR TITLE
fix: Prevent concurrent map writes to c.UnusedFields

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -65,9 +66,10 @@ var (
 // will be logging to, as well as all the plugins that the user has
 // specified
 type Config struct {
-	toml         *toml.Config
-	errs         []error // config load errors.
-	UnusedFields map[string]bool
+	toml              *toml.Config
+	errs              []error // config load errors.
+	UnusedFields      map[string]bool
+	unusedFieldsMutex *sync.Mutex
 
 	Tags          map[string]string
 	InputFilters  []string
@@ -91,7 +93,8 @@ type Config struct {
 // once the configuration is parsed.
 func NewConfig() *Config {
 	c := &Config{
-		UnusedFields: map[string]bool{},
+		UnusedFields:      map[string]bool{},
+		unusedFieldsMutex: &sync.Mutex{},
 
 		// Agent defaults:
 		Agent: &AgentConfig{
@@ -1312,12 +1315,12 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 	if t, ok := input.(telegraf.ParserFuncInput); ok {
 		missThreshold = 1
 		if c.probeParser(table) {
-			parser, err := c.addParser(name, table)
-			if err != nil {
-				return err
-			}
-			err = parser.Init()
 			t.SetParserFunc(func() (telegraf.Parser, error) {
+				parser, err := c.addParser(name, table)
+				if err != nil {
+					return nil, err
+				}
+				err = parser.Init()
 				return parser, err
 			})
 		} else {
@@ -1846,7 +1849,9 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 
 		// ignore fields that are common to all plugins.
 	default:
+		c.unusedFieldsMutex.Lock()
 		c.UnusedFields[key] = true
+		c.unusedFieldsMutex.Unlock()
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -65,9 +66,10 @@ var (
 // will be logging to, as well as all the plugins that the user has
 // specified
 type Config struct {
-	toml         *toml.Config
-	errs         []error // config load errors.
-	UnusedFields map[string]bool
+	toml              *toml.Config
+	errs              []error // config load errors.
+	UnusedFields      map[string]bool
+	unusedFieldsMutex *sync.Mutex
 
 	Tags          map[string]string
 	InputFilters  []string
@@ -91,7 +93,8 @@ type Config struct {
 // once the configuration is parsed.
 func NewConfig() *Config {
 	c := &Config{
-		UnusedFields: map[string]bool{},
+		UnusedFields:      map[string]bool{},
+		unusedFieldsMutex: &sync.Mutex{},
 
 		// Agent defaults:
 		Agent: &AgentConfig{
@@ -1846,7 +1849,9 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 
 		// ignore fields that are common to all plugins.
 	default:
+		c.unusedFieldsMutex.Lock()
 		c.UnusedFields[key] = true
+		c.unusedFieldsMutex.Unlock()
 	}
 	return nil
 }


### PR DESCRIPTION
resolve: https://github.com/influxdata/telegraf/issues/11308

Telegraf is panicking reporting the error "fatal error: concurrent map writes" because maps in Go are not safe for concurrent use. The method `missingTomlField` was writing to the map `c.UnusedFields` concurrently so this pull request wraps the write with a mutex to allow the map to be updated safely. This panic is easily reproducible with a config defining multiple similar inputs that have the data_format set as "csv". I think this bug was a side effect from [removing csv](https://github.com/influxdata/telegraf/pull/8791/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L1655-L1657) from the switch case to migrate it to the new parser. The function `missingTomlField` gets called "when the decoder encounters a key for which no matching struct field exists" , ~~so I don't think this has anything to do with the parser restructure itself but just helped identify this issue because this could happen by just providing an invalid config.~~

<details>
  <summary>I tested this by using the following configuration (Click to expand!)</summary>
  
```toml
[[inputs.file]]
  files =[ "test.csv" ]

  data_format = "csv"
  csv_header_row_count = 1
  csv_column_names = [ "usage_user_env","usage_user_server","usage_user_start_dt","usage_user_count" ]
  csv_tag_columns = [ "usage_user_env" ]
  csv_measurement_column = "usage_user_count"
  csv_timestamp_column = "usage_user_start_dt"
  csv_timestamp_ormat = "Monday, 02-01-06 15:04:05 MST"

[[inputs.file]]
    files =[ "test.csv" ]
    data_format = "csv"
    csv_header_row_count = 0
    csv_column_names = ["Backup_Type","Backup_Slug","Backup_State","Backup_Owner","Backup_Failed","Backup_Size","Backup_Duration","Backup_TimeStamp"]
    csv_tag_columns = [ "Backup_Type","Backup_Slug","Backup_State","Backup_Owner" ]
    csv_measurement_column = "Backup_Failed,Backup_Size,Backup_Duration"
     csv_timestamp_column = "Backup_TimeStamp"
    csv_timestamp_ormat = "Monday, 02-01-06 15:04:05 MST"

[[inputs.file]]
    files =[ "test.csv" ]
    data_format = "csv"
    csv_header_row_count = 1
    csv_column_names = [ "usage_user_env","usage_user_server","usage_user_start_dt","usage_user_count" ]
    csv_tag_columns = [ "usage_user_env" ]
    csv_measurement_column = "usage_user_count"
    csv_timestamp_column = "usage_user_start_dt"
    csv_timestamp_format = "Monday, 02-01-06 15:04:05 MST"

[[inputs.file]]
    files =[ "test.csv" ]
    data_format = "csv"
    csv_header_row_count = 1
    csv_column_names = [ "usage_process_env","usage_process_server","usage_process_start_dt","usage_process_count" ]
    csv_tag_columns = [ "usage_process_env" ]
    csv_measurement_column = "usage_process_count"
    csv_timestamp_column = "usage_process_start_dt"
    csv_timestamp_format = "Monday, 02-01-06 15:04:05 MST"

[[outputs.file]]
    files = ["stdout"]
```

</details>