### PR TITLE
fix(makefile): re-add build tags flag to go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ docs: build_tools embed_readme_inputs embed_readme_outputs embed_readme_processo
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" ./cmd/telegraf
+	CGO_ENABLED=0 go build -tags "$(BUILDTAGS)" -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
 .PHONY: telegraf
 telegraf: build


### PR DESCRIPTION
This should not have been removed and not sure why it was part of a previous PR.

fixes: #12846