### PR TITLE
chore: specify distro support (part 3)

### DIFF
--- a/plugins/inputs/cgroup/README.md
+++ b/plugins/inputs/cgroup/README.md
@@ -51,6 +51,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Read specific statistics per cgroup
+# This plugin ONLY supports Linux
 [[inputs.cgroup]]
   ## Directories in which to look for files, globs are supported.
   ## Consider restricting paths to the set of cgroups you really

--- a/plugins/inputs/cgroup/sample.conf
+++ b/plugins/inputs/cgroup/sample.conf
@@ -1,4 +1,5 @@
 # Read specific statistics per cgroup
+# This plugin ONLY supports Linux
 [[inputs.cgroup]]
   ## Directories in which to look for files, globs are supported.
   ## Consider restricting paths to the set of cgroups you really

--- a/plugins/inputs/diskio/README.md
+++ b/plugins/inputs/diskio/README.md
@@ -15,6 +15,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Read metrics about disk IO by device
+# This plugin ONLY supports Linux
 [[inputs.diskio]]
   ## By default, telegraf will gather stats for all devices including
   ## disk partitions.

--- a/plugins/inputs/diskio/sample.conf
+++ b/plugins/inputs/diskio/sample.conf
@@ -1,4 +1,5 @@
 # Read metrics about disk IO by device
+# This plugin ONLY supports Linux
 [[inputs.diskio]]
   ## By default, telegraf will gather stats for all devices including
   ## disk partitions.

--- a/plugins/inputs/dmcache/README.md
+++ b/plugins/inputs/dmcache/README.md
@@ -22,6 +22,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Provide a native collection for dmsetup based statistics for dm-cache
+# This plugin ONLY supports Linux
 [[inputs.dmcache]]
   ## Whether to report per-device stats or not
   per_device = true

--- a/plugins/inputs/dmcache/sample.conf
+++ b/plugins/inputs/dmcache/sample.conf
@@ -1,4 +1,5 @@
 # Provide a native collection for dmsetup based statistics for dm-cache
+# This plugin ONLY supports Linux
 [[inputs.dmcache]]
   ## Whether to report per-device stats or not
   per_device = true

--- a/plugins/inputs/ethtool/README.md
+++ b/plugins/inputs/ethtool/README.md
@@ -16,6 +16,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Returns ethtool statistics for given interfaces
+# This plugin ONLY supports Linux
 [[inputs.ethtool]]
   ## List of interfaces to pull metrics for
   # interface_include = ["eth0"]

--- a/plugins/inputs/ethtool/sample.conf
+++ b/plugins/inputs/ethtool/sample.conf
@@ -1,4 +1,5 @@
 # Returns ethtool statistics for given interfaces
+# This plugin ONLY supports Linux
 [[inputs.ethtool]]
   ## List of interfaces to pull metrics for
   # interface_include = ["eth0"]

--- a/plugins/inputs/infiniband/README.md
+++ b/plugins/inputs/infiniband/README.md
@@ -19,6 +19,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Gets counters from all InfiniBand cards and ports installed
+# This plugin ONLY supports Linux
 [[inputs.infiniband]]
   # no configuration
 ```

--- a/plugins/inputs/infiniband/sample.conf
+++ b/plugins/inputs/infiniband/sample.conf
@@ -1,3 +1,4 @@
 # Gets counters from all InfiniBand cards and ports installed
+# This plugin ONLY supports Linux
 [[inputs.infiniband]]
   # no configuration

--- a/plugins/inputs/kernel/README.md
+++ b/plugins/inputs/kernel/README.md
@@ -53,6 +53,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Get kernel statistics from /proc/stat
+# This plugin ONLY supports Linux
 [[inputs.kernel]]
   # no configuration
 ```

--- a/plugins/inputs/kernel/sample.conf
+++ b/plugins/inputs/kernel/sample.conf
@@ -1,3 +1,4 @@
 # Get kernel statistics from /proc/stat
+# This plugin ONLY supports Linux
 [[inputs.kernel]]
   # no configuration

--- a/plugins/inputs/nats/README.md
+++ b/plugins/inputs/nats/README.md
@@ -18,6 +18,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Provides metrics about the state of a NATS server
+# This plugin does NOT support FreeBSD
 [[inputs.nats]]
   ## The address of the monitoring endpoint of the NATS server
   server = "http://localhost:8222"

--- a/plugins/inputs/nats/sample.conf
+++ b/plugins/inputs/nats/sample.conf
@@ -1,4 +1,5 @@
 # Provides metrics about the state of a NATS server
+# This plugin does NOT support FreeBSD
 [[inputs.nats]]
   ## The address of the monitoring endpoint of the NATS server
   server = "http://localhost:8222"

--- a/plugins/inputs/processes/README.md
+++ b/plugins/inputs/processes/README.md
@@ -21,6 +21,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Get the number of processes and group them by status
+# This plugin ONLY supports non-Windows
 [[inputs.processes]]
   ## Use sudo to run ps command on *BSD systems. Linux systems will read
   ## /proc, so this does not apply there.

--- a/plugins/inputs/processes/sample.conf
+++ b/plugins/inputs/processes/sample.conf
@@ -1,4 +1,5 @@
 # Get the number of processes and group them by status
+# This plugin ONLY supports non-Windows
 [[inputs.processes]]
   ## Use sudo to run ps command on *BSD systems. Linux systems will read
   ## /proc, so this does not apply there.

--- a/plugins/inputs/synproxy/README.md
+++ b/plugins/inputs/synproxy/README.md
@@ -17,6 +17,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Get synproxy counter statistics from procfs
+# This plugin ONLY supports Linux
 [[inputs.synproxy]]
   # no configuration
 ```

--- a/plugins/inputs/synproxy/sample.conf
+++ b/plugins/inputs/synproxy/sample.conf
@@ -1,3 +1,4 @@
 # Get synproxy counter statistics from procfs
+# This plugin ONLY supports Linux
 [[inputs.synproxy]]
   # no configuration

--- a/plugins/inputs/wireless/README.md
+++ b/plugins/inputs/wireless/README.md
@@ -16,6 +16,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Monitor wifi signal strength and quality
+# This plugin ONLY supports Linux
 [[inputs.wireless]]
   ## Sets 'proc' directory path
   ## If not specified, then default is /proc

--- a/plugins/inputs/wireless/sample.conf
+++ b/plugins/inputs/wireless/sample.conf
@@ -1,4 +1,5 @@
 # Monitor wifi signal strength and quality
+# This plugin ONLY supports Linux
 [[inputs.wireless]]
   ## Sets 'proc' directory path
   ## If not specified, then default is /proc

--- a/plugins/inputs/zfs/README.md
+++ b/plugins/inputs/zfs/README.md
@@ -17,6 +17,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Read metrics of ZFS from arcstats, zfetchstats, vdev_cache_stats, pools and datasets
+# This plugin ONLY supports Linux & FreeBSD
 [[inputs.zfs]]
   ## ZFS kstat path. Ignored on FreeBSD
   ## If not specified, then default is:

--- a/plugins/inputs/zfs/sample.conf
+++ b/plugins/inputs/zfs/sample.conf
@@ -1,4 +1,5 @@
 # Read metrics of ZFS from arcstats, zfetchstats, vdev_cache_stats, pools and datasets
+# This plugin ONLY supports Linux & FreeBSD
 [[inputs.zfs]]
   ## ZFS kstat path. Ignored on FreeBSD
   ## If not specified, then default is:


### PR DESCRIPTION
Specify distro support for a few more input plugins that were missed in previous versions.
