### PR TITLE
feat(inputs.kafka_consumer): Add regular expression support for topics

### DIFF
--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -6,6 +6,17 @@ and creates metrics using one of the supported [input data formats][].
 For old kafka version (< 0.8), please use the [kafka_consumer_legacy][] input
 plugin and use the old zookeeper connection method.
 
+## Service Input <!-- @/docs/includes/service_input.md -->
+
+This plugin is a service input. Normal plugins gather metrics determined by the
+interval setting. Service plugins start a service to listens and waits for
+metrics or events to occur. Service plugins have two key differences from
+normal plugins:
+
+1. The global or plugin specific `interval` setting may not apply
+2. The CLI options of `--test`, `--test-wait`, and `--once` may not produce
+   output for this plugin
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -50,11 +50,6 @@ to use them.
   ## Example: topic_regexps = [ "*test", "metric[0-9A-z]*" ]
   # topic_regexps = [ ]
 
-  ## Topic discovery refresh interval.  If topic_regexps is set, then
-  ## every interval, topics will be rescanned to see if any new matches
-  ## are found.
-  # topic_refresh_interval = "0s"
-
   ## When set this tag will be added to all metrics with the topic as the value.
   # topic_tag = ""
 

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -6,17 +6,6 @@ and creates metrics using one of the supported [input data formats][].
 For old kafka version (< 0.8), please use the [kafka_consumer_legacy][] input
 plugin and use the old zookeeper connection method.
 
-## Service Input <!-- @/docs/includes/service_input.md -->
-
-This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
-metrics or events to occur. Service plugins have two key differences from
-normal plugins:
-
-1. The global or plugin specific `interval` setting may not apply
-2. The CLI options of `--test`, `--test-wait`, and `--once` may not produce
-   output for this plugin
-
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support
@@ -45,6 +34,14 @@ to use them.
 
   ## Topics to consume.
   topics = ["telegraf"]
+
+  ## Topic regular expressions to consume.  Matches will be added to topics.
+  # topic_regexps = [ "*test", "metric[0-9A-z]*" ]
+
+  ## Topic discovery refresh interval.  If topic_regexps is set, then
+  ## every interval, topics will be rescanned to see if any new matches
+  ## are found.
+  # topic_refresh_interval = "60s"
 
   ## When set this tag will be added to all metrics with the topic as the value.
   # topic_tag = ""

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -47,12 +47,13 @@ to use them.
   topics = ["telegraf"]
 
   ## Topic regular expressions to consume.  Matches will be added to topics.
-  # topic_regexps = [ "*test", "metric[0-9A-z]*" ]
+  ## Example: topic_regexps = [ "*test", "metric[0-9A-z]*" ]
+  # topic_regexps = [ ]
 
   ## Topic discovery refresh interval.  If topic_regexps is set, then
   ## every interval, topics will be rescanned to see if any new matches
   ## are found.
-  # topic_refresh_interval = "60s"
+  # topic_refresh_interval = "0s"
 
   ## When set this tag will be added to all metrics with the topic as the value.
   # topic_tag = ""

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -230,7 +230,7 @@ func (k *KafkaConsumer) refreshTopics() error {
 		for _, r := range k.regexps {
 			if r.MatchString(t) {
 				wantedTopicSet[t] = true
-				k.Log.Debugf("adding regexp-matched topic '%s'", t)
+				k.Log.Debugf("adding regexp-matched topic %q", t)
 				break
 			}
 		}
@@ -242,7 +242,7 @@ func (k *KafkaConsumer) refreshTopics() error {
 	sort.Strings(topicList)
 	fingerprint := strings.Join(topicList, ";")
 	if fingerprint != k.fingerprint {
-		k.Log.Infof("updating topics: replacing '%v' with '%v'", k.allWantedTopics, topicList)
+		k.Log.Infof("updating topics: replacing %q with %q", k.allWantedTopics, topicList)
 	}
 	k.topicLock.Lock()
 	k.fingerprint = fingerprint

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -152,11 +152,12 @@ func (k *KafkaConsumer) Init() error {
 
 	k.config = cfg
 
-	k.compileTopicRegexps()
-
-	if len(k.regexps) == 0 {
-		// There are no regexp-matched topics
+	if len(k.TopicRegexps) == 0 {
 		k.allWantedTopics = k.Topics
+	} else {
+		if err := k.compileTopicRegexps(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -190,7 +191,7 @@ func (k *KafkaConsumer) compileTopicRegexps() {
 			k.regexps = append(k.regexps, *re)
 			k.Log.Infof("Added regular expression '%s' to topics", r)
 		} else {
-			k.Log.Errorf("Regular expression '%s' did not compile: '%w'; not adding to topics", r, err)
+			return fmt.Errorf("regular expression %q did not compile: '%w", r, err)
 		}
 	}
 }
@@ -216,7 +217,7 @@ func (k *KafkaConsumer) refreshTopics() error {
 	if err != nil {
 		return err
 	}
-	k.Log.Infof("discovered topics: %v", allDiscoveredTopics)
+	k.Log.Debugf("discovered topics: %v", allDiscoveredTopics)
 
 	extantTopicSet := make(map[string]bool, len(allDiscoveredTopics))
 	for _, t := range allDiscoveredTopics {

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -63,6 +63,7 @@ type KafkaConsumer struct {
 	regexps         []regexp.Regexp
 	allWantedTopics []string
 	ticker          *time.Ticker
+	fingerprint     string
 
 	parser parsers.Parser
 	wg     sync.WaitGroup

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -65,10 +65,10 @@ type KafkaConsumer struct {
 	ticker          *time.Ticker
 	fingerprint     string
 
-	parser      parsers.Parser
-	topicLock   sync.Mutex
-	wg          sync.WaitGroup
-	cancel      context.CancelFunc
+	parser    parsers.Parser
+	topicLock sync.Mutex
+	wg        sync.WaitGroup
+	cancel    context.CancelFunc
 }
 
 type ConsumerGroup interface {
@@ -202,7 +202,7 @@ func (k *KafkaConsumer) refreshTopics() error {
 
 	k.topicLock.Lock()
 	defer k.topicLock.Unlock()
-	
+
 	if len(k.regexps) == 0 {
 		return nil
 	}

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -248,42 +248,6 @@ func (k *KafkaConsumer) refreshTopics() error {
 	return nil
 }
 
-func (k *KafkaConsumer) replaceTopics(newTopics []string) {
-	// From a functional standpoint, we could just replace the list
-	// each time.
-	//
-	// This is a little slower, but the motivation is that we'd like
-	// to log the event when the topic list changes, because it means
-	// we detected a change in our matched topics (either new topics
-	// appeared, or old ones went away).
-	//
-	// reflect.DeepEqual is said to be slow, so we implement our own
-	// list-detection change.
-	//
-	// This is pretty straightforward: we replace unless the old list
-	// and the new list have all the same members in the same order.  We
-	// keep them sorted internally for display purposes anyway, so we
-	// can make the decision as soon as we know the lists' lengths differ
-	// or we find a different topic than before at a given index.
-	replace := true
-	if len(newTopics) == len(k.allWantedTopics) {
-		// Assume it's gonna be fine
-		replace = false
-		for i := range newTopics {
-			// We know these are sorted, so if any don't match,
-			// we want to replace the list.
-			if newTopics[i] != k.allWantedTopics[i] {
-				replace = true
-				break
-			}
-		}
-	}
-	if replace {
-		k.Log.Infof("updating topics: replacing '%v' with '%v'", k.allWantedTopics, newTopics)
-		k.allWantedTopics = newTopics
-	}
-}
-
 func (k *KafkaConsumer) create() error {
 	var err error
 	k.consumer, err = k.ConsumerCreator.Create(

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -242,7 +242,7 @@ func (k *KafkaConsumer) refreshTopics() error {
 		for _, r := range k.regexps {
 			if r.MatchString(t) {
 				wantedTopicSet[t] = true
-				k.Log.Infof("adding regexp-matched topic '%v' -> '%s'", r, k)
+				k.Log.Infof("adding regexp-matched topic '%s'", t)
 				break
 			}
 		}

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -223,7 +223,7 @@ func (k *KafkaConsumer) refreshTopics() error {
 		k.Log.Debugf("adding literally-specified topic %s", t)
 		wantedTopicSet[t] = true
 	}
-	for t := range extantTopicSet {
+	for _, t := range allDiscoveredTopics {
 		// Add topics that match regexps
 		for _, r := range k.regexps {
 			if r.MatchString(t) {
@@ -238,7 +238,12 @@ func (k *KafkaConsumer) refreshTopics() error {
 		topicList = append(topicList, t)
 	}
 	sort.Strings(topicList)
-	k.replaceTopics(topicList)
+	fingerprint := strings.Join(topicList, ";")
+	if fingerprint != k.fingerprint {
+		k.Log.Infof("updating topics: replacing '%v' with '%v'", k.allWantedTopics, topicList)
+	}
+	k.fingerprint = fingerprint
+	k.allWantedTopics = topicList
 	return nil
 }
 

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -179,11 +179,10 @@ func (k *KafkaConsumer) compileTopicRegexps() error {
 	k.regexps = make([]regexp.Regexp, 0, len(k.TopicRegexps))
 	for _, r := range k.TopicRegexps {
 		re, err := regexp.Compile(r)
-		if err == nil {
-			k.regexps = append(k.regexps, *re)
-		} else {
+		if err != nil {
 			return fmt.Errorf("regular expression %q did not compile: '%w", r, err)
 		}
+		k.regexps = append(k.regexps, *re)
 	}
 	return nil
 }

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -603,7 +603,7 @@ func TestExponentialBackoff(t *testing.T) {
 	max := 3
 
 	// get an unused port by listening on next available port, then closing it
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	port := listener.Addr().(*net.TCPAddr).Port
 	require.NoError(t, listener.Close())

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -6,6 +6,14 @@
   ## Topics to consume.
   topics = ["telegraf"]
 
+  ## Topic regular expressions to consume.  Matches will be added to topics.
+  # topic_regexps = [ "*test", "metric[0-9A-z]*" ]
+
+  ## Topic discovery refresh interval.  If topic_regexps is set, then
+  ## every interval, topics will be rescanned to see if any new matches
+  ## are found.
+  # topic_refresh_interval = "60s"
+
   ## When set this tag will be added to all metrics with the topic as the value.
   # topic_tag = ""
 

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -10,11 +10,6 @@
   ## Example: topic_regexps = [ "*test", "metric[0-9A-z]*" ]
   # topic_regexps = [ ]
 
-  ## Topic discovery refresh interval.  If topic_regexps is set, then
-  ## every interval, topics will be rescanned to see if any new matches
-  ## are found.
-  # topic_refresh_interval = "0s"
-
   ## When set this tag will be added to all metrics with the topic as the value.
   # topic_tag = ""
 

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -7,12 +7,13 @@
   topics = ["telegraf"]
 
   ## Topic regular expressions to consume.  Matches will be added to topics.
-  # topic_regexps = [ "*test", "metric[0-9A-z]*" ]
+  ## Example: topic_regexps = [ "*test", "metric[0-9A-z]*" ]
+  # topic_regexps = [ ]
 
   ## Topic discovery refresh interval.  If topic_regexps is set, then
   ## every interval, topics will be rescanned to see if any new matches
   ## are found.
-  # topic_refresh_interval = "60s"
+  # topic_refresh_interval = "0s"
 
   ## When set this tag will be added to all metrics with the topic as the value.
   # topic_tag = ""


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

This is a companion piece to https://github.com/influxdata/telegraf/pull/11816 and builds on top of it.  It uses a connection to the Kafka broker to determine which topics are available, match them with a regular expression.  This requires the set-metric-from-measurement in the Avro handler, which requires the schema registry, and therefore this is only useful in conjunction with the Avro parser.

In the Rubin Observatory use case, we connect to a Kafka broker with a large number of topics, which are added to dynamically, and we therefore require something like this.  (For the time being, we will restart the broker to pick up new topics; dynamic detection is a planned future enhancement.)

The motivation is that this is essentially the behavior that lensesio/stream-reactor gives with its kafka-influx connector (which is what we have been using), except that that implementation only works with InfluxDBv1, while this will work with any Telegraf output.  Since Rubin Observatory is trying to move to InfluxDBv2, we require something like this.

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Added a configuration items to specify a list of regular expressions for topics to match; then I added an implementation for this item.