### PR TITLE
fix(agent): only set default snmp after reading all configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -426,6 +426,11 @@ func (c *Config) LoadAll(configFiles ...string) error {
 	sort.Stable(c.Processors)
 	sort.Stable(c.AggProcessors)
 
+	// Set snmp agent translator default
+	if c.Agent.SnmpTranslator == "" {
+		c.Agent.SnmpTranslator = "netsnmp"
+	}
+
 	// Let's link all secrets to their secret-stores
 	return c.LinkSecrets()
 }
@@ -481,10 +486,6 @@ func (c *Config) LoadConfigData(data []byte) error {
 			RemovalIn: "2.0.0",
 			Notice:    "Use 'gosmi' instead",
 		})
-	}
-	// Set snmp agent translator default
-	if c.Agent.SnmpTranslator == "" {
-		c.Agent.SnmpTranslator = "netsnmp"
 	}
 
 	if len(c.UnusedFields) > 0 {


### PR DESCRIPTION
Currently the default snmp reader is set after reading every file. This can lead to unnecessary deprecation messages that do not make sense to the user. Instead, only set the default, deprecated snmp reader after all files are read in. This way the user is only notified of the deprecation if they actually choose to use that value in their config.

fixes: #12454