### PR TITLE
chore: Increase golangci-lint timeout

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           version: v1.50.0
           only-new-issues: true
-          args: --timeout 5m0s --verbose
+          args: --timeout 15m0s --verbose
   golangci-master:
     if: github.ref == 'refs/heads/master'
     name: lint-master-all
@@ -43,4 +43,4 @@ jobs:
         with:
           version: v1.50.0
           only-new-issues: true
-          args: --timeout 5m0s --issues-exit-code=0 --verbose
+          args: --timeout 15m0s --issues-exit-code=0 --verbose

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           version: v1.50.0
           only-new-issues: true
-          args: --timeout 3m0s --verbose
+          args: --timeout 5m0s --verbose
   golangci-master:
     if: github.ref == 'refs/heads/master'
     name: lint-master-all
@@ -43,4 +43,4 @@ jobs:
         with:
           version: v1.50.0
           only-new-issues: true
-          args: --timeout 3m0s --issues-exit-code=0 --verbose
+          args: --timeout 5m0s --issues-exit-code=0 --verbose

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           version: v1.50.0
           only-new-issues: true
-          args: --timeout 3m0s
+          args: --timeout 3m0s --verbose
   golangci-master:
     if: github.ref == 'refs/heads/master'
     name: lint-master-all
@@ -43,4 +43,4 @@ jobs:
         with:
           version: v1.50.0
           only-new-issues: true
-          args: --timeout 3m0s --issues-exit-code=0
+          args: --timeout 3m0s --issues-exit-code=0 --verbose

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           version: v1.50.0
           only-new-issues: true
+          args: --timeout 3m0s
   golangci-master:
     if: github.ref == 'refs/heads/master'
     name: lint-master-all
@@ -42,4 +43,4 @@ jobs:
         with:
           version: v1.50.0
           only-new-issues: true
-          args: --issues-exit-code=0
+          args: --timeout 3m0s --issues-exit-code=0


### PR DESCRIPTION
Noticed golangci-lint github action is failing https://github.com/influxdata/telegraf/actions/runs/3328072758/jobs/5503637845
error:
`level=error msg="Timeout exceeded: try increasing it by passing --timeout option"`

This pull request increases the timeout from 1m to 3m, relevant upstream issue: https://github.com/golangci/golangci-lint-action/issues/297