### PR TITLE
fix(common.opcua): parse additional_valid_status_codes as uint32

### DIFF
--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -138,11 +138,11 @@ func (o *OpcUAClient) setupOptions() error {
 func (o *OpcUAClient) setupWorkarounds() error {
 	o.codes = []ua.StatusCode{ua.StatusOK}
 	for _, c := range o.Config.Workarounds.AdditionalValidStatusCodes {
-		val, err := strconv.ParseInt(c, 0, 32) // setting 32 bits to allow for safe conversion
+		val, err := strconv.ParseUint(c, 0, 32) // setting 32 bits to allow for safe conversion
 		if err != nil {
 			return err
 		}
-		o.codes = append(o.codes, ua.StatusCode(uint32(val)))
+		o.codes = append(o.codes, ua.StatusCode(val))
 	}
 
 	return nil

--- a/plugins/common/opcua/client_test.go
+++ b/plugins/common/opcua/client_test.go
@@ -10,7 +10,7 @@ func TestSetupWorkarounds(t *testing.T) {
 	o := OpcUAClient{
 		Config: &OpcUAClientConfig{
 			Workarounds: OpcUAWorkarounds{
-				AdditionalValidStatusCodes: []string{"0xC0", "0x00AA0000"},
+				AdditionalValidStatusCodes: []string{"0xC0", "0x00AA0000", "0x80000000"},
 			},
 		},
 	}
@@ -18,10 +18,11 @@ func TestSetupWorkarounds(t *testing.T) {
 	err := o.setupWorkarounds()
 	require.NoError(t, err)
 
-	require.Len(t, o.codes, 3)
+	require.Len(t, o.codes, 4)
 	require.Equal(t, o.codes[0], ua.StatusCode(0))
 	require.Equal(t, o.codes[1], ua.StatusCode(192))
 	require.Equal(t, o.codes[2], ua.StatusCode(11141120))
+	require.Equal(t, o.codes[3], ua.StatusCode(2147483648))
 }
 
 func TestCheckStatusCode(t *testing.T) {


### PR DESCRIPTION
# Required for all PRs

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Fixed an issue where [all OPC UA status codes](https://reference.opcfoundation.org/v104/Core/docs/Part6/A.2/) could not be used as `additional_valid_status_codes`.