### PR TITLE
feat(serializers.prometheus): give option to reduce payload size by removing HELP from payload

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -342,10 +342,9 @@ func (c *Config) LoadDirectory(path string) error {
 }
 
 // Try to find a default config file at these locations (in order):
-//   1. $TELEGRAF_CONFIG_PATH
-//   2. $HOME/.telegraf/telegraf.conf
-//   3. /etc/telegraf/telegraf.conf
-//
+//  1. $TELEGRAF_CONFIG_PATH
+//  2. $HOME/.telegraf/telegraf.conf
+//  3. /etc/telegraf/telegraf.conf
 func getDefaultConfigPath() (string, error) {
 	envfile := os.Getenv("TELEGRAF_CONFIG_PATH")
 	homefile := os.ExpandEnv("${HOME}/.telegraf/telegraf.conf")
@@ -1165,6 +1164,7 @@ func (c *Config) buildSerializer(tbl *ast.Table) (serializers.Serializer, error)
 	c.getFieldBool(tbl, "prometheus_export_timestamp", &sc.PrometheusExportTimestamp)
 	c.getFieldBool(tbl, "prometheus_sort_metrics", &sc.PrometheusSortMetrics)
 	c.getFieldBool(tbl, "prometheus_string_as_label", &sc.PrometheusStringAsLabel)
+	c.getFieldBool(tbl, "prometheus_compact_encoding", &sc.PrometheusCompactEncoding)
 
 	if c.hasErrs() {
 		return nil, c.firstErr()
@@ -1233,6 +1233,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 		"influx_max_line_bytes", "influx_sort_fields", "influx_uint_support",
 		"json_timestamp_format", "json_timestamp_units",
 		"prometheus_export_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label",
+		"prometheus_compact_encoding",
 		"splunkmetric_hec_routing", "splunkmetric_multimetric",
 		"wavefront_disable_prefix_conversion", "wavefront_source_override", "wavefront_use_strict":
 	default:

--- a/plugins/serializers/prometheus/README.md
+++ b/plugins/serializers/prometheus/README.md
@@ -31,6 +31,10 @@ reporting others every bucket/quantile will continue to exist.
   ## discarded.
   prometheus_string_as_label = false
 
+  ## Encode metrics without HELP metadata. This helps reduce the payload
+  ## size.
+  prometheus_compact_encoding = false
+
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/serializers/prometheus/collection.go
+++ b/plugins/serializers/prometheus/collection.go
@@ -412,8 +412,11 @@ func (c *Collection) GetProto() []*dto.MetricFamily {
 	for _, entry := range c.GetEntries(c.config.MetricSortOrder) {
 		mf := &dto.MetricFamily{
 			Name: proto.String(entry.Family.Name),
-			Help: proto.String(helpString),
 			Type: MetricType(entry.Family.Type),
+		}
+
+		if !c.config.CompactEncoding {
+			mf.Help = proto.String(helpString)
 		}
 
 		for _, metric := range c.GetMetrics(entry, c.config.MetricSortOrder) {

--- a/plugins/serializers/prometheus/prometheus.go
+++ b/plugins/serializers/prometheus/prometheus.go
@@ -36,6 +36,10 @@ type FormatConfig struct {
 	TimestampExport TimestampExport
 	MetricSortOrder MetricSortOrder
 	StringHandling  StringHandling
+	// CompactEncoding defines whether to include
+	// HELP metadata in Prometheus payload. Setting to true
+	// helps to reduce payload size.
+	CompactEncoding bool
 }
 
 type Serializer struct {

--- a/plugins/serializers/prometheus/prometheus_test.go
+++ b/plugins/serializers/prometheus/prometheus_test.go
@@ -158,6 +158,26 @@ http_request_duration_seconds_count 0
 cpu_time_idle{host="example.org"} 42 1574279268000
 `),
 		},
+		{
+			name: "simple with CompactEncoding",
+			config: FormatConfig{
+				CompactEncoding: true,
+			},
+			metric: testutil.MustMetric(
+				"cpu",
+				map[string]string{
+					"host": "example.org",
+				},
+				map[string]interface{}{
+					"time_idle": 42.0,
+				},
+				time.Unix(1574279268, 0),
+			),
+			expected: []byte(`
+# TYPE cpu_time_idle untyped
+cpu_time_idle{host="example.org"} 42
+`),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -165,6 +185,7 @@ cpu_time_idle{host="example.org"} 42 1574279268000
 				MetricSortOrder: SortMetrics,
 				TimestampExport: tt.config.TimestampExport,
 				StringHandling:  tt.config.StringHandling,
+				CompactEncoding: tt.config.CompactEncoding,
 			})
 			require.NoError(t, err)
 			actual, err := s.Serialize(tt.metric)

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -209,7 +209,7 @@ func NewPrometheusSerializer(config *Config) (Serializer, error) {
 		TimestampExport: exportTimestamp,
 		MetricSortOrder: sortMetrics,
 		StringHandling:  stringAsLabels,
-		CompactEncoding: config.CompactEncoding,
+		CompactEncoding: config.PrometheusCompactEncoding,
 	})
 }
 

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -130,6 +130,9 @@ type Config struct {
 	// Output string fields as metric labels; when false string fields are
 	// discarded.
 	PrometheusStringAsLabel bool `toml:"prometheus_string_as_label"`
+
+	// Encode metrics without HELP metadata. This helps reduce the payload size.
+	PrometheusCompactEncoding bool `toml:"prometheus_compact_encoding"`
 }
 
 // NewSerializer a Serializer interface based on the given config.
@@ -206,6 +209,7 @@ func NewPrometheusSerializer(config *Config) (Serializer, error) {
 		TimestampExport: exportTimestamp,
 		MetricSortOrder: sortMetrics,
 		StringHandling:  stringAsLabels,
+		CompactEncoding: config.CompactEncoding,
 	})
 }
 


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11390 (as much as is possible within Telegraf itself)

implements @srebhan feedback from https://github.com/influxdata/telegraf/pull/11417

Give option to reduce payload size by removing the HELP metadata from the payload.
