### PR TITLE
fix(inputs.statsd): Do not error out for parsing errors in datadog mode.

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -25,6 +25,7 @@ import (
 )
 
 // DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
+//
 //go:embed sample.conf
 var sampleConfig string
 
@@ -515,15 +516,19 @@ func (s *Statsd) parser() error {
 				case line == "":
 				case s.DataDogExtensions && strings.HasPrefix(line, "_e"):
 					if err := s.parseEventMessage(in.Time, line, in.Addr); err != nil {
-						return err
+						// Log the line causing the parsing error and continue
+						// with the next line to not stop the whole gathering
+						// process.
+						s.Log.Errorf("Parsing line failed: %v", err)
+						s.Log.Debugf("  line was: %s", line)
 					}
 				default:
 					if err := s.parseStatsdLine(line); err != nil {
-						if errors.Cause(err) == errParsing {
-							// parsing errors log when the error occurs
-							continue
+						if errors.Cause(err) != errParsing {
+							// Ignore parsing errors but error out on
+							// everything else...
+							return err
 						}
-						return err
 					}
 				}
 			}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11775 

Currently, the statsd plugin stops when receiving malformed lines in data-dog mode as the parsing will return an error which in turn stops the eternally running parsing function. As a result, no more messages can be received after the first parsing error is encountered.

This PR changes the behavior for the data-dog mode to the non-data-dog behavior by just logging the malformed line and continue.