### PR TITLE
chore: Fix linter findings for nolintlint (part2)

### DIFF
--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -204,9 +204,7 @@ func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 			err := k.consumer.Consume(ctx, k.Topics, handler)
 			if err != nil {
 				acc.AddError(fmt.Errorf("consume: %w", err))
-				// Ignore returned error as we cannot do anything about it anyway
-				//nolint:errcheck,revive
-				internal.SleepContext(ctx, reconnectDelay)
+				internal.SleepContext(ctx, reconnectDelay) //nolint:errcheck // ignore returned error as we cannot do anything about it anyway
 			}
 		}
 		err = k.consumer.Close()

--- a/plugins/inputs/leofs/leofs.go
+++ b/plugins/inputs/leofs/leofs.go
@@ -203,12 +203,10 @@ func (l *LeoFS) gatherServer(
 	if err := cmd.Start(); err != nil {
 		return err
 	}
-	// Ignore the returned error as we cannot do anything about it anyway
-	//nolint:errcheck,revive
-	defer internal.WaitTimeout(cmd, time.Second*5)
+	defer internal.WaitTimeout(cmd, time.Second*5) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
 	scanner := bufio.NewScanner(stdout)
 	if !scanner.Scan() {
-		return fmt.Errorf("Unable to retrieve the node name")
+		return fmt.Errorf("unable to retrieve the node name")
 	}
 	nodeName, err := retrieveTokenAfterColon(scanner.Text())
 	if err != nil {

--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -514,9 +514,7 @@ func (m *Mesos) gatherMainMetrics(u *url.URL, role Role, acc telegraf.Accumulato
 	}
 
 	data, err := io.ReadAll(resp.Body)
-	// Ignore the returned error to not shadow the initial one
-	//nolint:errcheck,revive
-	resp.Body.Close()
+	resp.Body.Close() //nolint:revive // ignore the returned error to not shadow the initial one
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/mesos/mesos_test.go
+++ b/plugins/inputs/mesos/mesos_test.go
@@ -288,9 +288,7 @@ func TestMain(m *testing.M) {
 	masterRouter.HandleFunc("/metrics/snapshot", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		// Ignore the returned error as we cannot do anything about it anyway
-		//nolint:errcheck,revive
-		json.NewEncoder(w).Encode(masterMetrics)
+		json.NewEncoder(w).Encode(masterMetrics) //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
 	})
 	masterTestServer = httptest.NewServer(masterRouter)
 
@@ -298,9 +296,7 @@ func TestMain(m *testing.M) {
 	slaveRouter.HandleFunc("/metrics/snapshot", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		// Ignore the returned error as we cannot do anything about it anyway
-		//nolint:errcheck,revive
-		json.NewEncoder(w).Encode(slaveMetrics)
+		json.NewEncoder(w).Encode(slaveMetrics) //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
 	})
 	slaveTestServer = httptest.NewServer(slaveRouter)
 

--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -119,18 +119,14 @@ func (n *NetResponse) UDPGather() (map[string]string, map[string]interface{}, er
 	// Handle error
 	if err != nil {
 		setResult(ConnectionFailed, fields, tags, n.Expect)
-		// Error encoded in result
-		//nolint:nilerr
-		return tags, fields, nil
+		return tags, fields, nil //nolint:nilerr // error encoded in result
 	}
 	// Connecting
 	conn, err := net.DialUDP("udp", nil, udpAddr)
 	// Handle error
 	if err != nil {
 		setResult(ConnectionFailed, fields, tags, n.Expect)
-		// Error encoded in result
-		//nolint:nilerr
-		return tags, fields, nil
+		return tags, fields, nil //nolint:nilerr // error encoded in result
 	}
 	defer conn.Close()
 	// Send string
@@ -151,9 +147,7 @@ func (n *NetResponse) UDPGather() (map[string]string, map[string]interface{}, er
 	// Handle error
 	if err != nil {
 		setResult(ReadFailed, fields, tags, n.Expect)
-		// Error encoded in result
-		//nolint:nilerr
-		return tags, fields, nil
+		return tags, fields, nil //nolint:nilerr // error encoded in result
 	}
 
 	// Looking for string in answer

--- a/plugins/inputs/nsq_consumer/nsq_consumer_test.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer_test.go
@@ -220,11 +220,8 @@ func (n *mockNSQD) handle(conn net.Conn) {
 	}
 
 exit:
-	// Ignore the returned error as we cannot do anything about it anyway
-	//nolint:errcheck,revive
-	n.tcpListener.Close()
-	//nolint:errcheck,revive
-	conn.Close()
+	n.tcpListener.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+	conn.Close()          //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 }
 
 func framedResponse(frameType int32, data []byte) ([]byte, error) {

--- a/plugins/inputs/passenger/passenger_test.go
+++ b/plugins/inputs/passenger/passenger_test.go
@@ -34,9 +34,7 @@ func fakePassengerStatus(stat string) (string, error) {
 }
 
 func teardown(tempFilePath string) {
-	// Ignore the returned error as we want to remove the file and ignore missing file errors
-	//nolint:errcheck,revive
-	os.Remove(tempFilePath)
+	os.Remove(tempFilePath) //nolint:revive // ignore the returned error as we want to remove the file and ignore missing file errors
 }
 
 func Test_Invalid_Passenger_Status_Cli(t *testing.T) {

--- a/plugins/inputs/phpfpm/child.go
+++ b/plugins/inputs/phpfpm/child.go
@@ -276,9 +276,7 @@ func (c *child) serveRequest(req *request, body io.ReadCloser) {
 		httpReq.Body = body
 		c.handler.ServeHTTP(r, httpReq)
 	}
-	// Ignore the returned error as we cannot do anything about it anyway
-	//nolint:errcheck,revive
-	r.Close()
+	r.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 	c.mu.Lock()
 	delete(c.requests, req.reqID)
 	c.mu.Unlock()
@@ -293,15 +291,11 @@ func (c *child) serveRequest(req *request, body io.ReadCloser) {
 	// some sort of abort request to the host, so the host
 	// can properly cut off the client sending all the data.
 	// For now just bound it a little and
-	//nolint:errcheck,revive
-	io.CopyN(io.Discard, body, 100<<20)
-	//nolint:errcheck,revive
-	body.Close()
+	io.CopyN(io.Discard, body, 100<<20) //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
+	body.Close()                        //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 
 	if !req.keepConn {
-		// Ignore the returned error as we cannot do anything about it anyway
-		//nolint:errcheck,revive
-		c.conn.Close()
+		c.conn.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 	}
 }
 
@@ -312,9 +306,7 @@ func (c *child) cleanUp() {
 		if req.pw != nil {
 			// race with call to Close in c.serveRequest doesn't matter because
 			// Pipe(Reader|Writer).Close are idempotent
-			// Ignore the returned error as we continue in the loop anyway
-			//nolint:errcheck,revive
-			req.pw.CloseWithError(ErrConnClosed)
+			req.pw.CloseWithError(ErrConnClosed) //nolint:revive // Ignore the returned error as we continue in the loop anyway
 		}
 	}
 }

--- a/plugins/inputs/phpfpm/fcgi.go
+++ b/plugins/inputs/phpfpm/fcgi.go
@@ -229,9 +229,7 @@ type bufWriter struct {
 
 func (w *bufWriter) Close() error {
 	if err := w.Writer.Flush(); err != nil {
-		// Ignore the returned error as we cannot do anything about it anyway
-		//nolint:errcheck,revive
-		w.closer.Close()
+		w.closer.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 		return err
 	}
 	return w.closer.Close()

--- a/plugins/inputs/phpfpm/phpfpm_test.go
+++ b/plugins/inputs/phpfpm/phpfpm_test.go
@@ -79,8 +79,7 @@ func TestPhpFpmGeneratesMetrics_From_Fcgi(t *testing.T) {
 	defer tcp.Close()
 
 	s := statServer{}
-	//nolint:errcheck,revive
-	go fcgi.Serve(tcp, s)
+	go fcgi.Serve(tcp, s) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
 
 	//Now we tested again above server
 	r := &phpfpm{
@@ -125,8 +124,7 @@ func TestPhpFpmGeneratesMetrics_From_Socket(t *testing.T) {
 
 	defer tcp.Close()
 	s := statServer{}
-	//nolint:errcheck,revive
-	go fcgi.Serve(tcp, s)
+	go fcgi.Serve(tcp, s) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
 
 	r := &phpfpm{
 		Urls: []string{tcp.Addr().String()},
@@ -178,10 +176,8 @@ func TestPhpFpmGeneratesMetrics_From_Multiple_Sockets_With_Glob(t *testing.T) {
 	defer tcp2.Close()
 
 	s := statServer{}
-	//nolint:errcheck,revive
-	go fcgi.Serve(tcp1, s)
-	//nolint:errcheck,revive
-	go fcgi.Serve(tcp2, s)
+	go fcgi.Serve(tcp1, s) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
+	go fcgi.Serve(tcp2, s) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
 
 	r := &phpfpm{
 		Urls: []string{"/tmp/test-fpm[\\-0-9]*.sock"},
@@ -234,8 +230,7 @@ func TestPhpFpmGeneratesMetrics_From_Socket_Custom_Status_Path(t *testing.T) {
 
 	defer tcp.Close()
 	s := statServer{}
-	//nolint:errcheck,revive
-	go fcgi.Serve(tcp, s)
+	go fcgi.Serve(tcp, s) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
 
 	r := &phpfpm{
 		Urls: []string{tcp.Addr().String() + ":custom-status-path"},

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -137,9 +137,7 @@ func (p *Service) Start(telegraf.Accumulator) (err error) {
 
 // Stop stops the services and closes any necessary channels and connections
 func (p *Service) Stop() {
-	// Ignore the returned error as we cannot do anything about it anyway
-	//nolint:errcheck,revive
-	p.DB.Close()
+	p.DB.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 }
 
 var kvMatcher, _ = regexp.Compile(`(password|sslcert|sslkey|sslmode|sslrootcert)=\S+ ?`)

--- a/plugins/inputs/powerdns/powerdns_test.go
+++ b/plugins/inputs/powerdns/powerdns_test.go
@@ -57,12 +57,8 @@ func (s statServer) serverSocket(l net.Listener) {
 
 			data := buf[:n]
 			if string(data) == "show * \n" {
-				// Ignore the returned error as we need to close the socket anyway
-				//nolint:errcheck,revive
-				c.Write([]byte(metrics))
-				// Ignore the returned error as we cannot do anything about it anyway
-				//nolint:errcheck,revive
-				c.Close()
+				c.Write([]byte(metrics)) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
+				c.Close()                //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 			}
 		}(conn)
 	}

--- a/plugins/inputs/powerdns_recursor/powerdns_recursor_test.go
+++ b/plugins/inputs/powerdns_recursor/powerdns_recursor_test.go
@@ -112,13 +112,8 @@ func TestV1PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer func() {
-			// Ignore the returned error as we need to remove the socket file anyway
-			//nolint:errcheck,revive
-			socket.Close()
-			// Ignore the returned error as we want to remove the file and ignore
-			// no-such-file errors
-			//nolint:errcheck,revive
-			os.Remove(controlSocket)
+			socket.Close()           //nolint:revive // ignore the returned error as we need to remove the socket file anyway
+			os.Remove(controlSocket) //nolint:revive // ignore the returned error as we want to remove the file and ignore no-such-file errors
 			wg.Done()
 		}()
 
@@ -126,20 +121,14 @@ func TestV1PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 			buf := make([]byte, 1024)
 			n, remote, err := socket.ReadFromUnix(buf)
 			if err != nil {
-				// Ignore the returned error as we cannot do anything about it anyway
-				//nolint:errcheck,revive
-				socket.Close()
+				socket.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 				return
 			}
 
 			data := buf[:n]
 			if string(data) == "get-all\n" {
-				// Ignore the returned error as we need to close the socket anyway
-				//nolint:errcheck,revive
-				socket.WriteToUnix([]byte(metrics), remote)
-				// Ignore the returned error as we cannot do anything about it anyway
-				//nolint:errcheck,revive
-				socket.Close()
+				socket.WriteToUnix([]byte(metrics), remote) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
+				socket.Close()                              //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 			}
 
 			time.Sleep(100 * time.Millisecond)
@@ -178,13 +167,8 @@ func TestV2PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer func() {
-			// Ignore the returned error as we need to remove the socket file anyway
-			//nolint:errcheck,revive
-			socket.Close()
-			// Ignore the returned error as we want to remove the file and ignore
-			// no-such-file errors
-			//nolint:errcheck,revive
-			os.Remove(controlSocket)
+			socket.Close()           //nolint:revive // ignore the returned error as we need to remove the socket file anyway
+			os.Remove(controlSocket) //nolint:revive // ignore the returned error as we want to remove the file and ignore no-such-file errors
 			wg.Done()
 		}()
 
@@ -192,31 +176,22 @@ func TestV2PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 			status := make([]byte, 4)
 			n, _, err := socket.ReadFromUnix(status)
 			if err != nil || n != 4 {
-				// Ignore the returned error as we cannot do anything about it anyway
-				//nolint:errcheck,revive
-				socket.Close()
+				socket.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 				return
 			}
 
 			buf := make([]byte, 1024)
 			n, remote, err := socket.ReadFromUnix(buf)
 			if err != nil {
-				// Ignore the returned error as we cannot do anything about it anyway
-				//nolint:errcheck,revive
-				socket.Close()
+				socket.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 				return
 			}
 
 			data := buf[:n]
 			if string(data) == "get-all" {
-				// Ignore the returned error as we need to close the socket anyway
-				//nolint:errcheck,revive
-				socket.WriteToUnix([]byte{0, 0, 0, 0}, remote)
-				//nolint:errcheck,revive
-				socket.WriteToUnix([]byte(metrics), remote)
-				// Ignore the returned error as we cannot do anything about it anyway
-				//nolint:errcheck,revive
-				socket.Close()
+				socket.WriteToUnix([]byte{0, 0, 0, 0}, remote) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
+				socket.WriteToUnix([]byte(metrics), remote)    //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
+				socket.Close()                                 //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 			}
 
 			time.Sleep(100 * time.Millisecond)
@@ -254,13 +229,8 @@ func TestV3PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer func() {
-			// Ignore the returned error as we need to remove the socket file anyway
-			//nolint:errcheck,revive
-			socket.Close()
-			// Ignore the returned error as we want to remove the file and ignore
-			// no-such-file errors
-			//nolint:errcheck,revive
-			os.Remove(controlSocket)
+			socket.Close()           //nolint:revive // ignore the returned error as we need to remove the socket file anyway
+			os.Remove(controlSocket) //nolint:revive // ignore the returned error as we want to remove the file and ignore no-such-file errors
 			wg.Done()
 		}()
 
@@ -288,21 +258,11 @@ func TestV3PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 			}
 
 			if string(buf) == "get-all" {
-				// Ignore the returned error as we need to close the socket anyway
-				//nolint:errcheck,revive
-				conn.Write([]byte{0, 0, 0, 0})
-
+				conn.Write([]byte{0, 0, 0, 0}) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
 				metrics := []byte(metrics)
-
-				//nolint:errcheck,revive
-				writeNativeUIntToConn(conn, uint(len(metrics)))
-
-				//nolint:errcheck,revive
-				conn.Write(metrics)
-
-				// Ignore the returned error as we cannot do anything about it anyway
-				//nolint:errcheck,revive
-				socket.Close()
+				writeNativeUIntToConn(conn, uint(len(metrics))) //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
+				conn.Write(metrics)                             //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
+				socket.Close()                                  //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 			}
 
 			time.Sleep(100 * time.Millisecond)

--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -8,7 +8,7 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 )
 
-// nolint:interfacebloat // conditionally allow to contain more methods
+//nolint:interfacebloat // conditionally allow to contain more methods
 type Process interface {
 	PID() PID
 	Tags() map[string]string

--- a/plugins/inputs/sflow/sflow.go
+++ b/plugins/inputs/sflow/sflow.go
@@ -90,9 +90,7 @@ func (s *SFlow) Gather(_ telegraf.Accumulator) error {
 
 func (s *SFlow) Stop() {
 	if s.closer != nil {
-		// Ignore the returned error as we cannot do anything about it anyway
-		//nolint:errcheck,revive
-		s.closer.Close()
+		s.closer.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
 	}
 	s.wg.Wait()
 }

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -567,7 +567,7 @@ func (m *Smart) getVendorNVMeAttributes(acc telegraf.Accumulator, devices []stri
 
 	for _, device := range nvmeDevices {
 		if contains(m.EnableExtensions, "auto-on") {
-			// nolint:revive // one case switch on purpose to demonstrate potential extensions
+			//nolint:revive // one case switch on purpose to demonstrate potential extensions
 			switch device.vendorID {
 			case intelVID:
 				wg.Add(1)

--- a/plugins/inputs/snmp/gosmi.go
+++ b/plugins/inputs/snmp/gosmi.go
@@ -34,13 +34,13 @@ type gosmiSnmpTranslateCache struct {
 var gosmiSnmpTranslateCachesLock sync.Mutex
 var gosmiSnmpTranslateCaches map[string]gosmiSnmpTranslateCache
 
-//nolint:revive
-func (g *gosmiTranslator) SnmpTranslate(oid string) (string, string, string, string, error) {
-	a, b, c, d, _, e := g.SnmpTranslateFull(oid)
-	return a, b, c, d, e
+//nolint:revive //function-result-limit conditionally 5 return results allowed
+func (g *gosmiTranslator) SnmpTranslate(oid string) (mibName string, oidNum string, oidText string, conversion string, err error) {
+	mibName, oidNum, oidText, conversion, _, err = g.SnmpTranslateFull(oid)
+	return mibName, oidNum, oidText, conversion, err
 }
 
-//nolint:revive
+//nolint:revive //function-result-limit conditionally 6 return results allowed
 func (g *gosmiTranslator) SnmpTranslateFull(oid string) (
 	mibName string, oidNum string, oidText string,
 	conversion string,

--- a/plugins/inputs/snmp/netsnmp.go
+++ b/plugins/inputs/snmp/netsnmp.go
@@ -60,7 +60,7 @@ var snmpTableCachesLock sync.Mutex
 // snmpTable resolves the given OID as a table, providing information about the
 // table and fields within.
 //
-//nolint:revive
+//nolint:revive //function-result-limit conditionally 5 return results allowed
 func (n *netsnmpTranslator) SnmpTable(oid string) (
 	mibName string, oidNum string, oidText string,
 	fields []Field,
@@ -81,7 +81,7 @@ func (n *netsnmpTranslator) SnmpTable(oid string) (
 	return stc.mibName, stc.oidNum, stc.oidText, stc.fields, stc.err
 }
 
-//nolint:revive
+//nolint:revive //function-result-limit conditionally 5 return results allowed
 func (n *netsnmpTranslator) snmpTableCall(oid string) (
 	mibName string, oidNum string, oidText string,
 	fields []Field,
@@ -157,7 +157,7 @@ var snmpTranslateCaches map[string]snmpTranslateCache
 
 // snmpTranslate resolves the given OID.
 //
-//nolint:revive
+//nolint:revive //function-result-limit conditionally 5 return results allowed
 func (n *netsnmpTranslator) SnmpTranslate(oid string) (
 	mibName string, oidNum string, oidText string,
 	conversion string,
@@ -187,7 +187,7 @@ func (n *netsnmpTranslator) SnmpTranslate(oid string) (
 	return stc.mibName, stc.oidNum, stc.oidText, stc.conversion, stc.err
 }
 
-//nolint:revive
+//nolint:revive //function-result-limit conditionally 5 return results allowed
 func snmpTranslateCall(oid string) (mibName string, oidNum string, oidText string, conversion string, err error) {
 	var out []byte
 	if strings.ContainsAny(oid, ":abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") {

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -53,7 +53,7 @@ type SnmpTrap struct {
 
 	Log telegraf.Logger `toml:"-"`
 
-	translator translator //nolint:revive
+	transl translator
 }
 
 func (*SnmpTrap) SampleConfig() string {
@@ -84,12 +84,12 @@ func (s *SnmpTrap) Init() error {
 	var err error
 	switch s.Translator {
 	case "gosmi":
-		s.translator, err = newGosmiTranslator(s.Path, s.Log)
+		s.transl, err = newGosmiTranslator(s.Path, s.Log)
 		if err != nil {
 			return err
 		}
 	case "netsnmp":
-		s.translator = newNetsnmpTranslator(s.Timeout)
+		s.transl = newNetsnmpTranslator(s.Timeout)
 	default:
 		return fmt.Errorf("invalid translator value")
 	}
@@ -253,7 +253,7 @@ func makeTrapHandler(s *SnmpTrap) gosnmp.TrapHandlerFunc {
 			}
 
 			if trapOid != "" {
-				e, err := s.translator.lookup(trapOid)
+				e, err := s.transl.lookup(trapOid)
 				if err != nil {
 					s.Log.Errorf("Error resolving V1 OID, oid=%s, source=%s: %v", trapOid, tags["source"], err)
 					return
@@ -291,7 +291,7 @@ func makeTrapHandler(s *SnmpTrap) gosnmp.TrapHandlerFunc {
 
 				var e snmp.MibEntry
 				var err error
-				e, err = s.translator.lookup(val)
+				e, err = s.transl.lookup(val)
 				if nil != err {
 					s.Log.Errorf("Error resolving value OID, oid=%s, source=%s: %v", val, tags["source"], err)
 					return
@@ -309,7 +309,7 @@ func makeTrapHandler(s *SnmpTrap) gosnmp.TrapHandlerFunc {
 				value = v.Value
 			}
 
-			e, err := s.translator.lookup(v.Name)
+			e, err := s.transl.lookup(v.Name)
 			if nil != err {
 				s.Log.Errorf("Error resolving OID oid=%s, source=%s: %v", v.Name, tags["source"], err)
 				return

--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -1286,7 +1286,7 @@ func TestReceiveTrap(t *testing.T) {
 			require.NoError(t, s.Init())
 
 			//inject test translator
-			s.translator = newTestTranslator(tt.entries)
+			s.transl = newTestTranslator(tt.entries)
 
 			var acc testutil.Accumulator
 			require.NoError(t, s.Start(&acc))


### PR DESCRIPTION
Address findings for [nolintlint](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint/) - Finds ill-formed or insufficiently explained `//nolint` directives.

It is only part of the bigger job.
After all findings in whole project are handled, we can enable `nolintlint` linter to guard this.

Following findings were fixed:
```
plugins/inputs/kafka_consumer/kafka_consumer.go:208:5                           nolintlint  directive `//nolint:errcheck,revive` is unused for linter "revive"
plugins/inputs/kafka_consumer/kafka_consumer.go:208:5                           nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/leofs/leofs.go:207:2                                             nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/leofs/leofs.go:207:2                                             nolintlint  directive `//nolint:errcheck,revive` is unused for linter "revive"
plugins/inputs/mesos/mesos.go:518:2                                             nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/mesos/mesos.go:518:2                                             nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/mesos/mesos_test.go:292:3                                        nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/mesos/mesos_test.go:302:3                                        nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/mongodb/mongodb.go:112:18                                        nolintlint  directive `//nolint:revive` should provide explanation such as `//nolint:revive // this is why`
plugins/inputs/net_response/net_response.go:123:3                               nolintlint  directive `//nolint:nilerr` should provide explanation such as `//nolint:nilerr // this is why`
plugins/inputs/net_response/net_response.go:132:3                               nolintlint  directive `//nolint:nilerr` should provide explanation such as `//nolint:nilerr // this is why`
plugins/inputs/net_response/net_response.go:155:3                               nolintlint  directive `//nolint:nilerr` should provide explanation such as `//nolint:nilerr // this is why`
plugins/inputs/nsq_consumer/nsq_consumer_test.go:224:2                          nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/nsq_consumer/nsq_consumer_test.go:224:2                          nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/nsq_consumer/nsq_consumer_test.go:226:2                          nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/nsq_consumer/nsq_consumer_test.go:226:2                          nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/passenger/passenger_test.go:38:2                                 nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/passenger/passenger_test.go:38:2                                 nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/child.go:280:2                                            nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/child.go:280:2                                            nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/phpfpm/child.go:296:2                                            nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/child.go:298:2                                            nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/phpfpm/child.go:298:2                                            nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/child.go:303:3                                            nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/phpfpm/child.go:303:3                                            nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/child.go:316:4                                            nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/phpfpm/child.go:316:4                                            nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/fcgi.go:233:3                                             nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/phpfpm/fcgi.go:233:3                                             nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/phpfpm_test.go:82:2                                       nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/phpfpm_test.go:82:2                                       nolintlint  directive `//nolint:errcheck,revive` is unused for linter "revive"
plugins/inputs/phpfpm/phpfpm_test.go:128:2                                      nolintlint  directive `//nolint:errcheck,revive` is unused for linter "revive"
plugins/inputs/phpfpm/phpfpm_test.go:128:2                                      nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/phpfpm_test.go:181:2                                      nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/phpfpm_test.go:181:2                                      nolintlint  directive `//nolint:errcheck,revive` is unused for linter "revive"
plugins/inputs/phpfpm/phpfpm_test.go:183:2                                      nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/phpfpm_test.go:183:2                                      nolintlint  directive `//nolint:errcheck,revive` is unused for linter "revive"
plugins/inputs/phpfpm/phpfpm_test.go:237:2                                      nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/phpfpm/phpfpm_test.go:237:2                                      nolintlint  directive `//nolint:errcheck,revive` is unused for linter "revive"
plugins/inputs/postgresql/service.go:141:2                                      nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/postgresql/service.go:141:2                                      nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns/powerdns_test.go:61:5                                   nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns/powerdns_test.go:64:5                                   nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns/powerdns_test.go:64:5                                   nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:116:4                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:116:4                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:120:4                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:120:4                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:130:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:130:5                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:138:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:141:5                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:141:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:182:4                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:182:4                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:186:4                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:186:4                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:196:5                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:196:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:205:5                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:205:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:213:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:215:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:218:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:218:5                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:258:4                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:258:4                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:262:4                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:262:4                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:292:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:297:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:300:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:304:5                nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/powerdns_recursor/powerdns_recursor_test.go:304:5                nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/procstat/process.go:11:1                                         nolintlint  directive `// nolint:interfacebloat // conditionally allow to contain more methods` should be written without leading space as `//nolint:interfacebloat // conditionally allow to contain more methods`
plugins/inputs/sflow/sflow.go:94:3                                              nolintlint  directive `//nolint:errcheck,revive` is unused for linter "errcheck"
plugins/inputs/sflow/sflow.go:94:3                                              nolintlint  directive `//nolint:errcheck,revive` should provide explanation such as `//nolint:errcheck,revive // this is why`
plugins/inputs/smart/smart.go:570:4                                             nolintlint  directive `// nolint:revive // one case switch on purpose to demonstrate potential extensions` should be written without leading space as `//nolint:revive // one case switch on purpose to demonstrate potential extensions`
plugins/inputs/snmp/gosmi.go:37:1                                               nolintlint  directive `//nolint:revive` should provide explanation such as `//nolint:revive // this is why`
plugins/inputs/snmp/gosmi.go:43:1                                               nolintlint  directive `//nolint:revive` should provide explanation such as `//nolint:revive // this is why`
plugins/inputs/snmp/netsnmp.go:63:1                                             nolintlint  directive `//nolint:revive` should provide explanation such as `//nolint:revive // this is why`
plugins/inputs/snmp/netsnmp.go:84:1                                             nolintlint  directive `//nolint:revive` should provide explanation such as `//nolint:revive // this is why`
plugins/inputs/snmp/netsnmp.go:160:1                                            nolintlint  directive `//nolint:revive` should provide explanation such as `//nolint:revive // this is why`
plugins/inputs/snmp/netsnmp.go:190:1                                            nolintlint  directive `//nolint:revive` should provide explanation such as `//nolint:revive // this is why`
plugins/inputs/snmp_trap/snmp_trap.go:56:24                                     nolintlint  directive `//nolint:revive` should provide explanation such as `//nolint:revive // this is why`
```