### PR TITLE
chore: Show file names and line numbers for found issues in github action logs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,4 +26,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.0
-          args: --timeout 15m0s --verbose
+          args: --timeout 15m0s --verbose --out-${NO_FUTURE}format tab

--- a/metric.go
+++ b/metric.go
@@ -32,8 +32,6 @@ type Field struct {
 // Metric is the type of data that is processed by Telegraf.  Input plugins,
 // and to a lesser degree, Processor and Aggregator plugins create new Metrics
 // and Output plugins write them.
-//
-//nolint:interfacebloat // conditionally allow to contain more methods
 type Metric interface {
 	// Name is the primary identifier for the Metric and corresponds to the
 	// measurement in the InfluxDB data model.

--- a/metric.go
+++ b/metric.go
@@ -32,6 +32,8 @@ type Field struct {
 // Metric is the type of data that is processed by Telegraf.  Input plugins,
 // and to a lesser degree, Processor and Aggregator plugins create new Metrics
 // and Output plugins write them.
+//
+//nolint:interfacebloat // conditionally allow to contain more methods
 type Metric interface {
 	// Name is the primary identifier for the Metric and corresponds to the
 	// measurement in the InfluxDB data model.


### PR DESCRIPTION
Right now there file names and line numbers are not shown in github action logs:
![image](https://user-images.githubusercontent.com/17336997/216714683-9880be58-5e7a-4b41-8258-4ff7dcf98026.png)

This PR implements workaround provided here https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648