### PR TITLE
feat(processors.converter): convert tag or field as metric timestamp

### DIFF
--- a/plugins/processors/converter/README.md
+++ b/plugins/processors/converter/README.md
@@ -41,6 +41,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     boolean = []
     float = []
 
+    ## Optional tag to use as metric timestamp
+    # timestmap = ""
+    ## Optional format of the timestamp determined by the tag above.
+    ## This can be any of "unix", "unix_ms", "unix_us", "unix_ns" or a valid Golang
+    ## time format. If not specified, a "unix" timestamp (in seconds) is expected.
+    # timestamp_format = ""
+
   ## Fields to convert
   ##
   ## The table key determines the target type, and the array of key-values
@@ -54,6 +61,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     unsigned = []
     boolean = []
     float = []
+
+    ## Optional field to use as metric timestamp
+    # timestmap = ""
+    ## Optional format of the timestamp determined by the field above.
+    ## This can be any of "unix", "unix_ms", "unix_us", "unix_ns" or a valid Golang
+    ## time format. If not specified, a "unix" timestamp (in seconds) is expected.
+    # timestamp_format = ""
 ```
 
 ### Example
@@ -96,3 +110,19 @@ Rename the measurement from a tag value:
 - mqtt_consumer,topic=sensor temp=42
 + sensor temp=42
 ```
+
+Set the metric timestamp from a tag:
+
+```toml
+[[processors.converter]]
+  [processors.converter.tags]
+    timestamp = ["time"]
+    timestamp_format = "unix
+```
+
+```diff
+- metric,time="1677610769" temp=42
++ metric temp=42 1677610769
+```
+
+This is also possible via the fields converter.

--- a/plugins/processors/converter/README.md
+++ b/plugins/processors/converter/README.md
@@ -14,6 +14,10 @@ string value to a numeric type, precision may be lost if the number is too
 large. The largest numeric type this plugin supports is `float64`, and if a
 string 'number' exceeds its size limit, accuracy may be lost.
 
+**Note on multiple measurement or timestamps:** Users can provide multiple
+tags or fields to use as the measurement name or timestamp. However, note that
+the order in the array is not guaranteed!
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support
@@ -42,10 +46,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     float = []
 
     ## Optional tag to use as metric timestamp
-    # timestmap = ""
+    # timestamp = []
 
     ## Format of the timestamp determined by the tag above. This can be any of
     ## "unix", "unix_ms", "unix_us", "unix_ns", or a valid Golang time format.
+    ## It is required, when using the timestamp option.
     # timestamp_format = ""
 
   ## Fields to convert
@@ -63,11 +68,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     float = []
 
     ## Optional field to use as metric timestamp
-    # timestmap = ""
+    # timestamp = []
 
     ## Format of the timestamp determined by the field above. This can be any
     ## of "unix", "unix_ms", "unix_us", "unix_ns", or a valid Golang time
-    ## format.
+    ## format. It is required, when using the timestamp option.
     # timestamp_format = ""
 ```
 

--- a/plugins/processors/converter/README.md
+++ b/plugins/processors/converter/README.md
@@ -43,9 +43,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
     ## Optional tag to use as metric timestamp
     # timestmap = ""
-    ## Optional format of the timestamp determined by the tag above.
-    ## This can be any of "unix", "unix_ms", "unix_us", "unix_ns" or a valid Golang
-    ## time format. If not specified, a "unix" timestamp (in seconds) is expected.
+
+    ## Format of the timestamp determined by the tag above. This can be any of
+    ## "unix", "unix_ms", "unix_us", "unix_ns", or a valid Golang time format.
     # timestamp_format = ""
 
   ## Fields to convert
@@ -64,9 +64,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
     ## Optional field to use as metric timestamp
     # timestmap = ""
-    ## Optional format of the timestamp determined by the field above.
-    ## This can be any of "unix", "unix_ms", "unix_us", "unix_ns" or a valid Golang
-    ## time format. If not specified, a "unix" timestamp (in seconds) is expected.
+
+    ## Format of the timestamp determined by the field above. This can be any
+    ## of "unix", "unix_ms", "unix_us", "unix_ns", or a valid Golang time
+    ## format.
     # timestamp_format = ""
 ```
 

--- a/plugins/processors/converter/converter.go
+++ b/plugins/processors/converter/converter.go
@@ -27,7 +27,7 @@ type Conversion struct {
 	Unsigned        []string `toml:"unsigned"`
 	Boolean         []string `toml:"boolean"`
 	Float           []string `toml:"float"`
-	Timestamp       string   `toml:"timestamp"`
+	Timestamp       []string `toml:"timestamp"`
 	TimestampFormat string   `toml:"timestamp_format"`
 }
 
@@ -129,7 +129,7 @@ func compileFilter(conv *Conversion) (*ConversionFilter, error) {
 		return nil, err
 	}
 
-	cf.Timestamp, err = filter.Compile([]string{conv.Timestamp})
+	cf.Timestamp, err = filter.Compile(conv.Timestamp)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/processors/converter/converter_test.go
+++ b/plugins/processors/converter/converter_test.go
@@ -464,6 +464,148 @@ func TestConverter(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "from unix timestamp field",
+			converter: &Converter{
+				Fields: &Conversion{
+					Timestamp:       "time",
+					TimestampFormat: "unix",
+				},
+			},
+			input: testutil.MustMetric(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{
+					"a":    42.0,
+					"time": 1111111111,
+				},
+				time.Unix(0, 0),
+			),
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"a": 42.0,
+					},
+					time.Unix(1111111111, 0),
+				),
+			},
+		},
+		{
+			name: "from unix timestamp tag",
+			converter: &Converter{
+				Tags: &Conversion{
+					Timestamp:       "time",
+					TimestampFormat: "unix",
+				},
+			},
+			input: testutil.MustMetric(
+				"cpu",
+				map[string]string{
+					"time": "1677610769",
+				},
+				map[string]interface{}{
+					"a": 41.0,
+				},
+				time.Unix(0, 0),
+			),
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"a": 41.0,
+					},
+					time.Unix(1677610769, 0),
+				),
+			},
+		},
+		{
+			name: "from rfc3339 timestamp field",
+			converter: &Converter{
+				Fields: &Conversion{
+					Timestamp:       "time",
+					TimestampFormat: "rfc3339",
+				},
+			},
+			input: testutil.MustMetric(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{
+					"a":    42.0,
+					"time": "2009-02-13T23:31:30Z",
+				},
+				time.Unix(0, 0),
+			),
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"a": 42.0,
+					},
+					time.Unix(1234567890, 0),
+				),
+			},
+		},
+		{
+			name: "from custom timestamp field",
+			converter: &Converter{
+				Fields: &Conversion{
+					Timestamp:       "time",
+					TimestampFormat: "2006-01-02 15:04:05 MST",
+				},
+			},
+			input: testutil.MustMetric(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{
+					"a":    42.0,
+					"time": "2016-03-01 02:39:59 MST",
+				},
+				time.Unix(0, 0),
+			),
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"a": 42.0,
+					},
+					time.Unix(1456799999, 0),
+				),
+			},
+		},
+		{
+			name: "invalid timestamp format",
+			converter: &Converter{
+				Fields: &Conversion{
+					Timestamp:       "time",
+					TimestampFormat: "2006-01-0",
+				},
+			},
+			input: testutil.MustMetric(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{
+					"a":    42.0,
+					"time": "2022-07-04 01:30:59 MST",
+				},
+				time.Unix(0, 0),
+			),
+			expected: []telegraf.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{
+						"a":    42.0,
+						"time": "2022-07-04 01:30:59 MST",
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/plugins/processors/converter/sample.conf
+++ b/plugins/processors/converter/sample.conf
@@ -14,10 +14,11 @@
     float = []
 
     ## Optional tag to use as metric timestamp
-    # timestmap = ""
+    # timestamp = []
 
     ## Format of the timestamp determined by the tag above. This can be any of
     ## "unix", "unix_ms", "unix_us", "unix_ns", or a valid Golang time format.
+    ## It is required, when using the timestamp option.
     # timestamp_format = ""
 
   ## Fields to convert
@@ -35,9 +36,9 @@
     float = []
 
     ## Optional field to use as metric timestamp
-    # timestmap = ""
+    # timestamp = []
 
     ## Format of the timestamp determined by the field above. This can be any
     ## of "unix", "unix_ms", "unix_us", "unix_ns", or a valid Golang time
-    ## format.
+    ## format. It is required, when using the timestamp option.
     # timestamp_format = ""

--- a/plugins/processors/converter/sample.conf
+++ b/plugins/processors/converter/sample.conf
@@ -15,9 +15,9 @@
 
     ## Optional tag to use as metric timestamp
     # timestmap = ""
-    ## Optional format of the timestamp determined by the tag above.
-    ## This can be any of "unix", "unix_ms", "unix_us", "unix_ns" or a valid Golang
-    ## time format. If not specified, a "unix" timestamp (in seconds) is expected.
+
+    ## Format of the timestamp determined by the tag above. This can be any of
+    ## "unix", "unix_ms", "unix_us", "unix_ns", or a valid Golang time format.
     # timestamp_format = ""
 
   ## Fields to convert
@@ -36,7 +36,8 @@
 
     ## Optional field to use as metric timestamp
     # timestmap = ""
-    ## Optional format of the timestamp determined by the field above.
-    ## This can be any of "unix", "unix_ms", "unix_us", "unix_ns" or a valid Golang
-    ## time format. If not specified, a "unix" timestamp (in seconds) is expected.
+
+    ## Format of the timestamp determined by the field above. This can be any
+    ## of "unix", "unix_ms", "unix_us", "unix_ns", or a valid Golang time
+    ## format.
     # timestamp_format = ""

--- a/plugins/processors/converter/sample.conf
+++ b/plugins/processors/converter/sample.conf
@@ -13,6 +13,13 @@
     boolean = []
     float = []
 
+    ## Optional tag to use as metric timestamp
+    # timestmap = ""
+    ## Optional format of the timestamp determined by the tag above.
+    ## This can be any of "unix", "unix_ms", "unix_us", "unix_ns" or a valid Golang
+    ## time format. If not specified, a "unix" timestamp (in seconds) is expected.
+    # timestamp_format = ""
+
   ## Fields to convert
   ##
   ## The table key determines the target type, and the array of key-values
@@ -26,3 +33,10 @@
     unsigned = []
     boolean = []
     float = []
+
+    ## Optional field to use as metric timestamp
+    # timestmap = ""
+    ## Optional format of the timestamp determined by the field above.
+    ## This can be any of "unix", "unix_ms", "unix_us", "unix_ns" or a valid Golang
+    ## time format. If not specified, a "unix" timestamp (in seconds) is expected.
+    # timestamp_format = ""


### PR DESCRIPTION
This adds the timestamp and timestamp_format options to the converter processor. This allows users to take a tag or field and make it the metric timestamp. It uses the same format parsing code that is used throughout Telegraf.

fixes: #12746