### PR TITLE
test(inputs.statsd): increase sleep + expiration on test

### DIFF
--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -1032,7 +1032,7 @@ func TestParse_MeasurementsWithSameName(t *testing.T) {
 // Test that the metric caches expire (clear) an entry after the entry hasn't been updated for the configurable MaxTTL duration.
 func TestCachesExpireAfterMaxTTL(t *testing.T) {
 	s := NewTestStatsd()
-	s.MaxTTL = config.Duration(100 * time.Microsecond)
+	s.MaxTTL = config.Duration(10 * time.Millisecond)
 
 	acc := &testutil.Accumulator{}
 	require.NoError(t, s.parseStatsdLine("valid:45|c"))
@@ -1040,7 +1040,7 @@ func TestCachesExpireAfterMaxTTL(t *testing.T) {
 	require.NoError(t, s.Gather(acc))
 
 	// Max TTL goes by, our 'valid' entry is cleared.
-	time.Sleep(100 * time.Microsecond)
+	time.Sleep(100 * time.Millisecond)
 	require.NoError(t, s.Gather(acc))
 
 	// Now when we gather, we should have a counter that is reset to zero.


### PR DESCRIPTION
This test waits for 3 metrics to appear. On Windows, in CircleCI this test has become flaky and timing out after 10mins waiting for those metrics to show up. My hunch is that the microsecond sleep and expiration are too short and small even when the Windows machines tend to be very slow.

fixes: #12341