### PR TITLE
feat(agent): Add command-line option to specify password

### DIFF
--- a/cmd/telegraf/cmd_secretstore.go
+++ b/cmd/telegraf/cmd_secretstore.go
@@ -8,9 +8,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/influxdata/telegraf/config"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/term"
+
+	"github.com/influxdata/telegraf/config"
 )
 
 func processFilterOnlySecretStoreFlags(ctx *cli.Context) Filters {
@@ -78,6 +79,7 @@ To also reveal the actual secret, i.e. the value, you can pass the
 							config:     cCtx.StringSlice("config"),
 							configDir:  cCtx.StringSlice("config-directory"),
 							plugindDir: cCtx.String("plugin-directory"),
+							password:   cCtx.String("password"),
 							debug:      cCtx.Bool("debug"),
 						}
 						w := WindowFlags{}
@@ -155,6 +157,7 @@ with the ID 'mystore'.
 							config:     cCtx.StringSlice("config"),
 							configDir:  cCtx.StringSlice("config-directory"),
 							plugindDir: cCtx.String("plugin-directory"),
+							password:   cCtx.String("password"),
 							debug:      cCtx.Bool("debug"),
 						}
 						w := WindowFlags{}
@@ -218,6 +221,7 @@ you will be prompted to enter the value of the secret.
 							config:     cCtx.StringSlice("config"),
 							configDir:  cCtx.StringSlice("config-directory"),
 							plugindDir: cCtx.String("plugin-directory"),
+							password:   cCtx.String("password"),
 							debug:      cCtx.Bool("debug"),
 						}
 						w := WindowFlags{}

--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -224,6 +224,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 			watchConfig: cCtx.String("watch-config"),
 			pidFile:     cCtx.String("pidfile"),
 			plugindDir:  cCtx.String("plugin-directory"),
+			password:    cCtx.String("password"),
 			test:        cCtx.Bool("test"),
 			debug:       cCtx.Bool("debug"),
 			once:        cCtx.Bool("once"),
@@ -280,6 +281,10 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 				&cli.StringFlag{
 					Name:  "pidfile",
 					Usage: "file to write our pid to",
+				},
+				&cli.StringFlag{
+					Name:  "password",
+					Usage: "password to unlock secret-stores",
 				},
 				//
 				// Bool flags

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -38,6 +38,7 @@ type GlobalFlags struct {
 	watchConfig string
 	pidFile     string
 	plugindDir  string
+	password    string
 	test        bool
 	debug       bool
 	once        bool
@@ -81,6 +82,11 @@ func (t *Telegraf) Init(pprofErr <-chan error, f Filters, g GlobalFlags, w Windo
 	t.secretstoreFilters = f.secretstore
 	t.GlobalFlags = g
 	t.WindowFlags = w
+
+	// Set global password
+	if g.password != "" {
+		config.Password = config.NewSecret([]byte(g.password))
+	}
 }
 
 func (t *Telegraf) ListSecretStores() ([]string, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,9 @@ var (
 	// fetchURLRe is a regex to determine whether the requested file should
 	// be fetched from a remote or read from the filesystem.
 	fetchURLRe = regexp.MustCompile(`^\w+://`)
+
+	// Password specified via command-line
+	Password Secret
 )
 
 // Config specifies the URL/user/password for the database that telegraf

--- a/plugins/secretstores/jose/jose.go
+++ b/plugins/secretstores/jose/jose.go
@@ -40,15 +40,21 @@ func (j *Jose) Init() error {
 		return errors.New("path missing")
 	}
 
-	passwd, err := j.Password.Get()
-	if err != nil {
-		return fmt.Errorf("getting password failed: %w", err)
-	}
-	defer config.ReleaseSecret(passwd)
-
 	// Create the prompt-function in case we need it
 	promptFunc := keyring.TerminalPrompt
-	if len(passwd) != 0 {
+	if !j.Password.Empty() {
+		passwd, err := j.Password.Get()
+		if err != nil {
+			return fmt.Errorf("getting password failed: %w", err)
+		}
+		defer config.ReleaseSecret(passwd)
+		promptFunc = keyring.FixedStringPrompt(string(passwd))
+	} else if !config.Password.Empty() {
+		passwd, err := config.Password.Get()
+		if err != nil {
+			return fmt.Errorf("getting global password failed: %w", err)
+		}
+		defer config.ReleaseSecret(passwd)
 		promptFunc = keyring.FixedStringPrompt(string(passwd))
 	}
 


### PR DESCRIPTION
- [] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12651

This PR adds a `--password` option to specify a secret-store password  via command-line to for example set-up Telegraf using a script.