### PR TITLE
fix(parsers.csv): Allow null-delimiters

### DIFF
--- a/plugins/parsers/csv/README.md
+++ b/plugins/parsers/csv/README.md
@@ -106,6 +106,11 @@ values.
   ##    "always" -- reset the parser with each call (ignored in line-wise parsing)
   ##                Helpful when e.g. reading whole files in each gather-cycle.
   # csv_reset_mode = "none"
+  
+  ## This option will change all selected bytes to pipeline ('|', \u007C) before csv parsing.
+  ## Use this option if ypur csv delimiter is blacklisted (e.g. "\u0000")
+  ## Cannot be used together with "csv_delimiter" option.
+  #csv_force_replace_delimiter = "\u0000"
   ```
 
 ### csv_timestamp_column, csv_timestamp_format

--- a/plugins/parsers/csv/README.md
+++ b/plugins/parsers/csv/README.md
@@ -59,6 +59,8 @@ values.
 
   ## The separator between csv fields
   ## By default, the parser assumes a comma (",")
+  ## Please note that if you use blacklisted delimiters (e.g. "\u0000"), this will be changed to comma.
+  ## in the data the blacklisted delimiters will be changed to comma, and original commas will be changed to "\ufffd"
   csv_delimiter = ","
 
   ## The character reserved for marking a row as a comment row
@@ -106,11 +108,6 @@ values.
   ##    "always" -- reset the parser with each call (ignored in line-wise parsing)
   ##                Helpful when e.g. reading whole files in each gather-cycle.
   # csv_reset_mode = "none"
-  
-  ## This option will change all selected bytes to pipeline ('|', \u007C) before csv parsing.
-  ## Use this option if ypur csv delimiter is blacklisted (e.g. "\u0000")
-  ## Cannot be used together with "csv_delimiter" option.
-  #csv_force_replace_delimiter = "\u0000"
   ```
 
 ### csv_timestamp_column, csv_timestamp_format

--- a/plugins/parsers/csv/README.md
+++ b/plugins/parsers/csv/README.md
@@ -59,8 +59,10 @@ values.
 
   ## The separator between csv fields
   ## By default, the parser assumes a comma (",")
-  ## Please note that if you use blacklisted delimiters (e.g. "\u0000"), this will be changed to comma.
-  ## in the data the blacklisted delimiters will be changed to comma, and original commas will be changed to "\ufffd"
+  ## Please note that if you use invalid delimiters (e.g. "\u0000"), commas
+  ## will be changed to "\ufffd", the invalid delimiters changed to a comma
+  ## during parsing, and afterwards the invalid characters and commas are
+  ## returned to their original values.
   csv_delimiter = ","
 
   ## The character reserved for marking a row as a comment row

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -23,28 +23,31 @@ import (
 
 type TimeFunc func() time.Time
 
+var forceDelimiter = "\u007C"
+
 type Parser struct {
-	ColumnNames        []string        `toml:"csv_column_names"`
-	ColumnTypes        []string        `toml:"csv_column_types"`
-	Comment            string          `toml:"csv_comment"`
-	Delimiter          string          `toml:"csv_delimiter"`
-	HeaderRowCount     int             `toml:"csv_header_row_count"`
-	MeasurementColumn  string          `toml:"csv_measurement_column"`
-	MetricName         string          `toml:"metric_name"`
-	SkipColumns        int             `toml:"csv_skip_columns"`
-	SkipRows           int             `toml:"csv_skip_rows"`
-	TagColumns         []string        `toml:"csv_tag_columns"`
-	TimestampColumn    string          `toml:"csv_timestamp_column"`
-	TimestampFormat    string          `toml:"csv_timestamp_format"`
-	Timezone           string          `toml:"csv_timezone"`
-	TrimSpace          bool            `toml:"csv_trim_space"`
-	SkipValues         []string        `toml:"csv_skip_values"`
-	SkipErrors         bool            `toml:"csv_skip_errors"`
-	MetadataRows       int             `toml:"csv_metadata_rows"`
-	MetadataSeparators []string        `toml:"csv_metadata_separators"`
-	MetadataTrimSet    string          `toml:"csv_metadata_trim_set"`
-	ResetMode          string          `toml:"csv_reset_mode"`
-	Log                telegraf.Logger `toml:"-"`
+	ColumnNames           []string        `toml:"csv_column_names"`
+	ColumnTypes           []string        `toml:"csv_column_types"`
+	Comment               string          `toml:"csv_comment"`
+	Delimiter             string          `toml:"csv_delimiter"`
+	HeaderRowCount        int             `toml:"csv_header_row_count"`
+	MeasurementColumn     string          `toml:"csv_measurement_column"`
+	MetricName            string          `toml:"metric_name"`
+	SkipColumns           int             `toml:"csv_skip_columns"`
+	SkipRows              int             `toml:"csv_skip_rows"`
+	TagColumns            []string        `toml:"csv_tag_columns"`
+	TimestampColumn       string          `toml:"csv_timestamp_column"`
+	TimestampFormat       string          `toml:"csv_timestamp_format"`
+	Timezone              string          `toml:"csv_timezone"`
+	TrimSpace             bool            `toml:"csv_trim_space"`
+	SkipValues            []string        `toml:"csv_skip_values"`
+	SkipErrors            bool            `toml:"csv_skip_errors"`
+	MetadataRows          int             `toml:"csv_metadata_rows"`
+	MetadataSeparators    []string        `toml:"csv_metadata_separators"`
+	MetadataTrimSet       string          `toml:"csv_metadata_trim_set"`
+	ResetMode             string          `toml:"csv_reset_mode"`
+	Log                   telegraf.Logger `toml:"-"`
+	ForceReplaceDelimiter string          `toml:"csv_force_replace_delimiter"`
 
 	metadataSeparatorList metadataPattern
 
@@ -135,6 +138,10 @@ func (p *Parser) Init() error {
 		return fmt.Errorf("`csv_header_row_count` must be defined if `csv_column_names` is not specified")
 	}
 
+	if p.Delimiter != "" && p.ForceReplaceDelimiter != "" {
+		return fmt.Errorf("`csv_delimiter` must be empty if `csv_force_replace_delimiter` is used")
+	}
+
 	if p.Delimiter != "" {
 		runeStr := []rune(p.Delimiter)
 		if len(runeStr) > 1 {
@@ -184,6 +191,10 @@ func (p *Parser) compile(r io.Reader) *csv.Reader {
 	if p.Delimiter != "" {
 		csvReader.Comma = []rune(p.Delimiter)[0]
 	}
+	// ensure set of the forceDelimiter (default '|')
+	if p.ForceReplaceDelimiter != "" {
+		csvReader.Comma = []rune(forceDelimiter)[0]
+	}
 	if p.Comment != "" {
 		csvReader.Comment = []rune(p.Comment)[0]
 	}
@@ -196,7 +207,10 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	if p.ResetMode == "always" {
 		p.Reset()
 	}
-
+	// Replace blacklisted delimiter bytes
+	if p.ForceReplaceDelimiter != "" {
+		buf = bytes.Replace(buf, []byte(p.ForceReplaceDelimiter), []byte(forceDelimiter), -1)
+	}
 	r := bytes.NewReader(buf)
 	metrics, err := parseCSV(p, r)
 	if err != nil && errors.Is(err, io.EOF) {

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -192,7 +192,7 @@ func (p *Parser) compile(r io.Reader) *csv.Reader {
 		csvReader.Comma = []rune(p.Delimiter)[0]
 	}
 	// if the delimiter is balckited by the go reader
-	if p.delimiterReplaced && p.Delimiter != "" {
+	if p.invalidDelimiter && p.Delimiter != "" {
 		csvReader.Comma = []rune(commaByte)[0]
 	}
 	if p.Comment != "" {

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -24,8 +24,8 @@ import (
 
 type TimeFunc func() time.Time
 
-var replacementByte = "\ufffd"
-var commaByte = "\u002C"
+const replacementByte = "\ufffd"
+const commaByte = "\u002C"
 
 type Parser struct {
 	ColumnNames        []string        `toml:"csv_column_names"`

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -54,7 +54,7 @@ type Parser struct {
 
 	gotColumnNames bool
 
-	delimiterReplaced bool
+	invalidDelimiter bool
 
 	TimeFunc     func() time.Time
 	DefaultTags  map[string]string

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -211,11 +211,10 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	if p.ResetMode == "always" {
 		p.Reset()
 	}
-	// Replace blacklisted delimiter bytes
-	if p.delimiterReplaced {
-		// replace value commes to replacement bytes
+	// If using an invalid delimiter, replace commas with replacement and
+	// invalid delimiter with commas
+	if p.invalidDelimiter {
 		buf = bytes.Replace(buf, []byte(commaByte), []byte(replacementByte), -1)
-		// replace delimiters to comma
 		buf = bytes.Replace(buf, []byte(p.Delimiter), []byte(commaByte), -1)
 	}
 	r := bytes.NewReader(buf)

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -191,7 +191,7 @@ func (p *Parser) compile(r io.Reader) *csv.Reader {
 	if !p.delimiterReplaced && p.Delimiter != "" {
 		csvReader.Comma = []rune(p.Delimiter)[0]
 	}
-	// if the delimiter is balckited by the go reader
+	// Check if delimiter is invalid
 	if p.invalidDelimiter && p.Delimiter != "" {
 		csvReader.Comma = []rune(commaByte)[0]
 	}

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -188,7 +188,7 @@ func (p *Parser) compile(r io.Reader) *csv.Reader {
 	csvReader := csv.NewReader(r)
 	// ensures that the reader reads records of different lengths without an error
 	csvReader.FieldsPerRecord = -1
-	if !p.delimiterReplaced && p.Delimiter != "" {
+	if !p.invalidDelimiter && p.Delimiter != "" {
 		csvReader.Comma = []rune(p.Delimiter)[0]
 	}
 	// Check if delimiter is invalid

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -146,7 +146,7 @@ func (p *Parser) Init() error {
 		if len(runeStr) > 1 {
 			return fmt.Errorf("csv_delimiter must be a single character, got: %s", p.Delimiter)
 		}
-		p.delimiterReplaced = !validDelim(runeStr[0])
+		p.invalidDelimiter = !validDelim(runeStr[0])
 	}
 
 	if p.Comment != "" {

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -202,6 +202,8 @@ func (p *Parser) compile(r io.Reader) *csv.Reader {
 	return csvReader
 }
 
+// Taken from upstream Golang code see
+// https://github.com/golang/go/blob/release-branch.go1.19/src/encoding/csv/reader.go#L95
 func validDelim(r rune) bool {
 	return r != 0 && r != '"' && r != '\r' && r != '\n' && utf8.ValidRune(r) && r != utf8.RuneError
 }

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -243,7 +243,7 @@ func TestNullDelimiter(t *testing.T) {
 func TestDelimiterConfiguration(t *testing.T) {
 	p := &Parser{
 		HeaderRowCount:        0,
-		Delimiter:			   "%",
+		Delimiter:             "%",
 		ForceReplaceDelimiter: "\u0000",
 		ColumnNames:           []string{"first", "second", "third"},
 		TimeFunc:              DefaultTime,

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -219,6 +220,36 @@ func TestDelimiter(t *testing.T) {
 	metrics, err := p.Parse([]byte(testCSV))
 	require.NoError(t, err)
 	require.Equal(t, "3,4", metrics[0].Fields()["first"])
+}
+
+func TestNullDelimiter(t *testing.T) {
+	p := &Parser{
+		HeaderRowCount:        0,
+		ForceReplaceDelimiter: "\u0000",
+		ColumnNames:           []string{"first", "second", "third"},
+		TimeFunc:              DefaultTime,
+	}
+	err := p.Init()
+	require.NoError(t, err)
+
+	testCSV := strings.Join([]string{"3.4", "70", "test_name"}, "\u0000")
+	metrics, err := p.Parse([]byte(testCSV))
+	require.NoError(t, err)
+	require.Equal(t, float64(3.4), metrics[0].Fields()["first"])
+	require.Equal(t, int64(70), metrics[0].Fields()["second"])
+	require.Equal(t, "test_name", metrics[0].Fields()["third"])
+}
+
+func TestDelimiterConfiguration(t *testing.T) {
+	p := &Parser{
+		HeaderRowCount:        0,
+		Delimiter:			   "%",
+		ForceReplaceDelimiter: "\u0000",
+		ColumnNames:           []string{"first", "second", "third"},
+		TimeFunc:              DefaultTime,
+	}
+	err := p.Init()
+	require.Equal(t, fmt.Errorf("`csv_delimiter` must be empty if `csv_force_replace_delimiter` is used"), err)
 }
 
 func TestValueConversion(t *testing.T) {

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -224,10 +224,10 @@ func TestDelimiter(t *testing.T) {
 
 func TestNullDelimiter(t *testing.T) {
 	p := &Parser{
-		HeaderRowCount:        0,
-		ForceReplaceDelimiter: "\u0000",
-		ColumnNames:           []string{"first", "second", "third"},
-		TimeFunc:              DefaultTime,
+		HeaderRowCount: 0,
+		Delimiter:      "\u0000",
+		ColumnNames:    []string{"first", "second", "third"},
+		TimeFunc:       DefaultTime,
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -238,18 +238,6 @@ func TestNullDelimiter(t *testing.T) {
 	require.Equal(t, float64(3.4), metrics[0].Fields()["first"])
 	require.Equal(t, int64(70), metrics[0].Fields()["second"])
 	require.Equal(t, "test_name", metrics[0].Fields()["third"])
-}
-
-func TestDelimiterConfiguration(t *testing.T) {
-	p := &Parser{
-		HeaderRowCount:        0,
-		Delimiter:             "%",
-		ForceReplaceDelimiter: "\u0000",
-		ColumnNames:           []string{"first", "second", "third"},
-		TimeFunc:              DefaultTime,
-	}
-	err := p.Init()
-	require.Equal(t, fmt.Errorf("`csv_delimiter` must be empty if `csv_force_replace_delimiter` is used"), err)
 }
 
 func TestValueConversion(t *testing.T) {


### PR DESCRIPTION
[https://github.com/influxdata/telegraf/issues/12243](url)

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12243

Fixing null delimiters in csv, change the selected bytes before parsing to pipeline.