### PR TITLE
chore: Fix existing linter findings

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -8,9 +8,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/awnumar/memguard"
 	"github.com/urfave/cli/v2"
 
-	"github.com/awnumar/memguard"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/goplugin"
@@ -207,15 +207,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 		case cCtx.Bool("sample-config"):
 			filters := processFilterFlags(cCtx)
 
-			printSampleConfig(
-				outputBuffer,
-				filters.section,
-				filters.input,
-				filters.output,
-				filters.aggregator,
-				filters.processor,
-				filters.secretstore,
-			)
+			printSampleConfig(outputBuffer, filters)
 			return nil
 		}
 
@@ -352,15 +344,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 					// e.g. telegraf config --section-filter inputs
 					filters := processFilterFlags(cCtx)
 
-					printSampleConfig(
-						outputBuffer,
-						filters.section,
-						filters.input,
-						filters.output,
-						filters.aggregator,
-						filters.processor,
-						filters.secretstore,
-					)
+					printSampleConfig(outputBuffer, filters)
 					return nil
 				},
 			},

--- a/plugins/inputs/dns_query/dns_query_test.go
+++ b/plugins/inputs/dns_query/dns_query_test.go
@@ -30,9 +30,9 @@ func TestGathering(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, dnsConfig.Init())
 	require.NoError(t, acc.GatherError(dnsConfig.Gather))
-	metric, ok := acc.Get("dns_query")
+	m, ok := acc.Get("dns_query")
 	require.True(t, ok)
-	queryTime, ok := metric.Fields["query_time_ms"].(float64)
+	queryTime, ok := m.Fields["query_time_ms"].(float64)
 	require.True(t, ok)
 	require.NotEqual(t, float64(0), queryTime)
 }
@@ -52,9 +52,9 @@ func TestGatheringMxRecord(t *testing.T) {
 
 	require.NoError(t, dnsConfig.Init())
 	require.NoError(t, acc.GatherError(dnsConfig.Gather))
-	metric, ok := acc.Get("dns_query")
+	m, ok := acc.Get("dns_query")
 	require.True(t, ok)
-	queryTime, ok := metric.Fields["query_time_ms"].(float64)
+	queryTime, ok := m.Fields["query_time_ms"].(float64)
 	require.True(t, ok)
 	require.NotEqual(t, float64(0), queryTime)
 }

--- a/plugins/inputs/vsphere/client.go
+++ b/plugins/inputs/vsphere/client.go
@@ -117,7 +117,6 @@ func (cf *ClientFactory) testClient(ctx context.Context) error {
 		if err := cf.client.Client.SessionManager.Login(ctx2, auth); err != nil {
 			return fmt.Errorf("renewing authentication failed: %w", err)
 		}
-
 	}
 
 	return nil

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -426,9 +426,9 @@ func TestServerName(t *testing.T) {
 			if test.err {
 				require.Error(t, err)
 				return
-			} else {
-				require.NoError(t, err)
 			}
+			require.NoError(t, err)
+
 			u, err := url.Parse(test.url)
 			require.NoError(t, err)
 			require.Equal(t, test.expected, sc.serverName(u))

--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -121,72 +121,72 @@ type httpClient struct {
 	log telegraf.Logger
 }
 
-func NewHTTPClient(config HTTPConfig) (*httpClient, error) {
-	if config.URL == nil {
+func NewHTTPClient(cfg HTTPConfig) (*httpClient, error) {
+	if cfg.URL == nil {
 		return nil, ErrMissingURL
 	}
 
-	if config.Database == "" {
-		config.Database = defaultDatabase
+	if cfg.Database == "" {
+		cfg.Database = defaultDatabase
 	}
 
-	if config.Timeout == 0 {
-		config.Timeout = defaultRequestTimeout
+	if cfg.Timeout == 0 {
+		cfg.Timeout = defaultRequestTimeout
 	}
 
-	userAgent := config.UserAgent
+	userAgent := cfg.UserAgent
 	if userAgent == "" {
 		userAgent = internal.ProductToken()
 	}
 
-	if config.Headers == nil {
-		config.Headers = make(map[string]string)
+	if cfg.Headers == nil {
+		cfg.Headers = make(map[string]string)
 	}
-	config.Headers["User-Agent"] = userAgent
-	for k, v := range config.Headers {
-		config.Headers[k] = v
+	cfg.Headers["User-Agent"] = userAgent
+	for k, v := range cfg.Headers {
+		cfg.Headers[k] = v
 	}
 
 	var proxy func(*http.Request) (*url.URL, error)
-	if config.Proxy != nil {
-		proxy = http.ProxyURL(config.Proxy)
+	if cfg.Proxy != nil {
+		proxy = http.ProxyURL(cfg.Proxy)
 	} else {
 		proxy = http.ProxyFromEnvironment
 	}
 
-	if config.Serializer == nil {
-		config.Serializer = influx.NewSerializer()
+	if cfg.Serializer == nil {
+		cfg.Serializer = influx.NewSerializer()
 	}
 
 	var transport *http.Transport
-	switch config.URL.Scheme {
+	switch cfg.URL.Scheme {
 	case "http", "https":
 		transport = &http.Transport{
 			Proxy:           proxy,
-			TLSClientConfig: config.TLSConfig,
+			TLSClientConfig: cfg.TLSConfig,
 		}
 	case "unix":
 		transport = &http.Transport{
 			Dial: func(_, _ string) (net.Conn, error) {
 				return net.DialTimeout(
-					config.URL.Scheme,
-					config.URL.Path,
+					cfg.URL.Scheme,
+					cfg.URL.Path,
 					defaultRequestTimeout,
 				)
 			},
 		}
 	default:
-		return nil, fmt.Errorf("unsupported scheme %q", config.URL.Scheme)
+		return nil, fmt.Errorf("unsupported scheme %q", cfg.URL.Scheme)
 	}
 
 	client := &httpClient{
 		client: &http.Client{
-			Timeout:   config.Timeout,
+			Timeout:   cfg.Timeout,
 			Transport: transport,
 		},
 		createDatabaseExecuted: make(map[string]bool),
-		config:                 config,
-		log:                    config.Log,
+		config:                 cfg,
+		log:                    cfg.Log,
 	}
 	return client, nil
 }

--- a/plugins/outputs/influxdb/http_test.go
+++ b/plugins/outputs/influxdb/http_test.go
@@ -34,28 +34,28 @@ func getHTTPURL() *url.URL {
 }
 
 func TestHTTP_EmptyConfig(t *testing.T) {
-	config := influxdb.HTTPConfig{}
-	_, err := influxdb.NewHTTPClient(config)
+	cfg := influxdb.HTTPConfig{}
+	_, err := influxdb.NewHTTPClient(cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), influxdb.ErrMissingURL.Error())
 }
 
 func TestHTTP_MinimalConfig(t *testing.T) {
-	config := influxdb.HTTPConfig{
+	cfg := influxdb.HTTPConfig{
 		URL: getHTTPURL(),
 	}
-	_, err := influxdb.NewHTTPClient(config)
+	_, err := influxdb.NewHTTPClient(cfg)
 	require.NoError(t, err)
 }
 
 func TestHTTP_UnsupportedScheme(t *testing.T) {
-	config := influxdb.HTTPConfig{
+	cfg := influxdb.HTTPConfig{
 		URL: &url.URL{
 			Scheme: "foo",
 			Host:   "localhost",
 		},
 	}
-	_, err := influxdb.NewHTTPClient(config)
+	_, err := influxdb.NewHTTPClient(cfg)
 	require.Error(t, err)
 }
 
@@ -562,15 +562,15 @@ func TestHTTP_WritePathPrefix(t *testing.T) {
 	)
 	metrics := []telegraf.Metric{m}
 
-	config := influxdb.HTTPConfig{
+	cfg := influxdb.HTTPConfig{
 		URL:      u,
 		Database: "telegraf",
 		Log:      testutil.Logger{},
 	}
 
-	client, err := influxdb.NewHTTPClient(config)
+	client, err := influxdb.NewHTTPClient(cfg)
 	require.NoError(t, err)
-	err = client.CreateDatabase(ctx, config.Database)
+	err = client.CreateDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
 	err = client.Write(ctx, metrics)
 	require.NoError(t, err)
@@ -616,14 +616,14 @@ func TestHTTP_WriteContentEncodingGzip(t *testing.T) {
 	require.NoError(t, err)
 	metrics := []telegraf.Metric{m}
 
-	config := influxdb.HTTPConfig{
+	cfg := influxdb.HTTPConfig{
 		URL:             u,
 		Database:        "telegraf",
 		ContentEncoding: "gzip",
 		Log:             testutil.Logger{},
 	}
 
-	client, err := influxdb.NewHTTPClient(config)
+	client, err := influxdb.NewHTTPClient(cfg)
 	require.NoError(t, err)
 	err = client.Write(ctx, metrics)
 	require.NoError(t, err)
@@ -730,7 +730,7 @@ func TestHTTP_WriteDatabaseTagWorksOnRetry(t *testing.T) {
 		Host:   ts.Listener.Addr().String(),
 	}
 
-	config := influxdb.HTTPConfig{
+	cfg := influxdb.HTTPConfig{
 		URL:                addr,
 		Database:           "telegraf",
 		DatabaseTag:        "database",
@@ -738,7 +738,7 @@ func TestHTTP_WriteDatabaseTagWorksOnRetry(t *testing.T) {
 		Log:                testutil.Logger{},
 	}
 
-	client, err := influxdb.NewHTTPClient(config)
+	client, err := influxdb.NewHTTPClient(cfg)
 	require.NoError(t, err)
 
 	metrics := []telegraf.Metric{

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -795,15 +795,15 @@ func TestShortPatternRegression(t *testing.T) {
 	}
 	require.NoError(t, p.Compile())
 
-	metric, err := p.ParseLine(`Wed Apr 12 13:10:34 PST 2017 42`)
+	m, err := p.ParseLine(`Wed Apr 12 13:10:34 PST 2017 42`)
 	require.NoError(t, err)
-	require.NotNil(t, metric)
+	require.NotNil(t, m)
 
 	require.Equal(t,
 		map[string]interface{}{
 			"value": int64(42),
 		},
-		metric.Fields())
+		m.Fields())
 }
 
 func TestTimezoneEmptyCompileFileAndParse(t *testing.T) {


### PR DESCRIPTION
Fixes linter findings (issues accidentally created in last weeks) with little cleanup:
```
cmd/telegraf/printer.go:114:1                      revive  argument-limit: maximum number of arguments per function exceeded; max 6 but got 7
plugins/inputs/dns_query/dns_query_test.go:33:2    revive  import-shadowing: The name 'metric' shadows an import name
plugins/inputs/dns_query/dns_query_test.go:55:2    revive  import-shadowing: The name 'metric' shadows an import name
plugins/inputs/vsphere/client.go:99:74             revive  empty-lines: extra empty line at the end of a block
plugins/inputs/x509_cert/x509_cert_test.go:429:11  revive  indent-error-flow: if block ends with a return statement, so drop this else and outdent its block
plugins/outputs/influxdb/http.go:124:20            revive  import-shadowing: The name 'config' shadows an import name
plugins/outputs/influxdb/http_test.go:37:2         revive  import-shadowing: The name 'config' shadows an import name
plugins/outputs/influxdb/http_test.go:44:2         revive  import-shadowing: The name 'config' shadows an import name
plugins/outputs/influxdb/http_test.go:52:2         revive  import-shadowing: The name 'config' shadows an import name
plugins/outputs/influxdb/http_test.go:565:2        revive  import-shadowing: The name 'config' shadows an import name
plugins/outputs/influxdb/http_test.go:619:2        revive  import-shadowing: The name 'config' shadows an import name
plugins/outputs/influxdb/http_test.go:733:2        revive  import-shadowing: The name 'config' shadows an import name
plugins/parsers/grok/parser_test.go:798:2          revive  import-shadowing: The name 'metric' shadows an import name

```