### PR TITLE
fix(inputs.prometheus): correctly set timeout param

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -125,12 +125,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Optional custom HTTP headers
   # http_headers = {"X-Special-Header" = "Special-Value"}
 
-  ## Specify timeout duration for slower prometheus clients (default is 3s)
-  # timeout = "3s"
-  
-  ##   deprecated in 1.26; use the timeout option
-  # response_timeout = "3s"
-  
+  ## Specify timeout duration for slower prometheus clients (default is 5s)
+  # timeout = "5s"
+
+  ## deprecated in 1.26; use the timeout option
+  # response_timeout = "5s"
+
   ## HTTP Proxy support
   # use_system_proxy = false
   # http_proxy_url = ""

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -6,9 +6,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"github.com/influxdata/telegraf/models"
 	"io"
-	"k8s.io/client-go/tools/cache"
 	"net"
 	"net/http"
 	"net/url"
@@ -16,6 +14,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/influxdata/telegraf/models"
+	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -74,7 +75,6 @@ type Prometheus struct {
 	HTTPHeaders map[string]string `toml:"http_headers"`
 
 	ResponseTimeout config.Duration `toml:"response_timeout" deprecated:"1.26.0;use 'timeout' instead"`
-	Timeout         config.Duration `toml:"timeout"`
 
 	MetricVersion int `toml:"metric_version"`
 
@@ -194,7 +194,10 @@ func (p *Prometheus) Init() error {
 	}
 
 	ctx := context.Background()
-	p.HTTPClientConfig.Timeout = p.ResponseTimeout
+	if p.ResponseTimeout != 0 {
+		p.HTTPClientConfig.Timeout = p.ResponseTimeout
+	}
+
 	client, err := p.HTTPClientConfig.CreateClient(ctx, p.Log)
 	if err != nil {
 		return err
@@ -331,7 +334,9 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) error 
 					return c, err
 				},
 			},
-			Timeout: time.Duration(p.ResponseTimeout),
+		}
+		if p.ResponseTimeout != 0 {
+			uClient.Timeout = time.Duration(p.ResponseTimeout)
 		}
 	} else {
 		if u.URL.Path == "" {
@@ -487,10 +492,9 @@ func (p *Prometheus) Stop() {
 func init() {
 	inputs.Add("prometheus", func() telegraf.Input {
 		return &Prometheus{
-			ResponseTimeout: config.Duration(time.Second * 3),
-			kubernetesPods:  map[PodID]URLAndAddress{},
-			consulServices:  map[string]URLAndAddress{},
-			URLTag:          "url",
+			kubernetesPods: map[PodID]URLAndAddress{},
+			consulServices: map[string]URLAndAddress{},
+			URLTag:         "url",
 		}
 	})
 }

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -205,13 +205,13 @@ func TestPrometheusGeneratesMetricsSlowEndpointNewConfigParameter(t *testing.T) 
 	defer ts.Close()
 
 	p := &Prometheus{
-		Log:     testutil.Logger{},
-		URLs:    []string{ts.URL},
-		URLTag:  "url",
-		Timeout: config.Duration(time.Second * 5),
+		Log:    testutil.Logger{},
+		URLs:   []string{ts.URL},
+		URLTag: "url",
 	}
 	err := p.Init()
 	require.NoError(t, err)
+	p.client.Timeout = time.Second * 5
 
 	var acc testutil.Accumulator
 
@@ -235,13 +235,13 @@ func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeoutNewConfigParameter(t
 	defer ts.Close()
 
 	p := &Prometheus{
-		Log:     testutil.Logger{},
-		URLs:    []string{ts.URL},
-		URLTag:  "url",
-		Timeout: config.Duration(time.Second * 5),
+		Log:    testutil.Logger{},
+		URLs:   []string{ts.URL},
+		URLTag: "url",
 	}
 	err := p.Init()
 	require.NoError(t, err)
+	p.client.Timeout = time.Second * 5
 
 	var acc testutil.Accumulator
 

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -108,12 +108,12 @@
   ## Optional custom HTTP headers
   # http_headers = {"X-Special-Header" = "Special-Value"}
 
-  ## Specify timeout duration for slower prometheus clients (default is 3s)
-  # timeout = "3s"
-  
-  ##   deprecated in 1.26; use the timeout option
-  # response_timeout = "3s"
-  
+  ## Specify timeout duration for slower prometheus clients (default is 5s)
+  # timeout = "5s"
+
+  ## deprecated in 1.26; use the timeout option
+  # response_timeout = "5s"
+
   ## HTTP Proxy support
   # use_system_proxy = false
   # http_proxy_url = ""


### PR DESCRIPTION
* Only print deprecation warning if response_timeout is used
* Only set timeouts with response_timeout if it is set
* Allow the use of the timeout param in TOML
* Use HTTPClientConfig default of 5s timeout (versus 3s)
* Update tests

fixes: #12859