### PR TITLE
fix(parsers.prometheus): Histogram infinity bucket not being generated when using protobuf protocol

### DIFF
--- a/plugins/parsers/prometheus/parser.go
+++ b/plugins/parsers/prometheus/parser.go
@@ -147,6 +147,7 @@ func makeBuckets(m *dto.Metric, tags map[string]string, metricName string, metri
 	met := metric.New("prometheus", tags, fields, t, common.ValueType(metricType))
 	metrics = append(metrics, met)
 
+	infSeen := false
 	for _, b := range m.GetHistogram().Bucket {
 		newTags := tags
 		fields = make(map[string]interface{})
@@ -155,6 +156,20 @@ func makeBuckets(m *dto.Metric, tags map[string]string, metricName string, metri
 
 		histogramMetric := metric.New("prometheus", newTags, fields, t, common.ValueType(metricType))
 		metrics = append(metrics, histogramMetric)
+		if math.IsInf(b.GetUpperBound(), +1) {
+			infSeen = true
+		}
+	}
+	// Infinity bucket is required for proper function of histogram in prometheus
+	if !infSeen {
+		newTags := tags
+		newTags["le"] = "+Inf"
+
+		fields = make(map[string]interface{})
+		fields[metricName+"_bucket"] = float64(m.GetHistogram().GetSampleCount())
+
+		histogramInfMetric := metric.New("prometheus", newTags, fields, t, common.ValueType(metricType))
+		metrics = append(metrics, histogramInfMetric)
 	}
 	return metrics
 }


### PR DESCRIPTION
In some cases the infinity bucked is not being parsed or generated from text prometheus input by the library **github.com/prometheus/common/expfmt**

I have not found the specifics, but it must be related to the version of libc because the same telegraf binary works on ubuntu with libc6:amd64 2.27-3ubuntu1.6, but does not work on debian with 2.28-10.

Because the infinity bucket has the same value as histogram sample count we can just enforce creation of this bucket if it is missing. They are doing basically the same thing in the underlying [library used to parse metrics](https://github.com/prometheus/common/blob/main/expfmt/text_create.go#L221) when generating text format from metrics.

resolves #11490 