### PR TITLE
chore(linter): Disable linter warning for Freeze() in starlark

### DIFF
--- a/plugins/common/starlark/field_dict.go
+++ b/plugins/common/starlark/field_dict.go
@@ -38,6 +38,10 @@ func (d FieldDict) Type() string {
 }
 
 func (d FieldDict) Freeze() {
+	// Disable linter check as the frozen variable is modified despite
+	// passing a value instead of a pointer, because `FieldDict` holds
+	// a pointer to the underlying metric containing the `frozen` field.
+	//revive:disable:modifies-value-receiver
 	d.frozen = true
 }
 

--- a/plugins/common/starlark/tag_dict.go
+++ b/plugins/common/starlark/tag_dict.go
@@ -37,6 +37,10 @@ func (d TagDict) Type() string {
 }
 
 func (d TagDict) Freeze() {
+	// Disable linter check as the frozen variable is modified despite
+	// passing a value instead of a pointer, because `FieldDict` holds
+	// a pointer to the underlying metric containing the `frozen` field.
+	//revive:disable:modifies-value-receiver
 	d.frozen = true
 }
 

--- a/plugins/common/starlark/tag_dict.go
+++ b/plugins/common/starlark/tag_dict.go
@@ -38,7 +38,7 @@ func (d TagDict) Type() string {
 
 func (d TagDict) Freeze() {
 	// Disable linter check as the frozen variable is modified despite
-	// passing a value instead of a pointer, because `FieldDict` holds
+	// passing a value instead of a pointer, because `TagDict` holds
 	// a pointer to the underlying metric containing the `frozen` field.
 	//revive:disable:modifies-value-receiver
 	d.frozen = true


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12042 

Disable linter for two false-positives.