### PR TITLE
fix(inputs.execd): read from stdout using ReadLine instead of scanner.Scan to overcome 64kb buffer limit

### DIFF
--- a/plugins/inputs/execd/README.md
+++ b/plugins/inputs/execd/README.md
@@ -50,6 +50,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Delay before the process is restarted after an unexpected termination
   restart_delay = "10s"
 
+  ## Buffer size used to read from the command output stream
+  ## Optional parameter. Default is 64 Kib, minimum is 16 bytes
+  buffer_size = "64Kib"
+
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/inputs/execd/README.md
+++ b/plugins/inputs/execd/README.md
@@ -52,7 +52,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Buffer size used to read from the command output stream
   ## Optional parameter. Default is 64 Kib, minimum is 16 bytes
-  buffer_size = "64Kib"
+  # buffer_size = "64Kib"
 
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -105,7 +105,6 @@ func (e *Execd) cmdReadOut(out io.Reader) {
 			e.acc.AddMetric(metric)
 		}
 	}
-
 }
 
 func (e *Execd) cmdReadOutStream(out io.Reader) {

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -29,7 +29,7 @@ type Execd struct {
 	Signal       string          `toml:"signal"`
 	RestartDelay config.Duration `toml:"restart_delay"`
 	Log          telegraf.Logger `toml:"-"`
-	BufferSize   int             `toml:"buffer_size"`
+	BufferSize   config.Size     `toml:"buffer_size"`
 
 	process      *process.Process
 	acc          telegraf.Accumulator
@@ -84,7 +84,7 @@ func (e *Execd) Stop() {
 }
 
 func (e *Execd) cmdReadOut(out io.Reader) {
-	rdr := bufio.NewReaderSize(out, e.BufferSize*1024)
+	rdr := bufio.NewReaderSize(out, int(e.BufferSize))
 
 	for {
 		data, err := rdr.ReadBytes('\n')
@@ -156,7 +156,7 @@ func init() {
 		return &Execd{
 			Signal:       "none",
 			RestartDelay: config.Duration(10 * time.Second),
-			BufferSize:   64,
+			BufferSize:   config.Size(64 * 1024),
 		}
 	})
 }

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -84,18 +84,16 @@ func (e *Execd) Stop() {
 }
 
 func (e *Execd) cmdReadOut(out io.Reader) {
-
 	rdr := bufio.NewReaderSize(out, e.BufferSize*1024)
 
 	for {
 		data, err := rdr.ReadBytes('\n')
 		if err != nil {
-			if err == io.EOF || errors.Is(err, os.ErrClosed) {
+			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
 				break
-			} else {
-				e.acc.AddError(fmt.Errorf("error reading stdout: %w", err))
-				continue
 			}
+			e.acc.AddError(fmt.Errorf("error reading stdout: %w", err))
+			continue
 		}
 
 		metrics, err := e.parser.Parse(data)

--- a/plugins/inputs/execd/sample.conf
+++ b/plugins/inputs/execd/sample.conf
@@ -25,7 +25,7 @@
 
   ## Buffer size used to read from the command output stream
   ## Optional parameter. Default is 64 Kib, minimum is 16 bytes
-  buffer_size = "64Kib"
+  # buffer_size = "64Kib"
 
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/inputs/execd/sample.conf
+++ b/plugins/inputs/execd/sample.conf
@@ -23,6 +23,10 @@
   ## Delay before the process is restarted after an unexpected termination
   restart_delay = "10s"
 
+  ## Buffer size used to read from the command output stream
+  ## Optional parameter. Default is 64 Kib, minimum is 16 bytes
+  buffer_size = "64Kib"
+
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format]

Resolves #12934

- Fixed code for reading stdout from the underlying command. See #12934 for details.
- Introduced additional parameter to control the buffer size (in kb) used to read the stream. Not strictly required, but handy.