### PR TITLE
docs: add configuration preface

### DIFF
--- a/plugins/inputs/activemq/README.md
+++ b/plugins/inputs/activemq/README.md
@@ -5,6 +5,13 @@ API.
 
 ## Configuration
 
+In addition to the plugin-specific configuration settings, plugins support
+additional global and plugin configuration settings. These settings are used to
+modify metrics, tags, and field or create aliases and configure ordering, etc.
+See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
+
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md
+
 ```toml @sample.conf
 # Gather ActiveMQ metrics
 [[inputs.activemq]]


### PR DESCRIPTION
Provide additional awareness of the many other configuration settings
and global settings that exist. When a user comes to a plugin page, they
may not know these more extensive settings also exist as well.

fixes: #9065

