### PR TITLE
fix: allow 201 for cookies, update header docs

### DIFF
--- a/plugins/common/cookie/cookie.go
+++ b/plugins/common/cookie/cookie.go
@@ -110,7 +110,8 @@ func (c *CookieAuthConfig) auth() error {
 		return err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	// check either 200 or 201 as some devices may return either
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("cookie auth renewal received status code: %v (%v)",
 			resp.StatusCode,
 			http.StatusText(resp.StatusCode),

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -58,7 +58,7 @@ configuration.
   # cookie_auth_method = "POST"
   # cookie_auth_username = "username"
   # cookie_auth_password = "pa$$word"
-  # cookie_auth_headers = '{"Content-Type": "application/json", "X-MY-HEADER":"hello"}'
+  # cookie_auth_headers = { Content-Type = "application/json", X-MY-HEADER = "hello" }
   # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
   ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
   # cookie_auth_renewal = "5m"

--- a/plugins/inputs/http/sample.conf
+++ b/plugins/inputs/http/sample.conf
@@ -47,7 +47,7 @@
   # cookie_auth_method = "POST"
   # cookie_auth_username = "username"
   # cookie_auth_password = "pa$$word"
-  # cookie_auth_headers = '{"Content-Type": "application/json", "X-MY-HEADER":"hello"}'
+  # cookie_auth_headers = { Content-Type = "application/json", X-MY-HEADER = "hello" }
   # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
   ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
   # cookie_auth_renewal = "5m"


### PR DESCRIPTION
This allows both a 200 and 201 response code when generating auth using
the cookie auth plugin. Additionally, this updates the docs for the
cookie headers to show a TOML map rather than a string.

fixes: #11134