### PR TITLE
fix: sort and send all metric samples in a batch (prometheusremotewrite)

### DIFF
--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -127,6 +127,21 @@ http_request_duration_seconds_sum 53423
 http_request_duration_seconds_bucket{le="0.5"} 129389
 `),
 		},
+		{
+			name: "invalid histogram buckets dropped",
+			metric: testutil.MustMetric(
+				"prometheus",
+				map[string]string{
+					"le": "invalid_bound",
+				},
+				map[string]interface{}{
+					"http_request_duration_seconds_bucket": 129389.0,
+				},
+				time.Unix(0, 0),
+				telegraf.Histogram,
+			),
+			expected: []byte(``),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -348,6 +363,40 @@ rpc_duration_seconds{quantile="0.05"} 3272
 rpc_duration_seconds{quantile="0.5"} 4773
 rpc_duration_seconds{quantile="0.9"} 9001
 rpc_duration_seconds{quantile="0.99"} 76656
+`),
+		},
+		{
+			name: "no samples dropped",
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"time_idle": 35.0,
+					},
+					time.Unix(0, 0),
+				),
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"time_idle": 25.0,
+					},
+					time.Unix(1, 0),
+				),
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"time_idle": 85.0,
+					},
+					time.Unix(3, 0),
+				),
+			},
+			expected: []byte(`
+cpu_time_idle 35
+cpu_time_idle 25
+cpu_time_idle 85
 `),
 		},
 		{

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -108,7 +108,6 @@ http_requests_total{code="400", method="post"} 3
 			expected: []byte(`
 http_request_duration_seconds_count 144320
 http_request_duration_seconds_sum 53423
-http_request_duration_seconds_bucket{le="+Inf"} 144320
 `),
 		},
 		{
@@ -125,9 +124,6 @@ http_request_duration_seconds_bucket{le="+Inf"} 144320
 				telegraf.Histogram,
 			),
 			expected: []byte(`
-http_request_duration_seconds_count 0
-http_request_duration_seconds_sum 0
-http_request_duration_seconds_bucket{le="+Inf"} 0
 http_request_duration_seconds_bucket{le="0.5"} 129389
 `),
 		},
@@ -355,7 +351,7 @@ rpc_duration_seconds{quantile="0.99"} 76656
 `),
 		},
 		{
-			name: "newer sample",
+			name: "samples in series sorted chronologically",
 			metrics: []telegraf.Metric{
 				testutil.MustMetric(
 					"cpu",
@@ -369,13 +365,32 @@ rpc_duration_seconds{quantile="0.99"} 76656
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
+						"time_idle": 50.0,
+					},
+					time.Unix(4, 0),
+				),
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"time_idle": 38.0,
+					},
+					time.Unix(2, 0),
+				),
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
 						"time_idle": 42.0,
 					},
 					time.Unix(0, 0),
 				),
 			},
 			expected: []byte(`
+cpu_time_idle 42
 cpu_time_idle 43
+cpu_time_idle 38
+cpu_time_idle 50
 `),
 		},
 		{
@@ -582,16 +597,16 @@ cpu_time_idle{host_name="example.org"} 42
 			},
 			expected: []byte(`
 cpu_time_guest{cpu="cpu0"} 8106.04
-cpu_time_system{cpu="cpu0"} 26271.4
-cpu_time_user{cpu="cpu0"} 92904.33
 cpu_time_guest{cpu="cpu1"} 8181.63
-cpu_time_system{cpu="cpu1"} 25351.49
-cpu_time_user{cpu="cpu1"} 96912.57
 cpu_time_guest{cpu="cpu2"} 7470.04
-cpu_time_system{cpu="cpu2"} 24998.43
-cpu_time_user{cpu="cpu2"} 96034.08
 cpu_time_guest{cpu="cpu3"} 7517.95
+cpu_time_system{cpu="cpu0"} 26271.4
+cpu_time_system{cpu="cpu1"} 25351.49
+cpu_time_system{cpu="cpu2"} 24998.43
 cpu_time_system{cpu="cpu3"} 24970.82
+cpu_time_user{cpu="cpu0"} 92904.33
+cpu_time_user{cpu="cpu1"} 96912.57
+cpu_time_user{cpu="cpu2"} 96034.08
 cpu_time_user{cpu="cpu3"} 94148
 `),
 		},


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #11682
includes same fixes for #9365 (https://github.com/influxdata/telegraf/pull/11674)

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

This PR will ensure all metric samples are added to their time series samples object and sent on to the output plugin. Each prometheus time series object should contain all samples in the batch, sorted by the timestamp of each sample.

One area of concern is the Histogram type. The original serialiser code has logic to add zero values for missing fields that are part of a histogram metric (sum, count, inf bucket). I have had to remove these (temporarily commented out while in draft), as each histogram measurement produces extra sum/count/inf samples for every measurement.

I think the original code assumes that there will only be one period of histogram samples, so it only takes the first sample value.  This assumption can't be made when batching metrics, there's no guarantee that a batch will only contain a single period of samples. So I'm thinking all that logic may either need to be removed, or rewritten properly to determine which set metrics belong to a given histogram sample period. Not too sure on the downstream impact of dropping this and assuming that the histogram metric should always be complete/valid.

FYI  @aarnaud, @nvinzens