### PR TITLE
chore: Improve processor ordering

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -578,17 +578,14 @@ func (c *Config) LoadConfigData(data []byte) error {
 
 	// Sort the processor according to the order they appeared in this file
 	// In a later stage, we sort them using the `order` option.
-	if len(c.fileProcessors) > 1 {
-		sort.Sort(c.fileProcessors)
-		for _, op := range c.fileProcessors {
-			c.Processors = append(c.Processors, op.plugin.(*models.RunningProcessor))
-		}
+	sort.Sort(c.fileProcessors)
+	for _, op := range c.fileProcessors {
+		c.Processors = append(c.Processors, op.plugin.(*models.RunningProcessor))
 	}
-	if len(c.fileAggProcessors) > 1 {
-		sort.Sort(c.fileAggProcessors)
-		for _, op := range c.fileAggProcessors {
-			c.AggProcessors = append(c.AggProcessors, op.plugin.(*models.RunningProcessor))
-		}
+
+	sort.Sort(c.fileAggProcessors)
+	for _, op := range c.fileAggProcessors {
+		c.AggProcessors = append(c.AggProcessors, op.plugin.(*models.RunningProcessor))
 	}
 
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -825,9 +825,11 @@ func TestConfig_MultipleProcessorsOrder(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := NewConfig()
-			for _, f := range test.filename {
-				require.NoError(t, c.LoadConfig(filepath.Join("./testdata/processor_order", f)))
+			filenames := make([]string, 0, len(test.filename))
+			for _, fn := range test.filename {
+				filenames = append(filenames, filepath.Join("./testdata/processor_order", fn))
 			}
+			require.NoError(t, c.LoadAll(filenames...))
 
 			require.Equal(t, len(test.expectedOrder), len(c.Processors))
 
@@ -862,7 +864,7 @@ func TestConfig_ProcessorsWithParsers(t *testing.T) {
 	}
 
 	c := NewConfig()
-	require.NoError(t, c.LoadConfig("./testdata/processors_with_parsers.toml"))
+	require.NoError(t, c.LoadAll("./testdata/processors_with_parsers.toml"))
 	require.Len(t, c.Processors, len(formats))
 
 	override := map[string]struct {

--- a/models/running_processor.go
+++ b/models/running_processor.go
@@ -16,48 +16,15 @@ type RunningProcessor struct {
 
 type RunningProcessors []*RunningProcessor
 
-func (rp RunningProcessors) Len() int {
-	return len(rp)
-}
-func (rp RunningProcessors) Swap(i, j int) {
-	rp[i], rp[j] = rp[j], rp[i]
-}
-func (rp RunningProcessors) Less(i, j int) bool {
-	// If the processors are defined in separate files only sort based on order
-	if rp[i].Config.ID != rp[j].Config.ID {
-		return rp[i].Config.Order < rp[j].Config.Order
-	}
-
-	// If Order is defined for both processors, sort according to the number set
-	if rp[i].Config.Order != 0 && rp[j].Config.Order != 0 {
-		// If both orders are equal, ensure config order is maintained
-		if rp[i].Config.Order == rp[j].Config.Order {
-			return rp[i].Config.Line < rp[j].Config.Line
-		}
-
-		return rp[i].Config.Order < rp[j].Config.Order
-	}
-
-	// If "Order" is defined for one processor but not another,
-	// the processor without an "Order" will always take precedence.
-	// This adheres to the original implementation.
-	if rp[i].Config.Order != 0 {
-		return false
-	}
-	if rp[j].Config.Order != 0 {
-		return true
-	}
-
-	return rp[i].Config.Line < rp[j].Config.Line
-}
+func (rp RunningProcessors) Len() int           { return len(rp) }
+func (rp RunningProcessors) Swap(i, j int)      { rp[i], rp[j] = rp[j], rp[i] }
+func (rp RunningProcessors) Less(i, j int) bool { return rp[i].Config.Order < rp[j].Config.Order }
 
 // ProcessorConfig containing a name and filter
 type ProcessorConfig struct {
-	ID     string
 	Name   string
 	Alias  string
 	Order  int64
-	Line   int
 	Filter Filter
 }
 


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

follow-up on #12113

PR #12113 improved the processor ordering by keeping the loading order within a file. This PR is a follow-up to make the ordering less intrusive, keeping the `addProcessor()` similar to other `add...` function and remove the input-file information from the model. 

This is achieved by sorting the loaded processors by the line number (similar to #12113) _within the loaded file_ and then add the new chunk to the config's processor array. This way, the loading order of the _files_ is also preserved. To also take the `order` option into account the processor array is sorted a second time, this time by the `order` flag using a stable sort. This way all plugins containing an `order` option are sorted by this value, whereas all other plugins will keep their loading order (across files) and specification order (within each file).