### PR TITLE
fix: Enable TLS in Kafka without custom config

### DIFF
--- a/plugins/common/kafka/config.go
+++ b/plugins/common/kafka/config.go
@@ -93,7 +93,6 @@ func (k *Config) SetConfig(config *sarama.Config) error {
 		// To maintain backwards compatibility, if the enable_tls option is not
 		// set TLS is enabled if a non-default TLS config is used.
 		if k.EnableTLS == nil {
-			k.Log.Warnf("Use of deprecated configuration: enable_tls should be set when using TLS")
 			config.Net.TLS.Enable = true
 		}
 	}

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -29,6 +29,7 @@ plugin and use the old zookeeper connection method.
   # version = ""
 
   ## Optional TLS Config
+  # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -136,6 +136,20 @@ func TestInit(t *testing.T) {
 			},
 		},
 		{
+			name: "enabled tls without tls config",
+			plugin: &KafkaConsumer{
+				ReadConfig: kafka.ReadConfig{
+					Config: kafka.Config{
+						EnableTLS: func(b bool) *bool { return &b }(true),
+					},
+				},
+				Log: testutil.Logger{},
+			},
+			check: func(t *testing.T, plugin *KafkaConsumer) {
+				require.True(t, plugin.config.Net.TLS.Enable)
+			},
+		},
+		{
 			name: "default tls with a tls config",
 			plugin: &KafkaConsumer{
 				ReadConfig: kafka.ReadConfig{
@@ -143,6 +157,7 @@ func TestInit(t *testing.T) {
 						ClientConfig: tls.ClientConfig{
 							InsecureSkipVerify: true,
 						},
+						Log: testutil.Logger{},
 					},
 				},
 				Log: testutil.Logger{},
@@ -159,6 +174,7 @@ func TestInit(t *testing.T) {
 						ClientConfig: tls.ClientConfig{
 							InsecureSkipVerify: true,
 						},
+						Log: testutil.Logger{},
 					},
 				},
 				Log: testutil.Logger{},

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -157,7 +157,6 @@ func TestInit(t *testing.T) {
 						ClientConfig: tls.ClientConfig{
 							InsecureSkipVerify: true,
 						},
-						Log: testutil.Logger{},
 					},
 				},
 				Log: testutil.Logger{},
@@ -174,7 +173,6 @@ func TestInit(t *testing.T) {
 						ClientConfig: tls.ClientConfig{
 							InsecureSkipVerify: true,
 						},
-						Log: testutil.Logger{},
 					},
 				},
 				Log: testutil.Logger{},

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -18,6 +18,7 @@
   # version = ""
 
   ## Optional TLS Config
+  # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -113,6 +113,7 @@ Broker](http://kafka.apache.org/07/quickstart.html) acting a Kafka Producer.
   # max_message_bytes = 1000000
 
   ## Optional TLS Config
+  # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/outputs/kafka/sample.conf
+++ b/plugins/outputs/kafka/sample.conf
@@ -105,6 +105,7 @@
   # max_message_bytes = 1000000
 
   ## Optional TLS Config
+  # enable_tls = true
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Since the enable_tls configuration option in the Kafka config plugin was
deprecated, TLS is enabled only when other TLS configuration options
are also set (ie, custom CA, client certificate, or skipping TLS
verification).  In effect, TLS cannot be enabled without setting any of those options.

This change is essentially a reversion to the pre-1.17 behavior, to
undeprecate enable_tls and thusly re-enable TLS for the general use
case.