### PR TITLE
Fix: Add support for opcua datetime values

### DIFF
--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -476,6 +476,14 @@ func (o *OpcUA) getData() error {
 			o.nodeData[i].Value = d.Value.Value()
 			o.nodeData[i].DataType = d.Value.Type()
 		}
+
+		if t, ok := d.Value.Value().(time.Time); ok {
+			if o.nodes[i].tag.IdentifierType == "s" {
+				o.nodeData[i].Value = t.String()
+				o.nodeData[i].DataType = ua.TypeIDString
+			}
+		}
+
 		o.nodeData[i].Quality = d.Status
 		o.nodeData[i].ServerTime = d.ServerTimestamp
 		o.nodeData[i].SourceTime = d.SourceTimestamp


### PR DESCRIPTION
Resolves #12006

This PR adds support for returning OPCUA DateTime values via the opc-ua input plugin. Prior to this PR, we silently drop those values.

## Details 
The `gopcua` library returns these values as the time.Time type, which telegraf doesn't handle in `metric.go:convertField`. To make the smallest change possible, we simply convert the datetime value to a string in the default golang format before returning the updated value.

## Example
Example telegraf.toml
```yaml
[inputs.opcua]
  # Authentication details redacted
  nodes = [
  {name="TimeEnded", namespace="4", identifier_type="s", identifier="TimeEnded"},
  ]
```

### Before: 
Notice the TimeEnded value has `Quality=OK` but the time value itself has failed to parse or be returned. This is because it falls into the `default` case in `metric.go:convertField`
```sh
❯ go run ./cmd/telegraf --config ~/telegraf-config-file.toml --test
...
2022-10-14T17:42:28Z D! [agent] Starting service inputs
> MACHINE123,host=HOST123,id=ns\=4;s\=TimeEnded Quality="OK (0x0)" 1665769360000000000
2022-10-14T17:42:40Z D! [agent] Stopping service inputs
2022-10-14T17:42:40Z D! [agent] Input channel closed
2022-10-14T17:42:40Z D! [agent] Stopped Successfully
```

### After:
We return the time as a string as intended
```sh
❯ go run ./cmd/telegraf --config ~/telegraf-config-file.toml --test
...
2022-10-14T17:46:49Z D! [agent] Starting service inputs
> MACHINE123,host=HOST123,id=ns\=4;s\=TimeEnded="2022-10-18 02:13:29.222 +0000 UTC",Quality="OK (0x0)" 1665769610000000000
2022-10-14T17:46:50Z D! [agent] Stopping service inputs
2022-10-14T17:46:50Z D! [agent] Input channel closed
2022-10-14T17:46:50Z D! [agent] Stopped Successfully
```