### PR TITLE
fix(inputs.modbus): Fix Windows COM-port path

### DIFF
--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -47,9 +47,16 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # parity = "N"
   # stop_bits = 1
 
-  ## For Modbus over TCP you can choose between "TCP", "RTUoverTCP" and "ASCIIoverTCP"
-  ## default behaviour is "TCP" if the controller is TCP
-  ## For Serial you can choose between "RTU" and "ASCII"
+  ## Serial (RS485; RS232) [Windows]
+  # controller = "COM1"
+  # baud_rate = 9600
+  # data_bits = 8
+  # parity = "N"
+  # stop_bits = 1
+
+  ## For Modbus over TCP you can choose between "TCP", "RTUoverTCP" and
+  ## "ASCIIoverTCP". The default behaviour is "TCP" for ModbusTCP controllers.
+  ## For Serial controllers you can choose between "RTU" and "ASCII".
   # transmission_mode = "RTU"
 
   ## Trace the connection to the modbus device as debug messages

--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -41,13 +41,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   controller = "tcp://localhost:502"
 
   ## Serial (RS485; RS232)
+  ## For unix-like operating systems use:
   # controller = "file:///dev/ttyUSB0"
-  # baud_rate = 9600
-  # data_bits = 8
-  # parity = "N"
-  # stop_bits = 1
-
-  ## Serial (RS485; RS232) [Windows]
+  ## For Windows operating systems use:
   # controller = "COM1"
   # baud_rate = 9600
   # data_bits = 8

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -256,7 +256,7 @@ func (m *Modbus) initClient() error {
 			}
 			m.handler = handler
 		}
-	case "file":
+	case "", "file":
 		switch m.TransmissionMode {
 		case "RTU":
 			handler := mb.NewRTUClientHandler(u.Path)

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -257,9 +258,13 @@ func (m *Modbus) initClient() error {
 			m.handler = handler
 		}
 	case "", "file":
+		path := filepath.Join(u.Host, u.Path)
+		if path == "" {
+			return fmt.Errorf("invalid path for controller %q", m.Controller)
+		}
 		switch m.TransmissionMode {
 		case "RTU":
-			handler := mb.NewRTUClientHandler(u.Path)
+			handler := mb.NewRTUClientHandler(path)
 			handler.Timeout = time.Duration(m.Timeout)
 			handler.BaudRate = m.BaudRate
 			handler.DataBits = m.DataBits
@@ -270,7 +275,7 @@ func (m *Modbus) initClient() error {
 			}
 			m.handler = handler
 		case "ASCII":
-			handler := mb.NewASCIIClientHandler(u.Path)
+			handler := mb.NewASCIIClientHandler(path)
 			handler.Timeout = time.Duration(m.Timeout)
 			handler.BaudRate = m.BaudRate
 			handler.DataBits = m.DataBits

--- a/plugins/inputs/modbus/modbus_test.go
+++ b/plugins/inputs/modbus/modbus_test.go
@@ -21,6 +21,16 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
+func TestControllers(t *testing.T) {
+	plugin := Modbus{
+		Name:             "dummy",
+		Controller:       "COM2",
+		TransmissionMode: "RTU",
+		Log:              testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+}
+
 func TestCoils(t *testing.T) {
 	var coilTests = []struct {
 		name     string

--- a/plugins/inputs/modbus/sample_general_begin.conf
+++ b/plugins/inputs/modbus/sample_general_begin.conf
@@ -30,9 +30,16 @@
   # parity = "N"
   # stop_bits = 1
 
-  ## For Modbus over TCP you can choose between "TCP", "RTUoverTCP" and "ASCIIoverTCP"
-  ## default behaviour is "TCP" if the controller is TCP
-  ## For Serial you can choose between "RTU" and "ASCII"
+  ## Serial (RS485; RS232) [Windows]
+  # controller = "COM1"
+  # baud_rate = 9600
+  # data_bits = 8
+  # parity = "N"
+  # stop_bits = 1
+
+  ## For Modbus over TCP you can choose between "TCP", "RTUoverTCP" and
+  ## "ASCIIoverTCP". The default behaviour is "TCP" for ModbusTCP controllers.
+  ## For Serial controllers you can choose between "RTU" and "ASCII".
   # transmission_mode = "RTU"
 
   ## Trace the connection to the modbus device as debug messages

--- a/plugins/inputs/modbus/sample_general_begin.conf
+++ b/plugins/inputs/modbus/sample_general_begin.conf
@@ -24,13 +24,9 @@
   controller = "tcp://localhost:502"
 
   ## Serial (RS485; RS232)
+  ## For unix-like operating systems use:
   # controller = "file:///dev/ttyUSB0"
-  # baud_rate = 9600
-  # data_bits = 8
-  # parity = "N"
-  # stop_bits = 1
-
-  ## Serial (RS485; RS232) [Windows]
+  ## For Windows operating systems use:
   # controller = "COM1"
   # baud_rate = 9600
   # data_bits = 8


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12331

Windows users need to specify a COM port when dealing with serial devices. Currently, this is not easily possible as, without this PR, the `file://` scheme will parse `file://comX` into a _host_ instead of a path.
The present PR allows Windows users to specify a COM-port either via `controller = 'file://comX'` or directly via `controller = 'comX'` which is more intuitive. Furthermore, we fix relative paths and error out if we get strange paths to the controller.