### PR TITLE
docs: add link to docs on how to enable mysql's performance schema

### DIFF
--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -18,6 +18,11 @@ This plugin gathers the statistic data from MySQL server
 * File events statistics
 * Table schema statistics
 
+In order to gather metrics from the performance schema, it must first be enabled
+in mySQL configuration. See the performance schema [quick start][quick-start].
+
+[quick-start]: https://dev.mysql.com/doc/refman/8.0/en/performance-schema-quick-start.html
+
 ## Configuration
 
 ```toml @sample.conf


### PR DESCRIPTION
resolves #4810

This PR adds a notice in inputs.mysql's readme to tell the user that the performance schema needs to be enabled.