### PR TITLE
chore: Fix linter findings for makezero (part2)

### DIFF
--- a/plugins/aggregators/quantile/quantile.go
+++ b/plugins/aggregators/quantile/quantile.go
@@ -123,8 +123,8 @@ func (q *Quantile) Init() error {
 	}
 
 	duplicates := make(map[float64]bool)
-	q.suffixes = make([]string, len(q.Quantiles))
-	for i, qtl := range q.Quantiles {
+	q.suffixes = make([]string, 0, len(q.Quantiles))
+	for _, qtl := range q.Quantiles {
 		if qtl < 0.0 || qtl > 1.0 {
 			return fmt.Errorf("quantile %v out of range", qtl)
 		}
@@ -132,7 +132,7 @@ func (q *Quantile) Init() error {
 			return fmt.Errorf("duplicate quantile %v", qtl)
 		}
 		duplicates[qtl] = true
-		q.suffixes[i] = fmt.Sprintf("_%03d", int(qtl*100.0))
+		q.suffixes = append(q.suffixes, fmt.Sprintf("_%03d", int(qtl*100.0)))
 	}
 
 	q.Reset()

--- a/plugins/aggregators/quantile/quantile_test.go
+++ b/plugins/aggregators/quantile/quantile_test.go
@@ -84,9 +84,9 @@ func TestSingleMetricTDigest(t *testing.T) {
 		),
 	}
 
-	metrics := make([]telegraf.Metric, 100)
-	for i := range metrics {
-		metrics[i] = testutil.MustMetric(
+	metrics := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, testutil.MustMetric(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -101,7 +101,7 @@ func TestSingleMetricTDigest(t *testing.T) {
 				"x2": true,
 			},
 			time.Now(),
-		)
+		))
 	}
 
 	for _, m := range metrics {
@@ -144,23 +144,22 @@ func TestMultipleMetricsTDigest(t *testing.T) {
 		),
 	}
 
-	metricsA := make([]telegraf.Metric, 100)
-	metricsB := make([]telegraf.Metric, 100)
-	for i := range metricsA {
-		metricsA[i] = testutil.MustMetric(
+	metricsA := make([]telegraf.Metric, 0, 100)
+	metricsB := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metricsA = append(metricsA, testutil.MustMetric(
 			"test",
 			map[string]string{"series": "foo"},
 			map[string]interface{}{"a": int64(i), "b": float64(i), "x1": "string", "x2": true},
 			time.Now(),
-		)
-	}
-	for i := range metricsB {
-		metricsB[i] = testutil.MustMetric(
+		))
+
+		metricsB = append(metricsB, testutil.MustMetric(
 			"test",
 			map[string]string{"series": "bar"},
 			map[string]interface{}{"a": int64(2 * i), "b": float64(2 * i), "x1": "string", "x2": true},
 			time.Now(),
-		)
+		))
 	}
 
 	for _, m := range metricsA {
@@ -217,9 +216,9 @@ func TestSingleMetricExactR7(t *testing.T) {
 		),
 	}
 
-	metrics := make([]telegraf.Metric, 100)
-	for i := range metrics {
-		metrics[i] = testutil.MustMetric(
+	metrics := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, testutil.MustMetric(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -234,7 +233,7 @@ func TestSingleMetricExactR7(t *testing.T) {
 				"x2": true,
 			},
 			time.Now(),
-		)
+		))
 	}
 
 	for _, m := range metrics {
@@ -277,23 +276,22 @@ func TestMultipleMetricsExactR7(t *testing.T) {
 		),
 	}
 
-	metricsA := make([]telegraf.Metric, 100)
-	metricsB := make([]telegraf.Metric, 100)
-	for i := range metricsA {
-		metricsA[i] = testutil.MustMetric(
+	metricsA := make([]telegraf.Metric, 0, 100)
+	metricsB := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metricsA = append(metricsA, testutil.MustMetric(
 			"test",
 			map[string]string{"series": "foo"},
 			map[string]interface{}{"a": int64(i), "b": float64(i), "x1": "string", "x2": true},
 			time.Now(),
-		)
-	}
-	for i := range metricsB {
-		metricsB[i] = testutil.MustMetric(
+		))
+
+		metricsB = append(metricsB, testutil.MustMetric(
 			"test",
 			map[string]string{"series": "bar"},
 			map[string]interface{}{"a": int64(2 * i), "b": float64(2 * i), "x1": "string", "x2": true},
 			time.Now(),
-		)
+		))
 	}
 
 	for _, m := range metricsA {
@@ -350,9 +348,9 @@ func TestSingleMetricExactR8(t *testing.T) {
 		),
 	}
 
-	metrics := make([]telegraf.Metric, 100)
-	for i := range metrics {
-		metrics[i] = testutil.MustMetric(
+	metrics := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, testutil.MustMetric(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -367,7 +365,7 @@ func TestSingleMetricExactR8(t *testing.T) {
 				"x2": true,
 			},
 			time.Now(),
-		)
+		))
 	}
 
 	for _, m := range metrics {
@@ -410,23 +408,22 @@ func TestMultipleMetricsExactR8(t *testing.T) {
 		),
 	}
 
-	metricsA := make([]telegraf.Metric, 100)
-	metricsB := make([]telegraf.Metric, 100)
-	for i := range metricsA {
-		metricsA[i] = testutil.MustMetric(
+	metricsA := make([]telegraf.Metric, 0, 100)
+	metricsB := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metricsA = append(metricsA, testutil.MustMetric(
 			"test",
 			map[string]string{"series": "foo"},
 			map[string]interface{}{"a": int64(i), "b": float64(i), "x1": "string", "x2": true},
 			time.Now(),
-		)
-	}
-	for i := range metricsB {
-		metricsB[i] = testutil.MustMetric(
+		))
+
+		metricsB = append(metricsB, testutil.MustMetric(
 			"test",
 			map[string]string{"series": "bar"},
 			map[string]interface{}{"a": int64(2 * i), "b": float64(2 * i), "x1": "string", "x2": true},
 			time.Now(),
-		)
+		))
 	}
 
 	for _, m := range metricsA {
@@ -443,9 +440,9 @@ func TestMultipleMetricsExactR8(t *testing.T) {
 }
 
 func BenchmarkDefaultTDigest(b *testing.B) {
-	metrics := make([]telegraf.Metric, 100)
-	for i := range metrics {
-		metrics[i] = testutil.MustMetric(
+	metrics := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, testutil.MustMetric(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -459,7 +456,7 @@ func BenchmarkDefaultTDigest(b *testing.B) {
 				"x2": true,
 			},
 			time.Now(),
-		)
+		))
 	}
 
 	q := Quantile{
@@ -479,9 +476,9 @@ func BenchmarkDefaultTDigest(b *testing.B) {
 }
 
 func BenchmarkDefaultTDigest100Q(b *testing.B) {
-	metrics := make([]telegraf.Metric, 100)
-	for i := range metrics {
-		metrics[i] = testutil.MustMetric(
+	metrics := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, testutil.MustMetric(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -495,11 +492,11 @@ func BenchmarkDefaultTDigest100Q(b *testing.B) {
 				"x2": true,
 			},
 			time.Now(),
-		)
+		))
 	}
-	quantiles := make([]float64, 100)
-	for i := range quantiles {
-		quantiles[i] = 0.01 * float64(i)
+	quantiles := make([]float64, 0, 100)
+	for i := 0; i < 100; i++ {
+		quantiles = append(quantiles, 0.01*float64(i))
 	}
 
 	q := Quantile{
@@ -520,9 +517,9 @@ func BenchmarkDefaultTDigest100Q(b *testing.B) {
 }
 
 func BenchmarkDefaultExactR7(b *testing.B) {
-	metrics := make([]telegraf.Metric, 100)
-	for i := range metrics {
-		metrics[i] = testutil.MustMetric(
+	metrics := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, testutil.MustMetric(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -536,7 +533,7 @@ func BenchmarkDefaultExactR7(b *testing.B) {
 				"x2": true,
 			},
 			time.Now(),
-		)
+		))
 	}
 
 	q := Quantile{
@@ -556,9 +553,9 @@ func BenchmarkDefaultExactR7(b *testing.B) {
 }
 
 func BenchmarkDefaultExactR7100Q(b *testing.B) {
-	metrics := make([]telegraf.Metric, 100)
-	for i := range metrics {
-		metrics[i] = testutil.MustMetric(
+	metrics := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, testutil.MustMetric(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -572,11 +569,11 @@ func BenchmarkDefaultExactR7100Q(b *testing.B) {
 				"x2": true,
 			},
 			time.Now(),
-		)
+		))
 	}
-	quantiles := make([]float64, 100)
-	for i := range quantiles {
-		quantiles[i] = 0.01 * float64(i)
+	quantiles := make([]float64, 0, 100)
+	for i := 0; i < 100; i++ {
+		quantiles = append(quantiles, 0.01*float64(i))
 	}
 
 	q := Quantile{
@@ -597,9 +594,9 @@ func BenchmarkDefaultExactR7100Q(b *testing.B) {
 }
 
 func BenchmarkDefaultExactR8(b *testing.B) {
-	metrics := make([]telegraf.Metric, 100)
-	for i := range metrics {
-		metrics[i] = testutil.MustMetric(
+	metrics := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, testutil.MustMetric(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -613,7 +610,7 @@ func BenchmarkDefaultExactR8(b *testing.B) {
 				"x2": true,
 			},
 			time.Now(),
-		)
+		))
 	}
 
 	q := Quantile{
@@ -633,9 +630,9 @@ func BenchmarkDefaultExactR8(b *testing.B) {
 }
 
 func BenchmarkDefaultExactR8100Q(b *testing.B) {
-	metrics := make([]telegraf.Metric, 100)
-	for i := range metrics {
-		metrics[i] = testutil.MustMetric(
+	metrics := make([]telegraf.Metric, 0, 100)
+	for i := 0; i < 100; i++ {
+		metrics = append(metrics, testutil.MustMetric(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -649,11 +646,11 @@ func BenchmarkDefaultExactR8100Q(b *testing.B) {
 				"x2": true,
 			},
 			time.Now(),
-		)
+		))
 	}
-	quantiles := make([]float64, 100)
-	for i := range quantiles {
-		quantiles[i] = 0.01 * float64(i)
+	quantiles := make([]float64, 0, 100)
+	for i := 0; i < 100; i++ {
+		quantiles = append(quantiles, 0.01*float64(i))
 	}
 
 	q := Quantile{

--- a/plugins/common/jolokia2/client.go
+++ b/plugins/common/jolokia2/client.go
@@ -231,9 +231,9 @@ func makeReadResponses(jresponses []jolokiaResponse) []ReadResponse {
 				rrequest.Attributes = []string{attribute}
 			} else {
 				attributes, _ := attrValue.([]interface{})
-				rrequest.Attributes = make([]string, len(attributes))
-				for i, attr := range attributes {
-					rrequest.Attributes[i] = attr.(string)
+				rrequest.Attributes = make([]string, 0, len(attributes))
+				for _, attr := range attributes {
+					rrequest.Attributes = append(rrequest.Attributes, attr.(string))
 				}
 			}
 		}

--- a/plugins/common/shim/processor_test.go
+++ b/plugins/common/shim/processor_test.go
@@ -22,9 +22,9 @@ func TestProcessorShim(t *testing.T) {
 
 func TestProcessorShimWithLargerThanDefaultScannerBufferSize(t *testing.T) {
 	letters := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	b := make([]rune, bufio.MaxScanTokenSize*2)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+	b := make([]rune, 0, bufio.MaxScanTokenSize*2)
+	for i := 0; i < bufio.MaxScanTokenSize*2; i++ {
+		b = append(b, letters[rand.Intn(len(letters))])
 	}
 
 	testSendAndReceive(t, "f1", string(b))

--- a/plugins/common/starlark/builtins.go
+++ b/plugins/common/starlark/builtins.go
@@ -262,9 +262,9 @@ func dictItems(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple
 		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
 	}
 	items := b.Receiver().(starlark.IterableMapping).Items()
-	res := make([]starlark.Value, len(items))
-	for i, item := range items {
-		res[i] = item // convert [2]starlark.Value to starlark.Value
+	res := make([]starlark.Value, 0, len(items))
+	for _, item := range items {
+		res = append(res, item) // convert [2]starlark.Value to starlark.Value
 	}
 	return starlark.NewList(res), nil
 }
@@ -276,9 +276,9 @@ func dictKeys(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple)
 	}
 
 	items := b.Receiver().(starlark.IterableMapping).Items()
-	res := make([]starlark.Value, len(items))
-	for i, item := range items {
-		res[i] = item[0]
+	res := make([]starlark.Value, 0, len(items))
+	for _, item := range items {
+		res = append(res, item[0])
 	}
 	return starlark.NewList(res), nil
 }
@@ -289,9 +289,9 @@ func dictValues(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tupl
 		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
 	}
 	items := b.Receiver().(starlark.IterableMapping).Items()
-	res := make([]starlark.Value, len(items))
-	for i, item := range items {
-		res[i] = item[1]
+	res := make([]starlark.Value, 0, len(items))
+	for _, item := range items {
+		res = append(res, item[1])
 	}
 	return starlark.NewList(res), nil
 }

--- a/plugins/common/starlark/field_dict.go
+++ b/plugins/common/starlark/field_dict.go
@@ -218,13 +218,13 @@ func asStarlarkValue(value interface{}) (starlark.Value, error) {
 	switch v.Kind() {
 	case reflect.Slice:
 		length := v.Len()
-		array := make([]starlark.Value, length)
+		array := make([]starlark.Value, 0, length)
 		for i := 0; i < length; i++ {
 			sVal, err := asStarlarkValue(v.Index(i).Interface())
 			if err != nil {
 				return starlark.None, err
 			}
-			array[i] = sVal
+			array = append(array, sVal)
 		}
 		return starlark.NewList(array), nil
 	case reflect.Map:

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -126,16 +126,16 @@ func (am *AzureMonitor) Gather(acc telegraf.Accumulator) error {
 }
 
 func (am *AzureMonitor) setReceiver() error {
-	var resourceTargets []*receiver.ResourceTarget
-	var resourceGroupTargets []*receiver.ResourceGroupTarget
-	var subscriptionTargets []*receiver.Resource
+	resourceTargets := make([]*receiver.ResourceTarget, 0, len(am.ResourceTargets))
+	resourceGroupTargets := make([]*receiver.ResourceGroupTarget, 0, len(am.ResourceGroupTargets))
+	subscriptionTargets := make([]*receiver.Resource, 0, len(am.SubscriptionTargets))
 
 	for _, target := range am.ResourceTargets {
 		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
 	}
 
 	for _, target := range am.ResourceGroupTargets {
-		var resources []*receiver.Resource
+		resources := make([]*receiver.Resource, 0, len(target.Resources))
 		for _, resource := range target.Resources {
 			resources = append(resources, receiver.NewResource(resource.ResourceType, resource.Metrics, resource.Aggregations))
 		}

--- a/plugins/inputs/azure_monitor/azure_monitor_test.go
+++ b/plugins/inputs/azure_monitor/azure_monitor_test.go
@@ -975,7 +975,7 @@ func TestGather_Success(t *testing.T) {
 	am.Log = testutil.Logger{}
 	am.azureManager = &mockAzureClientsManager{}
 
-	var resourceTargets []*receiver.ResourceTarget
+	resourceTargets := make([]*receiver.ResourceTarget, 0, len(am.ResourceTargets))
 	for _, target := range am.ResourceTargets {
 		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
 	}

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -241,12 +241,12 @@ func getFilteredMetrics(c *CloudWatch) ([]filteredMetric, error) {
 		for _, m := range c.Metrics {
 			metrics := []types.Metric{}
 			if !hasWildcard(m.Dimensions) {
-				dimensions := make([]types.Dimension, len(m.Dimensions))
-				for k, d := range m.Dimensions {
-					dimensions[k] = types.Dimension{
+				dimensions := make([]types.Dimension, 0, len(m.Dimensions))
+				for _, d := range m.Dimensions {
+					dimensions = append(dimensions, types.Dimension{
 						Name:  aws.String(d.Name),
 						Value: aws.String(d.Value),
-					}
+					})
 				}
 				for _, name := range m.MetricNames {
 					for _, namespace := range c.Namespaces {

--- a/plugins/inputs/redis_sentinel/redis_sentinel.go
+++ b/plugins/inputs/redis_sentinel/redis_sentinel.go
@@ -216,21 +216,20 @@ func (client *RedisSentinelClient) gatherInfoStats(acc telegraf.Accumulator) err
 }
 
 func (client *RedisSentinelClient) gatherMasterStats(acc telegraf.Accumulator) ([]string, error) {
-	var masterNames []string
-
 	mastersCmd := redis.NewSliceCmd("sentinel", "masters")
 	if err := client.sentinel.Process(mastersCmd); err != nil {
-		return masterNames, err
+		return nil, err
 	}
 
 	masters, err := mastersCmd.Result()
 	if err != nil {
-		return masterNames, err
+		return nil, err
 	}
 
 	// Break out of the loop if one of the items comes out malformed
 	// It's safe to assume that if we fail parsing one item that the rest will fail too
 	// This is because we are iterating over a single server response
+	masterNames := make([]string, 0, len(masters))
 	for _, master := range masters {
 		master, ok := master.([]interface{})
 		if !ok {

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -356,8 +356,8 @@ func (g *Graylog) Connect() error {
 		servers := strings.Join(unconnected, ",")
 		return fmt.Errorf("connect: connection failed for %s", servers)
 	}
-	var writers []io.Writer
-	var closers []io.WriteCloser
+	writers := make([]io.Writer, 0, len(gelfs))
+	closers := make([]io.WriteCloser, 0, len(gelfs))
 	for _, w := range gelfs {
 		writers = append(writers, w)
 		closers = append(closers, w)


### PR DESCRIPTION
Address findings for [makezero](https://github.com/ashanbrown/makezero) - Finds slice declarations with non-zero initial length.

It is only part of the bigger job.
After all findings in whole project are handled, we can enable `makezero` linter to guard this.
