### PR TITLE
fix(inputs.upsd): Move to new sample.conf style

### DIFF
--- a/plugins/inputs/upsd/README.md
+++ b/plugins/inputs/upsd/README.md
@@ -9,15 +9,12 @@ upsd should be installed and it's daemon should be running.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
+# Monitor UPSes connected via Network UPS Tools
 [[inputs.upsd]]
   ## A running NUT server to connect to.
-  # If not provided will default to 127.0.0.1
   # server = "127.0.0.1"
-  
-  ## The default NUT port 3493 can be overridden with:
   # port = 3493
-  
   # username = "user"
   # password = "password"
 ```

--- a/plugins/inputs/upsd/sample.conf
+++ b/plugins/inputs/upsd/sample.conf
@@ -1,0 +1,7 @@
+# Monitor UPSes connected via Network UPS Tools
+[[inputs.upsd]]
+  ## A running NUT server to connect to.
+  # server = "127.0.0.1"
+  # port = 3493
+  # username = "user"
+  # password = "password"

--- a/plugins/inputs/upsd/upsd.go
+++ b/plugins/inputs/upsd/upsd.go
@@ -1,13 +1,20 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package upsd
 
 import (
+	_ "embed"
 	"fmt"
+	"strings"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/choice"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	nut "github.com/robbiet480/go.nut"
-	"strings"
 )
+
+// DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
+//go:embed sample.conf
+var sampleConfig string
 
 //See: https://networkupstools.org/docs/developer-guide.chunked/index.html
 
@@ -23,18 +30,6 @@ type Upsd struct {
 
 	batteryRuntimeTypeWarningIssued bool
 }
-
-func (*Upsd) Description() string {
-	return "Monitor UPSes connected via Network UPS Tools"
-}
-
-var sampleConfig = `
- ## A running NUT server to connect to.
- # server = "127.0.0.1"
- # port = 3493
- # username = "user"
- # password = "password"
-`
 
 func (*Upsd) SampleConfig() string {
 	return sampleConfig


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR moves `inputs.upsd`'s sample-configuration to a `sample.conf` file and embeds the data into both the code and the README. By doing so, we fix the missing `[[inputs.upsd]]` header when generating Telegraf's sample-configuration (see [comment](https://github.com/influxdata/telegraf/pull/9890#issuecomment-1176893362) in #9890).
