### PR TITLE
chore: prevent RPM from changing permissions on telegraf.d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,7 @@ $(include_packages):
 	@mkdir -p $(pkgdir)
 
 	@if [ "$(suffix $@)" = ".rpm" ]; then \
+		echo -e "# DO NOT EDIT OR REMOVE\n# This file prevents rpm from changing permissions on this directory\n# and the files within it\n" > $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
 		fpm --force \
 			--log info \
 			--architecture $(basename $@) \
@@ -347,6 +348,7 @@ $(include_packages):
 			--license MIT \
 			--maintainer support@influxdb.com \
 			--config-files /etc/telegraf/telegraf.conf \
+			--config-files /etc/telegraf/telegraf.d/.ignore \
 			--config-files /etc/logrotate.d/telegraf \
 			--after-install scripts/rpm/post-install.sh \
 			--before-install scripts/rpm/pre-install.sh \

--- a/Makefile
+++ b/Makefile
@@ -338,8 +338,7 @@ $(include_packages):
 
 	@if [ "$(suffix $@)" = ".rpm" ]; then \
 		echo "# DO NOT EDIT OR REMOVE" > $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
-		echo "# This file prevents rpm from changing permissions on this directory" >> $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
-		echo "# and the files within it" >> $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
+		echo "# This file prevents the rpm from changing permissions on this directory" >> $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
 		fpm --force \
 			--log info \
 			--architecture $(basename $@) \

--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,9 @@ $(include_packages):
 	@mkdir -p $(pkgdir)
 
 	@if [ "$(suffix $@)" = ".rpm" ]; then \
-		echo -e "# DO NOT EDIT OR REMOVE\n# This file prevents rpm from changing permissions on this directory\n# and the files within it\n" > $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
+		echo "# DO NOT EDIT OR REMOVE" > $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
+		echo "# This file prevents rpm from changing permissions on this directory" >> $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
+		echo "# and the files within it" >> $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
 		fpm --force \
 			--log info \
 			--architecture $(basename $@) \


### PR DESCRIPTION
fixes: #9521

Test Cases: run on RHEL/CentOS 7 + Fedora 37

- [x] Fresh install of this package - ensure it completes successfully
- [x] Upgrade from v1.25.1 to this package - ensure the upgrade completes successfully
- [x] Upgrade from this package to an even newer version (nightly) after changing ownership of telegraf.d directory - ensure the permissions on the telegraf.d directory does not change