### PR TITLE
Add optional tls parameters to the documentation of the Prometheus Input Plugin

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -142,6 +142,17 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## Use the given name as the SNI server name on each URL
+  # tls_server_name = ""
+
+  ## TLS renegotiation method, choose from "never", "once", "freely"
+  # tls_renegotiation_method = "never"
+
+  ## Enable/disable TLS
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
 ```
 
 `urls` can contain a unix socket as well. If a different path is required

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -125,3 +125,14 @@
 
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## Use the given name as the SNI server name on each URL
+  # tls_server_name = "myhost.example.org"
+
+  ## TLS renegotiation method, choose from "never", "once", "freely"
+  # tls_renegotiation_method = "never"
+
+  ## Enable/disable TLS
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable = true


### PR DESCRIPTION
The Prometheus input plugin uses the `plugins/common/tls`, hence this alignment of the tls parameters documenatation.

# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
