### PR TITLE
feat(inputs.openweathermap): add option to change timestamp option

### DIFF
--- a/plugins/inputs/openweathermap/README.md
+++ b/plugins/inputs/openweathermap/README.md
@@ -52,6 +52,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Query interval; OpenWeatherMap weather data is updated every 10
   ## minutes.
   interval = "10m"
+
+  ## Timestamp: default to "issue" which is the time the forecast data was
+  ## made. Use "prediction", to instead use the future time of the forecast.
+  ## This is 3 hours later.
+  # timestamp = "issue"
 ```
 
 ## Metrics

--- a/plugins/inputs/openweathermap/sample.conf
+++ b/plugins/inputs/openweathermap/sample.conf
@@ -28,3 +28,8 @@
   ## Query interval; OpenWeatherMap weather data is updated every 10
   ## minutes.
   interval = "10m"
+
+  ## Timestamp: default to "issue" which is the time the forecast data was
+  ## made. Use "prediction", to instead use the future time of the forecast.
+  ## This is 3 hours later.
+  # timestamp = "issue"


### PR DESCRIPTION
With this option, users can set the timestamp to 3 hours in the future to match the prediction of the weather then. Otherwise, by default, the time the prediction was issued is used.

fixes: #9239