### PR TITLE
fix(inputs.jti_openconfig_telemetry): Fix complex tag value

### DIFF
--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
@@ -84,7 +84,7 @@ func spitTagsNPath(xmlpath string) (string, map[string]string) {
 			// we must emit multiple tags
 			for _, kv := range strings.Split(sub[2], " and ") {
 				key := tagKey + strings.TrimSpace(strings.Split(kv, "=")[0])
-				tagValue := strings.ReplaceAll(strings.Split(kv, "=")[1], "'", "")
+				tagValue := strings.ReplaceAll(strings.SplitN(kv, "=", 2)[1], "'", "")
 				tags[key] = tagValue
 			}
 


### PR DESCRIPTION
Hi!

MR fix making tag of complex values.

Example telemetry metric:
```
kv:{key:"__prefix__"  str_value:"/junos/firewall[name='__flowspec_default_inet__']/state/"}
kv:{key:"counter[name='95.213.157.162,*,proto=17,dstport=123']/packets"  uint_value:19}
```
strings.Split breaks counter name value:
```
/junos/firewall/state/counter/@name:95.213.157.162,*,proto
```
with strings.SplitN:
```
/junos/firewall/state/counter/@name:95.213.157.162,*,proto=17,dstport=123
```
