### PR TITLE
fix(inputs.cisco_telemetry_mdt): add operation-metric/class-policy prefix

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -405,6 +405,14 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 
 		// Parse values
 		for _, subfield := range content.Fields {
+			prefix := ""
+			if subfield.Name == "operation-metric" {
+				prefix = subfield.Fields[0].Fields[0].GetStringValue()
+			}
+			if subfield.Name == "class-stats" {
+				prefix = subfield.Fields[0].Fields[1].GetStringValue()
+			}
+
 			c.parseContentField(grouper, subfield, "", msg.EncodingPath, tags, timestamp)
 		}
 	}


### PR DESCRIPTION


# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #
#8261
<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->


adds class policy and operation-metric as prefix to the metrics so the metrics don't get overwritten in cases where are multiple class types and metric types