### PR TITLE
chore: log errors when adding to quantile aggregator

### DIFF
--- a/plugins/aggregators/quantile/quantile.go
+++ b/plugins/aggregators/quantile/quantile.go
@@ -21,6 +21,8 @@ type Quantile struct {
 
 	cache    map[uint64]aggregate
 	suffixes []string
+
+	Log telegraf.Logger `toml:"-"`
 }
 
 type aggregate struct {
@@ -42,7 +44,10 @@ func (q *Quantile) Add(in telegraf.Metric) {
 		for k, algo := range cached.fields {
 			if field, ok := fields[k]; ok {
 				if v, isconvertible := convert(field); isconvertible {
-					algo.Add(v)
+					err := algo.Add(v)
+					if err != nil {
+						q.Log.Errorf("adding field %s: %v", k, err)
+					}
 				}
 			}
 		}

--- a/plugins/aggregators/quantile/quantile.go
+++ b/plugins/aggregators/quantile/quantile.go
@@ -46,7 +46,7 @@ func (q *Quantile) Add(in telegraf.Metric) {
 				if v, isconvertible := convert(field); isconvertible {
 					err := algo.Add(v)
 					if err != nil {
-						q.Log.Errorf("adding field %s: %v", k, err)
+						q.Log.Errorf("adding cached field %s: %v", k, err)
 					}
 				}
 			}
@@ -64,7 +64,10 @@ func (q *Quantile) Add(in telegraf.Metric) {
 		if v, isconvertible := convert(field); isconvertible {
 			// This should never error out as we tested it in Init()
 			algo, _ := q.newAlgorithm(q.Compression)
-			algo.Add(v)
+			err := algo.Add(v)
+			if err != nil {
+				q.Log.Errorf("adding field %s: %v", k, err)
+			}
 			a.fields[k] = algo
 		}
 	}

--- a/plugins/aggregators/quantile/quantile_test.go
+++ b/plugins/aggregators/quantile/quantile_test.go
@@ -46,7 +46,10 @@ func TestConfigInvalidQuantiles(t *testing.T) {
 func TestSingleMetricTDigest(t *testing.T) {
 	acc := testutil.Accumulator{}
 
-	q := Quantile{Compression: 100}
+	q := Quantile{
+		Compression: 100,
+		Log:         testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(t, err)
 
@@ -113,7 +116,10 @@ func TestSingleMetricTDigest(t *testing.T) {
 func TestMultipleMetricsTDigest(t *testing.T) {
 	acc := testutil.Accumulator{}
 
-	q := Quantile{Compression: 100}
+	q := Quantile{
+		Compression: 100,
+		Log:         testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(t, err)
 
@@ -173,7 +179,10 @@ func TestMultipleMetricsTDigest(t *testing.T) {
 func TestSingleMetricExactR7(t *testing.T) {
 	acc := testutil.Accumulator{}
 
-	q := Quantile{AlgorithmType: "exact R7"}
+	q := Quantile{
+		AlgorithmType: "exact R7",
+		Log:           testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(t, err)
 
@@ -240,7 +249,10 @@ func TestSingleMetricExactR7(t *testing.T) {
 func TestMultipleMetricsExactR7(t *testing.T) {
 	acc := testutil.Accumulator{}
 
-	q := Quantile{AlgorithmType: "exact R7"}
+	q := Quantile{
+		AlgorithmType: "exact R7",
+		Log:           testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(t, err)
 
@@ -300,7 +312,10 @@ func TestMultipleMetricsExactR7(t *testing.T) {
 func TestSingleMetricExactR8(t *testing.T) {
 	acc := testutil.Accumulator{}
 
-	q := Quantile{AlgorithmType: "exact R8"}
+	q := Quantile{
+		AlgorithmType: "exact R8",
+		Log:           testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(t, err)
 
@@ -367,7 +382,10 @@ func TestSingleMetricExactR8(t *testing.T) {
 func TestMultipleMetricsExactR8(t *testing.T) {
 	acc := testutil.Accumulator{}
 
-	q := Quantile{AlgorithmType: "exact R8"}
+	q := Quantile{
+		AlgorithmType: "exact R8",
+		Log:           testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(t, err)
 
@@ -444,7 +462,10 @@ func BenchmarkDefaultTDigest(b *testing.B) {
 		)
 	}
 
-	q := Quantile{Compression: 100}
+	q := Quantile{
+		Compression: 100,
+		Log:         testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(b, err)
 
@@ -481,7 +502,11 @@ func BenchmarkDefaultTDigest100Q(b *testing.B) {
 		quantiles[i] = 0.01 * float64(i)
 	}
 
-	q := Quantile{Compression: 100, Quantiles: quantiles}
+	q := Quantile{
+		Compression: 100,
+		Quantiles:   quantiles,
+		Log:         testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(b, err)
 
@@ -514,7 +539,10 @@ func BenchmarkDefaultExactR7(b *testing.B) {
 		)
 	}
 
-	q := Quantile{AlgorithmType: "exact R7"}
+	q := Quantile{
+		AlgorithmType: "exact R7",
+		Log:           testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(b, err)
 
@@ -551,7 +579,11 @@ func BenchmarkDefaultExactR7100Q(b *testing.B) {
 		quantiles[i] = 0.01 * float64(i)
 	}
 
-	q := Quantile{AlgorithmType: "exact R7", Quantiles: quantiles}
+	q := Quantile{
+		AlgorithmType: "exact R7",
+		Quantiles:     quantiles,
+		Log:           testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(b, err)
 
@@ -584,7 +616,10 @@ func BenchmarkDefaultExactR8(b *testing.B) {
 		)
 	}
 
-	q := Quantile{AlgorithmType: "exact R8"}
+	q := Quantile{
+		AlgorithmType: "exact R8",
+		Log:           testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(b, err)
 
@@ -621,7 +656,11 @@ func BenchmarkDefaultExactR8100Q(b *testing.B) {
 		quantiles[i] = 0.01 * float64(i)
 	}
 
-	q := Quantile{AlgorithmType: "exact R8", Quantiles: quantiles}
+	q := Quantile{
+		AlgorithmType: "exact R8",
+		Quantiles:     quantiles,
+		Log:           testutil.Logger{},
+	}
 	err := q.Init()
 	require.NoError(b, err)
 


### PR DESCRIPTION
fixes #12040

In this plugin, the add method of the algorithm interface returns an error. Both places the method is called, the error is ignored. 

There are three types that implement the interface: exact r7, exact r8, and t-digest. The exact types never return an error but the t-digest does. In cases when t-digest returns an error, it is ignored and not passed to the user.

This PR adds a logger to this plugin and uses the logger to log the error in places where it was previously ignored. Thanks @zak-pawel for finding this by adding linters to the project!