### PR TITLE
feat(inputs.gnmi): set max gRPC message size

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -36,7 +36,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # encoding = "proto"
 
   ## redial in case of failures after
-  redial = "10s"
+  # redial = "10s"
+
+  ## gRPC Maximum Message Size in bytes, default is 4MB.
+  # max_msg_size = 4000000
 
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = false

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -38,8 +38,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## redial in case of failures after
   # redial = "10s"
 
-  ## gRPC Maximum Message Size in bytes, default is 4MB.
-  # max_msg_size = 4000000
+  ## gRPC Maximum Message Size
+  # max_msg_size = "4MB"
 
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = false

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -52,6 +52,7 @@ type GNMI struct {
 	Subscriptions    []Subscription    `toml:"subscription"`
 	TagSubscriptions []TagSubscription `toml:"tag_subscription"`
 	Aliases          map[string]string `toml:"aliases"`
+	MaxMsgSize       int               `toml:"max_msg_size"`
 
 	// Optional subscription configuration
 	Encoding    string
@@ -298,9 +299,17 @@ func (c *GNMI) subscribeGNMI(ctx context.Context, worker *Worker, tlscfg *tls.Co
 	} else {
 		creds = insecure.NewCredentials()
 	}
-	opt := grpc.WithTransportCredentials(creds)
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+	}
 
-	client, err := grpc.DialContext(ctx, worker.address, opt)
+	if c.MaxMsgSize > 0 {
+		opts = append(opts, grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(c.MaxMsgSize),
+		))
+	}
+
+	client, err := grpc.DialContext(ctx, worker.address, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to dial: %v", err)
 	}

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -52,7 +52,7 @@ type GNMI struct {
 	Subscriptions    []Subscription    `toml:"subscription"`
 	TagSubscriptions []TagSubscription `toml:"tag_subscription"`
 	Aliases          map[string]string `toml:"aliases"`
-	MaxMsgSize       int               `toml:"max_msg_size"`
+	MaxMsgSize       config.Size       `toml:"max_msg_size"`
 
 	// Optional subscription configuration
 	Encoding    string
@@ -305,7 +305,7 @@ func (c *GNMI) subscribeGNMI(ctx context.Context, worker *Worker, tlscfg *tls.Co
 
 	if c.MaxMsgSize > 0 {
 		opts = append(opts, grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(c.MaxMsgSize),
+			grpc.MaxCallRecvMsgSize(int(c.MaxMsgSize)),
 		))
 	}
 

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -13,8 +13,8 @@
   ## redial in case of failures after
   # redial = "10s"
 
-  ## gRPC Maximum Message Size in bytes, default is 4MB.
-  # max_msg_size = 4000000
+  ## gRPC Maximum Message Size
+  # max_msg_size = "4MB"
 
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = false

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -11,7 +11,10 @@
   # encoding = "proto"
 
   ## redial in case of failures after
-  redial = "10s"
+  # redial = "10s"
+
+  ## gRPC Maximum Message Size in bytes, default is 4MB.
+  # max_msg_size = 4000000
 
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = false


### PR DESCRIPTION
Adds an option to let a user set the max gRPC message size. By default, this is set to 4MB and allows a user to receive larger messages if required by the end device.

fixes: #12463

