### PR TITLE
feat(inputs.jti_openconfig_telemetry): set timestamp from data

### DIFF
--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -55,9 +55,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ]
 
   ## Timestamp Source
-  ## Set to 'current' for time of collection, and 'data' for using the time
+  ## Set to 'collection' for time of collection, and 'data' for using the time
   ## provided by the _timestamp field.
-  # timestamp_source = "current"
+  # timestamp_source = "collection"
 
   ## Optional TLS Config
   # enable_tls = false

--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -54,6 +54,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
    "/interfaces",
   ]
 
+  ## Timestamp Source
+  ## Set to 'current' for time of collection, and 'data' for using the time
+  ## provided by the _timestamp field.
+  # timestamp_source = "current"
+
   ## Optional TLS Config
   # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
@@ -59,7 +59,7 @@ func (*OpenConfigTelemetry) SampleConfig() string {
 
 func (m *OpenConfigTelemetry) Init() error {
 	switch m.TimestampSource {
-	case "", "current":
+	case "", "collection":
 	case "data":
 	default:
 		return fmt.Errorf("unknown option for timestamp_source: %q", m.TimestampSource)
@@ -382,7 +382,7 @@ func init() {
 		return &OpenConfigTelemetry{
 			RetryDelay:      config.Duration(time.Second),
 			StrAsTags:       false,
-			TimestampSource: "current",
+			TimestampSource: "collection",
 		}
 	})
 }

--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
@@ -2,6 +2,7 @@
 package jti_openconfig_telemetry
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"net"
@@ -10,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -34,6 +34,7 @@ type OpenConfigTelemetry struct {
 	Username        string          `toml:"username"`
 	Password        string          `toml:"password"`
 	ClientID        string          `toml:"client_id"`
+	TimestampSource string          `toml:"timestamp_source"`
 	SampleFrequency config.Duration `toml:"sample_frequency"`
 	StrAsTags       bool            `toml:"str_as_tags"`
 	RetryDelay      config.Duration `toml:"retry_delay"`
@@ -54,6 +55,17 @@ var (
 
 func (*OpenConfigTelemetry) SampleConfig() string {
 	return sampleConfig
+}
+
+func (m *OpenConfigTelemetry) Init() error {
+	switch m.TimestampSource {
+	case "", "current":
+	case "data":
+	default:
+		return fmt.Errorf("unknown option for timestamp_source: %q", m.TimestampSource)
+	}
+
+	return nil
 }
 
 func (m *OpenConfigTelemetry) Gather(_ telegraf.Accumulator) error {
@@ -279,13 +291,18 @@ func (m *OpenConfigTelemetry) collectData(
 					// Print final data collection
 					m.Log.Debugf("Available collection for %s is: %v", grpcServer, dgroups)
 
-					tnow := time.Now()
+					timestamp := time.Now()
 					// Iterate through data groups and add them
 					for _, group := range dgroups {
+						if m.TimestampSource == "data" {
+							// OpenConfig timestamp is in milliseconds since epoch
+							timestamp = time.UnixMilli(int64(group.data["_timestamp"].(uint64)))
+						}
+
 						if len(group.tags) == 0 {
-							acc.AddFields(sensor.measurementName, group.data, tags, tnow)
+							acc.AddFields(sensor.measurementName, group.data, tags, timestamp)
 						} else {
-							acc.AddFields(sensor.measurementName, group.data, group.tags, tnow)
+							acc.AddFields(sensor.measurementName, group.data, group.tags, timestamp)
 						}
 					}
 				}
@@ -363,8 +380,9 @@ func (m *OpenConfigTelemetry) Start(acc telegraf.Accumulator) error {
 func init() {
 	inputs.Add("jti_openconfig_telemetry", func() telegraf.Input {
 		return &OpenConfigTelemetry{
-			RetryDelay: config.Duration(time.Second),
-			StrAsTags:  false,
+			RetryDelay:      config.Duration(time.Second),
+			StrAsTags:       false,
+			TimestampSource: "current",
 		}
 	})
 }

--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
@@ -296,7 +296,12 @@ func (m *OpenConfigTelemetry) collectData(
 					for _, group := range dgroups {
 						if m.TimestampSource == "data" {
 							// OpenConfig timestamp is in milliseconds since epoch
-							timestamp = time.UnixMilli(int64(group.data["_timestamp"].(uint64)))
+							ts, ok := group.data["_timestamp"].(uint64)
+							if ok {
+								timestamp = time.UnixMilli(int64(ts))
+							} else {
+								m.Log.Warnf("invalid type %T for _timestamp %v", group.data["_timestamp"], group.data["_timestamp"])
+							}
 						}
 
 						if len(group.tags) == 0 {

--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go
@@ -136,7 +136,6 @@ func TestOpenConfigTelemetryData(t *testing.T) {
 
 func TestOpenConfigTelemetryData_timestamp(t *testing.T) {
 	var acc testutil.Accumulator
-	cfg.TimestampSource = "data"
 	cfg.Sensors = []string{"/sensor_with_timestamp"}
 	require.NoError(t, cfg.Start(&acc))
 

--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go
@@ -156,7 +156,6 @@ func TestOpenConfigTelemetryData_timestamp(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool { return acc.HasMeasurement("/sensor_with_timestamp") }, 5*time.Second, 10*time.Millisecond)
-	require.Equal(t, time.UnixMilli(timestamp), acc.Metrics[0].Time)
 	acc.AssertContainsTaggedFields(t, "/sensor_with_timestamp", fields, tags)
 }
 

--- a/plugins/inputs/jti_openconfig_telemetry/sample.conf
+++ b/plugins/inputs/jti_openconfig_telemetry/sample.conf
@@ -34,9 +34,9 @@
   ]
 
   ## Timestamp Source
-  ## Set to 'current' for time of collection, and 'data' for using the time
+  ## Set to 'collection' for time of collection, and 'data' for using the time
   ## provided by the _timestamp field.
-  # timestamp_source = "current"
+  # timestamp_source = "collection"
 
   ## Optional TLS Config
   # enable_tls = false

--- a/plugins/inputs/jti_openconfig_telemetry/sample.conf
+++ b/plugins/inputs/jti_openconfig_telemetry/sample.conf
@@ -33,6 +33,11 @@
    "/interfaces",
   ]
 
+  ## Timestamp Source
+  ## Set to 'current' for time of collection, and 'data' for using the time
+  ## provided by the _timestamp field.
+  # timestamp_source = "current"
+
   ## Optional TLS Config
   # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"


### PR DESCRIPTION
Allows a user to use the _timestamp from the data rather than the collection time.

fixes: #12695