### PR TITLE
chore: shut down plugins gracefully to prevent race

### DIFF
--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -470,8 +470,6 @@ func TestConsumerGroupHandler_Handle(t *testing.T) {
 }
 
 func TestKafkaRoundTripIntegration(t *testing.T) {
-	t.Skip("fails race check")
-
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -573,6 +571,10 @@ func TestKafkaRoundTripIntegration(t *testing.T) {
 	t.Logf("rt: expecting")
 	acc.Wait(len(expected))
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
+
+	t.Logf("rt: shutdown")
+	require.NoError(t, output.Close())
+	input.Stop()
 
 	t.Logf("rt: done")
 }


### PR DESCRIPTION
Re-enables test added in #12058 and disabled in #12100 because it failed `go test -race`

CI logs seemed to show that the race was detected after the test was done. I think the consumer plugin continued to run after the containers were shut down and the race was happening when the consumer was trying to reconnect to the nonexistent broker.

This PR gracefully shuts down the plugins. I ran this `go test -run Integration -race -count 1000` for 30 min or so and it didn't detect a race.