### PR TITLE
build(rpm): Allow building RPMs cross-OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,6 +360,7 @@ $(include_packages):
 			--depends shadow-utils \
 			--rpm-digest sha256 \
 			--rpm-posttrans scripts/rpm/post-install.sh \
+			--rpm-os ${GOOS} \
 			--name telegraf \
 			--version $(version) \
 			--iteration $(rpm_iteration) \


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

The RPM build process uses all of the cross-compiling infrastructure to build an RPM that contains correct binaries for the target OS, but, unfortunately the RPM itself would be tagged for the host OS, preventing installation.

Now we use GOOS for the target OS for the RPM as well, making cross-building possible.