### PR TITLE
fix: Rename the Prometheus Input Plugin Timeout variable

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -126,12 +126,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # headers = {"X-Special-Header" = "Special-Value"}
 
   ## Specify timeout duration for slower prometheus clients (default is 3s)
+  # timeout = "3s"
+  
   ##   deprecated in 1.26; use the timeout option
   # response_timeout = "3s"
-
-  ## Specify timeout duration for slower prometheus clients (default is 3s)
-  # timeout = "3s"
-
+  
   ## HTTP Proxy support
   # use_system_proxy = false
   # http_proxy_url = ""

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -126,7 +126,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # headers = {"X-Special-Header" = "Special-Value"}
 
   ## Specify timeout duration for slower prometheus clients (default is 3s)
+  ##   deprecated in 1.26; use the timeout option
   # response_timeout = "3s"
+
+  ## Specify timeout duration for slower prometheus clients (default is 3s)
+  # timeout = "3s"
 
   ## HTTP Proxy support
   # use_system_proxy = false

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -71,7 +71,8 @@ type Prometheus struct {
 
 	HTTPHeaders map[string]string `toml:"http_headers"`
 
-	ResponseTimeout config.Duration `toml:"response_timeout"`
+	ResponseTimeout config.Duration `toml:"response_timeout" deprecated:"1.26.0;use 'timeout' instead"`
+	Timeout         config.Duration `toml:"timeout"`
 
 	MetricVersion int `toml:"metric_version"`
 

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -246,11 +246,7 @@ func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeoutNewConfigParameter(t
 	var acc testutil.Accumulator
 
 	err = acc.GatherError(p.Gather)
-	errMessage := fmt.Sprintf("error making HTTP request to %s/metrics: Get \"%s/metrics\": "+
-		"context deadline exceeded (Client.Timeout exceeded while awaiting headers)", ts.URL, ts.URL)
-	errExpected := errors.New(errMessage)
-	require.Equal(t, errExpected, err)
-	require.Error(t, err)
+	require.ErrorContains(t, err, "error making HTTP request to "+ts.URL+"/metrics")
 }
 
 func TestPrometheusGeneratesSummaryMetricsV2(t *testing.T) {

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -109,12 +109,11 @@
   # headers = {"X-Special-Header" = "Special-Value"}
 
   ## Specify timeout duration for slower prometheus clients (default is 3s)
+  # timeout = "3s"
+  
   ##   deprecated in 1.26; use the timeout option
   # response_timeout = "3s"
-
-  ## Specify timeout duration for slower prometheus clients (default is 3s)
-  # timeout = "3s"
-
+  
   ## HTTP Proxy support
   # use_system_proxy = false
   # http_proxy_url = ""

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -109,7 +109,11 @@
   # headers = {"X-Special-Header" = "Special-Value"}
 
   ## Specify timeout duration for slower prometheus clients (default is 3s)
+  ##   deprecated in 1.26; use the timeout option
   # response_timeout = "3s"
+
+  ## Specify timeout duration for slower prometheus clients (default is 3s)
+  # timeout = "3s"
 
   ## HTTP Proxy support
   # use_system_proxy = false


### PR DESCRIPTION
Rename the Timeout Prometheus Input Plugin variable inside the configuration and the code to parse the corresponding value directly

**Be aware it's a breaking change for older versions and should be merged into the next major version.**

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12565

Fix the corresponding case and renames the variable as already discussed inside #12565
