### PR TITLE
feat(inputs.modbus): add pause after connect config parameter

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -5907,6 +5907,8 @@
 #
 #   ## Enable workarounds required by some devices to work correctly
 #   # [inputs.modbus.workarounds]
+#     ## Pause after connect delays the first request by the specified time. This might be necessary for (slow) devices.
+#     # pause_after_connect = "0ms"
 #     ## Pause between read requests sent to the device. This might be necessary for (slow) serial devices.
 #     # pause_between_requests = "0ms"
 #     ## Close the connection after every gather cycle. Usually the plugin closes the connection after a certain

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -5727,6 +5727,8 @@
 #
 #   ## Enable workarounds required by some devices to work correctly
 #   # [inputs.modbus.workarounds]
+#     ## Pause after connect delays the first request by the specified time. This might be necessary for (slow) devices.
+#     # pause_after_connect = "0ms"
 #     ## Pause between read requests sent to the device. This might be necessary for (slow) serial devices.
 #     # pause_between_requests = "0ms"
 #     ## Close the connection after every gather cycle. Usually the plugin closes the connection after a certain

--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -213,7 +213,9 @@ those debug messages, Telegraf has to be started with debugging enabled
 (i.e. with the `--debug` option). Please be aware that connection tracing will
 produce a lot of messages and should __NOT__ be used in production environments.
 
-Please use `pause_after_connect` / `pause_between_requests` with care. Ensure the total gather time, including the pause(s), does not exceed the configured collection interval. Note that pauses add up if multiple requests are sent!
+Please use `pause_after_connect` / `pause_between_requests` with care. Ensure
+the total gather time, including the pause(s), does not exceed the configured
+collection interval. Note that pauses add up if multiple requests are sent!
 
 ## Configuration styles
 

--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -213,7 +213,7 @@ those debug messages, Telegraf has to be started with debugging enabled
 (i.e. with the `--debug` option). Please be aware that connection tracing will
 produce a lot of messages and should __NOT__ be used in production environments.
 
-Please use `pause_after_connect` / `pause_between_requests`with care. Ensure the total gather time, including the pause(s), does not exceed the configured collection interval. Note that pauses add up if multiple requests are sent!
+Please use `pause_after_connect` / `pause_between_requests` with care. Ensure the total gather time, including the pause(s), does not exceed the configured collection interval. Note that pauses add up if multiple requests are sent!
 
 ## Configuration styles
 

--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -196,6 +196,8 @@ Registers via Modbus TCP or Modbus RTU/ASCII.
 
   ## Enable workarounds required by some devices to work correctly
   # [inputs.modbus.workarounds]
+    ## Pause after connect delays the first request by the specified time. This might be necessary for (slow) devices.
+    # pause_after_connect = "0ms"
     ## Pause between read requests sent to the device. This might be necessary for (slow) serial devices.
     # pause_between_requests = "0ms"
     ## Close the connection after every gather cycle. Usually the plugin closes the connection after a certain
@@ -211,9 +213,7 @@ those debug messages, Telegraf has to be started with debugging enabled
 (i.e. with the `--debug` option). Please be aware that connection tracing will
 produce a lot of messages and should __NOT__ be used in production environments.
 
-Please use `pause_between_requests` with care. Ensure the total gather time,
-including the pause(s), does not exceed the configured collection interval. Note
-that pauses add up if multiple requests are sent!
+Please use `pause_after_connect` / `pause_between_requests`with care. Ensure the total gather time, including the pause(s), does not exceed the configured collection interval. Note that pauses add up if multiple requests are sent!
 
 ## Configuration styles
 

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -24,8 +24,9 @@ var sampleConfigStart string
 var sampleConfigEnd string
 
 type ModbusWorkarounds struct {
-	PollPause        config.Duration `toml:"pause_between_requests"`
-	CloseAfterGather bool            `toml:"close_connection_after_gather"`
+	AfterConnectPause config.Duration `toml:"pause_after_connect"`
+	PollPause         config.Duration `toml:"pause_between_requests"`
+	CloseAfterGather  bool            `toml:"close_connection_after_gather"`
 }
 
 // Modbus holds all data relevant to the plugin
@@ -265,6 +266,10 @@ func (m *Modbus) initClient() error {
 func (m *Modbus) connect() error {
 	err := m.handler.Connect()
 	m.isConnected = err == nil
+	if m.isConnected && m.Workarounds.AfterConnectPause != 0 {
+		nextRequest := time.Now().Add(time.Duration(m.Workarounds.AfterConnectPause))
+		time.Sleep(time.Until(nextRequest))
+	}
 	return err
 }
 

--- a/plugins/inputs/modbus/sample.conf
+++ b/plugins/inputs/modbus/sample.conf
@@ -188,6 +188,8 @@
 
   ## Enable workarounds required by some devices to work correctly
   # [inputs.modbus.workarounds]
+    ## Pause after connect delays the first request by the specified time. This might be necessary for (slow) devices.
+    # pause_after_connect = "0ms"
     ## Pause between read requests sent to the device. This might be necessary for (slow) serial devices.
     # pause_between_requests = "0ms"
     ## Close the connection after every gather cycle. Usually the plugin closes the connection after a certain

--- a/plugins/inputs/modbus/sample_general_end.conf
+++ b/plugins/inputs/modbus/sample_general_end.conf
@@ -1,5 +1,7 @@
   ## Enable workarounds required by some devices to work correctly
   # [inputs.modbus.workarounds]
+    ## Pause after connect delays the first request by the specified time. This might be necessary for (slow) devices.
+    # pause_after_connect = "0ms"
     ## Pause between read requests sent to the device. This might be necessary for (slow) serial devices.
     # pause_between_requests = "0ms"
     ## Close the connection after every gather cycle. Usually the plugin closes the connection after a certain


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves feature request #11919

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
Allows to add a pause (warm-up time) for the slave device after modbus connect. E.g. Huawei solar inverter ethernet dongles need this pause to response the first request.
