### PR TITLE
fix(inputs.sqlserver): Add SPID filter for sqlserverqueries.go

### DIFF
--- a/plugins/inputs/sqlserver/sqlserverqueries.go
+++ b/plugins/inputs/sqlserver/sqlserverqueries.go
@@ -1133,6 +1133,7 @@ WHERE
 			[is_user_process] = 1
 			OR [status] COLLATE Latin1_General_BIN NOT IN (''background'', ''sleeping'')
 		)
+		AND [session_id] <> @@SPID  --Exclude current SPID
 	)
 OPTION(MAXDOP 1)'
 


### PR DESCRIPTION
This filter has been set on all other source files (azureSqlDB and azureSqlMI) but not on the on-prem version

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #11709 also for on-prem
