### PR TITLE
docs: Add details on overriding timezone used by Elasticsearch output plugin

### DIFF
--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -156,6 +156,33 @@ This plugin will format the events in the following way:
 }
 ```
 
+### Timestamp Timezone
+
+Elasticsearch documents use RFC3339 timestamps, which denote timezone information
+(for example `2017-01-01T00:00:00-08:00`) and by default, Telegraf will use the
+host system's configured timezone.
+
+However, this may not always be desirable. Elasticsearch preserves the timezone
+information and uses it when returning associated documents. This can cause issues
+for some pipelines (those that don't parse the timestamp and instead assume
+that the timezone returned will always be consistent).
+
+Telegraf honours the timezone configured in the environment variable `TZ`, so it
+is possible to influence the timezone used in timestamps sent to Elasticsearch
+without needing to change the timezone configured in the host system:
+
+```sh
+export TZ="America/Los_Angeles"
+export TZ="UTC"
+```
+
+If Telegraf is being run using SystemD, this can be achieved with
+
+```sh
+echo TZ="UTC" | sudo tee -a /etc/default/telegraf
+```
+
+
 ## OpenSearch Support
 
 OpenSearch is a fork of Elasticsearch hosted by AWS. The OpenSearch server will
@@ -194,33 +221,6 @@ POST https://es.us-east-1.amazonaws.com/2021-01-01/opensearch/upgradeDomain
 ```
 
 [3]: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html#rename-upgrade
-
-
-## Timestamp Timezone
-
-Elasticsearch documents use RFC3339 timestamps, which denote timezone information
-(for example `2017-01-01T00:00:00-08:00`) and by default, Telegraf will use the
-host system's configured timezone.
-
-However, this may not always be desirable. Elasticsearch preserves the timezone
-information and uses it when returning associated documents. This can cause issues
-for some pipelines (those that don't parse the timestamp and instead assume
-that the timezone returned will always be consistent).
-
-Telegraf honours the timezone configured in the environment variable `TZ`, so it
-is possible to influence the timezone used in timestamps sent to Elasticsearch
-without needing to change the timezone configured in the host system:
-
-```sh
-export TZ="America/Los_Angeles"
-export TZ="UTC"
-```
-
-If Telegraf is being run using SystemD, this can be achieved with
-
-```sh
-echo TZ="UTC" | sudo tee -a /etc/default/telegraf
-```
 
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->

--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -158,17 +158,18 @@ This plugin will format the events in the following way:
 
 ### Timestamp Timezone
 
-Elasticsearch documents use RFC3339 timestamps, which include timezone information
-(for example `2017-01-01T00:00:00-08:00`). By default, the Telegraf system's
-configured timezone will be used.
+Elasticsearch documents use RFC3339 timestamps, which include timezone
+information (for example `2017-01-01T00:00:00-08:00`). By default, the Telegraf
+system's configured timezone will be used.
 
 However, this may not always be desirable: Elasticsearch preserves timezone
-information and includes it when returning associated documents. This can cause issues
-for some pipelines (in particular, those that don't parse retrieved timestamps
-and instead assume that the timezone returned will always be consistent).
+information and includes it when returning associated documents. This can cause
+issues for some pipelines. In particular, those that do not parse retrieved
+timestamps and instead assume that the timezone returned will always be
+consistent.
 
-Telegraf honours the timezone configured in the environment variable `TZ`, so the
-timezone sent to Elasticsearch can be amended without needing to change the
+Telegraf honours the timezone configured in the environment variable `TZ`, so
+the timezone sent to Elasticsearch can be amended without needing to change the
 timezone configured in the host system:
 
 ```sh
@@ -176,13 +177,12 @@ export TZ="America/Los_Angeles"
 export TZ="UTC"
 ```
 
-If Telegraf is being run as a system service with SystemD, this can be configured
-in the following way
+If Telegraf is being run as a system service, this can be configured in the
+following way on Linux:
 
 ```sh
 echo TZ="UTC" | sudo tee -a /etc/default/telegraf
 ```
-
 
 ## OpenSearch Support
 
@@ -222,7 +222,6 @@ POST https://es.us-east-1.amazonaws.com/2021-01-01/opensearch/upgradeDomain
 ```
 
 [3]: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html#rename-upgrade
-
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -195,6 +195,34 @@ POST https://es.us-east-1.amazonaws.com/2021-01-01/opensearch/upgradeDomain
 
 [3]: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html#rename-upgrade
 
+
+### Timestamp Timezone
+
+Elasticsearch documents use RFC3339 timestamps, which denote timezone information
+(for example `2017-01-01T00:00:00-08:00`) and by default, Telegraf will use the
+host system's configured timezone.
+
+However, this may not always be desirable. Elasticsearch preserves the timezone
+information and uses it when returning associated documents. This can cause issues
+for some pipelines (those that don't parse the timestamp and instead assume
+that the timezone returned will always be consistent).
+
+Telegraf honours the timezone configured in the environment variable `TZ`, so it
+is possible to influence the timezone used in timestamps sent to Elasticsearch
+without needing to change the timezone configured in the host system:
+
+```sh
+export TZ="America/Los_Angeles"
+export TZ="UTC"
+```
+
+If Telegraf is being run using SystemD, this can be achieved with
+
+```sh
+echo TZ="UTC" | sudo tee -a /etc/default/telegraf
+```
+
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support

--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -196,7 +196,7 @@ POST https://es.us-east-1.amazonaws.com/2021-01-01/opensearch/upgradeDomain
 [3]: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html#rename-upgrade
 
 
-### Timestamp Timezone
+## Timestamp Timezone
 
 Elasticsearch documents use RFC3339 timestamps, which denote timezone information
 (for example `2017-01-01T00:00:00-08:00`) and by default, Telegraf will use the

--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -158,25 +158,26 @@ This plugin will format the events in the following way:
 
 ### Timestamp Timezone
 
-Elasticsearch documents use RFC3339 timestamps, which denote timezone information
-(for example `2017-01-01T00:00:00-08:00`) and by default, Telegraf will use the
-host system's configured timezone.
+Elasticsearch documents use RFC3339 timestamps, which include timezone information
+(for example `2017-01-01T00:00:00-08:00`). By default, the Telegraf system's
+configured timezone will be used.
 
-However, this may not always be desirable. Elasticsearch preserves the timezone
-information and uses it when returning associated documents. This can cause issues
-for some pipelines (those that don't parse the timestamp and instead assume
-that the timezone returned will always be consistent).
+However, this may not always be desirable: Elasticsearch preserves timezone
+information and includes it when returning associated documents. This can cause issues
+for some pipelines (in particular, those that don't parse retrieved timestamps
+and instead assume that the timezone returned will always be consistent).
 
-Telegraf honours the timezone configured in the environment variable `TZ`, so it
-is possible to influence the timezone used in timestamps sent to Elasticsearch
-without needing to change the timezone configured in the host system:
+Telegraf honours the timezone configured in the environment variable `TZ`, so the
+timezone sent to Elasticsearch can be amended without needing to change the
+timezone configured in the host system:
 
 ```sh
 export TZ="America/Los_Angeles"
 export TZ="UTC"
 ```
 
-If Telegraf is being run using SystemD, this can be achieved with
+If Telegraf is being run as a system service with SystemD, this can be configured
+in the following way
 
 ```sh
 echo TZ="UTC" | sudo tee -a /etc/default/telegraf


### PR DESCRIPTION
# Required for all PRs


- [X ] Updated associated README.md.
- [ N/A] Wrote appropriate unit tests.
- [ X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Documents written to an Elasticsearch output include a RFC3339 timestamp, using whichever timezone the host system is configured to use.

If documents are later queried out of ES, the same timestamp will be returned. If Telegraf is running on machines in different timezones (or *using* different timezones) this can cause issues for some downstream pipelines which don't fully parse the timestamp and assume a consistent timezone.

Because Go's `time.time` honour's the `TZ` environment variable, it's possible to influence the reported timezone without having to change the system's timezone. 

This PR adds details on how to do that the the relevant README.
