### PR TITLE
fix(govulncheck): Downgrade govulncheck to fix github action

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -15,5 +15,5 @@ jobs:
         uses: Templum/govulncheck-action@v0.0.9
         with:
           go-version: '1.20'
-          vulncheck-version: latest
+          vulncheck-version: v0.0.0-20230320232729-bfc1eaef17a4
           package: ./...


### PR DESCRIPTION
The latest govulcheck version changed the report formatting which is not yet picked up by the github action. Bug filed upstream as https://github.com/Templum/govulncheck-action/issues/33.