### PR TITLE
fix(input.redis_sentinel): fix sentinel and replica stats gathering

### DIFF
--- a/plugins/inputs/redis_sentinel/redis_sentinel.go
+++ b/plugins/inputs/redis_sentinel/redis_sentinel.go
@@ -243,6 +243,7 @@ func (client *RedisSentinelClient) gatherMasterStats(acc telegraf.Accumulator) (
 		if !ok {
 			return masterNames, fmt.Errorf("unable to resolve master name")
 		}
+		masterNames = append(masterNames, masterName)
 
 		quorumCmd := redis.NewStringCmd("sentinel", "ckquorum", masterName)
 		quorumErr := client.sentinel.Process(quorumCmd)

--- a/plugins/inputs/redis_sentinel/redis_sentinel_test.go
+++ b/plugins/inputs/redis_sentinel/redis_sentinel_test.go
@@ -362,6 +362,7 @@ func createRedisContainer() testutil.Container {
 		Name:     "telegraf-test-redis-sentinel-redis",
 		Networks: []string{networkName},
 		WaitingFor: wait.ForAll(
+			wait.ForLog("Ready to accept connections"),
 			wait.ForExposedPort(),
 		),
 	}


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #12152

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

---

I improved the integration test by making sure the plugin gets Initialized and talks to an actual Redis Sentinel instance.
