### PR TITLE
chore: Remove usages of github.com/pkg/errors dependency (archived)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -138,7 +138,6 @@ require (
 	github.com/p4lang/p4runtime v1.3.0
 	github.com/pborman/ansi v1.0.0
 	github.com/pion/dtls/v2 v2.2.4
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus-community/pro-bing v0.1.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
@@ -374,6 +373,7 @@ require (
 	github.com/pion/transport/v2 v2.0.0 // indirect
 	github.com/pion/udp v0.1.4 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.13.5 // indirect
 	github.com/pkg/xattr v0.4.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/plugins/common/opcua/opcua_util.go
+++ b/plugins/common/opcua/opcua_util.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/debug"
 	"github.com/gopcua/opcua/ua"
-	"github.com/pkg/errors"
 )
 
 // SELF SIGNED CERT FUNCTIONS
@@ -345,6 +344,5 @@ func validateEndpointConfig(endpoints []*ua.EndpointDescription, secPolicy strin
 		}
 	}
 
-	err := errors.Errorf("server does not support an endpoint with security : %s , %s", secPolicy, secMode)
-	return err
+	return fmt.Errorf("server does not support an endpoint with security: %q, %q", secPolicy, secMode)
 }

--- a/plugins/inputs/aliyuncms/aliyuncms_test.go
+++ b/plugins/inputs/aliyuncms/aliyuncms_test.go
@@ -2,6 +2,8 @@ package aliyuncms
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -12,7 +14,6 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cms"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
@@ -93,13 +94,13 @@ func getDiscoveryTool(project string, discoverRegions []string) (*discoveryTool,
 	}
 	credential, err = providers.NewChainProvider(credentialProviders).Retrieve()
 	if err != nil {
-		return nil, errors.Errorf("failed to retrieve credential: %v", err)
+		return nil, fmt.Errorf("failed to retrieve credential: %w", err)
 	}
 
 	dt, err := newDiscoveryTool(discoverRegions, project, testutil.Logger{Name: inputTitle}, credential, 1, time.Minute*2)
 
 	if err != nil {
-		return nil, errors.Errorf("Can't create discovery tool object: %v", err)
+		return nil, fmt.Errorf("can't create discovery tool object: %w", err)
 	}
 	return dt, nil
 }
@@ -107,7 +108,7 @@ func getDiscoveryTool(project string, discoverRegions []string) (*discoveryTool,
 func getMockSdkCli(httpResp *http.Response) (mockAliyunSDKCli, error) {
 	resp := responses.NewCommonResponse()
 	if err := responses.Unmarshal(resp, httpResp, "JSON"); err != nil {
-		return mockAliyunSDKCli{}, errors.Errorf("Can't parse response: %v", err)
+		return mockAliyunSDKCli{}, fmt.Errorf("can't parse response: %w", err)
 	}
 	return mockAliyunSDKCli{resp: resp}, nil
 }
@@ -273,7 +274,7 @@ func TestPluginMetricsInitialize(t *testing.T) {
 			regions:             []string{"cn-shanghai"},
 			accessKeyID:         "dummy",
 			accessKeySecret:     "dummy",
-			expectedErrorString: `cannot parse dimensions (neither obj, nor array) "[" :unexpected end of JSON input`,
+			expectedErrorString: `cannot parse dimensions (neither obj, nor array) "[": unexpected end of JSON input`,
 			metrics: []*Metric{
 				{
 					MetricNames: []string{},

--- a/plugins/inputs/aliyuncms/discovery.go
+++ b/plugins/inputs/aliyuncms/discovery.go
@@ -2,6 +2,8 @@ package aliyuncms
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -16,7 +18,6 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/slb"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
-	"github.com/pkg/errors"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/limiter"
@@ -58,7 +59,7 @@ type parsedDResp struct {
 func getRPCReqFromDiscoveryRequest(req discoveryRequest) (*requests.RpcRequest, error) {
 	if reflect.ValueOf(req).Type().Kind() != reflect.Ptr ||
 		reflect.ValueOf(req).IsNil() {
-		return nil, errors.Errorf("unexpected type of the discovery request object: %q, %q", reflect.ValueOf(req).Type(), reflect.ValueOf(req).Kind())
+		return nil, fmt.Errorf("unexpected type of the discovery request object: %q, %q", reflect.ValueOf(req).Type(), reflect.ValueOf(req).Kind())
 	}
 
 	ptrV := reflect.Indirect(reflect.ValueOf(req))
@@ -66,19 +67,19 @@ func getRPCReqFromDiscoveryRequest(req discoveryRequest) (*requests.RpcRequest, 
 	for i := 0; i < ptrV.NumField(); i++ {
 		if ptrV.Field(i).Type().String() == "*requests.RpcRequest" {
 			if !ptrV.Field(i).CanInterface() {
-				return nil, errors.Errorf("can't get interface of %v", ptrV.Field(i))
+				return nil, fmt.Errorf("can't get interface of %q", ptrV.Field(i))
 			}
 
 			rpcReq, ok := ptrV.Field(i).Interface().(*requests.RpcRequest)
 
 			if !ok {
-				return nil, errors.Errorf("can't convert interface of %v to '*requests.RpcRequest' type", ptrV.Field(i).Interface())
+				return nil, fmt.Errorf("can't convert interface of %q to '*requests.RpcRequest' type", ptrV.Field(i).Interface())
 			}
 
 			return rpcReq, nil
 		}
 	}
-	return nil, errors.Errorf("didn't find *requests.RpcRequest embedded struct in %q", ptrV.Type())
+	return nil, fmt.Errorf("didn't find *requests.RpcRequest embedded struct in %q", ptrV.Type())
 }
 
 // newDiscoveryTool function returns discovery tool object.
@@ -101,7 +102,7 @@ func newDiscoveryTool(
 		responseRootKey       string
 		responseObjectIDKey   string
 		err                   error
-		noDiscoverySupportErr = errors.Errorf("no discovery support for project %q", project)
+		noDiscoverySupportErr = fmt.Errorf("no discovery support for project %q", project)
 	)
 
 	if len(regions) == 0 {
@@ -232,7 +233,7 @@ func newDiscoveryTool(
 		case "acs_cds":
 			return nil, noDiscoverySupportErr
 		default:
-			return nil, errors.Errorf("project %q is not recognized by discovery", project)
+			return nil, fmt.Errorf("project %q is not recognized by discovery", project)
 		}
 
 		cli[region], err = sdk.NewClientWithOptions(region, sdk.NewConfig(), credential)
@@ -242,7 +243,7 @@ func newDiscoveryTool(
 	}
 
 	if len(dscReq) == 0 || len(cli) == 0 {
-		return nil, errors.Errorf("can't build discovery request for project: %q, regions: %v", project, regions)
+		return nil, fmt.Errorf("can't build discovery request for project: %q, regions: %v", project, regions)
 	}
 
 	return &discoveryTool{
@@ -273,7 +274,7 @@ func (dt *discoveryTool) parseDiscoveryResponse(resp *responses.CommonResponse) 
 	}
 
 	if err := json.Unmarshal(data, &fullOutput); err != nil {
-		return nil, errors.Errorf("can't parse JSON from discovery response: %v", err)
+		return nil, fmt.Errorf("can't parse JSON from discovery response: %w", err)
 	}
 
 	for key, val := range fullOutput {
@@ -282,7 +283,7 @@ func (dt *discoveryTool) parseDiscoveryResponse(resp *responses.CommonResponse) 
 			foundRootKey = true
 			rootKeyVal, ok := val.(map[string]interface{})
 			if !ok {
-				return nil, errors.Errorf("content of root key %q, is not an object: %v", key, val)
+				return nil, fmt.Errorf("content of root key %q, is not an object: %q", key, val)
 			}
 
 			//It should contain the array with discovered data
@@ -292,7 +293,7 @@ func (dt *discoveryTool) parseDiscoveryResponse(resp *responses.CommonResponse) 
 				}
 			}
 			if !foundDataItem {
-				return nil, errors.Errorf("didn't find array item in root key %q", key)
+				return nil, fmt.Errorf("didn't find array item in root key %q", key)
 			}
 		case "TotalCount", "TotalRecordCount":
 			pdResp.totalCount = int(val.(float64))
@@ -303,7 +304,7 @@ func (dt *discoveryTool) parseDiscoveryResponse(resp *responses.CommonResponse) 
 		}
 	}
 	if !foundRootKey {
-		return nil, errors.Errorf("didn't find root key %q in discovery response", dt.respRootKey)
+		return nil, fmt.Errorf("didn't find root key %q in discovery response", dt.respRootKey)
 	}
 
 	return pdResp, nil
@@ -371,7 +372,7 @@ func (dt *discoveryTool) getDiscoveryDataAcrossRegions(lmtr chan bool) (map[stri
 		//which aliyun object type (project) is used
 		dscReq, ok := dt.req[region]
 		if !ok {
-			return nil, errors.Errorf("error building common discovery request: not valid region %q", region)
+			return nil, fmt.Errorf("error building common discovery request: not valid region %q", region)
 		}
 
 		rpcReq, err := getRPCReqFromDiscoveryRequest(dscReq)

--- a/plugins/inputs/ethtool/ethtool_linux.go
+++ b/plugins/inputs/ethtool/ethtool_linux.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/vishvananda/netns"
 
 	"github.com/influxdata/telegraf"
@@ -115,8 +114,7 @@ func (e *Ethtool) gatherEthtoolStats(iface NamespacedInterface, acc telegraf.Acc
 
 	driverName, err := e.command.DriverName(iface)
 	if err != nil {
-		driverErr := errors.Wrapf(err, "%s driver", iface.Name)
-		acc.AddError(driverErr)
+		acc.AddError(fmt.Errorf("%q driver: %w", iface.Name, err))
 		return
 	}
 
@@ -125,8 +123,7 @@ func (e *Ethtool) gatherEthtoolStats(iface NamespacedInterface, acc telegraf.Acc
 	fields := make(map[string]interface{})
 	stats, err := e.command.Stats(iface)
 	if err != nil {
-		statsErr := errors.Wrapf(err, "%s stats", iface.Name)
-		acc.AddError(statsErr)
+		acc.AddError(fmt.Errorf("%q stats: %w", iface.Name, err))
 		return
 	}
 

--- a/plugins/inputs/ethtool/ethtool_test.go
+++ b/plugins/inputs/ethtool/ethtool_test.go
@@ -3,10 +3,10 @@
 package ethtool
 
 import (
+	"errors"
 	"net"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -3,12 +3,13 @@ package filecount
 
 import (
 	_ "embed"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/karrick/godirwalk"
-	"github.com/pkg/errors"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
@@ -177,7 +178,7 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 		Unsorted:             true,
 		FollowSymbolicLinks:  fc.FollowSymlinks,
 		ErrorCallback: func(osPathname string, err error) godirwalk.ErrorAction {
-			if os.IsPermission(errors.Cause(err)) {
+			if errors.Is(err, fs.ErrPermission) {
 				fc.Log.Debug(err)
 				return godirwalk.SkipNode
 			}


### PR DESCRIPTION
[github.com/pkg/errors](https://github.com/pkg/errors) has been deprecated and archived: https://github.com/pkg/errors/issues/245

I don't think we still need to use it after all error wrapping done in https://github.com/influxdata/telegraf/pull/12701 https://github.com/influxdata/telegraf/pull/12702 https://github.com/influxdata/telegraf/pull/12704 https://github.com/influxdata/telegraf/pull/12723 https://github.com/influxdata/telegraf/pull/12731 https://github.com/influxdata/telegraf/pull/12733 https://github.com/influxdata/telegraf/pull/12772 and enabling [errorlint](https://github.com/polyfloyd/go-errorlint) for guarding it in https://github.com/influxdata/telegraf/pull/12785.

It needs to still be our indirect dependency and cannot be removed from `LICENSE_OF_DEPENDENCIES.md` because docker still uses it:
```
go mod why github.com/pkg/errors

# github.com/pkg/errors
github.com/influxdata/telegraf/plugins/inputs/docker
github.com/docker/docker/api/types/filters
github.com/pkg/errors
```