### PR TITLE
fix(parsers): Unwrap parser and remove some special handling

### DIFF
--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -17,7 +17,6 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
-	"github.com/influxdata/telegraf/plugins/parsers/prometheus"
 )
 
 //go:embed sample.conf
@@ -83,16 +82,10 @@ func (e *Execd) Stop() {
 }
 
 func (e *Execd) cmdReadOut(out io.Reader) {
-	_, isPrometheus := e.parser.(*prometheus.Parser)
-
 	scanner := bufio.NewScanner(out)
 
 	for scanner.Scan() {
 		data := scanner.Bytes()
-		if isPrometheus {
-			data = append(data, []byte("\n")...)
-		}
-
 		metrics, err := e.parser.Parse(data)
 		if err != nil {
 			e.acc.AddError(fmt.Errorf("parse error: %w", err))

--- a/plugins/parsers/prometheus/parser.go
+++ b/plugins/parsers/prometheus/parser.go
@@ -30,8 +30,13 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	var parser expfmt.TextParser
 	var metrics []telegraf.Metric
 	var err error
-	// parse even if the buffer begins with a newline
+
+	// Make sure we have a finishing newline but no trailing one
 	buf = bytes.TrimPrefix(buf, []byte("\n"))
+	if !bytes.HasSuffix(buf, []byte("\n")) {
+		buf = append(buf, []byte("\n")...)
+	}
+
 	// Read raw data
 	buffer := bytes.NewBuffer(buf)
 	reader := bufio.NewReader(buffer)


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

partially resolves #11820 
resolves: #11811 
replaces #11821 

This PR removes as much special handling of parsers as possible and unwraps the remainders from `models.RunningParse` correctly.