### PR TITLE
fix(inputs.influxdb_listener): error on invalid precision

### DIFF
--- a/plugins/inputs/influxdb_listener/influxdb_listener.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener.go
@@ -371,7 +371,14 @@ func (h *InfluxDBListener) handleWriteUpstreamParser(res http.ResponseWriter, re
 	precisionStr := req.URL.Query().Get("precision")
 	if precisionStr != "" {
 		precision := getPrecisionMultiplier(precisionStr)
-		parser.SetTimePrecision(precision)
+		err := parser.SetTimePrecision(precision)
+		if err != nil {
+			h.Log.Debugf("error in upstream parser: %v", err)
+			if err := badRequest(res, err.Error()); err != nil {
+				h.Log.Debugf("error in bad-request: %v", err)
+			}
+			return
+		}
 	}
 
 	if req.ContentLength >= 0 {

--- a/plugins/parsers/influx/influx_upstream/parser.go
+++ b/plugins/parsers/influx/influx_upstream/parser.go
@@ -226,7 +226,7 @@ func (sp *StreamParser) SetTimeFunc(f TimeFunc) {
 	sp.defaultTime = f
 }
 
-func (sp *StreamParser) SetTimePrecision(u time.Duration) {
+func (sp *StreamParser) SetTimePrecision(u time.Duration) error {
 	switch u {
 	case time.Nanosecond:
 		sp.precision = lineprotocol.Nanosecond
@@ -236,7 +236,13 @@ func (sp *StreamParser) SetTimePrecision(u time.Duration) {
 		sp.precision = lineprotocol.Millisecond
 	case time.Second:
 		sp.precision = lineprotocol.Second
+	case time.Minute:
+		return fmt.Errorf("time precision 'm' is not supported")
+	case time.Hour:
+		return fmt.Errorf("time precision 'h' is not supported")
 	}
+
+	return nil
 }
 
 // Next parses the next item from the stream.  You can repeat calls to this


### PR DESCRIPTION
The upstream parser does not support the m and h precision values. This will throw and error rather than silently dropping metrics.

Adds the following message to the telegraf log:

> 2022-09-22T15:34:55Z D! [inputs.influxdb_listener] error in upstream parser: time precision 'm' is not supported

Returns this response to the user:

> influxdb.exceptions.InfluxDBClientError: 400: {"error":"time precision 'm' is not supported"}

fixes: #11771