### PR TITLE
feat: Implement minimum TLS version for clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+### BREAKING CHANGES
+
+- [#11493](https://github.com/influxdata/telegraf/pull/11493) `common.tls` Set default minimum TLS version to v1.2 for security reasons on both server and client connections. This is a change from the previous defaults (TLS v1.0) on the server configuration and might break clients relying on older TLS versions. You can manually revert to older versions on a per-plugin basis using the `tls_min_version` option in the plugins required.
+
 ## v1.23.3 [2022-07-25]
 
 ### Bugfixes

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -84,6 +84,10 @@ func (c *ClientConfig) TLSConfig() (*tls.Config, error) {
 		}
 	}
 
+	// Explicitly and consistently set the minimal accepted version using the
+	// defined default. We use this setting for both clients and servers
+	// instead of relying on Golang's default that is different for clients
+	// and servers and might change over time.
 	tlsConfig.MinVersion = TLSMinVersionDefault
 	if c.TLSMinVersion != "" {
 		version, err := ParseTLSVersion(c.TLSMinVersion)
@@ -143,6 +147,10 @@ func (c *ServerConfig) TLSConfig() (*tls.Config, error) {
 		tlsConfig.MaxVersion = version
 	}
 
+	// Explicitly and consistently set the minimal accepted version using the
+	// defined default. We use this setting for both clients and servers
+	// instead of relying on Golang's default that is different for clients
+	// and servers and might change over time.
 	tlsConfig.MinVersion = TLSMinVersionDefault
 	if c.TLSMinVersion != "" {
 		version, err := ParseTLSVersion(c.TLSMinVersion)

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -10,6 +10,8 @@ import (
 	"github.com/influxdata/telegraf/internal/choice"
 )
 
+const TLSMinVersionDefault = tls.VersionTLS12
+
 // ClientConfig represents the standard client TLS config.
 type ClientConfig struct {
 	TLSCA              string `toml:"tls_ca"`
@@ -82,6 +84,7 @@ func (c *ClientConfig) TLSConfig() (*tls.Config, error) {
 		}
 	}
 
+	tlsConfig.MinVersion = TLSMinVersionDefault
 	if c.TLSMinVersion != "" {
 		version, err := ParseTLSVersion(c.TLSMinVersion)
 		if err != nil {
@@ -141,6 +144,7 @@ func (c *ServerConfig) TLSConfig() (*tls.Config, error) {
 		tlsConfig.MaxVersion = version
 	}
 
+	tlsConfig.MinVersion = TLSMinVersionDefault
 	if c.TLSMinVersion != "" {
 		version, err := ParseTLSVersion(c.TLSMinVersion)
 		if err != nil {

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -88,8 +88,7 @@ func (c *ClientConfig) TLSConfig() (*tls.Config, error) {
 	if c.TLSMinVersion != "" {
 		version, err := ParseTLSVersion(c.TLSMinVersion)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"could not parse tls min version %q: %v", c.TLSMinVersion, err)
+			return nil, fmt.Errorf("could not parse tls min version %q: %w", c.TLSMinVersion, err)
 		}
 		tlsConfig.MinVersion = version
 	}

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -16,6 +16,7 @@ type ClientConfig struct {
 	TLSCert            string `toml:"tls_cert"`
 	TLSKey             string `toml:"tls_key"`
 	TLSKeyPwd          string `toml:"tls_key_pwd"`
+	TLSMinVersion      string `toml:"tls_min_version"`
 	InsecureSkipVerify bool   `toml:"insecure_skip_verify"`
 	ServerName         string `toml:"tls_server_name"`
 
@@ -79,6 +80,15 @@ func (c *ClientConfig) TLSConfig() (*tls.Config, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if c.TLSMinVersion != "" {
+		version, err := ParseTLSVersion(c.TLSMinVersion)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"could not parse tls min version %q: %v", c.TLSMinVersion, err)
+		}
+		tlsConfig.MinVersion = version
 	}
 
 	if c.ServerName != "" {

--- a/plugins/common/tls/config_test.go
+++ b/plugins/common/tls/config_test.go
@@ -435,8 +435,8 @@ func TestConnectClientMinTLSVersion(t *testing.T) {
 		}
 
 		clientMinVersion := clientTLSConfig.MinVersion
-		if clientMinVersion == 0 {
-			clientMinVersion = cryptotls.VersionTLS12 // As defined in https://pkg.go.dev/crypto/tls#Config
+		if tt.cfg.TLSMinVersion == "" {
+			clientMinVersion = tls.TLSMinVersionDefault
 		}
 
 		for i, serverTLSMaxVersion := range tlsVersions {
@@ -445,6 +445,7 @@ func TestConnectClientMinTLSVersion(t *testing.T) {
 				// Constrain the server's maximum TLS version
 				serverTLSConfig, err := serverConfig.TLSConfig()
 				require.NoError(t, err)
+				serverTLSConfig.MinVersion = cryptotls.VersionTLS10
 				serverTLSConfig.MaxVersion = serverTLSMaxVersion
 
 				// Start the server

--- a/plugins/common/tls/config_test.go
+++ b/plugins/common/tls/config_test.go
@@ -482,7 +482,8 @@ func TestConnectClientInvalidMinTLSVersion(t *testing.T) {
 	}
 
 	_, err := clientConfig.TLSConfig()
-	require.EqualError(t, err, `could not parse tls min version "garbage": unsupported version "garbage"`)
+	expected := `could not parse tls min version "garbage": unsupported version "garbage" (available: TLS10,TLS11,TLS12,TLS13)`
+	require.EqualError(t, err, expected)
 }
 
 func TestConnectWrongDNS(t *testing.T) {

--- a/plugins/common/tls/utils.go
+++ b/plugins/common/tls/utils.go
@@ -2,6 +2,8 @@ package tls
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 )
 
 // ParseCiphers returns a `[]uint16` by received `[]string` key that represents ciphers from crypto/tls.
@@ -26,5 +28,11 @@ func ParseTLSVersion(version string) (uint16, error) {
 	if v, ok := tlsVersionMap[version]; ok {
 		return v, nil
 	}
-	return 0, fmt.Errorf("unsupported version %q", version)
+
+	var available []string
+	for n := range tlsVersionMap {
+		available = append(available, n)
+	}
+	sort.Strings(available)
+	return 0, fmt.Errorf("unsupported version %q (available: %s)", version, strings.Join(available, ","))
 }

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -33,8 +33,8 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR
   # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
   ## Minimal TLS version to accept by the client
-  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
-  # tls_min_version = ""
+  # tls_min_version = "TLS12"
+  ## Use TLS but skip chain & host verification
   # insecure_skip_verify = true
 
   ## define client-side TLS certificate & key to authenticate to the device

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -32,6 +32,9 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
+  ## Minimal TLS version to accept by the client
+  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
+  # tls_min_version = ""
   # insecure_skip_verify = true
 
   ## define client-side TLS certificate & key to authenticate to the device

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -16,6 +16,9 @@
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
+  ## Minimal TLS version to accept by the client
+  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
+  # tls_min_version = ""
   # insecure_skip_verify = true
 
   ## define client-side TLS certificate & key to authenticate to the device

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -16,8 +16,7 @@
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
-  ## Minimal TLS version to accept by the client
-  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
+  ## Minimal TLS version to accept by the client (defaults to Golang's default)
   # tls_min_version = ""
   # insecure_skip_verify = true
 

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -16,8 +16,9 @@
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
-  ## Minimal TLS version to accept by the client (defaults to Golang's default)
-  # tls_min_version = ""
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
+  ## Use TLS but skip chain & host verification
   # insecure_skip_verify = true
 
   ## define client-side TLS certificate & key to authenticate to the device

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -112,5 +112,3 @@ an authorization cookie.  The Cookie Auth Renewal interval will renew the
 authorization by retrieving a new cookie at the given interval.
 
 [tesla]: https://www.tesla.com/support/energy/powerwall/own/monitoring-from-home-network
-
-## Example Output

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -51,8 +51,7 @@ configuration.
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
   ## Minimal TLS version to accept by the client
-  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
-  # tls_min_version = ""
+  # tls_min_version = "TLS12"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -113,3 +113,5 @@ an authorization cookie.  The Cookie Auth Renewal interval will renew the
 authorization by retrieving a new cookie at the given interval.
 
 [tesla]: https://www.tesla.com/support/energy/powerwall/own/monitoring-from-home-network
+
+## Example Output

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -50,6 +50,9 @@ configuration.
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
+  ## Minimal TLS version to accept by the client
+  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
+  # tls_min_version = ""
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/plugins/inputs/http/sample.conf
+++ b/plugins/inputs/http/sample.conf
@@ -39,6 +39,9 @@
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
+  ## Minimal TLS version to accept by the client
+  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
+  # tls_min_version = ""
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/plugins/inputs/http/sample.conf
+++ b/plugins/inputs/http/sample.conf
@@ -39,8 +39,8 @@
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
-  ## Minimal TLS version to accept by the client (defaults to Golang's default)
-  # tls_min_version = ""
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/plugins/inputs/http/sample.conf
+++ b/plugins/inputs/http/sample.conf
@@ -39,8 +39,7 @@
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
-  ## Minimal TLS version to accept by the client
-  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
+  ## Minimal TLS version to accept by the client (defaults to Golang's default)
   # tls_min_version = ""
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false

--- a/plugins/inputs/http_listener_v2/README.md
+++ b/plugins/inputs/http_listener_v2/README.md
@@ -49,6 +49,9 @@ InfluxDB it is recommended to use [`influxdb_listener`][influxdb_listener] or
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
 
+  ## Minimal TLS version accepted by the server
+  # tls_min_version = "TLS12"
+
   ## Optional username and password to accept for HTTP basic authentication.
   ## You probably want to make sure you have TLS configured above for this.
   # basic_username = "foobar"

--- a/plugins/inputs/http_listener_v2/README.md
+++ b/plugins/inputs/http_listener_v2/README.md
@@ -74,6 +74,8 @@ InfluxDB it is recommended to use [`influxdb_listener`][influxdb_listener] or
 Metrics are collected from the part of the request specified by the
 `data_source` param and are parsed depending on the value of `data_format`.
 
+## Example Output
+
 ## Troubleshooting
 
 Send Line Protocol:

--- a/plugins/inputs/http_listener_v2/sample.conf
+++ b/plugins/inputs/http_listener_v2/sample.conf
@@ -33,6 +33,9 @@
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
 
+  ## Minimal TLS version accepted by the server
+  # tls_min_version = "TLS12"
+
   ## Optional username and password to accept for HTTP basic authentication.
   ## You probably want to make sure you have TLS configured above for this.
   # basic_username = "foobar"

--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -68,3 +68,7 @@ from listed sensors using Junos Telemetry Interface. Refer to
 
 - All measurements are tagged appropriately using the identifier information
   in incoming data
+
+## Example Output
+
+## Metrics

--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -50,6 +50,9 @@ from listed sensors using Junos Telemetry Interface. Refer to
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
+  ## Minimal TLS version to accept by the client
+  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
+  # tls_min_version = ""
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -51,8 +51,7 @@ from listed sensors using Junos Telemetry Interface. Refer to
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
   ## Minimal TLS version to accept by the client
-  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
-  # tls_min_version = ""
+  # tls_min_version = "TLS12"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/plugins/inputs/jti_openconfig_telemetry/sample.conf
+++ b/plugins/inputs/jti_openconfig_telemetry/sample.conf
@@ -38,6 +38,9 @@
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
+  ## Minimal TLS version to accept by the client
+  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
+  # tls_min_version = ""
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/plugins/inputs/jti_openconfig_telemetry/sample.conf
+++ b/plugins/inputs/jti_openconfig_telemetry/sample.conf
@@ -38,8 +38,7 @@
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
-  ## Minimal TLS version to accept by the client
-  ## If undet, the value defaults to Golang's default which is TLS v1.2 currently.
+  ## Minimal TLS version to accept by the client (defaults to Golang's default)
   # tls_min_version = ""
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false

--- a/plugins/inputs/jti_openconfig_telemetry/sample.conf
+++ b/plugins/inputs/jti_openconfig_telemetry/sample.conf
@@ -38,8 +38,8 @@
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
-  ## Minimal TLS version to accept by the client (defaults to Golang's default)
-  # tls_min_version = ""
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #8699
resolves #8171
resolves #8124 (at least partially)

replaces #8959

All credits for this PR go to @jdstrand! This PR allows to set a minimum TLS version required by the client for all plugins that use `common/tls` to configure their TLS setup. This includes, but is probably not limited to, `inputs.http`, `inputs.gnmi` and `inputs.jti_openconfig_telemetry`. This allows to change Golang's default of TLS 1.2 in both directions, i.e. downgrade (which implies some security risk) as well as setting it to TLS 1.3.
Unit-tests are added by the PR to check if lower server versions are rejected successfully.