### PR TITLE
chore: bump golangci-lint from v1.50.1 to v1.51.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,5 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.0
           args: --timeout 15m0s --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - errcheck
     - errname
     - exportloopref
+    - gocheckcompilerdirectives
     - goprintffuncname
     - gosimple
     - govet
@@ -130,7 +131,7 @@ linters-settings:
       - name: unconditional-recursion
       - name: unexported-naming
       - name: unhandled-error
-        arguments: [ "outputBuffer.Write", "fmt.Printf", "fmt.Println", "fmt.Print", "fmt.Fprintf", "fmt.Fprint", "fmt.Fprintln" ]
+        arguments: [ "fmt.Printf", "fmt.Println", "fmt.Print", "fmt.Fprintf", "fmt.Fprint", "fmt.Fprintln" ]
       - name: unnecessary-stmt
       - name: unreachable-code
       - name: unused-parameter
@@ -182,6 +183,9 @@ issues:
 
     - path: cmd/telegraf/(main|printer).go
       text: "Error return value of `outputBuffer.Write` is not checked"
+
+    - path: cmd/telegraf/(main|printer).go
+      text: "unhandled-error: Unhandled error in call to function outputBuffer.Write"
 
 # output configuration options
 output:

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/plugins/inputs/jti_openconfig_telemetry/collection.go
+++ b/plugins/inputs/jti_openconfig_telemetry/collection.go
@@ -30,12 +30,8 @@ func (a CollectionByKeys) IsAvailable(tags map[string]string) *DataGroup {
 
 		matchFound := true
 		for k, v := range tags {
-			if val, ok := group.tags[k]; ok {
-				if val != v {
-					matchFound = false
-					break
-				}
-			} else {
+			val, ok := group.tags[k]
+			if !ok || val != v {
 				matchFound = false
 				break
 			}

--- a/plugins/inputs/leofs/leofs.go
+++ b/plugins/inputs/leofs/leofs.go
@@ -165,15 +165,15 @@ func (l *LeoFS) Gather(acc telegraf.Accumulator) error {
 
 		port := "4020"
 		if len(results) > 2 {
-			acc.AddError(fmt.Errorf("Unable to parse address %q", endpoint))
+			acc.AddError(fmt.Errorf("unable to parse address %q", endpoint))
 			continue
 		} else if len(results) == 2 {
-			if _, err := strconv.Atoi(results[1]); err == nil {
-				port = results[1]
-			} else {
-				acc.AddError(fmt.Errorf("Unable to parse port from %q", endpoint))
+			_, err := strconv.Atoi(results[1])
+			if err != nil {
+				acc.AddError(fmt.Errorf("unable to parse port from %q", endpoint))
 				continue
 			}
+			port = results[1]
 		}
 
 		st, ok := serverTypeMapping[port]

--- a/plugins/inputs/pf/pf.go
+++ b/plugins/inputs/pf/pf.go
@@ -92,11 +92,10 @@ func (pf *PF) parsePfctlOutput(pfoutput string, acc telegraf.Accumulator) error 
 				for !anyTableHeaderRE.MatchString(line) {
 					stanzaLines = append(stanzaLines, line)
 					more := scanner.Scan()
-					if more {
-						line = scanner.Text()
-					} else {
+					if !more {
 						break
 					}
+					line = scanner.Text()
 				}
 				if perr := s.ParseFunc(stanzaLines, fields); perr != nil {
 					return perr

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -147,9 +147,7 @@ func (p *Postgresql) gatherMetricsFromQuery(acc telegraf.Accumulator, sqlQuery s
 	p.AdditionalTags = nil
 	if tagValue != "" {
 		tagList := strings.Split(tagValue, ",")
-		for t := range tagList {
-			p.AdditionalTags = append(p.AdditionalTags, tagList[t])
-		}
+		p.AdditionalTags = append(p.AdditionalTags, tagList...)
 	}
 
 	p.Timestamp = timestamp

--- a/plugins/inputs/systemd_units/systemd_units.go
+++ b/plugins/inputs/systemd_units/systemd_units.go
@@ -196,9 +196,7 @@ func setSystemctl(timeout config.Duration, unitType string, pattern string) (*by
 	// create patterns parameters if provided in config
 	if pattern != "" {
 		psplit := strings.SplitN(pattern, " ", -1)
-		for v := range psplit {
-			params = append(params, psplit[v])
-		}
+		params = append(params, psplit...)
 	}
 	params = append(params, "--all", "--plain")
 	// add type as configured in config

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -213,18 +213,18 @@ func (g *Graphite) send(batch []byte) error {
 			g.failedServers = append(g.failedServers, g.conns[n].RemoteAddr().String())
 			break
 		}
-		if _, e := g.conns[n].Write(batch); e != nil {
-			// Error
-			g.Log.Debugf("Graphite Error: " + e.Error())
-			// Close explicitly and let's try the next one
-			err := g.conns[n].Close()
-			g.Log.Debugf("Failed to close the connection: %v", err)
-			// Mark server as failed so a new connection will be made
-			g.failedServers = append(g.failedServers, g.conns[n].RemoteAddr().String())
-		} else {
+		_, e := g.conns[n].Write(batch)
+		if e == nil {
 			globalErr = nil
 			break
 		}
+		// Error
+		g.Log.Debugf("Graphite Error: " + e.Error())
+		// Close explicitly and let's try the next one
+		err = g.conns[n].Close()
+		g.Log.Debugf("Failed to close the connection: %v", err)
+		// Mark server as failed so a new connection will be made
+		g.failedServers = append(g.failedServers, g.conns[n].RemoteAddr().String())
 	}
 
 	return globalErr


### PR DESCRIPTION
- chore: bump `golangci-lint` from v1.50.1 to [v1.51.0](https://github.com/golangci/golangci-lint/releases/tag/v1.51.0)
- enable new [gocheckcompilerdirectives](https://github.com/leighmcculloch/gocheckcompilerdirectives) linter:

  > Check that go compiler directives (`//go:` comments) are valid and catch easy mistakes.
  > Compiler directives are comments like `//go:generate`, `//go:embed`, `//go:build`, etc.
  >
  > ## Why
  > 
  > Go compiler directives are comments in the form of `//go:` that provide an instruction to the compiler.
  > The directives are easy to make mistakes with. The linter will detect the following mistakes:
  > 1. Adding a space in between the comment bars and the first character, e.g. `//go:`, will cause the compiler to silently ignore the comment.
  > 2. Mistyping a directives name, e.g. `//go:embod`, will cause the compiler to silently ignore the comment.
- fix issues which were found by new version of `golangci-lint`:
```
cmd/telegraf/main.go:161:4                                           revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/main.go:163:4                                           revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/main.go:165:4                                           revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/main.go:167:4                                           revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/main.go:172:4                                           revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/main.go:179:5                                           revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/main.go:184:4                                           revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/main.go:191:5                                           revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/main.go:204:4                                           revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/main.go:355:6                                           revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:113:2                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:142:5                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:146:4                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:163:5                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:167:4                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:180:5                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:184:4                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:197:5                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:201:4                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:291:2                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:348:3                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:352:3                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:367:3                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:373:3                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:374:3                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:377:3                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:380:5                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
cmd/telegraf/printer.go:383:4                                        revive    unhandled-error: Unhandled error in call to function outputBuffer.Write
plugins/inputs/jti_openconfig_telemetry/collection.go:33:4           revive    early-return: if c { ... } else { ... break } can be simplified to if !c { ... break } ... (move short variable declaration to its own line if necessary)
plugins/inputs/leofs/leofs.go:171:4                                  revive    early-return: if c { ... } else { ... continue } can be simplified to if !c { ... continue } ... (move short variable declaration to its own line if necessary)
plugins/inputs/pf/pf.go:95:6                                         revive    early-return: if c { ... } else { ... break } can be simplified to if !c { ... break } ...
plugins/inputs/postgresql_extensible/postgresql_extensible.go:150:3  gosimple  S1011: should replace loop with `p.AdditionalTags = append(p.AdditionalTags, tagList...)`
plugins/inputs/snmp_legacy/snmp_legacy.go:387:6                      revive    early-return: if c { ... } else { ... break } can be simplified to if !c { ... break } ...
plugins/inputs/snmp_legacy/snmp_legacy.go:664:7                      revive    early-return: if c { ... } else { ... continue } can be simplified to if !c { ... continue } ... (move short variable declaration to its own line if necessary)
plugins/inputs/systemd_units/systemd_units.go:199:3                  gosimple  S1011: should replace loop with `params = append(params, psplit...)`
plugins/outputs/graphite/graphite.go:216:3                           revive    early-return: if c { ... } else { ... break } can be simplified to if !c { ... break } ... (move short variable declaration to its own line if necessary)
```
