### PR TITLE
fix(inputs.statsd): On close, verify listener is not nil

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -945,9 +945,14 @@ func (s *Statsd) Stop() {
 	s.Log.Infof("Stopping the statsd service")
 	close(s.done)
 	if s.isUDP() {
-		s.UDPlistener.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+		if s.UDPlistener != nil {
+			s.UDPlistener.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+		}
 	} else {
-		s.TCPlistener.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+		if s.TCPlistener != nil {
+			s.TCPlistener.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+		}
+
 		// Close all open TCP connections
 		//  - get all conns from the s.conns map and put into slice
 		//  - this is so the forget() function doesnt conflict with looping


### PR DESCRIPTION
If we attempt to close a listener that is nil, telegraf will panic. This
can occur if the port is already in use and we never start the listener.
For example, in test mode.

fixes: #12744
