### PR TITLE
fix(inputs.internet_speed): Add the best server selection and jitter field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -148,7 +148,7 @@ require (
 	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1
 	github.com/sensu/sensu-go/api/core/v2 v2.15.0
 	github.com/shirou/gopsutil/v3 v3.22.12
-	github.com/showwin/speedtest-go v1.2.1
+	github.com/showwin/speedtest-go v1.4.1
 	github.com/signalfx/golib/v3 v3.3.46
 	github.com/sirupsen/logrus v1.9.0
 	github.com/sleepinggenius2/gosmi v0.4.4

--- a/go.sum
+++ b/go.sum
@@ -2073,8 +2073,8 @@ github.com/shirou/gopsutil/v3 v3.22.12/go.mod h1:Xd7P1kwZcp5VW52+9XsirIKd/BROzbb
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/showwin/speedtest-go v1.2.1 h1:5GrQFGn5N4YRBCaiph6ay6Py9yL2k7Ja10bbUZl9HPE=
-github.com/showwin/speedtest-go v1.2.1/go.mod h1:dJugxvC/AQDt4HQQKZ9lKNa2+b1c8nzj9IL0a/F8l1U=
+github.com/showwin/speedtest-go v1.4.1 h1:A+3gmwKIQz9RVlXSilLNadcH6j4wUXF0giIqQeANOdg=
+github.com/showwin/speedtest-go v1.4.1/go.mod h1:Y7c+pxzaNAlo4mYP+x83pnYY8IM3bkHGDhTdrgUnkNE=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Recently, [speedtest-go](https://github.com/showwin/speedtest-go) has had a lot of bugfixes, It time to upgrade to 1.4.1 now.
resolves:
1. fix #11625 select based on real server latency information.
2. When the filter #12617 mismatches all servers, a server with the lowest latency will be chosen.
3. Add a new field: latency jitter.

Other related issues #11449 #12595

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
