### PR TITLE
feat(inputs.graylog): deprecate plugin

### DIFF
--- a/plugins/inputs/deprecations.go
+++ b/plugins/inputs/deprecations.go
@@ -12,6 +12,10 @@ var Deprecations = map[string]telegraf.DeprecationInfo{
 		Since:  "1.15.0",
 		Notice: "has been renamed to 'gnmi'",
 	},
+	"graylog": {
+		Since:  "1.25.0",
+		Notice: "use 'inputs.prometheus' with Graylog's Prometheus metric exporting enabled",
+	},
 	"http_listener": {
 		Since:  "1.9.0",
 		Notice: "has been renamed to 'influxdb_listener', use 'inputs.influxdb_listener' or 'inputs.http_listener_v2' instead",

--- a/plugins/inputs/graylog/README.md
+++ b/plugins/inputs/graylog/README.md
@@ -1,5 +1,7 @@
 # GrayLog Input Plugin
 
+## Plugin Deprecated
+
 **Deprecated in version 1.25. Use the Prometheus input plugin**
 
 Graylog supports exporting metrics as Prometheus format, which the Prometheus
@@ -66,3 +68,7 @@ call.
 
 Please refer to GrayLog metrics api browser for full metric end points:
 `http://host:9000/api/api-browser`
+
+## Metrics
+
+## Example Output

--- a/plugins/inputs/graylog/README.md
+++ b/plugins/inputs/graylog/README.md
@@ -1,5 +1,13 @@
 # GrayLog Input Plugin
 
+**Deprecated in version 1.25. Use the Prometheus input plugin**
+
+Graylog supports exporting metrics as Prometheus format, which the Prometheus
+input plugin can collect and parse. See the [Prometheus metric exporting][1]
+page for information to turn this on.
+
+[1]: https://docs.graylog.org/docs/metrics#prometheus-metric-exporting
+
 The Graylog plugin can collect data from remote Graylog service URLs.
 
 Plugin currently support two type of end points:-


### PR DESCRIPTION
The graylog plugin has not worked for some time on any current version of graylog. Instead, graylog has the ability to produce and export prometheus metrics. Users can take advantage of the prometheus input plugin to easily gather and parse these metrics rather than updating this plugin to do the same thing.

fixes: #11918 