### PR TITLE
docs: Add example output section to HTTP plugin 

### DIFF
--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -77,6 +77,16 @@ configuration.
 
 ```
 
+## Example Output
+
+This example output was taken from [this instructional article](https://docs.influxdata.com/telegraf/v1.21/guides/using_http/).
+
+```shell
+citibike,station_id=4703 eightd_has_available_keys=false,is_installed=1,is_renting=1,is_returning=1,legacy_id="4703",num_bikes_available=6,num_bikes_disabled=2,num_docks_available=26,num_docks_disabled=0,num_ebikes_available=0,station_status="active" 1641505084000000000
+citibike,station_id=4704 eightd_has_available_keys=false,is_installed=1,is_renting=1,is_returning=1,legacy_id="4704",num_bikes_available=10,num_bikes_disabled=2,num_docks_available=36,num_docks_disabled=0,num_ebikes_available=0,station_status="active" 1641505084000000000
+citibike,station_id=4711 eightd_has_available_keys=false,is_installed=1,is_renting=1,is_returning=1,legacy_id="4711",num_bikes_available=9,num_bikes_disabled=0,num_docks_available=36,num_docks_disabled=0,num_ebikes_available=1,station_status="active" 1641505084000000000
+```
+
 ## Metrics
 
 The metrics collected by this input plugin will depend on the configured

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -79,7 +79,9 @@ configuration.
 
 ## Example Output
 
-This example output was taken from [this instructional article](https://docs.influxdata.com/telegraf/v1.21/guides/using_http/).
+This example output was taken from [this instructional article][1].
+
+[1]: https://docs.influxdata.com/telegraf/v1.21/guides/using_http/
 
 ```shell
 citibike,station_id=4703 eightd_has_available_keys=false,is_installed=1,is_renting=1,is_returning=1,legacy_id="4703",num_bikes_available=6,num_bikes_disabled=2,num_docks_available=26,num_docks_disabled=0,num_ebikes_available=0,station_status="active" 1641505084000000000

--- a/tools/readme_linter/rules.go
+++ b/tools/readme_linter/rules.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"regexp"
 	"strings"
 
 	"github.com/yuin/goldmark/ast"
@@ -80,9 +81,6 @@ func requiredSectionsClose(headings []string) func(*T, ast.Node) error {
 
 func noLongLinesInParagraphs(threshold int) func(*T, ast.Node) error {
 	return func(t *T, root ast.Node) error {
-		// We're looking for long lines in paragraphs. Find paragraphs
-		// first, then which lines are in paragraphs
-		paraLines := []int{}
 		for n := root.FirstChild(); n != nil; n = n.NextSibling() {
 			var p *ast.Paragraph
 			var ok bool
@@ -92,47 +90,16 @@ func noLongLinesInParagraphs(threshold int) func(*T, ast.Node) error {
 
 			segs := p.Lines()
 			for _, seg := range segs.Sliced(0, segs.Len()) {
-				line := t.line(seg.Start)
-				paraLines = append(paraLines, line)
-				// t.printFileLine(line)
-				// fmt.Printf("paragraph line\n")
+				line := string(seg.Value(t.markdown))
+				// Remove links to get an accurate line size, this will allow long URLs for example
+				// Reference: https://github.com/writeas/go-strip-markdown
+				linksReg := regexp.MustCompile(`\[(.*?)\][\[\(].*?[\]\)]`)
+				res := linksReg.ReplaceAllString(line, "$1")
+				if len(res) > threshold {
+					lineNumber := t.line(seg.Start)
+					t.assertLinef(lineNumber, "long line in paragraph")
+				}
 			}
-		}
-
-		// Find long lines in the whole file
-		longLines := []int{}
-		last := 0
-		for i, cur := range t.newlineOffsets {
-			length := cur - last - 1 // -1 to exclude the newline
-			if length > threshold {
-				longLines = append(longLines, i)
-				// t.printFileLine(i)
-				// fmt.Printf("long line\n")
-			}
-			last = cur
-		}
-
-		// Merge both lists
-		p := 0
-		l := 0
-		bads := []int{}
-		for p < len(paraLines) && l < len(longLines) {
-			long := longLines[l]
-			para := paraLines[p]
-			switch {
-			case long == para:
-				bads = append(bads, long)
-				p++
-				l++
-			case long < para:
-				l++
-			case long > para:
-				p++
-			}
-		}
-
-		for _, bad := range bads {
-			t.assertLinef(bad, "long line in paragraph")
 		}
 		return nil
 	}


### PR DESCRIPTION
This pull request:
* Adds a `example output` section to the http plugin readme to resolve linter error I noticed here: https://github.com/influxdata/telegraf/runs/7306583417?check_suite_focus=true, this failing in an unrelated PR is probably something that needs to be fixed in the github action but I didn't address this.
* Make the linter more lenient and doesn't mark links against the long line rule, it looks like the logic is simpler now using the actual string to get the length as well. Still seems accurate when testing it locally.