### PR TITLE
fix(inputs.prometheus): Set the timeout for slow running API endpoints correctly

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -163,6 +163,7 @@ func (p *Prometheus) Init() error {
 	}
 
 	ctx := context.Background()
+	p.HTTPClientConfig.Timeout = p.ResponseTimeout
 	client, err := p.HTTPClientConfig.CreateClient(ctx, p.Log)
 	if err != nil {
 		return err

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -1,7 +1,9 @@
 package prometheus
 
 import (
+	"errors"
 	"fmt"
+	"github.com/influxdata/telegraf/config"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -135,6 +137,63 @@ func TestPrometheusGeneratesMetricsAlthoughFirstDNSFailsIntegration(t *testing.T
 	require.True(t, acc.HasFloatField("go_goroutines", "gauge"))
 	require.True(t, acc.HasFloatField("test_metric", "value"))
 	require.True(t, acc.HasTimestamp("test_metric", time.Unix(1490802350, 0)))
+}
+
+func TestPrometheusGeneratesMetricsSlowEndpoint(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(4 * time.Second)
+		_, err := fmt.Fprintln(w, sampleTextFormat)
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	p := &Prometheus{
+		Log:             testutil.Logger{},
+		URLs:            []string{ts.URL},
+		URLTag:          "url",
+		ResponseTimeout: config.Duration(time.Second * 5),
+	}
+	err := p.Init()
+	require.NoError(t, err)
+
+	var acc testutil.Accumulator
+
+	err = acc.GatherError(p.Gather)
+	require.NoError(t, err)
+
+	require.True(t, acc.HasFloatField("go_gc_duration_seconds", "count"))
+	require.True(t, acc.HasFloatField("go_goroutines", "gauge"))
+	require.True(t, acc.HasFloatField("test_metric", "value"))
+	require.True(t, acc.HasTimestamp("test_metric", time.Unix(1490802350, 0)))
+	require.False(t, acc.HasTag("test_metric", "address"))
+	require.True(t, acc.TagValue("test_metric", "url") == ts.URL+"/metrics")
+}
+
+func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(6 * time.Second)
+		_, err := fmt.Fprintln(w, sampleTextFormat)
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	p := &Prometheus{
+		Log:             testutil.Logger{},
+		URLs:            []string{ts.URL},
+		URLTag:          "url",
+		ResponseTimeout: config.Duration(time.Second * 5),
+	}
+	err := p.Init()
+	require.NoError(t, err)
+
+	var acc testutil.Accumulator
+
+	err = acc.GatherError(p.Gather)
+	errMessage := fmt.Sprintf("error making HTTP request to %s/metrics: Get \"%s/metrics\": "+
+		"context deadline exceeded (Client.Timeout exceeded while awaiting headers)", ts.URL, ts.URL)
+	errExpected := errors.New(errMessage)
+	require.Equal(t, errExpected, err)
+	require.Error(t, err)
 }
 
 func TestPrometheusGeneratesSummaryMetricsV2(t *testing.T) {


### PR DESCRIPTION
<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #12485 

*Description:*
The issue was related to a missed timeout configuration inside http client to establish a connection to an slow responsed Promtheus endpoint.
