### PR TITLE
feat: added metrics for member and replica-set avg health of MongoDB …

### DIFF
--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -159,6 +159,8 @@ by running Telegraf with the `--debug` argument.
     - repl_updates (integer)
     - repl_oplog_window_sec (integer)
     - repl_state (integer)
+    - repl_member_health (integer)
+    - repl_health_avg (float)
     - resident_megabytes (integer)
     - state (string)
     - storage_freelist_search_bucket_exhausted (integer)

--- a/plugins/inputs/mongodb/mongodb_data.go
+++ b/plugins/inputs/mongodb/mongodb_data.go
@@ -149,6 +149,8 @@ var defaultReplStats = map[string]string{
 	"member_status":                            "NodeType",
 	"state":                                    "NodeState",
 	"repl_state":                               "NodeStateInt",
+	"repl_member_health":                       "NodeHealthInt",
+	"repl_health_avg":                          "ReplHealthAvg",
 	"repl_lag":                                 "ReplLag",
 	"repl_network_bytes":                       "ReplNetworkBytes",
 	"repl_network_getmores_num":                "ReplNetworkGetmoresNum",

--- a/plugins/inputs/mongodb/mongodb_data_test.go
+++ b/plugins/inputs/mongodb/mongodb_data_test.go
@@ -447,6 +447,8 @@ func TestStateTag(t *testing.T) {
 		"repl_updates":                              int64(0),
 		"repl_updates_per_sec":                      int64(0),
 		"repl_state":                                int64(0),
+		"repl_member_health":                        int64(0),
+		"repl_health_avg":                           float64(0),
 		"resident_megabytes":                        int64(0),
 		"state":                                     "PRIMARY",
 		"storage_freelist_search_bucket_exhausted":  int64(0),

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -139,6 +139,7 @@ type OplogStats struct {
 // ReplSetMember stores information related to a replica set member
 type ReplSetMember struct {
 	Name       string    `bson:"name"`
+	Health     int64     `bson:"health"`
 	State      int64     `bson:"state"`
 	StateStr   string    `bson:"stateStr"`
 	OptimeDate time.Time `bson:"optimeDate"`
@@ -783,9 +784,11 @@ type StatLine struct {
 	NetOut, NetOutCnt                        int64
 	NumConnections                           int64
 	ReplSetName                              string
+	ReplHealthAvg                            float64
 	NodeType                                 string
 	NodeState                                string
 	NodeStateInt                             int64
+	NodeHealthInt                            int64
 
 	// Replicated Metrics fields
 	ReplNetworkBytes                    int64
@@ -1332,6 +1335,8 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 					returnVal.NodeState = member.StateStr
 					// Store my state integer
 					returnVal.NodeStateInt = member.State
+					// Store my health integer
+					returnVal.NodeHealthInt = member.Health
 
 					if member.State == 1 {
 						// I'm the master
@@ -1355,6 +1360,26 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 				} else {
 					returnVal.ReplLag = lag
 				}
+			}
+
+			// Prepartions for the average health state of the replica-set
+			var ReplMemberCount int = len(newReplStat.Members)
+			var ReplMemberHealthyCount int = 0
+
+			// Second for-loop is needed, because of break-construct above
+			for _, member := range newReplStat.Members {
+				// Count only healthy members for the average health state of the replica-set
+				if member.Health == 1 {
+					ReplMemberHealthyCount++
+				}
+			}
+
+			// Calculate the average health state of the replica-set (For precise monitoring alerts)
+			// To detect if a member is unhealthy from the perspective of another member and also how bad the replica-set health is
+			if ReplMemberCount > 0 {
+				returnVal.ReplHealthAvg = float64(ReplMemberHealthyCount) / float64(ReplMemberCount)
+			} else {
+				returnVal.ReplHealthAvg = 0.00
 			}
 		}
 	}

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -1363,21 +1363,21 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 			}
 
 			// Prepartions for the average health state of the replica-set
-			var ReplMemberCount int = len(newReplStat.Members)
-			var ReplMemberHealthyCount int = 0
+			var replMemberCount int = len(newReplStat.Members)
+			var replMemberHealthyCount int = 0
 
 			// Second for-loop is needed, because of break-construct above
 			for _, member := range newReplStat.Members {
 				// Count only healthy members for the average health state of the replica-set
 				if member.Health == 1 {
-					ReplMemberHealthyCount++
+					replMemberHealthyCount++
 				}
 			}
 
 			// Calculate the average health state of the replica-set (For precise monitoring alerts)
 			// To detect if a member is unhealthy from the perspective of another member and also how bad the replica-set health is
-			if ReplMemberCount > 0 {
-				returnVal.ReplHealthAvg = float64(ReplMemberHealthyCount) / float64(ReplMemberCount)
+			if replMemberCount > 0 {
+				returnVal.ReplHealthAvg = float64(replMemberHealthyCount) / float64(replMemberCount)
 			} else {
 				returnVal.ReplHealthAvg = 0.00
 			}

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -1363,8 +1363,8 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 			}
 
 			// Prepartions for the average health state of the replica-set
-			var replMemberCount int = len(newReplStat.Members)
-			var replMemberHealthyCount int = 0
+			replMemberCount := len(newReplStat.Members)
+			replMemberHealthyCount := 0
 
 			// Second for-loop is needed, because of break-construct above
 			for _, member := range newReplStat.Members {


### PR DESCRIPTION
…input plugin

- [x]  make check 
- [x]  make check-deps
- [x]  make test
- [x]  make docs
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)


resolves #11515

Added metrics for member and replica-set average health of MongoDB input plugin.
With this additional Telegraf metrics, you have all needed data ready to build monitoring alerts on unhealthy MongoDB replica-set events.
