### PR TITLE
chore: Use depguard instead of revive.imports-blacklist

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   enable:
     # - telegraflinter
     - bodyclose
+    - depguard
     - dogsled
     - errcheck
     - goprintffuncname
@@ -20,6 +21,45 @@ linters:
     - unused
 
 linters-settings:
+  depguard:
+    # Kind of list is passed in.
+    # Allowed values: allowlist|denylist
+    # Default: denylist
+    list-type: denylist
+    # Check the list against standard lib.
+    # Default: false
+    include-go-root: true
+    # A list of packages for the list type specified.
+    # Can accept both string prefixes and string glob patterns.
+    # Default: []
+    packages:
+      - log
+    # A list of packages for the list type specified.
+    # Specify an error message to output when a denied package is used.
+    # Default: []
+    packages-with-error-message:
+      - log: 'Use injected telegraf.Logger instead'
+    # Specify rules by which the linter ignores certain files for consideration.
+    # Can accept both string prefixes and string glob patterns.
+    # The ! character in front of the rule is a special character
+    # which signals that the linter should negate the rule.
+    # This allows for more precise control, but it is only available for glob patterns.
+    # Default: []
+    ignore-file-rules:
+      - "**/agent/**"
+      - "**/cmd/**"
+      - "**/config/**"
+      - "**/filter/**"
+      - "**/internal/**"
+      - "**/logger/**"
+      - "**/metric/**"
+      - "**/models/**"
+      - "**/plugins/serializers/**"
+      - "**/scripts/**"
+      - "**/selfstat/**"
+      - "**/testutil/**"
+      - "**/tools/**"
+      - "**/*_test.go"
   revive:
     rules:
       - name: argument-limit
@@ -45,13 +85,10 @@ linters-settings:
       - name: error-return
       - name: error-strings
       - name: errorf
-      #      - name: flag-parameter #disable for now
       - name: function-result-limit
         arguments: [ 3 ]
       - name: identical-branches
       - name: if-return
-      - name: imports-blacklist
-        arguments: [ "log" ]
       - name: import-shadowing
       - name: increment-decrement
       - name: indent-error-flow
@@ -95,8 +132,6 @@ run:
     - assets
     - docs
     - etc
-    - scripts
-    # - plugins/parsers/influx/machine.go
 
   # which files to skip: they will be analyzed, but issues from them
   # won't be reported. Default value is empty list, but there is
@@ -121,14 +156,6 @@ issues:
     - path: plugins/parsers/influx
       linters:
         - govet
-
-    - path: _test\.go
-      text: "parameter.*seems to be a control flag, avoid control coupling"
-
-    - path: (^agent/|^cmd/|^config/|^filter/|^internal/|^logger/|^metric/|^models/|^selfstat/|^testutil/|^tools|^plugins/serializers/|^plugins/inputs/zipkin/cmd)
-      text: "imports-blacklist: should not use the following blacklisted import: \"log\""
-      linters:
-        - revive
 
     - path: cmd/telegraf/(main|printer).go
       text: "Error return value of `outputBuffer.Write` is not checked"

--- a/plugins/common/logrus/hook.go
+++ b/plugins/common/logrus/hook.go
@@ -2,7 +2,7 @@ package logrus
 
 import (
 	"io"
-	"log" //nolint:revive // Allow exceptional but valid use of log here.
+	"log" //nolint:depguard // Allow exceptional but valid use of log here.
 	"strings"
 	"sync"
 

--- a/plugins/common/shim/config.go
+++ b/plugins/common/shim/config.go
@@ -3,10 +3,11 @@ package shim
 import (
 	"errors"
 	"fmt"
-	"log" //nolint:revive // Allow exceptional but valid use of log here.
+	"log" //nolint:depguard // Allow exceptional but valid use of log here.
 	"os"
 
 	"github.com/BurntSushi/toml"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/outputs"

--- a/plugins/common/shim/logger.go
+++ b/plugins/common/shim/logger.go
@@ -2,7 +2,7 @@ package shim
 
 import (
 	"fmt"
-	"log" //nolint:revive // Allow exceptional but valid use of log here.
+	"log" //nolint:depguard // Allow exceptional but valid use of log here.
 	"os"
 	"reflect"
 

--- a/plugins/inputs/snmp/netsnmp.go
+++ b/plugins/inputs/snmp/netsnmp.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log" //nolint:revive
+	"log" //nolint:depguard // Allow exceptional but valid use of log here.
 	"os/exec"
 	"strings"
 	"sync"


### PR DESCRIPTION
`depguard` is a great linter which can combine multiple allow and deny lists. Highly configurable. 