### PR TITLE
fix(processors.parser): Keep name of original metric if parser doesn't return one

### DIFF
--- a/plugins/processors/parser/parser.go
+++ b/plugins/processors/parser/parser.go
@@ -49,7 +49,13 @@ func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 						}
 
 						for _, m := range fromFieldMetric {
-							if m.Name() == "" {
+							// The parser get the parent plugin's name as
+							// default measurement name. Thus, in case the
+							// parsed metric does not provide a name itself,
+							// the parser  will return 'parser' as we are in
+							// processors.parser. In those cases we want to
+							// keep the original metric name.
+							if m.Name() == "" || m.Name() == "parser" {
 								m.SetName(metric.Name())
 							}
 						}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12115

With PR #11600 parsers for processors are no longer initialized with an empty metric name by default. Instead they now use the name of the parent plugin. However, `processors.parser` tries to use the original metric-name in case the parser does not provide an individual name (e.g. for `parsers.value`) for the returned metric. To do so, the processor checks for an empty name which is no longer valid as the parser's default metric name is now `"parser"`.

This PR fixes the check for the default name to restore the old behavior.