### PR TITLE
chore(inputs.powerdns): Don't run  flaky test on Windows

### DIFF
--- a/plugins/inputs/powerdns/powerdns_linux_test.go
+++ b/plugins/inputs/powerdns/powerdns_linux_test.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build !windows
 
 package powerdns
 

--- a/plugins/inputs/powerdns/powerdns_linux_test.go
+++ b/plugins/inputs/powerdns/powerdns_linux_test.go
@@ -1,0 +1,52 @@
+//go:build linux || darwin
+
+package powerdns
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPowerdnsGeneratesMetrics(t *testing.T) {
+	// We create a fake server to return test data
+	randomNumber := int64(5239846799706671610)
+	sockname := filepath.Join(os.TempDir(), fmt.Sprintf("pdns%d.controlsocket", randomNumber))
+	socket, err := net.Listen("unix", sockname)
+	if err != nil {
+		t.Fatal("Cannot initialize server on port ")
+	}
+
+	defer socket.Close()
+
+	s := statServer{}
+	go s.serverSocket(socket)
+
+	p := &Powerdns{
+		UnixSockets: []string{sockname},
+	}
+
+	var acc testutil.Accumulator
+	err = acc.GatherError(p.Gather)
+	require.NoError(t, err)
+
+	intMetrics := []string{"corrupt-packets", "deferred-cache-inserts",
+		"deferred-cache-lookup", "dnsupdate-answers", "dnsupdate-changes",
+		"dnsupdate-queries", "dnsupdate-refused", "packetcache-hit",
+		"packetcache-miss", "packetcache-size", "query-cache-hit", "query-cache-miss",
+		"rd-queries", "recursing-answers", "recursing-questions",
+		"recursion-unanswered", "security-status", "servfail-packets", "signatures",
+		"tcp-answers", "tcp-queries", "timedout-packets", "udp-answers",
+		"udp-answers-bytes", "udp-do-queries", "udp-queries", "udp4-answers",
+		"udp4-queries", "udp6-answers", "udp6-queries", "key-cache-size", "latency",
+		"meta-cache-size", "qsize-q", "signature-cache-size", "sys-msec", "uptime", "user-msec"}
+
+	for _, metric := range intMetrics {
+		require.True(t, acc.HasInt64Field("powerdns", metric), metric)
+	}
+}

--- a/plugins/inputs/powerdns/powerdns_test.go
+++ b/plugins/inputs/powerdns/powerdns_test.go
@@ -1,13 +1,8 @@
 package powerdns
 
 import (
-	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -70,44 +65,6 @@ func (s statServer) serverSocket(l net.Listener) {
 				c.Close()
 			}
 		}(conn)
-	}
-}
-
-func TestPowerdnsGeneratesMetrics(t *testing.T) {
-	// We create a fake server to return test data
-	randomNumber := int64(5239846799706671610)
-	sockname := filepath.Join(os.TempDir(), fmt.Sprintf("pdns%d.controlsocket", randomNumber))
-	socket, err := net.Listen("unix", sockname)
-	if err != nil {
-		t.Fatal("Cannot initialize server on port ")
-	}
-
-	defer socket.Close()
-
-	s := statServer{}
-	go s.serverSocket(socket)
-
-	p := &Powerdns{
-		UnixSockets: []string{sockname},
-	}
-
-	var acc testutil.Accumulator
-	err = acc.GatherError(p.Gather)
-	require.NoError(t, err)
-
-	intMetrics := []string{"corrupt-packets", "deferred-cache-inserts",
-		"deferred-cache-lookup", "dnsupdate-answers", "dnsupdate-changes",
-		"dnsupdate-queries", "dnsupdate-refused", "packetcache-hit",
-		"packetcache-miss", "packetcache-size", "query-cache-hit", "query-cache-miss",
-		"rd-queries", "recursing-answers", "recursing-questions",
-		"recursion-unanswered", "security-status", "servfail-packets", "signatures",
-		"tcp-answers", "tcp-queries", "timedout-packets", "udp-answers",
-		"udp-answers-bytes", "udp-do-queries", "udp-queries", "udp4-answers",
-		"udp4-queries", "udp6-answers", "udp6-queries", "key-cache-size", "latency",
-		"meta-cache-size", "qsize-q", "signature-cache-size", "sys-msec", "uptime", "user-msec"}
-
-	for _, metric := range intMetrics {
-		require.True(t, acc.HasInt64Field("powerdns", metric), metric)
 	}
 }
 


### PR DESCRIPTION
The test `TestPowerdnsGeneratesMetrics` has been failing randomly on Windows with `read unix @->C:\Users\CIRCLE~1.PAC\AppData\Local\Temp\pdns5239846799706671610.controlsocket: i/o timeout` 

recent example: https://app.circleci.com/pipelines/github/influxdata/telegraf/13161/workflows/570a6b15-97a1-46ed-bc5e-b5e20f32fc12/jobs/210212

Moving the test to only run on linux and darwin to avoid this, refactoring the test to also support Windows would be nice.