### PR TITLE
fix(inputs.statsd): Add temporality tag for statsd counters

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -652,6 +652,12 @@ func (s *Statsd) parseStatsdLine(line string) error {
 		switch m.mtype {
 		case "c":
 			m.tags["metric_type"] = "counter"
+
+			if s.DeleteCounters {
+				m.tags["temporality"] = "delta"
+			} else {
+				m.tags["temporality"] = "cumulative"
+			}
 		case "g":
 			m.tags["metric_type"] = "gauge"
 		case "s":

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -1810,6 +1810,7 @@ func TestParse_InvalidAndRecoverIntegration(t *testing.T) {
 			"cpu_time_idle",
 			map[string]string{
 				"metric_type": "counter",
+				"aggregation": "cumulative",
 			},
 			map[string]interface{}{
 				"value": 42,


### PR DESCRIPTION
# Required for all PRs

Ref https://github.com/influxdata/telegraf/issues/12507

The idea here is to set temporality tag based on the Telegraf configuration.

Then we can introduce a change in influ2otel library to make a switch based on this tag -> https://github.com/influxdata/influxdb-observability/blob/main/influx2otel/metrics.go#L148

<!-- Before opening a pull request you should run the following checks to make sure the CI will pass.

make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
