### PR TITLE
fix(inputs.ethtool): close namespace

### DIFF
--- a/plugins/inputs/ethtool/ethtool_linux.go
+++ b/plugins/inputs/ethtool/ethtool_linux.go
@@ -229,6 +229,7 @@ func (c *CommandEthtool) Interfaces(includeNamespaces bool) ([]NamespacedInterfa
 		c.Log.Errorf("Could not get initial namespace: %s", err)
 		return nil, err
 	}
+	defer initialNamespace.Close()
 
 	// Gather the list of namespace names to from which to retrieve interfaces.
 	initialNamespaceIsNamed := false


### PR DESCRIPTION
Close the namespace to prevent constantly chewing up file descriptors on a system.

fixes: #12813