### PR TITLE
feat: Migrate form_urlencoded parser to new style

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1520,8 +1520,6 @@ func (c *Config) getParserConfig(name string, tbl *ast.Table) (*parsers.Config, 
 	c.getFieldString(tbl, "grok_timezone", &pc.GrokTimezone)
 	c.getFieldString(tbl, "grok_unique_timestamp", &pc.GrokUniqueTimestamp)
 
-	c.getFieldStringSlice(tbl, "form_urlencoded_tag_keys", &pc.FormUrlencodedTagKeys)
-
 	c.getFieldString(tbl, "value_field_name", &pc.ValueFieldName)
 
 	// for influx parser
@@ -1764,7 +1762,6 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 		// "templates", // shared with serializers
 		"dropwizard_metric_registry_path", "dropwizard_tags_path", "dropwizard_tag_paths",
 		"dropwizard_time_format", "dropwizard_time_path",
-		"form_urlencoded_tag_keys",
 		"grok_custom_pattern_files", "grok_custom_patterns", "grok_named_patterns", "grok_patterns",
 		"grok_timezone", "grok_unique_timestamp",
 		"influx_parser_type",

--- a/config/config.go
+++ b/config/config.go
@@ -1520,6 +1520,8 @@ func (c *Config) getParserConfig(name string, tbl *ast.Table) (*parsers.Config, 
 	c.getFieldString(tbl, "grok_timezone", &pc.GrokTimezone)
 	c.getFieldString(tbl, "grok_unique_timestamp", &pc.GrokUniqueTimestamp)
 
+	c.getFieldStringSlice(tbl, "form_urlencoded_tag_keys", &pc.FormUrlencodedTagKeys)
+
 	c.getFieldString(tbl, "value_field_name", &pc.ValueFieldName)
 
 	// for influx parser

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -593,10 +593,11 @@ func TestWriteHTTPTransformHeaderValuesToTagsBulkWrite(t *testing.T) {
 }
 
 func TestWriteHTTPQueryParams(t *testing.T) {
-	parser := form_urlencoded.Parser{}
+	parser := form_urlencoded.Parser{
+		MetricName: "query_measurement"
+		TagKeys: []string{"tagKey"}
+	}
 	require.NoError(t, parser.Init())
-	parser.MetricName = "query_measurement"
-	parser.TagKeys = []string{"tagKey"}
 
 	listener := newTestHTTPListenerV2()
 	listener.DataSource = "query"

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -597,7 +597,6 @@ func TestWriteHTTPQueryParams(t *testing.T) {
 		MetricName: "query_measurement",
 		TagKeys:    []string{"tagKey"},
 	}
-	require.NoError(t, parser.Init())
 
 	listener := newTestHTTPListenerV2()
 	listener.DataSource = "query"
@@ -625,7 +624,6 @@ func TestWriteHTTPFormData(t *testing.T) {
 		MetricName: "query_measurement",
 		TagKeys:    []string{"tagKey"},
 	}
-	require.NoError(t, parser.Init())
 
 	listener := newTestHTTPListenerV2()
 	listener.Parser = &parser

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -628,7 +628,7 @@ func TestWriteHTTPFormData(t *testing.T) {
 	require.NoError(t, parser.Init())
 
 	listener := newTestHTTPListenerV2()
-	listener.Parser = parser
+	listener.Parser = &parser
 
 	acc := &testutil.Accumulator{}
 	require.NoError(t, listener.Init())

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/influxdata/telegraf/plugins/parsers/form_urlencoded"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -592,7 +593,11 @@ func TestWriteHTTPTransformHeaderValuesToTagsBulkWrite(t *testing.T) {
 }
 
 func TestWriteHTTPQueryParams(t *testing.T) {
-	parser, _ := parsers.NewFormUrlencodedParser("query_measurement", nil, []string{"tagKey"})
+	parser := form_urlencoded.Parser{}
+	require.NoError(t, parser.Init())
+	parser.MetricName = "query_measurement"
+	parser.TagKeys = []string{"tagKey"}
+
 	listener := newTestHTTPListenerV2()
 	listener.DataSource = "query"
 	listener.Parser = parser
@@ -615,7 +620,11 @@ func TestWriteHTTPQueryParams(t *testing.T) {
 }
 
 func TestWriteHTTPFormData(t *testing.T) {
-	parser, _ := parsers.NewFormUrlencodedParser("query_measurement", nil, []string{"tagKey"})
+	parser := form_urlencoded.Parser{}
+	require.NoError(t, parser.Init())
+	parser.MetricName = "query_measurement"
+	parser.TagKeys = []string{"tagKey"}
+
 	listener := newTestHTTPListenerV2()
 	listener.Parser = parser
 

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -594,8 +594,8 @@ func TestWriteHTTPTransformHeaderValuesToTagsBulkWrite(t *testing.T) {
 
 func TestWriteHTTPQueryParams(t *testing.T) {
 	parser := form_urlencoded.Parser{
-		MetricName: "query_measurement"
-		TagKeys: []string{"tagKey"}
+		MetricName: "query_measurement",
+		TagKeys:    []string{"tagKey"},
 	}
 	require.NoError(t, parser.Init())
 
@@ -621,10 +621,11 @@ func TestWriteHTTPQueryParams(t *testing.T) {
 }
 
 func TestWriteHTTPFormData(t *testing.T) {
-	parser := form_urlencoded.Parser{}
+	parser := form_urlencoded.Parser{
+		MetricName: "query_measurement",
+		TagKeys:    []string{"tagKey"},
+	}
 	require.NoError(t, parser.Init())
-	parser.MetricName = "query_measurement"
-	parser.TagKeys = []string{"tagKey"}
 
 	listener := newTestHTTPListenerV2()
 	listener.Parser = parser

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -601,7 +601,7 @@ func TestWriteHTTPQueryParams(t *testing.T) {
 
 	listener := newTestHTTPListenerV2()
 	listener.DataSource = "query"
-	listener.Parser = parser
+	listener.Parser = &parser
 
 	acc := &testutil.Accumulator{}
 	require.NoError(t, listener.Init())

--- a/plugins/parsers/all/all.go
+++ b/plugins/parsers/all/all.go
@@ -4,6 +4,7 @@ import (
 	//Blank imports for plugins to register themselves
 	_ "github.com/influxdata/telegraf/plugins/parsers/collectd"
 	_ "github.com/influxdata/telegraf/plugins/parsers/csv"
+	_ "github.com/influxdata/telegraf/plugins/parsers/form_urlencoded"
 	_ "github.com/influxdata/telegraf/plugins/parsers/json"
 	_ "github.com/influxdata/telegraf/plugins/parsers/json_v2"
 	_ "github.com/influxdata/telegraf/plugins/parsers/wavefront"

--- a/plugins/parsers/form_urlencoded/parser.go
+++ b/plugins/parsers/form_urlencoded/parser.go
@@ -60,7 +60,7 @@ func (p Parser) ParseLine(line string) (telegraf.Metric, error) {
 }
 
 // SetDefaultTags sets the default tags for every metric
-func (p Parser) SetDefaultTags(tags map[string]string) {
+func (p *Parser) SetDefaultTags(tags map[string]string) {
 	p.DefaultTags = tags
 }
 

--- a/plugins/parsers/form_urlencoded/parser.go
+++ b/plugins/parsers/form_urlencoded/parser.go
@@ -99,14 +99,10 @@ func (p Parser) parseFields(values url.Values) map[string]interface{} {
 	return fields
 }
 
-func (p *Parser) Init() error {
-	return nil
-}
-
 func (p *Parser) InitFromConfig(config *parsers.Config) error {
 	p.MetricName = config.MetricName
 	p.TagKeys = config.FormUrlencodedTagKeys
-	return p.Init()
+	return nil
 }
 
 func init() {

--- a/plugins/parsers/form_urlencoded/parser.go
+++ b/plugins/parsers/form_urlencoded/parser.go
@@ -16,7 +16,7 @@ var ErrNoMetric = fmt.Errorf("no metric in line")
 
 // Parser decodes "application/x-www-form-urlencoded" data into metrics
 type Parser struct {
-	MetricName  string            `toml:"metric_name"`
+	MetricName  string            `toml:"-"`
 	TagKeys     []string          `toml:"form_urlencoded_tag_keys"`
 	DefaultTags map[string]string `toml:"-"`
 }

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/parsers/dropwizard"
-	"github.com/influxdata/telegraf/plugins/parsers/form_urlencoded"
 	"github.com/influxdata/telegraf/plugins/parsers/graphite"
 	"github.com/influxdata/telegraf/plugins/parsers/grok"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
@@ -238,12 +237,6 @@ func NewParser(config *Config) (Parser, error) {
 			config.GrokUniqueTimestamp)
 	case "logfmt":
 		parser, err = NewLogFmtParser(config.MetricName, config.DefaultTags, config.LogFmtTagKeys)
-	case "form_urlencoded":
-		parser, err = NewFormUrlencodedParser(
-			config.MetricName,
-			config.DefaultTags,
-			config.FormUrlencodedTagKeys,
-		)
 	case "prometheus":
 		parser, err = NewPrometheusParser(
 			config.DefaultTags,
@@ -347,18 +340,6 @@ func NewLogFmtParser(metricName string, defaultTags map[string]string, tagKeys [
 	parser := logfmt.NewParser(metricName, defaultTags, tagKeys)
 	err := parser.Init()
 	return parser, err
-}
-
-func NewFormUrlencodedParser(
-	metricName string,
-	defaultTags map[string]string,
-	tagKeys []string,
-) (Parser, error) {
-	return &form_urlencoded.Parser{
-		MetricName:  metricName,
-		DefaultTags: defaultTags,
-		TagKeys:     tagKeys,
-	}, nil
 }
 
 func NewPrometheusParser(defaultTags map[string]string, ignoreTimestamp bool) (Parser, error) {


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11355

This PR migrates the `form_urlencoded` parser to the new-style parser structure. The change is backward compatible. Furthermore, we cleanup the parser a bit.