### PR TITLE
feat(serializers.prometheus): allow serializing metrics without HELP and TYPE metadata

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1366,6 +1366,7 @@ func (c *Config) buildSerializer(tbl *ast.Table) (serializers.Serializer, error)
 	c.getFieldBool(tbl, "prometheus_export_timestamp", &sc.PrometheusExportTimestamp)
 	c.getFieldBool(tbl, "prometheus_sort_metrics", &sc.PrometheusSortMetrics)
 	c.getFieldBool(tbl, "prometheus_string_as_label", &sc.PrometheusStringAsLabel)
+	c.getFieldBool(tbl, "prometheus_compact_encoding", &sc.PrometheusCompactEncoding)
 
 	if c.hasErrs() {
 		return nil, c.firstErr()
@@ -1442,7 +1443,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 		"graphite_tag_sanitize_mode", "graphite_tag_support", "graphite_separator",
 		"influx_max_line_bytes", "influx_sort_fields", "influx_uint_support",
 		"json_timestamp_format", "json_timestamp_units",
-		"prometheus_export_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label",
+		"prometheus_export_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label", "prometheus_compact_encoding",
 		"splunkmetric_hec_routing", "splunkmetric_multimetric",
 		"wavefront_disable_prefix_conversion", "wavefront_source_override", "wavefront_use_strict":
 	default:

--- a/plugins/serializers/prometheus/README.md
+++ b/plugins/serializers/prometheus/README.md
@@ -23,6 +23,10 @@ reporting others every bucket/quantile will continue to exist.
   ## Include the metric timestamp on each sample.
   prometheus_export_timestamp = false
 
+  ## Encode metrics without TYPE and HELP metadata, i.e. compacted Prometheus exposition format;
+  ## when false the standard Prometheus exposition format is used.
+  prometheus_compact_encoding = false
+
   ## Sort prometheus metric families and metric samples.  Useful for
   ## debugging.
   prometheus_sort_metrics = false

--- a/plugins/serializers/prometheus/encode.go
+++ b/plugins/serializers/prometheus/encode.go
@@ -146,7 +146,7 @@ func MetricFamilyToCompactText(out io.Writer, in *dto.MetricFamily) (written int
 				)
 				written += n
 				if err != nil {
-					return
+					return // nolint: revive
 				}
 			}
 			n, err = writeSample(
@@ -155,7 +155,7 @@ func MetricFamilyToCompactText(out io.Writer, in *dto.MetricFamily) (written int
 			)
 			written += n
 			if err != nil {
-				return
+				return // nolint: revive
 			}
 			n, err = writeSample(
 				w, name, "_count", metric, "", 0,
@@ -176,7 +176,7 @@ func MetricFamilyToCompactText(out io.Writer, in *dto.MetricFamily) (written int
 				)
 				written += n
 				if err != nil {
-					return
+					return // nolint: revive
 				}
 				if math.IsInf(b.GetUpperBound(), +1) {
 					infSeen = true
@@ -190,7 +190,7 @@ func MetricFamilyToCompactText(out io.Writer, in *dto.MetricFamily) (written int
 				)
 				written += n
 				if err != nil {
-					return
+					return // nolint: revive
 				}
 			}
 			n, err = writeSample(
@@ -199,7 +199,7 @@ func MetricFamilyToCompactText(out io.Writer, in *dto.MetricFamily) (written int
 			)
 			written += n
 			if err != nil {
-				return
+				return // nolint: revive
 			}
 			n, err = writeSample(
 				w, name, "_count", metric, "", 0,
@@ -212,10 +212,10 @@ func MetricFamilyToCompactText(out io.Writer, in *dto.MetricFamily) (written int
 		}
 		written += n
 		if err != nil {
-			return
+			return // nolint: revive
 		}
 	}
-	return
+	return // nolint: nakedret, revive
 }
 
 // writeSample writes a single sample in text format to w, given the metric
@@ -223,6 +223,7 @@ func MetricFamilyToCompactText(out io.Writer, in *dto.MetricFamily) (written int
 // with a float64 value (use empty string as label name if not required), and
 // the value. The function returns the number of bytes written and any error
 // encountered.
+// nolint: revive
 func writeSample(
 	w enhancedWriter,
 	name, suffix string,

--- a/plugins/serializers/prometheus/encode.go
+++ b/plugins/serializers/prometheus/encode.go
@@ -1,0 +1,414 @@
+package prometheus
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+)
+
+// enhancedWriter has all the enhanced write functions needed here. bufio.Writer
+// implements it.
+type enhancedWriter interface {
+	io.Writer
+	WriteRune(r rune) (n int, err error)
+	WriteString(s string) (n int, err error)
+	WriteByte(c byte) error
+}
+
+type compactEncoder struct {
+	encode func(*dto.MetricFamily) error
+	close  func() error
+}
+
+func (ce compactEncoder) Encode(v *dto.MetricFamily) error {
+	return ce.encode(v)
+}
+
+// Implement expfmt.Closer as this method will be
+// a part of the `expfmt.Encoder` interface in the future (currently, it's not).
+func (ce compactEncoder) Close() error {
+	return ce.close()
+}
+
+const (
+	initialNumBufSize = 24
+)
+
+var (
+	bufPool = sync.Pool{
+		New: func() interface{} {
+			return bufio.NewWriter(ioutil.Discard)
+		},
+	}
+	numBufPool = sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, 0, initialNumBufSize)
+			return &b
+		},
+	}
+)
+
+func NewCompactEncoder(w io.Writer) expfmt.Encoder {
+	return compactEncoder{
+		encode: func(v *dto.MetricFamily) error {
+			_, err := MetricFamilyToCompactText(w, v)
+			return err
+		},
+		close: func() error { return nil },
+	}
+}
+
+// It's similar to `expfmt.MetricFamilyToText` with the only difference in
+// HELP and TYPE comments handling.
+func MetricFamilyToCompactText(out io.Writer, in *dto.MetricFamily) (written int, err error) {
+	// Fail-fast checks.
+	if len(in.Metric) == 0 {
+		return 0, fmt.Errorf("MetricFamily has no metrics: %s", in)
+	}
+	name := in.GetName()
+	if name == "" {
+		return 0, fmt.Errorf("MetricFamily has no name: %s", in)
+	}
+
+	// Try the interface upgrade. If it doesn't work, we'll use a
+	// bufio.Writer from the sync.Pool.
+	w, ok := out.(enhancedWriter)
+	if !ok {
+		b := bufPool.Get().(*bufio.Writer)
+		b.Reset(out)
+		w = b
+		defer func() {
+			bErr := b.Flush()
+			if err == nil {
+				err = bErr
+			}
+			bufPool.Put(b)
+		}()
+	}
+
+	var n int
+
+	// Don't produce HELP and TYPE comments, instead,
+	// produce the samples only, one line for each.
+	metricType := in.GetType()
+	for _, metric := range in.Metric {
+		switch metricType {
+		case dto.MetricType_COUNTER:
+			if metric.Counter == nil {
+				return written, fmt.Errorf(
+					"expected counter in metric %s %s", name, metric,
+				)
+			}
+			n, err = writeSample(
+				w, name, "", metric, "", 0,
+				metric.Counter.GetValue(),
+			)
+		case dto.MetricType_GAUGE:
+			if metric.Gauge == nil {
+				return written, fmt.Errorf(
+					"expected gauge in metric %s %s", name, metric,
+				)
+			}
+			n, err = writeSample(
+				w, name, "", metric, "", 0,
+				metric.Gauge.GetValue(),
+			)
+		case dto.MetricType_UNTYPED:
+			if metric.Untyped == nil {
+				return written, fmt.Errorf(
+					"expected untyped in metric %s %s", name, metric,
+				)
+			}
+			n, err = writeSample(
+				w, name, "", metric, "", 0,
+				metric.Untyped.GetValue(),
+			)
+		case dto.MetricType_SUMMARY:
+			if metric.Summary == nil {
+				return written, fmt.Errorf(
+					"expected summary in metric %s %s", name, metric,
+				)
+			}
+			for _, q := range metric.Summary.Quantile {
+				n, err = writeSample(
+					w, name, "", metric,
+					model.QuantileLabel, q.GetQuantile(),
+					q.GetValue(),
+				)
+				written += n
+				if err != nil {
+					return
+				}
+			}
+			n, err = writeSample(
+				w, name, "_sum", metric, "", 0,
+				metric.Summary.GetSampleSum(),
+			)
+			written += n
+			if err != nil {
+				return
+			}
+			n, err = writeSample(
+				w, name, "_count", metric, "", 0,
+				float64(metric.Summary.GetSampleCount()),
+			)
+		case dto.MetricType_HISTOGRAM:
+			if metric.Histogram == nil {
+				return written, fmt.Errorf(
+					"expected histogram in metric %s %s", name, metric,
+				)
+			}
+			infSeen := false
+			for _, b := range metric.Histogram.Bucket {
+				n, err = writeSample(
+					w, name, "_bucket", metric,
+					model.BucketLabel, b.GetUpperBound(),
+					float64(b.GetCumulativeCount()),
+				)
+				written += n
+				if err != nil {
+					return
+				}
+				if math.IsInf(b.GetUpperBound(), +1) {
+					infSeen = true
+				}
+			}
+			if !infSeen {
+				n, err = writeSample(
+					w, name, "_bucket", metric,
+					model.BucketLabel, math.Inf(+1),
+					float64(metric.Histogram.GetSampleCount()),
+				)
+				written += n
+				if err != nil {
+					return
+				}
+			}
+			n, err = writeSample(
+				w, name, "_sum", metric, "", 0,
+				metric.Histogram.GetSampleSum(),
+			)
+			written += n
+			if err != nil {
+				return
+			}
+			n, err = writeSample(
+				w, name, "_count", metric, "", 0,
+				float64(metric.Histogram.GetSampleCount()),
+			)
+		default:
+			return written, fmt.Errorf(
+				"unexpected type in metric %s %s", name, metric,
+			)
+		}
+		written += n
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// writeSample writes a single sample in text format to w, given the metric
+// name, the metric proto message itself, optionally an additional label name
+// with a float64 value (use empty string as label name if not required), and
+// the value. The function returns the number of bytes written and any error
+// encountered.
+func writeSample(
+	w enhancedWriter,
+	name, suffix string,
+	metric *dto.Metric,
+	additionalLabelName string, additionalLabelValue float64,
+	value float64,
+) (int, error) {
+	var written int
+	n, err := w.WriteString(name)
+	written += n
+	if err != nil {
+		return written, err
+	}
+	if suffix != "" {
+		n, err = w.WriteString(suffix)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+	n, err = writeLabelPairs(
+		w, metric.Label, additionalLabelName, additionalLabelValue,
+	)
+	written += n
+	if err != nil {
+		return written, err
+	}
+	err = w.WriteByte(' ')
+	written++
+	if err != nil {
+		return written, err
+	}
+	n, err = writeFloat(w, value)
+	written += n
+	if err != nil {
+		return written, err
+	}
+	if metric.TimestampMs != nil {
+		err = w.WriteByte(' ')
+		written++
+		if err != nil {
+			return written, err
+		}
+		n, err = writeInt(w, *metric.TimestampMs)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+	err = w.WriteByte('\n')
+	written++
+	if err != nil {
+		return written, err
+	}
+	return written, nil
+}
+
+// writeLabelPairs converts a slice of LabelPair proto messages plus the
+// explicitly given additional label pair into text formatted as required by the
+// text format and writes it to 'w'. An empty slice in combination with an empty
+// string 'additionalLabelName' results in nothing being written. Otherwise, the
+// label pairs are written, escaped as required by the text format, and enclosed
+// in '{...}'. The function returns the number of bytes written and any error
+// encountered.
+func writeLabelPairs(
+	w enhancedWriter,
+	in []*dto.LabelPair,
+	additionalLabelName string, additionalLabelValue float64,
+) (int, error) {
+	if len(in) == 0 && additionalLabelName == "" {
+		return 0, nil
+	}
+	var (
+		written   int
+		separator byte = '{'
+	)
+	for _, lp := range in {
+		err := w.WriteByte(separator)
+		written++
+		if err != nil {
+			return written, err
+		}
+		n, err := w.WriteString(lp.GetName())
+		written += n
+		if err != nil {
+			return written, err
+		}
+		n, err = w.WriteString(`="`)
+		written += n
+		if err != nil {
+			return written, err
+		}
+		n, err = writeEscapedString(w, lp.GetValue(), true)
+		written += n
+		if err != nil {
+			return written, err
+		}
+		err = w.WriteByte('"')
+		written++
+		if err != nil {
+			return written, err
+		}
+		separator = ','
+	}
+	if additionalLabelName != "" {
+		err := w.WriteByte(separator)
+		written++
+		if err != nil {
+			return written, err
+		}
+		n, err := w.WriteString(additionalLabelName)
+		written += n
+		if err != nil {
+			return written, err
+		}
+		n, err = w.WriteString(`="`)
+		written += n
+		if err != nil {
+			return written, err
+		}
+		n, err = writeFloat(w, additionalLabelValue)
+		written += n
+		if err != nil {
+			return written, err
+		}
+		err = w.WriteByte('"')
+		written++
+		if err != nil {
+			return written, err
+		}
+	}
+	err := w.WriteByte('}')
+	written++
+	if err != nil {
+		return written, err
+	}
+	return written, nil
+}
+
+// writeEscapedString replaces '\' by '\\', new line character by '\n', and - if
+// includeDoubleQuote is true - '"' by '\"'.
+var (
+	escaper       = strings.NewReplacer("\\", `\\`, "\n", `\n`)
+	quotedEscaper = strings.NewReplacer("\\", `\\`, "\n", `\n`, "\"", `\"`)
+)
+
+func writeEscapedString(w enhancedWriter, v string, includeDoubleQuote bool) (int, error) {
+	if includeDoubleQuote {
+		return quotedEscaper.WriteString(w, v)
+	}
+	return escaper.WriteString(w, v)
+}
+
+// writeFloat is equivalent to fmt.Fprint with a float64 argument but hardcodes
+// a few common cases for increased efficiency. For non-hardcoded cases, it uses
+// strconv.AppendFloat to avoid allocations, similar to writeInt.
+func writeFloat(w enhancedWriter, f float64) (int, error) {
+	switch {
+	case f == 1:
+		return 1, w.WriteByte('1')
+	case f == 0:
+		return 1, w.WriteByte('0')
+	case f == -1:
+		return w.WriteString("-1")
+	case math.IsNaN(f):
+		return w.WriteString("NaN")
+	case math.IsInf(f, +1):
+		return w.WriteString("+Inf")
+	case math.IsInf(f, -1):
+		return w.WriteString("-Inf")
+	default:
+		bp := numBufPool.Get().(*[]byte)
+		*bp = strconv.AppendFloat((*bp)[:0], f, 'g', -1, 64)
+		written, err := w.Write(*bp)
+		numBufPool.Put(bp)
+		return written, err
+	}
+}
+
+// writeInt is equivalent to fmt.Fprint with an int64 argument but uses
+// strconv.AppendInt with a byte slice taken from a sync.Pool to avoid
+// allocations.
+func writeInt(w enhancedWriter, i int64) (int, error) {
+	bp := numBufPool.Get().(*[]byte)
+	*bp = strconv.AppendInt((*bp)[:0], i, 10)
+	written, err := w.Write(*bp)
+	numBufPool.Put(bp)
+	return written, err
+}

--- a/plugins/serializers/prometheus/prometheus.go
+++ b/plugins/serializers/prometheus/prometheus.go
@@ -69,7 +69,6 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	var buf bytes.Buffer
 
 	for _, mf := range coll.GetProto() {
-
 		var enc expfmt.Encoder
 		switch s.config.MetricEncoding {
 		case StandardEncoding:

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -127,6 +127,9 @@ type Config struct {
 	// Output string fields as metric labels; when false string fields are
 	// discarded.
 	PrometheusStringAsLabel bool `toml:"prometheus_string_as_label"`
+
+	// Produce metrics without HELP and TYPE metadata.
+	PrometheusCompactEncoding bool `toml:"prometheus_compact_encoding"`
 }
 
 // NewSerializer a Serializer interface based on the given config.
@@ -199,10 +202,16 @@ func NewPrometheusSerializer(config *Config) (Serializer, error) {
 		stringAsLabels = prometheus.StringAsLabel
 	}
 
+	metricEncoding := prometheus.StandardEncoding
+	if config.PrometheusCompactEncoding {
+		metricEncoding = prometheus.CompactEncoding
+	}
+
 	return prometheus.NewSerializer(prometheus.FormatConfig{
 		TimestampExport: exportTimestamp,
 		MetricSortOrder: sortMetrics,
 		StringHandling:  stringAsLabels,
+		MetricEncoding:  metricEncoding,
 	})
 }
 


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #11390

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Added `prometheus_compact_encoding` option, `false` by default. It's basically another Prometheus encoder which is mostly a copy of the standard lib implementation:
https://github.com/prometheus/common/blob/main/expfmt/text_create.go
with the only difference in HELP and TYPE comments handling that are just skipped here.