### PR TITLE
fix: switch to sarama's new consumer group rebalance strategy setting

### DIFF
--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -112,11 +112,11 @@ func (k *KafkaConsumer) Init() error {
 
 	switch strings.ToLower(k.BalanceStrategy) {
 	case "range", "":
-		cfg.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
+		cfg.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.BalanceStrategyRange}
 	case "roundrobin":
-		cfg.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
+		cfg.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.BalanceStrategyRoundRobin}
 	case "sticky":
-		cfg.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategySticky
+		cfg.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.BalanceStrategySticky}
 	default:
 		return fmt.Errorf("invalid balance strategy %q", k.BalanceStrategy)
 	}


### PR DESCRIPTION
Sarama recently changed the consumer group rebalance strategy setting. I think telegraf updated to a version that uses the new setting in #11980. This PR uses telegraf's existing setting with the new sarama setting.

The old setting is deprecated but it is backward compatible
See https://github.com/Shopify/sarama/pull/2352

Although it's backward compatible, sarama logs that a deprecated setting is used, so it is useful to switch to the new setting.

The new setting allows consumers to choose more than one strategy. We may need to add a similar setting to telegraf in the future so users of inputs.kafka can choose which strategies they want instead of being limited to one.
