### PR TITLE
feat(outputs.mqtt): add support for MQTT 5 publish properties

### DIFF
--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -106,10 +106,12 @@ to use them.
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "influx"
 
-  ## Optional publish properties that are specific to MQTT 5.
-  ## These will only have an effect if the "procotol" property is set
-  ## to 5. Read more about them here:
-  ## https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901109.
+  ## Optional MQTT 5 publish properties
+  ## These setting only apply if the "protocol" property is set to 5. This must
+  ## be defined at the end of the plugin settings, otherwise TOML will assume
+  ## anything else is part of this table. For more details on publish properties
+  ## see the spec:
+  ## https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901109
   # [outputs.mqtt.v5]
   #   content_type = ""
   #   response_topic = ""

--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -105,4 +105,17 @@ to use them.
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "influx"
+
+  ## Optional publish properties that are specific to MQTT 5.
+  ## These will only have an effect if the "procotol" property is set
+  ## to 5. Read more about them here:
+  ## https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901109.
+  # [outputs.mqtt.v5]
+  #   content_type = ""
+  #   response_topic = ""
+  #   message_expiry = "0s"
+  #   topic_alias = 0
+  # [outputs.mqtt.v5.user_properties]
+  #   "key1" = "value 1"
+  #   "key2" = "value 2"
 ```

--- a/plugins/outputs/mqtt/mqtt.go
+++ b/plugins/outputs/mqtt/mqtt.go
@@ -35,10 +35,11 @@ type MQTT struct {
 	QoS         int             `toml:"qos"`
 	ClientID    string          `toml:"client_id"`
 	tls.ClientConfig
-	BatchMessage bool            `toml:"batch"`
-	Retain       bool            `toml:"retain"`
-	KeepAlive    int64           `toml:"keep_alive"`
-	Log          telegraf.Logger `toml:"-"`
+	BatchMessage        bool                     `toml:"batch"`
+	Retain              bool                     `toml:"retain"`
+	KeepAlive           int64                    `toml:"keep_alive"`
+	V5PublishProperties *mqttv5PublishProperties `toml:"v5"`
+	Log                 telegraf.Logger          `toml:"-"`
 
 	client     Client
 	serializer serializers.Serializer

--- a/plugins/outputs/mqtt/mqtt_test.go
+++ b/plugins/outputs/mqtt/mqtt_test.go
@@ -2,7 +2,6 @@ package mqtt
 
 import (
 	"fmt"
-	"github.com/influxdata/telegraf/metric"
 	"path/filepath"
 	"testing"
 	"time"
@@ -10,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/serializers"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -104,6 +105,12 @@ func TestConnectAndWriteIntegrationMQTTv5(t *testing.T) {
 		serializer: s,
 		KeepAlive:  30,
 		Log:        testutil.Logger{Name: "mqttv5-integration-test"},
+		V5PublishProperties: &mqttv5PublishProperties{
+			MessageExpiry: config.Duration(10 * time.Minute),
+			UserProperties: map[string]string{
+				"key": "value",
+			},
+		},
 	}
 
 	// Verify that we can connect to the MQTT broker

--- a/plugins/outputs/mqtt/mqtt_v5.go
+++ b/plugins/outputs/mqtt/mqtt_v5.go
@@ -54,7 +54,6 @@ func buildPublishProperties(cfg *MQTT) *mqttv5.PublishProperties {
 	}
 
 	messageExpiry := time.Duration(cfgProps.MessageExpiry)
-
 	if expirySeconds := uint32(messageExpiry.Seconds()); expirySeconds > 0 {
 		publishProperties.MessageExpiry = &expirySeconds
 	}

--- a/plugins/outputs/mqtt/mqtt_v5.go
+++ b/plugins/outputs/mqtt/mqtt_v5.go
@@ -40,25 +40,23 @@ func newMQTTv5Client(cfg *MQTT) *mqttv5Client {
 // config.
 // These should not change during the lifecycle of the client.
 func buildPublishProperties(cfg *MQTT) *mqttv5.PublishProperties {
-	cfgProps := cfg.V5PublishProperties
-
-	if cfgProps == nil {
+	if cfg.V5PublishProperties == nil {
 		return nil
 	}
 
 	publishProperties := &mqttv5.PublishProperties{
-		ContentType:   cfgProps.ContentType,
-		ResponseTopic: cfgProps.ResponseTopic,
-		TopicAlias:    cfgProps.TopicAlias,
-		User:          make([]mqttv5.UserProperty, 0, len(cfgProps.UserProperties)),
+		ContentType:   cfg.V5PublishProperties.ContentType,
+		ResponseTopic: cfg.V5PublishProperties.ResponseTopic,
+		TopicAlias:    cfg.V5PublishProperties.TopicAlias,
+		User:          make([]mqttv5.UserProperty, 0, len(cfg.V5PublishProperties.UserProperties)),
 	}
 
-	messageExpiry := time.Duration(cfgProps.MessageExpiry)
+	messageExpiry := time.Duration(cfg.V5PublishProperties.MessageExpiry)
 	if expirySeconds := uint32(messageExpiry.Seconds()); expirySeconds > 0 {
 		publishProperties.MessageExpiry = &expirySeconds
 	}
 
-	for k, v := range cfgProps.UserProperties {
+	for k, v := range cfg.V5PublishProperties.UserProperties {
 		publishProperties.User.Add(k, v)
 	}
 

--- a/plugins/outputs/mqtt/sample.conf
+++ b/plugins/outputs/mqtt/sample.conf
@@ -70,3 +70,16 @@
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "influx"
+
+  ## Optional publish properties that are specific to MQTT 5.
+  ## These will only have an effect if the "procotol" property is set
+  ## to 5. Read more about them here:
+  ## https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901109.
+  # [outputs.mqtt.v5]
+  #   content_type = ""
+  #   response_topic = ""
+  #   message_expiry = "0s"
+  #   topic_alias = 0
+  # [outputs.mqtt.v5.user_properties]
+  #   "key1" = "value 1"
+  #   "key2" = "value 2"

--- a/plugins/outputs/mqtt/sample.conf
+++ b/plugins/outputs/mqtt/sample.conf
@@ -71,7 +71,6 @@
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "influx"
 
-```suggestion
   ## Optional MQTT 5 publish properties
   ## These setting only apply if the "protocol" property is set to 5. This must
   ## be defined at the end of the plugin settings, otherwise TOML will assume

--- a/plugins/outputs/mqtt/sample.conf
+++ b/plugins/outputs/mqtt/sample.conf
@@ -71,10 +71,13 @@
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "influx"
 
-  ## Optional publish properties that are specific to MQTT 5.
-  ## These will only have an effect if the "procotol" property is set
-  ## to 5. Read more about them here:
-  ## https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901109.
+```suggestion
+  ## Optional MQTT 5 publish properties
+  ## These setting only apply if the "protocol" property is set to 5. This must
+  ## be defined at the end of the plugin settings, otherwise TOML will assume
+  ## anything else is part of this table. For more details on publish properties
+  ## see the spec:
+  ## https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901109
   # [outputs.mqtt.v5]
   #   content_type = ""
   #   response_topic = ""


### PR DESCRIPTION
resolves: https://github.com/influxdata/telegraf/issues/12526

Add optional support for MQTT 5 publish properties in the config

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)