### PR TITLE
docs: explain directly connecting to mongo node

### DIFF
--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -12,6 +12,10 @@ All MongoDB server versions from 2.6 and higher are supported.
   ## For example:
   ##   mongodb://user:auth_key@10.10.3.30:27017,
   ##   mongodb://10.10.3.33:18832,
+  ##
+  ## If connecting to a cluster, users must include the "?connect=direct" in
+  ## the URL to ensure that the connection goes directly to the specified node
+  ## and not have all connections passed to the master node.
   servers = ["mongodb://127.0.0.1:27017/?connect=direct"]
 
   ## When true, collect cluster status.

--- a/plugins/inputs/mongodb/sample.conf
+++ b/plugins/inputs/mongodb/sample.conf
@@ -5,6 +5,10 @@
   ## For example:
   ##   mongodb://user:auth_key@10.10.3.30:27017,
   ##   mongodb://10.10.3.33:18832,
+  ##
+  ## If connecting to a cluster, users must include the "?connect=direct" in
+  ## the URL to ensure that the connection goes directly to the specified node
+  ## and not have all connections passed to the master node.
   servers = ["mongodb://127.0.0.1:27017/?connect=direct"]
 
   ## When true, collect cluster status.


### PR DESCRIPTION
By default, the mongo-driver library will attempt to use the primary
node of a cluster. For monitoring with Telegraf, users may specify a
secondary node that they want to monitor. In these cases, the user will
need to specify a direct connection to that node.

The library has a number of options for how it connects, which include
primary, primary preferred, secondary, secondary preferred, and closest.
None of these are options to ensure that the specified node is used.

fixes: #11275
fixes: #9555