### PR TITLE
feat(inputs.diskio): Allow selecting devices by ID

### DIFF
--- a/plugins/inputs/diskio/README.md
+++ b/plugins/inputs/diskio/README.md
@@ -10,7 +10,9 @@ The diskio input plugin gathers metrics about disk traffic and timing.
   ## By default, telegraf will gather stats for all devices including
   ## disk partitions.
   ## Setting devices will restrict the stats to the specified devices.
-  # devices = ["sda", "sdb", "vd*"]
+  ## NOTE: Globbing expressions (e.g. asterix) are not supported for
+  ##       disk synonyms like '/dev/disk/by-id'.
+  # devices = ["sda", "sdb", "vd*", "/dev/disk/by-id/nvme-eui.00123deadc0de123"]
   ## Uncomment the following line if you need disk serial numbers.
   # skip_serial_number = false
   #

--- a/plugins/inputs/diskio/diskio.go
+++ b/plugins/inputs/diskio/diskio.go
@@ -57,9 +57,11 @@ func (d *DiskIO) Init() error {
 }
 
 func (d *DiskIO) Gather(acc telegraf.Accumulator) error {
-	devices := []string{}
+	var devices []string
 	if d.deviceFilter == nil {
-		devices = d.Devices
+		for _, dev := range d.Devices {
+			devices = append(devices, resolveName(dev))
+		}
 	}
 
 	diskio, err := d.ps.DiskIO(devices)
@@ -76,6 +78,10 @@ func (d *DiskIO) Gather(acc telegraf.Accumulator) error {
 		tags := map[string]string{}
 		var devLinks []string
 		tags["name"], devLinks = d.diskName(io.Name)
+
+		if wwid := getDeviceWWID(io.Name); wwid != "" {
+			tags["wwid"] = wwid
+		}
 
 		if d.deviceFilter != nil && !match {
 			for _, devLink := range devLinks {

--- a/plugins/inputs/diskio/diskio_other.go
+++ b/plugins/inputs/diskio/diskio_other.go
@@ -7,3 +7,11 @@ type diskInfoCache struct{}
 func (d *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	return nil, nil
 }
+
+func resolveName(name string) string {
+	return name
+}
+
+func getDeviceWWID(name string) string {
+	return ""
+}

--- a/plugins/inputs/diskio/sample.conf
+++ b/plugins/inputs/diskio/sample.conf
@@ -3,7 +3,9 @@
   ## By default, telegraf will gather stats for all devices including
   ## disk partitions.
   ## Setting devices will restrict the stats to the specified devices.
-  # devices = ["sda", "sdb", "vd*"]
+  ## NOTE: Globbing expressions (e.g. asterix) are not supported for
+  ##       disk synonyms like '/dev/disk/by-id'.
+  # devices = ["sda", "sdb", "vd*", "/dev/disk/by-id/nvme-eui.00123deadc0de123"]
   ## Uncomment the following line if you need disk serial numbers.
   # skip_serial_number = false
   #


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11685 

This PR will try to resolve all given devices on Linux, i.e. follow the (potential) symlinks of each device to their native "name"/device file which is helpful when specifying disk-ids or uuids. Furthermore, the PR adds the WWID of disks as tag.

**Note:** All of the above will only work on Linux and only if there are **no wildcards** used!