### PR TITLE
fix(agent): correctly reload files

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -111,6 +111,11 @@ func (t *Telegraf) GetSecretStore(id string) (telegraf.SecretStore, error) {
 }
 
 func (t *Telegraf) reloadLoop() error {
+	_, err := t.loadConfiguration()
+	if err != nil {
+		return err
+	}
+
 	reload := make(chan bool, 1)
 	reload <- true
 	for <-reload {


### PR DESCRIPTION
PR #12127 added the ability to reload on files in configuration directories. However, this broke any and all reloading. The PR assumed that the list of config files was initialized and set up, however, it is always empty as-is.

To populate the config files variable, the secret-store PR, #11232, added the loadConfiguraiton call. This needs to be run first before attempting to watch any files.