### PR TITLE
fix: Add missing entry json_transformation to missingTomlField

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1231,7 +1231,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 		"csv_column_prefix", "csv_header", "csv_separator", "csv_timestamp_format",
 		"graphite_tag_sanitize_mode", "graphite_tag_support", "graphite_separator",
 		"influx_max_line_bytes", "influx_sort_fields", "influx_uint_support",
-		"json_timestamp_format", "json_timestamp_units",
+		"json_timestamp_format", "json_timestamp_units", "json_transformation",
 		"prometheus_export_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label",
 		"prometheus_compact_encoding",
 		"splunkmetric_hec_routing", "splunkmetric_multimetric",


### PR DESCRIPTION
This fixes the error `2022-09-08T09:13:14Z E! [telegraf] Error running agent: Error loading config file test.config: plugin outputs.http: line 27: configuration specified the fields ["json_transformation"], but they weren't used` when using json_transformation

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Adds what was forgotten in https://github.com/influxdata/telegraf/pull/11251