### PR TITLE
chore: Fix linter findings for tenv

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - revive
     - sqlclosecheck
     - staticcheck
+    - tenv
     - tparallel
     - typecheck
     - unconvert
@@ -141,6 +142,11 @@ linters-settings:
   nakedret:
     # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
     max-func-lines: 1
+  tenv:
+    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
+    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
+    # Default: false
+    all: true
 
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -480,8 +480,7 @@ func TestConfig_getDefaultConfigPathFromEnvURL(t *testing.T) {
 	defer ts.Close()
 
 	c := NewConfig()
-	err := os.Setenv("TELEGRAF_CONFIG_PATH", ts.URL)
-	require.NoError(t, err)
+	t.Setenv("TELEGRAF_CONFIG_PATH", ts.URL)
 	configPath, err := getDefaultConfigPath()
 	require.NoError(t, err)
 	require.Equal(t, ts.URL, configPath)

--- a/plugins/common/shim/config_test.go
+++ b/plugins/common/shim/config_test.go
@@ -1,7 +1,6 @@
 package shim
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -14,10 +13,8 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	err := os.Setenv("SECRET_TOKEN", "xxxxxxxxxx")
-	require.NoError(t, err)
-	err = os.Setenv("SECRET_VALUE", `test"\test`)
-	require.NoError(t, err)
+	t.Setenv("SECRET_TOKEN", "xxxxxxxxxx")
+	t.Setenv("SECRET_VALUE", `test"\test`)
 
 	inputs.Add("test", func() telegraf.Input {
 		return &serviceInput{}

--- a/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
+++ b/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
@@ -416,7 +416,5 @@ func readJSON(t *testing.T, jsonFilePath string) []byte {
 }
 
 func emulatorSetEnv(t *testing.T, srv *httptest.Server) {
-	if err := os.Setenv("STORAGE_EMULATOR_HOST", strings.ReplaceAll(srv.URL, "http://", "")); err != nil {
-		t.Error(err)
-	}
+	t.Setenv("STORAGE_EMULATOR_HOST", strings.ReplaceAll(srv.URL, "http://", ""))
 }

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -17,18 +17,14 @@ func TestDockerHost(t *testing.T) {
 		t.Fatalf("Host should be localhost when DOCKER_HOST is not set. Current value [%s]", host)
 	}
 
-	err = os.Setenv("DOCKER_HOST", "1.1.1.1")
-	require.NoError(t, err)
-
+	t.Setenv("DOCKER_HOST", "1.1.1.1")
 	host = GetLocalHost()
 
 	if host != "1.1.1.1" {
 		t.Fatalf("Host should take DOCKER_HOST value when set. Current value is [%s] and DOCKER_HOST is [%s]", host, os.Getenv("DOCKER_HOST"))
 	}
 
-	err = os.Setenv("DOCKER_HOST", "tcp://1.1.1.1:8080")
-	require.NoError(t, err)
-
+	t.Setenv("DOCKER_HOST", "tcp://1.1.1.1:8080")
 	host = GetLocalHost()
 
 	if host != "1.1.1.1" {


### PR DESCRIPTION
Address findings for [tenv](https://github.com/sivchari/tenv) - analyzer that detects using os.Setenv instead of t.Setenv since Go1.17.


Following findings were fixed:
```
config/config_test.go:483:2                                             tenv  os.Setenv() can be replaced by `t.Setenv()` in TestConfig_getDefaultConfigPathFromEnvURL
plugins/common/shim/config_test.go:17:2                                 tenv  os.Setenv() can be replaced by `t.Setenv()` in TestLoadConfig
plugins/common/shim/config_test.go:19:2                                 tenv  os.Setenv() can be replaced by `t.Setenv()` in TestLoadConfig
plugins/inputs/google_cloud_storage/google_cloud_storage_test.go:419:2  tenv  os.Setenv() can be replaced by `t.Setenv()` in emulatorSetEnv
plugins/outputs/azure_monitor/azure_monitor_test.go:217:4               tenv  os.Setenv() can be replaced by `t.Setenv()` in anonymous function
plugins/outputs/azure_monitor/azure_monitor_test.go:381:2               tenv  os.Setenv() can be replaced by `testing.Setenv()` in TestMain
plugins/outputs/azure_monitor/azure_monitor_test.go:385:2               tenv  os.Setenv() can be replaced by `testing.Setenv()` in TestMain
plugins/outputs/azure_monitor/azure_monitor_test.go:389:2               tenv  os.Setenv() can be replaced by `testing.Setenv()` in TestMain
testutil/testutil_test.go:20:2                                          tenv  os.Setenv() can be replaced by `t.Setenv()` in TestDockerHost
testutil/testutil_test.go:29:2                                          tenv  os.Setenv() can be replaced by `t.Setenv()` in TestDockerHost
```