### PR TITLE
feat(inputs.smart): Add additional SMART metrics that indicate/predict device failure

### DIFF
--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -80,10 +80,19 @@ var (
 
 	deviceFieldIds = map[string]string{
 		"1":   "read_error_rate",
+		"5":   "reallocated_sectors_count",
 		"7":   "seek_error_rate",
+		"10":  "spin_retry_count",
+		"184": "end_to_end_error",
+		"187": "uncorrectable_errors",
+		"188": "command_timeout",
 		"190": "temp_c",
 		"194": "temp_c",
+		"196": "realloc_event_count",
+		"197": "pending_sector_count",
+		"198": "uncorrectable_sector_count",
 		"199": "udma_crc_errors",
+		"201": "soft_read_error_rate",
 	}
 
 	// There are some fields we're interested in which use the vendor specific device ids

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -1411,13 +1411,13 @@ var (
 	}{
 		{
 			map[string]interface{}{
-				"exit_status":         int(0),
-				"health_ok":           bool(true),
-				"read_error_rate":     int64(0),
-				"temp_c":              int64(34),
-				"udma_crc_errors":     int64(0),
-				"wear_leveling_count": int64(185),
-				"pending_sector_count":int64(0),
+				"exit_status":               int(0),
+				"health_ok":                 bool(true),
+				"read_error_rate":           int64(0),
+				"temp_c":                    int64(34),
+				"udma_crc_errors":           int64(0),
+				"wear_leveling_count":       int64(185),
+				"pending_sector_count":      int64(0),
 				"reallocated_sectors_count": int64(0),
 			},
 			map[string]string{

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -52,7 +52,7 @@ func TestGatherAttributes(t *testing.T) {
 			err := s.Gather(&acc)
 
 			require.NoError(t, err)
-			assert.Equal(t, 66, acc.NFields(), "Wrong number of fields gathered")
+			assert.Equal(t, 68, acc.NFields(), "Wrong number of fields gathered")
 
 			for _, test := range testsAda0Attributes {
 				acc.AssertContainsTaggedFields(t, "smart_attribute", test.fields, test.tags)
@@ -171,7 +171,7 @@ func TestGatherNoAttributes(t *testing.T) {
 		err := s.Gather(&acc)
 
 		require.NoError(t, err)
-		assert.Equal(t, 9, acc.NFields(), "Wrong number of fields gathered")
+		assert.Equal(t, 11, acc.NFields(), "Wrong number of fields gathered")
 		acc.AssertDoesNotContainMeasurement(t, "smart_attribute")
 
 		for _, test := range testsAda0Device {
@@ -212,7 +212,7 @@ func TestGatherSATAInfo(t *testing.T) {
 	wg.Add(1)
 
 	sampleSmart.gatherDisk(acc, "", wg)
-	assert.Equal(t, 101, acc.NFields(), "Wrong number of fields gathered")
+	assert.Equal(t, 106, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(20), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
@@ -228,7 +228,7 @@ func TestGatherSATAInfo65(t *testing.T) {
 
 	wg.Add(1)
 	sampleSmart.gatherDisk(acc, "", wg)
-	assert.Equal(t, 91, acc.NFields(), "Wrong number of fields gathered")
+	assert.Equal(t, 96, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(18), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
@@ -293,7 +293,7 @@ func TestGatherSSD(t *testing.T) {
 
 	wg.Add(1)
 	sampleSmart.gatherDisk(acc, "", wg)
-	assert.Equal(t, 106, acc.NFields(), "Wrong number of fields gathered")
+	assert.Equal(t, 110, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(26), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
@@ -309,7 +309,7 @@ func TestGatherSSDRaid(t *testing.T) {
 
 	wg.Add(1)
 	sampleSmart.gatherDisk(acc, "", wg)
-	assert.Equal(t, 75, acc.NFields(), "Wrong number of fields gathered")
+	assert.Equal(t, 77, acc.NFields(), "Wrong number of fields gathered")
 	assert.Equal(t, uint64(15), acc.NMetrics(), "Wrong number of metrics gathered")
 }
 
@@ -1417,6 +1417,8 @@ var (
 				"temp_c":              int64(34),
 				"udma_crc_errors":     int64(0),
 				"wear_leveling_count": int64(185),
+				"pending_sector_count":int64(0),
+				"reallocated_sectors_count": int64(0),
 			},
 			map[string]string{
 				"device":    "ada0",


### PR DESCRIPTION
Additional critical SMART metrics that are helpful in indicating/predicting device failure. From https://en.wikipedia.org/wiki/Self-Monitoring,_Analysis_and_Reporting_Technology#Known_ATA_S.M.A.R.T._attributes