### PR TITLE
fix: Pass the actual parser intead of models.RunningParser

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -870,7 +870,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 		if err != nil {
 			return fmt.Errorf("adding parser failed: %w", err)
 		}
-		t.SetParser(parser)
+		t.SetParser(parser.Parser)
 	}
 
 	// Keep the old interface for backward compatibility
@@ -880,7 +880,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 		if err != nil {
 			return fmt.Errorf("adding parser failed: %w", err)
 		}
-		t.SetParser(parser)
+		t.SetParser(parser.Parser)
 	}
 
 	if t, ok := input.(telegraf.ParserFuncInput); ok {
@@ -893,7 +893,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 				return nil, err
 			}
 			err = parser.Init()
-			return parser, err
+			return parser.Parser, err
 		})
 	}
 
@@ -908,7 +908,7 @@ func (c *Config) addInput(name string, table *ast.Table) error {
 				return nil, err
 			}
 			err = parser.Init()
-			return parser, err
+			return parser.Parser, err
 		})
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -235,11 +235,8 @@ func TestConfig_LoadDirectory(t *testing.T) {
 
 		// Check the parsers if any
 		if expectedPlugins[i].parser != nil {
-			runningParser, ok := input.parser.(*models.RunningParser)
-			require.True(t, ok)
-
 			// We only use the JSON parser here
-			parser, ok := runningParser.Parser.(*json.Parser)
+			parser, ok := input.parser.(*json.Parser)
 			require.True(t, ok)
 
 			// Prepare parser for comparison
@@ -616,21 +613,11 @@ func TestConfig_ParserInterfaceOldFormat(t *testing.T) {
 	for _, plugin := range c.Inputs {
 		input, ok := plugin.Input.(*MockupInputPluginParserOld)
 		require.True(t, ok)
-		// Get the parser set with 'SetParser()'
-		if p, ok := input.Parser.(*models.RunningParser); ok {
-			require.NoError(t, p.Init())
-			actual = append(actual, p.Parser)
-		} else {
-			actual = append(actual, input.Parser)
-		}
+		actual = append(actual, input.Parser)
 		// Get the parser set with 'SetParserFunc()'
 		g, err := input.ParserFunc()
 		require.NoError(t, err)
-		if rp, ok := g.(*models.RunningParser); ok {
-			generated = append(generated, rp.Parser)
-		} else {
-			generated = append(generated, g)
-		}
+		generated = append(generated, g)
 	}
 	require.Len(t, actual, len(formats))
 


### PR DESCRIPTION
resolve: https://github.com/influxdata/telegraf/issues/11820
resolve: https://github.com/influxdata/telegraf/issues/11811

The exec input plugin type asserts if the parser is of type nagios, but when migrating to use running parsers this caused the type assertion to fail (https://github.com/influxdata/telegraf/blob/master/plugins/inputs/exec/exec.go#L137). There are also other plugins that do similar assertions, a possible solution is to pass the parser directly as before instead of passing "models.RunningParser".