### PR TITLE
fix(secrets): Warn if OS limit for locked memory is too low

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -315,6 +315,18 @@ func (t *Telegraf) runAgent(ctx context.Context, c *config.Config, reloadConfig 
 		log.Printf("W! Deprecated secretstores: %d and %d options", count[0], count[1])
 	}
 
+	// Compute the amount of locked memory needed for the secrets
+	log.Printf("I! Managed secrets: %d", c.NumberSecrets)
+	required := 2 * c.NumberSecrets * uint64(os.Getpagesize())
+	available := getLockedMemoryLimit()
+	if required > available {
+		required /= 1024
+		available /= 1024
+		msg := fmt.Sprintf("Insufficient lockable memory %dkb when %dkb is required.", available, required)
+		msg += " Please increase the limit for Telegraf in your Operating System!"
+		log.Printf("W! " + color.RedString(msg))
+	}
+
 	ag := agent.NewAgent(c)
 
 	// Notify systemd that telegraf is ready

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -316,12 +316,12 @@ func (t *Telegraf) runAgent(ctx context.Context, c *config.Config, reloadConfig 
 	}
 
 	// Compute the amount of locked memory needed for the secrets
-	log.Printf("I! Managed secrets: %d", c.NumberSecrets)
 	required := 2 * c.NumberSecrets * uint64(os.Getpagesize())
 	available := getLockedMemoryLimit()
 	if required > available {
 		required /= 1024
 		available /= 1024
+		log.Printf("I! Found %d secrets...", c.NumberSecrets)
 		msg := fmt.Sprintf("Insufficient lockable memory %dkb when %dkb is required.", available, required)
 		msg += " Please increase the limit for Telegraf in your Operating System!"
 		log.Printf("W! " + color.RedString(msg))

--- a/cmd/telegraf/telegraf_posix.go
+++ b/cmd/telegraf/telegraf_posix.go
@@ -2,7 +2,12 @@
 
 package main
 
-import "github.com/urfave/cli/v2"
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/urfave/cli/v2"
+)
 
 func (t *Telegraf) Run() error {
 	stop = make(chan struct{})
@@ -11,4 +16,14 @@ func (t *Telegraf) Run() error {
 
 func cliFlags() []cli.Flag {
 	return []cli.Flag{}
+}
+
+func getLockedMemoryLimit() uint64 {
+	const RLIMIT_MEMLOCK = 8
+
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(RLIMIT_MEMLOCK, &limit); err != nil {
+		panic(fmt.Errorf("Cannot get limit for locked memory: %w", err))
+	}
+	return limit.Max
 }

--- a/cmd/telegraf/telegraf_posix.go
+++ b/cmd/telegraf/telegraf_posix.go
@@ -27,5 +27,6 @@ func getLockedMemoryLimit() uint64 {
 		log.Printf("E! Cannot get limit for locked memory: %v", err)
 		return 0
 	}
-	return limit.Max
+	//nolint:unconvert // required for e.g. FreeBSD that has the field as int64
+	return uint64(limit.Max)
 }

--- a/cmd/telegraf/telegraf_posix.go
+++ b/cmd/telegraf/telegraf_posix.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"syscall"
 
 	"github.com/urfave/cli/v2"
@@ -19,10 +19,11 @@ func cliFlags() []cli.Flag {
 }
 
 func getLockedMemoryLimit() uint64 {
-	const RLIMIT_MEMLOCK = 8
+	// From https://elixir.bootlin.com/linux/latest/source/include/uapi/asm-generic/resource.h#L35
+	const rlimit_memlock = 8
 
 	var limit syscall.Rlimit
-	if err := syscall.Getrlimit(RLIMIT_MEMLOCK, &limit); err != nil {
+	if err := syscall.Getrlimit(rlimit_memlock, &limit); err != nil {
 		panic(fmt.Errorf("Cannot get limit for locked memory: %w", err))
 	}
 	return limit.Max

--- a/cmd/telegraf/telegraf_posix.go
+++ b/cmd/telegraf/telegraf_posix.go
@@ -20,11 +20,12 @@ func cliFlags() []cli.Flag {
 
 func getLockedMemoryLimit() uint64 {
 	// From https://elixir.bootlin.com/linux/latest/source/include/uapi/asm-generic/resource.h#L35
-	const rlimit_memlock = 8
+	const rLimitMemlock = 8
 
 	var limit syscall.Rlimit
-	if err := syscall.Getrlimit(rlimit_memlock, &limit); err != nil {
-		panic(fmt.Errorf("Cannot get limit for locked memory: %w", err))
+	if err := syscall.Getrlimit(rLimitMemlock, &limit); err != nil {
+		log.Printf("E! Cannot get limit for locked memory: %v", err)
+		return 0
 	}
 	return limit.Max
 }

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kardianos/service"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/sys/windows"
 
 	"github.com/influxdata/telegraf/logger"
 )
@@ -43,6 +44,18 @@ func cliFlags() []cli.Flag {
 			Usage: "run as console application (windows only)",
 		},
 	}
+}
+
+func getLockedMemoryLimit() uint64 {
+	handle := windows.CurrentProcess()
+
+	var min, max uintptr
+	var flag uint32
+	windows.GetProcessWorkingSetSizeEx(handle, &min, &max, &flag)
+	fmt.Println("min:", min)
+	fmt.Println("max:", max)
+
+	return uint64(max)
 }
 
 func (t *Telegraf) Run() error {

--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -52,8 +52,6 @@ func getLockedMemoryLimit() uint64 {
 	var min, max uintptr
 	var flag uint32
 	windows.GetProcessWorkingSetSizeEx(handle, &min, &max, &flag)
-	fmt.Println("min:", min)
-	fmt.Println("max:", max)
 
 	return uint64(max)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,8 @@ type Config struct {
 	version      *semver.Version
 
 	Persister *persister.Persister
+
+	NumberSecrets uint64
 }
 
 // Ordered plugins used to keep the order in which they appear in a file
@@ -470,6 +472,9 @@ func (c *Config) LoadAll(configFiles ...string) error {
 	if c.Agent.SnmpTranslator == "" {
 		c.Agent.SnmpTranslator = "netsnmp"
 	}
+
+	// Check if there is enough lockable memory for the secret
+	c.NumberSecrets = uint64(secretCount.Load())
 
 	// Let's link all secrets to their secret-stores
 	return c.LinkSecrets()


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

relates to #12980 

Plugins using secrets rely on locked memory in Telegraf. Due to limitations in the underlying library, each secret will use two pages of (locked) memory for the access time. Some operating systems or operators set a low limit on the maximum allowed amount of locked memory, making Telegraf hang (see #12924 or #12980) or panic of too many secrets are accessed at the same time. To be on the safe-side, warn the user if the limit set by the OS is too low for the number of secrets managed.