### PR TITLE
chore(deps): Bump govulncheck-action from 0.0.9 to 0.10.0

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Scan for Vulnerabilities in Code
-        uses: Templum/govulncheck-action@v0.0.9
+        uses: Templum/govulncheck-action@v0.10.0
         with:
           go-version: '1.20'
           vulncheck-version: latest


### PR DESCRIPTION
Bump github action to latest version.