### PR TITLE
docs: specify the time for nightly builds

### DIFF
--- a/docs/NIGHTLIES.md
+++ b/docs/NIGHTLIES.md
@@ -1,7 +1,7 @@
 
 # Nightly Builds
 
-These builds are generated from the master branch each night:
+These builds are generated from the master branch at midnight UTC:
 
 | DEB             | RPM             | TAR GZ                        | ZIP |
 | --------------- | --------------- | ------------------------------| --- |


### PR DESCRIPTION
Prior to this PR, nightly builds were at noon UTC, which is in the middle of the day for EU users, causing confusion, so let's move this to be midnight UTC while at least the EU and most of the US are done of the day.

The change has already been made in CircleCI config, this is only to update the docs to be more specific.