### PR TITLE
fix(agent): Only rotate log on SIGHUP if needed

### DIFF
--- a/internal/rotate/file_writer.go
+++ b/internal/rotate/file_writer.go
@@ -99,6 +99,11 @@ func (w *FileWriter) Close() (err error) {
 		return err
 	}
 
+	// Close the file if we did not rotate
+	if err = w.current.Close(); err != nil {
+		return err
+	}
+
 	w.current = nil
 	return nil
 }

--- a/internal/rotate/file_writer.go
+++ b/internal/rotate/file_writer.go
@@ -95,7 +95,7 @@ func (w *FileWriter) Close() (err error) {
 	defer w.Unlock()
 
 	// Rotate before closing
-	if err = w.rotate(); err != nil {
+	if err = w.rotateIfNeeded(); err != nil {
 		return err
 	}
 

--- a/internal/rotate/file_writer.go
+++ b/internal/rotate/file_writer.go
@@ -95,12 +95,12 @@ func (w *FileWriter) Close() (err error) {
 	defer w.Unlock()
 
 	// Rotate before closing
-	if err = w.rotateIfNeeded(); err != nil {
+	if err := w.rotateIfNeeded(); err != nil {
 		return err
 	}
 
 	// Close the file if we did not rotate
-	if err = w.current.Close(); err != nil {
+	if err := w.current.Close(); err != nil {
 		return err
 	}
 

--- a/internal/rotate/file_writer_test.go
+++ b/internal/rotate/file_writer_test.go
@@ -129,7 +129,7 @@ func TestFileWriter_DeleteArchives(t *testing.T) {
 	}
 }
 
-func TestFileWriter_CloseRotates(t *testing.T) {
+func TestFileWriter_CloseDoesNotRotate(t *testing.T) {
 	tempDir := t.TempDir()
 	maxSize := int64(9)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), 0, maxSize, -1)
@@ -138,5 +138,5 @@ func TestFileWriter_CloseRotates(t *testing.T) {
 
 	files, _ := os.ReadDir(tempDir)
 	assert.Equal(t, 1, len(files))
-	assert.Regexp(t, "^test\\.[^\\.]+\\.log$", files[0].Name())
+	assert.Regexp(t, "^test.log$", files[0].Name())
 }


### PR DESCRIPTION
The current code will rotate a log on a SIGHUP. Whether the log needs to be rotated or not. There are checks at start-up and at each write if a log needs to be rotated. Meaning that we should not be forcing a rotation at close, and instead check to verify the conditions are even met first.

fixes: #12709