### PR TITLE
fix(inputs.x509): Multiple sources with non-overlapping DNS entries.

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -146,11 +146,11 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 			return nil, err
 		}
 
-		downloadTlsCfg := c.tlsCfg.Clone()
-		downloadTlsCfg.ServerName = serverName
-		downloadTlsCfg.InsecureSkipVerify = true
+		downloadTLSCfg := c.tlsCfg.Clone()
+		downloadTLSCfg.ServerName = serverName
+		downloadTLSCfg.InsecureSkipVerify = true
 
-		conn := tls.Client(ipConn, downloadTlsCfg)
+		conn := tls.Client(ipConn, downloadTLSCfg)
 		defer conn.Close()
 
 		hsErr := conn.Handshake()
@@ -198,16 +198,16 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 			return nil, err
 		}
 
-		downloadTlsCfg := c.tlsCfg.Clone()
-		downloadTlsCfg.ServerName = serverName
-		downloadTlsCfg.InsecureSkipVerify = true
+		downloadTLSCfg := c.tlsCfg.Clone()
+		downloadTLSCfg.ServerName = serverName
+		downloadTLSCfg.InsecureSkipVerify = true
 
 		smtpConn, err := smtp.NewClient(ipConn, u.Host)
 		if err != nil {
 			return nil, err
 		}
 
-		err = smtpConn.Hello(downloadTlsCfg.ServerName)
+		err = smtpConn.Hello(downloadTLSCfg.ServerName)
 		if err != nil {
 			return nil, err
 		}
@@ -224,7 +224,7 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 			return nil, fmt.Errorf("did not get 220 after STARTTLS: %s", err.Error())
 		}
 
-		tlsConn := tls.Client(ipConn, downloadTlsCfg)
+		tlsConn := tls.Client(ipConn, downloadTLSCfg)
 		defer tlsConn.Close()
 
 		hsErr := tlsConn.Handshake()

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -1,5 +1,6 @@
-//go:generate ../../../tools/readme_config_includer/generator
 // Package x509_cert reports metrics from an SSL certificate.
+//
+//go:generate ../../../tools/readme_config_includer/generator
 package x509_cert
 
 import (
@@ -28,6 +29,7 @@ import (
 )
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
+//
 //go:embed sample.conf
 var sampleConfig string
 
@@ -143,6 +145,7 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 		if err != nil {
 			return nil, err
 		}
+
 		c.tlsCfg.ServerName = serverName
 
 		c.tlsCfg.InsecureSkipVerify = true
@@ -196,6 +199,7 @@ func (c *X509Cert) getCert(u *url.URL, timeout time.Duration) ([]*x509.Certifica
 		if err != nil {
 			return nil, err
 		}
+
 		c.tlsCfg.ServerName = serverName
 		c.tlsCfg.InsecureSkipVerify = true
 
@@ -363,6 +367,15 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 				tags["verification"] = "valid"
 				fields["verification_code"] = 0
 			} else {
+				c.Log.Debugf("Invalid certificate at index %2d!", i)
+				c.Log.Debugf("  cert DNS names:    %v", cert.DNSNames)
+				c.Log.Debugf("  cert IP addresses: %v", cert.IPAddresses)
+				c.Log.Debugf("  opts.DNSName:      %v", opts.DNSName)
+				c.Log.Debugf("  verify options:    %v", opts)
+				c.Log.Debugf("  verify error:      %v", err)
+				c.Log.Debugf("  location:          %v", location)
+				c.Log.Debugf("  tlsCfg.ServerName: %v", c.tlsCfg.ServerName)
+				c.Log.Debugf("  ServerName:        %v", c.ServerName)
 				tags["verification"] = "invalid"
 				fields["verification_code"] = 1
 				fields["verification_error"] = err.Error()

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -103,6 +103,7 @@ func TestGatherRemoteIntegration(t *testing.T) {
 			sc := X509Cert{
 				Sources: []string{test.server},
 				Timeout: config.Duration(test.timeout),
+				Log:     testutil.Logger{},
 			}
 			require.NoError(t, sc.Init())
 
@@ -165,6 +166,7 @@ func TestGatherLocal(t *testing.T) {
 
 			sc := X509Cert{
 				Sources: []string{f.Name()},
+				Log:     testutil.Logger{},
 			}
 			require.NoError(t, sc.Init())
 
@@ -193,6 +195,7 @@ func TestTags(t *testing.T) {
 
 	sc := X509Cert{
 		Sources: []string{f.Name()},
+		Log:     testutil.Logger{},
 	}
 	require.NoError(t, sc.Init())
 
@@ -242,6 +245,7 @@ func TestGatherExcludeRootCerts(t *testing.T) {
 	sc := X509Cert{
 		Sources:          []string{f.Name()},
 		ExcludeRootCerts: true,
+		Log:              testutil.Logger{},
 	}
 	require.NoError(t, sc.Init())
 
@@ -277,6 +281,7 @@ func TestGatherChain(t *testing.T) {
 
 			sc := X509Cert{
 				Sources: []string{f.Name()},
+				Log:     testutil.Logger{},
 			}
 			require.NoError(t, sc.Init())
 
@@ -365,8 +370,8 @@ func TestGatherCertMustNotTimeoutIntegration(t *testing.T) {
 	duration := time.Duration(15) * time.Second
 	m := &X509Cert{
 		Sources: []string{"https://www.influxdata.com:443"},
-		Log:     testutil.Logger{},
 		Timeout: config.Duration(duration),
+		Log:     testutil.Logger{},
 	}
 	require.NoError(t, m.Init())
 
@@ -379,6 +384,7 @@ func TestGatherCertMustNotTimeoutIntegration(t *testing.T) {
 func TestSourcesToURLs(t *testing.T) {
 	m := &X509Cert{
 		Sources: []string{"https://www.influxdata.com:443", "tcp://influxdata.com:443", "smtp://influxdata.com:25", "file:///dummy_test_path_file.pem", "/tmp/dummy_test_path_glob*.pem"},
+		Log:     testutil.Logger{},
 	}
 	require.NoError(t, m.Init())
 
@@ -407,6 +413,7 @@ func TestServerName(t *testing.T) {
 			sc := &X509Cert{
 				ServerName:   test.fromCfg,
 				ClientConfig: _tls.ClientConfig{ServerName: test.fromTLS},
+				Log:          testutil.Logger{},
 			}
 			require.NoError(t, sc.Init())
 			u, err := url.Parse(test.url)


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11623 

This PR fixes an issue for `https`, `tcp` and `smtp` certificate validation when using multiple sources with non-overlapping DNS entries in the certificates. That is if the DNS name of the first source is not valid in, at least one, other certificates.

The error results from a stateful behavior of the `serverName()` function, evaluating the `c.tlsCfg.ServerName` entry and returning this with priority in combination with setting exactly this field (`c.tlsCfg.ServerName`) when getting the certificate via `getCert()`. After getting the first source (e.g. `server-A.org`), the, previously empty, `c.tlsCfg.ServerName` field is set to `server-A.org` in `getCert()`. While the `https` and `tcp` variants of the function is emptying the field (leading to issues where the name was set by the user), the `smtp` variant leaves the field as is. Due to the fact that `getCert()` also uses `serverName()` to get the property, any further call to `getCert()` will not be able to overwrite the setting as `c.tlsCfg.ServerName` is now set (to `server-A.org`) and this is returned with priority. Therefore, from now on (after the first call to `getCert()`), `serverName()` will _always_ return the name of the first entry in `sources`!
As the server name is also used to verify the certificate in `Gather()`, the verification of all certificates runs against the name of the first entry in `sources`, which will fail in case that name is not in the certificates of any of the other sources!

The PR removes the state in `c.tlsCfg` by cloning the configuration for certificate retrieval. This way, only user-set names are returned by `serverName()` and thus the verification works.