### PR TITLE
chore: Remove prefix to use the default `chore(deps)`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,3 @@ updates:
     ignore:
       # Dependabot isn't able to update this packages that do not match the source, so anything with a version
       - dependency-name: "*.v*"
-    commit-message:
-      prefix: "fix:"


### PR DESCRIPTION
For Dependabot, updating the config to remove the prefix `fix:` in favor of using the default `chore(deps):`, you can see an example of this here: https://github.com/influxdata/influxdb_iox/pull/4861

