### PR TITLE
feat(serializers.json): Support serializing JSON nested in string fields

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1196,6 +1196,8 @@ func (c *Config) buildSerializer(tbl *ast.Table) (serializers.Serializer, error)
 	c.getFieldDuration(tbl, "json_timestamp_units", &sc.TimestampUnits)
 	c.getFieldString(tbl, "json_timestamp_format", &sc.TimestampFormat)
 	c.getFieldString(tbl, "json_transformation", &sc.Transformation)
+	c.getFieldStringSlice(tbl, "json_nested_fields_include", &sc.JSONNestedFieldInclude)
+	c.getFieldStringSlice(tbl, "json_nested_fields_exclude", &sc.JSONNestedFieldExclude)
 
 	c.getFieldBool(tbl, "splunkmetric_hec_routing", &sc.HecRouting)
 	c.getFieldBool(tbl, "splunkmetric_multimetric", &sc.SplunkmetricMultiMetric)
@@ -1276,6 +1278,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 		"graphite_tag_sanitize_mode", "graphite_tag_support", "graphite_separator",
 		"influx_max_line_bytes", "influx_sort_fields", "influx_uint_support",
 		"json_timestamp_format", "json_timestamp_units", "json_transformation",
+		"json_nested_fields_include", "json_nested_fields_exclude",
 		"prometheus_export_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label",
 		"prometheus_compact_encoding",
 		"splunkmetric_hec_routing", "splunkmetric_multimetric", "splunkmetric_omit_event_tag",

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer.go
@@ -323,7 +323,10 @@ func (adx *AzureDataExplorer) Init() error {
 		return fmt.Errorf("unknown ingestion type %q", adx.IngestionType)
 	}
 
-	serializer, err := json.NewSerializer(time.Nanosecond, time.RFC3339Nano, "")
+	serializer, err := json.NewSerializer(json.FormatConfig{
+		TimestampUnits:  time.Nanosecond,
+		TimestampFormat: time.RFC3339Nano,
+	})
 	if err != nil {
 		return err
 	}

--- a/plugins/outputs/azure_data_explorer/azure_data_explorer_test.go
+++ b/plugins/outputs/azure_data_explorer/azure_data_explorer_test.go
@@ -140,7 +140,10 @@ func TestWrite(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.name, func(t *testing.T) {
-			serializer, err := telegrafJson.NewSerializer(time.Second, "", "")
+			serializer, err := telegrafJson.NewSerializer(
+				telegrafJson.FormatConfig{
+					TimestampUnits: time.Second,
+				})
 			require.NoError(t, err)
 
 			plugin := AzureDataExplorer{
@@ -264,7 +267,7 @@ func TestWriteWithType(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			serializer, err := telegrafJson.NewSerializer(time.Second, "", "")
+			serializer, err := telegrafJson.NewSerializer(telegrafJson.FormatConfig{TimestampUnits: time.Second})
 			require.NoError(t, err)
 			for tableName, jsonValue := range testCase.tableNameToExpectedResult {
 				ingestionType := "queued"

--- a/plugins/outputs/event_hubs/event_hubs_test.go
+++ b/plugins/outputs/event_hubs/event_hubs_test.go
@@ -42,7 +42,7 @@ func (eh *mockEventHub) SendBatch(ctx context.Context, iterator eventhub.BatchIt
 /* End wrapper interface */
 
 func TestInitAndWrite(t *testing.T) {
-	serializer, err := json.NewSerializer(time.Second, "", "")
+	serializer, err := json.NewSerializer(json.FormatConfig{TimestampUnits: time.Second})
 	require.NoError(t, err)
 	mockHub := &mockEventHub{}
 	e := &EventHubs{
@@ -101,7 +101,7 @@ func TestInitAndWriteIntegration(t *testing.T) {
 	testHubCS := os.Getenv("EVENTHUB_CONNECTION_STRING") + ";EntityPath=" + entity.Name
 
 	// Configure the plugin to target the newly created hub
-	serializer, err := json.NewSerializer(time.Second, "", "")
+	serializer, err := json.NewSerializer(json.FormatConfig{TimestampUnits: time.Second})
 	require.NoError(t, err)
 	e := &EventHubs{
 		Hub:              &eventHub{},

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -661,7 +661,7 @@ func TestBatchedUnbatched(t *testing.T) {
 		Method: defaultMethod,
 	}
 
-	jsonSerializer, err := json.NewSerializer(time.Second, "", "")
+	jsonSerializer, err := json.NewSerializer(json.FormatConfig{TimestampUnits: time.Second})
 	require.NoError(t, err)
 	s := map[string]serializers.Serializer{
 		"influx": influx.NewSerializer(),

--- a/plugins/outputs/stomp/stomp_test.go
+++ b/plugins/outputs/stomp/stomp_test.go
@@ -28,7 +28,11 @@ func TestConnectAndWrite(t *testing.T) {
 	require.NoError(t, err, "failed to start container")
 	defer container.Terminate()
 	var url = fmt.Sprintf("%s:%s", container.Address, container.Ports[servicePort])
-	s, err := serializers.NewJSONSerializer(10*time.Second, "yyy-dd-mmThh:mm:ss", "")
+	s, err := serializers.NewJSONSerializer(
+		&serializers.Config{
+			TimestampUnits:  10 * time.Second,
+			TimestampFormat: "yyy-dd-mmThh:mm:ss",
+		})
 	require.NoError(t, err)
 	st := &STOMP{
 		Host:          url,

--- a/plugins/serializers/json/README.md
+++ b/plugins/serializers/json/README.md
@@ -33,6 +33,13 @@ The `json` output data format converts metrics into JSON documents.
   ## This allows to generate an arbitrary output form based on the metric(s). Please use
   ## multiline strings (starting and ending with three single-quotes) if needed.
   #json_transformation = ""
+
+  ## Filter for fields that contain nested JSON data.
+  ## The serializer will try to decode matching STRING fields containing
+  ## valid JSON. This is done BEFORE any JSON transformation. The filters
+  ## can contain wildcards.
+  #json_nested_fields_include = []
+  #json_nested_fields_exclude = []
 ```
 
 ## Examples

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -135,7 +135,6 @@ func (s *Serializer) createObject(metric telegraf.Metric) map[string]interface{}
 					}
 				}
 			}
-
 		}
 		fields[field.Key] = val
 	}

--- a/plugins/serializers/json/testcases/nested_fields_exclude.conf
+++ b/plugins/serializers/json/testcases/nested_fields_exclude.conf
@@ -1,0 +1,6 @@
+# Example for decoding fields that contain nested JSON structures.
+#
+# Input:
+# in,host=myhost,type=diagnostic hops=10,latency=1.23,id-1234="{\"address\": \"AB1A\", \"status\": \"online\"}",id-0000="{\"status\": \"offline\"}",id-5678="{\"address\": \"0000\", \"status\": \"online\"}" 1666006350000000000
+
+json_nested_fields_exclude = ["hops", "latency"]

--- a/plugins/serializers/json/testcases/nested_fields_include.conf
+++ b/plugins/serializers/json/testcases/nested_fields_include.conf
@@ -1,0 +1,6 @@
+# Example for decoding fields that contain nested JSON structures.
+#
+# Input:
+# in,host=myhost,type=diagnostic hops=10,latency=1.23,id-1234="{\"address\": \"AB1A\", \"status\": \"online\"}",id-0000="{\"status\": \"offline\"}",id-5678="{\"address\": \"0000\", \"status\": \"online\"}" 1666006350000000000
+
+json_nested_fields_include = ["id-*"]

--- a/plugins/serializers/json/testcases/nested_fields_out.json
+++ b/plugins/serializers/json/testcases/nested_fields_out.json
@@ -1,0 +1,23 @@
+{
+    "fields": {
+      "id-1234": {
+          "address": "AB1A",
+          "status": "online"
+        },
+      "id-0000": {
+        "status": "offline"
+      },
+      "id-5678": {
+        "address": "0000",
+        "status": "online"
+      },
+      "hops": 10,
+      "latency": 1.23
+    },
+    "name": "in",
+    "tags": {
+      "host": "myhost",
+      "type": "diagnostic"
+    },
+    "timestamp": 1666006350
+}


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12070

This PR allows the user to specify fields that contain JSON object nested in a string value. When serializing these fields, the string is first unmarshalled to it's JSON object. The un-nesting happens before transformation in order to allow for arbitrary processing.