### PR TITLE
feat: add settings for go sql.DB settings

### DIFF
--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -114,6 +114,20 @@ convert settings.
   ## the unsigned option. This is useful for a database like ClickHouse where
   ## the unsigned value should use a value like "uint64".
   # conversion_style = "unsigned_suffix"
+
+  ## Maximum amount of time a connection may be idle. "0s" means connections are
+  ## never closed due to idle time.
+  # conn_max_idle_time = "0s"
+
+  ## Maximum amount of time a connection may be reused. "0s" means connections
+  ## are never closed due to age.
+  # conn_max_lifetime = "0s"
+
+  ## Maximum number of connections in the idle connection pool. 0 means unlimited.
+  # max_idle_conns = 2
+
+  ## Maximum number of open connections to the database. 0 means unlimited.
+  # max_open_conns = 0
 ```
 
 ## Driver-specific information

--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -117,17 +117,17 @@ convert settings.
 
   ## Maximum amount of time a connection may be idle. "0s" means connections are
   ## never closed due to idle time.
-  # conn_max_idle_time = "0s"
+  # connection_max_idle_time = "0s"
 
   ## Maximum amount of time a connection may be reused. "0s" means connections
   ## are never closed due to age.
-  # conn_max_lifetime = "0s"
+  # connection_max_lifetime = "0s"
 
   ## Maximum number of connections in the idle connection pool. 0 means unlimited.
-  # max_idle_conns = 2
+  # connection_max_idle = 2
 
   ## Maximum number of open connections to the database. 0 means unlimited.
-  # max_open_conns = 0
+  # connection_max_open = 0
 ```
 
 ## Driver-specific information

--- a/plugins/outputs/sql/sample.conf
+++ b/plugins/outputs/sql/sample.conf
@@ -54,14 +54,14 @@
 
   ## Maximum amount of time a connection may be idle. "0s" means connections are
   ## never closed due to idle time.
-  # conn_max_idle_time = "0s"
+  # connection_max_idle_time = "0s"
 
   ## Maximum amount of time a connection may be reused. "0s" means connections
   ## are never closed due to age.
-  # conn_max_lifetime = "0s"
+  # connection_max_lifetime = "0s"
 
   ## Maximum number of connections in the idle connection pool. 0 means unlimited.
-  # max_idle_conns = 2
+  # connection_max_idle = 2
 
   ## Maximum number of open connections to the database. 0 means unlimited.
-  # max_open_conns = 0
+  # connection_max_open = 0

--- a/plugins/outputs/sql/sample.conf
+++ b/plugins/outputs/sql/sample.conf
@@ -51,3 +51,17 @@
   ## the unsigned option. This is useful for a database like ClickHouse where
   ## the unsigned value should use a value like "uint64".
   # conversion_style = "unsigned_suffix"
+
+  ## Maximum amount of time a connection may be idle. "0s" means connections are
+  ## never closed due to idle time.
+  # conn_max_idle_time = "0s"
+
+  ## Maximum amount of time a connection may be reused. "0s" means connections
+  ## are never closed due to age.
+  # conn_max_lifetime = "0s"
+
+  ## Maximum number of connections in the idle connection pool. 0 means unlimited.
+  # max_idle_conns = 2
+
+  ## Maximum number of open connections to the database. 0 means unlimited.
+  # max_open_conns = 0


### PR DESCRIPTION
resolves #11498

The golang SQL API exposes a few settings related to pooled connections. (see https://pkg.go.dev/database/sql#DB) These settings need to be changed for some SQL drivers to connect reliably to some databases.

This PR adds telegraf settings that mirror the golang sql settings. This allows users to set them through telegraf.conf and be able to connect to databases that require specific settings.

The golang sql settings have defaults and since telegraf didn't set the settings, it was using the defaults. I mirrored the default values in the new telegraf settings. This should make the sql output behave the same as before.