### PR TITLE
feat: add bytesRecv metric to Internal plugin

### DIFF
--- a/plugins/inputs/internal/sample.conf
+++ b/plugins/inputs/internal/sample.conf
@@ -2,3 +2,7 @@
 [[inputs.internal]]
   ## If true, collect telegraf memory stats.
   # collect_memstats = true
+
+  ## Address and port to host InfluxDB listener on
+  ## (Double check the port. Could be 9999 if using OSS Beta)
+  service_address = ":8086"


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #11334 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
Extended the Internal input plugin to gather bytesRecv in the metrics. This was done in a similar fashion to [this addition to Influxdb v2 Listener](https://github.com/influxdata/telegraf/issues/11334#:~:text=telegraf/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go)
