### PR TITLE
fix(agent): Handle float time with fractions of seconds correctly

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/alecthomas/units"
@@ -15,7 +14,7 @@ type Duration time.Duration
 type Size int64
 
 // UnmarshalTOML parses the duration from the TOML config file
-func (d *Duration) UnmarshalTOML(b []byte) error {
+func (d *Duration) UnmarshalText(b []byte) error {
 	// convert to string
 	durStr := string(b)
 
@@ -36,8 +35,6 @@ func (d *Duration) UnmarshalTOML(b []byte) error {
 	}
 
 	// Finally, try value is a TOML string (e.g. "3s", 3s) or literal (e.g. '3s')
-	durStr = strings.ReplaceAll(durStr, "'", "")
-	durStr = strings.ReplaceAll(durStr, "\"", "")
 	if durStr == "" {
 		durStr = "0s"
 	}
@@ -57,23 +54,12 @@ func (d *Duration) UnmarshalTOML(b []byte) error {
 	return nil
 }
 
-func (d *Duration) UnmarshalText(text []byte) error {
-	return d.UnmarshalTOML(text)
-}
-
-func (s *Size) UnmarshalTOML(b []byte) error {
-	var err error
+func (s *Size) UnmarshalText(b []byte) error {
 	if len(b) == 0 {
 		return nil
 	}
-	str := string(b)
-	if b[0] == '"' || b[0] == '\'' {
-		str, err = strconv.Unquote(str)
-		if err != nil {
-			return err
-		}
-	}
 
+	str := string(b)
 	val, err := strconv.ParseInt(str, 10, 64)
 	if err == nil {
 		*s = Size(val)
@@ -85,8 +71,4 @@ func (s *Size) UnmarshalTOML(b []byte) error {
 	}
 	*s = Size(val)
 	return nil
-}
-
-func (s *Size) UnmarshalText(text []byte) error {
-	return s.UnmarshalTOML(text)
 }

--- a/config/types.go
+++ b/config/types.go
@@ -30,7 +30,7 @@ func (d *Duration) UnmarshalTOML(b []byte) error {
 	// Second try parsing as float seconds
 	sF, err := strconv.ParseFloat(durStr, 64)
 	if err == nil {
-		dur := time.Second * time.Duration(sF)
+		dur := float64(time.Second) * sF
 		*d = Duration(dur)
 		return nil
 	}

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/processors/reverse_dns"
-	"github.com/stretchr/testify/require"
 )
 
 func TestConfigDuration(t *testing.T) {
@@ -35,43 +36,32 @@ func TestConfigDuration(t *testing.T) {
 func TestDuration(t *testing.T) {
 	var d config.Duration
 
-	require.NoError(t, d.UnmarshalTOML([]byte(`"1s"`)))
+	d = config.Duration(0)
+	require.NoError(t, d.UnmarshalText([]byte(`1s`)))
 	require.Equal(t, time.Second, time.Duration(d))
 
 	d = config.Duration(0)
-	require.NoError(t, d.UnmarshalTOML([]byte(`1s`)))
-	require.Equal(t, time.Second, time.Duration(d))
-
-	d = config.Duration(0)
-	require.NoError(t, d.UnmarshalTOML([]byte(`'1s'`)))
-	require.Equal(t, time.Second, time.Duration(d))
-
-	d = config.Duration(0)
-	require.NoError(t, d.UnmarshalTOML([]byte(`10`)))
+	require.NoError(t, d.UnmarshalText([]byte(`10`)))
 	require.Equal(t, 10*time.Second, time.Duration(d))
 
 	d = config.Duration(0)
-	require.NoError(t, d.UnmarshalTOML([]byte(`1.5`)))
+	require.NoError(t, d.UnmarshalText([]byte(`1.5`)))
 	require.Equal(t, 1500*time.Millisecond, time.Duration(d))
 
 	d = config.Duration(0)
-	require.NoError(t, d.UnmarshalTOML([]byte(``)))
+	require.NoError(t, d.UnmarshalText([]byte(``)))
 	require.Equal(t, 0*time.Second, time.Duration(d))
 
-	d = config.Duration(0)
-	require.NoError(t, d.UnmarshalTOML([]byte(`""`)))
-	require.Equal(t, 0*time.Second, time.Duration(d))
-
-	require.Error(t, d.UnmarshalTOML([]byte(`"1"`)))  // string missing unit
-	require.Error(t, d.UnmarshalTOML([]byte(`'2'`)))  // string missing unit
-	require.Error(t, d.UnmarshalTOML([]byte(`'ns'`))) // string missing time
-	require.Error(t, d.UnmarshalTOML([]byte(`'us'`))) // string missing time
+	require.Error(t, d.UnmarshalText([]byte(`"1"`)))  // string missing unit
+	require.Error(t, d.UnmarshalText([]byte(`'2'`)))  // string missing unit
+	require.Error(t, d.UnmarshalText([]byte(`'ns'`))) // string missing time
+	require.Error(t, d.UnmarshalText([]byte(`'us'`))) // string missing time
 }
 
 func TestSize(t *testing.T) {
 	var s config.Size
 
-	require.NoError(t, s.UnmarshalText([]byte(`"1B"`)))
+	require.NoError(t, s.UnmarshalText([]byte(`1B`)))
 	require.Equal(t, int64(1), int64(s))
 
 	s = config.Size(0)
@@ -79,15 +69,11 @@ func TestSize(t *testing.T) {
 	require.Equal(t, int64(1), int64(s))
 
 	s = config.Size(0)
-	require.NoError(t, s.UnmarshalText([]byte(`'1'`)))
-	require.Equal(t, int64(1), int64(s))
-
-	s = config.Size(0)
-	require.NoError(t, s.UnmarshalText([]byte(`"1GB"`)))
+	require.NoError(t, s.UnmarshalText([]byte(`1GB`)))
 	require.Equal(t, int64(1000*1000*1000), int64(s))
 
 	s = config.Size(0)
-	require.NoError(t, s.UnmarshalText([]byte(`"12GiB"`)))
+	require.NoError(t, s.UnmarshalText([]byte(`12GiB`)))
 	require.Equal(t, int64(12*1024*1024*1024), int64(s))
 }
 
@@ -100,6 +86,7 @@ func TestTOMLParsingStringDurations(t *testing.T) {
 		'1s',
 		"1.5s",
 		"",
+		'',
 		"2h",
 		"42m",
 		"100ms",
@@ -113,6 +100,7 @@ func TestTOMLParsingStringDurations(t *testing.T) {
 		1 * time.Second,
 		1 * time.Second,
 		1500 * time.Millisecond,
+		0,
 		0,
 		2 * time.Hour,
 		42 * time.Minute,
@@ -200,6 +188,8 @@ func TestTOMLParsingStringSizes(t *testing.T) {
 		"1B",
 		"1",
 		'1',
+		'''15kB''',
+		"""15KiB""",
 		"1GB",
 		"12GiB"
 	]
@@ -209,6 +199,8 @@ func TestTOMLParsingStringSizes(t *testing.T) {
 		1,
 		1,
 		1,
+		15 * 1000,
+		15 * 1024,
 		1000 * 1000 * 1000,
 		12 * 1024 * 1024 * 1024,
 	}

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -52,7 +52,7 @@ func TestDuration(t *testing.T) {
 
 	d = config.Duration(0)
 	require.NoError(t, d.UnmarshalTOML([]byte(`1.5`)))
-	require.Equal(t, time.Second, time.Duration(d))
+	require.Equal(t, 1500*time.Millisecond, time.Duration(d))
 
 	d = config.Duration(0)
 	require.NoError(t, d.UnmarshalTOML([]byte(``)))


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

In the course of #12490 I found an issue when specifying a duration with fractions of seconds as a plain floating point value e.g. `timeout = 1.5`, where you would expect the timeout to be 1500 milliseconds. However the current code will just floor that value to 1 second.

This PR fixes the handling of plain floating point values that contain fractions of seconds and also gets rid of the necessity for TOML quotation handling by using the `UnmarshalText` interface.