### PR TITLE
test: exchange confused parameters (expected vs actual)

### DIFF
--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -667,9 +667,9 @@ func TestBatchedUnbatched(t *testing.T) {
 				require.NoError(t, err)
 
 				if client.UseBatchFormat {
-					require.Equal(t, requests, 1, "batched")
+					require.Equal(t, 1, requests, "batched")
 				} else {
-					require.Equal(t, requests, 3, "unbatched")
+					require.Equal(t, 3, requests, "unbatched")
 				}
 			}
 		})


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

The testcase I provided for Batched/Unbatched output had confused parameters for `require.Equal`. This is fixed now.