### PR TITLE
feat(agent): add /etc/telegraf/telegraf.d to default config locations

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -208,19 +208,20 @@ func (t *Telegraf) loadConfiguration() (*config.Config, error) {
 	c.SecretStoreFilters = t.secretstoreFilters
 
 	var configFiles []string
-	// providing no "config" flag should load default config
-	if len(t.config) == 0 {
-		configFiles = append(configFiles, "")
-	} else {
-		configFiles = append(configFiles, t.config...)
-	}
 
+	configFiles = append(configFiles, t.config...)
 	for _, fConfigDirectory := range t.configDir {
 		files, err := config.WalkDirectory(fConfigDirectory)
 		if err != nil {
 			return c, err
 		}
 		configFiles = append(configFiles, files...)
+	}
+
+	// providing no "config" or "config-directory" flag(s) should load default
+	// configuration files
+	if len(configFiles) == 0 {
+		configFiles = append(configFiles, "")
 	}
 
 	t.configFiles = configFiles

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -484,7 +484,7 @@ func TestConfig_getDefaultConfigPathFromEnvURL(t *testing.T) {
 	require.NoError(t, err)
 	configPath, err := getDefaultConfigPath()
 	require.NoError(t, err)
-	require.Equal(t, ts.URL, configPath)
+	require.Equal(t, []string{ts.URL}, configPath)
 	err = c.LoadConfig("")
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This will add /etc/telegraf/telegraf.d to the list of default
configuration locations to load from.  A common use case is for
Docker where users want to upload an entire directory of 
configurations and run telegraf. Right now they have to add
a custom launch command, when in reality we should include this
directory by default.

This also means that the --config option can be omitted from the CLI
if a user is only using --config-directory. Currently, users need to specify
an empty /etc/telegraf/telegraf.conf file and specify they want to
include only a configuration directory.

fixes: https://github.com/influxdata/telegraf/issues/5656
fixes: https://github.com/influxdata/telegraf/issues/5571