### PR TITLE
fix(agent): panic as tickers slice was off-by-one in size

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -280,7 +280,7 @@ func (a *Agent) runInputs(
 	unit *inputUnit,
 ) {
 	var wg sync.WaitGroup
-	tickers := make([]Ticker, len(unit.inputs))
+	tickers := make([]Ticker, 0, len(unit.inputs))
 	for _, input := range unit.inputs {
 		// Overwrite agent interval if this plugin has its own.
 		interval := time.Duration(a.Config.Agent.Interval)


### PR DESCRIPTION
When we were declaring the slice, it was given a length, which then grew and doubled when a ticker was added. Really wanted to set the capacity to the number of inputs.

fixes: #12072
