### PR TITLE
chore: document linux only plugins (part 2)

### DIFF
--- a/plugins/inputs/intel_pmu/README.md
+++ b/plugins/inputs/intel_pmu/README.md
@@ -27,6 +27,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Intel Performance Monitoring Unit plugin exposes Intel PMU metrics available through Linux Perf subsystem
+# This plugin ONLY supports Linux on amd64
 [[inputs.intel_pmu]]
   ## List of filesystem locations of JSON files that contain PMU event definitions.
   event_definitions = ["/var/cache/pmu/GenuineIntel-6-55-4-core.json", "/var/cache/pmu/GenuineIntel-6-55-4-uncore.json"]

--- a/plugins/inputs/intel_pmu/sample.conf
+++ b/plugins/inputs/intel_pmu/sample.conf
@@ -1,4 +1,5 @@
 # Intel Performance Monitoring Unit plugin exposes Intel PMU metrics available through Linux Perf subsystem
+# This plugin ONLY supports Linux on amd64
 [[inputs.intel_pmu]]
   ## List of filesystem locations of JSON files that contain PMU event definitions.
   event_definitions = ["/var/cache/pmu/GenuineIntel-6-55-4-core.json", "/var/cache/pmu/GenuineIntel-6-55-4-uncore.json"]

--- a/plugins/inputs/intel_rdt/README.md
+++ b/plugins/inputs/intel_rdt/README.md
@@ -104,6 +104,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Read Intel RDT metrics
+# This plugin ONLY supports non-Windows
 [[inputs.intel_rdt]]
   ## Optionally set sampling interval to Nx100ms.
   ## This value is propagated to pqos tool. Interval format is defined by pqos itself.

--- a/plugins/inputs/intel_rdt/sample.conf
+++ b/plugins/inputs/intel_rdt/sample.conf
@@ -1,4 +1,5 @@
 # Read Intel RDT metrics
+# This plugin ONLY supports non-Windows
 [[inputs.intel_rdt]]
   ## Optionally set sampling interval to Nx100ms.
   ## This value is propagated to pqos tool. Interval format is defined by pqos itself.

--- a/plugins/inputs/mdstat/README.md
+++ b/plugins/inputs/mdstat/README.md
@@ -26,6 +26,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Get kernel statistics from /proc/mdstat
+# This plugin ONLY supports Linux
 [[inputs.mdstat]]
   ## Sets file path
   ## If not specified, then default is /proc/mdstat

--- a/plugins/inputs/mdstat/sample.conf
+++ b/plugins/inputs/mdstat/sample.conf
@@ -1,4 +1,5 @@
 # Get kernel statistics from /proc/mdstat
+# This plugin ONLY supports Linux
 [[inputs.mdstat]]
   ## Sets file path
   ## If not specified, then default is /proc/mdstat

--- a/plugins/inputs/postfix/README.md
+++ b/plugins/inputs/postfix/README.md
@@ -20,6 +20,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Measure postfix queue statistics
+# This plugin ONLY supports non-Windows OSes
 [[inputs.postfix]]
   ## Postfix queue directory. If not provided, telegraf will try to use
   ## 'postconf -h queue_directory' to determine it.

--- a/plugins/inputs/postfix/README.md
+++ b/plugins/inputs/postfix/README.md
@@ -20,7 +20,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Measure postfix queue statistics
-# This plugin ONLY supports non-Windows OSes
+# This plugin ONLY supports non-Windows
 [[inputs.postfix]]
   ## Postfix queue directory. If not provided, telegraf will try to use
   ## 'postconf -h queue_directory' to determine it.

--- a/plugins/inputs/postfix/sample.conf
+++ b/plugins/inputs/postfix/sample.conf
@@ -1,4 +1,5 @@
 # Measure postfix queue statistics
+# This plugin ONLY supports non-Windows OSes
 [[inputs.postfix]]
   ## Postfix queue directory. If not provided, telegraf will try to use
   ## 'postconf -h queue_directory' to determine it.

--- a/plugins/inputs/postfix/sample.conf
+++ b/plugins/inputs/postfix/sample.conf
@@ -1,5 +1,5 @@
 # Measure postfix queue statistics
-# This plugin ONLY supports non-Windows OSes
+# This plugin ONLY supports non-Windows
 [[inputs.postfix]]
   ## Postfix queue directory. If not provided, telegraf will try to use
   ## 'postconf -h queue_directory' to determine it.

--- a/plugins/inputs/ras/README.md
+++ b/plugins/inputs/ras/README.md
@@ -19,6 +19,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # RAS plugin exposes counter metrics for Machine Check Errors provided by RASDaemon (sqlite3 output is required).
+# This plugin ONLY supports Linux on 386, amd64, arm, and arm64
 [[inputs.ras]]
   ## Optional path to RASDaemon sqlite3 database.
   ## Default: /var/lib/rasdaemon/ras-mc_event.db

--- a/plugins/inputs/ras/sample.conf
+++ b/plugins/inputs/ras/sample.conf
@@ -1,4 +1,5 @@
 # RAS plugin exposes counter metrics for Machine Check Errors provided by RASDaemon (sqlite3 output is required).
+# This plugin ONLY supports Linux on 386, amd64, arm, and arm64
 [[inputs.ras]]
   ## Optional path to RASDaemon sqlite3 database.
   ## Default: /var/lib/rasdaemon/ras-mc_event.db

--- a/plugins/inputs/sensors/README.md
+++ b/plugins/inputs/sensors/README.md
@@ -19,6 +19,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Monitor sensors, requires lm-sensors package
+# This plugin ONLY supports Linux
 [[inputs.sensors]]
   ## Remove numbers from field names.
   ## If true, a field name like 'temp1_input' will be changed to 'temp_input'.

--- a/plugins/inputs/sensors/sample.conf
+++ b/plugins/inputs/sensors/sample.conf
@@ -1,4 +1,5 @@
 # Monitor sensors, requires lm-sensors package
+# This plugin ONLY supports Linux
 [[inputs.sensors]]
   ## Remove numbers from field names.
   ## If true, a field name like 'temp1_input' will be changed to 'temp_input'.

--- a/plugins/inputs/slab/README.md
+++ b/plugins/inputs/slab/README.md
@@ -27,6 +27,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Get slab statistics from procfs
+# This plugin ONLY supports Linux
 [[inputs.slab]]
   # no configuration - please see the plugin's README for steps to configure
   # sudo properly

--- a/plugins/inputs/slab/sample.conf
+++ b/plugins/inputs/slab/sample.conf
@@ -1,4 +1,5 @@
 # Get slab statistics from procfs
+# This plugin ONLY supports Linux
 [[inputs.slab]]
   # no configuration - please see the plugin's README for steps to configure
   # sudo properly

--- a/plugins/inputs/socketstat/README.md
+++ b/plugins/inputs/socketstat/README.md
@@ -22,6 +22,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Gather indicators from established connections, using iproute2's ss command.
+# This plugin ONLY supports non-Windows
 [[inputs.socketstat]]
   ## ss can display information about tcp, udp, raw, unix, packet, dccp and sctp sockets
   ## Specify here the types you want to gather

--- a/plugins/inputs/socketstat/sample.conf
+++ b/plugins/inputs/socketstat/sample.conf
@@ -1,4 +1,5 @@
 # Gather indicators from established connections, using iproute2's ss command.
+# This plugin ONLY supports non-Windows
 [[inputs.socketstat]]
   ## ss can display information about tcp, udp, raw, unix, packet, dccp and sctp sockets
   ## Specify here the types you want to gather

--- a/plugins/inputs/sysstat/README.md
+++ b/plugins/inputs/sysstat/README.md
@@ -19,6 +19,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Sysstat metrics collector
+# This plugin ONLY supports Linux
 [[inputs.sysstat]]
   ## Path to the sadc command.
   #

--- a/plugins/inputs/sysstat/sample.conf
+++ b/plugins/inputs/sysstat/sample.conf
@@ -1,4 +1,5 @@
 # Sysstat metrics collector
+# This plugin ONLY supports Linux
 [[inputs.sysstat]]
   ## Path to the sadc command.
   #

--- a/plugins/inputs/varnish/README.md
+++ b/plugins/inputs/varnish/README.md
@@ -15,6 +15,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # A plugin to collect stats from Varnish HTTP Cache
+# This plugin ONLY supports non-Windows
 [[inputs.varnish]]
   ## If running as a restricted user you can prepend sudo for additional access:
   #use_sudo = false

--- a/plugins/inputs/varnish/sample.conf
+++ b/plugins/inputs/varnish/sample.conf
@@ -1,4 +1,5 @@
 # A plugin to collect stats from Varnish HTTP Cache
+# This plugin ONLY supports non-Windows
 [[inputs.varnish]]
   ## If running as a restricted user you can prepend sudo for additional access:
   #use_sudo = false


### PR DESCRIPTION
Adds a note to the config for linux-only or non-windows only plugins as well as any arch limitations.