### PR TITLE
chore: Enable G102 rule for gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,7 @@ linters-settings:
     # Available rules: https://github.com/securego/gosec#available-rules
     # Default: [] - means include all rules
     includes:
+      - G102
       - G106
       - G108
       - G109

--- a/plugins/common/proxy/socks5_test.go
+++ b/plugins/common/proxy/socks5_test.go
@@ -20,7 +20,7 @@ func TestSocks5ProxyConfigIntegration(t *testing.T) {
 		proxyPassword = "password"
 	)
 
-	l, err := net.Listen("tcp", "0.0.0.0:0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	server, err := socks5.New(&socks5.Config{


### PR DESCRIPTION
resolves https://github.com/influxdata/telegraf/issues/12890
