### PR TITLE
chore(inputs.cloud_pubsub_push): Don't run flaky test on Windows

### DIFF
--- a/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package cloud_pubsub_push
 
 import (

--- a/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build !windows
 
 package cloud_pubsub_push
 


### PR DESCRIPTION
recent example: https://app.circleci.com/pipelines/github/influxdata/telegraf/13122/workflows/af708f74-8b50-4440-9d01-b43eb1fa6ede/jobs/210110

`TestServeHTTP` is failing randomly on Windows, adding build tags to only run it on linux and darwin.