### PR TITLE
fix(agent): watch for changes in configuration files in config directories

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -72,7 +72,6 @@ func (t *Telegraf) Init(pprofErr <-chan error, f Filters, g GlobalFlags, w Windo
 	t.pprofErr = pprofErr
 	t.inputFilters = f.input
 	t.outputFilters = f.output
-	t.configFiles = []string{}
 	t.GlobalFlags = g
 	t.WindowFlags = w
 }
@@ -183,7 +182,6 @@ func (t *Telegraf) runAgent(ctx context.Context) error {
 	c := config.NewConfig()
 	c.OutputFilters = t.outputFilters
 	c.InputFilters = t.inputFilters
-	var err error
 
 	t.configFiles = configFiles
 	if err := c.LoadAll(configFiles...); err != nil {
@@ -218,7 +216,7 @@ func (t *Telegraf) runAgent(ctx context.Context) error {
 		LogWithTimezone:     c.Agent.LogWithTimezone,
 	}
 
-	err = logger.SetupLogging(logConfig)
+	err := logger.SetupLogging(logConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -62,6 +62,7 @@ type Telegraf struct {
 
 	inputFilters  []string
 	outputFilters []string
+	configFiles   []string
 
 	GlobalFlags
 	WindowFlags
@@ -71,6 +72,7 @@ func (t *Telegraf) Init(pprofErr <-chan error, f Filters, g GlobalFlags, w Windo
 	t.pprofErr = pprofErr
 	t.inputFilters = f.input
 	t.outputFilters = f.output
+	t.configFiles = []string{}
 	t.GlobalFlags = g
 	t.WindowFlags = w
 }
@@ -86,7 +88,7 @@ func (t *Telegraf) reloadLoop() error {
 		signal.Notify(signals, os.Interrupt, syscall.SIGHUP,
 			syscall.SIGTERM, syscall.SIGINT)
 		if t.watchConfig != "" {
-			for _, fConfig := range t.config {
+			for _, fConfig := range t.configFiles {
 				if _, err := os.Stat(fConfig); err == nil {
 					go t.watchLocalConfig(signals, fConfig)
 				} else {
@@ -161,30 +163,31 @@ func (t *Telegraf) watchLocalConfig(signals chan os.Signal, fConfig string) {
 }
 
 func (t *Telegraf) runAgent(ctx context.Context) error {
+	var configFiles []string
+	// providing no "config" flag should load default config
+	if len(t.config) == 0 {
+		configFiles = append(configFiles, "")
+	} else {
+		configFiles = append(configFiles, t.config...)
+	}
+
+	for _, fConfigDirectory := range t.configDir {
+		files, err := config.WalkDirectory(fConfigDirectory)
+		if err != nil {
+			return err
+		}
+		configFiles = append(configFiles, files...)
+	}
+
 	// If no other options are specified, load the config file and run.
 	c := config.NewConfig()
 	c.OutputFilters = t.outputFilters
 	c.InputFilters = t.inputFilters
 	var err error
-	// providing no "config" flag should load default config
-	if len(t.config) == 0 {
-		err = c.LoadConfig("")
-		if err != nil {
-			return err
-		}
-	}
-	for _, fConfig := range t.config {
-		err = c.LoadConfig(fConfig)
-		if err != nil {
-			return err
-		}
-	}
 
-	for _, fConfigDirectory := range t.configDir {
-		err = c.LoadDirectory(fConfigDirectory)
-		if err != nil {
-			return err
-		}
+	t.configFiles = configFiles
+	if err := c.LoadAll(configFiles...); err != nil {
+		return err
 	}
 
 	if !(t.test || t.testWait != 0) && len(c.Outputs) == 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -140,8 +140,11 @@ func TestConfig_LoadSingleInput(t *testing.T) {
 
 func TestConfig_LoadDirectory(t *testing.T) {
 	c := NewConfig()
-	require.NoError(t, c.LoadConfig("./testdata/single_plugin.toml"))
-	require.NoError(t, c.LoadDirectory("./testdata/subconfig"))
+
+	files, err := WalkDirectory("./testdata/subconfig")
+	files = append([]string{"./testdata/single_plugin.toml"}, files...)
+	require.NoError(t, err)
+	require.NoError(t, c.LoadAll(files...))
 
 	// Create the expected data
 	expectedPlugins := make([]*MockupInputPlugin, 4)


### PR DESCRIPTION
# Required for all PRs

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #9985

Another iteration on the fix from #10379 by @conorevans. 

Extracted config.WalkDirectory to collect a list of config files to load configuration from. Reuse the same list later to schedule automatic reloads for changed files.

