### PR TITLE
fix(inputs.conntrack): Skip gather tests if conntrack module not loaded

### DIFF
--- a/plugins/inputs/conntrack/conntrack_test.go
+++ b/plugins/inputs/conntrack/conntrack_test.go
@@ -128,6 +128,9 @@ func TestCollectStats(t *testing.T) {
 	cs.Collect = []string{"all"}
 
 	err := cs.Gather(&acc)
+	if err != nil && strings.Contains(err.Error(), "Is the conntrack kernel module loaded?") {
+		t.Skip("Conntrack kernel module not loaded.")
+	}
 	require.NoError(t, err)
 
 	expectedTags := map[string]string{
@@ -214,6 +217,9 @@ func TestCollectStatsPerCpu(t *testing.T) {
 	cs.Collect = []string{"all", "percpu"}
 
 	err := cs.Gather(&acc)
+	if err != nil && strings.Contains(err.Error(), "Is the conntrack kernel module loaded?") {
+		t.Skip("Conntrack kernel module not loaded.")
+	}
 	require.NoError(t, err)
 
 	//cpu0


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR skips the `inputs.conntrack` tests for machines where the conntrack kernel module is not loaded. In those cases tests currently fail with

```shell
plugins/inputs/conntrack# go test -v -race
=== RUN   TestNoFilesFound
--- PASS: TestNoFilesFound (0.00s)
=== RUN   TestDefaultsUsed
--- PASS: TestDefaultsUsed (0.00s)
=== RUN   TestConfigsUsed
--- PASS: TestConfigsUsed (0.00s)
=== RUN   TestCollectStats
    conntrack_test.go:131: 
                Error Trace:    /home/sven/Development/InfluxData/telegraf/plugins/inputs/conntrack/conntrack_test.go:131
                Error:          Received unexpected error:
                                Conntrack input failed to collect metrics. Is the conntrack kernel module loaded?
                Test:           TestCollectStats
    panic.go:540: PASS: NetConntrack(bool)
--- FAIL: TestCollectStats (0.00s)
=== RUN   TestCollectStatsPerCpu
    conntrack_test.go:217: 
                Error Trace:    /home/sven/Development/InfluxData/telegraf/plugins/inputs/conntrack/conntrack_test.go:217
                Error:          Received unexpected error:
                                Conntrack input failed to collect metrics. Is the conntrack kernel module loaded?
                Test:           TestCollectStatsPerCpu
    panic.go:540: PASS: NetConntrack(bool)
--- FAIL: TestCollectStatsPerCpu (0.00s)
FAIL
exit status 1
FAIL    github.com/influxdata/telegraf/plugins/inputs/conntrack 0.017sl
```