### PR TITLE
fix(inputs.mongodb): resolve SIGSEGV when restarting MongoDB node

### DIFF
--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -1222,16 +1222,18 @@ func NewStatLine(oldMongo, newMongo MongoStatus, key string, all bool, sampleSec
 		oldStat.ExtraInfo.PageFaults != nil && newStat.ExtraInfo.PageFaults != nil {
 		returnVal.Faults, returnVal.FaultsCnt = diff(*(newStat.ExtraInfo.PageFaults), *(oldStat.ExtraInfo.PageFaults), sampleSecs)
 	}
-	if !returnVal.IsMongos && oldStat.Locks != nil {
-		globalCheck, hasGlobal := oldStat.Locks["Global"]
-		if hasGlobal && globalCheck.AcquireCount != nil {
+	if !returnVal.IsMongos && oldStat.Locks != nil && newStat.Locks != nil {
+		globalCheckOld, hasGlobalOld := oldStat.Locks["Global"]
+		globalCheckNew, hasGlobalNew := newStat.Locks["Global"]
+		if hasGlobalOld && globalCheckOld.AcquireCount != nil && hasGlobalNew && globalCheckNew.AcquireCount != nil {
 			// This appears to be a 3.0+ server so the data in these fields do *not* refer to
 			// actual namespaces and thus we can't compute lock %.
 			returnVal.HighestLocked = nil
 
 			// Check if it's a 3.0+ MMAP server so we can still compute collection locks
-			collectionCheck, hasCollection := oldStat.Locks["Collection"]
-			if hasCollection && collectionCheck.AcquireWaitCount != nil {
+			collectionCheckOld, hasCollectionOld := oldStat.Locks["Collection"]
+			collectionCheckNew, hasCollectionNew := newStat.Locks["Collection"]
+			if hasCollectionOld && collectionCheckOld.AcquireWaitCount != nil && hasCollectionNew && collectionCheckNew.AcquireWaitCount != nil {
 				readWaitCountDiff := newStat.Locks["Collection"].AcquireWaitCount.Read - oldStat.Locks["Collection"].AcquireWaitCount.Read
 				readTotalCountDiff := newStat.Locks["Collection"].AcquireCount.Read - oldStat.Locks["Collection"].AcquireCount.Read
 				writeWaitCountDiff := newStat.Locks["Collection"].AcquireWaitCount.Write - oldStat.Locks["Collection"].AcquireWaitCount.Write

--- a/plugins/inputs/mongodb/mongostat_test.go
+++ b/plugins/inputs/mongodb/mongostat_test.go
@@ -198,3 +198,414 @@ func TestLatencyStatsDiff(t *testing.T) {
 	require.Equal(t, sl.ReadOpsCnt, int64(4189049884))
 	require.Equal(t, sl.WriteOpsCnt, int64(1691021287))
 }
+
+func TestLocksStatsNilWhenLocksMissingInOldStat(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	require.Nil(t, sl.CollectionLocks)
+}
+
+func TestLocksStatsNilWhenGlobalLockStatsMissingInOldStat(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	require.Nil(t, sl.CollectionLocks)
+}
+
+func TestLocksStatsNilWhenGlobalLockStatsEmptyInOldStat(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {},
+				},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	require.Nil(t, sl.CollectionLocks)
+}
+
+func TestLocksStatsNilWhenCollectionLockStatsMissingInOldStat(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	require.Nil(t, sl.CollectionLocks)
+}
+
+func TestLocksStatsNilWhenCollectionLockStatsEmptyInOldStat(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+					"Collection": {},
+				},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	require.Nil(t, sl.CollectionLocks)
+}
+
+func TestLocksStatsNilWhenLocksMissingInNewStat(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	require.Nil(t, sl.CollectionLocks)
+}
+
+func TestLocksStatsNilWhenGlobalLockStatsMissingInNewStat(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	require.Nil(t, sl.CollectionLocks)
+}
+
+func TestLocksStatsNilWhenGlobalLockStatsEmptyInNewStat(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {},
+				},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	require.Nil(t, sl.CollectionLocks)
+}
+
+func TestLocksStatsNilWhenCollectionLockStatsMissingInNewStat(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	require.Nil(t, sl.CollectionLocks)
+}
+
+func TestLocksStatsNilWhenCollectionLockStatsEmptyInNewStat(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+				},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+					"Collection": {},
+				},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	require.Nil(t, sl.CollectionLocks)
+}
+
+func TestLocksStatsPopulated(t *testing.T) {
+	sl := NewStatLine(
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+					"Collection": {
+						AcquireWaitCount: &ReadWriteLockTimes{
+							Read:  1,
+							Write: 2,
+						},
+						AcquireCount: &ReadWriteLockTimes{
+							Read:  5,
+							Write: 10,
+						},
+						TimeAcquiringMicros: ReadWriteLockTimes{
+							Read:  100,
+							Write: 200,
+						},
+					},
+				},
+			},
+		},
+		MongoStatus{
+			ServerStatus: &ServerStatus{
+				Connections: &ConnectionStats{},
+				Mem: &MemStats{
+					Supported: false,
+				},
+				Locks: map[string]LockStats{
+					"Global": {
+						AcquireCount: &ReadWriteLockTimes{},
+					},
+					"Collection": {
+						AcquireWaitCount: &ReadWriteLockTimes{
+							Read:  2,
+							Write: 4,
+						},
+						AcquireCount: &ReadWriteLockTimes{
+							Read:  10,
+							Write: 30,
+						},
+						TimeAcquiringMicros: ReadWriteLockTimes{
+							Read:  250,
+							Write: 310,
+						},
+					},
+				},
+			},
+		},
+		"foo",
+		true,
+		60,
+	)
+
+	expected := &CollectionLockStatus{
+		ReadAcquireWaitsPercentage:  20,
+		WriteAcquireWaitsPercentage: 10,
+		ReadAcquireTimeMicros:       150,
+		WriteAcquireTimeMicros:      55,
+	}
+
+	require.Equal(t, expected, sl.CollectionLocks)
+}


### PR DESCRIPTION
Below is an example of the SIGSEGV I occasionally get when restarting a MongoDB node that is being monitored by Telegraf MongoDB plugin. I think it rather happens during the node shutdown, though. Because according to the stacktrace, it's the `newStat` variable that doesn't have `Locks` populated as the code expects. The proposed fix is quite straightforward. It just adds adds necessary `nil` checks that are the same (symmetric) as those performed on the `oldStat` data.

The stacktrace below is for Telegraf 1.24.2. The line with "nil pointer dereference" can be found at https://github.com/influxdata/telegraf/blob/9550e7a533dd00632e14435e87ed3eb4b04832c6/plugins/inputs/mongodb/mongostat.go#L1227
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2637e51]

goroutine 6343563 [running]:
[github.com/influxdata/telegraf/plugins/inputs/mongodb.NewStatLine(](http://github.com/influxdata/telegraf/plugins/inputs/mongodb.NewStatLine(){{0xc0eeb390fb1262f5, 0x1a554c27316d, 0x95c0b40}, 0xc00167a360, 0xc0027761a0, 0xc001db02d0, 0xc000760060, 0xc0029b8e88, 0xc00076e2d0, 0xc0019800e8, ...}, ...)
	/go/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongostat.go:1227 +0x1871
[github.com/influxdata/telegraf/plugins/inputs/mongodb.(*Server).gatherData(0xc00146a5a0,](http://github.com/influxdata/telegraf/plugins/inputs/mongodb.(*Server).gatherData(0xc00146a5a0,) {0x671b7a0, 0xc0009a6460}, 0x1, 0x1, 0x1, 0x1, {0x9603620, 0x0, 0x0})
	/go/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongodb_server.go:363 +0x79d
[github.com/influxdata/telegraf/plugins/inputs/mongodb.(*MongoDB).Gather.func1(0xc002622850?)](http://github.com/influxdata/telegraf/plugins/inputs/mongodb.(*MongoDB).Gather.func1(0xc002622850?))
	/go/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongodb.go:164 +0x1a9
created by [github.com/influxdata/telegraf/plugins/inputs/mongodb.(*MongoDB).Gather](http://github.com/influxdata/telegraf/plugins/inputs/mongodb.(*MongoDB).Gather)
	/go/src/github.com/influxdata/telegraf/plugins/inputs/mongodb/mongodb.go:155 +0x65
```
Also, quite often but not always, I can catch the following error in the plugin before the crash:
```
2023-02-01T12:11:10Z E! [inputs.mongodb] failed to gather data: %!w(mongo.CommandError={13436 node is not in primary or recovering state [] NotPrimaryOrSecondary <nil> [180 0 0 0 3 116 111 112 111 108 111 103 121 86 101 114 115 105 111 110 0 45 0 0 0 7 112 114 111 99 101 115 115 73 100 0 99 218 86 207 130 25 202 195 230 35 33 178 18 99 111 117 110 116 101 114 0 0 0 0 0 0 0 0 0 0 1 111 107 0 0 0 0 0 0 0 0 0 2 101 114 114 109 115 103 0 43 0 0 0 110 111 100 101 32 105 115 32 110 111 116 32 105 110 32 112 114 105 109 97 114 121 32 111 114 32 114 101 99 111 118 101 114 105 110 103 32 115 116 97 116 101 0 16 99 111 100 101 0 124 52 0 0 2 99 111 100 101 78 97 109 101 0 22 0 0 0 78 111 116 80 114 105 109 97 114 121 79 114 83 101 99 111 110 100 97 114 121 0 0]})
```

# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12611

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
