### PR TITLE
refactor: Prevent import from going the wrong way

### DIFF
--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -8,10 +8,10 @@ import (
 	"regexp"
 	"strings"
 
-	wavefront "github.com/wavefronthq/wavefront-sdk-go/senders"
-
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/outputs"
+	serializer "github.com/influxdata/telegraf/plugins/serializers/wavefront"
+	wavefront "github.com/wavefronthq/wavefront-sdk-go/senders"
 )
 
 //go:embed sample.conf
@@ -64,14 +64,6 @@ var sanitizedRegex = regexp.MustCompile(`[^a-zA-Z\d_.-]`)
 var tagValueReplacer = strings.NewReplacer("*", "-")
 
 var pathReplacer = strings.NewReplacer("_", "_")
-
-type MetricPoint struct {
-	Metric    string
-	Value     float64
-	Timestamp int64
-	Source    string
-	Tags      map[string]string
-}
 
 func (*Wavefront) SampleConfig() string {
 	return sampleConfig
@@ -153,8 +145,8 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 	return nil
 }
 
-func (w *Wavefront) buildMetrics(m telegraf.Metric) []*MetricPoint {
-	ret := make([]*MetricPoint, 0)
+func (w *Wavefront) buildMetrics(m telegraf.Metric) []*serializer.MetricPoint {
+	ret := make([]*serializer.MetricPoint, 0)
 
 	for fieldName, value := range m.Fields() {
 		var name string
@@ -176,7 +168,7 @@ func (w *Wavefront) buildMetrics(m telegraf.Metric) []*MetricPoint {
 			name = pathReplacer.Replace(name)
 		}
 
-		metric := &MetricPoint{
+		metric := &serializer.MetricPoint{
 			Metric:    name,
 			Timestamp: m.Time().Unix(),
 		}

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/outputs"
+	serializer "github.com/influxdata/telegraf/plugins/serializers/wavefront"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -45,25 +46,25 @@ func TestBuildMetrics(t *testing.T) {
 
 	var metricTests = []struct {
 		metric       telegraf.Metric
-		metricPoints []MetricPoint
+		metricPoints []serializer.MetricPoint
 	}{
 		{
 			testutil.TestMetric(float64(1), "testing_just*a%metric:float", "metric2"),
-			[]MetricPoint{
+			[]serializer.MetricPoint{
 				{Metric: w.Prefix + "testing.just-a-metric-float", Value: 1, Timestamp: timestamp, Tags: map[string]string{"tag1": "value1"}},
 				{Metric: w.Prefix + "testing.metric2", Value: 1, Timestamp: timestamp, Tags: map[string]string{"tag1": "value1"}},
 			},
 		},
 		{
 			testutil.TestMetric(float64(1), "testing_just/another,metric:float", "metric2"),
-			[]MetricPoint{
+			[]serializer.MetricPoint{
 				{Metric: w.Prefix + "testing.just-another-metric-float", Value: 1, Timestamp: timestamp, Tags: map[string]string{"tag1": "value1"}},
 				{Metric: w.Prefix + "testing.metric2", Value: 1, Timestamp: timestamp, Tags: map[string]string{"tag1": "value1"}},
 			},
 		},
 		{
 			testMetric1,
-			[]MetricPoint{{Metric: w.Prefix + "test.simple.metric", Value: 123, Timestamp: timestamp, Source: "testHost", Tags: map[string]string{"tag1": "value1"}}},
+			[]serializer.MetricPoint{{Metric: w.Prefix + "test.simple.metric", Value: 123, Timestamp: timestamp, Source: "testHost", Tags: map[string]string{"tag1": "value1"}}},
 		},
 	}
 
@@ -88,18 +89,18 @@ func TestBuildMetricsStrict(t *testing.T) {
 
 	var metricTests = []struct {
 		metric       telegraf.Metric
-		metricPoints []MetricPoint
+		metricPoints []serializer.MetricPoint
 	}{
 		{
 			testutil.TestMetric(float64(1), "testing_just*a%metric:float", "metric2"),
-			[]MetricPoint{
+			[]serializer.MetricPoint{
 				{Metric: w.Prefix + "testing.just-a-metric-float", Value: 1, Timestamp: timestamp, Tags: map[string]string{"tag1": "value1"}},
 				{Metric: w.Prefix + "testing.metric2", Value: 1, Timestamp: timestamp, Tags: map[string]string{"tag1": "value1"}},
 			},
 		},
 		{
 			testutil.TestMetric(float64(1), "testing_just/another,metric:float", "metric2"),
-			[]MetricPoint{
+			[]serializer.MetricPoint{
 				{Metric: w.Prefix + "testing.just/another,metric-float", Value: 1, Timestamp: timestamp, Tags: map[string]string{"tag/1": "value1", "tag,2": "value2"}},
 				{Metric: w.Prefix + "testing.metric2", Value: 1, Timestamp: timestamp, Tags: map[string]string{"tag/1": "value1", "tag,2": "value2"}},
 			},
@@ -132,15 +133,15 @@ func TestBuildMetricsWithSimpleFields(t *testing.T) {
 
 	var metricTests = []struct {
 		metric      telegraf.Metric
-		metricLines []MetricPoint
+		metricLines []serializer.MetricPoint
 	}{
 		{
 			testutil.TestMetric(float64(1), "testing_just*a%metric:float"),
-			[]MetricPoint{{Metric: w.Prefix + "testing.just-a-metric-float.value", Value: 1}},
+			[]serializer.MetricPoint{{Metric: w.Prefix + "testing.just-a-metric-float.value", Value: 1}},
 		},
 		{
 			testMetric1,
-			[]MetricPoint{{Metric: w.Prefix + "test.simple.metric.value", Value: 123}},
+			[]serializer.MetricPoint{{Metric: w.Prefix + "test.simple.metric.value", Value: 123}},
 		},
 	}
 

--- a/plugins/serializers/wavefront/wavefront_test.go
+++ b/plugins/serializers/wavefront/wavefront_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
-	"github.com/influxdata/telegraf/plugins/outputs/wavefront"
 )
 
 func TestBuildTags(t *testing.T) {
@@ -106,11 +105,11 @@ func TestBuildTagsHostTag(t *testing.T) {
 
 func TestFormatMetricPoint(t *testing.T) {
 	var pointTests = []struct {
-		ptIn *wavefront.MetricPoint
+		ptIn *MetricPoint
 		out  string
 	}{
 		{
-			&wavefront.MetricPoint{
+			&MetricPoint{
 				Metric:    "cpu.idle",
 				Value:     1,
 				Timestamp: 1554172967,
@@ -120,7 +119,7 @@ func TestFormatMetricPoint(t *testing.T) {
 			"\"cpu.idle\" 1.000000 1554172967 source=\"testHost\" \"aaa\"=\"bbb\"\n",
 		},
 		{
-			&wavefront.MetricPoint{
+			&MetricPoint{
 				Metric:    "cpu.idle",
 				Value:     1,
 				Timestamp: 1554172967,
@@ -144,11 +143,11 @@ func TestFormatMetricPoint(t *testing.T) {
 
 func TestUseStrict(t *testing.T) {
 	var pointTests = []struct {
-		ptIn *wavefront.MetricPoint
+		ptIn *MetricPoint
 		out  string
 	}{
 		{
-			&wavefront.MetricPoint{
+			&MetricPoint{
 				Metric:    "cpu.idle",
 				Value:     1,
 				Timestamp: 1554172967,


### PR DESCRIPTION
Signed-off-by: Devon Warshaw <warshawd@vmware.com>

# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [Won't fix] Updated associated README.md. -- I didn't, since this was a refactor, rather than a change.
- [Won't fix] Wrote appropriate unit tests. -- Fixed existing tests but did not write any new ones.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #12003

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed a potential dependency cycle by having Wavefront output plugin import the Wavefront serializer, rather than the other way around. 