### PR TITLE
fix(serializers.graphite): allow for specifying regex to sanitize

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1397,9 +1397,10 @@ func (c *Config) buildSerializer(tbl *ast.Table) (serializers.Serializer, error)
 	c.getFieldInt(tbl, "influx_max_line_bytes", &sc.InfluxMaxLineBytes)
 	c.getFieldBool(tbl, "influx_sort_fields", &sc.InfluxSortFields)
 	c.getFieldBool(tbl, "influx_uint_support", &sc.InfluxUintSupport)
+
+	c.getFieldString(tbl, "graphite_strict_sanitize_regex", &sc.GraphiteStrictRegex)
 	c.getFieldBool(tbl, "graphite_tag_support", &sc.GraphiteTagSupport)
 	c.getFieldString(tbl, "graphite_tag_sanitize_mode", &sc.GraphiteTagSanitizeMode)
-
 	c.getFieldString(tbl, "graphite_separator", &sc.GraphiteSeparator)
 
 	c.getFieldDuration(tbl, "json_timestamp_units", &sc.TimestampUnits)
@@ -1489,6 +1490,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 	case "prefix", "template", "templates",
 		"carbon2_format", "carbon2_sanitize_replace_char",
 		"csv_column_prefix", "csv_header", "csv_separator", "csv_timestamp_format",
+		"graphite_strict_sanitize_regex",
 		"graphite_tag_sanitize_mode", "graphite_tag_support", "graphite_separator",
 		"influx_max_line_bytes", "influx_sort_fields", "influx_uint_support",
 		"json_timestamp_format", "json_timestamp_units", "json_transformation",

--- a/plugins/outputs/graphite/README.md
+++ b/plugins/outputs/graphite/README.md
@@ -32,12 +32,20 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## see https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   template = "host.tags.measurement.field"
 
+  ## Strict sanitization regex
+  ## This is the default sanitization regex that is used on data passed to the
+  ## graphite serializer. Users can add additional characters here if required.
+  ## Be aware that the characters, '/' '@' '*' are always replaced with '_',
+  ## '..' is replaced with '.', and '\' is removed even if added to the
+  ## following regex.
+  # graphite_strict_sanitize_regex = '[^a-zA-Z0-9-:._=\p{L}]'
+
   ## Enable Graphite tags support
   # graphite_tag_support = false
 
-  ## Define how metric names and tags are sanitized; options are "strict", or "compatible"
-  ## strict - Default method, and backwards compatible with previous versionf of Telegraf
-  ## compatible - More relaxed sanitizing when using tags, and compatible with the graphite spec
+  ## Applied sanitization mode when graphite tag support is enabled.
+  ## * strict - uses the regex specified above
+  ## * compatible - allows for greater number of characters
   # graphite_tag_sanitize_mode = "strict"
 
   ## Character for separating metric name and field for Graphite tags

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -165,7 +165,7 @@ func (g *Graphite) checkEOF(conn net.Conn) error {
 func (g *Graphite) Write(metrics []telegraf.Metric) error {
 	// Prepare data
 	var batch []byte
-	s, err := serializers.NewGraphiteSerializer(g.Prefix, g.Template, g.GraphiteTagSupport, g.GraphiteTagSanitizeMode, g.GraphiteSeparator, g.Templates)
+	s, err := serializers.NewGraphiteSerializer(g.Prefix, g.Template, "", g.GraphiteTagSupport, g.GraphiteTagSanitizeMode, g.GraphiteSeparator, g.Templates)
 	if err != nil {
 		return err
 	}

--- a/plugins/outputs/graphite/sample.conf
+++ b/plugins/outputs/graphite/sample.conf
@@ -10,12 +10,20 @@
   ## see https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   template = "host.tags.measurement.field"
 
+  ## Strict sanitization regex
+  ## This is the default sanitization regex that is used on data passed to the
+  ## graphite serializer. Users can add additional characters here if required.
+  ## Be aware that the characters, '/' '@' '*' are always replaced with '_',
+  ## '..' is replaced with '.', and '\' is removed even if added to the
+  ## following regex.
+  # graphite_strict_sanitize_regex = '[^a-zA-Z0-9-:._=\p{L}]'
+
   ## Enable Graphite tags support
   # graphite_tag_support = false
 
-  ## Define how metric names and tags are sanitized; options are "strict", or "compatible"
-  ## strict - Default method, and backwards compatible with previous versionf of Telegraf
-  ## compatible - More relaxed sanitizing when using tags, and compatible with the graphite spec
+  ## Applied sanitization mode when graphite tag support is enabled.
+  ## * strict - uses the regex specified above
+  ## * compatible - allows for greater number of characters
   # graphite_tag_sanitize_mode = "strict"
 
   ## Character for separating metric name and field for Graphite tags

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -84,7 +84,7 @@ func (i *Instrumental) Write(metrics []telegraf.Metric) error {
 		}
 	}
 
-	s, err := serializers.NewGraphiteSerializer(i.Prefix, i.Template, false, "strict", ".", i.Templates)
+	s, err := serializers.NewGraphiteSerializer(i.Prefix, i.Template, "", false, "strict", ".", i.Templates)
 	if err != nil {
 		return err
 	}

--- a/plugins/serializers/graphite/README.md
+++ b/plugins/serializers/graphite/README.md
@@ -35,10 +35,22 @@ method is used, otherwise the [Template Pattern][templates] is used.
   #  "host.measurement.tags.field"
   #]
 
+  ## Strict sanitization regex
+  ## This is the default sanitization regex that is used on data passed to the
+  ## graphite serializer. Users can add additional characters here if required.
+  ## Be aware that the characters, '/' '@' '*' are always replaced with '_',
+  ## '..' is replaced with '.', and '\' is removed even if added to the
+  ## following regex.
+  # graphite_strict_sanitize_regex = '[^a-zA-Z0-9-:._=\p{L}]'
+
   ## Support Graphite tags, recommended to enable when using Graphite 1.1 or later.
   # graphite_tag_support = false
-  ## Enable Graphite tags to support the full list of allowed characters
-  # graphite_tag_new_sanitize = false
+
+  ## Applied sanitization mode when graphite tag support is enabled.
+  ## * strict - uses the regex specified above
+  ## * compatible - allows for greater number of characters
+  # graphite_tag_sanitize_mode = "strict"
+
   ## Character for separating metric name and field for Graphite tags
   # graphite_separator = "."
 ```

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -48,6 +48,10 @@ type GraphiteSerializer struct {
 }
 
 func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
+	if s.StrictAllowedChars == nil {
+		s.StrictAllowedChars = regexp.MustCompile(`[^a-zA-Z0-9-:._=\p{L}]`)
+	}
+
 	out := []byte{}
 
 	// Convert UnixNano to Unix timestamps

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -16,7 +16,6 @@ import (
 const DefaultTemplate = "host.tags.measurement.field"
 
 var (
-	strictAllowedChars          = regexp.MustCompile(`[^a-zA-Z0-9-:._=\p{L}]`)
 	compatibleAllowedCharsName  = regexp.MustCompile(`[^ "-:\<>-\]_a-~\p{L}]`)
 	compatibleAllowedCharsValue = regexp.MustCompile(`[^ -:<-~\p{L}]`)
 	compatibleLeadingTildeDrop  = regexp.MustCompile(`^[~]*(.*)`)
@@ -39,12 +38,13 @@ type GraphiteTemplate struct {
 }
 
 type GraphiteSerializer struct {
-	Prefix          string
-	Template        string
-	TagSupport      bool
-	TagSanitizeMode string
-	Separator       string
-	Templates       []*GraphiteTemplate
+	Prefix             string              `json:"prefix"`
+	Template           string              `json:"template"`
+	StrictAllowedChars *regexp.Regexp      `json:"graphite_strict_sanitize_regex"`
+	TagSupport         bool                `json:"graphite_tag_support"`
+	TagSanitizeMode    string              `json:"graphite_tag_sanitize_mode"`
+	Separator          string              `json:"graphite_separator"`
+	Templates          []*GraphiteTemplate `json:"templates"`
 }
 
 func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
@@ -60,7 +60,7 @@ func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 			if fieldValue == "" {
 				continue
 			}
-			bucket := SerializeBucketNameWithTags(metric.Name(), metric.Tags(), s.Prefix, s.Separator, fieldName, s.TagSanitizeMode)
+			bucket := s.SerializeBucketNameWithTags(metric.Name(), metric.Tags(), s.Prefix, s.Separator, fieldName, s.TagSanitizeMode)
 			metricString := fmt.Sprintf("%s %s %d\n",
 				// insert "field" section of template
 				bucket,
@@ -91,7 +91,7 @@ func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 			}
 			metricString := fmt.Sprintf("%s %s %d\n",
 				// insert "field" section of template
-				strictSanitize(InsertField(bucket, fieldName)),
+				s.strictSanitize(InsertField(bucket, fieldName)),
 				fieldValue,
 				timestamp)
 			point := []byte(metricString)
@@ -245,7 +245,7 @@ func InitGraphiteTemplates(templates []string) ([]*GraphiteTemplate, string, err
 // SerializeBucketNameWithTags will take the given measurement name and tags and
 // produce a graphite bucket. It will use the Graphite11Serializer.
 // http://graphite.readthedocs.io/en/latest/tags.html
-func SerializeBucketNameWithTags(
+func (s *GraphiteSerializer) SerializeBucketNameWithTags(
 	measurement string,
 	tags map[string]string,
 	prefix string,
@@ -262,7 +262,7 @@ func SerializeBucketNameWithTags(
 		if tagSanitizeMode == "compatible" {
 			tagsCopy = append(tagsCopy, compatibleSanitize(k, v))
 		} else {
-			tagsCopy = append(tagsCopy, strictSanitize(k+"="+v))
+			tagsCopy = append(tagsCopy, s.strictSanitize(k+"="+v))
 		}
 	}
 	sort.Strings(tagsCopy)
@@ -277,7 +277,7 @@ func SerializeBucketNameWithTags(
 		out += separator + field
 	}
 
-	out = strictSanitize(out)
+	out = s.strictSanitize(out)
 
 	if len(tagsCopy) > 0 {
 		out += ";" + strings.Join(tagsCopy, ";")
@@ -316,13 +316,13 @@ func buildTags(tags map[string]string) string {
 	return tagStr
 }
 
-func strictSanitize(value string) string {
+func (s *GraphiteSerializer) strictSanitize(value string) string {
 	// Apply special hyphenation rules to preserve backwards compatibility
 	value = hyphenChars.Replace(value)
 	// Apply rule to drop some chars to preserve backwards compatibility
 	value = dropChars.Replace(value)
 	// Replace any remaining illegal chars
-	return strictAllowedChars.ReplaceAllLiteralString(value, "_")
+	return s.StrictAllowedChars.ReplaceAllLiteralString(value, "_")
 }
 
 func compatibleSanitize(name string, value string) string {

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -2,6 +2,7 @@ package serializers
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -74,6 +75,9 @@ type Config struct {
 
 	// Character for separating metric name and field for Graphite tags
 	GraphiteSeparator string `toml:"graphite_separator"`
+
+	// Regex string
+	GraphiteStrictRegex string `toml:"graphite_strict_sanitize_regex"`
 
 	// Maximum line length in bytes; influx format only
 	InfluxMaxLineBytes int `toml:"influx_max_line_bytes"`
@@ -155,6 +159,7 @@ func NewSerializer(config *Config) (Serializer, error) {
 		serializer, err = NewGraphiteSerializer(
 			config.Prefix,
 			config.Template,
+			config.GraphiteStrictRegex,
 			config.GraphiteTagSupport,
 			config.GraphiteTagSanitizeMode,
 			config.GraphiteSeparator,
@@ -280,9 +285,17 @@ func NewInfluxSerializer() Serializer {
 	return influx.NewSerializer()
 }
 
-func NewGraphiteSerializer(prefix, template string, tagSupport bool, tagSanitizeMode string, separator string, templates []string) (Serializer, error) {
+//nolint:revive //argument-limit conditionally more arguments allowed
+func NewGraphiteSerializer(
+	prefix,
+	template string,
+	strictRegex string,
+	tagSupport bool,
+	tagSanitizeMode string,
+	separator string,
+	templates []string,
+) (Serializer, error) {
 	graphiteTemplates, defaultTemplate, err := graphite.InitGraphiteTemplates(templates)
-
 	if err != nil {
 		return nil, err
 	}
@@ -299,13 +312,23 @@ func NewGraphiteSerializer(prefix, template string, tagSupport bool, tagSanitize
 		separator = "."
 	}
 
+	strictAllowedChars := regexp.MustCompile(`[^a-zA-Z0-9-:._=\p{L}]`)
+	if strictRegex != "" {
+		strictAllowedChars, err = regexp.Compile(strictRegex)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex provided %q: %w", strictRegex, err)
+		}
+	}
+	fmt.Printf("using regex: %s\n", strictAllowedChars)
+
 	return &graphite.GraphiteSerializer{
-		Prefix:          prefix,
-		Template:        template,
-		TagSupport:      tagSupport,
-		TagSanitizeMode: tagSanitizeMode,
-		Separator:       separator,
-		Templates:       graphiteTemplates,
+		Prefix:             prefix,
+		Template:           template,
+		StrictAllowedChars: strictAllowedChars,
+		TagSupport:         tagSupport,
+		TagSanitizeMode:    tagSanitizeMode,
+		Separator:          separator,
+		Templates:          graphiteTemplates,
 	}, nil
 }
 

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -319,7 +319,6 @@ func NewGraphiteSerializer(
 			return nil, fmt.Errorf("invalid regex provided %q: %w", strictRegex, err)
 		}
 	}
-	fmt.Printf("using regex: %s\n", strictAllowedChars)
 
 	return &graphite.GraphiteSerializer{
 		Prefix:             prefix,


### PR DESCRIPTION
The graphite serializer is very strict as to what characters are allowed to pass through. This allows the user to override the regex used and specify their own.

fixes: #12832
