### PR TITLE
fix(inputs.bond): Reset slave stats for each interface

### DIFF
--- a/plugins/inputs/bond/bond.go
+++ b/plugins/inputs/bond/bond.go
@@ -245,6 +245,9 @@ func (bond *Bond) gatherSlavePart(bondName string, rawFile string, acc telegraf.
 			fields["failures"] = count
 			if !scanPast {
 				acc.AddFields("bond_slave", fields, tags)
+				fields = map[string]interface{}{
+					"status": 0,
+				}
 			}
 		}
 		if strings.Contains(name, "Actor Churned Count") {
@@ -262,6 +265,9 @@ func (bond *Bond) gatherSlavePart(bondName string, rawFile string, acc telegraf.
 			fields["partner_churned"] = count
 			fields["total_churned"] = fields["actor_churned"].(int) + fields["partner_churned"].(int)
 			acc.AddFields("bond_slave", fields, tags)
+			fields = map[string]interface{}{
+				"status": 0,
+			}
 		}
 	}
 	tags = map[string]string{

--- a/plugins/inputs/bond/bond_test.go
+++ b/plugins/inputs/bond/bond_test.go
@@ -77,6 +77,48 @@ Actor Churned Count: 0
 Partner Churned Count: 0
 `
 
+const sampleTestLACPFirstUpSecondDown = `
+Ethernet Channel Bonding Driver: v3.7.1 (April 27, 2011)
+
+Bonding Mode: IEEE 802.3ad Dynamic link aggregation
+Transmit Hash Policy: layer2 (0)
+MII Status: up
+MII Polling Interval (ms): 100
+Up Delay (ms): 0
+Down Delay (ms): 0
+
+802.3ad info
+LACP rate: fast
+Min links: 0
+Aggregator selection policy (ad_select): stable
+
+Slave Interface: eth0
+MII Status: up
+Speed: 10000 Mbps
+Duplex: full
+Link Failure Count: 2
+Permanent HW addr: 3c:ec:ef:5e:71:58
+Slave queue ID: 0
+Aggregator ID: 2
+Actor Churn State: none
+Partner Churn State: none
+Actor Churned Count: 2
+Partner Churned Count: 0
+
+Slave Interface: eth1
+MII Status: down
+Speed: Unknown
+Duplex: Unkown
+Link Failure Count: 1
+Permanent HW addr: 3c:ec:ef:5e:71:59
+Slave queue ID: 0
+Aggregator ID: 2
+Actor Churn State: none
+Partner Churn State: none
+Actor Churned Count: 0
+Partner Churned Count: 0
+`
+
 const sampleSysMode = "802.3ad 5"
 const sampleSysSlaves = "eth0 eth1 "
 const sampleSysAdPorts = " 2 "
@@ -123,5 +165,29 @@ func TestGatherBondInterface(t *testing.T) {
 		"bond_sys",
 		map[string]interface{}{"slave_count": 2, "ad_port_count": 2},
 		map[string]string{"bond": "bondLACP", "mode": "802.3ad"},
+	)
+
+	acc = testutil.Accumulator{}
+	require.NoError(t, bond.gatherBondInterface("bondLACPUpDown", sampleTestLACPFirstUpSecondDown, &acc))
+	bond.gatherSysDetails("bondLACPUpDown", sysFiles{ModeFile: sampleSysMode, SlaveFile: sampleSysSlaves, ADPortsFile: sampleSysAdPorts}, &acc)
+	acc.AssertContainsTaggedFields(t, "bond", map[string]interface{}{"status": 1}, map[string]string{"bond": "bondLACPUpDown"})
+	acc.AssertContainsTaggedFields(
+		t,
+		"bond_slave",
+		map[string]interface{}{"failures": 2, "status": 1, "actor_churned": 2, "partner_churned": 0, "total_churned": 2},
+		map[string]string{"bond": "bondLACPUpDown", "interface": "eth0"},
+	)
+	acc.AssertContainsTaggedFields(
+		t,
+		"bond_slave",
+		map[string]interface{}{"failures": 1, "status": 0, "actor_churned": 0, "partner_churned": 0, "total_churned": 0},
+		map[string]string{"bond": "bondLACPUpDown", "interface": "eth1"},
+	)
+	acc.AssertContainsTaggedFields(t, "bond_slave", map[string]interface{}{"count": 2}, map[string]string{"bond": "bondLACPUpDown"})
+	acc.AssertContainsTaggedFields(
+		t,
+		"bond_sys",
+		map[string]interface{}{"slave_count": 2, "ad_port_count": 2},
+		map[string]string{"bond": "bondLACPUpDown", "mode": "802.3ad"},
 	)
 }


### PR DESCRIPTION
Previously the `status` value has been initialized to 0 only when starting to parse a whole bond. If any single interface in the bond is up the `status` is set to 1 for all following interfaces (even if they are down).

To fix this we reset all collected fields after each interface is finished. This should also resolve the unlikely case that some interfaces have different fields than others.

# Required for all PRs

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

---

CLA signing is still in progress
