### PR TITLE
chore: Move influxdb_v2 to be first in sample config

### DIFF
--- a/cmd/telegraf/printer.go
+++ b/cmd/telegraf/printer.go
@@ -305,12 +305,25 @@ func printFilteredInputs(inputFilters []string, commented bool, outputBuffer io.
 func printFilteredOutputs(outputFilters []string, commented bool, outputBuffer io.Writer) {
 	// Filter outputs
 	var onames []string
+	var influxdbV2 string
+
 	for oname := range outputs.Outputs {
 		if sliceContains(oname, outputFilters) {
+			// Make influxdb_v2 the exception and have it be first in the list
+			// Store it and add it later
+			if oname == "influxdb_v2" {
+				influxdbV2 = oname
+				continue
+			}
+
 			onames = append(onames, oname)
 		}
 	}
 	sort.Strings(onames)
+
+	if influxdbV2 != "" {
+		onames = append([]string{influxdbV2}, onames...)
+	}
 
 	// Print Outputs
 	for _, oname := range onames {


### PR DESCRIPTION
resolve: https://github.com/influxdata/telegraf/issues/11074

From the discussion in the issue, it seems the intention was to have `outputs.influxdb_v2` be an exception to the alphabetically sorted outputs and be the first in the list. `outputs.influxdb` will still be first because it is enabled by default, this will change come 2.0 (https://github.com/influxdata/telegraf/pull/12158)