### PR TITLE
fix(inputs.amqp_consumer): Fix panic on Stop() if not connected successfully

### DIFF
--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -439,6 +439,10 @@ func (a *AMQPConsumer) onDelivery(track telegraf.DeliveryInfo) bool {
 }
 
 func (a *AMQPConsumer) Stop() {
+	// We did not connect successfully so there is nothing to do here.
+	if a.conn == nil || a.conn.IsClosed() {
+		return
+	}
 	a.cancel()
 	a.wg.Wait()
 	err := a.conn.Close()


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

If the connection to the brokers fails, stopping Telegraf will result in a panic as neither `cancel` nor `conn` is set. Prevent the panic by exiting early on `Stop()`.