### PR TITLE
fix(inputs.x509_cert): Fix Windows path handling

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -391,12 +391,7 @@ func (c *X509Cert) collectCertURLs() ([]*url.URL, error) {
 			continue
 		}
 		for _, file := range files {
-			file = "file://" + file
-			u, err := url.Parse(file)
-			if err != nil {
-				return urls, fmt.Errorf("failed to parse cert location - %s", err.Error())
-			}
-			urls = append(urls, u)
+			urls = append(urls, &url.URL{Scheme: "file", Path: filepath.ToSlash(file)})
 		}
 	}
 

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -86,12 +86,9 @@ func (c *X509Cert) Init() error {
 // Gather adds metrics into the accumulator.
 func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 	now := time.Now()
-	collectedUrls, err := c.collectCertURLs()
-	if err != nil {
-		acc.AddError(fmt.Errorf("getting some certificates failed: %w", err))
-	}
 
-	for _, location := range append(c.locations, collectedUrls...) {
+	collectedUrls := append(c.locations, c.collectCertURLs()...)
+	for _, location := range collectedUrls {
 		certs, err := c.getCert(location, time.Duration(c.Timeout))
 		if err != nil {
 			acc.AddError(fmt.Errorf("cannot get SSL cert '%s': %s", location, err.Error()))
@@ -381,7 +378,7 @@ func getTags(cert *x509.Certificate, location string) map[string]string {
 	return tags
 }
 
-func (c *X509Cert) collectCertURLs() ([]*url.URL, error) {
+func (c *X509Cert) collectCertURLs() []*url.URL {
 	var urls []*url.URL
 
 	for _, path := range c.globpaths {
@@ -395,7 +392,7 @@ func (c *X509Cert) collectCertURLs() ([]*url.URL, error) {
 		}
 	}
 
-	return urls, nil
+	return urls
 }
 
 func init() {

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -390,6 +390,7 @@ func TestSourcesToURLs(t *testing.T) {
 			"file:///dummy_test_path_file.pem",
 			"file:///windows/temp/test.pem",
 			`file://C:\windows\temp\test.pem`,
+			`file:///C:/windows/temp/test.pem`,
 			"/tmp/dummy_test_path_glob*.pem",
 		},
 		Log: testutil.Logger{},
@@ -402,7 +403,14 @@ func TestSourcesToURLs(t *testing.T) {
 		"smtp://influxdata.com:25",
 	}
 
-	for _, p := range []string{"/dummy_test_path_file.pem", "/windows/temp/test.pem", "C:\\windows\\temp\\test.pem"} {
+	expectedPaths := []string{
+		"/dummy_test_path_file.pem",
+		"/windows/temp/test.pem",
+		"C:\\windows\\temp\\test.pem",
+		"C:/windows/temp/test.pem",
+	}
+
+	for _, p := range expectedPaths {
 		expected = append(expected, filepath.FromSlash(p))
 	}
 
@@ -413,7 +421,7 @@ func TestSourcesToURLs(t *testing.T) {
 	for _, p := range m.locations {
 		actual = append(actual, p.String())
 	}
-	require.Equal(t, len(m.globpaths), 4)
+	require.Equal(t, len(m.globpaths), 5)
 	require.Equal(t, len(m.locations), 3)
 	require.ElementsMatch(t, expected, actual)
 }

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -402,7 +402,7 @@ func TestSourcesToURLs(t *testing.T) {
 		"smtp://influxdata.com:25",
 	}
 
-	for _, p := range []string{"/dummy_test_path_file.pem", "/windows/temp/test.pem", "C:/windows/temp/test.pem"} {
+	for _, p := range []string{"/dummy_test_path_file.pem", "/windows/temp/test.pem", "C:\\windows\\temp\\test.pem"} {
 		expected = append(expected, filepath.FromSlash(p))
 	}
 

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -406,7 +406,7 @@ func TestSourcesToURLs(t *testing.T) {
 		expected = append(expected, filepath.FromSlash(p))
 	}
 
-	var actual []string
+	actual := make([]string, 0, len(m.globpaths)+len(m.locations))
 	for _, p := range m.globpaths {
 		actual = append(actual, p.GetRoots()...)
 	}

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -388,14 +388,34 @@ func TestSourcesToURLs(t *testing.T) {
 			"tcp://influxdata.com:443",
 			"smtp://influxdata.com:25",
 			"file:///dummy_test_path_file.pem",
+			"file:///windows/temp/test.pem",
+			`file://C:\windows\temp\test.pem`,
 			"/tmp/dummy_test_path_glob*.pem",
 		},
 		Log: testutil.Logger{},
 	}
 	require.NoError(t, m.Init())
 
-	require.Equal(t, len(m.globpaths), 2)
+	expected := []string{
+		"https://www.influxdata.com:443",
+		"tcp://influxdata.com:443",
+		"smtp://influxdata.com:25",
+	}
+
+	for _, p := range []string{"/dummy_test_path_file.pem", "/windows/temp/test.pem", "C:/windows/temp/test.pem"} {
+		expected = append(expected, filepath.FromSlash(p))
+	}
+
+	var actual []string
+	for _, p := range m.globpaths {
+		actual = append(actual, p.GetRoots()...)
+	}
+	for _, p := range m.locations {
+		actual = append(actual, p.String())
+	}
+	require.Equal(t, len(m.globpaths), 4)
 	require.Equal(t, len(m.locations), 3)
+	require.ElementsMatch(t, expected, actual)
 }
 
 func TestServerName(t *testing.T) {


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10580

This PR fixes the handling of Windows paths by directly creating the URL instead of using a fragile indirection parsing a hand-crafted string.