### PR TITLE
feat(parsers.grok): Add option to allow multiline messages

### DIFF
--- a/plugins/parsers/grok/README.md
+++ b/plugins/parsers/grok/README.md
@@ -124,6 +124,9 @@ Debug](https://grokdebug.herokuapp.com) application quite useful!
   ## When set to "disable" timestamp will not incremented if there is a
   ## duplicate.
   # grok_unique_timestamp = "auto"
+
+  ## Enable multiline messages to be processed.
+  # grok_multiline = false
 ```
 
 ### Timestamp Examples

--- a/plugins/parsers/grok/influx_patterns.go
+++ b/plugins/parsers/grok/influx_patterns.go
@@ -37,4 +37,7 @@ COMBINED_LOG_FORMAT %{COMMON_LOG_FORMAT} "%{DATA:referrer}" "%{DATA:agent}"
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:loglevel:tag}\] (?:\[client %{IPORHOST:clientip}\] ){0,1}%{GREEDYDATA:errormsg}
 HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:module}:%{LOGLEVEL:loglevel:tag}\] \[pid %{POSINT:pid:int}:tid %{NUMBER:tid:int}\]( \(%{POSINT:proxy_errorcode:int}\)%{DATA:proxy_errormessage}:)?( \[client %{IPORHOST:client}:%{POSINT:clientport}\])? %{DATA:errorcode}: %{GREEDYDATA:message}
 HTTPD_ERRORLOG %{HTTPD20_ERRORLOG}|%{HTTPD24_ERRORLOG}
+
+# DATA spanning multiple lines
+MULTILINEDATA (.|\n)*
 `

--- a/plugins/parsers/grok/testdata/test_multiline.log
+++ b/plugins/parsers/grok/testdata/test_multiline.log
@@ -1,0 +1,3 @@
+2022-12-01T12:41:45Z Error A long and
+    multiline
+    message

--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -139,6 +139,7 @@ type Config struct {
 	GrokCustomPatternFiles []string `toml:"grok_custom_pattern_files"`
 	GrokTimezone           string   `toml:"grok_timezone"`
 	GrokUniqueTimestamp    string   `toml:"grok_unique_timestamp"`
+	GrokMultiline          bool     `toml:"grok_multiline"`
 
 	//csv configuration
 	CSVColumnNames        []string `toml:"csv_column_names"`


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Recently, in PR #12281, the `tail` plugin was empowered to read multi-line messages and pass them on to the parser.
When passing those message  (i.e. text containing newline characters `\n`) to the grok parser's `Parse()` function, it will split the message at the newline character. While this is a sensible default, some error messages might span multiple lines and will thus be truncated, making it hard to pass them on to log-specific outputs. 

This PR adds a new option `grok_multiline` as well as a new pattern `MULTILINEDATA` (as `GREEDYDATA` will not match newlines) to the grok parser allowing to parse multi-line messages correctly, retaining the newline characters and message layout.