### PR TITLE
fix: Handle error properly if pprof server fails

### DIFF
--- a/cmd/telegraf/telegraf_posix.go
+++ b/cmd/telegraf/telegraf_posix.go
@@ -3,9 +3,10 @@
 
 package main
 
-func run(inputFilters, outputFilters []string) {
+func run(pprofErr <-chan error, inputFilters, outputFilters []string) error {
 	stop = make(chan struct{})
-	reloadLoop(
+	return reloadLoop(
+		pprofErr,
 		inputFilters,
 		outputFilters,
 	)

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -26,7 +26,7 @@ func run(pprofErr <-chan error, inputFilters, outputFilters []string) error {
 	} else {
 		stop = make(chan struct{})
 		return reloadLoop(
-			pprofErr
+			pprofErr,
 			inputFilters,
 			outputFilters,
 		)

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kardianos/service"
 )
 
-func run(inputFilters, outputFilters []string) {
+func run(pprofErr <-chan error, inputFilters, outputFilters []string) error {
 	// Register the eventlog logging target for windows.
 	logger.RegisterEventLogger(*fServiceName)
 
@@ -25,11 +25,13 @@ func run(inputFilters, outputFilters []string) {
 		)
 	} else {
 		stop = make(chan struct{})
-		reloadLoop(
+		return reloadLoop(
+			pprofErr
 			inputFilters,
 			outputFilters,
 		)
 	}
+	return nil
 }
 
 type program struct {

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -20,6 +20,7 @@ func run(pprofErr <-chan error, inputFilters, outputFilters []string) error {
 
 	if runtime.GOOS == "windows" && windowsRunAsService() {
 		runAsWindowsService(
+			pprofErr,
 			inputFilters,
 			outputFilters,
 		)
@@ -35,6 +36,7 @@ func run(pprofErr <-chan error, inputFilters, outputFilters []string) error {
 }
 
 type program struct {
+	pprofErr      <-chan error
 	inputFilters  []string
 	outputFilters []string
 }
@@ -46,6 +48,7 @@ func (p *program) Start(s service.Service) error {
 func (p *program) run() {
 	stop = make(chan struct{})
 	reloadLoop(
+		p.pprofErr,
 		p.inputFilters,
 		p.outputFilters,
 	)
@@ -58,7 +61,7 @@ func (p *program) Stop(s service.Service) error {
 	return nil
 }
 
-func runAsWindowsService(inputFilters, outputFilters []string) {
+func runAsWindowsService(pprofErr <-chan error, inputFilters, outputFilters []string) {
 	programFiles := os.Getenv("ProgramFiles")
 	if programFiles == "" { // Should never happen
 		programFiles = "C:\\Program Files"
@@ -72,6 +75,7 @@ func runAsWindowsService(inputFilters, outputFilters []string) {
 	}
 
 	prg := &program{
+		pprofErr:      pprofErr,
 		inputFilters:  inputFilters,
 		outputFilters: outputFilters,
 	}


### PR DESCRIPTION
Currently if you are profiling Telegraf using pprof it starts a goroutine for the server and something goes wrong, it will call `log.Fatal` which calls `os.exit` preventing "defer" statements to be called. Because it is in a goroutine this fatal error could happen at anytime and cause potential memory leaks. There isn't an open issue for this, but I noticed this potential problem and thought it would be worthwhile to fix. I would like a design review from the team first to see if passing the error channel as a parameter to run in the best approach?

Also needs more testing.