### PR TITLE
fix(inputs.cisco_telemetry_mdt): check subfield sizes

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -409,11 +409,21 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 		if content != nil {
 			// Parse values
 			for _, subfield := range content.Fields {
+				if len(subfield.Fields) == 0 {
+					continue
+				}
+
 				prefix := ""
 				switch subfield.Name {
 				case "operation-metric":
+					if len(subfield.Fields[0].Fields) < 1 {
+						continue
+					}
 					prefix = subfield.Fields[0].Fields[0].GetStringValue()
 				case "class-stats":
+					if len(subfield.Fields[0].Fields) < 2 {
+						continue
+					}
 					prefix = subfield.Fields[0].Fields[1].GetStringValue()
 				}
 				c.parseContentField(grouper, subfield, prefix, encodingPath, tags, timestamp)


### PR DESCRIPTION
fixes: #12635
