### PR TITLE
feat: Migrate nagios parser to new style

### DIFF
--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -135,7 +135,7 @@ func (*Exec) SampleConfig() string {
 
 func (e *Exec) ProcessCommand(command string, acc telegraf.Accumulator, wg *sync.WaitGroup) {
 	defer wg.Done()
-	_, isNagios := e.parser.(*nagios.NagiosParser)
+	_, isNagios := e.parser.(*nagios.Parser)
 
 	out, errBuf, runErr := e.runner.Run(command, e.Environment, time.Duration(e.Timeout))
 	if !isNagios && runErr != nil {

--- a/plugins/parsers/all/all.go
+++ b/plugins/parsers/all/all.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/parsers/json"
 	_ "github.com/influxdata/telegraf/plugins/parsers/json_v2"
 	_ "github.com/influxdata/telegraf/plugins/parsers/logfmt"
+	_ "github.com/influxdata/telegraf/plugins/parsers/nagios"
 	_ "github.com/influxdata/telegraf/plugins/parsers/value"
 	_ "github.com/influxdata/telegraf/plugins/parsers/wavefront"
 	_ "github.com/influxdata/telegraf/plugins/parsers/xpath"

--- a/plugins/parsers/nagios/parser.go
+++ b/plugins/parsers/nagios/parser.go
@@ -311,10 +311,6 @@ func parseThreshold(threshold string) (min float64, max float64, err error) {
 	return min, max, err
 }
 
-func (p *Parser) Init() error {
-	return nil
-}
-
 func init() {
 	// Register parser
 	parsers.Add("nagios",
@@ -328,5 +324,5 @@ func init() {
 func (p *Parser) InitFromConfig(config *parsers.Config) error {
 	p.metricName = config.MetricName
 	p.DefaultTags = config.DefaultTags
-	return p.Init()
+	return nil
 }

--- a/plugins/parsers/nagios/parser_test.go
+++ b/plugins/parsers/nagios/parser_test.go
@@ -215,8 +215,8 @@ func assertNagiosState(t *testing.T, m telegraf.Metric, f map[string]interface{}
 }
 
 func TestParse(t *testing.T) {
-	parser := NagiosParser{
-		MetricName: "nagios_test",
+	parser := Parser{
+		metricName: "nagios_test",
 	}
 
 	tests := []struct {

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -6,7 +6,6 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/plugins/parsers/influx/influx_upstream"
-	"github.com/influxdata/telegraf/plugins/parsers/nagios"
 	"github.com/influxdata/telegraf/plugins/parsers/prometheus"
 	"github.com/influxdata/telegraf/plugins/parsers/prometheusremotewrite"
 	"github.com/influxdata/telegraf/plugins/parsers/temporary/json_v2"
@@ -203,8 +202,6 @@ func NewParser(config *Config) (Parser, error) {
 		} else {
 			parser, err = NewInfluxParser()
 		}
-	case "nagios":
-		parser, err = NewNagiosParser()
 	case "prometheus":
 		parser, err = NewPrometheusParser(
 			config.DefaultTags,
@@ -228,10 +225,6 @@ func NewParser(config *Config) (Parser, error) {
 		err = p.InitFromConfig(config)
 	}
 	return parser, err
-}
-
-func NewNagiosParser() (Parser, error) {
-	return &nagios.NagiosParser{}, nil
 }
 
 func NewInfluxParser() (Parser, error) {


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11360 

This PR migrates the `nagios` parser to the new-style parser structure. The change is backward compatible. Furthermore, we cleanup the parser a bit.