### PR TITLE
docs: Indicate secret-store support

### DIFF
--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -15,6 +15,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -11,6 +11,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -15,6 +15,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `sasl_username`,
+`sasl_password` and `sasl_access_token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -12,6 +12,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `usernane` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf
@@ -206,7 +215,7 @@ sensors,site=CLE,version=v1,device_name=device5 temp=390,rpm=45.0,ph=1.45
 - when [[inputs.internal]] is set:
   - payload_size (int): get the cumulative size in bytes that have been received from incoming messages
   - messages_received (int): count of the number of messages that have been received from mqtt
-  
+
 This will result in the following metric:
 
 ```text

--- a/plugins/inputs/postgresql/README.md
+++ b/plugins/inputs/postgresql/README.md
@@ -13,6 +13,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `address` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -20,6 +20,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `address` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -20,6 +20,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `sec_name`,
+`auth_password` and `priv_password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -28,6 +28,7 @@ See the [secret-store documentation][SECRETSTORE] for more details on how
 to use them.
 
 [SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/sql/README.md
+++ b/plugins/inputs/sql/README.md
@@ -15,6 +15,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `dsn` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/sql/README.md
+++ b/plugins/inputs/sql/README.md
@@ -193,3 +193,8 @@ nation,host=Hugin,name=Beast guest_id=5i 1611332164000000000
 ```
 
 [maria-sample]: https://www.mariadbtutorial.com/getting-started/mariadb-sample-database
+
+## Metrics
+
+The format of metrics produced by this plugin depends on the content and data
+format of the file.

--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -118,6 +118,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `servers` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/vsphere/README.md
+++ b/plugins/inputs/vsphere/README.md
@@ -27,6 +27,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf
@@ -393,7 +402,7 @@ instance. For example:
 [[inputs.vsphere]]
 
   interval = "300s"
-  
+
   vcenters = [ "https://someaddress/sdk" ]
   username = "someuser@vsphere.local"
   password = "secret"

--- a/plugins/outputs/amqp/README.md
+++ b/plugins/outputs/amqp/README.md
@@ -19,6 +19,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -100,6 +100,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `api_token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -232,6 +232,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username`,
+`password` and `auth_bearer_token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/groundwork/README.md
+++ b/plugins/outputs/groundwork/README.md
@@ -14,6 +14,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -127,9 +127,11 @@ to use them.
 
 ### Google API Auth
 
-The `google_application_credentials` setting is used with Google Cloud APIs. It specifies the json key file. To learn about creating Google service accounts, consult Google's
-[oauth2 service account documentation][create_service_account]. An example use case is a metrics proxy deployed to
-Cloud Run. In this example, the service account must have the "run.routes.invoke" permission.
+The `google_application_credentials` setting is used with Google Cloud APIs.
+It specifies the json key file. To learn about creating Google service accounts,
+consult Google's [oauth2 service account documentation][create_service_account].
+An example use case is a metrics proxy deployed to Cloud Run. In this example,
+the service account must have the "run.routes.invoke" permission.
 
 [create_service_account]: https://cloud.google.com/docs/authentication/production#create_service_account
 

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -13,6 +13,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/influxdb/README.md
+++ b/plugins/outputs/influxdb/README.md
@@ -12,6 +12,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/influxdb_v2/README.md
+++ b/plugins/outputs/influxdb_v2/README.md
@@ -11,6 +11,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/instrumental/README.md
+++ b/plugins/outputs/instrumental/README.md
@@ -18,6 +18,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `api_token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/iotdb/README.md
+++ b/plugins/outputs/iotdb/README.md
@@ -83,6 +83,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf
@@ -101,7 +110,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # timeout = "5s"
 
   ## Configuration of type conversion for 64-bit unsigned int
-  ## IoTDB currently DOES NOT support unsigned integers (version 13.x). 
+  ## IoTDB currently DOES NOT support unsigned integers (version 13.x).
   ## 32-bit unsigned integers are safely converted into 64-bit signed integers by the plugin,
   ## however, this is not true for 64-bit values in general as overflows may occur.
   ## The following setting allows to specify the handling of 64-bit unsigned integers.
@@ -112,16 +121,16 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # uint64_conversion = "int64_clip"
 
   ## Configuration of TimeStamp
-  ## TimeStamp is always saved in 64bits int. timestamp_precision specifies the unit of timestamp. 
+  ## TimeStamp is always saved in 64bits int. timestamp_precision specifies the unit of timestamp.
   ## Available value:
   ## "second", "millisecond", "microsecond", "nanosecond"(default)
   # timestamp_precision = "nanosecond"
 
   ## Handling of tags
-  ## Tags are not fully supported by IoTDB. 
+  ## Tags are not fully supported by IoTDB.
   ## A guide with suggestions on how to handle tags can be found here:
   ##     https://iotdb.apache.org/UserGuide/Master/API/InfluxDB-Protocol.html
-  ## 
+  ##
   ## Available values are:
   ##   - "fields"     --  convert tags to fields in the measurement
   ##   - "device_id"  --  attach tags to the device ID

--- a/plugins/outputs/iotdb/sample.conf
+++ b/plugins/outputs/iotdb/sample.conf
@@ -13,7 +13,7 @@
   # timeout = "5s"
 
   ## Configuration of type conversion for 64-bit unsigned int
-  ## IoTDB currently DOES NOT support unsigned integers (version 13.x). 
+  ## IoTDB currently DOES NOT support unsigned integers (version 13.x).
   ## 32-bit unsigned integers are safely converted into 64-bit signed integers by the plugin,
   ## however, this is not true for 64-bit values in general as overflows may occur.
   ## The following setting allows to specify the handling of 64-bit unsigned integers.
@@ -24,16 +24,16 @@
   # uint64_conversion = "int64_clip"
 
   ## Configuration of TimeStamp
-  ## TimeStamp is always saved in 64bits int. timestamp_precision specifies the unit of timestamp. 
+  ## TimeStamp is always saved in 64bits int. timestamp_precision specifies the unit of timestamp.
   ## Available value:
   ## "second", "millisecond", "microsecond", "nanosecond"(default)
   # timestamp_precision = "nanosecond"
 
   ## Handling of tags
-  ## Tags are not fully supported by IoTDB. 
+  ## Tags are not fully supported by IoTDB.
   ## A guide with suggestions on how to handle tags can be found here:
   ##     https://iotdb.apache.org/UserGuide/Master/API/InfluxDB-Protocol.html
-  ## 
+  ##
   ## Available values are:
   ##   - "fields"     --  convert tags to fields in the measurement
   ##   - "device_id"  --  attach tags to the device ID

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -12,6 +12,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `sasl_username`,
+`sasl_password` and `sasl_access_token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/librato/README.md
+++ b/plugins/outputs/librato/README.md
@@ -24,6 +24,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `api_user` and
+`api_token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/logzio/README.md
+++ b/plugins/outputs/logzio/README.md
@@ -11,6 +11,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/loki/README.md
+++ b/plugins/outputs/loki/README.md
@@ -15,6 +15,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/mongodb/README.md
+++ b/plugins/outputs/mongodb/README.md
@@ -13,6 +13,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -21,6 +21,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -11,6 +11,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -24,7 +24,7 @@ type NATS struct {
 	Name        string        `toml:"name"`
 	Username    config.Secret `toml:"username"`
 	Password    config.Secret `toml:"password"`
-	Credentials config.Secret `toml:"credentials"`
+	Credentials string        `toml:"credentials"`
 	Subject     string        `toml:"subject"`
 
 	tls.ClientConfig
@@ -66,13 +66,8 @@ func (n *NATS) Connect() error {
 		config.ReleaseSecret(password)
 	}
 
-	if !n.Credentials.Empty() {
-		credentials, err := n.Credentials.Get()
-		if err != nil {
-			return fmt.Errorf("getting credentials failed: %w", err)
-		}
-		opts = append(opts, nats.UserCredentials(string(credentials)))
-		config.ReleaseSecret(credentials)
+	if n.Credentials != "" {
+		opts = append(opts, nats.UserCredentials(n.Credentials))
 	}
 
 	if n.Name != "" {

--- a/plugins/outputs/redistimeseries/README.md
+++ b/plugins/outputs/redistimeseries/README.md
@@ -11,6 +11,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/signalfx/README.md
+++ b/plugins/outputs/signalfx/README.md
@@ -13,6 +13,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `access_token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/stomp/README.md
+++ b/plugins/outputs/stomp/README.md
@@ -14,6 +14,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/warp10/README.md
+++ b/plugins/outputs/warp10/README.md
@@ -11,6 +11,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -12,6 +12,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR adds a small section about secret-store support for each related plugin. Additionally, the PR removes secret-store support for the `credentials` option in `outputs.nats` as this references a file and should not be secret.