### PR TITLE
fix(inputs.gnmi):  Do not provide empty prefix for subscription request

### DIFF
--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -255,6 +255,12 @@ func (c *GNMI) newSubscribeRequest() (*gnmiLib.SubscribeRequest, error) {
 		return nil, err
 	}
 
+	// Do not provide an empty prefix. Required for Huawei NE40 router v8.21
+	// (and possibly others). See https://github.com/influxdata/telegraf/issues/12273.
+	if gnmiPath.Origin == "" && gnmiPath.Target == "" && len(gnmiPath.Elem) == 0 {
+		gnmiPath = nil
+	}
+
 	if c.Encoding != "proto" && c.Encoding != "json" && c.Encoding != "json_ietf" && c.Encoding != "bytes" {
 		return nil, fmt.Errorf("unsupported encoding %s", c.Encoding)
 	}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12273 

Do use a `nil` pointer instead of an empty path for `prefix` when creating a subscription request. This is necessary for (at least one) Huawei router(s) as they do not implement `prefix` support.