### PR TITLE
Revert "feat: run govulncheck nightly on master branch (#11977)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,16 +402,6 @@ jobs:
               --include "*.rpm" \
               --include "*.zip" \
               --acl public-read
-  govulncheck:
-    executor: telegraf-ci
-    steps:
-      - checkout
-      - run:
-          name: Install latest govulncheck
-          command: go install golang.org/x/vuln/cmd/govulncheck@latest
-      - run:
-          name: Scan master with govulncheck
-          command: govulncheck ./...
   docker-nightly:
     machine:
       image: ubuntu-2004:current
@@ -853,6 +843,3 @@ workflows:
       - amd64-package-test-nightly:
           requires:
             - 'amd64-package-nightly'
-      - govulncheck:
-          requires:
-            - 'nightly'


### PR DESCRIPTION
This reverts commit bf1353c09041497b8012f2342898422f12031860.

From CircleCI, it appears running this there gets killed. Revert till we can look into this more and see some upstream performance issues, get fixed/merged:

```
govulncheck is an experimental tool. Share feedback at https://go.dev/s/govulncheck-feedback.

Scanning for dependencies with known vulnerabilities...

Received "killed" signal
```