### PR TITLE
chore: Resolve linter issues for ineffassign, nilerr, gosimple...

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,7 +69,7 @@ linters-settings:
       - name: unconditional-recursion
       - name: unexported-naming
       - name: unhandled-error
-        arguments: ["outputBuffer.Write", "fmt.Printf", "fmt.Println", "fmt.Print"]
+        arguments: ["outputBuffer.Write", "fmt.Printf", "fmt.Println", "fmt.Print", "rand.Read"]
       - name: unnecessary-stmt
       - name: unreachable-code
       # - name: unused-parameter

--- a/agent/tick_test.go
+++ b/agent/tick_test.go
@@ -41,10 +41,9 @@ func TestAlignedTicker(t *testing.T) {
 
 	clk.Add(10 * time.Second)
 	for !clk.Now().After(until) {
-		select {
-		case tm := <-ticker.Elapsed():
-			actual = append(actual, tm.UTC())
-		}
+		tm := <-ticker.Elapsed()
+		actual = append(actual, tm.UTC())
+
 		clk.Add(10 * time.Second)
 	}
 

--- a/internal/content_coding.go
+++ b/internal/content_coding.go
@@ -88,7 +88,7 @@ type AutoDecoder struct {
 	identity *IdentityDecoder
 }
 
-func (a *AutoDecoder) SetEnconding(encoding string) {
+func (a *AutoDecoder) SetEncoding(encoding string) {
 	a.encoding = encoding
 }
 
@@ -199,7 +199,7 @@ func (*IdentityEncoder) Encode(data []byte) ([]byte, error) {
 
 // ContentDecoder removes a wrapper encoding from byte buffers.
 type ContentDecoder interface {
-	SetEnconding(string)
+	SetEncoding(string)
 	Decode([]byte) ([]byte, error)
 }
 
@@ -216,13 +216,16 @@ func NewGzipDecoder() (*GzipDecoder, error) {
 	}, nil
 }
 
-func (*GzipDecoder) SetEnconding(string) {}
+func (*GzipDecoder) SetEncoding(string) {}
 
 func (d *GzipDecoder) Decode(data []byte) ([]byte, error) {
-	d.reader.Reset(bytes.NewBuffer(data))
+	err := d.reader.Reset(bytes.NewBuffer(data))
+	if err != nil {
+		return nil, err
+	}
 	d.buf.Reset()
 
-	_, err := d.buf.ReadFrom(d.reader)
+	_, err = d.buf.ReadFrom(d.reader)
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
@@ -243,7 +246,7 @@ func NewZlibDecoder() (*ZlibDecoder, error) {
 	}, nil
 }
 
-func (*ZlibDecoder) SetEnconding(string) {}
+func (*ZlibDecoder) SetEncoding(string) {}
 
 func (d *ZlibDecoder) Decode(data []byte) ([]byte, error) {
 	d.buf.Reset()
@@ -271,7 +274,7 @@ func NewIdentityDecoder() *IdentityDecoder {
 	return &IdentityDecoder{}
 }
 
-func (*IdentityDecoder) SetEnconding(string) {}
+func (*IdentityDecoder) SetEncoding(string) {}
 
 func (*IdentityDecoder) Decode(data []byte) ([]byte, error) {
 	return data, nil

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -75,7 +75,7 @@ func ReadLines(filename string) ([]string, error) {
 	return ReadLinesOffsetN(filename, 0, -1)
 }
 
-// ReadLines reads contents from file and splits them by new line.
+// ReadLinesOffsetN reads contents from file and splits them by new line.
 // The offset tells at which line number to start.
 // The count determines the number of lines to read (starting from offset):
 //
@@ -94,7 +94,10 @@ func ReadLinesOffsetN(filename string, offset uint, n int) ([]string, error) {
 	for i := 0; i < n+int(offset) || n < 0; i++ {
 		line, err := r.ReadString('\n')
 		if err != nil {
-			break
+			if err == io.EOF {
+				break
+			}
+			return []string{""}, err
 		}
 		if i < int(offset) {
 			continue
@@ -105,7 +108,7 @@ func ReadLinesOffsetN(filename string, offset uint, n int) ([]string, error) {
 	return ret, nil
 }
 
-// RandomString returns a random string of alpha-numeric characters
+// RandomString returns a random string of alphanumeric characters
 func RandomString(n int) string {
 	var bytes = make([]byte, n)
 	rand.Read(bytes)
@@ -249,7 +252,7 @@ func CompressWithGzip(data io.Reader) (io.ReadCloser, error) {
 // The format can be one of "unix", "unix_ms", "unix_us", "unix_ns", or a Go
 // time layout suitable for time.Parse.
 //
-// When using the "unix" format, a optional fractional component is allowed.
+// When using the "unix" format, an optional fractional component is allowed.
 // Specific unix time precisions cannot have a fractional component.
 //
 // Unix times may be an int64, float64, or string.  When using a Go format
@@ -344,17 +347,17 @@ func timeFromFraction(f *big.Rat, factor int64) time.Time {
 
 // sanitizeTimestamp removes thousand separators and uses dot as
 // decimal separator. Returns also a boolean indicating success.
-func sanitizeTimestamp(timestamp string, decimalSeparartor []string) string {
+func sanitizeTimestamp(timestamp string, decimalSeparator []string) string {
 	// Remove thousand-separators that are not used for decimal separation
 	sanitized := timestamp
 	for _, s := range []string{" ", ",", "."} {
-		if !choice.Contains(s, decimalSeparartor) {
+		if !choice.Contains(s, decimalSeparator) {
 			sanitized = strings.ReplaceAll(sanitized, s, "")
 		}
 	}
 
 	// Replace decimal separators by dot to have a standard, parsable format
-	for _, s := range decimalSeparartor {
+	for _, s := range decimalSeparator {
 		// Make sure we replace only the first occurrence of any separator.
 		if strings.Contains(sanitized, s) {
 			return strings.Replace(sanitized, s, ".", 1)

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -125,6 +125,7 @@ func TestCombinedOutputError(t *testing.T) {
 	}
 	cmd := exec.Command(shell, "-c", "false")
 	expected, err := cmd.CombinedOutput()
+	assert.Error(t, err)
 
 	cmd2 := exec.Command(shell, "-c", "false")
 	actual, err := CombinedOutputTimeout(cmd2, time.Second)

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -46,7 +46,7 @@ func TestRestartingRebindsPipes(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 
-	syscall.Kill(p.Pid(), syscall.SIGKILL)
+	require.NoError(t, syscall.Kill(p.Pid(), syscall.SIGKILL))
 
 	for atomic.LoadInt64(&linesRead) < 2 {
 		time.Sleep(1 * time.Millisecond)
@@ -74,7 +74,7 @@ func TestMain(m *testing.M) {
 // cleanly.
 func externalProcess() {
 	wait := make(chan int)
-	fmt.Fprintln(os.Stdout, "started")
+	_, _ = fmt.Fprintln(os.Stdout, "started")
 	<-wait
 	os.Exit(2)
 }

--- a/internal/syslog/framing.go
+++ b/internal/syslog/framing.go
@@ -26,12 +26,12 @@ func (f Framing) String() string {
 }
 
 // UnmarshalTOML implements ability to unmarshal framing from TOML files.
-func (f *Framing) UnmarshalTOML(data []byte) (err error) {
+func (f *Framing) UnmarshalTOML(data []byte) error {
 	return f.UnmarshalText(data)
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler
-func (f *Framing) UnmarshalText(data []byte) (err error) {
+func (f *Framing) UnmarshalText(data []byte) error {
 	s := string(data)
 	switch strings.ToUpper(s) {
 	case `OCTET-COUNTING`:
@@ -40,21 +40,20 @@ func (f *Framing) UnmarshalText(data []byte) (err error) {
 		fallthrough
 	case `'OCTET-COUNTING'`:
 		*f = OctetCounting
-		return
-
+		return nil
 	case `NON-TRANSPARENT`:
 		fallthrough
 	case `"NON-TRANSPARENT"`:
 		fallthrough
 	case `'NON-TRANSPARENT'`:
 		*f = NonTransparent
-		return
+		return nil
 	}
 	*f = -1
 	return fmt.Errorf("unknown framing")
 }
 
-// MarshalText implements encoding.TextMarshaler
+// MarshalText implements encoding.TextMarshaller
 func (f Framing) MarshalText() ([]byte, error) {
 	s := f.String()
 	if s != "" {

--- a/internal/templating/engine.go
+++ b/internal/templating/engine.go
@@ -19,7 +19,9 @@ type Engine struct {
 
 // Apply extracts the template fields from the given line and returns the measurement
 // name, tags and field name
-func (e *Engine) Apply(line string) (string, map[string]string, string, error) {
+//
+//nolint:revive //function-result-limit conditionally 4 return results allowed
+func (e *Engine) Apply(line string) (measurementName string, tags map[string]string, field string, err error) {
 	return e.matcher.match(line).Apply(line, e.joiner)
 }
 

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -78,17 +78,17 @@ func TestRemoveTagNoEffectOnMissingTags(t *testing.T) {
 func TestGetTag(t *testing.T) {
 	m := baseMetric()
 
-	value, ok := m.GetTag("host")
+	_, ok := m.GetTag("host")
 	require.False(t, ok)
 
 	m.AddTag("host", "localhost")
 
-	value, ok = m.GetTag("host")
+	value, ok := m.GetTag("host")
 	require.True(t, ok)
 	require.Equal(t, "localhost", value)
 
 	m.RemoveTag("host")
-	value, ok = m.GetTag("host")
+	_, ok = m.GetTag("host")
 	require.False(t, ok)
 }
 
@@ -143,17 +143,17 @@ func TestRemoveFieldNoEffectOnMissingFields(t *testing.T) {
 func TestGetField(t *testing.T) {
 	m := baseMetric()
 
-	value, ok := m.GetField("foo")
+	_, ok := m.GetField("foo")
 	require.False(t, ok)
 
 	m.AddField("foo", "bar")
 
-	value, ok = m.GetField("foo")
+	value, ok := m.GetField("foo")
 	require.True(t, ok)
 	require.Equal(t, "bar", value)
 
 	m.RemoveTag("foo")
-	value, ok = m.GetTag("foo")
+	_, ok = m.GetTag("foo")
 	require.False(t, ok)
 }
 

--- a/metric/tracking.go
+++ b/metric/tracking.go
@@ -1,7 +1,6 @@
 package metric
 
 import (
-	"log"
 	"runtime"
 	"sync/atomic"
 
@@ -24,10 +23,6 @@ func WithGroupTracking(metric []telegraf.Metric, fn NotifyFunc) ([]telegraf.Metr
 	return newTrackingMetricGroup(metric, fn)
 }
 
-func EnableDebugFinalizer() {
-	finalizer = debugFinalizer
-}
-
 var (
 	lastID    uint64
 	finalizer func(*trackingData)
@@ -35,13 +30,6 @@ var (
 
 func newTrackingID() telegraf.TrackingID {
 	return telegraf.TrackingID(atomic.AddUint64(&lastID, 1))
-}
-
-func debugFinalizer(d *trackingData) {
-	rc := atomic.LoadInt32(&d.rc)
-	if rc != 0 {
-		log.Fatalf("E! [agent] metric collected with non-zero reference count rc: %d", rc)
-	}
 }
 
 type trackingData struct {

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -395,7 +395,7 @@ func (a *AMQPConsumer) onMessage(acc telegraf.TrackingAccumulator, d amqp.Delive
 		}
 	}
 
-	a.decoder.SetEnconding(d.ContentEncoding)
+	a.decoder.SetEncoding(d.ContentEncoding)
 	body, err := a.decoder.Decode(d.Body)
 	if err != nil {
 		onError()

--- a/plugins/inputs/opentelemetry/opentelemetry_test.go
+++ b/plugins/inputs/opentelemetry/opentelemetry_test.go
@@ -50,6 +50,7 @@ func TestOpenTelemetry(t *testing.T) {
 
 	meter := mp.Meter("library-name")
 	counter, err := meter.SyncInt64().Counter("measurement-counter")
+	require.NoError(t, err)
 	counter.Add(ctx, 7)
 
 	// write metrics through the telegraf OpenTelemetry input plugin


### PR DESCRIPTION
And few others, plus some typos etc...

```
agent/tick_test.go:44:3                                   gosimple     S1000: should use a simple channel send/receive instead of `select` with a single case
internal/content_coding.go:222:2                          revive       unhandled-error: Unhandled error in call to function d.reader.Reset
internal/internal.go:105:2                                nilerr       error is not nil (line 95) but it returns nil
internal/internal_test.go:127:12                          ineffassign  ineffectual assignment to err
internal/process/process_test.go:49:2                     revive       unhandled-error: Unhandled error in call to function syscall.Kill
internal/process/process_test.go:77:2                     revive       unhandled-error: Unhandled error in call to function fmt.Fprintln
internal/process/process_test.go:79:2                     revive       deep-exit: calls to os.Exit only in main() or init() functions
internal/syslog/framing.go:43:3                           revive       bare-return: avoid using bare returns, please add return expressions
internal/syslog/framing.go:51:3                           revive       bare-return: avoid using bare returns, please add return expressions
internal/templating/engine.go:22:1                        revive       function-result-limit: maximum number of return results per function exceeded; max 3 but got 4
internal/templating/template.go:19:1                      revive       function-result-limit: maximum number of return results per function exceeded; max 3 but got 4
metric/metric_test.go:81:2                                ineffassign  ineffectual assignment to value
metric/metric_test.go:91:2                                ineffassign  ineffectual assignment to value
metric/metric_test.go:146:2                               ineffassign  ineffectual assignment to value
metric/metric_test.go:156:2                               ineffassign  ineffectual assignment to value
metric/tracking.go:43:3                                   revive       deep-exit: calls to log.Fatalf only in main() or init() functions
plugins/inputs/opentelemetry/opentelemetry_test.go:52:11  ineffassign  ineffectual assignment to err
```