### PR TITLE
chore: Remove deprecated build tags

### DIFF
--- a/agent/agent_posix.go
+++ b/agent/agent_posix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package agent
 

--- a/agent/agent_windows.go
+++ b/agent/agent_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package agent
 

--- a/cmd/telegraf/main_win_test.go
+++ b/cmd/telegraf/main_win_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package main
 

--- a/cmd/telegraf/telegraf_posix.go
+++ b/cmd/telegraf/telegraf_posix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 //go:generate goversioninfo -icon=../../assets/windows/tiger.ico
 

--- a/internal/exec_unix.go
+++ b/internal/exec_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package internal
 

--- a/internal/exec_windows.go
+++ b/internal/exec_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package internal
 

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // TODO: Windows - should be enabled for Windows when super asterisk is fixed on Windows
 // https://github.com/influxdata/telegraf/issues/6248

--- a/internal/goplugin/noplugin.go
+++ b/internal/goplugin/noplugin.go
@@ -1,5 +1,4 @@
 //go:build !goplugin
-// +build !goplugin
 
 package goplugin
 

--- a/internal/goplugin/plugin.go
+++ b/internal/goplugin/plugin.go
@@ -1,5 +1,4 @@
 //go:build goplugin
-// +build goplugin
 
 package goplugin
 

--- a/internal/process/process_posix.go
+++ b/internal/process/process_posix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package process
 

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package process
 

--- a/internal/process/process_windows.go
+++ b/internal/process/process_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package process
 

--- a/logger/event_logger.go
+++ b/logger/event_logger.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package logger
 

--- a/logger/event_logger_test.go
+++ b/logger/event_logger_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package logger
 

--- a/plugins/inputs/bcache/bcache.go
+++ b/plugins/inputs/bcache/bcache.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
-// +build !windows
 
 // bcache doesn't aim for Windows
 

--- a/plugins/inputs/bcache/bcache_test.go
+++ b/plugins/inputs/bcache/bcache_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package bcache
 

--- a/plugins/inputs/bcache/bcache_windows.go
+++ b/plugins/inputs/bcache/bcache_windows.go
@@ -1,4 +1,3 @@
 //go:build windows
-// +build windows
 
 package bcache

--- a/plugins/inputs/cgroup/cgroup_linux.go
+++ b/plugins/inputs/cgroup/cgroup_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroup
 

--- a/plugins/inputs/cgroup/cgroup_notlinux.go
+++ b/plugins/inputs/cgroup/cgroup_notlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package cgroup
 

--- a/plugins/inputs/cgroup/cgroup_test.go
+++ b/plugins/inputs/cgroup/cgroup_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cgroup
 

--- a/plugins/inputs/conntrack/conntrack.go
+++ b/plugins/inputs/conntrack/conntrack.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package conntrack
 

--- a/plugins/inputs/conntrack/conntrack_notlinux.go
+++ b/plugins/inputs/conntrack/conntrack_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package conntrack

--- a/plugins/inputs/conntrack/conntrack_test.go
+++ b/plugins/inputs/conntrack/conntrack_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package conntrack
 

--- a/plugins/inputs/diskio/diskio_linux_test.go
+++ b/plugins/inputs/diskio/diskio_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package diskio
 

--- a/plugins/inputs/diskio/diskio_other.go
+++ b/plugins/inputs/diskio/diskio_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package diskio
 

--- a/plugins/inputs/dmcache/dmcache_linux.go
+++ b/plugins/inputs/dmcache/dmcache_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package dmcache
 

--- a/plugins/inputs/dmcache/dmcache_linux_test.go
+++ b/plugins/inputs/dmcache/dmcache_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package dmcache
 

--- a/plugins/inputs/dmcache/dmcache_notlinux.go
+++ b/plugins/inputs/dmcache/dmcache_notlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package dmcache
 

--- a/plugins/inputs/dpdk/dpdk.go
+++ b/plugins/inputs/dpdk/dpdk.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package dpdk
 

--- a/plugins/inputs/dpdk/dpdk_connector.go
+++ b/plugins/inputs/dpdk/dpdk_connector.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package dpdk
 

--- a/plugins/inputs/dpdk/dpdk_connector_test.go
+++ b/plugins/inputs/dpdk/dpdk_connector_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package dpdk
 

--- a/plugins/inputs/dpdk/dpdk_notlinux.go
+++ b/plugins/inputs/dpdk/dpdk_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package dpdk

--- a/plugins/inputs/dpdk/dpdk_test.go
+++ b/plugins/inputs/dpdk/dpdk_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package dpdk
 

--- a/plugins/inputs/dpdk/dpdk_utils.go
+++ b/plugins/inputs/dpdk/dpdk_utils.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package dpdk
 

--- a/plugins/inputs/dpdk/dpdk_utils_test.go
+++ b/plugins/inputs/dpdk/dpdk_utils_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package dpdk
 

--- a/plugins/inputs/ethtool/ethtool_linux.go
+++ b/plugins/inputs/ethtool/ethtool_linux.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package ethtool
 

--- a/plugins/inputs/ethtool/ethtool_notlinux.go
+++ b/plugins/inputs/ethtool/ethtool_notlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package ethtool
 

--- a/plugins/inputs/ethtool/ethtool_test.go
+++ b/plugins/inputs/ethtool/ethtool_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package ethtool
 

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // TODO: Windows - should be enabled for Windows when super asterisk is fixed on Windows
 // https://github.com/influxdata/telegraf/issues/6248

--- a/plugins/inputs/execd/execd_posix.go
+++ b/plugins/inputs/execd/execd_posix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package execd
 

--- a/plugins/inputs/execd/execd_windows.go
+++ b/plugins/inputs/execd/execd_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package execd
 

--- a/plugins/inputs/execd/shim/goshim_posix.go
+++ b/plugins/inputs/execd/shim/goshim_posix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package shim
 

--- a/plugins/inputs/execd/shim/goshim_windows.go
+++ b/plugins/inputs/execd/shim/goshim_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package shim
 

--- a/plugins/inputs/execd/shim/shim_posix_test.go
+++ b/plugins/inputs/execd/shim/shim_posix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package shim
 

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // TODO: Windows - should be enabled for Windows when super asterisk is fixed on Windows
 // https://github.com/influxdata/telegraf/issues/6248

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // TODO: Windows - should be enabled for Windows when super asterisk is fixed on Windows
 // https://github.com/influxdata/telegraf/issues/6248

--- a/plugins/inputs/filecount/filesystem_helpers_test.go
+++ b/plugins/inputs/filecount/filesystem_helpers_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // TODO: Windows - should be enabled for Windows when super asterisk is fixed on Windows
 // https://github.com/influxdata/telegraf/issues/6248

--- a/plugins/inputs/filestat/filestat_test.go
+++ b/plugins/inputs/filestat/filestat_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // TODO: Windows - should be enabled for Windows when super asterisk is fixed on Windows
 // https://github.com/influxdata/telegraf/issues/6248

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // TODO: Windows - should be enabled for Windows when https://github.com/influxdata/telegraf/issues/8451 is fixed
 

--- a/plugins/inputs/hugepages/hugepages.go
+++ b/plugins/inputs/hugepages/hugepages.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package hugepages
 

--- a/plugins/inputs/hugepages/hugepages_notlinux.go
+++ b/plugins/inputs/hugepages/hugepages_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package hugepages

--- a/plugins/inputs/hugepages/hugepages_test.go
+++ b/plugins/inputs/hugepages/hugepages_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package hugepages
 

--- a/plugins/inputs/infiniband/infiniband_linux.go
+++ b/plugins/inputs/infiniband/infiniband_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package infiniband
 

--- a/plugins/inputs/infiniband/infiniband_notlinux.go
+++ b/plugins/inputs/infiniband/infiniband_notlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package infiniband
 

--- a/plugins/inputs/infiniband/infiniband_test.go
+++ b/plugins/inputs/infiniband/infiniband_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package infiniband
 

--- a/plugins/inputs/intel_pmu/activators.go
+++ b/plugins/inputs/intel_pmu/activators.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_pmu/activators_test.go
+++ b/plugins/inputs/intel_pmu/activators_test.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_pmu/config.go
+++ b/plugins/inputs/intel_pmu/config.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_pmu/config_test.go
+++ b/plugins/inputs/intel_pmu/config_test.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_pmu/intel_pmu.go
+++ b/plugins/inputs/intel_pmu/intel_pmu.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_pmu/intel_pmu_notamd64linux.go
+++ b/plugins/inputs/intel_pmu/intel_pmu_notamd64linux.go
@@ -1,4 +1,3 @@
 //go:build !linux || !amd64
-// +build !linux !amd64
 
 package intel_pmu

--- a/plugins/inputs/intel_pmu/intel_pmu_test.go
+++ b/plugins/inputs/intel_pmu/intel_pmu_test.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_pmu/mocks.go
+++ b/plugins/inputs/intel_pmu/mocks.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_pmu/reader.go
+++ b/plugins/inputs/intel_pmu/reader.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_pmu/reader_test.go
+++ b/plugins/inputs/intel_pmu/reader_test.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_pmu/resolver.go
+++ b/plugins/inputs/intel_pmu/resolver.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_pmu/resolver_test.go
+++ b/plugins/inputs/intel_pmu/resolver_test.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64
-// +build linux,amd64
 
 package intel_pmu
 

--- a/plugins/inputs/intel_powerstat/file.go
+++ b/plugins/inputs/intel_powerstat/file.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package intel_powerstat
 

--- a/plugins/inputs/intel_powerstat/intel_powerstat.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package intel_powerstat
 

--- a/plugins/inputs/intel_powerstat/intel_powerstat_notlinux.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package intel_powerstat

--- a/plugins/inputs/intel_powerstat/intel_powerstat_test.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package intel_powerstat
 

--- a/plugins/inputs/intel_powerstat/msr.go
+++ b/plugins/inputs/intel_powerstat/msr.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package intel_powerstat
 

--- a/plugins/inputs/intel_powerstat/msr_test.go
+++ b/plugins/inputs/intel_powerstat/msr_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package intel_powerstat
 

--- a/plugins/inputs/intel_powerstat/rapl.go
+++ b/plugins/inputs/intel_powerstat/rapl.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package intel_powerstat
 

--- a/plugins/inputs/intel_powerstat/rapl_test.go
+++ b/plugins/inputs/intel_powerstat/rapl_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package intel_powerstat
 

--- a/plugins/inputs/intel_powerstat/unit_converter.go
+++ b/plugins/inputs/intel_powerstat/unit_converter.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package intel_powerstat
 

--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
-// +build !windows
 
 package intel_rdt
 

--- a/plugins/inputs/intel_rdt/intel_rdt_test.go
+++ b/plugins/inputs/intel_rdt/intel_rdt_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package intel_rdt
 

--- a/plugins/inputs/intel_rdt/intel_rdt_windows.go
+++ b/plugins/inputs/intel_rdt/intel_rdt_windows.go
@@ -1,4 +1,3 @@
 //go:build windows
-// +build windows
 
 package intel_rdt

--- a/plugins/inputs/intel_rdt/processes.go
+++ b/plugins/inputs/intel_rdt/processes.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package intel_rdt
 

--- a/plugins/inputs/intel_rdt/publisher.go
+++ b/plugins/inputs/intel_rdt/publisher.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package intel_rdt
 

--- a/plugins/inputs/intel_rdt/publisher_test.go
+++ b/plugins/inputs/intel_rdt/publisher_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package intel_rdt
 

--- a/plugins/inputs/iptables/iptables.go
+++ b/plugins/inputs/iptables/iptables.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package iptables
 

--- a/plugins/inputs/iptables/iptables_nocompile.go
+++ b/plugins/inputs/iptables/iptables_nocompile.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package iptables

--- a/plugins/inputs/iptables/iptables_test.go
+++ b/plugins/inputs/iptables/iptables_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package iptables
 

--- a/plugins/inputs/ipvs/ipvs.go
+++ b/plugins/inputs/ipvs/ipvs.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package ipvs
 

--- a/plugins/inputs/ipvs/ipvs_notlinux.go
+++ b/plugins/inputs/ipvs/ipvs_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package ipvs

--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"

--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 
 	"github.com/influxdata/telegraf/config"

--- a/plugins/inputs/kernel/kernel.go
+++ b/plugins/inputs/kernel/kernel.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package kernel
 

--- a/plugins/inputs/kernel/kernel_notlinux.go
+++ b/plugins/inputs/kernel/kernel_notlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package kernel
 

--- a/plugins/inputs/kernel/kernel_test.go
+++ b/plugins/inputs/kernel/kernel_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package kernel
 

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package kernel_vmstat
 

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat_notlinux.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package kernel_vmstat

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat_test.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package kernel_vmstat
 

--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build !solaris
-// +build !solaris
 
 package logparser
 

--- a/plugins/inputs/logparser/logparser_solaris.go
+++ b/plugins/inputs/logparser/logparser_solaris.go
@@ -1,4 +1,3 @@
 //go:build solaris
-// +build solaris
 
 package logparser

--- a/plugins/inputs/lustre2/lustre2.go
+++ b/plugins/inputs/lustre2/lustre2.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
-// +build !windows
 
 // Package lustre2 (doesn't aim for Windows)
 // Lustre 2.x Telegraf plugin

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package lustre2
 

--- a/plugins/inputs/lustre2/lustre2_windows.go
+++ b/plugins/inputs/lustre2/lustre2_windows.go
@@ -1,4 +1,3 @@
 //go:build windows
-// +build windows
 
 package lustre2

--- a/plugins/inputs/mdstat/mdstat.go
+++ b/plugins/inputs/mdstat/mdstat.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 // Copyright 2018 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/plugins/inputs/mdstat/mdstat_notlinux.go
+++ b/plugins/inputs/mdstat/mdstat_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package mdstat

--- a/plugins/inputs/mdstat/mdstat_test.go
+++ b/plugins/inputs/mdstat/mdstat_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package mdstat
 

--- a/plugins/inputs/nats/nats.go
+++ b/plugins/inputs/nats/nats.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build !freebsd || (freebsd && cgo)
-// +build !freebsd freebsd,cgo
 
 package nats
 

--- a/plugins/inputs/nats/nats_freebsd.go
+++ b/plugins/inputs/nats/nats_freebsd.go
@@ -1,4 +1,3 @@
 //go:build freebsd && !cgo
-// +build freebsd,!cgo
 
 package nats

--- a/plugins/inputs/nats/nats_test.go
+++ b/plugins/inputs/nats/nats_test.go
@@ -1,5 +1,4 @@
 //go:build !freebsd || (freebsd && cgo)
-// +build !freebsd freebsd,cgo
 
 package nats
 

--- a/plugins/inputs/phpfpm/phpfpm_test.go
+++ b/plugins/inputs/phpfpm/phpfpm_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // TODO: Windows - should be enabled for Windows when super asterisk is fixed on Windows
 // https://github.com/influxdata/telegraf/issues/6248

--- a/plugins/inputs/ping/ping_notwindows.go
+++ b/plugins/inputs/ping/ping_notwindows.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package ping
 

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package ping
 

--- a/plugins/inputs/ping/ping_windows.go
+++ b/plugins/inputs/ping/ping_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package ping
 

--- a/plugins/inputs/ping/ping_windows_test.go
+++ b/plugins/inputs/ping/ping_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package ping
 

--- a/plugins/inputs/postfix/postfix.go
+++ b/plugins/inputs/postfix/postfix.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
-// +build !windows
 
 // postfix doesn't aim for Windows
 

--- a/plugins/inputs/postfix/postfix_test.go
+++ b/plugins/inputs/postfix/postfix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package postfix
 

--- a/plugins/inputs/postfix/postfix_windows.go
+++ b/plugins/inputs/postfix/postfix_windows.go
@@ -1,4 +1,3 @@
 //go:build windows
-// +build windows
 
 package postfix

--- a/plugins/inputs/postfix/stat_ctim.go
+++ b/plugins/inputs/postfix/stat_ctim.go
@@ -1,5 +1,4 @@
 //go:build dragonfly || linux || netbsd || openbsd || solaris
-// +build dragonfly linux netbsd openbsd solaris
 
 package postfix
 

--- a/plugins/inputs/postfix/stat_ctimespec.go
+++ b/plugins/inputs/postfix/stat_ctimespec.go
@@ -1,5 +1,4 @@
 //go:build darwin || freebsd
-// +build darwin freebsd
 
 package postfix
 

--- a/plugins/inputs/postfix/stat_none.go
+++ b/plugins/inputs/postfix/stat_none.go
@@ -1,5 +1,4 @@
 //go:build !dragonfly && !linux && !netbsd && !openbsd && !solaris && !darwin && !freebsd
-// +build !dragonfly,!linux,!netbsd,!openbsd,!solaris,!darwin,!freebsd
 
 package postfix
 

--- a/plugins/inputs/processes/processes_notwindows.go
+++ b/plugins/inputs/processes/processes_notwindows.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
-// +build !windows
 
 package processes
 

--- a/plugins/inputs/processes/processes_test.go
+++ b/plugins/inputs/processes/processes_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package processes
 

--- a/plugins/inputs/processes/processes_windows.go
+++ b/plugins/inputs/processes/processes_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package processes
 

--- a/plugins/inputs/procstat/native_finder_notwindows.go
+++ b/plugins/inputs/procstat/native_finder_notwindows.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package procstat
 

--- a/plugins/inputs/procstat/win_service_notwindows.go
+++ b/plugins/inputs/procstat/win_service_notwindows.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package procstat
 

--- a/plugins/inputs/procstat/win_service_windows.go
+++ b/plugins/inputs/procstat/win_service_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package procstat
 

--- a/plugins/inputs/ras/ras.go
+++ b/plugins/inputs/ras/ras.go
@@ -1,7 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux && (386 || amd64 || arm || arm64)
-// +build linux
-// +build 386 amd64 arm arm64
 
 package ras
 

--- a/plugins/inputs/ras/ras_notlinux.go
+++ b/plugins/inputs/ras/ras_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux || (linux && !386 && !amd64 && !arm && !arm64)
-// +build !linux linux,!386,!amd64,!arm,!arm64
 
 package ras

--- a/plugins/inputs/ras/ras_test.go
+++ b/plugins/inputs/ras/ras_test.go
@@ -1,6 +1,4 @@
 //go:build linux && (386 || amd64 || arm || arm64)
-// +build linux
-// +build 386 amd64 arm arm64
 
 package ras
 

--- a/plugins/inputs/rethinkdb/rethinkdb_server_test.go
+++ b/plugins/inputs/rethinkdb/rethinkdb_server_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package rethinkdb
 

--- a/plugins/inputs/rethinkdb/rethinkdb_test.go
+++ b/plugins/inputs/rethinkdb/rethinkdb_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package rethinkdb
 

--- a/plugins/inputs/sensors/sensors.go
+++ b/plugins/inputs/sensors/sensors.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package sensors
 

--- a/plugins/inputs/sensors/sensors_notlinux.go
+++ b/plugins/inputs/sensors/sensors_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package sensors

--- a/plugins/inputs/sensors/sensors_test.go
+++ b/plugins/inputs/sensors/sensors_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package sensors
 

--- a/plugins/inputs/slab/slab.go
+++ b/plugins/inputs/slab/slab.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package slab
 

--- a/plugins/inputs/slab/slab_notlinux.go
+++ b/plugins/inputs/slab/slab_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package slab

--- a/plugins/inputs/slab/slab_test.go
+++ b/plugins/inputs/slab/slab_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package slab
 

--- a/plugins/inputs/snmp/snmp_mocks_generate.go
+++ b/plugins/inputs/snmp/snmp_mocks_generate.go
@@ -1,5 +1,4 @@
 //go:build generate
-// +build generate
 
 package main
 

--- a/plugins/inputs/socketstat/socketstat.go
+++ b/plugins/inputs/socketstat/socketstat.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
-// +build !windows
 
 // iproute2 doesn't exist on Windows
 

--- a/plugins/inputs/socketstat/socketstat_test.go
+++ b/plugins/inputs/socketstat/socketstat_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package socketstat
 

--- a/plugins/inputs/socketstat/socketstat_windows.go
+++ b/plugins/inputs/socketstat/socketstat_windows.go
@@ -1,4 +1,3 @@
 //go:build windows
-// +build windows
 
 package socketstat

--- a/plugins/inputs/sql/drivers_sqlite.go
+++ b/plugins/inputs/sql/drivers_sqlite.go
@@ -1,8 +1,4 @@
 //go:build linux && freebsd && darwin && (!mips || !mips64)
-// +build linux
-// +build freebsd
-// +build darwin
-// +build !mips !mips64
 
 package sql
 

--- a/plugins/inputs/synproxy/synproxy_linux.go
+++ b/plugins/inputs/synproxy/synproxy_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package synproxy
 

--- a/plugins/inputs/synproxy/synproxy_notlinux.go
+++ b/plugins/inputs/synproxy/synproxy_notlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package synproxy
 

--- a/plugins/inputs/synproxy/synproxy_test.go
+++ b/plugins/inputs/synproxy/synproxy_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package synproxy
 

--- a/plugins/inputs/sysstat/sysstat.go
+++ b/plugins/inputs/sysstat/sysstat.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build linux
-// +build linux
 
 package sysstat
 

--- a/plugins/inputs/sysstat/sysstat_interval_test.go
+++ b/plugins/inputs/sysstat/sysstat_interval_test.go
@@ -1,5 +1,4 @@
 //go:build !race && linux
-// +build !race,linux
 
 package sysstat
 

--- a/plugins/inputs/sysstat/sysstat_notlinux.go
+++ b/plugins/inputs/sysstat/sysstat_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package sysstat

--- a/plugins/inputs/sysstat/sysstat_test.go
+++ b/plugins/inputs/sysstat/sysstat_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package sysstat
 

--- a/plugins/inputs/systemd_units/systemd_units_notlinux.go
+++ b/plugins/inputs/systemd_units/systemd_units_notlinux.go
@@ -1,4 +1,3 @@
 //go:build !linux
-// +build !linux
 
 package systemd_units

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build !solaris
-// +build !solaris
 
 package tail
 

--- a/plugins/inputs/tail/tail_solaris.go
+++ b/plugins/inputs/tail/tail_solaris.go
@@ -1,6 +1,5 @@
 // Skipping plugin on Solaris due to fsnotify support
 //
 //go:build solaris
-// +build solaris
 
 package tail

--- a/plugins/inputs/varnish/varnish.go
+++ b/plugins/inputs/varnish/varnish.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
-// +build !windows
 
 package varnish
 

--- a/plugins/inputs/varnish/varnish_test.go
+++ b/plugins/inputs/varnish/varnish_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package varnish
 

--- a/plugins/inputs/varnish/varnish_windows.go
+++ b/plugins/inputs/varnish/varnish_windows.go
@@ -1,4 +1,3 @@
 //go:build windows
-// +build windows
 
 package varnish

--- a/plugins/inputs/win_eventlog/event.go
+++ b/plugins/inputs/win_eventlog/event.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/plugins/inputs/win_eventlog/syscall_windows.go
+++ b/plugins/inputs/win_eventlog/syscall_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/plugins/inputs/win_eventlog/util.go
+++ b/plugins/inputs/win_eventlog/util.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/plugins/inputs/win_eventlog/util_test.go
+++ b/plugins/inputs/win_eventlog/util_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/plugins/inputs/win_eventlog/win_eventlog_notwindows.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_notwindows.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/plugins/inputs/win_eventlog/win_eventlog_test.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/plugins/inputs/win_eventlog/zsyscall_windows.go
+++ b/plugins/inputs/win_eventlog/zsyscall_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Package win_eventlog Input plugin to collect Windows Event Log messages
 //

--- a/plugins/inputs/win_perf_counters/kernel32.go
+++ b/plugins/inputs/win_perf_counters/kernel32.go
@@ -29,7 +29,6 @@
 // Kevin Pors <krpors@gmail.com>
 
 //go:build windows
-// +build windows
 
 package win_perf_counters
 

--- a/plugins/inputs/win_perf_counters/pdh.go
+++ b/plugins/inputs/win_perf_counters/pdh.go
@@ -29,7 +29,6 @@
 // Kevin Pors <krpors@gmail.com>
 
 //go:build windows
-// +build windows
 
 package win_perf_counters
 

--- a/plugins/inputs/win_perf_counters/pdh_386.go
+++ b/plugins/inputs/win_perf_counters/pdh_386.go
@@ -29,7 +29,6 @@
 // Kevin Pors <krpors@gmail.com>
 
 //go:build windows
-// +build windows
 
 package win_perf_counters
 

--- a/plugins/inputs/win_perf_counters/pdh_amd64.go
+++ b/plugins/inputs/win_perf_counters/pdh_amd64.go
@@ -29,7 +29,6 @@
 // Kevin Pors <krpors@gmail.com>
 
 //go:build windows
-// +build windows
 
 package win_perf_counters
 

--- a/plugins/inputs/win_perf_counters/performance_query.go
+++ b/plugins/inputs/win_perf_counters/performance_query.go
@@ -1,6 +1,5 @@
 // Go API over pdh syscalls
 //go:build windows
-// +build windows
 
 package win_perf_counters
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build windows
-// +build windows
 
 package win_perf_counters
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package win_perf_counters
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters_notwindows.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_notwindows.go
@@ -1,4 +1,3 @@
 //go:build !windows
-// +build !windows
 
 package win_perf_counters

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package win_perf_counters
 

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -1,6 +1,5 @@
 //go:generate ../../../tools/readme_config_includer/generator
 //go:build windows
-// +build windows
 
 package win_services
 

--- a/plugins/inputs/win_services/win_services_integration_test.go
+++ b/plugins/inputs/win_services/win_services_integration_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // these tests must be run under administrator account
 package win_services

--- a/plugins/inputs/win_services/win_services_notwindows.go
+++ b/plugins/inputs/win_services/win_services_notwindows.go
@@ -1,4 +1,3 @@
 //go:build !windows
-// +build !windows
 
 package win_services

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package win_services
 

--- a/plugins/inputs/wireless/wireless_linux.go
+++ b/plugins/inputs/wireless/wireless_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package wireless
 

--- a/plugins/inputs/wireless/wireless_notlinux.go
+++ b/plugins/inputs/wireless/wireless_notlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package wireless
 

--- a/plugins/inputs/wireless/wireless_test.go
+++ b/plugins/inputs/wireless/wireless_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package wireless
 

--- a/plugins/inputs/zfs/zfs_freebsd.go
+++ b/plugins/inputs/zfs/zfs_freebsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package zfs
 

--- a/plugins/inputs/zfs/zfs_freebsd_test.go
+++ b/plugins/inputs/zfs/zfs_freebsd_test.go
@@ -1,5 +1,4 @@
 //go:build freebsd
-// +build freebsd
 
 package zfs
 

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package zfs
 

--- a/plugins/inputs/zfs/zfs_linux_test.go
+++ b/plugins/inputs/zfs/zfs_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package zfs
 

--- a/plugins/inputs/zfs/zfs_other.go
+++ b/plugins/inputs/zfs/zfs_other.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package zfs
 

--- a/plugins/outputs/sql/sqlite.go
+++ b/plugins/outputs/sql/sqlite.go
@@ -1,8 +1,4 @@
 //go:build linux && freebsd && darwin && (!mips || !mips64)
-// +build linux
-// +build freebsd
-// +build darwin
-// +build !mips !mips64
 
 package sql
 

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -1,7 +1,4 @@
 //go:build linux && freebsd && (!mips || !mips64)
-// +build linux
-// +build freebsd
-// +build !mips !mips64
 
 package sql
 

--- a/plugins/processors/filepath/filepath_test.go
+++ b/plugins/processors/filepath/filepath_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package filepath
 

--- a/plugins/processors/port_name/services_path.go
+++ b/plugins/processors/port_name/services_path.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package port_name
 

--- a/plugins/processors/port_name/services_path_notwindows.go
+++ b/plugins/processors/port_name/services_path_notwindows.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package port_name
 

--- a/testutil/container.go
+++ b/testutil/container.go
@@ -1,5 +1,4 @@
 //go:build !freebsd
-// +build !freebsd
 
 package testutil
 


### PR DESCRIPTION
I ran `go fix ./...` which removes the old style of build tags.

more info here: https://stackoverflow.com/questions/68360688/whats-the-difference-between-gobuild-and-build-directives