### PR TITLE
docs(aggregators.derivative): Remove incorrect comment

### DIFF
--- a/plugins/aggregators/derivative/README.md
+++ b/plugins/aggregators/derivative/README.md
@@ -15,9 +15,7 @@ aggregated metrics.
   # suffix = "_rate"
   ##
   ## Field to use for the quotient when computing the derivative.
-  ## When using a field as the derivation parameter the name of that field will
-  ## be used for the resulting derivative, e.g. *fieldname_by_parameter*.
-  ## By default the timestamps of the metrics are used and the suffix is omitted.
+  ## By default the timestamps of the metrics are used.
   # variable = ""
   ##
   ## Maximum number of roll-overs in case only one measurement is found during a period.


### PR DESCRIPTION
This comment states that *if* the variable option is used, the name of the resulting variable is generated differently. However, in practice the name of the resulting variable will always just use the (specified or default) suffix, regardless of whether the variable option is set.

It seems this behavior and this comment were both already present when the plugin was first introduced in PR #3762 (commit 927d34f) by @KarstenSchnitter, probably a remnant of changes during PR discussion.

# Required for all PRs
- [ ] ~~Updated associated README.md.~~ Not applicable
- [ ] ~~Wrote appropriate unit tests.~~ Not applicable
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)