### PR TITLE
chore: Sign nightly artifacts to detect issues before release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -755,6 +755,7 @@ workflows:
             - 'test-go-linux'
       - 'mips-package':
           name: 'mips-package-nightly'
+          nightly: true
           requires:
             - 'test-go-linux'
       - 'package-sign-windows':

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -755,9 +755,15 @@ workflows:
             - 'test-go-linux'
       - 'mips-package':
           name: 'mips-package-nightly'
-          nightly: true
           requires:
             - 'test-go-linux'
+      - 'package-sign-windows':
+          requires:
+            - 'windows-package-nightly'
+      - 'package-sign-mac':
+           requires:
+            - 'darwin-amd64-package-nightly'
+            - 'darwin-arm64-package-nightly'
       - nightly:
           requires:
             - 'amd64-package-test-nightly'


### PR DESCRIPTION
During a release it is possible for the Mac signing step to fail due to a manual step of having to agree to the updated license agreement. The idea is that if we start signing the nightly artifacts we can potentially detect if there are any failures earlier. There hasn't been an issue with the windows signing step, but I added it as well to be consistent.

Of course this depends on someone checking to make sure the nightly build has failed/passed everyday, future work could be to add an obvious notification if there is a failure (tiger bot send a slack message or something for example).