### PR TITLE
feat(outputs.event_hubs): Expose max message size batch option

### DIFF
--- a/plugins/outputs/event_hubs/README.md
+++ b/plugins/outputs/event_hubs/README.md
@@ -34,7 +34,7 @@ JSON is probably the easiest to integrate with downstream components.
   ## Set the maximum batch message size in bytes
   ## The allowable size depends on the Event Hub tier
   ## See: https://learn.microsoft.com/azure/event-hubs/event-hubs-quotas#basic-vs-standard-vs-premium-vs-dedicated-tiers
-  ## Setting this to 0 means using the default from the Azure Event Hubs Client library (1000000)
+  ## Setting this to 0 means using the default size from the Azure Event Hubs Client library (1000000 bytes)
   # max_message_size = 1000000
 
   ## Data format to output.

--- a/plugins/outputs/event_hubs/README.md
+++ b/plugins/outputs/event_hubs/README.md
@@ -32,8 +32,9 @@ JSON is probably the easiest to integrate with downstream components.
   # partition_key = ""
 
   ## Set the maximum batch message size in bytes
-  ## Allowable size depends on the Event Hub tier
+  ## The allowable size depends on the Event Hub tier
   ## See: https://learn.microsoft.com/azure/event-hubs/event-hubs-quotas#basic-vs-standard-vs-premium-vs-dedicated-tiers
+  ## Setting this to 0 means using the default from the Azure Event Hubs Client library (1000000)
   # max_message_size = 1000000
 
   ## Data format to output.

--- a/plugins/outputs/event_hubs/README.md
+++ b/plugins/outputs/event_hubs/README.md
@@ -31,6 +31,11 @@ JSON is probably the easiest to integrate with downstream components.
   ## and field, exist the tag is preferred.
   # partition_key = ""
 
+  ## Set the maximum batch message size in bytes
+  ## Allowable size depends on the Event Hub tier
+  ## See: https://learn.microsoft.com/azure/event-hubs/event-hubs-quotas#basic-vs-standard-vs-premium-vs-dedicated-tiers
+  # max_message_size = 1000000
+
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/event_hubs/event_hubs_test.go
+++ b/plugins/outputs/event_hubs/event_hubs_test.go
@@ -49,6 +49,7 @@ func TestInitAndWrite(t *testing.T) {
 		Hub:              mockHub,
 		ConnectionString: "mock",
 		Timeout:          config.Duration(time.Second * 5),
+		MaxMessageSize:   1000000,
 		serializer:       serializer,
 	}
 

--- a/plugins/outputs/event_hubs/sample.conf
+++ b/plugins/outputs/event_hubs/sample.conf
@@ -13,6 +13,11 @@
   ## and field, exist the tag is preferred.
   # partition_key = ""
 
+  ## Set the maximum batch message size in bytes
+  ## Allowable size depends on the Event Hub tier
+  ## See: https://learn.microsoft.com/azure/event-hubs/event-hubs-quotas#basic-vs-standard-vs-premium-vs-dedicated-tiers
+  # max_message_size = 1000000
+
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/event_hubs/sample.conf
+++ b/plugins/outputs/event_hubs/sample.conf
@@ -16,7 +16,7 @@
   ## Set the maximum batch message size in bytes
   ## The allowable size depends on the Event Hub tier
   ## See: https://learn.microsoft.com/azure/event-hubs/event-hubs-quotas#basic-vs-standard-vs-premium-vs-dedicated-tiers
-  ## Setting this to 0 means using the default from the Azure Event Hubs Client library (1000000)
+  ## Setting this to 0 means using the default size from the Azure Event Hubs Client library (1000000 bytes)
   # max_message_size = 1000000
 
   ## Data format to output.

--- a/plugins/outputs/event_hubs/sample.conf
+++ b/plugins/outputs/event_hubs/sample.conf
@@ -14,8 +14,9 @@
   # partition_key = ""
 
   ## Set the maximum batch message size in bytes
-  ## Allowable size depends on the Event Hub tier
+  ## The allowable size depends on the Event Hub tier
   ## See: https://learn.microsoft.com/azure/event-hubs/event-hubs-quotas#basic-vs-standard-vs-premium-vs-dedicated-tiers
+  ## Setting this to 0 means using the default from the Azure Event Hubs Client library (1000000)
   # max_message_size = 1000000
 
   ## Data format to output.


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #11990

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Made the existing batch option for max message size configurable using the Telegraf config. The default value of 1,000,000 is not suitable for all use cases. The basic event hub tier is 262144 bytes and the other tiers are 1048576 bytes.
