### PR TITLE
fix!: Remove deprecated settings functionality for output plugins

### DIFF
--- a/plugins/outputs/amqp/README.md
+++ b/plugins/outputs/amqp/README.md
@@ -15,10 +15,6 @@ For an introduction to AMQP see:
 ```toml @sample.conf
 # Publishes metrics to an AMQP broker
 [[outputs.amqp]]
-  ## Broker to publish to.
-  ##   deprecated in 1.7; use the brokers option
-  # url = "amqp://localhost:5672/influxdb"
-
   ## Brokers to publish to.  If multiple brokers are specified a random broker
   ## will be selected anytime a connection is established.  This can be
   ## helpful for load balancing when not using a dedicated load balancer.
@@ -66,14 +62,6 @@ For an introduction to AMQP see:
   ## Delivery Mode controls if a published message is persistent.
   ##   One of "transient" or "persistent".
   # delivery_mode = "transient"
-
-  ## InfluxDB database added as a message header.
-  ##   deprecated in 1.7; use the headers option
-  # database = "telegraf"
-
-  ## InfluxDB retention policy added as a message header
-  ##   deprecated in 1.7; use the headers option
-  # retention_policy = "default"
 
   ## Static headers added to each published message.
   # headers = { }

--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -42,6 +42,7 @@ func (a *externalAuth) Response() string {
 }
 
 type AMQP struct {
+	URL                string            `toml:"url" deprecated:"1.7.0;use 'brokers' instead"`
 	Brokers            []string          `toml:"brokers"`
 	Exchange           string            `toml:"exchange"`
 	ExchangeType       string            `toml:"exchange_type"`
@@ -55,6 +56,9 @@ type AMQP struct {
 	RoutingTag         string            `toml:"routing_tag"`
 	RoutingKey         string            `toml:"routing_key"`
 	DeliveryMode       string            `toml:"delivery_mode"`
+	Database           string            `toml:"database" deprecated:"1.7.0;use 'headers' instead"`
+	RetentionPolicy    string            `toml:"retention_policy" deprecated:"1.7.0;use 'headers' instead"`
+	Precision          string            `toml:"precision" deprecated:"1.2.0;option is ignored"`
 	Headers            map[string]string `toml:"headers"`
 	Timeout            config.Duration   `toml:"timeout"`
 	UseBatchFormat     bool              `toml:"use_batch_format"`

--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -42,7 +42,6 @@ func (a *externalAuth) Response() string {
 }
 
 type AMQP struct {
-	URL                string            `toml:"url" deprecated:"1.7.0;use 'brokers' instead"`
 	Brokers            []string          `toml:"brokers"`
 	Exchange           string            `toml:"exchange"`
 	ExchangeType       string            `toml:"exchange_type"`
@@ -56,9 +55,6 @@ type AMQP struct {
 	RoutingTag         string            `toml:"routing_tag"`
 	RoutingKey         string            `toml:"routing_key"`
 	DeliveryMode       string            `toml:"delivery_mode"`
-	Database           string            `toml:"database" deprecated:"1.7.0;use 'headers' instead"`
-	RetentionPolicy    string            `toml:"retention_policy" deprecated:"1.7.0;use 'headers' instead"`
-	Precision          string            `toml:"precision" deprecated:"1.2.0;option is ignored"`
 	Headers            map[string]string `toml:"headers"`
 	Timeout            config.Duration   `toml:"timeout"`
 	UseBatchFormat     bool              `toml:"use_batch_format"`
@@ -247,9 +243,6 @@ func (q *AMQP) makeClientConfig() (*ClientConfig, error) {
 	}
 
 	clientConfig.brokers = q.Brokers
-	if len(clientConfig.brokers) == 0 {
-		clientConfig.brokers = []string{q.URL}
-	}
 
 	switch q.DeliveryMode {
 	case "transient":
@@ -264,12 +257,6 @@ func (q *AMQP) makeClientConfig() (*ClientConfig, error) {
 		clientConfig.headers = make(amqp.Table, len(q.Headers))
 		for k, v := range q.Headers {
 			clientConfig.headers[k] = v
-		}
-	} else {
-		// Copy deprecated fields into message header
-		clientConfig.headers = amqp.Table{
-			"database":         q.Database,
-			"retention_policy": q.RetentionPolicy,
 		}
 	}
 
@@ -315,13 +302,10 @@ func connect(clientConfig *ClientConfig) (Client, error) {
 func init() {
 	outputs.Add("amqp", func() telegraf.Output {
 		return &AMQP{
-			URL:             DefaultURL,
-			ExchangeType:    DefaultExchangeType,
-			AuthMethod:      DefaultAuthMethod,
-			Database:        DefaultDatabase,
-			RetentionPolicy: DefaultRetentionPolicy,
-			Timeout:         config.Duration(time.Second * 5),
-			connect:         connect,
+			ExchangeType: DefaultExchangeType,
+			AuthMethod:   DefaultAuthMethod,
+			Timeout:      config.Duration(time.Second * 5),
+			connect:      connect,
 		}
 	})
 }

--- a/plugins/outputs/amqp/amqp_test.go
+++ b/plugins/outputs/amqp/amqp_test.go
@@ -75,24 +75,6 @@ func TestConnect(t *testing.T) {
 			},
 		},
 		{
-			name: "headers overrides deprecated dbrp",
-			output: &AMQP{
-				Headers: map[string]string{
-					"foo": "bar",
-				},
-				connect: func(_ *ClientConfig) (Client, error) {
-					return NewMockClient(), nil
-				},
-			},
-			errFunc: func(t *testing.T, output *AMQP, err error) {
-				cfg := output.config
-				require.Equal(t, amqp.Table{
-					"foo": "bar",
-				}, cfg.headers)
-				require.NoError(t, err)
-			},
-		},
-		{
 			name: "exchange args",
 			output: &AMQP{
 				ExchangeArguments: map[string]string{

--- a/plugins/outputs/amqp/amqp_test.go
+++ b/plugins/outputs/amqp/amqp_test.go
@@ -51,9 +51,11 @@ func TestConnect(t *testing.T) {
 				ExchangeType:       DefaultExchangeType,
 				ExchangeDurability: "durable",
 				AuthMethod:         DefaultAuthMethod,
-				Database:           DefaultDatabase,
-				RetentionPolicy:    DefaultRetentionPolicy,
-				Timeout:            config.Duration(time.Second * 5),
+				Headers: map[string]string{
+					"database":         DefaultDatabase,
+					"retention_policy": DefaultRetentionPolicy,
+				},
+				Timeout: config.Duration(time.Second * 5),
 				connect: func(_ *ClientConfig) (Client, error) {
 					return NewMockClient(), nil
 				},
@@ -95,7 +97,7 @@ func TestConnect(t *testing.T) {
 		{
 			name: "username password",
 			output: &AMQP{
-				URL:      "amqp://foo:bar@localhost",
+				Brokers:  []string{"amqp://foo:bar@localhost"},
 				Username: "telegraf",
 				Password: "pa$$word",
 				connect: func(_ *ClientConfig) (Client, error) {
@@ -117,7 +119,7 @@ func TestConnect(t *testing.T) {
 		{
 			name: "url support",
 			output: &AMQP{
-				URL: DefaultURL,
+				Brokers: []string{DefaultURL},
 				connect: func(_ *ClientConfig) (Client, error) {
 					return NewMockClient(), nil
 				},

--- a/plugins/outputs/amqp/sample.conf
+++ b/plugins/outputs/amqp/sample.conf
@@ -1,9 +1,5 @@
 # Publishes metrics to an AMQP broker
 [[outputs.amqp]]
-  ## Broker to publish to.
-  ##   deprecated in 1.7; use the brokers option
-  # url = "amqp://localhost:5672/influxdb"
-
   ## Brokers to publish to.  If multiple brokers are specified a random broker
   ## will be selected anytime a connection is established.  This can be
   ## helpful for load balancing when not using a dedicated load balancer.
@@ -51,14 +47,6 @@
   ## Delivery Mode controls if a published message is persistent.
   ##   One of "transient" or "persistent".
   # delivery_mode = "transient"
-
-  ## InfluxDB database added as a message header.
-  ##   deprecated in 1.7; use the headers option
-  # database = "telegraf"
-
-  ## InfluxDB retention policy added as a message header
-  ##   deprecated in 1.7; use the headers option
-  # retention_policy = "default"
 
   ## Static headers added to each published message.
   # headers = { }

--- a/plugins/outputs/influxdb/http_test.go
+++ b/plugins/outputs/influxdb/http_test.go
@@ -1,4 +1,4 @@
-//nolint
+// nolint
 package influxdb_test
 
 import (
@@ -1045,7 +1045,7 @@ func TestDBRPTagsCreateDatabaseNotCalledOnRetryAfterForbidden(t *testing.T) {
 	}
 
 	output := influxdb.InfluxDB{
-		URL:         u.String(),
+		URLs:        []string{u.String()},
 		Database:    "telegraf",
 		DatabaseTag: "database",
 		Log:         testutil.Logger{},
@@ -1130,7 +1130,7 @@ func TestDBRPTagsCreateDatabaseCalledOnDatabaseNotFound(t *testing.T) {
 	}
 
 	output := influxdb.InfluxDB{
-		URL:         u.String(),
+		URLs:        []string{u.String()},
 		Database:    "telegraf",
 		DatabaseTag: "database",
 		Log:         testutil.Logger{},
@@ -1184,7 +1184,7 @@ func TestDBNotFoundShouldDropMetricWhenSkipDatabaseCreateIsTrue(t *testing.T) {
 
 	logger := &testutil.CaptureLogger{}
 	output := influxdb.InfluxDB{
-		URL:                  u.String(),
+		URLs:                 []string{u.String()},
 		Database:             "telegraf",
 		DatabaseTag:          "database",
 		SkipDatabaseCreation: true,

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -40,6 +40,7 @@ type Client interface {
 
 // InfluxDB struct is the primary data structure for the plugin
 type InfluxDB struct {
+	URL                       string            `toml:"url" deprecated:"0.1.9;2.0.0;use 'urls' instead"`
 	URLs                      []string          `toml:"urls"`
 	Username                  string            `toml:"username"`
 	Password                  string            `toml:"password"`
@@ -58,6 +59,7 @@ type InfluxDB struct {
 	ContentEncoding           string            `toml:"content_encoding"`
 	SkipDatabaseCreation      bool              `toml:"skip_database_creation"`
 	InfluxUintSupport         bool              `toml:"influx_uint_support"`
+	Precision                 string            `toml:"precision" deprecated:"1.0.0;option is ignored"`
 	tls.ClientConfig
 
 	clients []Client

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -1,5 +1,6 @@
+// nolint
+//
 //go:generate ../../../tools/readme_config_includer/generator
-//nolint
 package influxdb
 
 import (
@@ -19,6 +20,7 @@ import (
 )
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
+//
 //go:embed sample.conf
 var sampleConfig string
 
@@ -38,7 +40,6 @@ type Client interface {
 
 // InfluxDB struct is the primary data structure for the plugin
 type InfluxDB struct {
-	URL                       string            `toml:"url" deprecated:"0.1.9;2.0.0;use 'urls' instead"`
 	URLs                      []string          `toml:"urls"`
 	Username                  string            `toml:"username"`
 	Password                  string            `toml:"password"`
@@ -59,8 +60,6 @@ type InfluxDB struct {
 	InfluxUintSupport         bool              `toml:"influx_uint_support"`
 	tls.ClientConfig
 
-	Precision string `toml:"precision" deprecated:"1.0.0;option is ignored"`
-
 	clients []Client
 
 	CreateHTTPClientF func(config *HTTPConfig) (Client, error)
@@ -78,9 +77,6 @@ func (i *InfluxDB) Connect() error {
 
 	urls := make([]string, 0, len(i.URLs))
 	urls = append(urls, i.URLs...)
-	if i.URL != "" {
-		urls = append(urls, i.URL)
-	}
 
 	if len(urls) == 0 {
 		urls = append(urls, defaultURL)

--- a/plugins/outputs/influxdb/influxdb_test.go
+++ b/plugins/outputs/influxdb/influxdb_test.go
@@ -49,24 +49,6 @@ func (c *MockClient) SetLogger(log telegraf.Logger) {
 	c.log = log
 }
 
-func TestDeprecatedURLSupport(t *testing.T) {
-	var actual *influxdb.UDPConfig
-	output := influxdb.InfluxDB{
-		URL: "udp://localhost:8089",
-
-		CreateUDPClientF: func(config *influxdb.UDPConfig) (influxdb.Client, error) {
-			actual = config
-			return &MockClient{}, nil
-		},
-	}
-
-	output.Log = testutil.Logger{}
-
-	err := output.Connect()
-	require.NoError(t, err)
-	require.Equal(t, "udp://localhost:8089", actual.URL.String())
-}
-
 func TestDefaultURL(t *testing.T) {
 	var actual *influxdb.HTTPConfig
 	output := influxdb.InfluxDB{

--- a/plugins/outputs/kinesis/README.md
+++ b/plugins/outputs/kinesis/README.md
@@ -126,20 +126,6 @@ Kinesis stream. It is important to note that the stream *MUST* be pre-configured
 for this plugin to function correctly. If the stream does not exist the plugin
 will result in telegraf exiting with an exit code of 1.
 
-### partitionkey [DEPRECATED]
-
-This is used to group data within a stream. Currently this plugin only supports
-a single partitionkey.  Manually configuring different hosts, or groups of hosts
-with manually selected partitionkeys might be a workable solution to scale out.
-
-### use_random_partitionkey [DEPRECATED]
-
-When true a random UUID will be generated and used as the partitionkey when
-sending data to Kinesis. This allows data to evenly spread across multiple
-shards in the stream. Due to using a random partitionKey there can be no
-guarantee of ordering when consuming the data off the shards.  If true then the
-partitionkey option will be ignored.
-
 ### partition
 
 This is used to group data within a stream. Currently four methods are

--- a/plugins/outputs/kinesis/kinesis.go
+++ b/plugins/outputs/kinesis/kinesis.go
@@ -27,9 +27,11 @@ const maxRecordsPerRequest uint32 = 500
 
 type (
 	KinesisOutput struct {
-		StreamName string     `toml:"streamname"`
-		Partition  *Partition `toml:"partition"`
-		Debug      bool       `toml:"debug"`
+		StreamName         string     `toml:"streamname"`
+		PartitionKey       string     `toml:"partitionkey" deprecated:"1.5.0;use 'partition.key' instead"`
+		RandomPartitionKey bool       `toml:"use_random_partitionkey" deprecated:"1.5.0;use 'partition.method' instead"`
+		Partition          *Partition `toml:"partition"`
+		Debug              bool       `toml:"debug"`
 
 		Log        telegraf.Logger `toml:"-"`
 		serializer serializers.Serializer

--- a/plugins/outputs/kinesis/kinesis.go
+++ b/plugins/outputs/kinesis/kinesis.go
@@ -108,7 +108,6 @@ func (k *KinesisOutput) writeKinesis(r []types.PutRecordsRequestEntry) time.Dura
 }
 
 func (k *KinesisOutput) getPartitionKey(metric telegraf.Metric) string {
-	defaultKey := "telegraf"
 	if k.Partition != nil {
 		switch k.Partition.Method {
 		case "static":
@@ -128,12 +127,12 @@ func (k *KinesisOutput) getPartitionKey(metric telegraf.Metric) string {
 				return k.Partition.Default
 			}
 			// Default partition name if default is not set
-			return defaultKey
+			return "telegraf"
 		default:
 			k.Log.Errorf("You have configured a Partition method of '%s' which is not supported", k.Partition.Method)
 		}
 	}
-	return defaultKey
+	return ""
 }
 
 func (k *KinesisOutput) Write(metrics []telegraf.Metric) error {

--- a/plugins/outputs/kinesis/kinesis_test.go
+++ b/plugins/outputs/kinesis/kinesis_test.go
@@ -91,14 +91,18 @@ func TestPartitionKey(t *testing.T) {
 	require.Equal(t, byte(4), u.Version(), "PartitionKey should be UUIDv4")
 
 	k = KinesisOutput{
-		Log:          testutil.Logger{},
-		PartitionKey: "-",
+		Log: testutil.Logger{},
+		Partition: &Partition{
+			Key: "-",
+		},
 	}
 	require.Equal(t, "-", k.getPartitionKey(testPoint), "PartitionKey should be '-'")
 
 	k = KinesisOutput{
-		Log:                testutil.Logger{},
-		RandomPartitionKey: true,
+		Log: testutil.Logger{},
+		Partition: &Partition{
+			Method: "random",
+		},
 	}
 	partitionKey = k.getPartitionKey(testPoint)
 	u, err = uuid.FromString(partitionKey)

--- a/plugins/outputs/kinesis/kinesis_test.go
+++ b/plugins/outputs/kinesis/kinesis_test.go
@@ -93,7 +93,8 @@ func TestPartitionKey(t *testing.T) {
 	k = KinesisOutput{
 		Log: testutil.Logger{},
 		Partition: &Partition{
-			Key: "-",
+			Key:    "-",
+			Method: "static",
 		},
 	}
 	require.Equal(t, "-", k.getPartitionKey(testPoint), "PartitionKey should be '-'")

--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -18,18 +18,18 @@ import (
 )
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
+//
 //go:embed sample.conf
 var sampleConfig string
 
 // Librato structure for configuration and client
 type Librato struct {
-	APIUser   string          `toml:"api_user"`
-	APIToken  string          `toml:"api_token"`
-	Debug     bool            `toml:"debug"`
-	SourceTag string          `toml:"source_tag" deprecated:"1.0.0;use 'template' instead"`
-	Timeout   config.Duration `toml:"timeout"`
-	Template  string          `toml:"template"`
-	Log       telegraf.Logger `toml:"-"`
+	APIUser  string          `toml:"api_user"`
+	APIToken string          `toml:"api_token"`
+	Debug    bool            `toml:"debug"`
+	Timeout  config.Duration `toml:"timeout"`
+	Template string          `toml:"template"`
+	Log      telegraf.Logger `toml:"-"`
 
 	APIUrl string
 	client *http.Client
@@ -87,9 +87,6 @@ func (l *Librato) Write(metrics []telegraf.Metric) error {
 	}
 	if l.Template == "" {
 		l.Template = "host"
-	}
-	if l.SourceTag != "" {
-		l.Template = l.SourceTag
 	}
 
 	tempGauges := []*Gauge{}
@@ -233,7 +230,7 @@ func (g *Gauge) setValue(v interface{}) error {
 	return nil
 }
 
-//Close is used to close the connection to librato Output
+// Close is used to close the connection to librato Output
 func (l *Librato) Close() error {
 	return nil
 }

--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -24,12 +24,13 @@ var sampleConfig string
 
 // Librato structure for configuration and client
 type Librato struct {
-	APIUser  string          `toml:"api_user"`
-	APIToken string          `toml:"api_token"`
-	Debug    bool            `toml:"debug"`
-	Timeout  config.Duration `toml:"timeout"`
-	Template string          `toml:"template"`
-	Log      telegraf.Logger `toml:"-"`
+	APIUser   string          `toml:"api_user"`
+	APIToken  string          `toml:"api_token"`
+	Debug     bool            `toml:"debug"`
+	SourceTag string          `toml:"source_tag" deprecated:"1.0.0;use 'template' instead"`
+	Timeout   config.Duration `toml:"timeout"`
+	Template  string          `toml:"template"`
+	Log       telegraf.Logger `toml:"-"`
 
 	APIUrl string
 	client *http.Client

--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -16,12 +16,6 @@ Wavefront Proxy instance over HTTP or HTTPS.
   ## Maximum number of metrics to send per HTTP request. This value should be higher than the `metric_batch_size`. Default is 10,000. Values higher than 40,000 are not recommended.
   # http_maximum_batch_size = 10000
 
-  ## Deprecated. DNS name of the Wavefront server or Wavefront Proxy. Use the `url` field instead.
-  #host = "wavefront.example.com"
-
-  ## Deprecated. Wavefront proxy port. Use the `url` field instead.
-  #port = 2878
-
   ## prefix for metrics keys
   #prefix = "my.specific.prefix."
 

--- a/plugins/outputs/wavefront/sample.conf
+++ b/plugins/outputs/wavefront/sample.conf
@@ -8,12 +8,6 @@
   ## Maximum number of metrics to send per HTTP request. This value should be higher than the `metric_batch_size`. Default is 10,000. Values higher than 40,000 are not recommended.
   # http_maximum_batch_size = 10000
 
-  ## Deprecated. DNS name of the Wavefront server or Wavefront Proxy. Use the `url` field instead.
-  #host = "wavefront.example.com"
-
-  ## Deprecated. Wavefront proxy port. Use the `url` field instead.
-  #port = 2878
-
   ## prefix for metrics keys
   #prefix = "my.specific.prefix."
 

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -22,19 +22,22 @@ var sampleConfig string
 const maxTagLength = 254
 
 type Wavefront struct {
-	URL                  string   `toml:"url"`
-	Token                string   `toml:"token"`
-	Prefix               string   `toml:"prefix"`
-	SimpleFields         bool     `toml:"simple_fields"`
-	MetricSeparator      string   `toml:"metric_separator"`
-	ConvertPaths         bool     `toml:"convert_paths"`
-	ConvertBool          bool     `toml:"convert_bool"`
-	HTTPMaximumBatchSize int      `toml:"http_maximum_batch_size"`
-	UseRegex             bool     `toml:"use_regex"`
-	UseStrict            bool     `toml:"use_strict"`
-	TruncateTags         bool     `toml:"truncate_tags"`
-	ImmediateFlush       bool     `toml:"immediate_flush"`
-	SourceOverride       []string `toml:"source_override"`
+	URL                  string                          `toml:"url"`
+	Token                string                          `toml:"token"`
+	Host                 string                          `toml:"host" deprecated:"2.4.0;use url instead"`
+	Port                 int                             `toml:"port" deprecated:"2.4.0;use url instead"`
+	Prefix               string                          `toml:"prefix"`
+	SimpleFields         bool                            `toml:"simple_fields"`
+	MetricSeparator      string                          `toml:"metric_separator"`
+	ConvertPaths         bool                            `toml:"convert_paths"`
+	ConvertBool          bool                            `toml:"convert_bool"`
+	HTTPMaximumBatchSize int                             `toml:"http_maximum_batch_size"`
+	UseRegex             bool                            `toml:"use_regex"`
+	UseStrict            bool                            `toml:"use_strict"`
+	TruncateTags         bool                            `toml:"truncate_tags"`
+	ImmediateFlush       bool                            `toml:"immediate_flush"`
+	SourceOverride       []string                        `toml:"source_override"`
+	StringToNumber       map[string][]map[string]float64 `toml:"string_to_number" deprecated:"1.9.0;use the enum processor instead"`
 
 	sender wavefront.Sender
 	Log    telegraf.Logger `toml:"-"`

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -15,28 +15,26 @@ import (
 )
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
+//
 //go:embed sample.conf
 var sampleConfig string
 
 const maxTagLength = 254
 
 type Wavefront struct {
-	URL                  string                          `toml:"url"`
-	Token                string                          `toml:"token"`
-	Host                 string                          `toml:"host" deprecated:"2.4.0;use url instead"`
-	Port                 int                             `toml:"port" deprecated:"2.4.0;use url instead"`
-	Prefix               string                          `toml:"prefix"`
-	SimpleFields         bool                            `toml:"simple_fields"`
-	MetricSeparator      string                          `toml:"metric_separator"`
-	ConvertPaths         bool                            `toml:"convert_paths"`
-	ConvertBool          bool                            `toml:"convert_bool"`
-	HTTPMaximumBatchSize int                             `toml:"http_maximum_batch_size"`
-	UseRegex             bool                            `toml:"use_regex"`
-	UseStrict            bool                            `toml:"use_strict"`
-	TruncateTags         bool                            `toml:"truncate_tags"`
-	ImmediateFlush       bool                            `toml:"immediate_flush"`
-	SourceOverride       []string                        `toml:"source_override"`
-	StringToNumber       map[string][]map[string]float64 `toml:"string_to_number" deprecated:"1.9.0;use the enum processor instead"`
+	URL                  string   `toml:"url"`
+	Token                string   `toml:"token"`
+	Prefix               string   `toml:"prefix"`
+	SimpleFields         bool     `toml:"simple_fields"`
+	MetricSeparator      string   `toml:"metric_separator"`
+	ConvertPaths         bool     `toml:"convert_paths"`
+	ConvertBool          bool     `toml:"convert_bool"`
+	HTTPMaximumBatchSize int      `toml:"http_maximum_batch_size"`
+	UseRegex             bool     `toml:"use_regex"`
+	UseStrict            bool     `toml:"use_strict"`
+	TruncateTags         bool     `toml:"truncate_tags"`
+	ImmediateFlush       bool     `toml:"immediate_flush"`
+	SourceOverride       []string `toml:"source_override"`
 
 	sender wavefront.Sender
 	Log    telegraf.Logger `toml:"-"`
@@ -105,10 +103,6 @@ func (w *Wavefront) Connect() error {
 			return err
 		}
 		connectionURL = connectionURLWithToken
-	} else {
-		w.Log.Warnf("configuration with host/port is deprecated. Please use url.")
-		w.Log.Debugf("connecting over http using Host: %q and Port: %d", w.Host, w.Port)
-		connectionURL = senderURLFromHostAndPort(w.Host, w.Port)
 	}
 
 	sender, err := wavefront.NewSender(connectionURL,
@@ -283,18 +277,6 @@ func buildValue(v interface{}, name string, w *Wavefront) (float64, error) {
 		return float64(v.(uint64)), nil
 	case float64:
 		return v.(float64), nil
-	case string:
-		for prefix, mappings := range w.StringToNumber {
-			if strings.HasPrefix(name, prefix) {
-				for _, mapping := range mappings {
-					val, hasVal := mapping[p]
-					if hasVal {
-						return val, nil
-					}
-				}
-			}
-		}
-		return 0, fmt.Errorf("unexpected type: %T, with value: %v, for: %s", v, v, name)
 	default:
 		return 0, fmt.Errorf("unexpected type: %T, with value: %v, for: %s", v, v, name)
 	}

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -16,8 +16,6 @@ import (
 // default config used by Tests
 func defaultWavefront() *Wavefront {
 	return &Wavefront{
-		Host:            "localhost",
-		Port:            2878,
 		Prefix:          "testWF.",
 		SimpleFields:    false,
 		MetricSeparator: ".",
@@ -291,10 +289,6 @@ func TestBuildValue(t *testing.T) {
 
 func TestBuildValueString(t *testing.T) {
 	w := defaultWavefront()
-	w.StringToNumber = map[string][]map[string]float64{
-		"test1": {{"green": 1, "red": 10}},
-		"test2": {{"active": 1, "hidden": 2}},
-	}
 
 	var valuetests = []struct {
 		value interface{}

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -287,32 +287,6 @@ func TestBuildValue(t *testing.T) {
 	}
 }
 
-func TestBuildValueString(t *testing.T) {
-	w := defaultWavefront()
-
-	var valuetests = []struct {
-		value interface{}
-		name  string
-		out   float64
-		isErr bool
-	}{
-		{value: int64(123), name: "", out: 123},
-		{value: "green", name: "test1", out: 1},
-		{value: "red", name: "test1", out: 10},
-		{value: "hidden", name: "test2", out: 2},
-		{value: "bad", name: "test1", out: 0, isErr: true},
-	}
-
-	for _, vt := range valuetests {
-		value, err := buildValue(vt.value, vt.name, w)
-		if vt.isErr && err == nil {
-			t.Errorf("\nexpected error with\t%+v\nreceived\t%+v\n", vt.out, value)
-		} else if value != vt.out {
-			t.Errorf("\nexpected\t%+v\nreceived\t%+v\n", vt.out, value)
-		}
-	}
-}
-
 func TestTagLimits(t *testing.T) {
 	w := defaultWavefront()
 	w.TruncateTags = true


### PR DESCRIPTION
DON'T MERGE TO MASTER, the strategy will be to merge all breaking changes to a separate branch.

Remove the deprecated settings for output plugins listed in https://github.com/influxdata/telegraf/issues/9478. Since this breaks compatibility, it will not be merged until the next major release (2.0).

Semantic PR checker is failing because: https://github.com/influxdata/validate-semantic-github-messages/pull/20