### PR TITLE
chore(inputs.x509_cert): Fix linter warning

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -431,9 +431,7 @@ func TestServerName(t *testing.T) {
 			}
 			u, err := url.Parse(test.url)
 			require.NoError(t, err)
-			actual, err := sc.serverName(u)
-			require.NoError(t, err)
-			require.Equal(t, test.expected, actual)
+			require.Equal(t, test.expected, sc.serverName(u))
 		})
 	}
 }


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Fix a linter issue caused by always returning a `nil` error. So we simply remove the returned error param and simplify the code.