### PR TITLE
fix: Rename inputs.internet_speed.enable_file_download to match upstream intent

### DIFF
--- a/plugins/inputs/internet_speed/README.md
+++ b/plugins/inputs/internet_speed/README.md
@@ -3,6 +3,8 @@
 The `Internet Speed Monitor` collects data about the internet speed on the
 system.
 
+On some systems, the default settings may cause speed tests to fail; if this affects you then try enabling `memory_saving_mode`. This reduces the memory requirements for the test, and may reduce the runtime of the test. However, please be aware that this may also reduce the accuracy of the test for fast (>30Mb/s) connections. This setting enables the upstream [Memory Saving Mode](https://github.com/showwin/speedtest-go#memory-saving-mode).
+
 ## Configuration
 
 ```toml @sample.conf
@@ -13,8 +15,8 @@ system.
   ## demand on your internet connection.
   # interval = "60m"
 
-  ## Sets if runs file download test
-  # enable_file_download = false
+  ## Enable to reduce memory usage
+  # memory_saving_mode = false
 
   ## Caches the closest server location
   # cache = false

--- a/plugins/inputs/internet_speed/README.md
+++ b/plugins/inputs/internet_speed/README.md
@@ -3,7 +3,12 @@
 The `Internet Speed Monitor` collects data about the internet speed on the
 system.
 
-On some systems, the default settings may cause speed tests to fail; if this affects you then try enabling `memory_saving_mode`. This reduces the memory requirements for the test, and may reduce the runtime of the test. However, please be aware that this may also reduce the accuracy of the test for fast (>30Mb/s) connections. This setting enables the upstream [Memory Saving Mode](https://github.com/showwin/speedtest-go#memory-saving-mode).
+On some systems, the default settings may cause speed tests to fail; if this
+affects you then try enabling `memory_saving_mode`. This reduces the memory
+requirements for the test, and may reduce the runtime of the test. However,
+please be aware that this may also reduce the accuracy of the test for fast
+(>30Mb/s) connections. This setting enables the upstream
+[Memory Saving Mode](https://github.com/showwin/speedtest-go#memory-saving-mode)
 
 ## Configuration
 

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -17,7 +17,8 @@ var sampleConfig string
 
 // InternetSpeed is used to store configuration values.
 type InternetSpeed struct {
-	EnableFileDownload bool            `toml:"enable_file_download"`
+	EnableFileDownload bool            `toml:"enable_file_download" deprecated:"1.25.0;use 'memory_saving_mode' instead"`
+	MemorySavingMode   bool            `toml:"memory_saving_mode"`
 	Cache              bool            `toml:"cache"`
 	Log                telegraf.Logger `toml:"-"`
 	serverCache        *speedtest.Server
@@ -27,6 +28,12 @@ const measurement = "internet_speed"
 
 func (*InternetSpeed) SampleConfig() string {
 	return sampleConfig
+}
+
+func (is *InternetSpeed) Init() error {
+	is.MemorySavingMode = is.MemorySavingMode || is.EnableFileDownload
+
+	return nil
 }
 
 func (is *InternetSpeed) Gather(acc telegraf.Accumulator) error {
@@ -58,13 +65,15 @@ func (is *InternetSpeed) Gather(acc telegraf.Accumulator) error {
 		return fmt.Errorf("ping test failed: %v", err)
 	}
 	is.Log.Debug("Running Download...")
-	err = s.DownloadTest(is.EnableFileDownload)
+	err = s.DownloadTest(is.MemorySavingMode)
 	if err != nil {
+		is.Log.Debug("try `memory_saving_mode = true` if this fails consistently")
 		return fmt.Errorf("download test failed: %v", err)
 	}
 	is.Log.Debug("Running Upload...")
-	err = s.UploadTest(is.EnableFileDownload)
+	err = s.UploadTest(is.MemorySavingMode)
 	if err != nil {
+		is.Log.Debug("try `memory_saving_mode = true` if this fails consistently")
 		return fmt.Errorf("upload test failed failed: %v", err)
 	}
 

--- a/plugins/inputs/internet_speed/internet_speed_test.go
+++ b/plugins/inputs/internet_speed/internet_speed_test.go
@@ -12,8 +12,8 @@ func TestGathering(t *testing.T) {
 		t.Skip("Skipping network-dependent test in short mode.")
 	}
 	internetSpeed := &InternetSpeed{
-		EnableFileDownload: true,
-		Log:                testutil.Logger{},
+		MemorySavingMode: true,
+		Log:              testutil.Logger{},
 	}
 
 	acc := &testutil.Accumulator{}
@@ -26,8 +26,8 @@ func TestDataGen(t *testing.T) {
 		t.Skip("Skipping network-dependent test in short mode.")
 	}
 	internetSpeed := &InternetSpeed{
-		EnableFileDownload: true,
-		Log:                testutil.Logger{},
+		MemorySavingMode: true,
+		Log:              testutil.Logger{},
 	}
 
 	acc := &testutil.Accumulator{}

--- a/plugins/inputs/internet_speed/sample.conf
+++ b/plugins/inputs/internet_speed/sample.conf
@@ -5,8 +5,8 @@
   ## demand on your internet connection.
   # interval = "60m"
 
-  ## Sets if runs file download test
-  # enable_file_download = false
+  ## Enable to reduce memory usage
+  # memory_saving_mode = false
 
   ## Caches the closest server location
   # cache = false

--- a/plugins/inputs/processes/processes_test.go
+++ b/plugins/inputs/processes/processes_test.go
@@ -17,8 +17,8 @@ import (
 func TestProcesses(t *testing.T) {
 	tester := tester{}
 	processes := &Processes{
-		Log: testutil.Logger{},
-		execPS: testExecPS("STAT\n		Ss  \n		S   \n		Z   \n		R   \n		S<  \n		SNs \n		Ss+ \n		\n		\n"),
+		Log:          testutil.Logger{},
+		execPS:       testExecPS("STAT\n		Ss  \n		S   \n		Z   \n		R   \n		S<  \n		SNs \n		Ss+ \n		\n		\n"),
 		readProcFile: tester.testProcFile,
 	}
 	var acc testutil.Accumulator

--- a/plugins/inputs/processes/processes_test.go
+++ b/plugins/inputs/processes/processes_test.go
@@ -17,8 +17,8 @@ import (
 func TestProcesses(t *testing.T) {
 	tester := tester{}
 	processes := &Processes{
-		Log:          testutil.Logger{},
-		execPS:       testExecPS("STAT\n		Ss  \n		S   \n		Z   \n		R   \n		S<  \n		SNs \n		Ss+ \n		\n		\n"),
+		Log: testutil.Logger{},
+		execPS: testExecPS("STAT\n		Ss  \n		S   \n		Z   \n		R   \n		S<  \n		SNs \n		Ss+ \n		\n		\n"),
 		readProcFile: tester.testProcFile,
 	}
 	var acc testutil.Accumulator


### PR DESCRIPTION
`memory_saving_mode` is a more appropriate name for this variable, as this is the upstream feature that is toggled.

Also add a paragraph to the README to explain what this option does, and why it might be required.

# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves influxdata/telegraf#11870

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
