### PR TITLE
feat(inputs.ntpq): Add option to specify command flags

### DIFF
--- a/plugins/inputs/ntpq/README.md
+++ b/plugins/inputs/ntpq/README.md
@@ -30,8 +30,21 @@ server (RMS of difference of multiple time samples, milliseconds);
 # Get standard NTP query metrics, requires ntpq executable.
 [[inputs.ntpq]]
   ## If false, set the -n ntpq flag. Can reduce metric gather time.
-  dns_lookup = true
+  ## DEPRECATED since 1.24.0: add '-n' to 'options' instead to skip DNS lookup
+  # dns_lookup = true
+
+  ## Options to pass to the ntpq command.
+  # options = "-p"
 ```
+
+You can pass arbitrary options accepted by the `ntpq` command using the
+`options` setting. In case you want to skip DNS lookups use
+
+```toml
+  options = "-p -n"
+```
+
+for example.
 
 ## Metrics
 

--- a/plugins/inputs/ntpq/sample.conf
+++ b/plugins/inputs/ntpq/sample.conf
@@ -1,4 +1,8 @@
 # Get standard NTP query metrics, requires ntpq executable.
 [[inputs.ntpq]]
   ## If false, set the -n ntpq flag. Can reduce metric gather time.
-  dns_lookup = true
+  ## DEPRECATED since 1.24.0: add '-n' to 'options' instead to skip DNS lookup
+  # dns_lookup = true
+
+  ## Options to pass to the ntpq command.
+  # options = "-p"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #4746
partially replaces #7840 

This PR adds an `options` setting to specify flags passed on to the `ntpq` command. This way you can both add additional flags or remove default flags (e.g. `-p`). Due to it's capabilities the new `options` setting replaces the `dns_lookup` option which is deprecated in the PR.