### PR TITLE
chore: Enable asciicheck, asasalint, bidichk and exportloopref linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,12 @@ linters:
   disable-all: true
   enable:
     # - telegraflinter
+    - asciicheck
+    - asasalint
+    - bidichk
     - bodyclose
     - dogsled
+    - exportloopref
     - errcheck
     - goprintffuncname
     - gosimple

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
@@ -174,9 +174,10 @@ func (c *CloudWatchLogs) Connect() error {
 			queryToken = logGroupsOutput.NextToken
 
 			for _, logGroup := range logGroupsOutput.LogGroups {
-				if *(logGroup.LogGroupName) == c.LogGroup {
+				lg := logGroup
+				if *(lg.LogGroupName) == c.LogGroup {
 					c.Log.Debugf("Found log group %q", c.LogGroup)
-					c.lg = &logGroup //nolint:revive
+					c.lg = &lg
 				}
 			}
 		}

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -80,7 +80,7 @@ func (l *DebugLogger) Printf(format string, v ...interface{}) {
 }
 
 func (l *DebugLogger) Println(v ...interface{}) {
-	l.Print(v)
+	l.Print(v...)
 }
 
 func ValidateTopicSuffixMethod(method string) error {


### PR DESCRIPTION
- [asciicheck](https://github.com/tdakkota/asciicheck) - Simple linter to check that your code does not contain non-ASCII identifiers
- [asasalint](https://github.com/alingse/asasalint) - check for pass []any as any in variadic func(...any)
- [bidichk](https://github.com/breml/bidichk) - Checks for dangerous unicode character sequences
- [exportloopref](https://github.com/kyoh86/exportloopref) - checks for pointers to enclosing loop variables

Fix two new findings:
```
plugins/outputs/cloudwatch_logs/cloudwatch_logs.go:179:14  exportloopref  exporting a pointer for the loop variable logGroup
plugins/outputs/kafka/kafka.go:83:10                       asasalint      pass []any as any to func l.Print func(v ...interface{})
```
