### PR TITLE
feat(inputs.sqlserver): Add db name to io stats for MI

### DIFF
--- a/plugins/inputs/sqlserver/azuresqlmanagedqueries.go
+++ b/plugins/inputs/sqlserver/azuresqlmanagedqueries.go
@@ -102,7 +102,7 @@ END
 SELECT
 	'sqlserver_database_io' AS [measurement]
 	,REPLACE(@@SERVERNAME,'\',':') AS [sql_instance]
-	,DB_NAME(mf.database_id) AS [database_name]
+	,DB_NAME(mf.[database_id]) AS [database_name]
 	,COALESCE(mf.[physical_name],'RBPEX') AS [physical_filename]	--RPBEX = Resilient Buffer Pool Extension
 	,COALESCE(mf.[name],'RBPEX') AS [logical_filename]	--RPBEX = Resilient Buffer Pool Extension	
 	,mf.[type_desc] AS [file_type]

--- a/plugins/inputs/sqlserver/azuresqlmanagedqueries.go
+++ b/plugins/inputs/sqlserver/azuresqlmanagedqueries.go
@@ -102,6 +102,7 @@ END
 SELECT
 	'sqlserver_database_io' AS [measurement]
 	,REPLACE(@@SERVERNAME,'\',':') AS [sql_instance]
+	,DB_NAME(mf.database_id) AS [database_name]
 	,COALESCE(mf.[physical_name],'RBPEX') AS [physical_filename]	--RPBEX = Resilient Buffer Pool Extension
 	,COALESCE(mf.[name],'RBPEX') AS [logical_filename]	--RPBEX = Resilient Buffer Pool Extension	
 	,mf.[type_desc] AS [file_type]

--- a/plugins/inputs/sqlserver/azuresqlmanagedqueries_test.go
+++ b/plugins/inputs/sqlserver/azuresqlmanagedqueries_test.go
@@ -107,6 +107,7 @@ func TestAzureSQLIntegration_Managed_DatabaseIO_Query(t *testing.T) {
 
 	require.True(t, acc.HasMeasurement("sqlserver_database_io"))
 	require.True(t, acc.HasTag("sqlserver_database_io", "sql_instance"))
+	require.True(t, acc.HasTag("sqlserver_database_io", "database_name"))
 	require.True(t, acc.HasTag("sqlserver_database_io", "physical_filename"))
 	require.True(t, acc.HasTag("sqlserver_database_io", "logical_filename"))
 	require.True(t, acc.HasTag("sqlserver_database_io", "file_type"))


### PR DESCRIPTION
<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Similarly to the query used for SQL Server, it adds the database name to the io stats output for Azure Managed Instance. It helps to better visualize and link collected data.