### PR TITLE
chore: Enable tparallel linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - revive
     - sqlclosecheck
     - staticcheck
+    - tparallel
     - typecheck
     - unconvert
     - unused

--- a/plugins/inputs/neptune_apex/neptune_apex_test.go
+++ b/plugins/inputs/neptune_apex/neptune_apex_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGather(t *testing.T) {
@@ -378,6 +379,8 @@ func TestParseXML(t *testing.T) {
 }
 
 func TestSendRequest(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		statusCode int
@@ -428,6 +431,8 @@ func TestSendRequest(t *testing.T) {
 }
 
 func TestParseTime(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    string
@@ -474,6 +479,8 @@ func TestParseTime(t *testing.T) {
 }
 
 func TestFindProbe(t *testing.T) {
+	t.Parallel()
+
 	fakeProbes := []probe{
 		{
 			Name: "test1",


### PR DESCRIPTION
[tparallel](https://github.com/moricho/tparallel) - detects inappropriate usage of `t.Parallel()` method in your Go test codes.

Fix 3 new findings:
```
plugins/inputs/neptune_apex/neptune_apex_test.go:380:6  tparallel  TestSendRequest should call t.Parallel on the top level as well as its subtests
plugins/inputs/neptune_apex/neptune_apex_test.go:430:6  tparallel  TestParseTime should call t.Parallel on the top level as well as its subtests
plugins/inputs/neptune_apex/neptune_apex_test.go:476:6  tparallel  TestFindProbe should call t.Parallel on the top level as well as its subtests
```