### PR TITLE
test(outputs.sql): wait for db dump file to exist

### DIFF
--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -227,7 +227,7 @@ func TestMysqlIntegration(t *testing.T) {
 	dumpfile := filepath.Join(outDir, "dump")
 	require.Eventually(t, func() bool {
 		_, err := os.Stat(dumpfile)
-		return os.IsExist(err)
+		return !os.IsNotExist(err)
 	}, 5*time.Second, 10*time.Millisecond)
 
 	//compare the dump to what we expected

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -225,7 +225,10 @@ func TestMysqlIntegration(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, rc)
 	dumpfile := filepath.Join(outDir, "dump")
-	require.FileExists(t, dumpfile)
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(dumpfile)
+		return os.IsExist(err)
+	}, 5*time.Second, 10*time.Millisecond)
 
 	//compare the dump to what we expected
 	expected, err := os.ReadFile("testdata/mariadb/expected.sql")


### PR DESCRIPTION
This is a flaky test that does not always fail. When it does fail it says the file does not exist. My guess is that the file is not fully written or present.

fixes: #12148
