### PR TITLE
fix: refactor telegraf version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
 BUILD_INFO_IMPORT_PATH=github.com/influxdata/telegraf/internal
-LDFLAGS := $(LDFLAGS) -X $(BUILD_INFO_IMPORT_PATH).commit=$(commit) -X $(BUILD_INFO_IMPORT_PATH).branch=$(branch)
+LDFLAGS := $(LDFLAGS) -X $(BUILD_INFO_IMPORT_PATH).commit=$(commit) -X $(BUILD_INFO_IMPORT_PATH).branch=$(branch) -X $(BUILD_INFO_IMPORT_PATH).goos=$(GOOS) -X $(BUILD_INFO_IMPORT_PATH).goarch=$(GOARCH)
 ifneq ($(tag),)
 	LDFLAGS += -X $(BUILD_INFO_IMPORT_PATH).version=$(version)
 else

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ MAKEFLAGS += --no-print-directory
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
-BUILD_INFO_IMPORT_PATH=github.com/influxdata/telegraf/internal
-LDFLAGS := $(LDFLAGS) -X $(BUILD_INFO_IMPORT_PATH).commit=$(commit) -X $(BUILD_INFO_IMPORT_PATH).branch=$(branch) -X $(BUILD_INFO_IMPORT_PATH).goos=$(GOOS) -X $(BUILD_INFO_IMPORT_PATH).goarch=$(GOARCH)
+INTERNAL_PKG=github.com/influxdata/telegraf/internal
+LDFLAGS := $(LDFLAGS) -X $(INTERNAL_PKG).commit=$(commit) -X $(INTERNAL_PKG).branch=$(branch)
 ifneq ($(tag),)
 	LDFLAGS += -X $(BUILD_INFO_IMPORT_PATH).version=$(version)
 else

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,12 @@ MAKEFLAGS += --no-print-directory
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
-
-LDFLAGS := $(LDFLAGS) -X main.commit=$(commit) -X main.branch=$(branch) -X main.goos=$(GOOS) -X main.goarch=$(GOARCH)
+BUILD_INFO_IMPORT_PATH=github.com/influxdata/telegraf/internal
+LDFLAGS := $(LDFLAGS) -X $(BUILD_INFO_IMPORT_PATH).commit=$(commit) -X $(BUILD_INFO_IMPORT_PATH).branch=$(branch)
 ifneq ($(tag),)
-	LDFLAGS += -X main.version=$(version)
+	LDFLAGS += -X $(BUILD_INFO_IMPORT_PATH).version=$(version)
 else
-	LDFLAGS += -X main.version=$(version)-$(commit)
+	LDFLAGS += -X $(BUILD_INFO_IMPORT_PATH).version=$(version)-$(commit)
 endif
 
 # Go built-in race detector works only for 64 bits architectures.

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
 INTERNAL_PKG=github.com/influxdata/telegraf/internal
 LDFLAGS := $(LDFLAGS) -X $(INTERNAL_PKG).commit=$(commit) -X $(INTERNAL_PKG).branch=$(branch)
 ifneq ($(tag),)
-	LDFLAGS += -X $(BUILD_INFO_IMPORT_PATH).version=$(version)
+	LDFLAGS += -X $(INTERNAL_PKG).version=$(version)
 else
-	LDFLAGS += -X $(BUILD_INFO_IMPORT_PATH).version=$(version)-$(commit)
+	LDFLAGS += -X $(INTERNAL_PKG).version=$(version)-$(commit)
 endif
 
 # Go built-in race detector works only for 64 bits architectures.

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -126,12 +126,6 @@ var fPlugins = flag.String("plugin-directory", "",
 	"path to directory containing external plugins")
 var fRunOnce = flag.Bool("once", false, "run one gather and exit")
 
-var (
-	version string
-	commit  string
-	branch  string
-)
-
 var stop chan struct{}
 
 func reloadLoop(
@@ -277,7 +271,7 @@ func runAgent(ctx context.Context,
 
 	logger.SetupLogging(logConfig)
 
-	log.Printf("I! Starting Telegraf %s", version)
+	log.Printf("I! Starting Telegraf %s", internal.Version())
 	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))
 	log.Printf("I! Loaded aggregators: %s", strings.Join(c.AggregatorNames(), " "))
 	log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))
@@ -348,29 +342,6 @@ func usageExit(rc int) {
 	os.Exit(rc)
 }
 
-func formatFullVersion() string {
-	var parts = []string{"Telegraf"}
-
-	if version != "" {
-		parts = append(parts, version)
-	} else {
-		parts = append(parts, "unknown")
-	}
-
-	if branch != "" || commit != "" {
-		if branch == "" {
-			branch = "unknown"
-		}
-		if commit == "" {
-			commit = "unknown"
-		}
-		git := fmt.Sprintf("(git: %s %s)", branch, commit)
-		parts = append(parts, git)
-	}
-
-	return strings.Join(parts, " ")
-}
-
 func deleteEmpty(s []string) []string {
 	var r []string
 	for _, str := range s {
@@ -410,11 +381,6 @@ func main() {
 
 	logger.SetupLogging(logger.LogConfig{})
 
-	// Configure version
-	if err := internal.SetVersion(version); err != nil {
-		log.Println("Telegraf version already configured to: " + internal.Version())
-	}
-
 	// Load external plugins, if requested.
 	if *fPlugins != "" {
 		log.Printf("I! Loading external plugins from: %s", *fPlugins)
@@ -443,7 +409,7 @@ func main() {
 	if len(args) > 0 {
 		switch args[0] {
 		case "version":
-			fmt.Println(formatFullVersion())
+			fmt.Println(internal.FormatFullVersion())
 			return
 		case "config":
 			err := configCmd.Parse(args[1:])
@@ -534,7 +500,7 @@ func main() {
 		}
 		return
 	case *fVersion:
-		fmt.Println(formatFullVersion())
+		fmt.Println(internal.FormatFullVersion())
 		return
 	case *fSampleConfig:
 		printer.PrintSampleConfig(

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -60,7 +60,7 @@ func FormatFullVersion() string {
 		if commit == "" {
 			commit = "unknown"
 		}
-		git := fmt.Sprintf("(git: %s %s)", branch, commit)
+		git := fmt.Sprintf("(git: %s@%s)", branch, commit)
 		parts = append(parts, git)
 	}
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -27,7 +27,7 @@ var (
 	ErrorNotImplemented = errors.New("not implemented yet")
 )
 
-// Set via the LDFLAGS.
+// Set via LDFLAGS -X
 var (
 	version = "unknown"
 	branch  = ""

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -23,35 +23,48 @@ import (
 const alphanum string = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 var (
-	ErrTimeout             = errors.New("command timed out")
-	ErrorNotImplemented    = errors.New("not implemented yet")
-	ErrorVersionAlreadySet = errors.New("version has already been set")
+	ErrTimeout          = errors.New("command timed out")
+	ErrorNotImplemented = errors.New("not implemented yet")
 )
 
-// Set via the main module
-var version string
+// Set via the LDFLAGS.
+var (
+	version = "unknown"
+	branch  = ""
+	commit  = ""
+)
 
 type ReadWaitCloser struct {
 	pipeReader *io.PipeReader
 	wg         sync.WaitGroup
 }
 
-// SetVersion sets the telegraf agent version
-func SetVersion(v string) error {
-	if version != "" {
-		return ErrorVersionAlreadySet
-	}
-	version = v
-	if version == "" {
-		version = "unknown"
-	}
-
-	return nil
-}
-
 // Version returns the telegraf agent version
 func Version() string {
 	return version
+}
+
+func FormatFullVersion() string {
+	var parts = []string{"Telegraf"}
+
+	if version != "" {
+		parts = append(parts, version)
+	} else {
+		parts = append(parts, "unknown")
+	}
+
+	if branch != "" || commit != "" {
+		if branch == "" {
+			branch = "unknown"
+		}
+		if commit == "" {
+			commit = "unknown"
+		}
+		git := fmt.Sprintf("(git: %s %s)", branch, commit)
+		parts = append(parts, git)
+	}
+
+	return strings.Join(parts, " ")
 }
 
 // ProductToken returns a tag for Telegraf that can be used in user agents.

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -219,18 +219,6 @@ func TestCompressWithGzipEarlyClose(t *testing.T) {
 	assert.Equal(t, r1, r2)
 }
 
-func TestVersionAlreadySet(t *testing.T) {
-	err := SetVersion("foo")
-	assert.NoError(t, err)
-
-	err = SetVersion("bar")
-
-	assert.Error(t, err)
-	assert.IsType(t, ErrorVersionAlreadySet, err)
-
-	assert.Equal(t, "foo", Version())
-}
-
 func TestAlignDuration(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/plugins/inputs/internal/internal_test.go
+++ b/plugins/inputs/internal/internal_test.go
@@ -21,13 +21,14 @@ func TestSelfPlugin(t *testing.T) {
 	stat.Incr(1)
 	stat.Incr(2)
 	require.NoError(t, s.Gather(acc))
+
 	acc.AssertContainsTaggedFields(t, "internal_mytest",
 		map[string]interface{}{
 			"test": int64(3),
 		},
 		map[string]string{
 			"test":    "foo",
-			"version": "",
+			"version": "unknown",
 		},
 	)
 	acc.ClearMetrics()
@@ -41,7 +42,7 @@ func TestSelfPlugin(t *testing.T) {
 		},
 		map[string]string{
 			"test":    "foo",
-			"version": "",
+			"version": "unknown",
 		},
 	)
 	acc.ClearMetrics()
@@ -59,7 +60,7 @@ func TestSelfPlugin(t *testing.T) {
 		},
 		map[string]string{
 			"test":    "foo",
-			"version": "",
+			"version": "unknown",
 		},
 	)
 }

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -23,11 +23,12 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
-var userAgent = fmt.Sprintf("telegraf (%s/%s)", runtime.GOOS, runtime.GOARCH)
+var userAgent = fmt.Sprintf("telegraf %s (%s/%s)", internal.Version(), runtime.GOOS, runtime.GOARCH)
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
 //go:embed sample.conf

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -4,8 +4,6 @@ package opentelemetry
 import (
 	"context"
 	_ "embed"
-	"fmt"
-	"runtime"
 	"time"
 
 	ntls "crypto/tls"
@@ -28,7 +26,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
-var userAgent = fmt.Sprintf("telegraf %s (%s/%s)", internal.Version(), runtime.GOOS, runtime.GOARCH)
+var userAgent = internal.ProductToken()
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
 //go:embed sample.conf


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves https://github.com/influxdata/telegraf/issues/11655

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->


Additionally tested locally:

Here is how the userAgent looks: 
```
telegraf 1.24.0-35803efd (linux/amd64)`
```

```
./telegraf --version             
Telegraf 1.24.0-35803efd (git: master 35803efd)
```

Message printed during startup:

```
/telegraf --config telegraf.conf
2022-08-10T08:32:05Z I! Starting Telegraf 1.24.0-35803efd
```