### PR TITLE
fix(inputs.prometheus): respect selectors when scraping pods

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -134,7 +134,14 @@ func (p *Prometheus) Init() error {
 
 			p.NodeIP = envVarNodeIP
 		}
+		p.Log.Infof("Using pod scrape scope at node level to get pod list using cAdvisor.")
+	}
 
+	if p.MonitorKubernetesPodsMethod == MonitorMethodNone {
+		p.MonitorKubernetesPodsMethod = MonitorMethodAnnotations
+	}
+
+	if p.isNodeScrapeScope || p.MonitorKubernetesPodsMethod != MonitorMethodAnnotations {
 		// Parse label and field selectors - will be used to filter pods after cAdvisor call
 		var err error
 		p.podLabelSelector, err = labels.Parse(p.KubernetesLabelSelector)
@@ -150,12 +157,7 @@ func (p *Prometheus) Init() error {
 			return fmt.Errorf("the field selector %s is not supported for pods", invalidSelector)
 		}
 
-		p.Log.Infof("Using pod scrape scope at node level to get pod list using cAdvisor.")
 		p.Log.Infof("Using the label selector: %v and field selector: %v", p.podLabelSelector, p.podFieldSelector)
-	}
-
-	if p.MonitorKubernetesPodsMethod == MonitorMethodNone {
-		p.MonitorKubernetesPodsMethod = MonitorMethodAnnotations
 	}
 
 	ctx := context.Background()

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -326,3 +326,22 @@ func TestInitConfigErrors(t *testing.T) {
 	expectedMessage = "the field selector spec.containerNames is not supported for pods"
 	require.Error(t, err, expectedMessage)
 }
+
+func TestInitConfigSelectors(t *testing.T) {
+	p := &Prometheus{
+		MetricVersion:               2,
+		Log:                         testutil.Logger{},
+		URLs:                        nil,
+		URLTag:                      "url",
+		MonitorPods:                 true,
+		MonitorKubernetesPodsMethod: MonitorMethodSettings,
+		PodScrapeInterval:           60,
+		KubernetesLabelSelector:     "app=test",
+		KubernetesFieldSelector:     "spec.nodeName=node-0",
+	}
+	err := p.Init()
+	require.NoError(t, err)
+
+	require.NotNil(t, p.podLabelSelector)
+	require.NotNil(t, p.podFieldSelector)
+}


### PR DESCRIPTION
# Required for all PRs

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

field and labels selectors were ignored unless `pod_scrape_scope = "node"` was specified, this breaks `monitor_kubernetes_pods_method != "annotations"` (default), because then all pods become candidate for scraping.

This PR enables field and label selectors. I am keeping existing behaviour where field and label selectors are not used with default pod scraping (`monitor_kubernetes_pods_method == "annotations"`) for now, but I'd prefer any pod scraping to respect selectors same as it currently respects namespace.