### PR TITLE
feat(inputs.redfish): add power control metric

### DIFF
--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -338,16 +338,17 @@ func (r *Redfish) Gather(acc telegraf.Accumulator) error {
 				tags["row"] = chassis.Location.Placement.Row
 			}
 
-			fields := make(map[string]interface{})
-			fields["power_allocated_watts"] = j.PowerAllocatedWatts
-			fields["power_available_watts"] = j.PowerAvailableWatts
-			fields["power_capacity_watts"] = j.PowerCapacityWatts
-			fields["power_consumed_watts"] = j.PowerConsumedWatts
-			fields["power_requested_watts"] = j.PowerRequestedWatts
-			fields["average_consumed_watts"] = j.PowerMetrics.AverageConsumedWatts
-			fields["interval_in_min"] = j.PowerMetrics.IntervalInMin
-			fields["max_consumed_watts"] = j.PowerMetrics.MaxConsumedWatts
-			fields["min_consumed_watts"] = j.PowerMetrics.MinConsumedWatts
+			fields := map[string]interface{}{
+				"power_allocated_watts":  j.PowerAllocatedWatts,
+				"power_available_watts":  j.PowerAvailableWatts,
+				"power_capacity_watts":   j.PowerCapacityWatts,
+				"power_consumed_watts":   j.PowerConsumedWatts,
+				"power_requested_watts":  j.PowerRequestedWatts,
+				"average_consumed_watts": j.PowerMetrics.AverageConsumedWatts,
+				"interval_in_min":        j.PowerMetrics.IntervalInMin,
+				"max_consumed_watts":     j.PowerMetrics.MaxConsumedWatts,
+				"min_consumed_watts":     j.PowerMetrics.MinConsumedWatts,
+			}
 
 			acc.AddFields("redfish_power_powercontrol", fields, tags)
 		}

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -53,6 +53,21 @@ type Chassis struct {
 }
 
 type Power struct {
+	PowerControl []struct {
+		Name                string
+		MemberID            string
+		PowerAllocatedWatts *float64
+		PowerAvailableWatts *float64
+		PowerCapacityWatts  *float64
+		PowerConsumedWatts  *float64
+		PowerRequestedWatts *float64
+		PowerMetrics        struct {
+			AverageConsumedWatts *float64
+			IntervalInMin        int
+			MaxConsumedWatts     *float64
+			MinConsumedWatts     *float64
+		}
+	}
 	PowerSupplies []struct {
 		Name                 string
 		MemberID             string
@@ -307,6 +322,33 @@ func (r *Redfish) Gather(acc telegraf.Accumulator) error {
 		power, err := r.getPower(chassis.Power.Ref)
 		if err != nil {
 			return err
+		}
+
+		for _, j := range power.PowerControl {
+			tags := map[string]string{}
+			tags["member_id"] = j.MemberID
+			tags["address"] = address
+			tags["name"] = j.Name
+			tags["source"] = system.Hostname
+			if chassis.Location != nil {
+				tags["datacenter"] = chassis.Location.PostalAddress.DataCenter
+				tags["room"] = chassis.Location.PostalAddress.Room
+				tags["rack"] = chassis.Location.Placement.Rack
+				tags["row"] = chassis.Location.Placement.Row
+			}
+
+			fields := make(map[string]interface{})
+			fields["power_allocated_watts"] = j.PowerAllocatedWatts
+			fields["power_available_watts"] = j.PowerAvailableWatts
+			fields["power_capacity_watts"] = j.PowerCapacityWatts
+			fields["power_consumed_watts"] = j.PowerConsumedWatts
+			fields["power_requested_watts"] = j.PowerRequestedWatts
+			fields["average_consumed_watts"] = j.PowerMetrics.AverageConsumedWatts
+			fields["interval_in_min"] = j.PowerMetrics.IntervalInMin
+			fields["max_consumed_watts"] = j.PowerMetrics.MaxConsumedWatts
+			fields["min_consumed_watts"] = j.PowerMetrics.MinConsumedWatts
+
+			acc.AddFields("redfish_power_powercontrol", fields, tags)
 		}
 
 		for _, j := range power.PowerSupplies {

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -325,11 +325,12 @@ func (r *Redfish) Gather(acc telegraf.Accumulator) error {
 		}
 
 		for _, j := range power.PowerControl {
-			tags := map[string]string{}
-			tags["member_id"] = j.MemberID
-			tags["address"] = address
-			tags["name"] = j.Name
-			tags["source"] = system.Hostname
+			tags := map[string]string{
+				"member_id": j.MemberID,
+				"address":   address,
+				"name":      j.Name,
+				"source":    system.Hostname,
+			}
 			if chassis.Location != nil {
 				tags["datacenter"] = chassis.Location.PostalAddress.DataCenter
 				tags["room"] = chassis.Location.PostalAddress.Room

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -403,6 +403,31 @@ func TestDellApis(t *testing.T) {
 			time.Unix(0, 0),
 		),
 		testutil.MustMetric(
+			"redfish_power_powercontrol",
+			map[string]string{
+				"source":     "tpa-hostname",
+				"name":       "System Power Control",
+				"member_id":  "PowerControl",
+				"address":    address,
+				"datacenter": "",
+				"rack":       "",
+				"room":       "",
+				"row":        "",
+			},
+			map[string]interface{}{
+				"average_consumed_watts": 426.0,
+				"interval_in_min":        int64(1),
+				"max_consumed_watts":     436.0,
+				"min_consumed_watts":     425.0,
+				"power_allocated_watts":  1628.0,
+				"power_available_watts":  0.0,
+				"power_capacity_watts":   1628.0,
+				"power_consumed_watts":   429.0,
+				"power_requested_watts":  704.0,
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric(
 			"redfish_power_powersupplies",
 			map[string]string{
 				"source":     "tpa-hostname",
@@ -604,6 +629,24 @@ func TestHPApis(t *testing.T) {
 			},
 			map[string]interface{}{
 				"reading_percent": 23,
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric(
+			"redfish_power_powercontrol",
+			map[string]string{
+				"source":    "tpa-hostname",
+				"name":      "",
+				"member_id": "0",
+				"address":   address,
+			},
+			map[string]interface{}{
+				"average_consumed_watts": 221.0,
+				"interval_in_min":        int64(20),
+				"max_consumed_watts":     252.0,
+				"min_consumed_watts":     220.0,
+				"power_capacity_watts":   1600.0,
+				"power_consumed_watts":   221.0,
 			},
 			time.Unix(0, 0),
 		),


### PR DESCRIPTION
This adds the ability to parse the power control data. This includes values like the power consumed watts as well as other metrics.

fixes: #9575