### PR TITLE
feat(inputs.internet_speed): server ID include and exclude filter

### DIFF
--- a/plugins/inputs/internet_speed/README.md
+++ b/plugins/inputs/internet_speed/README.md
@@ -34,20 +34,38 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Caches the closest server location
   # cache = false
+
+  ## Server ID exclude filter
+  ## Allows the user to exclude or include specific server IDs received by
+  ## speedtest-go. Values in the exclude option will be skipped over. Values in
+  ## the include option are the only options that will be picked from.
+  ##
+  ## See the list of servers speedtest-go will return at:
+  ##     https://www.speedtest.net/api/js/servers?engine=js&limit=10
+  ##
+  # server_id_exclude = []
+  # server_id_include = []
 ```
 
 ## Metrics
 
-It collects latency, download speed and upload speed
+It collects the following fields:
 
-| Name           | filed name | type    | Unit |
+| Name           | field name | type    | Unit |
 | -------------- | ---------- | ------- | ---- |
 | Download Speed | download   | float64 | Mbps |
 | Upload Speed   | upload     | float64 | Mbps |
 | Latency        | latency    | float64 | ms   |
 
+And the following tags:
+
+| Name      | tag name  |
+| --------- | --------- |
+| Host      | host      |
+| Server ID | server_id |
+
 ## Example Output
 
 ```sh
-internet_speed,host=Sanyam-Ubuntu download=41.791,latency=28.518,upload=59.798 1631031183000000000
+internet_speed,host=speedtest02.z4internet.com:8080,server_id=54619 download=318.37580265897725,upload=30.444407341274385,latency=37.73174 1675458921000000000
 ```

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -66,7 +66,7 @@ func (is *InternetSpeed) Gather(acc telegraf.Accumulator) error {
 	}
 	err = is.server.UploadTest(is.MemorySavingMode)
 	if err != nil {
-		return fmt.Errorf("upload test failed failed, try `memory_saving_mode = true` if this fails consistently: %v", err)
+		return fmt.Errorf("upload test failed failed, try `memory_saving_mode = true` if this fails consistently: %w", err)
 	}
 
 	fields := map[string]any{

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -42,7 +42,7 @@ func (is *InternetSpeed) Init() error {
 	var err error
 	is.serverFilter, err = filter.NewIncludeExcludeFilter(is.ServerIDInclude, is.ServerIDExclude)
 	if err != nil {
-		return fmt.Errorf("error compiling server ID filters: %v", err)
+		return fmt.Errorf("error compiling server ID filters: %w", err)
 	}
 
 	return nil

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -52,7 +52,7 @@ func (is *InternetSpeed) Gather(acc telegraf.Accumulator) error {
 	// if not caching, go find closest server each time
 	if !is.Cache || is.server == nil {
 		if err := is.FindClosestServer(); err != nil {
-			return fmt.Errorf("unable to find closest server: %s", err)
+			return fmt.Errorf("unable to find closest server: %w", err)
 		}
 	}
 

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -62,7 +62,7 @@ func (is *InternetSpeed) Gather(acc telegraf.Accumulator) error {
 	}
 	err = is.server.DownloadTest(is.MemorySavingMode)
 	if err != nil {
-		return fmt.Errorf("download test failed, try `memory_saving_mode = true` if this fails consistently: %v", err)
+		return fmt.Errorf("download test failed, try `memory_saving_mode = true` if this fails consistently: %w", err)
 	}
 	err = is.server.UploadTest(is.MemorySavingMode)
 	if err != nil {

--- a/plugins/inputs/internet_speed/sample.conf
+++ b/plugins/inputs/internet_speed/sample.conf
@@ -10,3 +10,14 @@
 
   ## Caches the closest server location
   # cache = false
+
+  ## Server ID exclude filter
+  ## Allows the user to exclude or include specific server IDs received by
+  ## speedtest-go. Values in the exclude option will be skipped over. Values in
+  ## the include option are the only options that will be picked from.
+  ##
+  ## See the list of servers speedtest-go will return at:
+  ##     https://www.speedtest.net/api/js/servers?engine=js&limit=10
+  ##
+  # server_id_exclude = []
+  # server_id_include = []


### PR DESCRIPTION
This adds the ability to exclude or include specific speedtest server IDs. If a user excludes a server ID that server is always excluded from selection. If a user includes a specific server ID, we will look for only that ID.

This does not let a user pick a random server ID. The speedtest-go library will receive the 10 closet servers. As such, users need to be careful as they can prevent any server from being picked.

fixes: #11449
fixes: #11625
fixes: #12595