### PR TITLE
fix(agent): add flushBatch method

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -824,7 +824,7 @@ func (a *Agent) flushLoop(
 		case <-flushRequested:
 			logError(a.flushOnce(output, ticker, output.Write))
 		case <-output.BatchReady:
-			logError(a.flushBatch(output, ticker, output.WriteBatch))
+			logError(a.flushBatch(output, output.WriteBatch))
 		}
 	}
 }
@@ -858,7 +858,6 @@ func (a *Agent) flushOnce(
 // interval elapsing is not considered during these flushes.
 func (a *Agent) flushBatch(
 	output *models.RunningOutput,
-	ticker Ticker,
 	writeFunc func() error,
 ) error {
 	err := writeFunc()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -861,16 +861,9 @@ func (a *Agent) flushBatch(
 	ticker Ticker,
 	writeFunc func() error,
 ) error {
-	done := make(chan error)
-	go func() {
-		done <- writeFunc()
-	}()
-
-	for {
-		err := <-done
-		output.LogBufferStatus()
-		return err
-	}
+	err := writeFunc()
+	output.LogBufferStatus()
+	return err
 }
 
 // Test runs the inputs, processors and aggregators for a single gather and


### PR DESCRIPTION
When Telegraf processes a very large amount of data, such that the
batch size is constantly hit, then Telegraf may be sending batches
constantly. At the same time, the flush interval could be hit. During
the sending of a batch, the ticker for the flush interval can go to
zero, and as a result, the batch will produce a warning about not
sending within the interval time.

Sending batches should not send messages to the user that the interval
expired as they are separate paths.

Previously, #8953 attempted to reset the ticker while sending a
batch. This introduced an issue where the buffer was never fully
flushed.

fixes: #8941