### PR TITLE
chore: Skip building artifacts on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,9 +533,6 @@ workflows:
           requires:
             - 'test-go-mac'
           filters:
-            branches:
-              ignore:
-                - master
             tags:
               only: /.*/
       - 'darwin-arm64-package':

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,78 +533,117 @@ workflows:
           requires:
             - 'test-go-mac'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'darwin-arm64-package':
           requires:
             - 'test-go-mac'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'i386-package':
           requires:
             - 'test-go-linux-386'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'ppc64le-package':
           requires:
             - 'test-go-linux'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'riscv64-package':
           requires:
             - 'test-go-linux'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 's390x-package':
           requires:
             - 'test-go-linux'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'armel-package':
           requires:
             - 'test-go-linux'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'amd64-package':
           requires:
             - 'test-go-linux'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'arm64-package':
           requires:
             - 'test-go-linux'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'armhf-package':
           requires:
             - 'test-go-linux'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'static-package':
           requires:
             - 'test-go-linux'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'mipsel-package':
           requires:
             - 'test-go-linux'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'mips-package':
           requires:
             - 'test-go-linux'
           filters:
+            branches:
+              ignore:
+                - master
             tags:
               only: /.*/
       - 'generate-config':


### PR DESCRIPTION
This is a proposal to skip building all the artifacts whenever a pull request is merged, except only building the windows and amd64 artifacts so that the updated configurations can be generated. The benefit would be faster builds on master branch. During a day lots of pull requests could be merged which would lead to a set of artifacts built for each, this seems like a waste as they will be lost in the pile. I don't know why users would use the artifacts from master opposed to the artifacts built in the nightly job,