### PR TITLE
chore: Fix linter findings for errname

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,14 +2,15 @@ linters:
   disable-all: true
   enable:
     # - telegraflinter
-    - asciicheck
     - asasalint
+    - asciicheck
     - bidichk
     - bodyclose
     - depguard
     - dogsled
-    - exportloopref
     - errcheck
+    - errname
+    - exportloopref
     - goprintffuncname
     - gosimple
     - govet

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -24,8 +24,8 @@ import (
 const alphanum string = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 var (
-	ErrTimeout          = errors.New("command timed out")
-	ErrorNotImplemented = errors.New("not implemented yet")
+	ErrTimeout        = errors.New("command timed out")
+	ErrNotImplemented = errors.New("not implemented yet")
 )
 
 // Set via LDFLAGS -X

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -5,14 +5,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/internal"
-
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/host"
 	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/shirou/gopsutil/v3/net"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
 )
 
 type PS interface {
@@ -198,7 +198,7 @@ func (s *SystemPS) NetConntrack(perCPU bool) ([]net.ConntrackStat, error) {
 
 func (s *SystemPS) DiskIO(names []string) (map[string]disk.IOCountersStat, error) {
 	m, err := disk.IOCounters(names...)
-	if err == internal.ErrorNotImplemented {
+	if err == internal.ErrNotImplemented {
 		return nil, nil
 	}
 

--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -59,8 +59,8 @@ type DatabaseNotFoundError struct {
 	Database string
 }
 
-// QueryResponse is the response body from the /query endpoint
-type QueryResponse struct {
+// QueryResponseError is the response body from the /query endpoint
+type QueryResponseError struct {
 	Results []QueryResult `json:"results"`
 }
 
@@ -68,19 +68,19 @@ type QueryResult struct {
 	Err string `json:"error,omitempty"`
 }
 
-func (r QueryResponse) Error() string {
+func (r QueryResponseError) Error() string {
 	if len(r.Results) > 0 {
 		return r.Results[0].Err
 	}
 	return ""
 }
 
-// WriteResponse is the response body from the /write endpoint
-type WriteResponse struct {
+// WriteResponseError is the response body from the /write endpoint
+type WriteResponseError struct {
 	Err string `json:"error,omitempty"`
 }
 
-func (r WriteResponse) Error() string {
+func (r WriteResponseError) Error() string {
 	return r.Err
 }
 
@@ -229,7 +229,7 @@ func (c *httpClient) CreateDatabase(ctx context.Context, database string) error 
 		}
 	}
 
-	queryResp := &QueryResponse{}
+	queryResp := &QueryResponseError{}
 	dec := json.NewDecoder(body)
 	err = dec.Decode(queryResp)
 
@@ -365,7 +365,7 @@ func (c *httpClient) writeBatch(ctx context.Context, db, rp string, metrics []te
 		}
 	}
 
-	writeResp := &WriteResponse{}
+	writeResp := &WriteResponseError{}
 	dec := json.NewDecoder(body)
 
 	var desc string


### PR DESCRIPTION
Address findings for [errname](https://github.com/Antonboom/errname) - Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.