### PR TITLE
fix(agent): Watch for changes in configuration files in config directories

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -302,7 +302,8 @@ func sliceContains(name string, list []string) bool {
 }
 
 // LoadDirectory loads all toml config files found in the specified path, recursively.
-func (c *Config) LoadDirectory(path string) error {
+func (c *Config) LoadDirectory(path string) ([]string, error) {
+	var loadedConfigs []string
 	walkfn := func(thispath string, info os.FileInfo, _ error) error {
 		if info == nil {
 			log.Printf("W! Telegraf is not permitted to read %s", thispath)
@@ -311,7 +312,7 @@ func (c *Config) LoadDirectory(path string) error {
 
 		if info.IsDir() {
 			if strings.HasPrefix(info.Name(), "..") {
-				// skip Kubernetes mounts, prevening loading the same config twice
+				// skip Kubernetes mounts, preventing loading the same config twice
 				return filepath.SkipDir
 			}
 
@@ -325,9 +326,12 @@ func (c *Config) LoadDirectory(path string) error {
 		if err != nil {
 			return err
 		}
+
+		loadedConfigs = append(loadedConfigs, thispath)
+
 		return nil
 	}
-	return filepath.Walk(path, walkfn)
+	return loadedConfigs, filepath.Walk(path, walkfn)
 }
 
 // Try to find a default config file at these locations (in order):

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -141,7 +141,8 @@ func TestConfig_LoadSingleInput(t *testing.T) {
 func TestConfig_LoadDirectory(t *testing.T) {
 	c := NewConfig()
 	require.NoError(t, c.LoadConfig("./testdata/single_plugin.toml"))
-	require.NoError(t, c.LoadDirectory("./testdata/subconfig"))
+	_, err := c.LoadDirectory("./testdata/subconfig")
+	require.NoError(t, err)
 
 	// Create the expected data
 	expectedPlugins := make([]*MockupInputPlugin, 4)


### PR DESCRIPTION
replaces: https://github.com/influxdata/telegraf/pull/10379
resolves: https://github.com/influxdata/telegraf/issues/9985

Update the `--watch-config` to also work with configurations loaded when using `--config-directory`.

Created this pull request based on the recommendations discussed here: https://github.com/influxdata/telegraf/pull/10379#discussion_r948323019

@conorevans thank you for getting this work started!