### PR TITLE
chore: Fix linter findings for nolintlint (part1)

### DIFF
--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -182,7 +182,6 @@ func GetIndex(mibPrefix string, node gosmi.SmiNode) (col []string, tagOids map[s
 
 	// mimcks grabbing INDEX {} that is returned from snmptranslate -Td MibName
 	for _, index := range node.GetIndex() {
-		//nolint:staticcheck //assaignment to nil map to keep backwards compatibilty
 		tagOids[mibPrefix+index.Name] = struct{}{}
 	}
 
@@ -247,8 +246,7 @@ func SnmpTranslateCall(oid string) (mibName string, oidNum string, oidText strin
 		out, err = gosmi.GetNodeByOID(types.OidMustFromString(oid))
 		oidNum = oid
 		// ensure modules are loaded or node will be empty (might not error)
-		// do not return the err as the oid is numeric and telegraf can continue
-		//nolint:nilerr
+		//nolint:nilerr // do not return the err as the oid is numeric and telegraf can continue
 		if err != nil || out.Name == "iso" {
 			return oid, oid, oid, oid, out, nil
 		}

--- a/metric.go
+++ b/metric.go
@@ -32,7 +32,8 @@ type Field struct {
 // Metric is the type of data that is processed by Telegraf.  Input plugins,
 // and to a lesser degree, Processor and Aggregator plugins create new Metrics
 // and Output plugins write them.
-// nolint:interfacebloat // conditionally allow to contain more methods
+//
+//nolint:interfacebloat // conditionally allow to contain more methods
 type Metric interface {
 	// Name is the primary identifier for the Metric and corresponds to the
 	// measurement in the InfluxDB data model.

--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -206,7 +206,6 @@ func (o *OpcUAClient) Disconnect(ctx context.Context) error {
 	case "opc.tcp":
 		o.State = Disconnected
 		// We can't do anything about failing to close a connection
-		//nolint:errcheck,revive
 		err := o.Client.CloseWithContext(ctx)
 		o.Client = nil
 		return err

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -198,19 +198,11 @@ func newMP(n *NodeMetricMapping) metricParts {
 	var sb strings.Builder
 	for i, key := range keys {
 		if i != 0 {
-			// Writes to a string-builder will always succeed
-			//nolint:errcheck,revive
-			sb.WriteString(", ")
+			sb.WriteString(", ") //nolint:revive // writes to a string-builder will always succeed
 		}
-		// Writes to a string-builder will always succeed
-		//nolint:errcheck,revive
-		sb.WriteString(key)
-		// Writes to a string-builder will always succeed
-		//nolint:errcheck,revive
-		sb.WriteString("=")
-		// Writes to a string-builder will always succeed
-		//nolint:errcheck,revive
-		sb.WriteString(n.MetricTags[key])
+		sb.WriteString(key)               //nolint:revive // writes to a string-builder will always succeed
+		sb.WriteString("=")               //nolint:revive // writes to a string-builder will always succeed
+		sb.WriteString(n.MetricTags[key]) //nolint:revive // writes to a string-builder will always succeed
 	}
 	x := metricParts{
 		metricName: n.metricName,

--- a/plugins/inputs/burrow/burrow_test.go
+++ b/plugins/inputs/burrow/burrow_test.go
@@ -37,9 +37,7 @@ func getHTTPServer() *httptest.Server {
 		body, code := getResponseJSON(r.RequestURI)
 		w.WriteHeader(code)
 		w.Header().Set("Content-Type", "application/json")
-		// Ignore the returned error as the test will fail anyway
-		//nolint:errcheck,revive
-		w.Write(body)
+		w.Write(body) //nolint:errcheck,revive // ignore the returned error as the test will fail anyway
 	}))
 }
 
@@ -63,9 +61,7 @@ func getHTTPServerBasicAuth() *httptest.Server {
 		body, code := getResponseJSON(r.RequestURI)
 		w.WriteHeader(code)
 		w.Header().Set("Content-Type", "application/json")
-		// Ignore the returned error as the test will fail anyway
-		//nolint:errcheck,revive
-		w.Write(body)
+		w.Write(body) //nolint:errcheck,revive // ignore the returned error as the test will fail anyway
 	}))
 }
 

--- a/plugins/inputs/ceph/ceph.go
+++ b/plugins/inputs/ceph/ceph.go
@@ -222,11 +222,9 @@ func (m *metric) name() string {
 	buf := bytes.Buffer{}
 	for i := len(m.pathStack) - 1; i >= 0; i-- {
 		if buf.Len() > 0 {
-			//nolint:errcheck,revive // should never return an error
-			buf.WriteString(".")
+			buf.WriteString(".") //nolint:revive // should never return an error
 		}
-		//nolint:errcheck,revive // should never return an error
-		buf.WriteString(m.pathStack[i])
+		buf.WriteString(m.pathStack[i]) //nolint:revive // should never return an error
 	}
 	return buf.String()
 }

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -177,8 +177,7 @@ func (c *CiscoTelemetryMDT) Start(acc telegraf.Accumulator) error {
 		var opts []grpc.ServerOption
 		tlsConfig, err := c.ServerConfig.TLSConfig()
 		if err != nil {
-			//nolint:errcheck,revive // we cannot do anything if the closing fails
-			c.listener.Close()
+			c.listener.Close() //nolint:revive // we cannot do anything if the closing fails
 			return err
 		} else if tlsConfig != nil {
 			opts = append(opts, grpc.Creds(credentials.NewTLS(tlsConfig)))
@@ -209,8 +208,7 @@ func (c *CiscoTelemetryMDT) Start(acc telegraf.Accumulator) error {
 		}()
 
 	default:
-		//nolint:errcheck,revive // we cannot do anything if the closing fails
-		c.listener.Close()
+		c.listener.Close() //nolint:revive // we cannot do anything if the closing fails
 		return fmt.Errorf("invalid Cisco MDT transport: %s", c.Transport)
 	}
 
@@ -695,12 +693,10 @@ func (c *CiscoTelemetryMDT) Address() net.Addr {
 func (c *CiscoTelemetryMDT) Stop() {
 	if c.grpcServer != nil {
 		// Stop server and terminate all running dialout routines
-		//nolint:errcheck,revive // we cannot do anything if the stopping fails
 		c.grpcServer.Stop()
 	}
 	if c.listener != nil {
-		//nolint:errcheck,revive // we cannot do anything if the closing fails
-		c.listener.Close()
+		c.listener.Close() //nolint:revive // we cannot do anything if the closing fails
 	}
 	c.wg.Wait()
 }

--- a/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
@@ -194,8 +194,7 @@ func TestServeHTTP(t *testing.T) {
 			defer wg.Done()
 			for m := range d {
 				ro.AddMetric(m)
-				//nolint:errcheck,revive // test will fail anyway if the write fails
-				ro.Write()
+				ro.Write() //nolint:errcheck // test will fail anyway if the write fails
 			}
 		}(dst)
 

--- a/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
+++ b/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
@@ -392,9 +392,7 @@ func (cms *CloudWatchMetricStreams) authenticateIfSet(handler http.HandlerFunc, 
 // Stop cleans up all resources
 func (cms *CloudWatchMetricStreams) Stop() {
 	if cms.listener != nil {
-		// Ignore the returned error as we cannot do anything about it anyway
-		//nolint:errcheck,revive
-		cms.listener.Close()
+		cms.listener.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 	}
 	cms.wg.Wait()
 }

--- a/plugins/inputs/dcos/client.go
+++ b/plugins/inputs/dcos/client.go
@@ -292,8 +292,7 @@ func (c *ClusterClient) doGet(ctx context.Context, address string, v interface{}
 		return err
 	}
 	defer func() {
-		//nolint:errcheck,revive // we cannot do anything if the closing fails
-		resp.Body.Close()
+		resp.Body.Close() //nolint:revive // we cannot do anything if the closing fails
 		<-c.semaphore
 	}()
 

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -81,8 +81,7 @@ func (monitor *DirectoryMonitor) Gather(_ telegraf.Accumulator) error {
 
 		stat, err := times.Stat(path)
 		if err != nil {
-			// Don't stop traversing if there is an eror
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // don't stop traversing if there is an error
 		}
 
 		timeThresholdExceeded := time.Since(stat.AccessTime()) >= time.Duration(monitor.DirectoryDurationThreshold)
@@ -105,7 +104,6 @@ func (monitor *DirectoryMonitor) Gather(_ telegraf.Accumulator) error {
 			})
 		// We've been cancelled via Stop().
 		if err == io.EOF {
-			//nolint:nilerr // context cancelation is not an error
 			return nil
 		}
 		if err != nil {
@@ -126,7 +124,6 @@ func (monitor *DirectoryMonitor) Gather(_ telegraf.Accumulator) error {
 			err := processFile(path)
 			// We've been cancelled via Stop().
 			if err == io.EOF {
-				//nolint:nilerr // context cancelation is not an error
 				return nil
 			}
 		}

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -83,13 +83,10 @@ func (d *DiskIO) diskInfo(devName string) (map[string]string, error) {
 		}
 		if l[:2] == "S:" {
 			if devlinks.Len() > 0 {
-				//nolint:errcheck,revive // this will never fail
-				devlinks.WriteString(" ")
+				devlinks.WriteString(" ") //nolint:revive // this will never fail
 			}
-			//nolint:errcheck,revive // this will never fail
-			devlinks.WriteString("/dev/")
-			//nolint:errcheck,revive // this will never fail
-			devlinks.WriteString(l[2:])
+			devlinks.WriteString("/dev/") //nolint:revive // this will never fail
+			devlinks.WriteString(l[2:])   //nolint:revive // this will never fail
 			continue
 		}
 		if l[:2] != "E:" {

--- a/plugins/inputs/diskio/diskio_linux_test.go
+++ b/plugins/inputs/diskio/diskio_linux_test.go
@@ -37,8 +37,7 @@ func setupNullDisk(t *testing.T, s *DiskIO, devName string) func() {
 
 	cleanFunc := func() {
 		ic.udevDataPath = origUdevPath
-		//nolint:errcheck,revive // we cannot do anything if file cannot be removed
-		os.Remove(td.Name())
+		os.Remove(td.Name()) //nolint:revive // we cannot do anything if file cannot be removed
 	}
 
 	ic.udevDataPath = td.Name()

--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -360,12 +360,9 @@ func tailMultiplexed(
 	}()
 
 	_, err := stdcopy.StdCopy(outWriter, errWriter, src)
-	//nolint:errcheck,revive // we cannot do anything if the closing fails
-	outWriter.Close()
-	//nolint:errcheck,revive // we cannot do anything if the closing fails
-	errWriter.Close()
-	//nolint:errcheck,revive // we cannot do anything if the closing fails
-	src.Close()
+	outWriter.Close() //nolint:revive // we cannot do anything if the closing fails
+	errWriter.Close() //nolint:revive // we cannot do anything if the closing fails
+	src.Close()       //nolint:revive // we cannot do anything if the closing fails
 	wg.Wait()
 	return err
 }

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -110,8 +110,7 @@ func (c CommandRunner) truncate(buf bytes.Buffer) bytes.Buffer {
 		buf.Truncate(i)
 	}
 	if didTruncate {
-		//nolint:errcheck,revive // Will always return nil or panic
-		buf.WriteString("...")
+		buf.WriteString("...") //nolint:revive // will always return nil or panic
 	}
 	return buf
 }

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -136,8 +136,7 @@ func (h *HTTPListenerV2) createHTTPServer() *http.Server {
 // Stop cleans up all resources
 func (h *HTTPListenerV2) Stop() {
 	if h.listener != nil {
-		//nolint:revive // ignore the returned error as we cannot do anything about it anyway
-		h.listener.Close()
+		h.listener.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 	}
 	h.wg.Wait()
 }

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -136,8 +136,7 @@ func (h *HTTPListenerV2) createHTTPServer() *http.Server {
 // Stop cleans up all resources
 func (h *HTTPListenerV2) Stop() {
 	if h.listener != nil {
-		// Ignore the returned error as we cannot do anything about it anyway
-		//nolint:errcheck,revive
+		//nolint:revive // ignore the returned error as we cannot do anything about it anyway
 		h.listener.Close()
 	}
 	h.wg.Wait()

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -99,8 +99,7 @@ func setUpTestMux() http.Handler {
 		fmt.Fprintf(w, "hit the good page!")
 	})
 	mux.HandleFunc("/invalidUTF8", func(w http.ResponseWriter, req *http.Request) {
-		//nolint:errcheck,revive
-		w.Write([]byte{0xff, 0xfe, 0xfd})
+		w.Write([]byte{0xff, 0xfe, 0xfd}) //nolint:errcheck,revive // ignore the returned error as the test will fail anyway
 	})
 	mux.HandleFunc("/noheader", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "hit the good page!")
@@ -120,8 +119,7 @@ func setUpTestMux() http.Handler {
 	})
 	mux.HandleFunc("/musthaveabody", func(w http.ResponseWriter, req *http.Request) {
 		body, err := io.ReadAll(req.Body)
-		//nolint:errcheck,revive
-		req.Body.Close()
+		defer req.Body.Close()
 		if err != nil {
 			http.Error(w, "couldn't read request body", http.StatusBadRequest)
 			return

--- a/plugins/inputs/jenkins/client.go
+++ b/plugins/inputs/jenkins/client.go
@@ -69,9 +69,7 @@ func (c *client) doGet(ctx context.Context, url string, v interface{}) error {
 		return err
 	}
 	defer func() {
-		// Ignore the returned error as we cannot do anything about it anyway
-		//nolint:errcheck,revive
-		resp.Body.Close()
+		resp.Body.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 		<-c.semaphore
 	}()
 	// Clear invalid token if unauthorized

--- a/plugins/inputs/jenkins/jenkins_test.go
+++ b/plugins/inputs/jenkins/jenkins_test.go
@@ -98,8 +98,7 @@ func (h mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//nolint:errcheck,revive // ignore the returned error as the tests will fail anyway
-	w.Write(b)
+	w.Write(b) //nolint:errcheck,revive // ignore the returned error as the tests will fail anyway
 }
 
 func TestGatherNodeData(t *testing.T) {

--- a/plugins/inputs/jenkins/jenkins_test.go
+++ b/plugins/inputs/jenkins/jenkins_test.go
@@ -97,8 +97,8 @@ func (h mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	// Ignore the returned error as the tests will fail anyway
-	//nolint:errcheck,revive
+
+	//nolint:errcheck,revive // ignore the returned error as the tests will fail anyway
 	w.Write(b)
 }
 

--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go
@@ -225,9 +225,7 @@ func TestMain(m *testing.M) {
 	grpcServer := grpc.NewServer(opts...)
 	telemetry.RegisterOpenConfigTelemetryServer(grpcServer, newServer())
 	go func() {
-		// Ignore the returned error as the tests will fail anyway
-		//nolint:errcheck,revive
-		grpcServer.Serve(lis)
+		grpcServer.Serve(lis) //nolint:errcheck // ignore the returned error as the tests will fail anyway
 	}()
 	defer grpcServer.Stop()
 	os.Exit(m.Run())


### PR DESCRIPTION
Address findings for [nolintlint](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint/) - Finds ill-formed or insufficiently explained `//nolint` directives.

It is only part of the bigger job.
After all findings in whole project are handled, we can enable `nolintlint` linter to guard this.

Following findings were fixed:
```
internal/snmp/translate.go:251:3                                                nolintlint  directive `//nolint:nilerr` should provide explanation such as `//nolint:nilerr // this is why`
metric.go:35:1                                                                  nolintlint  directive `// nolint:interfacebloat // conditionally allow to contain more methods` should be written without leading space as `//nolint:interfacebloat // conditionally allow to contain more methods`
plugins/common/opcua/client.go:209:3                                            nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/common/opcua/client.go:209:3                                            nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/common/opcua/client.go:209:3                                            nolintlint  directive `//nolint:errcheck,revive` is unused for linter "revive"
plugins/common/opcua/input/input_client.go:202:4                                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/common/opcua/input/input_client.go:202:4                                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/common/opcua/input/input_client.go:206:3                                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/common/opcua/input/input_client.go:206:3                                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/common/opcua/input/input_client.go:209:3                                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/common/opcua/input/input_client.go:209:3                                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/common/opcua/input/input_client.go:212:3                                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/common/opcua/input/input_client.go:212:3                                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/burrow/burrow_test.go:41:3                                       nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/burrow/burrow_test.go:67:3                                       nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/ceph/ceph.go:225:4                                               nolintlint  directive `//nolint:errcheck,revive // should never return an error` is unused for linter "errcheck"
plugins/inputs/ceph/ceph.go:228:3                                               nolintlint  directive `//nolint:errcheck,revive // should never return an error` is unused for linter "errcheck"
plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go:180:4                 nolintlint  directive `//nolint:errcheck,revive // we cannot do anything if the closing fails` is unused for linter "errcheck"
plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go:212:3                 nolintlint  directive `//nolint:errcheck,revive // we cannot do anything if the closing fails` is unused for linter "errcheck"
plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go:698:3                 nolintlint  directive `//nolint:errcheck,revive // we cannot do anything if the stopping fails` is unused for linter "revive"
plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go:698:3                 nolintlint  directive `//nolint:errcheck,revive // we cannot do anything if the stopping fails` is unused for linter "errcheck"
plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go:702:3                 nolintlint  directive `//nolint:errcheck,revive // we cannot do anything if the closing fails` is unused for linter "errcheck"
plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go:197:5                nolintlint  directive `//nolint:errcheck,revive // test will fail anyway if the write fails` is unused for linter "revive"
plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go:396:3     nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go:396:3     nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/dcos/client.go:295:3                                             nolintlint  directive `//nolint:errcheck,revive // we cannot do anything if the closing fails` is unused for linter "errcheck"
plugins/inputs/directory_monitor/directory_monitor.go:85:15                     nolintlint  directive `//nolint:nilerr` should provide explanation such as `//nolint:nilerr // this is why`
plugins/inputs/directory_monitor/directory_monitor.go:108:4                     nolintlint  directive `//nolint:nilerr // context cancelation is not an error` is unused for linter "nilerr"
plugins/inputs/directory_monitor/directory_monitor.go:129:5                     nolintlint  directive `//nolint:nilerr // context cancelation is not an error` is unused for linter "nilerr"
plugins/inputs/diskio/diskio_linux.go:86:5                                      nolintlint  directive `//nolint:errcheck,revive // this will never fail` is unused for linter "errcheck"
plugins/inputs/diskio/diskio_linux.go:89:4                                      nolintlint  directive `//nolint:errcheck,revive // this will never fail` is unused for linter "errcheck"
plugins/inputs/diskio/diskio_linux.go:91:4                                      nolintlint  directive `//nolint:errcheck,revive // this will never fail` is unused for linter "errcheck"
plugins/inputs/diskio/diskio_linux_test.go:40:3                                 nolintlint  directive `//nolint:errcheck,revive // we cannot do anything if file cannot be removed` is unused for linter "errcheck"
plugins/inputs/docker_log/docker_log.go:363:2                                   nolintlint  directive `//nolint:errcheck,revive // we cannot do anything if the closing fails` is unused for linter "errcheck"
plugins/inputs/docker_log/docker_log.go:365:2                                   nolintlint  directive `//nolint:errcheck,revive // we cannot do anything if the closing fails` is unused for linter "errcheck"
plugins/inputs/docker_log/docker_log.go:367:2                                   nolintlint  directive `//nolint:errcheck,revive // we cannot do anything if the closing fails` is unused for linter "errcheck"
plugins/inputs/exec/exec.go:113:3                                               nolintlint  directive `//nolint:errcheck,revive // Will always return nil or panic` is unused for linter "errcheck"
plugins/inputs/http_listener_v2/http_listener_v2.go:140:3                       nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/http_listener_v2/http_listener_v2.go:140:3                       nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/http_response/http_response_test.go:102:3                        nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/http_response/http_response_test.go:123:3                        nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/http_response/http_response_test.go:123:3                        nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/jenkins/client.go:73:3                                           nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/jenkins/client.go:73:3                                           nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/jenkins/jenkins_test.go:101:2                                    nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go:229:3  nolintlint  directive `//nolint:errcheck,revive` is unused for linter "revive"
plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go:229:3  nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`

```
