### PR TITLE
fix(parsers): Memory leak for plugins using ParserFunc.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -200,13 +200,6 @@ func (a *Agent) initPlugins() error {
 				input.LogName(), err)
 		}
 	}
-	for _, parser := range a.Config.Parsers {
-		err := parser.Init()
-		if err != nil {
-			return fmt.Errorf("could not initialize parser %s::%s: %v",
-				parser.Config.DataFormat, parser.Config.Parent, err)
-		}
-	}
 	for _, processor := range a.Config.Processors {
 		err := processor.Init()
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,8 @@ type Config struct {
 	// Processors have a slice wrapper type because they need to be sorted
 	Processors    models.RunningProcessors
 	AggProcessors models.RunningProcessors
+	// Parsers are created by their inputs during gather. Config doesn't keep track of them
+	// like the other plugins because they need to be garbage collected (See issue #11809)
 
 	Deprecations map[string][]int64
 	version      *semver.Version

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -497,7 +497,6 @@ func TestConfig_ParserInterfaceNewFormat(t *testing.T) {
 		require.True(t, ok)
 		// Get the parser set with 'SetParser()'
 		if p, ok := input.Parser.(*models.RunningParser); ok {
-			require.NoError(t, p.Init())
 			actual = append(actual, p.Parser)
 		} else {
 			actual = append(actual, input.Parser)
@@ -618,7 +617,6 @@ func TestConfig_ParserInterfaceOldFormat(t *testing.T) {
 		require.True(t, ok)
 		// Get the parser set with 'SetParser()'
 		if p, ok := input.Parser.(*models.RunningParser); ok {
-			require.NoError(t, p.Init())
 			actual = append(actual, p.Parser)
 		} else {
 			actual = append(actual, input.Parser)


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11809 

When input plugins (or processors) use the passed `ParserFunc`, the new parser gets added to the list of running parsers in `config.Parsers`. As this instantiation of parsers can happen often and is out of the control of Telegraf's general framework, the array of running parsers will keep growing and is newer cleaned up. This means that a reference to the no-longer-used parsers is kept, garbage collection cannot free the parsers' space and we slowly eat up all memory.

The PR completely removes tracking the running parsers and thus solves the memory leak. However, once we want to go to dynamic plugin starting/stopping this problem will hit us for other categories as well as there is currently no way to remove running plugin instances from the corresponding lists.

