### PR TITLE
fix(agent): Allow gracefull shutdown on interrupt (e.g. Ctrl-C)

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -362,7 +362,6 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 	}
 
 	// Make sure we safely erase secrets
-	memguard.CatchInterrupt()
 	defer memguard.Purge()
 
 	return app.Run(args)


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

In v1.25.0 we introduced secret-stores (PR #11232) and with this added a call to `memguard.CatchInterrupt()` however, this created a race-condition with the usual signal handling in  [telegraf](https://github.com/influxdata/telegraf/blob/f87916aaa96368ca6d8a2de3e38a513785a1ee99/cmd/telegraf/telegraf.go#L127) where almost always `memguard` was successful in calling `os.Exit` __before__ the agent finished shutting down the plugins etc.

This PR removes the call to `memguard.CatchInterrupt()`. This is safe as we handle interrupts already and use the `defer memguard.Purge()` statement to safely erase all secrets.