### PR TITLE
chore(internal.gzip): Cleanup `CompressWithGzip`

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -199,7 +199,7 @@ func (r *ReadWaitCloser) Close() error {
 // Errors occurring during compression are returned to the instance reading
 // from the returned reader via through the corresponding read call
 // (e.g. io.Copy or io.ReadAll).
-func CompressWithGzip(data io.Reader) (io.ReadCloser, error) {
+func CompressWithGzip(data io.Reader) io.ReadCloser {
 	pipeReader, pipeWriter := io.Pipe()
 	gzipWriter := gzip.NewWriter(pipeWriter)
 
@@ -226,7 +226,7 @@ func CompressWithGzip(data io.Reader) (io.ReadCloser, error) {
 
 	// Return a reader which then can be read by the caller to collect the
 	// compressed stream.
-	return pipeReader, nil
+	return pipeReader
 }
 
 // ParseTimestamp parses a Time according to the standard Telegraf options.

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -243,6 +243,20 @@ func TestCompressWithGzipErrorPropagationCopy(t *testing.T) {
 	}
 }
 
+func TestCompressWithGzipErrorPropagationReadAll(t *testing.T) {
+	errs := []error{io.ErrClosedPipe, io.ErrNoProgress, io.ErrUnexpectedEOF}
+	for _, expected := range errs {
+		r := &mockReader{msg: []byte("this is a test"), err: expected}
+		rc, err := CompressWithGzip(r)
+		require.NoError(t, err)
+
+		buf, err := io.ReadAll(rc)
+		require.NotEmpty(t, buf)
+		require.ErrorIs(t, err, expected)
+		require.NoError(t, rc.Close())
+	}
+}
+
 func TestAlignDuration(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -174,9 +174,7 @@ func TestCompressWithGzip(t *testing.T) {
 	testData := "the quick brown fox jumps over the lazy dog"
 	inputBuffer := bytes.NewBuffer([]byte(testData))
 
-	outputBuffer, err := CompressWithGzip(inputBuffer)
-	require.NoError(t, err)
-
+	outputBuffer := CompressWithGzip(inputBuffer)
 	gzipReader, err := gzip.NewReader(outputBuffer)
 	require.NoError(t, err)
 	defer gzipReader.Close()
@@ -210,9 +208,7 @@ func (r *mockReader) Read(p []byte) (n int, err error) {
 func TestCompressWithGzipEarlyClose(t *testing.T) {
 	mr := &mockReader{}
 
-	rc, err := CompressWithGzip(mr)
-	require.NoError(t, err)
-
+	rc := CompressWithGzip(mr)
 	n, err := io.CopyN(io.Discard, rc, 10000)
 	require.NoError(t, err)
 	require.Equal(t, int64(10000), n)
@@ -233,9 +229,8 @@ func TestCompressWithGzipErrorPropagationCopy(t *testing.T) {
 	errs := []error{io.ErrClosedPipe, io.ErrNoProgress, io.ErrUnexpectedEOF}
 	for _, expected := range errs {
 		r := &mockReader{msg: []byte("this is a test"), err: expected}
-		rc, err := CompressWithGzip(r)
-		require.NoError(t, err)
 
+		rc := CompressWithGzip(r)
 		n, err := io.Copy(io.Discard, rc)
 		require.Greater(t, n, int64(0))
 		require.ErrorIs(t, err, expected)
@@ -247,9 +242,8 @@ func TestCompressWithGzipErrorPropagationReadAll(t *testing.T) {
 	errs := []error{io.ErrClosedPipe, io.ErrNoProgress, io.ErrUnexpectedEOF}
 	for _, expected := range errs {
 		r := &mockReader{msg: []byte("this is a test"), err: expected}
-		rc, err := CompressWithGzip(r)
-		require.NoError(t, err)
 
+		rc := CompressWithGzip(r)
 		buf, err := io.ReadAll(rc)
 		require.NotEmpty(t, buf)
 		require.ErrorIs(t, err, expected)

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -207,11 +207,10 @@ func TestCompressWithGzipEarlyClose(t *testing.T) {
 	require.Equal(t, int64(10000), n)
 
 	r1 := mr.readN
-	err = rc.Close()
-	require.NoError(t, err)
+	require.NoError(t, rc.Close())
 
 	n, err = io.CopyN(io.Discard, rc, 10000)
-	require.Error(t, io.EOF, err)
+	require.ErrorIs(t, err, io.ErrClosedPipe)
 	require.Equal(t, int64(0), n)
 
 	r2 := mr.readN

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -2,7 +2,6 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	_ "embed"
 	"fmt"
@@ -214,15 +213,7 @@ func makeRequestBodyReader(contentEncoding, body string) (io.Reader, error) {
 
 	var reader io.Reader = strings.NewReader(body)
 	if contentEncoding == "gzip" {
-		rc, err := internal.CompressWithGzip(reader)
-		if err != nil {
-			return nil, err
-		}
-		data, err := io.ReadAll(rc)
-		if err != nil {
-			return nil, err
-		}
-		return bytes.NewReader(data), nil
+		return internal.CompressWithGzip(reader), nil
 	}
 
 	return reader, nil

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -136,10 +136,7 @@ func (h *HTTP) writeMetric(reqBody []byte) error {
 
 	var err error
 	if h.ContentEncoding == "gzip" {
-		rc, err := internal.CompressWithGzip(reqBodyBuffer)
-		if err != nil {
-			return err
-		}
+		rc := internal.CompressWithGzip(reqBodyBuffer)
 		defer rc.Close()
 		reqBodyBuffer = rc
 	}

--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -485,12 +485,7 @@ func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) (io.ReadCloser
 	reader := influx.NewReader(metrics, c.config.Serializer)
 
 	if c.config.ContentEncoding == "gzip" {
-		rc, err := internal.CompressWithGzip(reader)
-		if err != nil {
-			return nil, err
-		}
-
-		return rc, nil
+		return internal.CompressWithGzip(reader), nil
 	}
 
 	return io.NopCloser(reader), nil

--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -391,12 +391,7 @@ func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) (io.ReadCloser
 	reader := influx.NewReader(metrics, c.serializer)
 
 	if c.ContentEncoding == "gzip" {
-		rc, err := internal.CompressWithGzip(reader)
-		if err != nil {
-			return nil, err
-		}
-
-		return rc, nil
+		return internal.CompressWithGzip(reader), nil
 	}
 
 	return io.NopCloser(reader), nil

--- a/plugins/outputs/loki/loki.go
+++ b/plugins/outputs/loki/loki.go
@@ -143,10 +143,7 @@ func (l *Loki) writeMetrics(s Streams) error {
 	var reqBodyBuffer io.Reader = bytes.NewBuffer(bs)
 
 	if l.GZipRequest {
-		rc, err := internal.CompressWithGzip(reqBodyBuffer)
-		if err != nil {
-			return err
-		}
+		rc := internal.CompressWithGzip(reqBodyBuffer)
 		defer rc.Close()
 		reqBodyBuffer = rc
 	}

--- a/plugins/outputs/sensu/sensu.go
+++ b/plugins/outputs/sensu/sensu.go
@@ -213,10 +213,7 @@ func (s *Sensu) writeMetrics(reqBody []byte) error {
 	method := http.MethodPost
 
 	if s.ContentEncoding == "gzip" {
-		rc, err := internal.CompressWithGzip(reqBodyBuffer)
-		if err != nil {
-			return err
-		}
+		rc := internal.CompressWithGzip(reqBodyBuffer)
 		defer rc.Close()
 		reqBodyBuffer = rc
 	}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12044 

This PR fixes the linter issue described in #12044. While on it, I cleaned-up the `CompressWithGzip()` function, clarified and documented the error propagation and added unit-tests to ensure errors are propagated correctly.