### PR TITLE
fix: Change debugging message wording from wrote to accepted

### DIFF
--- a/models/running_output.go
+++ b/models/running_output.go
@@ -246,7 +246,7 @@ func (r *RunningOutput) write(metrics []telegraf.Metric) error {
 	r.WriteTime.Incr(elapsed.Nanoseconds())
 
 	if err == nil {
-		r.log.Debugf("Wrote batch of %d metrics in %s", len(metrics), elapsed)
+		r.log.Debugf("Output accepted batch of %d metrics in %s", len(metrics), elapsed)
 	}
 	return err
 }


### PR DESCRIPTION
resolves #11942

Since outputs already output error messages when writes fail and can't be retried, The running output shouldn't say the batch was written which implies that the output succeeded in writing.