### PR TITLE
fix(inputs.kube_inventory): change default token path, use in-cluster config by default

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -5436,11 +5436,11 @@
 #   ## Use bearer token for authorization. ('bearer_token' takes priority)
 #   ##
 #   ## If both of these are empty, we'll use the default serviceaccount:
-#   ## at: /run/secrets/kubernetes.io/serviceaccount/token
+#   ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
 #   ##
 #   ## To auto-refresh the token, please use a file with the bearer_token option.
 #   ## If given a string, Telegraf cannot refresh the token periodically.
-#   # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+#   # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 #   ## OR
 #   ## deprecated in 1.24.0; use bearer_token with a file
 #   # bearer_token_string = "abc_123"
@@ -5488,12 +5488,12 @@
 #
 #   ## Use bearer token for authorization. ('bearer_token' takes priority)
 #   ## If both of these are empty, we'll use the default serviceaccount:
-#   ## at: /run/secrets/kubernetes.io/serviceaccount/token
+#   ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
 #   ##
 #   ## To re-read the token at each interval, please use a file with the
 #   ## bearer_token option. If given a string, Telegraf will always use that
 #   ## token.
-#   # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+#   # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 #   ## OR
 #   # bearer_token_string = "abc_123"
 #

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -5269,11 +5269,11 @@
 #   ## Use bearer token for authorization. ('bearer_token' takes priority)
 #   ##
 #   ## If both of these are empty, we'll use the default serviceaccount:
-#   ## at: /run/secrets/kubernetes.io/serviceaccount/token
+#   ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
 #   ##
 #   ## To auto-refresh the token, please use a file with the bearer_token option.
 #   ## If given a string, Telegraf cannot refresh the token periodically.
-#   # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+#   # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 #   ## OR
 #   ## deprecated in 1.24.0; use bearer_token with a file
 #   # bearer_token_string = "abc_123"
@@ -5321,12 +5321,12 @@
 #
 #   ## Use bearer token for authorization. ('bearer_token' takes priority)
 #   ## If both of these are empty, we'll use the default serviceaccount:
-#   ## at: /run/secrets/kubernetes.io/serviceaccount/token
+#   ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
 #   ##
 #   ## To re-read the token at each interval, please use a file with the
 #   ## bearer_token option. If given a string, Telegraf will always use that
 #   ## token.
-#   # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+#   # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 #   ## OR
 #   # bearer_token_string = "abc_123"
 #

--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -47,13 +47,16 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Read metrics from the Kubernetes api
 [[inputs.kube_inventory]]
-  ## URL for the Kubernetes API
-  url = "https://127.0.0.1"
+  ## URL for the Kubernetes API.
+  ## If empty in-cluster config with POD's service account token will be used.
+  # url = ""
 
   ## Namespace to use. Set to "" to use all namespaces.
   # namespace = "default"
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
+  ##
+  ## Ignored if url is empty and in-cluster config is used.
   ##
   ## If both of these are empty, we'll use the default serviceaccount:
   ## at: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -56,11 +56,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ##
   ## If both of these are empty, we'll use the default serviceaccount:
-  ## at: /run/secrets/kubernetes.io/serviceaccount/token
+  ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
   ##
   ## To auto-refresh the token, please use a file with the bearer_token option.
   ## If given a string, Telegraf cannot refresh the token periodically.
-  # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+  # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
   ## deprecated in 1.24.0; use bearer_token with a file
   # bearer_token_string = "abc_123"

--- a/plugins/inputs/kube_inventory/client.go
+++ b/plugins/inputs/kube_inventory/client.go
@@ -21,22 +21,32 @@ type client struct {
 }
 
 func newClient(baseURL, namespace, bearerTokenFile string, bearerToken string, timeout time.Duration, tlsConfig tls.ClientConfig) (*client, error) {
-	config := &rest.Config{
-		TLSClientConfig: rest.TLSClientConfig{
-			ServerName: tlsConfig.ServerName,
-			Insecure:   tlsConfig.InsecureSkipVerify,
-			CAFile:     tlsConfig.TLSCA,
-			CertFile:   tlsConfig.TLSCert,
-			KeyFile:    tlsConfig.TLSKey,
-		},
-		Host:          baseURL,
-		ContentConfig: rest.ContentConfig{},
-	}
+	var config *rest.Config
+	var err error
 
-	if bearerTokenFile != "" {
-		config.BearerTokenFile = bearerTokenFile
-	} else if bearerToken != "" {
-		config.BearerToken = bearerToken
+	if baseURL == "" {
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		config = &rest.Config{
+			TLSClientConfig: rest.TLSClientConfig{
+				ServerName: tlsConfig.ServerName,
+				Insecure:   tlsConfig.InsecureSkipVerify,
+				CAFile:     tlsConfig.TLSCA,
+				CertFile:   tlsConfig.TLSCert,
+				KeyFile:    tlsConfig.TLSKey,
+			},
+			Host:          baseURL,
+			ContentConfig: rest.ContentConfig{},
+		}
+
+		if bearerTokenFile != "" {
+			config.BearerTokenFile = bearerTokenFile
+		} else if bearerToken != "" {
+			config.BearerToken = bearerToken
+		}
 	}
 
 	c, err := kubernetes.NewForConfig(config)

--- a/plugins/inputs/kube_inventory/kube_inventory.go
+++ b/plugins/inputs/kube_inventory/kube_inventory.go
@@ -22,7 +22,7 @@ import (
 var sampleConfig string
 
 const (
-	defaultServiceAccountPath = "/run/secrets/kubernetes.io/serviceaccount/token"
+	defaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 // KubernetesInventory represents the config object for the plugin.

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -9,11 +9,11 @@
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ##
   ## If both of these are empty, we'll use the default serviceaccount:
-  ## at: /run/secrets/kubernetes.io/serviceaccount/token
+  ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
   ##
   ## To auto-refresh the token, please use a file with the bearer_token option.
   ## If given a string, Telegraf cannot refresh the token periodically.
-  # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+  # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
   ## deprecated in 1.24.0; use bearer_token with a file
   # bearer_token_string = "abc_123"

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -1,12 +1,15 @@
 # Read metrics from the Kubernetes api
 [[inputs.kube_inventory]]
-  ## URL for the Kubernetes API
-  url = "https://127.0.0.1"
+  ## URL for the Kubernetes API.
+  ## If empty in-cluster config with POD's service account token will be used.
+  # url = ""
 
   ## Namespace to use. Set to "" to use all namespaces.
   # namespace = "default"
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
+  ##
+  ## Ignored if url is empty and in-cluster config is used.
   ##
   ## If both of these are empty, we'll use the default serviceaccount:
   ## at: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/plugins/inputs/kubernetes/README.md
+++ b/plugins/inputs/kubernetes/README.md
@@ -53,12 +53,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ## If both of these are empty, we'll use the default serviceaccount:
-  ## at: /run/secrets/kubernetes.io/serviceaccount/token
+  ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
   ##
   ## To re-read the token at each interval, please use a file with the
   ## bearer_token option. If given a string, Telegraf will always use that
   ## token.
-  # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+  # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
   # bearer_token_string = "abc_123"
 

--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -42,7 +42,7 @@ type Kubernetes struct {
 }
 
 const (
-	defaultServiceAccountPath = "/run/secrets/kubernetes.io/serviceaccount/token"
+	defaultServiceAccountPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 func init() {

--- a/plugins/inputs/kubernetes/sample.conf
+++ b/plugins/inputs/kubernetes/sample.conf
@@ -5,12 +5,12 @@
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ## If both of these are empty, we'll use the default serviceaccount:
-  ## at: /run/secrets/kubernetes.io/serviceaccount/token
+  ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
   ##
   ## To re-read the token at each interval, please use a file with the
   ## bearer_token option. If given a string, Telegraf will always use that
   ## token.
-  # bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+  # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   ## OR
   # bearer_token_string = "abc_123"
 


### PR DESCRIPTION
# Required for all PRs

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

