### PR TITLE
fix(agent): only read the config once

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -111,7 +111,7 @@ func (t *Telegraf) GetSecretStore(id string) (telegraf.SecretStore, error) {
 }
 
 func (t *Telegraf) reloadLoop() error {
-	config, err := t.loadConfiguration()
+	cfg, err := t.loadConfiguration()
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func (t *Telegraf) reloadLoop() error {
 			}
 		}()
 
-		err := t.runAgent(ctx, config)
+		err := t.runAgent(ctx, cfg)
 		if err != nil && err != context.Canceled {
 			return fmt.Errorf("[telegraf] Error running agent: %v", err)
 		}

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -111,7 +111,7 @@ func (t *Telegraf) GetSecretStore(id string) (telegraf.SecretStore, error) {
 }
 
 func (t *Telegraf) reloadLoop() error {
-	_, err := t.loadConfiguration()
+	config, err := t.loadConfiguration()
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func (t *Telegraf) reloadLoop() error {
 			}
 		}()
 
-		err := t.runAgent(ctx)
+		err := t.runAgent(ctx, config)
 		if err != nil && err != context.Canceled {
 			return fmt.Errorf("[telegraf] Error running agent: %v", err)
 		}
@@ -230,12 +230,7 @@ func (t *Telegraf) loadConfiguration() (*config.Config, error) {
 	return c, nil
 }
 
-func (t *Telegraf) runAgent(ctx context.Context) error {
-	c, err := t.loadConfiguration()
-	if err != nil {
-		return err
-	}
-
+func (t *Telegraf) runAgent(ctx context.Context, c *config.Config) error {
 	if !(t.test || t.testWait != 0) && len(c.Outputs) == 0 {
 		return errors.New("no outputs found, did you provide a valid config file?")
 	}


### PR DESCRIPTION
Pass the contents of the config from the reloadLoop into runAgent. Currently the behavior is to go through and read the config twice.

fixes: #12606
