### PR TITLE
fix(inputs.x509_cert): Fix off-by-one when adding intermediates

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -119,7 +119,7 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 			// Add all returned certs to the pool if intermediates except for
 			// the leaf node and ourself
 			for j, c := range certs[1:] {
-				if i != j {
+				if i+1 != j {
 					opts.Intermediates.AddCert(c)
 				}
 			}
@@ -131,6 +131,8 @@ func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 				c.Log.Debugf("Invalid certificate at index %2d!", i)
 				c.Log.Debugf("  cert DNS names:    %v", cert.DNSNames)
 				c.Log.Debugf("  cert IP addresses: %v", cert.IPAddresses)
+				c.Log.Debugf("  cert subject:      %v", cert.Subject)
+				c.Log.Debugf("  cert issuer:       %v", cert.Issuer)
 				c.Log.Debugf("  opts.DNSName:      %v", opts.DNSName)
 				c.Log.Debugf("  verify options:    %v", opts)
 				c.Log.Debugf("  verify error:      %v", err)


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12402 

When adding intermediate certificates we always omit the first certificate, thus we need to add +1 when comparing the inputs as index 0 of the intermediates is actually index 1 in the certs.