### PR TITLE
feat(inputs.http_listener_v2): add custom server http headers

### DIFF
--- a/plugins/inputs/http_listener_v2/README.md
+++ b/plugins/inputs/http_listener_v2/README.md
@@ -37,6 +37,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## HTTP methods to accept.
   # methods = ["POST", "PUT"]
 
+  ## Optional HTTP headers
+  ## These headers are applied to the server that is listening for HTTP
+  ## requests and included in responses.
+  # http_headers = {"HTTP_HEADER" = "TAG_NAME"}
+
   ## maximum duration before timing out read of the request
   # read_timeout = "10s"
   ## maximum duration before timing out write of the response

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -49,6 +49,7 @@ type HTTPListenerV2 struct {
 	Paths          []string          `toml:"paths"`
 	PathTag        bool              `toml:"path_tag"`
 	Methods        []string          `toml:"methods"`
+	HTTPHeaders    map[string]string `toml:"http_headers"`
 	DataSource     string            `toml:"data_source"`
 	ReadTimeout    config.Duration   `toml:"read_timeout"`
 	WriteTimeout   config.Duration   `toml:"write_timeout"`
@@ -168,6 +169,10 @@ func (h *HTTPListenerV2) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 
 	if !choice.Contains(req.URL.Path, h.Paths) {
 		handler = http.NotFound
+	}
+
+	for key, value := range h.HTTPHeaders {
+		res.Header().Set(key, value)
 	}
 
 	h.authenticateIfSet(handler, res, req)

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -686,6 +686,27 @@ func TestWriteHTTPFormData(t *testing.T) {
 	)
 }
 
+func TestServerHeaders(t *testing.T) {
+	listener, err := newTestHTTPListenerV2()
+	require.NoError(t, err)
+
+	listener.HTTPHeaders = map[string]string{
+		"key": "value",
+	}
+
+	acc := &testutil.Accumulator{}
+	require.NoError(t, listener.Init())
+	require.NoError(t, listener.Start(acc))
+	defer listener.Stop()
+
+	// post single message to listener
+	resp, err := http.Post(createURL(listener, "http", "/write", "db=mydb"), "", bytes.NewBuffer([]byte(testMsg)))
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.EqualValues(t, 204, resp.StatusCode)
+	require.Equal(t, "value", resp.Header.Get("key"))
+}
+
 func mustReadHugeMetric() []byte {
 	filePath := "testdata/huge_metric"
 	data, err := os.ReadFile(filePath)

--- a/plugins/inputs/http_listener_v2/sample.conf
+++ b/plugins/inputs/http_listener_v2/sample.conf
@@ -12,6 +12,11 @@
   ## HTTP methods to accept.
   # methods = ["POST", "PUT"]
 
+  ## Optional HTTP headers
+  ## These headers are applied to the server that is listening for HTTP
+  ## requests and included in responses.
+  # http_headers = {"HTTP_HEADER" = "TAG_NAME"}
+
   ## maximum duration before timing out read of the request
   # read_timeout = "10s"
   ## maximum duration before timing out write of the response


### PR DESCRIPTION
This allows the user to add custom HTTP headers that are included in the response of the HTTP listener itself.

fixes: #8175