### PR TITLE
feat: collect SSD endurance information where available in smartctl

### DIFF
--- a/plugins/inputs/smart/README.md
+++ b/plugins/inputs/smart/README.md
@@ -179,6 +179,7 @@ execute this script.
     - wwn
   - fields:
     - exit_status
+    - endurance_remain_perc
     - health_ok
     - read_error_rate
     - seek_error

--- a/plugins/inputs/smart/README.md
+++ b/plugins/inputs/smart/README.md
@@ -179,7 +179,9 @@ execute this script.
     - wwn
   - fields:
     - exit_status
+    - endurance_media_wearout
     - endurance_remain_perc
+    - endurance_wear_levelling
     - health_ok
     - read_error_rate
     - seek_error

--- a/plugins/inputs/smart/README.md
+++ b/plugins/inputs/smart/README.md
@@ -179,14 +179,14 @@ execute this script.
     - wwn
   - fields:
     - exit_status
-    - endurance_media_wearout
-    - endurance_remain_perc
-    - endurance_wear_levelling
     - health_ok
+    - media_wearout_indicator
+    - percent_lifetime_remain
     - read_error_rate
     - seek_error
     - temp_c
     - udma_crc_errors
+    - wear_leveling_count
 
 - smart_attribute:
   - tags:

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -837,7 +837,6 @@ func (m *Smart) gatherDisk(acc telegraf.Accumulator, device string, wg *sync.Wai
 					deviceFields[field] = val
 				}
 			}
-
 		} else {
 			// what was found is not a vendor attribute
 			if matches := sasNVMeAttr.FindStringSubmatch(line); len(matches) > 2 {

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -87,6 +87,13 @@ var (
 		"199": "udma_crc_errors",
 	}
 
+	// There are some fields we're interested in which use the vendor specific device ids
+	// so we need to be able to match on name instead
+	deviceFieldNames = map[string]string{
+		"Percent_Lifetime_Remain":   "endurance_remain_perc",
+		"Wear_Leveling_Count":   "endurance_remain_perc",
+	}	
+	
 	// to obtain metrics from smartctl
 	sasNVMeAttributes = map[string]struct {
 		ID    string
@@ -817,6 +824,15 @@ func (m *Smart) gatherDisk(acc telegraf.Accumulator, device string, wg *sync.Wai
 					deviceFields[field] = val
 				}
 			}
+			
+			// If the attribute name matches on in deviceFieldNames
+			// save the value to a field
+			if field, ok := deviceFieldNames[attr[2]]; ok {
+				if val, err := parseRawValue(attr[4]); err == nil {
+					deviceFields[field] = val
+				}
+			}			
+
 		} else {
 			// what was found is not a vendor attribute
 			if matches := sasNVMeAttr.FindStringSubmatch(line); len(matches) > 2 {

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -90,11 +90,11 @@ var (
 	// There are some fields we're interested in which use the vendor specific device ids
 	// so we need to be able to match on name instead
 	deviceFieldNames = map[string]string{
-		"Percent_Lifetime_Remain":   "endurance_remain_perc",
-		"Wear_Leveling_Count":   "endurance_wear_levelling",
+		"Percent_Lifetime_Remain": "endurance_remain_perc",
+		"Wear_Leveling_Count":     "endurance_wear_levelling",
 		"Media_Wearout_Indicator": "endurance_media_wearout",
-	}	
-	
+	}
+
 	// to obtain metrics from smartctl
 	sasNVMeAttributes = map[string]struct {
 		ID    string
@@ -161,7 +161,7 @@ var (
 		"Percentage used endurance indicator": {
 			Name:  "Percentage_Used",
 			Parse: parsePercentageInt,
-		},     
+		},
 		"Data Units Read": {
 			Name:  "Data_Units_Read",
 			Parse: parseDataUnits,
@@ -829,14 +829,14 @@ func (m *Smart) gatherDisk(acc telegraf.Accumulator, device string, wg *sync.Wai
 					deviceFields[field] = val
 				}
 			}
-			
+
 			// If the attribute name matches on in deviceFieldNames
 			// save the value to a field
 			if field, ok := deviceFieldNames[attr[2]]; ok {
 				if val, err := parseRawValue(attr[4]); err == nil {
 					deviceFields[field] = val
 				}
-			}			
+			}
 
 		} else {
 			// what was found is not a vendor attribute

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -157,6 +157,10 @@ var (
 			Name:  "Percentage_Used",
 			Parse: parsePercentageInt,
 		},
+		"Percentage used endurance indicator": {
+			Name:  "Percentage_Used",
+			Parse: parsePercentageInt,
+		},     
 		"Data Units Read": {
 			Name:  "Data_Units_Read",
 			Parse: parseDataUnits,

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -830,11 +830,13 @@ func (m *Smart) gatherDisk(acc telegraf.Accumulator, device string, wg *sync.Wai
 				}
 			}
 
-			// If the attribute name matches on in deviceFieldNames
-			// save the value to a field
-			if field, ok := deviceFieldNames[attr[2]]; ok {
-				if val, err := parseRawValue(attr[4]); err == nil {
-					deviceFields[field] = val
+			if len(attr) > 4 {
+				// If the attribute name matches on in deviceFieldNames
+				// save the value to a field
+				if field, ok := deviceFieldNames[attr[2]]; ok {
+					if val, err := parseRawValue(attr[4]); err == nil {
+						deviceFields[field] = val
+					}
 				}
 			}
 		} else {

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -90,9 +90,9 @@ var (
 	// There are some fields we're interested in which use the vendor specific device ids
 	// so we need to be able to match on name instead
 	deviceFieldNames = map[string]string{
-		"Percent_Lifetime_Remain": "endurance_remain_perc",
-		"Wear_Leveling_Count":     "endurance_wear_levelling",
-		"Media_Wearout_Indicator": "endurance_media_wearout",
+		"Percent_Lifetime_Remain": "percent_lifetime_remain",
+		"Wear_Leveling_Count":     "wear_leveling_count",
+		"Media_Wearout_Indicator": "media_wearout_indicator",
 	}
 
 	// to obtain metrics from smartctl

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -92,6 +92,7 @@ var (
 	deviceFieldNames = map[string]string{
 		"Percent_Lifetime_Remain":   "endurance_remain_perc",
 		"Wear_Leveling_Count":   "endurance_remain_perc",
+		"Media_Wearout_Indicator": "endurance_remain_perc",
 	}	
 	
 	// to obtain metrics from smartctl

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -91,8 +91,8 @@ var (
 	// so we need to be able to match on name instead
 	deviceFieldNames = map[string]string{
 		"Percent_Lifetime_Remain":   "endurance_remain_perc",
-		"Wear_Leveling_Count":   "endurance_remain_perc",
-		"Media_Wearout_Indicator": "endurance_remain_perc",
+		"Wear_Leveling_Count":   "endurance_wear_levelling",
+		"Media_Wearout_Indicator": "endurance_media_wearout",
 	}	
 	
 	// to obtain metrics from smartctl

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -52,7 +52,7 @@ func TestGatherAttributes(t *testing.T) {
 			err := s.Gather(&acc)
 
 			require.NoError(t, err)
-			assert.Equal(t, 65, acc.NFields(), "Wrong number of fields gathered")
+			assert.Equal(t, 66, acc.NFields(), "Wrong number of fields gathered")
 
 			for _, test := range testsAda0Attributes {
 				acc.AssertContainsTaggedFields(t, "smart_attribute", test.fields, test.tags)
@@ -171,7 +171,7 @@ func TestGatherNoAttributes(t *testing.T) {
 		err := s.Gather(&acc)
 
 		require.NoError(t, err)
-		assert.Equal(t, 8, acc.NFields(), "Wrong number of fields gathered")
+		assert.Equal(t, 9, acc.NFields(), "Wrong number of fields gathered")
 		acc.AssertDoesNotContainMeasurement(t, "smart_attribute")
 
 		for _, test := range testsAda0Device {
@@ -293,7 +293,7 @@ func TestGatherSSD(t *testing.T) {
 
 	wg.Add(1)
 	sampleSmart.gatherDisk(acc, "", wg)
-	assert.Equal(t, 105, acc.NFields(), "Wrong number of fields gathered")
+	assert.Equal(t, 106, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(26), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
@@ -309,7 +309,7 @@ func TestGatherSSDRaid(t *testing.T) {
 
 	wg.Add(1)
 	sampleSmart.gatherDisk(acc, "", wg)
-	assert.Equal(t, 74, acc.NFields(), "Wrong number of fields gathered")
+	assert.Equal(t, 75, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(15), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
@@ -1416,6 +1416,7 @@ var (
 				"read_error_rate": int64(0),
 				"temp_c":          int64(34),
 				"udma_crc_errors": int64(0),
+				"endurance_wear_levelling": int64(185),
 			},
 			map[string]string{
 				"device":    "ada0",

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -1411,11 +1411,11 @@ var (
 	}{
 		{
 			map[string]interface{}{
-				"exit_status":              int(0),
-				"health_ok":                bool(true),
-				"read_error_rate":          int64(0),
-				"temp_c":                   int64(34),
-				"udma_crc_errors":          int64(0),
+				"exit_status":         int(0),
+				"health_ok":           bool(true),
+				"read_error_rate":     int64(0),
+				"temp_c":              int64(34),
+				"udma_crc_errors":     int64(0),
 				"wear_leveling_count": int64(185),
 			},
 			map[string]string{

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -265,20 +265,20 @@ func TestGatherHtSAS(t *testing.T) {
 }
 
 func TestGatherLongFormEnduranceAttrib(t *testing.T) {
-        runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
-                return []byte(mockHGST), nil
-        }
+	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+		return []byte(mockHGST), nil
+	}
 
-        var (
-                acc = &testutil.Accumulator{}
-                wg  = &sync.WaitGroup{}
-        )
+	var (
+		acc = &testutil.Accumulator{}
+		wg  = &sync.WaitGroup{}
+	)
 
-        wg.Add(1)
+	wg.Add(1)
 
-        sampleSmart.gatherDisk(acc, "", wg)
-        assert.Equal(t, 7, acc.NFields(), "Wrong number of fields gathered")
-        assert.Equal(t, uint64(5), acc.NMetrics(), "Wrong number of metrics gathered")
+	sampleSmart.gatherDisk(acc, "", wg)
+	assert.Equal(t, 7, acc.NFields(), "Wrong number of fields gathered")
+	assert.Equal(t, uint64(5), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
 func TestGatherSSD(t *testing.T) {
@@ -1411,11 +1411,11 @@ var (
 	}{
 		{
 			map[string]interface{}{
-				"exit_status":     int(0),
-				"health_ok":       bool(true),
-				"read_error_rate": int64(0),
-				"temp_c":          int64(34),
-				"udma_crc_errors": int64(0),
+				"exit_status":              int(0),
+				"health_ok":                bool(true),
+				"read_error_rate":          int64(0),
+				"temp_c":                   int64(34),
+				"udma_crc_errors":          int64(0),
 				"endurance_wear_levelling": int64(185),
 			},
 			map[string]string{
@@ -1830,7 +1830,7 @@ ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
                             |______ P prefailure warning
 `
 
-    mockHGST = `
+	mockHGST = `
 smartctl 6.6 2016-05-31 r4324 [x86_64-linux-4.9.0-3-amd64] (local build)
 Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org
 

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -1416,7 +1416,7 @@ var (
 				"read_error_rate":          int64(0),
 				"temp_c":                   int64(34),
 				"udma_crc_errors":          int64(0),
-				"endurance_wear_levelling": int64(185),
+				"wear_leveling_count": int64(185),
 			},
 			map[string]string{
 				"device":    "ada0",

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -264,6 +264,23 @@ func TestGatherHtSAS(t *testing.T) {
 	testutil.RequireMetricsEqual(t, testHtsasAtributtes, acc.GetTelegrafMetrics(), testutil.SortMetrics(), testutil.IgnoreTime())
 }
 
+func TestGatherLongFormEnduranceAttrib(t *testing.T) {
+        runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+                return []byte(mockHGST), nil
+        }
+
+        var (
+                acc = &testutil.Accumulator{}
+                wg  = &sync.WaitGroup{}
+        )
+
+        wg.Add(1)
+
+        sampleSmart.gatherDisk(acc, "", wg)
+        assert.Equal(t, 7, acc.NFields(), "Wrong number of fields gathered")
+        assert.Equal(t, uint64(5), acc.NMetrics(), "Wrong number of metrics gathered")
+}
+
 func TestGatherSSD(t *testing.T) {
 	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
 		return []byte(ssdInfoData), nil
@@ -1810,6 +1827,52 @@ ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
                             |||____ S speed/performance
                             ||_____ O updated online
                             |______ P prefailure warning
+`
+
+    mockHGST = `
+smartctl 6.6 2016-05-31 r4324 [x86_64-linux-4.9.0-3-amd64] (local build)
+Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org
+
+=== START OF INFORMATION SECTION ===
+Vendor:               HGST
+Product:              HUSMM1640ASS200
+Revision:             A360
+Compliance:           SPC-4
+User Capacity:        400,088,457,216 bytes [400 GB]
+Logical block size:   512 bytes
+Physical block size:  4096 bytes
+LU is resource provisioned, LBPRZ=1
+Rotation Rate:        Solid State Device
+Form Factor:          2.5 inches
+Logical Unit id:      0x5000cca04ec26364
+Serial number:        ZZZZZZZZZ
+Device type:          disk
+Transport protocol:   SAS (SPL-3)
+Local Time is:        Mon Nov  6 10:20:33 2017 CET
+SMART support is:     Available - device has SMART capability.
+SMART support is:     Enabled
+Temperature Warning:  Enabled
+Read Cache is:        Enabled
+Writeback Cache is:   Enabled
+
+=== START OF READ SMART DATA SECTION ===
+SMART Health Status: OK
+
+Percentage used endurance indicator: 0%
+Current Drive Temperature:     28 C
+Drive Trip Temperature:        70 C
+
+Manufactured in week 30 of year 2017
+Specified cycle count over device lifetime:  0
+Accumulated start-stop cycles:  0
+Specified load-unload count over device lifetime:  0
+Accumulated load-unload cycles:  0
+defect list format 6 unknown
+Elements in grown defect list: 0
+
+Vendor (Seagate) cache information
+  Blocks sent to initiator = 3400674574336
+
 `
 
 	htSASInfoData = `smartctl 6.6 2016-05-31 r4324 [x86_64-linux-4.15.18-12-pve] (local build)


### PR DESCRIPTION
### Required for all PRs:

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Adjusts the `smart` input plugin to collect SSD endurance information in more situations (for example, resolves #8701)

The `smart` plugin already collects endurance information if `attributes` is `true` **and** the NVME log contains the attribute `Percentage Used`.

However, this PR adjusts the plugin to also collect endurance information if it's available in the following locations

* in the NVME log with name `Percentage used endurance indicator`
* For SATA SSDs, in the SMART data labelled as one of `Percent_Lifetime_Remain`, `Wear_Leveling_Count` or `Media_Wearout_Indicator`

Because the SMART data fields are vendor specific, the ID cannot be relied on, so this PR introduces the ability to match rows by name rather than ID.

Additionally, for safety, it is not assumed that the value of any one of those field values could/should overwrite the other, so three new output fields are created

* `endurance_remain_perc`
* `endurance_wear_levelling`
* `endurance_media_wearout`

For the majority of vendors, these values start at 100 and count down - it is expected that there will be exceptions, but this PR doesn't attempt to address those as it *seems* better to let the user handle those as they see fit at query time.
