### PR TITLE
feat: add disk label tag to disk plugin #12594

### DIFF
--- a/plugins/inputs/disk/README.md
+++ b/plugins/inputs/disk/README.md
@@ -54,6 +54,7 @@ docker run -v /:/hostfs:ro -e HOST_MOUNT_PREFIX=/hostfs -e HOST_PROC=/hostfs/pro
     - device (device file)
     - path (mount point path)
     - mode (whether the mount is rw or ro)
+    - label (disk label if present)
   - fields:
     - free (integer, bytes)
     - total (integer, bytes)
@@ -84,7 +85,7 @@ sudo setfacl -R -m u:telegraf:X /var/lib/docker/volumes/
 ## Example Output
 
 ```shell
-disk,fstype=hfs,mode=ro,path=/ free=398407520256i,inodes_free=97267461i,inodes_total=121847806i,inodes_used=24580345i,total=499088621568i,used=100418957312i,used_percent=20.131039916242397 1453832006274071563
+disk,fstype=hfs,label=root,mode=ro,path=/ free=398407520256i,inodes_free=97267461i,inodes_total=121847806i,inodes_used=24580345i,total=499088621568i,used=100418957312i,used_percent=20.131039916242397 1453832006274071563
 disk,fstype=devfs,mode=rw,path=/dev free=0i,inodes_free=0i,inodes_total=628i,inodes_used=628i,total=185856i,used=185856i,used_percent=100 1453832006274137913
 disk,fstype=autofs,mode=rw,path=/net free=0i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=0i,used=0i,used_percent=0 1453832006274157077
 disk,fstype=autofs,mode=rw,path=/home free=0i,inodes_free=0i,inodes_total=0i,inodes_used=0i,total=0i,used=0i,used_percent=0 1453832006274169688

--- a/plugins/inputs/disk/disk.go
+++ b/plugins/inputs/disk/disk.go
@@ -57,6 +57,7 @@ func (ds *DiskStats) Gather(acc telegraf.Accumulator) error {
 		tags := map[string]string{
 			"path":   du.Path,
 			"device": strings.ReplaceAll(partitions[i].Device, "/dev/", ""),
+			"label": partitions[i].Label,
 			"fstype": du.Fstype,
 			"mode":   mountOpts.Mode(),
 		}


### PR DESCRIPTION
this adds the functionality of being able to associate partition information with a meaningful identifier (not dm-#)

resolves[ #12594](https://github.com/influxdata/telegraf/issues/12594)

created an extended struct for disk partition information that added a new field for partition label, then used the disk.Label function from github.com/shirou/gopsutil/v3/disk to populate the field if the device starts with /dev
