### PR TITLE
chore(outputs.wavefront): Reduce code duplication

### DIFF
--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -380,7 +380,7 @@ func TestDefaults(t *testing.T) {
 	require.Equal(t, 10000, defaultWavefront.HTTPMaximumBatchSize)
 }
 
-// Benchmarks to test performance of string replacement via Regex and Replacer
+// Benchmarks to test performance of string replacement via Regex and Sanitize
 var testString = "this_is*my!test/string\\for=replacement"
 
 func BenchmarkReplaceAllString(b *testing.B) {
@@ -397,6 +397,6 @@ func BenchmarkReplaceAllLiteralString(b *testing.B) {
 
 func BenchmarkReplacer(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		sanitizedChars.Replace(testString)
+		serializer.Sanitize(false, testString)
 	}
 }

--- a/plugins/serializers/wavefront/replacers.go
+++ b/plugins/serializers/wavefront/replacers.go
@@ -1,0 +1,31 @@
+package wavefront
+
+import "strings"
+
+// catch many of the invalid chars that could appear in a metric or tag name
+var sanitizedChars = strings.NewReplacer(
+	"!", "-", "@", "-", "#", "-", "$", "-", "%", "-", "^", "-", "&", "-",
+	"*", "-", "(", "-", ")", "-", "+", "-", "`", "-", "'", "-", "\"", "-",
+	"[", "-", "]", "-", "{", "-", "}", "-", ":", "-", ";", "-", "<", "-",
+	">", "-", ",", "-", "?", "-", "/", "-", "\\", "-", "|", "-", " ", "-",
+	"=", "-",
+)
+
+// catch many of the invalid chars that could appear in a metric or tag name
+var strictSanitizedChars = strings.NewReplacer(
+	"!", "-", "@", "-", "#", "-", "$", "-", "%", "-", "^", "-", "&", "-",
+	"*", "-", "(", "-", ")", "-", "+", "-", "`", "-", "'", "-", "\"", "-",
+	"[", "-", "]", "-", "{", "-", "}", "-", ":", "-", ";", "-", "<", "-",
+	">", "-", "?", "-", "\\", "-", "|", "-", " ", "-", "=", "-",
+)
+
+var tagValueReplacer = strings.NewReplacer("\"", "\\\"", "*", "-")
+
+var pathReplacer = strings.NewReplacer("_", ".")
+
+func Sanitize(strict bool, val string) string {
+	if strict {
+		return strictSanitizedChars.Replace(val)
+	}
+	return sanitizedChars.Replace(val)
+}

--- a/plugins/serializers/wavefront/wavefront.go
+++ b/plugins/serializers/wavefront/wavefront.go
@@ -3,7 +3,6 @@ package wavefront
 import (
 	"log"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/influxdata/telegraf"
@@ -18,27 +17,6 @@ type WavefrontSerializer struct {
 	scratch                  buffer
 	mu                       sync.Mutex // buffer mutex
 }
-
-// catch many of the invalid chars that could appear in a metric or tag name
-var sanitizedChars = strings.NewReplacer(
-	"!", "-", "@", "-", "#", "-", "$", "-", "%", "-", "^", "-", "&", "-",
-	"*", "-", "(", "-", ")", "-", "+", "-", "`", "-", "'", "-", "\"", "-",
-	"[", "-", "]", "-", "{", "-", "}", "-", ":", "-", ";", "-", "<", "-",
-	">", "-", ",", "-", "?", "-", "/", "-", "\\", "-", "|", "-", " ", "-",
-	"=", "-",
-)
-
-// catch many of the invalid chars that could appear in a metric or tag name
-var strictSanitizedChars = strings.NewReplacer(
-	"!", "-", "@", "-", "#", "-", "$", "-", "%", "-", "^", "-", "&", "-",
-	"*", "-", "(", "-", ")", "-", "+", "-", "`", "-", "'", "-", "\"", "-",
-	"[", "-", "]", "-", "{", "-", "}", "-", ":", "-", ";", "-", "<", "-",
-	">", "-", "?", "-", "\\", "-", "|", "-", " ", "-", "=", "-",
-)
-
-var tagValueReplacer = strings.NewReplacer("\"", "\\\"", "*", "-")
-
-var pathReplacer = strings.NewReplacer("_", ".")
 
 type MetricPoint struct {
 	Metric    string
@@ -70,11 +48,7 @@ func (s *WavefrontSerializer) serializeMetric(m telegraf.Metric) {
 			name = s.Prefix + m.Name() + metricSeparator + fieldName
 		}
 
-		if s.UseStrict {
-			name = strictSanitizedChars.Replace(name)
-		} else {
-			name = sanitizedChars.Replace(name)
-		}
+		name = Sanitize(s.UseStrict, name)
 
 		if !s.DisablePrefixConversions {
 			name = pathReplacer.Replace(name)
@@ -182,11 +156,7 @@ func formatMetricPoint(b *buffer, metricPoint *MetricPoint, s *WavefrontSerializ
 
 	for k, v := range metricPoint.Tags {
 		b.WriteString(` "`)
-		if s.UseStrict {
-			b.WriteString(strictSanitizedChars.Replace(k))
-		} else {
-			b.WriteString(sanitizedChars.Replace(k))
-		}
+		b.WriteString(Sanitize(s.UseStrict, k))
 		b.WriteString(`"="`)
 		b.WriteString(tagValueReplacer.Replace(v))
 		b.WriteChar('"')


### PR DESCRIPTION
# Required for all PRs


<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Currently, the wavefront output plugin and serializer plugin have identical definitions for string replacers called `sanitizedChars` and `strictSanitizedChars`.

This PR deletes the output plugin's copy of these replacers and has the output plugin use the version from the serializer instead. To avoid exporting the replacers, this PR also introduces a `Sanitize` function wrapping these replacers, which simplifies calling code slightly.

Finally, the replacers are moved into their own .go file within the serializer's package.
