### PR TITLE
fix: Add support for opcua datetime values

### DIFF
--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -3,13 +3,14 @@ package opcua
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
 	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/ua"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
-	"net/url"
-	"strconv"
-	"time"
 )
 
 type OpcUAWorkarounds struct {
@@ -17,16 +18,17 @@ type OpcUAWorkarounds struct {
 }
 
 type OpcUAClientConfig struct {
-	Endpoint       string          `toml:"endpoint"`
-	SecurityPolicy string          `toml:"security_policy"`
-	SecurityMode   string          `toml:"security_mode"`
-	Certificate    string          `toml:"certificate"`
-	PrivateKey     string          `toml:"private_key"`
-	Username       string          `toml:"username"`
-	Password       string          `toml:"password"`
-	AuthMethod     string          `toml:"auth_method"`
-	ConnectTimeout config.Duration `toml:"connect_timeout"`
-	RequestTimeout config.Duration `toml:"request_timeout"`
+	Endpoint        string          `toml:"endpoint"`
+	SecurityPolicy  string          `toml:"security_policy"`
+	SecurityMode    string          `toml:"security_mode"`
+	Certificate     string          `toml:"certificate"`
+	PrivateKey      string          `toml:"private_key"`
+	Username        string          `toml:"username"`
+	Password        string          `toml:"password"`
+	AuthMethod      string          `toml:"auth_method"`
+	ConnectTimeout  config.Duration `toml:"connect_timeout"`
+	RequestTimeout  config.Duration `toml:"request_timeout"`
+	TimestampFormat string          `toml:"timestamp_format"`
 
 	Workarounds OpcUAWorkarounds `toml:"workarounds"`
 }
@@ -55,6 +57,10 @@ func (o *OpcUAClientConfig) validateEndpoint() error {
 	case "None", "Sign", "SignAndEncrypt", "auto":
 	default:
 		return fmt.Errorf("invalid security type '%s' in '%s'", o.SecurityMode, o.Endpoint)
+	}
+
+	if o.TimestampFormat == "" {
+		o.TimestampFormat = time.RFC3339Nano
 	}
 	return nil
 }

--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -18,17 +18,16 @@ type OpcUAWorkarounds struct {
 }
 
 type OpcUAClientConfig struct {
-	Endpoint        string          `toml:"endpoint"`
-	SecurityPolicy  string          `toml:"security_policy"`
-	SecurityMode    string          `toml:"security_mode"`
-	Certificate     string          `toml:"certificate"`
-	PrivateKey      string          `toml:"private_key"`
-	Username        string          `toml:"username"`
-	Password        string          `toml:"password"`
-	AuthMethod      string          `toml:"auth_method"`
-	ConnectTimeout  config.Duration `toml:"connect_timeout"`
-	RequestTimeout  config.Duration `toml:"request_timeout"`
-	TimestampFormat string          `toml:"timestamp_format"`
+	Endpoint       string          `toml:"endpoint"`
+	SecurityPolicy string          `toml:"security_policy"`
+	SecurityMode   string          `toml:"security_mode"`
+	Certificate    string          `toml:"certificate"`
+	PrivateKey     string          `toml:"private_key"`
+	Username       string          `toml:"username"`
+	Password       string          `toml:"password"`
+	AuthMethod     string          `toml:"auth_method"`
+	ConnectTimeout config.Duration `toml:"connect_timeout"`
+	RequestTimeout config.Duration `toml:"request_timeout"`
 
 	Workarounds OpcUAWorkarounds `toml:"workarounds"`
 }
@@ -59,9 +58,6 @@ func (o *OpcUAClientConfig) validateEndpoint() error {
 		return fmt.Errorf("invalid security type '%s' in '%s'", o.SecurityMode, o.Endpoint)
 	}
 
-	if o.TimestampFormat == "" {
-		o.TimestampFormat = time.RFC3339Nano
-	}
 	return nil
 }
 

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -3,15 +3,16 @@ package input
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/gopcua/opcua/ua"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/choice"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/common/opcua"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // NodeSettings describes how to map from a OPC UA node to a Metric
@@ -356,8 +357,13 @@ func (o *OpcUAInputClient) UpdateNodeValue(nodeIdx int, d *ua.DataValue) {
 	}
 
 	if d.Value != nil {
-		o.LastReceivedData[nodeIdx].Value = d.Value.Value()
 		o.LastReceivedData[nodeIdx].DataType = d.Value.Type()
+
+		if o.LastReceivedData[nodeIdx].DataType == ua.TypeIDDateTime {
+			o.LastReceivedData[nodeIdx].Value = d.Value.Value().(time.Time).Format(time.RFC3339Nano)
+		} else {
+			o.LastReceivedData[nodeIdx].Value = d.Value.Value()
+		}
 	}
 	o.LastReceivedData[nodeIdx].ServerTime = d.ServerTimestamp
 	o.LastReceivedData[nodeIdx].SourceTime = d.SourceTimestamp

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -360,7 +360,7 @@ func (o *OpcUAInputClient) UpdateNodeValue(nodeIdx int, d *ua.DataValue) {
 		o.LastReceivedData[nodeIdx].DataType = d.Value.Type()
 
 		if o.LastReceivedData[nodeIdx].DataType == ua.TypeIDDateTime {
-			o.LastReceivedData[nodeIdx].Value = d.Value.Value().(time.Time).Format(time.RFC3339Nano)
+			o.LastReceivedData[nodeIdx].Value = d.Value.Value().(time.Time).Format(o.Config.TimestampFormat)
 		} else {
 			o.LastReceivedData[nodeIdx].Value = d.Value.Value()
 		}

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -53,10 +53,11 @@ const (
 // InputClientConfig a configuration for the input client
 type InputClientConfig struct {
 	opcua.OpcUAClientConfig
-	MetricName string              `toml:"name"`
-	Timestamp  TimestampSource     `toml:"timestamp"`
-	RootNodes  []NodeSettings      `toml:"nodes"`
-	Groups     []NodeGroupSettings `toml:"group"`
+	MetricName      string              `toml:"name"`
+	Timestamp       TimestampSource     `toml:"timestamp"`
+	TimestampFormat string              `toml:"timestamp_format"`
+	RootNodes       []NodeSettings      `toml:"nodes"`
+	Groups          []NodeGroupSettings `toml:"group"`
 }
 
 func (o *InputClientConfig) Validate() error {
@@ -67,6 +68,10 @@ func (o *InputClientConfig) Validate() error {
 	err := choice.Check(string(o.Timestamp), []string{"", "gather", "server", "source"})
 	if err != nil {
 		return err
+	}
+
+	if o.TimestampFormat == "" {
+		o.TimestampFormat = time.RFC3339Nano
 	}
 
 	return nil

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -2,6 +2,9 @@ package opcua
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/docker/go-connections/nat"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/opcua"
@@ -9,8 +12,6 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"testing"
-	"time"
 )
 
 const servicePort = "4840"
@@ -119,6 +120,7 @@ func TestReadClientIntegration(t *testing.T) {
 		{"ManufacturerName", "0", "i", "2263", "open62541"},
 		{"badnode", "1", "i", "1337", nil},
 		{"goodnode", "1", "s", "the.answer", int32(42)},
+		{"DateTime", "1", "s", "51037", "0001-01-01T00:00:00Z"},
 	}
 
 	readConfig := ReadClientConfig{

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -120,7 +120,7 @@ func TestReadClientIntegration(t *testing.T) {
 		{"ManufacturerName", "0", "i", "2263", "open62541"},
 		{"badnode", "1", "i", "1337", nil},
 		{"goodnode", "1", "s", "the.answer", int32(42)},
-		{"DateTime", "1", "s", "51037", "0001-01-01T00:00:00Z"},
+		{"DateTime", "1", "i", "51037", "0001-01-01T00:00:00Z"},
 	}
 
 	readConfig := ReadClientConfig{

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -56,6 +56,12 @@ Plugin minimum tested version: 1.25
   ##     "source" -- uses the timestamp provided by the source
   # timestamp = "gather"
   #
+  ## The default timetsamp format is RFC3339Nano
+  # Other timestamp layouts can be configured using the Go language time
+  # layout specification from https://golang.org/pkg/time/#Time.Format
+  # e.g.: json_timestamp_format = "2006-01-02T15:04:05Z07:00"
+  #timestamp_format = ""
+  #
   ## Node ID configuration
   ## name              - field name to use in the output
   ## namespace         - OPC UA namespace of the node (integer value 0 thru 3)

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -3,6 +3,9 @@ package opcua_listener
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/docker/go-connections/nat"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/opcua"
@@ -10,8 +13,6 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"testing"
-	"time"
 )
 
 const servicePort = "4840"
@@ -54,6 +55,8 @@ func TestSubscribeClientIntegration(t *testing.T) {
 		{"ManufacturerName", "0", "i", "2263", "open62541"},
 		{"badnode", "1", "i", "1337", nil},
 		{"goodnode", "1", "s", "the.answer", int32(42)},
+		{"DateTime2", "1", "s", "some_date_one", "hello"},
+		{"DateTime", "1", "s", "some_date", "0001-01-01T00:00:00Z"},
 	}
 	var tagsRemaining = make([]string, 0, len(testopctags))
 	for i, tag := range testopctags {

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -55,8 +55,7 @@ func TestSubscribeClientIntegration(t *testing.T) {
 		{"ManufacturerName", "0", "i", "2263", "open62541"},
 		{"badnode", "1", "i", "1337", nil},
 		{"goodnode", "1", "s", "the.answer", int32(42)},
-		{"DateTime2", "1", "s", "some_date_one", "hello"},
-		{"DateTime", "1", "s", "some_date", "0001-01-01T00:00:00Z"},
+		{"DateTime", "1", "i", "51037", "0001-01-01T00:00:00Z"},
 	}
 	var tagsRemaining = make([]string, 0, len(testopctags))
 	for i, tag := range testopctags {

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -154,6 +154,7 @@ security_mode = "auto"
 certificate = "/etc/telegraf/cert.pem"
 private_key = "/etc/telegraf/key.pem"
 auth_method = "Anonymous"
+timestamp_format = "2006-01-02T15:04:05Z07:00"
 username = ""
 password = ""
 nodes = [

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -46,6 +46,12 @@
   ##     "source" -- uses the timestamp provided by the source
   # timestamp = "gather"
   #
+  ## The default timetsamp format is RFC3339Nano
+  # Other timestamp layouts can be configured using the Go language time
+  # layout specification from https://golang.org/pkg/time/#Time.Format
+  # e.g.: json_timestamp_format = "2006-01-02T15:04:05Z07:00"
+  #timestamp_format = ""
+  #
   ## Node ID configuration
   ## name              - field name to use in the output
   ## namespace         - OPC UA namespace of the node (integer value 0 thru 3)


### PR DESCRIPTION
Resolves #12006

This PR adds support for returning OPCUA DateTime values via the opc-ua input plugin. Prior to this PR, we silently drop those values. Reopened because I made a mistake in #12020. 

## Details 
The `gopcua` library returns these values as the time.Time type, which telegraf doesn't handle in `metric.go:convertField`. To make the smallest change possible, we simply convert the datetime value to a string in the default golang format before returning the updated value.

## Example
Example telegraf.toml
```yaml
[inputs.opcua]
  # Authentication details redacted
  nodes = [
  {name="TimeEnded", namespace="4", identifier_type="s", identifier="TimeEnded"},
  ]
```

### Before: 
Notice the TimeEnded value has `Quality=OK` but the time value itself has failed to parse or be returned. This is because it falls into the `default` case in `metric.go:convertField`
```sh
❯ go run ./cmd/telegraf --config ~/telegraf-config-file.toml --test
...
2022-10-14T17:42:28Z D! [agent] Starting service inputs
> MACHINE123,host=HOST123,id=ns\=4;s\=TimeEnded Quality="OK (0x0)" 1665769360000000000
2022-10-14T17:42:40Z D! [agent] Stopping service inputs
2022-10-14T17:42:40Z D! [agent] Input channel closed
2022-10-14T17:42:40Z D! [agent] Stopped Successfully
```

### After:
We return the time as a string as intended
```sh
❯ go run ./cmd/telegraf --config ~/telegraf-config-file.toml --test
...
2022-10-14T17:46:49Z D! [agent] Starting service inputs
> MACHINE123,host=HOST123,id=ns\=4;s\=TimeEnded "2022-10-18 02:13:29.222 +0000 UTC",Quality="OK (0x0)" 1665769610000000000
2022-10-14T17:46:50Z D! [agent] Stopping service inputs
2022-10-14T17:46:50Z D! [agent] Input channel closed
2022-10-14T17:46:50Z D! [agent] Stopped Successfully
```