### PR TITLE
feat(inputs.statsd): Add pending messages stat and allow to configure number of threads

### DIFF
--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -75,6 +75,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## the statsd server will start dropping packets
   allowed_pending_messages = 10000
 
+  ## Number of worker threads used to parse the incoming messages.
+  # number_workers_threads = 5
+
   ## Number of timing/histogram values to track per-measurement in the
   ## calculation of percentiles. Raising this limit increases the accuracy
   ## of percentiles but also increases the memory usage and cpu time.

--- a/plugins/inputs/statsd/sample.conf
+++ b/plugins/inputs/statsd/sample.conf
@@ -59,6 +59,9 @@
   ## the statsd server will start dropping packets
   allowed_pending_messages = 10000
 
+  ## Number of worker threads used to parse the incoming messages.
+  # number_workers_threads = 5
+
   ## Number of timing/histogram values to track per-measurement in the
   ## calculation of percentiles. Raising this limit increases the accuracy
   ## of percentiles but also increases the memory usage and cpu time.

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -63,25 +63,24 @@ type Statsd struct {
 	Protocol string `toml:"protocol"`
 
 	// Address & Port to serve from
-	ServiceAddress string
+	ServiceAddress string `toml:"service_address"`
 
 	// Number of messages allowed to queue up in between calls to Gather. If this
 	// fills up, packets will get dropped until the next Gather interval is ran.
-	AllowedPendingMessages int
+	AllowedPendingMessages int `toml:"allowed_pending_messages"`
 
 	// Percentiles specifies the percentiles that will be calculated for timing
 	// and histogram stats.
-	Percentiles     []Number
-	PercentileLimit int
-
-	DeleteGauges   bool
-	DeleteCounters bool
-	DeleteSets     bool
-	DeleteTimings  bool
-	ConvertNames   bool `toml:"convert_names" deprecated:"0.12.0;2.0.0;use 'metric_separator' instead"`
+	Percentiles     []Number `toml:"percentiles"`
+	PercentileLimit int      `toml:"percentile_limit"`
+	DeleteGauges    bool     `toml:"delete_gauges"`
+	DeleteCounters  bool     `toml:"delete_counters"`
+	DeleteSets      bool     `toml:"delete_sets"`
+	DeleteTimings   bool     `toml:"delete_timings"`
+	ConvertNames    bool     `toml:"convert_names" deprecated:"0.12.0;2.0.0;use 'metric_separator' instead"`
 
 	// MetricSeparator is the separator between parts of the metric name.
-	MetricSeparator string
+	MetricSeparator string `toml:"metric_separator"`
 	// This flag enables parsing of tags in the dogstatsd extension to the
 	// statsd protocol (http://docs.datadoghq.com/guides/dogstatsd/)
 	ParseDataDogTags bool `toml:"parse_data_dog_tags" deprecated:"1.10.0;use 'datadog_extensions' instead"`
@@ -102,9 +101,16 @@ type Statsd struct {
 	// see https://github.com/influxdata/telegraf/pull/992
 	UDPPacketSize int `toml:"udp_packet_size" deprecated:"0.12.1;2.0.0;option is ignored"`
 
-	ReadBufferSize int `toml:"read_buffer_size"`
+	ReadBufferSize      int              `toml:"read_buffer_size"`
+	SanitizeNamesMethod string           `toml:"sanitize_name_method"`
+	Templates           []string         `toml:"templates"` // bucket -> influx templates
+	MaxTCPConnections   int              `toml:"max_tcp_connections"`
+	TCPKeepAlive        bool             `toml:"tcp_keep_alive"`
+	TCPKeepAlivePeriod  *config.Duration `toml:"tcp_keep_alive_period"`
 
-	SanitizeNamesMethod string `toml:"sanitize_name_method"`
+	// Max duration for each metric to stay cached without being updated.
+	MaxTTL config.Duration `toml:"max_ttl"`
+	Log    telegraf.Logger `toml:"-"`
 
 	sync.Mutex
 	// Lock for preventing a data race during resource cleanup
@@ -131,23 +137,12 @@ type Statsd struct {
 	timings       map[string]cachedtimings
 	distributions []cacheddistributions
 
-	// bucket -> influx templates
-	Templates []string
-
 	// Protocol listeners
 	UDPlistener *net.UDPConn
 	TCPlistener *net.TCPListener
 
 	// track current connections so we can close them in Stop()
 	conns map[string]*net.TCPConn
-
-	MaxTCPConnections int `toml:"max_tcp_connections"`
-
-	TCPKeepAlive       bool             `toml:"tcp_keep_alive"`
-	TCPKeepAlivePeriod *config.Duration `toml:"tcp_keep_alive_period"`
-
-	// Max duration for each metric to stay cached without being updated.
-	MaxTTL config.Duration `toml:"max_ttl"`
 
 	graphiteParser *graphite.Parser
 
@@ -163,8 +158,6 @@ type Statsd struct {
 	UDPBytesRecv       selfstat.Stat
 	ParseTimeNS        selfstat.Stat
 	PendingMessages    selfstat.Stat
-
-	Log telegraf.Logger `toml:"-"`
 
 	// A pool of byte slices to handle parsing
 	bufPool sync.Pool

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -142,12 +142,12 @@ type Statsd struct {
 	TCPlistener *net.TCPListener
 
 	// track current connections so we can close them in Stop()
-	conns map[string]*net.TCPConn
-
+	conns          map[string]*net.TCPConn
 	graphiteParser *graphite.Parser
+	acc            telegraf.Accumulator
+	bufPool        sync.Pool // pool of byte slices to handle parsing
 
-	acc telegraf.Accumulator
-
+	// Internal statistics counters
 	MaxConnections     selfstat.Stat
 	CurrentConnections selfstat.Stat
 	TotalConnections   selfstat.Stat
@@ -158,9 +158,6 @@ type Statsd struct {
 	UDPBytesRecv       selfstat.Stat
 	ParseTimeNS        selfstat.Stat
 	PendingMessages    selfstat.Stat
-
-	// A pool of byte slices to handle parsing
-	bufPool sync.Pool
 }
 
 type input struct {

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -38,8 +38,6 @@ const (
 
 	defaultSeparator           = "_"
 	defaultAllowPendingMessage = 10000
-
-	parserGoRoutines = 5
 )
 
 var errParsing = errors.New("error parsing statsd line")
@@ -68,6 +66,7 @@ type Statsd struct {
 	// Number of messages allowed to queue up in between calls to Gather. If this
 	// fills up, packets will get dropped until the next Gather interval is ran.
 	AllowedPendingMessages int `toml:"allowed_pending_messages"`
+	NumberWorkerThreads    int `toml:"number_workers_threads"`
 
 	// Percentiles specifies the percentiles that will be calculated for timing
 	// and histogram stats.
@@ -383,7 +382,7 @@ func (s *Statsd) Start(ac telegraf.Accumulator) error {
 		}()
 	}
 
-	for i := 1; i <= parserGoRoutines; i++ {
+	for i := 1; i <= s.NumberWorkerThreads; i++ {
 		// Start the line parser
 		s.wg.Add(1)
 		go func() {
@@ -1017,14 +1016,13 @@ func init() {
 			Protocol:               defaultProtocol,
 			ServiceAddress:         ":8125",
 			MaxTCPConnections:      250,
-			TCPKeepAlive:           false,
 			MetricSeparator:        "_",
 			AllowedPendingMessages: defaultAllowPendingMessage,
 			DeleteCounters:         true,
 			DeleteGauges:           true,
 			DeleteSets:             true,
 			DeleteTimings:          true,
-			SanitizeNamesMethod:    "",
+			NumberWorkerThreads:    5,
 		}
 	})
 }

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -118,6 +118,26 @@ func TestCloseConcurrentConns(t *testing.T) {
 	listener.Stop()
 }
 
+// benchmark how long it takes to parse metrics:
+func BenchmarkParser(b *testing.B) {
+	plugin := Statsd{
+		Log:                    testutil.Logger{},
+		Protocol:               "udp",
+		ServiceAddress:         "localhost:8125",
+		AllowedPendingMessages: 250000,
+	}
+	acc := &testutil.Accumulator{Discard: true}
+
+	require.NoError(b, plugin.Start(acc))
+
+	// send multiple messages to socket
+	for n := 0; n < b.N; n++ {
+		require.NoError(b, plugin.parseStatsdLine(testMsg))
+	}
+
+	plugin.Stop()
+}
+
 // benchmark how long it takes to accept & process 100,000 metrics:
 func BenchmarkUDP(b *testing.B) {
 	listener := Statsd{

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -202,7 +202,8 @@ func BenchmarkUDPThreads4(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 1000; i++ {
-				conn.Write([]byte(testMsg))
+				_, err := conn.Write([]byte(testMsg))
+				require.NoError(b, err)
 			}
 		}()
 	}
@@ -238,7 +239,8 @@ func BenchmarkUDPThreads8(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 1000; i++ {
-				conn.Write([]byte(testMsg))
+				_, err := conn.Write([]byte(testMsg))
+				require.NoError(b, err)
 			}
 		}()
 	}
@@ -274,7 +276,8 @@ func BenchmarkUDPThreads16(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 1000; i++ {
-				conn.Write([]byte(testMsg))
+				_, err := conn.Write([]byte(testMsg))
+				require.NoError(b, err)
 			}
 		}()
 	}


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12432

This PR adds a stat for the number of pending messages accessible through the `inputs.internal` plugin. Furthermore, it allows to configure the number of parallel threads used to parse incoming data.