### PR TITLE
feat(inputs.modbus): Add workaround to enforce reads from zero for coil registers

### DIFF
--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -256,6 +256,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     ## This might be necessary for devices not conforming to the spec,
     ## see https://github.com/influxdata/telegraf/issues/12071.
     # one_request_per_field = false
+
+    ## Enforce the starting address to be zero for the first request on
+    ## coil registers. This is necessary for some devices see
+    ## https://github.com/influxdata/telegraf/issues/8905
+    # read_coils_starting_at_zero
 ```
 
 ## Notes

--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -260,7 +260,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     ## Enforce the starting address to be zero for the first request on
     ## coil registers. This is necessary for some devices see
     ## https://github.com/influxdata/telegraf/issues/8905
-    # read_coils_starting_at_zero
+    # read_coils_starting_at_zero = false
 ```
 
 ## Notes

--- a/plugins/inputs/modbus/configuration_register.go
+++ b/plugins/inputs/modbus/configuration_register.go
@@ -95,7 +95,12 @@ func (c *ConfigurationOriginal) initRequests(fieldDefs []fieldDefinition, maxQua
 	if err != nil {
 		return nil, err
 	}
-	return groupFieldsToRequests(fields, nil, maxQuantity, "none", 0), nil
+	params := groupingParams{
+		MaxBatchSize: maxQuantity,
+		Optimization: "none",
+	}
+
+	return groupFieldsToRequests(fields, params), nil
 }
 
 func (c *ConfigurationOriginal) initFields(fieldDefs []fieldDefinition) ([]field, error) {

--- a/plugins/inputs/modbus/configuration_register.go
+++ b/plugins/inputs/modbus/configuration_register.go
@@ -96,8 +96,9 @@ func (c *ConfigurationOriginal) initRequests(fieldDefs []fieldDefinition, maxQua
 		return nil, err
 	}
 	params := groupingParams{
-		MaxBatchSize: maxQuantity,
-		Optimization: "none",
+		MaxBatchSize:    maxQuantity,
+		Optimization:    "none",
+		EnforceFromZero: c.workarounds.ReadCoilsStartingAtZero,
 	}
 
 	return groupFieldsToRequests(fields, params), nil

--- a/plugins/inputs/modbus/configuration_request.go
+++ b/plugins/inputs/modbus/configuration_request.go
@@ -189,6 +189,7 @@ func (c *ConfigurationPerRequest) Process() (map[byte]requestSet, error) {
 			if c.workarounds.OnRequestPerField {
 				params.MaxBatchSize = 1
 			}
+			params.EnforceFromZero = c.workarounds.ReadCoilsStartingAtZero
 			requests := groupFieldsToRequests(fields, params)
 			set.coil = append(set.coil, requests...)
 		case "discrete":
@@ -215,7 +216,9 @@ func (c *ConfigurationPerRequest) Process() (map[byte]requestSet, error) {
 		default:
 			return nil, fmt.Errorf("unknown register type %q", def.RegisterType)
 		}
-		result[def.SlaveID] = set
+		if !set.Empty() {
+			result[def.SlaveID] = set
+		}
 	}
 
 	return result, nil

--- a/plugins/inputs/modbus/configuration_request.go
+++ b/plugins/inputs/modbus/configuration_request.go
@@ -178,34 +178,39 @@ func (c *ConfigurationPerRequest) Process() (map[byte]requestSet, error) {
 			}
 		}
 
+		params := groupingParams{
+			MaxExtraRegisters: def.MaxExtraRegisters,
+			Optimization:      def.Optimization,
+			Tags:              def.Tags,
+		}
 		switch def.RegisterType {
 		case "coil":
-			maxQuantity := maxQuantityCoils
+			params.MaxBatchSize = maxQuantityCoils
 			if c.workarounds.OnRequestPerField {
-				maxQuantity = 1
+				params.MaxBatchSize = 1
 			}
-			requests := groupFieldsToRequests(fields, def.Tags, maxQuantity, def.Optimization, def.MaxExtraRegisters)
+			requests := groupFieldsToRequests(fields, params)
 			set.coil = append(set.coil, requests...)
 		case "discrete":
-			maxQuantity := maxQuantityDiscreteInput
+			params.MaxBatchSize = maxQuantityDiscreteInput
 			if c.workarounds.OnRequestPerField {
-				maxQuantity = 1
+				params.MaxBatchSize = 1
 			}
-			requests := groupFieldsToRequests(fields, def.Tags, maxQuantity, def.Optimization, def.MaxExtraRegisters)
+			requests := groupFieldsToRequests(fields, params)
 			set.discrete = append(set.discrete, requests...)
 		case "holding":
-			maxQuantity := maxQuantityHoldingRegisters
+			params.MaxBatchSize = maxQuantityHoldingRegisters
 			if c.workarounds.OnRequestPerField {
-				maxQuantity = 1
+				params.MaxBatchSize = 1
 			}
-			requests := groupFieldsToRequests(fields, def.Tags, maxQuantity, def.Optimization, def.MaxExtraRegisters)
+			requests := groupFieldsToRequests(fields, params)
 			set.holding = append(set.holding, requests...)
 		case "input":
-			maxQuantity := maxQuantityInputRegisters
+			params.MaxBatchSize = maxQuantityInputRegisters
 			if c.workarounds.OnRequestPerField {
-				maxQuantity = 1
+				params.MaxBatchSize = 1
 			}
-			requests := groupFieldsToRequests(fields, def.Tags, maxQuantity, def.Optimization, def.MaxExtraRegisters)
+			requests := groupFieldsToRequests(fields, params)
 			set.input = append(set.input, requests...)
 		default:
 			return nil, fmt.Errorf("unknown register type %q", def.RegisterType)

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -25,10 +25,11 @@ var sampleConfigStart string
 var sampleConfigEnd string
 
 type ModbusWorkarounds struct {
-	AfterConnectPause config.Duration `toml:"pause_after_connect"`
-	PollPause         config.Duration `toml:"pause_between_requests"`
-	CloseAfterGather  bool            `toml:"close_connection_after_gather"`
-	OnRequestPerField bool            `toml:"one_request_per_field"`
+	AfterConnectPause       config.Duration `toml:"pause_after_connect"`
+	PollPause               config.Duration `toml:"pause_between_requests"`
+	CloseAfterGather        bool            `toml:"close_connection_after_gather"`
+	OnRequestPerField       bool            `toml:"one_request_per_field"`
+	ReadCoilsStartingAtZero bool            `toml:"read_coils_starting_at_zero"`
 }
 
 // Modbus holds all data relevant to the plugin
@@ -66,6 +67,14 @@ type requestSet struct {
 	discrete []request
 	holding  []request
 	input    []request
+}
+
+func (r requestSet) Empty() bool {
+	l := len(r.coil)
+	l += len(r.discrete)
+	l += len(r.holding)
+	l += len(r.input)
+	return l == 0
 }
 
 type field struct {

--- a/plugins/inputs/modbus/modbus_test.go
+++ b/plugins/inputs/modbus/modbus_test.go
@@ -4732,7 +4732,7 @@ func TestRequestsWorkaroundsReadCoilsStartingAtZeroRequest(t *testing.T) {
 				},
 				{
 					Name:    "coil-new-group",
-					Address: uint16(maxQuantityCoils),
+					Address: maxQuantityCoils,
 				},
 			},
 		},
@@ -4746,7 +4746,7 @@ func TestRequestsWorkaroundsReadCoilsStartingAtZeroRequest(t *testing.T) {
 
 	// The second field should form a new group as the previous request
 	// is now too large (beyond max-coils-per-read) after zero enforcement.
-	require.Equal(t, uint16(maxQuantityCoils), plugin.requests[1].coil[1].address)
+	require.Equal(t, maxQuantityCoils, plugin.requests[1].coil[1].address)
 	require.Equal(t, uint16(1), plugin.requests[1].coil[1].length)
 }
 
@@ -4778,6 +4778,6 @@ func TestRequestsWorkaroundsReadCoilsStartingAtZeroRegister(t *testing.T) {
 
 	// The second field should form a new group as the previous request
 	// is now too large (beyond max-coils-per-read) after zero enforcement.
-	require.Equal(t, uint16(maxQuantityCoils), plugin.requests[1].coil[1].address)
+	require.Equal(t, maxQuantityCoils, plugin.requests[1].coil[1].address)
 	require.Equal(t, uint16(1), plugin.requests[1].coil[1].length)
 }

--- a/plugins/inputs/modbus/sample_general_end.conf
+++ b/plugins/inputs/modbus/sample_general_end.conf
@@ -19,3 +19,8 @@
     ## This might be necessary for devices not conforming to the spec,
     ## see https://github.com/influxdata/telegraf/issues/12071.
     # one_request_per_field = false
+
+    ## Enforce the starting address to be zero for the first request on
+    ## coil registers. This is necessary for some devices see
+    ## https://github.com/influxdata/telegraf/issues/8905
+    # read_coils_starting_at_zero

--- a/plugins/inputs/modbus/sample_general_end.conf
+++ b/plugins/inputs/modbus/sample_general_end.conf
@@ -23,4 +23,4 @@
     ## Enforce the starting address to be zero for the first request on
     ## coil registers. This is necessary for some devices see
     ## https://github.com/influxdata/telegraf/issues/8905
-    # read_coils_starting_at_zero
+    # read_coils_starting_at_zero = false


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #8905

This PR allows to enforce reading coil-registers starting at zero which is required for some devices (see issue #8905). This replaces a workaround to define all fields between the register you want to read (e.g. 1000) and zero with the omit flag being set to true.