### PR TITLE
chore: unify sample configs across OSes

### DIFF
--- a/plugins/inputs/bcache/bcache_notlinux.go
+++ b/plugins/inputs/bcache/bcache_notlinux.go
@@ -20,8 +20,8 @@ func (b *Bcache) Init() error {
 	b.Log.Warn("current platform is not supported")
 	return nil
 }
-func (b *Bcache) SampleConfig() string                { return sampleConfig }
-func (b *Bcache) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Bcache) SampleConfig() string                { return sampleConfig }
+func (*Bcache) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("bcache", func() telegraf.Input {

--- a/plugins/inputs/bcache/bcache_notlinux.go
+++ b/plugins/inputs/bcache/bcache_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package bcache
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Bcache struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (b *Bcache) Init() error {
+	b.Log.Warn("current platform is not supported")
+	return nil
+}
+func (b *Bcache) SampleConfig() string                { return sampleConfig }
+func (b *Bcache) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("bcache", func() telegraf.Input {
+		return &Bcache{}
+	})
+}

--- a/plugins/inputs/conntrack/conntrack_notlinux.go
+++ b/plugins/inputs/conntrack/conntrack_notlinux.go
@@ -20,8 +20,8 @@ func (c *Conntrack) Init() error {
 	c.Log.Warn("current platform is not supported")
 	return nil
 }
-func (c *Conntrack) SampleConfig() string                { return sampleConfig }
-func (c *Conntrack) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Conntrack) SampleConfig() string                { return sampleConfig }
+func (*Conntrack) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("conntrack", func() telegraf.Input {

--- a/plugins/inputs/conntrack/conntrack_notlinux.go
+++ b/plugins/inputs/conntrack/conntrack_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package conntrack
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Conntrack struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (c *Conntrack) Init() error {
+	c.Log.Warn("current platform is not supported")
+	return nil
+}
+func (c *Conntrack) SampleConfig() string                { return sampleConfig }
+func (c *Conntrack) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("conntrack", func() telegraf.Input {
+		return &Conntrack{}
+	})
+}

--- a/plugins/inputs/dpdk/dpdk_notlinux.go
+++ b/plugins/inputs/dpdk/dpdk_notlinux.go
@@ -20,8 +20,8 @@ func (d *Dpdk) Init() error {
 	d.Log.Warn("current platform is not supported")
 	return nil
 }
-func (d *Dpdk) SampleConfig() string                { return sampleConfig }
-func (d *Dpdk) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Dpdk) SampleConfig() string                { return sampleConfig }
+func (*Dpdk) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("dpdk", func() telegraf.Input {

--- a/plugins/inputs/dpdk/dpdk_notlinux.go
+++ b/plugins/inputs/dpdk/dpdk_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package dpdk
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Dpdk struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (d *Dpdk) Init() error {
+	d.Log.Warn("current platform is not supported")
+	return nil
+}
+func (d *Dpdk) SampleConfig() string                { return sampleConfig }
+func (d *Dpdk) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("dpdk", func() telegraf.Input {
+		return &Dpdk{}
+	})
+}

--- a/plugins/inputs/hugepages/hugepages_notlinux.go
+++ b/plugins/inputs/hugepages/hugepages_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package hugepages
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Hugepages struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (h *Hugepages) Init() error {
+	h.Log.Warn("current platform is not supported")
+	return nil
+}
+func (h *Hugepages) SampleConfig() string                { return sampleConfig }
+func (h *Hugepages) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("hugepages", func() telegraf.Input {
+		return &Hugepages{}
+	})
+}

--- a/plugins/inputs/hugepages/hugepages_notlinux.go
+++ b/plugins/inputs/hugepages/hugepages_notlinux.go
@@ -20,8 +20,8 @@ func (h *Hugepages) Init() error {
 	h.Log.Warn("current platform is not supported")
 	return nil
 }
-func (h *Hugepages) SampleConfig() string                { return sampleConfig }
-func (h *Hugepages) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Hugepages) SampleConfig() string                { return sampleConfig }
+func (*Hugepages) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("hugepages", func() telegraf.Input {

--- a/plugins/inputs/intel_dlb/intel_dlb_notlinux.go
+++ b/plugins/inputs/intel_dlb/intel_dlb_notlinux.go
@@ -20,8 +20,8 @@ func (i *IntelDLB) Init() error {
 	i.Log.Warn("current platform is not supported")
 	return nil
 }
-func (i *IntelDLB) SampleConfig() string                { return sampleConfig }
-func (i *IntelDLB) Gather(_ telegraf.Accumulator) error { return nil }
+func (*IntelDLB) SampleConfig() string                { return sampleConfig }
+func (*IntelDLB) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("intel_dlb", func() telegraf.Input {

--- a/plugins/inputs/intel_dlb/intel_dlb_notlinux.go
+++ b/plugins/inputs/intel_dlb/intel_dlb_notlinux.go
@@ -1,4 +1,30 @@
 //go:build !linux
-// +build !linux
 
 package intel_dlb
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type IntelDLB struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (i *IntelDLB) Init() error {
+	i.Log.Warn("current platform is not supported")
+	return nil
+}
+func (i *IntelDLB) SampleConfig() string                { return sampleConfig }
+func (i *IntelDLB) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("intel_dlb", func() telegraf.Input {
+		return &IntelDLB{}
+	})
+}

--- a/plugins/inputs/intel_pmu/intel_pmu_notamd64linux.go
+++ b/plugins/inputs/intel_pmu/intel_pmu_notamd64linux.go
@@ -1,3 +1,32 @@
 //go:build !linux || !amd64
 
 package intel_pmu
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type IntelPMU struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (i *IntelPMU) Init() error {
+	i.Log.Warn("current platform is not supported")
+	return nil
+}
+func (i *IntelPMU) SampleConfig() string                { return sampleConfig }
+func (i *IntelPMU) Gather(_ telegraf.Accumulator) error { return nil }
+func (i *IntelPMU) Start(_ telegraf.Accumulator) error  { return nil }
+func (i *IntelPMU) Stop()                               {}
+
+func init() {
+	inputs.Add("intel_pmu", func() telegraf.Input {
+		return &IntelPMU{}
+	})
+}

--- a/plugins/inputs/intel_pmu/intel_pmu_notamd64linux.go
+++ b/plugins/inputs/intel_pmu/intel_pmu_notamd64linux.go
@@ -20,10 +20,10 @@ func (i *IntelPMU) Init() error {
 	i.Log.Warn("current platform is not supported")
 	return nil
 }
-func (i *IntelPMU) SampleConfig() string                { return sampleConfig }
-func (i *IntelPMU) Gather(_ telegraf.Accumulator) error { return nil }
-func (i *IntelPMU) Start(_ telegraf.Accumulator) error  { return nil }
-func (i *IntelPMU) Stop()                               {}
+func (*IntelPMU) SampleConfig() string                { return sampleConfig }
+func (*IntelPMU) Gather(_ telegraf.Accumulator) error { return nil }
+func (*IntelPMU) Start(_ telegraf.Accumulator) error  { return nil }
+func (*IntelPMU) Stop()                               {}
 
 func init() {
 	inputs.Add("intel_pmu", func() telegraf.Input {

--- a/plugins/inputs/intel_powerstat/intel_powerstat_notlinux.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package intel_powerstat
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type IntelPowerstat struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (i *IntelPowerstat) Init() error {
+	i.Log.Warn("current platform is not supported")
+	return nil
+}
+func (i *IntelPowerstat) SampleConfig() string                { return sampleConfig }
+func (i *IntelPowerstat) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("intel_powerstat", func() telegraf.Input {
+		return &IntelPowerstat{}
+	})
+}

--- a/plugins/inputs/intel_powerstat/intel_powerstat_notlinux.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat_notlinux.go
@@ -20,8 +20,8 @@ func (i *IntelPowerstat) Init() error {
 	i.Log.Warn("current platform is not supported")
 	return nil
 }
-func (i *IntelPowerstat) SampleConfig() string                { return sampleConfig }
-func (i *IntelPowerstat) Gather(_ telegraf.Accumulator) error { return nil }
+func (*IntelPowerstat) SampleConfig() string                { return sampleConfig }
+func (*IntelPowerstat) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("intel_powerstat", func() telegraf.Input {

--- a/plugins/inputs/intel_rdt/intel_rdt_windows.go
+++ b/plugins/inputs/intel_rdt/intel_rdt_windows.go
@@ -20,10 +20,10 @@ func (i *IntelRDT) Init() error {
 	i.Log.Warn("current platform is not supported")
 	return nil
 }
-func (i *IntelRDT) SampleConfig() string                { return sampleConfig }
-func (i *IntelRDT) Gather(_ telegraf.Accumulator) error { return nil }
-func (i *IntelRDT) Start(_ telegraf.Accumulator) error  { return nil }
-func (i *IntelRDT) Stop()                               {}
+func (*IntelRDT) SampleConfig() string                { return sampleConfig }
+func (*IntelRDT) Gather(_ telegraf.Accumulator) error { return nil }
+func (*IntelRDT) Start(_ telegraf.Accumulator) error  { return nil }
+func (*IntelRDT) Stop()                               {}
 
 func init() {
 	inputs.Add("intel_rdt", func() telegraf.Input {

--- a/plugins/inputs/intel_rdt/intel_rdt_windows.go
+++ b/plugins/inputs/intel_rdt/intel_rdt_windows.go
@@ -1,3 +1,32 @@
 //go:build windows
 
 package intel_rdt
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type IntelRDT struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (i *IntelRDT) Init() error {
+	i.Log.Warn("current platform is not supported")
+	return nil
+}
+func (i *IntelRDT) SampleConfig() string                { return sampleConfig }
+func (i *IntelRDT) Gather(_ telegraf.Accumulator) error { return nil }
+func (i *IntelRDT) Start(_ telegraf.Accumulator) error  { return nil }
+func (i *IntelRDT) Stop()                               {}
+
+func init() {
+	inputs.Add("intel_rdt", func() telegraf.Input {
+		return &IntelRDT{}
+	})
+}

--- a/plugins/inputs/iptables/iptables_notlinux.go
+++ b/plugins/inputs/iptables/iptables_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package iptables
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Iptables struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (i *Iptables) Init() error {
+	i.Log.Warn("current platform is not supported")
+	return nil
+}
+func (i *Iptables) SampleConfig() string                { return sampleConfig }
+func (i *Iptables) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("iptables", func() telegraf.Input {
+		return &Iptables{}
+	})
+}

--- a/plugins/inputs/iptables/iptables_notlinux.go
+++ b/plugins/inputs/iptables/iptables_notlinux.go
@@ -20,8 +20,8 @@ func (i *Iptables) Init() error {
 	i.Log.Warn("current platform is not supported")
 	return nil
 }
-func (i *Iptables) SampleConfig() string                { return sampleConfig }
-func (i *Iptables) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Iptables) SampleConfig() string                { return sampleConfig }
+func (*Iptables) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("iptables", func() telegraf.Input {

--- a/plugins/inputs/ipvs/ipvs_notlinux.go
+++ b/plugins/inputs/ipvs/ipvs_notlinux.go
@@ -20,8 +20,8 @@ func (i *Ipvs) Init() error {
 	i.Log.Warn("current platform is not supported")
 	return nil
 }
-func (i *Ipvs) SampleConfig() string                { return sampleConfig }
-func (i *Ipvs) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Ipvs) SampleConfig() string                { return sampleConfig }
+func (*Ipvs) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("ipvs", func() telegraf.Input {

--- a/plugins/inputs/ipvs/ipvs_notlinux.go
+++ b/plugins/inputs/ipvs/ipvs_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package ipvs
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Ipvs struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (i *Ipvs) Init() error {
+	i.Log.Warn("current platform is not supported")
+	return nil
+}
+func (i *Ipvs) SampleConfig() string                { return sampleConfig }
+func (i *Ipvs) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("ipvs", func() telegraf.Input {
+		return &Ipvs{}
+	})
+}

--- a/plugins/inputs/kernel/README.md
+++ b/plugins/inputs/kernel/README.md
@@ -53,6 +53,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Get kernel statistics from /proc/stat
+# This plugin ONLY supports Linux
 [[inputs.kernel]]
   # no configuration
 ```

--- a/plugins/inputs/kernel/kernel_notlinux.go
+++ b/plugins/inputs/kernel/kernel_notlinux.go
@@ -13,12 +13,15 @@ import (
 var sampleConfig string
 
 type Kernel struct {
+	Log telegraf.Logger `toml:"-"`
 }
 
-func (k *Kernel) SampleConfig() string { return sampleConfig }
-func (k *Kernel) Gather(acc telegraf.Accumulator) error {
+func (k *Kernel) Init() error {
+	k.Log.Warn("current platform is not supported")
 	return nil
 }
+func (*Kernel) SampleConfig() string                  { return sampleConfig }
+func (*Kernel) Gather(acc telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("kernel", func() telegraf.Input {

--- a/plugins/inputs/kernel/kernel_notlinux.go
+++ b/plugins/inputs/kernel/kernel_notlinux.go
@@ -3,19 +3,19 @@
 package kernel
 
 import (
+	_ "embed"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
+//go:embed sample.conf
+var sampleConfig string
+
 type Kernel struct {
 }
 
-func (k *Kernel) Description() string {
-	return "Get kernel statistics from /proc/stat"
-}
-
-func (k *Kernel) SampleConfig() string { return "" }
-
+func (k *Kernel) SampleConfig() string { return sampleConfig }
 func (k *Kernel) Gather(acc telegraf.Accumulator) error {
 	return nil
 }

--- a/plugins/inputs/kernel/sample.conf
+++ b/plugins/inputs/kernel/sample.conf
@@ -1,3 +1,4 @@
 # Get kernel statistics from /proc/stat
+# This plugin ONLY supports Linux
 [[inputs.kernel]]
   # no configuration

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat_notlinux.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package kernel_vmstat
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type KernelVmstat struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (k *KernelVmstat) Init() error {
+	k.Log.Warn("current platform is not supported")
+	return nil
+}
+func (k *KernelVmstat) SampleConfig() string                { return sampleConfig }
+func (k *KernelVmstat) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("kernel_vmstat", func() telegraf.Input {
+		return &KernelVmstat{}
+	})
+}

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat_notlinux.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat_notlinux.go
@@ -20,8 +20,8 @@ func (k *KernelVmstat) Init() error {
 	k.Log.Warn("current platform is not supported")
 	return nil
 }
-func (k *KernelVmstat) SampleConfig() string                { return sampleConfig }
-func (k *KernelVmstat) Gather(_ telegraf.Accumulator) error { return nil }
+func (*KernelVmstat) SampleConfig() string                { return sampleConfig }
+func (*KernelVmstat) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("kernel_vmstat", func() telegraf.Input {

--- a/plugins/inputs/linux_cpu/linux_cpu_nonlinux.go
+++ b/plugins/inputs/linux_cpu/linux_cpu_nonlinux.go
@@ -20,8 +20,8 @@ func (l *LinuxCPU) Init() error {
 	l.Log.Warn("current platform is not supported")
 	return nil
 }
-func (l *LinuxCPU) SampleConfig() string                { return sampleConfig }
-func (l *LinuxCPU) Gather(_ telegraf.Accumulator) error { return nil }
+func (*LinuxCPU) SampleConfig() string                { return sampleConfig }
+func (*LinuxCPU) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("linux_cpu", func() telegraf.Input {

--- a/plugins/inputs/linux_cpu/linux_cpu_nonlinux.go
+++ b/plugins/inputs/linux_cpu/linux_cpu_nonlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package linux_cpu
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type LinuxCPU struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (l *LinuxCPU) Init() error {
+	l.Log.Warn("current platform is not supported")
+	return nil
+}
+func (l *LinuxCPU) SampleConfig() string                { return sampleConfig }
+func (l *LinuxCPU) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("linux_cpu", func() telegraf.Input {
+		return &LinuxCPU{}
+	})
+}

--- a/plugins/inputs/lustre2/lustre2_notlinux.go
+++ b/plugins/inputs/lustre2/lustre2_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package lustre2
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Lustre2 struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (l *Lustre2) Init() error {
+	l.Log.Warn("current platform is not supported")
+	return nil
+}
+func (l *Lustre2) SampleConfig() string                { return sampleConfig }
+func (l *Lustre2) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("lustre2", func() telegraf.Input {
+		return &Lustre2{}
+	})
+}

--- a/plugins/inputs/lustre2/lustre2_notlinux.go
+++ b/plugins/inputs/lustre2/lustre2_notlinux.go
@@ -20,8 +20,8 @@ func (l *Lustre2) Init() error {
 	l.Log.Warn("current platform is not supported")
 	return nil
 }
-func (l *Lustre2) SampleConfig() string                { return sampleConfig }
-func (l *Lustre2) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Lustre2) SampleConfig() string                { return sampleConfig }
+func (*Lustre2) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("lustre2", func() telegraf.Input {

--- a/plugins/inputs/mdstat/mdstat_notlinux.go
+++ b/plugins/inputs/mdstat/mdstat_notlinux.go
@@ -20,8 +20,8 @@ func (m *Mdstat) Init() error {
 	m.Log.Warn("current platform is not supported")
 	return nil
 }
-func (m *Mdstat) SampleConfig() string                { return sampleConfig }
-func (m *Mdstat) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Mdstat) SampleConfig() string                { return sampleConfig }
+func (*Mdstat) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("mdstat", func() telegraf.Input {

--- a/plugins/inputs/mdstat/mdstat_notlinux.go
+++ b/plugins/inputs/mdstat/mdstat_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package mdstat
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Mdstat struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (m *Mdstat) Init() error {
+	m.Log.Warn("current platform is not supported")
+	return nil
+}
+func (m *Mdstat) SampleConfig() string                { return sampleConfig }
+func (m *Mdstat) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("mdstat", func() telegraf.Input {
+		return &Mdstat{}
+	})
+}

--- a/plugins/inputs/postfix/postfix_windows.go
+++ b/plugins/inputs/postfix/postfix_windows.go
@@ -1,3 +1,30 @@
 //go:build windows
 
 package postfix
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Postfix struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (p *Postfix) Init() error {
+	p.Log.Warn("current platform is not supported")
+	return nil
+}
+func (p *Postfix) SampleConfig() string                { return sampleConfig }
+func (p *Postfix) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("postfix", func() telegraf.Input {
+		return &Postfix{}
+	})
+}

--- a/plugins/inputs/postfix/postfix_windows.go
+++ b/plugins/inputs/postfix/postfix_windows.go
@@ -20,8 +20,8 @@ func (p *Postfix) Init() error {
 	p.Log.Warn("current platform is not supported")
 	return nil
 }
-func (p *Postfix) SampleConfig() string                { return sampleConfig }
-func (p *Postfix) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Postfix) SampleConfig() string                { return sampleConfig }
+func (*Postfix) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("postfix", func() telegraf.Input {

--- a/plugins/inputs/ras/ras_notlinux.go
+++ b/plugins/inputs/ras/ras_notlinux.go
@@ -1,3 +1,32 @@
 //go:build !linux || (linux && !386 && !amd64 && !arm && !arm64)
 
 package ras
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Ras struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (r *Ras) Init() error {
+	r.Log.Warn("current platform is not supported")
+	return nil
+}
+func (r *Ras) SampleConfig() string                { return sampleConfig }
+func (r *Ras) Gather(_ telegraf.Accumulator) error { return nil }
+func (r *Ras) Start(_ telegraf.Accumulator) error  { return nil }
+func (r *Ras) Stop()                               {}
+
+func init() {
+	inputs.Add("ras", func() telegraf.Input {
+		return &Ras{}
+	})
+}

--- a/plugins/inputs/ras/ras_notlinux.go
+++ b/plugins/inputs/ras/ras_notlinux.go
@@ -20,10 +20,10 @@ func (r *Ras) Init() error {
 	r.Log.Warn("current platform is not supported")
 	return nil
 }
-func (r *Ras) SampleConfig() string                { return sampleConfig }
-func (r *Ras) Gather(_ telegraf.Accumulator) error { return nil }
-func (r *Ras) Start(_ telegraf.Accumulator) error  { return nil }
-func (r *Ras) Stop()                               {}
+func (*Ras) SampleConfig() string                { return sampleConfig }
+func (*Ras) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Ras) Start(_ telegraf.Accumulator) error  { return nil }
+func (*Ras) Stop()                               {}
 
 func init() {
 	inputs.Add("ras", func() telegraf.Input {

--- a/plugins/inputs/sensors/sensors_notlinux.go
+++ b/plugins/inputs/sensors/sensors_notlinux.go
@@ -20,8 +20,8 @@ func (s *Sensors) Init() error {
 	s.Log.Warn("current platform is not supported")
 	return nil
 }
-func (s *Sensors) SampleConfig() string                { return sampleConfig }
-func (s *Sensors) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Sensors) SampleConfig() string                { return sampleConfig }
+func (*Sensors) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("sensors", func() telegraf.Input {

--- a/plugins/inputs/sensors/sensors_notlinux.go
+++ b/plugins/inputs/sensors/sensors_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package sensors
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Sensors struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (s *Sensors) Init() error {
+	s.Log.Warn("current platform is not supported")
+	return nil
+}
+func (s *Sensors) SampleConfig() string                { return sampleConfig }
+func (s *Sensors) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("sensors", func() telegraf.Input {
+		return &Sensors{}
+	})
+}

--- a/plugins/inputs/slab/slab_notlinux.go
+++ b/plugins/inputs/slab/slab_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package slab
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Slab struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (s *Slab) Init() error {
+	s.Log.Warn("current platform is not supported")
+	return nil
+}
+func (s *Slab) SampleConfig() string                { return sampleConfig }
+func (s *Slab) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("slab", func() telegraf.Input {
+		return &Slab{}
+	})
+}

--- a/plugins/inputs/slab/slab_notlinux.go
+++ b/plugins/inputs/slab/slab_notlinux.go
@@ -20,8 +20,8 @@ func (s *Slab) Init() error {
 	s.Log.Warn("current platform is not supported")
 	return nil
 }
-func (s *Slab) SampleConfig() string                { return sampleConfig }
-func (s *Slab) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Slab) SampleConfig() string                { return sampleConfig }
+func (*Slab) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("slab", func() telegraf.Input {

--- a/plugins/inputs/socketstat/socketstat_windows.go
+++ b/plugins/inputs/socketstat/socketstat_windows.go
@@ -1,3 +1,30 @@
 //go:build windows
 
 package socketstat
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Socketstat struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (s *Socketstat) Init() error {
+	s.Log.Warn("current platform is not supported")
+	return nil
+}
+func (s *Socketstat) SampleConfig() string                { return sampleConfig }
+func (s *Socketstat) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("socketstat", func() telegraf.Input {
+		return &Socketstat{}
+	})
+}

--- a/plugins/inputs/socketstat/socketstat_windows.go
+++ b/plugins/inputs/socketstat/socketstat_windows.go
@@ -20,8 +20,8 @@ func (s *Socketstat) Init() error {
 	s.Log.Warn("current platform is not supported")
 	return nil
 }
-func (s *Socketstat) SampleConfig() string                { return sampleConfig }
-func (s *Socketstat) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Socketstat) SampleConfig() string                { return sampleConfig }
+func (*Socketstat) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("socketstat", func() telegraf.Input {

--- a/plugins/inputs/sysstat/sysstat_notlinux.go
+++ b/plugins/inputs/sysstat/sysstat_notlinux.go
@@ -20,8 +20,8 @@ func (s *Sysstat) Init() error {
 	s.Log.Warn("current platform is not supported")
 	return nil
 }
-func (s *Sysstat) SampleConfig() string                { return sampleConfig }
-func (s *Sysstat) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Sysstat) SampleConfig() string                { return sampleConfig }
+func (*Sysstat) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("sysstat", func() telegraf.Input {

--- a/plugins/inputs/sysstat/sysstat_notlinux.go
+++ b/plugins/inputs/sysstat/sysstat_notlinux.go
@@ -1,3 +1,30 @@
 //go:build !linux
 
 package sysstat
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Sysstat struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (s *Sysstat) Init() error {
+	s.Log.Warn("current platform is not supported")
+	return nil
+}
+func (s *Sysstat) SampleConfig() string                { return sampleConfig }
+func (s *Sysstat) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("sysstat", func() telegraf.Input {
+		return &Sysstat{}
+	})
+}

--- a/plugins/inputs/varnish/varnish_windows.go
+++ b/plugins/inputs/varnish/varnish_windows.go
@@ -20,8 +20,8 @@ func (v *Varnish) Init() error {
 	v.Log.Warn("current platform is not supported")
 	return nil
 }
-func (v *Varnish) SampleConfig() string                { return sampleConfig }
-func (v *Varnish) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Varnish) SampleConfig() string                { return sampleConfig }
+func (*Varnish) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("varnish", func() telegraf.Input {

--- a/plugins/inputs/varnish/varnish_windows.go
+++ b/plugins/inputs/varnish/varnish_windows.go
@@ -1,3 +1,30 @@
 //go:build windows
 
 package varnish
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Varnish struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (v *Varnish) Init() error {
+	v.Log.Warn("current platform is not supported")
+	return nil
+}
+func (v *Varnish) SampleConfig() string                { return sampleConfig }
+func (v *Varnish) Gather(_ telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("varnish", func() telegraf.Input {
+		return &Varnish{}
+	})
+}


### PR DESCRIPTION
This will enable producing the same sample config across all OSes. This way no matter what binary a user has they can use the "config" subcommand to always get the full and complete sample configuration.