### PR TITLE
fix(json_v2): In case of invalid json, log messsage to debug log

### DIFF
--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -80,6 +80,7 @@ func (p *Parser) Parse(input []byte) ([]telegraf.Metric, error) {
 
 	// Only valid JSON is supported
 	if !gjson.Valid(string(input)) {
+		p.Log.Debugf("Message: %s", input)
 		return nil, fmt.Errorf("invalid JSON provided, unable to parse")
 	}
 

--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -80,7 +80,7 @@ func (p *Parser) Parse(input []byte) ([]telegraf.Metric, error) {
 
 	// Only valid JSON is supported
 	if !gjson.Valid(string(input)) {
-		return nil, fmt.Errorf("invalid JSON provided, unable to parse: %s", input)
+		return nil, fmt.Errorf("invalid JSON provided, unable to parse: %s", string(input))
 	}
 
 	var metrics []telegraf.Metric

--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -80,8 +80,7 @@ func (p *Parser) Parse(input []byte) ([]telegraf.Metric, error) {
 
 	// Only valid JSON is supported
 	if !gjson.Valid(string(input)) {
-		p.Log.Debugf("Message: %s", input)
-		return nil, fmt.Errorf("invalid JSON provided, unable to parse")
+		return nil, fmt.Errorf("invalid JSON provided, unable to parse: %s", input)
 	}
 
 	var metrics []telegraf.Metric


### PR DESCRIPTION
Currently the log only says "Error in plugin: invalid JSON provided, unable to parse". 
Most other error cases in this parser already emit the message to debug log, use the same pattern for this error case as well

# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x ] Updated associated README.md.
- [ x] Wrote appropriate unit tests.
- [ x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
