### PR TITLE
feat: add User-Agent header to http_response input plugin

### DIFF
--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
@@ -196,6 +197,10 @@ func (h *HTTPResponse) httpGather(u string) (map[string]interface{}, map[string]
 	request, err := http.NewRequest(h.Method, u, body)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if _, uaPresent := h.Headers["User-Agent"]; !uaPresent {
+		request.Header.Set("User-Agent", internal.ProductToken())
 	}
 
 	if h.BearerToken != "" {

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -169,8 +170,10 @@ func checkOutput(
 func TestHeaders(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cHeader := r.Header.Get("Content-Type")
+		uaHeader := r.Header.Get("User-Agent")
 		require.Equal(t, "Hello", r.Host)
 		require.Equal(t, "application/json", cHeader)
+		require.Equal(t, internal.ProductToken(), uaHeader)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()


### PR DESCRIPTION
If merged, this PR would auto-set the HTTP User-Agent header for outgoing requests from the http_response input plugin according to industry best-practice, rather than relying on the default `Go-http-client/1.1` value. Additionally, it is backwards compatible as we respect any UA header that the user may have configured for themselves and do not override it.

- [x] Updated associated README.md (nothing to update).
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)
