### PR TITLE
fix(inputs.mongodb): fix error logging

### DIFF
--- a/plugins/inputs/mongodb/mongodb.go
+++ b/plugins/inputs/mongodb/mongodb.go
@@ -68,7 +68,7 @@ func (m *MongoDB) Init() error {
 			InsecureSkipVerify: m.ClientConfig.InsecureSkipVerify,
 		}
 		if len(m.Ssl.CaCerts) == 0 {
-			return fmt.Errorf("you must explicitly set insecure_skip_verify to skip cerificate validation")
+			return fmt.Errorf("you must explicitly set insecure_skip_verify to skip certificate validation")
 		}
 
 		roots := x509.NewCertPool()
@@ -139,7 +139,7 @@ func (m *MongoDB) setupConnection(connURL string) error {
 			return fmt.Errorf("unable to ping MongoDB: %w", err)
 		}
 
-		m.Log.Errorf("unable to ping MongoDB: %w", err)
+		m.Log.Errorf("unable to ping MongoDB: %s", err)
 	}
 
 	server := &Server{
@@ -156,7 +156,7 @@ func (m *MongoDB) Stop() {
 	for _, server := range m.clients {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		if err := server.client.Disconnect(ctx); err != nil {
-			m.Log.Errorf("disconnecting from %q failed: %w", server, err)
+			m.Log.Errorf("disconnecting from %q failed: %s", server, err)
 		}
 		cancel()
 	}
@@ -172,14 +172,14 @@ func (m *MongoDB) Gather(acc telegraf.Accumulator) error {
 			defer wg.Done()
 			if m.DisconnectedServersBehavior == "skip" {
 				if err := srv.ping(); err != nil {
-					m.Log.Debugf("failed to ping server: %w", err)
+					m.Log.Debugf("failed to ping server: %s", err)
 					return
 				}
 			}
 
 			err := srv.gatherData(acc, m.GatherClusterStatus, m.GatherPerdbStats, m.GatherColStats, m.GatherTopStat, m.ColStatsDbs)
 			if err != nil {
-				m.Log.Errorf("failed to gather data: %w", err)
+				m.Log.Errorf("failed to gather data: %s", err)
 			}
 		}(client)
 	}


### PR DESCRIPTION
Resolves #12598.

Using `%w` in logs is not valid, it should only be used with `fmt.Errorf`.
