### PR TITLE
feat(outputs.graylog): Implement connection retries

### DIFF
--- a/plugins/inputs/tcp_listener/tcp_listener_test.go
+++ b/plugins/inputs/tcp_listener/tcp_listener_test.go
@@ -270,8 +270,10 @@ func TestRunParser(t *testing.T) {
 func TestRunParserInvalidMsg(t *testing.T) {
 	var testmsg = []byte("cpu_load_short")
 
+	logger := &testutil.CaptureLogger{}
+
 	listener, in := newTestTCPListener()
-	listener.Log = &testutil.CaptureLogger{}
+	listener.Log = logger
 	listener.acc = &testutil.Accumulator{}
 
 	parser := &influx.Parser{}
@@ -283,8 +285,7 @@ func TestRunParserInvalidMsg(t *testing.T) {
 	in <- testmsg
 
 	listener.Stop()
-	errmsg := listener.Log.(*testutil.CaptureLogger).LastError
-	require.Contains(t, errmsg, "tcp_listener has received 1 malformed packets thus far.")
+	require.Contains(t, logger.LastError(), "tcp_listener has received 1 malformed packets thus far.")
 }
 
 func TestRunParserGraphiteMsg(t *testing.T) {

--- a/plugins/outputs/graylog/README.md
+++ b/plugins/outputs/graylog/README.md
@@ -51,6 +51,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Set to true for backward compatibility.
   # name_field_no_prefix = false
 
+  ## Connection retry options
+  ## Number of attempts to reconnect to the enpoints. If zero, only
+  ## a single connection attempt will be made. For negative values,
+  ## the plugin will try infinite number of times.
+  # reconnection_attemps = 0
+  ## Time to wait between reconnection attempts.
+  # reconnection_wait_time = "100ms"
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"

--- a/plugins/outputs/graylog/README.md
+++ b/plugins/outputs/graylog/README.md
@@ -52,12 +52,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # name_field_no_prefix = false
 
   ## Connection retry options
-  ## Number of attempts to reconnect to the enpoints. If zero, only
+  ## Number of attempts to reconnect to the endpoints. If zero, only
   ## a single connection attempt will be made. For negative values,
   ## the plugin will try infinite number of times.
   # reconnection_attempts = 0
   ## Time to wait between reconnection attempts.
-  # reconnection_wait_time = "100ms"
+  # reconnection_wait_time = "30s"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/outputs/graylog/README.md
+++ b/plugins/outputs/graylog/README.md
@@ -55,7 +55,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Number of attempts to reconnect to the enpoints. If zero, only
   ## a single connection attempt will be made. For negative values,
   ## the plugin will try infinite number of times.
-  # reconnection_attemps = 0
+  # reconnection_attempts = 0
   ## Time to wait between reconnection attempts.
   # reconnection_wait_time = "100ms"
 

--- a/plugins/outputs/graylog/README.md
+++ b/plugins/outputs/graylog/README.md
@@ -57,7 +57,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## the plugin will try infinite number of times.
   # reconnection_attempts = 0
   ## Time to wait between reconnection attempts.
-  # reconnection_wait_time = "30s"
+  # reconnection_wait_time = "15s"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/outputs/graylog/README.md
+++ b/plugins/outputs/graylog/README.md
@@ -57,7 +57,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## the plugin will try infinite number of times.
   # reconnection_attempts = 0
   ## Time to wait between reconnection attempts.
-  # reconnection_wait_time = "100ms"
+  # reconnection_wait_time = "30s"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/outputs/graylog/README.md
+++ b/plugins/outputs/graylog/README.md
@@ -52,12 +52,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # name_field_no_prefix = false
 
   ## Connection retry options
-  ## Number of attempts to reconnect to the endpoints. If zero, only
+  ## Number of attempts to reconnect to the enpoints. If zero, only
   ## a single connection attempt will be made. For negative values,
   ## the plugin will try infinite number of times.
   # reconnection_attempts = 0
   ## Time to wait between reconnection attempts.
-  # reconnection_wait_time = "30s"
+  # reconnection_wait_time = "100ms"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/outputs/graylog/README.md
+++ b/plugins/outputs/graylog/README.md
@@ -56,7 +56,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## If 'false', Telegraf will give up after 3 connection attempt and will
   ## exit with an error. If set to 'true', the plugin will retry to connect
   ## to the unconnected endpoints infinitely.
-  # connection_retry = true
+  # connection_retry = false
   ## Time to wait between connection retry attempts.
   # connection_retry_wait_time = "15s"
 

--- a/plugins/outputs/graylog/README.md
+++ b/plugins/outputs/graylog/README.md
@@ -52,12 +52,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # name_field_no_prefix = false
 
   ## Connection retry options
-  ## Number of attempts to reconnect to the enpoints. If zero, only
-  ## a single connection attempt will be made. For negative values,
-  ## the plugin will try infinite number of times.
-  # reconnection_attempts = 0
-  ## Time to wait between reconnection attempts.
-  # reconnection_wait_time = "15s"
+  ## Attempt to connect to the enpoints if the initial connection fails.
+  ## If 'false', Telegraf will give up after 3 connection attempt and will
+  ## exit with an error. If set to 'true', the plugin will retry to connect
+  ## to the unconnected endpoints infinitely.
+  # connection_retry = true
+  ## Time to wait between connection retry attempts.
+  # connection_retry_wait_time = "15s"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -411,8 +411,8 @@ func (g *Graylog) connectRetry(tlsCfg *tls.Config) {
 }
 
 func (g *Graylog) connectEndpoints(servers []string, tlsCfg *tls.Config) ([]string, []gelf) {
-	var writers []gelf
-	var unconnected []string
+	writers := make([]gelf, 0, len(servers))
+	unconnected := make([]string, 0, len(servers))
 	dialer := &net.Dialer{Timeout: time.Duration(g.Timeout)}
 	for _, server := range servers {
 		w := newGelfWriter(gelfConfig{Endpoint: server}, dialer, tlsCfg)

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -354,7 +354,7 @@ func (g *Graylog) Connect() error {
 	unconnected, gelfs := g.connectEndpoints(g.Servers, tlsCfg)
 	if len(unconnected) > 0 {
 		servers := strings.Join(unconnected, ",")
-		return fmt.Errorf("connect: connection refused for %s", servers)
+		return fmt.Errorf("connect: connection failed for %s", servers)
 	}
 	var writers []io.Writer
 	var closers []io.WriteCloser

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -314,18 +314,20 @@ func (g *gelfTCP) send(b []byte) error {
 }
 
 type Graylog struct {
-	Servers              []string        `toml:"servers"`
-	ShortMessageField    string          `toml:"short_message_field"`
-	NameFieldNoPrefix    bool            `toml:"name_field_noprefix"`
-	Timeout              config.Duration `toml:"timeout"`
-	ReconnectionAttempts int64           `toml:"reconnection_attempts"`
-	ReconnectionTime     config.Duration `toml:"reconnection_wait_time"`
-	Log                  telegraf.Logger `toml:"-"`
+	Servers           []string        `toml:"servers"`
+	ShortMessageField string          `toml:"short_message_field"`
+	NameFieldNoPrefix bool            `toml:"name_field_noprefix"`
+	Timeout           config.Duration `toml:"timeout"`
+	Reconnection      bool            `toml:"connection_retry"`
+	ReconnectionTime  config.Duration `toml:"connection_retry_wait_time"`
+	Log               telegraf.Logger `toml:"-"`
 	tlsint.ClientConfig
 
 	writer      io.Writer
 	closers     []io.WriteCloser
 	unconnected []string
+	stopRetry   bool
+	wg          sync.WaitGroup
 
 	sync.Mutex
 }
@@ -344,25 +346,26 @@ func (g *Graylog) Connect() error {
 		return err
 	}
 
-	if g.ReconnectionAttempts == 0 {
-		unconnected, gelfs := g.connectEndpoints(g.Servers, tlsCfg)
-		if len(unconnected) > 0 {
-			servers := strings.Join(unconnected, ",")
-			return fmt.Errorf("connect: connection refused for %s", servers)
-		}
-		writers := make([]io.Writer, 0, len(gelfs))
-		closers := make([]io.WriteCloser, 0, len(gelfs))
-		for _, w := range gelfs {
-			writers = append(writers, w)
-			closers = append(closers, w)
-		}
-		g.Lock()
-		defer g.Unlock()
-		g.writer = io.MultiWriter(writers...)
-		g.closers = closers
-	} else {
+	if g.Reconnection {
 		go g.connectRetry(tlsCfg)
+		return nil
 	}
+
+	unconnected, gelfs := g.connectEndpoints(g.Servers, tlsCfg)
+	if len(unconnected) > 0 {
+		servers := strings.Join(unconnected, ",")
+		return fmt.Errorf("connect: connection refused for %s", servers)
+	}
+	var writers []io.Writer
+	var closers []io.WriteCloser
+	for _, w := range gelfs {
+		writers = append(writers, w)
+		closers = append(closers, w)
+	}
+	g.Lock()
+	defer g.Unlock()
+	g.writer = io.MultiWriter(writers...)
+	g.closers = closers
 
 	return nil
 }
@@ -371,6 +374,8 @@ func (g *Graylog) connectRetry(tlsCfg *tls.Config) {
 	var writers []io.Writer
 	var closers []io.WriteCloser
 	var attempt int64
+
+	g.wg.Add(1)
 
 	unconnected := append([]string{}, g.Servers...)
 	for {
@@ -381,25 +386,28 @@ func (g *Graylog) connectRetry(tlsCfg *tls.Config) {
 		}
 		g.Lock()
 		g.unconnected = unconnected
+		stopRetry := g.stopRetry
 		g.Unlock()
+		if stopRetry {
+			g.Log.Info("Stopping connection retries...")
+			break
+		}
 		if len(unconnected) == 0 {
 			break
 		}
 		attempt++
 		servers := strings.Join(unconnected, ",")
 		g.Log.Infof("Not connected to endpoints %s after attempt #%d...", servers, attempt)
-		if attempt > g.ReconnectionAttempts && g.ReconnectionAttempts >= 0 {
-			g.Log.Errorf("Giving up on connecting to %s, attempts exceeded.", servers)
-			return
-		}
 		time.Sleep(time.Duration(g.ReconnectionTime))
 	}
 	g.Log.Info("Connected!")
 
 	g.Lock()
-	defer g.Unlock()
 	g.writer = io.MultiWriter(writers...)
 	g.closers = closers
+	g.Unlock()
+
+	g.wg.Done()
 }
 
 func (g *Graylog) connectEndpoints(servers []string, tlsCfg *tls.Config) ([]string, []gelf) {
@@ -419,6 +427,11 @@ func (g *Graylog) connectEndpoints(servers []string, tlsCfg *tls.Config) ([]stri
 }
 
 func (g *Graylog) Close() error {
+	g.Lock()
+	g.stopRetry = true
+	g.Unlock()
+	g.wg.Wait()
+
 	for _, closer := range g.closers {
 		_ = closer.Close()
 	}

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -35,7 +35,7 @@ const (
 	defaultMaxChunkSizeLan  = 8154
 	defaultScheme           = "udp"
 	defaultTimeout          = 5 * time.Second
-	defaultReconnectionTime = 30 * time.Second
+	defaultReconnectionTime = 15 * time.Second
 )
 
 var defaultSpecFields = []string{"version", "host", "short_message", "full_message", "timestamp", "level", "facility", "line", "file"}

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -35,7 +35,7 @@ const (
 	defaultMaxChunkSizeLan  = 8154
 	defaultScheme           = "udp"
 	defaultTimeout          = 5 * time.Second
-	defaultReconnectionTime = 100 * time.Millisecond
+	defaultReconnectionTime = 30 * time.Second
 )
 
 var defaultSpecFields = []string{"version", "host", "short_message", "full_message", "timestamp", "level", "facility", "line", "file"}

--- a/plugins/outputs/graylog/sample.conf
+++ b/plugins/outputs/graylog/sample.conf
@@ -21,7 +21,7 @@
   ## If 'false', Telegraf will give up after 3 connection attempt and will
   ## exit with an error. If set to 'true', the plugin will retry to connect
   ## to the unconnected endpoints infinitely.
-  # connection_retry = true
+  # connection_retry = false
   ## Time to wait between connection retry attempts.
   # connection_retry_wait_time = "15s"
 

--- a/plugins/outputs/graylog/sample.conf
+++ b/plugins/outputs/graylog/sample.conf
@@ -16,6 +16,14 @@
   ## Set to true for backward compatibility.
   # name_field_no_prefix = false
 
+  ## Connection retry options
+  ## Number of attempts to reconnect to the enpoints. If zero, only
+  ## a single connection attempt will be made. For negative values,
+  ## the plugin will try infinite number of times.
+  # reconnection_attemps = 0
+  ## Time to wait between reconnection attempts.
+  # reconnection_wait_time = "100ms"
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"

--- a/plugins/outputs/graylog/sample.conf
+++ b/plugins/outputs/graylog/sample.conf
@@ -22,7 +22,7 @@
   ## the plugin will try infinite number of times.
   # reconnection_attempts = 0
   ## Time to wait between reconnection attempts.
-  # reconnection_wait_time = "100ms"
+  # reconnection_wait_time = "30s"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/outputs/graylog/sample.conf
+++ b/plugins/outputs/graylog/sample.conf
@@ -22,7 +22,7 @@
   ## the plugin will try infinite number of times.
   # reconnection_attempts = 0
   ## Time to wait between reconnection attempts.
-  # reconnection_wait_time = "30s"
+  # reconnection_wait_time = "15s"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/outputs/graylog/sample.conf
+++ b/plugins/outputs/graylog/sample.conf
@@ -20,7 +20,7 @@
   ## Number of attempts to reconnect to the enpoints. If zero, only
   ## a single connection attempt will be made. For negative values,
   ## the plugin will try infinite number of times.
-  # reconnection_attemps = 0
+  # reconnection_attempts = 0
   ## Time to wait between reconnection attempts.
   # reconnection_wait_time = "100ms"
 

--- a/plugins/outputs/graylog/sample.conf
+++ b/plugins/outputs/graylog/sample.conf
@@ -17,12 +17,13 @@
   # name_field_no_prefix = false
 
   ## Connection retry options
-  ## Number of attempts to reconnect to the enpoints. If zero, only
-  ## a single connection attempt will be made. For negative values,
-  ## the plugin will try infinite number of times.
-  # reconnection_attempts = 0
-  ## Time to wait between reconnection attempts.
-  # reconnection_wait_time = "15s"
+  ## Attempt to connect to the enpoints if the initial connection fails.
+  ## If 'false', Telegraf will give up after 3 connection attempt and will
+  ## exit with an error. If set to 'true', the plugin will retry to connect
+  ## to the unconnected endpoints infinitely.
+  # connection_retry = true
+  ## Time to wait between connection retry attempts.
+  # connection_retry_wait_time = "15s"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/outputs/influxdb/http_test.go
+++ b/plugins/outputs/influxdb/http_test.go
@@ -1215,10 +1215,10 @@ func TestDBNotFoundShouldDropMetricWhenSkipDatabaseCreateIsTrue(t *testing.T) {
 	err = output.Connect()
 	require.NoError(t, err)
 	err = output.Write(metrics)
-	require.Contains(t, logger.LastError, "database not found")
+	require.Contains(t, logger.LastError(), "database not found")
 	require.NoError(t, err)
 
 	err = output.Write(metrics)
-	require.Contains(t, logger.LastError, "database not found")
+	require.Contains(t, logger.LastError(), "database not found")
 	require.NoError(t, err)
 }

--- a/testutil/capturelog.go
+++ b/testutil/capturelog.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"fmt"
 	"log"
+	"sync"
 
 	"github.com/influxdata/telegraf"
 )
@@ -11,21 +12,26 @@ var _ telegraf.Logger = &CaptureLogger{}
 
 // CaptureLogger defines a logging structure for plugins.
 type CaptureLogger struct {
-	Name      string // Name is the plugin name, will be printed in the `[]`.
-	LastError string
+	Name   string // Name is the plugin name, will be printed in the `[]`.
+	errors []string
+	sync.Mutex
 }
 
 // Errorf logs an error message, patterned after log.Printf.
 func (l *CaptureLogger) Errorf(format string, args ...interface{}) {
 	s := fmt.Sprintf("E! ["+l.Name+"] "+format, args...)
-	l.LastError = s
+	l.Lock()
+	l.errors = append(l.errors, s)
+	l.Unlock()
 	log.Print(s)
 }
 
 // Error logs an error message, patterned after log.Print.
 func (l *CaptureLogger) Error(args ...interface{}) {
 	s := fmt.Sprint(append([]interface{}{"E! [" + l.Name + "] "}, args...)...)
-	l.LastError = s
+	l.Lock()
+	l.errors = append(l.errors, s)
+	l.Unlock()
 	log.Print(s)
 }
 
@@ -57,4 +63,20 @@ func (l *CaptureLogger) Infof(format string, args ...interface{}) {
 // Info logs an information message, patterned after log.Print.
 func (l *CaptureLogger) Info(args ...interface{}) {
 	log.Print(append([]interface{}{"I! [" + l.Name + "] "}, args...)...)
+}
+
+func (l *CaptureLogger) Errors() []string {
+	l.Lock()
+	defer l.Unlock()
+	e := append([]string{}, l.errors...)
+	return e
+}
+
+func (l *CaptureLogger) LastError() string {
+	l.Lock()
+	defer l.Unlock()
+	if len(l.errors) > 0 {
+		return l.errors[len(l.errors)-1]
+	}
+	return ""
 }


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR adds code to retry to connect to the given endpoints if `connection_retry` is set to `true`. This is helpful in cases where Telegraf is started, but the servers are not up or not reachable yet. The wait-time between retry attempts can be specified via `connection_retry_wait_time` option.
Please note, Telegraf will try to connect only 3 times if `connection_retry = false` (default) and will terminate if not successful. To connect forever set `connection_retry = true`, but be aware that metrics might get lost if the metric buffer overflows before a successful connection was made. 