### PR TITLE
fix: mongodb input incorrect type int64 for ServerStatus

### DIFF
--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -324,12 +324,12 @@ type DurTiming struct {
 
 // DurStats stores information related to journaling statistics.
 type DurStats struct {
-	Commits            int64 `bson:"commits"`
-	JournaledMB        int64 `bson:"journaledMB"`
-	WriteToDataFilesMB int64 `bson:"writeToDataFilesMB"`
-	Compression        int64 `bson:"compression"`
-	CommitsInWriteLock int64 `bson:"commitsInWriteLock"`
-	EarlyCommits       int64 `bson:"earlyCommits"`
+	Commits            float64 `bson:"commits"`
+	JournaledMB        float64 `bson:"journaledMB"`
+	WriteToDataFilesMB float64 `bson:"writeToDataFilesMB"`
+	Compression        float64 `bson:"compression"`
+	CommitsInWriteLock float64 `bson:"commitsInWriteLock"`
+	EarlyCommits       float64 `bson:"earlyCommits"`
 	TimeMs             DurTiming
 }
 


### PR DESCRIPTION
<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #12047

`db.runCommand("serverStatus")` on mongo 2.6 returns a float or an int depending on the value for several fields. If the value is a whole number then the result is a whole number. This always uses a float64 to prevent serialization issues.