### PR TITLE
fix(inputs.opcua): Assign node id correctly

### DIFF
--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -326,7 +326,7 @@ func (o *OpcUA) validateOPCTags() error {
 		o.nodes[i].idStr = BuildNodeID(node.tag)
 
 		//parse NodeIds and NodeIds errors
-		nid, niderr := ua.ParseNodeID(node.idStr)
+		nid, niderr := ua.ParseNodeID(o.nodes[i].idStr)
 		// build NodeIds and Errors
 		o.nodeIDs = append(o.nodeIDs, nid)
 		o.nodeIDerror = append(o.nodeIDerror, niderr)

--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -22,6 +22,7 @@ import (
 )
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
+//
 //go:embed sample.conf
 var sampleConfig string
 
@@ -205,7 +206,7 @@ func tagsSliceToMap(tags [][]string) (map[string]string, error) {
 	return m, nil
 }
 
-//InitNodes Method on OpcUA
+// InitNodes Method on OpcUA
 func (o *OpcUA) InitNodes() error {
 	for _, node := range o.RootNodes {
 		o.nodes = append(o.nodes, Node{
@@ -295,7 +296,7 @@ func newMP(n *Node) metricParts {
 
 func (o *OpcUA) validateOPCTags() error {
 	nameEncountered := map[metricParts]struct{}{}
-	for _, node := range o.nodes {
+	for i, node := range o.nodes {
 		mp := newMP(&node)
 		//check empty name
 		if node.tag.FieldName == "" {
@@ -322,7 +323,7 @@ func (o *OpcUA) validateOPCTags() error {
 			return fmt.Errorf("invalid identifier type '%s' in '%s'", node.tag.IdentifierType, node.tag.FieldName)
 		}
 
-		node.idStr = BuildNodeID(node.tag)
+		o.nodes[i].idStr = BuildNodeID(node.tag)
 
 		//parse NodeIds and NodeIds errors
 		nid, niderr := ua.ParseNodeID(node.idStr)


### PR DESCRIPTION
resolve: https://github.com/influxdata/telegraf/issues/11719

The ID was being set to the local copy of "node" in the loop, in order for the to be saved so it can be used later in the code: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/opcua/opcua.go#L516 it needs to be assigned using the index so that the original value gets updated. More context of this behavior: https://stackoverflow.com/questions/61605727/why-does-normal-for-loop-allows-assigning-value-to-struct-fields-while-for-range