### PR TITLE
fix: Bring back old xpath section names

### DIFF
--- a/models/log.go
+++ b/models/log.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"reflect"
 
+	"github.com/fatih/color"
 	"github.com/influxdata/telegraf"
 )
 
@@ -100,4 +101,36 @@ func SetLoggerOnPlugin(i interface{}, logger telegraf.Logger) {
 		logger.Debugf("Plugin %q defines a 'Log' field on its struct of an unexpected type %q. Expected telegraf.Logger",
 			valI.Type().Name(), field.Type().String())
 	}
+}
+
+func PrintPluginDeprecationNotice(level telegraf.Escalation, name string, info telegraf.DeprecationInfo) {
+	var prefix string
+
+	switch level {
+	case telegraf.Warn:
+		prefix = "W! " + color.YellowString("DeprecationWarning")
+	case telegraf.Error:
+		prefix = "E! " + color.RedString("DeprecationError")
+	}
+
+	log.Printf(
+		"%s: Plugin %q deprecated since version %s and will be removed in %s: %s",
+		prefix, name, info.Since, info.RemovalIn, info.Notice,
+	)
+}
+
+func PrintOptionDeprecationNotice(level telegraf.Escalation, plugin, option string, info telegraf.DeprecationInfo) {
+	var prefix string
+
+	switch level {
+	case telegraf.Warn:
+		prefix = "W! " + color.YellowString("DeprecationWarning")
+	case telegraf.Error:
+		prefix = "E! " + color.RedString("DeprecationError")
+	}
+
+	log.Printf(
+		"%s: Option %q of plugin %q deprecated since version %s and will be removed in %s: %s",
+		prefix, option, plugin, info.Since, info.RemovalIn, info.Notice,
+	)
 }

--- a/plugin.go
+++ b/plugin.go
@@ -2,6 +2,28 @@ package telegraf
 
 var Debug bool
 
+// Escalation level for the plugin or option
+type Escalation int
+
+func (e Escalation) String() string {
+	switch e {
+	case Warn:
+		return "WARN"
+	case Error:
+		return "ERROR"
+	}
+	return "NONE"
+}
+
+const (
+	// None means no deprecation
+	None Escalation = iota
+	// Warn means deprecated but still within the grace period
+	Warn
+	// Error means deprecated and beyond grace period
+	Error
+)
+
 // DeprecationInfo contains information for marking a plugin deprecated.
 type DeprecationInfo struct {
 	// Since specifies the version since when the plugin is deprecated

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/parsers/temporary/xpath"
 )
@@ -39,10 +40,10 @@ type Parser struct {
 	Log                 telegraf.Logger   `toml:"-"`
 
 	// Required for backward compatibility
-	ConfigsXML     []Config `toml:"xml" deprecated:"1.23.1;use 'xpath' instead"`
-	ConfigsJSON    []Config `toml:"xpath_json"`
-	ConfigsMsgPack []Config `toml:"xpath_msgpack"`
-	ConfigsProto   []Config `toml:"xpath_protobuf"`
+	ConfigsXML     []xpath.Config `toml:"xml" deprecated:"1.23.1;use 'xpath' instead"`
+	ConfigsJSON    []xpath.Config `toml:"xpath_json"`
+	ConfigsMsgPack []xpath.Config `toml:"xpath_msgpack"`
+	ConfigsProto   []xpath.Config `toml:"xpath_protobuf"`
 
 	document dataDocument
 }
@@ -53,17 +54,38 @@ func (p *Parser) Init() error {
 		p.document = &xmlDocument{}
 
 		// Required for backward compatibility
-		p.Configs = append(p.Configs, p.ConfigsXML...)
+		if len(p.ConfigsXML) > 0 {
+			p.Configs = append(p.Configs, p.ConfigsXML...)
+			models.PrintOptionDeprecationNotice(telegraf.Warn, "parsers.xpath", "xml", telegraf.DeprecationInfo{
+				Since:     "1.23.1",
+				RemovalIn: "2.0.0",
+				Notice:    "use 'xpath' instead",
+			})
+		}
 	case "xpath_json":
 		p.document = &jsonDocument{}
 
 		// Required for backward compatibility
-		p.Configs = append(p.Configs, p.ConfigsJSON...)
+		if len(p.ConfigsJSON) > 0 {
+			p.Configs = append(p.Configs, p.ConfigsJSON...)
+			models.PrintOptionDeprecationNotice(telegraf.Warn, "parsers.xpath", "xpath_json", telegraf.DeprecationInfo{
+				Since:     "1.23.1",
+				RemovalIn: "2.0.0",
+				Notice:    "use 'xpath' instead",
+			})
+		}
 	case "xpath_msgpack":
 		p.document = &msgpackDocument{}
 
 		// Required for backward compatibility
-		p.Configs = append(p.Configs, p.ConfigsMsgPack...)
+		if len(p.ConfigsMsgPack) > 0 {
+			p.Configs = append(p.Configs, p.ConfigsMsgPack...)
+			models.PrintOptionDeprecationNotice(telegraf.Warn, "parsers.xpath", "xpath_msgpack", telegraf.DeprecationInfo{
+				Since:     "1.23.1",
+				RemovalIn: "2.0.0",
+				Notice:    "use 'xpath' instead",
+			})
+		}
 	case "xpath_protobuf":
 		pbdoc := protobufDocument{
 			MessageDefinition: p.ProtobufMessageDef,
@@ -77,7 +99,14 @@ func (p *Parser) Init() error {
 		p.document = &pbdoc
 
 		// Required for backward compatibility
-		p.Configs = append(p.Configs, p.ConfigsProto...)
+		if len(p.ConfigsProto) > 0 {
+			p.Configs = append(p.Configs, p.ConfigsProto...)
+			models.PrintOptionDeprecationNotice(telegraf.Warn, "parsers.xpath", "xpath_proto", telegraf.DeprecationInfo{
+				Since:     "1.23.1",
+				RemovalIn: "2.0.0",
+				Notice:    "use 'xpath' instead",
+			})
+		}
 	default:
 		return fmt.Errorf("unknown data-format %q for xpath parser", p.Format)
 	}
@@ -552,7 +581,7 @@ func init() {
 	)
 }
 
-// InitFromConfig is a compatibitlity function to construct the parser the old way
+// InitFromConfig is a compatibility function to construct the parser the old way
 func (p *Parser) InitFromConfig(config *parsers.Config) error {
 	p.Format = config.DataFormat
 	if p.Format == "xpath_protobuf" {

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -38,6 +38,12 @@ type Parser struct {
 	DefaultTags         map[string]string `toml:"-"`
 	Log                 telegraf.Logger   `toml:"-"`
 
+	// Required for backward compatibility
+	ConfigsXML     []Config `toml:"xml" deprecated:"1.23.1;use 'xpath' instead"`
+	ConfigsJSON    []Config `toml:"xpath_json"`
+	ConfigsMsgPack []Config `toml:"xpath_msgpack"`
+	ConfigsProto   []Config `toml:"xpath_protobuf"`
+
 	document dataDocument
 }
 
@@ -45,10 +51,19 @@ func (p *Parser) Init() error {
 	switch p.Format {
 	case "", "xml":
 		p.document = &xmlDocument{}
+
+		// Required for backward compatibility
+		p.Configs = append(p.Configs, p.ConfigsXML...)
 	case "xpath_json":
 		p.document = &jsonDocument{}
+
+		// Required for backward compatibility
+		p.Configs = append(p.Configs, p.ConfigsJSON...)
 	case "xpath_msgpack":
 		p.document = &msgpackDocument{}
+
+		// Required for backward compatibility
+		p.Configs = append(p.Configs, p.ConfigsMsgPack...)
 	case "xpath_protobuf":
 		pbdoc := protobufDocument{
 			MessageDefinition: p.ProtobufMessageDef,
@@ -60,6 +75,9 @@ func (p *Parser) Init() error {
 			return err
 		}
 		p.document = &pbdoc
+
+		// Required for backward compatibility
+		p.Configs = append(p.Configs, p.ConfigsProto...)
 	default:
 		return fmt.Errorf("unknown data-format %q for xpath parser", p.Format)
 	}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves: #11336 

This PR brings back the old `xml`, `xpath_json`, `xpath_msgpack` and `xpath_protobuf` sections to fix a regression introduced in #11218. We also print deprecation notices and modify the infrastructure to be able to do so.