### PR TITLE
chore(inputs.opcua): rename regular reads to unregistered reads

### DIFF
--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -96,8 +96,8 @@ Plugin minimum tested version: 1.16
     ## Set additional valid status codes, StatusOK (0x0) is always considered valid
     # additional_valid_status_codes = ["0xC0"]
 
-    ## Use regular reads instead of registered reads
-    # use_regular_reads = false
+    ## Use unregistered reads instead of registered reads
+    # use_unregistered_reads = false
 ```
 
 ## Node Configuration

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -97,7 +97,7 @@ Plugin minimum tested version: 1.16
     # additional_valid_status_codes = ["0xC0"]
 
     ## Use regular reads instead of registered reads
-    # use_unregistered_reads = false
+    # use_regular_reads = false
 ```
 
 ## Node Configuration

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -97,7 +97,7 @@ Plugin minimum tested version: 1.16
     # additional_valid_status_codes = ["0xC0"]
 
     ## Use regular reads instead of registered reads
-    # use_regular_reads = false
+    # use_unregistered_reads = false
 ```
 
 ## Node Configuration

--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -26,7 +26,7 @@ var sampleConfig string
 
 type OpcuaWorkarounds struct {
 	AdditionalValidStatusCodes []string `toml:"additional_valid_status_codes"`
-	UseRegularReads            bool     `toml:"use_regular_reads"`
+	UseUnregisteredReads       bool     `toml:"use_unregistered_reads"`
 }
 
 // OpcUA type
@@ -366,7 +366,7 @@ func Connect(o *OpcUA) error {
 			return fmt.Errorf("error in Client Connection: %s", err)
 		}
 
-		if !o.Workarounds.UseRegularReads {
+		if !o.Workarounds.UseUnregisteredReads {
 			regResp, err := o.client.RegisterNodes(&ua.RegisterNodesRequest{
 				NodesToRegister: o.nodeIDs,
 			})

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -137,8 +137,8 @@ func TestClient1Integration(t *testing.T) {
 		}
 	}
 
-	// test regular reads workaround
-	o.Workarounds.UseRegularReads = true
+	// test unregistered reads workaround
+	o.Workarounds.UseUnregisteredReads = true
 
 	for i := range o.nodeData {
 		o.nodeData[i] = OPCData{}

--- a/plugins/inputs/opcua/sample.conf
+++ b/plugins/inputs/opcua/sample.conf
@@ -86,5 +86,5 @@
     ## Set additional valid status codes, StatusOK (0x0) is always considered valid
     # additional_valid_status_codes = ["0xC0"]
 
-    ## Use regular reads instead of registered reads
-    # use_regular_reads = false
+    ## Use unregistered reads instead of registered reads
+    # use_unregistered_reads = false


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
[This](https://github.com/influxdata/telegraf/pull/11630#issuecomment-1259705882) comment recommends a rename from `use_regular_reads` to `use_unregistered_reads` to reduce confusion.