### PR TITLE
chore: Bump go to 1.20 for golangci-lint-action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,7 +8,7 @@ on:
       - master
   schedule:
     # Trigger every day at 16:00 UTC
-    - cron:  '0 16 * * *'
+    - cron: '0 16 * * *'
 permissions:
   contents: read # to fetch code (actions/checkout)
   pull-requests: read # to fetch pull requests (golangci/golangci-lint-action)

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
+	cryptoRand "crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -87,13 +88,16 @@ func ReadLines(filename string) ([]string, error) {
 }
 
 // RandomString returns a random string of alphanumeric characters
-func RandomString(n int) string {
+func RandomString(n int) (string, error) {
 	var bytes = make([]byte, n)
-	rand.Read(bytes) //nolint:revive // from math/rand/rand.go: "It always returns len(p) and a nil error."
+	_, err := cryptoRand.Read(bytes)
+	if err != nil {
+		return "", err
+	}
 	for i, b := range bytes {
 		bytes[i] = alphanum[b%byte(len(alphanum))]
 	}
-	return string(bytes)
+	return string(bytes), nil
 }
 
 // SnakeCase converts the given string to snake case following the Golang format:

--- a/plugins/inputs/mock/mock.go
+++ b/plugins/inputs/mock/mock.go
@@ -15,8 +15,6 @@ import (
 var sampleConfig string
 
 type Mock struct {
-	counter int64
-
 	MetricName string            `toml:"metric_name"`
 	Tags       map[string]string `toml:"tags"`
 
@@ -25,6 +23,9 @@ type Mock struct {
 	Step     []*step     `toml:"step"`
 	Stock    []*stock    `toml:"stock"`
 	SineWave []*sineWave `toml:"sine_wave"`
+
+	counter int64
+	rand    *rand.Rand
 }
 
 type constant struct {
@@ -65,7 +66,7 @@ func (*Mock) SampleConfig() string {
 }
 
 func (m *Mock) Init() error {
-	rand.Seed(time.Now().UnixNano())
+	m.rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 	return nil
 }
 
@@ -92,17 +93,17 @@ func (m *Mock) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-// Generate random value between min and max, inclusivly
+// Generate random value between min and max, inclusively
 func (m *Mock) generateRandomFloat64(fields map[string]interface{}) {
 	for _, random := range m.Random {
-		fields[random.Name] = random.Min + rand.Float64()*(random.Max-random.Min)
+		fields[random.Name] = random.Min + m.rand.Float64()*(random.Max-random.Min)
 	}
 }
 
 // Create sine waves
 func (m *Mock) generateSineWave(fields map[string]interface{}) {
 	for _, field := range m.SineWave {
-		fields[field.Name] = math.Sin((float64(m.counter) * field.Period * math.Pi)) * field.Amplitude
+		fields[field.Name] = math.Sin(float64(m.counter)*field.Period*math.Pi) * field.Amplitude
 	}
 }
 
@@ -125,7 +126,7 @@ func (m *Mock) generateStockPrice(fields map[string]interface{}) {
 		if stock.latest == 0.0 {
 			stock.latest = stock.Price
 		} else {
-			noise := 2 * (rand.Float64() - 0.5)
+			noise := 2 * (m.rand.Float64() - 0.5)
 			stock.latest = stock.latest + (stock.latest * stock.Volatility * noise)
 
 			// avoid going below zero

--- a/plugins/inputs/mock/mock_test.go
+++ b/plugins/inputs/mock/mock_test.go
@@ -3,8 +3,9 @@ package mock
 import (
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestGather(t *testing.T) {
@@ -62,6 +63,7 @@ func TestGather(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
+	require.NoError(t, m.Init())
 	require.NoError(t, m.Gather(&acc))
 
 	require.Len(t, acc.Metrics, 1)
@@ -100,6 +102,7 @@ func TestGatherEmpty(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
+	require.NoError(t, m.Init())
 	require.NoError(t, m.Gather(&acc))
 
 	acc.AssertDoesNotContainMeasurement(t, "test_empty")

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -320,7 +320,11 @@ func (m *MQTTConsumer) createOpts() (*mqtt.ClientOptions, error) {
 	opts := mqtt.NewClientOptions()
 	opts.ConnectTimeout = time.Duration(m.ConnectionTimeout)
 	if m.ClientID == "" {
-		opts.SetClientID("Telegraf-Consumer-" + internal.RandomString(5))
+		randomString, err := internal.RandomString(5)
+		if err != nil {
+			return nil, fmt.Errorf("generating random string for client ID failed: %w", err)
+		}
+		opts.SetClientID("Telegraf-Consumer-" + randomString)
 	} else {
 		opts.SetClientID(m.ClientID)
 	}

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -435,7 +435,11 @@ func (s *Statsd) tcpListen(listener *net.TCPListener) error {
 				// not over connection limit, handle the connection properly.
 				s.wg.Add(1)
 				// generate a random id for this TCPConn
-				id := internal.RandomString(6)
+				id, err := internal.RandomString(6)
+				if err != nil {
+					return err
+				}
+
 				s.remember(id, conn)
 				go s.handler(conn, id)
 			default:

--- a/plugins/inputs/tcp_listener/tcp_listener.go
+++ b/plugins/inputs/tcp_listener/tcp_listener.go
@@ -170,10 +170,16 @@ func (t *TCPListener) tcpListen() {
 
 			select {
 			case <-t.accept:
+				// generate a random id for this TCPConn
+				id, err := internal.RandomString(6)
+				if err != nil {
+					t.Log.Errorf("generating a random id for TCP connection failed: %v", err)
+					return
+				}
+
 				// not over connection limit, handle the connection properly.
 				t.wg.Add(1)
-				// generate a random id for this TCPConn
-				id := internal.RandomString(6)
+
 				t.remember(id, conn)
 				go t.handler(conn, id)
 			default:

--- a/plugins/outputs/file/file_test.go
+++ b/plugins/outputs/file/file_test.go
@@ -185,7 +185,9 @@ func createFile(t *testing.T) *os.File {
 }
 
 func tmpFile(t *testing.T) string {
-	return t.TempDir() + internal.RandomString(10)
+	randomString, err := internal.RandomString(10)
+	require.NoError(t, err)
+	return t.TempDir() + randomString
 }
 
 func validateFile(t *testing.T, fileName, expS string) {

--- a/plugins/outputs/mqtt/mqtt_v3.go
+++ b/plugins/outputs/mqtt/mqtt_v3.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	// Library that supports v3.1.1
-	mqttv3 "github.com/eclipse/paho.mqtt.golang"
+	mqttv3 "github.com/eclipse/paho.mqtt.golang" // Library that supports v3.1.1
+
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 )
@@ -31,7 +31,11 @@ func (m *mqttv311Client) Connect() error {
 	if m.ClientID != "" {
 		opts.SetClientID(m.ClientID)
 	} else {
-		opts.SetClientID("Telegraf-Output-" + internal.RandomString(5))
+		randomString, err := internal.RandomString(5)
+		if err != nil {
+			return fmt.Errorf("generating random string for client ID failed: %w", err)
+		}
+		opts.SetClientID("Telegraf-Output-" + randomString)
 	}
 
 	tlsCfg, err := m.ClientConfig.TLSConfig()

--- a/plugins/outputs/mqtt/mqtt_v5.go
+++ b/plugins/outputs/mqtt/mqtt_v5.go
@@ -8,6 +8,7 @@ import (
 
 	mqttv5auto "github.com/eclipse/paho.golang/autopaho"
 	mqttv5 "github.com/eclipse/paho.golang/paho"
+
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 )
@@ -26,7 +27,11 @@ func (m *mqttv5Client) Connect() error {
 	if m.ClientID != "" {
 		opts.ClientID = m.ClientID
 	} else {
-		opts.ClientID = "Telegraf-Output-" + internal.RandomString(5)
+		randomString, err := internal.RandomString(5)
+		if err != nil {
+			return fmt.Errorf("generating random string for client ID failed: %w", err)
+		}
+		opts.ClientID = "Telegraf-Output-" + randomString
 	}
 
 	user, err := m.Username.Get()

--- a/tools/update_goversion/main.go
+++ b/tools/update_goversion/main.go
@@ -144,6 +144,11 @@ func main() {
 			Replace:  fmt.Sprintf("$1:%s", version),
 		},
 		{
+			FileName: ".github/workflows/golangci-lint.yml",
+			Regex:    `(go-version).*`,
+			Replace:  fmt.Sprintf("$1: '%s'", zeroPatchVersion),
+		},
+		{
 			FileName: "Makefile",
 			Regex:    `(quay\.io\/influxdb\/telegraf-ci):(\d.\d*.\d)`,
 			Replace:  fmt.Sprintf("$1:%s", version),


### PR DESCRIPTION
- Bump go to 1.20 for `golangci-lint-action`
- Bumping go version for `.github/workflows/golangci-lint.yml` added to `tools/update_goversion`
- Fixed issues found for go 1.20:
```
internal/internal.go:92:2         staticcheck  SA1019: rand.Read has been deprecated since Go 1.20 because it shouldn't be used: For almost all use cases, crypto/rand.Read is more appropriate. 
plugins/inputs/mock/mock.go:68:2  staticcheck  SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access. 
 ```