### PR TITLE
chore: Wrap long lines in plugins/inputs/[e-h]*

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -417,7 +417,6 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gotest.tools v2.2.0+incompatible
 	honnef.co/go/tools v0.2.2 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803164354-a70c9af30aea // indirect

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -641,7 +641,11 @@ func (e *Elasticsearch) getCatMaster(url string) (string, error) {
 		// NOTE: we are not going to read/discard r.Body under the assumption we'd prefer
 		// to let the underlying transport close the connection and re-establish a new one for
 		// future calls.
-		return "", fmt.Errorf("elasticsearch: Unable to retrieve master node information. API responded with status-code %d, expected %d", r.StatusCode, http.StatusOK)
+		return "", fmt.Errorf(
+			"elasticsearch: Unable to retrieve master node information. API responded with status-code %d, expected %d",
+			r.StatusCode,
+			http.StatusOK,
+		)
 	}
 	response, err := io.ReadAll(r.Body)
 

--- a/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
+++ b/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
@@ -11,33 +11,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/plugins/parsers"
 	_ "github.com/influxdata/telegraf/plugins/parsers/all"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 )
 
-const (
-	singleObjectNotFound = "{\"error\":{\"code\":404,\"message\":\"No such object: test-iteration-bucket/prefix/offset-key.json\",\"errors\":[{\"message\":\"No such object: test-iteration-bucket/prefix/offset-key.json\",\"domain\":\"global\",\"reason\":\"notFound\"}]}}"
-	singleFileList       = "{\"kind\":\"storage#objects\",\"items\":[{\"kind\":\"storage#object\",\"id\":\"test-iteration-bucket/1604148850990/1604148851295698\",\"selfLink\":\"https://www.googleapis.com/storage/v1/b/1604148850990/o/1604148850990\",\"mediaLink\":\"https://content-storage.googleapis.com/download/storage/v1/b/test-iteration-bucket/o/1604148850990?generation=1604148851295698&alt=media\",\"name\":\"1604148850990\",\"bucket\":\"test-iteration-bucket\",\"generation\":\"1604148851295698\",\"metageneration\":\"1\",\"contentType\":\"text/plain; charset=utf-8\",\"storageClass\":\"STANDARD\",\"size\":\"161\",\"md5Hash\":\"y59iuRCTpkm7wpvU5YHUYw==\",\"crc32c\":\"y57reA==\",\"etag\":\"CNKLy5Pw3uwCEAE=\",\"timeCreated\":\"2020-10-31T12:54:11.295Z\",\"updated\":\"2020-10-31T12:54:11.295Z\",\"timeStorageClassUpdated\":\"2020-10-31T12:54:11.295Z\"}]}"
-	firstFile            = "{\"metrics\":[{\"fields\":{\"cosine\":10,\"sine\":-1.0975806427415925e-12},\"name\":\"cpu\",\"tags\":{\"datacenter\":\"us-east-1\",\"host\":\"localhost\"},\"timestamp\":1604148850991}]}"
-	secondFile           = "{\"metrics\":[{\"fields\":{\"cosine\":11,\"sine\":-2.0975806427415925e-12},\"name\":\"cpu\",\"tags\":{\"datacenter\":\"us-east-1\",\"host\":\"localhost\"},\"timestamp\":1604148850992}]}"
-	thirdFile            = "{\"metrics\":[{\"fields\":{\"cosine\":12,\"sine\":-3.0975806427415925e-12},\"name\":\"cpu\",\"tags\":{\"datacenter\":\"us-east-1\",\"host\":\"localhost\"},\"timestamp\":1604148850993}]}"
-	fourthFile           = "{\"metrics\":[{\"fields\":{\"cosine\":13,\"sine\":-4.0975806427415925e-12},\"name\":\"cpu\",\"tags\":{\"datacenter\":\"us-east-1\",\"host\":\"localhost\"},\"timestamp\":1604148850994}]}"
-	firstFileListing     = "{\"kind\":\"storage#object\",\"id\":\"test-iteration-bucket/prefix/1604148850991/1604148851353983\",\"selfLink\":\"https://www.googleapis.com/storage/v1/b/test-iteration-bucket/o/1604148850991\",\"mediaLink\":\"https://content-storage.googleapis.com/download/storage/v1/b/test-iteration-bucket/o/1604148850991?generation=1604148851353983&alt=media\",\"name\":\"prefix/1604148850991\",\"bucket\":\"test-iteration-bucket\",\"generation\":\"1604148851353983\",\"metageneration\":\"1\",\"contentType\":\"text/plain; charset=utf-8\",\"storageClass\":\"STANDARD\",\"size\":\"161\",\"md5Hash\":\"y59iuRCTpkm7wpvU5YHUYw==\",\"crc32c\":\"y57reA==\",\"etag\":\"CP/SzpPw3uwCEAE=\",\"timeCreated\":\"2020-10-31T12:54:11.353Z\",\"updated\":\"2020-10-31T12:54:11.353Z\",\"timeStorageClassUpdated\":\"2020-10-31T12:54:11.353Z\"}"
-	secondFileListing    = "{\"kind\":\"storage#object\",\"id\":\"test-iteration-bucket/prefix/1604148850992/1604148851414237\",\"selfLink\":\"https://www.googleapis.com/storage/v1/b/test-iteration-bucket/o/1604148850992\",\"mediaLink\":\"https://content-storage.googleapis.com/download/storage/v1/b/test-iteration-bucket/o/1604148850992?generation=1604148851414237&alt=media\",\"name\":\"prefix/1604148850992\",\"bucket\":\"test-iteration-bucket\",\"generation\":\"1604148851414237\",\"metageneration\":\"1\",\"contentType\":\"text/plain; charset=utf-8\",\"storageClass\":\"STANDARD\",\"size\":\"161\",\"md5Hash\":\"y59iuRCTpkm7wpvU5YHUYw==\",\"crc32c\":\"y57reA==\",\"etag\":\"CN2p0pPw3uwCEAE=\",\"timeCreated\":\"2020-10-31T12:54:11.414Z\",\"updated\":\"2020-10-31T12:54:11.414Z\",\"timeStorageClassUpdated\":\"2020-10-31T12:54:11.414Z\"}"
-	thirdFileListing     = "{\"kind\":\"storage#object\",\"id\":\"test-iteration-bucket/prefix/1604148850993/1604148851467554\",\"selfLink\":\"https://www.googleapis.com/storage/v1/b/test-iteration-bucket/o/1604148850993\",\"mediaLink\":\"https://content-storage.googleapis.com/download/storage/v1/b/test-iteration-bucket/o/1604148850993?generation=1604148851467554&alt=media\",\"name\":\"prefix/1604148850993\",\"bucket\":\"test-iteration-bucket\",\"generation\":\"1604148851467554\",\"metageneration\":\"1\",\"contentType\":\"text/plain; charset=utf-8\",\"storageClass\":\"STANDARD\",\"size\":\"161\",\"md5Hash\":\"y59iuRCTpkm7wpvU5YHUYw==\",\"crc32c\":\"y57reA==\",\"etag\":\"CKLK1ZPw3uwCEAE=\",\"timeCreated\":\"2020-10-31T12:54:11.467Z\",\"updated\":\"2020-10-31T12:54:11.467Z\",\"timeStorageClassUpdated\":\"2020-10-31T12:54:11.467Z\"}"
-	fourthFileListing    = "{\"kind\":\"storage#object\",\"id\":\"test-iteration-bucket/prefix/1604148850994/1604148851467554\",\"selfLink\":\"https://www.googleapis.com/storage/v1/b/test-iteration-bucket/o/1604148850994\",\"mediaLink\":\"https://content-storage.googleapis.com/download/storage/v1/b/test-iteration-bucket/o/1604148850994?generation=1604148851467554&alt=media\",\"name\":\"prefix/1604148850994\",\"bucket\":\"test-iteration-bucket\",\"generation\":\"1604148851467554\",\"metageneration\":\"1\",\"contentType\":\"text/plain; charset=utf-8\",\"storageClass\":\"STANDARD\",\"size\":\"161\",\"md5Hash\":\"y59iuRCTpkm7wpvU5YHUYw==\",\"crc32c\":\"y57reA==\",\"etag\":\"CKLK1ZPw3uwCEAE=\",\"timeCreated\":\"2020-10-31T12:54:11.467Z\",\"updated\":\"2020-10-31T12:54:11.467Z\",\"timeStorageClassUpdated\":\"2020-10-31T12:54:11.467Z\"}"
-	fileListing          = "{\"kind\":\"storage#objects\"}"
-	offSetTemplate       = "{\"offSet\":\"%s\"}"
-)
-
-var objListing = parseJSONFromText(fileListing)
-var firstElement = parseJSONFromText(firstFileListing)
-var secondElement = parseJSONFromText(secondFileListing)
-var thirdElement = parseJSONFromText(thirdFileListing)
-var fourthElement = parseJSONFromText(fourthFileListing)
+const offSetTemplate = "{\"offSet\":\"%s\"}"
 
 func TestRunSetUpClient(t *testing.T) {
 	gcs := &GCS{
@@ -67,7 +48,7 @@ func TestRunInit(t *testing.T) {
 
 	require.NoError(t, gcs.Init())
 
-	assert.Equal(t, "offsetfile", gcs.offSet.OffSet)
+	require.Equal(t, "offsetfile", gcs.offSet.OffSet)
 }
 
 func TestRunInitNoOffsetKey(t *testing.T) {
@@ -84,8 +65,8 @@ func TestRunInitNoOffsetKey(t *testing.T) {
 
 	require.NoError(t, gcs.Init())
 
-	assert.Equal(t, "offsetfile", gcs.offSet.OffSet)
-	assert.Equal(t, "prefix/offset-key.json", gcs.OffsetKey)
+	require.Equal(t, "offsetfile", gcs.offSet.OffSet)
+	require.Equal(t, "prefix/offset-key.json", gcs.OffsetKey)
 }
 
 func TestRunGatherOneItem(t *testing.T) {
@@ -108,11 +89,11 @@ func TestRunGatherOneItem(t *testing.T) {
 	require.NoError(t, gcs.Gather(acc))
 
 	metric := acc.Metrics[0]
-	assert.Equal(t, "cpu", metric.Measurement)
-	assert.Equal(t, "us-east-1", metric.Tags["tags_datacenter"])
-	assert.Equal(t, "localhost", metric.Tags["tags_host"])
-	assert.Equal(t, 10.0, metric.Fields["fields_cosine"])
-	assert.Equal(t, -1.0975806427415925e-12, metric.Fields["fields_sine"])
+	require.Equal(t, "cpu", metric.Measurement)
+	require.Equal(t, "us-east-1", metric.Tags["tags_datacenter"])
+	require.Equal(t, "localhost", metric.Tags["tags_host"])
+	require.Equal(t, 10.0, metric.Fields["fields_cosine"])
+	require.Equal(t, -1.0975806427415925e-12, metric.Fields["fields_sine"])
 }
 
 func TestRunGatherOneIteration(t *testing.T) {
@@ -135,7 +116,7 @@ func TestRunGatherOneIteration(t *testing.T) {
 
 	require.NoError(t, gcs.Gather(acc))
 
-	assert.Equal(t, 3, len(acc.Metrics))
+	require.Equal(t, 3, len(acc.Metrics))
 }
 
 func TestRunGatherIteratiosnWithLimit(t *testing.T) {
@@ -159,13 +140,13 @@ func TestRunGatherIteratiosnWithLimit(t *testing.T) {
 
 	require.NoError(t, gcs.Gather(acc))
 
-	assert.Equal(t, 1, len(acc.Metrics))
+	require.Equal(t, 1, len(acc.Metrics))
 	require.NoError(t, gcs.Gather(acc))
 
-	assert.Equal(t, 2, len(acc.Metrics))
+	require.Equal(t, 2, len(acc.Metrics))
 	require.NoError(t, gcs.Gather(acc))
 
-	assert.Equal(t, 3, len(acc.Metrics))
+	require.Equal(t, 3, len(acc.Metrics))
 }
 
 func TestRunGatherIterationWithPages(t *testing.T) {
@@ -188,14 +169,14 @@ func TestRunGatherIterationWithPages(t *testing.T) {
 
 	require.NoError(t, gcs.Gather(acc))
 
-	assert.Equal(t, 4, len(acc.Metrics))
-	assert.Equal(t, true, gcs.offSet.isPresent())
-	assert.Equal(t, "prefix/1604148850994", gcs.offSet.OffSet)
+	require.Equal(t, 4, len(acc.Metrics))
+	require.Equal(t, true, gcs.offSet.isPresent())
+	require.Equal(t, "prefix/1604148850994", gcs.offSet.OffSet)
 
 	emptyAcc := &testutil.Accumulator{}
 	require.NoError(t, gcs.Gather(emptyAcc))
 
-	assert.Equal(t, 0, len(emptyAcc.Metrics))
+	require.Equal(t, 0, len(emptyAcc.Metrics))
 }
 
 func createParser() parsers.Parser {
@@ -236,13 +217,14 @@ func startGCSServer(t *testing.T) *httptest.Server {
 
 func startOneItemGCSServer(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(http.NotFoundHandler())
+	singleFileList := readJSON(t, "testdata/single_file_list.json")
 
 	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/b/test-iteration-bucket/o":
 			serveJSONText(w, singleFileList)
 		default:
-			serveBlobs(r.URL.Path, "", t, w)
+			serveBlobs(t, w, r.URL.Path, "")
 		}
 	})
 
@@ -250,6 +232,12 @@ func startOneItemGCSServer(t *testing.T) *httptest.Server {
 }
 
 func startMultipleItemGCSServer(t *testing.T) *httptest.Server {
+	objListing := parseJSONFromFile(t, "testdata/file_listing.json")
+	firstElement := parseJSONFromFile(t, "testdata/first_file_listing.json")
+	secondElement := parseJSONFromFile(t, "testdata/second_file_listing.json")
+	thirdElement := parseJSONFromFile(t, "testdata/third_file_listing.json")
+	fourthElement := parseJSONFromFile(t, "testdata/fourth_file_listing.json")
+
 	srv := httptest.NewServer(http.NotFoundHandler())
 
 	currentOffSetKey := fmt.Sprintf(offSetTemplate, "prefix/1604148850991")
@@ -282,7 +270,7 @@ func startMultipleItemGCSServer(t *testing.T) *httptest.Server {
 			}
 
 		default:
-			serveBlobs(r.URL.Path, currentOffSetKey, t, w)
+			serveBlobs(t, w, r.URL.Path, currentOffSetKey)
 		}
 	})
 
@@ -292,13 +280,17 @@ func startMultipleItemGCSServer(t *testing.T) *httptest.Server {
 func stateFulGCSServer(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(http.NotFoundHandler())
 
+	firstElement := parseJSONFromFile(t, "testdata/first_file_listing.json")
+	secondElement := parseJSONFromFile(t, "testdata/second_file_listing.json")
+	thirdElement := parseJSONFromFile(t, "testdata/third_file_listing.json")
+	fourthElement := parseJSONFromFile(t, "testdata/fourth_file_listing.json")
 	currentOffSetKey := fmt.Sprintf(offSetTemplate, "prefix/1604148850990")
 
 	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/b/test-iteration-bucket/o":
 			offset := r.URL.Query().Get("startOffset")
-			objListing := parseJSONFromText(fileListing)
+			objListing := parseJSONFromFile(t, "testdata/file_listing.json")
 
 			pageToken := r.URL.Query().Get("pageToken")
 
@@ -329,18 +321,24 @@ func stateFulGCSServer(t *testing.T) *httptest.Server {
 			boundary := params["boundary"]
 			currentOffSetKey, _ = fetchJSON(t, boundary, r.Body)
 		default:
-			serveBlobs(r.URL.Path, currentOffSetKey, t, w)
+			serveBlobs(t, w, r.URL.Path, currentOffSetKey)
 		}
 	})
 
 	return srv
 }
 
-func serveBlobs(urlPath string, offsetKey string, t *testing.T, w http.ResponseWriter) {
+func serveBlobs(t *testing.T, w http.ResponseWriter, urlPath string, offsetKey string) {
+	singleObjectNotFound := readJSON(t, "testdata/single_object_not_found.json")
+	firstFile := readJSON(t, "testdata/first_file.json")
+	secondFile := readJSON(t, "testdata/second_file.json")
+	thirdFile := readJSON(t, "testdata/third_file.json")
+	fourthFile := readJSON(t, "testdata/fourth_file.json")
+
 	switch urlPath {
 	case "/test-iteration-bucket/prefix/offset-key.json":
 		w.WriteHeader(http.StatusNotFound)
-		_, err := w.Write([]byte(singleObjectNotFound))
+		_, err := w.Write(singleObjectNotFound)
 		require.NoError(t, err)
 	case "/test-bucket/prefix/offset.json":
 		w.WriteHeader(http.StatusOK)
@@ -387,9 +385,9 @@ func fetchJSON(t *testing.T, boundary string, rc io.ReadCloser) (string, error) 
 	return offsets[3], nil
 }
 
-func serveJSONText(w http.ResponseWriter, jsonText string) {
+func serveJSONText(w http.ResponseWriter, jsonText []byte) {
 	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte(jsonText)); err != nil {
+	if _, err := w.Write(jsonText); err != nil {
 		fmt.Println(err)
 	}
 }
@@ -399,13 +397,22 @@ func failPath(path string, t *testing.T, w http.ResponseWriter) {
 	t.Fatalf("unexpected path: " + path)
 }
 
-func parseJSONFromText(jsonText string) map[string]interface{} {
+func parseJSONFromFile(t *testing.T, jsonFilePath string) map[string]interface{} {
+	data := readJSON(t, jsonFilePath)
+
 	var element map[string]interface{}
-	if err := json.Unmarshal([]byte(jsonText), &element); err != nil {
-		fmt.Println(err)
+	if err := json.Unmarshal(data, &element); err != nil {
+		require.NoErrorf(t, err, "could not parse from data file %s", jsonFilePath)
 	}
 
 	return element
+}
+
+func readJSON(t *testing.T, jsonFilePath string) []byte {
+	data, err := os.ReadFile(jsonFilePath)
+	require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
+
+	return data
 }
 
 func emulatorSetEnv(t *testing.T, srv *httptest.Server) {

--- a/plugins/inputs/google_cloud_storage/testdata/file_listing.json
+++ b/plugins/inputs/google_cloud_storage/testdata/file_listing.json
@@ -1,0 +1,3 @@
+{
+  "kind": "storage#objects"
+}

--- a/plugins/inputs/google_cloud_storage/testdata/first_file.json
+++ b/plugins/inputs/google_cloud_storage/testdata/first_file.json
@@ -1,0 +1,16 @@
+{
+  "metrics": [
+    {
+      "fields": {
+        "cosine": 10,
+        "sine": -1.0975806427415925e-12
+      },
+      "name": "cpu",
+      "tags": {
+        "datacenter": "us-east-1",
+        "host": "localhost"
+      },
+      "timestamp": 1604148850991
+    }
+  ]
+}

--- a/plugins/inputs/google_cloud_storage/testdata/first_file_listing.json
+++ b/plugins/inputs/google_cloud_storage/testdata/first_file_listing.json
@@ -1,0 +1,19 @@
+{
+  "kind": "storage#object",
+  "id": "test-iteration-bucket/prefix/1604148850991/1604148851353983",
+  "selfLink": "https://www.googleapis.com/storage/v1/b/test-iteration-bucket/o/1604148850991",
+  "mediaLink": "https://content-storage.googleapis.com/download/storage/v1/b/test-iteration-bucket/o/1604148850991?generation=1604148851353983&alt=media",
+  "name": "prefix/1604148850991",
+  "bucket": "test-iteration-bucket",
+  "generation": "1604148851353983",
+  "metageneration": "1",
+  "contentType": "text/plain; charset=utf-8",
+  "storageClass": "STANDARD",
+  "size": "161",
+  "md5Hash": "y59iuRCTpkm7wpvU5YHUYw==",
+  "crc32c": "y57reA==",
+  "etag": "CP/SzpPw3uwCEAE=",
+  "timeCreated": "2020-10-31T12:54:11.353Z",
+  "updated": "2020-10-31T12:54:11.353Z",
+  "timeStorageClassUpdated": "2020-10-31T12:54:11.353Z"
+}

--- a/plugins/inputs/google_cloud_storage/testdata/fourth_file.json
+++ b/plugins/inputs/google_cloud_storage/testdata/fourth_file.json
@@ -1,0 +1,16 @@
+{
+  "metrics": [
+    {
+      "fields": {
+        "cosine": 13,
+        "sine": -4.0975806427415925e-12
+      },
+      "name": "cpu",
+      "tags": {
+        "datacenter": "us-east-1",
+        "host": "localhost"
+      },
+      "timestamp": 1604148850994
+    }
+  ]
+}

--- a/plugins/inputs/google_cloud_storage/testdata/fourth_file_listing.json
+++ b/plugins/inputs/google_cloud_storage/testdata/fourth_file_listing.json
@@ -1,0 +1,19 @@
+{
+  "kind": "storage#object",
+  "id": "test-iteration-bucket/prefix/1604148850994/1604148851467554",
+  "selfLink": "https://www.googleapis.com/storage/v1/b/test-iteration-bucket/o/1604148850994",
+  "mediaLink": "https://content-storage.googleapis.com/download/storage/v1/b/test-iteration-bucket/o/1604148850994?generation=1604148851467554&alt=media",
+  "name": "prefix/1604148850994",
+  "bucket": "test-iteration-bucket",
+  "generation": "1604148851467554",
+  "metageneration": "1",
+  "contentType": "text/plain; charset=utf-8",
+  "storageClass": "STANDARD",
+  "size": "161",
+  "md5Hash": "y59iuRCTpkm7wpvU5YHUYw==",
+  "crc32c": "y57reA==",
+  "etag": "CKLK1ZPw3uwCEAE=",
+  "timeCreated": "2020-10-31T12:54:11.467Z",
+  "updated": "2020-10-31T12:54:11.467Z",
+  "timeStorageClassUpdated": "2020-10-31T12:54:11.467Z"
+}

--- a/plugins/inputs/google_cloud_storage/testdata/second_file.json
+++ b/plugins/inputs/google_cloud_storage/testdata/second_file.json
@@ -1,0 +1,16 @@
+{
+  "metrics": [
+    {
+      "fields": {
+        "cosine": 11,
+        "sine": -2.0975806427415925e-12
+      },
+      "name": "cpu",
+      "tags": {
+        "datacenter": "us-east-1",
+        "host": "localhost"
+      },
+      "timestamp": 1604148850992
+    }
+  ]
+}

--- a/plugins/inputs/google_cloud_storage/testdata/second_file_listing.json
+++ b/plugins/inputs/google_cloud_storage/testdata/second_file_listing.json
@@ -1,0 +1,19 @@
+{
+  "kind": "storage#object",
+  "id": "test-iteration-bucket/prefix/1604148850992/1604148851414237",
+  "selfLink": "https://www.googleapis.com/storage/v1/b/test-iteration-bucket/o/1604148850992",
+  "mediaLink": "https://content-storage.googleapis.com/download/storage/v1/b/test-iteration-bucket/o/1604148850992?generation=1604148851414237&alt=media",
+  "name": "prefix/1604148850992",
+  "bucket": "test-iteration-bucket",
+  "generation": "1604148851414237",
+  "metageneration": "1",
+  "contentType": "text/plain; charset=utf-8",
+  "storageClass": "STANDARD",
+  "size": "161",
+  "md5Hash": "y59iuRCTpkm7wpvU5YHUYw==",
+  "crc32c": "y57reA==",
+  "etag": "CN2p0pPw3uwCEAE=",
+  "timeCreated": "2020-10-31T12:54:11.414Z",
+  "updated": "2020-10-31T12:54:11.414Z",
+  "timeStorageClassUpdated": "2020-10-31T12:54:11.414Z"
+}

--- a/plugins/inputs/google_cloud_storage/testdata/single_file_list.json
+++ b/plugins/inputs/google_cloud_storage/testdata/single_file_list.json
@@ -1,0 +1,24 @@
+{
+  "kind": "storage#objects",
+  "items": [
+    {
+      "kind": "storage#object",
+      "id": "test-iteration-bucket/1604148850990/1604148851295698",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/1604148850990/o/1604148850990",
+      "mediaLink": "https://content-storage.googleapis.com/download/storage/v1/b/test-iteration-bucket/o/1604148850990?generation=1604148851295698&alt=media",
+      "name": "1604148850990",
+      "bucket": "test-iteration-bucket",
+      "generation": "1604148851295698",
+      "metageneration": "1",
+      "contentType": "text/plain; charset=utf-8",
+      "storageClass": "STANDARD",
+      "size": "161",
+      "md5Hash": "y59iuRCTpkm7wpvU5YHUYw==",
+      "crc32c": "y57reA==",
+      "etag": "CNKLy5Pw3uwCEAE=",
+      "timeCreated": "2020-10-31T12:54:11.295Z",
+      "updated": "2020-10-31T12:54:11.295Z",
+      "timeStorageClassUpdated": "2020-10-31T12:54:11.295Z"
+    }
+  ]
+}

--- a/plugins/inputs/google_cloud_storage/testdata/single_object_not_found.json
+++ b/plugins/inputs/google_cloud_storage/testdata/single_object_not_found.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "code": 404,
+    "message": "No such object: test-iteration-bucket/prefix/offset-key.json",
+    "errors": [
+      {
+        "message": "No such object: test-iteration-bucket/prefix/offset-key.json",
+        "domain": "global",
+        "reason": "notFound"
+      }
+    ]
+  }
+}

--- a/plugins/inputs/google_cloud_storage/testdata/third_file.json
+++ b/plugins/inputs/google_cloud_storage/testdata/third_file.json
@@ -1,0 +1,16 @@
+{
+  "metrics": [
+    {
+      "fields": {
+        "cosine": 12,
+        "sine": -3.0975806427415925e-12
+      },
+      "name": "cpu",
+      "tags": {
+        "datacenter": "us-east-1",
+        "host": "localhost"
+      },
+      "timestamp": 1604148850993
+    }
+  ]
+}

--- a/plugins/inputs/google_cloud_storage/testdata/third_file_listing.json
+++ b/plugins/inputs/google_cloud_storage/testdata/third_file_listing.json
@@ -1,0 +1,19 @@
+{
+  "kind": "storage#object",
+  "id": "test-iteration-bucket/prefix/1604148850993/1604148851467554",
+  "selfLink": "https://www.googleapis.com/storage/v1/b/test-iteration-bucket/o/1604148850993",
+  "mediaLink": "https://content-storage.googleapis.com/download/storage/v1/b/test-iteration-bucket/o/1604148850993?generation=1604148851467554&alt=media",
+  "name": "prefix/1604148850993",
+  "bucket": "test-iteration-bucket",
+  "generation": "1604148851467554",
+  "metageneration": "1",
+  "contentType": "text/plain; charset=utf-8",
+  "storageClass": "STANDARD",
+  "size": "161",
+  "md5Hash": "y59iuRCTpkm7wpvU5YHUYw==",
+  "crc32c": "y57reA==",
+  "etag": "CKLK1ZPw3uwCEAE=",
+  "timeCreated": "2020-10-31T12:54:11.467Z",
+  "updated": "2020-10-31T12:54:11.467Z",
+  "timeStorageClassUpdated": "2020-10-31T12:54:11.467Z"
+}

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -551,7 +551,11 @@ func TestWriteHTTPEmpty(t *testing.T) {
 func TestWriteHTTPTransformHeaderValuesToTagsSingleWrite(t *testing.T) {
 	listener, err := newTestHTTPListenerV2()
 	require.NoError(t, err)
-	listener.HTTPHeaderTags = map[string]string{"Present_http_header_1": "presentMeasurementKey1", "present_http_header_2": "presentMeasurementKey2", "NOT_PRESENT_HEADER": "notPresentMeasurementKey"}
+	listener.HTTPHeaderTags = map[string]string{
+		"Present_http_header_1": "presentMeasurementKey1",
+		"present_http_header_2": "presentMeasurementKey2",
+		"NOT_PRESENT_HEADER":    "notPresentMeasurementKey",
+	}
 
 	acc := &testutil.Accumulator{}
 	require.NoError(t, listener.Init())
@@ -591,7 +595,11 @@ func TestWriteHTTPTransformHeaderValuesToTagsSingleWrite(t *testing.T) {
 func TestWriteHTTPTransformHeaderValuesToTagsBulkWrite(t *testing.T) {
 	listener, err := newTestHTTPListenerV2()
 	require.NoError(t, err)
-	listener.HTTPHeaderTags = map[string]string{"Present_http_header_1": "presentMeasurementKey1", "Present_http_header_2": "presentMeasurementKey2", "NOT_PRESENT_HEADER": "notPresentMeasurementKey"}
+	listener.HTTPHeaderTags = map[string]string{
+		"Present_http_header_1": "presentMeasurementKey1",
+		"Present_http_header_2": "presentMeasurementKey2",
+		"NOT_PRESENT_HEADER":    "notPresentMeasurementKey",
+	}
 
 	acc := &testutil.Accumulator{}
 	require.NoError(t, listener.Init())

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -140,7 +140,14 @@ func setUpTestMux() http.Handler {
 	return mux
 }
 
-func checkOutput(t *testing.T, acc *testutil.Accumulator, presentFields map[string]interface{}, presentTags map[string]interface{}, absentFields []string, absentTags []string) {
+func checkOutput(
+	t *testing.T,
+	acc *testutil.Accumulator,
+	presentFields map[string]interface{},
+	presentTags map[string]interface{},
+	absentFields []string,
+	absentTags []string,
+) {
 	t.Helper()
 	if presentFields != nil {
 		checkFields(t, presentFields, acc)

--- a/plugins/inputs/hugepages/hugepages.go
+++ b/plugins/inputs/hugepages/hugepages.go
@@ -151,7 +151,12 @@ func (h *Hugepages) gatherStatsPerNode(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (h *Hugepages) gatherFromHugepagePath(acc telegraf.Accumulator, measurement, path string, fileFilter map[string]string, defaultTags map[string]string) error {
+func (h *Hugepages) gatherFromHugepagePath(
+	acc telegraf.Accumulator,
+	measurement, path string,
+	fileFilter map[string]string,
+	defaultTags map[string]string,
+) error {
 	// read metrics from: hugepages/hugepages-*/*
 	hugepagesDirs, err := os.ReadDir(path)
 	if err != nil {


### PR DESCRIPTION
Wrap lines longer than 160 characters.

It is only part of the bigger job.
After long lines in whole project are handled, we can enable proper linter to guard this.