### PR TITLE
fix(inputs.sqlserver): fixing wrong filtering for sqlAzureMIRequests and sqlAzureDBRequests

### DIFF
--- a/plugins/inputs/sqlserver/azuresqldbqueries.go
+++ b/plugins/inputs/sqlserver/azuresqldbqueries.go
@@ -604,7 +604,7 @@ FROM (
 		,REPLACE(@@SERVERNAME,'\',':') AS [sql_instance]
 		,DB_NAME() as [database_name]
 		,s.[session_id]
-		,ISNULL(r.[request_id], 0) as [request_id]
+		,r.[request_id]
 		,DB_NAME(COALESCE(r.[database_id], s.[database_id])) AS [session_db_name]
 		,COALESCE(r.[status], s.[status]) AS [status]
 		,COALESCE(r.[cpu_time], s.[cpu_time]) AS [cpu_time_ms]
@@ -660,7 +660,7 @@ WHERE
 		AND (	--Always fetch user process (in any state), fetch system process only if active
 			[is_user_process] = 1
 			OR [status] COLLATE Latin1_General_BIN NOT IN ('background', 'sleeping')
-		)
+		)		
 	)  
 OPTION(MAXDOP 1);
 `

--- a/plugins/inputs/sqlserver/azuresqlmanagedqueries.go
+++ b/plugins/inputs/sqlserver/azuresqlmanagedqueries.go
@@ -471,7 +471,7 @@ FROM (
 		,REPLACE(@@SERVERNAME,'\',':') AS [sql_instance]
 		,DB_NAME() as [database_name]
 		,s.[session_id]
-		,ISNULL(r.[request_id], 0) as [request_id]	
+		,r.[request_id]
 		,DB_NAME(COALESCE(r.[database_id], s.[database_id])) AS [session_db_name]
 		,COALESCE(r.[status], s.[status]) AS [status]
 		,COALESCE(r.[cpu_time], s.[cpu_time]) AS [cpu_time_ms]


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

PR [#10553](https://github.com/influxdata/telegraf/pull/10553) for an issue [#10741](https://github.com/influxdata/telegraf/issues/10741) introduced a wrong filtering which leads to the state that all sessions are shown in the output - disregarding if they are running requests or not. 

The filtering condition:
`[request_id] IS NOT NULL	--A request must exists`
couldn't be ever true as in the previous code the [request_id] has been already changed to NonNullable inside the inner query:
`NULLIF(r.[blocking_session_id],0) AS [blocking_session_id]`