### PR TITLE
fix: update systemd unit description

### DIFF
--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=The plugin-driven server agent for reporting metrics into InfluxDB
+Description=Telegraf
 Documentation=https://github.com/influxdata/telegraf
 After=network-online.target
 Wants=network-online.target


### PR DESCRIPTION
Updates the "description" field in the systemd service file. This way the systemd logs more clearly and crisply say starting telegraf.

fixes: #12092
