### PR TITLE
fix(output.datadog): log response in case of non 2XX response from API

### DIFF
--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -168,6 +169,9 @@ func (d *Datadog) Write(metrics []telegraf.Metric) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 209 {
+		// err can be ignored
+		body, _ := io.ReadAll(resp.Body)
+		d.Log.Debugf("Response from datadog api %s", string(body))
 		return fmt.Errorf("received bad status code, %d", resp.StatusCode)
 	}
 

--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -171,8 +171,7 @@ func (d *Datadog) Write(metrics []telegraf.Metric) error {
 	if resp.StatusCode < 200 || resp.StatusCode > 209 {
 		// err can be ignored
 		body, _ := io.ReadAll(resp.Body)
-		d.Log.Debugf("Response from datadog api %s", string(body))
-		return fmt.Errorf("received bad status code, %d", resp.StatusCode)
+		return fmt.Errorf("received bad status code, %d: %s", resp.StatusCode, string(body))
 	}
 
 	return nil

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -24,6 +24,7 @@ var (
 func NewDatadog(url string) *Datadog {
 	return &Datadog{
 		URL: url,
+		Log: testutil.Logger{},
 	}
 }
 

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -68,14 +68,10 @@ func TestCompressionOverride(t *testing.T) {
 }
 
 func TestBadStatusCode(t *testing.T) {
+	errorString := `{"errors": ["Something bad happened to the server.", "Your query made the server very sad."]}`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		//nolint:errcheck,revive // Ignore the returned error as the test will fail anyway
-		json.NewEncoder(w).Encode(`{ 'errors': [
-    	'Something bad happened to the server.',
-    	'Your query made the server very sad.'
-  		]
-		}`)
+		fmt.Fprint(w, errorString)
 	}))
 	defer ts.Close()
 
@@ -87,7 +83,7 @@ func TestBadStatusCode(t *testing.T) {
 	if err == nil {
 		t.Errorf("error expected but none returned")
 	} else {
-		require.EqualError(t, fmt.Errorf("received bad status code, 500"), err.Error())
+		require.EqualError(t, err, fmt.Sprintf("received bad status code, %v: %s", http.StatusInternalServerError, errorString))
 	}
 }
 


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves: NA

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Add a debug log to print the response string obtained from API in case of a non 2XX status.
