### PR TITLE
chore: Enable G106, G108, G109, G111, G201, G203 rules for gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - exportloopref
     - gocheckcompilerdirectives
     - goprintffuncname
+    - gosec
     - gosimple
     - govet
     - ineffassign
@@ -75,6 +76,17 @@ linters-settings:
       - "**/testutil/**"
       - "**/tools/**"
       - "**/*_test.go"
+  gosec:
+    # To select a subset of rules to run.
+    # Available rules: https://github.com/securego/gosec#available-rules
+    # Default: [] - means include all rules
+    includes:
+      - G106
+      - G108
+      - G109
+      - G111
+      - G201
+      - G203
   lll:
     # Max line length, lines longer will be reported.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option.


### PR DESCRIPTION
Enable following rules for [gosec](https://github.com/securego/gosec) (agreed with community):

- G106: Audit the use of ssh.InsecureIgnoreHostKey
- G108: Profiling endpoint automatically exposed on /debug/pprof
- G109: Potential Integer overflow made by strconv.Atoi result conversion to int16/32
- G111: Potential directory traversal
- G201: SQL query construction using format string
- G203: Use of unescaped data in HTML templates

resolves: https://github.com/influxdata/telegraf/issues/12893 https://github.com/influxdata/telegraf/issues/12895 https://github.com/influxdata/telegraf/issues/12896 https://github.com/influxdata/telegraf/issues/12898 https://github.com/influxdata/telegraf/issues/12902 https://github.com/influxdata/telegraf/issues/12904