### PR TITLE
feat(inputs.cisco_telemetry_mdt): Add GRPC Keepalive/timeout config options

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/README.md
+++ b/plugins/inputs/cisco_telemetry_mdt/README.md
@@ -27,6 +27,12 @@ later.
  ## Grpc Maximum Message Size, default is 4MB, increase the size.
  max_msg_size = 4000000
 
+ ## GRPC permit keepalives without calls, set to true if your clients are sending pings without calls in-flight.
+ # permit_keepalive_without_calls = false
+
+ ## GRPC minimum timeout between successive pings, decreasing this value may help if this plugin is closing connections with ENHANCE_YOUR_CALM (too_many_pings).
+ # keepalive_minimum_time = "5m"
+
  ## Enable TLS; grpc transport only.
  # tls_cert = "/etc/telegraf/cert.pem"
  # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/inputs/cisco_telemetry_mdt/README.md
+++ b/plugins/inputs/cisco_telemetry_mdt/README.md
@@ -27,10 +27,14 @@ later.
  ## Grpc Maximum Message Size, default is 4MB, increase the size.
  max_msg_size = 4000000
 
- ## GRPC permit keepalives without calls, set to true if your clients are sending pings without calls in-flight.
+ ## GRPC permit keepalives without calls, set to true if your clients are
+ ## sending pings without calls in-flight. This can sometimes happen on IOS-XE
+ ## devices where the GRPC connection is left open but subscriptions have been
+ ## removed, and adding subsequent subscriptions does not keep a stable session.
  # permit_keepalive_without_calls = false
 
- ## GRPC minimum timeout between successive pings, decreasing this value may help if this plugin is closing connections with ENHANCE_YOUR_CALM (too_many_pings).
+ ## GRPC minimum timeout between successive pings, decreasing this value may 
+ ## help if this plugin is closing connections with ENHANCE_YOUR_CALM (too_many_pings).
  # keepalive_minimum_time = "5m"
 
  ## Enable TLS; grpc transport only.
@@ -65,11 +69,12 @@ later.
 
 ## Metrics
 
-Metrics are named by the encoding path that generated the data, or by the alias if the
-`inputs.cisco_telemetry_mdt.aliases` config section is defined.
+Metrics are named by the encoding path that generated the data, or by the alias
+if the `inputs.cisco_telemetry_mdt.aliases` config section is defined.
 Metric fields are dependent on the device type and path.
 
 Tags included in all metrics:
+
 - source
 - path
 - subscription

--- a/plugins/inputs/cisco_telemetry_mdt/README.md
+++ b/plugins/inputs/cisco_telemetry_mdt/README.md
@@ -27,16 +27,6 @@ later.
  ## Grpc Maximum Message Size, default is 4MB, increase the size.
  max_msg_size = 4000000
 
- ## GRPC permit keepalives without calls, set to true if your clients are
- ## sending pings without calls in-flight. This can sometimes happen on IOS-XE
- ## devices where the GRPC connection is left open but subscriptions have been
- ## removed, and adding subsequent subscriptions does not keep a stable session.
- # permit_keepalive_without_calls = false
-
- ## GRPC minimum timeout between successive pings, decreasing this value may 
- ## help if this plugin is closing connections with ENHANCE_YOUR_CALM (too_many_pings).
- # keepalive_minimum_time = "5m"
-
  ## Enable TLS; grpc transport only.
  # tls_cert = "/etc/telegraf/cert.pem"
  # tls_key = "/etc/telegraf/key.pem"
@@ -65,6 +55,18 @@ later.
 #    dnpath = '{"Name": "show ip route summary","prop": [{"Key": "routes","Value": "string"}, {"Key": "best-paths","Value": "string"}]}'
 #    dnpath2 = '{"Name": "show processes cpu","prop": [{"Key": "kernel_percent","Value": "float"}, {"Key": "idle_percent","Value": "float"}, {"Key": "process","Value": "string"}, {"Key": "user_percent","Value": "float"}, {"Key": "onesec","Value": "float"}]}'
 #    dnpath3 = '{"Name": "show processes memory physical","prop": [{"Key": "processname","Value": "string"}]}'
+
+ ## Additional GRPC connection settings.
+ [inputs.cisco_telemetry_mdt.grpc_enforcement_policy]
+  ## GRPC permit keepalives without calls, set to true if your clients are
+  ## sending pings without calls in-flight. This can sometimes happen on IOS-XE
+  ## devices where the GRPC connection is left open but subscriptions have been
+  ## removed, and adding subsequent subscriptions does not keep a stable session.
+  # permit_keepalive_without_calls = false
+
+  ## GRPC minimum timeout between successive pings, decreasing this value may 
+  ## help if this plugin is closing connections with ENHANCE_YOUR_CALM (too_many_pings).
+  # keepalive_minimum_time = "5m"
 ```
 
 ## Metrics

--- a/plugins/inputs/cisco_telemetry_mdt/README.md
+++ b/plugins/inputs/cisco_telemetry_mdt/README.md
@@ -63,6 +63,18 @@ later.
 #    dnpath3 = '{"Name": "show processes memory physical","prop": [{"Key": "processname","Value": "string"}]}'
 ```
 
+## Metrics
+
+Metrics are named by the encoding path that generated the data, or by the alias if the `inputs.cisco_telemetry_mdt.aliases` config section is defined.
+Metric fields are dependent on the device type and path.
+
+Tags included in all metrics:
+- source
+- path
+- subscription
+
+Additional tags (such as interface_name) may be included depending on the path.
+
 ## Example Output
 
 ```shell

--- a/plugins/inputs/cisco_telemetry_mdt/README.md
+++ b/plugins/inputs/cisco_telemetry_mdt/README.md
@@ -65,7 +65,8 @@ later.
 
 ## Metrics
 
-Metrics are named by the encoding path that generated the data, or by the alias if the `inputs.cisco_telemetry_mdt.aliases` config section is defined.
+Metrics are named by the encoding path that generated the data, or by the alias if the
+`inputs.cisco_telemetry_mdt.aliases` config section is defined.
 Metric fields are dependent on the device type and path.
 
 Tags included in all metrics:

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -721,8 +721,8 @@ func (c *CiscoTelemetryMDT) Gather(_ telegraf.Accumulator) error {
 func init() {
 	inputs.Add("cisco_telemetry_mdt", func() telegraf.Input {
 		return &CiscoTelemetryMDT{
-			Transport:        "grpc",
-			ServiceAddress:   "127.0.0.1:57000",
+			Transport:      "grpc",
+			ServiceAddress: "127.0.0.1:57000",
 		}
 	})
 }

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -20,10 +20,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	_ "google.golang.org/grpc/encoding/gzip" // Required to allow gzip encoding
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/metric"
 	internaltls "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -38,15 +40,21 @@ const (
 	tcpMaxMsgLen uint32 = 1024 * 1024
 )
 
+// default minimum time between successive pings
+// this value is specified in the GRPC docs via GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS
+const defaultKeepaliveMinTime = config.Duration(time.Second * 300)
+
 // CiscoTelemetryMDT plugin for IOS XR, IOS XE and NXOS platforms
 type CiscoTelemetryMDT struct {
 	// Common configuration
-	Transport      string
-	ServiceAddress string            `toml:"service_address"`
-	MaxMsgSize     int               `toml:"max_msg_size"`
-	Aliases        map[string]string `toml:"aliases"`
-	Dmes           map[string]string `toml:"dmes"`
-	EmbeddedTags   []string          `toml:"embedded_tags"`
+	Transport                   string
+	ServiceAddress              string            `toml:"service_address"`
+	MaxMsgSize                  int               `toml:"max_msg_size"`
+	Aliases                     map[string]string `toml:"aliases"`
+	Dmes                        map[string]string `toml:"dmes"`
+	EmbeddedTags                []string          `toml:"embedded_tags"`
+	PermitKeepaliveWithoutCalls bool              `toml:"permit_keepalive_without_calls"`
+	KeepaliveMinTime            config.Duration   `toml:"keepalive_minimum_time"`
 
 	Log telegraf.Logger
 
@@ -175,6 +183,14 @@ func (c *CiscoTelemetryMDT) Start(acc telegraf.Accumulator) error {
 
 		if c.MaxMsgSize > 0 {
 			opts = append(opts, grpc.MaxRecvMsgSize(c.MaxMsgSize))
+		}
+
+		if c.PermitKeepaliveWithoutCalls || c.KeepaliveMinTime != defaultKeepaliveMinTime {
+			// Only set if either parameter does not match defaults
+			opts = append(opts, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+				MinTime:             time.Duration(c.KeepaliveMinTime),
+				PermitWithoutStream: c.PermitKeepaliveWithoutCalls,
+			}))
 		}
 
 		c.grpcServer = grpc.NewServer(opts...)
@@ -701,8 +717,9 @@ func (c *CiscoTelemetryMDT) Gather(_ telegraf.Accumulator) error {
 func init() {
 	inputs.Add("cisco_telemetry_mdt", func() telegraf.Input {
 		return &CiscoTelemetryMDT{
-			Transport:      "grpc",
-			ServiceAddress: "127.0.0.1:57000",
+			Transport:        "grpc",
+			ServiceAddress:   "127.0.0.1:57000",
+			KeepaliveMinTime: defaultKeepaliveMinTime,
 		}
 	})
 }

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
@@ -781,7 +781,10 @@ func TestGRPCDialoutMultiple(t *testing.T) {
 }
 
 func TestGRPCDialoutKeepalive(t *testing.T) {
-	c := &CiscoTelemetryMDT{Log: testutil.Logger{}, Transport: "grpc", ServiceAddress: "127.0.0.1:0", PermitKeepaliveWithoutCalls: true}
+	c := &CiscoTelemetryMDT{Log: testutil.Logger{}, Transport: "grpc", ServiceAddress: "127.0.0.1:0", EnforcementPolicy: GRPCEnforcementPolicy{
+		PermitKeepaliveWithoutCalls: true,
+		KeepaliveMinTime: 0,
+	}}
 	acc := &testutil.Accumulator{}
 	err := c.Start(acc)
 	require.NoError(t, err)

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
@@ -12,6 +12,7 @@ import (
 	telemetryBis "github.com/cisco-ie/nx-telemetry-proto/telemetry_bis"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/influxdata/telegraf/testutil"
@@ -699,7 +700,7 @@ func TestGRPCDialoutError(t *testing.T) {
 	require.NoError(t, err)
 
 	addr := c.Address()
-	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	conn, err := grpc.Dial(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	client := dialout.NewGRPCMdtDialoutClient(conn)
 	stream, err := client.MdtDialout(context.Background())
@@ -725,7 +726,7 @@ func TestGRPCDialoutMultiple(t *testing.T) {
 	telemetry := mockTelemetryMessage()
 
 	addr := c.Address()
-	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure(), grpc.WithBlock())
+	conn, err := grpc.Dial(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	require.NoError(t, err)
 	client := dialout.NewGRPCMdtDialoutClient(conn)
 	stream, err := client.MdtDialout(context.TODO())
@@ -736,7 +737,7 @@ func TestGRPCDialoutMultiple(t *testing.T) {
 	args := &dialout.MdtDialoutArgs{Data: data, ReqId: 456}
 	require.NoError(t, stream.Send(args))
 
-	conn2, err := grpc.Dial(addr.String(), grpc.WithInsecure(), grpc.WithBlock())
+	conn2, err := grpc.Dial(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	require.NoError(t, err)
 	client2 := dialout.NewGRPCMdtDialoutClient(conn2)
 	stream2, err := client2.MdtDialout(context.TODO())
@@ -786,7 +787,7 @@ func TestGRPCDialoutKeepalive(t *testing.T) {
 	require.NoError(t, err)
 
 	addr := c.Address()
-	conn, err := grpc.Dial(addr.String(), grpc.WithInsecure())
+	conn, err := grpc.Dial(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	client := dialout.NewGRPCMdtDialoutClient(conn)
 	stream, err := client.MdtDialout(context.Background())

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
@@ -783,7 +783,7 @@ func TestGRPCDialoutMultiple(t *testing.T) {
 func TestGRPCDialoutKeepalive(t *testing.T) {
 	c := &CiscoTelemetryMDT{Log: testutil.Logger{}, Transport: "grpc", ServiceAddress: "127.0.0.1:0", EnforcementPolicy: GRPCEnforcementPolicy{
 		PermitKeepaliveWithoutCalls: true,
-		KeepaliveMinTime: 0,
+		KeepaliveMinTime:            0,
 	}}
 	acc := &testutil.Accumulator{}
 	err := c.Start(acc)

--- a/plugins/inputs/cisco_telemetry_mdt/sample.conf
+++ b/plugins/inputs/cisco_telemetry_mdt/sample.conf
@@ -10,10 +10,14 @@
  ## Grpc Maximum Message Size, default is 4MB, increase the size.
  max_msg_size = 4000000
 
- ## GRPC permit keepalives without calls, set to true if your clients are sending pings without calls in-flight.
+ ## GRPC permit keepalives without calls, set to true if your clients are
+ ## sending pings without calls in-flight. This can sometimes happen on IOS-XE
+ ## devices where the GRPC connection is left open but subscriptions have been
+ ## removed, and adding subsequent subscriptions does not keep a stable session.
  # permit_keepalive_without_calls = false
 
- ## GRPC minimum timeout between successive pings, decreasing this value may help if this plugin is closing connections with ENHANCE_YOUR_CALM (too_many_pings).
+ ## GRPC minimum timeout between successive pings, decreasing this value may 
+ ## help if this plugin is closing connections with ENHANCE_YOUR_CALM (too_many_pings).
  # keepalive_minimum_time = "5m"
 
  ## Enable TLS; grpc transport only.

--- a/plugins/inputs/cisco_telemetry_mdt/sample.conf
+++ b/plugins/inputs/cisco_telemetry_mdt/sample.conf
@@ -10,16 +10,6 @@
  ## Grpc Maximum Message Size, default is 4MB, increase the size.
  max_msg_size = 4000000
 
- ## GRPC permit keepalives without calls, set to true if your clients are
- ## sending pings without calls in-flight. This can sometimes happen on IOS-XE
- ## devices where the GRPC connection is left open but subscriptions have been
- ## removed, and adding subsequent subscriptions does not keep a stable session.
- # permit_keepalive_without_calls = false
-
- ## GRPC minimum timeout between successive pings, decreasing this value may 
- ## help if this plugin is closing connections with ENHANCE_YOUR_CALM (too_many_pings).
- # keepalive_minimum_time = "5m"
-
  ## Enable TLS; grpc transport only.
  # tls_cert = "/etc/telegraf/cert.pem"
  # tls_key = "/etc/telegraf/key.pem"
@@ -48,3 +38,15 @@
 #    dnpath = '{"Name": "show ip route summary","prop": [{"Key": "routes","Value": "string"}, {"Key": "best-paths","Value": "string"}]}'
 #    dnpath2 = '{"Name": "show processes cpu","prop": [{"Key": "kernel_percent","Value": "float"}, {"Key": "idle_percent","Value": "float"}, {"Key": "process","Value": "string"}, {"Key": "user_percent","Value": "float"}, {"Key": "onesec","Value": "float"}]}'
 #    dnpath3 = '{"Name": "show processes memory physical","prop": [{"Key": "processname","Value": "string"}]}'
+
+ ## Additional GRPC connection settings.
+ [inputs.cisco_telemetry_mdt.grpc_enforcement_policy]
+  ## GRPC permit keepalives without calls, set to true if your clients are
+  ## sending pings without calls in-flight. This can sometimes happen on IOS-XE
+  ## devices where the GRPC connection is left open but subscriptions have been
+  ## removed, and adding subsequent subscriptions does not keep a stable session.
+  # permit_keepalive_without_calls = false
+
+  ## GRPC minimum timeout between successive pings, decreasing this value may 
+  ## help if this plugin is closing connections with ENHANCE_YOUR_CALM (too_many_pings).
+  # keepalive_minimum_time = "5m"

--- a/plugins/inputs/cisco_telemetry_mdt/sample.conf
+++ b/plugins/inputs/cisco_telemetry_mdt/sample.conf
@@ -10,6 +10,12 @@
  ## Grpc Maximum Message Size, default is 4MB, increase the size.
  max_msg_size = 4000000
 
+ ## GRPC permit keepalives without calls, set to true if your clients are sending pings without calls in-flight.
+ # permit_keepalive_without_calls = false
+
+ ## GRPC minimum timeout between successive pings, decreasing this value may help if this plugin is closing connections with ENHANCE_YOUR_CALM (too_many_pings).
+ # keepalive_minimum_time = "5m"
+
  ## Enable TLS; grpc transport only.
  # tls_cert = "/etc/telegraf/cert.pem"
  # tls_key = "/etc/telegraf/key.pem"


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

This PR adds configuration options for changing server-side GRPC keepalive/ping settings. We've found when some Cisco IOS-XE devices send telemetry data on GRPC-Dialout over a firewall, some timings on ping packets are affected so that pings arrive without data faster than the minimum ping interval time (5 minute default). This can also be exacerbated by using telemetry intervals longer than 5 minutes.
Each time this happens is a "strike", and if it happens more than 2 times the GRPC server in cisco_telemetry_mdt.go closes out the connection with a GRPC GOAWAY (ENHANCE_YOUR_CALM) error. Sometimes the telemetry device sets up a new connection to continue sending data; other times it fails and we lose data that should otherwise make it to Telegraf.

More information on the keepalive/strike behavior is documented here: https://github.com/grpc/grpc/blob/master/doc/keepalive.md

The two config options added are:
- permit_keepalive_without_calls (bool) - enable/disable enforcement of requiring in-flight calls for pings
- keepalive_minimum_time (duration) - set a custom minimum time in between successive pings.

These settings can allow Cisco MDT users to adjust the sensitivity of these keepalive timeouts, so GRPC sessions won't be closed as often for misbehaving devices.
Default/unfilled options won't change the current plugin behavior.