### PR TITLE
fix: enable_tls has incorrect default value (true) in sample.conf and README.md

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -30,7 +30,7 @@ It has been optimized to support gNMI telemetry as produced by Cisco IOS XR
   redial = "10s"
 
   ## enable client-side TLS and define CA to authenticate the device
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   ## Minimal TLS version to accept by the client
   # tls_min_version = "TLS12"

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -14,7 +14,7 @@
   redial = "10s"
 
   ## enable client-side TLS and define CA to authenticate the device
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   ## Minimal TLS version to accept by the client
   # tls_min_version = "TLS12"

--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -46,7 +46,7 @@ from listed sensors using Junos Telemetry Interface. Refer to
   ]
 
   ## Optional TLS Config
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/inputs/jti_openconfig_telemetry/sample.conf
+++ b/plugins/inputs/jti_openconfig_telemetry/sample.conf
@@ -34,7 +34,7 @@
   ]
 
   ## Optional TLS Config
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -29,7 +29,7 @@ plugin and use the old zookeeper connection method.
   # version = ""
 
   ## Optional TLS Config
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -18,7 +18,7 @@
   # version = ""
 
   ## Optional TLS Config
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/inputs/memcached/README.md
+++ b/plugins/inputs/memcached/README.md
@@ -14,7 +14,7 @@ This plugin gathers statistics data from a Memcached server.
   # unix_sockets = ["/var/run/memcached.sock"]
 
   ## Optional TLS Config
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/inputs/memcached/sample.conf
+++ b/plugins/inputs/memcached/sample.conf
@@ -7,7 +7,7 @@
   # unix_sockets = ["/var/run/memcached.sock"]
 
   ## Optional TLS Config
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/inputs/zookeeper/README.md
+++ b/plugins/inputs/zookeeper/README.md
@@ -25,7 +25,7 @@ specific to using `mntr` to collect the Java Properties format.
   # timeout = "5s"
 
   ## Optional TLS Config
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/inputs/zookeeper/sample.conf
+++ b/plugins/inputs/zookeeper/sample.conf
@@ -11,7 +11,7 @@
   # timeout = "5s"
 
   ## Optional TLS Config
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -113,7 +113,7 @@ Broker](http://kafka.apache.org/07/quickstart.html) acting a Kafka Producer.
   # max_message_bytes = 1000000
 
   ## Optional TLS Config
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/outputs/kafka/sample.conf
+++ b/plugins/outputs/kafka/sample.conf
@@ -105,7 +105,7 @@
   # max_message_bytes = 1000000
 
   ## Optional TLS Config
-  # enable_tls = true
+  # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"


### PR DESCRIPTION
It should be `false` for every plugin which uses this config (to match code behaviour).