### PR TITLE
chore: use type on powershell/command prompt only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ ifneq (,$(filter $(OS),Windows_NT Windows))
 	EXEEXT=.exe
 endif
 
-next_version := $(file < build_version.txt)
+cat := $(if $(filter $(OS),sh.exe),type,cat)
+next_version := $(shell $(cat) build_version.txt)
 tag := $(shell git describe --exact-match --tags 2>/dev/null)
 
 branch := $(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
This will use cat in the makefile for all systems and prompts, except for on Windows where a user is using PowerShell or Command Prompt. That way existing usage of bash on Windows continues to work as expected.

Using file is only supported on Makefile 4.2.1 and newer. Which is not available in OS X and older RHEL 7 for example.

fixes: #12573