### PR TITLE
fix(agent): Catch non-existing commands and error out.

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -129,8 +129,13 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 	extraFlags := append(pluginFilterFlags, cliFlags()...)
 
 	// This function is used when Telegraf is run with only flags
-
 	action := func(cCtx *cli.Context) error {
+		// We do not expect any arguments this is likely a misspelling of
+		// a command...
+		if cCtx.NArg() > 0 {
+			return fmt.Errorf("unknown command %q", cCtx.Args().First())
+		}
+
 		err := logger.SetupLogging(logger.LogConfig{})
 		if err != nil {
 			return err


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR catches commands that do not exist, likely due to a misspelling, like
```shell
> telegraf secret list
```
with `secret` instead of `secrets`. We error out on this now.