### PR TITLE
fix(inputs.mongodb): actually start plugin correctly

### DIFF
--- a/plugins/inputs/mongodb/mongodb.go
+++ b/plugins/inputs/mongodb/mongodb.go
@@ -94,7 +94,7 @@ func (m *MongoDB) Init() error {
 }
 
 // Start runs after init and setup mongodb connections
-func (m *MongoDB) Start() error {
+func (m *MongoDB) Start(telegraf.Accumulator) error {
 	for _, connURL := range m.Servers {
 		if !strings.HasPrefix(connURL, "mongodb://") && !strings.HasPrefix(connURL, "mongodb+srv://") {
 			// Preserve backwards compatibility for hostnames without a
@@ -143,6 +143,8 @@ func (m *MongoDB) Start() error {
 
 	return nil
 }
+
+func (m *MongoDB) Stop() {}
 
 // Reads stats from all configured servers accumulates stats.
 // Returns one of the errors encountered while gather stats (if any).

--- a/plugins/inputs/mongodb/mongodb_server_test.go
+++ b/plugins/inputs/mongodb/mongodb_server_test.go
@@ -47,7 +47,8 @@ func TestGetDefaultTagsIntegration(t *testing.T) {
 	}
 	err := m.Init()
 	require.NoError(t, err)
-	err = m.Start()
+	var acc testutil.Accumulator
+	err = m.Start(&acc)
 	require.NoError(t, err)
 
 	server := m.clients[0]
@@ -84,12 +85,12 @@ func TestAddDefaultStatsIntegration(t *testing.T) {
 	}
 	err := m.Init()
 	require.NoError(t, err)
-	err = m.Start()
+	var acc testutil.Accumulator
+	err = m.Start(&acc)
 	require.NoError(t, err)
 
 	server := m.clients[0]
 
-	var acc testutil.Accumulator
 	err = server.gatherData(&acc, false, true, true, true, []string{"local"})
 	require.NoError(t, err)
 
@@ -115,10 +116,10 @@ func TestSkipBehaviorIntegration(t *testing.T) {
 	m.DisconnectedServersBehavior = "skip"
 	err := m.Init()
 	require.NoError(t, err)
-	err = m.Start()
+	var acc testutil.Accumulator
+	err = m.Start(&acc)
 	require.NoError(t, err)
 
-	var acc testutil.Accumulator
 	err = m.Gather(&acc)
 	require.NoError(t, err)
 	require.NotContains(t, m.Log.(*testutil.CaptureLogger).LastError, "failed to gather data: ")
@@ -136,16 +137,16 @@ func TestErrorBehaviorIntegration(t *testing.T) {
 
 	err := m.Init()
 	require.NoError(t, err)
-	err = m.Start()
+	var acc testutil.Accumulator
+	err = m.Start(&acc)
 	require.Error(t, err)
 
 	// set to skip to bypass start error
 	m.DisconnectedServersBehavior = "skip"
-	err = m.Start()
+	err = m.Start(&acc)
 	require.NoError(t, err)
 	m.DisconnectedServersBehavior = "error"
 
-	var acc testutil.Accumulator
 	err = m.Gather(&acc)
 	require.NoError(t, err)
 	require.Contains(t, m.Log.(*testutil.CaptureLogger).LastError, "failed to gather data: ")


### PR DESCRIPTION
The start method handler did not match the interface, nor was there a
stop function. As a result, start was never called and the plugin was
never setting up the servers to connect to and collect from correctly.

This was introduced in #11629.

fixes: #11830