### PR TITLE
feat(inputs.system): Allow merging metrics

### DIFF
--- a/plugins/inputs/system/README.md
+++ b/plugins/inputs/system/README.md
@@ -10,7 +10,9 @@ Number of CPUs is obtained from the /proc/cpuinfo file.
 ```toml @sample.conf
 # Read metrics about system load & uptime
 [[inputs.system]]
-  # no configuration
+  # Publishes all metrics at once, opposed to three separate metrics
+  # Enabling this will lose metric type support (used in outputs such as prometheus)
+  # merge_metrics = false
 ```
 
 ### Permissions

--- a/plugins/inputs/system/sample.conf
+++ b/plugins/inputs/system/sample.conf
@@ -1,3 +1,5 @@
 # Read metrics about system load & uptime
 [[inputs.system]]
-  # no configuration
+  # Publishes all metrics at once, opposed to three separate metrics
+  # Enabling this will lose metric type support (used in outputs such as prometheus)
+  # merge_metrics = false

--- a/plugins/inputs/system/system_test.go
+++ b/plugins/inputs/system/system_test.go
@@ -1,0 +1,48 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddFields(t *testing.T) {
+	tests := []struct {
+		MergeMetrics bool
+		expectedLen  int
+	}{
+		{
+			false,
+			3,
+		},
+		{
+			true,
+			1,
+		},
+	}
+
+	for _, test := range tests {
+		var testAcc testutil.Accumulator
+
+		loadFields := map[string]interface{}{
+			"load1":   3.72,
+			"load5":   2.4,
+			"load15":  2.1,
+			"n_cpus":  4,
+			"n_users": 3,
+		}
+		uptimeFields := map[string]interface{}{
+			"uptime": uint64(1249632),
+		}
+		uptimeFormatfields := map[string]interface{}{
+			"uptimeFormat": "14 days, 11:07",
+		}
+
+		var s SystemStats
+		s.MergeMetrics = test.MergeMetrics
+		s.addFields(&testAcc, loadFields, uptimeFields, uptimeFormatfields)
+
+		require.Equal(t, test.expectedLen, len(testAcc.GetTelegrafMetrics()))
+	}
+}


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolve: https://github.com/influxdata/telegraf/issues/7772

The system input plugin returns three separate metrics, #7772 requested to be able to return a single metric instead. I think it is using three separate metrics so it can support "metric types" (used by output plugins like Prometheus). I added a boolean configuration `merge_metrics` to optionally create a single metric instead without types. I realize boolean configs aren't usually recommended, but I can't think of a better alternative. Suggestions welcome.

original behavior:

```toml
[[inputs.system]]
```

expected output:

```shell
> system,host=thinkpad load1=8.27,load15=8.41,load5=12.66,n_cpus=8i,n_users=1i 1666109492000000000
> system,host=thinkpad uptime=5044i 1666109492000000000
> system,host=thinkpad uptime_format=" 1:24" 1666109492000000000
```

enabling new configuration:

```toml
[[inputs.system]]
    merge_metrics = true
```

expected output:

```shell
> system,host=thinkpad load1=9.87,load15=8.51,load5=13.17,n_cpus=8i,n_users=1i,uptime=5028i,uptime_format=" 1:23" 1666109475000000000
```
