### PR TITLE
chore: Fix installgo_mac.sh using correct hash

### DIFF
--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -12,10 +12,10 @@ GO_VERSION_SHA_amd64="16f8047d7b627699b3773680098fbaf7cc962b7db02b3e02726f78c4db
 
 if [ "$ARCH" = 'arm64' ]; then
     GO_ARCH="darwin-arm64"
-    GO_VERSION_SHA=GO_VERSION_SHA_arm64
+    GO_VERSION_SHA=${GO_VERSION_SHA_arm64}
 elif [ "$ARCH" = 'x86_64' ]; then
     GO_ARCH="darwin-amd64"
-    GO_VERSION_SHA=GO_VERSION_SHA_amd64
+    GO_VERSION_SHA=${GO_VERSION_SHA_amd64}
 fi
 
 # This path is cachable. (Saving in /usr/local/ would cause issues restoring the cache.)

--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -4,10 +4,7 @@ set -eux
 
 ARCH=$(uname -m)
 GO_VERSION="1.19.2"
-# To easily find and replace the hashes
-# shellcheck disable=SC2034
 GO_VERSION_SHA_arm64="35d819df25197c0be45f36ce849b994bba3b0559b76d4538b910d28f6395c00d" # from https://golang.org/dl
-# shellcheck disable=SC2034
 GO_VERSION_SHA_amd64="16f8047d7b627699b3773680098fbaf7cc962b7db02b3e02726f78c4db26dfde" # from https://golang.org/dl
 
 if [ "$ARCH" = 'arm64' ]; then


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/influxdata/telegraf/13218/workflows/4d7b46cf-c3cb-46d4-9da5-403a5b969f06/jobs/210992

The Mac installation script broke after I refactored it to help with automating the Go version updates: https://github.com/influxdata/telegraf/pull/11968

This fixes the mistake of not assigning the values of the variables, I assume it didn't break the tests originally because it was cached.