### PR TITLE
fix(inputs.sqlserver): SqlRequests include sleeping sessions with open transactions

### DIFF
--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -355,7 +355,7 @@ The new (version 2) metrics provide:
 - *Wait stats*: Wait time in ms, number of waiting tasks, resource wait time, signal wait time, max wait time in ms, wait type, and wait category. The waits are categorized using the same categories used in Query Store.
 - *Schedulers* - This captures `sys.dm_os_schedulers`.
 - *SqlRequests* - This captures a snapshot of `sys.dm_exec_requests` and `sys.dm_exec_sessions` that gives you running requests as well as wait types and
-  blocking sessions. Telegraf's monitoring request is omitted unless it is a heading blocker.
+  blocking sessions. Telegraf's monitoring request is omitted unless it is a heading blocker. Also includes sleeping sessions with open transactions.
 - *VolumeSpace* - uses `sys.dm_os_volume_stats` to get total, used and occupied space on every disk that contains a data or log file. (Note that even if enabled it won't get any data from Azure SQL Database or SQL Managed Instance). It is pointless to run this with high frequency (ie: every 10s), but it won't cause any problem.
 - *Cpu* - uses the buffer ring (`sys.dm_os_ring_buffers`) to get CPU data, the table is updated once per minute. (Note that even if enabled it won't get any data from Azure SQL Database or SQL Managed Instance).
 

--- a/plugins/inputs/sqlserver/azuresqldbqueries.go
+++ b/plugins/inputs/sqlserver/azuresqldbqueries.go
@@ -658,7 +658,8 @@ FROM (
 	OUTER APPLY sys.dm_exec_sql_text(r.[sql_handle]) AS qt
 ) AS data
 WHERE
-	[blocking_or_blocked] > 1	--Always include blocking or blocked sessions/requests
+	   [blocking_or_blocked] > 1 --Always include blocking or blocked sessions/requests
+	OR [open_transaction] >= 1   --Always include sessions with open transactions
 	OR (
 		[request_id] IS NOT NULL	--A request must exists
 		AND (	--Always fetch user process (in any state), fetch system process only if active

--- a/plugins/inputs/sqlserver/azuresqlmanagedqueries.go
+++ b/plugins/inputs/sqlserver/azuresqlmanagedqueries.go
@@ -522,7 +522,8 @@ FROM (
 	OUTER APPLY sys.dm_exec_sql_text(r.[sql_handle]) AS qt
 ) AS data
 WHERE
-	[blocking_or_blocked] > 1	--Always include blocking or blocked sessions/requests
+	   [blocking_or_blocked] > 1 --Always include blocking or blocked sessions/requests
+	OR [open_transaction] >= 1   --Always include sessions with open transactions
 	OR (
 		[request_id] IS NOT NULL	--A request must exists
 		AND (	--Always fetch user process (in any state), fetch system process only if active

--- a/plugins/inputs/sqlserver/sqlserverqueries.go
+++ b/plugins/inputs/sqlserver/sqlserverqueries.go
@@ -1126,7 +1126,8 @@ FROM (
 	OUTER APPLY sys.dm_exec_sql_text(r.[sql_handle]) AS qt
 ) AS data
 WHERE
-	[blocking_or_blocked] > 1	--Always include blocking or blocked sessions/requests
+	   [blocking_or_blocked] > 1 --Always include blocking or blocked sessions/requests
+	OR [open_transaction] >= 1   --Always include sessions with open transactions
 	OR (
 		[request_id] IS NOT NULL	--A request must exists
 		AND (	--Always fetch user process (in any state), fetch system process only if active


### PR DESCRIPTION
- [X] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

example: Fixed an off by one error in counter variable in type FooBar.

SqlRequests did not include sleeping sessions with open transactions. This can make troubleshooting slightly problematic in some cases, where you see a blocked SPID but you don't see how long the blocking session has been sleeping. This fix will allow tracking sleeping sessions that keep transactions open.