### PR TITLE
fix(inputs.sql): Sync build constraints for sqlite from output

### DIFF
--- a/plugins/inputs/sql/drivers_sqlite.go
+++ b/plugins/inputs/sql/drivers_sqlite.go
@@ -1,11 +1,8 @@
-//go:build !arm && !mips && !mipsle && !mips64 && !mips64le && !ppc64 && !(freebsd && arm64)
-// +build !arm
-// +build !mips
-// +build !mipsle
-// +build !mips64
-// +build !mips64le
-// +build !ppc64
-// +build !freebsd !arm64
+//go:build linux && freebsd && darwin && (!mips || !mips64)
+// +build linux
+// +build freebsd
+// +build darwin
+// +build !mips !mips64
 
 package sql
 


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR copies the build constraints found in the `sql` output for the `sqlite` driver to have both in sync and to handle the new `loong64` in go1.19. If we do not exclude `loong64` we get the following errors:

```text
linux/loong64
package github.com/influxdata/telegraf/cmd/telegraf
        imports github.com/influxdata/telegraf/plugins/inputs/all
        imports github.com/influxdata/telegraf/plugins/inputs/sql
        imports modernc.org/sqlite
        imports modernc.org/libc
        imports modernc.org/libc/errno: build constraints exclude all Go files in /home/sven/go/pkg/mod/modernc.org/libc@v1.16.7/errno
package github.com/influxdata/telegraf/cmd/telegraf
        imports github.com/influxdata/telegraf/plugins/inputs/all
        imports github.com/influxdata/telegraf/plugins/inputs/sql
        imports modernc.org/sqlite
        imports modernc.org/libc
        imports modernc.org/libc/fcntl: build constraints exclude all Go files in /home/sven/go/pkg/mod/modernc.org/libc@v1.16.7/fcntl
...
```
