### PR TITLE
fix(outputs.prometheus): expire during add

### DIFF
--- a/plugins/outputs/prometheus_client/v1/collector.go
+++ b/plugins/outputs/prometheus_client/v1/collector.go
@@ -77,6 +77,8 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.Lock()
 	defer c.Unlock()
 
+	// Expire metrics, doing this on Collect ensure metrics are removed even if no
+	// new metrics are added to the output.
 	c.Expire(time.Now(), c.ExpirationInterval)
 
 	for name, family := range c.fam {
@@ -366,6 +368,10 @@ func (c *Collector) Add(metrics []telegraf.Metric) error {
 				c.addMetricFamily(point, sample, mname, sampleID)
 			}
 		}
+
+		// Expire metrics, doing this on Add ensure metrics are removed even if no
+		// one is querying the data.
+		c.Expire(time.Now(), c.ExpirationInterval)
 	}
 	return nil
 }


### PR DESCRIPTION
Currently, we are only expiring data is someone is getting the data. This means that if data is continuously pushed but not gathered, the usage can grow and grow. This change forces expiration during add, similar to how v2 handles this.

fixes: #9821
