### PR TITLE
fix(inputs.modbus): Fix default value of transmission mode

### DIFF
--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -50,10 +50,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # parity = "N"
   # stop_bits = 1
 
-  ## For Modbus over TCP you can choose between "TCP", "RTUoverTCP" and
-  ## "ASCIIoverTCP". The default behaviour is "TCP" for ModbusTCP controllers.
+  ## Transmission mode for Modbus packets depending on the controller type.
+  ## For Modbus over TCP you can choose between "TCP" , "RTUoverTCP" and
+  ## "ASCIIoverTCP".
   ## For Serial controllers you can choose between "RTU" and "ASCII".
-  # transmission_mode = "RTU"
+  ## By default this is set to "auto" selecting "TCP" for ModbusTCP connections
+  ## and "RTU" for serial connections.
+  # transmission_mode = "auto"
 
   ## Trace the connection to the modbus device as debug messages
   ## Note: You have to enable telegraf's debug mode to see those messages!

--- a/plugins/inputs/modbus/modbus_test.go
+++ b/plugins/inputs/modbus/modbus_test.go
@@ -25,6 +25,7 @@ func TestControllers(t *testing.T) {
 	var tests = []struct {
 		name       string
 		controller string
+		mode       string
 		errmsg     string
 	}{
 		{
@@ -32,9 +33,41 @@ func TestControllers(t *testing.T) {
 			controller: "tcp://localhost:502",
 		},
 		{
-			name:       "invalid TCP host",
+			name:       "TCP mode auto",
+			controller: "tcp://localhost:502",
+			mode:       "auto",
+		},
+		{
+			name:       "TCP mode TCP",
+			controller: "tcp://localhost:502",
+			mode:       "TCP",
+		},
+		{
+			name:       "TCP mode RTUoverTCP",
+			controller: "tcp://localhost:502",
+			mode:       "RTUoverTCP",
+		},
+		{
+			name:       "TCP mode ASCIIoverTCP",
+			controller: "tcp://localhost:502",
+			mode:       "ASCIIoverTCP",
+		},
+		{
+			name:       "TCP invalid host",
 			controller: "tcp://localhost",
-			errmsg:     "initializing client failed: address localhost: missing port in address",
+			errmsg:     "address localhost: missing port in address",
+		},
+		{
+			name:       "TCP invalid mode RTU",
+			controller: "tcp://localhost:502",
+			mode:       "RTU",
+			errmsg:     "invalid transmission mode",
+		},
+		{
+			name:       "TCP invalid mode ASCII",
+			controller: "tcp://localhost:502",
+			mode:       "ASCII",
+			errmsg:     "invalid transmission mode",
 		},
 		{
 			name:       "absolute file path",
@@ -57,19 +90,40 @@ func TestControllers(t *testing.T) {
 			controller: "file://com2",
 		},
 		{
+			name:       "serial mode auto",
+			controller: "file:///dev/ttyUSB0",
+			mode:       "auto",
+		},
+		{
+			name:       "serial mode RTU",
+			controller: "file:///dev/ttyUSB0",
+			mode:       "RTU",
+		},
+		{
+			name:       "serial mode ASCII",
+			controller: "file:///dev/ttyUSB0",
+			mode:       "ASCII",
+		},
+		{
 			name:       "empty file path",
 			controller: "file://",
-			errmsg:     "initializing client failed: invalid path for controller",
+			errmsg:     "invalid path for controller",
 		},
 		{
 			name:       "empty controller",
 			controller: "",
-			errmsg:     "initializing client failed: invalid path for controller",
+			errmsg:     "invalid path for controller",
 		},
 		{
 			name:       "invalid scheme",
 			controller: "foo://bar",
-			errmsg:     "initializing client failed: invalid controller",
+			errmsg:     "invalid controller",
+		},
+		{
+			name:       "serial invalid mode TCP",
+			controller: "file:///dev/ttyUSB0",
+			mode:       "TCP",
+			errmsg:     "invalid transmission mode",
 		},
 	}
 
@@ -78,7 +132,7 @@ func TestControllers(t *testing.T) {
 			plugin := Modbus{
 				Name:             "dummy",
 				Controller:       tt.controller,
-				TransmissionMode: "RTU",
+				TransmissionMode: tt.mode,
 				Log:              testutil.Logger{},
 			}
 			err := plugin.Init()

--- a/plugins/inputs/modbus/sample_general_begin.conf
+++ b/plugins/inputs/modbus/sample_general_begin.conf
@@ -33,10 +33,13 @@
   # parity = "N"
   # stop_bits = 1
 
-  ## For Modbus over TCP you can choose between "TCP", "RTUoverTCP" and
-  ## "ASCIIoverTCP". The default behaviour is "TCP" for ModbusTCP controllers.
+  ## Transmission mode for Modbus packets depending on the controller type.
+  ## For Modbus over TCP you can choose between "TCP" , "RTUoverTCP" and
+  ## "ASCIIoverTCP".
   ## For Serial controllers you can choose between "RTU" and "ASCII".
-  # transmission_mode = "RTU"
+  ## By default this is set to "auto" selecting "TCP" for ModbusTCP connections
+  ## and "RTU" for serial connections.
+  # transmission_mode = "auto"
 
   ## Trace the connection to the modbus device as debug messages
   ## Note: You have to enable telegraf's debug mode to see those messages!


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11837

Currently, the `transmission_mode`'s default value in the config does not match the actual behavior as pointed out in #11837. The difficulty is that we have a different default for TCP-based controllers (`"TCP"`) and serial-controllers (`"RTU"`). This PR introduces a new `"auto"` value to capture this different behavior and makes it the new default.

This PR does not change the actual behavior of the plugin but makes the configuration behavior more clear.