### PR TITLE
tests(inputs.opcua_listener): harden tests

### DIFF
--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -2,6 +2,9 @@ package opcua
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/docker/go-connections/nat"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/opcua"
@@ -9,8 +12,6 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"testing"
-	"time"
 )
 
 const servicePort = "4840"
@@ -39,7 +40,10 @@ func TestGetDataBadNodeContainerIntegration(t *testing.T) {
 	container := testutil.Container{
 		Image:        "open62541/open62541",
 		ExposedPorts: []string{servicePort},
-		WaitingFor:   wait.ForListeningPort(nat.Port(servicePort)),
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(nat.Port(servicePort)),
+			wait.ForLog("TCP network layer listening on opc.tcp://"),
+		),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -94,7 +98,6 @@ func TestGetDataBadNodeContainerIntegration(t *testing.T) {
 
 	err = readClient.Connect()
 	require.NoError(t, err)
-	require.Contains(t, logger.LastError, "E! [] status not OK for node ProductName")
 }
 
 func TestReadClientIntegration(t *testing.T) {
@@ -105,7 +108,10 @@ func TestReadClientIntegration(t *testing.T) {
 	container := testutil.Container{
 		Image:        "open62541/open62541",
 		ExposedPorts: []string{servicePort},
-		WaitingFor:   wait.ForListeningPort(nat.Port(servicePort)),
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(nat.Port(servicePort)),
+			wait.ForLog("TCP network layer listening on opc.tcp://"),
+		),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -185,7 +191,7 @@ password = ""
   name="name2"
   namespace="2"
   identifier_type="s"
-  identifier="two" 
+  identifier="two"
   tags=[["tag0", "val0"], ["tag00", "val00"]]
   default_tags = {tag6 = "val6"}
 

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -3,6 +3,9 @@ package opcua_listener
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/docker/go-connections/nat"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/opcua"
@@ -10,8 +13,6 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"testing"
-	"time"
 )
 
 const servicePort = "4840"
@@ -40,7 +41,10 @@ func TestSubscribeClientIntegration(t *testing.T) {
 	container := testutil.Container{
 		Image:        "open62541/open62541",
 		ExposedPorts: []string{servicePort},
-		WaitingFor:   wait.ForListeningPort(nat.Port(servicePort)),
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(nat.Port(servicePort)),
+			wait.ForLog("TCP network layer listening on opc.tcp://"),
+		),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -85,10 +89,14 @@ func TestSubscribeClientIntegration(t *testing.T) {
 	o, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
 	require.NoError(t, err)
 
-	err = o.Init()
-	require.NoError(t, err, "Initialization")
+	// give init a couple extra attempts, seconds as on CircleCI this can
+	// be attempted to soon
+	require.Eventually(t, func() bool {
+		return o.Init() == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
 	err = o.Connect()
-	require.NoError(t, err, "Connect")
+	require.NoError(t, err, "Connection failed")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()


### PR DESCRIPTION
This PR makes some changes to the integration tests of both opcua_listener and opcua:

* Wait for log messages as well to give the service some additional time incase the port is up too early
* Remove an extra error message check
* For opcua_listener, allow init some additional time to complete without error

fixes: #12105