### PR TITLE
docs(inputs.syslog): Add BSD syslog to readme intro

### DIFF
--- a/plugins/inputs/syslog/README.md
+++ b/plugins/inputs/syslog/README.md
@@ -7,7 +7,8 @@ socket, [UDP](https://tools.ietf.org/html/rfc5426),
 framing.
 
 Syslog messages should be formatted according to
-[RFC 5424](https://tools.ietf.org/html/rfc5424) (syslog protocol) or [RFC 3164](https://tools.ietf.org/html/rfc3164) (BSD syslog protocol).
+[RFC 5424](https://tools.ietf.org/html/rfc5424) (syslog protocol) or
+[RFC 3164](https://tools.ietf.org/html/rfc3164) (BSD syslog protocol).
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/inputs/syslog/README.md
+++ b/plugins/inputs/syslog/README.md
@@ -7,7 +7,7 @@ socket, [UDP](https://tools.ietf.org/html/rfc5426),
 framing.
 
 Syslog messages should be formatted according to
-[RFC 5424](https://tools.ietf.org/html/rfc5424).
+[RFC 5424](https://tools.ietf.org/html/rfc5424) (syslog protocol) or [RFC 3164](https://tools.ietf.org/html/rfc3164) (BSD syslog protocol).
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 


### PR DESCRIPTION
Whilst support for the BSD syslog protocol (RFC 3164) has recently been added to this plugin, the introduction section still stated that only the newer RFC5424 protocol was supported. This was despite the subsequent sections of the readme explaining how to optionally use the BSD syslog protocol.

Update the introduction section of the readme to clarify that both the RFC5424 or RFC3164 protocols are supported.

# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
