### PR TITLE
chore: Fix linter findings for errorlint (part2)

### DIFF
--- a/plugins/aggregators/quantile/quantile.go
+++ b/plugins/aggregators/quantile/quantile.go
@@ -115,7 +115,7 @@ func (q *Quantile) Init() error {
 		return fmt.Errorf("unknown algorithm type %q", q.AlgorithmType)
 	}
 	if _, err := q.newAlgorithm(q.Compression); err != nil {
-		return fmt.Errorf("cannot create %q algorithm: %v", q.AlgorithmType, err)
+		return fmt.Errorf("cannot create %q algorithm: %w", q.AlgorithmType, err)
 	}
 
 	if len(q.Quantiles) == 0 {

--- a/plugins/common/jolokia2/client.go
+++ b/plugins/common/jolokia2/client.go
@@ -160,7 +160,7 @@ func (c *Client) read(requests []ReadRequest) ([]ReadResponse, error) {
 
 	var jResponses []jolokiaResponse
 	if err = json.Unmarshal(responseBody, &jResponses); err != nil {
-		return nil, fmt.Errorf("decoding JSON response: %s: %s", err, responseBody)
+		return nil, fmt.Errorf("decoding JSON response: %w: %s", err, responseBody)
 	}
 
 	return makeReadResponses(jResponses), nil

--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/ua"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 )
@@ -184,7 +185,7 @@ func (o *OpcUAClient) Connect() error {
 		defer cancel()
 		if err := o.Client.Connect(ctx); err != nil {
 			o.State = Disconnected
-			return fmt.Errorf("error in Client Connection: %s", err)
+			return fmt.Errorf("error in Client Connection: %w", err)
 		}
 
 		o.State = Connected

--- a/plugins/common/opcua/opcua_util.go
+++ b/plugins/common/opcua/opcua_util.go
@@ -47,7 +47,7 @@ func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.D
 
 	priv, err := rsa.GenerateKey(rand.Reader, rsaBits)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to generate private key: %s", err)
+		return "", "", fmt.Errorf("failed to generate private key: %w", err)
 	}
 
 	notBefore := time.Now()
@@ -56,7 +56,7 @@ func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.D
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to generate serial number: %s", err)
+		return "", "", fmt.Errorf("failed to generate serial number: %w", err)
 	}
 
 	template := x509.Certificate{
@@ -87,33 +87,33 @@ func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.D
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create certificate: %s", err)
+		return "", "", fmt.Errorf("failed to create certificate: %w", err)
 	}
 
 	certOut, err := os.Create(certFile)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to open %s for writing: %s", certFile, err)
+		return "", "", fmt.Errorf("failed to open %s for writing: %w", certFile, err)
 	}
 	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		return "", "", fmt.Errorf("failed to write data to %s: %s", certFile, err)
+		return "", "", fmt.Errorf("failed to write data to %s: %w", certFile, err)
 	}
 	if err := certOut.Close(); err != nil {
-		return "", "", fmt.Errorf("error closing %s: %s", certFile, err)
+		return "", "", fmt.Errorf("error closing %s: %w", certFile, err)
 	}
 
 	keyOut, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to open %s for writing: %s", keyFile, err)
+		return "", "", fmt.Errorf("failed to open %s for writing: %w", keyFile, err)
 	}
 	keyBlock, err := pemBlockForKey(priv)
 	if err != nil {
-		return "", "", fmt.Errorf("error generating block: %v", err)
+		return "", "", fmt.Errorf("error generating block: %w", err)
 	}
 	if err := pem.Encode(keyOut, keyBlock); err != nil {
-		return "", "", fmt.Errorf("failed to write data to %s: %s", keyFile, err)
+		return "", "", fmt.Errorf("failed to write data to %s: %w", keyFile, err)
 	}
 	if err := keyOut.Close(); err != nil {
-		return "", "", fmt.Errorf("error closing %s: %s", keyFile, err)
+		return "", "", fmt.Errorf("error closing %s: %w", keyFile, err)
 	}
 
 	return certFile, keyFile, nil
@@ -137,7 +137,7 @@ func pemBlockForKey(priv interface{}) (*pem.Block, error) {
 	case *ecdsa.PrivateKey:
 		b, err := x509.MarshalECPrivateKey(k)
 		if err != nil {
-			return nil, fmt.Errorf("unable to marshal ECDSA private key: %v", err)
+			return nil, fmt.Errorf("unable to marshal ECDSA private key: %w", err)
 		}
 		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}, nil
 	default:
@@ -282,7 +282,7 @@ func (o *OpcUAClient) generateClientOpts(endpoints []*ua.EndpointDescription) ([
 	// Check that the selected endpoint is a valid combo
 	err = validateEndpointConfig(endpoints, secPolicy, secMode, authMode)
 	if err != nil {
-		return nil, fmt.Errorf("error validating input: %s", err)
+		return nil, fmt.Errorf("error validating input: %w", err)
 	}
 
 	opts = append(opts, opcua.SecurityFromEndpoint(serverEndpoint, authMode))
@@ -304,13 +304,13 @@ func (o *OpcUAClient) generateAuth(a string, cert []byte, un, pw string) (ua.Use
 
 		if un == "" {
 			if err != nil {
-				return 0, nil, fmt.Errorf("error reading the username input: %s", err)
+				return 0, nil, fmt.Errorf("error reading the username input: %w", err)
 			}
 		}
 
 		if pw == "" {
 			if err != nil {
-				return 0, nil, fmt.Errorf("error reading the password input: %s", err)
+				return 0, nil, fmt.Errorf("error reading the password input: %w", err)
 			}
 		}
 

--- a/plugins/common/shim/goshim.go
+++ b/plugins/common/shim/goshim.go
@@ -110,12 +110,12 @@ func (s *Shim) writeProcessedMetrics() error {
 			}
 			b, err := serializer.Serialize(m)
 			if err != nil {
-				return fmt.Errorf("failed to serialize metric: %s", err)
+				return fmt.Errorf("failed to serialize metric: %w", err)
 			}
 			// Write this to stdout
 			_, err = fmt.Fprint(s.stdout, string(b))
 			if err != nil {
-				return fmt.Errorf("failed to write metric: %s", err)
+				return fmt.Errorf("failed to write metric: %w", err)
 			}
 		}
 	}

--- a/plugins/common/shim/input.go
+++ b/plugins/common/shim/input.go
@@ -17,7 +17,7 @@ func (s *Shim) AddInput(input telegraf.Input) error {
 	if p, ok := input.(telegraf.Initializer); ok {
 		err := p.Init()
 		if err != nil {
-			return fmt.Errorf("failed to init input: %s", err)
+			return fmt.Errorf("failed to init input: %w", err)
 		}
 	}
 
@@ -38,7 +38,7 @@ func (s *Shim) RunInput(pollInterval time.Duration) error {
 
 	if serviceInput, ok := s.Input.(telegraf.ServiceInput); ok {
 		if err := serviceInput.Start(acc); err != nil {
-			return fmt.Errorf("failed to start input: %s", err)
+			return fmt.Errorf("failed to start input: %w", err)
 		}
 	}
 	s.gatherPromptCh = make(chan empty, 1)

--- a/plugins/common/shim/output.go
+++ b/plugins/common/shim/output.go
@@ -14,7 +14,7 @@ func (s *Shim) AddOutput(output telegraf.Output) error {
 	if p, ok := output.(telegraf.Initializer); ok {
 		err := p.Init()
 		if err != nil {
-			return fmt.Errorf("failed to init input: %s", err)
+			return fmt.Errorf("failed to init input: %w", err)
 		}
 	}
 

--- a/plugins/common/starlark/builtins.go
+++ b/plugins/common/starlark/builtins.go
@@ -101,7 +101,7 @@ func builtinAttrNames(methods map[string]builtinMethod) []string {
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·clear
 func dictClear(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 
 	type HasClear interface {
@@ -114,14 +114,14 @@ func dictClear(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple
 func dictPop(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var k, d starlark.Value
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &k, &d); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 
 	type HasDelete interface {
 		Delete(k starlark.Value) (starlark.Value, bool, error)
 	}
 	if v, found, err := b.Receiver().(HasDelete).Delete(k); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err) // dict is frozen or key is unhashable
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err) // dict is frozen or key is unhashable
 	} else if found {
 		return v, nil
 	} else if d != nil {
@@ -133,7 +133,7 @@ func dictPop(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·popitem
 func dictPopitem(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 
 	type HasPopItem interface {
@@ -146,10 +146,10 @@ func dictPopitem(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tup
 func dictGet(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var key, dflt starlark.Value
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 	if v, ok, err := b.Receiver().(starlark.Mapping).Get(key); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	} else if ok {
 		return v, nil
 	} else if dflt != nil {
@@ -162,18 +162,18 @@ func dictGet(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) 
 func dictSetdefault(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var key, dflt starlark.Value = nil, starlark.None
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 
 	recv := b.Receiver().(starlark.HasSetKey)
 	v, found, err := recv.Get(key)
 	if err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 	if !found {
 		v = dflt
 		if err := recv.SetKey(key, dflt); err != nil {
-			return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+			return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 		}
 	}
 	return v, nil
@@ -259,7 +259,7 @@ func dictUpdate(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tupl
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·items
 func dictItems(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 	items := b.Receiver().(starlark.IterableMapping).Items()
 	res := make([]starlark.Value, 0, len(items))
@@ -272,7 +272,7 @@ func dictItems(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·keys
 func dictKeys(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 
 	items := b.Receiver().(starlark.IterableMapping).Items()
@@ -286,7 +286,7 @@ func dictKeys(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple)
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·update
 func dictValues(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 	items := b.Receiver().(starlark.IterableMapping).Items()
 	res := make([]starlark.Value, 0, len(items))

--- a/plugins/common/starlark/logging.go
+++ b/plugins/common/starlark/logging.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/influxdata/telegraf"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
+
+	"github.com/influxdata/telegraf"
 )
 
 // Builds a module that defines all the supported logging functions which will log using the provided logger
@@ -29,7 +30,7 @@ func LogModule(logger telegraf.Logger) *starlarkstruct.Module {
 func log(b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple, logger telegraf.Logger) (starlark.Value, error) {
 	var msg starlark.String
 	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &msg); err != nil {
-		return starlark.None, fmt.Errorf("%s: %v", b.Name(), err)
+		return starlark.None, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 	switch b.Name() {
 	case "log.debug":

--- a/plugins/common/starlark/starlark.go
+++ b/plugins/common/starlark/starlark.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/influxdata/telegraf"
 	"go.starlark.net/lib/json"
 	"go.starlark.net/lib/math"
 	"go.starlark.net/lib/time"
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
+
+	"github.com/influxdata/telegraf"
 )
 
 type Common struct {
@@ -108,7 +109,7 @@ func (s *Common) addConstants(builtins *starlark.StringDict) error {
 	for key, val := range s.Constants {
 		sVal, err := asStarlarkValue(val)
 		if err != nil {
-			return fmt.Errorf("converting type %T failed: %v", val, err)
+			return fmt.Errorf("converting type %T failed: %w", val, err)
 		}
 		(*builtins)[key] = sVal
 	}
@@ -138,7 +139,8 @@ func (s *Common) Call(name string) (starlark.Value, error) {
 }
 
 func (s *Common) LogError(err error) {
-	if evalErr, ok := err.(*starlark.EvalError); ok {
+	var evalErr *starlark.EvalError
+	if errors.As(err, &evalErr) {
 		for _, line := range strings.Split(evalErr.Backtrace(), "\n") {
 			s.Log.Error(line)
 		}

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -149,7 +149,7 @@ func (c *ServerConfig) TLSConfig() (*tls.Config, error) {
 		cipherSuites, err := ParseCiphers(c.TLSCipherSuites)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"could not parse server cipher suites %s: %v", strings.Join(c.TLSCipherSuites, ","), err)
+				"could not parse server cipher suites %s: %w", strings.Join(c.TLSCipherSuites, ","), err)
 		}
 		tlsConfig.CipherSuites = cipherSuites
 	}
@@ -158,7 +158,7 @@ func (c *ServerConfig) TLSConfig() (*tls.Config, error) {
 		version, err := ParseTLSVersion(c.TLSMaxVersion)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"could not parse tls max version %q: %v", c.TLSMaxVersion, err)
+				"could not parse tls max version %q: %w", c.TLSMaxVersion, err)
 		}
 		tlsConfig.MaxVersion = version
 	}
@@ -171,15 +171,13 @@ func (c *ServerConfig) TLSConfig() (*tls.Config, error) {
 	if c.TLSMinVersion != "" {
 		version, err := ParseTLSVersion(c.TLSMinVersion)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"could not parse tls min version %q: %v", c.TLSMinVersion, err)
+			return nil, fmt.Errorf("could not parse tls min version %q: %w", c.TLSMinVersion, err)
 		}
 		tlsConfig.MinVersion = version
 	}
 
 	if tlsConfig.MinVersion != 0 && tlsConfig.MaxVersion != 0 && tlsConfig.MinVersion > tlsConfig.MaxVersion {
-		return nil, fmt.Errorf(
-			"tls min version %q can't be greater than tls max version %q", tlsConfig.MinVersion, tlsConfig.MaxVersion)
+		return nil, fmt.Errorf("tls min version %q can't be greater than tls max version %q", tlsConfig.MinVersion, tlsConfig.MaxVersion)
 	}
 
 	// Since clientAuth is tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
@@ -196,12 +194,10 @@ func makeCertPool(certFiles []string) (*x509.CertPool, error) {
 	for _, certFile := range certFiles {
 		pem, err := os.ReadFile(certFile)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"could not read certificate %q: %v", certFile, err)
+			return nil, fmt.Errorf("could not read certificate %q: %w", certFile, err)
 		}
 		if !pool.AppendCertsFromPEM(pem) {
-			return nil, fmt.Errorf(
-				"could not parse any PEM certificates %q: %v", certFile, err)
+			return nil, fmt.Errorf("could not parse any PEM certificates %q: %w", certFile, err)
 		}
 	}
 	return pool, nil
@@ -210,8 +206,7 @@ func makeCertPool(certFiles []string) (*x509.CertPool, error) {
 func loadCertificate(config *tls.Config, certFile, keyFile string) error {
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return fmt.Errorf(
-			"could not load keypair %s:%s: %v", certFile, keyFile, err)
+		return fmt.Errorf("could not load keypair %s:%s: %w", certFile, keyFile, err)
 	}
 
 	config.Certificates = []tls.Certificate{cert}
@@ -223,7 +218,7 @@ func (c *ServerConfig) verifyPeerCertificate(rawCerts [][]byte, _ [][]*x509.Cert
 	// Let's review the client certificate.
 	cert, err := x509.ParseCertificate(rawCerts[0])
 	if err != nil {
-		return fmt.Errorf("could not validate peer certificate: %v", err)
+		return fmt.Errorf("could not validate peer certificate: %w", err)
 	}
 
 	for _, name := range cert.DNSNames {

--- a/plugins/parsers/collectd/parser.go
+++ b/plugins/parsers/collectd/parser.go
@@ -68,7 +68,7 @@ func (p *Parser) Init() error {
 func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	valueLists, err := network.Parse(buf, p.popts)
 	if err != nil {
-		return nil, fmt.Errorf("collectd parser error: %s", err)
+		return nil, fmt.Errorf("collectd parser error: %w", err)
 	}
 
 	metrics := []telegraf.Metric{}

--- a/plugins/parsers/csv/parser.go
+++ b/plugins/parsers/csv/parser.go
@@ -163,7 +163,7 @@ func (p *Parser) Init() error {
 	}
 
 	if err := p.initializeMetadataSeparators(); err != nil {
-		return fmt.Errorf("initializing separators failed: %v", err)
+		return fmt.Errorf("initializing separators failed: %w", err)
 	}
 
 	if p.TimeFunc == nil {
@@ -393,17 +393,17 @@ outer:
 				case "int":
 					val, err = strconv.ParseInt(value, 10, 64)
 					if err != nil {
-						return nil, fmt.Errorf("column type: parse int error %s", err)
+						return nil, fmt.Errorf("column type: parse int error %w", err)
 					}
 				case "float":
 					val, err = strconv.ParseFloat(value, 64)
 					if err != nil {
-						return nil, fmt.Errorf("column type: parse float error %s", err)
+						return nil, fmt.Errorf("column type: parse float error %w", err)
 					}
 				case "bool":
 					val, err = strconv.ParseBool(value)
 					if err != nil {
-						return nil, fmt.Errorf("column type: parse bool error %s", err)
+						return nil, fmt.Errorf("column type: parse bool error %w", err)
 					}
 				default:
 					val = value

--- a/plugins/parsers/dropwizard/parser.go
+++ b/plugins/parsers/dropwizard/parser.go
@@ -128,7 +128,7 @@ func (p *Parser) parseTime(buf []byte) (time.Time, error) {
 		}
 		t, err := time.Parse(timeFormat, timeString)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("time %s cannot be parsed with format %s, %s", timeString, timeFormat, err)
+			return time.Time{}, fmt.Errorf("time %s cannot be parsed with format %s, %w", timeString, timeFormat, err)
 		}
 		return t.UTC(), nil
 	}
@@ -154,7 +154,7 @@ func (p *Parser) unmarshalMetrics(buf []byte) (map[string]interface{}, error) {
 	var jsonOut map[string]interface{}
 	err := json.Unmarshal(registryBytes, &jsonOut)
 	if err != nil {
-		err = fmt.Errorf("unable to parse dropwizard metric registry from JSON document, %s", err)
+		err = fmt.Errorf("unable to parse dropwizard metric registry from JSON document, %w", err)
 		return nil, err
 	}
 	return jsonOut, nil

--- a/plugins/parsers/graphite/parser.go
+++ b/plugins/parsers/graphite/parser.go
@@ -108,7 +108,7 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 	// Parse value.
 	v, err := strconv.ParseFloat(fields[1], 64)
 	if err != nil {
-		return nil, fmt.Errorf(`field "%s" value: %s`, fields[0], err)
+		return nil, fmt.Errorf(`field "%s" value: %w`, fields[0], err)
 	}
 
 	fieldValues := map[string]interface{}{}
@@ -125,7 +125,7 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 		// Parse timestamp.
 		unixTime, err := strconv.ParseFloat(fields[2], 64)
 		if err != nil {
-			return nil, fmt.Errorf(`field "%s" time: %s`, fields[0], err)
+			return nil, fmt.Errorf(`field "%s" time: %w`, fields[0], err)
 		}
 
 		// -1 is a special value that gets converted to current UTC time

--- a/plugins/parsers/influx/handler.go
+++ b/plugins/parsers/influx/handler.go
@@ -62,8 +62,9 @@ func (h *MetricHandler) AddInt(key []byte, value []byte) error {
 	fk := unescape(key)
 	fv, err := parseIntBytes(bytes.TrimSuffix(value, []byte("i")), 10, 64)
 	if err != nil {
-		if numerr, ok := err.(*strconv.NumError); ok {
-			return numerr.Err
+		var numErr *strconv.NumError
+		if errors.As(err, &numErr) {
+			return numErr.Err
 		}
 		return err
 	}
@@ -75,8 +76,9 @@ func (h *MetricHandler) AddUint(key []byte, value []byte) error {
 	fk := unescape(key)
 	fv, err := parseUintBytes(bytes.TrimSuffix(value, []byte("u")), 10, 64)
 	if err != nil {
-		if numerr, ok := err.(*strconv.NumError); ok {
-			return numerr.Err
+		var numErr *strconv.NumError
+		if errors.As(err, &numErr) {
+			return numErr.Err
 		}
 		return err
 	}
@@ -88,8 +90,9 @@ func (h *MetricHandler) AddFloat(key []byte, value []byte) error {
 	fk := unescape(key)
 	fv, err := parseFloatBytes(value, 64)
 	if err != nil {
-		if numerr, ok := err.(*strconv.NumError); ok {
-			return numerr.Err
+		var numErr *strconv.NumError
+		if errors.As(err, &numErr) {
+			return numErr.Err
 		}
 		return err
 	}
@@ -117,8 +120,9 @@ func (h *MetricHandler) AddBool(key []byte, value []byte) error {
 func (h *MetricHandler) SetTimestamp(tm []byte) error {
 	v, err := parseIntBytes(tm, 10, 64)
 	if err != nil {
-		if numerr, ok := err.(*strconv.NumError); ok {
-			return numerr.Err
+		var numErr *strconv.NumError
+		if errors.As(err, &numErr) {
+			return numErr.Err
 		}
 		return err
 	}

--- a/plugins/parsers/influx/influx_upstream/parser_test.go
+++ b/plugins/parsers/influx/influx_upstream/parser_test.go
@@ -659,7 +659,7 @@ func TestStreamParser(t *testing.T) {
 			for {
 				m, err := parser.Next()
 				if err != nil {
-					if err == ErrEOF {
+					if errors.Is(err, ErrEOF) {
 						break
 					}
 					require.Equal(t, tt.err.Error(), err.Error())
@@ -849,7 +849,7 @@ func TestStreamParserErrorString(t *testing.T) {
 			var errs []error
 			for i := 0; i < 20; i++ {
 				_, err := parser.Next()
-				if err == ErrEOF {
+				if errors.Is(err, ErrEOF) {
 					break
 				}
 

--- a/plugins/parsers/influx/machine_test.go
+++ b/plugins/parsers/influx/machine_test.go
@@ -1710,7 +1710,7 @@ func TestMachine(t *testing.T) {
 
 			for i := 0; i < 20; i++ {
 				err := fsm.Next()
-				if err != nil && err == influx.EOF {
+				if err != nil && errors.Is(err, influx.EOF) {
 					break
 				}
 				handler.Result(err)
@@ -2138,7 +2138,7 @@ func TestHandlerErrorRecovery(t *testing.T) {
 
 			for i := 0; i < 20; i++ {
 				err := fsm.Next()
-				if err != nil && err == influx.EOF {
+				if err != nil && errors.Is(err, influx.EOF) {
 					break
 				}
 				tt.handler.Result(err)
@@ -2177,7 +2177,7 @@ func TestStreamMachine(t *testing.T) {
 			// isn't terminated.
 			for i := 0; i < 20; i++ {
 				err := fsm.Next()
-				if err != nil && err == influx.EOF {
+				if err != nil && errors.Is(err, influx.EOF) {
 					break
 				}
 				handler.Result(err)

--- a/plugins/parsers/influx/parser.go
+++ b/plugins/parsers/influx/parser.go
@@ -85,7 +85,7 @@ func (p *Parser) Parse(input []byte) ([]telegraf.Metric, error) {
 
 	for {
 		err := p.machine.Next()
-		if err == EOF {
+		if errors.Is(err, EOF) {
 			break
 		}
 
@@ -203,11 +203,12 @@ func (sp *StreamParser) SetTimePrecision(u time.Duration) {
 // function if it returns ParseError to get the next metric or error.
 func (sp *StreamParser) Next() (telegraf.Metric, error) {
 	err := sp.machine.Next()
-	if err == EOF {
+	if errors.Is(err, EOF) {
 		return nil, err
 	}
 
-	if e, ok := err.(*readErr); ok {
+	var e *readErr
+	if errors.As(err, &e) {
 		return nil, e.Err
 	}
 

--- a/plugins/parsers/influx/parser_test.go
+++ b/plugins/parsers/influx/parser_test.go
@@ -629,7 +629,7 @@ func TestStreamParser(t *testing.T) {
 			for {
 				m, err := parser.Next()
 				if err != nil {
-					if err == EOF {
+					if errors.Is(err, EOF) {
 						break
 					}
 					require.Equal(t, tt.err, err)
@@ -816,7 +816,7 @@ func TestStreamParserErrorString(t *testing.T) {
 			var errs []error
 			for i := 0; i < 20; i++ {
 				_, err := parser.Next()
-				if err == EOF {
+				if errors.Is(err, EOF) {
 					break
 				}
 

--- a/plugins/parsers/json/parser.go
+++ b/plugins/parsers/json/parser.go
@@ -161,12 +161,12 @@ func (p *Parser) Init() error {
 
 	p.stringFilter, err = filter.Compile(p.StringFields)
 	if err != nil {
-		return fmt.Errorf("compiling string-fields filter failed: %v", err)
+		return fmt.Errorf("compiling string-fields filter failed: %w", err)
 	}
 
 	p.tagFilter, err = filter.Compile(p.TagKeys)
 	if err != nil {
-		return fmt.Errorf("compiling tag-key filter failed: %v", err)
+		return fmt.Errorf("compiling tag-key filter failed: %w", err)
 	}
 
 	return nil

--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -75,7 +75,7 @@ func (p *Parser) Parse(input []byte) ([]telegraf.Metric, error) {
 	body, _ := utfbom.Skip(reader)
 	input, err := io.ReadAll(body)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read body after BOM removal: %v", err)
+		return nil, fmt.Errorf("unable to read body after BOM removal: %w", err)
 	}
 
 	// Only valid JSON is supported
@@ -102,7 +102,7 @@ func (p *Parser) Parse(input []byte) ([]telegraf.Metric, error) {
 
 			if result.Type == gjson.Null {
 				p.Log.Debugf("Message: %s", input)
-				return nil, fmt.Errorf("The timestamp path %s returned NULL", c.TimestampPath)
+				return nil, fmt.Errorf("the timestamp path %s returned NULL", c.TimestampPath)
 			}
 			if !result.IsArray() && !result.IsObject() {
 				if c.TimestampFormat == "" {
@@ -586,25 +586,25 @@ func (p *Parser) convertType(input gjson.Result, desiredType string, name string
 		case "uint":
 			r, err := strconv.ParseUint(inputType, 10, 64)
 			if err != nil {
-				return nil, fmt.Errorf("Unable to convert field '%s' to type uint: %v", name, err)
+				return nil, fmt.Errorf("unable to convert field '%s' to type uint: %w", name, err)
 			}
 			return r, nil
 		case "int":
 			r, err := strconv.ParseInt(inputType, 10, 64)
 			if err != nil {
-				return nil, fmt.Errorf("Unable to convert field '%s' to type int: %v", name, err)
+				return nil, fmt.Errorf("unable to convert field '%s' to type int: %w", name, err)
 			}
 			return r, nil
 		case "float":
 			r, err := strconv.ParseFloat(inputType, 64)
 			if err != nil {
-				return nil, fmt.Errorf("Unable to convert field '%s' to type float: %v", name, err)
+				return nil, fmt.Errorf("unable to convert field '%s' to type float: %w", name, err)
 			}
 			return r, nil
 		case "bool":
 			r, err := strconv.ParseBool(inputType)
 			if err != nil {
-				return nil, fmt.Errorf("Unable to convert field '%s' to type bool: %v", name, err)
+				return nil, fmt.Errorf("unable to convert field '%s' to type bool: %w", name, err)
 			}
 			return r, nil
 		}
@@ -639,7 +639,7 @@ func (p *Parser) convertType(input gjson.Result, desiredType string, name string
 			} else if inputType == 1 {
 				return true, nil
 			} else {
-				return nil, fmt.Errorf("Unable to convert field '%s' to type bool", name)
+				return nil, fmt.Errorf("unable to convert field '%s' to type bool", name)
 			}
 		}
 	default:

--- a/plugins/parsers/json_v2/testdata/wrong_path/expected.err
+++ b/plugins/parsers/json_v2/testdata/wrong_path/expected.err
@@ -1,6 +1,6 @@
 the path wrong doesn't exist
 the path wrong doesn't exist
 the path wrong doesn't exist
-The timestamp path wrong returned NULL
+the timestamp path wrong returned NULL
 the path wrong doesn't exist
 the path wrong doesn't exist

--- a/plugins/parsers/nagios/parser.go
+++ b/plugins/parsers/nagios/parser.go
@@ -27,8 +27,8 @@ func getExitCode(err error) (int, error) {
 		return 0, nil
 	}
 
-	ee, ok := err.(*exec.ExitError)
-	if !ok {
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
 		return unknownExitCode, err
 	}
 

--- a/plugins/parsers/prometheus/parser.go
+++ b/plugins/parsers/prometheus/parser.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -50,17 +51,17 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		for {
 			mf := &dto.MetricFamily{}
 			if _, ierr := pbutil.ReadDelimited(reader, mf); ierr != nil {
-				if ierr == io.EOF {
+				if errors.Is(ierr, io.EOF) {
 					break
 				}
-				return nil, fmt.Errorf("reading metric family protocol buffer failed: %s", ierr)
+				return nil, fmt.Errorf("reading metric family protocol buffer failed: %w", ierr)
 			}
 			metricFamilies[mf.GetName()] = mf
 		}
 	} else {
 		metricFamilies, err = parser.TextToMetricFamilies(reader)
 		if err != nil {
-			return nil, fmt.Errorf("reading text format failed: %s", err)
+			return nil, fmt.Errorf("reading text format failed: %w", err)
 		}
 	}
 

--- a/plugins/parsers/prometheusremotewrite/parser.go
+++ b/plugins/parsers/prometheusremotewrite/parser.go
@@ -23,7 +23,7 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	var req prompb.WriteRequest
 
 	if err := req.Unmarshal(buf); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal request body: %s", err)
+		return nil, fmt.Errorf("unable to unmarshal request body: %w", err)
 	}
 
 	now := time.Now()
@@ -70,11 +70,11 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 	}
 
 	if len(metrics) < 1 {
-		return nil, fmt.Errorf("No metrics in line")
+		return nil, fmt.Errorf("no metrics in line")
 	}
 
 	if len(metrics) > 1 {
-		return nil, fmt.Errorf("More than one metric in line")
+		return nil, fmt.Errorf("more than one metric in line")
 	}
 
 	return metrics[0], nil

--- a/plugins/parsers/wavefront/element.go
+++ b/plugins/parsers/wavefront/element.go
@@ -92,7 +92,7 @@ func (ep *TimestampParser) parse(p *PointParser, pt *Point) error {
 	}
 
 	p.writeBuf.Reset()
-	for tok != EOF && tok == Number {
+	for tok == Number {
 		if _, err := p.writeBuf.WriteString(lit); err != nil {
 			return fmt.Errorf("unable to write: %w", err)
 		}
@@ -136,7 +136,7 @@ func (ep *LoopedParser) parse(p *PointParser, pt *Point) error {
 			return err
 		}
 		err = ep.wsParser.parse(p, pt)
-		if err == ErrEOF {
+		if errors.Is(err, ErrEOF) {
 			break
 		}
 	}
@@ -170,7 +170,7 @@ func (ep *TagParser) parse(p *PointParser, pt *Point) error {
 
 func (ep *WhiteSpaceParser) parse(p *PointParser, _ *Point) error {
 	tok := Ws
-	for tok != EOF && tok == Ws {
+	for tok == Ws {
 		tok, _ = p.scan()
 	}
 

--- a/plugins/parsers/xpath/msgpack_document.go
+++ b/plugins/parsers/xpath/msgpack_document.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/tinylib/msgp/msgp"
-
 	"github.com/antchfx/jsonquery"
 	path "github.com/antchfx/xpath"
+	"github.com/tinylib/msgp/msgp"
 )
 
 type msgpackDocument jsonDocument
@@ -17,7 +16,7 @@ func (d *msgpackDocument) Parse(buf []byte) (dataNode, error) {
 
 	// Unmarshal the message-pack binary message to JSON and proceed with the jsonquery class
 	if _, err := msgp.UnmarshalAsJSON(&json, buf); err != nil {
-		return nil, fmt.Errorf("unmarshalling to json failed: %v", err)
+		return nil, fmt.Errorf("unmarshalling to json failed: %w", err)
 	}
 	return jsonquery.Parse(&json)
 }

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -212,7 +212,7 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 	if len(config.MetricQuery) > 0 {
 		v, err := p.executeQuery(doc, selected, config.MetricQuery)
 		if err != nil {
-			return nil, fmt.Errorf("failed to query metric name: %v", err)
+			return nil, fmt.Errorf("failed to query metric name: %w", err)
 		}
 		var ok bool
 		if metricname, ok = v.(string); !ok {
@@ -229,7 +229,7 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 	if len(config.Timestamp) > 0 {
 		v, err := p.executeQuery(doc, selected, config.Timestamp)
 		if err != nil {
-			return nil, fmt.Errorf("failed to query timestamp: %v", err)
+			return nil, fmt.Errorf("failed to query timestamp: %w", err)
 		}
 		if v != nil {
 			timestamp, err = internal.ParseTimestamp(config.TimestampFmt, v, "")
@@ -245,7 +245,7 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 		// Execute the query and cast the returned values into strings
 		v, err := p.executeQuery(doc, selected, query)
 		if err != nil {
-			return nil, fmt.Errorf("failed to query tag '%s': %v", name, err)
+			return nil, fmt.Errorf("failed to query tag '%s': %w", name, err)
 		}
 		switch v := v.(type) {
 		case string:
@@ -282,7 +282,7 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 			for _, selectedtag := range selectedTagNodes {
 				n, err := p.executeQuery(doc, selectedtag, tagnamequery)
 				if err != nil {
-					return nil, fmt.Errorf("failed to query tag name with query '%s': %v", tagnamequery, err)
+					return nil, fmt.Errorf("failed to query tag name with query '%s': %w", tagnamequery, err)
 				}
 				name, ok := n.(string)
 				if !ok {
@@ -290,7 +290,7 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 				}
 				v, err := p.executeQuery(doc, selectedtag, tagvaluequery)
 				if err != nil {
-					return nil, fmt.Errorf("failed to query tag value for '%s': %v", name, err)
+					return nil, fmt.Errorf("failed to query tag value for '%s': %w", name, err)
 				}
 
 				if config.TagNameExpand {
@@ -333,13 +333,13 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 		// Execute the query and cast the returned values into integers
 		v, err := p.executeQuery(doc, selected, query)
 		if err != nil {
-			return nil, fmt.Errorf("failed to query field (int) '%s': %v", name, err)
+			return nil, fmt.Errorf("failed to query field (int) '%s': %w", name, err)
 		}
 		switch v := v.(type) {
 		case string:
 			fields[name], err = strconv.ParseInt(v, 10, 54)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse field (int) '%s': %v", name, err)
+				return nil, fmt.Errorf("failed to parse field (int) '%s': %w", name, err)
 			}
 		case bool:
 			fields[name] = int64(0)
@@ -359,7 +359,7 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 		// Execute the query and store the result in fields
 		v, err := p.executeQuery(doc, selected, query)
 		if err != nil {
-			return nil, fmt.Errorf("failed to query field '%s': %v", name, err)
+			return nil, fmt.Errorf("failed to query field '%s': %w", name, err)
 		}
 		fields[name] = v
 	}
@@ -385,7 +385,7 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 			for _, selectedfield := range selectedFieldNodes {
 				n, err := p.executeQuery(doc, selectedfield, fieldnamequery)
 				if err != nil {
-					return nil, fmt.Errorf("failed to query field name with query '%s': %v", fieldnamequery, err)
+					return nil, fmt.Errorf("failed to query field name with query '%s': %w", fieldnamequery, err)
 				}
 				name, ok := n.(string)
 				if !ok {
@@ -393,7 +393,7 @@ func (p *Parser) parseQuery(starttime time.Time, doc, selected dataNode, config 
 				}
 				v, err := p.executeQuery(doc, selectedfield, fieldvaluequery)
 				if err != nil {
-					return nil, fmt.Errorf("failed to query field value for '%s': %v", name, err)
+					return nil, fmt.Errorf("failed to query field value for '%s': %w", name, err)
 				}
 
 				if config.FieldNameExpand {
@@ -439,7 +439,7 @@ func (p *Parser) executeQuery(doc, selected dataNode, query string) (r interface
 	// Compile the query
 	expr, err := path.Compile(query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compile query '%s': %v", query, err)
+		return nil, fmt.Errorf("failed to compile query '%s': %w", query, err)
 	}
 
 	// Evaluate the compiled expression and handle returned node-iterators

--- a/plugins/parsers/xpath/protocolbuffer_document.go
+++ b/plugins/parsers/xpath/protocolbuffer_document.go
@@ -43,7 +43,7 @@ func (d *protobufDocument) Init() error {
 	}
 	fds, err := parser.ParseFiles(d.MessageDefinition)
 	if err != nil {
-		return fmt.Errorf("parsing protocol-buffer definition in %q failed: %v", d.MessageDefinition, err)
+		return fmt.Errorf("parsing protocol-buffer definition in %q failed: %w", d.MessageDefinition, err)
 	}
 	if len(fds) < 1 {
 		return fmt.Errorf("file %q does not contain file descriptors", d.MessageDefinition)
@@ -52,7 +52,7 @@ func (d *protobufDocument) Init() error {
 	// Register all definitions in the file in the global registry
 	registry, err := protodesc.NewFiles(desc.ToFileDescriptorSet(fds...))
 	if err != nil {
-		return fmt.Errorf("constructing registry failed: %v", err)
+		return fmt.Errorf("constructing registry failed: %w", err)
 	}
 
 	// Lookup given type in the loaded file descriptors

--- a/plugins/processors/enum/enum.go
+++ b/plugins/processors/enum/enum.go
@@ -47,7 +47,7 @@ func (mapper *EnumMapper) Init() error {
 		if mapping.Tag != "" {
 			tagFilter, err := filter.NewIncludeExcludeFilter([]string{mapping.Tag}, nil)
 			if err != nil {
-				return fmt.Errorf("failed to create new tag filter: %s", err)
+				return fmt.Errorf("failed to create new tag filter: %w", err)
 			}
 			mapper.TagFilters[mapping.Tag] = tagFilter
 		}

--- a/plugins/processors/execd/execd.go
+++ b/plugins/processors/execd/execd.go
@@ -139,11 +139,12 @@ func (e *Execd) cmdReadOutStream(out io.Reader) {
 
 		if err != nil {
 			// Stop parsing when we've reached the end.
-			if err == influx.EOF {
+			if errors.Is(err, influx.EOF) {
 				break
 			}
 
-			if parseErr, isParseError := err.(*influx.ParseError); isParseError {
+			var parseErr *influx.ParseError
+			if errors.As(err, &parseErr) {
 				// Continue past parse errors.
 				e.acc.AddError(parseErr)
 				continue

--- a/plugins/processors/execd/execd_test.go
+++ b/plugins/processors/execd/execd_test.go
@@ -1,6 +1,7 @@
 package execd
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -156,10 +157,11 @@ func runCountMultiplierProgram() {
 	for {
 		m, err := parser.Next()
 		if err != nil {
-			if err == influx.EOF {
+			if errors.Is(err, influx.EOF) {
 				return // stream ended
 			}
-			if parseErr, isParseError := err.(*influx.ParseError); isParseError {
+			var parseErr *influx.ParseError
+			if errors.As(err, &parseErr) {
 				fmt.Fprintf(os.Stderr, "parse ERR %v\n", parseErr)
 				//nolint:revive // os.Exit called intentionally
 				os.Exit(1)

--- a/plugins/processors/ifname/ifname.go
+++ b/plugins/processors/ifname/ifname.go
@@ -144,11 +144,11 @@ func (d *IfName) Start(acc telegraf.Accumulator) error {
 
 	d.ifTable, err = d.makeTable("1.3.6.1.2.1.2.2.1.2")
 	if err != nil {
-		return fmt.Errorf("preparing ifTable: %v", err)
+		return fmt.Errorf("preparing ifTable: %w", err)
 	}
 	d.ifXTable, err = d.makeTable("1.3.6.1.2.1.31.1.1.1.1")
 	if err != nil {
-		return fmt.Errorf("preparing ifXTable: %v", err)
+		return fmt.Errorf("preparing ifXTable: %w", err)
 	}
 
 	fn := func(m telegraf.Metric) []telegraf.Metric {

--- a/plugins/processors/noise/noise.go
+++ b/plugins/processors/noise/noise.go
@@ -94,7 +94,7 @@ func (*Noise) SampleConfig() string {
 func (p *Noise) Init() error {
 	fieldFilter, err := filter.NewIncludeExcludeFilter(p.IncludeFields, p.ExcludeFields)
 	if err != nil {
-		return fmt.Errorf("creating fieldFilter failed: %v", err)
+		return fmt.Errorf("creating fieldFilter failed: %w", err)
 	}
 	p.fieldFilter = fieldFilter
 

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -61,7 +61,7 @@ func (r *Regex) Init() error {
 			c.ResultKey = "keep"
 		}
 		if err := choice.Check(c.ResultKey, resultOptions); err != nil {
-			return fmt.Errorf("invalid metrics result_key: %v", err)
+			return fmt.Errorf("invalid metrics result_key: %w", err)
 		}
 
 		if _, compiled := r.regexCache[c.Pattern]; !compiled {
@@ -78,7 +78,7 @@ func (r *Regex) Init() error {
 			c.ResultKey = "keep"
 		}
 		if err := choice.Check(c.ResultKey, resultOptions); err != nil {
-			return fmt.Errorf("invalid metrics result_key: %v", err)
+			return fmt.Errorf("invalid metrics result_key: %w", err)
 		}
 
 		if _, compiled := r.regexCache[c.Pattern]; !compiled {

--- a/plugins/processors/topk/topk.go
+++ b/plugins/processors/topk/topk.go
@@ -91,7 +91,7 @@ func (t *TopK) generateGroupByKey(m telegraf.Metric) (string, error) {
 		var err error
 		t.tagsGlobs, err = filter.Compile(t.GroupBy)
 		if err != nil {
-			return "", fmt.Errorf("could not compile pattern: %v %v", t.GroupBy, err)
+			return "", fmt.Errorf("could not compile pattern: %v %w", t.GroupBy, err)
 		}
 	}
 

--- a/plugins/secretstores/jose/jose.go
+++ b/plugins/secretstores/jose/jose.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/99designs/keyring"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/secretstores"
@@ -41,7 +42,7 @@ func (j *Jose) Init() error {
 
 	passwd, err := j.Password.Get()
 	if err != nil {
-		return fmt.Errorf("getting password failed: %v", err)
+		return fmt.Errorf("getting password failed: %w", err)
 	}
 	defer config.ReleaseSecret(passwd)
 
@@ -59,7 +60,7 @@ func (j *Jose) Init() error {
 	}
 	kr, err := keyring.Open(cfg)
 	if err != nil {
-		return fmt.Errorf("opening keyring failed: %v", err)
+		return fmt.Errorf("opening keyring failed: %w", err)
 	}
 	j.ring = kr
 

--- a/plugins/secretstores/os/os.go
+++ b/plugins/secretstores/os/os.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/99designs/keyring"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/secretstores"
@@ -43,11 +44,11 @@ func (o *OS) Init() error {
 	// Setup the actual keyring
 	cfg, err := o.createKeyringConfig()
 	if err != nil {
-		return fmt.Errorf("getting keyring config failed: %v", err)
+		return fmt.Errorf("getting keyring config failed: %w", err)
 	}
 	kr, err := keyring.Open(cfg)
 	if err != nil {
-		return fmt.Errorf("opening keyring failed: %v", err)
+		return fmt.Errorf("opening keyring failed: %w", err)
 	}
 	o.ring = kr
 

--- a/plugins/serializers/influx/influx.go
+++ b/plugins/serializers/influx/influx.go
@@ -2,6 +2,7 @@ package influx
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -113,7 +114,8 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	for _, m := range metrics {
 		err := s.Write(&s.buf, m)
 		if err != nil {
-			if _, ok := err.(*MetricError); ok {
+			var mErr *MetricError
+			if errors.As(err, &mErr) {
 				continue
 			}
 			return nil, err

--- a/plugins/serializers/influx/reader.go
+++ b/plugins/serializers/influx/reader.go
@@ -2,6 +2,7 @@ package influx
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"log"
 
@@ -53,7 +54,8 @@ func (r *reader) Read(p []byte) (int, error) {
 		r.offset++
 		if err != nil {
 			r.buf.Reset()
-			if _, ok := err.(*MetricError); ok {
+			var mErr *MetricError
+			if errors.As(err, &mErr) {
 				continue
 			}
 			// Since we are serializing multiple metrics, don't fail the

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"time"
 
-	jsonata "github.com/blues/jsonata-go"
+	"github.com/blues/jsonata-go"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/filter"
@@ -62,7 +62,7 @@ func (s *Serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 		var err error
 		if obj, err = s.transform(obj); err != nil {
 			if errors.Is(err, jsonata.ErrUndefined) {
-				return nil, fmt.Errorf("%v (maybe configured for batch mode?)", err)
+				return nil, fmt.Errorf("%w (maybe configured for batch mode?)", err)
 			}
 			return nil, err
 		}
@@ -93,7 +93,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		var err error
 		if obj, err = s.transform(obj); err != nil {
 			if errors.Is(err, jsonata.ErrUndefined) {
-				return nil, fmt.Errorf("%v (maybe configured for non-batch mode?)", err)
+				return nil, fmt.Errorf("%w (maybe configured for non-batch mode?)", err)
 			}
 			return nil, err
 		}

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -236,7 +236,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	pb := &prompb.WriteRequest{Timeseries: promTS}
 	data, err := pb.Marshal()
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal protobuf: %v", err)
+		return nil, fmt.Errorf("unable to marshal protobuf: %w", err)
 	}
 	encoded := snappy.Encode(nil, data)
 	buf.Write(encoded) //nolint:revive // from buffer.go: "err is always nil"


### PR DESCRIPTION
Address findings for [errorlint](https://github.com/polyfloyd/go-errorlint) - finds code that can cause problems with the error wrapping scheme introduced in Go 1.13.

It is only part of the bigger job.
After all findings in whole project are handled, we can enable `errorlint` linter to guard this.

Following findings in `plugins/aggregators`, `plugins/common`, `plugins/parsers`, `plugins/processors`, `plugins/secretstores` and `plugins/serializers` packages were fixed:
```
plugins/aggregators/quantile/quantile.go:118:72                             errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/encoding/decoder_reader.go:136:64                            errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/common/encoding/decoder_reader.go:148:9                             errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/common/encoding/decoder_reader.go:151:9                             errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/common/encoding/decoder_reader.go:157:24                            errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/common/jolokia2/client.go:163:60                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/client.go:187:56                                       errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:50:67                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:59:69                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:90:65                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:95:76                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:98:73                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:101:63                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:106:75                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:110:59                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:113:72                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:116:62                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:140:70                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:285:56                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:307:71                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/opcua/opcua_util.go:313:71                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/shim/goshim.go:113:57                                        errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/shim/goshim.go:118:53                                        errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/shim/input.go:20:50                                          errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/shim/input.go:41:51                                          errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/shim/output.go:17:50                                         errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/shim/processor.go:27:50                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/shim/processor.go:58:7                                       errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/common/shim/processor.go:61:33                                      errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/common/starlark/builtins.go:104:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:117:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:124:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:136:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:149:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:152:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:165:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:171:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:176:57                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:262:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:275:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/builtins.go:289:56                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/logging.go:32:56                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/starlark.go:111:60                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/starlark/starlark.go:141:20                                  errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/common/tls/config.go:152:90                                         errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/tls/config.go:161:64                                         errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/tls/config.go:175:64                                         errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/tls/config.go:200:52                                         errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/tls/config.go:204:62                                         errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/tls/config.go:214:59                                         errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/common/tls/config.go:226:64                                         errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/collectd/parser.go:71:55                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/csv/parser.go:166:59                                        errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/csv/parser.go:396:65                                        errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/csv/parser.go:401:67                                        errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/csv/parser.go:406:66                                        errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/dropwizard/parser.go:131:106                                errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/dropwizard/parser.go:157:89                                 errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/graphite/parser.go:111:61                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/graphite/parser.go:128:61                                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/influx/handler.go:65:20                                     errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/parsers/influx/handler.go:78:20                                     errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/parsers/influx/handler.go:91:20                                     errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/parsers/influx/handler.go:120:20                                    errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/parsers/influx/influx_upstream/parser.go:91:13                      errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/parsers/influx/influx_upstream/parser.go:252:45                     errorlint  comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/influx/influx_upstream/parser_test.go:662:9                 errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/influx/influx_upstream/parser_test.go:852:8                 errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/influx/machine_test.go:1713:22                              errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/influx/machine_test.go:2141:22                              errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/influx/machine_test.go:2180:22                              errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/influx/parser.go:88:6                                       errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/influx/parser.go:206:5                                      errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/influx/parser.go:210:14                                     errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/parsers/influx/parser_test.go:632:9                                 errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/influx/parser_test.go:819:8                                 errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/json/parser.go:164:66                                       errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/json/parser.go:169:60                                       errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/json_v2/parser.go:78:71                                     errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/json_v2/parser.go:589:83                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/json_v2/parser.go:595:82                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/json_v2/parser.go:601:84                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/json_v2/parser.go:607:83                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/nagios/parser.go:30:12                                      errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/parsers/prometheus/parser.go:53:8                                   errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/prometheus/parser.go:56:80                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/prometheus/parser.go:63:61                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/prometheusremotewrite/parser.go:26:66                       errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/wavefront/element.go:139:6                                  errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/parsers/xpath/msgpack_document.go:20:62                             errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:215:62                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:232:60                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:248:65                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:285:91                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:293:77                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:336:73                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:342:74                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:362:67                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:388:95                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:396:79                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/parser.go:442:69                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/protocolbuffer_document.go:46:97                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/parsers/xpath/protocolbuffer_document.go:55:57                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/processors/enum/enum.go:50:62                                       errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/processors/execd/execd.go:142:7                                     errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/processors/execd/execd.go:146:33                                    errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/processors/execd/execd_test.go:159:7                                errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/processors/execd/execd_test.go:162:33                               errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/processors/ifname/ifname.go:147:46                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/processors/ifname/ifname.go:151:47                                  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/processors/noise/noise.go:97:56                                     errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/processors/regex/regex.go:64:56                                     errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/processors/regex/regex.go:81:56                                     errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/processors/topk/topk.go:94:73                                       errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/secretstores/jose/jose.go:44:52                                     errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/secretstores/jose/jose.go:62:51                                     errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/secretstores/os/os.go:46:58                                         errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/secretstores/os/os.go:50:51                                         errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/serializers/influx/influx.go:116:16                                 errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/serializers/influx/reader.go:56:16                                  errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/serializers/json/json.go:65:69                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/serializers/json/json.go:96:73                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/serializers/prometheusremotewrite/prometheusremotewrite.go:239:60   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
```
