### PR TITLE
test: update integration test occurrences

### DIFF
--- a/plugins/inputs/pgbouncer/pgbouncer_test.go
+++ b/plugins/inputs/pgbouncer/pgbouncer_test.go
@@ -26,7 +26,7 @@ func TestPgBouncerGeneratesMetricsIntegration(t *testing.T) {
 		Env: map[string]string{
 			"POSTGRES_HOST_AUTH_METHOD": "trust",
 		},
-		WaitingFor: wait.ForLog("database system is ready to accept connections"),
+		WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
 	}
 	err := backend.Start()
 	require.NoError(t, err, "failed to start container")

--- a/plugins/inputs/sql/sql_test.go
+++ b/plugins/inputs/sql/sql_test.go
@@ -55,7 +55,7 @@ func TestMariaDBIntegration(t *testing.T) {
 			"/docker-entrypoint-initdb.d": testdata,
 		},
 		WaitingFor: wait.ForAll(
-			wait.ForLog("Buffer pool(s) load completed at"),
+			wait.ForLog("mariadbd: ready for connections.").WithOccurrence(2),
 			wait.ForListeningPort(nat.Port(port)),
 		),
 	}
@@ -162,7 +162,7 @@ func TestPostgreSQLIntegration(t *testing.T) {
 			"/docker-entrypoint-initdb.d": testdata,
 		},
 		WaitingFor: wait.ForAll(
-			wait.ForLog("database system is ready to accept connections"),
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
 			wait.ForListeningPort(nat.Port(port)),
 		),
 	}
@@ -266,7 +266,7 @@ func TestClickHouseIntegration(t *testing.T) {
 		WaitingFor: wait.ForAll(
 			wait.NewHTTPStrategy("/").WithPort(nat.Port("8123")),
 			wait.ForListeningPort(nat.Port(port)),
-			wait.ForLog("Saved preprocessed configuration to '/var/lib/clickhouse/preprocessed_configs/users.xml'"),
+			wait.ForLog("Saved preprocessed configuration to '/var/lib/clickhouse/preprocessed_configs/users.xml'.").WithOccurrence(2),
 		),
 	}
 	err = container.Start()

--- a/plugins/inputs/supervisor/supervisor_test.go
+++ b/plugins/inputs/supervisor/supervisor_test.go
@@ -143,7 +143,7 @@ func TestIntegration_BasicGathering(t *testing.T) {
 			"/etc/supervisor/supervisord.conf": supervisorConfig,
 		},
 		WaitingFor: wait.ForAll(
-			wait.ForLog("supervisord started with pid"),
+			wait.ForLog("entered RUNNING state").WithOccurrence(6),
 			wait.ForListeningPort(nat.Port(supervisorPort)),
 		),
 	}

--- a/plugins/outputs/mongodb/mongodb_test.go
+++ b/plugins/outputs/mongodb/mongodb_test.go
@@ -69,7 +69,7 @@ func TestConnectAndWriteIntegrationSCRAMAuth(t *testing.T) {
 		},
 		WaitingFor: wait.ForAll(
 			wait.NewHTTPStrategy("/").WithPort(nat.Port(servicePort)),
-			wait.ForLog("Waiting for connections"),
+			wait.ForLog("Waiting for connections").WithOccurrence(2),
 		),
 	}
 	err = container.Start()
@@ -174,7 +174,7 @@ func TestConnectAndWriteIntegrationX509Auth(t *testing.T) {
 		},
 		WaitingFor: wait.ForAll(
 			wait.NewHTTPStrategy("/").WithPort(nat.Port(servicePort)),
-			wait.ForLog("Waiting for connections"),
+			wait.ForLog("Waiting for connections").WithOccurrence(2),
 		),
 	}
 	err = container.Start()


### PR DESCRIPTION
Many of the database integration tests will start the database up, then do some initialization of settings or load some data and then reload or reboot the database.

These tests generally work because there is only 1-2 second delay, but sometimes that is enough to cause a failure trying to connect during a container/service reload.

fixes: #12083