### PR TITLE
feat(agent): add ignore_error_inputs option for inputs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -184,6 +184,12 @@ func (a *Agent) Run(ctx context.Context) error {
 	return err
 }
 
+// determine whether to ignore the Input of the error
+// It has two option: input.ignore_init_error and agent.ignore_error_inputs
+func (a *Agent) isIgnoreInput(errInput *models.RunningInput) bool {
+	return errInput.Config.IgnoreInitError || a.Config.Agent.IgnoreErrorInputs
+}
+
 // initPlugins runs the Init function on plugins.
 func (a *Agent) initPlugins() error {
 	inputs := make([]*models.RunningInput, 0)
@@ -193,7 +199,7 @@ func (a *Agent) initPlugins() error {
 			tp.SetTranslator(a.Config.Agent.SnmpTranslator)
 		}
 		err := input.Init()
-		if err != nil && a.Config.Agent.IgnoreErrorInputs {
+		if err != nil && a.isIgnoreInput(input) {
 			log.Printf("W! [agent] Ignore initialize error input %s: %v", input.LogName(), err)
 			continue
 		} else if err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -46,7 +46,6 @@ func TestAgent_isIgnoreInput(t *testing.T) {
 	a.Config.Agent.IgnoreErrorInputs = false
 	// input.ignore_init_error=false and agent.ignore_error_inputs=false
 	assert.True(t, a.isIgnoreInput(input))
-
 }
 
 type testIgnoreErrorInput struct {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -22,6 +22,33 @@ func TestAgent_OmitHostname(t *testing.T) {
 	assert.NotContains(t, c.Tags, "host")
 }
 
+func TestAgent_isIgnoreInput(t *testing.T) {
+	c := config.NewConfig()
+	assert.False(t, c.Agent.IgnoreErrorInputs)
+	a, err := NewAgent(c)
+	assert.NoError(t, err)
+	input := &models.RunningInput{
+		Config: &models.InputConfig{},
+	}
+	assert.False(t, a.Config.Agent.IgnoreErrorInputs)
+	assert.False(t, input.Config.IgnoreInitError)
+	// default: input.ignore_init_error=false and agent.ignore_error_inputs=false
+	assert.False(t, a.isIgnoreInput(input))
+
+	a.Config.Agent.IgnoreErrorInputs = true
+	// input.ignore_init_error=false and agent.ignore_error_inputs=true
+	assert.True(t, a.isIgnoreInput(input))
+
+	input.Config.IgnoreInitError = true
+	// input.ignore_init_error=true and agent.ignore_error_inputs=true
+	assert.True(t, a.isIgnoreInput(input))
+
+	a.Config.Agent.IgnoreErrorInputs = false
+	// input.ignore_init_error=false and agent.ignore_error_inputs=false
+	assert.True(t, a.isIgnoreInput(input))
+
+}
+
 type testIgnoreErrorInput struct {
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -42,7 +42,8 @@ func TestAgent_IgnoreErrorInputs(t *testing.T) {
 	c.Inputs = []*models.RunningInput{{}}
 	a, err := NewAgent(c)
 	assert.NoError(t, err)
-	a.initPlugins()
+	err = a.initPlugins()
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(c.Inputs))
 
 	c.Inputs = []*models.RunningInput{{

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,10 +1,13 @@
 package agent
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/models"
 	_ "github.com/influxdata/telegraf/plugins/inputs/all"
 	_ "github.com/influxdata/telegraf/plugins/outputs/all"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +20,49 @@ func TestAgent_OmitHostname(t *testing.T) {
 	_, err := NewAgent(c)
 	assert.NoError(t, err)
 	assert.NotContains(t, c.Tags, "host")
+}
+
+type testIgnoreErrorInput struct {
+}
+
+func (i *testIgnoreErrorInput) Init() error {
+	return fmt.Errorf("could not initialize input: test error")
+}
+
+func (i *testIgnoreErrorInput) Gather(telegraf.Accumulator) error {
+	return nil
+}
+func (i *testIgnoreErrorInput) SampleConfig() string {
+	return ""
+}
+
+func TestAgent_IgnoreErrorInputs(t *testing.T) {
+	c := config.NewConfig()
+	assert.False(t, c.Agent.IgnoreErrorInputs)
+	c.Inputs = []*models.RunningInput{{}}
+	a, err := NewAgent(c)
+	assert.NoError(t, err)
+	a.initPlugins()
+	assert.Equal(t, 1, len(c.Inputs))
+
+	c.Inputs = []*models.RunningInput{{
+		Config: &models.InputConfig{
+			Name:     "test error input",
+			Alias:    "test alias",
+			Interval: 10 * time.Second,
+		},
+		Input: &testIgnoreErrorInput{},
+	}}
+	a, err = NewAgent(c)
+	assert.NoError(t, err)
+	err = a.initPlugins()
+	assert.Error(t, err)
+
+	assert.Equal(t, 1, len(c.Inputs))
+	c.Agent.IgnoreErrorInputs = true
+	err = a.initPlugins()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(c.Inputs))
 }
 
 func TestAgent_LoadPlugin(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -223,6 +223,9 @@ type AgentConfig struct {
 	// Pick a timezone to use when logging or type 'local' for local time.
 	LogWithTimezone string `toml:"log_with_timezone"`
 
+	// Ignore Inputs that error to initialize
+	IgnoreErrorInputs bool `toml:"ignore_error_inputs"`
+
 	Hostname     string
 	OmitHostname bool
 

--- a/config/config.go
+++ b/config/config.go
@@ -421,6 +421,9 @@ var agentConfig = `
   ## Example: America/Chicago
   # log_with_timezone = ""
 
+  ## Indicated whether ignore input plugins that produce the error during the initialization.
+  # ignore_error_inputs = false
+
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""
   ## If set to true, do no set the "host" tag in the telegraf agent.

--- a/config/config.go
+++ b/config/config.go
@@ -1523,6 +1523,7 @@ func (c *Config) buildInput(name string, tbl *ast.Table) (*models.InputConfig, e
 	c.getFieldString(tbl, "name_suffix", &cp.MeasurementSuffix)
 	c.getFieldString(tbl, "name_override", &cp.NameOverride)
 	c.getFieldString(tbl, "alias", &cp.Alias)
+	c.getFieldBool(tbl, "ignore_init_error", &cp.IgnoreInitError)
 
 	cp.Tags = make(map[string]string)
 	if node, ok := tbl.Fields["tags"]; ok {
@@ -1848,7 +1849,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 		"prefix", "prometheus_export_timestamp", "prometheus_ignore_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label",
 		"separator", "splunkmetric_hec_routing", "splunkmetric_multimetric", "tag_keys",
 		"tagdrop", "tagexclude", "taginclude", "tagpass", "tags", "template", "templates",
-		"value_field_name", "wavefront_source_override", "wavefront_use_strict", "wavefront_disable_prefix_conversion":
+		"value_field_name", "wavefront_source_override", "wavefront_use_strict", "wavefront_disable_prefix_conversion", "ignore_init_error":
 
 		// ignore fields that are common to all plugins.
 	default:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,11 +109,22 @@ func TestConfig_LoadSingleInput(t *testing.T) {
 
 func TestConfig_ignoreErrorInput(t *testing.T) {
 	c := NewConfig()
+	c.InputFilters = []string{"memcached"}
 	err := c.LoadConfig("./testdata/ignore_error_input.toml")
 	require.NoError(t, err)
 	require.True(t, c.Inputs[0].Config.IgnoreInitError)
-	require.False(t, c.Inputs[1].Config.IgnoreInitError)
-	require.False(t, c.Inputs[2].Config.IgnoreInitError)
+
+	c = NewConfig()
+	c.InputFilters = []string{"http_listener_v2"}
+	err = c.LoadConfig("./testdata/ignore_error_input.toml")
+	require.NoError(t, err)
+	require.False(t, c.Inputs[0].Config.IgnoreInitError)
+
+	c = NewConfig()
+	c.InputFilters = []string{"ignore_init_error_test"}
+	err = c.LoadConfig("./testdata/ignore_error_input.toml")
+	require.NoError(t, err)
+	require.False(t, c.Inputs[0].Config.IgnoreInitError)
 }
 
 func TestConfig_LoadDirectory(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -107,6 +107,15 @@ func TestConfig_LoadSingleInput(t *testing.T) {
 	require.Equal(t, inputConfig, c.Inputs[0].Config, "Testdata did not produce correct memcached metadata.")
 }
 
+func TestConfig_ignoreErrorInput(t *testing.T) {
+	c := NewConfig()
+	err := c.LoadConfig("./testdata/ignore_error_input.toml")
+	require.NoError(t, err)
+	require.True(t, c.Inputs[0].Config.IgnoreInitError)
+	require.False(t, c.Inputs[1].Config.IgnoreInitError)
+	require.False(t, c.Inputs[2].Config.IgnoreInitError)
+}
+
 func TestConfig_LoadDirectory(t *testing.T) {
 	c := NewConfig()
 	require.NoError(t, c.LoadConfig("./testdata/single_plugin.toml"))
@@ -719,6 +728,8 @@ func init() {
 	inputs.Add("http_listener_v2", func() telegraf.Input { return &MockupInputPlugin{} })
 	inputs.Add("memcached", func() telegraf.Input { return &MockupInputPlugin{} })
 	inputs.Add("procstat", func() telegraf.Input { return &MockupInputPlugin{} })
+
+	inputs.Add("ignore_init_error_test", func() telegraf.Input { return &MockupInputPlugin{} })
 
 	// Register the mockup output plugin for the required names
 	outputs.Add("azure_monitor", func() telegraf.Output { return &MockupOuputPlugin{NamespacePrefix: "Telegraf/"} })

--- a/config/testdata/ignore_error_input.toml
+++ b/config/testdata/ignore_error_input.toml
@@ -1,0 +1,7 @@
+[[inputs.memcached]]
+  ignore_init_error=true
+
+[[inputs.ignore_init_error_test]]
+
+[[inputs.ignore_init_error_test]]
+  ignore_init_error=false

--- a/config/testdata/ignore_error_input.toml
+++ b/config/testdata/ignore_error_input.toml
@@ -1,7 +1,7 @@
 [[inputs.memcached]]
   ignore_init_error=true
 
-[[inputs.ignore_init_error_test]]
+[[inputs.http_listener_v2]]
 
 [[inputs.ignore_init_error_test]]
   ignore_init_error=false

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -251,6 +251,11 @@ The agent table configures Telegraf and the defaults used across all plugins.
   translates by calling external programs snmptranslate and snmptable,
   or "gosmi" which translates using the built-in gosmi library.
 
+- **ignore_error_inputs**:
+  If set to true, discard the input plugins that produce the error during initialization.
+  If set to false, the program will exit when an input plugin has an error occurred during the initialization.
+  Default: false
+
 ## Plugins
 
 Telegraf plugins are divided into 4 types: [inputs][], [outputs][],

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -252,10 +252,11 @@ The agent table configures Telegraf and the defaults used across all plugins.
   or "gosmi" which translates using the built-in gosmi library.
 
 - **ignore_error_inputs**:
-  If set to true, discard the input plugins that produce the error during initialization.
-  If set to false, the program will exit when an input plugin has an error occurred during the initialization.
-  Default: false
+  Together with plugin.ignore_init_error it forms a configuration: 
 
+  If (plugin.ignore_init_error || ignore_error_inputs) is true, discard the input plugins that produce the error during initialization. Otherwise, the program will exit when an input plugin has an error occurred during the initialization.
+
+  Default: false
 ## Plugins
 
 Telegraf plugins are divided into 4 types: [inputs][], [outputs][],
@@ -305,6 +306,12 @@ Parameters that can be used with any input plugin:
 - **name_override**: Override the base name of the measurement.  (Default is
   the name of the input).
 
+- **ignore_init_error**:
+  Together with agent.ignore_error_inputs it forms a configuration: 
+
+  If (ignore_init_error || agent.ignore_error_inputs) is true, discard the input plugin that produce the error during initialization. Otherwise, the program will exit when the input plugin has an error occurred during the initialization.
+
+  Default: false
 - **name_prefix**: Specifies a prefix to attach to the measurement name.
 
 - **name_suffix**: Specifies a suffix to attach to the measurement name.
@@ -333,6 +340,14 @@ Use the name_override parameter to emit measurements with the name `foobar`:
   percpu = false
   totalcpu = true
 ```
+
+Use the ignore_init_error parameter to ignore the `docker` when it init fail:
+```toml
+[[inputs.docker]]
+  ignore_init_error = true
+  servers = ["127.0.0.1:27017"]
+```
+
 
 Emit measurements with two additional tags: `tag1=foo` and `tag2=bar`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -252,11 +252,8 @@ The agent table configures Telegraf and the defaults used across all plugins.
   or "gosmi" which translates using the built-in gosmi library.
 
 - **ignore_error_inputs**:
-  Together with plugin.ignore_init_error it forms a configuration: 
+  If set to true, discard the input plugins that produce an error during initialization. Otherwise, the program will exit when an input plugin has an error occurred during the initialization.
 
-  If (plugin.ignore_init_error || ignore_error_inputs) is true, discard the input plugins that produce the error during initialization. Otherwise, the program will exit when an input plugin has an error occurred during the initialization.
-
-  Default: false
 ## Plugins
 
 Telegraf plugins are divided into 4 types: [inputs][], [outputs][],
@@ -307,11 +304,9 @@ Parameters that can be used with any input plugin:
   the name of the input).
 
 - **ignore_init_error**:
-  Together with agent.ignore_error_inputs it forms a configuration: 
-
-  If (ignore_init_error || agent.ignore_error_inputs) is true, discard the input plugin that produce the error during initialization. Otherwise, the program will exit when the input plugin has an error occurred during the initialization.
-
-  Default: false
+  Overrides the `ignore_error_inputs` setting of the [agent][Agent] for the plugin.
+  If set to true, discard the error during initialization. Otherwise, the program will exit when the plugin has an error occurred during the initialization.
+  
 - **name_prefix**: Specifies a prefix to attach to the measurement name.
 
 - **name_suffix**: Specifies a suffix to attach to the measurement name.
@@ -342,12 +337,12 @@ Use the name_override parameter to emit measurements with the name `foobar`:
 ```
 
 Use the ignore_init_error parameter to ignore the `docker` when it init fail:
+
 ```toml
 [[inputs.docker]]
   ignore_init_error = true
   servers = ["127.0.0.1:27017"]
 ```
-
 
 Emit measurements with two additional tags: `tag1=foo` and `tag2=bar`
 

--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -103,6 +103,9 @@
   ## Example: America/Chicago
   # log_with_timezone = ""
 
+  ## Indicated whether ignore input plugins that produce the error during the initialization.
+  # ignore_error_inputs = false
+
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""
   ## If set to true, do no set the "host" tag in the telegraf agent.

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -103,6 +103,9 @@
   ## Example: America/Chicago
   # log_with_timezone = ""
 
+  ## Indicated whether ignore input plugins that produce the error during the initialization.
+  # ignore_error_inputs = false
+
   ## Override default hostname, if empty use os.Hostname()
   hostname = ""
   ## If set to true, do no set the "host" tag in the telegraf agent.

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -62,6 +62,7 @@ type InputConfig struct {
 	CollectionJitter time.Duration
 	CollectionOffset time.Duration
 	Precision        time.Duration
+	IgnoreInitError  bool
 
 	NameOverride      string
 	MeasurementPrefix string

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -1046,7 +1046,7 @@ func TestCachesExpireAfterMaxTTL(t *testing.T) {
 	require.NoError(t, s.parseStatsdLine("valid:45|c"))
 	require.NoError(t, s.Gather(acc))
 
-	// Wait for the metrics to arrive
+	// Wait for the metrics to  arrive
 	acc.Wait(3)
 
 	testutil.RequireMetricsEqual(t,

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -1046,7 +1046,7 @@ func TestCachesExpireAfterMaxTTL(t *testing.T) {
 	require.NoError(t, s.parseStatsdLine("valid:45|c"))
 	require.NoError(t, s.Gather(acc))
 
-	// Wait for the metrics to  arrive
+	// Wait for the metrics to arrive
 	acc.Wait(3)
 
 	testutil.RequireMetricsEqual(t,


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #11289, resolves #10694, resolves #3167

revival of #11304 

### Summary
Add two options: agent.ignore_error_inputs and plugin.IgnoreInitError
If (plugin.ignore_init_error || ignore_error_inputs) is true, discard the input plugins that produce the error during initialization. Otherwise, the program will exit when an input plugin has an error occurred during the initialization.

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->