### PR TITLE
docs: Give example of how to enable nvidia-smi to run via docker without creating custom image

### DIFF
--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -110,4 +110,19 @@ confirmed to be an issue on an EVGA 2080 Ti.
 **NOTE:** For use with docker either generate your own custom docker image based
 on nvidia/cuda which also installs a telegraf package or use [volume mount
 binding](https://docs.docker.com/storage/bind-mounts/) to inject the required
-binary into the docker container.
+binary into the docker container. In particular you will need to pass through the /dev/nvidia* devices, the nvidia-smi binary and the nvidia libraries.
+An minimal docker-compose example of how to do this is:
+```text
+  telegraf:
+    image: telegraf
+    runtime: nvidia
+    devices:
+      - /dev/nvidiactl:/dev/nvidiactl
+      - /dev/nvidia0:/dev/nvidia0
+    volumes:
+      - ./telegraf/etc/telegraf.conf:/etc/telegraf/telegraf.conf:ro
+      - /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro
+      - /usr/lib/x86_64-linux-gnu/nvidia:/usr/lib/x86_64-linux-gnu/nvidia:ro
+    environment:
+      - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/nvidia/current/libnvidia-ml.so
+```


### PR DESCRIPTION
Give example of how to enable nvidia-smi to run via docker without creating custom image

# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #8531

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

Wanted to setup my telegraf docker container to support nvidia-smi but wasn't able to find complete explanation on how to do this.
So wrote up this quick update to the nvidia-smi README.md to reference how to get the plugin working via docker without having to build a custom image