### PR TITLE
feat(ethtool): Possibility to skip gathering metrics for downed interfaces

### DIFF
--- a/plugins/inputs/ethtool/README.md
+++ b/plugins/inputs/ethtool/README.md
@@ -14,6 +14,12 @@ on the network device and driver.
   ## List of interfaces to ignore when pulling metrics.
   # interface_exclude = ["eth1"]
 
+  ## Specifies plugin behavior regarding metrics for downed interfaces.
+  ## Available choices:
+  ##   - expose: Telegraf will expose all available metrics for downed interfaces
+  ##   - skip: Telegraf will not expose all available metrics for downed interfaces
+  # interface_down_metrics = "expose"
+
   ## Some drivers declare statistics with extra whitespace, different spacing,
   ## and mix cases. This list, when enabled, can be used to clean the keys.
   ## Here are the current possible normalizations:

--- a/plugins/inputs/ethtool/README.md
+++ b/plugins/inputs/ethtool/README.md
@@ -14,11 +14,11 @@ on the network device and driver.
   ## List of interfaces to ignore when pulling metrics.
   # interface_exclude = ["eth1"]
 
-  ## Specifies plugin behavior regarding metrics for downed interfaces.
+  ## Plugin behavior for downed interfaces
   ## Available choices:
-  ##   - expose: Telegraf will expose all available metrics for downed interfaces
-  ##   - skip: Telegraf will not expose all available metrics for downed interfaces
-  # interface_down_metrics = "expose"
+  ##   - expose: collect & report metrics for down interfaces
+  ##   - skip: ignore interfaces that are marked down
+  # down_interfaces = "expose"
 
   ## Some drivers declare statistics with extra whitespace, different spacing,
   ## and mix cases. This list, when enabled, can be used to clean the keys.

--- a/plugins/inputs/ethtool/ethtool.go
+++ b/plugins/inputs/ethtool/ethtool.go
@@ -5,10 +5,13 @@ import (
 	"net"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/filter"
 )
 
 //go:embed sample.conf
 var sampleConfig string
+
+var interfaceDownMetricsOptions = []string{"expose", "skip"}
 
 type Command interface {
 	Init() error
@@ -24,10 +27,15 @@ type Ethtool struct {
 	// This is the list of interface names to ignore
 	InterfaceExclude []string `toml:"interface_exclude"`
 
+	// Behavior regarding metrics for downed interfaces
+	InterfaceDownMetrics string `toml:" interface_down_metrics"`
+
 	// Normalization on the key names
 	NormalizeKeys []string `toml:"normalize_keys"`
 
 	Log telegraf.Logger `toml:"-"`
+
+	interfaceFilter filter.Filter
 
 	// the ethtool command
 	command Command

--- a/plugins/inputs/ethtool/ethtool.go
+++ b/plugins/inputs/ethtool/ethtool.go
@@ -11,7 +11,7 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-var interfaceDownMetricsOptions = []string{"expose", "skip"}
+var downInterfacesBehaviors = []string{"expose", "skip"}
 
 type Command interface {
 	Init() error
@@ -28,7 +28,7 @@ type Ethtool struct {
 	InterfaceExclude []string `toml:"interface_exclude"`
 
 	// Behavior regarding metrics for downed interfaces
-	InterfaceDownMetrics string `toml:" interface_down_metrics"`
+	DownInterfaces string `toml:" down_interfaces"`
 
 	// Normalization on the key names
 	NormalizeKeys []string `toml:"normalize_keys"`

--- a/plugins/inputs/ethtool/ethtool_linux.go
+++ b/plugins/inputs/ethtool/ethtool_linux.go
@@ -4,6 +4,7 @@
 package ethtool
 
 import (
+	"fmt"
 	"net"
 	"regexp"
 	"strings"
@@ -14,11 +15,30 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/filter"
+	"github.com/influxdata/telegraf/internal/choice"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
 type CommandEthtool struct {
 	ethtool *ethtoolLib.Ethtool
+}
+
+func (e *Ethtool) Init() error {
+	var err error
+	e.interfaceFilter, err = filter.NewIncludeExcludeFilter(e.InterfaceInclude, e.InterfaceExclude)
+	if err != nil {
+		return err
+	}
+
+	if e.InterfaceDownMetrics == "" {
+		e.InterfaceDownMetrics = "expose"
+	}
+
+	if err = choice.Check(e.InterfaceDownMetrics, interfaceDownMetricsOptions); err != nil {
+		return fmt.Errorf("interface_down_metrics: %w", err)
+	}
+
+	return e.command.Init()
 }
 
 func (e *Ethtool) Gather(acc telegraf.Accumulator) error {
@@ -29,17 +49,11 @@ func (e *Ethtool) Gather(acc telegraf.Accumulator) error {
 		return nil
 	}
 
-	interfaceFilter, err := filter.NewIncludeExcludeFilter(e.InterfaceInclude, e.InterfaceExclude)
-	if err != nil {
-		return err
-	}
-
 	// parallelize the ethtool call in event of many interfaces
 	var wg sync.WaitGroup
 
 	for _, iface := range interfaces {
-		// Check this isn't a loop back and that its matched by the filter
-		if (iface.Flags&net.FlagLoopback == 0) && interfaceFilter.Match(iface.Name) {
+		if e.interfaceEligibleForGather(iface) {
 			wg.Add(1)
 
 			go func(i net.Interface) {
@@ -54,9 +68,18 @@ func (e *Ethtool) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-// Initialise the Command Tool
-func (e *Ethtool) Init() error {
-	return e.command.Init()
+func (e *Ethtool) interfaceEligibleForGather(iface net.Interface) bool {
+	// Don't gather if it is a loop back, or it isn't matched by the filter
+	if isLoopback(iface) || !e.interfaceFilter.Match(iface.Name) {
+		return false
+	}
+
+	// For downed interfaces, gather only for "expose"
+	if !interfaceUp(iface) {
+		return e.InterfaceDownMetrics == "expose"
+	}
+
+	return true
 }
 
 // Gather the stats for the interface.
@@ -81,7 +104,7 @@ func (e *Ethtool) gatherEthtoolStats(iface net.Interface, acc telegraf.Accumulat
 		return
 	}
 
-	fields[fieldInterfaceUp] = e.interfaceUp(iface)
+	fields[fieldInterfaceUp] = interfaceUp(iface)
 	for k, v := range stats {
 		fields[e.normalizeKey(k)] = v
 	}
@@ -134,7 +157,11 @@ func inStringSlice(slice []string, value string) bool {
 	return false
 }
 
-func (e *Ethtool) interfaceUp(iface net.Interface) bool {
+func isLoopback(iface net.Interface) bool {
+	return (iface.Flags & net.FlagLoopback) != 0
+}
+
+func interfaceUp(iface net.Interface) bool {
 	return (iface.Flags & net.FlagUp) != 0
 }
 

--- a/plugins/inputs/ethtool/ethtool_linux.go
+++ b/plugins/inputs/ethtool/ethtool_linux.go
@@ -30,12 +30,12 @@ func (e *Ethtool) Init() error {
 		return err
 	}
 
-	if e.InterfaceDownMetrics == "" {
-		e.InterfaceDownMetrics = "expose"
+	if e.DownInterfaces == "" {
+		e.DownInterfaces = "expose"
 	}
 
-	if err = choice.Check(e.InterfaceDownMetrics, interfaceDownMetricsOptions); err != nil {
-		return fmt.Errorf("interface_down_metrics: %w", err)
+	if err = choice.Check(e.DownInterfaces, downInterfacesBehaviors); err != nil {
+		return fmt.Errorf("down_interfaces: %w", err)
 	}
 
 	return e.command.Init()
@@ -76,7 +76,7 @@ func (e *Ethtool) interfaceEligibleForGather(iface net.Interface) bool {
 
 	// For downed interfaces, gather only for "expose"
 	if !interfaceUp(iface) {
-		return e.InterfaceDownMetrics == "expose"
+		return e.DownInterfaces == "expose"
 	}
 
 	return true

--- a/plugins/inputs/ethtool/ethtool_test.go
+++ b/plugins/inputs/ethtool/ethtool_test.go
@@ -290,10 +290,10 @@ func setup() {
 
 	c := &CommandEthtoolMock{interfaceMap}
 	command = &Ethtool{
-		InterfaceInclude:     []string{},
-		InterfaceExclude:     []string{},
-		InterfaceDownMetrics: "expose",
-		command:              c,
+		InterfaceInclude: []string{},
+		InterfaceExclude: []string{},
+		DownInterfaces:   "expose",
+		command:          c,
 	}
 }
 
@@ -415,7 +415,7 @@ func TestGatherIgnoreInterfaces(t *testing.T) {
 func TestSkipMetricsForInterfaceDown(t *testing.T) {
 	setup()
 
-	command.InterfaceDownMetrics = "skip"
+	command.DownInterfaces = "skip"
 
 	err := command.Init()
 	require.NoError(t, err)

--- a/plugins/inputs/ethtool/ethtool_test.go
+++ b/plugins/inputs/ethtool/ethtool_test.go
@@ -290,9 +290,10 @@ func setup() {
 
 	c := &CommandEthtoolMock{interfaceMap}
 	command = &Ethtool{
-		InterfaceInclude: []string{},
-		InterfaceExclude: []string{},
-		command:          c,
+		InterfaceInclude:     []string{},
+		InterfaceExclude:     []string{},
+		InterfaceDownMetrics: "expose",
+		command:              c,
 	}
 }
 
@@ -315,9 +316,12 @@ func toStringMapUint(in map[string]interface{}) map[string]uint64 {
 
 func TestGather(t *testing.T) {
 	setup()
-	var acc testutil.Accumulator
 
-	err := command.Gather(&acc)
+	err := command.Init()
+	require.NoError(t, err)
+
+	var acc testutil.Accumulator
+	err = command.Gather(&acc)
 	require.NoError(t, err)
 	require.Len(t, acc.Metrics, 2)
 
@@ -342,11 +346,14 @@ func TestGather(t *testing.T) {
 
 func TestGatherIncludeInterfaces(t *testing.T) {
 	setup()
-	var acc testutil.Accumulator
 
 	command.InterfaceInclude = append(command.InterfaceInclude, "eth1")
 
-	err := command.Gather(&acc)
+	err := command.Init()
+	require.NoError(t, err)
+
+	var acc testutil.Accumulator
+	err = command.Gather(&acc)
 	require.NoError(t, err)
 	require.Len(t, acc.Metrics, 1)
 
@@ -373,11 +380,14 @@ func TestGatherIncludeInterfaces(t *testing.T) {
 
 func TestGatherIgnoreInterfaces(t *testing.T) {
 	setup()
-	var acc testutil.Accumulator
 
 	command.InterfaceExclude = append(command.InterfaceExclude, "eth1")
 
-	err := command.Gather(&acc)
+	err := command.Init()
+	require.NoError(t, err)
+
+	var acc testutil.Accumulator
+	err = command.Gather(&acc)
 	require.NoError(t, err)
 	require.Len(t, acc.Metrics, 1)
 
@@ -400,6 +410,30 @@ func TestGatherIgnoreInterfaces(t *testing.T) {
 		"driver":    "driver1",
 	}
 	acc.AssertContainsTaggedFields(t, pluginName, expectedFieldsEth2, expectedTagsEth2)
+}
+
+func TestSkipMetricsForInterfaceDown(t *testing.T) {
+	setup()
+
+	command.InterfaceDownMetrics = "skip"
+
+	err := command.Init()
+	require.NoError(t, err)
+
+	var acc testutil.Accumulator
+	err = command.Gather(&acc)
+	require.NoError(t, err)
+	require.Len(t, acc.Metrics, 1)
+
+	expectedFieldsEth1 := toStringMapInterface(interfaceMap["eth1"].Stat)
+	expectedFieldsEth1["interface_up_counter"] = expectedFieldsEth1["interface_up"]
+	expectedFieldsEth1["interface_up"] = true
+
+	expectedTagsEth1 := map[string]string{
+		"interface": "eth1",
+		"driver":    "driver1",
+	}
+	acc.AssertContainsTaggedFields(t, pluginName, expectedFieldsEth1, expectedTagsEth1)
 }
 
 type TestCase struct {
@@ -525,8 +559,11 @@ func TestNormalizedKeys(t *testing.T) {
 			command:          cmd,
 		}
 
+		err := command.Init()
+		require.NoError(t, err)
+
 		var acc testutil.Accumulator
-		err := command.Gather(&acc)
+		err = command.Gather(&acc)
 
 		require.NoError(t, err)
 		require.Len(t, acc.Metrics, 1)

--- a/plugins/inputs/ethtool/sample.conf
+++ b/plugins/inputs/ethtool/sample.conf
@@ -6,11 +6,11 @@
   ## List of interfaces to ignore when pulling metrics.
   # interface_exclude = ["eth1"]
 
-  ## Specifies plugin behavior regarding metrics for downed interfaces.
+  ## Plugin behavior for downed interfaces
   ## Available choices:
-  ##   - expose: Telegraf will expose all available metrics for downed interfaces
-  ##   - skip: Telegraf will not expose all available metrics for downed interfaces
-  # interface_down_metrics = "expose"
+  ##   - expose: collect & report metrics for down interfaces
+  ##   - skip: ignore interfaces that are marked down
+  # down_interfaces = "expose"
 
   ## Some drivers declare statistics with extra whitespace, different spacing,
   ## and mix cases. This list, when enabled, can be used to clean the keys.

--- a/plugins/inputs/ethtool/sample.conf
+++ b/plugins/inputs/ethtool/sample.conf
@@ -6,6 +6,12 @@
   ## List of interfaces to ignore when pulling metrics.
   # interface_exclude = ["eth1"]
 
+  ## Specifies plugin behavior regarding metrics for downed interfaces.
+  ## Available choices:
+  ##   - expose: Telegraf will expose all available metrics for downed interfaces
+  ##   - skip: Telegraf will not expose all available metrics for downed interfaces
+  # interface_down_metrics = "expose"
+
   ## Some drivers declare statistics with extra whitespace, different spacing,
   ## and mix cases. This list, when enabled, can be used to clean the keys.
   ## Here are the current possible normalizations:


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Some interfaces can expose a few thousands fields. It may not be necessary to gather and expose metrics for interfaces which are not `UP`.
This PR adds possibility to skip such metrics (but it defaults to exposing them - to be backward compatible):
```
  ## Specifies plugin behavior regarding metrics for downed interfaces.
  ## Available choices:
  ##   - expose: Telegraf will expose all available metrics for downed interfaces
  ##   - skip: Telegraf will not expose all available metrics for downed interfaces
  # interface_down_metrics = "expose"
```

Moreover, creation of `IncludeExcludeFilter` was moved from `Gather` to `Init` (input to this filter doesn't change so it makes sense to create it only once).