### PR TITLE
fix(inputs.temp): ignore warnings returned by gopsutil

### DIFF
--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -217,8 +217,8 @@ func (s *SystemPS) SwapStat() (*mem.SwapMemoryStat, error) {
 func (s *SystemPS) Temperature() ([]host.TemperatureStat, error) {
 	temp, err := host.SensorsTemperatures()
 	if err != nil {
-		_, ok := err.(*host.Warnings)
-		if !ok {
+		var hostWarnings *host.Warnings
+		if errors.As(err, &hostWarnings) {
 			return temp, err
 		}
 	}

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -215,7 +215,14 @@ func (s *SystemPS) SwapStat() (*mem.SwapMemoryStat, error) {
 }
 
 func (s *SystemPS) Temperature() ([]host.TemperatureStat, error) {
-	return host.SensorsTemperatures()
+	temp, err := host.SensorsTemperatures()
+	if err != nil {
+		_, ok := err.(*host.Warnings)
+		if !ok {
+			return temp, err
+		}
+	}
+	return temp, nil
 }
 
 func (s *SystemPSDisk) Partitions(all bool) ([]disk.PartitionStat, error) {


### PR DESCRIPTION
The temperature sensor reading can return warnings as an error. Previously we ignored these, but they were removed from gopsutil. The warning was returned to gopsutil and we should continue to ignore warnings and only fail on a true error.

fixes: #12841