### PR TITLE
fix(inputs.kube_inventory): send file location to enable token auto-refresh

### DIFF
--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -52,6 +52,7 @@ avoid cardinality issues:
   ## If given a string, Telegraf cannot refresh the token periodically.
   # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
+  ## deprecated in 1.24.0; use bearer_token with a file
   # bearer_token_string = "abc_123"
 
   ## Set response_timeout (default 5 seconds)

--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -44,9 +44,13 @@ avoid cardinality issues:
   # namespace = "default"
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
+  ##
   ## If both of these are empty, we'll use the default serviceaccount:
   ## at: /run/secrets/kubernetes.io/serviceaccount/token
-  # bearer_token = "/path/to/bearer/token"
+  ##
+  ## To auto-refresh the token, please use a file with the bearer_token option.
+  ## If given a string, Telegraf cannot refresh the token periodically.
+  # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
   # bearer_token_string = "abc_123"
 

--- a/plugins/inputs/kube_inventory/client.go
+++ b/plugins/inputs/kube_inventory/client.go
@@ -20,8 +20,8 @@ type client struct {
 	*kubernetes.Clientset
 }
 
-func newClient(baseURL, namespace, bearerToken string, timeout time.Duration, tlsConfig tls.ClientConfig) (*client, error) {
-	c, err := kubernetes.NewForConfig(&rest.Config{
+func newClient(baseURL, namespace, bearerTokenFile string, bearerToken string, timeout time.Duration, tlsConfig tls.ClientConfig) (*client, error) {
+	config := &rest.Config{
 		TLSClientConfig: rest.TLSClientConfig{
 			ServerName: tlsConfig.ServerName,
 			Insecure:   tlsConfig.InsecureSkipVerify,
@@ -30,9 +30,16 @@ func newClient(baseURL, namespace, bearerToken string, timeout time.Duration, tl
 			KeyFile:    tlsConfig.TLSKey,
 		},
 		Host:          baseURL,
-		BearerToken:   bearerToken,
 		ContentConfig: rest.ContentConfig{},
-	})
+	}
+
+	if bearerTokenFile != "" {
+		config.BearerTokenFile = bearerTokenFile
+	} else if bearerToken != "" {
+		config.BearerToken = bearerToken
+	}
+
+	c, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/kube_inventory/client_test.go
+++ b/plugins/inputs/kube_inventory/client_test.go
@@ -25,6 +25,9 @@ func toBoolPtr(b bool) *bool {
 }
 
 func TestNewClient(t *testing.T) {
-	_, err := newClient("https://127.0.0.1:443/", "default", "abc123", time.Second, tls.ClientConfig{})
+	_, err := newClient("https://127.0.0.1:443/", "default", "", "abc123", time.Second, tls.ClientConfig{})
 	require.NoErrorf(t, err, "Failed to create new client - %v", err)
+
+	_, err = newClient("https://127.0.0.1:443/", "default", "nonexistantFile", "", time.Second, tls.ClientConfig{})
+	require.Errorf(t, err, "failed to read token file \"file\": open file: no such file or directory", err)
 }

--- a/plugins/inputs/kube_inventory/kube_inventory.go
+++ b/plugins/inputs/kube_inventory/kube_inventory.go
@@ -5,9 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -32,7 +30,7 @@ const (
 type KubernetesInventory struct {
 	URL               string          `toml:"url"`
 	BearerToken       string          `toml:"bearer_token"`
-	BearerTokenString string          `toml:"bearer_token_string"`
+	BearerTokenString string          `toml:"bearer_token_string" deprecated:"1.22.4;use 'BearerToken' with a file instead"`
 	Namespace         string          `toml:"namespace"`
 	ResponseTimeout   config.Duration `toml:"response_timeout"` // Timeout specified as a string - 3s, 1m, 1h
 	ResourceExclude   []string        `toml:"resource_exclude"`
@@ -60,16 +58,12 @@ func (ki *KubernetesInventory) Init() error {
 		ki.BearerToken = defaultServiceAccountPath
 	}
 
-	if ki.BearerToken != "" {
-		token, err := os.ReadFile(ki.BearerToken)
-		if err != nil {
-			return err
-		}
-		ki.BearerTokenString = strings.TrimSpace(string(token))
+	if ki.BearerTokenString != "" {
+		ki.Log.Warn("Telegraf cannot auto-refresh a bearer token string, use BearerToken file instead")
 	}
 
 	var err error
-	ki.client, err = newClient(ki.URL, ki.Namespace, ki.BearerTokenString, time.Duration(ki.ResponseTimeout), ki.ClientConfig)
+	ki.client, err = newClient(ki.URL, ki.Namespace, ki.BearerToken, ki.BearerTokenString, time.Duration(ki.ResponseTimeout), ki.ClientConfig)
 
 	if err != nil {
 		return err

--- a/plugins/inputs/kube_inventory/kube_inventory.go
+++ b/plugins/inputs/kube_inventory/kube_inventory.go
@@ -30,7 +30,7 @@ const (
 type KubernetesInventory struct {
 	URL               string          `toml:"url"`
 	BearerToken       string          `toml:"bearer_token"`
-	BearerTokenString string          `toml:"bearer_token_string" deprecated:"1.22.4;use 'BearerToken' with a file instead"`
+	BearerTokenString string          `toml:"bearer_token_string" deprecated:"1.24.0;use 'BearerToken' with a file instead"`
 	Namespace         string          `toml:"namespace"`
 	ResponseTimeout   config.Duration `toml:"response_timeout"` // Timeout specified as a string - 3s, 1m, 1h
 	ResourceExclude   []string        `toml:"resource_exclude"`

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -7,9 +7,13 @@
   # namespace = "default"
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
+  ##
   ## If both of these are empty, we'll use the default serviceaccount:
   ## at: /run/secrets/kubernetes.io/serviceaccount/token
-  # bearer_token = "/path/to/bearer/token"
+  ##
+  ## To auto-refresh the token, please use a file with the bearer_token option.
+  ## If given a string, Telegraf cannot refresh the token periodically.
+  # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
   # bearer_token_string = "abc_123"
 

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -15,6 +15,7 @@
   ## If given a string, Telegraf cannot refresh the token periodically.
   # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
+  ## deprecated in 1.24.0; use bearer_token with a file
   # bearer_token_string = "abc_123"
 
   ## Set response_timeout (default 5 seconds)


### PR DESCRIPTION
Currently, Telegraf will read a token file and provide that as a string
to the K8s client. This will prevent the K8s client from attempting to
auto-refresh the token. In newer versions of K8s, tokens will expire
every hour as a security measure.

This, instead will pass the file location rather than having telegraf
read it directly. Because of this new K8s behavior, this also deprecates
and warns the user when using a hard-coded string token.

fixes: #11267
