### PR TITLE
fix(inputs.cloudwatch): enable custom endpoint support

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	cwClient "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 
@@ -190,7 +189,7 @@ func (c *CloudWatch) initializeCloudWatch() error {
 
 	var customResolver cwClient.EndpointResolver
 	if c.CredentialConfig.EndpointURL != "" && c.CredentialConfig.Region != "" {
-		customResolver = cloudwatch.EndpointResolverFromURL(c.CredentialConfig.EndpointURL)
+		customResolver = cwClient.EndpointResolverFromURL(c.CredentialConfig.EndpointURL)
 	}
 
 	c.client = cwClient.NewFromConfig(awsCreds, func(options *cwClient.Options) {


### PR DESCRIPTION
If a user specifies a specific region and endpoint, then the cloudwatch client needs to be set up to use those two values and override the default values that are provided.

fixes: #12653
