### PR TITLE
feat(inputs.zookeeper): option to use prometheus metric provider

### DIFF
--- a/plugins/inputs/zookeeper/sample.conf
+++ b/plugins/inputs/zookeeper/sample.conf
@@ -1,14 +1,23 @@
-# Reads 'mntr' stats from one or many zookeeper servers
+# Reads metrics from one or many zookeeper servers
 [[inputs.zookeeper]]
   ## An array of address to gather stats about. Specify an ip or hostname
   ## with port. ie localhost:2181, 10.0.0.1:2181, etc.
-
   ## If no servers are specified, then localhost is used as the host.
-  ## If no port is specified, 2181 is used
+  ## If no port is specified, 2181 is used for java and 7000 for prometheus
+  ## metric providers.
   servers = [":2181"]
 
   ## Timeout for metric collections from all servers.  Minimum timeout is "1s".
   # timeout = "5s"
+
+  ## Metrics Provider
+  ## Choose from: "java" or "prometheus". By default, mntr is used to collect
+  ## metrics produced in the Java Properties format. There is the option to
+  ## also produce Prometheus style metrics from Zookeeper. This requires
+  ## additional configuraiton. Using this provider requires the use of a
+  ## different port, 7000 by default, and will produce metrics in a different
+  ## format.
+  # metrics_provider = "java"
 
   ## Optional TLS Config
   # enable_tls = true


### PR DESCRIPTION
This adds the ability to the zookeeper plugin to read metrics from
Zookeeper's Prometheus metric provider. A user can optionally enable
this feature in Prometheus and then in Telegraf, to get Prometheus style
metrics from Zookeeper.

fixes: #11520