### PR TITLE
feat(inputs.pgbouncer): Add databases and pool size metrics

### DIFF
--- a/plugins/inputs/pgbouncer/README.md
+++ b/plugins/inputs/pgbouncer/README.md
@@ -80,9 +80,25 @@ the server and doesn't restrict the databases we are trying to grab metrics for.
     - sv_tested
     - sv_used
 
+- pgbouncer_databases
+  - tags:
+    - db
+    - pg_dbname
+    - server
+  - fields:
+    - current_connections
+    - pool_size
+    - min_pool_size
+    - reserve_pool
+    - max_connections
+    - paused
+    - disabled
+
 ## Example Output
 
 ```shell
 pgbouncer,db=pgbouncer,server=host\=debian-buster-postgres\ user\=dbn\ port\=6432\ dbname\=pgbouncer\  avg_query_count=0i,avg_query_time=0i,avg_wait_time=0i,avg_xact_count=0i,avg_xact_time=0i,total_query_count=26i,total_query_time=0i,total_received=0i,total_sent=0i,total_wait_time=0i,total_xact_count=26i,total_xact_time=0i 1581569936000000000
 pgbouncer_pools,db=pgbouncer,pool_mode=statement,server=host\=debian-buster-postgres\ user\=dbn\ port\=6432\ dbname\=pgbouncer\ ,user=pgbouncer cl_active=1i,cl_waiting=0i,maxwait=0i,maxwait_us=0i,sv_active=0i,sv_idle=0i,sv_login=0i,sv_tested=0i,sv_used=0i 1581569936000000000
+pgbouncer_databases,db=pgbouncer,pg_dbname=pgbouncer,server=host\=debian-buster-postgres\ user\=dbn\ port\=6432\ dbname\=pgbouncer\ ,name=pgbouncer disabled=0i,pool_size=2i,current_connections=0i,min_pool_size=0i,reserve_pool=0i,max_connections=0i,paused=0i 1581569936000000000
+pgbouncer_databases,db=postgres,pg_dbname=postgres,server=host\=debian-buster-postgres\ user\=dbn\ port\=6432\ dbname\=pgbouncer\ ,name=postgres current_connections=0i,disabled=0i,pool_size=20i,min_pool_size=0i,reserve_pool=0i,paused=0i,max_connections=0i 1581569936000000000
 ```

--- a/plugins/inputs/pgbouncer/pgbouncer_test.go
+++ b/plugins/inputs/pgbouncer/pgbouncer_test.go
@@ -90,6 +90,16 @@ func TestPgBouncerGeneratesMetricsIntegration(t *testing.T) {
 		"maxwait",
 	}
 
+	intMetricsPgBouncerDatabases := []string{
+		"current_connections",
+		"pool_size",
+		"min_pool_size",
+		"reserve_pool",
+		"max_connections",
+		"paused",
+		"disabled",
+	}
+
 	int32Metrics := []string{}
 
 	metricsCounted := 0
@@ -104,11 +114,16 @@ func TestPgBouncerGeneratesMetricsIntegration(t *testing.T) {
 		metricsCounted++
 	}
 
+	for _, metric := range intMetricsPgBouncerDatabases {
+		require.True(t, acc.HasInt64Field("pgbouncer_databases", metric))
+		metricsCounted++
+	}
+
 	for _, metric := range int32Metrics {
 		require.True(t, acc.HasInt32Field("pgbouncer", metric))
 		metricsCounted++
 	}
 
 	require.True(t, metricsCounted > 0)
-	require.Equal(t, len(intMetricsPgBouncer)+len(intMetricsPgBouncerPools)+len(int32Metrics), metricsCounted)
+	require.Equal(t, len(intMetricsPgBouncer)+len(intMetricsPgBouncerPools)+len(intMetricsPgBouncerDatabases)+len(int32Metrics), metricsCounted)
 }


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Introduce metrics coming from pgbouncer `SHOW DATABASES` command. Being able to specifically record pool size metrics can provide the starting point for further calculating pool usage percentages.
