### PR TITLE
fix(inputs.syslog): print error when no error or message given

### DIFF
--- a/plugins/inputs/syslog/syslog.go
+++ b/plugins/inputs/syslog/syslog.go
@@ -209,6 +209,9 @@ func (s *Syslog) listenPacket(acc telegraf.Accumulator) {
 		if err != nil {
 			acc.AddError(err)
 		}
+		if err == nil && message == nil {
+			acc.AddError(fmt.Errorf("unable to parse message: %s", string(b[:n])))
+		}
 	}
 }
 


### PR DESCRIPTION
There are scenarios where the syslog libraries that telegraf uses no message or error is returned. In these cases, it is helpful to print a message saying that the message was received, but failed to parse.

fixes: #11989