### PR TITLE
fix(inputs.prometheus): correctly track deleted pods

### DIFF
--- a/plugins/inputs/prometheus/kubernetes_test.go
+++ b/plugins/inputs/prometheus/kubernetes_test.go
@@ -178,8 +178,8 @@ func TestDeletePods(t *testing.T) {
 	p.Annotations = map[string]string{"prometheus.io/scrape": "true"}
 	registerPod(p, prom)
 
-	podId, _ := cache.MetaNamespaceKeyFunc(p)
-	unregisterPod(PodID(podId), prom)
+	podID, _ := cache.MetaNamespaceKeyFunc(p)
+	unregisterPod(PodID(podID), prom)
 	require.Equal(t, 0, len(prom.kubernetesPods))
 }
 
@@ -190,8 +190,8 @@ func TestKeepDefaultNamespaceLabelName(t *testing.T) {
 	p.Annotations = map[string]string{"prometheus.io/scrape": "true"}
 	registerPod(p, prom)
 
-	podId, _ := cache.MetaNamespaceKeyFunc(p)
-	tags := prom.kubernetesPods[PodID(podId)].Tags
+	podID, _ := cache.MetaNamespaceKeyFunc(p)
+	tags := prom.kubernetesPods[PodID(podID)].Tags
 	require.Equal(t, "default", tags["namespace"])
 }
 
@@ -202,8 +202,8 @@ func TestChangeNamespaceLabelName(t *testing.T) {
 	p.Annotations = map[string]string{"prometheus.io/scrape": "true"}
 	registerPod(p, prom)
 
-	podId, _ := cache.MetaNamespaceKeyFunc(p)
-	tags := prom.kubernetesPods[PodID(podId)].Tags
+	podID, _ := cache.MetaNamespaceKeyFunc(p)
+	tags := prom.kubernetesPods[PodID(podID)].Tags
 	require.Equal(t, "default", tags["pod_namespace"])
 	require.Equal(t, "", tags["namespace"])
 }

--- a/plugins/inputs/prometheus/kubernetes_test.go
+++ b/plugins/inputs/prometheus/kubernetes_test.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"k8s.io/client-go/tools/cache"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -153,7 +154,9 @@ func TestAddMultipleDuplicatePods(t *testing.T) {
 	registerPod(p, prom)
 	p.Name = "Pod2"
 	registerPod(p, prom)
-	require.Equal(t, 1, len(prom.kubernetesPods))
+
+	urls, _ := prom.GetAllURLs()
+	require.Equal(t, 1, len(urls))
 }
 
 func TestAddMultiplePods(t *testing.T) {
@@ -174,7 +177,9 @@ func TestDeletePods(t *testing.T) {
 	p := pod()
 	p.Annotations = map[string]string{"prometheus.io/scrape": "true"}
 	registerPod(p, prom)
-	unregisterPod(p, prom)
+
+	podId, _ := cache.MetaNamespaceKeyFunc(p)
+	unregisterPod(PodID(podId), prom)
 	require.Equal(t, 0, len(prom.kubernetesPods))
 }
 
@@ -184,7 +189,9 @@ func TestKeepDefaultNamespaceLabelName(t *testing.T) {
 	p := pod()
 	p.Annotations = map[string]string{"prometheus.io/scrape": "true"}
 	registerPod(p, prom)
-	tags := prom.kubernetesPods["http://127.0.0.1:9102/metrics"].Tags
+
+	podId, _ := cache.MetaNamespaceKeyFunc(p)
+	tags := prom.kubernetesPods[PodID(podId)].Tags
 	require.Equal(t, "default", tags["namespace"])
 }
 
@@ -194,7 +201,9 @@ func TestChangeNamespaceLabelName(t *testing.T) {
 	p := pod()
 	p.Annotations = map[string]string{"prometheus.io/scrape": "true"}
 	registerPod(p, prom)
-	tags := prom.kubernetesPods["http://127.0.0.1:9102/metrics"].Tags
+
+	podId, _ := cache.MetaNamespaceKeyFunc(p)
+	tags := prom.kubernetesPods[PodID(podId)].Tags
 	require.Equal(t, "default", tags["pod_namespace"])
 	require.Equal(t, "", tags["namespace"])
 }

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -40,6 +40,8 @@ const (
 	MonitorMethodSettingsAndAnnotations MonitorMethod = "settings+annotations"
 )
 
+type PodID string
+
 type Prometheus struct {
 	// An array of urls to scrape metrics from.
 	URLs []string `toml:"urls"`
@@ -92,7 +94,7 @@ type Prometheus struct {
 	PodNamespace          string `toml:"monitor_kubernetes_pods_namespace"`
 	PodNamespaceLabelName string `toml:"pod_namespace_label_name"`
 	lock                  sync.Mutex
-	kubernetesPods        map[string]URLAndAddress
+	kubernetesPods        map[PodID]URLAndAddress
 	cancel                context.CancelFunc
 	wg                    sync.WaitGroup
 
@@ -201,7 +203,7 @@ type URLAndAddress struct {
 }
 
 func (p *Prometheus) GetAllURLs() (map[string]URLAndAddress, error) {
-	allURLs := make(map[string]URLAndAddress)
+	allURLs := make(map[string]URLAndAddress, len(p.URLs)+len(p.consulServices)+len(p.kubernetesPods))
 	for _, u := range p.URLs {
 		address, err := url.Parse(u)
 		if err != nil {
@@ -218,8 +220,8 @@ func (p *Prometheus) GetAllURLs() (map[string]URLAndAddress, error) {
 		allURLs[k] = v
 	}
 	// loop through all pods scraped via the prometheus annotation on the pods
-	for k, v := range p.kubernetesPods {
-		allURLs[k] = v
+	for _, v := range p.kubernetesPods {
+		allURLs[v.URL.String()] = v
 	}
 
 	for _, service := range p.KubernetesServices {
@@ -452,7 +454,7 @@ func init() {
 	inputs.Add("prometheus", func() telegraf.Input {
 		return &Prometheus{
 			ResponseTimeout: config.Duration(time.Second * 3),
-			kubernetesPods:  map[string]URLAndAddress{},
+			kubernetesPods:  map[PodID]URLAndAddress{},
 			consulServices:  map[string]URLAndAddress{},
 			URLTag:          "url",
 		}


### PR DESCRIPTION
# Required for all PRs

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)


Deleted pods were not always unregistered. It was happening when telegraf is briefly disconnected from Kubernetes API server, in that case Informer OnDelete doesn't just return corev1.Pod object, but a special marker indicating that pod was deleted, but it's state might not be up to date. This PR accounts for such behaviour.

It also reworks Informer is used to track pods, summary is like following:
- register/unregister Pod now tracks each pod by their ID "$namespace/$podName"
- state of the pod passed in the Informer handler funcs is used as is to simplify tracking logic

Fixes #12527 
