### PR TITLE
chore: Run amd64 package on master so config is generated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,9 +609,6 @@ workflows:
           requires:
             - 'test-go-linux'
           filters:
-            branches:
-              ignore:
-                - master
             tags:
               only: /.*/
       - 'arm64-package':


### PR DESCRIPTION
Noticed it has been a while since our tiger bot made a PR to update the config, this process requires the amd64 package step to be run so that the config is generated. This was being skipped, so I am removing the ignore master filter so that it will run.

From the config:

```yaml
      - 'generate-config':
          requires:
            - 'amd64-package'
          filters:
            branches:
              only:
                - master
```
