### PR TITLE
docs(secretstores): document systemd-nspawn requirement

### DIFF
--- a/plugins/secretstores/README.md
+++ b/plugins/secretstores/README.md
@@ -1,0 +1,6 @@
+# Secret-Stores
+
+This folder contains the plugins for the secret-store functionality:
+
+* jose: Javascript Object Signing and Encryption
+* os: Native tooling provided on Linux, MacOS, or Windows.

--- a/plugins/secretstores/os/README.md
+++ b/plugins/secretstores/os/README.md
@@ -44,6 +44,17 @@ namespaced, you should be aware of the security implication! One implication
 is for example that keys added in one container are accessible by __all__
 other containers running on the same host, not only within the same container.
 
+### systemd-nspawn
+
+The memguard dependency that Telegraf uses to secure memory for secret storage
+requires the `CAP_IPC_LOCK` capability to correctly lock memory. Without this
+capability Telegraf will panic. Users will need to start a container with the
+`--capability=CAP_IPC_LOCK` flag for telegraf to correctly work.
+
+See [github.com/awnumar/memguard#144][memguard-issue] for more information.
+
+[memguard-issue]: https://github.com/awnumar/memguard/issues/144
+
 ### Windows
 
 ```toml @sample_windows.conf


### PR DESCRIPTION
Telegraf will now panic when launched in a systemd-nspawn. This is because of the memguard dependency. It requires the CAP_IPC_LOCK capability to correctly lock and secure memory.

fixes: #12403