### PR TITLE
docs: Run `make docs` to fix CI on master

### DIFF
--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -92,6 +92,13 @@
   ## '2 * max_processing_time'.
   # max_processing_time = "100ms"
 
+  ## The default number of message bytes to fetch from the broker in each
+  ## request (default 1MB). This should be larger than the majority of
+  ## your messages, or else the consumer will spend a lot of time
+  ## negotiating sizes and not actually consuming. Similar to the JVM's
+  ## `fetch.message.max.bytes`.
+  # consumer_fetch_default = "1MB"
+
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:


### PR DESCRIPTION
#11220 edited sample config in the readme.md but not in the sample.conf. I evidently didn't notice the PR didn't pass ci and merged it. This caused master ci to start failing.

This PR adds the missing section to the sample.conf