### PR TITLE
fix(inputs.mysql): Avoid side-effects for TLS between plugin instances

### DIFF
--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -86,11 +86,11 @@ func (m *Mysql) Init() error {
 	// one for the mysql package, we need to define unique IDs to avoid
 	// side effects and races between different plugin instances. Therefore,
 	// we decorate the "custom" naming of the "tls" parameter with an UUID.
-	uuid, err := uuid.NewV7()
+	tlsuuid, err := uuid.NewV7()
 	if err != nil {
 		return fmt.Errorf("cannot create UUID: %w", err)
 	}
-	tlsid := "custom-" + uuid.String()
+	tlsid := "custom-" + tlsuuid.String()
 	tlsConfig, err := m.ClientConfig.TLSConfig()
 	if err != nil {
 		return fmt.Errorf("registering TLS config: %s", err)

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -167,44 +167,53 @@ func TestMysqlGetDSNTag(t *testing.T) {
 
 func TestMysqlDNSAddTimeout(t *testing.T) {
 	tests := []struct {
+		name   string
 		input  string
 		output string
 	}{
 		{
+			"empty",
 			"",
 			"tcp(127.0.0.1:3306)/?timeout=5s",
 		},
 		{
+			"no timeout",
 			"tcp(192.168.1.1:3306)/",
 			"tcp(192.168.1.1:3306)/?timeout=5s",
 		},
 		{
+			"no timeout with credentials",
 			"root:passwd@tcp(192.168.1.1:3306)/?tls=false",
 			"root:passwd@tcp(192.168.1.1:3306)/?timeout=5s&tls=false",
 		},
 		{
+			"with timeout and credentials",
 			"root:passwd@tcp(192.168.1.1:3306)/?tls=false&timeout=10s",
 			"root:passwd@tcp(192.168.1.1:3306)/?timeout=10s&tls=false",
 		},
 		{
+			"no timeout different IP",
 			"tcp(10.150.1.123:3306)/",
 			"tcp(10.150.1.123:3306)/?timeout=5s",
 		},
 		{
+			"no timeout with bracket credentials",
 			"root:@!~(*&$#%(&@#(@&#Password@tcp(10.150.1.123:3306)/",
 			"root:@!~(*&$#%(&@#(@&#Password@tcp(10.150.1.123:3306)/?timeout=5s",
 		},
 		{
+			"no timeout with strange credentials",
 			"root:Test3a#@!@tcp(10.150.1.123:3306)/",
 			"root:Test3a#@!@tcp(10.150.1.123:3306)/?timeout=5s",
 		},
 	}
 
-	for _, test := range tests {
-		output, _ := dsnAddTimeout(test.input)
-		if output != test.output {
-			t.Errorf("Expected %s, got %s\n", test.output, output)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Mysql{Servers: []string{tt.input}}
+			require.NoError(t, m.Init())
+			require.Equal(t, tt.output, m.Servers[0])
+		})
 	}
 }
 

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -3,12 +3,14 @@ package mysql
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -71,7 +73,7 @@ func TestMysqlMultipleInstancesIntegration(t *testing.T) {
 	testServer := fmt.Sprintf("root@tcp(%s:%s)/?tls=false", container.Address, container.Ports[servicePort])
 	m := &Mysql{
 		Servers:          []string{testServer},
-		IntervalSlow:     "30s",
+		IntervalSlow:     config.Duration(30 * time.Second),
 		GatherGlobalVars: true,
 		MetricVersion:    2,
 	}
@@ -96,14 +98,6 @@ func TestMysqlMultipleInstancesIntegration(t *testing.T) {
 	require.True(t, acc2.HasMeasurement("mysql"))
 	// acc2 should not have global variables
 	require.False(t, acc2.HasMeasurement("mysql_variables"))
-}
-
-func TestMysqlMultipleInits(t *testing.T) {
-	m := &Mysql{
-		IntervalSlow: "30s",
-	}
-	require.NoError(t, m.Init())
-	require.Equal(t, m.scanIntervalSlow, uint32(30))
 }
 
 func TestMysqlGetDSNTag(t *testing.T) {


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Currently, the plugin registers its TLS configuration as key `"custom"` to the MySQL driver. However, this registration is global to the driver package and therefor potential side-effects between multiple plugin instances arise if those instances register __different__ TLS configurations.

This PR fixes the issue by replacing the `"custom"` key with a unique key while keeping the user-facing configuration the same. Furthermore, we move the initialization to the `Init()` function in order to save some cycles and avoid the necessity to frequently create random registrations.