### PR TITLE
feat(inputs.influxdb): collect uptime statistics

### DIFF
--- a/plugins/inputs/influxdb/influxdb.go
+++ b/plugins/inputs/influxdb/influxdb.go
@@ -123,6 +123,12 @@ type memstats struct {
 	GCCPUFraction float64    `json:"GCCPUFraction"`
 }
 
+type system struct {
+	CurrentTime string `json:"currentTime"`
+	Started     string `json:"started"`
+	Uptime      uint64 `json:"uptime"`
+}
+
 // Gathers data from a particular URL
 // Parameters:
 //
@@ -189,6 +195,24 @@ func (i *InfluxDB) gatherURL(
 		}
 
 		if keyStr, ok := key.(string); ok {
+			if keyStr == "system" {
+				var p system
+				if err := dec.Decode(&p); err != nil {
+					continue
+				}
+
+				acc.AddFields("influxdb_system",
+					map[string]interface{}{
+						"current_time": p.CurrentTime,
+						"started":      p.Started,
+						"uptime":       p.Uptime,
+					},
+					map[string]string{
+						"url": url,
+					},
+				)
+			}
+
 			if keyStr == "memstats" {
 				var m memstats
 				if err := dec.Decode(&m); err != nil {

--- a/plugins/inputs/influxdb/influxdb_test.go
+++ b/plugins/inputs/influxdb/influxdb_test.go
@@ -82,7 +82,7 @@ func TestInfluxDB(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, acc.GatherError(plugin.Gather))
 
-	require.Len(t, acc.Metrics, 34)
+	require.Len(t, acc.Metrics, 35)
 
 	fields := map[string]interface{}{
 		"heap_inuse":      int64(18046976),
@@ -119,6 +119,13 @@ func TestInfluxDB(t *testing.T) {
 	}
 	acc.AssertContainsTaggedFields(t, "influxdb_memstats", fields, tags)
 
+	fields = map[string]interface{}{
+		"current_time": "2023-01-11T16:51:52.723166944Z",
+		"started":      "2023-01-11T16:51:23.355766023Z",
+		"uptime":       uint64(29),
+	}
+	acc.AssertContainsTaggedFields(t, "influxdb_system", fields, tags)
+
 	acc.AssertContainsTaggedFields(t, "influxdb",
 		map[string]interface{}{
 			"n_shards": 1,
@@ -147,12 +154,22 @@ func TestInfluxDB2(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, acc.GatherError(plugin.Gather))
 
-	require.Len(t, acc.Metrics, 34)
+	require.Len(t, acc.Metrics, 35)
 
 	acc.AssertContainsTaggedFields(t, "influxdb",
 		map[string]interface{}{
 			"n_shards": 1,
 		}, map[string]string{})
+
+	fields := map[string]interface{}{
+		"current_time": "2023-01-11T17:04:59.928454705Z",
+		"started":      "2023-01-11T16:51:23.355766023Z",
+		"uptime":       uint64(816),
+	}
+	tags := map[string]string{
+		"url": fakeInfluxServer.URL + "/endpoint",
+	}
+	acc.AssertContainsTaggedFields(t, "influxdb_system", fields, tags)
 }
 
 func TestErrorHandling(t *testing.T) {

--- a/plugins/inputs/influxdb/testdata/influx_return.json
+++ b/plugins/inputs/influxdb/testdata/influx_return.json
@@ -270,6 +270,11 @@
       "numSeries": 1
     }
   },
+  "system": {
+    "currentTime": "2023-01-11T16:51:52.723166944Z",
+    "started": "2023-01-11T16:51:23.355766023Z",
+    "uptime": 29
+  },
   "memstats": {
     "Alloc": 17034016,
     "TotalAlloc": 201739016,

--- a/plugins/inputs/influxdb/testdata/influx_return2.json
+++ b/plugins/inputs/influxdb/testdata/influx_return2.json
@@ -270,6 +270,11 @@
       "numSeries": 1
     }
   },
+  "system": {
+    "currentTime": "2023-01-11T17:04:59.928454705Z",
+    "started": "2023-01-11T16:51:23.355766023Z",
+    "uptime": 816
+  },
   "memstats": {
     "Alloc": 17034016,
     "TotalAlloc": 201739016,


### PR DESCRIPTION
Collect the system stats from influxdb metrics as well. These include the current time, started time, and uptime of the database.

fixes: #11071
