### PR TITLE
fix(inputs.sqlserver): Converted THROW to RAISERROR for 2008 compatibility

### DIFF
--- a/plugins/inputs/sqlserver/sqlserverqueries.go
+++ b/plugins/inputs/sqlserver/sqlserverqueries.go
@@ -1143,8 +1143,12 @@ BEGIN TRY
 	EXEC sp_executesql @SqlStatement
 END TRY
 BEGIN CATCH
+	SET @ErrorMessage = ERROR_MESSAGE();
+	DECLARE @ErrorSeverity INT = ERROR_SEVERITY();
+	DECLARE @ErrorState INT = ERROR_STATE();
+
    IF (ERROR_NUMBER() <> 976) --Avoid possible errors from secondary replica
-        THROW;
+	    RAISERROR (@ErrorMessage, @ErrorSeverity, @ErrorState );
 END CATCH
 `
 


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format]

resolves #12978

In SQLServerRequests, converted THROW to RAISERROR for 2008 compatibility