### PR TITLE
chore: Fix linter findings for prealloc (part1)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -513,14 +513,13 @@ func (a *Agent) startProcessors(
 	dst chan<- telegraf.Metric,
 	processors models.RunningProcessors,
 ) (chan<- telegraf.Metric, []*processorUnit, error) {
-	var units []*processorUnit
-
 	// Sort from last to first
 	sort.SliceStable(processors, func(i, j int) bool {
 		return processors[i].Config.Order > processors[j].Config.Order
 	})
 
 	var src chan telegraf.Metric
+	units := make([]*processorUnit, 0, len(processors))
 	for _, processor := range processors {
 		src = make(chan telegraf.Metric, 100)
 		acc := NewAccumulator(processor, dst)

--- a/config/config.go
+++ b/config/config.go
@@ -225,7 +225,7 @@ type AgentConfig struct {
 
 // InputNames returns a list of strings of the configured inputs.
 func (c *Config) InputNames() []string {
-	var name []string
+	name := make([]string, 0, len(c.Inputs))
 	for _, input := range c.Inputs {
 		name = append(name, input.Config.Name)
 	}
@@ -234,7 +234,7 @@ func (c *Config) InputNames() []string {
 
 // AggregatorNames returns a list of strings of the configured aggregators.
 func (c *Config) AggregatorNames() []string {
-	var name []string
+	name := make([]string, 0, len(c.Aggregators))
 	for _, aggregator := range c.Aggregators {
 		name = append(name, aggregator.Config.Name)
 	}
@@ -243,7 +243,7 @@ func (c *Config) AggregatorNames() []string {
 
 // ProcessorNames returns a list of strings of the configured processors.
 func (c *Config) ProcessorNames() []string {
-	var name []string
+	name := make([]string, 0, len(c.Processors))
 	for _, processor := range c.Processors {
 		name = append(name, processor.Config.Name)
 	}
@@ -252,7 +252,7 @@ func (c *Config) ProcessorNames() []string {
 
 // OutputNames returns a list of strings of the configured outputs.
 func (c *Config) OutputNames() []string {
-	var name []string
+	name := make([]string, 0, len(c.Outputs))
 	for _, output := range c.Outputs {
 		name = append(name, output.Config.Name)
 	}
@@ -282,8 +282,7 @@ func PluginNameCounts(plugins []string) []string {
 // ListTags returns a string of tags specified in the config,
 // line-protocol style
 func (c *Config) ListTags() string {
-	var tags []string
-
+	tags := make([]string, 0, len(c.Tags))
 	for k, v := range c.Tags {
 		tags = append(tags, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gopcua/opcua/ua"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/choice"
 	"github.com/influxdata/telegraf/metric"
@@ -189,7 +190,7 @@ type metricParts struct {
 }
 
 func newMP(n *NodeMetricMapping) metricParts {
-	var keys []string
+	keys := make([]string, 0, len(n.MetricTags))
 	for key := range n.MetricTags {
 		keys = append(keys, key)
 	}

--- a/plugins/common/tls/utils.go
+++ b/plugins/common/tls/utils.go
@@ -29,7 +29,7 @@ func ParseTLSVersion(version string) (uint16, error) {
 		return v, nil
 	}
 
-	var available []string
+	available := make([]string, 0, len(tlsVersionMap))
 	for n := range tlsVersionMap {
 		available = append(available, n)
 	}

--- a/plugins/inputs/apcupsd/apcupsd_test.go
+++ b/plugins/inputs/apcupsd/apcupsd_test.go
@@ -215,7 +215,7 @@ func genOutput() [][]byte {
 		"ALARMDEL : Low Battery",
 	}
 
-	var out [][]byte
+	out := make([][]byte, 0, 2*len(kvs))
 	for _, kv := range kvs {
 		lenb, kvb := kvBytes(kv)
 		out = append(out, lenb)
@@ -230,7 +230,7 @@ func genBadOutput() [][]byte {
 		"STATFLAG : 0x08Status Flag",
 	}
 
-	var out [][]byte
+	out := make([][]byte, 0, 2*len(kvs))
 	for _, kv := range kvs {
 		lenb, kvb := kvBytes(kv)
 		out = append(out, lenb)

--- a/plugins/inputs/dpdk/dpdk_utils.go
+++ b/plugins/inputs/dpdk/dpdk_utils.go
@@ -70,12 +70,12 @@ func jsonToArray(input []byte, command string) ([]string, error) {
 	}
 
 	var intArray []int64
-	var stringArray []string
 	err = json.Unmarshal(rawMessage[command], &intArray)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshall json response - %v", err)
 	}
 
+	stringArray := make([]string, 0, len(intArray))
 	for _, value := range intArray {
 		stringArray = append(stringArray, strconv.FormatInt(value, 10))
 	}

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -690,8 +690,7 @@ func TestElasticsearchQueryIntegration_getMetricFields(t *testing.T) {
 		wantErr bool
 	}
 
-	var tests []test
-
+	tests := make([]test, 0, len(testEsAggregationData))
 	for _, d := range testEsAggregationData {
 		tests = append(tests, test{
 			"getMetricFields " + d.queryName,
@@ -724,8 +723,8 @@ func TestElasticsearchQuery_buildAggregationQuery(t *testing.T) {
 		want        []aggregationQueryData
 		wantErr     bool
 	}
-	var tests []test
 
+	tests := make([]test, 0, len(testEsAggregationData))
 	for _, d := range testEsAggregationData {
 		tests = append(tests, test{
 			"build " + d.queryName,

--- a/plugins/inputs/intel_pmu/activators.go
+++ b/plugins/inputs/intel_pmu/activators.go
@@ -107,11 +107,11 @@ func (ea *iaEntitiesActivator) activateCoreEvents(entity *CoreEventEntity) error
 			if err != nil {
 				return fmt.Errorf("failed to create core placements for event `%s`: %v", event.name, err)
 			}
-			activeEvent, err := ea.activateEventForPlacements(event, placements)
+			activeEvents, err := ea.activateEventForPlacements(event, placements)
 			if err != nil {
 				return fmt.Errorf("failed to activate core event `%s`: %v", event.name, err)
 			}
-			entity.activeEvents = append(entity.activeEvents, activeEvent...)
+			entity.activeEvents = append(entity.activeEvents, activeEvents...)
 		}
 	}
 	return nil
@@ -158,7 +158,7 @@ func (ea *iaEntitiesActivator) activateCoreEventsGroup(entity *CoreEventEntity) 
 		return fmt.Errorf("missing parsed events")
 	}
 
-	var events []ia.CustomizableEvent
+	events := make([]ia.CustomizableEvent, 0, len(entity.parsedEvents))
 	for _, event := range entity.parsedEvents {
 		if event == nil {
 			return fmt.Errorf("core event is nil")
@@ -189,7 +189,8 @@ func (ea *iaEntitiesActivator) activateEventForPlacements(event *eventWithQuals,
 	if ea.perfActivator == nil {
 		return nil, fmt.Errorf("missing perf activator")
 	}
-	var activeEvents []*ia.ActiveEvent
+
+	activeEvents := make([]*ia.ActiveEvent, 0, len(placements))
 	for _, placement := range placements {
 		perfEvent := event.custom.Event
 		options := event.custom.Options

--- a/plugins/inputs/intel_pmu/activators_test.go
+++ b/plugins/inputs/intel_pmu/activators_test.go
@@ -272,7 +272,7 @@ func TestActivateCoreEventsGroup(t *testing.T) {
 		parsedCores:  nil,
 	}
 
-	var events []ia.CustomizableEvent
+	events := make([]ia.CustomizableEvent, 0, len(parsedEvents))
 	for _, event := range parsedEvents {
 		events = append(events, event.custom)
 	}
@@ -386,7 +386,7 @@ func TestActivateEventForPlacement(t *testing.T) {
 		activeEvents, err := mActivator.activateEventForPlacements(nil, mPlacements)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "core event is nil")
-		require.Nil(t, activeEvents)
+		require.Len(t, activeEvents, 0)
 	})
 
 	t.Run("perf activator is nil", func(t *testing.T) {
@@ -394,13 +394,13 @@ func TestActivateEventForPlacement(t *testing.T) {
 		activeEvents, err := mActivator.activateEventForPlacements(mEvent, mPlacements)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing perf activator")
-		require.Nil(t, activeEvents)
+		require.Len(t, activeEvents, 0)
 	})
 
 	t.Run("placements are nil", func(t *testing.T) {
 		activeEvents, err := mActivator.activateEventForPlacements(mEvent, nil)
 		require.NoError(t, err)
-		require.Nil(t, activeEvents)
+		require.Len(t, activeEvents, 0)
 	})
 
 	t.Run("activation error", func(t *testing.T) {

--- a/plugins/inputs/intel_pmu/config.go
+++ b/plugins/inputs/intel_pmu/config.go
@@ -157,8 +157,7 @@ func (cp *configParser) parseIntRanges(ranges []string) ([]int, error) {
 }
 
 func parseEventsWithQualifiers(events []string) []*eventWithQuals {
-	var result []*eventWithQuals
-
+	result := make([]*eventWithQuals, 0, len(events))
 	for _, event := range events {
 		newEventWithQualifiers := &eventWithQuals{}
 
@@ -170,6 +169,7 @@ func parseEventsWithQualifiers(events []string) []*eventWithQuals {
 		}
 		result = append(result, newEventWithQualifiers)
 	}
+
 	return result
 }
 

--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -400,10 +400,10 @@ func validatePqosPath(pqosPath string) error {
 }
 
 func parseCoresConfig(cores []string) ([]string, error) {
-	var parsedCores []string
 	var allCores []int
 	configError := fmt.Errorf("wrong cores input config data format")
 
+	parsedCores := make([]string, 0, len(cores))
 	for _, singleCoreGroup := range cores {
 		var actualGroupOfCores []int
 		separatedCores := strings.Split(singleCoreGroup, ",")
@@ -421,6 +421,7 @@ func parseCoresConfig(cores []string) ([]string, error) {
 		}
 		parsedCores = append(parsedCores, arrayToString(actualGroupOfCores))
 	}
+
 	return parsedCores, nil
 }
 

--- a/plugins/inputs/intel_rdt/intel_rdt_test.go
+++ b/plugins/inputs/intel_rdt/intel_rdt_test.go
@@ -5,8 +5,9 @@ package intel_rdt
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 )
 
 type MockProc struct{}
@@ -30,19 +31,19 @@ func TestAssociateProcessesWithPIDs(t *testing.T) {
 	processes := []string{"process"}
 	expectedPID := "1000"
 	result, err := rdt.associateProcessesWithPIDs(processes)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedPID, result[processes[0]])
+	require.Nil(t, err)
+	require.Equal(t, expectedPID, result[processes[0]])
 
 	processes = []string{"process2"}
 	expectedPID = "1002,1003"
 	result, err = rdt.associateProcessesWithPIDs(processes)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedPID, result[processes[0]])
+	require.Nil(t, err)
+	require.Equal(t, expectedPID, result[processes[0]])
 
 	processes = []string{"process1"}
 	result, err = rdt.associateProcessesWithPIDs(processes)
-	assert.Nil(t, err)
-	assert.Len(t, result, 0)
+	require.Nil(t, err)
+	require.Len(t, result, 0)
 }
 
 func TestSplitCSVLineIntoValues(t *testing.T) {
@@ -52,30 +53,30 @@ func TestSplitCSVLineIntoValues(t *testing.T) {
 	expectedCoreOrPidsValue := []string{"\"45417", "29170\"", "37", "44"}
 
 	splitCSV, err := splitCSVLineIntoValues(line)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedTimeValue, splitCSV.timeValue)
-	assert.Equal(t, expectedMetricsValue, splitCSV.metricsValues)
-	assert.Equal(t, expectedCoreOrPidsValue, splitCSV.coreOrPIDsValues)
+	require.Nil(t, err)
+	require.Equal(t, expectedTimeValue, splitCSV.timeValue)
+	require.Equal(t, expectedMetricsValue, splitCSV.metricsValues)
+	require.Equal(t, expectedCoreOrPidsValue, splitCSV.coreOrPIDsValues)
 
 	wrongLine := "2020-08-12 13:34:36,37,44,0.00,0,0.0"
 	splitCSV, err = splitCSVLineIntoValues(wrongLine)
-	assert.NotNil(t, err)
-	assert.Equal(t, "", splitCSV.timeValue)
-	assert.Nil(t, nil, splitCSV.metricsValues)
-	assert.Nil(t, nil, splitCSV.coreOrPIDsValues)
+	require.NotNil(t, err)
+	require.Equal(t, "", splitCSV.timeValue)
+	require.Nil(t, nil, splitCSV.metricsValues)
+	require.Nil(t, nil, splitCSV.coreOrPIDsValues)
 }
 
 func TestFindPIDsInMeasurement(t *testing.T) {
 	line := "2020-08-12 13:34:36,\"45417,29170\""
 	expected := "45417,29170"
 	result, err := findPIDsInMeasurement(line)
-	assert.Nil(t, err)
-	assert.Equal(t, expected, result)
+	require.Nil(t, err)
+	require.Equal(t, expected, result)
 
 	line = "pids not included"
 	result, err = findPIDsInMeasurement(line)
-	assert.NotNil(t, err)
-	assert.Equal(t, "", result)
+	require.NotNil(t, err)
+	require.Equal(t, "", result)
 }
 
 func TestCreateArgsProcesses(t *testing.T) {
@@ -84,7 +85,7 @@ func TestCreateArgsProcesses(t *testing.T) {
 	}
 	expected := "--mon-pid=all:[12345, 99999];mbt:[12345, 99999];"
 	result := createArgProcess(processesPIDs)
-	assert.EqualValues(t, expected, result)
+	require.EqualValues(t, expected, result)
 
 	processesPIDs = map[string]string{
 		"process":  "12345, 99999",
@@ -94,183 +95,183 @@ func TestCreateArgsProcesses(t *testing.T) {
 	expectedSubstring := "all:[12345, 99999];mbt:[12345, 99999];"
 	expectedSubstring2 := "all:[44444, 11111];mbt:[44444, 11111];"
 	result = createArgProcess(processesPIDs)
-	assert.Contains(t, result, expectedPrefix)
-	assert.Contains(t, result, expectedSubstring)
-	assert.Contains(t, result, expectedSubstring2)
+	require.Contains(t, result, expectedPrefix)
+	require.Contains(t, result, expectedSubstring)
+	require.Contains(t, result, expectedSubstring2)
 }
 
 func TestCreateArgsCores(t *testing.T) {
 	cores := []string{"1,2,3"}
 	expected := "--mon-core=all:[1,2,3];mbt:[1,2,3];"
 	result := createArgCores(cores)
-	assert.EqualValues(t, expected, result)
+	require.EqualValues(t, expected, result)
 
 	cores = []string{"1,2,3", "4,5,6"}
 	expectedPrefix := "--mon-core="
 	expectedSubstring := "all:[1,2,3];mbt:[1,2,3];"
 	expectedSubstring2 := "all:[4,5,6];mbt:[4,5,6];"
 	result = createArgCores(cores)
-	assert.Contains(t, result, expectedPrefix)
-	assert.Contains(t, result, expectedSubstring)
-	assert.Contains(t, result, expectedSubstring2)
+	require.Contains(t, result, expectedPrefix)
+	require.Contains(t, result, expectedSubstring)
+	require.Contains(t, result, expectedSubstring2)
 }
 
 func TestParseCoresConfig(t *testing.T) {
 	t.Run("empty slice", func(t *testing.T) {
 		var configCores []string
 		result, err := parseCoresConfig(configCores)
-		assert.Nil(t, err)
-		assert.Nil(t, result)
+		require.Nil(t, err)
+		require.Len(t, result, 0)
 	})
 
 	t.Run("empty string in slice", func(t *testing.T) {
 		configCores := []string{""}
 		result, err := parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Len(t, result, 0)
 	})
 
 	t.Run("not correct string", func(t *testing.T) {
 		configCores := []string{"wrong string"}
 		result, err := parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Len(t, result, 0)
 	})
 
 	t.Run("not correct string", func(t *testing.T) {
 		configCores := []string{"1,2", "wasd:#$!;"}
 		result, err := parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Len(t, result, 0)
 	})
 
 	t.Run("not correct string", func(t *testing.T) {
 		configCores := []string{"1,2,2"}
 		result, err := parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Len(t, result, 0)
 	})
 
 	t.Run("coma separated cores - positive", func(t *testing.T) {
 		configCores := []string{"0,1,2,3,4,5"}
 		expected := []string{"0,1,2,3,4,5"}
 		result, err := parseCoresConfig(configCores)
-		assert.Nil(t, err)
-		assert.EqualValues(t, expected, result)
+		require.Nil(t, err)
+		require.EqualValues(t, expected, result)
 
 		configCores = []string{"0,1,2", "3,4,5"}
 		expected = []string{"0,1,2", "3,4,5"}
 		result, err = parseCoresConfig(configCores)
-		assert.Nil(t, err)
-		assert.EqualValues(t, expected, result)
+		require.Nil(t, err)
+		require.EqualValues(t, expected, result)
 
 		configCores = []string{"0,4,1", "2,3,5", "9"}
 		expected = []string{"0,4,1", "2,3,5", "9"}
 		result, err = parseCoresConfig(configCores)
-		assert.Nil(t, err)
-		assert.EqualValues(t, expected, result)
+		require.Nil(t, err)
+		require.EqualValues(t, expected, result)
 	})
 
 	t.Run("coma separated cores - negative", func(t *testing.T) {
 		// cannot monitor same cores in different groups
 		configCores := []string{"0,1,2", "2"}
 		result, err := parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Nil(t, result)
 
 		configCores = []string{"0,1,2", "2,3,4"}
 		result, err = parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Nil(t, result)
 
 		configCores = []string{"0,-1,2", "2,3,4"}
 		result, err = parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Nil(t, result)
 	})
 
 	t.Run("dash separated cores - positive", func(t *testing.T) {
 		configCores := []string{"0-5"}
 		expected := []string{"0,1,2,3,4,5"}
 		result, err := parseCoresConfig(configCores)
-		assert.Nil(t, err)
-		assert.EqualValues(t, expected, result)
+		require.Nil(t, err)
+		require.EqualValues(t, expected, result)
 
 		configCores = []string{"0-5", "7-10"}
 		expected = []string{"0,1,2,3,4,5", "7,8,9,10"}
 		result, err = parseCoresConfig(configCores)
-		assert.Nil(t, err)
-		assert.EqualValues(t, expected, result)
+		require.Nil(t, err)
+		require.EqualValues(t, expected, result)
 
 		configCores = []string{"5-5"}
 		expected = []string{"5"}
 		result, err = parseCoresConfig(configCores)
-		assert.Nil(t, err)
-		assert.EqualValues(t, expected, result)
+		require.Nil(t, err)
+		require.EqualValues(t, expected, result)
 	})
 
 	t.Run("dash separated cores - negative", func(t *testing.T) {
 		// cannot monitor same cores in different groups
 		configCores := []string{"0-5", "2-7"}
 		result, err := parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Nil(t, result)
 
 		// more than two values in range
 		configCores = []string{"0-5-10"}
 		result, err = parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Nil(t, result)
 
 		// first value cannot be higher than second
 		configCores = []string{"12-5"}
 		result, err = parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Nil(t, result)
 
 		configCores = []string{"0-"}
 		result, err = parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Nil(t, result)
 	})
 
 	t.Run("mixed separator - positive", func(t *testing.T) {
 		configCores := []string{"0-5,6,7"}
 		expected := []string{"0,1,2,3,4,5,6,7"}
 		result, err := parseCoresConfig(configCores)
-		assert.Nil(t, err)
-		assert.EqualValues(t, expected, result)
+		require.Nil(t, err)
+		require.EqualValues(t, expected, result)
 
 		configCores = []string{"0-5,6,7", "8,9,10"}
 		expected = []string{"0,1,2,3,4,5,6,7", "8,9,10"}
 		result, err = parseCoresConfig(configCores)
-		assert.Nil(t, err)
-		assert.EqualValues(t, expected, result)
+		require.Nil(t, err)
+		require.EqualValues(t, expected, result)
 
 		configCores = []string{"0-7", "8-10"}
 		expected = []string{"0,1,2,3,4,5,6,7", "8,9,10"}
 		result, err = parseCoresConfig(configCores)
-		assert.Nil(t, err)
-		assert.EqualValues(t, expected, result)
+		require.Nil(t, err)
+		require.EqualValues(t, expected, result)
 	})
 
 	t.Run("mixed separator - negative", func(t *testing.T) {
 		// cannot monitor same cores in different groups
 		configCores := []string{"0-5,", "2-7"}
 		result, err := parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Nil(t, result)
 
 		// cores cannot be duplicated
 		configCores = []string{"0-5,5"}
 		result, err = parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Nil(t, result)
 
 		// more than two values in range
 		configCores = []string{"0-5-6,9"}
 		result, err = parseCoresConfig(configCores)
-		assert.NotNil(t, err)
-		assert.Nil(t, result)
+		require.NotNil(t, err)
+		require.Nil(t, result)
 	})
 }

--- a/plugins/inputs/intel_rdt/processes.go
+++ b/plugins/inputs/intel_rdt/processes.go
@@ -20,11 +20,12 @@ func NewProcessor() ProcessesHandler {
 }
 
 func (p *ProcessManager) getAllProcesses() ([]Process, error) {
-	var processes []Process
 	allProcesses, err := procfs.AllProcs()
 	if err != nil {
 		return nil, err
 	}
+
+	processes := make([]Process, 0, len(allProcesses))
 	for _, proc := range allProcesses {
 		procComm, err := proc.Comm()
 		if err != nil {

--- a/plugins/inputs/intel_rdt/publisher.go
+++ b/plugins/inputs/intel_rdt/publisher.go
@@ -79,7 +79,6 @@ func (p *Publisher) publishProcess(measurement processMeasurement) {
 }
 
 func parseCoresMeasurement(measurements string) (parsedCoresMeasurement, error) {
-	var values []float64
 	splitCSV, err := splitCSVLineIntoValues(measurements)
 	if err != nil {
 		return parsedCoresMeasurement{}, err
@@ -93,6 +92,7 @@ func parseCoresMeasurement(measurements string) (parsedCoresMeasurement, error) 
 	// trim unwanted quotes
 	coresString = strings.Trim(coresString, "\"")
 
+	values := make([]float64, 0, len(splitCSV.metricsValues))
 	for _, metric := range splitCSV.metricsValues {
 		parsedValue, err := parseFloat(metric)
 		if err != nil {
@@ -143,7 +143,7 @@ func parseProcessesMeasurement(measurement processMeasurement) (parsedProcessMea
 	actualProcess := measurement.name
 	cores := strings.Trim(strings.Join(splitCSV.coreOrPIDsValues[lenOfPIDs:], ","), `"`)
 
-	var values []float64
+	values := make([]float64, 0, len(splitCSV.metricsValues))
 	for _, metric := range splitCSV.metricsValues {
 		parsedValue, err := parseFloat(metric)
 		if err != nil {

--- a/plugins/inputs/jolokia/jolokia.go
+++ b/plugins/inputs/jolokia/jolokia.go
@@ -101,7 +101,7 @@ func (j *Jolokia) prepareRequest(server Server, metrics []Metric) (*http.Request
 	var jolokiaURL *url.URL
 	context := j.Context // Usually "/jolokia/"
 
-	var bulkBodyContent []map[string]interface{}
+	bulkBodyContent := make([]map[string]interface{}, 0, len(metrics))
 	for _, metric := range metrics {
 		// Create bodyContent
 		bodyContent := map[string]interface{}{

--- a/plugins/inputs/jolokia2_agent/jolokia2_agent.go
+++ b/plugins/inputs/jolokia2_agent/jolokia2_agent.go
@@ -78,11 +78,9 @@ func (ja *JolokiaAgent) Gather(acc telegraf.Accumulator) error {
 }
 
 func (ja *JolokiaAgent) createMetrics() []common.Metric {
-	var metrics []common.Metric
-
+	metrics := make([]common.Metric, 0, len(ja.Metrics))
 	for _, metricConfig := range ja.Metrics {
-		metrics = append(metrics, common.NewMetric(metricConfig,
-			ja.DefaultFieldPrefix, ja.DefaultFieldSeparator, ja.DefaultTagPrefix))
+		metrics = append(metrics, common.NewMetric(metricConfig, ja.DefaultFieldPrefix, ja.DefaultFieldSeparator, ja.DefaultTagPrefix))
 	}
 
 	return metrics

--- a/plugins/inputs/jolokia2_proxy/jolokia2_proxy.go
+++ b/plugins/inputs/jolokia2_proxy/jolokia2_proxy.go
@@ -65,11 +65,9 @@ func (jp *JolokiaProxy) Gather(acc telegraf.Accumulator) error {
 }
 
 func (jp *JolokiaProxy) createMetrics() []common.Metric {
-	var metrics []common.Metric
-
+	metrics := make([]common.Metric, 0, len(jp.Metrics))
 	for _, metricConfig := range jp.Metrics {
-		metrics = append(metrics, common.NewMetric(metricConfig,
-			jp.DefaultFieldPrefix, jp.DefaultFieldSeparator, jp.DefaultTagPrefix))
+		metrics = append(metrics, common.NewMetric(metricConfig, jp.DefaultFieldPrefix, jp.DefaultFieldSeparator, jp.DefaultTagPrefix))
 	}
 
 	return metrics

--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -150,7 +150,7 @@ func (k *Kubernetes) gatherPodInfo(baseURL string) ([]Metadata, error) {
 	if err != nil {
 		return nil, err
 	}
-	var podInfos []Metadata
+	podInfos := make([]Metadata, 0, len(podAPI.Items))
 	for _, podMetadata := range podAPI.Items {
 		podInfos = append(podInfos, podMetadata.Metadata)
 	}

--- a/plugins/inputs/minecraft/client.go
+++ b/plugins/inputs/minecraft/client.go
@@ -138,7 +138,7 @@ func parsePlayers(input string) []string {
 		names = append(head, strings.SplitN(tail, " and ", 2)...)
 	}
 
-	var players []string
+	players := make([]string, 0, len(names))
 	for _, name := range names {
 		name := strings.TrimSpace(name)
 		if name == "" {
@@ -168,8 +168,8 @@ func parseScores(input string) []Score {
 		re = scoreboardRegex
 	}
 
-	var scores []Score
 	matches := re.FindAllStringSubmatch(input, -1)
+	scores := make([]Score, 0, len(matches))
 	for _, match := range matches {
 		score := Score{}
 		for i, subexp := range re.SubexpNames() {

--- a/plugins/inputs/mongodb/mongodb_data_test.go
+++ b/plugins/inputs/mongodb/mongodb_data_test.go
@@ -318,7 +318,7 @@ func TestAddShardHostStats(t *testing.T) {
 	d.AddShardHostStats()
 	d.flush(&acc)
 
-	var hostsFound []string
+	hostsFound := make([]string, 0, len(hostStatLines))
 	for host := range hostStatLines {
 		for key := range shardHostStats {
 			require.True(t, acc.HasInt64Field("mongodb_shard_stats", key))
@@ -498,7 +498,7 @@ func TestStateTag(t *testing.T) {
 
 func TestAddTopStats(t *testing.T) {
 	collections := []string{"collectionOne", "collectionTwo"}
-	var topStatLines []TopStatLine
+	topStatLines := make([]TopStatLine, 0, len(collections))
 	for _, collection := range collections {
 		topStatLine := TopStatLine{
 			CollectionName: collection,


### PR DESCRIPTION
Address findings for [prealloc](https://github.com/alexkohler/prealloc) - Finds slice declarations that could potentially be pre-allocated.

It is only part of the bigger job.
After not pre-allocated slices in whole project are handled, we can enable proper linter to guard this.

