### PR TITLE
fix(inputs.internet_speed): rename host tag to source

### DIFF
--- a/plugins/inputs/internet_speed/README.md
+++ b/plugins/inputs/internet_speed/README.md
@@ -62,11 +62,11 @@ And the following tags:
 
 | Name      | tag name  |
 | --------- | --------- |
-| Host      | host      |
+| Source    | source    |
 | Server ID | server_id |
 
 ## Example Output
 
 ```sh
-internet_speed,host=speedtest02.z4internet.com:8080,server_id=54619 download=318.37580265897725,upload=30.444407341274385,latency=37.73174,jitter=1.99810 1675458921000000000
+internet_speed,source=speedtest02.z4internet.com:8080,server_id=54619 download=318.37580265897725,upload=30.444407341274385,latency=37.73174,jitter=1.99810 1675458921000000000
 ```

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -78,7 +78,7 @@ func (is *InternetSpeed) Gather(acc telegraf.Accumulator) error {
 	}
 	tags := map[string]string{
 		"server_id": is.server.ID,
-		"host":      is.server.Host,
+		"source":    is.server.Host,
 	}
 	// recycle the detailed data of each test to prevent data backlog
 	is.server.Context.Reset()


### PR DESCRIPTION
This avoids conflict with the global 'host' tag.

fixes: #12876