### PR TITLE
chore: do not start service on deb install

### DIFF
--- a/scripts/deb/post-install.sh
+++ b/scripts/deb/post-install.sh
@@ -52,9 +52,10 @@ test -d $LOG_DIR || mkdir -p $LOG_DIR
 chown -R -L telegraf:telegraf $LOG_DIR
 chmod 755 $LOG_DIR
 
-if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
-	install_systemd /lib/systemd/system/telegraf.service
-	deb-systemd-invoke restart telegraf.service || echo "WARNING: systemd not running."
+if [ -d /run/systemd/system ]; then
+    install_systemd /lib/systemd/system/telegraf.service
+    # if and only if the service was already running then restart
+    deb-systemd-invoke try-restart telegraf.service >/dev/null || true
 else
 	# Assuming SysVinit
 	install_init

--- a/scripts/deb/post-install.sh
+++ b/scripts/deb/post-install.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-BIN_DIR=/usr/bin
 LOG_DIR=/var/log/telegraf
 SCRIPT_DIR=/usr/lib/telegraf/scripts
-LOGROTATE_DIR=/etc/logrotate.d
 
 function install_init {
     cp -f $SCRIPT_DIR/init.sh /etc/init.d/telegraf
@@ -11,6 +9,7 @@ function install_init {
 }
 
 function install_systemd {
+    #shellcheck disable=SC2086
     cp -f $SCRIPT_DIR/telegraf.service $1
     systemctl enable telegraf || true
     systemctl daemon-reload || true

--- a/scripts/deb/pre-remove.sh
+++ b/scripts/deb/pre-remove.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-BIN_DIR=/usr/bin
-
-if [[ "$(readlink /proc/1/exe)" == */systemd ]]; then
-	deb-systemd-invoke stop telegraf.service
+if [ -d /run/systemd/system ]; then
+	if [ "$1" = remove ]; then
+		deb-systemd-invoke stop telegraf.service
+	fi
 else
 	# Assuming sysv
 	invoke-rc.d telegraf stop


### PR DESCRIPTION
Because the default config is no longer valid, telegraf will error out, and the systemd service will be marked as failed. Instead, no longer start the service on installation.

Additionally, if the service is already running on an upgrade, restart the service, but again do not start it if it was not already started.

fixes: #12397