### PR TITLE
feat(common.opcua): Add support for secret-store secrets

### DIFF
--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -24,8 +24,8 @@ type OpcUAClientConfig struct {
 	SecurityMode   string          `toml:"security_mode"`
 	Certificate    string          `toml:"certificate"`
 	PrivateKey     string          `toml:"private_key"`
-	Username       string          `toml:"username"`
-	Password       string          `toml:"password"`
+	Username       config.Secret   `toml:"username"`
+	Password       config.Secret   `toml:"password"`
 	AuthMethod     string          `toml:"auth_method"`
 	ConnectTimeout config.Duration `toml:"connect_timeout"`
 	RequestTimeout config.Duration `toml:"request_timeout"`

--- a/plugins/common/opcua/opcua_util.go
+++ b/plugins/common/opcua/opcua_util.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/debug"
 	"github.com/gopcua/opcua/ua"
+	"github.com/influxdata/telegraf/config"
 )
 
 // SELF SIGNED CERT FUNCTIONS
@@ -288,42 +289,42 @@ func (o *OpcUAClient) generateClientOpts(endpoints []*ua.EndpointDescription) ([
 	return opts, nil
 }
 
-func (o *OpcUAClient) generateAuth(a string, cert []byte, un, pw string) (ua.UserTokenType, opcua.Option, error) {
-	var err error
-
+func (o *OpcUAClient) generateAuth(a string, cert []byte, user, passwd config.Secret) (ua.UserTokenType, opcua.Option, error) {
 	var authMode ua.UserTokenType
 	var authOption opcua.Option
 	switch strings.ToLower(a) {
 	case "anonymous":
 		authMode = ua.UserTokenTypeAnonymous
 		authOption = opcua.AuthAnonymous()
-
 	case "username":
 		authMode = ua.UserTokenTypeUserName
 
-		if un == "" {
+		var username, password []byte
+		if !user.Empty() {
+			var err error
+			username, err = user.Get()
 			if err != nil {
 				return 0, nil, fmt.Errorf("error reading the username input: %w", err)
 			}
+			defer config.ReleaseSecret(username)
 		}
 
-		if pw == "" {
+		if !passwd.Empty() {
+			var err error
+			password, err = passwd.Get()
 			if err != nil {
 				return 0, nil, fmt.Errorf("error reading the password input: %w", err)
 			}
+			defer config.ReleaseSecret(password)
 		}
-
-		authOption = opcua.AuthUsername(un, pw)
-
+		authOption = opcua.AuthUsername(string(username), string(password))
 	case "certificate":
 		authMode = ua.UserTokenTypeCertificate
 		authOption = opcua.AuthCertificate(cert)
-
 	case "issuedtoken":
 		// todo: this is unsupported, fail here or fail in the opcua package?
 		authMode = ua.UserTokenTypeIssuedToken
 		authOption = opcua.AuthIssuedToken([]byte(nil))
-
 	default:
 		o.Log.Warnf("unknown auth-mode, defaulting to Anonymous")
 		authMode = ua.UserTokenTypeAnonymous

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -14,6 +14,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -62,10 +62,6 @@ func TestGetDataBadNodeContainerIntegration(t *testing.T) {
 				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
 				SecurityPolicy: "None",
 				SecurityMode:   "None",
-				Certificate:    "",
-				PrivateKey:     "",
-				Username:       "",
-				Password:       "",
 				AuthMethod:     "Anonymous",
 				ConnectTimeout: config.Duration(10 * time.Second),
 				RequestTimeout: config.Duration(1 * time.Second),
@@ -128,10 +124,6 @@ func TestReadClientIntegration(t *testing.T) {
 				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
 				SecurityPolicy: "None",
 				SecurityMode:   "None",
-				Certificate:    "",
-				PrivateKey:     "",
-				Username:       "",
-				Password:       "",
 				AuthMethod:     "Anonymous",
 				ConnectTimeout: config.Duration(10 * time.Second),
 				RequestTimeout: config.Duration(1 * time.Second),
@@ -188,8 +180,8 @@ func TestReadClientIntegrationWithPasswordAuth(t *testing.T) {
 				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
 				SecurityPolicy: "None",
 				SecurityMode:   "None",
-				Username:       "peter",
-				Password:       "peter123",
+				Username:       config.NewSecret([]byte("peter")),
+				Password:       config.NewSecret([]byte("peter123")),
 				AuthMethod:     "UserName",
 				ConnectTimeout: config.Duration(10 * time.Second),
 				RequestTimeout: config.Duration(1 * time.Second),
@@ -293,8 +285,8 @@ use_unregistered_reads = true
 	require.Equal(t, "/etc/telegraf/cert.pem", o.ReadClientConfig.Certificate)
 	require.Equal(t, "/etc/telegraf/key.pem", o.ReadClientConfig.PrivateKey)
 	require.Equal(t, "Anonymous", o.ReadClientConfig.AuthMethod)
-	require.Equal(t, "", o.ReadClientConfig.Username)
-	require.Equal(t, "", o.ReadClientConfig.Password)
+	require.True(t, o.ReadClientConfig.Username.Empty())
+	require.True(t, o.ReadClientConfig.Password.Empty())
 	require.Equal(t, []input.NodeSettings{
 		{
 			FieldName:      "name",

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -14,6 +14,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -205,8 +205,8 @@ additional_valid_status_codes = ["0xC0"]
 	require.Equal(t, "/etc/telegraf/cert.pem", o.SubscribeClientConfig.Certificate)
 	require.Equal(t, "/etc/telegraf/key.pem", o.SubscribeClientConfig.PrivateKey)
 	require.Equal(t, "Anonymous", o.SubscribeClientConfig.AuthMethod)
-	require.Equal(t, "", o.SubscribeClientConfig.Username)
-	require.Equal(t, "", o.SubscribeClientConfig.Password)
+	require.True(t, o.SubscribeClientConfig.Username.Empty())
+	require.True(t, o.SubscribeClientConfig.Password.Empty())
 	require.Equal(t, []input.NodeSettings{
 		{
 			FieldName:      "name",

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -141,7 +141,7 @@ func (o *SubscribeClient) processReceivedNotifications() {
 					i := int(monitoredItemNotif.ClientHandle)
 					oldValue := o.LastReceivedData[i].Value
 					o.UpdateNodeValue(i, monitoredItemNotif.Value)
-					o.Log.Debugf("Data change notification: node %q value changed from %f to %f",
+					o.Log.Debugf("Data change notification: node %q value changed from %v to %v",
 						o.NodeIDs[i].String(), oldValue, o.LastReceivedData[i].Value)
 					o.metrics <- o.MetricForNode(i)
 				}


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12862

This PR adds support for secret-store secrets for the `username` and `password` setting in `inputs.opcua` and `inputs.opcua_listener`.