### PR TITLE
feat(common.tls): Add enable flag

### DIFF
--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -10,6 +10,11 @@ documented in the sample configuration.
 For client TLS support we have the following options:
 
 ```toml
+## Enable/disable TLS
+## Set to true/false to enforce TLS being enabled/disabled. If not set,
+## enable TLS only if any of the other options are specified.
+# tls_enable =
+
 ## Root certificates for verifying server certificates encoded in PEM format.
 # tls_ca = "/etc/telegraf/ca.pem"
 
@@ -21,6 +26,7 @@ For client TLS support we have the following options:
 # insecure_skip_verify = false
 ## Send the specified TLS server name via SNI.
 # tls_server_name = "foo.example.com"
+#
 ```
 
 ### Server Configuration
@@ -46,7 +52,7 @@ The server TLS configuration provides support for TLS mutual authentication:
 #### Advanced Configuration
 
 For plugins using the standard server configuration you can also set several
-advanced settings.  These options are not included in the sample configuration
+advanced settings. These options are not included in the sample configuration
 for the interest of brevity.
 
 ```toml

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -22,6 +22,7 @@ type ClientConfig struct {
 	InsecureSkipVerify  bool   `toml:"insecure_skip_verify"`
 	ServerName          string `toml:"tls_server_name"`
 	RenegotiationMethod string `toml:"tls_renegotiation_method"`
+	Enable              *bool  `toml:"tls_enable"`
 
 	SSLCA   string `toml:"ssl_ca" deprecated:"1.7.0;use 'tls_ca' instead"`
 	SSLCert string `toml:"ssl_cert" deprecated:"1.7.0;use 'tls_cert' instead"`
@@ -43,6 +44,11 @@ type ServerConfig struct {
 // TLSConfig returns a tls.Config, may be nil without error if TLS is not
 // configured.
 func (c *ClientConfig) TLSConfig() (*tls.Config, error) {
+	// Check if TLS config is forcefully disabled
+	if c.Enable != nil && !*c.Enable {
+		return nil, nil
+	}
+
 	// Support deprecated variable names
 	if c.TLSCA == "" && c.SSLCA != "" {
 		c.TLSCA = c.SSLCA
@@ -54,17 +60,25 @@ func (c *ClientConfig) TLSConfig() (*tls.Config, error) {
 		c.TLSKey = c.SSLKey
 	}
 
-	// This check returns a nil (aka, "use the default")
-	// tls.Config if no field is set that would have an effect on
+	// This check returns a nil (aka "disabled") or an empty config
+	// (aka, "use the default") if no field is set that would have an effect on
 	// a TLS connection. That is, any of:
 	//     * client certificate settings,
 	//     * peer certificate authorities,
 	//     * disabled security,
 	//     * an SNI server name, or
 	//     * empty/never renegotiation method
-	if c.TLSCA == "" && c.TLSKey == "" && c.TLSCert == "" &&
-		!c.InsecureSkipVerify && c.ServerName == "" &&
-		(c.RenegotiationMethod == "" || c.RenegotiationMethod == "never") {
+	empty := c.TLSCA == "" && c.TLSKey == "" && c.TLSCert == ""
+	empty = empty && !c.InsecureSkipVerify && c.ServerName == ""
+	empty = empty && (c.RenegotiationMethod == "" || c.RenegotiationMethod == "never")
+
+	if empty {
+		// Check if TLS config is forcefully enabled and supposed to
+		// use the system defaults.
+		if c.Enable != nil && *c.Enable {
+			return &tls.Config{}, nil
+		}
+
 		return nil, nil
 	}
 

--- a/plugins/common/tls/config_test.go
+++ b/plugins/common/tls/config_test.go
@@ -528,3 +528,37 @@ func TestConnectWrongDNS(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestEnableFlagAuto(t *testing.T) {
+	cfgEmpty := tls.ClientConfig{}
+	cfg, err := cfgEmpty.TLSConfig()
+	require.NoError(t, err)
+	require.Nil(t, cfg)
+
+	cfgSet := tls.ClientConfig{InsecureSkipVerify: true}
+	cfg, err = cfgSet.TLSConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+}
+
+func TestEnableFlagDisabled(t *testing.T) {
+	enabled := false
+	cfgSet := tls.ClientConfig{
+		InsecureSkipVerify: true,
+		Enable:             &enabled,
+	}
+	cfg, err := cfgSet.TLSConfig()
+	require.NoError(t, err)
+	require.Nil(t, cfg)
+}
+
+func TestEnableFlagEnabled(t *testing.T) {
+	enabled := true
+	cfgSet := tls.ClientConfig{Enable: &enabled}
+	cfg, err := cfgSet.TLSConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	expected := &cryptotls.Config{}
+	require.Equal(t, expected, cfg)
+}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Currently, TLS is disabled if no `tls_*` option is specified. This prevents users from using e.g. TLS on TCP connections using the system defaults. This PR adds a `tls_enable` flag to the common TLS client configuration. When not given, the behavior of Telegraf is unchanged. However, if explicitly set to `false` all TLS settings are ignored and TLS is disabled. When set to `true`, TLS is enforced even if no other TLS option is given, allowing for using the system's default settings.