### PR TITLE
fix(secretstores): Cleanup

### DIFF
--- a/cmd/telegraf/printer.go
+++ b/cmd/telegraf/printer.go
@@ -146,24 +146,6 @@ func printSampleConfig(
 		}
 	}
 
-	// print secretstore plugins
-	if sliceContains("secretstores", sectionFilters) {
-		if len(secretstoreFilters) != 0 {
-			if len(secretstoreFilters) >= 3 && secretstoreFilters[1] != "none" {
-				fmt.Print(secretstoreHeader)
-			}
-			printFilteredSecretstores(secretstoreFilters, false, outputBuffer)
-		} else {
-			fmt.Print(secretstoreHeader)
-			snames := []string{}
-			for sname := range secretstores.SecretStores {
-				snames = append(snames, sname)
-			}
-			sort.Strings(snames)
-			printFilteredSecretstores(snames, true, outputBuffer)
-		}
-	}
-
 	// print output plugins
 	if sliceContains("outputs", sectionFilters) {
 		if len(outputFilters) != 0 {

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -186,19 +186,24 @@ func (h *HTTP) gatherURL(
 }
 
 func (h *HTTP) setRequestAuth(request *http.Request) error {
+	if h.Username.Empty() && h.Password.Empty() {
+		return nil
+	}
+
 	username, err := h.Username.Get()
 	if err != nil {
 		return fmt.Errorf("getting username failed: %v", err)
 	}
 	defer config.ReleaseSecret(username)
+
 	password, err := h.Password.Get()
 	if err != nil {
 		return fmt.Errorf("getting password failed: %v", err)
 	}
 	defer config.ReleaseSecret(password)
-	if len(username) != 0 || len(password) != 0 {
-		request.SetBasicAuth(string(username), string(password))
-	}
+
+	request.SetBasicAuth(string(username), string(password))
+
 	return nil
 }
 

--- a/plugins/secretstores/jose/README.md
+++ b/plugins/secretstores/jose/README.md
@@ -22,7 +22,7 @@ to get more information on how to do this.
   id = "secretstore"
 
   ## Directory for storing the secrets
-  # path = "secrets"
+  path = "/etc/telegraf/secrets"
 
   ## Password to access the secrets.
   ## If no password is specified here, Telegraf will prompt for it at startup time.

--- a/plugins/secretstores/jose/README.md
+++ b/plugins/secretstores/jose/README.md
@@ -3,8 +3,13 @@
 The `jose` plugin allows to manage and store secrets locally
 protected by the [Javascript Object Signing and Encryption][jose] algorithm.
 
-To manage your secrets of this secret-store, you should use the
-[secrets command of Telegraf](/docs/COMMANDS_AND_FLAGS.md#secrets-management).
+To manage your secrets of this secret-store, you should use Telegraf. Run
+
+```shell
+telegraf secrets help
+```
+
+to get more information on how to do this.
 
 ## Configuration
 

--- a/plugins/secretstores/jose/jose.go
+++ b/plugins/secretstores/jose/jose.go
@@ -35,10 +35,15 @@ func (j *Jose) Init() error {
 		return errors.New("id missing")
 	}
 
+	if j.Path == "" {
+		return errors.New("path missing")
+	}
+
 	passwd, err := j.Password.Get()
 	if err != nil {
 		return fmt.Errorf("getting password failed: %v", err)
 	}
+	defer config.ReleaseSecret(passwd)
 
 	// Create the prompt-function in case we need it
 	promptFunc := keyring.TerminalPrompt
@@ -98,9 +103,6 @@ func (j *Jose) GetResolver(key string) (telegraf.ResolveFunc, error) {
 // Register the secret-store on load.
 func init() {
 	secretstores.Add("jose", func(id string) telegraf.SecretStore {
-		return &Jose{
-			ID:   id,
-			Path: "secrets",
-		}
+		return &Jose{ID: id}
 	})
 }

--- a/plugins/secretstores/jose/jose.go
+++ b/plugins/secretstores/jose/jose.go
@@ -12,8 +12,6 @@ import (
 	"github.com/influxdata/telegraf/plugins/secretstores"
 )
 
-// DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
-//
 //go:embed sample.conf
 var sampleConfig string
 

--- a/plugins/secretstores/jose/jose_test.go
+++ b/plugins/secretstores/jose/jose_test.go
@@ -25,9 +25,17 @@ func TestInitFail(t *testing.T) {
 			expected: "id missing",
 		},
 		{
+			name: "missing path",
+			plugin: &Jose{
+				ID: "test",
+			},
+			expected: "path missing",
+		},
+		{
 			name: "invalid password",
 			plugin: &Jose{
 				ID:       "test",
+				Path:     os.TempDir(),
 				Password: config.NewSecret([]byte("@{unresolvable:secret}")),
 			},
 			expected: "getting password failed",

--- a/plugins/secretstores/jose/sample.conf
+++ b/plugins/secretstores/jose/sample.conf
@@ -6,7 +6,7 @@
   id = "secretstore"
 
   ## Directory for storing the secrets
-  # path = "secrets"
+  path = "/etc/telegraf/secrets"
 
   ## Password to access the secrets.
   ## If no password is specified here, Telegraf will prompt for it at startup time.

--- a/plugins/secretstores/os/README.md
+++ b/plugins/secretstores/os/README.md
@@ -4,9 +4,14 @@ The `os` plugin allows to manage and store secrets using the native Operating
 System keyring. For Windows this plugin uses the credential manager, on Linux
 the kernel keyring is used and on MacOS we use the Keychain implementation.
 
-To manage your secrets you can either use the
-[secrets command of Telegraf](/docs/COMMANDS_AND_FLAGS.md#secrets-management)
-or the tools that natively comes with your operating system.
+To manage your secrets you can either use Telegraf or the tools that natively
+comes with your operating system. Run
+
+```shell
+telegraf secrets help
+```
+
+to get more information on how to do this with Telegraf.
 
 ## Configuration
 

--- a/plugins/secretstores/os/os.go
+++ b/plugins/secretstores/os/os.go
@@ -1,5 +1,4 @@
 //go:build darwin || linux || windows
-// +build darwin linux windows
 
 //go:generate ../../../tools/readme_config_includer/generator
 package os

--- a/plugins/secretstores/os/os_darwin.go
+++ b/plugins/secretstores/os/os_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package os
 
@@ -12,8 +11,6 @@ import (
 	"github.com/influxdata/telegraf/config"
 )
 
-// DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
-//
 //go:embed sample_darwin.conf
 var sampleConfig string
 

--- a/plugins/secretstores/os/os_linux.go
+++ b/plugins/secretstores/os/os_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package os
 
@@ -9,8 +8,6 @@ import (
 	"github.com/99designs/keyring"
 )
 
-// DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
-//
 //go:embed sample_linux.conf
 var sampleConfig string
 

--- a/plugins/secretstores/os/os_test.go
+++ b/plugins/secretstores/os/os_test.go
@@ -1,5 +1,4 @@
 //go:build darwin || linux || windows
-// +build darwin linux windows
 
 package os
 

--- a/plugins/secretstores/os/os_windows.go
+++ b/plugins/secretstores/os/os_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package os
 
@@ -9,8 +8,6 @@ import (
 	"github.com/99designs/keyring"
 )
 
-// DO NOT REMOVE THE NEXT TWO LINES! This is required to embed the sampleConfig data.
-//
 //go:embed sample_windows.conf
 var sampleConfig string
 


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR adds a helper to check for uninitialized and/or empty secrets without the need to decode them. It also removes the duplicate "secret store plugins" section (and plugins) in the generated sample config.
Furthermore, the PR addresses the comments of @Hipska in #11232, e.g. making the secret-path a mandatory option for the JOSE store.