### PR TITLE
test: update wait statement for postgresql_extensible

### DIFF
--- a/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
@@ -23,7 +23,7 @@ func queryRunner(t *testing.T, q query) *testutil.Accumulator {
 			"POSTGRES_HOST_AUTH_METHOD": "trust",
 		},
 		WaitingFor: wait.ForAll(
-			wait.ForLog("database system is ready to accept connections"),
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
 			wait.ForListeningPort(nat.Port(servicePort)),
 		),
 	}


### PR DESCRIPTION
Similar to #11309, need to wait for the second ready to accept
connections statement.

fixes: #11446