### PR TITLE
fix: Enable global confirmation for installing mingw

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,11 @@ commands:
             equal: [ windows, << parameters.os >> ]
           steps:
             - run: rm -rf /c/Go
+            - run: choco feature enable -n allowGlobalConfirmation
             - restore_cache:
                 key: windows-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
+            - run: choco install mingw
       - run: ./scripts/install_gotestsum.sh << parameters.os >> << parameters.gotestsum >>
       - unless:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ commands:
             - restore_cache:
                 key: windows-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
-            - run: choco install mingw
       - run: ./scripts/install_gotestsum.sh << parameters.os >> << parameters.gotestsum >>
       - unless:
           condition:

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -5,13 +5,11 @@ set -eux
 GO_VERSION="1.19.1"
 
 setup_go () {
-    choco feature enable -n allowGlobalConfirmation
     choco upgrade golang --allow-downgrade --version=${GO_VERSION}
     choco install make
     git config --system core.longpaths true
     rm -rf /c/Go
     cp -r /c/Program\ Files/Go /c/
-    choco install mingw
 }
 
 if command -v go >/dev/null 2>&1; then

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -11,6 +11,7 @@ setup_go () {
     git config --system core.longpaths true
     rm -rf /c/Go
     cp -r /c/Program\ Files/Go /c/
+    choco install mingw
 }
 
 if command -v go >/dev/null 2>&1; then


### PR DESCRIPTION
The windows tests are timing out due to requiring user input for installing mingw, the script to install Go resolved this issue by calling `choco feature enable -n allowGlobalConfirmation` so I moved this outside of the script to always run.

e.g. https://app.circleci.com/pipelines/github/influxdata/telegraf/12709/workflows/4d70fb4e-921c-4060-a605-d0d41100afbb/jobs/204886
```
mingw v11.2.0.07112021 [Approved]
mingw package files install completed. Performing other installation steps.
The package mingw wants to run 'chocolateyinstall.ps1'.
Note: If you don't run this script, the installation will fail.
Note: To confirm automatically next time, use '-y' or consider:
choco feature enable -n allowGlobalConfirmation
Do you want to run the script?([Y]es/[A]ll - yes to all/[N]o/[P]rint): 
```