### PR TITLE
chore: Lint whole codebase both in PR and master branch

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,9 +14,8 @@ permissions:
   pull-requests: read # to fetch pull requests (golangci/golangci-lint-action)
 
 jobs:
-  golangci-pr:
-    if: github.ref != 'refs/heads/master'
-    name: lint-pr-changes
+  golangci:
+    name: lint-codebase
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
@@ -26,21 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.0
-          only-new-issues: true
+          version: v1.50.1
           args: --timeout 15m0s --verbose
-  golangci-master:
-    if: github.ref == 'refs/heads/master'
-    name: lint-master-all
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.50.0
-          only-new-issues: true
-          args: --timeout 15m0s --issues-exit-code=0 --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -183,5 +183,19 @@ issues:
     - path: cmd/telegraf/(main|printer).go
       text: "Error return value of `outputBuffer.Write` is not checked"
 
+# output configuration options
 output:
+  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  #
+  # Multiple can be specified by separating them by comma, output can be provided
+  # for each of them by separating format name and path by colon symbol.
+  # Output path can be either `stdout`, `stderr` or path to the file to write to.
+  # Example: "checkstyle:report.json,colored-line-number"
+  #
+  # Default: colored-line-number
   format: tab
+  # Make issues output unique by line.
+  # Default: true
+  uniq-by-line: false
+  # Sort results by: filepath, line and column.
+  sort-results: true

--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,7 @@ lint-branch:
 		echo "golangci-lint not found, please run: make lint-install"; \
 		exit 1; \
 	}
-
-	golangci-lint run --new-from-rev master
+	golangci-lint run
 
 .PHONY: tidy
 tidy:

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -103,11 +103,7 @@ func (h *HTTP) gatherURL(
 	acc telegraf.Accumulator,
 	url string,
 ) error {
-	body, err := makeRequestBodyReader(h.ContentEncoding, h.Body)
-	if err != nil {
-		return err
-	}
-
+	body := makeRequestBodyReader(h.ContentEncoding, h.Body)
 	request, err := http.NewRequest(h.Method, url, body)
 	if err != nil {
 		return err
@@ -206,17 +202,17 @@ func (h *HTTP) setRequestAuth(request *http.Request) error {
 	return nil
 }
 
-func makeRequestBodyReader(contentEncoding, body string) (io.Reader, error) {
+func makeRequestBodyReader(contentEncoding, body string) io.Reader {
 	if body == "" {
-		return nil, nil
+		return nil
 	}
 
 	var reader io.Reader = strings.NewReader(body)
 	if contentEncoding == "gzip" {
-		return internal.CompressWithGzip(reader), nil
+		return internal.CompressWithGzip(reader)
 	}
 
-	return reader, nil
+	return reader
 }
 
 func init() {

--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -333,10 +333,7 @@ func (c *httpClient) writeBatch(ctx context.Context, db, rp string, metrics []te
 		return fmt.Errorf("failed making write url: %s", err.Error())
 	}
 
-	reader, err := c.requestBodyReader(metrics)
-	if err != nil {
-		return err
-	}
+	reader := c.requestBodyReader(metrics)
 	defer reader.Close()
 
 	req, err := c.makeWriteRequest(loc, reader)
@@ -481,14 +478,14 @@ func (c *httpClient) makeWriteRequest(address string, body io.Reader) (*http.Req
 
 // requestBodyReader warp io.Reader from influx.NewReader to io.ReadCloser, which is usefully to fast close the write
 // side of the connection in case of error
-func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) (io.ReadCloser, error) {
+func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) io.ReadCloser {
 	reader := influx.NewReader(metrics, c.config.Serializer)
 
 	if c.config.ContentEncoding == "gzip" {
-		return internal.CompressWithGzip(reader), nil
+		return internal.CompressWithGzip(reader)
 	}
 
-	return io.NopCloser(reader), nil
+	return io.NopCloser(reader)
 }
 
 func (c *httpClient) addHeaders(req *http.Request) error {

--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -249,10 +249,7 @@ func (c *httpClient) writeBatch(ctx context.Context, bucket string, metrics []te
 		return err
 	}
 
-	reader, err := c.requestBodyReader(metrics)
-	if err != nil {
-		return err
-	}
+	reader := c.requestBodyReader(metrics)
 	defer reader.Close()
 
 	req, err := c.makeWriteRequest(loc, reader)
@@ -387,14 +384,14 @@ func (c *httpClient) makeWriteRequest(address string, body io.Reader) (*http.Req
 
 // requestBodyReader warp io.Reader from influx.NewReader to io.ReadCloser, which is usefully to fast close the write
 // side of the connection in case of error
-func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) (io.ReadCloser, error) {
+func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) io.ReadCloser {
 	reader := influx.NewReader(metrics, c.serializer)
 
 	if c.ContentEncoding == "gzip" {
-		return internal.CompressWithGzip(reader), nil
+		return internal.CompressWithGzip(reader)
 	}
 
-	return io.NopCloser(reader), nil
+	return io.NopCloser(reader)
 }
 
 func (c *httpClient) addHeaders(req *http.Request) {


### PR DESCRIPTION
- Merge `golangci-pr` and `golangci-master` jobs into `golangci` job run both in PRs and on master branch. It will fail (for both cases) when any issue is found for whole codebase.
- bump `golangci-lint-action` from `v1.50.0` to `v1.50.1`
- Fix last findings introduced in https://github.com/influxdata/telegraf/pull/12587:
```
plugins/inputs/http/http.go:209:70          unparam  makeRequestBodyReader - result 1 (error) is always nil
plugins/outputs/influxdb/http.go:484:83     unparam  (*httpClient).requestBodyReader - result 1 (error) is always nil
plugins/outputs/influxdb_v2/http.go:390:83  unparam  (*httpClient).requestBodyReader - result 1 (error) is always nil
```