### PR TITLE
chore: Bump golangci-lint from v1.51.0 to v1.51.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,5 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.0
+          version: v1.51.2
           args: --timeout 15m0s --verbose --out-${NO_FUTURE}format tab

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -16,7 +16,6 @@ func ParseImage(image string) (imageName string, imageVersion string) {
 		domain, remainder = image[:i], image[i+1:]
 	}
 
-	imageName = ""
 	imageVersion = "unknown"
 	i = strings.LastIndex(remainder, ":")
 	if i > -1 {

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -44,7 +44,7 @@ func TestSnakeCase(t *testing.T) {
 }
 
 var (
-	sleepbin, _ = exec.LookPath("sleep") //nolint:unused // Used in skipped tests
+	sleepbin, _ = exec.LookPath("sleep")
 	echobin, _  = exec.LookPath("echo")
 	shell, _    = exec.LookPath("sh")
 )

--- a/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go
+++ b/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go
@@ -79,8 +79,6 @@ func TestReadsMetricsFromKafkaIntegration(t *testing.T) {
 }
 
 // Waits for the metric that was sent to the kafka broker to arrive at the kafka consumer
-//
-//nolint:unused // Used in skipped tests
 func waitForPoint(acc *testutil.Accumulator, t *testing.T) {
 	// Give the kafka container up to 2 seconds to get the point to the consumer
 	ticker := time.NewTicker(5 * time.Millisecond)

--- a/plugins/inputs/ping/ping_notwindows.go
+++ b/plugins/inputs/ping/ping_notwindows.go
@@ -201,7 +201,7 @@ func processPingOutput(out string) (stats, error) {
 }
 
 func getPacketStats(line string) (trans int, recv int, err error) {
-	trans, recv = 0, 0
+	recv = 0
 
 	stats := strings.Split(line, ", ")
 	// Transmitted packets

--- a/plugins/inputs/sqlserver/connectionstring.go
+++ b/plugins/inputs/sqlserver/connectionstring.go
@@ -72,7 +72,6 @@ func parseConnectionStringKeyValue(connectionString string) (sqlInstance string,
 
 // parseConnectionStringURL parses a URL-formatted connection string and returns the SQL instance and database name
 func parseConnectionStringURL(connectionString string) (sqlInstance string, databaseName string) {
-	sqlInstance = emptySQLInstance
 	databaseName = emptyDatabaseName
 
 	u, err := url.Parse(connectionString)
@@ -81,7 +80,6 @@ func parseConnectionStringURL(connectionString string) (sqlInstance string, data
 	}
 
 	sqlInstance = u.Hostname()
-
 	if len(u.Path) > 1 {
 		// There was a SQL instance name specified in addition to the host
 		// E.g. "the.host.com:1234/InstanceName" or "the.host.com/InstanceName"


### PR DESCRIPTION
Bump contains two patch releases:
https://github.com/golangci/golangci-lint/releases/tag/v1.51.1
https://github.com/golangci/golangci-lint/releases/tag/v1.51.2

New findings fixed:
```
internal/docker/docker.go:19:2                                                       ineffassign  ineffectual assignment to imageName
internal/internal_test.go:47:39                                                      nolintlint   directive `//nolint:unused // Used in skipped tests` is unused for linter "unused"
plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go:83:1  nolintlint   directive `//nolint:unused // Used in skipped tests` is unused for linter "unused"
plugins/inputs/ping/ping_notwindows.go:204:2                                         ineffassign  ineffectual assignment to trans
plugins/inputs/sqlserver/connectionstring.go:75:2                                    ineffassign  ineffectual assignment to sqlInstance
```

One additional highlight:
`sqlclosecheck` linter has been updated and supports generics right now so there will be no more:
`WARN [linters_context] sqlclosecheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.` in the logs.