### PR TITLE
fix(inputs.opcua): Fix opcua and opcua-listener for servers using password-based auth

### DIFF
--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -72,6 +72,7 @@ func (o *OpcUAClientConfig) CreateClient(log telegraf.Logger) (*OpcUAClient, err
 		Log:    log,
 	}
 	c.Log.Debug("Initialising OpcUAClient")
+	c.Init()
 	c.State = Disconnected
 
 	err = c.setupWorkarounds()

--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -72,7 +72,12 @@ func (o *OpcUAClientConfig) CreateClient(log telegraf.Logger) (*OpcUAClient, err
 		Log:    log,
 	}
 	c.Log.Debug("Initialising OpcUAClient")
-	c.Init()
+
+	err = c.Init()
+	if err != nil {
+		return nil, err
+	}
+
 	c.State = Disconnected
 
 	err = c.setupWorkarounds()
@@ -180,7 +185,10 @@ func (o *OpcUAClient) Connect() error {
 		}
 
 		o.Client = opcua.NewClient(o.Config.Endpoint, o.opts...)
-		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Config.ConnectTimeout))
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			time.Duration(o.Config.ConnectTimeout),
+		)
 		defer cancel()
 		if err := o.Client.Connect(ctx); err != nil {
 			o.State = Disconnected

--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -72,7 +72,6 @@ func (o *OpcUAClientConfig) CreateClient(log telegraf.Logger) (*OpcUAClient, err
 		Log:    log,
 	}
 	c.Log.Debug("Initialising OpcUAClient")
-
 	c.State = Disconnected
 
 	err = c.setupWorkarounds()
@@ -185,7 +184,7 @@ func (o *OpcUAClient) Connect() error {
 		}
 
 		o.Client = opcua.NewClient(o.Config.Endpoint, o.opts...)
-		ctx, cancel := context.WithTimeout( context.Background(), time.Duration(o.Config.ConnectTimeout))
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Config.ConnectTimeout))
 		defer cancel()
 		if err := o.Client.Connect(ctx); err != nil {
 			o.State = Disconnected

--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -101,12 +101,8 @@ type OpcUAClient struct {
 	codes []ua.StatusCode
 }
 
-func (o *OpcUAClient) Init() error {
-	return o.setupOptions()
-}
-
 // / setupOptions read the endpoints from the specified server and setup all authentication
-func (o *OpcUAClient) setupOptions() error {
+func (o *OpcUAClient) SetupOptions() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Config.ConnectTimeout))
 	defer cancel()
 	// Get a list of the endpoints for our target server
@@ -169,7 +165,7 @@ func (o *OpcUAClient) Connect() error {
 	case "opc.tcp":
 		o.State = Connecting
 
-		err = o.Init()
+		err = o.SetupOptions()
 		if err != nil {
 			return err
 		}

--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -185,10 +185,7 @@ func (o *OpcUAClient) Connect() error {
 		}
 
 		o.Client = opcua.NewClient(o.Config.Endpoint, o.opts...)
-		ctx, cancel := context.WithTimeout(
-			context.Background(),
-			time.Duration(o.Config.ConnectTimeout),
-		)
+		ctx, cancel := context.WithTimeout( context.Background(), time.Duration(o.Config.ConnectTimeout))
 		defer cancel()
 		if err := o.Client.Connect(ctx); err != nil {
 			o.State = Disconnected

--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -73,11 +73,6 @@ func (o *OpcUAClientConfig) CreateClient(log telegraf.Logger) (*OpcUAClient, err
 	}
 	c.Log.Debug("Initialising OpcUAClient")
 
-	err = c.Init()
-	if err != nil {
-		return nil, err
-	}
-
 	c.State = Disconnected
 
 	err = c.setupWorkarounds()
@@ -174,6 +169,11 @@ func (o *OpcUAClient) Connect() error {
 	switch u.Scheme {
 	case "opc.tcp":
 		o.State = Connecting
+
+		err = o.Init()
+		if err != nil {
+			return err
+		}
 
 		if o.Client != nil {
 			o.Log.Warnf("Closing connection due to Connect called while already instantiated", u)

--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -34,7 +34,7 @@ func (o *OpcUA) Init() (err error) {
 
 // Gather defines what data the plugin will gather.
 func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
-	metrics, err := o.client.CurrentValues()
+	metrics, err := o.client.CurrentValues() // Will (re)connect if the client is disconnected
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -34,7 +34,8 @@ func (o *OpcUA) Init() (err error) {
 
 // Gather defines what data the plugin will gather.
 func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
-	metrics, err := o.client.CurrentValues() // Will (re)connect if the client is disconnected
+	// Will (re)connect if the client is disconnected
+	metrics, err := o.client.CurrentValues()
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -71,16 +71,16 @@ func testReadClient(args TestReadClientArgs) {
 
 	args.readConfig.Groups = append(args.readConfig.Groups, args.testGroups...)
 
-	opcua_input := OpcUA{
+	opcuaInput := OpcUA{
 		ReadClientConfig: args.readConfig,
 		Log:              &testutil.CaptureLogger{},
 	}
 
-	require.NoError(args.t, opcua_input.Init(), "Initialization")
-	require.NoError(args.t, opcua_input.Gather(&testutil.Accumulator{}), "Gather")
+	require.NoError(args.t, opcuaInput.Init(), "Initialization")
+	require.NoError(args.t, opcuaInput.Gather(&testutil.Accumulator{}), "Gather")
 
 	if args.validateLastReceivedData {
-		for i, v := range opcua_input.client.LastReceivedData {
+		for i, v := range opcuaInput.client.LastReceivedData {
 			require.Equal(args.t, args.testOPCTags[i].Want, v.Value)
 		}
 	}

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -315,42 +315,14 @@ use_unregistered_reads = true
 			}},
 		},
 	}, o.ReadClientConfig.Groups)
-	require.Equal(
-		t,
-		opcua.OpcUAWorkarounds{AdditionalValidStatusCodes: []string{"0xC0"}},
-		o.ReadClientConfig.Workarounds,
-	)
-	require.Equal(
-		t,
-		ReadClientWorkarounds{UseUnregisteredReads: true},
-		o.ReadClientConfig.ReadClientWorkarounds,
-	)
+	require.Equal( t, opcua.OpcUAWorkarounds{AdditionalValidStatusCodes: []string{"0xC0"}}, o.ReadClientConfig.Workarounds)
+	require.Equal( t, ReadClientWorkarounds{UseUnregisteredReads: true}, o.ReadClientConfig.ReadClientWorkarounds)
 	err = o.Init()
 	require.NoError(t, err)
 	require.Len(t, o.client.NodeMetricMapping, 5, "incorrect number of nodes")
-	require.EqualValues(
-		t,
-		o.client.NodeMetricMapping[0].MetricTags,
-		map[string]string{"tag0": "val0"},
-	)
-	require.EqualValues(
-		t,
-		o.client.NodeMetricMapping[1].MetricTags,
-		map[string]string{"tag6": "val6"},
-	)
-	require.EqualValues(
-		t,
-		o.client.NodeMetricMapping[2].MetricTags,
-		map[string]string{"tag1": "val1", "tag2": "val2", "tag3": "val3"},
-	)
-	require.EqualValues(
-		t,
-		o.client.NodeMetricMapping[3].MetricTags,
-		map[string]string{"tag1": "override", "tag2": "val2"},
-	)
-	require.EqualValues(
-		t,
-		o.client.NodeMetricMapping[4].MetricTags,
-		map[string]string{"tag1": "val1", "tag2": "val2"},
-	)
+	require.EqualValues( t, o.client.NodeMetricMapping[0].MetricTags, map[string]string{"tag0": "val0"})
+	require.EqualValues( t, o.client.NodeMetricMapping[1].MetricTags, map[string]string{"tag6": "val6"})
+	require.EqualValues( t, o.client.NodeMetricMapping[2].MetricTags, map[string]string{"tag1": "val1", "tag2": "val2", "tag3": "val3"})
+	require.EqualValues( t, o.client.NodeMetricMapping[3].MetricTags, map[string]string{"tag1": "override", "tag2": "val2"})
+	require.EqualValues( t, o.client.NodeMetricMapping[4].MetricTags, map[string]string{"tag1": "val1", "tag2": "val2"})
 }

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -33,64 +33,48 @@ func MapOPCTag(tags OPCTags) (out input.NodeSettings) {
 	return out
 }
 
-type TestReadClientArgs struct {
-	t                        *testing.T
-	containerEntrypoint      []string
-	testOPCTags              []OPCTags
-	testGroups               []input.NodeGroupSettings
-	readConfig               ReadClientConfig
-	validateLastReceivedData bool
-}
-
-func testReadClient(args TestReadClientArgs) {
+func TestGetDataBadNodeContainerIntegration(t *testing.T) {
 	if testing.Short() {
-		args.t.Skip("Skipping integration test in short mode")
+		t.Skip("Skipping integration test in short mode")
 	}
 
 	container := testutil.Container{
 		Image:        "open62541/open62541",
 		ExposedPorts: []string{servicePort},
-		Entrypoint:   args.containerEntrypoint,
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort(nat.Port(servicePort)),
 			wait.ForLog("TCP network layer listening on opc.tcp://"),
 		),
 	}
-	require.NoError(args.t, container.Start(), "Failed to start container")
+	err := container.Start()
+	require.NoError(t, err, "failed to start container")
 	defer container.Terminate()
 
-	args.readConfig.InputClientConfig.OpcUAClientConfig.Endpoint = fmt.Sprintf(
-		"opc.tcp://%s:%s",
-		container.Address,
-		container.Ports[servicePort],
-	)
-
-	for _, tags := range args.testOPCTags {
-		args.readConfig.RootNodes = append(args.readConfig.RootNodes, MapOPCTag(tags))
-	}
-
-	args.readConfig.Groups = append(args.readConfig.Groups, args.testGroups...)
-
-	opcuaInput := OpcUA{
-		ReadClientConfig: args.readConfig,
-		Log:              &testutil.CaptureLogger{},
-	}
-
-	require.NoError(args.t, opcuaInput.Init(), "Initialization")
-	require.NoError(args.t, opcuaInput.Gather(&testutil.Accumulator{}), "Gather")
-
-	if args.validateLastReceivedData {
-		for i, v := range opcuaInput.client.LastReceivedData {
-			require.Equal(args.t, args.testOPCTags[i].Want, v.Value)
-		}
-	}
-}
-
-func TestGetDataBadNodeContainerIntegration2(t *testing.T) {
-	var testopctags = []OPCTags{
+	testopctags := []OPCTags{
 		{"ProductName", "1", "i", "2261", "open62541 OPC UA Server"},
 		{"ProductUri", "0", "i", "2262", "http://open62541.org"},
 		{"ManufacturerName", "0", "i", "2263", "open62541"},
+	}
+
+	readConfig := ReadClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				Certificate:    "",
+				PrivateKey:     "",
+				Username:       "",
+				Password:       "",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
+			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
+		},
 	}
 
 	g := input.NodeGroupSettings{
@@ -103,92 +87,133 @@ func TestGetDataBadNodeContainerIntegration2(t *testing.T) {
 	for _, tags := range testopctags {
 		g.Nodes = append(g.Nodes, MapOPCTag(tags))
 	}
+	readConfig.Groups = append(readConfig.Groups, g)
 
-	testReadClient(TestReadClientArgs{
-		t:                   t,
-		containerEntrypoint: nil,
-		testOPCTags:         testopctags,
-		testGroups:          []input.NodeGroupSettings{g},
-		readConfig: ReadClientConfig{
-			InputClientConfig: input.InputClientConfig{
-				OpcUAClientConfig: opcua.OpcUAClientConfig{
-					SecurityPolicy: "None",
-					SecurityMode:   "None",
-					Certificate:    "",
-					PrivateKey:     "",
-					Username:       "",
-					Password:       "",
-					AuthMethod:     "Anonymous",
-					ConnectTimeout: config.Duration(10 * time.Second),
-					RequestTimeout: config.Duration(1 * time.Second),
-					Workarounds:    opcua.OpcUAWorkarounds{},
-				},
-				MetricName: "testing",
-				RootNodes:  make([]input.NodeSettings, 0),
-				Groups:     make([]input.NodeGroupSettings, 0),
-			},
-		},
-	})
+	logger := &testutil.CaptureLogger{}
+	readClient, err := readConfig.CreateReadClient(logger)
+	require.NoError(t, err)
+	err = readClient.Connect()
+	require.NoError(t, err)
 }
 
 func TestReadClientIntegration(t *testing.T) {
-	testReadClient(TestReadClientArgs{
-		t: t,
-		testOPCTags: []OPCTags{
-			{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
-			{"ProductUri", "0", "i", "2262", "http://open62541.org"},
-			{"ManufacturerName", "0", "i", "2263", "open62541"},
-			{"badnode", "1", "i", "1337", nil},
-			{"goodnode", "1", "s", "the.answer", int32(42)},
-			{"DateTime", "1", "i", "51037", "0001-01-01T00:00:00Z"},
-		},
-		readConfig: ReadClientConfig{
-			InputClientConfig: input.InputClientConfig{
-				OpcUAClientConfig: opcua.OpcUAClientConfig{
-					SecurityPolicy: "None",
-					SecurityMode:   "None",
-					AuthMethod:     "Anonymous",
-					ConnectTimeout: config.Duration(10 * time.Second),
-					RequestTimeout: config.Duration(1 * time.Second),
-					Workarounds:    opcua.OpcUAWorkarounds{},
-				},
-				MetricName: "testing",
-				RootNodes:  make([]input.NodeSettings, 0),
-				Groups:     make([]input.NodeGroupSettings, 0),
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := testutil.Container{
+		Image:        "open62541/open62541",
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(nat.Port(servicePort)),
+			wait.ForLog("TCP network layer listening on opc.tcp://"),
+		),
+	}
+	err := container.Start()
+	require.NoError(t, err, "failed to start container")
+	defer container.Terminate()
+
+	testopctags := []OPCTags{
+		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
+		{"ProductUri", "0", "i", "2262", "http://open62541.org"},
+		{"ManufacturerName", "0", "i", "2263", "open62541"},
+		{"badnode", "1", "i", "1337", nil},
+		{"goodnode", "1", "s", "the.answer", int32(42)},
+		{"DateTime", "1", "i", "51037", "0001-01-01T00:00:00Z"},
+	}
+
+	readConfig := ReadClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				Certificate:    "",
+				PrivateKey:     "",
+				Username:       "",
+				Password:       "",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
 			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
 		},
-		validateLastReceivedData: true,
-	})
+	}
+
+	for _, tags := range testopctags {
+		readConfig.RootNodes = append(readConfig.RootNodes, MapOPCTag(tags))
+	}
+
+	client, err := readConfig.CreateReadClient(testutil.Logger{})
+	require.NoError(t, err)
+
+	err = client.Connect()
+	require.NoError(t, err, "Connect")
+
+	for i, v := range client.LastReceivedData {
+		require.Equal(t, testopctags[i].Want, v.Value)
+	}
 }
 
-func TestReadClientIntegrationWithAuth(t *testing.T) {
-	testReadClient(TestReadClientArgs{
-		t:                   t,
-		containerEntrypoint: []string{"/opt/open62541/build/bin/examples/access_control_server"},
-		testOPCTags: []OPCTags{
-			{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
-			{"ProductUri", "0", "i", "2262", "http://open62541.org"},
-			{"ManufacturerName", "0", "i", "2263", "open62541"},
-		},
-		readConfig: ReadClientConfig{
-			InputClientConfig: input.InputClientConfig{
-				OpcUAClientConfig: opcua.OpcUAClientConfig{
-					SecurityPolicy: "None",
-					SecurityMode:   "None",
-					Username:       "peter",
-					Password:       "peter123",
-					AuthMethod:     "UserName",
-					ConnectTimeout: config.Duration(10 * time.Second),
-					RequestTimeout: config.Duration(1 * time.Second),
-					Workarounds:    opcua.OpcUAWorkarounds{},
-				},
-				MetricName: "testing",
-				RootNodes:  make([]input.NodeSettings, 0),
-				Groups:     make([]input.NodeGroupSettings, 0),
+func TestReadClientIntegrationWithPasswordAuth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := testutil.Container{
+		Image:        "open62541/open62541",
+		Entrypoint:   []string{"/opt/open62541/build/bin/examples/access_control_server"},
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(nat.Port(servicePort)),
+			wait.ForLog("TCP network layer listening on opc.tcp://"),
+		),
+	}
+	err := container.Start()
+	require.NoError(t, err, "failed to start container")
+	defer container.Terminate()
+
+	testopctags := []OPCTags{
+		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
+		{"ProductUri", "0", "i", "2262", "http://open62541.org"},
+		{"ManufacturerName", "0", "i", "2263", "open62541"},
+	}
+
+	readConfig := ReadClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				Username:       "peter",
+				Password:       "peter123",
+				AuthMethod:     "UserName",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
 			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
 		},
-		validateLastReceivedData: true,
-	})
+	}
+
+	for _, tags := range testopctags {
+		readConfig.RootNodes = append(readConfig.RootNodes, MapOPCTag(tags))
+	}
+
+	client, err := readConfig.CreateReadClient(testutil.Logger{})
+	require.NoError(t, err)
+
+	err = client.Connect()
+	require.NoError(t, err, "Connect")
+
+	for i, v := range client.LastReceivedData {
+		require.Equal(t, testopctags[i].Want, v.Value)
+	}
 }
 
 func TestReadClientConfig(t *testing.T) {

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -315,14 +315,14 @@ use_unregistered_reads = true
 			}},
 		},
 	}, o.ReadClientConfig.Groups)
-	require.Equal( t, opcua.OpcUAWorkarounds{AdditionalValidStatusCodes: []string{"0xC0"}}, o.ReadClientConfig.Workarounds)
-	require.Equal( t, ReadClientWorkarounds{UseUnregisteredReads: true}, o.ReadClientConfig.ReadClientWorkarounds)
+	require.Equal(t, opcua.OpcUAWorkarounds{AdditionalValidStatusCodes: []string{"0xC0"}}, o.ReadClientConfig.Workarounds)
+	require.Equal(t, ReadClientWorkarounds{UseUnregisteredReads: true}, o.ReadClientConfig.ReadClientWorkarounds)
 	err = o.Init()
 	require.NoError(t, err)
 	require.Len(t, o.client.NodeMetricMapping, 5, "incorrect number of nodes")
-	require.EqualValues( t, o.client.NodeMetricMapping[0].MetricTags, map[string]string{"tag0": "val0"})
-	require.EqualValues( t, o.client.NodeMetricMapping[1].MetricTags, map[string]string{"tag6": "val6"})
-	require.EqualValues( t, o.client.NodeMetricMapping[2].MetricTags, map[string]string{"tag1": "val1", "tag2": "val2", "tag3": "val3"})
-	require.EqualValues( t, o.client.NodeMetricMapping[3].MetricTags, map[string]string{"tag1": "override", "tag2": "val2"})
-	require.EqualValues( t, o.client.NodeMetricMapping[4].MetricTags, map[string]string{"tag1": "val1", "tag2": "val2"})
+	require.EqualValues(t, o.client.NodeMetricMapping[0].MetricTags, map[string]string{"tag0": "val0"})
+	require.EqualValues(t, o.client.NodeMetricMapping[1].MetricTags, map[string]string{"tag6": "val6"})
+	require.EqualValues(t, o.client.NodeMetricMapping[2].MetricTags, map[string]string{"tag1": "val1", "tag2": "val2", "tag3": "val3"})
+	require.EqualValues(t, o.client.NodeMetricMapping[3].MetricTags, map[string]string{"tag1": "override", "tag2": "val2"})
+	require.EqualValues(t, o.client.NodeMetricMapping[4].MetricTags, map[string]string{"tag1": "val1", "tag2": "val2"})
 }

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -35,7 +35,7 @@ func MapOPCTag(tags OPCTags) (out input.NodeSettings) {
 
 type TestReadClientArgs struct {
 	t                        *testing.T
-	container_entrypoint     []string
+	containerEntrypoint      []string
 	testOPCTags              []OPCTags
 	testGroups               []input.NodeGroupSettings
 	readConfig               ReadClientConfig
@@ -50,7 +50,7 @@ func testReadClient(args TestReadClientArgs) {
 	container := testutil.Container{
 		Image:        "open62541/open62541",
 		ExposedPorts: []string{servicePort},
-		Entrypoint:   args.container_entrypoint,
+		Entrypoint:   args.containerEntrypoint,
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort(nat.Port(servicePort)),
 			wait.ForLog("TCP network layer listening on opc.tcp://"),
@@ -71,16 +71,16 @@ func testReadClient(args TestReadClientArgs) {
 
 	args.readConfig.Groups = append(args.readConfig.Groups, args.testGroups...)
 
-	opcua := OpcUA{
+	opcua_input := OpcUA{
 		ReadClientConfig: args.readConfig,
 		Log:              &testutil.CaptureLogger{},
 	}
 
-	require.NoError(args.t, opcua.Init(), "Initialization")
-	require.NoError(args.t, opcua.Gather(&testutil.Accumulator{}), "Gather")
+	require.NoError(args.t, opcua_input.Init(), "Initialization")
+	require.NoError(args.t, opcua_input.Gather(&testutil.Accumulator{}), "Gather")
 
 	if args.validateLastReceivedData {
-		for i, v := range opcua.client.LastReceivedData {
+		for i, v := range opcua_input.client.LastReceivedData {
 			require.Equal(args.t, args.testOPCTags[i].Want, v.Value)
 		}
 	}
@@ -105,10 +105,10 @@ func TestGetDataBadNodeContainerIntegration2(t *testing.T) {
 	}
 
 	testReadClient(TestReadClientArgs{
-		t:                    t,
-		container_entrypoint: nil,
-		testOPCTags:          testopctags,
-		testGroups:           []input.NodeGroupSettings{g},
+		t:                   t,
+		containerEntrypoint: nil,
+		testOPCTags:         testopctags,
+		testGroups:          []input.NodeGroupSettings{g},
 		readConfig: ReadClientConfig{
 			InputClientConfig: input.InputClientConfig{
 				OpcUAClientConfig: opcua.OpcUAClientConfig{
@@ -163,8 +163,8 @@ func TestReadClientIntegration(t *testing.T) {
 
 func TestReadClientIntegrationWithAuth(t *testing.T) {
 	testReadClient(TestReadClientArgs{
-		t:                    t,
-		container_entrypoint: []string{"/opt/open62541/build/bin/examples/access_control_server"},
+		t:                   t,
+		containerEntrypoint: []string{"/opt/open62541/build/bin/examples/access_control_server"},
 		testOPCTags: []OPCTags{
 			{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
 			{"ProductUri", "0", "i", "2262", "http://open62541.org"},

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -51,7 +51,7 @@ func TestSubscribeClientIntegration(t *testing.T) {
 	require.NoError(t, err, "failed to start container")
 	defer container.Terminate()
 
-	var testopctags = []OPCTags{
+	testopctags := []OPCTags{
 		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
 		{"ProductUri", "0", "i", "2262", "http://open62541.org"},
 		{"ManufacturerName", "0", "i", "2263", "open62541"},
@@ -59,7 +59,7 @@ func TestSubscribeClientIntegration(t *testing.T) {
 		{"goodnode", "1", "s", "the.answer", int32(42)},
 		{"DateTime", "1", "i", "51037", "0001-01-01T00:00:00Z"},
 	}
-	var tagsRemaining = make([]string, 0, len(testopctags))
+	tagsRemaining := make([]string, 0, len(testopctags))
 	for i, tag := range testopctags {
 		if tag.Want != nil {
 			tagsRemaining = append(tagsRemaining, testopctags[i].Name)
@@ -89,10 +89,10 @@ func TestSubscribeClientIntegration(t *testing.T) {
 	o, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
 	require.NoError(t, err)
 
-	// give init a couple extra attempts, seconds as on CircleCI this can
-	// be attempted to soon
+	// give initial setup a couple extra attempts, as on CircleCI this can be
+	// attempted to soon
 	require.Eventually(t, func() bool {
-		return o.Init() == nil
+		return o.SetupOptions() == nil
 	}, 5*time.Second, 10*time.Millisecond)
 
 	err = o.Connect()


### PR DESCRIPTION
The Gopcua/opcua client was never properly initialized, which meant that authentication to the opcua server was never configured. My guess is this got lost in the shuffle of the addition of the opcua_listener plugin.

In testing before this change, without calling init, the server gave an error like
```
2023-01-20T20:27:06Z E! [inputs.opcua] Error in plugin: error in Client Connection: The user identity token is not valid. StatusBadIdentityTokenInvalid (0x80200000)
```
After Init(), the plugin works and is able to ingest data as expected.