### PR TITLE
chore: Don't use all default exclude patterns for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -188,9 +188,25 @@ issues:
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
 
+  # List of regexps of issue texts to exclude.
+  #
+  # But independently of this option we use default exclude patterns,
+  # it can be disabled by `exclude-use-default: false`.
+  # To list all excluded by default patterns execute `golangci-lint run --help`
+  #
+  # Default: https://golangci-lint.run/usage/false-positives/#default-exclusions
   exclude:
-    - don't use an underscore in package name #revive:var-naming
+    # revive:var-naming
+    - don't use an underscore in package name
+    # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+    - Unhandled error in call to function ((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv)
+    # EXC0013 revive: Annoying issue about not having a comment. The rare codebase has such comments
+    - package comment should be of the form "(.+)...
+    # EXC0015 revive: Annoying issue about not having a comment. The rare codebase has such comments
+    - should have a package comment
 
+  # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
     - path: plugins/parsers/influx
       linters:
@@ -201,6 +217,12 @@ issues:
 
     - path: cmd/telegraf/(main|printer).go
       text: "unhandled-error: Unhandled error in call to function outputBuffer.Write"
+
+  # Independently of option `exclude` we use default exclude patterns,
+  # it can be disabled by this option.
+  # To list all excluded by default patterns execute `golangci-lint run --help`.
+  # Default: true.
+  exclude-use-default: false
 
 # output configuration options
 output:

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -767,7 +767,6 @@ func (a *Agent) push(
 		select {
 		case <-time.After(until):
 			aggregator.Push(acc)
-			break
 		case <-ctx.Done():
 			aggregator.Push(acc)
 			return

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -179,7 +179,7 @@ func (c *CiscoTelemetryMDT) Start(acc telegraf.Accumulator) error {
 		var opts []grpc.ServerOption
 		tlsConfig, err := c.ServerConfig.TLSConfig()
 		if err != nil {
-			c.listener.Close() //nolint:revive // we cannot do anything if the closing fails
+			c.listener.Close()
 			return err
 		} else if tlsConfig != nil {
 			opts = append(opts, grpc.Creds(credentials.NewTLS(tlsConfig)))
@@ -210,7 +210,7 @@ func (c *CiscoTelemetryMDT) Start(acc telegraf.Accumulator) error {
 		}()
 
 	default:
-		c.listener.Close() //nolint:revive // we cannot do anything if the closing fails
+		c.listener.Close()
 		return fmt.Errorf("invalid Cisco MDT transport: %s", c.Transport)
 	}
 
@@ -731,7 +731,7 @@ func (c *CiscoTelemetryMDT) Stop() {
 		c.grpcServer.Stop()
 	}
 	if c.listener != nil {
-		c.listener.Close() //nolint:revive // we cannot do anything if the closing fails
+		c.listener.Close()
 	}
 	c.wg.Wait()
 }

--- a/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
+++ b/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
@@ -392,7 +392,7 @@ func (cms *CloudWatchMetricStreams) authenticateIfSet(handler http.HandlerFunc, 
 // Stop cleans up all resources
 func (cms *CloudWatchMetricStreams) Stop() {
 	if cms.listener != nil {
-		cms.listener.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+		cms.listener.Close()
 	}
 	cms.wg.Wait()
 }

--- a/plugins/inputs/dcos/client.go
+++ b/plugins/inputs/dcos/client.go
@@ -292,7 +292,7 @@ func (c *ClusterClient) doGet(ctx context.Context, address string, v interface{}
 		return err
 	}
 	defer func() {
-		resp.Body.Close() //nolint:revive // we cannot do anything if the closing fails
+		resp.Body.Close()
 		<-c.semaphore
 	}()
 

--- a/plugins/inputs/diskio/diskio_linux_test.go
+++ b/plugins/inputs/diskio/diskio_linux_test.go
@@ -37,7 +37,7 @@ func setupNullDisk(t *testing.T, s *DiskIO, devName string) func() {
 
 	cleanFunc := func() {
 		ic.udevDataPath = origUdevPath
-		os.Remove(td.Name()) //nolint:revive // we cannot do anything if file cannot be removed
+		os.Remove(td.Name())
 	}
 
 	ic.udevDataPath = td.Name()

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -137,7 +137,7 @@ func (h *HTTPListenerV2) createHTTPServer() *http.Server {
 // Stop cleans up all resources
 func (h *HTTPListenerV2) Stop() {
 	if h.listener != nil {
-		h.listener.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+		h.listener.Close()
 	}
 	h.wg.Wait()
 }

--- a/plugins/inputs/jenkins/client.go
+++ b/plugins/inputs/jenkins/client.go
@@ -69,7 +69,7 @@ func (c *client) doGet(ctx context.Context, url string, v interface{}) error {
 		return err
 	}
 	defer func() {
-		resp.Body.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+		resp.Body.Close()
 		<-c.semaphore
 	}()
 	// Clear invalid token if unauthorized

--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -514,7 +514,7 @@ func (m *Mesos) gatherMainMetrics(u *url.URL, role Role, acc telegraf.Accumulato
 	}
 
 	data, err := io.ReadAll(resp.Body)
-	resp.Body.Close() //nolint:revive // ignore the returned error to not shadow the initial one
+	resp.Body.Close()
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/nsq_consumer/nsq_consumer_test.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer_test.go
@@ -220,8 +220,8 @@ func (n *mockNSQD) handle(conn net.Conn) {
 	}
 
 exit:
-	n.tcpListener.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
-	conn.Close()          //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+	n.tcpListener.Close()
+	conn.Close()
 }
 
 func framedResponse(frameType int32, data []byte) ([]byte, error) {

--- a/plugins/inputs/passenger/passenger_test.go
+++ b/plugins/inputs/passenger/passenger_test.go
@@ -34,7 +34,7 @@ func fakePassengerStatus(stat string) (string, error) {
 }
 
 func teardown(tempFilePath string) {
-	os.Remove(tempFilePath) //nolint:revive // ignore the returned error as we want to remove the file and ignore missing file errors
+	os.Remove(tempFilePath)
 }
 
 func Test_Invalid_Passenger_Status_Cli(t *testing.T) {

--- a/plugins/inputs/phpfpm/child.go
+++ b/plugins/inputs/phpfpm/child.go
@@ -276,7 +276,7 @@ func (c *child) serveRequest(req *request, body io.ReadCloser) {
 		httpReq.Body = body
 		c.handler.ServeHTTP(r, httpReq)
 	}
-	r.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+	r.Close()
 	c.mu.Lock()
 	delete(c.requests, req.reqID)
 	c.mu.Unlock()
@@ -292,10 +292,10 @@ func (c *child) serveRequest(req *request, body io.ReadCloser) {
 	// can properly cut off the client sending all the data.
 	// For now just bound it a little and
 	io.CopyN(io.Discard, body, 100<<20) //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
-	body.Close()                        //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+	body.Close()
 
 	if !req.keepConn {
-		c.conn.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+		c.conn.Close()
 	}
 }
 
@@ -306,7 +306,7 @@ func (c *child) cleanUp() {
 		if req.pw != nil {
 			// race with call to Close in c.serveRequest doesn't matter because
 			// Pipe(Reader|Writer).Close are idempotent
-			req.pw.CloseWithError(ErrConnClosed) //nolint:revive // Ignore the returned error as we continue in the loop anyway
+			req.pw.CloseWithError(ErrConnClosed)
 		}
 	}
 }

--- a/plugins/inputs/phpfpm/fcgi.go
+++ b/plugins/inputs/phpfpm/fcgi.go
@@ -229,7 +229,7 @@ type bufWriter struct {
 
 func (w *bufWriter) Close() error {
 	if err := w.Writer.Flush(); err != nil {
-		w.closer.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+		w.closer.Close()
 		return err
 	}
 	return w.closer.Close()

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -143,7 +143,7 @@ func (p *Service) Start(telegraf.Accumulator) (err error) {
 
 // Stop stops the services and closes any necessary channels and connections
 func (p *Service) Stop() {
-	p.DB.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+	p.DB.Close()
 }
 
 var kvMatcher, _ = regexp.Compile(`(password|sslcert|sslkey|sslmode|sslrootcert)=\S+ ?`)

--- a/plugins/inputs/powerdns/powerdns_test.go
+++ b/plugins/inputs/powerdns/powerdns_test.go
@@ -58,7 +58,7 @@ func (s statServer) serverSocket(l net.Listener) {
 			data := buf[:n]
 			if string(data) == "show * \n" {
 				c.Write([]byte(metrics)) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
-				c.Close()                //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+				c.Close()
 			}
 		}(conn)
 	}

--- a/plugins/inputs/powerdns_recursor/powerdns_recursor_test.go
+++ b/plugins/inputs/powerdns_recursor/powerdns_recursor_test.go
@@ -112,8 +112,8 @@ func TestV1PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer func() {
-			socket.Close()           //nolint:revive // ignore the returned error as we need to remove the socket file anyway
-			os.Remove(controlSocket) //nolint:revive // ignore the returned error as we want to remove the file and ignore no-such-file errors
+			socket.Close()
+			os.Remove(controlSocket)
 			wg.Done()
 		}()
 
@@ -121,14 +121,14 @@ func TestV1PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 			buf := make([]byte, 1024)
 			n, remote, err := socket.ReadFromUnix(buf)
 			if err != nil {
-				socket.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+				socket.Close()
 				return
 			}
 
 			data := buf[:n]
 			if string(data) == "get-all\n" {
 				socket.WriteToUnix([]byte(metrics), remote) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
-				socket.Close()                              //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+				socket.Close()
 			}
 
 			time.Sleep(100 * time.Millisecond)
@@ -167,8 +167,8 @@ func TestV2PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer func() {
-			socket.Close()           //nolint:revive // ignore the returned error as we need to remove the socket file anyway
-			os.Remove(controlSocket) //nolint:revive // ignore the returned error as we want to remove the file and ignore no-such-file errors
+			socket.Close()
+			os.Remove(controlSocket)
 			wg.Done()
 		}()
 
@@ -176,14 +176,14 @@ func TestV2PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 			status := make([]byte, 4)
 			n, _, err := socket.ReadFromUnix(status)
 			if err != nil || n != 4 {
-				socket.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+				socket.Close()
 				return
 			}
 
 			buf := make([]byte, 1024)
 			n, remote, err := socket.ReadFromUnix(buf)
 			if err != nil {
-				socket.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+				socket.Close()
 				return
 			}
 
@@ -191,7 +191,7 @@ func TestV2PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 			if string(data) == "get-all" {
 				socket.WriteToUnix([]byte{0, 0, 0, 0}, remote) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
 				socket.WriteToUnix([]byte(metrics), remote)    //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
-				socket.Close()                                 //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+				socket.Close()
 			}
 
 			time.Sleep(100 * time.Millisecond)
@@ -229,8 +229,8 @@ func TestV3PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer func() {
-			socket.Close()           //nolint:revive // ignore the returned error as we need to remove the socket file anyway
-			os.Remove(controlSocket) //nolint:revive // ignore the returned error as we want to remove the file and ignore no-such-file errors
+			socket.Close()
+			os.Remove(controlSocket)
 			wg.Done()
 		}()
 
@@ -262,7 +262,7 @@ func TestV3PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 				metrics := []byte(metrics)
 				writeNativeUIntToConn(conn, uint(len(metrics))) //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
 				conn.Write(metrics)                             //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
-				socket.Close()                                  //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+				socket.Close()
 			}
 
 			time.Sleep(100 * time.Millisecond)

--- a/plugins/inputs/sflow/sflow.go
+++ b/plugins/inputs/sflow/sflow.go
@@ -90,7 +90,7 @@ func (s *SFlow) Gather(_ telegraf.Accumulator) error {
 
 func (s *SFlow) Stop() {
 	if s.closer != nil {
-		s.closer.Close() //nolint:revive // ignore the returned error as we cannot do anything about it anyway
+		s.closer.Close()
 	}
 	s.wg.Wait()
 }

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -868,7 +868,7 @@ func (s *Statsd) handler(conn *net.TCPConn, id string) {
 	// connection cleanup function
 	defer func() {
 		s.wg.Done()
-		conn.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+		conn.Close()
 
 		// Add one connection potential back to channel when this one closes
 		s.accept <- true
@@ -920,7 +920,7 @@ func (s *Statsd) handler(conn *net.TCPConn, id string) {
 
 // refuser refuses a TCP connection
 func (s *Statsd) refuser(conn *net.TCPConn) {
-	conn.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+	conn.Close()
 	s.Log.Infof("Refused TCP Connection from %s", conn.RemoteAddr())
 	s.Log.Warn("Maximum TCP Connections reached, you may want to adjust max_tcp_connections")
 }
@@ -945,11 +945,11 @@ func (s *Statsd) Stop() {
 	close(s.done)
 	if s.isUDP() {
 		if s.UDPlistener != nil {
-			s.UDPlistener.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+			s.UDPlistener.Close()
 		}
 	} else {
 		if s.TCPlistener != nil {
-			s.TCPlistener.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+			s.TCPlistener.Close()
 		}
 
 		// Close all open TCP connections
@@ -963,7 +963,7 @@ func (s *Statsd) Stop() {
 		}
 		s.cleanup.Unlock()
 		for _, conn := range conns {
-			conn.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+			conn.Close()
 		}
 	}
 	s.Unlock()

--- a/plugins/inputs/suricata/suricata.go
+++ b/plugins/inputs/suricata/suricata.go
@@ -70,7 +70,7 @@ func (s *Suricata) Start(acc telegraf.Accumulator) error {
 // Stop causes the plugin to cease collecting JSON data from the socket provided
 // to Suricata.
 func (s *Suricata) Stop() {
-	s.inputListener.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+	s.inputListener.Close()
 	if s.cancel != nil {
 		s.cancel()
 	}

--- a/plugins/inputs/synproxy/synproxy_test.go
+++ b/plugins/inputs/synproxy/synproxy_test.go
@@ -58,7 +58,7 @@ func TestSynproxyFileInvalidHex(t *testing.T) {
 func TestNoSynproxyFile(t *testing.T) {
 	tmpfile := makeFakeSynproxyFile([]byte(synproxyFileNormal))
 	// Remove file to generate "no such file" error
-	os.Remove(tmpfile) //nolint:revive // Ignore errors if file does not yet exist
+	os.Remove(tmpfile)
 
 	k := Synproxy{
 		statFile: tmpfile,

--- a/plugins/inputs/syslog/syslog.go
+++ b/plugins/inputs/syslog/syslog.go
@@ -97,7 +97,7 @@ func (s *Syslog) Start(acc telegraf.Accumulator) error {
 	}
 
 	if scheme == "unix" || scheme == "unixpacket" || scheme == "unixgram" {
-		os.Remove(s.Address) //nolint:revive // Accept success and failure in case the file does not exist
+		os.Remove(s.Address)
 	}
 
 	if s.isStream {
@@ -139,7 +139,7 @@ func (s *Syslog) Stop() {
 	defer s.mu.Unlock()
 
 	if s.Closer != nil {
-		s.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+		s.Close()
 	}
 	s.wg.Wait()
 }
@@ -265,7 +265,7 @@ func (s *Syslog) removeConnection(c net.Conn) {
 func (s *Syslog) handle(conn net.Conn, acc telegraf.Accumulator) {
 	defer func() {
 		s.removeConnection(conn)
-		conn.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+		conn.Close()
 	}()
 
 	var p syslog.Parser
@@ -416,7 +416,7 @@ type unixCloser struct {
 
 func (uc unixCloser) Close() error {
 	err := uc.closer.Close()
-	os.Remove(uc.path) //nolint:revive // Accept success and failure in case the file does not exist
+	os.Remove(uc.path)
 	return err
 }
 

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -106,7 +106,7 @@ func formatUptime(uptime uint64) string {
 	minutes %= 60
 
 	fmt.Fprintf(w, "%2d:%02d", hours, minutes)
-	w.Flush() //nolint:revive // This will always succeed, so skip checking the error
+	w.Flush()
 	return buf.String()
 }
 

--- a/plugins/inputs/tcp_listener/tcp_listener.go
+++ b/plugins/inputs/tcp_listener/tcp_listener.go
@@ -128,7 +128,7 @@ func (t *TCPListener) Stop() {
 	defer t.Unlock()
 	close(t.done)
 
-	t.listener.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+	t.listener.Close()
 
 	// Close all open TCP connections
 	//  - get all conns from the t.conns map and put into slice
@@ -141,7 +141,7 @@ func (t *TCPListener) Stop() {
 	}
 	t.cleanup.Unlock()
 	for _, conn := range conns {
-		conn.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+		conn.Close()
 	}
 
 	t.wg.Wait()
@@ -194,7 +194,7 @@ func (t *TCPListener) refuser(conn *net.TCPConn) {
 		" reached, closing.\nYou may want to increase max_tcp_connections in"+
 		" the Telegraf tcp listener configuration.\n", t.MaxTCPConnections)
 
-	conn.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+	conn.Close()
 	t.Log.Infof("Refused TCP Connection from %s", conn.RemoteAddr())
 	t.Log.Warn("Maximum TCP Connections reached, you may want to adjust max_tcp_connections")
 }

--- a/plugins/inputs/udp_listener/udp_listener.go
+++ b/plugins/inputs/udp_listener/udp_listener.go
@@ -121,7 +121,7 @@ func (u *UDPListener) Stop() {
 	defer u.Unlock()
 	close(u.done)
 	u.wg.Wait()
-	u.listener.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+	u.listener.Close()
 	close(u.in)
 	u.Log.Infof("Stopped service on %q", u.ServiceAddress)
 }

--- a/plugins/inputs/webhooks/webhooks.go
+++ b/plugins/inputs/webhooks/webhooks.go
@@ -109,6 +109,6 @@ func (wb *Webhooks) Start(acc telegraf.Accumulator) error {
 }
 
 func (wb *Webhooks) Stop() {
-	wb.srv.Close() //nolint:revive // Ignore the returned error as we cannot do anything about it anyway
+	wb.srv.Close()
 	wb.Log.Infof("Stopping the Webhooks service")
 }

--- a/plugins/outputs/riemann/riemann.go
+++ b/plugins/outputs/riemann/riemann.go
@@ -82,7 +82,7 @@ func (r *Riemann) Write(metrics []telegraf.Metric) error {
 	}
 
 	if err := r.client.SendMulti(events); err != nil {
-		r.Close() //nolint:revive // There is another error which will be returned here
+		r.Close()
 		return fmt.Errorf("failed to send riemann message: %w", err)
 	}
 	return nil

--- a/plugins/outputs/riemann_legacy/riemann_legacy.go
+++ b/plugins/outputs/riemann_legacy/riemann_legacy.go
@@ -76,7 +76,7 @@ func (r *Riemann) Write(metrics []telegraf.Metric) error {
 
 	var senderr = r.client.SendMulti(events)
 	if senderr != nil {
-		r.Close() //nolint:revive // There is another error which will be returned here
+		r.Close()
 		return fmt.Errorf("failed to send riemann message (will try to reconnect): %w", senderr)
 	}
 

--- a/plugins/outputs/socket_writer/socket_writer.go
+++ b/plugins/outputs/socket_writer/socket_writer.go
@@ -123,7 +123,7 @@ func (sw *SocketWriter) Write(metrics []telegraf.Metric) error {
 			var netErr net.Error
 			if errors.As(err, &netErr) {
 				// permanent error. close the connection
-				sw.Close() //nolint:revive // There is another error which will be returned here
+				sw.Close()
 				sw.Conn = nil
 				return fmt.Errorf("closing connection: %w", netErr)
 			}

--- a/plugins/outputs/syslog/syslog.go
+++ b/plugins/outputs/syslog/syslog.go
@@ -123,7 +123,7 @@ func (s *Syslog) Write(metrics []telegraf.Metric) (err error) {
 		if _, err = s.Conn.Write(msgBytesWithFraming); err != nil {
 			var netErr net.Error
 			if errors.As(err, &netErr) {
-				s.Close() //nolint:revive // There is another error which will be returned here
+				s.Close()
 				s.Conn = nil
 				return fmt.Errorf("closing connection: %w", netErr)
 			}


### PR DESCRIPTION
Instead, include explicitly only these exclusions:
```
    # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
    # EXC0013 revive: Annoying issue about not having a comment. The rare codebase has such comments
    - package comment should be of the form "(.+)...
    # EXC0015 revive: Annoying issue about not having a comment. The rare codebase has such comments
    - should have a package comment
```

`EXC0001` is prepared only for `errcheck` linter, this line does the same for `revive:unhandled-error`:
```
- Unhandled error in call to function ((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv)
```
Thanks to that, a lot of `//nolint:revive...` for mentioned functions could be removed.


Also, fixed one finding (previously implicitly excluded):
```
agent/agent.go:770:4  staticcheck  SA4011: ineffective break statement. Did you mean to break out of the outer loop?
```
Mentioned break didn't do anything (based on [The Go Programming Language Specification](https://go.dev/ref/spec#Break_statements): `A "break" statement terminates execution of the innermost "for", "switch", or "select" statement within the same function.` - not the outer loop).