### PR TITLE
chore: ensure go generate runs on all platforms

### DIFF
--- a/plugins/inputs/bcache/bcache_notlinux.go
+++ b/plugins/inputs/bcache/bcache_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package bcache

--- a/plugins/inputs/conntrack/conntrack_notlinux.go
+++ b/plugins/inputs/conntrack/conntrack_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package conntrack

--- a/plugins/inputs/dpdk/dpdk_notlinux.go
+++ b/plugins/inputs/dpdk/dpdk_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package dpdk

--- a/plugins/inputs/hugepages/hugepages_notlinux.go
+++ b/plugins/inputs/hugepages/hugepages_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package hugepages

--- a/plugins/inputs/intel_dlb/intel_dlb_notlinux.go
+++ b/plugins/inputs/intel_dlb/intel_dlb_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package intel_dlb

--- a/plugins/inputs/intel_pmu/intel_pmu_notamd64linux.go
+++ b/plugins/inputs/intel_pmu/intel_pmu_notamd64linux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux || !amd64
 
 package intel_pmu

--- a/plugins/inputs/intel_powerstat/intel_powerstat_notlinux.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package intel_powerstat

--- a/plugins/inputs/iptables/iptables_notlinux.go
+++ b/plugins/inputs/iptables/iptables_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package iptables

--- a/plugins/inputs/ipvs/ipvs_notlinux.go
+++ b/plugins/inputs/ipvs/ipvs_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package ipvs

--- a/plugins/inputs/kernel/kernel_notlinux.go
+++ b/plugins/inputs/kernel/kernel_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package kernel

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat_notlinux.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package kernel_vmstat

--- a/plugins/inputs/lustre2/lustre2_notlinux.go
+++ b/plugins/inputs/lustre2/lustre2_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package lustre2

--- a/plugins/inputs/mdstat/mdstat_notlinux.go
+++ b/plugins/inputs/mdstat/mdstat_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package mdstat

--- a/plugins/inputs/p4runtime/p4runtime.go
+++ b/plugins/inputs/p4runtime/p4runtime.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 package p4runtime
 
 import (

--- a/plugins/inputs/ras/ras_notlinux.go
+++ b/plugins/inputs/ras/ras_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux || (linux && !386 && !amd64 && !arm && !arm64)
 
 package ras

--- a/plugins/inputs/sensors/sensors_notlinux.go
+++ b/plugins/inputs/sensors/sensors_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package sensors

--- a/plugins/inputs/slab/slab_notlinux.go
+++ b/plugins/inputs/slab/slab_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package slab

--- a/plugins/inputs/sysstat/sysstat_notlinux.go
+++ b/plugins/inputs/sysstat/sysstat_notlinux.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !linux
 
 package sysstat

--- a/plugins/inputs/win_eventlog/win_eventlog_notwindows.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_notwindows.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
 
 package win_eventlog

--- a/plugins/inputs/win_perf_counters/win_perf_counters_notwindows.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_notwindows.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
 
 package win_perf_counters

--- a/plugins/inputs/win_services/win_services_notwindows.go
+++ b/plugins/inputs/win_services/win_services_notwindows.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
 
 package win_services

--- a/plugins/inputs/win_wmi/README.md
+++ b/plugins/inputs/win_wmi/README.md
@@ -17,7 +17,7 @@ additional global and plugin configuration settings. These settings are used to
 modify metrics, tags, and field or create aliases and configure ordering, etc.
 See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
-[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
 ## Configuration
 
@@ -25,8 +25,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Input plugin to query Windows Management Instrumentation
 # This plugin ONLY supports Windows
 [[inputs.win_wmi]]
-  # specifies a prefix to attach to the measurement name
-  name_prefix = "win_wmi_"
   [[inputs.win_wmi.query]]
     # a string representing the WMI namespace to be queried
     namespace = "root\\cimv2"

--- a/plugins/inputs/win_wmi/win_wmi_notwindows.go
+++ b/plugins/inputs/win_wmi/win_wmi_notwindows.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/readme_config_includer/generator
 //go:build !windows
 
 package win_wmi


### PR DESCRIPTION
The go generate command to update the readmes needs to be included in both the plugin + notlinux or notwindows files.
