### PR TITLE
feat(inputs.amqp_consumer): Determine content encoding automatically

### DIFF
--- a/plugins/inputs/amqp_consumer/README.md
+++ b/plugins/inputs/amqp_consumer/README.md
@@ -82,8 +82,11 @@ For an introduction to AMQP see:
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
-  ## Content encoding for message payloads, can be set to "gzip" to or
-  ## "identity" to apply no encoding.
+  ## Content encoding for message payloads, can be set to
+  ## "gzip", "identity" or "auto"
+  ## - Use "gzip" to decode gzip
+  ## - Use "identity" to apply no encoding
+  ## - Use "auto" determine the encoding using the ContentEncoding header
   # content_encoding = "identity"
 
   ## Data format to consume.
@@ -92,3 +95,11 @@ For an introduction to AMQP see:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
 ```
+
+## Metrics
+
+TODO
+
+## Example Output
+
+TODO

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -395,6 +395,7 @@ func (a *AMQPConsumer) onMessage(acc telegraf.TrackingAccumulator, d amqp.Delive
 		}
 	}
 
+	a.decoder.SetEnconding(d.ContentEncoding)
 	body, err := a.decoder.Decode(d.Body)
 	if err != nil {
 		onError()

--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -1,0 +1,51 @@
+package amqp_consumer
+
+import (
+	"testing"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/parsers/influx"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoEncoding(t *testing.T) {
+	enc, err := internal.NewGzipEncoder()
+	require.NoError(t, err)
+	payload, err := enc.Encode([]byte(`measurementName fieldKey="gzip" 1556813561098000000`))
+	require.NoError(t, err)
+
+	var a AMQPConsumer
+	parser := &influx.Parser{}
+	require.NoError(t, parser.Init())
+	a.deliveries = make(map[telegraf.TrackingID]amqp091.Delivery)
+	a.parser = parser
+	a.decoder, err = internal.NewContentDecoder("auto")
+	require.NoError(t, err)
+
+	acc := &testutil.Accumulator{}
+
+	d := amqp091.Delivery{
+		ContentEncoding: "gzip",
+		Body:            payload,
+	}
+	err = a.onMessage(acc, d)
+	require.NoError(t, err)
+	acc.AssertContainsFields(t, "measurementName", map[string]interface{}{"fieldKey": "gzip"})
+
+	encIdentity := internal.NewIdentityEncoder()
+	require.NoError(t, err)
+	payload, err = encIdentity.Encode([]byte(`measurementName2 fieldKey="identity" 1556813561098000000`))
+	require.NoError(t, err)
+
+	d = amqp091.Delivery{
+		ContentEncoding: "not_gzip",
+		Body:            payload,
+	}
+
+	err = a.onMessage(acc, d)
+	require.NoError(t, err)
+	acc.AssertContainsFields(t, "measurementName2", map[string]interface{}{"fieldKey": "identity"})
+}

--- a/plugins/inputs/amqp_consumer/sample.conf
+++ b/plugins/inputs/amqp_consumer/sample.conf
@@ -63,8 +63,11 @@
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
-  ## Content encoding for message payloads, can be set to "gzip" to or
-  ## "identity" to apply no encoding.
+  ## Content encoding for message payloads, can be set to
+  ## "gzip", "identity" or "auto"
+  ## - Use "gzip" to decode gzip
+  ## - Use "identity" to apply no encoding
+  ## - Use "auto" determine the encoding using the ContentEncoding header
   # content_encoding = "identity"
 
   ## Data format to consume.


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format]

resolves https://github.com/influxdata/telegraf/issues/6998

Adds a new content encoding option called `auto` to allow a more flexible input that can be gzipped or not, the content encoding is determined by the set "ContentEncoding" header in the message.

