### PR TITLE
chore(external): Renaming Telegraf to PlayFab insights plugin

### DIFF
--- a/EXTERNAL_PLUGINS.md
+++ b/EXTERNAL_PLUGINS.md
@@ -41,7 +41,7 @@ Pull requests welcome.
 
 - [kinesis](https://github.com/morfien101/telegraf-output-kinesis) - Aggregation and compression of metrics to send Amazon Kinesis.
 - [firehose](https://github.com/muhlba91/telegraf-output-kinesis-data-firehose) - Sends metrics in batches to Amazon Kinesis Data Firehose.
-- [playfabinsights](https://github.com/dgkanatsios/telegraftoplayfabinsights) - Sends metrics to [Azure PlayFab Insights](https://learn.microsoft.com/en-us/gaming/playfab/features/insights/).
+- [playfab](https://github.com/dgkanatsios/telegraftoplayfab) - Sends metrics to [Azure PlayFab](https://learn.microsoft.com/en-us/gaming/playfab/).
 
 ## Processors
 


### PR DESCRIPTION
Renaming Telegraf to PlayFab insights plugin to be consistent with the new plugin name https://github.com/dgkanatsios/telegraftoplayfab

Thanks!