### PR TITLE
fix(inputs.sql): Cast measurement_column to string

### DIFF
--- a/plugins/inputs/sql/sql.go
+++ b/plugins/inputs/sql/sql.go
@@ -81,13 +81,13 @@ func (q *Query) parse(acc telegraf.Accumulator, rows *dbsql.Rows, t time.Time) (
 
 		for i, name := range columnNames {
 			if q.MeasurementColumn != "" && name == q.MeasurementColumn {
-				var ok bool
-				if measurement, ok = columnData[i].(string); !ok {
-					var fieldValue []uint8
-					if fieldValue, ok = columnData[i].([]uint8); !ok {
-						return 0, fmt.Errorf("measurement column type \"%T\" unsupported", columnData[i])
-					}
-					measurement = string(fieldValue)
+				switch raw := columnData[i].(type) {
+				case string:
+					measurement = raw
+				case []byte:
+					measurement = string(raw)
+				default:
+					return 0, fmt.Errorf("measurement column type \"%T\" unsupported", columnData[i])
 				}
 			}
 

--- a/plugins/inputs/sql/sql.go
+++ b/plugins/inputs/sql/sql.go
@@ -83,7 +83,11 @@ func (q *Query) parse(acc telegraf.Accumulator, rows *dbsql.Rows, t time.Time) (
 			if q.MeasurementColumn != "" && name == q.MeasurementColumn {
 				var ok bool
 				if measurement, ok = columnData[i].(string); !ok {
-					return 0, fmt.Errorf("measurement column type \"%T\" unsupported", columnData[i])
+					var fieldValue []uint8
+					if fieldValue, ok = columnData[i].([]uint8); !ok {
+						return 0, fmt.Errorf("measurement column type \"%T\" unsupported", columnData[i])
+					}
+					measurement = string(fieldValue)
 				}
 			}
 


### PR DESCRIPTION
resolves: #12322 

This PR casts measurement columns to string in case they are represented as byte- or uint8- array.