### PR TITLE
docs(inputs.zookeeper): document use of prometheus plugin

### DIFF
--- a/plugins/inputs/zookeeper/README.md
+++ b/plugins/inputs/zookeeper/README.md
@@ -3,6 +3,12 @@
 The zookeeper plugin collects variables outputted from the 'mntr' command
 [Zookeeper Admin](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html).
 
+If in Zookeper, the Prometheus Metric provider is enabled, instead use the
+`prometheus` input plugin. By default, the Prometheus metrics are exposed at
+`http://<ip>:7000/metrics` URL. Using the `prometheus` input plugin provides a
+native solution to read and process Prometheus metrics, while this plugin is
+specific to using `mntr` to collect the Java Properties format.
+
 ## Configuration
 
 ```toml @sample.conf


### PR DESCRIPTION
Rather than modify the existing zookeeper plugin to parse prometheus
metrics, point users at the existing prometheus plugin.

fixes: #11520