### PR TITLE
test(inputs.snmp) skip test on widnows

### DIFF
--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -287,6 +288,10 @@ func TestGetSNMPConnection_v2(t *testing.T) {
 }
 
 func TestGetSNMPConnectionTCP(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows")
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go stubTCPServer(&wg)


### PR DESCRIPTION
In CircleCI this test is flaky and report that bind attempted to access a socket in a forbidden way. This results in a panic and a test failure. It is not consistent and seems to only happen on Windows.
