### PR TITLE
fix(inputs.win_eventlog): Handle remote events more robustly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifneq (,$(filter $(OS),Windows_NT Windows))
 	EXEEXT=.exe
 endif
 
-next_version := $(shell cat build_version.txt)
+next_version := $(file < build_version.txt)
 tag := $(shell git describe --exact-match --tags 2>/dev/null)
 
 branch := $(shell git rev-parse --abbrev-ref HEAD)

--- a/plugins/inputs/win_eventlog/event.go
+++ b/plugins/inputs/win_eventlog/event.go
@@ -75,5 +75,11 @@ type TimeCreated struct {
 // RenderingInfo is provided for events forwarded by Windows Event Collector
 // see https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage#parameters
 type RenderingInfo struct {
-	InnerXML []byte `xml:",innerxml"`
+	Message  string   `xml:"Message"`
+	Level    string   `xml:"Level"`
+	Task     string   `xml:"Task"`
+	Opcode   string   `xml:"Opcode"`
+	Channel  string   `xml:"Channel"`
+	Provider string   `xml:"Provider"`
+	Keywords []string `xml:"Keywords>Keyword"`
 }

--- a/plugins/inputs/win_eventlog/event.go
+++ b/plugins/inputs/win_eventlog/event.go
@@ -10,26 +10,28 @@ package win_eventlog
 // More info on schema, if there will be need to add more:
 // https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-elements
 type Event struct {
-	Source        Provider    `xml:"System>Provider"`
-	EventID       int         `xml:"System>EventID"`
-	Version       int         `xml:"System>Version"`
-	Level         int         `xml:"System>Level"`
-	Task          int         `xml:"System>Task"`
-	Opcode        int         `xml:"System>Opcode"`
-	Keywords      string      `xml:"System>Keywords"`
-	TimeCreated   TimeCreated `xml:"System>TimeCreated"`
-	EventRecordID int         `xml:"System>EventRecordID"`
-	Correlation   Correlation `xml:"System>Correlation"`
-	Execution     Execution   `xml:"System>Execution"`
-	Channel       string      `xml:"System>Channel"`
-	Computer      string      `xml:"System>Computer"`
-	Security      Security    `xml:"System>Security"`
-	UserData      UserData    `xml:"UserData"`
-	EventData     EventData   `xml:"EventData"`
-	Message       string
-	LevelText     string
-	TaskText      string
-	OpcodeText    string
+	Source        Provider       `xml:"System>Provider"`
+	EventID       int            `xml:"System>EventID"`
+	Version       int            `xml:"System>Version"`
+	Level         int            `xml:"System>Level"`
+	Task          int            `xml:"System>Task"`
+	Opcode        int            `xml:"System>Opcode"`
+	Keywords      string         `xml:"System>Keywords"`
+	TimeCreated   TimeCreated    `xml:"System>TimeCreated"`
+	EventRecordID int            `xml:"System>EventRecordID"`
+	Correlation   Correlation    `xml:"System>Correlation"`
+	Execution     Execution      `xml:"System>Execution"`
+	Channel       string         `xml:"System>Channel"`
+	Computer      string         `xml:"System>Computer"`
+	Security      Security       `xml:"System>Security"`
+	UserData      UserData       `xml:"UserData"`
+	EventData     EventData      `xml:"EventData"`
+	RenderingInfo *RenderingInfo `xml:"RenderingInfo"`
+
+	Message    string
+	LevelText  string
+	TaskText   string
+	OpcodeText string
 }
 
 // UserData Application-provided XML data
@@ -68,4 +70,10 @@ type Security struct {
 // TimeCreated field for Event
 type TimeCreated struct {
 	SystemTime string `xml:"SystemTime,attr"`
+}
+
+// RenderingInfo is provided for events forwarded by Windows Event Collector
+// see https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage#parameters
+type RenderingInfo struct {
+	InnerXML []byte `xml:",innerxml"`
 }

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -333,6 +333,8 @@ func (w *WinEventLog) renderEvent(eventHandle EvtHandle) (Event, error) {
 	if err != nil {
 		return event, err
 	}
+	w.Log.Debugf("event XML: %s", string(eventXML))
+
 	err = xml.Unmarshal([]byte(eventXML), &event)
 	if err != nil {
 		// We can return event without most text values,
@@ -340,7 +342,7 @@ func (w *WinEventLog) renderEvent(eventHandle EvtHandle) (Event, error) {
 		// This can happen when processing Forwarded Events
 		return event, nil
 	}
-	w.Log.Debugf("event XML: %v", eventXML)
+	w.Log.Debugf("event: %+v", event)
 
 	publisherHandle, err := openPublisherMetadata(0, event.Source.Name, w.Locale)
 	if err != nil {

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -344,9 +344,9 @@ func (w *WinEventLog) renderEvent(eventHandle EvtHandle) (Event, error) {
 	}
 	w.Log.Debugf("event: %+v", event)
 
-	var publisherHandle uintptr
 	// We leave the publisher handle NIL for event forwarded by WEC, see
 	// https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage#parameters
+	var publisherHandle EvtHandle
 	if event.RenderingInfo == nil {
 		ph, err := openPublisherMetadata(0, event.Source.Name, w.Locale)
 		if err != nil {

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -388,6 +388,11 @@ func formatEventString(
 		return "", err
 	}
 
+	// Handle empty elements
+	if bufferUsed < 1 {
+		return "", nil
+	}
+
 	bufferUsed *= 2
 	buffer := make([]byte, bufferUsed)
 	bufferUsed = 0

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -330,7 +330,6 @@ func (w *WinEventLog) renderEvent(eventHandle EvtHandle) (Event, error) {
 	if err != nil {
 		return event, err
 	}
-	w.Log.Debugf("Event: %s", string(eventXML))
 
 	err = xml.Unmarshal([]byte(eventXML), &event)
 	if err != nil {

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -303,7 +303,6 @@ func (w *WinEventLog) fetchEvents(subsHandle EvtHandle) ([]Event, error) {
 		if eventHandle != 0 {
 			event, err := w.renderEvent(eventHandle)
 			if err == nil {
-				// w.Log.Debugf("Got event: %v", event)
 				events = append(events, event)
 			}
 		}
@@ -331,7 +330,7 @@ func (w *WinEventLog) renderEvent(eventHandle EvtHandle) (Event, error) {
 	if err != nil {
 		return event, err
 	}
-	w.Log.Debugf("event XML: %s", string(eventXML))
+	w.Log.Debugf("Event: %s", string(eventXML))
 
 	err = xml.Unmarshal([]byte(eventXML), &event)
 	if err != nil {
@@ -340,7 +339,6 @@ func (w *WinEventLog) renderEvent(eventHandle EvtHandle) (Event, error) {
 		// This can happen when processing Forwarded Events
 		return event, nil
 	}
-	w.Log.Debugf("event: %+v", event)
 
 	// Do resolve local messages the usual way, while using built-in information for events forwarded by WEC.
 	// This is a safety measure as the underlying Windows-internal EvtFormatMessage might segfault in cases

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -340,12 +340,14 @@ func (w *WinEventLog) renderEvent(eventHandle EvtHandle) (Event, error) {
 		// This can happen when processing Forwarded Events
 		return event, nil
 	}
+	w.Log.Debugf("event XML: %v", eventXML)
 
 	publisherHandle, err := openPublisherMetadata(0, event.Source.Name, w.Locale)
 	if err != nil {
 		return event, nil
 	}
 	defer _EvtClose(publisherHandle)
+	w.Log.Debugf("publisher handle: %v", publisherHandle)
 
 	// Populating text values
 	keywords, err := formatEventString(EvtFormatMessageKeyword, eventHandle, publisherHandle)


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12328

This PR fixes a panic in `inputs.win_eventlog` for cases where events are sent by a remote machine (i.e. via Windows-event-forwarding) which is unavailable at the time Telegraf gathers those events. The root cause is that Windows' `EvtFormatMessage` syscall is expecting a handle to the publisher (i.e. the machine that sent the event) which is becoming invalid if that publisher is down. As a consequence Windows throws an exception (read Golang panic) instead of returning a simple error.

The implemented approach is to completely avoid the `EvtFormatMessage` syscall for remote events and instead use the `RenderingInfo` attached to the event itself (only existing for remote events).
