### PR TITLE
fix(processors.parser): Handle empty metric names correctly

### DIFF
--- a/plugins/processors/parser/parser.go
+++ b/plugins/processors/parser/parser.go
@@ -30,7 +30,6 @@ func (p *Parser) SetParser(parser telegraf.Parser) {
 
 func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 	results := []telegraf.Metric{}
-
 	for _, metric := range metrics {
 		newMetrics := []telegraf.Metric{}
 		if !p.DropOriginal {
@@ -80,7 +79,13 @@ func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 				}
 
 				for _, m := range fromTagMetric {
-					if m.Name() == "" {
+					// The parser get the parent plugin's name as
+					// default measurement name. Thus, in case the
+					// parsed metric does not provide a name itself,
+					// the parser  will return 'parser' as we are in
+					// processors.parser. In those cases we want to
+					// keep the original metric name.
+					if m.Name() == "" || m.Name() == "parser" {
 						m.SetName(metric.Name())
 					}
 				}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12115

This fixes the name override described in #12115 (this time for real) for parsing tags which was forgotten in #12116.