### PR TITLE
fix(inputs.kubernetes): refresh token from file at each read

### DIFF
--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -48,6 +48,7 @@ avoid cardinality issues:
   ## at: /run/secrets/kubernetes.io/serviceaccount/token
   # bearer_token = "/path/to/bearer/token"
   ## OR
+  ## deprecated in 1.24.0; use bearer_token with a file
   # bearer_token_string = "abc_123"
 
   ## Set response_timeout (default 5 seconds)

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -11,6 +11,7 @@
   ## at: /run/secrets/kubernetes.io/serviceaccount/token
   # bearer_token = "/path/to/bearer/token"
   ## OR
+  ## deprecated in 1.24.0; use bearer_token with a file
   # bearer_token_string = "abc_123"
 
   ## Set response_timeout (default 5 seconds)

--- a/plugins/inputs/kubernetes/README.md
+++ b/plugins/inputs/kubernetes/README.md
@@ -45,7 +45,10 @@ avoid cardinality issues:
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ## If both of these are empty, we'll use the default serviceaccount:
   ## at: /run/secrets/kubernetes.io/serviceaccount/token
-  # bearer_token = "/path/to/bearer/token"
+  ##
+  ## To auto-refresh the token, please use a file with the bearer_token option.
+  ## If given a string, Telegraf cannot refresh the token periodically.
+  # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
   # bearer_token_string = "abc_123"
 

--- a/plugins/inputs/kubernetes/README.md
+++ b/plugins/inputs/kubernetes/README.md
@@ -46,8 +46,9 @@ avoid cardinality issues:
   ## If both of these are empty, we'll use the default serviceaccount:
   ## at: /run/secrets/kubernetes.io/serviceaccount/token
   ##
-  ## To auto-refresh the token, please use a file with the bearer_token option.
-  ## If given a string, Telegraf cannot refresh the token periodically.
+  ## To re-read the token at each interval, please use a file with the
+  ## bearer_token option. If given a string, Telegraf will always use that
+  ## token.
   # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
   # bearer_token_string = "abc_123"

--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -27,7 +27,7 @@ type Kubernetes struct {
 
 	// Bearer Token authorization file path
 	BearerToken       string `toml:"bearer_token"`
-	BearerTokenString string `toml:"bearer_token_string"`
+	BearerTokenString string `toml:"bearer_token_string" deprecated:"1.24.0;use 'BearerToken' with a file instead"`
 
 	LabelInclude []string `toml:"label_include"`
 	LabelExclude []string `toml:"label_exclude"`
@@ -63,14 +63,6 @@ func (k *Kubernetes) Init() error {
 	// If neither are provided, use the default service account.
 	if k.BearerToken == "" && k.BearerTokenString == "" {
 		k.BearerToken = defaultServiceAccountPath
-	}
-
-	if k.BearerToken != "" {
-		token, err := os.ReadFile(k.BearerToken)
-		if err != nil {
-			return err
-		}
-		k.BearerTokenString = strings.TrimSpace(string(token))
 	}
 
 	labelFilter, err := filter.NewIncludeExcludeFilter(k.LabelInclude, k.LabelExclude)
@@ -185,6 +177,13 @@ func (k *Kubernetes) LoadJSON(url string, v interface{}) error {
 			TLSClientConfig:       tlsCfg,
 			ResponseHeaderTimeout: time.Duration(k.ResponseTimeout),
 		}
+	}
+	if k.BearerToken != "" {
+		token, err := os.ReadFile(k.BearerToken)
+		if err != nil {
+			return err
+		}
+		k.BearerTokenString = strings.TrimSpace(string(token))
 	}
 	req.Header.Set("Authorization", "Bearer "+k.BearerTokenString)
 	req.Header.Add("Accept", "application/json")

--- a/plugins/inputs/kubernetes/sample.conf
+++ b/plugins/inputs/kubernetes/sample.conf
@@ -6,7 +6,11 @@
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ## If both of these are empty, we'll use the default serviceaccount:
   ## at: /run/secrets/kubernetes.io/serviceaccount/token
-  # bearer_token = "/path/to/bearer/token"
+  ##
+  ## To re-read the token at each interval, please use a file with the
+  ## bearer_token option. If given a string, Telegraf will always use that
+  ## token.
+  # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
   # bearer_token_string = "abc_123"
 


### PR DESCRIPTION
Similar to #11267, this allows for the token contained in the provided
file to get re-read at each interval. This way, if the token is
updated/refreshed Telegraf will also get the newer token.