### PR TITLE
feat(tls): allow setting renegotiation method

### DIFF
--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -21,7 +21,7 @@ type ClientConfig struct {
 	TLSMinVersion       string `toml:"tls_min_version"`
 	InsecureSkipVerify  bool   `toml:"insecure_skip_verify"`
 	ServerName          string `toml:"tls_server_name"`
-	RenegotiationMethod string `toml:"renegotiation_method"`
+	RenegotiationMethod string `toml:"tls_renegotiation_method"`
 
 	SSLCA   string `toml:"ssl_ca" deprecated:"1.7.0;use 'tls_ca' instead"`
 	SSLCert string `toml:"ssl_cert" deprecated:"1.7.0;use 'tls_cert' instead"`

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -68,21 +68,21 @@ func (c *ClientConfig) TLSConfig() (*tls.Config, error) {
 		return nil, nil
 	}
 
-	var renegotationMethod tls.RenegotiationSupport
+	var renegotiationMethod tls.RenegotiationSupport
 	switch c.RenegotiationMethod {
 	case "", "never":
-		renegotationMethod = tls.RenegotiateNever
+		renegotiationMethod = tls.RenegotiateNever
 	case "once":
-		renegotationMethod = tls.RenegotiateOnceAsClient
+		renegotiationMethod = tls.RenegotiateOnceAsClient
 	case "freely":
-		renegotationMethod = tls.RenegotiateFreelyAsClient
+		renegotiationMethod = tls.RenegotiateFreelyAsClient
 	default:
 		return nil, fmt.Errorf("unrecognized renegotation method '%s', choose from: 'never', 'once', 'freely'", c.RenegotiationMethod)
 	}
 
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: c.InsecureSkipVerify,
-		Renegotiation:      renegotationMethod,
+		Renegotiation:      renegotiationMethod,
 	}
 
 	if c.TLSCA != "" {

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -14,13 +14,14 @@ const TLSMinVersionDefault = tls.VersionTLS12
 
 // ClientConfig represents the standard client TLS config.
 type ClientConfig struct {
-	TLSCA              string `toml:"tls_ca"`
-	TLSCert            string `toml:"tls_cert"`
-	TLSKey             string `toml:"tls_key"`
-	TLSKeyPwd          string `toml:"tls_key_pwd"`
-	TLSMinVersion      string `toml:"tls_min_version"`
-	InsecureSkipVerify bool   `toml:"insecure_skip_verify"`
-	ServerName         string `toml:"tls_server_name"`
+	TLSCA               string `toml:"tls_ca"`
+	TLSCert             string `toml:"tls_cert"`
+	TLSKey              string `toml:"tls_key"`
+	TLSKeyPwd           string `toml:"tls_key_pwd"`
+	TLSMinVersion       string `toml:"tls_min_version"`
+	InsecureSkipVerify  bool   `toml:"insecure_skip_verify"`
+	ServerName          string `toml:"tls_server_name"`
+	RenegotiationMethod string `toml:"renegotiation_method"`
 
 	SSLCA   string `toml:"ssl_ca" deprecated:"1.7.0;use 'tls_ca' instead"`
 	SSLCert string `toml:"ssl_cert" deprecated:"1.7.0;use 'tls_cert' instead"`
@@ -58,15 +59,30 @@ func (c *ClientConfig) TLSConfig() (*tls.Config, error) {
 	// a TLS connection. That is, any of:
 	//     * client certificate settings,
 	//     * peer certificate authorities,
-	//     * disabled security, or
-	//     * an SNI server name.
-	if c.TLSCA == "" && c.TLSKey == "" && c.TLSCert == "" && !c.InsecureSkipVerify && c.ServerName == "" {
+	//     * disabled security,
+	//     * an SNI server name, or
+	//     * empty/never renegotiation method
+	if c.TLSCA == "" && c.TLSKey == "" && c.TLSCert == "" &&
+		!c.InsecureSkipVerify && c.ServerName == "" &&
+		(c.RenegotiationMethod == "" || c.RenegotiationMethod == "never") {
 		return nil, nil
+	}
+
+	var renegotationMethod tls.RenegotiationSupport
+	switch c.RenegotiationMethod {
+	case "", "never":
+		renegotationMethod = tls.RenegotiateNever
+	case "once":
+		renegotationMethod = tls.RenegotiateOnceAsClient
+	case "freely":
+		renegotationMethod = tls.RenegotiateFreelyAsClient
+	default:
+		return nil, fmt.Errorf("unrecognized renegotation method '%s', choose from: 'never', 'once', 'freely'", c.RenegotiationMethod)
 	}
 
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: c.InsecureSkipVerify,
-		Renegotiation:      tls.RenegotiateNever,
+		Renegotiation:      renegotationMethod,
 	}
 
 	if c.TLSCA != "" {

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -76,6 +76,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # insecure_skip_verify = false
   ## Use the given name as the SNI server name on each URL
   # tls_server_name = ""
+  ## TLS renegotiation method, choose from "never", "once", "freely"
+  # renegotiation_method = "never"
 
   ## HTTP Request Headers (all values must be strings)
   # [inputs.http_response.headers]

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -77,7 +77,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Use the given name as the SNI server name on each URL
   # tls_server_name = ""
   ## TLS renegotiation method, choose from "never", "once", "freely"
-  # renegotiation_method = "never"
+  # tls_renegotiation_method = "never"
 
   ## HTTP Request Headers (all values must be strings)
   # [inputs.http_response.headers]

--- a/plugins/inputs/http_response/sample.conf
+++ b/plugins/inputs/http_response/sample.conf
@@ -60,6 +60,8 @@
   # insecure_skip_verify = false
   ## Use the given name as the SNI server name on each URL
   # tls_server_name = ""
+  ## TLS renegotiation method, choose from "never", "once", "freely"
+  # renegotiation_method = "never"
 
   ## HTTP Request Headers (all values must be strings)
   # [inputs.http_response.headers]

--- a/plugins/inputs/http_response/sample.conf
+++ b/plugins/inputs/http_response/sample.conf
@@ -61,7 +61,7 @@
   ## Use the given name as the SNI server name on each URL
   # tls_server_name = ""
   ## TLS renegotiation method, choose from "never", "once", "freely"
-  # renegotiation_method = "never"
+  # tls_renegotiation_method = "never"
 
   ## HTTP Request Headers (all values must be strings)
   # [inputs.http_response.headers]


### PR DESCRIPTION
This allows the user to specify the renegotiation method used by the TLS client. By default, this is and will continue to be set to never. However, a user can now also set this to once or freely to allow for additional renegotiation attempts.

fixes: #3832
