### PR TITLE
feat(outputs.graphite): Retry connecting to servers with failed send attempts

### DIFF
--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -178,7 +178,7 @@ func (g *Graphite) Write(metrics []telegraf.Metric) error {
 
 	// If a send failed for a server, try to reconnect to that server
 	if len(g.failedServers) > 0 {
-		g.Log.Debugf("Graphite: Reconnecting and retrying for the following servers: %s", strings.Join(g.failedServers, ","))
+		g.Log.Debugf("Reconnecting and retrying for the following servers: %s", strings.Join(g.failedServers, ","))
 		err = g.Connect()
 		if err != nil {
 			return fmt.Errorf("Failed to reconnect: %v", err)

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -81,6 +81,7 @@ func (g *Graphite) Connect() error {
 
 	// Get Connections
 	var conns []net.Conn
+	var failedServers []string
 	for _, server := range servers {
 		// Dialer with timeout
 		d := net.Dialer{Timeout: time.Duration(g.Timeout) * time.Second}
@@ -95,12 +96,15 @@ func (g *Graphite) Connect() error {
 
 		if err == nil {
 			conns = append(conns, conn)
+		} else {
+			g.Log.Debugf("Failed to establish connection: %v", err)
+			failedServers = append(failedServers, server)
 		}
 	}
 
 	if len(g.failedServers) > 0 {
 		g.conns = append(g.conns, conns...)
-		g.failedServers = []string{}
+		g.failedServers = failedServers
 	} else {
 		g.conns = conns
 	}

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -94,7 +94,7 @@ func (g *Graphite) checkEOF(conn net.Conn) {
 	b := make([]byte, 1024)
 
 	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond)); err != nil {
-		g.Log.Errorf("Couldn't set read deadline for connection %s. closing conn explicitly", conn)
+		g.Log.Errorf("Couldn't set read deadline for connection due to error %v with remote address %s. closing conn explicitly", err, conn.RemoteAddr().String())
 		_ = conn.Close()
 		return
 	}

--- a/plugins/outputs/graphite/graphite_test.go
+++ b/plugins/outputs/graphite/graphite_test.go
@@ -98,7 +98,8 @@ func TestGraphiteOK(t *testing.T) {
 	require.NoError(t, err3)
 	t.Log("Finished writing third data")
 	wg2.Wait()
-	g.Close()
+	err := g.Close()
+	require.NoError(t, err)
 }
 
 func TestGraphiteOkWithSeparatorDot(t *testing.T) {
@@ -160,7 +161,8 @@ func TestGraphiteOkWithSeparatorDot(t *testing.T) {
 	require.NoError(t, err3)
 	t.Log("Finished writing third data")
 	wg2.Wait()
-	g.Close()
+	err := g.Close()
+	require.NoError(t, err)
 }
 
 func TestGraphiteOkWithSeparatorUnderscore(t *testing.T) {
@@ -222,7 +224,8 @@ func TestGraphiteOkWithSeparatorUnderscore(t *testing.T) {
 	require.NoError(t, err3)
 	t.Log("Finished writing third data")
 	wg2.Wait()
-	g.Close()
+	err := g.Close()
+	require.NoError(t, err)
 }
 
 func TestGraphiteOKWithMultipleTemplates(t *testing.T) {
@@ -288,7 +291,8 @@ func TestGraphiteOKWithMultipleTemplates(t *testing.T) {
 	require.NoError(t, err3)
 	t.Log("Finished writing third data")
 	wg2.Wait()
-	g.Close()
+	err := g.Close()
+	require.NoError(t, err)
 }
 
 func TestGraphiteOkWithTags(t *testing.T) {
@@ -350,7 +354,8 @@ func TestGraphiteOkWithTags(t *testing.T) {
 	require.NoError(t, err3)
 	t.Log("Finished writing third data")
 	wg2.Wait()
-	g.Close()
+	err := g.Close()
+	require.NoError(t, err)
 }
 
 func TestGraphiteOkWithTagsAndSeparatorDot(t *testing.T) {
@@ -413,7 +418,8 @@ func TestGraphiteOkWithTagsAndSeparatorDot(t *testing.T) {
 	require.NoError(t, err3)
 	t.Log("Finished writing third data")
 	wg2.Wait()
-	g.Close()
+	err := g.Close()
+	require.NoError(t, err)
 }
 
 func TestGraphiteOkWithTagsAndSeparatorUnderscore(t *testing.T) {
@@ -476,7 +482,8 @@ func TestGraphiteOkWithTagsAndSeparatorUnderscore(t *testing.T) {
 	require.NoError(t, err3)
 	t.Log("Finished writing third data")
 	wg2.Wait()
-	g.Close()
+	err := g.Close()
+	require.NoError(t, err)
 }
 
 func TCPServer1(t *testing.T, wg *sync.WaitGroup) {


### PR DESCRIPTION
resolve: #11429

The Graphite output plugin would only retry a server connection if it failed to send on all connections, this behavior wasn't obvious and if one server always remains up the other servers would never reconnect. This pull requests updates the retry logic to track the failed servers and reconnect to them after each send. I could also add a `retry_delay` configuration option similar to the [inputs.cloud_pubsub](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/cloud_pubsub) and [inputs.jti_openconfig_telemetry](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/jti_openconfig_telemetry) plugins, but from the issue the author mentioned this might not be necessary so I thought maybe we could add the config option if someone does require it?

I also updated the `log.Errorf` to `log.Debugf` for connection related errors, seeing as these servers will retry anyway this would help remove some noise in the logs which was also a concern in reported in #11429. If all servers fail it should print an error to the log though.