### PR TITLE
fix: sort labels in prometheusremotewrite serializer

### DIFF
--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -339,5 +339,11 @@ func getPromTS(name string, labels []prompb.Label, value float64, ts time.Time) 
 		Name:  "__name__",
 		Value: name,
 	})
+
+	// we sort the labels since Prometheus TSDB does not like out of order labels
+	sort.Slice(labels, func(i, j int) bool {
+		return labels[i].Name < labels[j].Name
+	})
+
 	return MakeMetricKey(labels), prompb.TimeSeries{Labels: labels, Samples: sample}
 }

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -582,16 +582,16 @@ cpu_time_idle{host_name="example.org"} 42
 			},
 			expected: []byte(`
 cpu_time_guest{cpu="cpu0"} 8106.04
-cpu_time_system{cpu="cpu0"} 26271.4
-cpu_time_user{cpu="cpu0"} 92904.33
 cpu_time_guest{cpu="cpu1"} 8181.63
-cpu_time_system{cpu="cpu1"} 25351.49
-cpu_time_user{cpu="cpu1"} 96912.57
 cpu_time_guest{cpu="cpu2"} 7470.04
-cpu_time_system{cpu="cpu2"} 24998.43
-cpu_time_user{cpu="cpu2"} 96034.08
 cpu_time_guest{cpu="cpu3"} 7517.95
+cpu_time_system{cpu="cpu0"} 26271.4
+cpu_time_system{cpu="cpu1"} 25351.49
+cpu_time_system{cpu="cpu2"} 24998.43
 cpu_time_system{cpu="cpu3"} 24970.82
+cpu_time_user{cpu="cpu0"} 92904.33
+cpu_time_user{cpu="cpu1"} 96912.57
+cpu_time_user{cpu="cpu2"} 96034.08
 cpu_time_user{cpu="cpu3"} 94148
 `),
 		},


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #9365

This ensures that metrics output by the prometheusremotewrite serializer have correct label ordering. This is an alternative fix to #11674 that would be more robust but also more intrusive. We need this because we have 2 telegraf processes that run in different environments (with different locales with different uppercase letter ordering).
I'm okay with both solutions or even to make this fix configurable, ie. via a `order_labels` boolean flag.
