### PR TITLE
chore: Fix linter findings introduced in last PRs

### DIFF
--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -553,7 +553,8 @@ func TestKafkaRoundTripIntegration(t *testing.T) {
 		MaxUndeliveredMessages: 1,
 	}
 	parser := &influx.Parser{}
-	parser.Init()
+	err = parser.Init()
+	require.NoError(t, err)
 	input.SetParser(parser)
 	err = input.Init()
 	require.NoError(t, err)

--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -3,12 +3,11 @@ package opcua
 
 import (
 	_ "embed"
-	"github.com/gopcua/opcua/ua"
-	"github.com/influxdata/telegraf/plugins/common/opcua"
 	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/common/opcua"
 	"github.com/influxdata/telegraf/plugins/common/opcua/input"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
@@ -21,7 +20,6 @@ type OpcUA struct {
 	Log telegraf.Logger `toml:"-"`
 
 	client *ReadClient
-	codes  []ua.StatusCode
 }
 
 func (*OpcUA) SampleConfig() string {

--- a/plugins/inputs/opentelemetry/grpc_services.go
+++ b/plugins/inputs/opentelemetry/grpc_services.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/influxdata/influxdb-observability/common"
+	"github.com/influxdata/influxdb-observability/otel2influx"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
-
-	"github.com/influxdata/influxdb-observability/common"
-	"github.com/influxdata/influxdb-observability/otel2influx"
 )
 
 type traceService struct {
@@ -27,9 +26,9 @@ func newTraceService(logger common.Logger, writer *writeToAccumulator) *traceSer
 	}
 }
 
-func (s *traceService) Export(ctx context.Context, req ptraceotlp.Request) (ptraceotlp.Response, error) {
+func (s *traceService) Export(ctx context.Context, req ptraceotlp.ExportRequest) (ptraceotlp.ExportResponse, error) {
 	err := s.converter.WriteTraces(ctx, req.Traces(), s.writer)
-	return ptraceotlp.NewResponse(), err
+	return ptraceotlp.NewExportResponse(), err
 }
 
 type metricsService struct {
@@ -60,9 +59,9 @@ func newMetricsService(logger common.Logger, writer *writeToAccumulator, schema 
 	}, nil
 }
 
-func (s *metricsService) Export(ctx context.Context, req pmetricotlp.Request) (pmetricotlp.Response, error) {
+func (s *metricsService) Export(ctx context.Context, req pmetricotlp.ExportRequest) (pmetricotlp.ExportResponse, error) {
 	err := s.converter.WriteMetrics(ctx, req.Metrics(), s.writer)
-	return pmetricotlp.NewResponse(), err
+	return pmetricotlp.NewExportResponse(), err
 }
 
 type logsService struct {
@@ -80,7 +79,7 @@ func newLogsService(logger common.Logger, writer *writeToAccumulator) *logsServi
 	}
 }
 
-func (s *logsService) Export(ctx context.Context, req plogotlp.Request) (plogotlp.Response, error) {
+func (s *logsService) Export(ctx context.Context, req plogotlp.ExportRequest) (plogotlp.ExportResponse, error) {
 	err := s.converter.WriteLogs(ctx, req.Logs(), s.writer)
-	return plogotlp.NewResponse(), err
+	return plogotlp.NewExportResponse(), err
 }

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -13,9 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-
-	// Blank import to allow gzip encoding
-	_ "google.golang.org/grpc/encoding/gzip"
+	_ "google.golang.org/grpc/encoding/gzip" // Blank import to allow gzip encoding
 	"google.golang.org/grpc/metadata"
 
 	"github.com/influxdata/telegraf"
@@ -101,7 +99,7 @@ func (o *OpenTelemetry) Connect() error {
 		return err
 	}
 
-	metricsServiceClient := pmetricotlp.NewClient(grpcClientConn)
+	metricsServiceClient := pmetricotlp.NewGRPCClient(grpcClientConn)
 
 	o.metricsConverter = metricsConverter
 	o.grpcClientConn = grpcClientConn
@@ -149,7 +147,7 @@ func (o *OpenTelemetry) Write(metrics []telegraf.Metric) error {
 		}
 	}
 
-	md := pmetricotlp.NewRequestFromMetrics(batch.GetMetrics())
+	md := pmetricotlp.NewExportRequestFromMetrics(batch.GetMetrics())
 	if md.Metrics().ResourceMetrics().Len() == 0 {
 		return nil
 	}

--- a/plugins/processors/parser/parser_test.go
+++ b/plugins/processors/parser/parser_test.go
@@ -4,19 +4,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/metric"
 	"github.com/stretchr/testify/require"
 
-	//Blank import to register all new-style parsers
-
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/parsers"
 	"github.com/influxdata/telegraf/plugins/parsers/grok"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/plugins/parsers/json"
 	"github.com/influxdata/telegraf/plugins/parsers/logfmt"
 	"github.com/influxdata/telegraf/plugins/parsers/value"
-
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -701,8 +698,8 @@ func TestBadApply(t *testing.T) {
 
 func getMetricFields(m telegraf.Metric) interface{} {
 	key := "field3"
-	if value, ok := m.Fields()[key]; ok {
-		return value
+	if v, ok := m.Fields()[key]; ok {
+		return v
 	}
 	return nil
 }


### PR DESCRIPTION
Fixing:

```
plugins/inputs/kafka_consumer/kafka_consumer_test.go:556:13  errcheck     Error return value of `parser.Init` is not checked
```
introduced here: https://github.com/influxdata/telegraf/pull/12058


```
plugins/inputs/opcua/opcua.go:24:2                           unused       field `codes` is unused
```
introduced here: https://github.com/influxdata/telegraf/pull/11786


```
plugins/inputs/opentelemetry/grpc_services.go:30:56          staticcheck  SA1019: ptraceotlp.Request is deprecated: [v0.63.0] use ExportRequest. 
plugins/inputs/opentelemetry/grpc_services.go:32:9           staticcheck  SA1019: ptraceotlp.NewResponse is deprecated: [v0.63.0] use NewExportResponse. 
plugins/inputs/opentelemetry/grpc_services.go:63:58          staticcheck  SA1019: pmetricotlp.Request is deprecated: [v0.63.0] use ExportRequest. 
plugins/inputs/opentelemetry/grpc_services.go:65:9           staticcheck  SA1019: pmetricotlp.NewResponse is deprecated: [v0.63.0] use NewExportResponse. 
plugins/inputs/opentelemetry/grpc_services.go:83:55          staticcheck  SA1019: plogotlp.Request is deprecated: [v0.63.0] use ExportRequest. 
plugins/inputs/opentelemetry/grpc_services.go:85:9           staticcheck  SA1019: plogotlp.NewResponse is deprecated: [v0.63.0] use NewExportResponse. 
plugins/outputs/opentelemetry/opentelemetry.go:104:26        staticcheck  SA1019: pmetricotlp.NewClient is deprecated: [v0.63.0]: use NewGRPCClient. 
plugins/outputs/opentelemetry/opentelemetry.go:152:8         staticcheck  SA1019: pmetricotlp.NewRequestFromMetrics is deprecated: [v0.63.0] use NewExportRequestFromMetrics. 
plugins/outputs/opentelemetry/opentelemetry_test.go:132:63   staticcheck  SA1019: pmetricotlp.Request is deprecated: [v0.63.0] use ExportRequest. 
plugins/outputs/opentelemetry/opentelemetry_test.go:138:9    staticcheck  SA1019: pmetricotlp.NewResponse is deprecated: [v0.63.0] use NewExportResponse. 
plugins/outputs/opentelemetry/opentelemetry_test.go:54:25    staticcheck  SA1019: pmetricotlp.NewClient is deprecated: [v0.63.0]: use NewGRPCClient. 
plugins/outputs/opentelemetry/opentelemetry_test.go:74:21    staticcheck  SA1019: pmetric.NewJSONMarshaler is deprecated: [v0.63.0] use &JSONMarshaler{} 
plugins/outputs/opentelemetry/opentelemetry_test.go:77:18    staticcheck  SA1019: pmetric.NewJSONMarshaler is deprecated: [v0.63.0] use &JSONMarshaler{} 
```
introduced here: https://github.com/influxdata/telegraf/pull/12119
```
plugins/processors/parser/parser_test.go:704:5               revive       import-shadowing: The name 'value' shadows an import name
```
introduced here: https://github.com/influxdata/telegraf/pull/12116