### PR TITLE
chore: Enable interfacebloat linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - interfacebloat
     - nakedret
     - nilerr
     - predeclared

--- a/metric.go
+++ b/metric.go
@@ -32,6 +32,7 @@ type Field struct {
 // Metric is the type of data that is processed by Telegraf.  Input plugins,
 // and to a lesser degree, Processor and Aggregator plugins create new Metrics
 // and Output plugins write them.
+// nolint:interfacebloat // conditionally allow to contain more methods
 type Metric interface {
 	// Name is the primary identifier for the Metric and corresponds to the
 	// measurement in the InfluxDB data model.

--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 )
 
+// nolint:interfacebloat // conditionally allow to contain more methods
 type Process interface {
 	PID() PID
 	Tags() map[string]string


### PR DESCRIPTION
[interfacebloat](https://github.com/sashamelentyev/interfacebloat) - A linter that checks the number of methods inside an interface.

Address two new findings (add `//nolint` as @reimda suggested):
```
metric.go:35:13                                 interfacebloat  the interface has more than 10 methods: 24
plugins/inputs/procstat/process.go:11:14        interfacebloat  the interface has more than 10 methods: 17
```