### PR TITLE
feat(inputs.cgroup): Added support for cpu.stat

### DIFF
--- a/plugins/inputs/cgroup/cgroup_linux.go
+++ b/plugins/inputs/cgroup/cgroup_linux.go
@@ -172,7 +172,7 @@ type fileFormat struct {
 	parser  func(measurement string, fields map[string]interface{}, b []byte)
 }
 
-const keyPattern = "[[:alnum:]:_]+"
+const keyPattern = "[[:alnum:]:_.]+"
 const valuePattern = "[\\d-]+"
 
 var fileFormats = [...]fileFormat{

--- a/plugins/inputs/cgroup/cgroup_test.go
+++ b/plugins/inputs/cgroup/cgroup_test.go
@@ -59,7 +59,10 @@ func TestCgroupStatistics_2(t *testing.T) {
 
 	var cg = &CGroup{
 		Paths: []string{"testdata/cpu"},
-		Files: []string{"cpuacct.usage_percpu"},
+		Files: []string{
+			"cpuacct.usage_percpu",
+			"cpu.stat",
+		},
 	}
 
 	require.NoError(t, acc.GatherError(cg.Gather))
@@ -70,10 +73,14 @@ func TestCgroupStatistics_2(t *testing.T) {
 				"path": "testdata/cpu",
 			},
 			map[string]interface{}{
-				"cpuacct.usage_percpu.0": int64(-1452543795404),
-				"cpuacct.usage_percpu.1": int64(1376681271659),
-				"cpuacct.usage_percpu.2": int64(1450950799997),
-				"cpuacct.usage_percpu.3": int64(-1473113374257),
+				"cpu.stat.core_sched.force_idle_usec": int64(0),
+				"cpu.stat.system_usec":                int64(103537582650),
+				"cpu.stat.usage_usec":                 int64(614953149468),
+				"cpu.stat.user_usec":                  int64(511415566817),
+				"cpuacct.usage_percpu.0":              int64(-1452543795404),
+				"cpuacct.usage_percpu.1":              int64(1376681271659),
+				"cpuacct.usage_percpu.2":              int64(1450950799997),
+				"cpuacct.usage_percpu.3":              int64(-1473113374257),
 			},
 			time.Unix(0, 0),
 		),

--- a/plugins/inputs/cgroup/testdata/cpu/cpu.stat
+++ b/plugins/inputs/cgroup/testdata/cpu/cpu.stat
@@ -1,0 +1,4 @@
+usage_usec 614953149468
+user_usec 511415566817
+system_usec 103537582650
+core_sched.force_idle_usec 0


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
cgroup v2 mounted with `hierarchy=unified` do not provide cpuacct [0], so this PR adds `.` to valid characters in keys for key-value pairs, which in turn fixes parsing `cpu.stat`, making it possible to measure cpu usage on v2 cgroup mounts with hierarchy=unified (default since systemd v243).

[0] https://github.com/systemd/systemd/issues/13477

