### PR TITLE
fix(inputs.ping): Use -W on newer version of FreeBSD with ping6

### DIFF
--- a/plugins/inputs/ping/ping_notwindows.go
+++ b/plugins/inputs/ping/ping_notwindows.go
@@ -257,7 +257,6 @@ func checkRoundTripTimeStats(line string) (roundTripTimeStats, error) {
 // to avoid changing behavior.
 func freeBSDMajorVersion() int {
 	out, err := exec.Command("freebsd-version", "-u").Output()
-
 	if err != nil {
 		return -1
 	}

--- a/plugins/inputs/ping/ping_notwindows.go
+++ b/plugins/inputs/ping/ping_notwindows.go
@@ -122,7 +122,7 @@ func (p *Ping) args(url string, system string) []string {
 	if p.Deadline > 0 {
 		switch system {
 		case "freebsd":
-			if strings.Contains(p.Binary, "ping6") {
+			if strings.Contains(p.Binary, "ping6") && freeBSDMajorVersion() <= 12 {
 				args = append(args, "-X", strconv.Itoa(p.Deadline))
 			} else {
 				args = append(args, "-t", strconv.Itoa(p.Deadline))

--- a/plugins/inputs/ping/ping_notwindows.go
+++ b/plugins/inputs/ping/ping_notwindows.go
@@ -105,7 +105,7 @@ func (p *Ping) args(url string, system string) []string {
 		case "darwin":
 			args = append(args, "-W", strconv.FormatFloat(p.Timeout*1000, 'f', -1, 64))
 		case "freebsd":
-			if strings.Contains(p.Binary, "ping6") {
+			if strings.Contains(p.Binary, "ping6") && freeBSDMajorVersion() <= 12 {
 				args = append(args, "-x", strconv.FormatFloat(p.Timeout*1000, 'f', -1, 64))
 			} else {
 				args = append(args, "-W", strconv.FormatFloat(p.Timeout*1000, 'f', -1, 64))
@@ -250,4 +250,23 @@ func checkRoundTripTimeStats(line string) (roundTripTimeStats, error) {
 		}
 	}
 	return roundTripTimeStats, err
+}
+
+// Due to different behavior in version of freebsd, get the major
+// version number. In the event of an error we assume we return a low number
+// to avoid changing behavior.
+func freeBSDMajorVersion() int {
+	out, err := exec.Command("freebsd-version", "-u").Output()
+
+	if err != nil {
+		return -1
+	}
+
+	majorVersionStr := strings.Split(string(out), ".")[0]
+	majorVersion, err := strconv.Atoi(majorVersionStr)
+	if err != nil {
+		return -1
+	}
+
+	return majorVersion
 }


### PR DESCRIPTION
This aligns the ping6 behavior of FreeBSD greater than version 13 with the other BSD commands. Because it is breaking, we need to check the major version of FreeBSD and for 12 and older we use the older -x option.

fixes: #10743
