### PR TITLE
build: github Workflows security hardening

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     # Trigger every day at 16:00 UTC
     - cron:  '0 16 * * *'
+permissions:
+  contents: read # to fetch code (actions/checkout)
+  pull-requests: read # to fetch pull requests (golangci/golangci-lint-action)
+
 jobs:
   golangci-pr:
     if: github.ref != 'refs/heads/master'

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,9 +24,15 @@ on:
 ###############
 # Set the Job #
 ###############
+permissions: {}
+
 jobs:
   build:
     # Name the Job
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      statuses: write # to mark status of each linter run (github/super-linter)
+
     name: Lint Code Base
     # Set the agent to run on
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.