### PR TITLE
chore: Markdown fixes for inputs/[a-m]*

### DIFF
--- a/plugins/inputs/aliyuncms/README.md
+++ b/plugins/inputs/aliyuncms/README.md
@@ -1,18 +1,20 @@
 # Alibaba (Aliyun) CloudMonitor Service Statistics Input Plugin
 
-Here and after we use `Aliyun` instead `Alibaba` as it is default naming across
-web console and docs.
+Here and after we use `Aliyun` instead `Alibaba` as it is default naming
+across web console and docs.
 
-This plugin will pull Metric Statistics from Aliyun CMS.
+This plugin will pull metric statistics from Aliyun CMS.
 
 ## Aliyun Authentication
 
-This plugin uses an [AccessKey][1] credential for Authentication with the Aliyun
-OpenAPI endpoint.  In the following order the plugin will attempt to
-authenticate.
+This plugin uses an [AccessKey][1] credential for Authentication with the
+Aliyun OpenAPI endpoint.  In the following order the plugin will attempt
+to authenticate.
 
-1. Ram RoleARN credential if `access_key_id`, `access_key_secret`, `role_arn`, `role_session_name` is specified
-2. AccessKey STS token credential if `access_key_id`, `access_key_secret`, `access_key_sts_token` is specified
+1. Ram RoleARN credential if `access_key_id`, `access_key_secret`, `role_arn`,
+   `role_session_name` is specified
+2. AccessKey STS token credential if `access_key_id`, `access_key_secret`,
+   `access_key_sts_token` is specified
 3. AccessKey credential if `access_key_id`, `access_key_secret` is specified
 4. Ecs Ram Role Credential if `role_name` is specified
 5. RSA keypair credential if `private_key`, `public_key_id` is specified
@@ -45,18 +47,21 @@ authenticate.
   # public_key_id = ""
   # role_name = ""
 
-  ## Specify the ali cloud region list to be queried for metrics and objects discovery
-  ## If not set, all supported regions (see below) would be covered, it can provide a significant load on API, so the recommendation here
-  ## is to limit the list as much as possible. Allowed values: https://www.alibabacloud.com/help/zh/doc-detail/40654.htm
+  ## Specify ali cloud regions to be queried for metric and object discovery
+  ## If not set, all supported regions (see below) would be covered, it can
+  ## provide a significant load on API, so the recommendation here is to
+  ## limit the list as much as possible.
+  ## Allowed values: https://www.alibabacloud.com/help/zh/doc-detail/40654.htm
   ## Default supported regions are:
-  ## 21 items: cn-qingdao,cn-beijing,cn-zhangjiakou,cn-huhehaote,cn-hangzhou,cn-shanghai,cn-shenzhen,
-  ##           cn-heyuan,cn-chengdu,cn-hongkong,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-5,
-  ##           ap-south-1,ap-northeast-1,us-west-1,us-east-1,eu-central-1,eu-west-1,me-east-1
+  ##   cn-qingdao,cn-beijing,cn-zhangjiakou,cn-huhehaote,cn-hangzhou,
+  ##   cn-shanghai, cn-shenzhen, cn-heyuan,cn-chengdu,cn-hongkong,
+  ##   ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-5,
+  ##   ap-south-1,ap-northeast-1, us-west-1,us-east-1,eu-central-1,
+  ##   eu-west-1,me-east-1
   ##
-  ## From discovery perspective it set the scope for object discovery, the discovered info can be used to enrich
-  ## the metrics with objects attributes/tags. Discovery is supported not for all projects (if not supported, then
-  ## it will be reported on the start - for example for 'acs_cdn' project:
-  ## 'E! [inputs.aliyuncms] Discovery tool is not activated: no discovery support for project "acs_cdn"' )
+  ## From discovery perspective it set the scope for object discovery,
+  ## the discovered info can be used to enrich the metrics with objects
+  ##  attributes/tags. Discovery is not supported for all projects.
   ## Currently, discovery supported for the following projects:
   ## - acs_ecs_dashboard
   ## - acs_rds_dashboard
@@ -64,22 +69,23 @@ authenticate.
   ## - acs_vpc_eip
   regions = ["cn-hongkong"]
 
-  # The minimum period for AliyunCMS metrics is 1 minute (60s). However not all
-  # metrics are made available to the 1 minute period. Some are collected at
-  # 3 minute, 5 minute, or larger intervals.
-  # See: https://help.aliyun.com/document_detail/51936.html?spm=a2c4g.11186623.2.18.2bc1750eeOw1Pv
-  # Note that if a period is configured that is smaller than the minimum for a
-  # particular metric, that metric will not be returned by the Aliyun OpenAPI
-  # and will not be collected by Telegraf.
-  #
-  ## Requested AliyunCMS aggregation Period (required - must be a multiple of 60s)
+  ## Requested AliyunCMS aggregation Period (required)
+  ## The period must be multiples of 60s and the minimum for AliyunCMS metrics
+  ## is 1 minute (60s). However not all metrics are made available to the
+  ## one minute period. Some are collected at 3 minute, 5 minute, or larger
+  ## intervals.
+  ## See: https://help.aliyun.com/document_detail/51936.html?spm=a2c4g.11186623.2.18.2bc1750eeOw1Pv
+  ## Note that if a period is configured that is smaller than the minimum for
+  ## a particular metric, that metric will not be returned by Aliyun's
+  ## OpenAPI and will not be collected by Telegraf.
   period = "5m"
 
-  ## Collection Delay (required - must account for metrics availability via AliyunCMS API)
+  ## Collection Delay (required)
+  ## The delay must account for metrics availability via AliyunCMS API.
   delay = "1m"
 
-  ## Recommended: use metric 'interval' that is a multiple of 'period' to avoid
-  ## gaps or overlap in pulled data
+  ## Recommended: use metric 'interval' that is a multiple of 'period'
+  ## to avoid gaps or overlap in pulled data
   interval = "5m"
 
   ## Metric Statistic Project (required)
@@ -94,15 +100,19 @@ authenticate.
   ## Metrics to Pull (Required)
   [[inputs.aliyuncms.metrics]]
   ## Metrics names to be requested,
-  ## described here (per project): https://help.aliyun.com/document_detail/28619.html?spm=a2c4g.11186623.6.690.1938ad41wg8QSq
+  ## Description can be found here (per project):
+  ## https://help.aliyun.com/document_detail/28619.html?spm=a2c4g.11186623.6.690.1938ad41wg8QSq
   names = ["InstanceActiveConnection", "InstanceNewConnection"]
 
-  ## Dimension filters for Metric (these are optional).
-  ## This allows to get additional metric dimension. If dimension is not specified it can be returned or
-  ## the data can be aggregated - it depends on particular metric, you can find details here: https://help.aliyun.com/document_detail/28619.html?spm=a2c4g.11186623.6.690.1938ad41wg8QSq
+  ## Dimension filters for Metric (optional).
+  ## This allows to get additional metric dimension. If dimension is not
+  ## specified it can be returned or the data can be aggregated - it depends
+  ## on particular metric, you can find details here:
+  ## https://help.aliyun.com/document_detail/28619.html?spm=a2c4g.11186623.6.690.1938ad41wg8QSq
   ##
-  ## Note, that by default dimension filter includes the list of discovered objects in scope (if discovery is enabled)
-  ## Values specified here would be added into the list of discovered objects.
+  ## Note, that by default dimension filter includes the list of discovered
+  ## objects in scope (if discovery is enabled).
+  # Values specified here would be added into the list of discovered objects.
   ## You can specify either single dimension:
   #dimensions = '{"instanceId": "p-example"}'
 
@@ -111,26 +121,30 @@ authenticate.
 
   ## Enrichment tags, can be added from discovery (if supported)
   ## Notation is <measurement_tag_name>:<JMES query path (https://jmespath.org/tutorial.html)>
-  ## To figure out which fields are available, consult the Describe<ObjectType> API per project.
+  ## To figure out which fields are available, consult the Describe<ObjectType>
+  ## API per project.
   ## For example, for SLB: https://api.aliyun.com/#/?product=Slb&version=2014-05-15&api=DescribeLoadBalancers&params={}&tab=MOCK&lang=GO
   #tag_query_path = [
   #    "address:Address",
   #    "name:LoadBalancerName",
   #    "cluster_owner:Tags.Tag[?TagKey=='cs.cluster.name'].TagValue | [0]"
   #    ]
-  ## The following tags added by default: regionId (if discovery enabled), userId, instanceId.
+  ## The following tags added by default:
+  ##   regionId (if discovery enabled), userId, instanceId.
 
-  ## Allow metrics without discovery data, if discovery is enabled. If set to true, then metric without discovery
-  ## data would be emitted, otherwise dropped. This cane be of help, in case debugging dimension filters, or partial coverage
-  ## of discovery scope vs monitoring scope
-  #allow_dps_without_discovery = false
+  ## Allow metrics without discovery data, if discovery is enabled.
+  ## If set to true, then metric without discovery data would be emitted, otherwise dropped.
+  ## This cane be of help, in case debugging dimension filters, or partial coverage of
+  ## discovery scope vs monitoring scope 
+  # allow_dps_without_discovery = false
 ```
 
 ### Requirements and Terminology
 
 Plugin Configuration utilizes [preset metric items references][2]
 
-- `discovery_region` must be a valid Aliyun [Region](https://www.alibabacloud.com/help/doc-detail/40654.htm) value
+- `discovery_region` must be a valid Aliyun
+  [Region](https://www.alibabacloud.com/help/doc-detail/40654.htm) value
 - `period` must be a valid duration value
 - `project` must be a preset project value
 - `names` must be preset metric names

--- a/plugins/inputs/aliyuncms/sample.conf
+++ b/plugins/inputs/aliyuncms/sample.conf
@@ -19,18 +19,21 @@
   # public_key_id = ""
   # role_name = ""
 
-  ## Specify the ali cloud region list to be queried for metrics and objects discovery
-  ## If not set, all supported regions (see below) would be covered, it can provide a significant load on API, so the recommendation here
-  ## is to limit the list as much as possible. Allowed values: https://www.alibabacloud.com/help/zh/doc-detail/40654.htm
+  ## Specify ali cloud regions to be queried for metric and object discovery
+  ## If not set, all supported regions (see below) would be covered, it can
+  ## provide a significant load on API, so the recommendation here is to
+  ## limit the list as much as possible.
+  ## Allowed values: https://www.alibabacloud.com/help/zh/doc-detail/40654.htm
   ## Default supported regions are:
-  ## 21 items: cn-qingdao,cn-beijing,cn-zhangjiakou,cn-huhehaote,cn-hangzhou,cn-shanghai,cn-shenzhen,
-  ##           cn-heyuan,cn-chengdu,cn-hongkong,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-5,
-  ##           ap-south-1,ap-northeast-1,us-west-1,us-east-1,eu-central-1,eu-west-1,me-east-1
+  ##   cn-qingdao,cn-beijing,cn-zhangjiakou,cn-huhehaote,cn-hangzhou,
+  ##   cn-shanghai, cn-shenzhen, cn-heyuan,cn-chengdu,cn-hongkong,
+  ##   ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-5,
+  ##   ap-south-1,ap-northeast-1, us-west-1,us-east-1,eu-central-1,
+  ##   eu-west-1,me-east-1
   ##
-  ## From discovery perspective it set the scope for object discovery, the discovered info can be used to enrich
-  ## the metrics with objects attributes/tags. Discovery is supported not for all projects (if not supported, then
-  ## it will be reported on the start - for example for 'acs_cdn' project:
-  ## 'E! [inputs.aliyuncms] Discovery tool is not activated: no discovery support for project "acs_cdn"' )
+  ## From discovery perspective it set the scope for object discovery,
+  ## the discovered info can be used to enrich the metrics with objects
+  ##  attributes/tags. Discovery is not supported for all projects.
   ## Currently, discovery supported for the following projects:
   ## - acs_ecs_dashboard
   ## - acs_rds_dashboard
@@ -38,22 +41,23 @@
   ## - acs_vpc_eip
   regions = ["cn-hongkong"]
 
-  # The minimum period for AliyunCMS metrics is 1 minute (60s). However not all
-  # metrics are made available to the 1 minute period. Some are collected at
-  # 3 minute, 5 minute, or larger intervals.
-  # See: https://help.aliyun.com/document_detail/51936.html?spm=a2c4g.11186623.2.18.2bc1750eeOw1Pv
-  # Note that if a period is configured that is smaller than the minimum for a
-  # particular metric, that metric will not be returned by the Aliyun OpenAPI
-  # and will not be collected by Telegraf.
-  #
-  ## Requested AliyunCMS aggregation Period (required - must be a multiple of 60s)
+  ## Requested AliyunCMS aggregation Period (required)
+  ## The period must be multiples of 60s and the minimum for AliyunCMS metrics
+  ## is 1 minute (60s). However not all metrics are made available to the
+  ## one minute period. Some are collected at 3 minute, 5 minute, or larger
+  ## intervals.
+  ## See: https://help.aliyun.com/document_detail/51936.html?spm=a2c4g.11186623.2.18.2bc1750eeOw1Pv
+  ## Note that if a period is configured that is smaller than the minimum for
+  ## a particular metric, that metric will not be returned by Aliyun's
+  ## OpenAPI and will not be collected by Telegraf.
   period = "5m"
 
-  ## Collection Delay (required - must account for metrics availability via AliyunCMS API)
+  ## Collection Delay (required)
+  ## The delay must account for metrics availability via AliyunCMS API.
   delay = "1m"
 
-  ## Recommended: use metric 'interval' that is a multiple of 'period' to avoid
-  ## gaps or overlap in pulled data
+  ## Recommended: use metric 'interval' that is a multiple of 'period'
+  ## to avoid gaps or overlap in pulled data
   interval = "5m"
 
   ## Metric Statistic Project (required)
@@ -68,15 +72,19 @@
   ## Metrics to Pull (Required)
   [[inputs.aliyuncms.metrics]]
   ## Metrics names to be requested,
-  ## described here (per project): https://help.aliyun.com/document_detail/28619.html?spm=a2c4g.11186623.6.690.1938ad41wg8QSq
+  ## Description can be found here (per project):
+  ## https://help.aliyun.com/document_detail/28619.html?spm=a2c4g.11186623.6.690.1938ad41wg8QSq
   names = ["InstanceActiveConnection", "InstanceNewConnection"]
 
-  ## Dimension filters for Metric (these are optional).
-  ## This allows to get additional metric dimension. If dimension is not specified it can be returned or
-  ## the data can be aggregated - it depends on particular metric, you can find details here: https://help.aliyun.com/document_detail/28619.html?spm=a2c4g.11186623.6.690.1938ad41wg8QSq
+  ## Dimension filters for Metric (optional).
+  ## This allows to get additional metric dimension. If dimension is not
+  ## specified it can be returned or the data can be aggregated - it depends
+  ## on particular metric, you can find details here:
+  ## https://help.aliyun.com/document_detail/28619.html?spm=a2c4g.11186623.6.690.1938ad41wg8QSq
   ##
-  ## Note, that by default dimension filter includes the list of discovered objects in scope (if discovery is enabled)
-  ## Values specified here would be added into the list of discovered objects.
+  ## Note, that by default dimension filter includes the list of discovered
+  ## objects in scope (if discovery is enabled).
+  # Values specified here would be added into the list of discovered objects.
   ## You can specify either single dimension:
   #dimensions = '{"instanceId": "p-example"}'
 
@@ -85,16 +93,19 @@
 
   ## Enrichment tags, can be added from discovery (if supported)
   ## Notation is <measurement_tag_name>:<JMES query path (https://jmespath.org/tutorial.html)>
-  ## To figure out which fields are available, consult the Describe<ObjectType> API per project.
+  ## To figure out which fields are available, consult the Describe<ObjectType>
+  ## API per project.
   ## For example, for SLB: https://api.aliyun.com/#/?product=Slb&version=2014-05-15&api=DescribeLoadBalancers&params={}&tab=MOCK&lang=GO
   #tag_query_path = [
   #    "address:Address",
   #    "name:LoadBalancerName",
   #    "cluster_owner:Tags.Tag[?TagKey=='cs.cluster.name'].TagValue | [0]"
   #    ]
-  ## The following tags added by default: regionId (if discovery enabled), userId, instanceId.
+  ## The following tags added by default:
+  ##   regionId (if discovery enabled), userId, instanceId.
 
-  ## Allow metrics without discovery data, if discovery is enabled. If set to true, then metric without discovery
-  ## data would be emitted, otherwise dropped. This cane be of help, in case debugging dimension filters, or partial coverage
-  ## of discovery scope vs monitoring scope
-  #allow_dps_without_discovery = false
+  ## Allow metrics without discovery data, if discovery is enabled.
+  ## If set to true, then metric without discovery data would be emitted, otherwise dropped.
+  ## This cane be of help, in case debugging dimension filters, or partial coverage of
+  ## discovery scope vs monitoring scope 
+  # allow_dps_without_discovery = false

--- a/plugins/inputs/azure_storage_queue/README.md
+++ b/plugins/inputs/azure_storage_queue/README.md
@@ -25,8 +25,9 @@ This plugin gathers sizes of Azure Storage Queues.
     - account
   - fields:
     - size (integer, count)
-    - oldest_message_age_ns (integer, nanoseconds) Age of message at the head of the queue.
-      Requires `peek_oldest_message_age` to be configured to `true`.
+    - oldest_message_age_ns (integer, nanoseconds) Age of message at the head
+      of the queue. Requires `peek_oldest_message_age` to be configured
+      to `true`.
 
 ## Example Output
 

--- a/plugins/inputs/bind/README.md
+++ b/plugins/inputs/bind/README.md
@@ -30,14 +30,15 @@ distros still do not enable support for JSON statistics in their BIND packages.
   # timeout = "4s"
 ```
 
-- **urls** []string: List of BIND statistics channel URLs to collect from. Do not include a
-  trailing slash in the URL. Default is "http://localhost:8053/xml/v3".
+- **urls** []string: List of BIND statistics channel URLs to collect from.
+  Do not include a trailing slash in the URL.
+  Default is "http://localhost:8053/xml/v3".
 - **gather_memory_contexts** bool: Report per-context memory statistics.
 - **gather_views** bool: Report per-view query statistics.
-- **timeout** Timeout for http requests made by bind nameserver (example: "4s").
+- **timeout** Timeout for http requests made by bind (example: "4s").
 
-The following table summarizes the URL formats which should be used, depending
-on your BIND version and configured statistics channel.
+The following table summarizes the URL formats which should be used,
+depending on your BIND version and configured statistics channel.
 
 | BIND Version | Statistics Format | Example URL                   |
 | ------------ | ----------------- | ----------------------------- |
@@ -48,8 +49,8 @@ on your BIND version and configured statistics channel.
 
 ### Configuration of BIND Daemon
 
-Add the following to your named.conf if running Telegraf on the same host as the
-BIND daemon:
+Add the following to your named.conf if running Telegraf on the same host
+as the BIND daemon:
 
 ```json
 statistics-channels {
@@ -57,10 +58,11 @@ statistics-channels {
 };
 ```
 
-Alternatively, specify a wildcard address (e.g., 0.0.0.0) or specific IP address
-of an interface to configure the BIND daemon to listen on that address. Note
-that you should secure the statistics channel with an ACL if it is publicly
-reachable. Consult the BIND Administrator Reference Manual for more information.
+Alternatively, specify a wildcard address (e.g., 0.0.0.0) or specific
+IP address of an interface to configure the BIND daemon to listen on that
+address. Note that you should secure the statistics channel with an ACL if
+it is publicly reachable. Consult the BIND Administrator Reference Manual
+for more information.
 
 ## Metrics
 

--- a/plugins/inputs/ceph/README.md
+++ b/plugins/inputs/ceph/README.md
@@ -3,20 +3,28 @@
 Collects performance metrics from the MON and OSD nodes in a Ceph storage
 cluster.
 
-Ceph has introduced a Telegraf and Influx plugin in the 13.x Mimic release. The
-Telegraf module sends to a Telegraf configured with a socket_listener. [Learn
-more in their docs](https://docs.ceph.com/en/latest/mgr/telegraf/)
+Ceph has introduced a Telegraf and Influx plugin in the 13.x Mimic release.
+The Telegraf module sends to a Telegraf configured with a socket_listener.
+[Learn more in their docs](https://docs.ceph.com/en/latest/mgr/telegraf/)
 
 ## Admin Socket Stats
 
-This gatherer works by scanning the configured SocketDir for OSD, MON, MDS and
-RGW socket files.  When it finds a MON socket, it runs **ceph --admin-daemon
-$file perfcounters_dump**. For OSDs it runs **ceph --admin-daemon $file perf
-dump**
+This gatherer works by scanning the configured SocketDir for OSD, MON, MDS
+and RGW socket files.  When it finds a MON socket, it runs
 
-The resulting JSON is parsed and grouped into collections, based on top-level
-key.  Top-level keys are used as collection tags, and all sub-keys are
-flattened. For example:
+```shell
+ceph --admin-daemon $file perfcounters_dump
+```
+
+For OSDs it runs
+
+```shell
+ceph --admin-daemon $file perf dump
+```
+
+The resulting JSON is parsed and grouped into collections, based on
+top-level key. Top-level keys are used as collection tags, and all
+sub-keys are flattened. For example:
 
 ```json
  {
@@ -30,8 +38,8 @@ flattened. For example:
  }
 ```
 
-Would be parsed into the following metrics, all of which would be tagged with
-collection=paxos:
+Would be parsed into the following metrics, all of which would be tagged
+with `collection=paxos`:
 
 - refresh = 9363435
 - refresh_latency.avgcount: 9363435
@@ -40,10 +48,10 @@ collection=paxos:
 ## Cluster Stats
 
 This gatherer works by invoking ceph commands against the cluster thus only
-requires the ceph client, valid ceph configuration and an access key to function
-(the ceph_config and ceph_user configuration variables work in conjunction to
-specify these prerequisites). It may be run on any server you wish which has
-access to the cluster.  The currently supported commands are:
+requires the ceph client, valid ceph configuration and an access key to
+function (the ceph_config and ceph_user configuration variables work in
+conjunction to specify these prerequisites). It may be run on any server you
+wish which has access to the cluster.  The currently supported commands are:
 
 - ceph status
 - ceph df
@@ -52,10 +60,11 @@ access to the cluster.  The currently supported commands are:
 ## Configuration
 
 ```toml @sample.conf
-# Collects performance metrics from the MON, OSD, MDS and RGW nodes in a Ceph storage cluster.
+# Collects performance metrics from the MON, OSD, MDS and RGW nodes
+# in a Ceph storage cluster.
 [[inputs.ceph]]
-  ## This is the recommended interval to poll.  Too frequent and you will lose
-  ## data points due to timeouts during rebalancing and recovery
+  ## This is the recommended interval to poll. Too frequent and you
+  ## will lose data points due to timeouts during rebalancing and recovery
   interval = '1m'
 
   ## All configuration values are optional, defaults are shown below
@@ -75,9 +84,9 @@ access to the cluster.  The currently supported commands are:
   ## suffix used to identify socket files
   socket_suffix = "asok"
 
-  ## Ceph user to authenticate as, ceph will search for the corresponding keyring
-  ## e.g. client.admin.keyring in /etc/ceph, or the explicit path defined in the
-  ## client section of ceph.conf for example:
+  ## Ceph user to authenticate as, ceph will search for the corresponding
+  ## keyring e.g. client.admin.keyring in /etc/ceph, or the explicit path
+  ## defined in the client section of ceph.conf for example:
   ##
   ##     [client.telegraf]
   ##         keyring = /etc/ceph/client.telegraf.keyring
@@ -91,8 +100,8 @@ access to the cluster.  The currently supported commands are:
   ## Whether to gather statistics via the admin socket
   gather_admin_socket_stats = true
 
-  ## Whether to gather statistics via ceph commands, requires ceph_user and ceph_config
-  ## to be specified
+  ## Whether to gather statistics via ceph commands, requires ceph_user
+  ## and ceph_config to be specified
   gather_cluster_stats = false
 ```
 
@@ -105,9 +114,10 @@ float64s. For a full list of fields, see the sample perf dumps in ceph_test.go.
 
 All admin measurements will have the following tags:
 
-- type: either 'osd', 'mon', 'mds' or 'rgw' to indicate which type of node was queried
+- type: either 'osd', 'mon', 'mds' or 'rgw' to indicate the queried node type
 - id: a unique string identifier, parsed from the socket file name for the node
-- collection: the top-level key under which these fields were reported. Possible values are:
+- collection: the top-level key under which these fields were reported.
+  Possible values are:
   - for MON nodes:
     - cluster
     - leveldb

--- a/plugins/inputs/ceph/sample.conf
+++ b/plugins/inputs/ceph/sample.conf
@@ -1,7 +1,8 @@
-# Collects performance metrics from the MON, OSD, MDS and RGW nodes in a Ceph storage cluster.
+# Collects performance metrics from the MON, OSD, MDS and RGW nodes
+# in a Ceph storage cluster.
 [[inputs.ceph]]
-  ## This is the recommended interval to poll.  Too frequent and you will lose
-  ## data points due to timeouts during rebalancing and recovery
+  ## This is the recommended interval to poll. Too frequent and you
+  ## will lose data points due to timeouts during rebalancing and recovery
   interval = '1m'
 
   ## All configuration values are optional, defaults are shown below
@@ -21,9 +22,9 @@
   ## suffix used to identify socket files
   socket_suffix = "asok"
 
-  ## Ceph user to authenticate as, ceph will search for the corresponding keyring
-  ## e.g. client.admin.keyring in /etc/ceph, or the explicit path defined in the
-  ## client section of ceph.conf for example:
+  ## Ceph user to authenticate as, ceph will search for the corresponding
+  ## keyring e.g. client.admin.keyring in /etc/ceph, or the explicit path
+  ## defined in the client section of ceph.conf for example:
   ##
   ##     [client.telegraf]
   ##         keyring = /etc/ceph/client.telegraf.keyring
@@ -37,6 +38,6 @@
   ## Whether to gather statistics via the admin socket
   gather_admin_socket_stats = true
 
-  ## Whether to gather statistics via ceph commands, requires ceph_user and ceph_config
-  ## to be specified
+  ## Whether to gather statistics via ceph commands, requires ceph_user
+  ## and ceph_config to be specified
   gather_cluster_stats = false

--- a/plugins/inputs/clickhouse/README.md
+++ b/plugins/inputs/clickhouse/README.md
@@ -9,11 +9,10 @@ This plugin gathers the statistic data from
 # Read metrics from one or many ClickHouse servers
 [[inputs.clickhouse]]
   ## Username for authorization on ClickHouse server
-  ## example: username = "default"
   username = "default"
 
   ## Password for authorization on ClickHouse server
-  # password = "super_secret"
+  # password = ""
 
   ## HTTP(s) timeout while getting metrics values
   ## The timeout includes connection time, any redirects, and reading the

--- a/plugins/inputs/clickhouse/README.md
+++ b/plugins/inputs/clickhouse/README.md
@@ -13,34 +13,32 @@ This plugin gathers the statistic data from
   username = "default"
 
   ## Password for authorization on ClickHouse server
-  ## example: password = "super_secret"
+  # password = "super_secret"
 
   ## HTTP(s) timeout while getting metrics values
-  ## The timeout includes connection time, any redirects, and reading the response body.
-  ##   example: timeout = 1s
+  ## The timeout includes connection time, any redirects, and reading the
+  ## response body.
   # timeout = 5s
 
   ## List of servers for metrics scraping
   ## metrics scrape via HTTP(s) clickhouse interface
   ## https://clickhouse.tech/docs/en/interfaces/http/
-  ##    example: servers = ["http://127.0.0.1:8123","https://custom-server.mdb.yandexcloud.net"]
-  servers         = ["http://127.0.0.1:8123"]
+  servers = ["http://127.0.0.1:8123"]
 
-  ## If "auto_discovery"" is "true" plugin tries to connect to all servers available in the cluster
-  ## with using same "user:password" described in "user" and "password" parameters
-  ## and get this server hostname list from "system.clusters" table
-  ## see
+  ## If "auto_discovery"" is "true" plugin tries to connect to all servers
+  ## available in the cluster with using same "user:password" described in
+  ## "user" and "password" parameters and get this server hostname list from
+  ## "system.clusters" table. See
   ## - https://clickhouse.tech/docs/en/operations/system_tables/#system-clusters
   ## - https://clickhouse.tech/docs/en/operations/server_settings/settings/#server_settings_remote_servers
   ## - https://clickhouse.tech/docs/en/operations/table_engines/distributed/
   ## - https://clickhouse.tech/docs/en/operations/table_engines/replication/#creating-replicated-tables
-  ##    example: auto_discovery = false
   # auto_discovery = true
 
   ## Filter cluster names in "system.clusters" when "auto_discovery" is "true"
   ## when this filter present then "WHERE cluster IN (...)" filter will apply
-  ## please use only full cluster names here, regexp and glob filters is not allowed
-  ## for "/etc/clickhouse-server/config.d/remote.xml"
+  ## please use only full cluster names here, regexp and glob filters is not
+  ## allowed for "/etc/clickhouse-server/config.d/remote.xml"
   ## <yandex>
   ##  <remote_servers>
   ##    <my-own-cluster>
@@ -60,8 +58,9 @@ This plugin gathers the statistic data from
   ## example: cluster_include = ["my-own-cluster"]
   # cluster_include = []
 
-  ## Filter cluster names in "system.clusters" when "auto_discovery" is "true"
-  ## when this filter present then "WHERE cluster NOT IN (...)" filter will apply
+  ## Filter cluster names in "system.clusters" when "auto_discovery" is
+  ## "true" when this filter present then "WHERE cluster NOT IN (...)"
+  ## filter will apply
   ##    example: cluster_exclude = ["my-internal-not-discovered-cluster"]
   # cluster_exclude = []
 
@@ -75,7 +74,7 @@ This plugin gathers the statistic data from
 
 ## Metrics
 
-- clickhouse_events
+- clickhouse_events (see [system.events][] for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
@@ -83,7 +82,7 @@ This plugin gathers the statistic data from
   - fields:
     - all rows from [system.events][]
 
-- clickhouse_metrics
+- clickhouse_metrics (see [system.metrics][] for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
@@ -91,7 +90,8 @@ This plugin gathers the statistic data from
   - fields:
     - all rows from [system.metrics][]
 
-- clickhouse_asynchronous_metrics
+- clickhouse_asynchronous_metrics (see [system.asynchronous_metrics][]
+  for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
@@ -111,51 +111,56 @@ This plugin gathers the statistic data from
     - parts
     - rows
 
-- clickhouse_zookeeper
+- clickhouse_zookeeper (see [system.zookeeper][] for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
     - shard_num (Shard number in the cluster [optional])
   - fields:
-    - root_nodes (count of node from [system.zookeeper][] where path=/)
+    - root_nodes (count of node where path=/)
 
-- clickhouse_replication_queue
+- clickhouse_replication_queue (see [system.replication_queue][] for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
     - shard_num (Shard number in the cluster [optional])
   - fields:
-    - too_many_tries_replicas (count of replicas which have  num_tries > 1 in `system.replication_queue`)
+    - too_many_tries_replicas (count of replicas which have `num_tries > 1`)
 
-- clickhouse_detached_parts
+- clickhouse_detached_parts (see [system.detached_parts][] for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
     - shard_num (Shard number in the cluster [optional])
   - fields:
-    - detached_parts (total detached parts for all tables and databases from [system.detached_parts][])
+    - detached_parts (total detached parts for all tables and databases
+      from [system.detached_parts][])
 
-- clickhouse_dictionaries
+- clickhouse_dictionaries (see [system.dictionaries][] for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
     - shard_num (Shard number in the cluster [optional])
-    - dict_origin (xml Filename when dictionary created from *_dictionary.xml, database.table when dictionary created from DDL)
+    - dict_origin (xml Filename when dictionary created from *_dictionary.xml,
+      database.table when dictionary created from DDL)
   - fields:
-    - is_loaded (0 - when dictionary data not successful load, 1 - when dictionary data loading fail, see [system.dictionaries][] for details)
-    - bytes_allocated (how many bytes allocated in RAM after a dictionary loaded)
+    - is_loaded (0 - when dictionary data not successful load, 1 - when
+      dictionary data loading fail
+    - bytes_allocated (bytes allocated in RAM after a dictionary loaded)
 
-- clickhouse_mutations
+- clickhouse_mutations (see [system.mutations][] for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
     - shard_num (Shard number in the cluster [optional])
   - fields:
-    - running - gauge which show how much mutation doesn't complete now, see [system.mutations][] for details
-    - failed - counter which show total failed mutations from first clickhouse-server run
-    - completed - counter which show total successful finished mutations from first clickhouse-server run
+    - running - gauge which show how much mutation doesn't complete now
+    - failed - counter which show total failed mutations from first
+      clickhouse-server run
+    - completed - counter which show total successful finished mutations
+      from first clickhouse-server run
 
-- clickhouse_disks
+- clickhouse_disks (see [system.disks][] for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
@@ -163,25 +168,31 @@ This plugin gathers the statistic data from
     - name (disk name in storage configuration)
     - path (path to disk)
   - fields:
-    - free_space_percent - 0-100, gauge which show current percent of free disk space bytes relative to total disk space bytes
-    - keep_free_space_percent - 0-100, gauge which show current percent of required keep free disk bytes relative to total disk space bytes
+    - free_space_percent - 0-100, gauge which show current percent of
+      free disk space bytes relative to total disk space bytes
+    - keep_free_space_percent - 0-100, gauge which show current percent
+      of required keep free disk bytes relative to total disk space bytes
 
-- clickhouse_processes
+- clickhouse_processes (see [system.processes][] for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
     - shard_num (Shard number in the cluster [optional])
   - fields:
-    - percentile_50 - float gauge which show 50% percentile (quantile 0.5) for `elapsed` field of running processes, see [system.processes][] for details
-    - percentile_90 - float gauge which show 90% percentile (quantile 0.9) for `elapsed` field of running processes, see [system.processes][] for details
-    - longest_running - float gauge which show maximum value for `elapsed` field of running processes, see [system.processes][] for details
+    - percentile_50 - float gauge which show 50% percentile (quantile 0.5) for
+      `elapsed` field of running processes
+    - percentile_90 - float gauge which show 90% percentile (quantile 0.9) for
+      `elapsed` field of running processes
+    - longest_running - float gauge which show maximum value for `elapsed`
+      field of running processes
 
-- clickhouse_text_log
+- clickhouse_text_log (see [system.text_log][] for details)
   - tags:
     - source (ClickHouse server hostname)
     - cluster (Name of the cluster [optional])
     - shard_num (Shard number in the cluster [optional])
-    - level (message level, only message with level less or equal Notice is collects), see details on [system.text_log][]
+    - level (message level, only messages with level less or equal Notice are
+      collected)
   - fields:
     - messages_last_10_min - gauge which show how many messages collected
 
@@ -195,13 +206,14 @@ clickhouse_tables,cluster=test_cluster_two_shards_localhost,database=system,host
 clickhouse_tables,cluster=test_cluster_two_shards_localhost,database=default,host=kshvakov,source=localhost,shard_num=1,table=example bytes=326i,parts=2i,rows=2i 1569421000000000000
 ```
 
-[system.events]: https://clickhouse.tech/docs/en/operations/system-tables/events/
-[system.metrics]: https://clickhouse.tech/docs/en/operations/system-tables/metrics/
 [system.asynchronous_metrics]: https://clickhouse.tech/docs/en/operations/system-tables/asynchronous_metrics/
-[system.zookeeper]: https://clickhouse.tech/docs/en/operations/system-tables/zookeeper/
 [system.detached_parts]: https://clickhouse.tech/docs/en/operations/system-tables/detached_parts/
 [system.dictionaries]: https://clickhouse.tech/docs/en/operations/system-tables/dictionaries/
-[system.mutations]: https://clickhouse.tech/docs/en/operations/system-tables/mutations/
 [system.disks]: https://clickhouse.tech/docs/en/operations/system-tables/disks/
+[system.events]: https://clickhouse.tech/docs/en/operations/system-tables/events/
+[system.metrics]: https://clickhouse.tech/docs/en/operations/system-tables/metrics/
+[system.mutations]: https://clickhouse.tech/docs/en/operations/system-tables/mutations/
 [system.processes]: https://clickhouse.tech/docs/en/operations/system-tables/processes/
+[system.replication_queue]:https://clickhouse.com/docs/en/operations/system-tables/replication_queue/
 [system.text_log]: https://clickhouse.tech/docs/en/operations/system-tables/text_log/
+[system.zookeeper]: https://clickhouse.tech/docs/en/operations/system-tables/zookeeper/

--- a/plugins/inputs/clickhouse/sample.conf
+++ b/plugins/inputs/clickhouse/sample.conf
@@ -1,11 +1,10 @@
 # Read metrics from one or many ClickHouse servers
 [[inputs.clickhouse]]
   ## Username for authorization on ClickHouse server
-  ## example: username = "default"
   username = "default"
 
   ## Password for authorization on ClickHouse server
-  # password = "super_secret"
+  # password = ""
 
   ## HTTP(s) timeout while getting metrics values
   ## The timeout includes connection time, any redirects, and reading the

--- a/plugins/inputs/clickhouse/sample.conf
+++ b/plugins/inputs/clickhouse/sample.conf
@@ -5,34 +5,32 @@
   username = "default"
 
   ## Password for authorization on ClickHouse server
-  ## example: password = "super_secret"
+  # password = "super_secret"
 
   ## HTTP(s) timeout while getting metrics values
-  ## The timeout includes connection time, any redirects, and reading the response body.
-  ##   example: timeout = 1s
+  ## The timeout includes connection time, any redirects, and reading the
+  ## response body.
   # timeout = 5s
 
   ## List of servers for metrics scraping
   ## metrics scrape via HTTP(s) clickhouse interface
   ## https://clickhouse.tech/docs/en/interfaces/http/
-  ##    example: servers = ["http://127.0.0.1:8123","https://custom-server.mdb.yandexcloud.net"]
-  servers         = ["http://127.0.0.1:8123"]
+  servers = ["http://127.0.0.1:8123"]
 
-  ## If "auto_discovery"" is "true" plugin tries to connect to all servers available in the cluster
-  ## with using same "user:password" described in "user" and "password" parameters
-  ## and get this server hostname list from "system.clusters" table
-  ## see
+  ## If "auto_discovery"" is "true" plugin tries to connect to all servers
+  ## available in the cluster with using same "user:password" described in
+  ## "user" and "password" parameters and get this server hostname list from
+  ## "system.clusters" table. See
   ## - https://clickhouse.tech/docs/en/operations/system_tables/#system-clusters
   ## - https://clickhouse.tech/docs/en/operations/server_settings/settings/#server_settings_remote_servers
   ## - https://clickhouse.tech/docs/en/operations/table_engines/distributed/
   ## - https://clickhouse.tech/docs/en/operations/table_engines/replication/#creating-replicated-tables
-  ##    example: auto_discovery = false
   # auto_discovery = true
 
   ## Filter cluster names in "system.clusters" when "auto_discovery" is "true"
   ## when this filter present then "WHERE cluster IN (...)" filter will apply
-  ## please use only full cluster names here, regexp and glob filters is not allowed
-  ## for "/etc/clickhouse-server/config.d/remote.xml"
+  ## please use only full cluster names here, regexp and glob filters is not
+  ## allowed for "/etc/clickhouse-server/config.d/remote.xml"
   ## <yandex>
   ##  <remote_servers>
   ##    <my-own-cluster>
@@ -52,8 +50,9 @@
   ## example: cluster_include = ["my-own-cluster"]
   # cluster_include = []
 
-  ## Filter cluster names in "system.clusters" when "auto_discovery" is "true"
-  ## when this filter present then "WHERE cluster NOT IN (...)" filter will apply
+  ## Filter cluster names in "system.clusters" when "auto_discovery" is
+  ## "true" when this filter present then "WHERE cluster NOT IN (...)"
+  ## filter will apply
   ##    example: cluster_exclude = ["my-internal-not-discovered-cluster"]
   # cluster_exclude = []
 

--- a/plugins/inputs/cloud_pubsub_push/README.md
+++ b/plugins/inputs/cloud_pubsub_push/README.md
@@ -1,11 +1,12 @@
 # Google Cloud PubSub Push Input Plugin
 
-The Google Cloud PubSub Push listener is a service input plugin that listens for
-messages sent via an HTTP POST from [Google Cloud PubSub][pubsub].  The plugin
-expects messages in Google's Pub/Sub JSON Format ONLY.  The intent of the plugin
-is to allow Telegraf to serve as an endpoint of the Google Pub/Sub 'Push'
-service.  Google's PubSub service will **only** send over HTTPS/TLS so this
-plugin must be behind a valid proxy or must be configured to use TLS.
+The Google Cloud PubSub Push listener is a service input plugin that listens
+for messages sent via an HTTP POST from [Google Cloud PubSub][pubsub].
+The plugin expects messages in Google's Pub/Sub JSON Format ONLY. The intent
+of the plugin is to allow Telegraf to serve as an endpoint of the
+Google Pub/Sub 'Push' service.  Google's PubSub service will **only** send
+over HTTPS/TLS so this plugin must be behind a valid proxy or must be
+configured to use TLS.
 
 Enable TLS by specifying the file names of a service TLS certificate and key.
 
@@ -29,16 +30,17 @@ in `tls_allowed_cacerts`.
 
   ## Maximum duration before timing out read of the request
   # read_timeout = "10s"
-  ## Maximum duration before timing out write of the response. This should be set to a value
-  ## large enough that you can send at least 'metric_batch_size' number of messages within the
-  ## duration.
+  ## Maximum duration before timing out write of the response. This should be
+  ## set to a value large enough that you can send at least 'metric_batch_size'
+  ## number of messages within the duration.
   # write_timeout = "10s"
 
   ## Maximum allowed http request body size in bytes.
   ## 0 means to use the default of 524,288,00 bytes (500 mebibytes)
   # max_body_size = "500MB"
 
-  ## Whether to add the pubsub metadata, such as message attributes and subscription as a tag.
+  ## Whether to add the pubsub metadata, such as message attributes and
+  ## subscription as a tag.
   # add_meta = false
 
   ## Optional. Maximum messages to read from PubSub that have not been written
@@ -71,4 +73,3 @@ This plugin assumes you have already created a PUSH subscription for a given
 PubSub topic.
 
 [pubsub]: https://cloud.google.com/pubsub
-[input data formats]: /docs/DATA_FORMATS_INPUT.md

--- a/plugins/inputs/cloud_pubsub_push/sample.conf
+++ b/plugins/inputs/cloud_pubsub_push/sample.conf
@@ -11,16 +11,17 @@
 
   ## Maximum duration before timing out read of the request
   # read_timeout = "10s"
-  ## Maximum duration before timing out write of the response. This should be set to a value
-  ## large enough that you can send at least 'metric_batch_size' number of messages within the
-  ## duration.
+  ## Maximum duration before timing out write of the response. This should be
+  ## set to a value large enough that you can send at least 'metric_batch_size'
+  ## number of messages within the duration.
   # write_timeout = "10s"
 
   ## Maximum allowed http request body size in bytes.
   ## 0 means to use the default of 524,288,00 bytes (500 mebibytes)
   # max_body_size = "500MB"
 
-  ## Whether to add the pubsub metadata, such as message attributes and subscription as a tag.
+  ## Whether to add the pubsub metadata, such as message attributes and
+  ## subscription as a tag.
   # add_meta = false
 
   ## Optional. Maximum messages to read from PubSub that have not been written

--- a/plugins/inputs/cloudwatch/README.md
+++ b/plugins/inputs/cloudwatch/README.md
@@ -7,12 +7,13 @@ This plugin will pull Metric Statistics from Amazon CloudWatch.
 This plugin uses a credential chain for Authentication with the CloudWatch
 API endpoint. In the following order the plugin will attempt to authenticate.
 
-1. Assumed credentials via STS if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules)
+1. Assumed credentials via STS if `role_arn` attribute is specified
+   (source credentials are evaluated from subsequent rules)
 2. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
 3. Shared profile from `profile` attribute
-4. [Environment Variables](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#environment-variables)
-5. [Shared Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#shared-credentials-file)
-6. [EC2 Instance Profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+4. [Environment Variables][env]
+5. [Shared Credentials][credentials]
+6. [EC2 Instance Profile][iam-roles]
 
 ## Configuration
 
@@ -24,7 +25,8 @@ API endpoint. In the following order the plugin will attempt to authenticate.
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 1) Web identity provider credentials via STS if role_arn and
+  ##    web_identity_token_file are specified
   ## 2) Assumed credentials via STS if role_arn is specified
   ## 3) explicit credentials from 'access_key' and 'secret_key'
   ## 4) shared profile from 'profile'
@@ -50,27 +52,33 @@ API endpoint. In the following order the plugin will attempt to authenticate.
   # use_system_proxy = false
   # http_proxy_url = "http://localhost:8888"
 
-  # The minimum period for Cloudwatch metrics is 1 minute (60s). However not all
-  # metrics are made available to the 1 minute period. Some are collected at
-  # 3 minute, 5 minute, or larger intervals. See https://aws.amazon.com/cloudwatch/faqs/#monitoring.
-  # Note that if a period is configured that is smaller than the minimum for a
-  # particular metric, that metric will not be returned by the Cloudwatch API
-  # and will not be collected by Telegraf.
+  ## The minimum period for Cloudwatch metrics is 1 minute (60s). However not
+  ## all metrics are made available to the 1 minute period. Some are collected
+  ## at 3 minute, 5 minute, or larger intervals.
+  ## See https://aws.amazon.com/cloudwatch/faqs/#monitoring.
+  ## Note that if a period is configured that is smaller than the minimum for a
+  ## particular metric, that metric will not be returned by the Cloudwatch API
+  ## and will not be collected by Telegraf.
   #
-  ## Requested CloudWatch aggregation Period (required - must be a multiple of 60s)
+  ## Requested CloudWatch aggregation Period (required)
+  ## Must be a multiple of 60s.
   period = "5m"
 
-  ## Collection Delay (required - must account for metrics availability via CloudWatch API)
+  ## Collection Delay (required)
+  ## Must account for metrics availability via CloudWatch API
   delay = "5m"
 
   ## Recommended: use metric 'interval' that is a multiple of 'period' to avoid
   ## gaps or overlap in pulled data
   interval = "5m"
 
-  ## Recommended if "delay" and "period" are both within 3 hours of request time. Invalid values will be ignored.
-  ## Recently Active feature will only poll for CloudWatch ListMetrics values that occurred within the last 3 Hours.
-  ## If enabled, it will reduce total API usage of the CloudWatch ListMetrics API and require less memory to retain.
-  ## Do not enable if "period" or "delay" is longer than 3 hours, as it will not return data more than 3 hours old.
+  ## Recommended if "delay" and "period" are both within 3 hours of request
+  ## time. Invalid values will be ignored. Recently Active feature will only
+  ## poll for CloudWatch ListMetrics values that occurred within the last 3h.
+  ## If enabled, it will reduce total API usage of the CloudWatch ListMetrics
+  ## API and require less memory to retain.
+  ## Do not enable if "period" or "delay" is longer than 3 hours, as it will
+  ## not return data more than 3 hours old.
   ## See https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html
   #recently_active = "PT3H"
 
@@ -79,12 +87,12 @@ API endpoint. In the following order the plugin will attempt to authenticate.
 
   ## Metric Statistic Namespaces (required)
   namespaces = ["AWS/ELB"]
-  # A single metric statistic namespace that will be appended to namespaces on startup
+  ## Single metric statistic namespace appended to namespaces on startup
   # namespace = "AWS/ELB"
 
-  ## Maximum requests per second. Note that the global default AWS rate limit is
-  ## 50 reqs/sec, so if you define multiple namespaces, these should add up to a
-  ## maximum of 50.
+  ## Maximum requests per second. Note that the global default AWS rate limit
+  ## is 50 reqs/sec, so if you define multiple namespaces, these should add up
+  ## to a maximum of 50.
   ## See http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
   # ratelimit = 25
 
@@ -99,7 +107,7 @@ API endpoint. In the following order the plugin will attempt to authenticate.
 
   ## Namespace-wide statistic filters. These allow fewer queries to be made to
   ## cloudwatch.
-  # statistic_include = [ "average", "sum", "minimum", "maximum", sample_count" ]
+  # statistic_include = ["average", "sum", "minimum", "maximum", sample_count"]
   # statistic_exclude = []
 
   ## Metrics to Pull
@@ -110,11 +118,12 @@ API endpoint. In the following order the plugin will attempt to authenticate.
   #
   #  ## Statistic filters for Metric.  These allow for retrieving specific
   #  ## statistics for an individual metric.
-  #  # statistic_include = [ "average", "sum", "minimum", "maximum", sample_count" ]
+  #  # statistic_include = ["average", "sum", "minimum", "maximum", sample_count"]
   #  # statistic_exclude = []
   #
-  #  ## Dimension filters for Metric.  All dimensions defined for the metric names
-  #  ## must be specified in order to retrieve the metric statistics.
+  #  ## Dimension filters for Metric.
+  #  ## All dimensions defined for the metric names must be specified in order
+  #  ## to retrieve the metric statistics.
   #  ## 'value' has wildcard / 'glob' matching support such as 'p-*'.
   #  [[inputs.cloudwatch.metrics.dimensions]]
   #    name = "LoadBalancerName"
@@ -123,14 +132,14 @@ API endpoint. In the following order the plugin will attempt to authenticate.
 
 ## Requirements and Terminology
 
-Plugin Configuration utilizes [CloudWatch concepts][1] and access pattern to
+Plugin Configuration utilizes [CloudWatch concepts][concept] and access pattern to
 allow monitoring of any CloudWatch Metric.
 
-- `region` must be a valid AWS [Region](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchRegions) value
-- `period` must be a valid CloudWatch [Period](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods) value
-- `namespace` must be a valid CloudWatch [Namespace](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#Namespace) value
-- `names` must be valid CloudWatch [Metric](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#Metric) names
-- `dimensions` must be valid CloudWatch [Dimension](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#Dimension) name/value pairs
+- `region` must be a valid AWS [region][] value
+- `period` must be a valid CloudWatch [period][] value
+- `namespace` must be a valid CloudWatch [namespace][] value
+- `names` must be valid CloudWatch [metric][] names
+- `dimensions` must be valid CloudWatch [dimension][] name/value pairs
 
 Omitting or specifying a value of `'*'` for a dimension value configures all
 available metrics that contain a dimension with the specified name to be
@@ -178,12 +187,12 @@ To maximize efficiency and savings, consider making fewer requests by increasing
 reported. The above example will request metrics from Cloudwatch every 5 minutes
 but will output five metrics timestamped one minute apart.
 
-[1]: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html
-
 ## Restrictions and Limitations
 
-- CloudWatch metrics are not available instantly via the CloudWatch API. You should adjust your collection `delay` to account for this lag in metrics availability based on your [monitoring subscription level](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html)
-- CloudWatch API usage incurs cost - see [GetMetricData Pricing](https://aws.amazon.com/cloudwatch/pricing/)
+- CloudWatch metrics are not available instantly via the CloudWatch API.
+  You should adjust your collection `delay` to account for this lag in metrics
+  availability based on your [monitoring subscription level][using]
+- CloudWatch API usage incurs cost - see [GetMetricData Pricing][pricing]
 
 ## Metrics
 
@@ -206,7 +215,7 @@ case](https://en.wikipedia.org/wiki/Snake_case)
 
 - All measurements have the following tags:
   - region           (CloudWatch Region)
-  - {dimension-name} (Cloudwatch Dimension value - one for each metric dimension)
+  - {dimension-name} (Cloudwatch Dimension value - one per metric dimension)
 
 ## Troubleshooting
 
@@ -252,3 +261,15 @@ aws cloudwatch get-metric-data \
 $ ./telegraf --config telegraf.conf --input-filter cloudwatch --test
 > cloudwatch_aws_elb,load_balancer_name=p-example,region=us-east-1 latency_average=0.004810798017284538,latency_maximum=0.1100282669067383,latency_minimum=0.0006084442138671875,latency_sample_count=4029,latency_sum=19.382705211639404 1459542420000000000
 ```
+
+[concept]: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html
+[credentials]: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#shared-credentials-file
+[dimension]: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#Dimension
+[env]: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#environment-variables
+[iam-roles]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+[metric]: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#Metric
+[namespace]: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#Namespace
+[period]: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchPeriods
+[pricing]: https://aws.amazon.com/cloudwatch/pricing/
+[region]: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#CloudWatchRegions
+[using]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html

--- a/plugins/inputs/cloudwatch/sample.conf
+++ b/plugins/inputs/cloudwatch/sample.conf
@@ -5,7 +5,8 @@
 
   ## Amazon Credentials
   ## Credentials are loaded in the following order
-  ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
+  ## 1) Web identity provider credentials via STS if role_arn and
+  ##    web_identity_token_file are specified
   ## 2) Assumed credentials via STS if role_arn is specified
   ## 3) explicit credentials from 'access_key' and 'secret_key'
   ## 4) shared profile from 'profile'
@@ -31,27 +32,33 @@
   # use_system_proxy = false
   # http_proxy_url = "http://localhost:8888"
 
-  # The minimum period for Cloudwatch metrics is 1 minute (60s). However not all
-  # metrics are made available to the 1 minute period. Some are collected at
-  # 3 minute, 5 minute, or larger intervals. See https://aws.amazon.com/cloudwatch/faqs/#monitoring.
-  # Note that if a period is configured that is smaller than the minimum for a
-  # particular metric, that metric will not be returned by the Cloudwatch API
-  # and will not be collected by Telegraf.
+  ## The minimum period for Cloudwatch metrics is 1 minute (60s). However not
+  ## all metrics are made available to the 1 minute period. Some are collected
+  ## at 3 minute, 5 minute, or larger intervals.
+  ## See https://aws.amazon.com/cloudwatch/faqs/#monitoring.
+  ## Note that if a period is configured that is smaller than the minimum for a
+  ## particular metric, that metric will not be returned by the Cloudwatch API
+  ## and will not be collected by Telegraf.
   #
-  ## Requested CloudWatch aggregation Period (required - must be a multiple of 60s)
+  ## Requested CloudWatch aggregation Period (required)
+  ## Must be a multiple of 60s.
   period = "5m"
 
-  ## Collection Delay (required - must account for metrics availability via CloudWatch API)
+  ## Collection Delay (required)
+  ## Must account for metrics availability via CloudWatch API
   delay = "5m"
 
   ## Recommended: use metric 'interval' that is a multiple of 'period' to avoid
   ## gaps or overlap in pulled data
   interval = "5m"
 
-  ## Recommended if "delay" and "period" are both within 3 hours of request time. Invalid values will be ignored.
-  ## Recently Active feature will only poll for CloudWatch ListMetrics values that occurred within the last 3 Hours.
-  ## If enabled, it will reduce total API usage of the CloudWatch ListMetrics API and require less memory to retain.
-  ## Do not enable if "period" or "delay" is longer than 3 hours, as it will not return data more than 3 hours old.
+  ## Recommended if "delay" and "period" are both within 3 hours of request
+  ## time. Invalid values will be ignored. Recently Active feature will only
+  ## poll for CloudWatch ListMetrics values that occurred within the last 3h.
+  ## If enabled, it will reduce total API usage of the CloudWatch ListMetrics
+  ## API and require less memory to retain.
+  ## Do not enable if "period" or "delay" is longer than 3 hours, as it will
+  ## not return data more than 3 hours old.
   ## See https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html
   #recently_active = "PT3H"
 
@@ -60,12 +67,12 @@
 
   ## Metric Statistic Namespaces (required)
   namespaces = ["AWS/ELB"]
-  # A single metric statistic namespace that will be appended to namespaces on startup
+  ## Single metric statistic namespace appended to namespaces on startup
   # namespace = "AWS/ELB"
 
-  ## Maximum requests per second. Note that the global default AWS rate limit is
-  ## 50 reqs/sec, so if you define multiple namespaces, these should add up to a
-  ## maximum of 50.
+  ## Maximum requests per second. Note that the global default AWS rate limit
+  ## is 50 reqs/sec, so if you define multiple namespaces, these should add up
+  ## to a maximum of 50.
   ## See http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
   # ratelimit = 25
 
@@ -80,7 +87,7 @@
 
   ## Namespace-wide statistic filters. These allow fewer queries to be made to
   ## cloudwatch.
-  # statistic_include = [ "average", "sum", "minimum", "maximum", sample_count" ]
+  # statistic_include = ["average", "sum", "minimum", "maximum", sample_count"]
   # statistic_exclude = []
 
   ## Metrics to Pull
@@ -91,11 +98,12 @@
   #
   #  ## Statistic filters for Metric.  These allow for retrieving specific
   #  ## statistics for an individual metric.
-  #  # statistic_include = [ "average", "sum", "minimum", "maximum", sample_count" ]
+  #  # statistic_include = ["average", "sum", "minimum", "maximum", sample_count"]
   #  # statistic_exclude = []
   #
-  #  ## Dimension filters for Metric.  All dimensions defined for the metric names
-  #  ## must be specified in order to retrieve the metric statistics.
+  #  ## Dimension filters for Metric.
+  #  ## All dimensions defined for the metric names must be specified in order
+  #  ## to retrieve the metric statistics.
   #  ## 'value' has wildcard / 'glob' matching support such as 'p-*'.
   #  [[inputs.cloudwatch.metrics.dimensions]]
   #    name = "LoadBalancerName"

--- a/plugins/inputs/cloudwatch_metric_streams/README.md
+++ b/plugins/inputs/cloudwatch_metric_streams/README.md
@@ -1,8 +1,7 @@
 # CloudWatch Metric Streams Input Plugin
 
-The CloudWatch Metric Streams plugin is a service input plugin that
-listens for metrics sent via HTTP and performs the required
-processing for
+The CloudWatch Metric Streams plugin is a service input plugin that listens
+for metrics sent via HTTP and performs the required processing for
 [Metric Streams from AWS](#troubleshooting-documentation).
 
 For cost, see the Metric Streams example in
@@ -11,6 +10,7 @@ For cost, see the Metric Streams example in
 ## Configuration
 
 ```toml @sample.conf
+# AWS Metric Streams listener
 [[inputs.cloudwatch_metric_streams]]
   ## Address and port to host HTTP listener on
   service_address = ":443"
@@ -31,7 +31,8 @@ For cost, see the Metric Streams example in
   ## Optional access key for Firehose security.
   # access_key = "test-key"
 
-  ## An optional flag to keep Metric Streams metrics compatible with CloudWatch's API naming
+  ## An optional flag to keep Metric Streams metrics compatible with
+  ## CloudWatch's API naming
   # api_compatability = false
 
   ## Set one or more allowed client CA certificate file names to
@@ -125,7 +126,9 @@ The plugin has its own internal metrics for troubleshooting:
 * Request Time
   * The duration of the request measured in ns.
 * Age Max
-  * The maximum age of a metric in this interval. This is useful for offsetting any lag or latency measurements in a metrics pipeline that measures based on the timestamp.
+  * The maximum age of a metric in this interval. This is useful for offsetting
+    any lag or latency measurements in a metrics pipeline that measures based
+    on the timestamp.
 * Age Min
   * The minimum age of a metric in this interval.
 

--- a/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
+++ b/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package cloudwatch_metric_streams
 
 import (
@@ -24,6 +25,7 @@ import (
 )
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
+//
 //go:embed sample.conf
 var sampleConfig string
 

--- a/plugins/inputs/cloudwatch_metric_streams/sample.conf
+++ b/plugins/inputs/cloudwatch_metric_streams/sample.conf
@@ -19,7 +19,8 @@
   ## Optional access key for Firehose security.
   # access_key = "test-key"
 
-  ## An optional flag to keep Metric Streams metrics compatible with CloudWatch's API naming
+  ## An optional flag to keep Metric Streams metrics compatible with
+  ## CloudWatch's API naming
   # api_compatability = false
 
   ## Set one or more allowed client CA certificate file names to

--- a/plugins/inputs/couchbase/README.md
+++ b/plugins/inputs/couchbase/README.md
@@ -46,7 +46,9 @@ couchbase server.
 
 Tags:
 
-- cluster: sanitized string from `servers` configuration field e.g.: `http://user:password@couchbase-0.example.com:8091/endpoint` -> `http://couchbase-0.example.com:8091/endpoint`
+- cluster: sanitized string from `servers` configuration field
+  e.g.: `http://user:password@couchbase-0.example.com:8091/endpoint` becomes
+  `http://couchbase-0.example.com:8091/endpoint`
 - hostname: Couchbase's name for the node and port, e.g., `172.16.10.187:8091`
 
 Fields:
@@ -58,9 +60,11 @@ Fields:
 
 Tags:
 
-- cluster: whatever you called it in `servers` in the configuration, e.g.: `http://couchbase-0.example.com/`)
+- cluster: whatever you called it in `servers` in the configuration,
+  e.g. `http://couchbase-0.example.com/`
 - bucket: the name of the couchbase bucket, e.g., `blastro-df`
-- hostname: the hostname of the node the bucket metrics were collected from, e.g., `172.16.10.187:8091` (only present in `couchbase_node_bucket`)
+- hostname: the hostname of the node the bucket metrics were collected
+  from, e.g. `172.16.10.187:8091` (only present in `couchbase_node_bucket`)
 
 Default bucket fields:
 

--- a/plugins/inputs/dpdk/README.md
+++ b/plugins/inputs/dpdk/README.md
@@ -28,49 +28,63 @@ Sample Applications](https://doc.dpdk.org/guides/sample_app_ug/index.html) is
 also available for users to discover and test the capabilities of DPDK libraries
 and to explore the exposed metrics.
 
-> **DPDK Version Info:** This plugin uses this `v2` interface to read telemetry data from applications build with
-> `DPDK version >= 20.05`. The default configuration include reading common statistics from `/ethdev/stats` that is
-> available from `DPDK version >= 20.11`. When using `DPDK 20.05 <= version < DPDK 20.11` it is recommended to disable
-> querying `/ethdev/stats` by setting corresponding `exclude_commands` configuration option.
-> **NOTE:** Since DPDK will most likely run with root privileges, the socket telemetry interface exposed by DPDK
-> will also require root access. This means that either access permissions have to be adjusted for socket telemetry
-> interface to allow Telegraf to access it, or Telegraf should run with root privileges.
-> **NOTE:** The DPDK socket must exist for Telegraf to start successfully. Telegraf will attempt
-> to connect to the DPDK socket during the initialization phase.
+> **DPDK Version Info:** This plugin uses this `v2` interface to read telemetry
+> data from applications build with `DPDK version >= 20.05`. The default
+> configuration include reading common statistics from `/ethdev/stats` that is
+> available from `DPDK version >= 20.11`. When using
+> `DPDK 20.05 <= version < DPDK 20.11` it is recommended to disable querying
+> `/ethdev/stats` by setting corresponding `exclude_commands` configuration
+> option.
+> **NOTE:** Since DPDK will most likely run with root privileges, the socket
+> telemetry interface exposed by DPDK will also require root access. This means
+> that either access permissions have to be adjusted for socket telemetry
+> interface to allow Telegraf to access it, or Telegraf should run with root
+> privileges.
+> **NOTE:** The DPDK socket must exist for Telegraf to start successfully.
+> Telegraf will attempt to connect to the DPDK socket during the initialization
+> phase.
 
 ## Configuration
 
 ```toml @sample.conf
 # Reads metrics from DPDK applications using v2 telemetry interface.
 [[inputs.dpdk]]
-  ## Path to DPDK telemetry socket. This shall point to v2 version of DPDK telemetry interface.
+  ## Path to DPDK telemetry socket. This shall point to v2 version of DPDK
+  ## telemetry interface.
   # socket_path = "/var/run/dpdk/rte/dpdk_telemetry.v2"
 
-  ## Duration that defines how long the connected socket client will wait for a response before terminating connection.
-  ## This includes both writing to and reading from socket. Since it's local socket access
-  ## to a fast packet processing application, the timeout should be sufficient for most users.
+  ## Duration that defines how long the connected socket client will wait for
+  ## a response before terminating connection.
+  ## This includes both writing to and reading from socket. Since it's local
+  ## socket access to a fast packet processing application, the timeout should
+  ## be sufficient for most users.
   ## Setting the value to 0 disables the timeout (not recommended)
   # socket_access_timeout = "200ms"
 
   ## Enables telemetry data collection for selected device types.
-  ## Adding "ethdev" enables collection of telemetry from DPDK NICs (stats, xstats, link_status).
-  ## Adding "rawdev" enables collection of telemetry from DPDK Raw Devices (xstats).
+  ## Adding "ethdev" enables collection of telemetry from DPDK NICs
+  ## (stats, xstats, link_status).
+  ## Adding "rawdev" enables collection of telemetry from DPDK Raw Devices
+  ## (xstats).
   # device_types = ["ethdev"]
 
   ## List of custom, application-specific telemetry commands to query
-  ## The list of available commands depend on the application deployed. Applications can register their own commands
-  ##   via telemetry library API http://doc.dpdk.org/guides/prog_guide/telemetry_lib.html#registering-commands
-  ## For e.g. L3 Forwarding with Power Management Sample Application this could be:
+  ## The list of available commands depend on the application deployed.
+  ## Applications can register their own commands via telemetry library API
+  ## http://doc.dpdk.org/guides/prog_guide/telemetry_lib.html#registering-commands
+  ## For L3 Forwarding with Power Management Sample Application this could be:
   ##   additional_commands = ["/l3fwd-power/stats"]
   # additional_commands = []
 
   ## Allows turning off collecting data for individual "ethdev" commands.
-  ## Remove "/ethdev/link_status" from list to start getting link status metrics.
+  ## Remove "/ethdev/link_status" from list to gather link status metrics.
   [inputs.dpdk.ethdev]
     exclude_commands = ["/ethdev/link_status"]
 
-  ## When running multiple instances of the plugin it's recommended to add a unique tag to each instance to identify
-  ## metrics exposed by an instance of DPDK application. This is useful when multiple DPDK apps run on a single host.
+  ## When running multiple instances of the plugin it's recommended to add a
+  ## unique tag to each instance to identify metrics exposed by an instance
+  ## of DPDK application. This is useful when multiple DPDK apps run on a
+  ## single host.
   ##  [inputs.dpdk.tags]
   ##    dpdk_instance = "my-fwd-app"
 ```
@@ -152,7 +166,8 @@ Management Sample Application][sample-app].
 Command entries specified in `additional_commands` should match DPDK command
 format:
 
-* Command entry format: either `command` or `command,params` for commands that expect parameters, where comma (`,`) separates command from params.
+* Command entry format: either `command` or `command,params` for commands that
+  expect parameters, where comma (`,`) separates command from params.
 * Command entry length (command with params) should be `< 1024` characters.
 * Command length (without params) should be `< 56` characters.
 * Commands have to start with `/`.
@@ -182,7 +197,8 @@ instance a unique tag `[inputs.dpdk.tags]` allows distinguishing between them.
   [inputs.dpdk.tags]
     dpdk_instance = "l3fwd-power"
 
-# Instance #2 - L2 Forwarding with Intel Cache Allocation Technology (CAT) Application
+# Instance #2 - L2 Forwarding with Intel Cache Allocation Technology (CAT)
+# Application
 [[inputs.dpdk]]
   socket_path = "/var/run/dpdk/rte/l2fwd-cat_telemetry.v2"
   device_types = ["ethdev"]
@@ -206,10 +222,12 @@ JSON Flattener](../../parsers/json/README.md) and exposed as fields.  If DPDK
 response contains no information (is empty or is null) then such response will
 be discarded.
 
-> **NOTE:**  Since DPDK allows registering custom metrics in its telemetry framework the JSON response from DPDK
-> may contain various sets of metrics. While metrics from `/ethdev/stats` should be most stable, the `/ethdev/xstats`
-> may contain driver-specific metrics (depending on DPDK application configuration). The application-specific commands
-> like `/l3fwd-power/stats` can return their own specific set of metrics.
+> **NOTE:**  Since DPDK allows registering custom metrics in its telemetry
+> framework the JSON response from DPDK may contain various sets of metrics.
+> While metrics from `/ethdev/stats` should be most stable, the `/ethdev/xstats`
+> may contain driver-specific metrics (depending on DPDK application
+> configuration). The application-specific commands like `/l3fwd-power/stats`
+> can return their own specific set of metrics.
 
 ## Example Output
 

--- a/plugins/inputs/dpdk/sample.conf
+++ b/plugins/inputs/dpdk/sample.conf
@@ -1,32 +1,40 @@
 # Reads metrics from DPDK applications using v2 telemetry interface.
 [[inputs.dpdk]]
-  ## Path to DPDK telemetry socket. This shall point to v2 version of DPDK telemetry interface.
+  ## Path to DPDK telemetry socket. This shall point to v2 version of DPDK
+  ## telemetry interface.
   # socket_path = "/var/run/dpdk/rte/dpdk_telemetry.v2"
 
-  ## Duration that defines how long the connected socket client will wait for a response before terminating connection.
-  ## This includes both writing to and reading from socket. Since it's local socket access
-  ## to a fast packet processing application, the timeout should be sufficient for most users.
+  ## Duration that defines how long the connected socket client will wait for
+  ## a response before terminating connection.
+  ## This includes both writing to and reading from socket. Since it's local
+  ## socket access to a fast packet processing application, the timeout should
+  ## be sufficient for most users.
   ## Setting the value to 0 disables the timeout (not recommended)
   # socket_access_timeout = "200ms"
 
   ## Enables telemetry data collection for selected device types.
-  ## Adding "ethdev" enables collection of telemetry from DPDK NICs (stats, xstats, link_status).
-  ## Adding "rawdev" enables collection of telemetry from DPDK Raw Devices (xstats).
+  ## Adding "ethdev" enables collection of telemetry from DPDK NICs
+  ## (stats, xstats, link_status).
+  ## Adding "rawdev" enables collection of telemetry from DPDK Raw Devices
+  ## (xstats).
   # device_types = ["ethdev"]
 
   ## List of custom, application-specific telemetry commands to query
-  ## The list of available commands depend on the application deployed. Applications can register their own commands
-  ##   via telemetry library API http://doc.dpdk.org/guides/prog_guide/telemetry_lib.html#registering-commands
-  ## For e.g. L3 Forwarding with Power Management Sample Application this could be:
+  ## The list of available commands depend on the application deployed.
+  ## Applications can register their own commands via telemetry library API
+  ## http://doc.dpdk.org/guides/prog_guide/telemetry_lib.html#registering-commands
+  ## For L3 Forwarding with Power Management Sample Application this could be:
   ##   additional_commands = ["/l3fwd-power/stats"]
   # additional_commands = []
 
   ## Allows turning off collecting data for individual "ethdev" commands.
-  ## Remove "/ethdev/link_status" from list to start getting link status metrics.
+  ## Remove "/ethdev/link_status" from list to gather link status metrics.
   [inputs.dpdk.ethdev]
     exclude_commands = ["/ethdev/link_status"]
 
-  ## When running multiple instances of the plugin it's recommended to add a unique tag to each instance to identify
-  ## metrics exposed by an instance of DPDK application. This is useful when multiple DPDK apps run on a single host.
+  ## When running multiple instances of the plugin it's recommended to add a
+  ## unique tag to each instance to identify metrics exposed by an instance
+  ## of DPDK application. This is useful when multiple DPDK apps run on a
+  ## single host.
   ##  [inputs.dpdk.tags]
   ##    dpdk_instance = "my-fwd-app"

--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -57,20 +57,22 @@ mid-low level.
   ## Set cluster_stats to true when you want to obtain cluster stats.
   cluster_stats = false
 
-  ## Only gather cluster_stats from the master node. To work this require local = true
+  ## Only gather cluster_stats from the master node.
+  ## To work this require local = true
   cluster_stats_only_from_master = true
 
   ## Indices to collect; can be one or more indices names or _all
-  ## Use of wildcards is allowed. Use a wildcard at the end to retrieve index names that end with a changing value, like a date.
+  ## Use of wildcards is allowed. Use a wildcard at the end to retrieve index
+  ## names that end with a changing value, like a date.
   indices_include = ["_all"]
 
   ## One of "shards", "cluster", "indices"
   ## Currently only "shards" is implemented
   indices_level = "shards"
 
-  ## node_stats is a list of sub-stats that you want to have gathered. Valid options
-  ## are "indices", "os", "process", "jvm", "thread_pool", "fs", "transport", "http",
-  ## "breaker". Per default, all stats are gathered.
+  ## node_stats is a list of sub-stats that you want to have gathered.
+  ## Valid options are "indices", "os", "process", "jvm", "thread_pool",
+  ## "fs", "transport", "http", "breaker". Per default, all stats are gathered.
   # node_stats = ["jvm", "http"]
 
   ## HTTP Basic Authentication username and password.
@@ -84,10 +86,12 @@ mid-low level.
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
-  ## Sets the number of most recent indices to return for indices that are configured with a date-stamped suffix.
-  ## Each 'indices_include' entry ending with a wildcard (*) or glob matching pattern will group together all indices that match it, and 
-  ## sort them by the date or number after the wildcard. Metrics then are gathered for only the 'num_most_recent_indices' amount of most 
-  ## recent indices.
+  ## Sets the number of most recent indices to return for indices that are
+  ## configured with a date-stamped suffix. Each 'indices_include' entry
+  ## ending with a wildcard (*) or glob matching pattern will group together
+  ## all indices that match it, and  sort them by the date or number after
+  ## the wildcard. Metrics then are gathered for only the
+  ## 'num_most_recent_indices' amount of most  recent indices.
   # num_most_recent_indices = 0
 ```
 
@@ -826,7 +830,8 @@ Emitted when the appropriate `shards_stats` options are set.
     - request_cache_miss_count (float)
     - retention_leases_primary_term (float)
     - retention_leases_version (float)
-    - routing_state (int) (UNASSIGNED = 1, INITIALIZING = 2, STARTED = 3, RELOCATING = 4, other = 0)
+    - routing_state (int)
+      (UNASSIGNED = 1, INITIALIZING = 2, STARTED = 3, RELOCATING = 4, other = 0)
     - search_fetch_current (float)
     - search_fetch_time_in_millis (float)
     - search_fetch_total (float)

--- a/plugins/inputs/elasticsearch/sample.conf
+++ b/plugins/inputs/elasticsearch/sample.conf
@@ -25,20 +25,22 @@
   ## Set cluster_stats to true when you want to obtain cluster stats.
   cluster_stats = false
 
-  ## Only gather cluster_stats from the master node. To work this require local = true
+  ## Only gather cluster_stats from the master node.
+  ## To work this require local = true
   cluster_stats_only_from_master = true
 
   ## Indices to collect; can be one or more indices names or _all
-  ## Use of wildcards is allowed. Use a wildcard at the end to retrieve index names that end with a changing value, like a date.
+  ## Use of wildcards is allowed. Use a wildcard at the end to retrieve index
+  ## names that end with a changing value, like a date.
   indices_include = ["_all"]
 
   ## One of "shards", "cluster", "indices"
   ## Currently only "shards" is implemented
   indices_level = "shards"
 
-  ## node_stats is a list of sub-stats that you want to have gathered. Valid options
-  ## are "indices", "os", "process", "jvm", "thread_pool", "fs", "transport", "http",
-  ## "breaker". Per default, all stats are gathered.
+  ## node_stats is a list of sub-stats that you want to have gathered.
+  ## Valid options are "indices", "os", "process", "jvm", "thread_pool",
+  ## "fs", "transport", "http", "breaker". Per default, all stats are gathered.
   # node_stats = ["jvm", "http"]
 
   ## HTTP Basic Authentication username and password.
@@ -52,8 +54,10 @@
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
-  ## Sets the number of most recent indices to return for indices that are configured with a date-stamped suffix.
-  ## Each 'indices_include' entry ending with a wildcard (*) or glob matching pattern will group together all indices that match it, and 
-  ## sort them by the date or number after the wildcard. Metrics then are gathered for only the 'num_most_recent_indices' amount of most 
-  ## recent indices.
+  ## Sets the number of most recent indices to return for indices that are
+  ## configured with a date-stamped suffix. Each 'indices_include' entry
+  ## ending with a wildcard (*) or glob matching pattern will group together
+  ## all indices that match it, and  sort them by the date or number after
+  ## the wildcard. Metrics then are gathered for only the
+  ## 'num_most_recent_indices' amount of most  recent indices.
   # num_most_recent_indices = 0

--- a/plugins/inputs/elasticsearch_query/README.md
+++ b/plugins/inputs/elasticsearch_query/README.md
@@ -1,7 +1,7 @@
 # Elasticsearch Query Input Plugin
 
-This [elasticsearch](https://www.elastic.co/) query plugin queries endpoints to
-obtain metrics from data stored in an Elasticsearch cluster.
+This [elasticsearch](https://www.elastic.co/) query plugin queries endpoints
+to obtain metrics from data stored in an Elasticsearch cluster.
 
 The following is supported:
 
@@ -12,8 +12,8 @@ The following is supported:
 
 ## Elasticsearch Support
 
-This plugins is tested against Elasticsearch 5.x and 6.x releases.  Currently it
-is known to break on 7.x or greater versions.
+This plugins is tested against Elasticsearch 5.x and 6.x releases.
+Currently it is known to break on 7.x or greater versions.
 
 ## Configuration
 
@@ -80,7 +80,8 @@ is known to break on 7.x or greater versions.
     # metric_function = "avg"
 
     ## Fields to be used as tags
-    ## Must be text, non-analyzed fields. Metric aggregations are performed per tag
+    ## Must be text, non-analyzed fields. Metric aggregations are performed
+    ## per tag
     # tags = ["field.keyword", "field2.keyword"]
 
     ## Set to true to not ignore documents when the tag(s) above are missing

--- a/plugins/inputs/elasticsearch_query/sample.conf
+++ b/plugins/inputs/elasticsearch_query/sample.conf
@@ -60,7 +60,8 @@
     # metric_function = "avg"
 
     ## Fields to be used as tags
-    ## Must be text, non-analyzed fields. Metric aggregations are performed per tag
+    ## Must be text, non-analyzed fields. Metric aggregations are performed
+    ## per tag
     # tags = ["field.keyword", "field2.keyword"]
 
     ## Set to true to not ignore documents when the tag(s) above are missing

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -10,7 +10,8 @@ This input plugin checks HTTP/HTTPS connections.
   ## List of urls to query.
   # urls = ["http://localhost"]
 
-  ## Set http_proxy (telegraf uses the system wide proxy settings if it's is not set)
+  ## Set http_proxy.
+  ## Telegraf uses the system wide proxy settings if it's is not set.
   # http_proxy = "http://localhost:8888"
 
   ## Set response_timeout (default 5 seconds)
@@ -36,12 +37,14 @@ This input plugin checks HTTP/HTTPS connections.
   # '''
 
   ## Optional name of the field that will contain the body of the response.
-  ## By default it is set to an empty String indicating that the body's content won't be added
+  ## By default it is set to an empty String indicating that the body's
+  ## content won't be added
   # response_body_field = ''
 
   ## Maximum allowed HTTP response body size in bytes.
   ## 0 means to use the default of 32MiB.
-  ## If the response body size exceeds this limit a "body_read_error" will be raised
+  ## If the response body size exceeds this limit a "body_read_error" will
+  ## be raised.
   # response_body_max_size = "32MiB"
 
   ## Optional substring or regex match in body of the response (case sensitive)
@@ -50,9 +53,10 @@ This input plugin checks HTTP/HTTPS connections.
   # response_string_match = "\".*_status\".?:.?\"up\""
 
   ## Expected response status code.
-  ## The status code of the response is compared to this value. If they match, the field
-  ## "response_status_code_match" will be 1, otherwise it will be 0. If the
-  ## expected status code is 0, the check is disabled and the field won't be added.
+  ## The status code of the response is compared to this value. If they match,
+  ## the field "response_status_code_match" will be 1, otherwise it will be 0.
+  ## If the expected status code is 0, the check is disabled and the field
+  ## won't be added.
   # response_status_code = 0
 
   ## Optional TLS Config
@@ -69,8 +73,9 @@ This input plugin checks HTTP/HTTPS connections.
   #   Host = "github.com"
 
   ## Optional setting to map response http headers into tags
-  ## If the http header is not present on the request, no corresponding tag will be added
-  ## If multiple instances of the http header are present, only the first value will be used
+  ## If the http header is not present on the request, no corresponding tag will
+  ## be added. If multiple instances of the http header are present, only the
+  ## first value will be used.
   # http_header_tags = {"HTTP_HEADER" = "TAG_NAME"}
 
   ## Interface to use when dialing an address
@@ -91,7 +96,8 @@ This input plugin checks HTTP/HTTPS connections.
     - response_string_match (int, 0 = mismatch / body read error, 1 = match)
     - response_status_code_match (int, 0 = mismatch, 1 = match)
     - http_response_code (int, response status code)
-    - result_type (string, deprecated in 1.6: use `result` tag and `result_code` field)
+    - result_type (string, deprecated in 1.6: use `result` tag and
+     `result_code` field)
     - result_code (int, [see below](#result--result_code))
 
 ### `result` / `result_code`

--- a/plugins/inputs/http_response/sample.conf
+++ b/plugins/inputs/http_response/sample.conf
@@ -3,7 +3,8 @@
   ## List of urls to query.
   # urls = ["http://localhost"]
 
-  ## Set http_proxy (telegraf uses the system wide proxy settings if it's is not set)
+  ## Set http_proxy.
+  ## Telegraf uses the system wide proxy settings if it's is not set.
   # http_proxy = "http://localhost:8888"
 
   ## Set response_timeout (default 5 seconds)
@@ -29,12 +30,14 @@
   # '''
 
   ## Optional name of the field that will contain the body of the response.
-  ## By default it is set to an empty String indicating that the body's content won't be added
+  ## By default it is set to an empty String indicating that the body's
+  ## content won't be added
   # response_body_field = ''
 
   ## Maximum allowed HTTP response body size in bytes.
   ## 0 means to use the default of 32MiB.
-  ## If the response body size exceeds this limit a "body_read_error" will be raised
+  ## If the response body size exceeds this limit a "body_read_error" will
+  ## be raised.
   # response_body_max_size = "32MiB"
 
   ## Optional substring or regex match in body of the response (case sensitive)
@@ -43,9 +46,10 @@
   # response_string_match = "\".*_status\".?:.?\"up\""
 
   ## Expected response status code.
-  ## The status code of the response is compared to this value. If they match, the field
-  ## "response_status_code_match" will be 1, otherwise it will be 0. If the
-  ## expected status code is 0, the check is disabled and the field won't be added.
+  ## The status code of the response is compared to this value. If they match,
+  ## the field "response_status_code_match" will be 1, otherwise it will be 0.
+  ## If the expected status code is 0, the check is disabled and the field
+  ## won't be added.
   # response_status_code = 0
 
   ## Optional TLS Config
@@ -62,8 +66,9 @@
   #   Host = "github.com"
 
   ## Optional setting to map response http headers into tags
-  ## If the http header is not present on the request, no corresponding tag will be added
-  ## If multiple instances of the http header are present, only the first value will be used
+  ## If the http header is not present on the request, no corresponding tag will
+  ## be added. If multiple instances of the http header are present, only the
+  ## first value will be used.
   # http_header_tags = {"HTTP_HEADER" = "TAG_NAME"}
 
   ## Interface to use when dialing an address

--- a/plugins/inputs/hugepages/README.md
+++ b/plugins/inputs/hugepages/README.md
@@ -4,8 +4,9 @@ Transparent Huge Pages (THP) is a Linux memory management system that reduces
 the overhead of Translation Lookaside Buffer (TLB) lookups on machines with
 large amounts of memory by using larger memory pages.
 
-Consult <https://www.kernel.org/doc/html/latest/admin-guide/mm/hugetlbpage.html>
-for more details.
+Consult [the website][website] for more details.
+
+[website]: https://www.kernel.org/doc/html/latest/admin-guide/mm/hugetlbpage.html
 
 ## Configuration
 
@@ -13,9 +14,11 @@ for more details.
 # Gathers huge pages measurements.
 [[inputs.hugepages]]
   ## Supported huge page types:
-  ##   - "root" - based on root huge page control directory: /sys/kernel/mm/hugepages
-  ##   - "per_node" - based on per NUMA node directories: /sys/devices/system/node/node[0-9]*/hugepages
-  ##   - "meminfo" - based on /proc/meminfo file
+  ##   - "root"     - based on root huge page control directory:
+  ##                  /sys/kernel/mm/hugepages
+  ##   - "per_node" - based on per NUMA node directories:
+  ##                  /sys/devices/system/node/node[0-9]*/hugepages
+  ##   - "meminfo"  - based on /proc/meminfo file
   # types = ["root", "per_node"]
 ```
 
@@ -23,7 +26,7 @@ for more details.
 
 **The following measurements are supported by Hugepages plugin:**
 
-- hugepages_root (gathered from root huge page control directory: `/sys/kernel/mm/hugepages`)
+- hugepages_root (gathered from `/sys/kernel/mm/hugepages`)
   - tags:
     - size_kb (integer, kB)
   - fields:
@@ -33,7 +36,7 @@ for more details.
     - reserved (integer)
     - surplus (integer)
     - total (integer)
-- hugepages_per_node (gathered from per NUMA node directories: `/sys/devices/system/node/node[0-9]*/hugepages`)
+- hugepages_per_node (gathered from `/sys/devices/system/node/node[0-9]*/hugepages`)
   - tags:
     - size_kb (integer, kB)
     - node (integer)
@@ -42,7 +45,8 @@ for more details.
     - surplus (integer)
     - total (integer)
 - hugepages_meminfo (gathered from `/proc/meminfo` file)
-  - The fields `total`, `free`, `reserved`, and `surplus` are counts of pages of default size. Fields with suffix `_kb` are in kilobytes.
+  - The fields `total`, `free`, `reserved`, and `surplus` are counts of pages
+    of default size. Fields with suffix `_kb` are in kilobytes.
   - fields:
     - anonymous_kb (integer, kB)
     - file_kb (integer, kB)

--- a/plugins/inputs/hugepages/sample.conf
+++ b/plugins/inputs/hugepages/sample.conf
@@ -1,7 +1,9 @@
 # Gathers huge pages measurements.
 [[inputs.hugepages]]
   ## Supported huge page types:
-  ##   - "root" - based on root huge page control directory: /sys/kernel/mm/hugepages
-  ##   - "per_node" - based on per NUMA node directories: /sys/devices/system/node/node[0-9]*/hugepages
-  ##   - "meminfo" - based on /proc/meminfo file
+  ##   - "root"     - based on root huge page control directory:
+  ##                  /sys/kernel/mm/hugepages
+  ##   - "per_node" - based on per NUMA node directories:
+  ##                  /sys/devices/system/node/node[0-9]*/hugepages
+  ##   - "meminfo"  - based on /proc/meminfo file
   # types = ["root", "per_node"]

--- a/plugins/inputs/influxdb/README.md
+++ b/plugins/inputs/influxdb/README.md
@@ -1,7 +1,7 @@
 # InfluxDB Input Plugin
 
-The InfluxDB plugin will collect metrics on the given InfluxDB servers. Read our
-[documentation][1] for detailed information about `influxdb` metrics.
+The InfluxDB plugin will collect metrics on the given InfluxDB servers. Read
+our [documentation][1] for detailed information about `influxdb` metrics.
 
 This plugin can also gather metrics from endpoints that expose
 InfluxDB-formatted endpoints. See below for more information.
@@ -43,86 +43,138 @@ InfluxDB-formatted endpoints. See below for more information.
 **Note:** The measurements and fields included in this plugin are dynamically
 built from the InfluxDB source, and may vary between versions:
 
-- **influxdb_ae** _(Enterprise Only)_ : Statistics related to the Anti-Entropy (AE) engine in InfluxDB Enterprise clusters.
+- **influxdb_ae** _(Enterprise Only)_ : Statistics related to the Anti-Entropy
+  (AE) engine in InfluxDB Enterprise clusters.
   - **bytesRx**: Number of bytes received by the data node.
   - **errors**: Total number of anti-entropy jobs that have resulted in errors.
   - **jobs**: Total number of jobs executed by the data node.
   - **jobsActive**: Number of active (currently executing) jobs.
-- **influxdb_cluster** _(Enterprise Only)_ : Statistics related to the clustering features of the data nodes in InfluxDB Enterprise clusters.
-  - **copyShardReq**: Number of internal requests made to copy a shard from one data node to another.
-  - **createIteratorReq**: Number of read requests from other data nodes in the cluster.
-  - **expandSourcesReq**: Number of remote node requests made to find measurements on this node that match a particular regular expression.
-  - **fieldDimensionsReq**: Number of remote node requests for information about the fields and associated types, and tag keys of measurements on this data node.
+- **influxdb_cluster** _(Enterprise Only)_ : Statistics related to the
+  clustering features of the data nodes in InfluxDB Enterprise clusters.
+  - **copyShardReq**: Number of internal requests made to copy a shard from
+    one data node to another.
+  - **createIteratorReq**: Number of read requests from other data nodes in
+    the cluster.
+  - **expandSourcesReq**: Number of remote node requests made to find
+    measurements on this node that match a particular regular expression.
+  - **fieldDimensionsReq**: Number of remote node requests for information
+    about the fields and associated types, and tag keys of measurements on
+    this data node.
   - **iteratorCostReq**: Number of internal requests for iterator cost.
-  - **openConnections**: Tracks the number of open connections being handled by the data node
-    (including logical connections multiplexed onto a single yamux connection).
-  - **removeShardReq**: Number of internal requests to delete a shard from this data node. Exclusively incremented by use of the influxd-ctl remove shard command.
-  - **writeShardFail**: Total number of internal write requests from a remote node that failed.
-  - **writeShardPointsReq**: Number of points in every internal write request from any remote node, regardless of success.
-  - **writeShardReq**: Number of internal write requests from a remote data node, regardless of success.
+  - **openConnections**: Tracks the number of open connections being handled by
+    the data node (including logical connections multiplexed onto a single
+    yamux connection).
+  - **removeShardReq**: Number of internal requests to delete a shard from this
+    data node. Exclusively incremented by use of the influxd-ctl remove shard
+    command.
+  - **writeShardFail**: Total number of internal write requests from a remote
+    node that failed.
+  - **writeShardPointsReq**: Number of points in every internal write request
+    from any remote node, regardless of success.
+  - **writeShardReq**: Number of internal write requests from a remote data
+    node, regardless of success.
 - **influxdb_cq**: Metrics related to continuous queries (CQs).
   - **queryFail**: Total number of continuous queries that executed but failed.
   - **queryOk**: Total number of continuous queries that executed successfully.
 - **influxdb_database**: Database metrics are collected from.
-  - **numMeasurements**: Current number of measurements in the specified database.
+  - **numMeasurements**: Current number of measurements in the specified
+    database.
   - **numSeries**: Current series cardinality of the specified database.
-- **influxdb_hh** _(Enterprise Only)_ : Events resulting in new hinted handoff (HH) processors in InfluxDB Enterprise clusters.
-  - **writeShardReq**: Number of initial write requests handled by the hinted handoff engine for a remote node.
-  - **writeShardReqPoints**: Number of write requests for each point in the initial request to the hinted handoff engine for a remote node.
-- **influxdb_hh_database** _(Enterprise Only)_ : Aggregates all hinted handoff queues for a single database and node.
-  - **bytesRead**: Size, in bytes, of points read from the hinted handoff queue and sent to its destination data node.
+- **influxdb_hh** _(Enterprise Only)_ : Events resulting in new hinted handoff
+  (HH) processors in InfluxDB Enterprise clusters.
+  - **writeShardReq**: Number of initial write requests handled by the hinted
+    handoff engine for a remote node.
+  - **writeShardReqPoints**: Number of write requests for each point in the
+    initial request to the hinted handoff engine for a remote node.
+- **influxdb_hh_database** _(Enterprise Only)_ : Aggregates all hinted handoff
+  queues for a single database and node.
+  - **bytesRead**: Size, in bytes, of points read from the hinted handoff queue
+    and sent to its destination data node.
   - **bytesWritten**: Total number of bytes written to the hinted handoff queue.
   - **queueBytes**: Total number of bytes remaining in the hinted handoff queue.
-  - **queueDepth**: Total number of segments in the hinted handoff queue. The HH queue is a sequence of 10MB “segment” files.
-  - **writeBlocked**: Number of writes blocked because the number of concurrent HH requests exceeds the limit.
-  - **writeDropped**: Number of writes dropped from the HH queue because the write appeared to be corrupted.
-  - **writeNodeReq**: Total number of write requests that succeeded in writing a batch to the destination node.
-  - **writeNodeReqFail**: Total number of write requests that failed in writing a batch of data from the hinted handoff queue to the destination node.
-  - **writeNodeReqPoints**: Total number of points successfully written from the HH queue to the destination node fr
-  - **writeShardReq**: Total number of every write batch request enqueued into the hinted handoff queue.
-  - **writeShardReqPoints**: Total number of points enqueued into the hinted handoff queue.  
-- **influxdb_hh_processor** _(Enterprise Only)_: Statistics stored for a single queue (shard).
-  - **bytesRead**: Size, in bytes, of points read from the hinted handoff queue and sent to its destination data node.
+  - **queueDepth**: Total number of segments in the hinted handoff queue.
+    The HH queue is a sequence of 10MB “segment” files.
+  - **writeBlocked**: Number of writes blocked because the number of concurrent
+    HH requests exceeds the limit.
+  - **writeDropped**: Number of writes dropped from the HH queue because the
+    write appeared to be corrupted.
+  - **writeNodeReq**: Total number of write requests that succeeded in writing
+    a batch to the destination node.
+  - **writeNodeReqFail**: Total number of write requests that failed in writing
+    a batch of data from the hinted handoff queue to the destination node.
+  - **writeNodeReqPoints**: Total number of points successfully written from
+    the HH queue to the destination node fr
+  - **writeShardReq**: Total number of every write batch request enqueued into
+    the hinted handoff queue.
+  - **writeShardReqPoints**: Total number of points enqueued into the hinted
+    handoff queue.
+- **influxdb_hh_processor** _(Enterprise Only)_: Statistics stored for a single
+  queue (shard).
+  - **bytesRead**: Size, in bytes, of points read from the hinted handoff queue
+    and sent to its destination data node.
   - **bytesWritten**: Total number of bytes written to the hinted handoff queue.
   - **queueBytes**: Total number of bytes remaining in the hinted handoff queue.
-  - **queueDepth**: Total number of segments in the hinted handoff queue. The HH queue is a sequence of 10MB “segment” files.
-  - **writeBlocked**: Number of writes blocked because the number of concurrent HH requests exceeds the limit.
-  - **writeDropped**: Number of writes dropped from the HH queue because the write appeared to be corrupted.
-  - **writeNodeReq**: Total number of write requests that succeeded in writing a batch to the destination node.
-  - **writeNodeReqFail**: Total number of write requests that failed in writing a batch of data from the hinted handoff queue to the destination node.
-  - **writeNodeReqPoints**: Total number of points successfully written from the HH queue to the destination node fr
-  - **writeShardReq**: Total number of every write batch request enqueued into the hinted handoff queue.
-  - **writeShardReqPoints**: Total number of points enqueued into the hinted handoff queue.
+  - **queueDepth**: Total number of segments in the hinted handoff queue.
+    The HH queue is a sequence of 10MB “segment” files.
+  - **writeBlocked**: Number of writes blocked because the number of concurrent
+    HH requests exceeds the limit.
+  - **writeDropped**: Number of writes dropped from the HH queue because the
+    write appeared to be corrupted.
+  - **writeNodeReq**: Total number of write requests that succeeded in writing
+    a batch to the destination node.
+  - **writeNodeReqFail**: Total number of write requests that failed in writing
+    a batch of data from the hinted handoff queue to the destination node.
+  - **writeNodeReqPoints**: Total number of points successfully written from
+    the HH queue to the destination node fr
+  - **writeShardReq**: Total number of every write batch request enqueued into
+    the hinted handoff queue.
+  - **writeShardReqPoints**: Total number of points enqueued into the hinted
+    handoff queue.
 - **influxdb_httpd**: Metrics related to the InfluxDB HTTP server.
-  - **authFail**: Number of HTTP requests that were aborted due to authentication being required, but not supplied or incorrect.
-  - **clientError**: Number of HTTP responses due to client errors, with a 4XX HTTP status code.
+  - **authFail**: Number of HTTP requests that were aborted due to
+    authentication being required, but not supplied or incorrect.
+  - **clientError**: Number of HTTP responses due to client errors, with
+    a 4XX HTTP status code.
   - **fluxQueryReq**: Number of Flux query requests served.
-  - **fluxQueryReqDurationNs**: Duration (wall-time), in nanoseconds, spent executing Flux query requests.
-  - **pingReq**: Number of times InfluxDB HTTP server served the /ping HTTP endpoint.
+  - **fluxQueryReqDurationNs**: Duration (wall-time), in nanoseconds, spent
+    executing Flux query requests.
+  - **pingReq**: Number of times InfluxDB HTTP server served the /ping HTTP
+    endpoint.
   - **pointsWrittenDropped**: Number of points dropped by the storage engine.
-  - **pointsWrittenFail**: Number of points accepted by the HTTP /write endpoint, but unable to be persisted.
-  - **pointsWrittenOK**: Number of points successfully accepted and persisted by the HTTP /write endpoint.
+  - **pointsWrittenFail**: Number of points accepted by the HTTP /write
+    endpoint, but unable to be persisted.
+  - **pointsWrittenOK**: Number of points successfully accepted and persisted
+    by the HTTP /write endpoint.
   - **promReadReq**: Number of read requests to the Prometheus /read endpoint.
-  - **promWriteReq**: Number of write requests to the Prometheus /write endpoint.
+  - **promWriteReq**: Number of write requests to the Prometheus /write
+    endpoint.
   - **queryReq**: Number of query requests.
   - **queryReqDurationNs**: Total query request duration, in nanosecond (ns).
   - **queryRespBytes**: Total number of bytes returned in query responses.
   - **recoveredPanics**: Total number of panics recovered by the HTTP handler.
   - **req**: Total number of HTTP requests served.
   - **reqActive**: Number of currently active requests.
-  - **reqDurationNs**: Duration (wall time), in nanoseconds, spent inside HTTP requests.
+  - **reqDurationNs**: Duration (wall time), in nanoseconds, spent inside HTTP
+    requests.
   - **serverError**: Number of HTTP responses due to server errors.
-  - **statusReq**: Number of status requests served using the HTTP /status endpoint.
-  - **valuesWrittenOK**: Number of values (fields) successfully accepted and persisted by the HTTP /write endpoint.
-  - **writeReq**: Number of write requests served using the HTTP /write endpoint.
+  - **statusReq**: Number of status requests served using the HTTP /status
+    endpoint.
+  - **valuesWrittenOK**: Number of values (fields) successfully accepted and
+    persisted by the HTTP /write endpoint.
+  - **writeReq**: Number of write requests served using the HTTP /write
+    endpoint.
   - **writeReqActive**: Number of currently active write requests.
-  - **writeReqBytes**: Total number of bytes of line protocol data received by write requests, using the HTTP /write endpoint.
-  - **writeReqDurationNs**: Duration, in nanoseconds, of write requests served using the /write HTTP endpoint.
-- **influxdb_memstats**: Statistics about the memory allocator in the specified database.
+  - **writeReqBytes**: Total number of bytes of line protocol data received by
+    write requests, using the HTTP /write endpoint.
+  - **writeReqDurationNs**: Duration, in nanoseconds, of write requests served
+    using the /write HTTP endpoint.
+- **influxdb_memstats**: Statistics about the memory allocator in the specified
+  database.
   - **Alloc**: Number of bytes allocated to heap objects.
   - **BuckHashSys**: Number of bytes of memory in profiling bucket hash tables.
   - **Frees**: Cumulative count of heap objects freed.
-  - **GCCPUFraction**: fraction of InfluxDB's available CPU time used by the garbage collector (GC) since InfluxDB started.
+  - **GCCPUFraction**: fraction of InfluxDB's available CPU time used by the
+    garbage collector (GC) since InfluxDB started.
   - **GCSys**: Number of bytes of memory in garbage collection metadata.
   - **HeapAlloc**: Number of bytes of allocated heap objects.
   - **HeapIdle**: Number of bytes in idle (unused) spans.
@@ -133,39 +185,51 @@ built from the InfluxDB source, and may vary between versions:
   - **LastGC**: Time the last garbage collection finished.
   - **Lookups**: Number of pointer lookups performed by the runtime.
   - **MCacheInuse**: Number of bytes of allocated mcache structures.
-  - **MCacheSys**: Number of bytes of memory obtained from the OS for mcache structures.
+  - **MCacheSys**: Number of bytes of memory obtained from the OS for mcache
+    structures.
   - **MSpanInuse**: Number of bytes of allocated mspan structures.
-  - **MSpanSys**: Number of bytes of memory obtained from the OS for mspan structures.
+  - **MSpanSys**: Number of bytes of memory obtained from the OS for mspan
+    structures.
   - **Mallocs**: Cumulative count of heap objects allocated.
   - **NextGC**: Target heap size of the next GC cycle.
-  - **NumForcedGC**: Number of GC cycles that were forced by the application calling the GC function.
+  - **NumForcedGC**: Number of GC cycles that were forced by the application
+    calling the GC function.
   - **NumGC**: Number of completed GC cycles.
-  - **OtherSys**: Number of bytes of memory in miscellaneous off-heap runtime allocations.
-  - **PauseTotalNs**: Cumulative nanoseconds in GC stop-the-world pauses since the program started.
+  - **OtherSys**: Number of bytes of memory in miscellaneous off-heap runtime
+    allocations.
+  - **PauseTotalNs**: Cumulative nanoseconds in GC stop-the-world pauses since
+    the program started.
   - **StackInuse**: Number of bytes in stack spans.
   - **StackSys**: Number of bytes of stack memory obtained from the OS.
   - **Sys**: Total bytes of memory obtained from the OS.
   - **TotalAlloc**: Cumulative bytes allocated for heap objects.
-- **influxdb_queryExecutor**: Metrics related to usage of the Query Executor of the InfluxDB engine.
+- **influxdb_queryExecutor**: Metrics related to usage of the Query Executor
+  of the InfluxDB engine.
   - **queriesActive**: Number of active queries currently being handled.
   - **queriesExecuted**: Number of queries executed (started).
   - **queriesFinished**: Number of queries that have finished executing.
   - **queryDurationNs**: Total duration, in nanoseconds, of executed queries.
   - **recoveredPanics**: Number of panics recovered by the Query Executor.
-- **influxdb_rpc** _(Enterprise Only)_ : Statistics related to the use of RPC calls within InfluxDB Enterprise clusters.
-  - **idleStreams**: Number of idle multiplexed streams across all live TCP connections.
+- **influxdb_rpc** _(Enterprise Only)_ : Statistics related to the use of RPC
+  calls within InfluxDB Enterprise clusters.
+  - **idleStreams**: Number of idle multiplexed streams across all live TCP
+    connections.
   - **liveConnections**: Current number of live TCP connections to other nodes.
-  - **liveStreams**: Current number of live multiplexed streams across all live TCP connections.
+  - **liveStreams**: Current number of live multiplexed streams across all live
+    TCP connections.
   - **rpcCalls**: Total number of RPC calls made to remote nodes.
-  - **rpcFailures**: Total number of RPC failures, which are RPCs that did not recover.
+  - **rpcFailures**: Total number of RPC failures, which are RPCs that did
+    not recover.
   - **rpcReadBytes**: Total number of RPC bytes read.
   - **rpcRetries**: Total number of RPC calls that retried at least once.
   - **rpcWriteBytes**: Total number of RPC bytes written.
   - **singleUse**: Total number of single-use connections opened using Dial.
   - **singleUseOpen**: Number of single-use connections currently open.
-  - **totalConnections**: Total number of TCP connections that have been established.
+  - **totalConnections**: Total number of TCP connections that have been
+    established.
   - **totalStreams**: Total number of streams established.
-- **influxdb_runtime**: Subset of memstat record statistics for the Go memory allocator.
+- **influxdb_runtime**: Subset of memstat record statistics for the Go memory
+  allocator.
   - **Alloc**: Currently allocated number of bytes of heap objects.
   - **Frees**: Cumulative number of freed (live) heap objects.
   - **HeapAlloc**: Size, in bytes, of all heap objects.
@@ -173,71 +237,112 @@ built from the InfluxDB source, and may vary between versions:
   - **HeapInUse**: Number of bytes in in-use spans.
   - **HeapObjects**: Number of allocated heap objects.
   - **HeapReleased**: Number of bytes of physical memory returned to the OS.
-  - **HeapSys**: Number of bytes of heap memory obtained from the OS. Measures the amount of virtual address space reserved for the heap.
-  - **Lookups**: Number of pointer lookups performed by the runtime. Primarily useful for debugging runtime internals.
-  - **Mallocs**: Total number of heap objects allocated. The total number of live objects is Frees.
+  - **HeapSys**: Number of bytes of heap memory obtained from the OS. Measures
+    the amount of virtual address space reserved for the heap.
+  - **Lookups**: Number of pointer lookups performed by the runtime. Primarily
+    useful for debugging runtime internals.
+  - **Mallocs**: Total number of heap objects allocated. The total number of
+    live objects is Frees.
   - **NumGC**: Number of completed GC (garbage collection) cycles.
   - **NumGoroutine**: Total number of Go routines.
-  - **PauseTotalNs**: Total duration, in nanoseconds, of total GC (garbage collection) pauses.
-  - **Sys**: Total number of bytes of memory obtained from the OS. Measures the virtual address space reserved by the Go runtime for the heap, stacks, and other internal data structures.
-  - **TotalAlloc**: Total number of bytes allocated for heap objects. This statistic does not decrease when objects are freed.
+  - **PauseTotalNs**: Total duration, in nanoseconds, of total GC
+    (garbage collection) pauses.
+  - **Sys**: Total number of bytes of memory obtained from the OS. Measures
+    the virtual address space reserved by the Go runtime for the heap, stacks,
+    and other internal data structures.
+  - **TotalAlloc**: Total number of bytes allocated for heap objects. This
+    statistic does not decrease when objects are freed.
 - **influxdb_shard**: Metrics related to InfluxDB shards.
-  - **diskBytes**: Size, in bytes, of the shard, including the size of the data directory and the WAL directory.
+  - **diskBytes**: Size, in bytes, of the shard, including the size of the
+    data directory and the WAL directory.
   - **fieldsCreate**: Number of fields created.
   - **indexType**: Type of index inmem or tsi1.
   - **n_shards**: Total number of shards in the specified database.
   - **seriesCreate**: Number of series created.
   - **writeBytes**: Number of bytes written to the shard.
-  - **writePointsDropped**: Number of requests to write points t dropped from a write.
-  - **writePointsErr**: Number of requests to write points that failed to be written due to errors.
+  - **writePointsDropped**: Number of requests to write points t dropped from
+    a write.
+  - **writePointsErr**: Number of requests to write points that failed to be
+    written due to errors.
   - **writePointsOk**: Number of points written successfully.
   - **writeReq**: Total number of write requests.
   - **writeReqErr**: Total number of write requests that failed due to errors.
   - **writeReqOk**: Total number of successful write requests.
 - **influxdb_subscriber**: InfluxDB subscription metrics.
   - **createFailures**: Number of subscriptions that failed to be created.
-  - **pointsWritten**: Total number of points that were successfully written to subscribers.
-  - **writeFailures**: Total number of batches that failed to be written to subscribers.
+  - **pointsWritten**: Total number of points that were successfully written
+    to subscribers.
+  - **writeFailures**: Total number of batches that failed to be written
+    to subscribers.
 - **influxdb_tsm1_cache**: TSM cache metrics.
-  - **cacheAgeMs**: Duration, in milliseconds, since the cache was last snapshotted at sample time.
+  - **cacheAgeMs**: Duration, in milliseconds, since the cache was last
+    snapshotted at sample time.
   - **cachedBytes**: Total number of bytes that have been written into snapshots.
   - **diskBytes**: Size, in bytes, of on-disk snapshots.
   - **memBytes**: Size, in bytes, of in-memory cache.
   - **snapshotCount**: Current level (number) of active snapshots.
-  - **WALCompactionTimeMs**: Duration, in milliseconds, that the commit lock is held while compacting snapshots.
+  - **WALCompactionTimeMs**: Duration, in milliseconds, that the commit lock is
+    held while compacting snapshots.
   - **writeDropped**: Total number of writes dropped due to timeouts.
   - **writeErr**: Total number of writes that failed.
   - **writeOk**: Total number of successful writes.
 - **influxdb_tsm1_engine**: TSM storage engine metrics.
-  - **cacheCompactionDuration** Duration (wall time), in nanoseconds, spent in cache compactions.
-  - **cacheCompactionErr** Number of cache compactions that have failed due to errors.
+  - **cacheCompactionDuration** Duration (wall time), in nanoseconds, spent in
+    cache compactions.
+  - **cacheCompactionErr** Number of cache compactions that have failed due
+    to errors.
   - **cacheCompactions** Total number of cache compactions that have ever run.
-  - **cacheCompactionsActive** Number of cache compactions that are currently running.
-  - **tsmFullCompactionDuration** Duration (wall time), in nanoseconds, spent in full compactions.
-  - **tsmFullCompactionErr** Total number of TSM full compactions that have failed due to errors.
+  - **cacheCompactionsActive** Number of cache compactions that are currently
+    running.
+  - **tsmFullCompactionDuration** Duration (wall time), in nanoseconds, spent
+    in full compactions.
+  - **tsmFullCompactionErr** Total number of TSM full compactions that have
+    failed due to errors.
   - **tsmFullCompactionQueue** Current number of pending TMS Full compactions.
-  - **tsmFullCompactions** Total number of TSM full compactions that have ever run.
-  - **tsmFullCompactionsActive** Number of TSM full compactions currently running.
-  - **tsmLevel1CompactionDuration** Duration (wall time), in nanoseconds, spent in TSM level 1 compactions.
-  - **tsmLevel1CompactionErr** Total number of TSM level 1 compactions that have failed due to errors.
-  - **tsmLevel1CompactionQueue** Current number of pending TSM level 1 compactions.
-  - **tsmLevel1Compactions** Total number of TSM level 1 compactions that have ever run.
-  - **tsmLevel1CompactionsActive** Number of TSM level 1 compactions that are currently running.
-  - **tsmLevel2CompactionDuration** Duration (wall time), in nanoseconds, spent in TSM level 2 compactions.
-  - **tsmLevel2CompactionErr** Number of TSM level 2 compactions that have failed due to errors.
-  - **tsmLevel2CompactionQueue** Current number of pending TSM level 2 compactions.
-  - **tsmLevel2Compactions** Total number of TSM level 2 compactions that have ever run.
-  - **tsmLevel2CompactionsActive** Number of TSM level 2 compactions that are currently running.
-  - **tsmLevel3CompactionDuration** Duration (wall time), in nanoseconds, spent in TSM level 3 compactions.
-  - **tsmLevel3CompactionErr** Number of TSM level 3 compactions that have failed due to errors.
-  - **tsmLevel3CompactionQueue** Current number of pending TSM level 3 compactions.
-  - **tsmLevel3Compactions** Total number of TSM level 3 compactions that have ever run.
-  - **tsmLevel3CompactionsActive** Number of TSM level 3 compactions that are currently running.
-  - **tsmOptimizeCompactionDuration** Duration (wall time), in nanoseconds, spent during TSM optimize compactions.
-  - **tsmOptimizeCompactionErr** Total number of TSM optimize compactions that have failed due to errors.
-  - **tsmOptimizeCompactionQueue** Current number of pending TSM optimize compactions.
-  - **tsmOptimizeCompactions** Total number of TSM optimize compactions that have ever run.
-  - **tsmOptimizeCompactionsActive** Number of TSM optimize compactions that are currently running.
+  - **tsmFullCompactions** Total number of TSM full compactions that have
+    ever run.
+  - **tsmFullCompactionsActive** Number of TSM full compactions currently
+    running.
+  - **tsmLevel1CompactionDuration** Duration (wall time), in nanoseconds,
+    spent in TSM level 1 compactions.
+  - **tsmLevel1CompactionErr** Total number of TSM level 1 compactions that
+    have failed due to errors.
+  - **tsmLevel1CompactionQueue** Current number of pending TSM level 1
+    compactions.
+  - **tsmLevel1Compactions** Total number of TSM level 1 compactions that have
+    ever run.
+  - **tsmLevel1CompactionsActive** Number of TSM level 1 compactions that are
+    currently running.
+  - **tsmLevel2CompactionDuration** Duration (wall time), in nanoseconds,
+    spent in TSM level 2 compactions.
+  - **tsmLevel2CompactionErr** Number of TSM level 2 compactions that have
+    failed due to errors.
+  - **tsmLevel2CompactionQueue** Current number of pending TSM level 2
+    compactions.
+  - **tsmLevel2Compactions** Total number of TSM level 2 compactions that
+    have ever run.
+  - **tsmLevel2CompactionsActive** Number of TSM level 2 compactions that
+    are currently running.
+  - **tsmLevel3CompactionDuration** Duration (wall time), in nanoseconds,
+    spent in TSM level 3 compactions.
+  - **tsmLevel3CompactionErr** Number of TSM level 3 compactions that have
+    failed due to errors.
+  - **tsmLevel3CompactionQueue** Current number of pending TSM level 3
+    compactions.
+  - **tsmLevel3Compactions** Total number of TSM level 3 compactions that
+    have ever run.
+  - **tsmLevel3CompactionsActive** Number of TSM level 3 compactions that
+    are currently running.
+  - **tsmOptimizeCompactionDuration** Duration (wall time), in nanoseconds,
+    spent during TSM optimize compactions.
+  - **tsmOptimizeCompactionErr** Total number of TSM optimize compactions
+   that have failed due to errors.
+  - **tsmOptimizeCompactionQueue** Current number of pending TSM optimize
+    compactions.
+  - **tsmOptimizeCompactions** Total number of TSM optimize compactions that
+    have ever run.
+  - **tsmOptimizeCompactionsActive** Number of TSM optimize compactions that
+    are currently running.
 - **influxdb_tsm1_filestore**: The TSM file store metrics.
   - **diskBytes**: Size, in bytes, of disk usage by the TSM file store.
   - **numFiles**: Total number of files in the TSM file store.
@@ -248,19 +353,32 @@ built from the InfluxDB source, and may vary between versions:
   - **writeOK**: Number of writes that succeeded.
 - **influxdb_write**: Metrics related to InfluxDB writes.
   - **pointReq**: Total number of points requested to be written.
-  - **pointReqHH** _(Enterprise only)_: Total number of points received for write by this node and then enqueued into hinted handoff for the destination node.
-  - **pointReqLocal** _(Enterprise only)_: Total number of point requests that have been attempted to be written into a shard on the same (local) node.
-  - **pointReqRemote** _(Enterprise only)_: Total number of points received for write by this node but needed to be forwarded into a shard on a remote node.
-  - **pointsWrittenOK**: Number of points written to the HTTP /write endpoint and persisted successfully.
+  - **pointReqHH** _(Enterprise only)_: Total number of points received for
+    write by this node and then enqueued into hinted handoff for the
+    destination node.
+  - **pointReqLocal** _(Enterprise only)_: Total number of point requests that
+    have been attempted to be written into a shard on the same (local) node.
+  - **pointReqRemote** _(Enterprise only)_: Total number of points received for
+    write by this node but needed to be forwarded into a shard on a remote node.
+  - **pointsWrittenOK**: Number of points written to the HTTP /write endpoint
+    and persisted successfully.
   - **req**: Total number of batches requested to be written.
-  - **subWriteDrop**: Total number of batches that failed to be sent to the subscription dispatcher.
-  - **subWriteOk**: Total number of batches successfully sent to the subscription dispatcher.
-  - **valuesWrittenOK**: Number of values (fields) written to the HTTP /write endpoint and persisted successfully.
-  - **writeDrop**: Total number of write requests for points that have been dropped due to timestamps not matching any existing retention policies.
-  - **writeError**: Total number of batches of points that were not successfully written, due to a failure to write to a local or remote shard.
-  - **writeOk**: Total number of batches of points written at the requested consistency level.
-  - **writePartial** _(Enterprise only)_: Total number of batches written to at least one node, but did not meet the requested consistency level.
-  - **writeTimeout**: Total number of write requests that failed to complete within the default write timeout duration.
+  - **subWriteDrop**: Total number of batches that failed to be sent to the
+    subscription dispatcher.
+  - **subWriteOk**: Total number of batches successfully sent to the
+    subscription dispatcher.
+  - **valuesWrittenOK**: Number of values (fields) written to the HTTP
+    /write endpoint and persisted successfully.
+  - **writeDrop**: Total number of write requests for points that have been
+    dropped due to timestamps not matching any existing retention policies.
+  - **writeError**: Total number of batches of points that were not
+    successfully written, due to a failure to write to a local or remote shard.
+  - **writeOk**: Total number of batches of points written at the requested
+    consistency level.
+  - **writePartial** _(Enterprise only)_: Total number of batches written to
+    at least one node, but did not meet the requested consistency level.
+  - **writeTimeout**: Total number of write requests that failed to complete
+    within the default write timeout duration.
 
 ## Example Output
 

--- a/plugins/inputs/intel_powerstat/README.md
+++ b/plugins/inputs/intel_powerstat/README.md
@@ -1,7 +1,7 @@
 # Intel PowerStat Input Plugin
 
-This input plugin monitors power statistics on Intel-based platforms and assumes
-presence of Linux based OS.
+This input plugin monitors power statistics on Intel-based platforms and
+assumes presence of Linux based OS.
 
 Main use cases are power saving and workload migration. Telemetry frameworks
 allow users to monitor critical platform level metrics. Key source of platform
@@ -12,28 +12,37 @@ temperature, actual CPU utilization and power statistics.
 ## Configuration
 
 ```toml @sample.conf
-# Intel PowerStat plugin enables monitoring of platform metrics (power, TDP) and per-CPU metrics like temperature, power and utilization.
+# Intel PowerStat plugin enables monitoring of platform metrics (power, TDP)
+# and per-CPU metrics like temperature, power and utilization.
 [[inputs.intel_powerstat]]
-  ## The user can choose which package metrics are monitored by the plugin with the package_metrics setting:
-  ## - The default, will collect "current_power_consumption", "current_dram_power_consumption" and "thermal_design_power"
-  ## - Setting this value to an empty array means no package metrics will be collected
-  ## - Finally, a user can specify individual metrics to capture from the supported options list
+  ## The user can choose which package metrics are monitored by the plugin with
+  ## the package_metrics setting:
+  ## - The default, will collect "current_power_consumption",
+  ##   "current_dram_power_consumption" and "thermal_design_power"
+  ## - Leaving this setting empty means no package metrics will be collected
+  ## - Finally, a user can specify individual metrics to capture from the
+  ##   supported options list
   ## Supported options:
-  ##   "current_power_consumption", "current_dram_power_consumption", "thermal_design_power", "max_turbo_frequency", "uncore_frequency"
+  ##   "current_power_consumption", "current_dram_power_consumption",
+  ##   "thermal_design_power", "max_turbo_frequency", "uncore_frequency"
   # package_metrics = ["current_power_consumption", "current_dram_power_consumption", "thermal_design_power"]
 
-  ## The user can choose which per-CPU metrics are monitored by the plugin in cpu_metrics array.
-  ## Empty or missing array means no per-CPU specific metrics will be collected by the plugin.
+  ## The user can choose which per-CPU metrics are monitored by the plugin in
+  ## cpu_metrics array.
+  ## Empty or missing array means no per-CPU specific metrics will be collected
+  ## by the plugin.
   ## Supported options:
-  ##   "cpu_frequency", "cpu_c0_state_residency", "cpu_c1_state_residency", "cpu_c6_state_residency", "cpu_busy_cycles", "cpu_temperature", "cpu_busy_frequency"
-  ## ATTENTION: cpu_busy_cycles option is DEPRECATED - superseded by cpu_c0_state_residency
+  ##   "cpu_frequency", "cpu_c0_state_residency", "cpu_c1_state_residency",
+  ##   "cpu_c6_state_residency", "cpu_busy_cycles", "cpu_temperature",
+  ##   "cpu_busy_frequency"
+  ## ATTENTION: cpu_busy_cycles is DEPRECATED - use cpu_c0_state_residency
   # cpu_metrics = []
 ```
 
 ## Example: Configuration with no per-CPU telemetry
 
-This configuration allows getting default processor package specific metrics, no
-per-CPU metrics are collected:
+This configuration allows getting default processor package specific metrics,
+no per-CPU metrics are collected:
 
 ```toml
 [[inputs.intel_powerstat]]
@@ -42,8 +51,8 @@ per-CPU metrics are collected:
 
 ## Example: Configuration with no per-CPU telemetry - equivalent case
 
-This configuration allows getting default processor package specific metrics, no
-per-CPU metrics are collected:
+This configuration allows getting default processor package specific metrics,
+no per-CPU metrics are collected:
 
 ```toml
 [[inputs.intel_powerstat]]
@@ -72,8 +81,8 @@ Temperature and CPU Frequency):
 
 ## Example: Configuration with all available metrics
 
-This configuration allows getting all processor package specific metrics and all
-per-CPU metrics:
+This configuration allows getting all processor package specific metrics and
+all per-CPU metrics:
 
 ```toml
 [[inputs.intel_powerstat]]
@@ -87,10 +96,14 @@ Plugin is based on Linux Kernel modules that expose specific metrics over
 `sysfs` or `devfs` interfaces. The following dependencies are expected by
 plugin:
 
-- _intel-rapl_ module which exposes Intel Runtime Power Limiting metrics over `sysfs` (`/sys/devices/virtual/powercap/intel-rapl`),
-- _msr_ kernel module that provides access to processor model specific registers over `devfs` (`/dev/cpu/cpu%d/msr`),
-- _cpufreq_ kernel module - which exposes per-CPU Frequency over `sysfs` (`/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq`).
-- _intel-uncore-frequency_ module exposes Intel uncore frequency metrics over `sysfs` (`/sys/devices/system/cpu/intel_uncore_frequency`),
+- _intel-rapl_ module which exposes Intel Runtime Power Limiting metrics over
+  `sysfs` (`/sys/devices/virtual/powercap/intel-rapl`),
+- _msr_ kernel module that provides access to processor model specific
+  registers over `devfs` (`/dev/cpu/cpu%d/msr`),
+- _cpufreq_ kernel module - which exposes per-CPU Frequency over `sysfs`
+ (`/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq`).
+- _intel-uncore-frequency_ module exposes Intel uncore frequency metrics
+  over `sysfs` (`/sys/devices/system/cpu/intel_uncore_frequency`),
 
 Minimum kernel version required is 3.13 to satisfy most of requirements,
 for `uncore_frequency` metrics `intel-uncore-frequency` module is required
@@ -143,17 +156,23 @@ The following processor properties are examined in more detail in this section:
 processor _cpu family_, _model_ and _flags_. The following processor properties
 are required by the plugin:
 
-- Processor _cpu family_ must be Intel (0x6) - since data used by the plugin assumes Intel specific
-model specific registers for all features
+- Processor _cpu family_ must be Intel (0x6) - since data used by the plugin
+  assumes Intel specific model specific registers for all features
 - The following processor flags shall be present:
-  - "_msr_" shall be present for plugin to read platform data from processor model specific registers and collect
-    the following metrics: _powerstat\_core.cpu\_temperature_, _powerstat\_core.cpu\_busy\_frequency_,
-    _powerstat\_core.cpu\_c0\_state\_residency_, _powerstat\_core.cpu\_c1\_state\_residency_, _powerstat\_core.cpu\_c6\_state\_residency_
-  - "_aperfmperf_" shall be present to collect the following metrics: _powerstat\_core.cpu\_busy\_frequency_,
-    _powerstat\_core.cpu\_c0\_state\_residency_, _powerstat\_core.cpu\_c1\_state\_residency_
+  - "_msr_" shall be present for plugin to read platform data from processor
+    model specific registers and collect the following metrics:
+    _powerstat\_core.cpu\_temperature_, _powerstat\_core.cpu\_busy\_frequency_,
+    _powerstat\_core.cpu\_c0\_state\_residency_,
+    _powerstat\_core.cpu\_c1\_state\_residency_,
+    _powerstat\_core.cpu\_c6\_state\_residency_
+  - "_aperfmperf_" shall be present to collect the following metrics:
+    _powerstat\_core.cpu\_busy\_frequency_,
+    _powerstat\_core.cpu\_c0\_state\_residency_,
+    _powerstat\_core.cpu\_c1\_state\_residency_
   - "_dts_" shall be present to collect _powerstat\_core.cpu\_temperature_
-- Processor _Model number_ must be one of the following values for plugin to read _powerstat\_core.cpu\_c1\_state\_residency_
-and _powerstat\_core.cpu\_c6\_state\_residency_ metrics:
+- Processor _Model number_ must be one of the following values for plugin to
+  read _powerstat\_core.cpu\_c1\_state\_residency_ and
+  _powerstat\_core.cpu\_c6\_state\_residency_ metrics:
 
 | Model number | Processor name |
 |-----|-------------|
@@ -228,7 +247,7 @@ value.
    while core_id and package_id tags are additional topology information.
 
   - Available metrics for powerstat_core measurement
-  
+
       | Metric name (field) | Description | Units |
       |---------------------|-------------|-------|
       | `cpu_frequency_mhz` | Current operational frequency of CPU Core | MHz |
@@ -240,7 +259,6 @@ value.
       | `cpu_busy_cycles_percent` | (**DEPRECATED** - superseded by cpu_c0_state_residency_percent) CPU Core Busy cycles as a ratio of Cycles spent in C0 state residency to all cycles executed by CPU Core | % |
 
 - powerstat_package
-
   - The following Tags are returned by plugin with powerstat_package measurements:
 
       | Tag | Description |
@@ -250,8 +268,8 @@ value.
       | `die`| Specific tag for all `uncore_frequency` metrics. Id of die
       | `type`| Specific tag for all `uncore_frequency` metrics. Type of uncore frequency (current or initial)
 
-   Measurement powerstat_package metrics are collected per processor package -_package_id_ tag indicates which package metric refers to.
-
+   Measurement powerstat_package metrics are collected per processor package
+   _package_id_ tag indicates which package metric refers to.
   - Available metrics for powerstat_package measurement
 
       | Metric name (field) | Description | Units |

--- a/plugins/inputs/intel_powerstat/sample.conf
+++ b/plugins/inputs/intel_powerstat/sample.conf
@@ -1,16 +1,25 @@
-# Intel PowerStat plugin enables monitoring of platform metrics (power, TDP) and per-CPU metrics like temperature, power and utilization.
+# Intel PowerStat plugin enables monitoring of platform metrics (power, TDP)
+# and per-CPU metrics like temperature, power and utilization.
 [[inputs.intel_powerstat]]
-  ## The user can choose which package metrics are monitored by the plugin with the package_metrics setting:
-  ## - The default, will collect "current_power_consumption", "current_dram_power_consumption" and "thermal_design_power"
-  ## - Setting this value to an empty array means no package metrics will be collected
-  ## - Finally, a user can specify individual metrics to capture from the supported options list
+  ## The user can choose which package metrics are monitored by the plugin with
+  ## the package_metrics setting:
+  ## - The default, will collect "current_power_consumption",
+  ##   "current_dram_power_consumption" and "thermal_design_power"
+  ## - Leaving this setting empty means no package metrics will be collected
+  ## - Finally, a user can specify individual metrics to capture from the
+  ##   supported options list
   ## Supported options:
-  ##   "current_power_consumption", "current_dram_power_consumption", "thermal_design_power", "max_turbo_frequency", "uncore_frequency"
+  ##   "current_power_consumption", "current_dram_power_consumption",
+  ##   "thermal_design_power", "max_turbo_frequency", "uncore_frequency"
   # package_metrics = ["current_power_consumption", "current_dram_power_consumption", "thermal_design_power"]
 
-  ## The user can choose which per-CPU metrics are monitored by the plugin in cpu_metrics array.
-  ## Empty or missing array means no per-CPU specific metrics will be collected by the plugin.
+  ## The user can choose which per-CPU metrics are monitored by the plugin in
+  ## cpu_metrics array.
+  ## Empty or missing array means no per-CPU specific metrics will be collected
+  ## by the plugin.
   ## Supported options:
-  ##   "cpu_frequency", "cpu_c0_state_residency", "cpu_c1_state_residency", "cpu_c6_state_residency", "cpu_busy_cycles", "cpu_temperature", "cpu_busy_frequency"
-  ## ATTENTION: cpu_busy_cycles option is DEPRECATED - superseded by cpu_c0_state_residency
+  ##   "cpu_frequency", "cpu_c0_state_residency", "cpu_c1_state_residency",
+  ##   "cpu_c6_state_residency", "cpu_busy_cycles", "cpu_temperature",
+  ##   "cpu_busy_frequency"
+  ## ATTENTION: cpu_busy_cycles is DEPRECATED - use cpu_c0_state_residency
   # cpu_metrics = []

--- a/plugins/inputs/iptables/README.md
+++ b/plugins/inputs/iptables/README.md
@@ -1,11 +1,11 @@
 # Iptables Input Plugin
 
-The iptables plugin gathers packets and bytes counters for rules within a set of
-table and chain from the Linux's iptables firewall.
+The iptables plugin gathers packets and bytes counters for rules within a set
+of table and chain from the Linux's iptables firewall.
 
 Rules are identified through associated comment. **Rules without comment are
-ignored**.  Indeed we need a unique ID for the rule and the rule number is not a
-constant: it may vary when rules are inserted/deleted at start-up or by
+ignored**.  Indeed we need a unique ID for the rule and the rule number is not
+a constant: it may vary when rules are inserted/deleted at start-up or by
 automatic tools (interactive firewalls, fail2ban, ...).  Also when the rule set
 is becoming big (hundreds of lines) most people are interested in monitoring
 only a small part of the rule set.
@@ -20,8 +20,8 @@ have several options to grant telegraf to run iptables:
 * Run telegraf as root. This is strongly discouraged.
 * Configure systemd to run telegraf with CAP_NET_ADMIN and CAP_NET_RAW. This is
   the simplest and recommended option.
-* Configure sudo to grant telegraf to run iptables. This is the most restrictive
-  option, but require sudo setup.
+* Configure sudo to grant telegraf to run iptables. This is the most
+  restrictive option, but require sudo setup.
 
 ## Using systemd capabilities
 
@@ -33,7 +33,8 @@ CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
 AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
 ```
 
-Since telegraf will fork a process to run iptables, `AmbientCapabilities` is required to transmit the capabilities bounding set to the forked process.
+Since telegraf will fork a process to run iptables, `AmbientCapabilities` is
+required to transmit the capabilities bounding set to the forked process.
 
 ## Using sudo
 
@@ -69,11 +70,13 @@ allowing a lock usage to prevent this error.
 [[inputs.iptables]]
   ## iptables require root access on most systems.
   ## Setting 'use_sudo' to true will make use of sudo to run iptables.
-  ## Users must configure sudo to allow telegraf user to run iptables with no password.
+  ## Users must configure sudo to allow telegraf user to run iptables with
+  ## no password.
   ## iptables can be restricted to only list command "iptables -nvL".
   use_sudo = false
   ## Setting 'use_lock' to true runs iptables with the "-w" option.
-  ## Adjust your sudo settings appropriately if using this option ("iptables -w 5 -nvl")
+  ## Adjust your sudo settings appropriately if using this option
+  ## ("iptables -w 5 -nvl")
   use_lock = false
   ## Define an alternate executable, such as "ip6tables". Default is "iptables".
   # binary = "ip6tables"

--- a/plugins/inputs/iptables/sample.conf
+++ b/plugins/inputs/iptables/sample.conf
@@ -2,11 +2,13 @@
 [[inputs.iptables]]
   ## iptables require root access on most systems.
   ## Setting 'use_sudo' to true will make use of sudo to run iptables.
-  ## Users must configure sudo to allow telegraf user to run iptables with no password.
+  ## Users must configure sudo to allow telegraf user to run iptables with
+  ## no password.
   ## iptables can be restricted to only list command "iptables -nvL".
   use_sudo = false
   ## Setting 'use_lock' to true runs iptables with the "-w" option.
-  ## Adjust your sudo settings appropriately if using this option ("iptables -w 5 -nvl")
+  ## Adjust your sudo settings appropriately if using this option
+  ## ("iptables -w 5 -nvl")
   use_lock = false
   ## Define an alternate executable, such as "ip6tables". Default is "iptables".
   # binary = "ip6tables"

--- a/plugins/inputs/jolokia2/README.md
+++ b/plugins/inputs/jolokia2/README.md
@@ -11,8 +11,8 @@ protocol](https://jolokia.org/reference/html/protocol.html).
 
 ### Jolokia Agent Configuration
 
-The `jolokia2_agent` input plugin reads JMX metrics from one or more [Jolokia
-agent](https://jolokia.org/agent/jvm.html) REST endpoints.
+The `jolokia2_agent` input plugin reads JMX metrics from one or more
+[Jolokia agent](https://jolokia.org/agent/jvm.html) REST endpoints.
 
 ```toml @sample.conf
 [[inputs.jolokia2_agent]]
@@ -205,3 +205,7 @@ configurations that apply to every `metric` declaration.
 
 Please help improve this list and contribute new configuration files by opening
 an issue or pull request.
+
+## Metrics
+
+## Example Output

--- a/plugins/inputs/jolokia2/README.md
+++ b/plugins/inputs/jolokia2/README.md
@@ -205,7 +205,3 @@ configurations that apply to every `metric` declaration.
 
 Please help improve this list and contribute new configuration files by opening
 an issue or pull request.
-
-## Metrics
-
-## Example Output

--- a/plugins/inputs/jolokia2/jolokia2_agent/README.md
+++ b/plugins/inputs/jolokia2/jolokia2_agent/README.md
@@ -1,8 +1,7 @@
-# Jolokia2 Proxy Input Plugin
+# Jolokia2 Agent Input Plugin
 
-The `jolokia2_proxy` input plugin reads JMX metrics from one or more _targets_
-by interacting with a [Jolokia proxy](https://jolokia.org/features/proxy.html)
-REST endpoint.
+The `jolokia2_agent` input plugin reads JMX metrics from one or more
+[Jolokia agent](https://jolokia.org/agent/jvm.html) REST endpoints.
 
 ## Configuration
 
@@ -31,7 +30,3 @@ REST endpoint.
     mbean = "java.lang:type=Runtime"
     paths = ["Uptime"]
 ```
-
-## Metrics
-
-## Example Output

--- a/plugins/inputs/jolokia2/jolokia2_agent/README.md
+++ b/plugins/inputs/jolokia2/jolokia2_agent/README.md
@@ -1,4 +1,4 @@
-# Jolokia2 Proxy input plugin
+# Jolokia2 Proxy Input Plugin
 
 The `jolokia2_proxy` input plugin reads JMX metrics from one or more _targets_
 by interacting with a [Jolokia proxy](https://jolokia.org/features/proxy.html)
@@ -31,3 +31,7 @@ REST endpoint.
     mbean = "java.lang:type=Runtime"
     paths = ["Uptime"]
 ```
+
+## Metrics
+
+## Example Output

--- a/plugins/inputs/jolokia2/jolokia2_agent/README.md
+++ b/plugins/inputs/jolokia2/jolokia2_agent/README.md
@@ -1,6 +1,8 @@
 # Jolokia2 Proxy input plugin
 
-The `jolokia2_proxy` input plugin reads JMX metrics from one or more _targets_ by interacting with a [Jolokia proxy](https://jolokia.org/features/proxy.html) REST endpoint.
+The `jolokia2_proxy` input plugin reads JMX metrics from one or more _targets_
+by interacting with a [Jolokia proxy](https://jolokia.org/features/proxy.html)
+REST endpoint.
 
 ## Configuration
 

--- a/plugins/inputs/jolokia2/jolokia2_agent/README.md
+++ b/plugins/inputs/jolokia2/jolokia2_agent/README.md
@@ -6,7 +6,7 @@ REST endpoint.
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Read JMX metrics from a Jolokia REST agent endpoint
 [[inputs.jolokia2_agent]]
   # default_tag_prefix      = ""

--- a/plugins/inputs/jolokia2/jolokia2_proxy/README.md
+++ b/plugins/inputs/jolokia2/jolokia2_proxy/README.md
@@ -1,6 +1,7 @@
 # Jolokia2 Agent plugin
 
-The `jolokia2_agent` input plugin reads JMX metrics from one or more [Jolokia agent](https://jolokia.org/agent/jvm.html) REST endpoints.
+The `jolokia2_agent` input plugin reads JMX metrics from one or more
+[Jolokia agent](https://jolokia.org/agent/jvm.html) REST endpoints.
 
 ## Configuration
 

--- a/plugins/inputs/jolokia2/jolokia2_proxy/README.md
+++ b/plugins/inputs/jolokia2/jolokia2_proxy/README.md
@@ -1,7 +1,8 @@
-# Jolokia2 Agent Input Plugin
+# Jolokia2 Proxy Input Plugin
 
-The `jolokia2_agent` input plugin reads JMX metrics from one or more
-[Jolokia agent](https://jolokia.org/agent/jvm.html) REST endpoints.
+The `jolokia2_proxy` input plugin reads JMX metrics from one or more _targets_
+by interacting with a [Jolokia proxy](https://jolokia.org/features/proxy.html)
+REST endpoint.
 
 ## Configuration
 
@@ -38,7 +39,3 @@ The `jolokia2_agent` input plugin reads JMX metrics from one or more
     mbean = "java.lang:type=Runtime"
     paths = ["Uptime"]
 ```
-
-## Metrics
-
-## Example Output

--- a/plugins/inputs/jolokia2/jolokia2_proxy/README.md
+++ b/plugins/inputs/jolokia2/jolokia2_proxy/README.md
@@ -5,7 +5,7 @@ The `jolokia2_agent` input plugin reads JMX metrics from one or more
 
 ## Configuration
 
-```toml
+```toml @sample.conf
 # Read JMX metrics from a Jolokia REST proxy endpoint
 [[inputs.jolokia2_proxy]]
   # default_tag_prefix      = ""

--- a/plugins/inputs/jolokia2/jolokia2_proxy/README.md
+++ b/plugins/inputs/jolokia2/jolokia2_proxy/README.md
@@ -1,4 +1,4 @@
-# Jolokia2 Agent plugin
+# Jolokia2 Agent Input Plugin
 
 The `jolokia2_agent` input plugin reads JMX metrics from one or more
 [Jolokia agent](https://jolokia.org/agent/jvm.html) REST endpoints.
@@ -38,3 +38,7 @@ The `jolokia2_agent` input plugin reads JMX metrics from one or more
     mbean = "java.lang:type=Runtime"
     paths = ["Uptime"]
 ```
+
+## Metrics
+
+## Example Output

--- a/plugins/inputs/kapacitor/README.md
+++ b/plugins/inputs/kapacitor/README.md
@@ -31,10 +31,11 @@ The Kapacitor plugin collects metrics from the given Kapacitor instances.
   - [num_subscriptions](#num_subscriptions) _(integer)_
   - [num_tasks](#num_tasks) _(integer)_
 - [kapacitor_alert](#kapacitor_alert)
-  - [notification_dropped](#notification_dropped) _(integer)_
+  - [notification_dropped](#notification-dropped) _(integer)_
   - [primary-handle-count](#primary-handle-count) _(integer)_
   - [secondary-handle-count](#secondary-handle-count) _(integer)_
-- (Kapacitor Enterprise only) [kapacitor_cluster](#kapacitor_cluster) _(integer)_
+- (Kapacitor Enterprise only) [kapacitor_cluster](#kapacitor_cluster)
+  _(integer)_
   - [dropped_member_events](#dropped_member_events) _(integer)_
   - [dropped_user_events](#dropped_user_events) _(integer)_
   - [query_handler_errors](#query_handler_errors) _(integer)_
@@ -90,8 +91,8 @@ The Kapacitor plugin collects metrics from the given Kapacitor instances.
 
 ## kapacitor
 
-The `kapacitor` measurement stores fields with information related to [Kapacitor
-tasks][tasks] and [subscriptions][subs].
+The `kapacitor` measurement stores fields with information related to
+[Kapacitor tasks][tasks] and [subscriptions][subs].
 
 [tasks]: https://docs.influxdata.com/kapacitor/latest/introduction/getting-started/#kapacitor-tasks
 
@@ -150,6 +151,10 @@ The number of gossip member events that were dropped.
 ### dropped_user_events
 
 The number of gossip user events that were dropped.
+
+### query_handler_errors
+
+The number of errors from event handlers.
 
 ---
 

--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -1,7 +1,7 @@
 # Kubernetes Inventory Input Plugin
 
-This plugin generates metrics derived from the state of the following Kubernetes
-resources:
+This plugin generates metrics derived from the state of the following
+Kubernetes resources:
 
 - daemonsets
 - deployments
@@ -14,9 +14,9 @@ resources:
 - services
 - statefulsets
 
-Kubernetes is a fast moving project, with a new minor release every 3 months. As
-such, we will aim to maintain support only for versions that are supported by
-the major cloud providers; this is roughly 4 release / 2 years.
+Kubernetes is a fast moving project, with a new minor release every 3 months.
+As such, we will aim to maintain support only for versions that are supported
+by the major cloud providers; this is roughly 4 release / 2 years.
 
 **This plugin supports Kubernetes 1.11 and later.**
 
@@ -30,7 +30,8 @@ avoid cardinality issues:
 - Write to a database with an appropriate [retention policy][].
 - Consider using the [Time Series Index][tsi].
 - Monitor your databases [series cardinality][].
-- Consult the [InfluxDB documentation][influx-docs] for the most up-to-date techniques.
+- Consult the [InfluxDB documentation][influx-docs] for the most up-to-date
+  techniques.
 
 ## Configuration
 
@@ -60,8 +61,9 @@ avoid cardinality issues:
 
   ## Optional Resources to exclude from gathering
   ## Leave them with blank with try to gather everything available.
-  ## Values can be - "daemonsets", deployments", "endpoints", "ingress", "nodes",
-  ## "persistentvolumes", "persistentvolumeclaims", "pods", "services", "statefulsets"
+  ## Values can be - "daemonsets", deployments", "endpoints", "ingress",
+  ## "nodes", "persistentvolumes", "persistentvolumeclaims", "pods", "services",
+  ## "statefulsets"
   # resource_exclude = [ "deployments", "nodes", "statefulsets" ]
 
   ## Optional Resources to include when gathering
@@ -352,4 +354,3 @@ kubernetes_statefulset,namespace=default,selector_select1=s1,statefulset_name=et
 [tsi]: https://docs.influxdata.com/influxdb/latest/concepts/time-series-index/
 [series cardinality]: https://docs.influxdata.com/influxdb/latest/query_language/spec/#show-cardinality
 [influx-docs]: https://docs.influxdata.com/influxdb/latest/
-[k8s-telegraf]: https://www.influxdata.com/blog/monitoring-kubernetes-architecture/

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -23,8 +23,9 @@
 
   ## Optional Resources to exclude from gathering
   ## Leave them with blank with try to gather everything available.
-  ## Values can be - "daemonsets", deployments", "endpoints", "ingress", "nodes",
-  ## "persistentvolumes", "persistentvolumeclaims", "pods", "services", "statefulsets"
+  ## Values can be - "daemonsets", deployments", "endpoints", "ingress",
+  ## "nodes", "persistentvolumes", "persistentvolumeclaims", "pods", "services",
+  ## "statefulsets"
   # resource_exclude = [ "deployments", "nodes", "statefulsets" ]
 
   ## Optional Resources to include when gathering

--- a/plugins/inputs/mdstat/README.md
+++ b/plugins/inputs/mdstat/README.md
@@ -1,9 +1,9 @@
 # mdstat Input Plugin
 
 The mdstat plugin gathers statistics about any Linux MD RAID arrays configured
-on the host by reading /proc/mdstat. For a full list of available fields see the
-/proc/mdstat section of the [proc man page][man-proc].  For a better idea of
-what each field represents, see the [mdstat man page][man-mdstat].
+on the host by reading /proc/mdstat. For a full list of available fields see
+the /proc/mdstat section of the [proc man page][man-proc].  For a better idea
+of what each field represents, see the [mdstat man page][man-mdstat].
 
 Stat collection based on Prometheus' [mdstat collection library][prom-lib].
 
@@ -26,12 +26,16 @@ Stat collection based on Prometheus' [mdstat collection library][prom-lib].
 ## Metrics
 
 - mdstat
-  - BlocksSynced (if the array is rebuilding/checking, this is the count of blocks that have been scanned)
-  - BlocksSyncedFinishTime (the expected finish time of the rebuild scan, listed in minutes remaining)
+  - BlocksSynced (if the array is rebuilding/checking, this is the count of
+    blocks that have been scanned)
+  - BlocksSyncedFinishTime (the expected finish time of the rebuild scan,
+    listed in minutes remaining)
   - BlocksSyncedPct (the percentage of the rebuild scan left)
-  - BlocksSyncedSpeed (the current speed the rebuild is running at, listed in K/sec)
+  - BlocksSyncedSpeed (the current speed the rebuild is running at, listed
+    in K/sec)
   - BlocksTotal (the total count of blocks in the array)
-  - DisksActive (the number of disks that are currently considered healthy in the array)
+  - DisksActive (the number of disks that are currently considered healthy
+    in the array)
   - DisksFailed (the current count of failed disks in the array)
   - DisksSpare (the current count of "spare" disks in the array)
   - DisksTotal (total count of disks in the array)

--- a/plugins/inputs/memcached/README.md
+++ b/plugins/inputs/memcached/README.md
@@ -34,27 +34,36 @@ Fields:
 * bytes - Current number of bytes used to store items
 * bytes_read - Total number of bytes read by this server from network
 * bytes_written - Total number of bytes sent by this server to network
-* cas_badval - Number of CAS reqs for which a key was found, but the CAS value did not match
+* cas_badval - Number of CAS reqs for which a key was found, but the CAS value
+  did not match
 * cas_hits - Number of successful CAS reqs
 * cas_misses - Number of CAS reqs against missing keys
 * cmd_flush - Cumulative number of flush reqs
 * cmd_get - Cumulative number of retrieval reqs
 * cmd_set - Cumulative number of storage reqs
 * cmd_touch - Cumulative number of touch reqs
-* conn_yields - Number of times any connection yielded to another due to hitting the -R limit
-* connection_structures - Number of connection structures allocated by the server
+* conn_yields - Number of times any connection yielded to another due to
+  hitting the -R limit
+* connection_structures - Number of connection structures allocated by the
+  server
 * curr_connections - Number of open connections
 * curr_items - Current number of items stored
 * decr_hits - Number of successful decr reqs
 * decr_misses - Number of decr reqs against missing keys
 * delete_hits - Number of deletion reqs resulting in an item being removed
 * delete_misses - umber of deletions reqs for missing keys
-* evicted_active - Items evicted from LRU that had been hit recently but did not jump to top of LRU
-* evicted_unfetched - Items evicted from LRU that were never touched by get/incr/append/etc
-* evictions - Number of valid items removed from cache to free memory for new items
-* expired_unfetched - Items pulled from LRU that were never touched by get/incr/append/etc before expiring
-* get_expired - Number of items that have been requested but had already expired
-* get_flushed - Number of items that have been requested but have been flushed via flush_all
+* evicted_active - Items evicted from LRU that had been hit recently but did
+  not jump to top of LRU
+* evicted_unfetched - Items evicted from LRU that were never touched by
+  get/incr/append/etc
+* evictions - Number of valid items removed from cache to free memory for
+  new items
+* expired_unfetched - Items pulled from LRU that were never touched by
+  get/incr/append/etc before expiring
+* get_expired - Number of items that have been requested but had already
+  expired
+* get_flushed - Number of items that have been requested but have been flushed
+  via flush_all
 * get_hits - Number of keys that have been requested and found present
 * get_misses - Number of items that have been requested and not found
 * hash_bytes - Bytes currently used by hash tables
@@ -63,14 +72,19 @@ Fields:
 * incr_hits - Number of successful incr reqs
 * incr_misses - Number of incr reqs against missing keys
 * limit_maxbytes - Number of bytes this server is allowed to use for storage
-* listen_disabled_num - Number of times server has stopped accepting new connections (maxconns)
+* listen_disabled_num - Number of times server has stopped accepting new
+  connections (maxconns)
 * max_connections - Max number of simultaneous connections
-* reclaimed - Number of times an entry was stored using memory from an expired entry
+* reclaimed - Number of times an entry was stored using memory from an
+  expired entry
 * rejected_connections - Conns rejected in maxconns_fast mode
-* store_no_memory - Number of rejected storage requests caused by exhaustion of the memory limit when evictions are disabled
-* store_too_large - Number of rejected storage requests caused by attempting to write a value larger than the item size limit
+* store_no_memory - Number of rejected storage requests caused by exhaustion
+  of the memory limit when evictions are disabled
+* store_too_large - Number of rejected storage requests caused by attempting
+  to write a value larger than the item size limit
 * threads - Number of worker threads requested
-* total_connections - Total number of connections opened since the server started running
+* total_connections - Total number of connections opened since the server
+  started running
 * total_items - Total number of items stored since the server started
 * touch_hits - Number of keys that have been touched with a new expiration time
 * touch_misses - Number of items that have been touched and not found

--- a/plugins/inputs/mock/README.md
+++ b/plugins/inputs/mock/README.md
@@ -51,7 +51,8 @@ The mock plugin only requires that:
 
 The available algorithms for generating mock data include:
 
-* Constant - generate a field with the given value of type string, float, int or bool
+* Constant - generate a field with the given value of type string, float, int
+  or bool
 * Random Float - generate a random float, inclusive of min and max
 * Sine Wave - produce a sine wave with a certain amplitude and period
 * Step - always add the step value, negative values accepted

--- a/plugins/inputs/multifile/README.md
+++ b/plugins/inputs/multifile/README.md
@@ -4,8 +4,9 @@ The multifile input plugin allows Telegraf to combine data from multiple files
 into a single metric, creating one field or tag per file.  This is often
 useful creating custom metrics from the `/sys` or `/proc` filesystems.
 
-> Note: If you wish to parse metrics from a single file formatted in one of the supported
-> [input data formats][], you should use the [file][] input plugin instead.
+> Note: If you wish to parse metrics from a single file formatted in one of
+> the supported [input data formats][], you should use the [file][] input
+> plugin instead.
 
 ## Configuration
 
@@ -43,8 +44,11 @@ Path of the file to be parsed, relative to the `base_dir`.
 Name of the field/tag key, defaults to `$(basename file)`.
 * `conversion`:
 Data format used to parse the file contents:
-  * `float(X)`: Converts the input value into a float and divides by the Xth power of 10. Effectively just moves the decimal left X places. For example a value of `123` with `float(2)` will result in `1.23`.
-  * `float`: Converts the value into a float with no adjustment. Same as `float(0)`.
+  * `float(X)`: Converts the input value into a float and divides by the Xth
+    power of 10. Effectively just moves the decimal left X places. For example
+    a value of `123` with `float(2)` will result in `1.23`.
+  * `float`: Converts the value into a float with no adjustment.
+    Same as `float(0)`.
   * `int`: Converts the value into an integer.
   * `string`, `""`: No conversion.
   * `bool`: Converts the value into a boolean.

--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -54,7 +54,8 @@ in mySQL configuration. See the performance schema [quick start][quick-start].
   ## if the list is empty, then metrics are gathered from all database tables
   # table_schema_databases = []
 
-  ## gather metrics from INFORMATION_SCHEMA.TABLES for databases provided above list
+  ## gather metrics from INFORMATION_SCHEMA.TABLES for databases provided
+  ## in the list above
   # gather_table_schema = false
 
   ## gather thread state counts from INFORMATION_SCHEMA.PROCESSLIST
@@ -120,7 +121,7 @@ in mySQL configuration. See the performance schema [quick start][quick-start].
   ##   example: interval_slow = "30m"
   # interval_slow = ""
 
-  ## Optional TLS Config (will be used if tls=custom parameter specified in server uri)
+  ## Optional TLS Config (used if tls=custom parameter specified in server uri)
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
@@ -236,9 +237,11 @@ differences.
 Requires to be turned on in configuration.
   * binary_size_bytes(int, number)
   * binary_files_count(int, number)
-* Process list - connection metrics from processlist for each user. It has the following tags
+* Process list - connection metrics from processlist for each user. It has the
+  following tags
   * connections(int, number)
-* User Statistics - connection metrics from user statistics for each user. It has the following fields
+* User Statistics - connection metrics from user statistics for each user.
+  It has the following fields
   * access_denied
   * binlog_bytes_written
   * busy_time
@@ -286,8 +289,8 @@ and process. It has following fields:
 for them. It has following fields:
   * auto_increment_column(int, number)
   * auto_increment_column_max(int, number)
-* InnoDB metrics - all metrics of information_schema.INNODB_METRICS with a status "enabled". For MariaDB,
-`mariadb_dialect = true` to use `ENABLED=1`.
+* InnoDB metrics - all metrics of information_schema.INNODB_METRICS with a
+  status "enabled". For MariaDB, `mariadb_dialect = true` to use `ENABLED=1`.
 * Perf table lock waits - gathers total number and time for SQL and external
 lock waits events for each table and operation. It has following fields.
 The unit of fields varies by the tags.
@@ -321,7 +324,7 @@ The unit of fields varies by the tags.
   * events_statements_sort_merge_passes_totals(float, number)
   * events_statements_sort_rows_total(float, number)
   * events_statements_no_index_used_total(float, number)
-* Table schema - gathers statistics of each schema. It has following measurements
+* Table schema - gathers statistics per schema. It has following measurements
   * info_schema_table_rows(float, number)
   * info_schema_table_size_data_length(float, number)
   * info_schema_table_size_index_length(float, number)
@@ -353,7 +356,8 @@ The unit of fields varies by the tags.
   * sql_lock_waits_total(fields including this tag have numeric unit)
   * external_lock_waits_total(fields including this tag have numeric unit)
   * sql_lock_waits_seconds_total(fields including this tag have millisecond unit)
-  * external_lock_waits_seconds_total(fields including this tag have millisecond unit)
+  * external_lock_waits_seconds_total(fields including this tag have
+    millisecond unit)
 * Perf events statements has following tags
   * event_name
 * Perf file events statuses has following tags

--- a/plugins/inputs/mysql/sample.conf
+++ b/plugins/inputs/mysql/sample.conf
@@ -26,7 +26,8 @@
   ## if the list is empty, then metrics are gathered from all database tables
   # table_schema_databases = []
 
-  ## gather metrics from INFORMATION_SCHEMA.TABLES for databases provided above list
+  ## gather metrics from INFORMATION_SCHEMA.TABLES for databases provided
+  ## in the list above
   # gather_table_schema = false
 
   ## gather thread state counts from INFORMATION_SCHEMA.PROCESSLIST
@@ -92,7 +93,7 @@
   ##   example: interval_slow = "30m"
   # interval_slow = ""
 
-  ## Optional TLS Config (will be used if tls=custom parameter specified in server uri)
+  ## Optional TLS Config (used if tls=custom parameter specified in server uri)
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR fixes markdown (and sample.conf) files for the input plugins starting with A to M. It also fixes the `sample.conf` embedding into the README for `cloudwatch_metric_streams`.

With this PR the mentioned input streams will pass `markdownlint` with the following configuration:

```yaml
{
    "MD013": {
      code_blocks: false,
      tables: false,
      headers: false
    },
    "MD033": {
      "allowed_elements": ["br"]
    }
}
```