### PR TITLE
feat(inputs.sqlserver): improved filtering for active requests

### DIFF
--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -341,7 +341,7 @@ The new (version 2) metrics provide:
 - *Wait stats*: Wait time in ms, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store.
 - *Schedulers* - This captures `sys.dm_os_schedulers`.
 - *SqlRequests* - This captures a snapshot of `sys.dm_exec_requests` and `sys.dm_exec_sessions` that gives you running requests as well as wait types and
-  blocking sessions.
+  blocking sessions. Telegraf's monitoring request is omitted unless it is a heading blocker.
 - *VolumeSpace* - uses `sys.dm_os_volume_stats` to get total, used and occupied space on every disk that contains a data or log file. (Note that even if enabled it won't get any data from Azure SQL Database or SQL Managed Instance). It is pointless to run this with high frequency (ie: every 10s), but it won't cause any problem.
 - *Cpu* - uses the buffer ring (`sys.dm_os_ring_buffers`) to get CPU data, the table is updated once per minute. (Note that even if enabled it won't get any data from Azure SQL Database or SQL Managed Instance).
 
@@ -371,7 +371,7 @@ to test,differences in DMVs:
 - *AzureSQLDBServerProperties*: Relevant Azure SQL relevant properties from  such as Tier, #Vcores, Memory etc, storage, etc.
 - *AzureSQLDBWaitstats*: Wait time in ms from `sys.dm_db_wait_stats`, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store. These waits are collected only as of the end of the a statement. and for a specific database only.
 - *AzureSQLOsWaitstats*: Wait time in ms from `sys.dm_os_wait_stats`, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store. These waits are collected as they occur and instance wide
-- *AzureSQLDBRequests: Requests which are blocked or have a wait type from `sys.dm_exec_sessions` and `sys.dm_exec_requests`
+- *AzureSQLDBRequests*: Requests which are blocked or have a wait type from `sys.dm_exec_sessions` and `sys.dm_exec_requests`. Telegraf's monitoring request is omitted unless it is a heading blocker
 - *AzureSQLDBSchedulers* - This captures `sys.dm_os_schedulers` snapshots.
 
 ### database_type = "AzureSQLManagedInstance"
@@ -386,7 +386,7 @@ in DMVs:
 - *AzureSQLMIPerformanceCounters*: A select list of performance counters from `sys.dm_os_performance_counters` including cloud specific counters for SQL Hyperscale.
 - *AzureSQLMIServerProperties*: Relevant Azure SQL relevant properties such as Tier, #Vcores, Memory etc, storage, etc.
 - *AzureSQLMIOsWaitstats*: Wait time in ms from `sys.dm_os_wait_stats`, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store. These waits are collected as they occur and instance wide
-- *AzureSQLMIRequests*: Requests which are blocked or have a wait type from `sys.dm_exec_sessions` and `sys.dm_exec_requests`
+- *AzureSQLMIRequests*: Requests which are blocked or have a wait type from `sys.dm_exec_sessions` and `sys.dm_exec_requests`. Telegraf's monitoring request is omitter unless it is a heading blocker
 - *AzureSQLMISchedulers*: This captures `sys.dm_os_schedulers` snapshots.
 
 ### database_type = "AzureSQLPool"

--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -386,7 +386,7 @@ in DMVs:
 - *AzureSQLMIPerformanceCounters*: A select list of performance counters from `sys.dm_os_performance_counters` including cloud specific counters for SQL Hyperscale.
 - *AzureSQLMIServerProperties*: Relevant Azure SQL relevant properties such as Tier, #Vcores, Memory etc, storage, etc.
 - *AzureSQLMIOsWaitstats*: Wait time in ms from `sys.dm_os_wait_stats`, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store. These waits are collected as they occur and instance wide
-- *AzureSQLMIRequests*: Requests which are blocked or have a wait type from `sys.dm_exec_sessions` and `sys.dm_exec_requests`. Telegraf's monitoring request is omitter unless it is a heading blocker
+- *AzureSQLMIRequests*: Requests which are blocked or have a wait type from `sys.dm_exec_sessions` and `sys.dm_exec_requests`. Telegraf's monitoring request is omitted unless it is a heading blocker
 - *AzureSQLMISchedulers*: This captures `sys.dm_os_schedulers` snapshots.
 
 ### database_type = "AzureSQLPool"

--- a/plugins/inputs/sqlserver/azuresqldbqueries.go
+++ b/plugins/inputs/sqlserver/azuresqldbqueries.go
@@ -660,7 +660,8 @@ WHERE
 		AND (	--Always fetch user process (in any state), fetch system process only if active
 			[is_user_process] = 1
 			OR [status] COLLATE Latin1_General_BIN NOT IN ('background', 'sleeping')
-		)		
+		)
+		AND [session_id] <> @@SPID		
 	)  
 OPTION(MAXDOP 1);
 `

--- a/plugins/inputs/sqlserver/azuresqlmanagedqueries.go
+++ b/plugins/inputs/sqlserver/azuresqlmanagedqueries.go
@@ -528,6 +528,7 @@ WHERE
 			[is_user_process] = 1
 			OR [status] COLLATE Latin1_General_BIN NOT IN ('background', 'sleeping')
 		)
+		AND [session_id] <> @@SPID
 	)  
 OPTION(MAXDOP 1);
 `

--- a/plugins/inputs/sqlserver/sqlqueriesV2.go
+++ b/plugins/inputs/sqlserver/sqlqueriesV2.go
@@ -1318,7 +1318,7 @@ LEFT OUTER JOIN sys.dm_exec_requests AS r
 OUTER APPLY sys.dm_exec_sql_text(r.sql_handle) AS qt
 WHERE 1 = 1
 	AND (r.session_id IS NOT NULL AND (s.is_user_process = 1 
-	OR r.status COLLATE Latin1_General_BIN NOT IN (''background'', ''sleeping'')))
+	OR r.status COLLATE Latin1_General_BIN NOT IN (''background'', ''sleeping'')) AND r.session_id <> @@SPID)
 	OR  (s.session_id IN (SELECT blocking_session_id FROM #blockingSessions))
 OPTION(MAXDOP 1)'
 


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

The output from sys.dm_exec_requests contains a static request from telegraf which has no added value and only makes the output larger and harder to read. The only situation, when this should be shown is when it becomes a heading blocker. This unlikely possibility is taken into account in a code. Similar filter is used by other monitoring tools and is included in Glenn Berry's [diagnostic queries solution](https://glennsqlperformance.com/resources/)

This is a sample ouput before this feat on idle system. It contains a telegraf request to gain the requests:
![image](https://user-images.githubusercontent.com/13314610/186006275-47c7ab1a-4f72-49f4-9b03-9c5e85044424.png)

This is a sample output after this change on idle system:
![image](https://user-images.githubusercontent.com/13314610/186005353-b9165dbe-d30a-44d3-837d-6675b691d39d.png)

