### PR TITLE
chore: Enable printing Windows sample configs on non-Windows

### DIFF
--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -24,9 +24,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Input plugin to collect Windows Event Log messages
+# This plugin ONLY supports Windows
 [[inputs.win_eventlog]]
-  ## NOTE: This plugin **only** works on Windows
-
   ## Telegraf should have Administrator permissions to subscribe for some Windows Events channels
   ## (System log, for example)
 

--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -25,6 +25,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Input plugin to collect Windows Event Log messages
 [[inputs.win_eventlog]]
+  ## NOTE: This plugin **only** works on Windows
+
   ## Telegraf should have Administrator permissions to subscribe for some Windows Events channels
   ## (System log, for example)
 

--- a/plugins/inputs/win_eventlog/sample.conf
+++ b/plugins/inputs/win_eventlog/sample.conf
@@ -1,5 +1,7 @@
 # Input plugin to collect Windows Event Log messages
 [[inputs.win_eventlog]]
+  ## NOTE: This plugin **only** works on Windows
+
   ## Telegraf should have Administrator permissions to subscribe for some Windows Events channels
   ## (System log, for example)
 

--- a/plugins/inputs/win_eventlog/sample.conf
+++ b/plugins/inputs/win_eventlog/sample.conf
@@ -1,7 +1,6 @@
 # Input plugin to collect Windows Event Log messages
+# This plugin ONLY supports Windows
 [[inputs.win_eventlog]]
-  ## NOTE: This plugin **only** works on Windows
-
   ## Telegraf should have Administrator permissions to subscribe for some Windows Events channels
   ## (System log, for example)
 

--- a/plugins/inputs/win_eventlog/win_eventlog_notwindows.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_notwindows.go
@@ -1,6 +1,30 @@
 //go:build !windows
 
-// Package win_eventlog Input plugin to collect Windows Event Log messages
-//
-//revive:disable-next-line:var-naming
 package win_eventlog
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type WinEventLog struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (w *WinEventLog) Init() error {
+	w.Log.Warn("current platform is not supported")
+	return nil
+}
+func (w *WinEventLog) SampleConfig() string                { return sampleConfig }
+func (w *WinEventLog) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("win_eventlog", func() telegraf.Input {
+		return &WinEventLog{}
+	})
+}

--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -303,9 +303,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # # Input plugin to counterPath Performance Counters on Windows operating systems
+# # This plugin ONLY supports Windows
 # [[inputs.win_perf_counters]]
-#   ## NOTE: This plugin **only** works on Windows
-#
 #   ## By default this plugin returns basic CPU and Disk statistics.
 #   ## See the README file for more examples.
 #   ## Uncomment examples below or write your own as you see fit. If the system

--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -304,6 +304,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # # Input plugin to counterPath Performance Counters on Windows operating systems
 # [[inputs.win_perf_counters]]
+#   ## NOTE: This plugin **only** works on Windows
+#
 #   ## By default this plugin returns basic CPU and Disk statistics.
 #   ## See the README file for more examples.
 #   ## Uncomment examples below or write your own as you see fit. If the system

--- a/plugins/inputs/win_perf_counters/sample.conf
+++ b/plugins/inputs/win_perf_counters/sample.conf
@@ -1,7 +1,6 @@
 # # Input plugin to counterPath Performance Counters on Windows operating systems
+# # This plugin ONLY supports Windows
 # [[inputs.win_perf_counters]]
-#   ## NOTE: This plugin **only** works on Windows
-#
 #   ## By default this plugin returns basic CPU and Disk statistics.
 #   ## See the README file for more examples.
 #   ## Uncomment examples below or write your own as you see fit. If the system

--- a/plugins/inputs/win_perf_counters/sample.conf
+++ b/plugins/inputs/win_perf_counters/sample.conf
@@ -1,5 +1,7 @@
 # # Input plugin to counterPath Performance Counters on Windows operating systems
 # [[inputs.win_perf_counters]]
+#   ## NOTE: This plugin **only** works on Windows
+#
 #   ## By default this plugin returns basic CPU and Disk statistics.
 #   ## See the README file for more examples.
 #   ## Uncomment examples below or write your own as you see fit. If the system

--- a/plugins/inputs/win_perf_counters/win_perf_counters_notwindows.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_notwindows.go
@@ -1,3 +1,30 @@
 //go:build !windows
 
 package win_perf_counters
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type WinPerfCounters struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (w *WinPerfCounters) Init() error {
+	w.Log.Warn("current platform is not supported")
+	return nil
+}
+func (w *WinPerfCounters) SampleConfig() string                { return sampleConfig }
+func (w *WinPerfCounters) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("win_perf_counters", func() telegraf.Input {
+		return &WinPerfCounters{}
+	})
+}

--- a/plugins/inputs/win_services/README.md
+++ b/plugins/inputs/win_services/README.md
@@ -18,9 +18,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Input plugin to report Windows services info.
+# This plugin ONLY supports Windows
 [[inputs.win_services]]
-  ## NOTE: This plugin **only** works on Windows
-
   ## Names of the services to monitor. Leave empty to monitor all the available services on the host. Globs accepted. Case sensitive.
   service_names = [
     "LanmanServer",

--- a/plugins/inputs/win_services/README.md
+++ b/plugins/inputs/win_services/README.md
@@ -19,6 +19,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Input plugin to report Windows services info.
 [[inputs.win_services]]
+  ## NOTE: This plugin **only** works on Windows
+
   ## Names of the services to monitor. Leave empty to monitor all the available services on the host. Globs accepted. Case sensitive.
   service_names = [
     "LanmanServer",

--- a/plugins/inputs/win_services/sample.conf
+++ b/plugins/inputs/win_services/sample.conf
@@ -1,5 +1,7 @@
 # Input plugin to report Windows services info.
 [[inputs.win_services]]
+  ## NOTE: This plugin **only** works on Windows
+
   ## Names of the services to monitor. Leave empty to monitor all the available services on the host. Globs accepted. Case sensitive.
   service_names = [
     "LanmanServer",

--- a/plugins/inputs/win_services/sample.conf
+++ b/plugins/inputs/win_services/sample.conf
@@ -1,7 +1,6 @@
 # Input plugin to report Windows services info.
+# This plugin ONLY supports Windows
 [[inputs.win_services]]
-  ## NOTE: This plugin **only** works on Windows
-
   ## Names of the services to monitor. Leave empty to monitor all the available services on the host. Globs accepted. Case sensitive.
   service_names = [
     "LanmanServer",

--- a/plugins/inputs/win_services/win_services_notwindows.go
+++ b/plugins/inputs/win_services/win_services_notwindows.go
@@ -1,3 +1,30 @@
 //go:build !windows
 
 package win_services
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type WinServices struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (w *WinServices) Init() error {
+	w.Log.Warn("current platform is not supported")
+	return nil
+}
+func (w *WinServices) SampleConfig() string                { return sampleConfig }
+func (w *WinServices) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("win_services", func() telegraf.Input {
+		return &WinServices{}
+	})
+}

--- a/plugins/inputs/win_wmi/README.md
+++ b/plugins/inputs/win_wmi/README.md
@@ -23,6 +23,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Input plugin to query Windows Management Instrumentation
+# This plugin ONLY supports Windows
 [[inputs.win_wmi]]
   # specifies a prefix to attach to the measurement name
   name_prefix = "win_wmi_"

--- a/plugins/inputs/win_wmi/sample.conf
+++ b/plugins/inputs/win_wmi/sample.conf
@@ -1,5 +1,7 @@
 # Input plugin to query Windows Management Instrumentation
 [[inputs.win_wmi]]
+  ## NOTE: This plugin **only** works on Windows
+
   [[inputs.win_wmi.query]]
     # a string representing the WMI namespace to be queried
     namespace = "root\\cimv2"

--- a/plugins/inputs/win_wmi/sample.conf
+++ b/plugins/inputs/win_wmi/sample.conf
@@ -1,7 +1,6 @@
 # Input plugin to query Windows Management Instrumentation
+# This plugin ONLY supports Windows
 [[inputs.win_wmi]]
-  ## NOTE: This plugin **only** works on Windows
-
   [[inputs.win_wmi.query]]
     # a string representing the WMI namespace to be queried
     namespace = "root\\cimv2"

--- a/plugins/inputs/win_wmi/win_wmi_notwindows.go
+++ b/plugins/inputs/win_wmi/win_wmi_notwindows.go
@@ -1,4 +1,30 @@
 //go:build !windows
-// +build !windows
 
 package win_wmi
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Wmi struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (w *Wmi) Init() error {
+	w.Log.Warn("current platform is not supported")
+	return nil
+}
+func (w *Wmi) SampleConfig() string                { return sampleConfig }
+func (w *Wmi) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("win_wmi", func() telegraf.Input {
+		return &Wmi{}
+	})
+}


### PR DESCRIPTION
Using the existing `telegraf config` subcommand we can generate the included sample config for users. With the goal of having all sample config options in one file, versus having one for Windows and one for non-Windows, this enables creating the file on non-Windows systems.