### PR TITLE
fix(inputs.lvm): Allow to specify path to binaries in config file

### DIFF
--- a/plugins/inputs/lvm/README.md
+++ b/plugins/inputs/lvm/README.md
@@ -19,9 +19,18 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 [[inputs.lvm]]
   ## Use sudo to run LVM commands
   use_sudo = false
+
+  ## The default location of the pvs binary can be overridden with:
+  pvs_binary = "/usr/sbin/pvs"
+
+  ## The default location of the vgs binary can be overridden with:
+  vgs_binary = "/usr/sbin/vgs"
+
+  ## The default location of the lvs binary can be overridden with:
+  lvs_binary = "/usr/sbin/lvs"
 ```
 
-The `lvm` command requires elevated permissions. If the user has configured sudo
+The LVM commands requires elevated permissions. If the user has configured sudo
 with the ability to run these commands, then set the `use_sudo` to true.
 
 ### Using sudo
@@ -39,6 +48,9 @@ Cmnd_Alias LVM = /usr/sbin/pvs *, /usr/sbin/vgs *, /usr/sbin/lvs *
 <username>  ALL=(root) NOPASSWD: LVM
 Defaults!LVM !logfile, !syslog, !pam_session
 ```
+
+Path to binaries must match those from config file (pvs_binary, vgs_binary and
+lvs_binary)
 
 ## Metrics
 

--- a/plugins/inputs/lvm/README.md
+++ b/plugins/inputs/lvm/README.md
@@ -21,13 +21,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   use_sudo = false
 
   ## The default location of the pvs binary can be overridden with:
-  pvs_binary = "/usr/sbin/pvs"
+  #pvs_binary = "/usr/sbin/pvs"
 
   ## The default location of the vgs binary can be overridden with:
-  vgs_binary = "/usr/sbin/vgs"
+  #vgs_binary = "/usr/sbin/vgs"
 
   ## The default location of the lvs binary can be overridden with:
-  lvs_binary = "/usr/sbin/lvs"
+  #lvs_binary = "/usr/sbin/lvs"
 ```
 
 The LVM commands requires elevated permissions. If the user has configured sudo

--- a/plugins/inputs/lvm/lvm.go
+++ b/plugins/inputs/lvm/lvm.go
@@ -285,7 +285,6 @@ type lvsReport struct {
 func init() {
 	inputs.Add("lvm", func() telegraf.Input {
 		return &LVM{
-			UseSudo:   false,
 			PVSBinary: "/usr/sbin/pvs",
 			VGSBinary: "/usr/sbin/vgs",
 			LVSBinary: "/usr/sbin/lvs",

--- a/plugins/inputs/lvm/lvm.go
+++ b/plugins/inputs/lvm/lvm.go
@@ -23,7 +23,10 @@ var (
 )
 
 type LVM struct {
-	UseSudo bool `toml:"use_sudo"`
+	UseSudo   bool   `toml:"use_sudo"`
+	PVSBinary string `toml:"pvs_binary"`
+	VGSBinary string `toml:"vgs_binary"`
+	LVSBinary string `toml:"lvs_binary"`
 }
 
 func (*LVM) SampleConfig() string {
@@ -47,12 +50,11 @@ func (lvm *LVM) Gather(acc telegraf.Accumulator) error {
 }
 
 func (lvm *LVM) gatherPhysicalVolumes(acc telegraf.Accumulator) error {
-	pvsCmd := "/usr/sbin/pvs"
 	args := []string{
 		"--reportformat", "json", "--units", "b", "--nosuffix",
 		"-o", "pv_name,vg_name,pv_size,pv_free,pv_used",
 	}
-	out, err := lvm.runCmd(pvsCmd, args)
+	out, err := lvm.runCmd(lvm.PVSBinary, args)
 	if err != nil {
 		return err
 	}
@@ -102,12 +104,11 @@ func (lvm *LVM) gatherPhysicalVolumes(acc telegraf.Accumulator) error {
 }
 
 func (lvm *LVM) gatherVolumeGroups(acc telegraf.Accumulator) error {
-	cmd := "/usr/sbin/vgs"
 	args := []string{
 		"--reportformat", "json", "--units", "b", "--nosuffix",
 		"-o", "vg_name,pv_count,lv_count,snap_count,vg_size,vg_free",
 	}
-	out, err := lvm.runCmd(cmd, args)
+	out, err := lvm.runCmd(lvm.VGSBinary, args)
 	if err != nil {
 		return err
 	}
@@ -166,12 +167,11 @@ func (lvm *LVM) gatherVolumeGroups(acc telegraf.Accumulator) error {
 }
 
 func (lvm *LVM) gatherLogicalVolumes(acc telegraf.Accumulator) error {
-	cmd := "/usr/sbin/lvs"
 	args := []string{
 		"--reportformat", "json", "--units", "b", "--nosuffix",
 		"-o", "lv_name,vg_name,lv_size,data_percent,metadata_percent",
 	}
-	out, err := lvm.runCmd(cmd, args)
+	out, err := lvm.runCmd(lvm.LVSBinary, args)
 	if err != nil {
 		return err
 	}
@@ -284,6 +284,11 @@ type lvsReport struct {
 
 func init() {
 	inputs.Add("lvm", func() telegraf.Input {
-		return &LVM{}
+		return &LVM{
+			UseSudo:   false,
+			PVSBinary: "/usr/sbin/pvs",
+			VGSBinary: "/usr/sbin/vgs",
+			LVSBinary: "/usr/sbin/lvs",
+		}
 	})
 }

--- a/plugins/inputs/lvm/lvm_test.go
+++ b/plugins/inputs/lvm/lvm_test.go
@@ -14,7 +14,6 @@ func TestGather(t *testing.T) {
 	var acc testutil.Accumulator
 
 	lvm := LVM{
-		UseSudo:   false,
 		PVSBinary: "/usr/sbin/pvs",
 		VGSBinary: "/usr/sbin/vgs",
 		LVSBinary: "/usr/sbin/lvs",
@@ -134,7 +133,6 @@ func TestGatherNoLVM(t *testing.T) {
 	var acc testutil.Accumulator
 
 	noLVM := LVM{
-		UseSudo:   false,
 		PVSBinary: "/usr/sbin/pvs",
 		VGSBinary: "/usr/sbin/vgs",
 		LVSBinary: "/usr/sbin/lvs",

--- a/plugins/inputs/lvm/lvm_test.go
+++ b/plugins/inputs/lvm/lvm_test.go
@@ -13,7 +13,12 @@ import (
 func TestGather(t *testing.T) {
 	var acc testutil.Accumulator
 
-	lvm := LVM{UseSudo: false}
+	lvm := LVM{
+		UseSudo:   false,
+		PVSBinary: "/usr/sbin/pvs",
+		VGSBinary: "/usr/sbin/vgs",
+		LVSBinary: "/usr/sbin/lvs",
+	}
 
 	// overwriting exec commands with mock commands
 	execCommand = fakeExecCommand
@@ -128,7 +133,12 @@ func TestHelperProcess(_ *testing.T) {
 func TestGatherNoLVM(t *testing.T) {
 	var acc testutil.Accumulator
 
-	noLVM := LVM{UseSudo: false}
+	noLVM := LVM{
+		UseSudo:   false,
+		PVSBinary: "/usr/sbin/pvs",
+		VGSBinary: "/usr/sbin/vgs",
+		LVSBinary: "/usr/sbin/lvs",
+	}
 
 	// overwriting exec commands with mock commands
 	execCommand = fakeExecCommandNoLVM

--- a/plugins/inputs/lvm/sample.conf
+++ b/plugins/inputs/lvm/sample.conf
@@ -2,3 +2,12 @@
 [[inputs.lvm]]
   ## Use sudo to run LVM commands
   use_sudo = false
+
+  ## The default location of the pvs binary can be overridden with:
+  pvs_binary = "/usr/sbin/pvs"
+
+  ## The default location of the vgs binary can be overridden with:
+  vgs_binary = "/usr/sbin/vgs"
+
+  ## The default location of the lvs binary can be overridden with:
+  lvs_binary = "/usr/sbin/lvs"

--- a/plugins/inputs/lvm/sample.conf
+++ b/plugins/inputs/lvm/sample.conf
@@ -4,10 +4,10 @@
   use_sudo = false
 
   ## The default location of the pvs binary can be overridden with:
-  pvs_binary = "/usr/sbin/pvs"
+  #pvs_binary = "/usr/sbin/pvs"
 
   ## The default location of the vgs binary can be overridden with:
-  vgs_binary = "/usr/sbin/vgs"
+  #vgs_binary = "/usr/sbin/vgs"
 
   ## The default location of the lvs binary can be overridden with:
-  lvs_binary = "/usr/sbin/lvs"
+  #lvs_binary = "/usr/sbin/lvs"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Fixes [this problem](https://github.com/influxdata/telegraf/pull/9771#issuecomment-1129038389) mentioned by @rafaelreis-r to @powersj.

I basically followed what is done in other plugins when it comes to make it possible for user to specify path to binary files.
In this specific situation, I need to be able to modify path for `lvs`, `vgs` and `lvs` as they are located in `/sbin/` on my Linux system (Debian Bullseye) rather than `/usr/sbin/` like it is currently hard-coded.