### PR TITLE
test: mark integration tests correctly

### DIFF
--- a/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go
+++ b/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func TestReadsMetricsFromKafka(t *testing.T) {
+func TestReadsMetricsFromKafkaIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/plugins/inputs/leofs/leofs_test.go
+++ b/plugins/inputs/leofs/leofs_test.go
@@ -159,7 +159,7 @@ func testMain(t *testing.T, code string, endpoint string, serverType ServerType)
 	}
 }
 
-func TestLeoFSManagerMasterMetrics(t *testing.T) {
+func TestLeoFSManagerMasterMetricsIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -167,7 +167,7 @@ func TestLeoFSManagerMasterMetrics(t *testing.T) {
 	testMain(t, fakeSNMP4Manager, "localhost:4020", ServerTypeManagerMaster)
 }
 
-func TestLeoFSManagerSlaveMetrics(t *testing.T) {
+func TestLeoFSManagerSlaveMetricsIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -175,7 +175,7 @@ func TestLeoFSManagerSlaveMetrics(t *testing.T) {
 	testMain(t, fakeSNMP4Manager, "localhost:4021", ServerTypeManagerSlave)
 }
 
-func TestLeoFSStorageMetrics(t *testing.T) {
+func TestLeoFSStorageMetricsIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -183,7 +183,7 @@ func TestLeoFSStorageMetrics(t *testing.T) {
 	testMain(t, fakeSNMP4Storage, "localhost:4010", ServerTypeStorage)
 }
 
-func TestLeoFSGatewayMetrics(t *testing.T) {
+func TestLeoFSGatewayMetricsIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/plugins/inputs/sqlserver/azuresqldbqueries_test.go
+++ b/plugins/inputs/sqlserver/azuresqldbqueries_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAzureSQL_Database_ResourceStats_Query(t *testing.T) {
+func TestAzureSQLIntegration_Database_ResourceStats_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -53,7 +53,7 @@ func TestAzureSQL_Database_ResourceStats_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Database_ResourceGovernance_Query(t *testing.T) {
+func TestAzureSQLIntegration_Database_ResourceGovernance_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -114,7 +114,7 @@ func TestAzureSQL_Database_ResourceGovernance_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Database_WaitStats_Query(t *testing.T) {
+func TestAzureSQLIntegration_Database_WaitStats_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -151,7 +151,7 @@ func TestAzureSQL_Database_WaitStats_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Database_DatabaseIO_Query(t *testing.T) {
+func TestAzureSQLIntegration_Database_DatabaseIO_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -197,7 +197,7 @@ func TestAzureSQL_Database_DatabaseIO_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Database_ServerProperties_Query(t *testing.T) {
+func TestAzureSQLIntegration_Database_ServerProperties_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -238,7 +238,7 @@ func TestAzureSQL_Database_ServerProperties_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Database_OsWaitstats_Query(t *testing.T) {
+func TestAzureSQLIntegration_Database_OsWaitstats_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -276,7 +276,7 @@ func TestAzureSQL_Database_OsWaitstats_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Database_MemoryClerks_Query(t *testing.T) {
+func TestAzureSQLIntegration_Database_MemoryClerks_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -309,7 +309,7 @@ func TestAzureSQL_Database_MemoryClerks_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Database_PerformanceCounters_Query(t *testing.T) {
+func TestAzureSQLIntegration_Database_PerformanceCounters_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -345,7 +345,7 @@ func TestAzureSQL_Database_PerformanceCounters_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Database_Requests_Query(t *testing.T) {
+func TestAzureSQLIntegration_Database_Requests_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -403,7 +403,7 @@ func TestAzureSQL_Database_Requests_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Database_Schedulers_Query(t *testing.T) {
+func TestAzureSQLIntegration_Database_Schedulers_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/plugins/inputs/sqlserver/azuresqlmanagedqueries_test.go
+++ b/plugins/inputs/sqlserver/azuresqlmanagedqueries_test.go
@@ -1,13 +1,14 @@
 package sqlserver
 
 import (
-	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
 )
 
-func TestAzureSQL_Managed_ResourceStats_Query(t *testing.T) {
+func TestAzureSQLIntegration_Managed_ResourceStats_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -40,7 +41,7 @@ func TestAzureSQL_Managed_ResourceStats_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Managed_ResourceGovernance_Query(t *testing.T) {
+func TestAzureSQLIntegration_Managed_ResourceGovernance_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -81,7 +82,7 @@ func TestAzureSQL_Managed_ResourceGovernance_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Managed_DatabaseIO_Query(t *testing.T) {
+func TestAzureSQLIntegration_Managed_DatabaseIO_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -122,7 +123,7 @@ func TestAzureSQL_Managed_DatabaseIO_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Managed_ServerProperties_Query(t *testing.T) {
+func TestAzureSQLIntegration_Managed_ServerProperties_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -169,7 +170,7 @@ func TestAzureSQL_Managed_ServerProperties_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Managed_OsWaitStats_Query(t *testing.T) {
+func TestAzureSQLIntegration_Managed_OsWaitStats_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -206,7 +207,7 @@ func TestAzureSQL_Managed_OsWaitStats_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Managed_MemoryClerks_Query(t *testing.T) {
+func TestAzureSQLIntegration_Managed_MemoryClerks_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -238,7 +239,7 @@ func TestAzureSQL_Managed_MemoryClerks_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Managed_PerformanceCounters_Query(t *testing.T) {
+func TestAzureSQLIntegration_Managed_PerformanceCounters_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -273,7 +274,7 @@ func TestAzureSQL_Managed_PerformanceCounters_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Managed_Requests_Query(t *testing.T) {
+func TestAzureSQLIntegration_Managed_Requests_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -331,7 +332,7 @@ func TestAzureSQL_Managed_Requests_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_Managed_Schedulers_Query(t *testing.T) {
+func TestAzureSQLIntegration_Managed_Schedulers_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/plugins/inputs/sqlserver/azuresqlpoolqueries_test.go
+++ b/plugins/inputs/sqlserver/azuresqlpoolqueries_test.go
@@ -1,13 +1,14 @@
 package sqlserver
 
 import (
-	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
 )
 
-func TestAzureSQL_ElasticPool_ResourceStats_Query(t *testing.T) {
+func TestAzureSQLIntegration_ElasticPool_ResourceStats_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -49,7 +50,7 @@ func TestAzureSQL_ElasticPool_ResourceStats_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_ElasticPool_ResourceGovernance_Query(t *testing.T) {
+func TestAzureSQLIntegration_ElasticPool_ResourceGovernance_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -112,7 +113,7 @@ func TestAzureSQL_ElasticPool_ResourceGovernance_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_ElasticPool_DatabaseIO_Query(t *testing.T) {
+func TestAzureSQLIntegration_ElasticPool_DatabaseIO_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -156,7 +157,7 @@ func TestAzureSQL_ElasticPool_DatabaseIO_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_ElasticPool_OsWaitStats_Query(t *testing.T) {
+func TestAzureSQLIntegration_ElasticPool_OsWaitStats_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -193,7 +194,7 @@ func TestAzureSQL_ElasticPool_OsWaitStats_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_ElasticPool_MemoryClerks_Query(t *testing.T) {
+func TestAzureSQLIntegration_ElasticPool_MemoryClerks_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -225,7 +226,7 @@ func TestAzureSQL_ElasticPool_MemoryClerks_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_ElasticPool_PerformanceCounters_Query(t *testing.T) {
+func TestAzureSQLIntegration_ElasticPool_PerformanceCounters_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -259,7 +260,7 @@ func TestAzureSQL_ElasticPool_PerformanceCounters_Query(t *testing.T) {
 	server.Stop()
 }
 
-func TestAzureSQL_ElasticPool_Schedulers_Query(t *testing.T) {
+func TestAzureSQLIntegration_ElasticPool_Schedulers_Query(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -1,6 +1,7 @@
 package sqlserver
 
 import (
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -108,7 +109,7 @@ func TestSqlServer_ParseMetrics(t *testing.T) {
 	}
 }
 
-func TestSqlServer_MultipleInstanceIntegration(t *testing.T) {
+func TestSqlServerIntegration_MultipleInstance(t *testing.T) {
 	// Invoke Gather() from two separate configurations and
 	//  confirm they don't interfere with each other
 	t.Skip("Skipping as unable to open tcp connection with host '127.0.0.1:1433")
@@ -143,7 +144,7 @@ func TestSqlServer_MultipleInstanceIntegration(t *testing.T) {
 	require.False(t, acc2.HasMeasurement("Log size (bytes)"))
 }
 
-func TestSqlServer_MultipleInstanceWithHealthMetricIntegration(t *testing.T) {
+func TestSqlServerIntegration_MultipleInstanceWithHealthMetric(t *testing.T) {
 	// Invoke Gather() from two separate configurations and
 	// confirm they don't interfere with each other.
 	// This test is intentionally similar to TestSqlServer_MultipleInstanceIntegration.
@@ -329,15 +330,18 @@ func TestSqlServer_ConnectionString(t *testing.T) {
 	require.Equal(t, emptyDatabaseName, database)
 }
 
-func TestSqlServer_AGQueriesApplicableForDatabaseTypeSQLServer(t *testing.T) {
+func TestSqlServerIntegration_AGQueriesApplicableForDatabaseTypeSQLServer(t *testing.T) {
 	// This test case checks where Availability Group (AG / HADR) queries return an output when included for processing for DatabaseType = SQLServer
 	// And they should not be processed when DatabaseType = AzureSQLDB
 
-	// Please change the connection string to connect to relevant database when executing the test case
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 
-	t.Skip("Skipping as unable to open tcp connection with host '127.0.0.1:1433")
-
-	testServer := "Server=127.0.0.1;Port=1433;Database=testdb1;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"
+	if os.Getenv("AZURESQL_POOL_CONNECTION_STRING") == "" {
+		t.Skip("Missing environment variable AZURESQL_POOL_CONNECTION_STRING")
+	}
+	testServer := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
 
 	s := &SQLServer{
 		Servers:      []string{testServer},
@@ -372,15 +376,22 @@ func TestSqlServer_AGQueriesApplicableForDatabaseTypeSQLServer(t *testing.T) {
 	s2.Stop()
 }
 
-func TestSqlServer_AGQueryFieldsOutputBasedOnSQLServerVersion(t *testing.T) {
+func TestSqlServerIntegration_AGQueryFieldsOutputBasedOnSQLServerVersion(t *testing.T) {
 	// This test case checks where Availability Group (AG / HADR) queries return specific fields supported by corresponding SQL Server version database being connected to.
 
-	// Please change the connection strings to connect to relevant database when executing the test case
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 
-	t.Skip("Skipping as unable to open tcp connection with host '127.0.0.1:1433")
+	if os.Getenv("AZURESQL_POOL_CONNECTION_STRING_2019") == "" {
+		t.Skip("Missing environment variable AZURESQL_POOL_CONNECTION_STRING_2019")
+	}
+	if os.Getenv("AZURESQL_POOL_CONNECTION_STRING_2012") == "" {
+		t.Skip("Missing environment variable AZURESQL_POOL_CONNECTION_STRING_2012")
+	}
 
-	testServer2019 := "Server=127.0.0.10;Port=1433;Database=testdb2019;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"
-	testServer2012 := "Server=127.0.0.20;Port=1433;Database=testdb2012;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"
+	testServer2019 := os.Getenv("AZURESQL_POOL_CONNECTION_STRING_2019")
+	testServer2012 := os.Getenv("AZURESQL_POOL_CONNECTION_STRING_2012")
 
 	s2019 := &SQLServer{
 		Servers:      []string{testServer2019},

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -287,7 +287,7 @@ func TestGatherChain(t *testing.T) {
 	}
 }
 
-func TestGatherUDPCert(t *testing.T) {
+func TestGatherUDPCertIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -336,7 +336,7 @@ func TestGatherCertIntegration(t *testing.T) {
 	require.True(t, acc.HasMeasurement("x509_cert"))
 }
 
-func TestGatherCertMustNotTimeout(t *testing.T) {
+func TestGatherCertMustNotTimeoutIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}

--- a/plugins/outputs/event_hubs/event_hubs_test.go
+++ b/plugins/outputs/event_hubs/event_hubs_test.go
@@ -69,6 +69,10 @@ func TestInitAndWrite(t *testing.T) {
  */
 
 func TestInitAndWriteIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	if os.Getenv("EVENTHUB_CONNECTION_STRING") == "" {
 		t.Skip("Missing environment variable EVENTHUB_CONNECTION_STRING")
 	}

--- a/plugins/outputs/opentsdb/opentsdb_test.go
+++ b/plugins/outputs/opentsdb/opentsdb_test.go
@@ -165,6 +165,10 @@ func BenchmarkHttpSend(b *testing.B) {
 	}
 }
 func TestWriteIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	t.Skip("Skip as OpenTSDB not running")
 
 	o := &OpenTSDB{

--- a/plugins/outputs/riemann_legacy/riemann_legacy_test.go
+++ b/plugins/outputs/riemann_legacy/riemann_legacy_test.go
@@ -1,17 +1,36 @@
 package riemann_legacy
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func TestConnectAndWrite(t *testing.T) {
-	// if this needs to run use: `docker run stealthly/docker-riemann`
-	t.Skip("Skipping legacy integration test")
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 
-	url := testutil.GetLocalHost() + ":5555"
+	servicePort := "5555"
+	container := testutil.Container{
+		Image:        "rlister/riemann",
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForLog("Hyperspace core online"),
+			wait.ForListeningPort(nat.Port(servicePort)),
+		),
+	}
+	err := container.Start()
+	require.NoError(t, err, "failed to start container")
+	defer func() {
+		require.NoError(t, container.Terminate(), "terminating container failed")
+	}()
+
+	url := fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort])
 
 	r := &Riemann{
 		URL:       url,
@@ -19,7 +38,7 @@ func TestConnectAndWrite(t *testing.T) {
 		Log:       testutil.Logger{},
 	}
 
-	err := r.Connect()
+	err = r.Connect()
 	require.NoError(t, err)
 
 	err = r.Write(testutil.MockMetrics())

--- a/plugins/processors/ifname/ifname_test.go
+++ b/plugins/processors/ifname/ifname_test.go
@@ -14,7 +14,11 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func TestTable(t *testing.T) {
+func TestTableIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	t.Skip("Skipping test due to connect failures")
 
 	d := IfName{}
@@ -42,6 +46,10 @@ func TestTable(t *testing.T) {
 }
 
 func TestIfNameIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	t.Skip("Skipping test due to connect failures")
 
 	d := IfName{


### PR DESCRIPTION
In a number of cases integration tests were not named correctly
and/or were not skipped during unit testing.

This also adds a riemann integration test.
