### PR TITLE
chore: update readme linter changed files version

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -45,7 +45,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0

--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v26.1
+        uses: tj-actions/changed-files@v34.4.2
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           files: ./plugins/**/README.md

--- a/plugins/inputs/activemq/README.md
+++ b/plugins/inputs/activemq/README.md
@@ -3,6 +3,10 @@
 This plugin gather queues, topics & subscribers metrics using ActiveMQ Console
 API.
 
+
+# fake bad change
+dfdfd
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support

--- a/plugins/inputs/activemq/README.md
+++ b/plugins/inputs/activemq/README.md
@@ -3,8 +3,6 @@
 This plugin gather queues, topics & subscribers metrics using ActiveMQ Console
 API.
 
-## Configuration
-
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support

--- a/plugins/inputs/activemq/README.md
+++ b/plugins/inputs/activemq/README.md
@@ -3,9 +3,7 @@
 This plugin gather queues, topics & subscribers metrics using ActiveMQ Console
 API.
 
-
-# fake bad change
-dfdfd
+## Configuration
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 


### PR DESCRIPTION
The node version used by these plugins is old and suddenly causing issues due to deprecation and changes by GitHub. This updates the versions used to ensure we are only reporting issues with files that have changed.

You can look at the 2nd and 3rd commits for examples of failures.