### PR TITLE
docs(inputs.socketstat): Fix wrong TOML option name.

### DIFF
--- a/plugins/inputs/socketstat/README.md
+++ b/plugins/inputs/socketstat/README.md
@@ -31,26 +31,29 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # timeout = "1s"
 ```
 
-## Measurements & Fields
+## Metrics
 
-- socketstat
-  - state (string) (for tcp, dccp and sctp protocols)
-  - If ss provides it (it depends on the protocol and ss version):
-    - bytes_acked (integer, bytes)
-    - bytes_received (integer, bytes)
-    - segs_out (integer, count)
-    - segs_in (integer, count)
-    - data_segs_out (integer, count)
-    - data_segs_in (integer, count)
+The measurements `socketstat` contains the following fields
 
-## Tags
+- state (string) (for tcp, dccp and sctp protocols)
 
-- All measurements have the following tags:
-  - proto
-  - local_addr
-  - local_port
-  - remote_addr
-  - remote_port
+If ss provides it (it depends on the protocol and ss version) it has the
+following additional fields
+
+- bytes_acked (integer, bytes)
+- bytes_received (integer, bytes)
+- segs_out (integer, count)
+- segs_in (integer, count)
+- data_segs_out (integer, count)
+- data_segs_in (integer, count)
+
+All measurements have the following tags:
+
+- proto
+- local_addr
+- local_port
+- remote_addr
+- remote_port
 
 ## Example Output
 

--- a/plugins/inputs/socketstat/README.md
+++ b/plugins/inputs/socketstat/README.md
@@ -25,7 +25,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 [[inputs.socketstat]]
   ## ss can display information about tcp, udp, raw, unix, packet, dccp and sctp sockets
   ## Specify here the types you want to gather
-  socket_types = [ "tcp", "udp" ]
+  protocols = [ "tcp", "udp" ]
+
   ## The default timeout of 1s for ss execution can be overridden here:
   # timeout = "1s"
 ```

--- a/plugins/inputs/socketstat/sample.conf
+++ b/plugins/inputs/socketstat/sample.conf
@@ -2,6 +2,7 @@
 [[inputs.socketstat]]
   ## ss can display information about tcp, udp, raw, unix, packet, dccp and sctp sockets
   ## Specify here the types you want to gather
-  socket_types = [ "tcp", "udp" ]
+  protocols = [ "tcp", "udp" ]
+
   ## The default timeout of 1s for ss execution can be overridden here:
   # timeout = "1s"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12479 

Fix the name of the option.