### PR TITLE
feat(prometheus client): type mappings for defining prometheus types

### DIFF
--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -48,6 +48,12 @@ metrics on `/metrics` (default) to be polled by a Prometheus server.
 
   ## Export metric collection time.
   # export_timestamp = false
+
+  # # Add one or more type mappings to force a metric type for a specific field
+  # # NOTE: This is only supported by metric_verison = 2
+  # [[outputs.prometheus_client.type_mapping]]
+  #   suffixes = ["_count", "_sum"]
+  #   type   = "counter"
 ```
 
 ## Metrics

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	v1 "github.com/influxdata/telegraf/plugins/outputs/prometheus_client/v1"
 	v2 "github.com/influxdata/telegraf/plugins/outputs/prometheus_client/v2"
+	serializer "github.com/influxdata/telegraf/plugins/serializers/prometheus"
 )
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
@@ -52,6 +53,8 @@ type PrometheusClient struct {
 	CollectorsExclude  []string        `toml:"collectors_exclude"`
 	StringAsLabel      bool            `toml:"string_as_label"`
 	ExportTimestamp    bool            `toml:"export_timestamp"`
+	TypeMappings       []serializer.TypeMapping   `toml:"type_mapping"`
+
 	tlsint.ServerConfig
 
 	Log telegraf.Logger `toml:"-"`
@@ -103,7 +106,7 @@ func (p *PrometheusClient) Init() error {
 			return err
 		}
 	case 2:
-		p.collector = v2.NewCollector(time.Duration(p.ExpirationInterval), p.StringAsLabel, p.ExportTimestamp)
+		p.collector = v2.NewCollector(time.Duration(p.ExpirationInterval), p.StringAsLabel, p.ExportTimestamp, p.TypeMappings)
 		err := registry.Register(p.collector)
 		if err != nil {
 			return err

--- a/plugins/outputs/prometheus_client/sample.conf
+++ b/plugins/outputs/prometheus_client/sample.conf
@@ -40,3 +40,9 @@
 
   ## Export metric collection time.
   # export_timestamp = false
+
+  # # Add one or more type mappings to force a metric type for a specific field
+  # # NOTE: This is only supported by metric_verison = 2
+  # [[outputs.prometheus_client.type_mapping]]
+  #   suffixes = ["_count", "_sum"]
+  #   type   = "counter"

--- a/plugins/outputs/prometheus_client/v2/collector.go
+++ b/plugins/outputs/prometheus_client/v2/collector.go
@@ -43,8 +43,11 @@ type Collector struct {
 	coll           *serializer.Collection
 }
 
-func NewCollector(expire time.Duration, stringsAsLabel bool, exportTimestamp bool) *Collector {
-	config := serializer.FormatConfig{}
+func NewCollector(expire time.Duration, stringsAsLabel bool, exportTimestamp bool, typeMappings []serializer.TypeMapping) *Collector {
+	config := serializer.FormatConfig{
+		TypeMappings: typeMappings,
+	}
+
 	if stringsAsLabel {
 		config.StringHandling = serializer.StringAsLabel
 	}

--- a/plugins/serializers/prometheus/prometheus.go
+++ b/plugins/serializers/prometheus/prometheus.go
@@ -36,6 +36,7 @@ type FormatConfig struct {
 	TimestampExport TimestampExport
 	MetricSortOrder MetricSortOrder
 	StringHandling  StringHandling
+	TypeMappings []TypeMapping
 }
 
 type Serializer struct {

--- a/plugins/serializers/prometheus/type_mapping.go
+++ b/plugins/serializers/prometheus/type_mapping.go
@@ -1,0 +1,48 @@
+package prometheus
+
+import (
+	"strings"
+
+	"github.com/influxdata/telegraf"
+)
+
+type PrometheusMetricType string
+
+const (
+	Gauge PrometheusMetricType = "gauge"
+	Counter PrometheusMetricType = "counter"
+)
+
+type TypeMapping struct {
+	Suffixes []string `toml:"suffixes"`
+	Type PrometheusMetricType `toml:"type"`
+}
+
+func (t *TypeMapping) anySuffixMatches(name string) bool {
+	for _, s := range t.Suffixes {
+		if strings.HasSuffix(name, s) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (t *TypeMapping) telegrafValueType() telegraf.ValueType {
+	switch t.Type{
+	case Gauge:
+		return telegraf.Gauge
+	case Counter:
+		return telegraf.Counter
+	default:
+		return telegraf.Untyped
+	}
+}
+
+func (t TypeMapping) InferValueType(prometheusMetricName string) (telegraf.ValueType, bool){
+	if t.anySuffixMatches(prometheusMetricName) {
+		return t.telegrafValueType(), true
+	}
+
+	return telegraf.Untyped, false
+}


### PR DESCRIPTION
This feature allows Telegraf users using the Prometheus Client Output plugin to define a suffix and a type so that the prometheus output can contain field-specific prometheus types

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Related Slack discussion: https://influxcommunity.slack.com/archives/CH99HUH8V/p1655460398172089

Added a Type Mapping configuration option to the prometheus client output (and serializer), allowing the Telegraf user to specify a suffix (other matchers can be added later) which expanded Prometheus metric names will be compared against to determine a specific prometheus metric type on the field-level (and not only on metric-level). 

### Example output and configuration: 
```toml
[[inputs.socket_listener]]
  service_address = "udp://:12345"
  data_format = "influx"

[[aggregators.basicstats]]
  period = "5s"
  drop_original = false
  stats = ["count","mean", "s2","sum"]

[[outputs.prometheus_client]]
  listen = ":9273"
  metric_version = 2
  expiration_interval = 0
  collectors_exclude = ["gocollector", "process"]
  [[outputs.prometheus_client.type_mapping]]
     suffixes = ["_count"]
     type   = "counter"
```
![image](https://user-images.githubusercontent.com/4710999/174314305-8d46c68d-2186-4db4-8f0c-1aa603eeea65.png)
