### PR TITLE
chore(deps): Bump github.com/gosnmp/gosnmp from 1.34.0 to 1.35.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/gophercloud/gophercloud v1.0.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/gosnmp/gosnmp v1.34.0
+	github.com/gosnmp/gosnmp v1.35.0
 	github.com/grid-x/modbus v0.0.0-20211113184042-7f2251c342c9
 	github.com/gwos/tcg/sdk v0.0.0-20220621192633-df0eac0a1a4c
 	github.com/harlow/kinesis-consumer v0.3.6-0.20211204214318-c2b9f79d7ab6

--- a/go.sum
+++ b/go.sum
@@ -1329,6 +1329,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosnmp/gosnmp v1.34.0 h1:p96iiNTTdL4ZYspPC3leSKXiHfE1NiIYffMu9100p5E=
 github.com/gosnmp/gosnmp v1.34.0/go.mod h1:QWTRprXN9haHFof3P96XTDYc46boCGAh5IXp0DniEx4=
+github.com/gosnmp/gosnmp v1.35.0 h1:EuWWNPxTCdAUx2/NbQcSa3WdNxjzpy4Phv57b4MWpJM=
+github.com/gosnmp/gosnmp v1.35.0/go.mod h1:2AvKZ3n9aEl5TJEo/fFmf/FGO4Nj4cVeEc5yuk88CYc=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gostaticanalysis/analysisutil v0.1.0/go.mod h1:dMhHRU9KTiDcuLGdy87/2gTR8WruwYZrKdRq9m1O6uw=

--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -50,7 +50,6 @@ func newMsgFlagsV3(secLevel string) gosnmp.SnmpV3MsgFlags {
 	default:
 		msgFlags = gosnmp.NoAuthNoPriv
 	}
-
 	return msgFlags
 }
 
@@ -96,7 +95,7 @@ func newUsmSecurityParametersForV3(authProto string, privProto string, username 
 	}
 
 	return &gosnmp.UsmSecurityParameters{
-		AuthoritativeEngineID:    "1",
+		AuthoritativeEngineID:    "deadbeef", // has to be between 5 & 32 chars
 		AuthoritativeEngineBoots: 1,
 		AuthoritativeEngineTime:  1,
 		UserName:                 username,
@@ -136,16 +135,11 @@ func newGoSNMP(version gosnmp.SnmpVersion, port uint16) gosnmp.GoSNMP {
 }
 
 func sendTrap(t *testing.T, goSNMP gosnmp.GoSNMP, trap gosnmp.SnmpTrap) {
-	err := goSNMP.Connect()
-	if err != nil {
-		t.Errorf("Connect() err: %v", err)
-	}
+	require.NoError(t, goSNMP.Connect())
 	defer goSNMP.Conn.Close()
 
-	_, err = goSNMP.SendTrap(trap)
-	if err != nil {
-		t.Errorf("SendTrap() err: %v", err)
-	}
+	_, err := goSNMP.SendTrap(trap)
+	require.NoError(t, err)
 }
 
 func TestReceiveTrap(t *testing.T) {
@@ -1295,7 +1289,7 @@ func TestReceiveTrap(t *testing.T) {
 			s.translator = newTestTranslator(tt.entries)
 
 			var acc testutil.Accumulator
-			require.Nil(t, s.Start(&acc))
+			require.NoError(t, s.Start(&acc))
 			defer s.Stop()
 
 			var goSNMP gosnmp.GoSNMP


### PR DESCRIPTION
replaces #11370 

With the new version a stricter check for the `msgAuthoritativeEngineID` field is implemented (see [gosnmp code](https://github.com/gosnmp/gosnmp/blob/33df32e33fbd043727a4a117a0ef6f2183607113/trap.go#L260)). This made the tests fro SNMPv3 traps fail in #11370.

To circumvent a missing call to `OnNewTrap` this PR makes sure the engine-ID is between 5 and 32 characters to pass the tests.