### PR TITLE
chore(ci): Migrate to scheduled pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,6 +519,9 @@ jobs:
 workflows:
   version: 2
   check:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - 'test-go-linux':
           filters:
@@ -658,9 +661,6 @@ workflows:
             tags:
               only: /.*/
       - 'generate-config':
-          when:
-            not:
-              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
           requires:
             - 'amd64-package'
           filters:
@@ -668,9 +668,6 @@ workflows:
               only:
                 - master
       - 'generate-config-win':
-          when:
-            not:
-              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
           requires:
             - 'windows-package'
           filters:
@@ -737,32 +734,112 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
-      - nightly:
-          when:
-              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+
+  nightly:
+    when:
+      equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+      - 'test-go-linux'
+      - 'test-go-linux-386'
+      - 'test-go-mac'
+      - 'test-go-windows'
+      - 'test-licenses'
+      - 'windows-package':
+          name: 'windows-package-nightly'
+          nightly: true
           requires:
-            - 'i386-package'
-            - 'ppc64le-package'
-            - 's390x-package'
-            - 'armel-package'
-            - 'amd64-package'
-            - 'mipsel-package'
-            - 'mips-package'
-            - 'static-package'
-            - 'arm64-package'
-            - 'armhf-package'
-            - 'riscv64-package'
-            - 'package-sign-mac'
-            - 'package-sign-windows'
+            - 'test-go-windows'
+      - 'darwin-amd64-package':
+          name: 'darwin-amd64-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-mac'
+      - 'darwin-arm64-package':
+          name: 'darwin-arm64-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-mac'
+      - 'i386-package':
+          name: 'i386-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux-386'
+      - 'ppc64le-package':
+          name: 'ppc64le-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
+      - 'riscv64-package':
+          name: 'riscv64-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
+      - 's390x-package':
+          name: 's390x-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
+      - 'armel-package':
+          name: 'armel-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
+      - 'amd64-package':
+          name: 'amd64-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
+      - 'arm64-package':
+          name: 'arm64-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
+      - 'armhf-package':
+          name: 'armhf-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
+      - 'static-package':
+          name: 'static-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
+      - 'mipsel-package':
+          name: 'mipsel-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
+      - 'mips-package':
+          name: 'mips-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
+      - 'package-sign-windows':
+          requires:
+            - 'windows-package-nightly'
+      - 'package-sign-mac':
+           requires:
+            - 'darwin-amd64-package-nightly'
+            - 'darwin-arm64-package-nightly'
+      - nightly:
+          requires:
+            - 'amd64-package-test-nightly'
+            - 'arm64-package-nightly'
+            - 'armel-package-nightly'
+            - 'armhf-package-nightly'
+            - 'darwin-amd64-package-nightly'
+            - 'darwin-arm64-package-nightly'
+            - 'i386-package-nightly'
+            - 'mips-package-nightly'
+            - 'mipsel-package-nightly'
+            - 'ppc64le-package-nightly'
+            - 'riscv64-package-nightly'
+            - 's390x-package-nightly'
+            - 'static-package-nightly'
+            - 'windows-package-nightly'
       - docker-nightly:
-          when:
-              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
           requires:
             - 'nightly'
       - amd64-package-test-nightly:
-          when:
-              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
           requires:
             - 'amd64-package-nightly'
-
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -658,6 +658,9 @@ workflows:
             tags:
               only: /.*/
       - 'generate-config':
+          when:
+            not:
+              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
           requires:
             - 'amd64-package'
           filters:
@@ -665,6 +668,9 @@ workflows:
               only:
                 - master
       - 'generate-config-win':
+          when:
+            not:
+              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
           requires:
             - 'windows-package'
           filters:
@@ -731,117 +737,32 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
-
-  nightly:
-    jobs:
-      - 'test-go-linux'
-      - 'test-go-linux-386'
-      - 'test-go-mac'
-      - 'test-go-windows'
-      - 'test-licenses'
-      - 'windows-package':
-          name: 'windows-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-windows'
-      - 'darwin-amd64-package':
-          name: 'darwin-amd64-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-mac'
-      - 'darwin-arm64-package':
-          name: 'darwin-arm64-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-mac'
-      - 'i386-package':
-          name: 'i386-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux-386'
-      - 'ppc64le-package':
-          name: 'ppc64le-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
-      - 'riscv64-package':
-          name: 'riscv64-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
-      - 's390x-package':
-          name: 's390x-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
-      - 'armel-package':
-          name: 'armel-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
-      - 'amd64-package':
-          name: 'amd64-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
-      - 'arm64-package':
-          name: 'arm64-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
-      - 'armhf-package':
-          name: 'armhf-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
-      - 'static-package':
-          name: 'static-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
-      - 'mipsel-package':
-          name: 'mipsel-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
-      - 'mips-package':
-          name: 'mips-package-nightly'
-          nightly: true
-          requires:
-            - 'test-go-linux'
-      - 'package-sign-windows':
-          requires:
-            - 'windows-package-nightly'
-      - 'package-sign-mac':
-           requires:
-            - 'darwin-amd64-package-nightly'
-            - 'darwin-arm64-package-nightly'
       - nightly:
+          when:
+              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
           requires:
-            - 'amd64-package-test-nightly'
-            - 'arm64-package-nightly'
-            - 'armel-package-nightly'
-            - 'armhf-package-nightly'
-            - 'darwin-amd64-package-nightly'
-            - 'darwin-arm64-package-nightly'
-            - 'i386-package-nightly'
-            - 'mips-package-nightly'
-            - 'mipsel-package-nightly'
-            - 'ppc64le-package-nightly'
-            - 'riscv64-package-nightly'
-            - 's390x-package-nightly'
-            - 'static-package-nightly'
-            - 'windows-package-nightly'
+            - 'i386-package'
+            - 'ppc64le-package'
+            - 's390x-package'
+            - 'armel-package'
+            - 'amd64-package'
+            - 'mipsel-package'
+            - 'mips-package'
+            - 'static-package'
+            - 'arm64-package'
+            - 'armhf-package'
+            - 'riscv64-package'
+            - 'package-sign-mac'
+            - 'package-sign-windows'
       - docker-nightly:
+          when:
+              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
           requires:
             - 'nightly'
       - amd64-package-test-nightly:
+          when:
+              equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
           requires:
             - 'amd64-package-nightly'
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only:
-                - master
+
+


### PR DESCRIPTION
**Scheduled workflows will be phased out by the end of 2022.**, this will effect how the nightly workflow gets triggered. The alternative is to define a trigger within the project settings that triggers nightly which I've setup:

You will need permissions to see this: https://app.circleci.com/settings/project/github/influxdata/telegraf/triggers

![image](https://user-images.githubusercontent.com/3441183/195145195-b923437b-f8a1-43d9-b72c-73706249ff18.png)

From the docs: `As a scheduled pipeline is essentially a triggered pipeline, it will run every workflow in the config.` while not obvious, it seems this means every workflow defined in the config will run unless you filter it not to. The most straightforward way to migrate our config (based on: https://github.com/influxdata/influxdb-client-python/pull/513) is to filter our nightly workflow to run when the `pipeline.trigger_source` variable is set to "scheduled_pipeline" (more info here: https://circleci.com/docs/configuration-reference/#using-pipeline-values) and don't run our main checks when it is set.

This would make it possible to delete the entire nightly section and move the `nightly` jobs to be conditionally run in the `check` workflow. You can only filter entire jobs by branch, to filter by variable the job will still need to run and then within the `steps` section you can filter using the logic statement `when`. Thinking its more important to migrate away from the deprecated trigger quickly, but could be a "nice to have" to clean up the duplication in this config.

