### PR TITLE
fix(inputs.mysql): Revert slices declarations with zero initial length

### DIFF
--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -607,13 +607,12 @@ func (m *Mysql) gatherSlaveStatuses(db *sql.DB, serv string, acc telegraf.Accumu
 			return err
 		}
 
-		vals := make([]sql.RawBytes, 0, len(cols))
-		valPtrs := make([]interface{}, 0, len(cols))
+		vals := make([]sql.RawBytes, len(cols))
+		valPtrs := make([]interface{}, len(cols))
 		// fill the array with sql.Rawbytes
-		for range cols {
-			rawBytes := sql.RawBytes{}
-			vals = append(vals, rawBytes)
-			valPtrs = append(valPtrs, &rawBytes)
+		for i := range vals {
+			vals[i] = sql.RawBytes{}
+			valPtrs[i] = &vals[i]
 		}
 		if err = rows.Scan(valPtrs...); err != nil {
 			return err


### PR DESCRIPTION
Reverts (`mysql.go` only): https://github.com/influxdata/telegraf/pull/12371
Fixes: https://github.com/influxdata/telegraf/issues/12398

Pointer to `rawBytes := sql.RawBytes{}` wrongly used (instead of pointer to slice).
In that case, enforcing slices declarations with zero initial length doesn't make much sense.