### PR TITLE
feat(inputs.rabbitmq): add support for `head_message_timestamp` metric

### DIFF
--- a/plugins/inputs/rabbitmq/README.md
+++ b/plugins/inputs/rabbitmq/README.md
@@ -163,6 +163,7 @@ Stats][management-reference].
     - consumer_utilisation (float, percent)
     - consumers (int, int)
     - idle_since (string, time - e.g., "2006-01-02 15:04:05")
+    - head_message_timestamp (int, unix timestamp - only emitted if available from API)
     - memory (int, bytes)
     - message_bytes (int, bytes)
     - message_bytes_persist (int, bytes)
@@ -233,7 +234,7 @@ SELECT NON_NEGATIVE_DERIVATIVE(LAST("messages_published"), 1m) AS messages_publi
 ## Example Output
 
 ```text
-rabbitmq_queue,url=http://amqp.example.org:15672,queue=telegraf,vhost=influxdb,node=rabbit@amqp.example.org,durable=true,auto_delete=false,host=amqp.example.org messages_deliver_get=0i,messages_publish=329i,messages_publish_rate=0.2,messages_redeliver_rate=0,message_bytes_ready=0i,message_bytes_unacked=0i,messages_deliver=329i,messages_unack=0i,consumers=1i,idle_since="",messages=0i,messages_deliver_rate=0.2,messages_deliver_get_rate=0.2,messages_redeliver=0i,memory=43032i,message_bytes_ram=0i,messages_ack=329i,messages_ready=0i,messages_ack_rate=0.2,consumer_utilisation=1,message_bytes=0i,message_bytes_persist=0i 1493684035000000000
+rabbitmq_queue,url=http://amqp.example.org:15672,queue=telegraf,vhost=influxdb,node=rabbit@amqp.example.org,durable=true,auto_delete=false,host=amqp.example.org head_message_timestamp=1493684017,messages_deliver_get=0i,messages_publish=329i,messages_publish_rate=0.2,messages_redeliver_rate=0,message_bytes_ready=0i,message_bytes_unacked=0i,messages_deliver=329i,messages_unack=0i,consumers=1i,idle_since="",messages=0i,messages_deliver_rate=0.2,messages_deliver_get_rate=0.2,messages_redeliver=0i,memory=43032i,message_bytes_ram=0i,messages_ack=329i,messages_ready=0i,messages_ack_rate=0.2,consumer_utilisation=1,message_bytes=0i,message_bytes_persist=0i 1493684035000000000
 rabbitmq_overview,url=http://amqp.example.org:15672,host=amqp.example.org channels=2i,consumers=1i,exchanges=17i,messages_acked=329i,messages=0i,messages_ready=0i,messages_unacked=0i,connections=2i,queues=1i,messages_delivered=329i,messages_published=329i,clustering_listeners=2i,amqp_listeners=1i 1493684035000000000
 rabbitmq_node,url=http://amqp.example.org:15672,node=rabbit@amqp.example.org,host=amqp.example.org fd_total=1024i,fd_used=32i,mem_limit=8363329126i,sockets_total=829i,disk_free=8175935488i,disk_free_limit=50000000i,mem_used=58771080i,proc_total=1048576i,proc_used=267i,run_queue=0i,sockets_used=2i,running=1i 149368403500000000
 rabbitmq_exchange,url=http://amqp.example.org:15672,exchange=telegraf,type=fanout,vhost=influxdb,internal=false,durable=true,auto_delete=false,host=amqp.example.org messages_publish_in=2i,messages_publish_out=1i 149368403500000000

--- a/plugins/inputs/rabbitmq/rabbitmq_test.go
+++ b/plugins/inputs/rabbitmq/rabbitmq_test.go
@@ -83,6 +83,7 @@ func TestRabbitMQGeneratesMetricsSet1(t *testing.T) {
 			map[string]interface{}{
 				"consumers":                 int64(3),
 				"consumer_utilisation":      float64(1.0),
+				"head_message_timestamp":    int64(1446362534),
 				"memory":                    int64(143776),
 				"message_bytes":             int64(3),
 				"message_bytes_ready":       int64(4),

--- a/plugins/inputs/rabbitmq/testdata/set1/queues.json
+++ b/plugins/inputs/rabbitmq/testdata/set1/queues.json
@@ -84,7 +84,7 @@
       "q4": 0,
       "target_ram_count": 0
     },
-    "head_message_timestamp": null,
+    "head_message_timestamp": 1446362534,
     "message_bytes_persistent": 7,
     "message_bytes_ram": 6,
     "message_bytes_unacknowledged": 5,


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11474

Adds support for the `head_message_timestamp` field to the `rabbitmq_queue` metric.

Note: This metric is only available from the API if there are messages in the queue, held in-memory by the broker, which have their timestamp metadata property set. The timestamp property can be set manually at time of message publication by the publisher, or it can be set automatically by the `rabbitmq_message_timestamp` plugin. Because the broker will not page messages in from disk just to read their timestamp, this metric is notably never present at the API for "lazy" queues (for which all messages are stored on disk and only loaded into memory briefly when a consumer grabs them). In cases where the `head_message_timestamp` field from the API is `null`, the `head_message_timestamp` field of the `rabbitmq_queue` measurement will simply be omitted.