### PR TITLE
fix: Support old style of filterting the configs

### DIFF
--- a/cmd/telegraf/main_test.go
+++ b/cmd/telegraf/main_test.go
@@ -199,9 +199,8 @@ func TestCommandConfig(t *testing.T) {
 		expectedPlugins []string
 		removedPlugins  []string
 	}{
-		// Deprecated flag replaced with command "config"
 		{
-			name:     "no filters",
+			name:     "deprecated flag --sample-config",
 			commands: []string{"--sample-config"},
 			expectedHeaders: []string{
 				outputHeader,
@@ -288,6 +287,27 @@ func TestCommandConfig(t *testing.T) {
 			},
 			removedPlugins: []string{
 				"[[aggregators.minmax]]",
+			},
+		},
+		{
+			name:     "test filters before config",
+			commands: []string{"--input-filter", "cpu:file", "config"},
+			expectedPlugins: []string{
+				"[[inputs.cpu]]",
+				"[[inputs.file]]",
+			},
+			removedPlugins: []string{
+				"[[inputs.disk]]",
+			},
+		},
+		{
+			name:     "test filters before and after config",
+			commands: []string{"--input-filter", "file", "config", "--input-filter", "cpu"},
+			expectedPlugins: []string{
+				"[[inputs.cpu]]",
+			},
+			removedPlugins: []string{
+				"[[inputs.file]]",
 			},
 		},
 	}


### PR DESCRIPTION
resolve: https://github.com/influxdata/telegraf/issues/11889

The old style of filtering sample configs still needs to be supported:
`./telegraf --section-filter inputs --input-filter cpu config >test.conf`