### PR TITLE
feat: Add exponential backoff when connecting or reconnecting and allow plugin to start without making initial connection

### DIFF
--- a/plugins/common/kafka/config.go
+++ b/plugins/common/kafka/config.go
@@ -140,7 +140,7 @@ func (k *Config) SetConfig(config *sarama.Config) error {
 		if k.MetadataRetryBackoff != 0 {
 			config.Metadata.Retry.BackoffFunc = makeBackoffFunc(k.MetadataRetryBackoff, k.MetadataRetryMaxDuration)
 		}
-	case "none":
+	case "constant":
 		fallthrough
 	case "":
 	}

--- a/plugins/common/kafka/config.go
+++ b/plugins/common/kafka/config.go
@@ -136,7 +136,7 @@ func (k *Config) SetConfig(config *sarama.Config, log telegraf.Logger) error {
 	default:
 		return fmt.Errorf("invalid metadata retry type")
 	case "exponential":
-		if k.MetadataRetryBackoff != 0 {
+		if k.MetadataRetryBackoff == 0 {
 			k.MetadataRetryBackoff = 250 * time.Millisecond
 			log.Warnf("metadata_retry_backoff is 0, using %s", k.MetadataRetryBackoff)
 		}

--- a/plugins/common/kafka/config.go
+++ b/plugins/common/kafka/config.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -133,7 +134,7 @@ func (k *Config) SetConfig(config *sarama.Config) error {
 		config.Metadata.Retry.Backoff = k.MetadataRetryBackoff
 	}
 
-	switch t := k.MetadataRetryType; t {
+	switch strings.ToLower(k.MetadataRetryType) {
 	default:
 		return fmt.Errorf("invalid metadata retry type")
 	case "exponential":

--- a/plugins/common/kafka/config.go
+++ b/plugins/common/kafka/config.go
@@ -139,11 +139,11 @@ func (k *Config) SetConfig(config *sarama.Config) error {
 		return fmt.Errorf("invalid metadata retry type")
 	case "exponential":
 		if k.MetadataRetryBackoff != 0 {
-			config.Metadata.Retry.BackoffFunc = makeBackoffFunc(k.MetadataRetryBackoff, k.MetadataRetryMaxDuration)
+			k.MetadataRetryBackoff = 250 * time.Millisecond
+			k.Log.Warnf("metadata_retry_backoff is 0, using %s", k.MetadataRetryBackoff)
 		}
-	case "constant":
-		fallthrough
-	case "":
+		config.Metadata.Retry.BackoffFunc = makeBackoffFunc(k.MetadataRetryBackoff, k.MetadataRetryMaxDuration)
+	case "constant", "":
 	}
 
 	return k.SetSASLConfig(config)

--- a/plugins/common/kafka/config_test.go
+++ b/plugins/common/kafka/config_test.go
@@ -1,0 +1,22 @@
+package kafka
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackoffFunc(t *testing.T) {
+	b := 250 * time.Millisecond
+	max := 1100 * time.Millisecond
+
+	f := makeBackoffFunc(b, max)
+	require.Equal(t, b, f(0, 0))
+	require.Equal(t, b*2, f(1, 0))
+	require.Equal(t, b*4, f(2, 0))
+	require.Equal(t, max, f(3, 0)) // would be 2000 but that's greater than max
+
+	f = makeBackoffFunc(b, 0)      // max = 0 means no max
+	require.Equal(t, b*8, f(3, 0)) // with no max, it's 2000
+}

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -109,6 +109,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## limit.
   # metadata_retry_max_duration = 0
 
+  ## Strategy for making connection to kafka brokers. Valid options: "startup",
+  ## "defer". If set to "defer" the plugin is allowed to start before making a
+  ## connection. This is useful if the broker may be down when telegraf is
+  ## started, but if there are any typos in the broker setting, they will cause
+  ## connection failures without warning at startup
+  # connection_strategy = "startup"
+
   ## Maximum length of a message to consume, in bytes (default 0/unlimited);
   ## larger messages are dropped
   max_message_len = 1000000

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -156,3 +156,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 [kafka]: https://kafka.apache.org
 [kafka_consumer_legacy]: /plugins/inputs/kafka_consumer_legacy/README.md
 [input data formats]: /docs/DATA_FORMATS_INPUT.md
+
+## Metrics
+
+The plugin accepts arbitrary input and parses it according to the `data_format`
+setting. There is no predefined metric format.
+
+## Example Output
+
+There is no predefined metric format, so output depends on plugin input.

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -90,6 +90,25 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Consumer group partition assignment strategy; one of "range", "roundrobin" or "sticky".
   # balance_strategy = "range"
 
+  ## Maximum number of retries for metadata operations including
+  ## connecting. Sets Sarama library's Metadata.Retry.Max config value. If 0 or
+  ## unset, use the Sarama default of 3,
+  # metadata_retry_max = 0
+
+  ## Type of retry backoff. Valid options: "constant", "exponential"
+  # metadata_retry_type = "constant"
+
+  ## Amount of time to wait before retrying. When metadata_retry_type is
+  ## "constant", each retry is delayed this amount. When "exponential", the
+  ## first retry is delayed this amount, and subsequent delays are doubled. If 0
+  ## or unset, use the Sarama default of 250 ms
+  # metadata_retry_backoff = 0
+
+  ## Maximum amount of time to wait before retrying when metadata_retry_type is
+  ## "exponential". Ignored for other retry types. If 0, there is no backoff
+  ## limit.
+  # metadata_retry_max_duration = 0
+
   ## Maximum length of a message to consume, in bytes (default 0/unlimited);
   ## larger messages are dropped
   max_message_len = 1000000

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -98,7 +98,7 @@ func (k *KafkaConsumer) Init() error {
 	// Kafka version 0.10.2.0 is required for consumer groups.
 	cfg.Version = sarama.V0_10_2_0
 
-	if err := k.SetConfig(cfg); err != nil {
+	if err := k.SetConfig(cfg, k.Log); err != nil {
 		return fmt.Errorf("SetConfig: %w", err)
 	}
 

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -135,10 +135,7 @@ func (k *KafkaConsumer) Init() error {
 	switch strings.ToLower(k.ConnectionStrategy) {
 	default:
 		return fmt.Errorf("invalid connection strategy %q", k.ConnectionStrategy)
-	case "defer":
-	case "startup":
-		fallthrough
-	case "":
+	case "defer", "startup", "":
 	}
 
 	k.config = cfg

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -43,6 +43,7 @@ type KafkaConsumer struct {
 	Topics                 []string        `toml:"topics"`
 	TopicTag               string          `toml:"topic_tag"`
 	ConsumerFetchDefault   config.Size     `toml:"consumer_fetch_default"`
+	ConnectionStrategy     string          `toml:"connection_strategy"`
 
 	kafka.ReadConfig
 
@@ -131,8 +132,38 @@ func (k *KafkaConsumer) Init() error {
 		cfg.Consumer.Fetch.Default = int32(k.ConsumerFetchDefault)
 	}
 
+	switch strings.ToLower(k.ConnectionStrategy) {
+	default:
+		return fmt.Errorf("invalid connection strategy %q", k.ConnectionStrategy)
+	case "defer":
+	case "startup":
+		fallthrough
+	case "":
+	}
+
 	k.config = cfg
 	return nil
+}
+
+func (k *KafkaConsumer) create() error {
+	var err error
+	k.consumer, err = k.ConsumerCreator.Create(
+		k.Brokers,
+		k.ConsumerGroup,
+		k.config,
+	)
+
+	return err
+}
+
+func (k *KafkaConsumer) startErrorAdder(acc telegraf.Accumulator) {
+	k.wg.Add(1)
+	go func() {
+		defer k.wg.Done()
+		for err := range k.consumer.Errors() {
+			acc.AddError(fmt.Errorf("channel: %w", err))
+		}
+	}()
 }
 
 func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
@@ -141,19 +172,30 @@ func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	k.cancel = cancel
 
-	k.consumer, err = k.ConsumerCreator.Create(
-		k.Brokers,
-		k.ConsumerGroup,
-		k.config,
-	)
-	if err != nil {
-		return fmt.Errorf("create consumer: %w", err)
+	if k.ConnectionStrategy != "defer" {
+		err = k.create()
+		if err != nil {
+			return fmt.Errorf("create consumer: %w", err)
+		}
+		k.startErrorAdder(acc)
 	}
 
 	// Start consumer goroutine
 	k.wg.Add(1)
 	go func() {
+		var err error
 		defer k.wg.Done()
+
+		if k.consumer == nil {
+			err = k.create()
+			if err != nil {
+				acc.AddError(fmt.Errorf("create consumer async: %w", err))
+				return
+			}
+		}
+
+		k.startErrorAdder(acc)
+
 		for ctx.Err() == nil {
 			handler := NewConsumerGroupHandler(acc, k.MaxUndeliveredMessages, k.parser, k.Log)
 			handler.MaxMessageLen = k.MaxMessageLen
@@ -169,14 +211,6 @@ func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 		err = k.consumer.Close()
 		if err != nil {
 			acc.AddError(fmt.Errorf("close: %w", err))
-		}
-	}()
-
-	k.wg.Add(1)
-	go func() {
-		defer k.wg.Done()
-		for err := range k.consumer.Errors() {
-			acc.AddError(fmt.Errorf("channel: %w", err))
 		}
 	}()
 

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -137,6 +137,10 @@ func (k *KafkaConsumer) Init() error {
 
 func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 	var err error
+
+	ctx, cancel := context.WithCancel(context.Background())
+	k.cancel = cancel
+
 	k.consumer, err = k.ConsumerCreator.Create(
 		k.Brokers,
 		k.ConsumerGroup,
@@ -145,9 +149,6 @@ func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 	if err != nil {
 		return fmt.Errorf("create consumer: %w", err)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	k.cancel = cancel
 
 	// Start consumer goroutine
 	k.wg.Add(1)

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -615,7 +615,7 @@ func TestExponentialBackoff(t *testing.T) {
 		ReadConfig: kafka.ReadConfig{
 			Config: kafka.Config{
 				MetadataRetryMax:     max,
-				MetadataRetryBackoff: backoff,
+				MetadataRetryBackoff: config.Duration(backoff),
 				MetadataRetryType:    "exponential",
 			},
 		},
@@ -675,5 +675,5 @@ func TestExponentialBackoffDefault(t *testing.T) {
 	// initialization
 
 	// if input.MetadataRetryBackoff isn't set, it should be 250 ms
-	require.Equal(t, input.MetadataRetryBackoff, 250*time.Millisecond)
+	require.Equal(t, input.MetadataRetryBackoff, config.Duration(250*time.Millisecond))
 }

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -651,3 +651,29 @@ func TestExponentialBackoff(t *testing.T) {
 
 	input.Stop()
 }
+
+func TestExponentialBackoffDefault(t *testing.T) {
+	input := KafkaConsumer{
+		Brokers:                []string{"broker"},
+		Log:                    testutil.Logger{},
+		Topics:                 []string{"topic"},
+		MaxUndeliveredMessages: 1,
+
+		ReadConfig: kafka.ReadConfig{
+			Config: kafka.Config{
+				MetadataRetryType: "exponential",
+			},
+		},
+	}
+	parser := &influx.Parser{}
+	require.NoError(t, parser.Init())
+	input.SetParser(parser)
+
+	require.NoError(t, input.Init())
+
+	// We don't need to start the plugin here since we're only testing
+	// initialization
+
+	// if input.MetadataRetryBackoff isn't set, it should be 250 ms
+	require.Equal(t, input.MetadataRetryBackoff, 250*time.Millisecond)
+}

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -599,7 +599,7 @@ func TestExponentialBackoff(t *testing.T) {
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
 	port := listener.Addr().(*net.TCPAddr).Port
-	listener.Close()
+	require.NoError(t, listener.Close())
 
 	// try to connect to kafka on that unused port
 	brokers := []string{
@@ -621,7 +621,7 @@ func TestExponentialBackoff(t *testing.T) {
 		},
 	}
 	parser := &influx.Parser{}
-	parser.Init()
+	require.NoError(t, parser.Init())
 	input.SetParser(parser)
 
 	//time how long initialization (connection) takes
@@ -630,7 +630,7 @@ func TestExponentialBackoff(t *testing.T) {
 
 	acc := testutil.Accumulator{}
 	require.Error(t, input.Start(&acc))
-	elapsed := time.Now().Sub(start)
+	elapsed := time.Since(start)
 	t.Logf("elapsed %d", elapsed)
 
 	var expectedRetryDuration time.Duration

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -89,6 +89,13 @@
   ## limit.
   # metadata_retry_max_duration = 0
 
+  ## Strategy for making connection to kafka brokers. Valid options: "startup",
+  ## "defer". If set to "defer" the plugin is allowed to start before making a
+  ## connection. This is useful if the broker may be down when telegraf is
+  ## started, but if there are any typos in the broker setting, they will cause
+  ## connection failures without warning at startup
+  # connection_strategy = "startup"
+
   ## Maximum length of a message to consume, in bytes (default 0/unlimited);
   ## larger messages are dropped
   max_message_len = 1000000

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -70,6 +70,25 @@
   ## Consumer group partition assignment strategy; one of "range", "roundrobin" or "sticky".
   # balance_strategy = "range"
 
+  ## Maximum number of retries for metadata operations including
+  ## connecting. Sets Sarama library's Metadata.Retry.Max config value. If 0 or
+  ## unset, use the Sarama default of 3,
+  # metadata_retry_max = 0
+
+  ## Type of retry backoff. Valid options: "constant", "exponential"
+  # metadata_retry_type = "constant"
+
+  ## Amount of time to wait before retrying. When metadata_retry_type is
+  ## "constant", each retry is delayed this amount. When "exponential", the
+  ## first retry is delayed this amount, and subsequent delays are doubled. If 0
+  ## or unset, use the Sarama default of 250 ms
+  # metadata_retry_backoff = 0
+
+  ## Maximum amount of time to wait before retrying when metadata_retry_type is
+  ## "exponential". Ignored for other retry types. If 0, there is no backoff
+  ## limit.
+  # metadata_retry_max_duration = 0
+
   ## Maximum length of a message to consume, in bytes (default 0/unlimited);
   ## larger messages are dropped
   max_message_len = 1000000

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -145,7 +145,7 @@ func (k *Kafka) Init() error {
 	}
 	config := sarama.NewConfig()
 
-	if err := k.SetConfig(config); err != nil {
+	if err := k.SetConfig(config, k.Log); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds the ability to start the kafka_consumer input even if the kafka broker is down. The default behavior of the plugin is to require connection for a successful plugin start, but users can set `connection_strategy = "defer"` to choose to connect after the plugin has started.

Since starting up without a connection means the plugin will immediately start to retry making a connection, this PR also adds settings to configure retries through sarama's Metadata.Retry.* settings. Previously telegraf always used the sarama defaults of 3 retries and 250ms delay before each retry. Now the Metadata.Retry.* settings are exposed through kafka_consumer's telegraf config so users can choose how many times to retry and configure the retry delay.

The PR also adds exponential backoff of connection retries by implementing a sarama Metadata.Retry.BackoffFunc. Telegraf's default backoff is constant for backward compatibility, but users can set `metadata_retry_type = "exponential"` to choose exponential backoff.

To test the new settings, I extended the integration test to run with both connection strategies and added two new tests around exponential backoff, one just checking that the BackoffFunc math is right and another that tries to connect to an unopen port on localhost to make sure backoff is configured in sarama correctly

related influxdata/feature-requests#461