### PR TITLE
fix: explain proxmox user/token and node_name

### DIFF
--- a/plugins/inputs/proxmox/README.md
+++ b/plugins/inputs/proxmox/README.md
@@ -13,7 +13,11 @@ Telegraf minimum version: Telegraf 1.16.0
   ## API connection configuration. The API token was introduced in Proxmox v6.2. Required permissions for user and token: PVEAuditor role on /.
   base_url = "https://localhost:8006/api2/json"
   api_token = "USER@REALM!TOKENID=UUID"
+
   ## Node name, defaults to OS hostname
+  ## Unless Telegraf is on the same host as Proxmox, setting this is required
+  ## for Telegraf to successfully connect to Proxmox. If not on the same host,
+  ## leaving this empty will often lead to a "search domain is not set" error.
   # node_name = ""
 
   ## Optional TLS Config
@@ -29,9 +33,26 @@ Telegraf minimum version: Telegraf 1.16.0
 
 ### Permissions
 
-The plugin will need to have access to the Proxmox API. An API token must be
-provided with the corresponding user being assigned at least the PVEAuditor role
-on /.
+The plugin will need to have access to the Proxmox API. In Proxmox API tokens
+are a subset of the corresponding user. This means an API token cannot execute
+commands that the user cannot either.
+
+For Telegraf, an API token and user must be provided with at least the
+PVEAuditor role on /. Below is an example of creating a telegraf user and token
+and then ensuring the user and token have the correct role:
+
+```s
+## Create a influx user with PVEAuditor role
+pveum user add influx@pve
+pveum acl modify / -role PVEAuditor -user influx@pve
+## Create a token with the PVEAuditor role
+pveum user token add influx@pve monitoring -privsep 1
+pveum acl modify / -role PVEAuditor -token 'influx@pve!monitoring'
+```
+
+See this [Proxmox docs example][1] for further details.
+
+[1]: https://pve.proxmox.com/wiki/User_Management#_limited_api_token_for_monitoring
 
 ## Metrics
 

--- a/plugins/inputs/proxmox/sample.conf
+++ b/plugins/inputs/proxmox/sample.conf
@@ -3,7 +3,11 @@
   ## API connection configuration. The API token was introduced in Proxmox v6.2. Required permissions for user and token: PVEAuditor role on /.
   base_url = "https://localhost:8006/api2/json"
   api_token = "USER@REALM!TOKENID=UUID"
+
   ## Node name, defaults to OS hostname
+  ## Unless Telegraf is on the same host as Proxmox, setting this is required
+  ## for Telegraf to successfully connect to Proxmox. If not on the same host,
+  ## leaving this empty will often lead to a "search domain is not set" error.
   # node_name = ""
 
   ## Optional TLS Config


### PR DESCRIPTION
In #8776, #8437, #8300, there is confusion around two areas of the
proxmox plugin:

1) The node_name setting is required unless telegraf is on the same host
   as the proxmox system itself. The plugin will need to resolve the
   hostname of the proxmox instance if it is not on the same host.

2) The user which a proxmox token is based off needs to have at least
   the same permissions as the token. If not, the token will not work
   correctly.

fixes: #8776
fixes: #8300