### PR TITLE
chore: Using Windows, add exe extension to tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@
 /telegraf.exe
 /telegraf.gz
 /tools/package_lxd_test/package_lxd_test
-/tools/license_checker/license_checker
-/tools/readme_config_includer/generator
+/tools/license_checker/license_checker*
+/tools/readme_config_includer/generator*
 /vendor
 .DS_Store
 process.yml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-ifeq ($(OS),$(filter $(OS),Windows_NT Windows))
-	EXEEXT=".exe"
+ifneq (,$(filter $(OS),Windows_NT Windows))
+	EXEEXT=.exe
 endif
 
 next_version := $(shell cat build_version.txt)

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,10 @@ endif
 MAKEFLAGS += --no-print-directory
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
-HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
+HOSTGO := env -u $(GOOS) -u $(GOARCH) -u $(GOARM) -- go
+ifeq ($(GOOS), windows)
+	EXEEXT := .exe
+endif
 
 LDFLAGS := $(LDFLAGS) -X main.commit=$(commit) -X main.branch=$(branch) -X main.goos=$(GOOS) -X main.goarch=$(GOARCH)
 ifneq ($(tag),)
@@ -115,8 +118,8 @@ versioninfo:
 	go generate cmd/telegraf/telegraf_windows.go; \
 
 build_tools:
-	$(HOSTGO) build -o ./tools/license_checker/license_checker ./tools/license_checker
-	$(HOSTGO) build -o ./tools/readme_config_includer/generator ./tools/readme_config_includer/generator.go
+	$(HOSTGO) build -o ./tools/license_checker/license_checker$(EXEEXT) ./tools/license_checker
+	$(HOSTGO) build -o ./tools/readme_config_includer/generator$(EXEEXT) ./tools/readme_config_includer/generator.go
 
 embed_readme_%:
 	go generate -run="readme_config_includer/generator$$" ./plugins/$*/...

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 MAKEFLAGS += --no-print-directory
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
-HOSTGO := env -u $(GOOS) -u $(GOARCH) -u $(GOARM) -- go
+HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
 
 LDFLAGS := $(LDFLAGS) -X main.commit=$(commit) -X main.branch=$(branch) -X main.goos=$(GOOS) -X main.goarch=$(GOARCH)
 ifneq ($(tag),)

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,6 @@ MAKEFLAGS += --no-print-directory
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 HOSTGO := env -u $(GOOS) -u $(GOARCH) -u $(GOARM) -- go
-ifeq ($(GOOS), windows)
-	EXEEXT := .exe
-endif
 
 LDFLAGS := $(LDFLAGS) -X main.commit=$(commit) -X main.branch=$(branch) -X main.goos=$(GOOS) -X main.goarch=$(GOARCH)
 ifneq ($(tag),)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
-ifeq ($(OS),Windows_NT)
-	next_version := $(shell type build_version.txt)
-	tag := $(shell git describe --exact-match --tags 2> nul)
-else
-	next_version := $(shell cat build_version.txt)
-	tag := $(shell git describe --exact-match --tags 2>/dev/null)
+ifeq ($(OS),$(filter $(OS),Windows_NT Windows))
+	EXEEXT=".exe"
 endif
+
+next_version := $(shell cat build_version.txt)
+tag := $(shell git describe --exact-match --tags 2>/dev/null)
 
 branch := $(shell git rev-parse --abbrev-ref HEAD)
 commit := $(shell git rev-parse --short=8 HEAD)

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ An easy option to get bash for windows is using the version that comes with [git
    git clone https://github.com/influxdata/telegraf.git
    ```
 
-3. Run `make` from the source directory
+3. Run `make build` from the source directory
 
    ```shell
    cd telegraf
-   make
+   make build
    ```
 
 ### Nightly Builds

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ sudo yum install telegraf
 
 Telegraf requires Go version 1.18 or newer, the Makefile requires GNU make.
 
+On Windows, the makefile requires the use of a bash terminal to support all makefile targets.
+An easy option to get bash for windows is using the version that comes with [git for windows](https://gitforwindows.org/).
+
 1. [Install Go](https://golang.org/doc/install) >=1.18 (1.18.0 recommended)
 2. Clone the Telegraf repository:
 


### PR DESCRIPTION
When building Telegraf on a Windows machine, the new tools were being built without `exe` extension causing the following error:

`plugins\inputs\wireguard\wireguard.go:1: running "../../../tools/readme_config_includer/generator": exec: "H:\\Sandbox\\telegraf\\tools\\readme_config_includer\\generator": file does not exist` for each plugin

Updated the makefile to add `exe` extension if `GOOS` is set to windows. 