### PR TITLE
fix(inputs.http): remove bom from response body

### DIFF
--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/dimchansky/utfbom"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
@@ -159,7 +161,8 @@ func (h *HTTP) gatherURL(
 			h.SuccessStatusCodes)
 	}
 
-	b, err := io.ReadAll(resp.Body)
+	body, _ = utfbom.Skip(resp.Body)
+	b, err := io.ReadAll(body)
 	if err != nil {
 		return fmt.Errorf("reading body failed: %v", err)
 	}


### PR DESCRIPTION
The file input will remove a bom from a file before attempting to parse it. If a body has the bom it will fail to parse.

fixes: #11916
