### PR TITLE
feat(inputs.directory_monitor): Traverse sub-directories

### DIFF
--- a/plugins/inputs/directory_monitor/README.md
+++ b/plugins/inputs/directory_monitor/README.md
@@ -1,6 +1,6 @@
 # Directory Monitor Input Plugin
 
-This plugin monitors a single directory (without looking at sub-directories),
+This plugin monitors a single directory (traversing sub-directories),
 and takes in each file placed in the directory.  The plugin will gather all
 files in the directory at the configured interval, and parse the ones that
 haven't been picked up yet.
@@ -18,10 +18,10 @@ be guaranteed to finish writing before the `directory_duration_threshold`.
 ```toml @sample.conf
 # Ingests files in a directory and then moves them to a target directory.
 [[inputs.directory_monitor]]
-  ## The directory to monitor and read files from.
+  ## The directory to monitor and read files from (including subdirectories.
   directory = ""
   #
-  ## The directory to move finished files to.
+  ## The directory to move finished files to (maintaining directory hierachy from source.
   finished_directory = ""
   #
   ## The directory to move files to upon file error.
@@ -56,7 +56,7 @@ be guaranteed to finish writing before the `directory_duration_threshold`.
   #
   ## Specify if the file can be read completely at once or if it needs to be read line by line (default).
   ## Possible values: "line-by-line", "at-once"
-  # parse_method = "line-by-line" 
+  # parse_method = "line-by-line"
   #
   ## The dataformat to be read from the files.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/inputs/directory_monitor/README.md
+++ b/plugins/inputs/directory_monitor/README.md
@@ -18,7 +18,7 @@ be guaranteed to finish writing before the `directory_duration_threshold`.
 ```toml @sample.conf
 # Ingests files in a directory and then moves them to a target directory.
 [[inputs.directory_monitor]]
-  ## The directory to monitor and read files from (including subdirectories.
+  ## The directory to monitor and read files from (including sub-directories.
   directory = ""
   #
   ## The directory to move finished files to (maintaining directory hierachy from source.

--- a/plugins/inputs/directory_monitor/README.md
+++ b/plugins/inputs/directory_monitor/README.md
@@ -18,11 +18,14 @@ be guaranteed to finish writing before the `directory_duration_threshold`.
 ```toml @sample.conf
 # Ingests files in a directory and then moves them to a target directory.
 [[inputs.directory_monitor]]
-  ## The directory to monitor and read files from (including sub-directories.
+  ## The directory to monitor and read files from (including sub-directories if "recursive" is true).
   directory = ""
   #
   ## The directory to move finished files to (maintaining directory hierachy from source.
   finished_directory = ""
+  #
+  ## Setting recursive to true will make the plugin recursively walk the directory and process all sub-directories.
+  # recursive = false
   #
   ## The directory to move files to upon file error.
   ## If not provided, erroring files will stay in the monitored directory.

--- a/plugins/inputs/directory_monitor/README.md
+++ b/plugins/inputs/directory_monitor/README.md
@@ -65,7 +65,12 @@ be guaranteed to finish writing before the `directory_duration_threshold`.
   data_format = "influx"
 ```
 
-## Example Output
+## Metrics
 
 The format of metrics produced by this plugin depends on the content and data
+format of the file.
+
+## Example Output
+
+The metrics produced by this plugin depends on the content and data
 format of the file.

--- a/plugins/inputs/directory_monitor/README.md
+++ b/plugins/inputs/directory_monitor/README.md
@@ -65,7 +65,7 @@ be guaranteed to finish writing before the `directory_duration_threshold`.
   data_format = "influx"
 ```
 
-## Metrics
+## Example Output
 
 The format of metrics produced by this plugin depends on the content and data
 format of the file.

--- a/plugins/inputs/directory_monitor/README.md
+++ b/plugins/inputs/directory_monitor/README.md
@@ -21,7 +21,7 @@ be guaranteed to finish writing before the `directory_duration_threshold`.
   ## The directory to monitor and read files from (including sub-directories if "recursive" is true).
   directory = ""
   #
-  ## The directory to move finished files to (maintaining directory hierachy from source.
+  ## The directory to move finished files to (maintaining directory hierachy from source).
   finished_directory = ""
   #
   ## Setting recursive to true will make the plugin recursively walk the directory and process all sub-directories.

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -29,6 +29,7 @@ import (
 )
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
+//
 //go:embed sample.conf
 var sampleConfig string
 
@@ -78,7 +79,6 @@ func (monitor *DirectoryMonitor) Gather(_ telegraf.Accumulator) error {
 	processFile := func(path string, name string) error {
 		// We've been cancelled via Stop().
 		if monitor.context.Err() != nil {
-			//nolint:nilerr // context cancelation is not an error
 			return io.EOF
 		}
 

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -74,7 +74,6 @@ func (*DirectoryMonitor) SampleConfig() string {
 }
 
 func (monitor *DirectoryMonitor) Gather(_ telegraf.Accumulator) error {
-
 	err := filepath.Walk(monitor.Directory,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -88,7 +88,8 @@ func (monitor *DirectoryMonitor) Gather(_ telegraf.Accumulator) error {
 
 			stat, err := times.Stat(path)
 			if err != nil {
-				return nil
+				// Don't stop traversing if there is an eror
+				return nil //nolint:nilerr
 			}
 
 			timeThresholdExceeded := time.Since(stat.AccessTime()) >= time.Duration(monitor.DirectoryDurationThreshold)

--- a/plugins/inputs/directory_monitor/directory_monitor_test.go
+++ b/plugins/inputs/directory_monitor/directory_monitor_test.go
@@ -468,6 +468,7 @@ func TestParseSubdirectories(t *testing.T) {
 	r := DirectoryMonitor{
 		Directory:          processDirectory,
 		FinishedDirectory:  finishedDirectory,
+		Recursive:          true,
 		MaxBufferedMetrics: defaultMaxBufferedMetrics,
 		FileQueueSize:      defaultFileQueueSize,
 		ParseMethod:        "at-once",

--- a/plugins/inputs/directory_monitor/directory_monitor_test.go
+++ b/plugins/inputs/directory_monitor/directory_monitor_test.go
@@ -514,7 +514,7 @@ func TestParseSubdirectories(t *testing.T) {
 	require.NoError(t, err)
 	err = r.Gather(&acc)
 	require.NoError(t, err)
-	acc.Wait(1)
+	acc.Wait(2)
 	r.Stop()
 
 	require.NoError(t, acc.FirstError())

--- a/plugins/inputs/directory_monitor/sample.conf
+++ b/plugins/inputs/directory_monitor/sample.conf
@@ -1,10 +1,13 @@
 # Ingests files in a directory and then moves them to a target directory.
 [[inputs.directory_monitor]]
-  ## The directory to monitor and read files from (including sub-directories.
+  ## The directory to monitor and read files from (including sub-directories if "recursive" is true).
   directory = ""
   #
   ## The directory to move finished files to (maintaining directory hierachy from source.
   finished_directory = ""
+  #
+  ## Setting recursive to true will make the plugin recursively walk the directory and process all sub-directories.
+  # recursive = false
   #
   ## The directory to move files to upon file error.
   ## If not provided, erroring files will stay in the monitored directory.

--- a/plugins/inputs/directory_monitor/sample.conf
+++ b/plugins/inputs/directory_monitor/sample.conf
@@ -1,6 +1,6 @@
 # Ingests files in a directory and then moves them to a target directory.
 [[inputs.directory_monitor]]
-  ## The directory to monitor and read files from (including subdirectories.
+  ## The directory to monitor and read files from (including sub-directories.
   directory = ""
   #
   ## The directory to move finished files to (maintaining directory hierachy from source.

--- a/plugins/inputs/directory_monitor/sample.conf
+++ b/plugins/inputs/directory_monitor/sample.conf
@@ -1,9 +1,9 @@
 # Ingests files in a directory and then moves them to a target directory.
 [[inputs.directory_monitor]]
-  ## The directory to monitor and read files from.
+  ## The directory to monitor and read files from (including subdirectories.
   directory = ""
   #
-  ## The directory to move finished files to.
+  ## The directory to move finished files to (maintaining directory hierachy from source.
   finished_directory = ""
   #
   ## The directory to move files to upon file error.
@@ -38,7 +38,7 @@
   #
   ## Specify if the file can be read completely at once or if it needs to be read line by line (default).
   ## Possible values: "line-by-line", "at-once"
-  # parse_method = "line-by-line" 
+  # parse_method = "line-by-line"
   #
   ## The dataformat to be read from the files.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/inputs/directory_monitor/sample.conf
+++ b/plugins/inputs/directory_monitor/sample.conf
@@ -3,7 +3,7 @@
   ## The directory to monitor and read files from (including sub-directories if "recursive" is true).
   directory = ""
   #
-  ## The directory to move finished files to (maintaining directory hierachy from source.
+  ## The directory to move finished files to (maintaining directory hierachy from source).
   finished_directory = ""
   #
   ## Setting recursive to true will make the plugin recursively walk the directory and process all sub-directories.


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11718
resolves https://github.com/influxdata/feature-requests/issues/441

This resolves a feature request to have the input plugin `directory_monitor` also process sub-directories. This does change the default behavior, I suppose this could be a breaking change? Not sure if this would be a problem for users? I could add a configuration flag but the best idea I have for this is a boolean flag called "recurse=true/false", so if you think a config option should be required be happy to hear suggestions.

edit: This feature has been put behind the boolean configuration option "recursive" to make this behavior optional