### PR TITLE
Tweak outputs.http Docs For aws_service Reqs.

### DIFF
--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -105,6 +105,9 @@ to use them.
   #region = "us-east-1"
 
   ## Amazon Credentials
+  ## Amazon Credentials are not attempted unless aws_service is set to a non-empty string and may need to match the name of the service you're outputting to
+  #aws_service = "execute-api"
+
   ## Credentials are loaded in the following order
   ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
   ## 2) Assumed credentials via STS if role_arn is specified

--- a/plugins/outputs/http/sample.conf
+++ b/plugins/outputs/http/sample.conf
@@ -80,6 +80,7 @@
   ## Amazon Credentials
   ## Amazon Credentials are not attempted unless aws_service is set to a non-empty string and may need to match the name of the service you're ouputting to
   #aws_service = "execute-api"
+ 
   ## Credentials are loaded in the following order
   ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
   ## 2) Assumed credentials via STS if role_arn is specified

--- a/plugins/outputs/http/sample.conf
+++ b/plugins/outputs/http/sample.conf
@@ -78,6 +78,8 @@
   #region = "us-east-1"
 
   ## Amazon Credentials
+  ## Amazon Credentials are not attempted unless aws_service is set to a non-empty string and may need to match the name of the service you're ouputting to
+  #aws_service = "execute-api"
   ## Credentials are loaded in the following order
   ## 1) Web identity provider credentials via STS if role_arn and web_identity_token_file are specified
   ## 2) Assumed credentials via STS if role_arn is specified


### PR DESCRIPTION
Updated outputs.http README & sample.conf to reflect un-documented requirement for aws_service to be set to a non-empty string in order for Amazon Credentials to be attempted, as was pointed out to me in the code:
    https://github.com/influxdata/telegraf/blob/master/plugins/outputs/http/http.go#L77-L82

 On branch aws_service_docs
 Changes to be committed:
	modified:   README.md
	modified:   sample.conf

# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
