### PR TITLE
chore: Remove deprecated io/ioutils

### DIFF
--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -2,7 +2,6 @@ package snmp
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,12 +56,17 @@ func LoadMibsFromPath(paths []string, log telegraf.Logger, loader MibLoader) err
 	}
 	for _, path := range folders {
 		loader.appendPath(path)
-		modules, err := ioutil.ReadDir(path)
+		modules, err := os.ReadDir(path)
 		if err != nil {
 			log.Warnf("Can't read directory %v", modules)
 		}
 
-		for _, info := range modules {
+		for _, entry := range modules {
+			info, err := entry.Info()
+			if err != nil {
+				log.Warnf("Couldn't get info for %v: %v", entry.Name(), err)
+				continue
+			}
 			if info.Mode()&os.ModeSymlink != 0 {
 				symlink := filepath.Join(path, info.Name())
 				target, err := filepath.EvalSymlinks(symlink)

--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -59,6 +59,7 @@ func LoadMibsFromPath(paths []string, log telegraf.Logger, loader MibLoader) err
 		modules, err := os.ReadDir(path)
 		if err != nil {
 			log.Warnf("Can't read directory %v", modules)
+			continue
 		}
 
 		for _, entry := range modules {

--- a/plugins/inputs/consul_agent/consul_agent_test.go
+++ b/plugins/inputs/consul_agent/consul_agent_test.go
@@ -2,9 +2,9 @@ package consul_agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -74,7 +74,7 @@ func TestConsulStats(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.RequestURI == "/v1/agent/metrics" {
 					w.WriteHeader(http.StatusOK)
-					responseKeyMetrics, _ := ioutil.ReadFile("testdata/response_key_metrics.json")
+					responseKeyMetrics, _ := os.ReadFile("testdata/response_key_metrics.json")
 					_, err := fmt.Fprintln(w, string(responseKeyMetrics))
 					require.NoError(t, err)
 				}

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -7,7 +7,6 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -196,7 +195,7 @@ func makeRequestBodyReader(contentEncoding, body string) (io.Reader, error) {
 		if err != nil {
 			return nil, err
 		}
-		data, err := ioutil.ReadAll(rc)
+		data, err := io.ReadAll(rc)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/inputs/hugepages/hugepages.go
+++ b/plugins/inputs/hugepages/hugepages.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -123,7 +123,7 @@ func (h *Hugepages) gatherRootStats(acc telegraf.Accumulator) error {
 
 // gatherStatsPerNode collects hugepages statistics per NUMA node
 func (h *Hugepages) gatherStatsPerNode(acc telegraf.Accumulator) error {
-	nodeDirs, err := ioutil.ReadDir(h.numaNodePath)
+	nodeDirs, err := os.ReadDir(h.numaNodePath)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (h *Hugepages) gatherStatsPerNode(acc telegraf.Accumulator) error {
 
 func (h *Hugepages) gatherFromHugepagePath(acc telegraf.Accumulator, measurement, path string, fileFilter map[string]string, defaultTags map[string]string) error {
 	// read metrics from: hugepages/hugepages-*/*
-	hugepagesDirs, err := ioutil.ReadDir(path)
+	hugepagesDirs, err := os.ReadDir(path)
 	if err != nil {
 		return fmt.Errorf("reading root dir failed: %v", err)
 	}
@@ -171,7 +171,7 @@ func (h *Hugepages) gatherFromHugepagePath(acc telegraf.Accumulator, measurement
 		}
 
 		metricsPath := filepath.Join(path, hugepagesDir.Name())
-		metricFiles, err := ioutil.ReadDir(metricsPath)
+		metricFiles, err := os.ReadDir(metricsPath)
 		if err != nil {
 			return fmt.Errorf("reading metric dir failed: %v", err)
 		}
@@ -179,12 +179,12 @@ func (h *Hugepages) gatherFromHugepagePath(acc telegraf.Accumulator, measurement
 		metrics := make(map[string]interface{})
 		for _, metricFile := range metricFiles {
 			metricName, ok := fileFilter[metricFile.Name()]
-			if mode := metricFile.Mode(); !mode.IsRegular() || !ok {
+			if mode := metricFile.Type(); !mode.IsRegular() || !ok {
 				continue
 			}
 
 			metricFullPath := filepath.Join(metricsPath, metricFile.Name())
-			metricBytes, err := ioutil.ReadFile(metricFullPath)
+			metricBytes, err := os.ReadFile(metricFullPath)
 			if err != nil {
 				return err
 			}
@@ -214,7 +214,7 @@ func (h *Hugepages) gatherFromHugepagePath(acc telegraf.Accumulator, measurement
 
 // gatherStatsFromMeminfo collects hugepages statistics from meminfo file
 func (h *Hugepages) gatherStatsFromMeminfo(acc telegraf.Accumulator) error {
-	meminfo, err := ioutil.ReadFile(h.meminfoPath)
+	meminfo, err := os.ReadFile(h.meminfoPath)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/intel_pmu/intel_pmu.go
+++ b/plugins/inputs/intel_pmu/intel_pmu.go
@@ -7,7 +7,6 @@ package intel_pmu
 import (
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"os"
@@ -36,7 +35,7 @@ type fileInfoProvider interface {
 type fileHelper struct{}
 
 func (fileHelper) readFile(path string) ([]byte, error) {
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func (fileHelper) lstat(path string) (os.FileInfo, error) {

--- a/plugins/inputs/nomad/nomad_test.go
+++ b/plugins/inputs/nomad/nomad_test.go
@@ -2,9 +2,9 @@ package nomad
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -81,7 +81,7 @@ func TestNomadStats(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.RequestURI == "/v1/metrics" {
 					w.WriteHeader(http.StatusOK)
-					responseKeyMetrics, _ := ioutil.ReadFile("testdata/response_key_metrics.json")
+					responseKeyMetrics, _ := os.ReadFile("testdata/response_key_metrics.json")
 					_, err := fmt.Fprintln(w, string(responseKeyMetrics))
 					require.NoError(t, err)
 				}

--- a/plugins/inputs/varnish/varnish_test.go
+++ b/plugins/inputs/varnish/varnish_test.go
@@ -6,7 +6,7 @@ package varnish
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -548,8 +548,9 @@ func TestVersions(t *testing.T) {
 		{jsonFile: "varnish6.6.json", activeReloadPrefix: "boot", size: 358},
 		{jsonFile: "varnish4_4.json", activeReloadPrefix: "boot", size: 295},
 	} {
-		output, _ := ioutil.ReadFile("test_data/" + c.jsonFile)
-		err := server.processMetricsV2(c.activeReloadPrefix, acc, bytes.NewBuffer(output))
+		output, err := os.ReadFile("test_data/" + c.jsonFile)
+		require.NoError(t, err)
+		err = server.processMetricsV2(c.activeReloadPrefix, acc, bytes.NewBuffer(output))
 		require.NoError(t, err)
 		require.Equal(t, c.size, len(acc.Metrics))
 		for _, m := range acc.Metrics {
@@ -619,12 +620,14 @@ func TestJsonTypes(t *testing.T) {
 }
 
 func TestVarnishAdmJson(t *testing.T) {
-	admJSON, _ := ioutil.ReadFile("test_data/" + "varnishadm-200.json")
+	admJSON, err := os.ReadFile("test_data/" + "varnishadm-200.json")
+	require.NoError(t, err)
 	activeVcl, err := getActiveVCLJson(bytes.NewBuffer(admJSON))
 	require.NoError(t, err)
 	require.Equal(t, activeVcl, "boot-123")
 
-	admJSON, _ = ioutil.ReadFile("test_data/" + "varnishadm-reload.json")
+	admJSON, err = os.ReadFile("test_data/" + "varnishadm-reload.json")
+	require.NoError(t, err)
 	activeVcl, err = getActiveVCLJson(bytes.NewBuffer(admJSON))
 	require.NoError(t, err)
 	require.Equal(t, activeVcl, "reload_20210723_091821_2056185")

--- a/plugins/inputs/vault/vault_test.go
+++ b/plugins/inputs/vault/vault_test.go
@@ -2,9 +2,9 @@ package vault
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -73,8 +73,9 @@ func TestVaultStats(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.RequestURI == "/v1/sys/metrics" {
 					w.WriteHeader(http.StatusOK)
-					responseKeyMetrics, _ := ioutil.ReadFile("testdata/response_key_metrics.json")
-					_, err := fmt.Fprintln(w, string(responseKeyMetrics))
+					responseKeyMetrics, err := os.ReadFile("testdata/response_key_metrics.json")
+					require.NoError(t, err)
+					_, err = fmt.Fprintln(w, string(responseKeyMetrics))
 					require.NoError(t, err)
 				}
 			}))

--- a/plugins/inputs/webhooks/filestack/filestack_webhooks.go
+++ b/plugins/inputs/webhooks/filestack/filestack_webhooks.go
@@ -2,7 +2,7 @@ package filestack
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -35,7 +35,7 @@ func (fs *FilestackWebhook) eventHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks.go
@@ -2,7 +2,7 @@ package mandrill
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -41,7 +41,7 @@ func (md *MandrillWebhook) eventHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks.go
@@ -3,7 +3,7 @@ package rollbar
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -35,7 +35,7 @@ func (rb *RollbarWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/plugins/inputs/xtremio/xtremio.go
+++ b/plugins/inputs/xtremio/xtremio.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -348,7 +348,7 @@ func (xio *XtremIO) call(endpoint string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/plugins/inputs/xtremio/xtremio_test.go
+++ b/plugins/inputs/xtremio/xtremio_test.go
@@ -2,14 +2,14 @@ package xtremio
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
@@ -84,13 +84,13 @@ func TestFixedValue(t *testing.T) {
 					_, err := fmt.Fprintln(w, "authentication succeeded")
 					require.NoError(t, err)
 				} else if r.URL.Path == "/api/json/v3/types/bbus" {
-					sampleGetBBUsResponse, err := ioutil.ReadFile(filepath.Join(testdataDir, "sample_get_bbu_response.json"))
+					sampleGetBBUsResponse, err := os.ReadFile(filepath.Join(testdataDir, "sample_get_bbu_response.json"))
 					require.NoError(t, err)
 					w.WriteHeader(http.StatusOK)
 					_, err = fmt.Fprintln(w, string(sampleGetBBUsResponse))
 					require.NoError(t, err)
 				} else if r.URL.Path == "/api/json/v3/types/bbus/987654321abcdef" {
-					sampleBBUResponseOne, err := ioutil.ReadFile(filepath.Join(testdataDir, "sample_bbu_response.json"))
+					sampleBBUResponseOne, err := os.ReadFile(filepath.Join(testdataDir, "sample_bbu_response.json"))
 					require.NoError(t, err)
 					w.WriteHeader(http.StatusOK)
 					_, err = fmt.Fprintln(w, string(sampleBBUResponseOne))

--- a/plugins/outputs/groundwork/groundwork_test.go
+++ b/plugins/outputs/groundwork/groundwork_test.go
@@ -3,7 +3,7 @@ package groundwork
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,7 +29,7 @@ func TestWriteWithDefaults(t *testing.T) {
 
 	// Simulate Groundwork server that should receive custom metrics
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		// Decode body to use in assertions below
@@ -81,7 +81,7 @@ func TestWriteWithFields(t *testing.T) {
 
 	// Simulate Groundwork server that should receive custom metrics
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		// Decode body to use in assertions below
@@ -142,7 +142,7 @@ func TestWriteWithTags(t *testing.T) {
 
 	// Simulate Groundwork server that should receive custom metrics
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
 		// Decode body to use in assertions below

--- a/scripts/generate_versioninfo/main.go
+++ b/scripts/generate_versioninfo/main.go
@@ -5,8 +5,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"log" //nolint:revive
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -40,7 +40,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to marshal json: %v", err)
 	}
-	if err := ioutil.WriteFile("cmd/telegraf/versioninfo.json", file, 0644); err != nil {
+	if err := os.WriteFile("cmd/telegraf/versioninfo.json", file, 0644); err != nil {
 		log.Fatalf("Failed to write versioninfo.json: %v", err)
 	}
 }


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR removes all usages of `io/ioutils` which is deprecated since go 1.16.