### PR TITLE
fix(outputs.wavefront): update wavefront sdk and use non-deprecated APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	github.com/vapourismo/knx-go v0.0.0-20211128234507-8198fa17db36
 	github.com/vjeantet/grok v1.0.1
 	github.com/vmware/govmomi v0.29.0
-	github.com/wavefronthq/wavefront-sdk-go v0.9.11
+	github.com/wavefronthq/wavefront-sdk-go v0.10.1
 	github.com/wvanbergen/kafka v0.0.0-20171203153745-e2edea948ddf
 	github.com/xdg/scram v1.0.5
 	github.com/yuin/goldmark v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -2267,8 +2267,8 @@ github.com/vjeantet/grok v1.0.1/go.mod h1:ax1aAchzC6/QMXMcyzHQGZWaW1l195+uMYIkCW
 github.com/vmware/govmomi v0.29.0 h1:SHJQ7DUc4fltFZv16znJNGHR1/XhiDK5iKxm2OqwkuU=
 github.com/vmware/govmomi v0.29.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4r3INMdY=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
-github.com/wavefronthq/wavefront-sdk-go v0.9.11 h1:3qv/yyNNyLKPQftQWFrfHGUv50e/gMxKlUQnILlvHKw=
-github.com/wavefronthq/wavefront-sdk-go v0.9.11/go.mod h1:AcW8zJJcYodB7B9KYzoxVH6K0fmYd6MgpmXE1LMo+OU=
+github.com/wavefronthq/wavefront-sdk-go v0.10.1 h1:my6q/yDaSi4bADHr9006YrHBhTdjEtpU0UpT0NDaSw8=
+github.com/wavefronthq/wavefront-sdk-go v0.10.1/go.mod h1:JHflWDtew1icwZB6OEvHedBFD9T1h7Se/m+dBSjywu8=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=

--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -1,27 +1,25 @@
 # Wavefront Output Plugin
 
-This plugin writes to a [Wavefront](https://www.wavefront.com) proxy, in
-Wavefront data format over TCP.
+This plugin writes to a [Wavefront](https://www.wavefront.com) instance or a
+Wavefront Proxy instance over HTTP or HTTPS.
 
 ## Configuration
 
 ```toml @sample.conf
-# Configuration for Wavefront server to send metrics to
 [[outputs.wavefront]]
-  ## Url for Wavefront Direct Ingestion. For Wavefront Proxy Ingestion, see
-  ## the 'host' and 'port' options below.
+  ## Url for Wavefront API or Wavefront Proxy instance.
   url = "https://metrics.wavefront.com"
 
-  ## Authentication Token for Wavefront. Only required if using Direct Ingestion
+  ## Authentication Token for Wavefront. Required if using Direct Ingestion. Not required if using a Wavefront Proxy.
   #token = "DUMMY_TOKEN"
 
-  ## Maximum number of metrics to send per batch for Direct Ingestion. Ignored unless 'url' is set. This value should be higher than the `metric_batch_size`. Default is 10,000. Values higher than 40,000 are not recommended.
+  ## Maximum number of metrics to send per HTTP request. This value should be higher than the `metric_batch_size`. Default is 10,000. Values higher than 40,000 are not recommended.
   # http_maximum_batch_size = 10000
 
-  ## DNS name of the wavefront proxy server. Do not use if url is specified
+  ## Deprecated. DNS name of the Wavefront server or Wavefront Proxy. Use the `url` field instead.
   #host = "wavefront.example.com"
 
-  ## Port that the Wavefront proxy server listens on. Do not use if url is specified
+  ## Deprecated. Wavefront proxy port. Use the `url` field instead.
   #port = 2878
 
   ## prefix for metrics keys

--- a/plugins/outputs/wavefront/sample.conf
+++ b/plugins/outputs/wavefront/sample.conf
@@ -1,19 +1,17 @@
-# Configuration for Wavefront server to send metrics to
 [[outputs.wavefront]]
-  ## Url for Wavefront Direct Ingestion. For Wavefront Proxy Ingestion, see
-  ## the 'host' and 'port' options below.
+  ## Url for Wavefront API or Wavefront Proxy instance.
   url = "https://metrics.wavefront.com"
 
-  ## Authentication Token for Wavefront. Only required if using Direct Ingestion
+  ## Authentication Token for Wavefront. Required if using Direct Ingestion. Not required if using a Wavefront Proxy.
   #token = "DUMMY_TOKEN"
 
-  ## Maximum number of metrics to send per batch for Direct Ingestion. Ignored unless 'url' is set. This value should be higher than the `metric_batch_size`. Default is 10,000. Values higher than 40,000 are not recommended.
+  ## Maximum number of metrics to send per HTTP request. This value should be higher than the `metric_batch_size`. Default is 10,000. Values higher than 40,000 are not recommended.
   # http_maximum_batch_size = 10000
 
-  ## DNS name of the wavefront proxy server. Do not use if url is specified
+  ## Deprecated. DNS name of the Wavefront server or Wavefront Proxy. Use the `url` field instead.
   #host = "wavefront.example.com"
 
-  ## Port that the Wavefront proxy server listens on. Do not use if url is specified
+  ## Deprecated. Wavefront proxy port. Use the `url` field instead.
   #port = 2878
 
   ## prefix for metrics keys

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -23,8 +23,8 @@ const maxTagLength = 254
 type Wavefront struct {
 	URL                  string                          `toml:"url"`
 	Token                string                          `toml:"token"`
-	Host                 string                          `toml:"host"`
-	Port                 int                             `toml:"port"`
+	Host                 string                          `toml:"host" deprecated:"2.4.0;use url instead"`
+	Port                 int                             `toml:"port" deprecated:"2.4.0;use url instead"`
 	Prefix               string                          `toml:"prefix"`
 	SimpleFields         bool                            `toml:"simple_fields"`
 	MetricSeparator      string                          `toml:"metric_separator"`

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -356,11 +356,11 @@ func TestTagLimits(t *testing.T) {
 }
 
 func TestSenderURLFromHostAndPort(t *testing.T) {
-	require.Equal(t, "tcp://localhost:2878", SenderURLFromHostAndPort("localhost", 2878))
+	require.Equal(t, "http://localhost:2878", senderURLFromHostAndPort("localhost", 2878))
 }
 
 func TestSenderURLFromURLAndToken(t *testing.T) {
-	url, err := SenderURLFromURLAndToken("https://surf.wavefront.com", "11111111-2222-3333-4444-555555555555")
+	url, err := senderURLFromURLAndToken("https://surf.wavefront.com", "11111111-2222-3333-4444-555555555555")
 	require.Nil(t, err)
 	require.Equal(t, "https://11111111-2222-3333-4444-555555555555@surf.wavefront.com",
 		url)

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -355,6 +355,17 @@ func TestTagLimits(t *testing.T) {
 	require.Equal(t, longKey, tags[longKey])
 }
 
+func TestSenderURLFromHostAndPort(t *testing.T) {
+	require.Equal(t, "tcp://localhost:2878", SenderURLFromHostAndPort("localhost", 2878))
+}
+
+func TestSenderURLFromURLAndToken(t *testing.T) {
+	url, err := SenderURLFromURLAndToken("https://surf.wavefront.com", "11111111-2222-3333-4444-555555555555")
+	require.Nil(t, err)
+	require.Equal(t, "https://11111111-2222-3333-4444-555555555555@surf.wavefront.com",
+		url)
+}
+
 func TestDefaults(t *testing.T) {
 	defaultWavefront := outputs.Outputs["wavefront"]().(*Wavefront)
 	require.Equal(t, 10000, defaultWavefront.HTTPMaximumBatchSize)


### PR DESCRIPTION
# Required for all PRs

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)


The Wavefront output plugin uses APIs from the Wavefront Go SDK that have been deprecated. This PR updates the SDK version and adopts the currently recommended APIs for configuring the Wavefront sender.
