### PR TITLE
fix(inputs.zfs): Unbreak datasets stats gathering in case listsnaps is enabled on a zfs pool

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -7809,8 +7809,6 @@
 #   # poolMetrics = false
 #
 #   ## By default, don't gather dataset stats
-#   ## On FreeBSD, if the user has enabled listsnapshots in the pool property,
-#   ## telegraf may not be able to correctly parse the output.
 #   # datasetMetrics = false
 
 

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -7705,8 +7705,6 @@
 #   # poolMetrics = false
 #
 #   ## By default, don't gather dataset stats
-#   ## On FreeBSD, if the user has enabled listsnapshots in the pool property,
-#   ## telegraf may not be able to correctly parse the output.
 #   # datasetMetrics = false
 
 

--- a/plugins/inputs/zfs/README.md
+++ b/plugins/inputs/zfs/README.md
@@ -34,8 +34,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # poolMetrics = false
 
   ## By default, don't gather dataset stats
-  ## On FreeBSD, if the user has enabled listsnapshots in the pool property,
-  ## telegraf may not be able to correctly parse the output.
   # datasetMetrics = false
 ```
 

--- a/plugins/inputs/zfs/sample.conf
+++ b/plugins/inputs/zfs/sample.conf
@@ -16,6 +16,4 @@
   # poolMetrics = false
 
   ## By default, don't gather dataset stats
-  ## On FreeBSD, if the user has enabled listsnapshots in the pool property,
-  ## telegraf may not be able to correctly parse the output.
   # datasetMetrics = false

--- a/plugins/inputs/zfs/zfs_freebsd.go
+++ b/plugins/inputs/zfs/zfs_freebsd.go
@@ -187,7 +187,7 @@ func zpool() ([]string, error) {
 }
 
 func zdataset(properties []string) ([]string, error) {
-	return run("zfs", []string{"list", "-Hp", "-o", strings.Join(properties, ",")}...)
+	return run("zfs", []string{"list", "-Hp", "-t", "filesystem,volume", "-o", strings.Join(properties, ",")}...)
 }
 
 func sysctl(metric string) ([]string, error) {


### PR DESCRIPTION
Introduce explicit dataset type filter for `zfs list` command. We are interested in filesystems and volumes only.

fixes: #12314