### PR TITLE
feat(secretstores): Add support for more plugins

### DIFF
--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -1115,8 +1115,8 @@ func TestBasicAuth(t *testing.T) {
 		Body:            "{ 'test': 'data'}",
 		Method:          "GET",
 		ResponseTimeout: config.Duration(time.Second * 20),
-		Username:        "me",
-		Password:        "mypassword",
+		Username:        config.NewSecret([]byte("me")),
+		Password:        config.NewSecret([]byte("mypassword")),
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 		},

--- a/plugins/inputs/pgbouncer/pgbouncer_test.go
+++ b/plugins/inputs/pgbouncer/pgbouncer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs/postgresql"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -48,13 +49,15 @@ func TestPgBouncerGeneratesMetricsIntegration(t *testing.T) {
 	require.NoError(t, err, "failed to start container")
 	defer container.Terminate()
 
+	addr := fmt.Sprintf(
+		"host=%s user=pgbouncer password=pgbouncer dbname=pgbouncer port=%s sslmode=disable",
+		container.Address,
+		container.Ports[pgBouncerServicePort],
+	)
+
 	p := &PgBouncer{
 		Service: postgresql.Service{
-			Address: fmt.Sprintf(
-				"host=%s user=pgbouncer password=pgbouncer dbname=pgbouncer port=%s sslmode=disable",
-				container.Address,
-				container.Ports[pgBouncerServicePort],
-			),
+			Address:     config.NewSecret([]byte(addr)),
 			IsPgBouncer: true,
 		},
 	}

--- a/plugins/inputs/postgresql/README.md
+++ b/plugins/inputs/postgresql/README.md
@@ -144,62 +144,6 @@ More information about the meaning of these metrics can be found in the
 [1]: http://www.postgresql.org/docs/9.2/static/monitoring-stats.html#PG-STAT-DATABASE-VIEW
 
 ## Example Output
-## Global configuration options <!-- @/docs/includes/plugin_config.md -->
-
-In addition to the plugin-specific configuration settings, plugins support
-additional global and plugin configuration settings. These settings are used to
-modify metrics, tags, and field or create aliases and configure ordering, etc.
-See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
-
-[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md
-
-## Configuration
-
-```toml @sample.conf
-# Read metrics from one or many postgresql servers
-[[inputs.postgresql]]
-  ## specify address via a url matching:
-  ##   postgres://[pqgotest[:password]]@localhost[/dbname]?sslmode=[disable|verify-ca|verify-full]&statement_timeout=...
-  ## or a simple string:
-  ##   host=localhost user=pqgotest password=... sslmode=... dbname=app_production
-  ##
-  ## All connection parameters are optional.
-  ##
-  ## Without the dbname parameter, the driver will default to a database
-  ## with the same name as the user. This dbname is just for instantiating a
-  ## connection with the server and doesn't restrict the databases we are trying
-  ## to grab metrics for.
-  ##
-  address = "host=localhost user=postgres sslmode=disable"
-
-  ## A custom name for the database that will be used as the "server" tag in the
-  ## measurement output. If not specified, a default one generated from
-  ## the connection address is used.
-  # outputaddress = "db01"
-
-  ## connection configuration.
-  ## maxlifetime - specify the maximum lifetime of a connection.
-  ## default is forever (0s)
-  ##
-  ## Note that this does not interrupt queries, the lifetime will not be enforced
-  ## whilst a query is running
-  # max_lifetime = "0s"
-
-  ## A  list of databases to explicitly ignore.  If not specified, metrics for all
-  ## databases are gathered.  Do NOT use with the 'databases' option.
-  # ignored_databases = ["postgres", "template0", "template1"]
-
-  ## A list of databases to pull metrics about. If not specified, metrics for all
-  ## databases are gathered.  Do NOT use with the 'ignored_databases' option.
-  # databases = ["app_production", "testing"]
-
-  ## Whether to use prepared statements when connecting to the database.
-  ## This should be set to false when connecting through a PgBouncer instance
-  ## with pool_mode set to transaction.
-  prepared_statements = true
-```
-
-Specify address via a postgresql connection string:
 
 ```text
 postgresql,db=postgres_global,server=dbname\=postgres\ host\=localhost\ port\=5432\ statement_timeout\=10000\ user\=postgres tup_fetched=1271i,tup_updated=5i,session_time=1451414320768.855,xact_rollback=2i,conflicts=0i,blk_write_time=0,temp_bytes=0i,datid=0i,sessions_fatal=0i,tup_returned=1339i,sessions_abandoned=0i,blk_read_time=0,blks_read=88i,idle_in_transaction_time=0,sessions=0i,active_time=0,tup_inserted=24i,tup_deleted=0i,temp_files=0i,numbackends=0i,xact_commit=4i,sessions_killed=0i,blks_hit=5616i,deadlocks=0i 1672399790000000000

--- a/plugins/inputs/postgresql/README.md
+++ b/plugins/inputs/postgresql/README.md
@@ -143,6 +143,59 @@ More information about the meaning of these metrics can be found in the
 [1]: http://www.postgresql.org/docs/9.2/static/monitoring-stats.html#PG-STAT-DATABASE-VIEW
 
 ## Example Output
+## Global configuration options <!-- @/docs/includes/plugin_config.md -->
+
+In addition to the plugin-specific configuration settings, plugins support
+additional global and plugin configuration settings. These settings are used to
+modify metrics, tags, and field or create aliases and configure ordering, etc.
+See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
+
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md
+
+## Configuration
+
+```toml @sample.conf
+# Read metrics from one or many postgresql servers
+[[inputs.postgresql]]
+  ## specify address via a url matching:
+  ##   postgres://[pqgotest[:password]]@localhost[/dbname]?sslmode=[disable|verify-ca|verify-full]
+  ## or a simple string:
+  ##   host=localhost user=pqgotest password=... sslmode=... dbname=app_production
+  ##
+  ## All connection parameters are optional.
+  ##
+  ## Without the dbname parameter, the driver will default to a database
+  ## with the same name as the user. This dbname is just for instantiating a
+  ## connection with the server and doesn't restrict the databases we are trying
+  ## to grab metrics for.
+  ##
+  address = "host=localhost user=postgres sslmode=disable"
+
+  ## A custom name for the database that will be used as the "server" tag in the
+  ## measurement output. If not specified, a default one generated from
+  ## the connection address is used.
+  # outputaddress = "db01"
+
+  ## connection configuration.
+  ## maxlifetime - specify the maximum lifetime of a connection.
+  ## default is forever (0s)
+  # max_lifetime = "0s"
+
+  ## A  list of databases to explicitly ignore.  If not specified, metrics for all
+  ## databases are gathered.  Do NOT use with the 'databases' option.
+  # ignored_databases = ["postgres", "template0", "template1"]
+
+  ## A list of databases to pull metrics about. If not specified, metrics for all
+  ## databases are gathered.  Do NOT use with the 'ignored_databases' option.
+  # databases = ["app_production", "testing"]
+
+  ## Whether to use prepared statements when connecting to the database.
+  ## This should be set to false when connecting through a PgBouncer instance
+  ## with pool_mode set to transaction.
+  prepared_statements = true
+```
+
+Specify address via a postgresql connection string:
 
 ```text
 postgresql,db=postgres_global,server=dbname\=postgres\ host\=localhost\ port\=5432\ statement_timeout\=10000\ user\=postgres tup_fetched=1271i,tup_updated=5i,session_time=1451414320768.855,xact_rollback=2i,conflicts=0i,blk_write_time=0,temp_bytes=0i,datid=0i,sessions_fatal=0i,tup_returned=1339i,sessions_abandoned=0i,blk_read_time=0,blks_read=88i,idle_in_transaction_time=0,sessions=0i,active_time=0,tup_inserted=24i,tup_deleted=0i,temp_files=0i,numbackends=0i,xact_commit=4i,sessions_killed=0i,blks_hit=5616i,deadlocks=0i 1672399790000000000

--- a/plugins/inputs/postgresql/README.md
+++ b/plugins/inputs/postgresql/README.md
@@ -31,6 +31,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## to grab metrics for.
   ##
   address = "host=localhost user=postgres sslmode=disable"
+
   ## A custom name for the database that will be used as the "server" tag in the
   ## measurement output. If not specified, a default one generated from
   ## the connection address is used.
@@ -158,7 +159,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Read metrics from one or many postgresql servers
 [[inputs.postgresql]]
   ## specify address via a url matching:
-  ##   postgres://[pqgotest[:password]]@localhost[/dbname]?sslmode=[disable|verify-ca|verify-full]
+  ##   postgres://[pqgotest[:password]]@localhost[/dbname]?sslmode=[disable|verify-ca|verify-full]&statement_timeout=...
   ## or a simple string:
   ##   host=localhost user=pqgotest password=... sslmode=... dbname=app_production
   ##
@@ -179,6 +180,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## connection configuration.
   ## maxlifetime - specify the maximum lifetime of a connection.
   ## default is forever (0s)
+  ##
+  ## Note that this does not interrupt queries, the lifetime will not be enforced
+  ## whilst a query is running
   # max_lifetime = "0s"
 
   ## A  list of databases to explicitly ignore.  If not specified, metrics for all

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -42,13 +43,15 @@ func TestPostgresqlGeneratesMetricsIntegration(t *testing.T) {
 	container := launchTestContainer(t)
 	defer container.Terminate()
 
+	addr := fmt.Sprintf(
+		"host=%s port=%s user=postgres sslmode=disable",
+		container.Address,
+		container.Ports[servicePort],
+	)
+
 	p := &Postgresql{
 		Service: Service{
-			Address: fmt.Sprintf(
-				"host=%s port=%s user=postgres sslmode=disable",
-				container.Address,
-				container.Ports[servicePort],
-			),
+			Address:     config.NewSecret([]byte(addr)),
 			IsPgBouncer: false,
 		},
 		Databases: []string{"postgres"},
@@ -131,13 +134,15 @@ func TestPostgresqlTagsMetricsWithDatabaseNameIntegration(t *testing.T) {
 	container := launchTestContainer(t)
 	defer container.Terminate()
 
+	addr := fmt.Sprintf(
+		"host=%s port=%s user=postgres sslmode=disable",
+		container.Address,
+		container.Ports[servicePort],
+	)
+
 	p := &Postgresql{
 		Service: Service{
-			Address: fmt.Sprintf(
-				"host=%s port=%s user=postgres sslmode=disable",
-				container.Address,
-				container.Ports[servicePort],
-			),
+			Address: config.NewSecret([]byte(addr)),
 		},
 		Databases: []string{"postgres"},
 	}
@@ -161,13 +166,15 @@ func TestPostgresqlDefaultsToAllDatabasesIntegration(t *testing.T) {
 	container := launchTestContainer(t)
 	defer container.Terminate()
 
+	addr := fmt.Sprintf(
+		"host=%s port=%s user=postgres sslmode=disable",
+		container.Address,
+		container.Ports[servicePort],
+	)
+
 	p := &Postgresql{
 		Service: Service{
-			Address: fmt.Sprintf(
-				"host=%s port=%s user=postgres sslmode=disable",
-				container.Address,
-				container.Ports[servicePort],
-			),
+			Address: config.NewSecret([]byte(addr)),
 		},
 	}
 
@@ -198,13 +205,15 @@ func TestPostgresqlIgnoresUnwantedColumnsIntegration(t *testing.T) {
 	container := launchTestContainer(t)
 	defer container.Terminate()
 
+	addr := fmt.Sprintf(
+		"host=%s port=%s user=postgres sslmode=disable",
+		container.Address,
+		container.Ports[servicePort],
+	)
+
 	p := &Postgresql{
 		Service: Service{
-			Address: fmt.Sprintf(
-				"host=%s port=%s user=postgres sslmode=disable",
-				container.Address,
-				container.Ports[servicePort],
-			),
+			Address: config.NewSecret([]byte(addr)),
 		},
 	}
 
@@ -225,13 +234,15 @@ func TestPostgresqlDatabaseWhitelistTestIntegration(t *testing.T) {
 	container := launchTestContainer(t)
 	defer container.Terminate()
 
+	addr := fmt.Sprintf(
+		"host=%s port=%s user=postgres sslmode=disable",
+		container.Address,
+		container.Ports[servicePort],
+	)
+
 	p := &Postgresql{
 		Service: Service{
-			Address: fmt.Sprintf(
-				"host=%s port=%s user=postgres sslmode=disable",
-				container.Address,
-				container.Ports[servicePort],
-			),
+			Address: config.NewSecret([]byte(addr)),
 		},
 		Databases: []string{"template0"},
 	}
@@ -269,13 +280,15 @@ func TestPostgresqlDatabaseBlacklistTestIntegration(t *testing.T) {
 	container := launchTestContainer(t)
 	defer container.Terminate()
 
+	addr := fmt.Sprintf(
+		"host=%s port=%s user=postgres sslmode=disable",
+		container.Address,
+		container.Ports[servicePort],
+	)
+
 	p := &Postgresql{
 		Service: Service{
-			Address: fmt.Sprintf(
-				"host=%s port=%s user=postgres sslmode=disable",
-				container.Address,
-				container.Ports[servicePort],
-			),
+			Address: config.NewSecret([]byte(addr)),
 		},
 		IgnoredDatabases: []string{"template0"},
 	}

--- a/plugins/inputs/postgresql/sample.conf
+++ b/plugins/inputs/postgresql/sample.conf
@@ -13,6 +13,7 @@
   ## to grab metrics for.
   ##
   address = "host=localhost user=postgres sslmode=disable"
+
   ## A custom name for the database that will be used as the "server" tag in the
   ## measurement output. If not specified, a default one generated from
   ## the connection address is used.

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs/postgresql"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -32,14 +33,16 @@ func queryRunner(t *testing.T, q query) *testutil.Accumulator {
 	require.NoError(t, err, "failed to start container")
 	defer container.Terminate()
 
+	addr := fmt.Sprintf(
+		"host=%s port=%s user=postgres sslmode=disable",
+		container.Address,
+		container.Ports[servicePort],
+	)
+
 	p := &Postgresql{
 		Log: testutil.Logger{},
 		Service: postgresql.Service{
-			Address: fmt.Sprintf(
-				"host=%s port=%s user=postgres sslmode=disable",
-				container.Address,
-				container.Ports[servicePort],
-			),
+			Address:     config.NewSecret([]byte(addr)),
 			IsPgBouncer: false,
 		},
 		Databases: []string{"postgres"},
@@ -239,13 +242,16 @@ func TestPostgresqlSqlScript(t *testing.T) {
 		Withdbname: false,
 		Tagvalue:   "",
 	}}
+
+	addr := fmt.Sprintf(
+		"host=%s user=postgres sslmode=disable",
+		testutil.GetLocalHost(),
+	)
+
 	p := &Postgresql{
 		Log: testutil.Logger{},
 		Service: postgresql.Service{
-			Address: fmt.Sprintf(
-				"host=%s user=postgres sslmode=disable",
-				testutil.GetLocalHost(),
-			),
+			Address:     config.NewSecret([]byte(addr)),
 			IsPgBouncer: false,
 		},
 		Databases: []string{"postgres"},
@@ -263,13 +269,15 @@ func TestPostgresqlIgnoresUnwantedColumnsIntegration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	addr := fmt.Sprintf(
+		"host=%s user=postgres sslmode=disable",
+		testutil.GetLocalHost(),
+	)
+
 	p := &Postgresql{
 		Log: testutil.Logger{},
 		Service: postgresql.Service{
-			Address: fmt.Sprintf(
-				"host=%s user=postgres sslmode=disable",
-				testutil.GetLocalHost(),
-			),
+			Address: config.NewSecret([]byte(addr)),
 		},
 	}
 

--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -109,5 +109,7 @@ snmp_trap,mib=SNMPv2-MIB,name=coldStart,oid=.1.3.6.1.6.3.1.1.5.1,source=192.168.
 snmp_trap,mib=NET-SNMP-AGENT-MIB,name=nsNotifyShutdown,oid=.1.3.6.1.4.1.8072.4.0.2,source=192.168.122.102,version=2c,community=public sysUpTimeInstance=5803i,snmpTrapEnterprise.0="netSnmpNotificationPrefix" 1574109186555115459
 ```
 
-[net-snmp]: http://www.net-snmp.org/
-[man snmpcmd]: http://net-snmp.sourceforge.net/docs/man/snmpcmd.html#lbAK
+## References
+
+- [net-snmp project home](http://www.net-snmp.org)
+- [`snmpcmd` man-page](http://net-snmp.sourceforge.net/docs/man/snmpcmd.html)

--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal/snmp"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -1274,12 +1275,12 @@ func TestReceiveTrap(t *testing.T) {
 				//if cold start be answer otherwise err
 				Log:          testutil.Logger{},
 				Version:      tt.version.String(),
-				SecName:      tt.secName,
+				SecName:      config.NewSecret([]byte(tt.secName)),
 				SecLevel:     tt.secLevel,
 				AuthProtocol: tt.authProto,
-				AuthPassword: tt.authPass,
+				AuthPassword: config.NewSecret([]byte(tt.authPass)),
 				PrivProtocol: tt.privProto,
-				PrivPassword: tt.privPass,
+				PrivPassword: config.NewSecret([]byte(tt.privPass)),
 				Translator:   "netsnmp",
 			}
 

--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -146,7 +146,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## "database_type" enables a specific set of queries depending on the database type. If specified, it replaces azuredb = true/false and query_version = 2
   ## In the config file, the sql server plugin section should be repeated each with a set of servers for a specific database_type.
   ## Possible values for database_type are - "SQLServer" or "AzureSQLDB" or "AzureSQLManagedInstance" or "AzureSQLPool"
-
   database_type = "SQLServer"
 
   ## A list of queries to include. If not specified, all the below listed queries are used.

--- a/plugins/inputs/sqlserver/azuresqldbqueries_test.go
+++ b/plugins/inputs/sqlserver/azuresqldbqueries_test.go
@@ -4,8 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestAzureSQLIntegration_Database_ResourceStats_Query(t *testing.T) {
@@ -18,9 +20,10 @@ func TestAzureSQLIntegration_Database_ResourceStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLDBResourceStats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -63,9 +66,10 @@ func TestAzureSQLIntegration_Database_ResourceGovernance_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLDBResourceGovernance"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -124,9 +128,10 @@ func TestAzureSQLIntegration_Database_WaitStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLDBWaitStats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -161,9 +166,10 @@ func TestAzureSQLIntegration_Database_DatabaseIO_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLDBDatabaseIO"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -207,9 +213,10 @@ func TestAzureSQLIntegration_Database_ServerProperties_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLDBServerProperties"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -248,9 +255,10 @@ func TestAzureSQLIntegration_Database_OsWaitstats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLDBOsWaitstats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -286,9 +294,10 @@ func TestAzureSQLIntegration_Database_MemoryClerks_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLDBMemoryClerks"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -319,9 +328,10 @@ func TestAzureSQLIntegration_Database_PerformanceCounters_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLDBPerformanceCounters"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -355,9 +365,10 @@ func TestAzureSQLIntegration_Database_Requests_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLDBRequests"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -413,9 +424,10 @@ func TestAzureSQLIntegration_Database_Schedulers_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLDBSchedulers"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",

--- a/plugins/inputs/sqlserver/azuresqlmanagedqueries_test.go
+++ b/plugins/inputs/sqlserver/azuresqlmanagedqueries_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -18,9 +19,10 @@ func TestAzureSQLIntegration_Managed_ResourceStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLMIResourceStats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -51,9 +53,10 @@ func TestAzureSQLIntegration_Managed_ResourceGovernance_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLMIResourceGovernance"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -92,9 +95,10 @@ func TestAzureSQLIntegration_Managed_DatabaseIO_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLMIDatabaseIO"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -134,9 +138,10 @@ func TestAzureSQLIntegration_Managed_ServerProperties_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLMIServerProperties"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -181,9 +186,10 @@ func TestAzureSQLIntegration_Managed_OsWaitStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLMIOsWaitstats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -218,9 +224,10 @@ func TestAzureSQLIntegration_Managed_MemoryClerks_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLMIMemoryClerks"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -250,9 +257,10 @@ func TestAzureSQLIntegration_Managed_PerformanceCounters_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLMIPerformanceCounters"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -285,9 +293,10 @@ func TestAzureSQLIntegration_Managed_Requests_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLMIRequests"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -343,9 +352,10 @@ func TestAzureSQLIntegration_Managed_Schedulers_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLMISchedulers"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",

--- a/plugins/inputs/sqlserver/azuresqlpoolqueries_test.go
+++ b/plugins/inputs/sqlserver/azuresqlpoolqueries_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -18,9 +19,10 @@ func TestAzureSQLIntegration_ElasticPool_ResourceStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLPoolResourceStats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -60,9 +62,10 @@ func TestAzureSQLIntegration_ElasticPool_ResourceGovernance_Query(t *testing.T) 
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLPoolResourceGovernance"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -123,9 +126,10 @@ func TestAzureSQLIntegration_ElasticPool_DatabaseIO_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLPoolDatabaseIO"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -167,9 +171,10 @@ func TestAzureSQLIntegration_ElasticPool_OsWaitStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLPoolOsWaitStats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -204,9 +209,10 @@ func TestAzureSQLIntegration_ElasticPool_MemoryClerks_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLPoolMemoryClerks"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -236,9 +242,10 @@ func TestAzureSQLIntegration_ElasticPool_PerformanceCounters_Query(t *testing.T)
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLPoolPerformanceCounters"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -270,9 +277,10 @@ func TestAzureSQLIntegration_ElasticPool_Schedulers_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
+	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
 
 	server := &SQLServer{
-		Servers:      []string{connectionString},
+		Servers:      serversList,
 		IncludeQuery: []string{"AzureSQLPoolSchedulers"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",

--- a/plugins/inputs/sqlserver/sample.conf
+++ b/plugins/inputs/sqlserver/sample.conf
@@ -23,7 +23,6 @@
   ## "database_type" enables a specific set of queries depending on the database type. If specified, it replaces azuredb = true/false and query_version = 2
   ## In the config file, the sql server plugin section should be repeated each with a set of servers for a specific database_type.
   ## Possible values for database_type are - "SQLServer" or "AzureSQLDB" or "AzureSQLManagedInstance" or "AzureSQLPool"
-
   database_type = "SQLServer"
 
   ## A list of queries to include. If not specified, all the below listed queries are used.

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -25,7 +25,7 @@ var sampleConfig string
 
 // SQLServer struct
 type SQLServer struct {
-	Servers      []string        `toml:"servers"`
+	Servers      []config.Secret `toml:"servers"`
 	QueryTimeout config.Duration `toml:"query_timeout"`
 	AuthMethod   string          `toml:"auth_method"`
 	QueryVersion int             `toml:"query_version" deprecated:"1.16.0;use 'database_type' instead"`
@@ -206,12 +206,17 @@ func (s *SQLServer) Gather(acc telegraf.Accumulator) error {
 			wg.Add(1)
 			go func(pool *sql.DB, query Query, serverIndex int) {
 				defer wg.Done()
-				connectionString := s.Servers[serverIndex]
-				queryError := s.gatherServer(pool, query, acc, connectionString)
+				dsn, err := s.Servers[serverIndex].Get()
+				if err != nil {
+					acc.AddError(err)
+					return
+				}
+				defer config.ReleaseSecret(dsn)
+				queryError := s.gatherServer(pool, query, acc, string(dsn))
 
 				if s.HealthMetric {
 					mutex.Lock()
-					s.gatherHealth(healthMetrics, connectionString, queryError)
+					s.gatherHealth(healthMetrics, string(dsn), queryError)
 					mutex.Unlock()
 				}
 
@@ -244,19 +249,24 @@ func (s *SQLServer) Start(acc telegraf.Accumulator) error {
 
 		switch strings.ToLower(s.AuthMethod) {
 		case "connection_string":
+			// Get the connection string potentially containing secrets
+			dsn, err := serv.Get()
+			if err != nil {
+				acc.AddError(err)
+				continue
+			}
+
 			// Use the DSN (connection string) directly. In this case,
 			// empty username/password causes use of Windows
 			// integrated authentication.
-			var err error
-			pool, err = sql.Open("mssql", serv)
-
+			pool, err = sql.Open("mssql", string(dsn))
+			config.ReleaseSecret(dsn)
 			if err != nil {
 				acc.AddError(err)
 				continue
 			}
 		case "aad":
 			// AAD Auth with system-assigned managed identity (MSI)
-
 			// AAD Auth is only supported for Azure SQL Database or Azure SQL Managed Instance
 			if s.DatabaseType == "SQLServer" {
 				err := errors.New("database connection failed : AAD auth is not supported for SQL VM i.e. DatabaseType=SQLServer")
@@ -271,7 +281,14 @@ func (s *SQLServer) Start(acc telegraf.Accumulator) error {
 				continue
 			}
 
-			connector, err := mssql.NewAccessTokenConnector(serv, tokenProvider)
+			// Get the connection string potentially containing secrets
+			dsn, err := serv.Get()
+			if err != nil {
+				acc.AddError(err)
+				continue
+			}
+			connector, err := mssql.NewAccessTokenConnector(string(dsn), tokenProvider)
+			config.ReleaseSecret(dsn)
 			if err != nil {
 				acc.AddError(fmt.Errorf("error creating the SQL connector : %s", err.Error()))
 				continue
@@ -529,7 +546,7 @@ func (s *SQLServer) refreshToken() (*adal.Token, error) {
 func init() {
 	inputs.Add("sqlserver", func() telegraf.Input {
 		return &SQLServer{
-			Servers:    []string{defaultServer},
+			Servers:    []config.Secret{config.NewSecret([]byte(defaultServer))},
 			AuthMethod: "connection_string",
 		}
 	})

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -116,12 +117,12 @@ func TestSqlServerIntegration_MultipleInstance(t *testing.T) {
 
 	testServer := "Server=127.0.0.1;Port=1433;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"
 	s := &SQLServer{
-		Servers:      []string{testServer},
+		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
 		ExcludeQuery: []string{"MemoryClerk"},
 		Log:          testutil.Logger{},
 	}
 	s2 := &SQLServer{
-		Servers:      []string{testServer},
+		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
 		ExcludeQuery: []string{"DatabaseSize"},
 		Log:          testutil.Logger{},
 	}
@@ -153,12 +154,12 @@ func TestSqlServerIntegration_MultipleInstanceWithHealthMetric(t *testing.T) {
 
 	testServer := "Server=127.0.0.1;Port=1433;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"
 	s := &SQLServer{
-		Servers:      []string{testServer},
+		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
 		ExcludeQuery: []string{"MemoryClerk"},
 		Log:          testutil.Logger{},
 	}
 	s2 := &SQLServer{
-		Servers:      []string{testServer},
+		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
 		ExcludeQuery: []string{"DatabaseSize"},
 		HealthMetric: true,
 		Log:          testutil.Logger{},
@@ -194,7 +195,10 @@ func TestSqlServer_HealthMetric(t *testing.T) {
 	fakeServer2 := "localhost\\fakeinstance2;Database=fakedb2;Password=ABCabc01;"
 
 	s1 := &SQLServer{
-		Servers:      []string{fakeServer1, fakeServer2},
+		Servers: []config.Secret{
+			config.NewSecret([]byte(fakeServer1)),
+			config.NewSecret([]byte(fakeServer2)),
+		},
 		IncludeQuery: []string{"DatabaseSize", "MemoryClerk"},
 		HealthMetric: true,
 		AuthMethod:   "connection_string",
@@ -202,7 +206,7 @@ func TestSqlServer_HealthMetric(t *testing.T) {
 	}
 
 	s2 := &SQLServer{
-		Servers:      []string{fakeServer1},
+		Servers:      []config.Secret{config.NewSecret([]byte(fakeServer1))},
 		IncludeQuery: []string{"DatabaseSize"},
 		AuthMethod:   "connection_string",
 		Log:          testutil.Logger{},
@@ -344,13 +348,13 @@ func TestSqlServerIntegration_AGQueriesApplicableForDatabaseTypeSQLServer(t *tes
 	testServer := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
 
 	s := &SQLServer{
-		Servers:      []string{testServer},
+		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
 		DatabaseType: "SQLServer",
 		IncludeQuery: []string{"SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates"},
 		Log:          testutil.Logger{},
 	}
 	s2 := &SQLServer{
-		Servers:      []string{testServer},
+		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
 		DatabaseType: "AzureSQLDB",
 		IncludeQuery: []string{"SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates"},
 		Log:          testutil.Logger{},
@@ -395,13 +399,13 @@ func TestSqlServerIntegration_AGQueryFieldsOutputBasedOnSQLServerVersion(t *test
 	testServer2012 := os.Getenv("AZURESQL_POOL_CONNECTION_STRING_2012")
 
 	s2019 := &SQLServer{
-		Servers:      []string{testServer2019},
+		Servers:      []config.Secret{config.NewSecret([]byte(testServer2019))},
 		DatabaseType: "SQLServer",
 		IncludeQuery: []string{"SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates"},
 		Log:          testutil.Logger{},
 	}
 	s2012 := &SQLServer{
-		Servers:      []string{testServer2012},
+		Servers:      []config.Secret{config.NewSecret([]byte(testServer2012))},
 		DatabaseType: "SQLServer",
 		IncludeQuery: []string{"SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates"},
 		Log:          testutil.Logger{},

--- a/plugins/inputs/vsphere/client.go
+++ b/plugins/inputs/vsphere/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 )
 
 // The highest number of metrics we can query for, no matter what settings
@@ -99,9 +100,24 @@ func (cf *ClientFactory) testClient(ctx context.Context) error {
 		cf.parent.Log.Info("Client session seems to have time out. Reauthenticating!")
 		ctx2, cancel2 := context.WithTimeout(ctx, time.Duration(cf.parent.Timeout))
 		defer cancel2()
-		if err := cf.client.Client.SessionManager.Login(ctx2, url.UserPassword(cf.parent.Username, cf.parent.Password)); err != nil {
-			return fmt.Errorf("renewing authentication failed: %s", err.Error())
+
+		// Resolving the secrets and construct the authentication info
+		username, err := cf.parent.Username.Get()
+		if err != nil {
+			return fmt.Errorf("getting username failed: %w", err)
 		}
+		defer config.ReleaseSecret(username)
+		password, err := cf.parent.Password.Get()
+		if err != nil {
+			return fmt.Errorf("getting password failed: %w", err)
+		}
+		defer config.ReleaseSecret(password)
+		auth := url.UserPassword(string(username), string(password))
+
+		if err := cf.client.Client.SessionManager.Login(ctx2, auth); err != nil {
+			return fmt.Errorf("renewing authentication failed: %w", err)
+		}
+
 	}
 
 	return nil
@@ -120,8 +136,19 @@ func NewClient(ctx context.Context, vSphereURL *url.URL, vs *VSphere) (*Client, 
 	if tlsCfg == nil {
 		tlsCfg = &tls.Config{}
 	}
-	if vs.Username != "" {
-		vSphereURL.User = url.UserPassword(vs.Username, vs.Password)
+	if !vs.Username.Empty() {
+		// Resolving the secrets and construct the authentication info
+		username, err := vs.Username.Get()
+		if err != nil {
+			return nil, fmt.Errorf("getting username failed: %w", err)
+		}
+		defer config.ReleaseSecret(username)
+		password, err := vs.Password.Get()
+		if err != nil {
+			return nil, fmt.Errorf("getting password failed: %w", err)
+		}
+		defer config.ReleaseSecret(password)
+		vSphereURL.User = url.UserPassword(string(username), string(password))
 	}
 
 	vs.Log.Debugf("Creating client: %s", vSphereURL.Host)

--- a/plugins/inputs/vsphere/vsphere.go
+++ b/plugins/inputs/vsphere/vsphere.go
@@ -22,8 +22,8 @@ var sampleConfig string
 // and a list of connected vSphere endpoints
 type VSphere struct {
 	Vcenters                  []string
-	Username                  string
-	Password                  string
+	Username                  config.Secret `toml:"username"`
+	Password                  config.Secret `toml:"password"`
 	DatacenterInstances       bool
 	DatacenterMetricInclude   []string
 	DatacenterMetricExclude   []string

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -225,9 +225,7 @@ func TestMaxQuery(t *testing.T) {
 		return
 	}
 	m, s, err := createSim(0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer m.Remove()
 	defer s.Close()
 
@@ -235,9 +233,7 @@ func TestMaxQuery(t *testing.T) {
 	v.MaxQueryMetrics = 256
 	ctx := context.Background()
 	c, err := NewClient(ctx, s.URL, v)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	require.Equal(t, 256, v.MaxQueryMetrics)
 
 	om := object.NewOptionManager(c.Client.Client, *c.Client.Client.ServiceContent.Setting)
@@ -245,16 +241,12 @@ func TestMaxQuery(t *testing.T) {
 		Key:   "config.vpxd.stats.maxQueryMetrics",
 		Value: "42",
 	}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	v.MaxQueryMetrics = 256
 	ctx = context.Background()
 	c2, err := NewClient(ctx, s.URL, v)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	require.Equal(t, 42, v.MaxQueryMetrics)
 	c.close()
 	c2.close()
@@ -287,9 +279,7 @@ func TestFinder(t *testing.T) {
 	}
 
 	m, s, err := createSim(0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer m.Remove()
 	defer s.Close()
 
@@ -413,9 +403,7 @@ func TestFolders(t *testing.T) {
 	}
 
 	m, s, err := createSim(1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer m.Remove()
 	defer s.Close()
 
@@ -477,8 +465,8 @@ func testCollection(t *testing.T, excludeClusters bool) {
 	v := defaultVSphere()
 	if vCenter != "" {
 		v.Vcenters = []string{vCenter}
-		v.Username = username
-		v.Password = password
+		v.Username = config.NewSecret([]byte(username))
+		v.Password = config.NewSecret([]byte(password))
 	} else {
 		// Don't run test on 32-bit machines due to bug in simulator.
 		// https://github.com/vmware/govmomi/issues/1330
@@ -488,9 +476,7 @@ func testCollection(t *testing.T, excludeClusters bool) {
 		}
 
 		m, s, err := createSim(0)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer m.Remove()
 		defer s.Close()
 		v.Vcenters = []string{s.URL.String()}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR is based on #11232 and adds secret- and thus secret-store support for more plugins, namely:
- `inputs.http_response` for username and password
- `inputs.kafka_consumer` and `outputs.kafka` via `common/kafka`
- `inputs.mqtt_consumer` for username and password
- `inputs.postgres` for `address`
- `inputs.postgres_extensible` for `address`
- `inputs.pgbouncer` for `address`
- `inputs.snmp_trap` for `sec_name`, `auth_password` and `priv_password`
- `inputs.sqlserver` when used with `auth_method = "connection_string"` (default)
- `inputs.vsphere` for username and password as well as token authentication