### PR TITLE
chore: Fix deprecated monitoringpb

### DIFF
--- a/plugins/inputs/stackdriver/stackdriver.go
+++ b/plugins/inputs/stackdriver/stackdriver.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"google.golang.org/api/iterator"
 	distributionpb "google.golang.org/genproto/googleapis/api/distribution"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
-	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 

--- a/plugins/inputs/stackdriver/stackdriver_test.go
+++ b/plugins/inputs/stackdriver/stackdriver_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/api/distribution"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
-	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/influxdata/telegraf"

--- a/plugins/outputs/stackdriver/counter_cache.go
+++ b/plugins/outputs/stackdriver/counter_cache.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	monpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	monpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/influxdata/telegraf"

--- a/plugins/outputs/stackdriver/counter_cache_test.go
+++ b/plugins/outputs/stackdriver/counter_cache_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf/models"
-
-	monpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	monpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/influxdata/telegraf/models"
 )
 
 func TestCreateCounterCacheEntry(t *testing.T) {

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"google.golang.org/api/option"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
-	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/influxdata/telegraf"

--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
-	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"


### PR DESCRIPTION
Fix deprecated `monitoringpb` in `stackdriver` plugins.
Introduced in https://github.com/influxdata/telegraf/pull/12385.

Fixed using:
```
go run cloud.google.com/go/internal/aliasfix/cmd/aliasfix@latest .
go mod tidy
```
proposed in https://github.com/googleapis/google-cloud-go/blob/main/migration.md

Following linter findings will not be shown anymore:
```
plugins/inputs/stackdriver/stackdriver.go:110:51          staticcheck  SA1019: monitoringpb.ListMetricDescriptorsRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:111:44          staticcheck  SA1019: monitoringpb.ListTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:136:7           staticcheck  SA1019: monitoringpb.ListMetricDescriptorsRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:165:7           staticcheck  SA1019: monitoringpb.ListTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:166:12          staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:167:23          staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:19:15           staticcheck  SA1019: "google.golang.org/genproto/googleapis/monitoring/v3" is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb. Please read https://github.com/googleapis/google-cloud-go/blob/main/migration.md for more details. 
plugins/inputs/stackdriver/stackdriver.go:355:15          staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:359:12          staticcheck  SA1019: monitoringpb.ListTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:391:16          staticcheck  SA1019: monitoringpb.Aggregation_Aligner_name is deprecated: Please use vars in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:393:13          staticcheck  SA1019: monitoringpb.Aggregation_Aligner is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:394:10          staticcheck  SA1019: monitoringpb.Aggregation is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:484:16          staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:495:10          staticcheck  SA1019: monitoringpb.ListMetricDescriptorsRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver.go:96:26           staticcheck  SA1019: monitoringpb.ListTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:107:6      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:108:17     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:113:14     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:1175:60    staticcheck  SA1019: monitoringpb.ListMetricDescriptorsRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:1181:53    staticcheck  SA1019: monitoringpb.ListTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:1182:23    staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:1184:8     staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:1185:19    staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:1190:16    staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:1218:11    staticcheck  SA1019: monitoringpb.ListMetricDescriptorsRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:1220:11    staticcheck  SA1019: monitoringpb.ListTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:13:15      staticcheck  SA1019: "google.golang.org/genproto/googleapis/monitoring/v3" is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb. Please read https://github.com/googleapis/google-cloud-go/blob/main/migration.md for more details. 
plugins/inputs/stackdriver/stackdriver_test.go:145:6      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:146:17     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:151:14     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:178:6      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:179:17     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:184:14     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:211:6      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:212:17     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:217:14     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:244:6      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:245:17     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:250:14     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:27:56      staticcheck  SA1019: monitoringpb.ListMetricDescriptorsRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:277:6      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:278:17     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:283:14     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:28:56      staticcheck  SA1019: monitoringpb.ListTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:309:17     staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:321:16     staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:323:18     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:328:15     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:356:6      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:357:17     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:362:14     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:37:7       staticcheck  SA1019: monitoringpb.ListMetricDescriptorsRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:451:6      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:452:17     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:457:14     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:48:7       staticcheck  SA1019: monitoringpb.ListTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:49:12      staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:546:6      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:547:17     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:552:14     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:629:6      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:630:17     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:635:14     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:722:61     staticcheck  SA1019: monitoringpb.ListMetricDescriptorsRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:728:54     staticcheck  SA1019: monitoringpb.ListTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:729:22     staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:769:17     staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:778:19     staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:77:9       staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:780:7      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:781:18     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:78:4       staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:786:15     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:79:10      staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:795:7      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:796:18     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:801:15     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:810:7      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:811:18     staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:816:15     staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:844:60     staticcheck  SA1019: monitoringpb.ListMetricDescriptorsRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:850:53     staticcheck  SA1019: monitoringpb.ListTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:851:23     staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:87:17      staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/inputs/stackdriver/stackdriver_test.go:97:15      staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache.go:10:8         staticcheck  SA1019: "google.golang.org/genproto/googleapis/monitoring/v3" is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb. Please read https://github.com/googleapis/google-cloud-go/blob/main/migration.md for more details. 
plugins/outputs/stackdriver/counter_cache.go:23:13        staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache.go:45:57        staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache.go:81:34        staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache_test.go:109:12  staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache_test.go:121:11  staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache_test.go:144:11  staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache_test.go:15:12   staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache_test.go:30:12   staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache_test.go:42:11   staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache_test.go:69:12   staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache_test.go:81:11   staticcheck  SA1019: monpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/counter_cache_test.go:9:8     staticcheck  SA1019: "google.golang.org/genproto/googleapis/monitoring/v3" is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb. Please read https://github.com/googleapis/google-cloud-go/blob/main/migration.md for more details. 
plugins/outputs/stackdriver/stackdriver.go:113:38         staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:115:76         staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:167:18         staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:17:15          staticcheck  SA1019: "google.golang.org/genproto/googleapis/monitoring/v3" is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb. Please read https://github.com/googleapis/google-cloud-go/blob/main/migration.md for more details. 
plugins/outputs/stackdriver/stackdriver.go:173:19         staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:183:16         staticcheck  SA1019: monitoringpb.Point is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:201:25         staticcheck  SA1019: monitoringpb.TimeSeries is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:218:25         staticcheck  SA1019: monitoringpb.CreateTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:242:9          staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:262:5          staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:265:11         staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:269:11         staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:295:52         staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:299:12         staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:305:11         staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:311:11         staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:317:11         staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver.go:323:11         staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:109:34    staticcheck  SA1019: monitoringpb.CreateTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:141:34    staticcheck  SA1019: monitoringpb.CreateTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:18:15     staticcheck  SA1019: "google.golang.org/genproto/googleapis/monitoring/v3" is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb. Please read https://github.com/googleapis/google-cloud-go/blob/main/migration.md for more details. 
plugins/outputs/stackdriver/stackdriver_test.go:189:34    staticcheck  SA1019: monitoringpb.CreateTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:193:43    staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:198:40    staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:204:33    staticcheck  SA1019: monitoringpb.CreateTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:208:43    staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:213:40    staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:320:34    staticcheck  SA1019: monitoringpb.CreateTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:324:43    staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:329:40    staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:337:43    staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:342:40    staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:350:43    staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:355:40    staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:363:43    staticcheck  SA1019: monitoringpb.TimeInterval is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:368:40    staticcheck  SA1019: monitoringpb.TypedValue is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:51:71     staticcheck  SA1019: monitoringpb.CreateTimeSeriesRequest is deprecated: Please use types in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 
plugins/outputs/stackdriver/stackdriver_test.go:65:2      staticcheck  SA1019: monitoringpb.RegisterMetricServiceServer is deprecated: Please use funcs in: cloud.google.com/go/monitoring/apiv3/v2/monitoringpb 

```