### PR TITLE
test(outputs.sql): print out what we get, bump time required

### DIFF
--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -235,8 +235,9 @@ func TestMysqlIntegration(t *testing.T) {
 			bytes, err := io.ReadAll(out)
 			require.NoError(t, err)
 
+			fmt.Println(string(bytes))
 			return strings.Contains(string(bytes), string(expected))
-		}, 5*time.Second, 500*time.Millisecond)
+		}, 10*time.Second, 500*time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
The eventually won't print what we are getting, so let's get that output. Additionally, let's give CircleCI some more time.