### PR TITLE
chore: Fix linter findings for makezero (part1)

### DIFF
--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -237,9 +237,9 @@ func (fc *FileCount) onlyDirectories(directories []string) []string {
 }
 
 func (fc *FileCount) getDirs() []string {
-	dirs := make([]string, len(fc.Directories))
-	for i, dir := range fc.Directories {
-		dirs[i] = filepath.Clean(dir)
+	dirs := make([]string, 0, len(fc.Directories)+1)
+	for _, dir := range fc.Directories {
+		dirs = append(dirs, filepath.Clean(dir))
 	}
 
 	if fc.Directory != "" {

--- a/plugins/inputs/jenkins/jenkins.go
+++ b/plugins/inputs/jenkins/jenkins.go
@@ -384,8 +384,8 @@ type jobRequest struct {
 }
 
 func (jr jobRequest) combined() []string {
-	path := make([]string, len(jr.parents))
-	copy(path, jr.parents)
+	path := make([]string, 0, len(jr.parents)+1)
+	path = append(path, jr.parents...)
 	return append(path, jr.name)
 }
 

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -41,10 +41,9 @@ func pwgen(n int) string {
 	charset := []byte("abcdedfghijklmnopqrstABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 	nchars := len(charset)
-	buffer := make([]byte, n)
-
-	for i := range buffer {
-		buffer[i] = charset[rand.Intn(nchars)]
+	buffer := make([]byte, 0, n)
+	for range buffer {
+		buffer = append(buffer, charset[rand.Intn(nchars)])
 	}
 
 	return string(buffer)

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -42,7 +42,7 @@ func pwgen(n int) string {
 
 	nchars := len(charset)
 	buffer := make([]byte, 0, n)
-	for range n {
+	for i := 0; i < n; i++ {
 		buffer = append(buffer, charset[rand.Intn(nchars)])
 	}
 

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -42,7 +42,7 @@ func pwgen(n int) string {
 
 	nchars := len(charset)
 	buffer := make([]byte, 0, n)
-	for range buffer {
+	for range n {
 		buffer = append(buffer, charset[rand.Intn(nchars)])
 	}
 

--- a/plugins/outputs/timestream/timestream.go
+++ b/plugins/outputs/timestream/timestream.go
@@ -543,8 +543,7 @@ func partitionRecords(size int, records []types.Record) [][]types.Record {
 		numberOfPartitions++
 	}
 
-	partitions := make([][]types.Record, numberOfPartitions)
-
+	partitions := make([][]types.Record, 0, numberOfPartitions)
 	for i := 0; i < numberOfPartitions; i++ {
 		start := size * i
 		end := size * (i + 1)
@@ -552,7 +551,7 @@ func partitionRecords(size int, records []types.Record) [][]types.Record {
 			end = len(records)
 		}
 
-		partitions[i] = records[start:end]
+		partitions = append(partitions, records[start:end])
 	}
 
 	return partitions

--- a/plugins/outputs/warp10/warp10.go
+++ b/plugins/outputs/warp10/warp10.go
@@ -151,16 +151,13 @@ func (w *Warp10) Write(metrics []telegraf.Metric) error {
 }
 
 func buildTags(tags []*telegraf.Tag) []string {
-	tagsString := make([]string, len(tags)+1)
-	indexSource := 0
-	for index, tag := range tags {
+	tagsString := make([]string, 0, len(tags)+1)
+	for _, tag := range tags {
 		key := url.QueryEscape(tag.Key)
 		value := url.QueryEscape(tag.Value)
-		tagsString[index] = fmt.Sprintf("%s=%s", key, value)
-		indexSource = index
+		tagsString = append(tagsString, fmt.Sprintf("%s=%s", key, value))
 	}
-	indexSource++
-	tagsString[indexSource] = "source=telegraf"
+	tagsString = append(tagsString, "source=telegraf")
 	sort.Strings(tagsString)
 	return tagsString
 }

--- a/plugins/parsers/influx/machine_test.go
+++ b/plugins/parsers/influx/machine_test.go
@@ -17,132 +17,118 @@ type TestingHandler struct {
 }
 
 func (h *TestingHandler) SetMeasurement(name []byte) error {
-	n := make([]byte, len(name))
-	copy(n, name)
+	n := make([]byte, 0, len(name))
 
-	mname := Result{
+	mName := Result{
 		Name:  Measurement,
-		Value: n,
+		Value: append(n, name...),
 	}
-	h.results = append(h.results, mname)
+	h.results = append(h.results, mName)
 	return nil
 }
 
 func (h *TestingHandler) AddTag(key []byte, value []byte) error {
-	k := make([]byte, len(key))
-	copy(k, key)
-	v := make([]byte, len(value))
-	copy(v, value)
+	k := make([]byte, 0, len(key))
+	v := make([]byte, 0, len(value))
 
-	tagkey := Result{
+	tagKey := Result{
 		Name:  TagKey,
-		Value: k,
+		Value: append(k, key...),
 	}
-	tagvalue := Result{
+	tagValue := Result{
 		Name:  TagValue,
-		Value: v,
+		Value: append(v, value...),
 	}
-	h.results = append(h.results, tagkey, tagvalue)
+	h.results = append(h.results, tagKey, tagValue)
 	return nil
 }
 
 func (h *TestingHandler) AddInt(key []byte, value []byte) error {
-	k := make([]byte, len(key))
-	copy(k, key)
-	v := make([]byte, len(value))
-	copy(v, value)
+	k := make([]byte, 0, len(key))
+	v := make([]byte, 0, len(value))
 
-	fieldkey := Result{
+	fieldKey := Result{
 		Name:  FieldKey,
-		Value: k,
+		Value: append(k, key...),
 	}
-	fieldvalue := Result{
+	fieldValue := Result{
 		Name:  FieldInt,
-		Value: v,
+		Value: append(v, value...),
 	}
-	h.results = append(h.results, fieldkey, fieldvalue)
+	h.results = append(h.results, fieldKey, fieldValue)
 	return nil
 }
 
 func (h *TestingHandler) AddUint(key []byte, value []byte) error {
-	k := make([]byte, len(key))
-	copy(k, key)
-	v := make([]byte, len(value))
-	copy(v, value)
+	k := make([]byte, 0, len(key))
+	v := make([]byte, 0, len(value))
 
-	fieldkey := Result{
+	fieldKey := Result{
 		Name:  FieldKey,
-		Value: key,
+		Value: append(k, key...),
 	}
-	fieldvalue := Result{
+	fieldValue := Result{
 		Name:  FieldUint,
-		Value: value,
+		Value: append(v, value...),
 	}
-	h.results = append(h.results, fieldkey, fieldvalue)
+	h.results = append(h.results, fieldKey, fieldValue)
 	return nil
 }
 
 func (h *TestingHandler) AddFloat(key []byte, value []byte) error {
-	k := make([]byte, len(key))
-	copy(k, key)
-	v := make([]byte, len(value))
-	copy(v, value)
+	k := make([]byte, 0, len(key))
+	v := make([]byte, 0, len(value))
 
-	fieldkey := Result{
+	fieldKey := Result{
 		Name:  FieldKey,
-		Value: k,
+		Value: append(k, key...),
 	}
-	fieldvalue := Result{
+	fieldValue := Result{
 		Name:  FieldFloat,
-		Value: v,
+		Value: append(v, value...),
 	}
-	h.results = append(h.results, fieldkey, fieldvalue)
+	h.results = append(h.results, fieldKey, fieldValue)
 	return nil
 }
 
 func (h *TestingHandler) AddString(key []byte, value []byte) error {
-	k := make([]byte, len(key))
-	copy(k, key)
-	v := make([]byte, len(value))
-	copy(v, value)
+	k := make([]byte, 0, len(key))
+	v := make([]byte, 0, len(value))
 
-	fieldkey := Result{
+	fieldKey := Result{
 		Name:  FieldKey,
-		Value: k,
+		Value: append(k, key...),
 	}
-	fieldvalue := Result{
+	fieldValue := Result{
 		Name:  FieldString,
-		Value: v,
+		Value: append(v, value...),
 	}
-	h.results = append(h.results, fieldkey, fieldvalue)
+	h.results = append(h.results, fieldKey, fieldValue)
 	return nil
 }
 
 func (h *TestingHandler) AddBool(key []byte, value []byte) error {
-	k := make([]byte, len(key))
-	copy(k, key)
-	v := make([]byte, len(value))
-	copy(v, value)
+	k := make([]byte, 0, len(key))
+	v := make([]byte, 0, len(value))
 
-	fieldkey := Result{
+	fieldKey := Result{
 		Name:  FieldKey,
-		Value: k,
+		Value: append(k, key...),
 	}
-	fieldvalue := Result{
+	fieldValue := Result{
 		Name:  FieldBool,
-		Value: v,
+		Value: append(v, value...),
 	}
-	h.results = append(h.results, fieldkey, fieldvalue)
+	h.results = append(h.results, fieldKey, fieldValue)
 	return nil
 }
 
 func (h *TestingHandler) SetTimestamp(tm []byte) error {
-	t := make([]byte, len(tm))
-	copy(t, tm)
+	t := make([]byte, 0, len(tm))
 
 	timestamp := Result{
 		Name:  Timestamp,
-		Value: t,
+		Value: append(t, tm...),
 	}
 	h.results = append(h.results, timestamp)
 	return nil

--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -230,14 +230,12 @@ func cartesianProduct(a, b []telegraf.Metric) []telegraf.Metric {
 	if len(b) == 0 {
 		return a
 	}
-	p := make([]telegraf.Metric, len(a)*len(b))
-	i := 0
+	p := make([]telegraf.Metric, 0, len(a)*len(b))
 	for _, a := range a {
 		for _, b := range b {
 			m := a.Copy()
 			mergeMetric(b, m)
-			p[i] = m
-			i++
+			p = append(p, m)
 		}
 	}
 

--- a/plugins/parsers/xpath/json_document.go
+++ b/plugins/parsers/xpath/json_document.go
@@ -22,9 +22,9 @@ func (d *jsonDocument) QueryAll(node dataNode, expr string) ([]dataNode, error) 
 		return nil, err
 	}
 
-	nodes := make([]dataNode, len(native))
-	for i, n := range native {
-		nodes[i] = n
+	nodes := make([]dataNode, 0, len(native))
+	for _, n := range native {
+		nodes = append(nodes, n)
 	}
 	return nodes, nil
 }

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -486,8 +486,8 @@ func splitLastPathElement(query string) []string {
 		base = "/"
 	}
 
-	elements := make([]string, 1)
-	elements[0] = base
+	elements := make([]string, 0, 3)
+	elements = append(elements, base)
 
 	offset := seperatorIdx
 	if i := strings.Index(query[offset:], "::"); i >= 0 {

--- a/plugins/parsers/xpath/protocolbuffer_document.go
+++ b/plugins/parsers/xpath/protocolbuffer_document.go
@@ -6,18 +6,16 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/influxdata/telegraf"
-
+	path "github.com/antchfx/xpath"
+	"github.com/doclambda/protobufquery"
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/desc/protoparse"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/dynamicpb"
 
-	"github.com/jhump/protoreflect/desc"
-	"github.com/jhump/protoreflect/desc/protoparse"
-
-	path "github.com/antchfx/xpath"
-	"github.com/doclambda/protobufquery"
+	"github.com/influxdata/telegraf"
 )
 
 type protobufDocument struct {
@@ -112,9 +110,9 @@ func (d *protobufDocument) QueryAll(node dataNode, expr string) ([]dataNode, err
 		return nil, err
 	}
 
-	nodes := make([]dataNode, len(native))
-	for i, n := range native {
-		nodes[i] = n
+	nodes := make([]dataNode, 0, len(native))
+	for _, n := range native {
+		nodes = append(nodes, n)
 	}
 	return nodes, nil
 }

--- a/plugins/parsers/xpath/xml_document.go
+++ b/plugins/parsers/xpath/xml_document.go
@@ -20,9 +20,9 @@ func (d *xmlDocument) QueryAll(node dataNode, expr string) ([]dataNode, error) {
 		return nil, err
 	}
 
-	nodes := make([]dataNode, len(native))
-	for i, n := range native {
-		nodes[i] = n
+	nodes := make([]dataNode, 0, len(native))
+	for _, n := range native {
+		nodes = append(nodes, n)
 	}
 	return nodes, nil
 }

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -273,9 +273,9 @@ func TestMetricNameConversions(t *testing.T) {
 
 	for _, test := range tests {
 		// Copy the inputs as they will be modified by the processor
-		input := make([]telegraf.Metric, len(inputTemplate))
-		for i, m := range inputTemplate {
-			input[i] = m.Copy()
+		input := make([]telegraf.Metric, 0, len(inputTemplate))
+		for _, m := range inputTemplate {
+			input = append(input, m.Copy())
 		}
 
 		t.Run(test.name, func(t *testing.T) {
@@ -483,9 +483,9 @@ func TestFieldRenameConversions(t *testing.T) {
 
 	for _, test := range tests {
 		// Copy the inputs as they will be modified by the processor
-		input := make([]telegraf.Metric, len(inputTemplate))
-		for i, m := range inputTemplate {
-			input[i] = m.Copy()
+		input := make([]telegraf.Metric, 0, len(inputTemplate))
+		for _, m := range inputTemplate {
+			input = append(input, m.Copy())
 		}
 
 		t.Run(test.name, func(t *testing.T) {
@@ -691,9 +691,9 @@ func TestTagRenameConversions(t *testing.T) {
 
 	for _, test := range tests {
 		// Copy the inputs as they will be modified by the processor
-		input := make([]telegraf.Metric, len(inputTemplate))
-		for i, m := range inputTemplate {
-			input[i] = m.Copy()
+		input := make([]telegraf.Metric, 0, len(inputTemplate))
+		for _, m := range inputTemplate {
+			input = append(input, m.Copy())
 		}
 
 		t.Run(test.name, func(t *testing.T) {

--- a/plugins/processors/tag_limit/tag_limit.go
+++ b/plugins/processors/tag_limit/tag_limit.go
@@ -52,13 +52,11 @@ func (d *TagLimit) Apply(in ...telegraf.Metric) []telegraf.Metric {
 		if lenPointTags <= d.Limit {
 			continue
 		}
-		tagsToRemove := make([]string, lenPointTags-d.Limit)
-		removeIdx := 0
+		tagsToRemove := make([]string, 0, lenPointTags-d.Limit)
 		// remove extraneous tags, stop once we're at the limit
 		for _, t := range pointOriginalTags {
 			if _, ok := d.keepTags[t.Key]; !ok {
-				tagsToRemove[removeIdx] = t.Key
-				removeIdx++
+				tagsToRemove = append(tagsToRemove, t.Key)
 				lenPointTags--
 			}
 			if lenPointTags <= d.Limit {

--- a/plugins/serializers/influx/influx.go
+++ b/plugins/serializers/influx/influx.go
@@ -102,9 +102,8 @@ func (s *Serializer) Serialize(m telegraf.Metric) ([]byte, error) {
 		return nil, err
 	}
 
-	out := make([]byte, s.buf.Len())
-	copy(out, s.buf.Bytes())
-	return out, nil
+	out := make([]byte, 0, s.buf.Len())
+	return append(out, s.buf.Bytes()...), nil
 }
 
 // SerializeBatch writes the slice of metrics and returns a byte slice of the
@@ -120,9 +119,8 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 			return nil, err
 		}
 	}
-	out := make([]byte, s.buf.Len())
-	copy(out, s.buf.Bytes())
-	return out, nil
+	out := make([]byte, 0, s.buf.Len())
+	return append(out, s.buf.Bytes()...), nil
 }
 func (s *Serializer) Write(w io.Writer, m telegraf.Metric) error {
 	return s.writeMetric(w, m)

--- a/plugins/serializers/wavefront/wavefront.go
+++ b/plugins/serializers/wavefront/wavefront.go
@@ -202,9 +202,8 @@ type buffer []byte
 func (b *buffer) Reset() { *b = (*b)[:0] }
 
 func (b *buffer) Copy() []byte {
-	p := make([]byte, len(*b))
-	copy(p, *b)
-	return p
+	p := make([]byte, 0, len(*b))
+	return append(p, *b...)
 }
 
 func (b *buffer) WriteString(s string) {

--- a/selfstat/selfstat.go
+++ b/selfstat/selfstat.go
@@ -79,8 +79,7 @@ func RegisterTiming(measurement, field string, tags map[string]string) Stat {
 func Metrics() []telegraf.Metric {
 	registry.mu.Lock()
 	now := time.Now()
-	metrics := make([]telegraf.Metric, len(registry.stats))
-	i := 0
+	metrics := make([]telegraf.Metric, 0, len(registry.stats))
 	for _, stats := range registry.stats {
 		if len(stats) > 0 {
 			var tags map[string]string
@@ -96,8 +95,7 @@ func Metrics() []telegraf.Metric {
 				j++
 			}
 			m := metric.New(name, tags, fields, now)
-			metrics[i] = m
-			i++
+			metrics = append(metrics, m)
 		}
 	}
 	registry.mu.Unlock()
@@ -179,11 +177,9 @@ func key(measurement string, tags map[string]string) uint64 {
 	h := fnv.New64a()
 	h.Write([]byte(measurement)) //nolint:revive // all Write() methods for hash in fnv.go returns nil err
 
-	tmp := make([]string, len(tags))
-	i := 0
+	tmp := make([]string, 0, len(tags))
 	for k, v := range tags {
-		tmp[i] = k + v
-		i++
+		tmp = append(tmp, k+v)
 	}
 	sort.Strings(tmp)
 


### PR DESCRIPTION
Address findings for [makezero](https://github.com/ashanbrown/makezero) - Finds slice declarations with non-zero initial length.

It is only part of the bigger job.
After all findings in whole project are handled, we can enable `makezero` linter to guard this.
