### PR TITLE
feat: Migrate graphite parser to new style

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -492,10 +492,6 @@ func TestConfig_ParserInterfaceNewFormat(t *testing.T) {
 	require.Len(t, actual, len(formats))
 
 	for i, format := range formats {
-		if format == "graphite" {
-			fmt.Printf("actual=%v\n", actual[i])
-			fmt.Printf("expected=%v\n", expected[i])
-		}
 		// Determine the underlying type of the parser
 		stype := reflect.Indirect(reflect.ValueOf(expected[i])).Interface()
 		// Ignore all unexported fields and fields not relevant for functionality

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -475,6 +475,7 @@ func TestConfig_ParserInterfaceNewFormat(t *testing.T) {
 		require.True(t, ok)
 		// Get the parser set with 'SetParser()'
 		if p, ok := input.Parser.(*models.RunningParser); ok {
+			require.NoError(t, p.Init())
 			actual = append(actual, p.Parser)
 		} else {
 			actual = append(actual, input.Parser)
@@ -491,6 +492,10 @@ func TestConfig_ParserInterfaceNewFormat(t *testing.T) {
 	require.Len(t, actual, len(formats))
 
 	for i, format := range formats {
+		if format == "graphite" {
+			fmt.Printf("actual=%v\n", actual[i])
+			fmt.Printf("expected=%v\n", expected[i])
+		}
 		// Determine the underlying type of the parser
 		stype := reflect.Indirect(reflect.ValueOf(expected[i])).Interface()
 		// Ignore all unexported fields and fields not relevant for functionality
@@ -614,6 +619,7 @@ func TestConfig_ParserInterfaceOldFormat(t *testing.T) {
 		require.True(t, ok)
 		// Get the parser set with 'SetParser()'
 		if p, ok := input.Parser.(*models.RunningParser); ok {
+			require.NoError(t, p.Init())
 			actual = append(actual, p.Parser)
 		} else {
 			actual = append(actual, input.Parser)

--- a/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_test.go
+++ b/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Shopify/sarama"
 
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/influxdata/telegraf/plugins/parsers/graphite"
 	"github.com/influxdata/telegraf/plugins/parsers/json"
 	"github.com/influxdata/telegraf/testutil"
 
@@ -115,9 +116,9 @@ func TestRunParserAndGatherGraphite(t *testing.T) {
 	k.acc = &acc
 	defer close(k.done)
 
-	var err error
-	k.parser, err = parsers.NewGraphiteParser("_", []string{}, nil)
-	require.NoError(t, err)
+	p := graphite.Parser{Separator: "_", Templates: []string{}}
+	require.NoError(t, p.Init())
+	k.parser = &p
 	go k.receiver()
 	in <- saramaMsg(testMsgGraphite)
 	acc.Wait(1)

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -150,7 +150,7 @@ type Statsd struct {
 	// Max duration for each metric to stay cached without being updated.
 	MaxTTL config.Duration `toml:"max_ttl"`
 
-	graphiteParser *graphite.GraphiteParser
+	graphiteParser *graphite.Parser
 
 	acc telegraf.Accumulator
 
@@ -713,7 +713,8 @@ func (s *Statsd) parseName(bucket string) (name string, field string, tags map[s
 	var err error
 
 	if p == nil || s.graphiteParser.Separator != s.MetricSeparator {
-		p, err = graphite.NewGraphiteParser(s.MetricSeparator, s.Templates, nil)
+		p = &graphite.Parser{Separator: s.MetricSeparator, Templates: s.Templates}
+		err = p.Init()
 		s.graphiteParser = p
 	}
 

--- a/plugins/inputs/tcp_listener/tcp_listener_test.go
+++ b/plugins/inputs/tcp_listener/tcp_listener_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/influxdata/telegraf/plugins/parsers/graphite"
 	"github.com/influxdata/telegraf/plugins/parsers/json"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -293,9 +294,9 @@ func TestRunParserGraphiteMsg(t *testing.T) {
 	listener.acc = &acc
 	defer close(listener.done)
 
-	var err error
-	listener.parser, err = parsers.NewGraphiteParser("_", []string{}, nil)
-	require.NoError(t, err)
+	p := graphite.Parser{Separator: "_", Templates: []string{}}
+	require.NoError(t, p.Init())
+	listener.parser = &p
 	listener.wg.Add(1)
 	go listener.tcpParser()
 

--- a/plugins/parsers/all/all.go
+++ b/plugins/parsers/all/all.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/parsers/collectd"
 	_ "github.com/influxdata/telegraf/plugins/parsers/csv"
 	_ "github.com/influxdata/telegraf/plugins/parsers/form_urlencoded"
+	_ "github.com/influxdata/telegraf/plugins/parsers/graphite"
 	_ "github.com/influxdata/telegraf/plugins/parsers/json"
 	_ "github.com/influxdata/telegraf/plugins/parsers/json_v2"
 	_ "github.com/influxdata/telegraf/plugins/parsers/value"

--- a/plugins/parsers/graphite/parser.go
+++ b/plugins/parsers/graphite/parser.go
@@ -168,6 +168,7 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 
 // ApplyTemplate extracts the template fields from the given line and
 // returns the measurement name and tags.
+//nolint:revive // This function should be eliminated anyway
 func (p *Parser) ApplyTemplate(line string) (string, map[string]string, string, error) {
 	// Break line into fields (name, value, timestamp), only name is used
 	fields := strings.Fields(line)

--- a/plugins/parsers/graphite/parser.go
+++ b/plugins/parsers/graphite/parser.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/templating"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/plugins/parsers"
 )
 
 // Minimum and maximum supported dates for timestamps.
@@ -20,45 +21,34 @@ var (
 	MaxDate = time.Date(2038, 1, 19, 0, 0, 0, 0, time.UTC)
 )
 
-type GraphiteParser struct {
-	Separator      string
-	Templates      []string
-	DefaultTags    map[string]string
+type Parser struct {
+	Separator   string            `toml:"separator"`
+	Templates   []string          `toml:"templates"`
+	DefaultTags map[string]string ` toml:"-"`
+
 	templateEngine *templating.Engine
 }
 
-func (p *GraphiteParser) SetDefaultTags(tags map[string]string) {
-	p.DefaultTags = tags
-}
-
-func NewGraphiteParser(
-	separator string,
-	templates []string,
-	defaultTags map[string]string,
-) (*GraphiteParser, error) {
-	var err error
-
-	if separator == "" {
-		separator = DefaultSeparator
-	}
-	p := &GraphiteParser{
-		Separator: separator,
-		Templates: templates,
+func (p *Parser) Init() error {
+	// Set defaults
+	if p.Separator == "" {
+		p.Separator = DefaultSeparator
 	}
 
-	if defaultTags != nil {
-		p.DefaultTags = defaultTags
-	}
-	defaultTemplate, _ := templating.NewDefaultTemplateWithPattern("measurement*")
-	p.templateEngine, err = templating.NewEngine(p.Separator, defaultTemplate, p.Templates)
-
+	defaultTemplate, err := templating.NewDefaultTemplateWithPattern("measurement*")
 	if err != nil {
-		return p, fmt.Errorf("exec input parser config is error: %s ", err.Error())
+		return fmt.Errorf("creating template failed: %w", err)
 	}
-	return p, nil
+
+	p.templateEngine, err = templating.NewEngine(p.Separator, defaultTemplate, p.Templates)
+	if err != nil {
+		return fmt.Errorf("creating template engine failed: %w ", err)
+	}
+
+	return nil
 }
 
-func (p *GraphiteParser) Parse(buf []byte) ([]telegraf.Metric, error) {
+func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	// parse even if the buffer begins with a newline
 	if len(buf) != 0 && buf[0] == '\n' {
 		buf = buf[1:]
@@ -95,7 +85,7 @@ func (p *GraphiteParser) Parse(buf []byte) ([]telegraf.Metric, error) {
 }
 
 // ParseLine performs Graphite parsing of a single line.
-func (p *GraphiteParser) ParseLine(line string) (telegraf.Metric, error) {
+func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 	// Break into 3 fields (name, value, timestamp).
 	fields := strings.Fields(line)
 	if len(fields) != 2 && len(fields) != 3 {
@@ -178,7 +168,7 @@ func (p *GraphiteParser) ParseLine(line string) (telegraf.Metric, error) {
 
 // ApplyTemplate extracts the template fields from the given line and
 // returns the measurement name and tags.
-func (p *GraphiteParser) ApplyTemplate(line string) (string, map[string]string, string, error) {
+func (p *Parser) ApplyTemplate(line string) (string, map[string]string, string, error) {
 	// Break line into fields (name, value, timestamp), only name is used
 	fields := strings.Fields(line)
 	if len(fields) == 0 {
@@ -195,4 +185,20 @@ func (p *GraphiteParser) ApplyTemplate(line string) (string, map[string]string, 
 	}
 
 	return name, tags, field, err
+}
+
+func (p *Parser) SetDefaultTags(tags map[string]string) {
+	p.DefaultTags = tags
+}
+
+func init() {
+	parsers.Add("graphite", func(_ string) telegraf.Parser { return &Parser{} })
+}
+
+func (p *Parser) InitFromConfig(config *parsers.Config) error {
+	p.Templates = append(p.Templates, config.Templates...)
+	p.Separator = config.Separator
+	p.DefaultTags = config.DefaultTags
+
+	return p.Init()
 }

--- a/plugins/parsers/graphite/parser_test.go
+++ b/plugins/parsers/graphite/parser_test.go
@@ -122,25 +122,18 @@ func TestTemplateApply(t *testing.T) {
 
 	for _, test := range tests {
 		tmpl, err := templating.NewDefaultTemplateWithPattern(test.template)
-		if errstr(err) != test.err {
-			t.Fatalf("err does not match.  expected %v, got %v", test.err, err)
-		}
-		if err != nil {
-			// If we erred out,it was intended and the following tests won't work
+		if test.err == "" {
+			require.NoError(t, err)
+		} else {
+			require.EqualError(t, err, test.err)
 			continue
 		}
 
 		measurement, tags, _, _ := tmpl.Apply(test.input, DefaultSeparator)
-		if measurement != test.measurement {
-			t.Fatalf("name parse failer.  expected %v, got %v", test.measurement, measurement)
-		}
-		if len(tags) != len(test.tags) {
-			t.Fatalf("unexpected number of tags.  expected %v, got %v", test.tags, tags)
-		}
+		require.Equal(t, test.measurement, measurement)
+		require.Len(t, tags, len(test.tags))
 		for k, v := range test.tags {
-			if tags[k] != v {
-				t.Fatalf("unexpected tag value for tags[%s].  expected %q, got %q", k, v, tags[k])
-			}
+			require.Equal(t, v, tags[k])
 		}
 	}
 }
@@ -283,13 +276,13 @@ func TestParseLine(t *testing.T) {
 		require.NoError(t, p.Init())
 
 		m, err := p.ParseLine(test.input)
-		if errstr(err) != test.err {
-			t.Fatalf("err does not match.  expected %v, got %v", test.err, err)
-		}
-		if err != nil {
-			// If we erred out,it was intended and the following tests won't work
+		if test.err == "" {
+			require.NoError(t, err)
+		} else {
+			require.EqualError(t, err, test.err)
 			continue
 		}
+
 		if m.Name() != test.measurement {
 			t.Fatalf("name parse failer.  expected %v, got %v",
 				test.measurement, m.Name())
@@ -396,13 +389,13 @@ func TestParse(t *testing.T) {
 		require.NoError(t, p.Init())
 
 		metrics, err := p.Parse(test.input)
-		if errstr(err) != test.err {
-			t.Fatalf("err does not match.  expected [%v], got [%v]", test.err, err)
-		}
-		if err != nil {
-			// If we erred out,it was intended and the following tests won't work
+		if test.err == "" {
+			require.NoError(t, err)
+		} else {
+			require.EqualError(t, err, test.err)
 			continue
 		}
+
 		if metrics[0].Name() != test.measurement {
 			t.Fatalf("name parse failer.  expected %v, got %v",
 				test.measurement, metrics[0].Name())
@@ -901,12 +894,4 @@ func TestApplyTemplateMostSpecificTemplate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "net", measurement)
 	require.Equal(t, map[string]string{"host": "server001", "metric": "a.b"}, tags)
-}
-
-// Test Helpers
-func errstr(err error) string {
-	if err != nil {
-		return err.Error()
-	}
-	return ""
 }

--- a/plugins/parsers/graphite/parser_test.go
+++ b/plugins/parsers/graphite/parser_test.go
@@ -275,12 +275,11 @@ func TestParseLine(t *testing.T) {
 		require.NoError(t, p.Init())
 
 		m, err := p.ParseLine(test.input)
-		if test.err == "" {
-			require.NoError(t, err)
-		} else {
+		if test.err != "" {
 			require.EqualError(t, err, test.err)
 			continue
 		}
+		require.NoError(t, err)
 
 		if m.Name() != test.measurement {
 			t.Fatalf("name parse failer.  expected %v, got %v",

--- a/plugins/parsers/graphite/parser_test.go
+++ b/plugins/parsers/graphite/parser_test.go
@@ -387,12 +387,11 @@ func TestParse(t *testing.T) {
 		require.NoError(t, p.Init())
 
 		metrics, err := p.Parse(test.input)
-		if test.err == "" {
-			require.NoError(t, err)
-		} else {
+		if test.err != ""  {
 			require.EqualError(t, err, test.err)
 			continue
 		}
+		require.NoError(t, err)
 
 		if metrics[0].Name() != test.measurement {
 			t.Fatalf("name parse failer.  expected %v, got %v",

--- a/plugins/parsers/graphite/parser_test.go
+++ b/plugins/parsers/graphite/parser_test.go
@@ -387,7 +387,7 @@ func TestParse(t *testing.T) {
 		require.NoError(t, p.Init())
 
 		metrics, err := p.Parse(test.input)
-		if test.err != ""  {
+		if test.err != "" {
 			require.EqualError(t, err, test.err)
 			continue
 		}

--- a/plugins/parsers/graphite/parser_test.go
+++ b/plugins/parsers/graphite/parser_test.go
@@ -122,12 +122,11 @@ func TestTemplateApply(t *testing.T) {
 
 	for _, test := range tests {
 		tmpl, err := templating.NewDefaultTemplateWithPattern(test.template)
-		if test.err == "" {
-			require.NoError(t, err)
-		} else {
+		if test.err != "" {
 			require.EqualError(t, err, test.err)
 			continue
 		}
+		require.NoError(t, err)
 
 		measurement, tags, _, _ := tmpl.Apply(test.input, DefaultSeparator)
 		require.Equal(t, test.measurement, measurement)

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/parsers/dropwizard"
-	"github.com/influxdata/telegraf/plugins/parsers/graphite"
 	"github.com/influxdata/telegraf/plugins/parsers/grok"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/plugins/parsers/influx/influx_upstream"
@@ -209,9 +208,6 @@ func NewParser(config *Config) (Parser, error) {
 		}
 	case "nagios":
 		parser, err = NewNagiosParser()
-	case "graphite":
-		parser, err = NewGraphiteParser(config.Separator,
-			config.Templates, config.DefaultTags)
 	case "dropwizard":
 		parser, err = NewDropwizardParser(
 			config.DropwizardMetricRegistryPath,
@@ -287,14 +283,6 @@ func NewInfluxParser() (Parser, error) {
 
 func NewInfluxUpstreamParser() (Parser, error) {
 	return influx_upstream.NewParser(), nil
-}
-
-func NewGraphiteParser(
-	separator string,
-	templates []string,
-	defaultTags map[string]string,
-) (Parser, error) {
-	return graphite.NewGraphiteParser(separator, templates, defaultTags)
 }
 
 func NewDropwizardParser(


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11356  

This PR migrates the `graphite` parser to the new-style parser structure. The change is backward compatible. Furthermore, we cleanup the parser a bit.