### PR TITLE
test: run check-update on dnf/yum

### DIFF
--- a/tools/package_lxd_test/container.go
+++ b/tools/package_lxd_test/container.go
@@ -175,7 +175,7 @@ func (c *Container) configureYum() error {
 		return err
 	}
 
-	return c.client.Exec(c.Name, "yum", "update")
+	return c.client.Exec(c.Name, "yum", "check-update")
 }
 
 // Create config and update dnf
@@ -189,7 +189,7 @@ func (c *Container) configureDnf() error {
 		return err
 	}
 
-	return c.client.Exec(c.Name, "dnf", "update")
+	return c.client.Exec(c.Name, "dnf", "check-update")
 }
 
 // Create config and update zypper


### PR DESCRIPTION
Tests were run using dnf/yum update, which will not only check for
updates, but also make updates. This is not the behavior wanted on the
test, instead, the desire is only to update the package listings and
check for updates. This is done with check-update.