### PR TITLE
test: always create test config for package testing

### DIFF
--- a/tools/package_lxd_test/container.go
+++ b/tools/package_lxd_test/container.go
@@ -95,30 +95,27 @@ func (c *Container) Install(packageName ...string) error {
 }
 
 func (c *Container) CheckStatus(serviceName string) error {
-	// the RPM does not start automatically service on install
-	// write valid, but simple config file and start
-	if c.packageManager != "apt" {
-		err := c.client.Exec(
-			c.Name,
-			"bash",
-			"-c",
-			"--",
-			"echo '[[inputs.cpu]]\n[[outputs.file]]' | "+
-				"tee /etc/telegraf/telegraf.conf",
-		)
-		if err != nil {
-			return err
-		}
-
-		err = c.client.Exec(c.Name, "systemctl", "start", serviceName)
-		if err != nil {
-			_ = c.client.Exec(c.Name, "systemctl", "status", serviceName)
-			_ = c.client.Exec(c.Name, "journalctl", "--no-pager", "--unit", serviceName)
-			return err
-		}
+	// push a valid config first, then start the service
+	err := c.client.Exec(
+		c.Name,
+		"bash",
+		"-c",
+		"--",
+		"echo '[[inputs.cpu]]\n[[outputs.file]]' | "+
+			"tee /etc/telegraf/telegraf.conf",
+	)
+	if err != nil {
+		return err
 	}
 
-	err := c.client.Exec(c.Name, "systemctl", "status", serviceName)
+	err = c.client.Exec(c.Name, "systemctl", "start", serviceName)
+	if err != nil {
+		_ = c.client.Exec(c.Name, "systemctl", "status", serviceName)
+		_ = c.client.Exec(c.Name, "journalctl", "--no-pager", "--unit", serviceName)
+		return err
+	}
+
+	err = c.client.Exec(c.Name, "systemctl", "status", serviceName)
 	if err != nil {
 		_ = c.client.Exec(c.Name, "journalctl", "--no-pager", "--unit", serviceName)
 		return err


### PR DESCRIPTION
The default config is no longer valid, so it will not attempt to start. As previously done with only the rpm/dnf based distros, provide a basic config for the deb based distros as well.

This is a fix for the new nightly failures:
https://app.circleci.com/pipelines/github/influxdata/telegraf/14270/workflows/e0117982-a55e-4365-a717-9a8c7274a35f/jobs/226539
