### PR TITLE
fix(outputs.stackdriver): group batches by timestamp

### DIFF
--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -314,14 +314,16 @@ func TestWriteBatchable(t *testing.T) {
 	err = s.Write(metrics)
 	require.NoError(t, err)
 
-	require.Len(t, mockMetric.reqs, 2)
+	require.Len(t, mockMetric.reqs, 5)
+
+	// Request 1 with two time series
 	request := mockMetric.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
-	require.Len(t, request.TimeSeries, 6)
+	require.Len(t, request.TimeSeries, 2)
 	ts := request.TimeSeries[0]
 	require.Len(t, ts.Points, 1)
 	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
 		EndTime: &timestamppb.Timestamp{
-			Seconds: 3,
+			Seconds: 1,
 		},
 	})
 	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
@@ -343,31 +345,47 @@ func TestWriteBatchable(t *testing.T) {
 		},
 	})
 
-	ts = request.TimeSeries[2]
+	// Request 2 with 1 time series
+	request = mockMetric.reqs[1].(*monitoringpb.CreateTimeSeriesRequest)
+	require.Len(t, request.TimeSeries, 1)
 	require.Len(t, ts.Points, 1)
-	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+	require.Equal(t, &monitoringpb.TimeInterval{
+		EndTime: &timestamppb.Timestamp{
+			Seconds: 2,
+		},
+	}, request.TimeSeries[0].Points[0].Interval)
+
+	// Request 3 with 1 time series with 1 point
+	request = mockMetric.reqs[2].(*monitoringpb.CreateTimeSeriesRequest)
+	require.Len(t, request.TimeSeries, 3)
+	require.Len(t, request.TimeSeries[0].Points, 1)
+	require.Len(t, request.TimeSeries[1].Points, 1)
+	require.Len(t, request.TimeSeries[2].Points, 1)
+	require.Equal(t, &monitoringpb.TimeInterval{
 		EndTime: &timestamppb.Timestamp{
 			Seconds: 3,
 		},
-	})
-	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
-		Value: &monitoringpb.TypedValue_Int64Value{
-			Int64Value: int64(43),
-		},
-	})
+	}, request.TimeSeries[0].Points[0].Interval)
 
-	ts = request.TimeSeries[4]
-	require.Len(t, ts.Points, 1)
-	require.Equal(t, ts.Points[0].Interval, &monitoringpb.TimeInterval{
+	// Request 4 with 1 time series with 1 point
+	request = mockMetric.reqs[3].(*monitoringpb.CreateTimeSeriesRequest)
+	require.Len(t, request.TimeSeries, 1)
+	require.Len(t, request.TimeSeries[0].Points, 1)
+	require.Equal(t, &monitoringpb.TimeInterval{
+		EndTime: &timestamppb.Timestamp{
+			Seconds: 4,
+		},
+	}, request.TimeSeries[0].Points[0].Interval)
+
+	// Request 5 with 1 time series with 1 point
+	request = mockMetric.reqs[4].(*monitoringpb.CreateTimeSeriesRequest)
+	require.Len(t, request.TimeSeries, 1)
+	require.Len(t, request.TimeSeries[0].Points, 1)
+	require.Equal(t, &monitoringpb.TimeInterval{
 		EndTime: &timestamppb.Timestamp{
 			Seconds: 5,
 		},
-	})
-	require.Equal(t, ts.Points[0].Value, &monitoringpb.TypedValue{
-		Value: &monitoringpb.TypedValue_Int64Value{
-			Int64Value: int64(43),
-		},
-	})
+	}, request.TimeSeries[0].Points[0].Interval)
 }
 
 func TestWriteIgnoredErrors(t *testing.T) {


### PR DESCRIPTION
In a perfect world, metrics come in to stackdriver grouped by timestamp
and all the timestamps are the same. This means that metrics go out
together and a user never has to worry about out of order metrics.
The world however is not perfect.

In the event that the connection to stackdriver goes down, telegraf will
start to save metrics to a buffer. Once reconnected, telegraf will send
a batch size of data to stackdriver to send. Stackdriver would then
ensure the metrics are sorted, but then break the metrics into
timeseries. In doing so metrics would no longer be in any order and
metrics could send duplicate time series. Meaning two idential metrics,
but with different time stamps.

What the user would see is first a message about duplicate timeseries
and then an error about out of order metrics, where an older metric was
trying to get added.

This ensures that we avoid different timestamps by batching metrics by
time. This way we avoid duplicate timeseries in the first place and
ensure we always send oldest to newest.

Fixes: #12963
