### PR TITLE
chore: Fix linter findings for errorlint (part8)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - dogsled
     - errcheck
     - errname
+    - errorlint
     - exportloopref
     - gocheckcompilerdirectives
     - goprintffuncname

--- a/config/plugin_id.go
+++ b/config/plugin_id.go
@@ -34,7 +34,7 @@ func processTable(parent string, table *ast.Table) ([]keyValuePair, error) {
 			key := prefix + k
 			childs, err := processTable(key, v)
 			if err != nil {
-				return nil, fmt.Errorf("parsing table for %q failed: %v", key, err)
+				return nil, fmt.Errorf("parsing table for %q failed: %w", key, err)
 			}
 			options = append(options, childs...)
 		case []*ast.Table:
@@ -42,7 +42,7 @@ func processTable(parent string, table *ast.Table) ([]keyValuePair, error) {
 				key := fmt.Sprintf("%s#%d.%s", prefix, i, k)
 				childs, err := processTable(key, t)
 				if err != nil {
-					return nil, fmt.Errorf("parsing table for %q #%d failed: %v", key, i, err)
+					return nil, fmt.Errorf("parsing table for %q #%d failed: %w", key, i, err)
 				}
 				options = append(options, childs...)
 			}

--- a/plugins/inputs/execd/shim/goshim.go
+++ b/plugins/inputs/execd/shim/goshim.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/agent"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -69,7 +70,7 @@ func (s *Shim) AddInput(input telegraf.Input) error {
 	if p, ok := input.(telegraf.Initializer); ok {
 		err := p.Init()
 		if err != nil {
-			return fmt.Errorf("failed to init input: %s", err)
+			return fmt.Errorf("failed to init input: %w", err)
 		}
 	}
 
@@ -113,7 +114,7 @@ func (s *Shim) Run(pollInterval time.Duration) error {
 
 		if serviceInput, ok := input.(telegraf.ServiceInput); ok {
 			if err := serviceInput.Start(acc); err != nil {
-				return fmt.Errorf("failed to start input: %s", err)
+				return fmt.Errorf("failed to start input: %w", err)
 			}
 		}
 		gatherPromptCh := make(chan empty, 1)
@@ -150,11 +151,11 @@ loop:
 			}
 			b, err := serializer.Serialize(m)
 			if err != nil {
-				return fmt.Errorf("failed to serialize metric: %s", err)
+				return fmt.Errorf("failed to serialize metric: %w", err)
 			}
 			// Write this to stdout
 			if _, err := fmt.Fprint(s.stdout, string(b)); err != nil {
-				return fmt.Errorf("failed to write %q to stdout: %s", string(b), err)
+				return fmt.Errorf("failed to write %q to stdout: %w", string(b), err)
 			}
 		}
 	}

--- a/plugins/inputs/mysql/v2/convert.go
+++ b/plugins/inputs/mysql/v2/convert.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"bytes"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
 )
@@ -14,7 +15,8 @@ func ParseInt(value sql.RawBytes) (interface{}, error) {
 
 	// Ignore ErrRange.  When this error is set the returned value is "the
 	// maximum magnitude integer of the appropriate bitSize and sign."
-	if err, ok := err.(*strconv.NumError); ok && err.Err == strconv.ErrRange {
+	var numErr *strconv.NumError
+	if errors.As(err, &numErr) && errors.Is(numErr, strconv.ErrRange) {
 		return v, nil
 	}
 

--- a/plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go
+++ b/plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go
@@ -90,7 +90,7 @@ func jsonToZipkinThrift(jsonRaw []byte) ([]byte, error) {
 	var spans []*zipkincore.Span
 	err := json.Unmarshal(jsonRaw, &spans)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling: %v", err)
+		return nil, fmt.Errorf("error unmarshalling: %w", err)
 	}
 
 	var zspans []*zipkincore.Span
@@ -103,18 +103,18 @@ func jsonToZipkinThrift(jsonRaw []byte) ([]byte, error) {
 	transport := thrift.NewTBinaryProtocolConf(buf, nil)
 
 	if err = transport.WriteListBegin(context.Background(), thrift.STRUCT, len(spans)); err != nil {
-		return nil, fmt.Errorf("error in beginning thrift write: %v", err)
+		return nil, fmt.Errorf("error in beginning thrift write: %w", err)
 	}
 
 	for _, span := range zspans {
 		err = span.Write(context.Background(), transport)
 		if err != nil {
-			return nil, fmt.Errorf("error converting zipkin struct to thrift: %v", err)
+			return nil, fmt.Errorf("error converting zipkin struct to thrift: %w", err)
 		}
 	}
 
 	if err = transport.WriteListEnd(context.Background()); err != nil {
-		return nil, fmt.Errorf("error finishing thrift write: %v", err)
+		return nil, fmt.Errorf("error finishing thrift write: %w", err)
 	}
 
 	return buf.Bytes(), nil


### PR DESCRIPTION
Address findings for [errorlint](https://github.com/polyfloyd/go-errorlint) - finds code that can cause problems with the error wrapping scheme introduced in Go 1.13.

This is the last part of addressing findings found by this linter, thus linter was also enabled in this PR.
related: https://github.com/influxdata/telegraf/pull/12701 https://github.com/influxdata/telegraf/pull/12702 https://github.com/influxdata/telegraf/pull/12704 https://github.com/influxdata/telegraf/pull/12723 https://github.com/influxdata/telegraf/pull/12731 https://github.com/influxdata/telegraf/pull/12733 https://github.com/influxdata/telegraf/pull/12772

Following findings were fixed:
```
config/plugin_id.go:37:68                                              errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
config/plugin_id.go:45:76                                              errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/execd/shim/goshim.go:72:50                              errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/execd/shim/goshim.go:116:52                             errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/execd/shim/goshim.go:153:57                             errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/execd/shim/goshim.go:157:70                             errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/mysql/v2/convert.go:17:16                               errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/inputs/mysql/v2/convert.go:17:47                               errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go:93:53   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go:106:65  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go:112:75  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go:117:62  errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
```