### PR TITLE
fix(inputs.docker): fallback to cache memory usage, prefer newer latest

### DIFF
--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -409,8 +409,8 @@ func TestDockerMemoryExcludesCache(t *testing.T) {
 		"total_unevictable":         uint64(0),
 		"total_writeback":           uint64(55),
 		"unevictable":               uint64(0),
-		"usage_percent":             float64(54.75), // 1095 / 2000
-		"usage":                     uint64(1095),
+		"usage_percent":             float64(55.2),
+		"usage":                     uint64(1104),
 		"writeback":                 uint64(0),
 	}
 

--- a/plugins/inputs/docker/stats_helpers.go
+++ b/plugins/inputs/docker/stats_helpers.go
@@ -49,16 +49,16 @@ func calculateCPUPercentWindows(v *types.StatsJSON) float64 {
 // This definition is designed to be consistent with past values and the latest docker CLI
 // * https://github.com/docker/cli/blob/6e2838e18645e06f3e4b6c5143898ccc44063e3b/cli/command/container/stats_helpers.go#L239
 func CalculateMemUsageUnixNoCache(mem types.MemoryStats) float64 {
-	// Docker 19.03 and older
-	if v, isOldDocker := mem.Stats["cache"]; isOldDocker && v < mem.Usage {
-		return float64(mem.Usage - v)
-	}
 	// cgroup v1
 	if v, isCgroup1 := mem.Stats["total_inactive_file"]; isCgroup1 && v < mem.Usage {
 		return float64(mem.Usage - v)
 	}
 	// cgroup v2
 	if v := mem.Stats["inactive_file"]; v < mem.Usage {
+		return float64(mem.Usage - v)
+	}
+	// Docker 19.03 and older
+	if v, isOldDocker := mem.Stats["cache"]; isOldDocker && v < mem.Usage {
 		return float64(mem.Usage - v)
 	}
 	return float64(mem.Usage)

--- a/plugins/inputs/ecs/stats_test.go
+++ b/plugins/inputs/ecs/stats_test.go
@@ -74,8 +74,8 @@ func Test_memstats(t *testing.T) {
 			"total_pgpgout":             uint64(1674),
 			"total_pgpgin":              uint64(3477),
 			"total_rss":                 uint64(1597440),
-			"usage":                     uint64(2392064),
-			"usage_percent":             float64(0.23141727228778164),
+			"usage":                     uint64(3858432),
+			"usage_percent":             float64(0.3732792302998122),
 		},
 		map[string]string{
 			"test_tag": "test",


### PR DESCRIPTION
This changes the ordering of how we determine memory usage. It prefers the usage of the newer methods and only uses the older method as a last resort.

fixes: #11596