### PR TITLE
fix(inputs.snmp_trap): nil map panic when use snmp_trap with netsnmp translator

### DIFF
--- a/plugins/inputs/snmp_trap/netsnmp.go
+++ b/plugins/inputs/snmp_trap/netsnmp.go
@@ -82,8 +82,10 @@ func (s *netsnmpTranslator) snmptranslate(oid string) (e snmp.MibEntry, err erro
 	return e, nil
 }
 
-func newNetsnmpTranslator() *netsnmpTranslator {
+func newNetsnmpTranslator(timeout config.Duration) *netsnmpTranslator {
 	return &netsnmpTranslator{
 		execCmd: realExecCmd,
+		cache:   make(map[string]snmp.MibEntry),
+		Timeout: timeout,
 	}
 }

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -17,6 +17,8 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
+var defaultTimeout = config.Duration(time.Second * 5)
+
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
 //go:embed sample.conf
 var sampleConfig string
@@ -68,6 +70,7 @@ func init() {
 		return &SnmpTrap{
 			timeFunc:       time.Now,
 			ServiceAddress: "udp://:162",
+			Timeout:        defaultTimeout,
 			Path:           []string{"/usr/share/snmp/mibs"},
 			Version:        "2c",
 		}
@@ -87,7 +90,7 @@ func (s *SnmpTrap) Init() error {
 			return err
 		}
 	case "netsnmp":
-		s.translator = newNetsnmpTranslator()
+		s.translator = newNetsnmpTranslator(s.Timeout)
 	default:
 		return fmt.Errorf("invalid translator value")
 	}


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #11428

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

This PR fix the nil map panic when running with default snmp_trap config and fix timeout config not work issue.
