### PR TITLE
feat: logstash

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1353,6 +1353,7 @@ func (c *Config) buildSerializer(tbl *ast.Table) (serializers.Serializer, error)
 
 	c.getFieldString(tbl, "graphite_separator", &sc.GraphiteSeparator)
 
+	c.getFieldBool(tbl, "json_logstash_support", &sc.JSONLogstashSupport)
 	c.getFieldDuration(tbl, "json_timestamp_units", &sc.TimestampUnits)
 	c.getFieldString(tbl, "json_timestamp_format", &sc.TimestampFormat)
 
@@ -1440,7 +1441,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 		"csv_column_prefix", "csv_header", "csv_separator", "csv_timestamp_format",
 		"graphite_tag_sanitize_mode", "graphite_tag_support", "graphite_separator",
 		"influx_max_line_bytes", "influx_sort_fields", "influx_uint_support",
-		"json_timestamp_format", "json_timestamp_units",
+		"json_logstash_support", "json_timestamp_format", "json_timestamp_units",
 		"prometheus_export_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label",
 		"splunkmetric_hec_routing", "splunkmetric_multimetric",
 		"wavefront_disable_prefix_conversion", "wavefront_source_override", "wavefront_use_strict":

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer.go
@@ -220,7 +220,7 @@ func (adx *AzureDataExplorer) Init() error {
 		return errors.New("Metrics grouping type is not valid")
 	}
 
-	serializer, err := json.NewSerializer(time.Nanosecond, time.RFC3339Nano)
+	serializer, err := json.NewSerializer(time.Nanosecond, time.RFC3339Nano, false) // FIXME: get the json.TimestampFormat, and json.LogstashSupport from the config file
 	if err != nil {
 		return err
 	}

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer_test.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer_test.go
@@ -134,7 +134,7 @@ func TestWrite(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.name, func(t *testing.T) {
-			serializer, err := telegrafJson.NewSerializer(time.Second, "")
+			serializer, err := telegrafJson.NewSerializer(time.Second, "", false)
 			require.NoError(t, err)
 
 			plugin := AzureDataExplorer{

--- a/plugins/outputs/event_hubs/event_hubs_test.go
+++ b/plugins/outputs/event_hubs/event_hubs_test.go
@@ -42,7 +42,7 @@ func (eh *mockEventHub) SendBatch(ctx context.Context, iterator eventhub.BatchIt
 /* End wrapper interface */
 
 func TestInitAndWrite(t *testing.T) {
-	serializer, _ := json.NewSerializer(time.Second, "")
+	serializer, _ := json.NewSerializer(time.Second, "", false)
 	mockHub := &mockEventHub{}
 	e := &EventHubs{
 		Hub:              mockHub,
@@ -100,7 +100,7 @@ func TestInitAndWriteIntegration(t *testing.T) {
 	testHubCS := os.Getenv("EVENTHUB_CONNECTION_STRING") + ";EntityPath=" + entity.Name
 
 	// Configure the plugin to target the newly created hub
-	serializer, _ := json.NewSerializer(time.Second, "")
+	serializer, _ := json.NewSerializer(time.Second, "", false)
 
 	e := &EventHubs{
 		Hub:              &eventHub{},

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -54,6 +54,10 @@ format by default.
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   # data_format = "influx"
 
+  ## Use logstash flavor of batch serialization.
+  ## Example of the different formats can be found in the [JSON](/plugins/serializers/json) documentation
+  # json_logstash_support = false
+
   ## Use batch serialization format (default) instead of line based format.
   ## Batch format is more efficient and should be used unless line based
   ## format is really needed.

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -645,7 +645,7 @@ func TestBatchedUnbatched(t *testing.T) {
 		"json": func(s serializers.Serializer, err error) serializers.Serializer {
 			require.NoError(t, err)
 			return s
-		}(json.NewSerializer(time.Second, "")),
+		}(json.NewSerializer(time.Second, "", false)),
 	}
 
 	for name, serializer := range s {

--- a/plugins/outputs/http/sample.conf
+++ b/plugins/outputs/http/sample.conf
@@ -45,6 +45,10 @@
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   # data_format = "influx"
 
+  ## Use logstash flavor of batch serialization.
+  ## Example of the different formats can be found in the [JSON](/plugins/serializers/json) documentation
+  # json_logstash_support = false
+
   ## Use batch serialization format (default) instead of line based format.
   ## Batch format is more efficient and should be used unless line based
   ## format is really needed.

--- a/plugins/serializers/json/README.md
+++ b/plugins/serializers/json/README.md
@@ -84,3 +84,36 @@ reference the documentation for the specific plugin.
     ]
 }
 ```
+
+Since Logstash has problems dealing with the metrics array there is an option (json\_logstash\_support) to use another format of batch that works better with logstash.
+
+```json
+[
+    {
+        "fields": {
+            "field_1": 30,
+            "field_2": 4,
+            "field_N": 59,
+            "n_images": 660
+        },
+        "name": "docker",
+        "tags": {
+            "host": "raynor"
+        },
+        "timestamp": 1458229140
+    },
+    {
+        "fields": {
+            "field_1": 30,
+            "field_2": 4,
+            "field_N": 59,
+            "n_images": 660
+        },
+        "name": "docker",
+        "tags": {
+            "host": "raynor"
+        },
+        "timestamp": 1458229140
+    }
+]
+```

--- a/plugins/serializers/json/json_test.go
+++ b/plugins/serializers/json/json_test.go
@@ -23,7 +23,7 @@ func TestSerializeMetricFloat(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s, _ := NewSerializer(0, "")
+	s, _ := NewSerializer(0, "", false)
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestSerialize_TimestampUnits(t *testing.T) {
 				},
 				time.Unix(1525478795, 123456789),
 			)
-			s, _ := NewSerializer(tt.timestampUnits, tt.timestampFormat)
+			s, _ := NewSerializer(tt.timestampUnits, tt.timestampFormat, false) // FIXME: add testcase
 			actual, err := s.Serialize(m)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected+"\n", string(actual))
@@ -102,7 +102,7 @@ func TestSerializeMetricInt(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s, _ := NewSerializer(0, "")
+	s, _ := NewSerializer(0, "", false)
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestSerializeMetricString(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s, _ := NewSerializer(0, "")
+	s, _ := NewSerializer(0, "", false)
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestSerializeMultiFields(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s, _ := NewSerializer(0, "")
+	s, _ := NewSerializer(0, "", false)
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -160,7 +160,7 @@ func TestSerializeMetricWithEscapes(t *testing.T) {
 	}
 	m := metric.New("My CPU", tags, fields, now)
 
-	s, _ := NewSerializer(0, "")
+	s, _ := NewSerializer(0, "", false)
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
 
@@ -179,7 +179,7 @@ func TestSerializeBatch(t *testing.T) {
 	)
 
 	metrics := []telegraf.Metric{m, m}
-	s, _ := NewSerializer(0, "")
+	s, _ := NewSerializer(0, "", false)
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"metrics":[{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0},{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0}]}`), buf)
@@ -198,7 +198,7 @@ func TestSerializeBatchSkipInf(t *testing.T) {
 		),
 	}
 
-	s, err := NewSerializer(0, "")
+	s, err := NewSerializer(0, "", false)
 	require.NoError(t, err)
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestSerializeBatchSkipInfAllFields(t *testing.T) {
 		),
 	}
 
-	s, err := NewSerializer(0, "")
+	s, err := NewSerializer(0, "", false)
 	require.NoError(t, err)
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)

--- a/plugins/serializers/json/json_test.go
+++ b/plugins/serializers/json/json_test.go
@@ -223,3 +223,20 @@ func TestSerializeBatchSkipInfAllFields(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"metrics":[{"fields":{},"name":"cpu","tags":{},"timestamp":0}]}`), buf)
 }
+
+func TestSerializeLogstashBatch(t *testing.T) {
+	m := metric.New(
+		"cpu",
+		map[string]string{},
+		map[string]interface{}{
+			"value": 42.0,
+		},
+		time.Unix(0, 0),
+	)
+
+	metrics := []telegraf.Metric{m, m}
+	s, _ := NewSerializer(0, "", true)
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+	require.Equal(t, []byte(`[{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0},{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0}]`), buf)
+}

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -85,6 +85,9 @@ type Config struct {
 	// Support unsigned integer output; influx format only
 	InfluxUintSupport bool `toml:"influx_uint_support"`
 
+	// Support for Logstash (send metrics as a simple array of single metrics)
+	JSONLogstashSupport bool `toml:"json_logstash_support"`
+
 	// Prefix to add to all measurements, only supports Graphite
 	Prefix string `toml:"prefix"`
 
@@ -141,7 +144,7 @@ func NewSerializer(config *Config) (Serializer, error) {
 	case "graphite":
 		serializer, err = NewGraphiteSerializer(config.Prefix, config.Template, config.GraphiteTagSupport, config.GraphiteTagSanitizeMode, config.GraphiteSeparator, config.Templates)
 	case "json":
-		serializer, err = NewJSONSerializer(config.TimestampUnits, config.TimestampFormat)
+		serializer, err = NewJSONSerializer(config.TimestampUnits, config.TimestampFormat, config.JSONLogstashSupport)
 	case "splunkmetric":
 		serializer, err = NewSplunkmetricSerializer(config.HecRouting, config.SplunkmetricMultiMetric)
 	case "nowmetric":
@@ -210,8 +213,8 @@ func NewWavefrontSerializer(prefix string, useStrict bool, sourceOverride []stri
 	return wavefront.NewSerializer(prefix, useStrict, sourceOverride, disablePrefixConversions)
 }
 
-func NewJSONSerializer(timestampUnits time.Duration, timestampFormat string) (Serializer, error) {
-	return json.NewSerializer(timestampUnits, timestampFormat)
+func NewJSONSerializer(timestampUnits time.Duration, timestampFormat string, jsonLogstashSupport bool) (Serializer, error) {
+	return json.NewSerializer(timestampUnits, timestampFormat, jsonLogstashSupport)
 }
 
 func NewCarbon2Serializer(carbon2format string, carbon2SanitizeReplaceChar string) (Serializer, error) {


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

In a large scale environment Telegraf sends data to Logstash instances. For some reason the Logstash receivers are not efficient in "unwrapping" the hash to get the `metrics` array.

Our change provides a new config option "json_logstash_support". This option defaults to "false", so the behaviour of existing instances is not changed. Setting this option to "true" drops the outermost envelope and sends the data just as an array with all metrics.

logstash support off (the default): `{ metrics => [ m1, m2, m3, ... ] }`
logstash support on               : `[m1, m2, m3, ...]`


This option is used in pre-production already and allows us more throughput when sending the metrics.