### PR TITLE
feat: Add method to inform of deprecated plugin option values

### DIFF
--- a/docs/developers/DEPRECATION.md
+++ b/docs/developers/DEPRECATION.md
@@ -49,7 +49,7 @@ Mark the option as deprecated in the sample config, include the deprecation
 version and any replacement.
 
 ```toml
-  ## Broker URL
+  ## Broker to publish to.
   ##   deprecated in 1.7; use the brokers option
   # url = "amqp://localhost:5672/influxdb"
 ```
@@ -57,16 +57,21 @@ version and any replacement.
 In the plugins configuration struct, add a `deprecated` tag to the option:
 
 ```go
-type AMQPConsumer struct {
-    URL string `toml:"url" deprecated:"1.7.0;use brokers"`
+type AMQP struct {
+    URL       string `toml:"url" deprecated:"1.7.0;use 'brokers' instead"`
+    Precision string `toml:"precision" deprecated:"1.2.0;option is ignored"`
 }
 ```
 
 The `deprecated` tag has the format `<since version>[;removal version];<notice>` where the `removal version` is optional. The specified deprecation info will automatically displayed by Telegraf if the option is used in the config
 
 ```text
-2022-01-26T20:08:15Z W! DeprecationWarning: Option "url" of plugin "inputs.amqp_consumer" deprecated since version 1.7.0 and will be removed in 2.0.0: use brokers
+2022-01-26T20:08:15Z W! DeprecationWarning: Option "url" of plugin "outputs.amqp" deprecated since version 1.7.0 and will be removed in 2.0.0: use 'brokers' instead
 ```
+
+### Option value
+
+In the case a specific option value is being deprecated, the method `models.PrintOptionValueDeprecationNotice` needs to be called in the plugin's `Init` method.
 
 ## Deprecate metrics
 

--- a/models/log.go
+++ b/models/log.go
@@ -135,3 +135,14 @@ func PrintOptionDeprecationNotice(level telegraf.Escalation, plugin, option stri
 		)
 	}
 }
+
+func PrintOptionValueDeprecationNotice(level telegraf.Escalation, plugin, option string, value interface{}, info telegraf.DeprecationInfo) {
+	switch level {
+	case telegraf.Warn, telegraf.Error:
+		prefix := deprecationPrefix(level)
+		log.Printf(
+			"%s: Option value %q for %q of plugin %q deprecated since version %s and will be removed in %s: %s",
+			prefix, value, option, plugin, info.Since, info.RemovalIn, info.Notice,
+		)
+	}
+}

--- a/models/log_test.go
+++ b/models/log_test.go
@@ -177,3 +177,77 @@ func TestPluginOptionDeprecation(t *testing.T) {
 		})
 	}
 }
+
+func TestPluginOptionValueDeprecation(t *testing.T) {
+	info := telegraf.DeprecationInfo{
+		Since:     "1.25.0",
+		RemovalIn: "2.0.0",
+		Notice:    "please check",
+	}
+	var tests = []struct {
+		name     string
+		level    telegraf.Escalation
+		expected string
+	}{
+		{
+			name:     "Error level",
+			level:    telegraf.Error,
+			expected: `Option value "foobar" for "option" of plugin "test" deprecated since version 1.25.0 and will be removed in 2.0.0: please check`,
+		},
+		{
+			name:     "Warn level",
+			level:    telegraf.Warn,
+			expected: `Option value "foobar" for "option" of plugin "test" deprecated since version 1.25.0 and will be removed in 2.0.0: please check`,
+		},
+		{
+			name:     "None",
+			level:    telegraf.None,
+			expected: ``,
+		},
+	}
+
+	// Switch the logger to log to a buffer
+	var buf bytes.Buffer
+	scanner := bufio.NewScanner(&buf)
+
+	previous := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(previous)
+
+	msg := make(chan string, 1)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.Reset()
+			PrintOptionValueDeprecationNotice(tt.level, "test", "option", "foobar", info)
+			// Wait for a newline to arrive and timeout for cases where
+			// we don't see a message.
+			go func() {
+				scanner.Scan()
+				msg <- scanner.Text()
+			}()
+
+			// Reduce the timeout if we do not expect a message
+			timeout := 1 * time.Second
+			if tt.expected == "" {
+				timeout = 100 * time.Microsecond
+			}
+
+			var actual string
+			select {
+			case actual = <-msg:
+			case <-time.After(timeout):
+			}
+
+			if tt.expected != "" {
+				// Remove the time for comparison
+				parts := strings.SplitN(actual, " ", 3)
+				require.Len(t, parts, 3)
+				actual = parts[2]
+				expected := deprecationPrefix(tt.level) + ": " + tt.expected
+				require.Equal(t, expected, actual)
+			} else {
+				require.Empty(t, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

At the same time, the docs for deprecating options is updated a bit to also include sample for unused options.