### PR TITLE
chore: fix gosec G102 issues

### DIFF
--- a/plugins/common/proxy/socks5_test.go
+++ b/plugins/common/proxy/socks5_test.go
@@ -15,7 +15,7 @@ func TestSocks5ProxyConfigIntegration(t *testing.T) {
 	}
 
 	const (
-		proxyAddress  = "0.0.0.0:12345"
+		proxyAddress  = "127.0.0.1:12345"
 		proxyUsername = "user"
 		proxyPassword = "password"
 	)

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -592,7 +592,7 @@ func TestExponentialBackoff(t *testing.T) {
 	max := 3
 
 	// get an unused port by listening on next available port, then closing it
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	port := listener.Addr().(*net.TCPAddr).Port
 	require.NoError(t, listener.Close())

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -83,7 +83,7 @@ func TestGatherRemoteIntegration(t *testing.T) {
 				}
 			}
 
-			ln, err := tls.Listen("tcp", ":0", cfg)
+			ln, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
 			require.NoError(t, err)
 			defer ln.Close()
 


### PR DESCRIPTION
Do not bind to all interfaces during tests, specify localhost