### PR TITLE
chore: Wrap long lines in plugins/processors

### DIFF
--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -116,7 +116,11 @@ func TestMappings(t *testing.T) {
 	for _, mapping := range mappings {
 		fieldName := mapping["field_name"][0].(string)
 		for index := range mapping["target_value"] {
-			mapper := EnumMapper{Mappings: []Mapping{{Field: fieldName, ValueMappings: map[string]interface{}{mapping["target_value"][index].(string): mapping["mapped_value"][index]}}}}
+			mapper := EnumMapper{
+				Mappings: []Mapping{
+					{Field: fieldName, ValueMappings: map[string]interface{}{mapping["target_value"][index].(string): mapping["mapped_value"][index]}},
+				},
+			}
 			err := mapper.Init()
 			require.Nil(t, err)
 			fields := calculateProcessedValues(mapper, createTestMetric())

--- a/plugins/processors/parser/parser_test.go
+++ b/plugins/processors/parser/parser_test.go
@@ -213,7 +213,9 @@ func TestApply(t *testing.T) {
 				"success",
 				map[string]string{},
 				map[string]interface{}{
-					"grokSample": "127.0.0.1 - - [11/Dec/2013:00:01:45 -0800] \"GET /xampp/status.php HTTP/1.1\" 200 3891 \"http://cadenza/xampp/navi.php\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0\"",
+					"grokSample": "127.0.0.1 - - [11/Dec/2013:00:01:45 -0800] \"" +
+						"GET /xampp/status.php HTTP/1.1\" 200 3891 \"http://cadenza/xampp/navi.php\" \"Mozilla/5.0 (Macintosh; " +
+						"Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0\"",
 				},
 				time.Unix(0, 0)),
 			expected: []telegraf.Metric{

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -1,15 +1,14 @@
 package regex
 
 import (
-	"github.com/influxdata/telegraf/metric"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/testutil"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func newM1() telegraf.Metric {
@@ -880,8 +879,8 @@ func TestAnyTagConversion(t *testing.T) {
 			"request": "/users/42/",
 		}
 
-		assert.Equal(t, expectedFields, processed[0].Fields(), test.message, "Should not change fields")
-		assert.Equal(t, test.expectedTags, processed[0].Tags(), test.message)
-		assert.Equal(t, "access_log", processed[0].Name(), "Should not change name")
+		require.Equal(t, expectedFields, processed[0].Fields(), test.message, "Should not change fields")
+		require.Equal(t, test.expectedTags, processed[0].Tags(), test.message)
+		require.Equal(t, "access_log", processed[0].Name(), "Should not change name")
 	}
 }

--- a/plugins/processors/template/template_test.go
+++ b/plugins/processors/template/template_test.go
@@ -65,7 +65,9 @@ func TestTagTemplateConcatenate(t *testing.T) {
 	actual := tmp.Apply(input[0])
 
 	// assert
-	expected := []telegraf.Metric{testutil.MustMetric("Tags", map[string]string{"hostname": "localhost", "level": "debug", "topic": "localhost.debug"}, nil, now)}
+	expected := []telegraf.Metric{
+		testutil.MustMetric("Tags", map[string]string{"hostname": "localhost", "level": "debug", "topic": "localhost.debug"}, nil, now),
+	}
 	testutil.RequireMetricsEqual(t, expected, actual)
 }
 
@@ -112,7 +114,14 @@ func TestTagAndFieldConcatenate(t *testing.T) {
 	actual := tmp.Apply(m1)
 
 	// assert
-	expected := []telegraf.Metric{testutil.MustMetric("weather", map[string]string{"location": "us-midwest", "LocalTemp": "us-midwest is too warm"}, map[string]interface{}{"temperature": "too warm"}, now)}
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"weather",
+			map[string]string{"location": "us-midwest", "LocalTemp": "us-midwest is too warm"},
+			map[string]interface{}{"temperature": "too warm"},
+			now,
+		),
+	}
 	testutil.RequireMetricsEqual(t, expected, actual)
 }
 


### PR DESCRIPTION
Wrap lines longer than 160 characters.

It is only part of the bigger job.
After long lines in whole project are handled, we can enable proper linter to guard this.