### PR TITLE
fix: makefile build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,11 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
 
-LDFLAGS := $(LDFLAGS) -X main.commit=$(commit) -X main.branch=$(branch) -X main.goos=$(GOOS) -X main.goarch=$(GOARCH)
-ifneq ($(tag),)
-	LDFLAGS += -X main.version=$(version)
-else
-	LDFLAGS += -X main.version=$(version)-$(commit)
-endif
+LDFLAGS := $(LDFLAGS) -X main.commit=$(commit) \
+	-X main.branch=$(branch) \
+	-X main.version=$(version) \
+	-X main.goarch=$(GOARCH) \
+	-X main.goos=$(GOOS)
 
 # Go built-in race detector works only for 64 bits architectures.
 ifneq ($(GOARCH), 386)


### PR DESCRIPTION
PR #11506 changed how the version was built, but it was also altered
just a few lines later, which resulted in the commit getting appended to
the version twice, producing an invalid semantic commit.

fixes: #11508
