### PR TITLE
chore: only lint READMEs when changed

### DIFF
--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -15,9 +15,10 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v18.7
+        uses: tj-actions/changed-files@v26.1
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
-          files: plugins/**/README.md
+          files: ./plugins/**/README.md
       - name: Run readme linter on changed files
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: go run ./tools/readme_linter ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
Update changed-files library to grab a [fix to the glob library](https://github.com/tj-actions/changed-files/issues/565) that was outputting all changed files if no file matched the pattern. Additionally, update the glob to be clear about where to start and put a check to only run the markdown linter with the changed files matching the previous filter.

Test Examples:

- [one readme updated](https://github.com/influxdata/telegraf/runs/7845373608?check_suite_focus=true) - expected one readme to be linted and find an issue
- [only a .go file updated](https://github.com/influxdata/telegraf/runs/7845361877?check_suite_focus=true) - expected no readme to be linted
- [no plugin code updated](https://github.com/influxdata/telegraf/runs/7845341912?check_suite_focus=true) - expected no readme to be linted 