### PR TITLE
fix: Deprecation warnings for non-deprecated packages

### DIFF
--- a/models/log.go
+++ b/models/log.go
@@ -103,34 +103,35 @@ func SetLoggerOnPlugin(i interface{}, logger telegraf.Logger) {
 	}
 }
 
-func PrintPluginDeprecationNotice(level telegraf.Escalation, name string, info telegraf.DeprecationInfo) {
-	var prefix string
-
+func deprecationPrefix(level telegraf.Escalation) string {
 	switch level {
 	case telegraf.Warn:
-		prefix = "W! " + color.YellowString("DeprecationWarning")
+		return "W! " + color.YellowString("DeprecationWarning")
 	case telegraf.Error:
-		prefix = "E! " + color.RedString("DeprecationError")
+		return "E! " + color.RedString("DeprecationError")
 	}
+	return ""
+}
 
-	log.Printf(
-		"%s: Plugin %q deprecated since version %s and will be removed in %s: %s",
-		prefix, name, info.Since, info.RemovalIn, info.Notice,
-	)
+func PrintPluginDeprecationNotice(level telegraf.Escalation, name string, info telegraf.DeprecationInfo) {
+	switch level {
+	case telegraf.Warn, telegraf.Error:
+		prefix := deprecationPrefix(level)
+
+		log.Printf(
+			"%s: Plugin %q deprecated since version %s and will be removed in %s: %s",
+			prefix, name, info.Since, info.RemovalIn, info.Notice,
+		)
+	}
 }
 
 func PrintOptionDeprecationNotice(level telegraf.Escalation, plugin, option string, info telegraf.DeprecationInfo) {
-	var prefix string
-
 	switch level {
-	case telegraf.Warn:
-		prefix = "W! " + color.YellowString("DeprecationWarning")
-	case telegraf.Error:
-		prefix = "E! " + color.RedString("DeprecationError")
+	case telegraf.Warn, telegraf.Error:
+		prefix := deprecationPrefix(level)
+		log.Printf(
+			"%s: Option %q of plugin %q deprecated since version %s and will be removed in %s: %s",
+			prefix, option, plugin, info.Since, info.RemovalIn, info.Notice,
+		)
 	}
-
-	log.Printf(
-		"%s: Option %q of plugin %q deprecated since version %s and will be removed in %s: %s",
-		prefix, option, plugin, info.Since, info.RemovalIn, info.Notice,
-	)
 }

--- a/models/log_test.go
+++ b/models/log_test.go
@@ -1,8 +1,14 @@
 package models
 
 import (
+	"bufio"
+	"bytes"
+	"log"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/selfstat"
 	"github.com/stretchr/testify/require"
 )
@@ -21,4 +27,153 @@ func TestErrorCounting(t *testing.T) {
 	iLog.Errorf("something went wrong")
 
 	require.Equal(t, int64(2), reg.Get())
+}
+
+func TestPluginDeprecation(t *testing.T) {
+	info := telegraf.DeprecationInfo{
+		Since:     "1.23.0",
+		RemovalIn: "2.0.0",
+		Notice:    "please check",
+	}
+	var tests = []struct {
+		name     string
+		level    telegraf.Escalation
+		expected string
+	}{
+		{
+			name:     "Error level",
+			level:    telegraf.Error,
+			expected: `Plugin "test" deprecated since version 1.23.0 and will be removed in 2.0.0: please check`,
+		},
+		{
+			name:     "Warn level",
+			level:    telegraf.Warn,
+			expected: `Plugin "test" deprecated since version 1.23.0 and will be removed in 2.0.0: please check`,
+		},
+		{
+			name:     "None",
+			level:    telegraf.None,
+			expected: ``,
+		},
+	}
+
+	// Switch the logger to log to a buffer
+	var buf bytes.Buffer
+	scanner := bufio.NewScanner(&buf)
+
+	previous := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(previous)
+
+	msg := make(chan string, 1)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.Reset()
+			PrintPluginDeprecationNotice(tt.level, "test", info)
+
+			// Wait for a newline to arrive and timeout for cases where
+			// we don't see a message.
+			go func() {
+				scanner.Scan()
+				msg <- scanner.Text()
+			}()
+
+			// Reduce the timeout if we do not expect a message
+			timeout := 1 * time.Second
+			if tt.expected == "" {
+				timeout = 100 * time.Microsecond
+			}
+
+			var actual string
+			select {
+			case actual = <-msg:
+			case <-time.After(timeout):
+			}
+
+			if tt.expected != "" {
+				// Remove the time for comparison
+				parts := strings.SplitN(actual, " ", 3)
+				require.Len(t, parts, 3)
+				actual = parts[2]
+				expected := deprecationPrefix(tt.level) + ": " + tt.expected
+				require.Equal(t, expected, actual)
+			} else {
+				require.Empty(t, actual)
+			}
+		})
+	}
+}
+
+func TestPluginOptionDeprecation(t *testing.T) {
+	info := telegraf.DeprecationInfo{
+		Since:     "1.23.0",
+		RemovalIn: "2.0.0",
+		Notice:    "please check",
+	}
+	var tests = []struct {
+		name     string
+		level    telegraf.Escalation
+		expected string
+	}{
+		{
+			name:     "Error level",
+			level:    telegraf.Error,
+			expected: `Option "option" of plugin "test" deprecated since version 1.23.0 and will be removed in 2.0.0: please check`,
+		},
+		{
+			name:     "Warn level",
+			level:    telegraf.Warn,
+			expected: `Option "option" of plugin "test" deprecated since version 1.23.0 and will be removed in 2.0.0: please check`,
+		},
+		{
+			name:     "None",
+			level:    telegraf.None,
+			expected: ``,
+		},
+	}
+
+	// Switch the logger to log to a buffer
+	var buf bytes.Buffer
+	scanner := bufio.NewScanner(&buf)
+
+	previous := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(previous)
+
+	msg := make(chan string, 1)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.Reset()
+			PrintOptionDeprecationNotice(tt.level, "test", "option", info)
+			// Wait for a newline to arrive and timeout for cases where
+			// we don't see a message.
+			go func() {
+				scanner.Scan()
+				msg <- scanner.Text()
+			}()
+
+			// Reduce the timeout if we do not expect a message
+			timeout := 1 * time.Second
+			if tt.expected == "" {
+				timeout = 100 * time.Microsecond
+			}
+
+			var actual string
+			select {
+			case actual = <-msg:
+			case <-time.After(timeout):
+			}
+
+			if tt.expected != "" {
+				// Remove the time for comparison
+				parts := strings.SplitN(actual, " ", 3)
+				require.Len(t, parts, 3)
+				actual = parts[2]
+				expected := deprecationPrefix(tt.level) + ": " + tt.expected
+				require.Equal(t, expected, actual)
+			} else {
+				require.Empty(t, actual)
+			}
+		})
+	}
 }


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11459

Starting with v1.23.1 telegraf outputs strange deprecation warnings for non-deprecated plugins (and options) caused during a migration of the printing routines to `models/log.go`. This PR fixes the issue, restores the old behavior and adds tests to make sure we get the right deprecation warnings (or non) as expected.