### PR TITLE
chore(processors): Convert processors to `ParserPlugin`s

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -870,6 +870,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 
 	// Keep the old interface for backward compatibility
 	if t, ok := input.(parsers.ParserInput); ok {
+		fmt.Println("[addInput] parsers.ParserInput")
 		// DEPRECATED: Please switch your plugin to telegraf.ParserInput.
 		parser, err := c.addParser(name, table)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -870,7 +870,6 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 
 	// Keep the old interface for backward compatibility
 	if t, ok := input.(parsers.ParserInput); ok {
-		fmt.Println("[addInput] parsers.ParserInput")
 		// DEPRECATED: Please switch your plugin to telegraf.ParserInput.
 		parser, err := c.addParser(name, table)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -761,7 +761,7 @@ func (c *Config) addProcessor(name string, table *ast.Table) error {
 	// If the (underlying) processor has a SetParser or SetParserFunc function,
 	// it can accept arbitrary data-formats, so build the requested parser and
 	// set it.
-	if t, ok := processor.(telegraf.ParserInput); ok {
+	if t, ok := processor.(telegraf.ParserPlugin); ok {
 		parser, err := c.addParser("processors", name, table)
 		if err != nil {
 			return fmt.Errorf("adding parser failed: %w", err)
@@ -769,7 +769,7 @@ func (c *Config) addProcessor(name string, table *ast.Table) error {
 		t.SetParser(parser)
 	}
 
-	if t, ok := processor.(telegraf.ParserFuncInput); ok {
+	if t, ok := processor.(telegraf.ParserFuncPlugin); ok {
 		if !c.probeParser(table) {
 			return errors.New("parser not found")
 		}
@@ -808,21 +808,14 @@ func (c *Config) setupProcessorOptions(name string, processor telegraf.Streaming
 		if err := c.toml.UnmarshalTable(table, unwrapped); err != nil {
 			return fmt.Errorf("unmarshalling unwrappable failed: %w", err)
 		}
-		if err := c.printUserDeprecation("processors", name, unwrapped); err != nil {
-			return err
-		}
-		return nil
+		return c.printUserDeprecation("processors", name, unwrapped)
 	}
 
 	if err := c.toml.UnmarshalTable(table, processor); err != nil {
 		return fmt.Errorf("unmarshalling failed: %w", err)
 	}
 
-	if err := c.printUserDeprecation("processors", name, processor); err != nil {
-		return err
-	}
-
-	return nil
+	return c.printUserDeprecation("processors", name, processor)
 }
 
 func (c *Config) addOutput(name string, table *ast.Table) error {
@@ -903,7 +896,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 
 	// If the input has a SetParser or SetParserFunc function, it can accept
 	// arbitrary data-formats, so build the requested parser and set it.
-	if t, ok := input.(telegraf.ParserInput); ok {
+	if t, ok := input.(telegraf.ParserPlugin); ok {
 		parser, err := c.addParser("inputs", name, table)
 		if err != nil {
 			return fmt.Errorf("adding parser failed: %w", err)
@@ -913,7 +906,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 
 	// Keep the old interface for backward compatibility
 	if t, ok := input.(parsers.ParserInput); ok {
-		// DEPRECATED: Please switch your plugin to telegraf.ParserInput.
+		// DEPRECATED: Please switch your plugin to telegraf.ParserPlugin.
 		parser, err := c.addParser("inputs", name, table)
 		if err != nil {
 			return fmt.Errorf("adding parser failed: %w", err)
@@ -921,7 +914,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 		t.SetParser(parser)
 	}
 
-	if t, ok := input.(telegraf.ParserFuncInput); ok {
+	if t, ok := input.(telegraf.ParserFuncPlugin); ok {
 		if !c.probeParser(table) {
 			return errors.New("parser not found")
 		}
@@ -936,7 +929,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 	}
 
 	if t, ok := input.(parsers.ParserFuncInput); ok {
-		// DEPRECATED: Please switch your plugin to telegraf.ParserFuncInput.
+		// DEPRECATED: Please switch your plugin to telegraf.ParserFuncPlugin.
 		if !c.probeParser(table) {
 			return errors.New("parser not found")
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -735,51 +735,94 @@ func (c *Config) addProcessor(name string, table *ast.Table) error {
 		}
 		return fmt.Errorf("Undefined but requested processor: %s", name)
 	}
+	streamingProcessor := creator()
+
+	// For processors with parsers we need to compute the set of
+	// options that is not covered by both, the parser and the processor.
+	// We achieve this by keeping a local book of missing entries
+	// that counts the number of misses. In case we have a parser
+	// for the input both need to miss the entry. We count the
+	// missing entries at the end.
+	missCount := make(map[string]int)
+	c.setLocalMissingTomlFieldTracker(missCount)
+	defer c.resetMissingTomlFieldTracker()
 
 	processorConfig, err := c.buildProcessor(name, table)
 	if err != nil {
 		return err
 	}
 
-	rf, err := c.newRunningProcessor(creator, processorConfig, table)
-	if err != nil {
+	var processor interface{}
+	processor = streamingProcessor
+	if p, ok := streamingProcessor.(unwrappable); ok {
+		processor = p.Unwrap()
+	}
+
+	// If the (underlying) processor has a SetParser or SetParserFunc function,
+	// it can accept arbitrary data-formats, so build the requested parser and
+	// set it.
+	if t, ok := processor.(telegraf.ParserInput); ok {
+		parser, err := c.addParser(name, table)
+		if err != nil {
+			return fmt.Errorf("adding parser failed: %w", err)
+		}
+		t.SetParser(parser)
+	}
+
+	if t, ok := processor.(telegraf.ParserFuncInput); ok {
+		if !c.probeParser(table) {
+			return errors.New("parser not found")
+		}
+		t.SetParserFunc(func() (telegraf.Parser, error) {
+			parser, err := c.addParser(name, table)
+			if err != nil {
+				return nil, err
+			}
+			err = parser.Init()
+			return parser, err
+		})
+	}
+
+	// Setup the processor
+	if err := c.setupProcessorOptions(processorConfig.Name, streamingProcessor, table); err != nil {
 		return err
 	}
+
+	rf := models.NewRunningProcessor(streamingProcessor, processorConfig)
 	c.Processors = append(c.Processors, rf)
 
-	// save a copy for the aggregator
-	rf, err = c.newRunningProcessor(creator, processorConfig, table)
-	if err != nil {
+	// Save a copy for the aggregator
+	if err := c.setupProcessorOptions(processorConfig.Name, streamingProcessor, table); err != nil {
 		return err
 	}
+
+	rf = models.NewRunningProcessor(streamingProcessor, processorConfig)
 	c.AggProcessors = append(c.AggProcessors, rf)
 
 	return nil
 }
 
-func (c *Config) newRunningProcessor(
-	creator processors.StreamingCreator,
-	processorConfig *models.ProcessorConfig,
-	table *ast.Table,
-) (*models.RunningProcessor, error) {
-	processor := creator()
-
+func (c *Config) setupProcessorOptions(name string, processor telegraf.StreamingProcessor, table *ast.Table) error {
 	if p, ok := processor.(unwrappable); ok {
-		if err := c.toml.UnmarshalTable(table, p.Unwrap()); err != nil {
-			return nil, err
+		unwrapped := p.Unwrap()
+		if err := c.toml.UnmarshalTable(table, unwrapped); err != nil {
+			return fmt.Errorf("unmarshalling unwrappable failed: %w", err)
 		}
-	} else {
-		if err := c.toml.UnmarshalTable(table, processor); err != nil {
-			return nil, err
+		if err := c.printUserDeprecation("processors", name, unwrapped); err != nil {
+			return err
 		}
+		return nil
 	}
 
-	if err := c.printUserDeprecation("processors", processorConfig.Name, processor); err != nil {
-		return nil, err
+	if err := c.toml.UnmarshalTable(table, processor); err != nil {
+		return fmt.Errorf("unmarshalling failed: %w", err)
 	}
 
-	rf := models.NewRunningProcessor(processor, processorConfig)
-	return rf, nil
+	if err := c.printUserDeprecation("processors", name, processor); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *Config) addOutput(name string, table *ast.Table) error {

--- a/config/config.go
+++ b/config/config.go
@@ -774,12 +774,7 @@ func (c *Config) addProcessor(name string, table *ast.Table) error {
 			return errors.New("parser not found")
 		}
 		t.SetParserFunc(func() (telegraf.Parser, error) {
-			parser, err := c.addParser("processors", name, table)
-			if err != nil {
-				return nil, err
-			}
-			err = parser.Init()
-			return parser, err
+			return c.addParser("processors", name, table)
 		})
 	}
 
@@ -919,12 +914,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 			return errors.New("parser not found")
 		}
 		t.SetParserFunc(func() (telegraf.Parser, error) {
-			parser, err := c.addParser("inputs", name, table)
-			if err != nil {
-				return nil, err
-			}
-			err = parser.Init()
-			return parser, err
+			return c.addParser("inputs", name, table)
 		})
 	}
 
@@ -934,12 +924,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 			return errors.New("parser not found")
 		}
 		t.SetParserFunc(func() (parsers.Parser, error) {
-			parser, err := c.addParser("inputs", name, table)
-			if err != nil {
-				return nil, err
-			}
-			err = parser.Init()
-			return parser, err
+			return c.addParser("inputs", name, table)
 		})
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -736,7 +736,6 @@ func TestConfig_ProcessorsWithParsers(t *testing.T) {
 
 		// Get the parser set with 'SetParser()'
 		if p, ok := processor.Parser.(*models.RunningParser); ok {
-			require.NoError(t, p.Init())
 			actual = append(actual, p.Parser)
 		} else {
 			actual = append(actual, processor.Parser)

--- a/config/testdata/processors_with_parsers.toml
+++ b/config/testdata/processors_with_parsers.toml
@@ -1,0 +1,60 @@
+[[processors.parser_test]]
+  data_format = "collectd"
+
+[[processors.parser_test]]
+  data_format = "csv"
+  csv_header_row_count = 42
+
+[[processors.parser_test]]
+  data_format = "dropwizard"
+
+[[processors.parser_test]]
+  data_format = "form_urlencoded"
+
+[[processors.parser_test]]
+  data_format = "graphite"
+
+[[processors.parser_test]]
+  data_format = "grok"
+  grok_patterns = ["%{COMBINED_LOG_FORMAT}"]
+
+[[processors.parser_test]]
+  data_format = "influx"
+
+[[processors.parser_test]]
+  data_format = "json"
+
+[[processors.parser_test]]
+  data_format = "json_v2"
+
+[[processors.parser_test]]
+  data_format = "logfmt"
+
+[[processors.parser_test]]
+  data_format = "nagios"
+
+[[processors.parser_test]]
+  data_format = "prometheus"
+
+[[processors.parser_test]]
+  data_format = "prometheusremotewrite"
+
+[[processors.parser_test]]
+  data_format = "value"
+
+[[processors.parser_test]]
+  data_format = "wavefront"
+
+[[processors.parser_test]]
+  data_format = "xml"
+
+[[processors.parser_test]]
+  data_format = "xpath_json"
+
+[[processors.parser_test]]
+  data_format = "xpath_msgpack"
+
+[[processors.parser_test]]
+  data_format = "xpath_protobuf"
+  xpath_protobuf_file = "testdata/addressbook.proto"
+  xpath_protobuf_type = "addressbook.AddressBook"

--- a/parser.go
+++ b/parser.go
@@ -24,16 +24,16 @@ type Parser interface {
 
 type ParserFunc func() (Parser, error)
 
-// ParserInput is an interface for input plugins that are able to parse
+// ParserPlugin is an interface for plugins that are able to parse
 // arbitrary data formats.
-type ParserInput interface {
+type ParserPlugin interface {
 	// SetParser sets the parser function for the interface
 	SetParser(parser Parser)
 }
 
-// ParserFuncInput is an interface for input plugins that are able to parse
+// ParserFuncPlugin is an interface for plugins that are able to parse
 // arbitrary data formats.
-type ParserFuncInput interface {
+type ParserFuncPlugin interface {
 	// GetParser returns a new parser.
 	SetParserFunc(fn ParserFunc)
 }

--- a/plugins/processors/execd/execd.go
+++ b/plugins/processors/execd/execd.go
@@ -13,7 +13,6 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal/process"
-	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/plugins/processors"
 	"github.com/influxdata/telegraf/plugins/serializers"
@@ -28,8 +27,7 @@ type Execd struct {
 	RestartDelay config.Duration `toml:"restart_delay"`
 	Log          telegraf.Logger
 
-	parserConfig     *parsers.Config
-	parser           parsers.Parser
+	parser           telegraf.Parser
 	serializerConfig *serializers.Config
 	serializer       serializers.Serializer
 	acc              telegraf.Accumulator
@@ -39,13 +37,14 @@ type Execd struct {
 func New() *Execd {
 	return &Execd{
 		RestartDelay: config.Duration(10 * time.Second),
-		parserConfig: &parsers.Config{
-			DataFormat: "influx",
-		},
 		serializerConfig: &serializers.Config{
 			DataFormat: "influx",
 		},
 	}
+}
+
+func (e *Execd) SetParser(p telegraf.Parser) {
+	e.parser = p
 }
 
 func (*Execd) SampleConfig() string {
@@ -54,10 +53,6 @@ func (*Execd) SampleConfig() string {
 
 func (e *Execd) Start(acc telegraf.Accumulator) error {
 	var err error
-	e.parser, err = parsers.NewParser(e.parserConfig)
-	if err != nil {
-		return fmt.Errorf("error creating parser: %w", err)
-	}
 	e.serializer, err = serializers.NewSerializer(e.serializerConfig)
 	if err != nil {
 		return fmt.Errorf("error creating serializer: %w", err)

--- a/plugins/processors/execd/execd_test.go
+++ b/plugins/processors/execd/execd_test.go
@@ -20,6 +20,10 @@ func TestExternalProcessorWorks(t *testing.T) {
 	e := New()
 	e.Log = testutil.Logger{}
 
+	parser := &influx.Parser{}
+	require.NoError(t, parser.Init())
+	e.SetParser(parser)
+
 	exe, err := os.Executable()
 	require.NoError(t, err)
 	t.Log(exe)
@@ -80,6 +84,10 @@ func TestExternalProcessorWorks(t *testing.T) {
 func TestParseLinesWithNewLines(t *testing.T) {
 	e := New()
 	e.Log = testutil.Logger{}
+
+	parser := &influx.Parser{}
+	require.NoError(t, parser.Init())
+	e.SetParser(parser)
 
 	exe, err := os.Executable()
 	require.NoError(t, err)

--- a/plugins/processors/parser/parser.go
+++ b/plugins/processors/parser/parser.go
@@ -5,8 +5,6 @@ import (
 	_ "embed"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/models"
-	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/processors"
 )
 
@@ -14,7 +12,6 @@ import (
 var sampleConfig string
 
 type Parser struct {
-	parsers.Config
 	DropOriginal bool            `toml:"drop_original"`
 	Merge        string          `toml:"merge"`
 	ParseFields  []string        `toml:"parse_fields"`
@@ -27,17 +24,11 @@ func (*Parser) SampleConfig() string {
 	return sampleConfig
 }
 
-func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
-	if p.parser == nil {
-		var err error
-		p.parser, err = parsers.NewParser(&p.Config)
-		if err != nil {
-			p.Log.Errorf("could not create parser: %v", err)
-			return metrics
-		}
-		models.SetLoggerOnPlugin(p.parser, p.Log)
-	}
+func (p *Parser) SetParser(parser telegraf.Parser) {
+	p.parser = parser
+}
 
+func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 	results := []telegraf.Metric{}
 
 	for _, metric := range metrics {


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR converts the processors `execd` and `parser` to derive their parsers from the config instead of fiddling with `data_format` directly. To do so, the PR creates the necessary infrastructure in `config` and the adds the `SetParser` functions to the two plugins mentioned.

This is in preparation of deprecating the old parser initialization style completely.