### PR TITLE
docs(inputs.influxdb): collect v2 with prometheus plugin

### DIFF
--- a/plugins/inputs/influxdb/README.md
+++ b/plugins/inputs/influxdb/README.md
@@ -63,7 +63,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   timeout = "5s"
 ```
 
-## Measurements & Fields
+## Metrics
 
 **Note:** The measurements and fields included in this plugin are dynamically
 built from the InfluxDB source, and may vary between versions:

--- a/plugins/inputs/influxdb/README.md
+++ b/plugins/inputs/influxdb/README.md
@@ -1,12 +1,28 @@
 # InfluxDB Input Plugin
 
-The InfluxDB plugin will collect metrics on the given InfluxDB servers. Read
-our [documentation][1] for detailed information about `influxdb` metrics.
+The InfluxDB plugin will collect metrics on the given InfluxDB v1 servers from
+the `/debug/vars` endpoint. Read the [documentation][1] for detailed
+information about `influxdb` metrics. For InfluxDB v2 and the `metrics`
+endpoint please see the section below.
 
 This plugin can also gather metrics from endpoints that expose
 InfluxDB-formatted endpoints. See below for more information.
 
 [1]: https://docs.influxdata.com/platform/monitoring/influxdata-platform/tools/measurements-internal/
+
+## InfluxDB v2 Metrics
+
+For [InfluxDB v2 metrics][2] are produced in Prometheus plain-text format. To
+collect metrics at the new `/metrics` endpoint, please use the Prometheus
+input plugin. This is an example to collect from a local database:
+
+```toml
+[[inputs.prometheus]]
+  urls = ["http://localhost:8086/metrics"]
+  metric_version = 1
+```
+
+[2]: https://docs.influxdata.com/influxdb/latest/reference/internals/metrics/
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 


### PR DESCRIPTION
This document how to use the existing Prometheus input plugin to collect metrics from InfluxDB v2. V1 uses a JSON document, while v2 uses a standard Prometheus text format. As such, users do not need to second plugin.

fixes: #10459