### PR TITLE
docs(inputs.exec): clarify parsing for ints

### DIFF
--- a/plugins/inputs/exec/README.md
+++ b/plugins/inputs/exec/README.md
@@ -43,7 +43,8 @@ scripts that match the pattern will cause them to be picked up immediately.
 ## Example
 
 This script produces static values, since no timestamp is specified the values
-are at the current time.
+are at the current time. Ensure that int values are followed with `i` for proper
+parsing.
 
 ```sh
 #!/bin/sh


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #11579 
[community thread](https://influxcommunity.slack.com/archives/CH99HUH8V/p1659451802945659?thread_ts=1659447861.506369&cid=CH99HUH8V)
<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
Thought the issue was that the commands needed to be in a script but the actual cause was no `i` after the int values. Clarified the docs for next time. 