### PR TITLE
test(outputs.sql): do not write to file during testing

### DIFF
--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -219,6 +219,9 @@ func TestMysqlIntegration(t *testing.T) {
 		{"./testdata/mariadb/expected_metric_three.sql"},
 	}
 	for _, tc := range cases {
+		expected, err := os.ReadFile(tc.expectedFile)
+		require.NoError(t, err)
+
 		require.Eventually(t, func() bool {
 			rc, out, err := container.Exec([]string{
 				"bash",
@@ -234,11 +237,8 @@ func TestMysqlIntegration(t *testing.T) {
 			bytes, err := io.ReadAll(out)
 			require.NoError(t, err)
 
-			expected, err := os.ReadFile(tc.expectedFile)
-			require.NoError(t, err)
-
 			return strings.Contains(string(bytes), string(expected))
-		}, 5*time.Second, 10*time.Millisecond)
+		}, 5*time.Second, 500*time.Millisecond)
 	}
 }
 
@@ -327,7 +327,7 @@ func TestPostgresIntegration(t *testing.T) {
 		require.NoError(t, err)
 
 		return strings.Contains(string(bytes), string(expected))
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 5*time.Second, 500*time.Millisecond)
 }
 
 func TestClickHouseIntegration(t *testing.T) {
@@ -413,6 +413,6 @@ func TestClickHouseIntegration(t *testing.T) {
 			bytes, err := io.ReadAll(out)
 			require.NoError(t, err)
 			return strings.Contains(string(bytes), tc.expected)
-		}, 5*time.Second, 10*time.Millisecond)
+		}, 5*time.Second, 500*time.Millisecond)
 	}
 }

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -212,11 +212,11 @@ func TestMysqlIntegration(t *testing.T) {
 	))
 
 	cases := []struct {
-		expected string
+		expectedFile string
 	}{
-		{"INSERT INTO `metric_one` VALUES ('2021-05-17 22:04:45','tag1','tag2',1234,2345,1,0,1000000000,3.1415);"},
-		{"INSERT INTO `metric_two` VALUES ('2021-05-17 22:04:45','tag3','string1');"},
-		{"INSERT INTO `metric three` VALUES ('2021-05-17 22:04:45','tag4','string2');"},
+		{"./testdata/mariadb/expected_metric_one.sql"},
+		{"./testdata/mariadb/expected_metric_two.sql"},
+		{"./testdata/mariadb/expected_metric_three.sql"},
 	}
 	for _, tc := range cases {
 		require.Eventually(t, func() bool {
@@ -234,7 +234,10 @@ func TestMysqlIntegration(t *testing.T) {
 			bytes, err := io.ReadAll(out)
 			require.NoError(t, err)
 
-			return strings.Contains(string(bytes), tc.expected)
+			expected, err := os.ReadFile(tc.expectedFile)
+			require.NoError(t, err)
+
+			return strings.Contains(string(bytes), string(expected))
 		}, 5*time.Second, 10*time.Millisecond)
 	}
 }

--- a/plugins/outputs/sql/testdata/mariadb/expected_metric_one.sql
+++ b/plugins/outputs/sql/testdata/mariadb/expected_metric_one.sql
@@ -1,0 +1,14 @@
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `metric_one` (
+  `timestamp` timestamp NOT NULL DEFAULT current_timestamp(),
+  `tag_one` text DEFAULT NULL,
+  `tag_two` text DEFAULT NULL,
+  `int64_one` int(11) DEFAULT NULL,
+  `int64_two` int(11) DEFAULT NULL,
+  `bool_one` tinyint(1) DEFAULT NULL,
+  `bool_two` tinyint(1) DEFAULT NULL,
+  `uint64_one` int(10) unsigned DEFAULT NULL,
+  `float64_one` double DEFAULT NULL
+);
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `metric_one` VALUES ('2021-05-17 22:04:45','tag1','tag2',1234,2345,1,0,1000000000,3.1415);

--- a/plugins/outputs/sql/testdata/mariadb/expected_metric_three.sql
+++ b/plugins/outputs/sql/testdata/mariadb/expected_metric_three.sql
@@ -1,0 +1,8 @@
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `metric three` (
+  `timestamp` timestamp NOT NULL DEFAULT current_timestamp(),
+  `tag four` text DEFAULT NULL,
+  `string two` text DEFAULT NULL
+);
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `metric three` VALUES ('2021-05-17 22:04:45','tag4','string2');

--- a/plugins/outputs/sql/testdata/mariadb/expected_metric_two.sql
+++ b/plugins/outputs/sql/testdata/mariadb/expected_metric_two.sql
@@ -1,0 +1,8 @@
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `metric_two` (
+  `timestamp` timestamp NOT NULL DEFAULT current_timestamp(),
+  `tag_three` text DEFAULT NULL,
+  `string_one` text DEFAULT NULL
+);
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `metric_two` VALUES ('2021-05-17 22:04:45','tag3','string1');


### PR DESCRIPTION
Instead, use the output of the commands and compare that to the expected values. Due to some extra encoding bytes, some need to be stripped before comparing so each metric was split out into different files.