### PR TITLE
feat(inputs.modbus): Error out on requests with no fields defined.

### DIFF
--- a/plugins/inputs/modbus/configuration_request.go
+++ b/plugins/inputs/modbus/configuration_request.go
@@ -2,6 +2,7 @@ package modbus
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"hash/maphash"
 )
@@ -63,6 +64,12 @@ func (c *ConfigurationPerRequest) Check() error {
 		// Set the default for measurement if required
 		if def.Measurement == "" {
 			def.Measurement = "modbus"
+		}
+
+		// Reject any configuration without fields as it
+		// makes no sense to not define anything but a request.
+		if len(def.Fields) == 0 {
+			return errors.New("found request section without fields")
 		}
 
 		// Check the fields

--- a/plugins/inputs/modbus/modbus_test.go
+++ b/plugins/inputs/modbus/modbus_test.go
@@ -1924,3 +1924,21 @@ func TestRequestsStartingWithOmits(t *testing.T) {
 	acc.Wait(len(expected))
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
+
+func TestRequestsEmptyFields(t *testing.T) {
+	modbus := Modbus{
+		Name:              "Test",
+		Controller:        "tcp://localhost:1502",
+		ConfigurationType: "request",
+		Log:               testutil.Logger{},
+	}
+	modbus.Requests = []requestDefinition{
+		{
+			SlaveID:      1,
+			ByteOrder:    "ABCD",
+			RegisterType: "holding",
+		},
+	}
+	err := modbus.Init()
+	require.EqualError(t, err, `configuraton invalid: found request section without fields`)
+}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Currently, the modbus request-based configuration accepts request sections with no fields defined. This setup does not make any sense, as subsequently no data is requested, and indicates a configuration error. To fail early and loudly, this PR will issue an error for these setups.