### PR TITLE
feat: add support for tcp endpoints in haproxy plugin

### DIFF
--- a/etc/telegraf.conf
+++ b/etc/telegraf.conf
@@ -4730,24 +4730,24 @@
 #   # insecure_skip_verify = false
 
 
-# # Read metrics of HAProxy, via socket or HTTP stats page
+# # Read metrics of HAProxy, via stats socket or http endpoints
 # [[inputs.haproxy]]
-#   ## An array of address to gather stats about. Specify an ip on hostname
-#   ## with optional port. ie localhost, 10.10.3.33:1936, etc.
-#   ## Make sure you specify the complete path to the stats endpoint
-#   ## including the protocol, ie http://10.10.3.33:1936/haproxy?stats
+#   ## List of stats endpoints. Metrics can be collected from both http and socket
+#   ## endpoints. Examples of valid endpoints:
+#   ##   - http://myhaproxy.com:1936/haproxy?stats
+#   ##   - https://myhaproxy.com:8000/stats
+#   ##   - socket:/run/haproxy/admin.sock
+#   ##   - /run/haproxy/*.sock
+#   ##   - tcp://127.0.0.1:1936
+#   ##
+#   ## Server addresses not starting with 'http://', 'https://', 'tcp://' will be
+#   ## treated as possible sockets. When specifying local socket, glob patterns are
+#   ## supported.
+#   servers = ["http://myhaproxy.com:1936/haproxy?stats"]
 #
 #   ## Credentials for basic HTTP authentication
 #   # username = "admin"
 #   # password = "admin"
-#
-#   ## If no servers are specified, then default to 127.0.0.1:1936/haproxy?stats
-#   servers = ["http://myhaproxy.com:1936/haproxy?stats"]
-#
-#   ## You can also use local socket with standard wildcard globbing.
-#   ## Server address not starting with 'http' will be treated as a possible
-#   ## socket, so both examples below are valid.
-#   # servers = ["socket:/run/haproxy/admin.sock", "/run/haproxy/*.sock"]
 #
 #   ## By default, some of the fields are renamed from what haproxy calls them.
 #   ## Setting this option to true results in the plugin keeping the original

--- a/etc/telegraf_windows.conf
+++ b/etc/telegraf_windows.conf
@@ -4656,24 +4656,24 @@
 #   # insecure_skip_verify = false
 
 
-# # Read metrics of HAProxy, via socket or HTTP stats page
+# # Read metrics of HAProxy, via stats socket or http endpoints
 # [[inputs.haproxy]]
-#   ## An array of address to gather stats about. Specify an ip on hostname
-#   ## with optional port. ie localhost, 10.10.3.33:1936, etc.
-#   ## Make sure you specify the complete path to the stats endpoint
-#   ## including the protocol, ie http://10.10.3.33:1936/haproxy?stats
+#   ## List of stats endpoints. Metrics can be collected from both http and socket
+#   ## endpoints. Examples of valid endpoints:
+#   ##   - http://myhaproxy.com:1936/haproxy?stats
+#   ##   - https://myhaproxy.com:8000/stats
+#   ##   - socket:/run/haproxy/admin.sock
+#   ##   - /run/haproxy/*.sock
+#   ##   - tcp://127.0.0.1:1936
+#   ##
+#   ## Server addresses not starting with 'http://', 'https://', 'tcp://' will be
+#   ## treated as possible sockets. When specifying local socket, glob patterns are
+#   ## supported.
+#   servers = ["http://myhaproxy.com:1936/haproxy?stats"]
 #
 #   ## Credentials for basic HTTP authentication
 #   # username = "admin"
 #   # password = "admin"
-#
-#   ## If no servers are specified, then default to 127.0.0.1:1936/haproxy?stats
-#   servers = ["http://myhaproxy.com:1936/haproxy?stats"]
-#
-#   ## You can also use local socket with standard wildcard globbing.
-#   ## Server address not starting with 'http' will be treated as a possible
-#   ## socket, so both examples below are valid.
-#   # servers = ["socket:/run/haproxy/admin.sock", "/run/haproxy/*.sock"]
 #
 #   ## By default, some of the fields are renamed from what haproxy calls them.
 #   ## Setting this option to true results in the plugin keeping the original

--- a/plugins/inputs/haproxy/README.md
+++ b/plugins/inputs/haproxy/README.md
@@ -31,10 +31,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # password = "admin"
 
   ## If no servers are specified, then default to 127.0.0.1:1936/haproxy?stats
-  servers = ["http://myhaproxy.com:1936/haproxy?stats"]
+  servers = ["http://myhaproxy.com:1936/haproxy?stats", "tcp://127.0.0.1:1936"]
 
   ## You can also use local socket with standard wildcard globbing.
-  ## Server address not starting with 'http' will be treated as a possible
+  ## Server address not starting with 'http://', 'https://', 'tcp://' will be treated as a possible
   ## socket, so both examples below are valid.
   # servers = ["socket:/run/haproxy/admin.sock", "/run/haproxy/*.sock"]
 

--- a/plugins/inputs/haproxy/README.md
+++ b/plugins/inputs/haproxy/README.md
@@ -19,24 +19,20 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ## Configuration
 
 ```toml @sample.conf
-# Read metrics of HAProxy, via socket or HTTP stats page
+# Read metrics of HAProxy, via stats socket or http endpoints
 [[inputs.haproxy]]
-  ## An array of address to gather stats about. Specify an ip on hostname
-  ## with optional port. ie localhost, 10.10.3.33:1936, etc.
-  ## Make sure you specify the complete path to the stats endpoint
-  ## including the protocol, ie http://10.10.3.33:1936/haproxy?stats
-
-  ## Credentials for basic HTTP authentication
-  # username = "admin"
-  # password = "admin"
-
-  ## If no servers are specified, then default to 127.0.0.1:1936/haproxy?stats
-  servers = ["http://myhaproxy.com:1936/haproxy?stats", "tcp://127.0.0.1:1936"]
-
-  ## You can also use local socket with standard wildcard globbing.
-  ## Server address not starting with 'http://', 'https://', 'tcp://' will be treated as a possible
-  ## socket, so both examples below are valid.
-  # servers = ["socket:/run/haproxy/admin.sock", "/run/haproxy/*.sock"]
+  ## List of stats endpoints. Metrics can be collected from both http and socket
+  ## endpoints. Examples of valid endpoints:
+  ##   - http://myhaproxy.com:1936/haproxy?stats
+  ##   - https://myhaproxy.com:8000/stats
+  ##   - socket:/run/haproxy/admin.sock
+  ##   - /run/haproxy/*.sock
+  ##   - tcp://127.0.0.1:1936
+  ##
+  ## Server addresses not starting with 'http://', 'https://', 'tcp://' will be
+  ## treated as possible sockets. When specifying local socket, glob patterns are
+  ## supported.
+  servers = ["http://myhaproxy.com:1936/haproxy?stats"]
 
   ## By default, some of the fields are renamed from what haproxy calls them.
   ## Setting this option to true results in the plugin keeping the original

--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -185,9 +185,7 @@ func TestHaproxyGeneratesMetricsUsingTcp(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-
-	err = r.Gather(&acc)
-	require.NoError(t, err)
+	require.NoError(t, r.Gather(&acc))
 
 	fields := HaproxyGetFieldValues()
 

--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -170,6 +170,39 @@ func TestHaproxyGeneratesMetricsUsingSocket(t *testing.T) {
 	require.NotEmpty(t, acc.Errors)
 }
 
+func TestHaproxyGeneratesMetricsUsingTcp(t *testing.T) {
+	l, err := net.Listen("tcp", "localhost:8192")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	s := statServer{}
+	go s.serverSocket(l)
+
+	r := &haproxy{
+		Servers: []string{"tcp://" + l.Addr().String()},
+	}
+
+	var acc testutil.Accumulator
+
+	err = r.Gather(&acc)
+	require.NoError(t, err)
+
+	fields := HaproxyGetFieldValues()
+
+	tags := map[string]string{
+		"server": l.Addr().String(),
+		"proxy":  "git",
+		"sv":     "www",
+		"type":   "server",
+	}
+
+	acc.AssertContainsTaggedFields(t, "haproxy", fields, tags)
+
+	require.NoError(t, r.Gather(&acc))
+}
+
 // When not passing server config, we default to localhost
 // We just want to make sure we did request stat from localhost
 func TestHaproxyDefaultGetFromLocalhost(t *testing.T) {

--- a/plugins/inputs/haproxy/sample.conf
+++ b/plugins/inputs/haproxy/sample.conf
@@ -1,21 +1,17 @@
-# Read metrics of HAProxy, via socket or HTTP stats page
+# Read metrics of HAProxy, via stats socket or http endpoints
 [[inputs.haproxy]]
-  ## An array of address to gather stats about. Specify an ip on hostname
-  ## with optional port. ie localhost, 10.10.3.33:1936, etc.
-  ## Make sure you specify the complete path to the stats endpoint
-  ## including the protocol, ie http://10.10.3.33:1936/haproxy?stats
-
-  ## Credentials for basic HTTP authentication
-  # username = "admin"
-  # password = "admin"
-
-  ## If no servers are specified, then default to 127.0.0.1:1936/haproxy?stats
+  ## List of stats endpoints. Metrics can be collected from both http and socket
+  ## endpoints. Examples of valid endpoints:
+  ##   - http://myhaproxy.com:1936/haproxy?stats
+  ##   - https://myhaproxy.com:8000/stats
+  ##   - socket:/run/haproxy/admin.sock
+  ##   - /run/haproxy/*.sock
+  ##   - tcp://127.0.0.1:1936
+  ##
+  ## Server addresses not starting with 'http://', 'https://', 'tcp://' will be
+  ## treated as possible sockets. When specifying local socket, glob patterns are
+  ## supported.
   servers = ["http://myhaproxy.com:1936/haproxy?stats"]
-
-  ## You can also use local socket with standard wildcard globbing.
-  ## Server address not starting with 'http' will be treated as a possible
-  ## socket, so both examples below are valid.
-  # servers = ["socket:/run/haproxy/admin.sock", "/run/haproxy/*.sock"]
 
   ## By default, some of the fields are renamed from what haproxy calls them.
   ## Setting this option to true results in the plugin keeping the original


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #12672 

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

- Added support for tcp endpoints in haproxy input plugin. For example, if haproxy is configured to expose stats endpoint with `stats socket ipv4@127.0.0.1:9999 level admin`, the plugin will be able to communicate with it with `servers = ["tcp://127.0.0.1:9999"]` configuration