### PR TITLE
fix(inputs.opcua): return an error with mismatched types

### DIFF
--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"net/url"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -312,7 +313,15 @@ func (o *OpcUA) validateOPCTags() error {
 
 		//search identifier type
 		switch node.tag.IdentifierType {
-		case "s", "i", "g", "b":
+		case "s":
+			if reflect.ValueOf(node.tag.Identifier).Kind() != reflect.String {
+				return fmt.Errorf("identifier type '%s' does not match the type of identifier '%s'", node.tag.IdentifierType, node.tag.Identifier)
+			}
+		case "i":
+			if _, err := strconv.Atoi(node.tag.Identifier); err != nil {
+				return fmt.Errorf("identifier type '%s' does not match the type of identifier '%s'", node.tag.IdentifierType, node.tag.Identifier)
+			}
+		case "g", "b":
 			// Valid identifier type - do nothing.
 		default:
 			return fmt.Errorf("invalid identifier type '%s' in '%s'", node.tag.IdentifierType, node.tag.FieldName)

--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"fmt"
 	"net/url"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -313,15 +312,11 @@ func (o *OpcUA) validateOPCTags() error {
 
 		//search identifier type
 		switch node.tag.IdentifierType {
-		case "s":
-			if reflect.ValueOf(node.tag.Identifier).Kind() != reflect.String {
-				return fmt.Errorf("identifier type '%s' does not match the type of identifier '%s'", node.tag.IdentifierType, node.tag.Identifier)
-			}
 		case "i":
 			if _, err := strconv.Atoi(node.tag.Identifier); err != nil {
 				return fmt.Errorf("identifier type '%s' does not match the type of identifier '%s'", node.tag.IdentifierType, node.tag.Identifier)
 			}
-		case "g", "b":
+		case "s", "g", "b":
 			// Valid identifier type - do nothing.
 		default:
 			return fmt.Errorf("invalid identifier type '%s' in '%s'", node.tag.IdentifierType, node.tag.FieldName)

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -202,7 +202,7 @@ additional_valid_status_codes = ["0xC0"]
 	require.NoError(t, o.InitNodes())
 	require.Len(t, o.nodes, 4)
 	fmt.Printf("%T", o.nodes[2])
-	require.Len(t, o.nodes[2].metricTags, 8)
+	require.Len(t, o.nodes[2].metricTags, 3)
 	require.Len(t, o.nodes[3].metricTags, 2)
 
 	require.Len(t, o.Workarounds.AdditionalValidStatusCodes, 1)
@@ -243,7 +243,6 @@ nodes = [
 	require.Equal(t, o.RootNodes[1].FieldName, "name2")
 
 	require.Error(t, o.InitNodes())
-	require.Len(t, o.nodes, 2)
 }
 
 func TestTagsSliceToMap(t *testing.T) {

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -201,7 +201,6 @@ additional_valid_status_codes = ["0xC0"]
 
 	require.NoError(t, o.InitNodes())
 	require.Len(t, o.nodes, 4)
-	fmt.Printf("%T", o.nodes[2])
 	require.Len(t, o.nodes[2].metricTags, 3)
 	require.Len(t, o.nodes[3].metricTags, 2)
 


### PR DESCRIPTION
# Required for all PRs

- [x] make check
- [x] make check-deps
- [x] make test
- [x] make docs

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9164 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
opcua is panicking if the `identifier_type` does not match the actual type of `identifier`. This pr checks the type for strings and ints. I could not come up with a way to check guid or opaque types. And added a unit test
