### PR TITLE
fix(secretstores): Handle array of secrets correctly

### DIFF
--- a/config/secret.go
+++ b/config/secret.go
@@ -162,6 +162,23 @@ func (s *Secret) Get() ([]byte, error) {
 	return newsecret, protect(newsecret)
 }
 
+// Set overwrites the secret's value with a new one. Please note, the secret
+// is not linked again, so only references to secret-stores can be used, e.g. by
+// adding more clear-text or reordering secrets.
+func (s *Secret) Set(value []byte) error {
+	// Link the new value can be resolved
+	secret, res, replaceErrs := resolve(value, s.resolvers)
+	if len(replaceErrs) > 0 {
+		return fmt.Errorf("linking new secrets failed: %s", strings.Join(replaceErrs, ";"))
+	}
+
+	// Set the new secret
+	s.enclave = memguard.NewEnclave(secret)
+	s.resolvers = res
+
+	return nil
+}
+
 // GetUnlinked return the parts of the secret that is not yet linked to a resolver
 func (s *Secret) GetUnlinked() []string {
 	return s.unlinked
@@ -170,9 +187,6 @@ func (s *Secret) GetUnlinked() []string {
 // Link used the given resolver map to link the secret parts to their
 // secret-store resolvers.
 func (s *Secret) Link(resolvers map[string]telegraf.ResolveFunc) error {
-	// Setup the resolver map
-	s.resolvers = make(map[string]telegraf.ResolveFunc)
-
 	// Decrypt the secret so we can return it
 	if s.enclave == nil {
 		return nil
@@ -186,7 +200,28 @@ func (s *Secret) Link(resolvers map[string]telegraf.ResolveFunc) error {
 
 	// Iterate through the parts and try to resolve them. For static parts
 	// we directly replace them, while for dynamic ones we store the resolver.
+	newsecret, res, replaceErrs := resolve(secret, resolvers)
+	if len(replaceErrs) > 0 {
+		return fmt.Errorf("linking secrets failed: %s", strings.Join(replaceErrs, ";"))
+	}
+	s.resolvers = res
+
+	// Store the secret if it has changed
+	if string(secret) != string(newsecret) {
+		s.enclave = memguard.NewEnclave(newsecret)
+	}
+
+	// All linked now
+	s.unlinked = nil
+
+	return nil
+}
+
+func resolve(secret []byte, resolvers map[string]telegraf.ResolveFunc) ([]byte, map[string]telegraf.ResolveFunc, []string) {
+	// Iterate through the parts and try to resolve them. For static parts
+	// we directly replace them, while for dynamic ones we store the resolver.
 	replaceErrs := make([]string, 0)
+	remaining := make(map[string]telegraf.ResolveFunc)
 	newsecret := secretPattern.ReplaceAllFunc(secret, func(match []byte) []byte {
 		resolver, found := resolvers[string(match)]
 		if !found {
@@ -205,22 +240,10 @@ func (s *Secret) Link(resolvers map[string]telegraf.ResolveFunc) error {
 		}
 
 		// Keep the resolver for dynamic secrets
-		s.resolvers[string(match)] = resolver
+		remaining[string(match)] = resolver
 		return match
 	})
-	if len(replaceErrs) > 0 {
-		return fmt.Errorf("linking secrets failed: %s", strings.Join(replaceErrs, ";"))
-	}
-
-	// Store the secret if it has changed
-	if string(secret) != string(newsecret) {
-		s.enclave = memguard.NewEnclave(newsecret)
-	}
-
-	// All linked now
-	s.unlinked = nil
-
-	return nil
+	return newsecret, remaining, replaceErrs
 }
 
 func splitLink(s string) (storeid string, key string) {

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -480,6 +480,8 @@ func TestSecretStoreInvalidReference(t *testing.T) {
 }
 
 func TestSecretStoreStaticChanging(t *testing.T) {
+	defer func() { unlinkedSecrets = make([]*Secret, 0) }()
+
 	cfg := []byte(
 		`
 [[inputs.mockup]]
@@ -520,6 +522,8 @@ func TestSecretStoreStaticChanging(t *testing.T) {
 }
 
 func TestSecretStoreDynamic(t *testing.T) {
+	defer func() { unlinkedSecrets = make([]*Secret, 0) }()
+
 	cfg := []byte(
 		`
 [[inputs.mockup]]
@@ -554,6 +558,8 @@ func TestSecretStoreDynamic(t *testing.T) {
 }
 
 func TestSecretStoreDeclarationMissingID(t *testing.T) {
+	defer func() { unlinkedSecrets = make([]*Secret, 0) }()
+
 	cfg := []byte(`[[secretstores.mockup]]`)
 
 	c := NewConfig()
@@ -562,6 +568,8 @@ func TestSecretStoreDeclarationMissingID(t *testing.T) {
 }
 
 func TestSecretStoreDeclarationInvalidID(t *testing.T) {
+	defer func() { unlinkedSecrets = make([]*Secret, 0) }()
+
 	invalidIDs := []string{"foo.bar", "dummy-123", "test!", "wohoo+"}
 	tmpl := `
   [[secretstores.mockup]]
@@ -578,6 +586,8 @@ func TestSecretStoreDeclarationInvalidID(t *testing.T) {
 }
 
 func TestSecretStoreDeclarationValidID(t *testing.T) {
+	defer func() { unlinkedSecrets = make([]*Secret, 0) }()
+
 	validIDs := []string{"foobar", "dummy123", "test_id", "W0Hoo_lala123"}
 	tmpl := `
   [[secretstores.mockup]]
@@ -591,6 +601,97 @@ func TestSecretStoreDeclarationValidID(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestSecretSet(t *testing.T) {
+	defer func() { unlinkedSecrets = make([]*Secret, 0) }()
+
+	cfg := []byte(`
+      [[inputs.mockup]]
+	    secret = "a secret"
+	`)
+	c := NewConfig()
+	require.NoError(t, c.LoadConfigData(cfg))
+	require.Len(t, c.Inputs, 1)
+	require.NoError(t, c.LinkSecrets())
+
+	plugin := c.Inputs[0].Input.(*MockupSecretPlugin)
+
+	secret, err := plugin.Secret.Get()
+	require.NoError(t, err)
+	defer ReleaseSecret(secret)
+	require.EqualValues(t, "a secret", string(secret))
+
+	require.NoError(t, plugin.Secret.Set([]byte("another secret")))
+	newsecret, err := plugin.Secret.Get()
+	require.NoError(t, err)
+	defer ReleaseSecret(newsecret)
+	require.EqualValues(t, "another secret", string(newsecret))
+}
+
+func TestSecretSetResolve(t *testing.T) {
+	defer func() { unlinkedSecrets = make([]*Secret, 0) }()
+
+	cfg := []byte(`
+      [[inputs.mockup]]
+	    secret = "@{mock:secret}"
+	`)
+	c := NewConfig()
+	require.NoError(t, c.LoadConfigData(cfg))
+	require.Len(t, c.Inputs, 1)
+
+	// Create a mockup secretstore
+	store := &MockupSecretStore{
+		Secrets: map[string][]byte{"secret": []byte("Ood Bnar")},
+		Dynamic: true,
+	}
+	require.NoError(t, store.Init())
+	c.SecretStores["mock"] = store
+	require.NoError(t, c.LinkSecrets())
+
+	plugin := c.Inputs[0].Input.(*MockupSecretPlugin)
+
+	secret, err := plugin.Secret.Get()
+	require.NoError(t, err)
+	defer ReleaseSecret(secret)
+	require.EqualValues(t, "Ood Bnar", string(secret))
+
+	require.NoError(t, plugin.Secret.Set([]byte("@{mock:secret} is cool")))
+	newsecret, err := plugin.Secret.Get()
+	require.NoError(t, err)
+	defer ReleaseSecret(newsecret)
+	require.EqualValues(t, "Ood Bnar is cool", string(newsecret))
+}
+
+func TestSecretSetResolveInvalid(t *testing.T) {
+	defer func() { unlinkedSecrets = make([]*Secret, 0) }()
+
+	cfg := []byte(`
+      [[inputs.mockup]]
+	    secret = "@{mock:secret}"
+	`)
+	c := NewConfig()
+	require.NoError(t, c.LoadConfigData(cfg))
+	require.Len(t, c.Inputs, 1)
+
+	// Create a mockup secretstore
+	store := &MockupSecretStore{
+		Secrets: map[string][]byte{"secret": []byte("Ood Bnar")},
+		Dynamic: true,
+	}
+	require.NoError(t, store.Init())
+	c.SecretStores["mock"] = store
+	require.NoError(t, c.LinkSecrets())
+
+	plugin := c.Inputs[0].Input.(*MockupSecretPlugin)
+
+	secret, err := plugin.Secret.Get()
+	require.NoError(t, err)
+	defer ReleaseSecret(secret)
+	require.EqualValues(t, "Ood Bnar", string(secret))
+
+	err = plugin.Secret.Set([]byte("@{mock:another_secret}"))
+	require.ErrorContains(t, err, `linking new secrets failed: unlinked part "@{mock:another_secret}"`)
 }
 
 /*** Mockup (input) plugin for testing to avoid cyclic dependencies ***/

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -26,31 +26,31 @@ import (
 var sampleConfig string
 
 type Mysql struct {
-	Servers                             []config.Secret `toml:"servers"`
-	PerfEventsStatementsDigestTextLimit int64           `toml:"perf_events_statements_digest_text_limit"`
-	PerfEventsStatementsLimit           int64           `toml:"perf_events_statements_limit"`
-	PerfEventsStatementsTimeLimit       int64           `toml:"perf_events_statements_time_limit"`
-	TableSchemaDatabases                []string        `toml:"table_schema_databases"`
-	GatherProcessList                   bool            `toml:"gather_process_list"`
-	GatherUserStatistics                bool            `toml:"gather_user_statistics"`
-	GatherInfoSchemaAutoInc             bool            `toml:"gather_info_schema_auto_inc"`
-	GatherInnoDBMetrics                 bool            `toml:"gather_innodb_metrics"`
-	GatherSlaveStatus                   bool            `toml:"gather_slave_status"`
-	GatherAllSlaveChannels              bool            `toml:"gather_all_slave_channels"`
-	MariadbDialect                      bool            `toml:"mariadb_dialect"`
-	GatherBinaryLogs                    bool            `toml:"gather_binary_logs"`
-	GatherTableIOWaits                  bool            `toml:"gather_table_io_waits"`
-	GatherTableLockWaits                bool            `toml:"gather_table_lock_waits"`
-	GatherIndexIOWaits                  bool            `toml:"gather_index_io_waits"`
-	GatherEventWaits                    bool            `toml:"gather_event_waits"`
-	GatherTableSchema                   bool            `toml:"gather_table_schema"`
-	GatherFileEventsStats               bool            `toml:"gather_file_events_stats"`
-	GatherPerfEventsStatements          bool            `toml:"gather_perf_events_statements"`
-	GatherGlobalVars                    bool            `toml:"gather_global_variables"`
-	GatherPerfSummaryPerAccountPerEvent bool            `toml:"gather_perf_sum_per_acc_per_event"`
-	PerfSummaryEvents                   []string        `toml:"perf_summary_events"`
-	IntervalSlow                        config.Duration `toml:"interval_slow"`
-	MetricVersion                       int             `toml:"metric_version"`
+	Servers                             []*config.Secret `toml:"servers"`
+	PerfEventsStatementsDigestTextLimit int64            `toml:"perf_events_statements_digest_text_limit"`
+	PerfEventsStatementsLimit           int64            `toml:"perf_events_statements_limit"`
+	PerfEventsStatementsTimeLimit       int64            `toml:"perf_events_statements_time_limit"`
+	TableSchemaDatabases                []string         `toml:"table_schema_databases"`
+	GatherProcessList                   bool             `toml:"gather_process_list"`
+	GatherUserStatistics                bool             `toml:"gather_user_statistics"`
+	GatherInfoSchemaAutoInc             bool             `toml:"gather_info_schema_auto_inc"`
+	GatherInnoDBMetrics                 bool             `toml:"gather_innodb_metrics"`
+	GatherSlaveStatus                   bool             `toml:"gather_slave_status"`
+	GatherAllSlaveChannels              bool             `toml:"gather_all_slave_channels"`
+	MariadbDialect                      bool             `toml:"mariadb_dialect"`
+	GatherBinaryLogs                    bool             `toml:"gather_binary_logs"`
+	GatherTableIOWaits                  bool             `toml:"gather_table_io_waits"`
+	GatherTableLockWaits                bool             `toml:"gather_table_lock_waits"`
+	GatherIndexIOWaits                  bool             `toml:"gather_index_io_waits"`
+	GatherEventWaits                    bool             `toml:"gather_event_waits"`
+	GatherTableSchema                   bool             `toml:"gather_table_schema"`
+	GatherFileEventsStats               bool             `toml:"gather_file_events_stats"`
+	GatherPerfEventsStatements          bool             `toml:"gather_perf_events_statements"`
+	GatherGlobalVars                    bool             `toml:"gather_global_variables"`
+	GatherPerfSummaryPerAccountPerEvent bool             `toml:"gather_perf_sum_per_acc_per_event"`
+	PerfSummaryEvents                   []string         `toml:"perf_summary_events"`
+	IntervalSlow                        config.Duration  `toml:"interval_slow"`
+	MetricVersion                       int              `toml:"metric_version"`
 
 	Log telegraf.Logger `toml:"-"`
 	tls.ClientConfig
@@ -80,7 +80,8 @@ func (m *Mysql) Init() error {
 
 	// Default to localhost if nothing specified.
 	if len(m.Servers) == 0 {
-		m.Servers = append(m.Servers, config.NewSecret([]byte(localhost)))
+		s := config.NewSecret([]byte(localhost))
+		m.Servers = append(m.Servers, &s)
 	}
 
 	// Register the TLS configuration. Due to the registry being a global
@@ -106,7 +107,7 @@ func (m *Mysql) Init() error {
 	for i, server := range m.Servers {
 		s, err := server.Get()
 		if err != nil {
-			return fmt.Errorf("getting server %d failed", i)
+			return fmt.Errorf("getting server %d failed: %w", i, err)
 		}
 		dsn := string(s)
 		config.ReleaseSecret(s)
@@ -140,7 +141,7 @@ func (m *Mysql) Gather(acc telegraf.Accumulator) error {
 	// Loop through each server and collect metrics
 	for _, server := range m.Servers {
 		wg.Add(1)
-		go func(s config.Secret) {
+		go func(s *config.Secret) {
 			defer wg.Done()
 			acc.AddError(m.gatherServer(s, acc))
 		}(server)
@@ -413,7 +414,7 @@ const (
 	`
 )
 
-func (m *Mysql) gatherServer(server config.Secret, acc telegraf.Accumulator) error {
+func (m *Mysql) gatherServer(server *config.Secret, acc telegraf.Accumulator) error {
 	s, err := server.Get()
 	if err != nil {
 		return err

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -125,8 +125,10 @@ func (m *Mysql) Init() error {
 			conf.TLSConfig = tlsid
 		}
 
-		server.Destroy()
-		m.Servers[i] = config.NewSecret([]byte(conf.FormatDSN()))
+		if err := server.Set([]byte(conf.FormatDSN())); err != nil {
+			return fmt.Errorf("replacing server %q failed: %w", dsn, err)
+		}
+		m.Servers[i] = server
 	}
 
 	return nil

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -37,8 +37,9 @@ func TestMysqlDefaultsToLocalIntegration(t *testing.T) {
 	defer container.Terminate()
 
 	dsn := fmt.Sprintf("root@tcp(%s:%s)/", container.Address, container.Ports[servicePort])
+	s := config.NewSecret([]byte(dsn))
 	m := &Mysql{
-		Servers: []config.Secret{config.NewSecret([]byte(dsn))},
+		Servers: []*config.Secret{&s},
 	}
 	require.NoError(t, m.Init())
 
@@ -72,8 +73,9 @@ func TestMysqlMultipleInstancesIntegration(t *testing.T) {
 	defer container.Terminate()
 
 	dsn := fmt.Sprintf("root@tcp(%s:%s)/?tls=false", container.Address, container.Ports[servicePort])
+	s := config.NewSecret([]byte(dsn))
 	m := &Mysql{
-		Servers:          []config.Secret{config.NewSecret([]byte(dsn))},
+		Servers:          []*config.Secret{&s},
 		IntervalSlow:     config.Duration(30 * time.Second),
 		GatherGlobalVars: true,
 		MetricVersion:    2,
@@ -87,8 +89,9 @@ func TestMysqlMultipleInstancesIntegration(t *testing.T) {
 	// acc should have global variables
 	require.True(t, acc.HasMeasurement("mysql_variables"))
 
+	s2 := config.NewSecret([]byte(dsn))
 	m2 := &Mysql{
-		Servers:       []config.Secret{config.NewSecret([]byte(dsn))},
+		Servers:       []*config.Secret{&s2},
 		MetricVersion: 2,
 	}
 	require.NoError(t, m2.Init())
@@ -205,8 +208,9 @@ func TestMysqlDNSAddTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			s := config.NewSecret([]byte(tt.input))
 			m := &Mysql{
-				Servers: []config.Secret{config.NewSecret([]byte(tt.input))},
+				Servers: []*config.Secret{&s},
 			}
 			require.NoError(t, m.Init())
 			equal, err := m.Servers[0].EqualTo([]byte(tt.output))

--- a/plugins/inputs/sqlserver/azuresqldbqueries_test.go
+++ b/plugins/inputs/sqlserver/azuresqldbqueries_test.go
@@ -20,10 +20,10 @@ func TestAzureSQLIntegration_Database_ResourceStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLDBResourceStats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -66,10 +66,10 @@ func TestAzureSQLIntegration_Database_ResourceGovernance_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLDBResourceGovernance"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -128,10 +128,10 @@ func TestAzureSQLIntegration_Database_WaitStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLDBWaitStats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -166,10 +166,10 @@ func TestAzureSQLIntegration_Database_DatabaseIO_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLDBDatabaseIO"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -213,10 +213,10 @@ func TestAzureSQLIntegration_Database_ServerProperties_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLDBServerProperties"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -255,10 +255,10 @@ func TestAzureSQLIntegration_Database_OsWaitstats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLDBOsWaitstats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -294,10 +294,10 @@ func TestAzureSQLIntegration_Database_MemoryClerks_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLDBMemoryClerks"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -328,10 +328,10 @@ func TestAzureSQLIntegration_Database_PerformanceCounters_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLDBPerformanceCounters"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -365,10 +365,10 @@ func TestAzureSQLIntegration_Database_Requests_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLDBRequests"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",
@@ -424,10 +424,10 @@ func TestAzureSQLIntegration_Database_Schedulers_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_DB_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLDBSchedulers"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLDB",

--- a/plugins/inputs/sqlserver/azuresqlmanagedqueries_test.go
+++ b/plugins/inputs/sqlserver/azuresqlmanagedqueries_test.go
@@ -19,10 +19,10 @@ func TestAzureSQLIntegration_Managed_ResourceStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLMIResourceStats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -53,10 +53,10 @@ func TestAzureSQLIntegration_Managed_ResourceGovernance_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLMIResourceGovernance"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -95,10 +95,10 @@ func TestAzureSQLIntegration_Managed_DatabaseIO_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLMIDatabaseIO"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -138,10 +138,10 @@ func TestAzureSQLIntegration_Managed_ServerProperties_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLMIServerProperties"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -186,10 +186,10 @@ func TestAzureSQLIntegration_Managed_OsWaitStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLMIOsWaitstats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -224,10 +224,10 @@ func TestAzureSQLIntegration_Managed_MemoryClerks_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLMIMemoryClerks"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -257,10 +257,10 @@ func TestAzureSQLIntegration_Managed_PerformanceCounters_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLMIPerformanceCounters"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -293,10 +293,10 @@ func TestAzureSQLIntegration_Managed_Requests_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLMIRequests"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",
@@ -352,10 +352,10 @@ func TestAzureSQLIntegration_Managed_Schedulers_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_MI_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLMISchedulers"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLManagedInstance",

--- a/plugins/inputs/sqlserver/azuresqlpoolqueries_test.go
+++ b/plugins/inputs/sqlserver/azuresqlpoolqueries_test.go
@@ -19,10 +19,10 @@ func TestAzureSQLIntegration_ElasticPool_ResourceStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLPoolResourceStats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -62,10 +62,10 @@ func TestAzureSQLIntegration_ElasticPool_ResourceGovernance_Query(t *testing.T) 
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLPoolResourceGovernance"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -126,10 +126,10 @@ func TestAzureSQLIntegration_ElasticPool_DatabaseIO_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLPoolDatabaseIO"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -171,10 +171,10 @@ func TestAzureSQLIntegration_ElasticPool_OsWaitStats_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLPoolOsWaitStats"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -209,10 +209,10 @@ func TestAzureSQLIntegration_ElasticPool_MemoryClerks_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLPoolMemoryClerks"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -242,10 +242,10 @@ func TestAzureSQLIntegration_ElasticPool_PerformanceCounters_Query(t *testing.T)
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLPoolPerformanceCounters"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",
@@ -277,10 +277,10 @@ func TestAzureSQLIntegration_ElasticPool_Schedulers_Query(t *testing.T) {
 	}
 
 	connectionString := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
-	serversList := []config.Secret{config.NewSecret([]byte(connectionString))}
+	sl := config.NewSecret([]byte(connectionString))
 
 	server := &SQLServer{
-		Servers:      serversList,
+		Servers:      []*config.Secret{&sl},
 		IncludeQuery: []string{"AzureSQLPoolSchedulers"},
 		AuthMethod:   "connection_string",
 		DatabaseType: "AzureSQLPool",

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -25,16 +25,16 @@ var sampleConfig string
 
 // SQLServer struct
 type SQLServer struct {
-	Servers      []config.Secret `toml:"servers"`
-	QueryTimeout config.Duration `toml:"query_timeout"`
-	AuthMethod   string          `toml:"auth_method"`
-	QueryVersion int             `toml:"query_version" deprecated:"1.16.0;use 'database_type' instead"`
-	AzureDB      bool            `toml:"azuredb" deprecated:"1.16.0;use 'database_type' instead"`
-	DatabaseType string          `toml:"database_type"`
-	IncludeQuery []string        `toml:"include_query"`
-	ExcludeQuery []string        `toml:"exclude_query"`
-	HealthMetric bool            `toml:"health_metric"`
-	Log          telegraf.Logger `toml:"-"`
+	Servers      []*config.Secret `toml:"servers"`
+	QueryTimeout config.Duration  `toml:"query_timeout"`
+	AuthMethod   string           `toml:"auth_method"`
+	QueryVersion int              `toml:"query_version" deprecated:"1.16.0;use 'database_type' instead"`
+	AzureDB      bool             `toml:"azuredb" deprecated:"1.16.0;use 'database_type' instead"`
+	DatabaseType string           `toml:"database_type"`
+	IncludeQuery []string         `toml:"include_query"`
+	ExcludeQuery []string         `toml:"exclude_query"`
+	HealthMetric bool             `toml:"health_metric"`
+	Log          telegraf.Logger  `toml:"-"`
 
 	pools       []*sql.DB
 	queries     MapQuery
@@ -450,7 +450,8 @@ func (s *SQLServer) getDatabaseTypeToLog() string {
 
 func (s *SQLServer) Init() error {
 	if len(s.Servers) == 0 {
-		s.Log.Warn("Warning: Server list is empty.")
+		srv := config.NewSecret([]byte(defaultServer))
+		s.Servers = append(s.Servers, &srv)
 	}
 
 	return nil
@@ -547,7 +548,6 @@ func (s *SQLServer) refreshToken() (*adal.Token, error) {
 func init() {
 	inputs.Add("sqlserver", func() telegraf.Input {
 		return &SQLServer{
-			Servers:    []config.Secret{config.NewSecret([]byte(defaultServer))},
 			AuthMethod: "connection_string",
 		}
 	})

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -116,13 +116,15 @@ func TestSqlServerIntegration_MultipleInstance(t *testing.T) {
 	t.Skip("Skipping as unable to open tcp connection with host '127.0.0.1:1433")
 
 	testServer := "Server=127.0.0.1;Port=1433;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"
+	sl := config.NewSecret([]byte(testServer))
 	s := &SQLServer{
-		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
+		Servers:      []*config.Secret{&sl},
 		ExcludeQuery: []string{"MemoryClerk"},
 		Log:          testutil.Logger{},
 	}
+	sl2 := config.NewSecret([]byte(testServer))
 	s2 := &SQLServer{
-		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
+		Servers:      []*config.Secret{&sl2},
 		ExcludeQuery: []string{"DatabaseSize"},
 		Log:          testutil.Logger{},
 	}
@@ -153,13 +155,16 @@ func TestSqlServerIntegration_MultipleInstanceWithHealthMetric(t *testing.T) {
 	t.Skip("Skipping as unable to open tcp connection with host '127.0.0.1:1433")
 
 	testServer := "Server=127.0.0.1;Port=1433;User Id=SA;Password=ABCabc01;app name=telegraf;log=1"
+	sl := config.NewSecret([]byte(testServer))
 	s := &SQLServer{
-		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
+		Servers:      []*config.Secret{&sl},
 		ExcludeQuery: []string{"MemoryClerk"},
 		Log:          testutil.Logger{},
 	}
+
+	sl2 := config.NewSecret([]byte(testServer))
 	s2 := &SQLServer{
-		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
+		Servers:      []*config.Secret{&sl2},
 		ExcludeQuery: []string{"DatabaseSize"},
 		HealthMetric: true,
 		Log:          testutil.Logger{},
@@ -194,19 +199,20 @@ func TestSqlServer_HealthMetric(t *testing.T) {
 	fakeServer1 := "localhost\\fakeinstance1;Database=fakedb1;Password=ABCabc01;"
 	fakeServer2 := "localhost\\fakeinstance2;Database=fakedb2;Password=ABCabc01;"
 
+	fs1 := config.NewSecret([]byte(fakeServer1))
+	fs2 := config.NewSecret([]byte(fakeServer2))
+
 	s1 := &SQLServer{
-		Servers: []config.Secret{
-			config.NewSecret([]byte(fakeServer1)),
-			config.NewSecret([]byte(fakeServer2)),
-		},
+		Servers:      []*config.Secret{&fs1, &fs2},
 		IncludeQuery: []string{"DatabaseSize", "MemoryClerk"},
 		HealthMetric: true,
 		AuthMethod:   "connection_string",
 		Log:          testutil.Logger{},
 	}
 
+	sl2 := config.NewSecret([]byte(fakeServer1))
 	s2 := &SQLServer{
-		Servers:      []config.Secret{config.NewSecret([]byte(fakeServer1))},
+		Servers:      []*config.Secret{&sl2},
 		IncludeQuery: []string{"DatabaseSize"},
 		AuthMethod:   "connection_string",
 		Log:          testutil.Logger{},
@@ -347,14 +353,17 @@ func TestSqlServerIntegration_AGQueriesApplicableForDatabaseTypeSQLServer(t *tes
 	}
 	testServer := os.Getenv("AZURESQL_POOL_CONNECTION_STRING")
 
+	sl := config.NewSecret([]byte(testServer))
 	s := &SQLServer{
-		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
+		Servers:      []*config.Secret{&sl},
 		DatabaseType: "SQLServer",
 		IncludeQuery: []string{"SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates"},
 		Log:          testutil.Logger{},
 	}
+
+	sl2 := config.NewSecret([]byte(testServer))
 	s2 := &SQLServer{
-		Servers:      []config.Secret{config.NewSecret([]byte(testServer))},
+		Servers:      []*config.Secret{&sl2},
 		DatabaseType: "AzureSQLDB",
 		IncludeQuery: []string{"SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates"},
 		Log:          testutil.Logger{},
@@ -398,14 +407,17 @@ func TestSqlServerIntegration_AGQueryFieldsOutputBasedOnSQLServerVersion(t *test
 	testServer2019 := os.Getenv("AZURESQL_POOL_CONNECTION_STRING_2019")
 	testServer2012 := os.Getenv("AZURESQL_POOL_CONNECTION_STRING_2012")
 
+	sl2019 := config.NewSecret([]byte(testServer2019))
+	sl2012 := config.NewSecret([]byte(testServer2012))
+
 	s2019 := &SQLServer{
-		Servers:      []config.Secret{config.NewSecret([]byte(testServer2019))},
+		Servers:      []*config.Secret{&sl2019},
 		DatabaseType: "SQLServer",
 		IncludeQuery: []string{"SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates"},
 		Log:          testutil.Logger{},
 	}
 	s2012 := &SQLServer{
-		Servers:      []config.Secret{config.NewSecret([]byte(testServer2012))},
+		Servers:      []*config.Secret{&sl2012},
 		DatabaseType: "SQLServer",
 		IncludeQuery: []string{"SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates"},
 		Log:          testutil.Logger{},


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12916

When dealing with arrays of secrets (`[]config.Secret`) the unlinked secret is not kept in the array leading to unresolved secrets. The main reason is that the array is referenced by value and thus the modifications done by config during unlinking are discarded. This PR changes the occurrences of secret arrays to be an array of pointers and thus fixing the issue.