### PR TITLE
test: add additional checks, waits in integration tests

### DIFF
--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -26,7 +26,7 @@ func TestMysqlDefaultsToLocalIntegration(t *testing.T) {
 		},
 		ExposedPorts: []string{servicePort},
 		WaitingFor: wait.ForAll(
-			wait.ForLog("/usr/sbin/mysqld: ready for connections"),
+			wait.ForLog("/usr/sbin/mysqld: ready for connections").WithOccurrence(2),
 			wait.ForListeningPort(nat.Port(servicePort)),
 		),
 	}
@@ -63,7 +63,7 @@ func TestMysqlMultipleInstancesIntegration(t *testing.T) {
 		},
 		ExposedPorts: []string{servicePort},
 		WaitingFor: wait.ForAll(
-			wait.ForLog("/usr/sbin/mysqld: ready for connections"),
+			wait.ForLog("/usr/sbin/mysqld: ready for connections").WithOccurrence(2),
 			wait.ForListeningPort(nat.Port(servicePort)),
 		),
 	}

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -352,7 +352,7 @@ func TestClickHouseIntegration(t *testing.T) {
 		WaitingFor: wait.ForAll(
 			wait.NewHTTPStrategy("/").WithPort(nat.Port("8123")),
 			wait.ForListeningPort(nat.Port(servicePort)),
-			wait.ForLog("Saved preprocessed configuration to '/var/lib/clickhouse/preprocessed_configs/users.xml'"),
+			wait.ForLog("Saved preprocessed configuration to '/var/lib/clickhouse/preprocessed_configs/users.xml'").WithOccurrence(2),
 		),
 	}
 	err = container.Start()


### PR DESCRIPTION
* inputs.mysql: wait for 2nd occurrence of connection messages due to the container reloading after setup
* outputs.sql: postgres: wait for 2nd occurrence of connection messages due to the container reloading after setup
* outputs.sql: clickhouse: wait for last metric to get written and available 