### PR TITLE
fix(systemd): increase lock memory for service to 8192kb

### DIFF
--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -13,6 +13,8 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE
 KillMode=control-group
+# increase lock memory for secret store library to 8192 kilobytes
+LimitMEMLOCK=8388608
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If set too low, the lock memory can run out when using any plugin that makes use of the secrets data type. Locking and unlocking memory takes a page each, so multiple plugins or multiple instances of a plugin can quickly go through pages.

fixes: #12980