### PR TITLE
test: use `t.Setenv` to set env vars

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -58,8 +58,8 @@ func TestReadBinaryFile(t *testing.T) {
 
 func TestConfig_LoadSingleInputWithEnvVars(t *testing.T) {
 	c := NewConfig()
-	require.NoError(t, os.Setenv("MY_TEST_SERVER", "192.168.1.1"))
-	require.NoError(t, os.Setenv("TEST_INTERVAL", "10s"))
+	t.Setenv("MY_TEST_SERVER", "192.168.1.1")
+	t.Setenv("TEST_INTERVAL", "10s")
 	require.NoError(t, c.LoadConfig("./testdata/single_plugin_env_vars.toml"))
 
 	input := inputs.Inputs["memcached"]().(*MockupInputPlugin)

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/awnumar/memguard"
@@ -325,7 +324,7 @@ func TestSecretEnvironmentVariable(t *testing.T) {
 [[inputs.mockup]]
 	secret = "$SOME_ENV_SECRET"
 `)
-	require.NoError(t, os.Setenv("SOME_ENV_SECRET", "an env secret"))
+	t.Setenv("SOME_ENV_SECRET", "an env secret")
 
 	c := NewConfig()
 	err := c.LoadConfigData(cfg)

--- a/plugins/inputs/disk/disk_test.go
+++ b/plugins/inputs/disk/disk_test.go
@@ -609,7 +609,7 @@ func TestDiskUsageIssues(t *testing.T) {
 
 			// Get the partitions in the test-case
 			os.Clearenv()
-			require.NoError(t, os.Setenv("HOST_PROC", hostProcPrefix))
+			t.Setenv("HOST_PROC", hostProcPrefix)
 			partitions, err := diskUtil.Partitions(true)
 			require.NoError(t, err)
 

--- a/plugins/inputs/ecs/ecs_test.go
+++ b/plugins/inputs/ecs/ecs_test.go
@@ -1,7 +1,6 @@
 package ecs
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -774,8 +773,7 @@ func TestResolveEndpoint(t *testing.T) {
 		name   string
 		given  Ecs
 		exp    Ecs
-		preF   func()
-		afterF func()
+		setEnv func(*testing.T)
 	}{
 		{
 			name: "Endpoint is explicitly set => use v2 metadata",
@@ -799,11 +797,8 @@ func TestResolveEndpoint(t *testing.T) {
 		},
 		{
 			name: "Endpoint is not set, ECS_CONTAINER_METADATA_URI is set => use v3 metadata",
-			preF: func() {
-				require.NoError(t, os.Setenv("ECS_CONTAINER_METADATA_URI", "v3-endpoint.local"))
-			},
-			afterF: func() {
-				require.NoError(t, os.Unsetenv("ECS_CONTAINER_METADATA_URI"))
+			setEnv: func(t *testing.T) {
+				t.Setenv("ECS_CONTAINER_METADATA_URI", "v3-endpoint.local")
 			},
 			given: Ecs{
 				EndpointURL: "",
@@ -816,11 +811,8 @@ func TestResolveEndpoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.preF != nil {
-				tt.preF()
-			}
-			if tt.afterF != nil {
-				defer tt.afterF()
+			if tt.setEnv != nil {
+				tt.setEnv(t)
 			}
 
 			act := tt.given

--- a/plugins/inputs/execd/shim/shim_test.go
+++ b/plugins/inputs/execd/shim/shim_test.go
@@ -3,7 +3,6 @@ package shim
 import (
 	"bufio"
 	"io"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -113,8 +112,8 @@ func (i *testInput) Stop() {
 }
 
 func TestLoadConfig(t *testing.T) {
-	require.NoError(t, os.Setenv("SECRET_TOKEN", "xxxxxxxxxx"))
-	require.NoError(t, os.Setenv("SECRET_VALUE", `test"\test`))
+	t.Setenv("SECRET_TOKEN", "xxxxxxxxxx")
+	t.Setenv("SECRET_VALUE", `test"\test`)
 
 	inputs.Add("test", func() telegraf.Input {
 		return &serviceInput{}

--- a/plugins/inputs/leofs/leofs_test.go
+++ b/plugins/inputs/leofs/leofs_test.go
@@ -140,10 +140,8 @@ func testMain(t *testing.T, code string, endpoint string, serverType ServerType)
 	currentWorkingDirectory, err := os.Getwd()
 	require.NoError(t, err)
 
-	envPathOrigin := os.Getenv("PATH")
 	// Refer to the fake snmpwalk
-	require.NoError(t, os.Setenv("PATH", currentWorkingDirectory))
-	defer os.Setenv("PATH", envPathOrigin)
+	t.Setenv("PATH", currentWorkingDirectory)
 
 	l := &LeoFS{
 		Servers: []string{endpoint},

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -8,26 +8,32 @@ import (
 )
 
 func TestDockerHost(t *testing.T) {
-	err := os.Unsetenv("DOCKER_HOST")
-	require.NoError(t, err)
+	t.Run("no DOCKER_HOST set", func(t *testing.T) {
+		err := os.Unsetenv("DOCKER_HOST")
+		require.NoError(t, err)
 
-	host := GetLocalHost()
+		host := GetLocalHost()
 
-	if host != localhost {
-		t.Fatalf("Host should be localhost when DOCKER_HOST is not set. Current value [%s]", host)
-	}
+		if host != localhost {
+			t.Fatalf("Host should be localhost when DOCKER_HOST is not set. Current value [%s]", host)
+		}
+	})
 
-	t.Setenv("DOCKER_HOST", "1.1.1.1")
-	host = GetLocalHost()
+	t.Run("DOCKER_HOST with IP address only", func(t *testing.T) {
+		t.Setenv("DOCKER_HOST", "1.1.1.1")
 
-	if host != "1.1.1.1" {
-		t.Fatalf("Host should take DOCKER_HOST value when set. Current value is [%s] and DOCKER_HOST is [%s]", host, os.Getenv("DOCKER_HOST"))
-	}
+		host := GetLocalHost()
+		if host != "1.1.1.1" {
+			t.Fatalf("Host should take DOCKER_HOST value when set. Current value is [%s] and DOCKER_HOST is [%s]", host, os.Getenv("DOCKER_HOST"))
+		}
+	})
 
-	t.Setenv("DOCKER_HOST", "tcp://1.1.1.1:8080")
-	host = GetLocalHost()
+	t.Run("DOCKER_HOST with protocol, IP address, and port", func(t *testing.T) {
+		t.Setenv("DOCKER_HOST", "tcp://1.1.1.1:8080")
 
-	if host != "1.1.1.1" {
-		t.Fatalf("Host should take DOCKER_HOST value when set. Current value is [%s] and DOCKER_HOST is [%s]", host, os.Getenv("DOCKER_HOST"))
-	}
+		host := GetLocalHost()
+		if host != "1.1.1.1" {
+			t.Fatalf("Host should take DOCKER_HOST value when set. Current value is [%s] and DOCKER_HOST is [%s]", host, os.Getenv("DOCKER_HOST"))
+		}
+	})
 }


### PR DESCRIPTION
# Required for all PRs

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)


Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	oldVal := os.Getenv("key")
	defer os.Setenv("key", oldVal)
	os.Setenv(key, "new value")
	
	// after
	t.Setenv(key, "new value")
}
```
