### PR TITLE
feat(inputs.tomcat): add source tag

### DIFF
--- a/plugins/inputs/tomcat/README.md
+++ b/plugins/inputs/tomcat/README.md
@@ -64,11 +64,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ### Tags
 
+- tomcat_jvm_memory
+  - source
 - tomcat_jvm_memorypool has the following tags:
   - name
   - type
+  - source
 - tomcat_connector
   - name
+  - source
 
 ## Example Output
 

--- a/plugins/inputs/tomcat/tomcat.go
+++ b/plugins/inputs/tomcat/tomcat.go
@@ -117,19 +117,24 @@ func (s *Tomcat) Gather(acc telegraf.Accumulator) error {
 		return err
 	}
 
+	tags := map[string]string{
+		"source": s.URL,
+	}
+
 	// add tomcat_jvm_memory measurements
 	tcm := map[string]interface{}{
 		"free":  status.TomcatJvm.JvmMemory.Free,
 		"total": status.TomcatJvm.JvmMemory.Total,
 		"max":   status.TomcatJvm.JvmMemory.Max,
 	}
-	acc.AddFields("tomcat_jvm_memory", tcm, nil)
+	acc.AddFields("tomcat_jvm_memory", tcm, tags)
 
 	// add tomcat_jvm_memorypool measurements
 	for _, mp := range status.TomcatJvm.JvmMemoryPools {
 		tcmpTags := map[string]string{
-			"name": mp.Name,
-			"type": mp.Type,
+			"name":   mp.Name,
+			"type":   mp.Type,
+			"source": s.URL,
 		}
 
 		tcmpFields := map[string]interface{}{
@@ -150,7 +155,8 @@ func (s *Tomcat) Gather(acc telegraf.Accumulator) error {
 		}
 
 		tccTags := map[string]string{
-			"name": name,
+			"name":   name,
+			"source": s.URL,
 		}
 
 		tccFields := map[string]interface{}{

--- a/plugins/inputs/tomcat/tomcat_test.go
+++ b/plugins/inputs/tomcat/tomcat_test.go
@@ -60,7 +60,16 @@ func TestHTTPTomcat8(t *testing.T) {
 		"total": int64(58195968),
 		"max":   int64(620756992),
 	}
-	acc.AssertContainsFields(t, "tomcat_jvm_memory", jvmMemoryFields)
+	jvmMemoryTags := map[string]string{
+		"source": ts.URL,
+	}
+	for _, metric := range acc.Metrics {
+		fmt.Println(metric.Measurement)
+		for k, v := range metric.Tags {
+			fmt.Printf("%s: %s\n", k, v)
+		}
+	}
+	acc.AssertContainsTaggedFields(t, "tomcat_jvm_memory", jvmMemoryFields, jvmMemoryTags)
 
 	// tomcat_jvm_memorypool
 	jvmMemoryPoolFields := map[string]interface{}{
@@ -70,8 +79,9 @@ func TestHTTPTomcat8(t *testing.T) {
 		"used":      int64(17533952),
 	}
 	jvmMemoryPoolTags := map[string]string{
-		"name": "PS Perm Gen",
-		"type": "Non-heap memory",
+		"name":   "PS Perm Gen",
+		"type":   "Non-heap memory",
+		"source": ts.URL,
 	}
 	acc.AssertContainsTaggedFields(t, "tomcat_jvm_memorypool", jvmMemoryPoolFields, jvmMemoryPoolTags)
 
@@ -88,7 +98,8 @@ func TestHTTPTomcat8(t *testing.T) {
 		"bytes_sent":           int64(9286),
 	}
 	connectorTags := map[string]string{
-		"name": "http-apr-8080",
+		"name":   "http-apr-8080",
+		"source": ts.URL,
 	}
 	acc.AssertContainsTaggedFields(t, "tomcat_connector", connectorFields, connectorTags)
 }
@@ -147,7 +158,8 @@ func TestHTTPTomcat6(t *testing.T) {
 		"request_count":        int(436),
 	}
 	connectorTags := map[string]string{
-		"name": "http-8080",
+		"name":   "http-8080",
+		"source": ts.URL,
 	}
 	acc.AssertContainsTaggedFields(t, "tomcat_connector", connectorFields, connectorTags)
 }


### PR DESCRIPTION
This adds a source tag which will help determine what server metrics are coming from. Currently, as there is no tag to determine where metrics are coming from, users have to use different tomcat plugins for each server. This would allow one plugin which would set the source field.

fixes: #3780