### PR TITLE
fix: Backport sync sample.conf and README.md files

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -58,7 +58,7 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR
     ## origin usually refers to a (YANG) data model implemented by the device
     ## and path to a specific substructure inside it that should be subscribed to (similar to an XPath)
     ## YANG models can be found e.g. here: https://github.com/YangModels/yang/tree/master/vendor/cisco/xr
-    origin = "openconfig"
+    origin = "openconfig-interfaces"
     path = "/interfaces/interface/state/counters"
 
     # Subscription mode (one of: "target_defined", "sample", "on_change") and interval
@@ -71,19 +71,17 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR
     ## If suppression is enabled, send updates at least every X seconds anyway
     # heartbeat_interval = "60s"
 
-  ## Tag subscriptions are subscriptions to paths intended to be applied as tags to other subscriptions
-  [[inputs.gnmi.tag_subscription]]
-    # When applying this value as a tag to other metrics, use this tag name
-    name = "descr"
-    # All other subscription fields are as normal
-    origin = "openconfig"
-    path = "/interfaces/interface/state/description"
-    subscription_mode = "on_change"
-    # At least one path element name must be supplied that contains at least one key to match on
-    # Multiple element names can be specified in any order - all element names must be present and contain
-    # to be stored as an in-memory tag
-    elements = ["interface"]
+  #[[inputs.gnmi.subscription]]
+    # name = "descr"
+    # origin = "openconfig-interfaces"
+    # path = "/interfaces/interface/state/description"
+    # subscription_mode = "on_change"
 
+    ## If tag_only is set, the subscription in question will be utilized to maintain a map of
+    ## tags to apply to other measurements emitted by the plugin, by matching path keys
+    ## All fields from the tag-only subscription will be applied as tags to other readings,
+    ## in the format <name>_<fieldBase>.
+    # tag_only = true
 ```
 
 ## Metrics

--- a/plugins/inputs/snmp/sample.conf
+++ b/plugins/inputs/snmp/sample.conf
@@ -16,6 +16,12 @@
   ## SNMP version; can be 1, 2, or 3.
   # version = 2
 
+  ## Unconnected UDP socket
+  ## When true, SNMP reponses are accepted from any address not just
+  ## the requested address. This can be useful when gathering from
+  ## redundant/failover systems.
+  # unconnected_udp_socket = false 
+
   ## Path to mib files
   ## Used by the gosmi translator.
   ## To add paths when translating with netsnmp, use the MIBDIRS environment variable


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Backport synchronization of sample.conf and README.md files from the v1.23.2 release.

(cherry picked from commit ccda9c5c5cd280e98b9984b46a0d9086a198778d)
