### PR TITLE
fix: prepend the special __name__  label to the front of the label slice (prometheusremotewrite)

### DIFF
--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -335,9 +335,11 @@ func getPromTS(name string, labels []prompb.Label, value float64, ts time.Time) 
 	}}
 	labelscopy := make([]prompb.Label, len(labels), len(labels)+1)
 	copy(labelscopy, labels)
-	labels = append(labelscopy, prompb.Label{
-		Name:  "__name__",
-		Value: name,
-	})
+	labels = append([]prompb.Label{
+		prompb.Label{
+			Name:  "__name__",
+			Value: name,
+		},
+	}, labelscopy...)
 	return MakeMetricKey(labels), prompb.TimeSeries{Labels: labels, Samples: sample}
 }

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -582,16 +582,16 @@ cpu_time_idle{host_name="example.org"} 42
 			},
 			expected: []byte(`
 cpu_time_guest{cpu="cpu0"} 8106.04
-cpu_time_system{cpu="cpu0"} 26271.4
-cpu_time_user{cpu="cpu0"} 92904.33
 cpu_time_guest{cpu="cpu1"} 8181.63
-cpu_time_system{cpu="cpu1"} 25351.49
-cpu_time_user{cpu="cpu1"} 96912.57
 cpu_time_guest{cpu="cpu2"} 7470.04
-cpu_time_system{cpu="cpu2"} 24998.43
-cpu_time_user{cpu="cpu2"} 96034.08
 cpu_time_guest{cpu="cpu3"} 7517.95
+cpu_time_system{cpu="cpu0"} 26271.4
+cpu_time_system{cpu="cpu1"} 25351.49
+cpu_time_system{cpu="cpu2"} 24998.43
 cpu_time_system{cpu="cpu3"} 24970.82
+cpu_time_user{cpu="cpu0"} 92904.33
+cpu_time_user{cpu="cpu1"} 96912.57
+cpu_time_user{cpu="cpu2"} 96034.08
 cpu_time_user{cpu="cpu3"} 94148
 `),
 		},


### PR DESCRIPTION
# Required for all PRs

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9365

The Thanos project recently merged https://github.com/thanos-io/thanos/pull/5508 which will break every setup that uses telegraf in its current state to remote write to Thanos. All write requests will be rejected with a 409.
There's a "hidden" prerequisite that all labels in Prometheus TSDB (which Thanos also uses) need to be sorted, I couldn't find official documentation that mentions this but it has come up in other PRs, for example https://github.com/prometheus/prometheus/pull/5372.

My change will always put the `__name__` as the first label. This could potentially also be wrong when labels that start with uppercase letters are used but since it was already completely broken I would like to fix this without introducing too big of a change (and why would you ever use uppercase label names?).

I'm not sure if this should be mentioned in any README and I'm also not sure how we can test this since I don't see anything regarding the `__name__` label in the telegraf metrics that are used in the tests. One of the tests has a slight change in the metric ordering but that should be OK since the goal is to sort by the metric names and not by the labels themselves.