### PR TITLE
fix(parsers.xpath): Add array index when expanding names.

### DIFF
--- a/plugins/parsers/xpath/testcases/name_expansion/expected.out
+++ b/plugins/parsers/xpath/testcases/name_expansion/expected.out
@@ -1,0 +1,3 @@
+devices ok=true,phases_0_load=34,phases_0_voltage=231,phases_1_load=35,phases_1_voltage=231,phases_2_load=36,phases_2_voltage=231,rpm=423,type="Motor" 1662730607000000000
+devices flow=3.1414,hours=8762,ok=true,type="Pump" 1662730607000000000
+devices ok=true,phases_0_load=341,phases_0_voltage=231,phases_1_load=352,phases_1_voltage=231,phases_2_load=363,phases_2_voltage=231,throughput=1026,type="Machine" 1662730607000000000

--- a/plugins/parsers/xpath/testcases/name_expansion/telegraf.conf
+++ b/plugins/parsers/xpath/testcases/name_expansion/telegraf.conf
@@ -1,0 +1,10 @@
+[[inputs.file]]
+  files = ["./testcases/name_expansion/test.json"]
+  data_format = "xpath_json"
+  xpath_native_types = true
+
+  [[inputs.file.xpath]]
+    metric_name = "'devices'"
+    metric_selection = "/devices/*"
+    field_selection = "descendant::*"
+    field_name_expansion = true

--- a/plugins/parsers/xpath/testcases/name_expansion/test.json
+++ b/plugins/parsers/xpath/testcases/name_expansion/test.json
@@ -1,0 +1,48 @@
+{
+  "devices": [
+    {
+      "type": "Motor",
+      "rpm": 423,
+      "phases": [
+        {
+          "load": 34,
+          "voltage": 231
+        },
+        {
+          "load": 35,
+          "voltage": 231
+        },
+        {
+          "load": 36,
+          "voltage": 231
+        }
+      ],
+      "ok": true
+    },
+    {
+      "type": "Pump",
+      "hours": 8762,
+      "flow": 3.1414,
+      "ok": true
+    },
+    {
+      "type": "Machine",
+      "throughput": 1026,
+      "phases": [
+        {
+          "load": 341,
+          "voltage": 231
+        },
+        {
+          "load": 352,
+          "voltage": 231
+        },
+        {
+          "load": 363,
+          "voltage": 231
+        }
+      ],
+      "ok": true
+    }
+  ]
+}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR fixes the name expansion for JSON arrays by adding the correct array index to the name.