### PR TITLE
fix(config): return error on order set as string

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1611,6 +1611,8 @@ func (c *Config) getFieldInt64(tbl *ast.Table, fieldName string, target *int64) 
 					return
 				}
 				*target = i
+			} else {
+				c.addError(tbl, fmt.Errorf("found unexpected format while parsing %q, expecting int", fieldName))
 			}
 		}
 	}


### PR DESCRIPTION
Order should be a number, not a string, so instead of silently failing we should call the user to action.

fixes: #12879
