### PR TITLE
chore: Remove `revive:unhandled-error` - `errcheck` is more flexible

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,13 @@ linters-settings:
       - "**/testutil/**"
       - "**/tools/**"
       - "**/*_test.go"
+  errcheck:
+    # List of functions to exclude from checking, where each entry is a single function to exclude.
+    # See https://github.com/kisielk/errcheck#excluding-functions for details.
+    exclude-functions:
+      - "(*hash/maphash.Hash).Write"
+      - "(*hash/maphash.Hash).WriteByte"
+      - "(*hash/maphash.Hash).WriteString"
   gosec:
     # To select a subset of rules to run.
     # Available rules: https://github.com/securego/gosec#available-rules
@@ -153,8 +160,6 @@ linters-settings:
       - name: time-naming
       - name: unconditional-recursion
       - name: unexported-naming
-      - name: unhandled-error
-        arguments: [ "fmt.Printf", "fmt.Println", "fmt.Print", "fmt.Fprintf", "fmt.Fprint", "fmt.Fprintln" ]
       - name: unnecessary-stmt
       - name: unreachable-code
       - name: unused-parameter

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -218,7 +218,6 @@ issues:
     - don't use an underscore in package name
     # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
     - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-    - Unhandled error in call to function ((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv)
     # EXC0013 revive: Annoying issue about not having a comment. The rare codebase has such comments
     - package comment should be of the form "(.+)...
     # EXC0015 revive: Annoying issue about not having a comment. The rare codebase has such comments

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -262,13 +262,13 @@ func (m *metric) Copy() telegraf.Metric {
 
 func (m *metric) HashID() uint64 {
 	h := fnv.New64a()
-	h.Write([]byte(m.name)) //nolint:revive // all Write() methods for hash in fnv.go returns nil err
-	h.Write([]byte("\n"))   //nolint:revive // all Write() methods for hash in fnv.go returns nil err
+	h.Write([]byte(m.name))
+	h.Write([]byte("\n"))
 	for _, tag := range m.tags {
-		h.Write([]byte(tag.Key))   //nolint:revive // all Write() methods for hash in fnv.go returns nil err
-		h.Write([]byte("\n"))      //nolint:revive // all Write() methods for hash in fnv.go returns nil err
-		h.Write([]byte(tag.Value)) //nolint:revive // all Write() methods for hash in fnv.go returns nil err
-		h.Write([]byte("\n"))      //nolint:revive // all Write() methods for hash in fnv.go returns nil err
+		h.Write([]byte(tag.Key))
+		h.Write([]byte("\n"))
+		h.Write([]byte(tag.Value))
+		h.Write([]byte("\n"))
 	}
 	return h.Sum64()
 }

--- a/metric/series_grouper.go
+++ b/metric/series_grouper.go
@@ -87,20 +87,20 @@ func groupID(seed maphash.Seed, measurement string, taglist []*telegraf.Tag, tm 
 	var mh maphash.Hash
 	mh.SetSeed(seed)
 
-	mh.WriteString(measurement) //nolint:errcheck,revive // all Write***() methods for hash in maphash.go returns nil err
-	mh.WriteByte(0)             //nolint:errcheck,revive // all Write***() methods for hash in maphash.go returns nil err
+	mh.WriteString(measurement)
+	mh.WriteByte(0)
 
 	for _, tag := range taglist {
-		mh.WriteString(tag.Key)   //nolint:errcheck,revive // all Write***() methods for hash in maphash.go returns nil err
-		mh.WriteByte(0)           //nolint:errcheck,revive // all Write***() methods for hash in maphash.go returns nil err
-		mh.WriteString(tag.Value) //nolint:errcheck,revive // all Write***() methods for hash in maphash.go returns nil err
-		mh.WriteByte(0)           //nolint:errcheck,revive // all Write***() methods for hash in maphash.go returns nil err
+		mh.WriteString(tag.Key)
+		mh.WriteByte(0)
+		mh.WriteString(tag.Value)
+		mh.WriteByte(0)
 	}
-	mh.WriteByte(0) //nolint:errcheck,revive // all Write***() methods for hash in maphash.go returns nil err
+	mh.WriteByte(0)
 
 	var tsBuf [8]byte
 	binary.BigEndian.PutUint64(tsBuf[:], uint64(tm.UnixNano()))
-	mh.Write(tsBuf[:]) //nolint:errcheck,revive // all Write***() methods for hash in maphash.go returns nil err
+	mh.Write(tsBuf[:])
 
 	return mh.Sum64()
 }

--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -40,7 +40,7 @@ func BenchmarkRunningOutputAddWrite(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		ro.AddMetric(testutil.TestMetric(101, "metric1"))
-		ro.Write() //nolint: errcheck,revive // skip checking err for benchmark tests
+		ro.Write() //nolint: errcheck // skip checking err for benchmark tests
 	}
 }
 
@@ -56,7 +56,7 @@ func BenchmarkRunningOutputAddWriteEvery100(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		ro.AddMetric(testutil.TestMetric(101, "metric1"))
 		if n%100 == 0 {
-			ro.Write() //nolint: errcheck,revive // skip checking err for benchmark tests
+			ro.Write() //nolint: errcheck // skip checking err for benchmark tests
 		}
 	}
 }

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -198,11 +198,11 @@ func newMP(n *NodeMetricMapping) metricParts {
 	var sb strings.Builder
 	for i, key := range keys {
 		if i != 0 {
-			sb.WriteString(", ") //nolint:revive // writes to a string-builder will always succeed
+			sb.WriteString(", ")
 		}
-		sb.WriteString(key)               //nolint:revive // writes to a string-builder will always succeed
-		sb.WriteString("=")               //nolint:revive // writes to a string-builder will always succeed
-		sb.WriteString(n.MetricTags[key]) //nolint:revive // writes to a string-builder will always succeed
+		sb.WriteString(key)
+		sb.WriteString("=")
+		sb.WriteString(n.MetricTags[key])
 	}
 	x := metricParts{
 		metricName: n.metricName,

--- a/plugins/common/starlark/field_dict.go
+++ b/plugins/common/starlark/field_dict.go
@@ -19,17 +19,17 @@ type FieldDict struct {
 
 func (d FieldDict) String() string {
 	buf := new(strings.Builder)
-	buf.WriteString("{") //nolint:revive // from builder.go: "It returns the length of r and a nil error."
+	buf.WriteString("{")
 	sep := ""
 	for _, item := range d.Items() {
 		k, v := item[0], item[1]
-		buf.WriteString(sep)        //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-		buf.WriteString(k.String()) //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-		buf.WriteString(": ")       //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-		buf.WriteString(v.String()) //nolint:revive // from builder.go: "It returns the length of r and a nil error."
+		buf.WriteString(sep)
+		buf.WriteString(k.String())
+		buf.WriteString(": ")
+		buf.WriteString(v.String())
 		sep = ", "
 	}
-	buf.WriteString("}") //nolint:revive // from builder.go: "It returns the length of r and a nil error."
+	buf.WriteString("}")
 	return buf.String()
 }
 

--- a/plugins/common/starlark/metric.go
+++ b/plugins/common/starlark/metric.go
@@ -37,15 +37,15 @@ func (m *Metric) Unwrap() telegraf.Metric {
 // it behaves more like the repr function would in Python.
 func (m *Metric) String() string {
 	buf := new(strings.Builder)
-	buf.WriteString("Metric(")           //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-	buf.WriteString(m.Name().String())   //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-	buf.WriteString(", tags=")           //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-	buf.WriteString(m.Tags().String())   //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-	buf.WriteString(", fields=")         //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-	buf.WriteString(m.Fields().String()) //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-	buf.WriteString(", time=")           //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-	buf.WriteString(m.Time().String())   //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-	buf.WriteString(")")                 //nolint:revive // from builder.go: "It returns the length of r and a nil error."
+	buf.WriteString("Metric(")
+	buf.WriteString(m.Name().String())
+	buf.WriteString(", tags=")
+	buf.WriteString(m.Tags().String())
+	buf.WriteString(", fields=")
+	buf.WriteString(m.Fields().String())
+	buf.WriteString(", time=")
+	buf.WriteString(m.Time().String())
+	buf.WriteString(")")
 	return buf.String()
 }
 

--- a/plugins/common/starlark/tag_dict.go
+++ b/plugins/common/starlark/tag_dict.go
@@ -18,17 +18,17 @@ type TagDict struct {
 
 func (d TagDict) String() string {
 	buf := new(strings.Builder)
-	buf.WriteString("{") //nolint:revive // from builder.go: "It returns the length of r and a nil error."
+	buf.WriteString("{")
 	sep := ""
 	for _, item := range d.Items() {
 		k, v := item[0], item[1]
-		buf.WriteString(sep)        //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-		buf.WriteString(k.String()) //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-		buf.WriteString(": ")       //nolint:revive // from builder.go: "It returns the length of r and a nil error."
-		buf.WriteString(v.String()) //nolint:revive // from builder.go: "It returns the length of r and a nil error."
+		buf.WriteString(sep)
+		buf.WriteString(k.String())
+		buf.WriteString(": ")
+		buf.WriteString(v.String())
 		sep = ", "
 	}
-	buf.WriteString("}") //nolint:revive // from builder.go: "It returns the length of r and a nil error."
+	buf.WriteString("}")
 	return buf.String()
 }
 

--- a/plugins/inputs/burrow/burrow_test.go
+++ b/plugins/inputs/burrow/burrow_test.go
@@ -37,7 +37,7 @@ func getHTTPServer() *httptest.Server {
 		body, code := getResponseJSON(r.RequestURI)
 		w.WriteHeader(code)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(body) //nolint:errcheck,revive // ignore the returned error as the test will fail anyway
+		w.Write(body) //nolint:errcheck // ignore the returned error as the test will fail anyway
 	}))
 }
 
@@ -61,7 +61,7 @@ func getHTTPServerBasicAuth() *httptest.Server {
 		body, code := getResponseJSON(r.RequestURI)
 		w.WriteHeader(code)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(body) //nolint:errcheck,revive // ignore the returned error as the test will fail anyway
+		w.Write(body) //nolint:errcheck // ignore the returned error as the test will fail anyway
 	}))
 }
 

--- a/plugins/inputs/ceph/ceph.go
+++ b/plugins/inputs/ceph/ceph.go
@@ -222,9 +222,9 @@ func (m *metric) name() string {
 	buf := bytes.Buffer{}
 	for i := len(m.pathStack) - 1; i >= 0; i-- {
 		if buf.Len() > 0 {
-			buf.WriteString(".") //nolint:revive // should never return an error
+			buf.WriteString(".")
 		}
-		buf.WriteString(m.pathStack[i]) //nolint:revive // should never return an error
+		buf.WriteString(m.pathStack[i])
 	}
 	return buf.String()
 }

--- a/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push.go
+++ b/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push.go
@@ -136,8 +136,7 @@ func (p *PubSubPush) Start(acc telegraf.Accumulator) error {
 // Stop cleans up all resources
 func (p *PubSubPush) Stop() {
 	p.cancel()
-	//nolint:errcheck,revive // we cannot do anything if the shutdown fails
-	p.server.Shutdown(p.ctx)
+	p.server.Shutdown(p.ctx) //nolint:errcheck // we cannot do anything if the shutdown fails
 	p.wg.Wait()
 }
 

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -83,10 +83,10 @@ func (d *DiskIO) diskInfo(devName string) (map[string]string, error) {
 		}
 		if l[:2] == "S:" {
 			if devlinks.Len() > 0 {
-				devlinks.WriteString(" ") //nolint:revive // this will never fail
+				devlinks.WriteString(" ")
 			}
-			devlinks.WriteString("/dev/") //nolint:revive // this will never fail
-			devlinks.WriteString(l[2:])   //nolint:revive // this will never fail
+			devlinks.WriteString("/dev/")
+			devlinks.WriteString(l[2:])
 			continue
 		}
 		if l[:2] != "E:" {

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -111,7 +111,7 @@ func (c CommandRunner) truncate(buf bytes.Buffer) bytes.Buffer {
 		buf.Truncate(i)
 	}
 	if didTruncate {
-		buf.WriteString("...") //nolint:revive // will always return nil or panic
+		buf.WriteString("...")
 	}
 	return buf
 }

--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -34,8 +34,7 @@ func (s statServer) serverSocket(l net.Listener) {
 
 			data := buf[:n]
 			if string(data) == "show stat\n" {
-				//nolint:errcheck,revive // we return anyway
-				c.Write(csvOutputSample)
+				c.Write(csvOutputSample) //nolint:errcheck // we return anyway
 			}
 		}(conn)
 	}

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -99,7 +99,7 @@ func setUpTestMux() http.Handler {
 		fmt.Fprintf(w, "hit the good page!")
 	})
 	mux.HandleFunc("/invalidUTF8", func(w http.ResponseWriter, req *http.Request) {
-		w.Write([]byte{0xff, 0xfe, 0xfd}) //nolint:errcheck,revive // ignore the returned error as the test will fail anyway
+		w.Write([]byte{0xff, 0xfe, 0xfd}) //nolint:errcheck // ignore the returned error as the test will fail anyway
 	})
 	mux.HandleFunc("/noheader", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "hit the good page!")

--- a/plugins/inputs/jenkins/jenkins_test.go
+++ b/plugins/inputs/jenkins/jenkins_test.go
@@ -98,7 +98,7 @@ func (h mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write(b) //nolint:errcheck,revive // ignore the returned error as the tests will fail anyway
+	w.Write(b) //nolint:errcheck // ignore the returned error as the tests will fail anyway
 }
 
 func TestGatherNodeData(t *testing.T) {

--- a/plugins/inputs/mesos/mesos_test.go
+++ b/plugins/inputs/mesos/mesos_test.go
@@ -288,7 +288,7 @@ func TestMain(m *testing.M) {
 	masterRouter.HandleFunc("/metrics/snapshot", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(masterMetrics) //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
+		json.NewEncoder(w).Encode(masterMetrics) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
 	})
 	masterTestServer = httptest.NewServer(masterRouter)
 
@@ -296,7 +296,7 @@ func TestMain(m *testing.M) {
 	slaveRouter.HandleFunc("/metrics/snapshot", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(slaveMetrics) //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
+		json.NewEncoder(w).Encode(slaveMetrics) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
 	})
 	slaveTestServer = httptest.NewServer(slaveRouter)
 

--- a/plugins/inputs/phpfpm/child.go
+++ b/plugins/inputs/phpfpm/child.go
@@ -291,7 +291,7 @@ func (c *child) serveRequest(req *request, body io.ReadCloser) {
 	// some sort of abort request to the host, so the host
 	// can properly cut off the client sending all the data.
 	// For now just bound it a little and
-	io.CopyN(io.Discard, body, 100<<20) //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
+	io.CopyN(io.Discard, body, 100<<20) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
 	body.Close()
 
 	if !req.keepConn {

--- a/plugins/inputs/powerdns/powerdns_linux_test.go
+++ b/plugins/inputs/powerdns/powerdns_linux_test.go
@@ -28,7 +28,7 @@ func (s statServer) serverSocket(l net.Listener) {
 
 			data := buf[:n]
 			if string(data) == "show * \n" {
-				c.Write([]byte(metrics)) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
+				c.Write([]byte(metrics)) //nolint:errcheck // ignore the returned error as we need to close the socket anyway
 				c.Close()
 			}
 		}(conn)

--- a/plugins/inputs/powerdns_recursor/powerdns_recursor_test.go
+++ b/plugins/inputs/powerdns_recursor/powerdns_recursor_test.go
@@ -127,7 +127,7 @@ func TestV1PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 
 			data := buf[:n]
 			if string(data) == "get-all\n" {
-				socket.WriteToUnix([]byte(metrics), remote) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
+				socket.WriteToUnix([]byte(metrics), remote) //nolint:errcheck // ignore the returned error as we need to close the socket anyway
 				socket.Close()
 			}
 
@@ -189,8 +189,8 @@ func TestV2PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 
 			data := buf[:n]
 			if string(data) == "get-all" {
-				socket.WriteToUnix([]byte{0, 0, 0, 0}, remote) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
-				socket.WriteToUnix([]byte(metrics), remote)    //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
+				socket.WriteToUnix([]byte{0, 0, 0, 0}, remote) //nolint:errcheck // ignore the returned error as we need to close the socket anyway
+				socket.WriteToUnix([]byte(metrics), remote)    //nolint:errcheck // ignore the returned error as we need to close the socket anyway
 				socket.Close()
 			}
 
@@ -258,10 +258,10 @@ func TestV3PowerdnsRecursorGeneratesMetrics(t *testing.T) {
 			}
 
 			if string(buf) == "get-all" {
-				conn.Write([]byte{0, 0, 0, 0}) //nolint:errcheck,revive // ignore the returned error as we need to close the socket anyway
+				conn.Write([]byte{0, 0, 0, 0}) //nolint:errcheck // ignore the returned error as we need to close the socket anyway
 				metrics := []byte(metrics)
-				writeNativeUIntToConn(conn, uint(len(metrics))) //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
-				conn.Write(metrics)                             //nolint:errcheck,revive // ignore the returned error as we cannot do anything about it anyway
+				writeNativeUIntToConn(conn, uint(len(metrics))) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
+				conn.Write(metrics)                             //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
 				socket.Close()
 			}
 

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -900,8 +900,8 @@ func (s *Statsd) handler(conn *net.TCPConn, id string) {
 
 			b := s.bufPool.Get().(*bytes.Buffer)
 			b.Reset()
-			b.Write(scanner.Bytes()) //nolint:revive // Writes to a bytes buffer always succeed, so do not check the errors here
-			b.WriteByte('\n')        //nolint:revive // Writes to a bytes buffer always succeed, so do not check the errors here
+			b.Write(scanner.Bytes())
+			b.WriteByte('\n')
 
 			select {
 			case s.in <- input{Buffer: b, Time: time.Now(), Addr: remoteIP}:

--- a/plugins/inputs/zipkin/zipkin.go
+++ b/plugins/inputs/zipkin/zipkin.go
@@ -120,7 +120,7 @@ func (z *Zipkin) Stop() {
 	defer z.waitGroup.Wait()
 	defer cancel()
 
-	z.server.Shutdown(ctx) //nolint:errcheck,revive // Ignore the returned error as we cannot do anything about it anyway
+	z.server.Shutdown(ctx) //nolint:errcheck // Ignore the returned error as we cannot do anything about it anyway
 }
 
 // Listen creates an http server on the zipkin instance it is called with, and

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -346,20 +346,20 @@ func (a *AzureMonitor) send(body []byte) error {
 
 func hashIDWithTagKeysOnly(m telegraf.Metric) uint64 {
 	h := fnv.New64a()
-	h.Write([]byte(m.Name())) //nolint:revive // from hash.go: "It never returns an error"
-	h.Write([]byte("\n"))     //nolint:revive // from hash.go: "It never returns an error"
+	h.Write([]byte(m.Name()))
+	h.Write([]byte("\n"))
 	for _, tag := range m.TagList() {
 		if tag.Key == "" || tag.Value == "" {
 			continue
 		}
 
-		h.Write([]byte(tag.Key)) //nolint:revive // from hash.go: "It never returns an error"
-		h.Write([]byte("\n"))    //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte(tag.Key))
+		h.Write([]byte("\n"))
 	}
 	b := make([]byte, binary.MaxVarintLen64)
 	n := binary.PutUvarint(b, uint64(m.Time().UnixNano()))
-	h.Write(b[:n])        //nolint:revive // from hash.go: "It never returns an error"
-	h.Write([]byte("\n")) //nolint:revive // from hash.go: "It never returns an error"
+	h.Write(b[:n])
+	h.Write([]byte("\n"))
 	return h.Sum64()
 }
 
@@ -553,10 +553,10 @@ func hashIDWithField(id uint64, fk string) uint64 {
 	h := fnv.New64a()
 	b := make([]byte, binary.MaxVarintLen64)
 	n := binary.PutUvarint(b, id)
-	h.Write(b[:n])        //nolint:revive // from hash.go: "It never returns an error"
-	h.Write([]byte("\n")) //nolint:revive // from hash.go: "It never returns an error"
-	h.Write([]byte(fk))   //nolint:revive // from hash.go: "It never returns an error"
-	h.Write([]byte("\n")) //nolint:revive // from hash.go: "It never returns an error"
+	h.Write(b[:n])
+	h.Write([]byte("\n"))
+	h.Write([]byte(fk))
+	h.Write([]byte("\n"))
 	return h.Sum64()
 }
 

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -202,7 +202,7 @@ func escapeString(s string, quote string) string {
 // [1] https://github.com/influxdata/telegraf/pull/3210#discussion_r148411201
 func hashID(m telegraf.Metric) int64 {
 	h := sha512.New()
-	h.Write([]byte(m.Name())) //nolint:revive // from hash.go: "It never returns an error"
+	h.Write([]byte(m.Name()))
 	tags := m.Tags()
 	tmp := make([]string, 0, len(tags))
 	for k, v := range tags {
@@ -211,7 +211,7 @@ func hashID(m telegraf.Metric) int64 {
 	sort.Strings(tmp)
 
 	for _, s := range tmp {
-		h.Write([]byte(s)) //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte(s))
 	}
 	sum := h.Sum(nil)
 

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -37,8 +37,7 @@ func fakeDatadog() *Datadog {
 func TestUriOverride(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		//nolint:errcheck,revive // Ignore the returned error as the test will fail anyway
-		json.NewEncoder(w).Encode(`{"status":"ok"}`)
+		json.NewEncoder(w).Encode(`{"status":"ok"}`) //nolint:errcheck // Ignore the returned error as the test will fail anyway
 	}))
 	defer ts.Close()
 
@@ -53,8 +52,7 @@ func TestUriOverride(t *testing.T) {
 func TestCompressionOverride(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		//nolint:errcheck,revive // Ignore the returned error as the test will fail anyway
-		json.NewEncoder(w).Encode(`{"status":"ok"}`)
+		json.NewEncoder(w).Encode(`{"status":"ok"}`) //nolint:errcheck // Ignore the returned error as the test will fail anyway
 	}))
 	defer ts.Close()
 

--- a/plugins/outputs/elasticsearch/elasticsearch.go
+++ b/plugins/outputs/elasticsearch/elasticsearch.go
@@ -237,9 +237,9 @@ func GetPointID(m telegraf.Metric) string {
 	var buffer bytes.Buffer
 	//Timestamp(ns),measurement name and Series Hash for compute the final SHA256 based hash ID
 
-	buffer.WriteString(strconv.FormatInt(m.Time().Local().UnixNano(), 10)) //nolint:revive // from buffer.go: "err is always nil"
-	buffer.WriteString(m.Name())                                           //nolint:revive // from buffer.go: "err is always nil"
-	buffer.WriteString(strconv.FormatUint(m.HashID(), 10))                 //nolint:revive // from buffer.go: "err is always nil"
+	buffer.WriteString(strconv.FormatInt(m.Time().Local().UnixNano(), 10))
+	buffer.WriteString(m.Name())
+	buffer.WriteString(strconv.FormatUint(m.HashID(), 10))
 
 	return fmt.Sprintf("%x", sha256.Sum256(buffer.Bytes()))
 }

--- a/plugins/outputs/exec/exec.go
+++ b/plugins/outputs/exec/exec.go
@@ -67,7 +67,7 @@ func (e *Exec) Write(metrics []telegraf.Metric) error {
 	if err != nil {
 		return err
 	}
-	buffer.Write(serializedMetrics) //nolint:revive // from buffer.go: "err is always nil"
+	buffer.Write(serializedMetrics)
 
 	if buffer.Len() <= 0 {
 		return nil
@@ -141,7 +141,7 @@ func (c *CommandRunner) truncate(buf bytes.Buffer) string {
 		buf.Truncate(i)
 	}
 	if didTruncate {
-		buf.WriteString("...") //nolint:revive // from buffer.go: "err is always nil"
+		buf.WriteString("...")
 	}
 	return buf.String()
 }

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -164,29 +164,29 @@ func (g *gelfUDP) createChunkedMessage(index int, chunkCountInt int, id []byte, 
 	if err != nil {
 		return packet, err
 	}
-	packet.Write(b) //nolint:revive // from buffer.go: "err is always nil"
+	packet.Write(b)
 
 	b, err = g.intToBytes(15)
 	if err != nil {
 		return packet, err
 	}
-	packet.Write(b) //nolint:revive // from buffer.go: "err is always nil"
+	packet.Write(b)
 
-	packet.Write(id) //nolint:revive // from buffer.go: "err is always nil"
+	packet.Write(id)
 
 	b, err = g.intToBytes(index)
 	if err != nil {
 		return packet, err
 	}
-	packet.Write(b) //nolint:revive // from buffer.go: "err is always nil"
+	packet.Write(b)
 
 	b, err = g.intToBytes(chunkCountInt)
 	if err != nil {
 		return packet, err
 	}
-	packet.Write(b) //nolint:revive // from buffer.go: "err is always nil"
+	packet.Write(b)
 
-	packet.Write(compressed.Next(chunksize)) //nolint:revive // from buffer.go: "err is always nil"
+	packet.Write(compressed.Next(chunksize))
 
 	return packet, nil
 }

--- a/plugins/outputs/influxdb/udp_test.go
+++ b/plugins/outputs/influxdb/udp_test.go
@@ -92,7 +92,7 @@ func TestUDP_Simple(t *testing.T) {
 			DialContextF: func(network, address string) (influxdb.Conn, error) {
 				conn := &MockConn{
 					WriteF: func(b []byte) (n int, err error) {
-						buffer.Write(b) //nolint:revive // MockConn with always-success return
+						buffer.Write(b)
 						return 0, nil
 					},
 				}

--- a/plugins/outputs/postgresql/sqltemplate/template.go
+++ b/plugins/outputs/postgresql/sqltemplate/template.go
@@ -384,8 +384,8 @@ func (cols Columns) Fields() Columns {
 func (cols Columns) Hash() string {
 	hash := fnv.New32a()
 	for _, tc := range cols.Sorted() {
-		hash.Write([]byte(tc.Name)) //nolint:revive // all Write() methods for hash in fnv.go returns nil err
-		hash.Write([]byte{0})       //nolint:revive // all Write() methods for hash in fnv.go returns nil err
+		hash.Write([]byte(tc.Name))
+		hash.Write([]byte{0})
 	}
 	return strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hash.Sum(nil)))
 }

--- a/plugins/outputs/postgresql/table_source.go
+++ b/plugins/outputs/postgresql/table_source.go
@@ -81,7 +81,7 @@ func NewTableSources(p *Postgresql, metrics []telegraf.Metric) map[string]*Table
 
 func NewTableSource(postgresql *Postgresql, name string) *TableSource {
 	h := fnv.New64a()
-	h.Write([]byte(name)) //nolint:revive // all Write() methods for hash in fnv.go returns nil err
+	h.Write([]byte(name))
 
 	tsrc := &TableSource{
 		postgresql:  postgresql,

--- a/plugins/outputs/postgresql/utils/utils.go
+++ b/plugins/outputs/postgresql/utils/utils.go
@@ -71,10 +71,10 @@ func (l PGXLogger) Log(_ context.Context, level pgx.LogLevel, msg string, data m
 func GetTagID(metric telegraf.Metric) int64 {
 	hash := fnv.New64a()
 	for _, tag := range metric.TagList() {
-		hash.Write([]byte(tag.Key))   //nolint:revive // all Write() methods for hash in fnv.go returns nil err
-		hash.Write([]byte{0})         //nolint:revive // all Write() methods for hash in fnv.go returns nil err
-		hash.Write([]byte(tag.Value)) //nolint:revive // all Write() methods for hash in fnv.go returns nil err
-		hash.Write([]byte{0})         //nolint:revive // all Write() methods for hash in fnv.go returns nil err
+		hash.Write([]byte(tag.Key))
+		hash.Write([]byte{0})
+		hash.Write([]byte(tag.Value))
+		hash.Write([]byte{0})
 	}
 	// Convert to int64 as postgres does not support uint64
 	return int64(hash.Sum64())

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -114,15 +114,15 @@ type timeSeriesBuckets map[uint64][]*monitoringpb.TimeSeries
 
 func (tsb timeSeriesBuckets) Add(m telegraf.Metric, f *telegraf.Field, ts *monitoringpb.TimeSeries) {
 	h := fnv.New64a()
-	h.Write([]byte(m.Name())) //nolint:revive // from hash.go: "It never returns an error"
-	h.Write([]byte{'\n'})     //nolint:revive // from hash.go: "It never returns an error"
-	h.Write([]byte(f.Key))    //nolint:revive // from hash.go: "It never returns an error"
-	h.Write([]byte{'\n'})     //nolint:revive // from hash.go: "It never returns an error"
+	h.Write([]byte(m.Name()))
+	h.Write([]byte{'\n'})
+	h.Write([]byte(f.Key))
+	h.Write([]byte{'\n'})
 	for key, value := range m.Tags() {
-		h.Write([]byte(key))   //nolint:revive // from hash.go: "It never returns an error"
-		h.Write([]byte{'\n'})  //nolint:revive // from hash.go: "It never returns an error"
-		h.Write([]byte(value)) //nolint:revive // from hash.go: "It never returns an error"
-		h.Write([]byte{'\n'})  //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte(key))
+		h.Write([]byte{'\n'})
+		h.Write([]byte(value))
+		h.Write([]byte{'\n'})
 	}
 	k := h.Sum64()
 

--- a/plugins/parsers/nagios/parser.go
+++ b/plugins/parsers/nagios/parser.go
@@ -135,7 +135,7 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		metrics = append(metrics, ms...)
 		fallthrough
 	case 1:
-		msg.Write(bytes.TrimSpace(parts[0])) //nolint:revive // from buffer.go: "err is always nil"
+		msg.Write(bytes.TrimSpace(parts[0]))
 	default:
 		return nil, errors.New("illegal output format")
 	}
@@ -145,9 +145,9 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		if bytes.Contains(s.Bytes(), []byte{'|'}) {
 			parts := bytes.Split(s.Bytes(), []byte{'|'})
 			if longmsg.Len() != 0 {
-				longmsg.WriteByte('\n') //nolint:revive // from buffer.go: "err is always nil"
+				longmsg.WriteByte('\n')
 			}
-			longmsg.Write(bytes.TrimSpace(parts[0])) //nolint:revive // from buffer.go: "err is always nil"
+			longmsg.Write(bytes.TrimSpace(parts[0]))
 
 			ms, err := parsePerfData(string(parts[1]), ts)
 			if err != nil {
@@ -157,9 +157,9 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 			break
 		}
 		if longmsg.Len() != 0 {
-			longmsg.WriteByte('\n') //nolint:revive // from buffer.go: "err is always nil"
+			longmsg.WriteByte('\n')
 		}
-		longmsg.Write(bytes.TrimSpace(s.Bytes())) //nolint:revive // from buffer.go: "err is always nil"
+		longmsg.Write(bytes.TrimSpace(s.Bytes()))
 	}
 
 	// Parse extra performance data.

--- a/plugins/parsers/wavefront/parser.go
+++ b/plugins/parsers/wavefront/parser.go
@@ -204,7 +204,7 @@ func (p *PointParser) unscanTokens(n int) {
 func (p *PointParser) reset(buf []byte) {
 	// reset the scan buffer and write new byte
 	p.scanBuf.Reset()
-	p.scanBuf.Write(buf) //nolint:revive // from buffer.go: "err is always nil"
+	p.scanBuf.Write(buf)
 
 	if p.s == nil {
 		p.s = NewScanner(&p.scanBuf)

--- a/plugins/serializers/carbon2/carbon2.go
+++ b/plugins/serializers/carbon2/carbon2.go
@@ -65,7 +65,7 @@ func (s *Serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	var batch bytes.Buffer
 	for _, metric := range metrics {
-		batch.Write(s.createObject(metric)) //nolint:revive // from buffer.go: "err is always nil"
+		batch.Write(s.createObject(metric))
 	}
 	return batch.Bytes(), nil
 }
@@ -83,27 +83,27 @@ func (s *Serializer) createObject(metric telegraf.Metric) []byte {
 
 		switch metricsFormat {
 		case Carbon2FormatFieldSeparate:
-			m.WriteString(serializeMetricFieldSeparate(name, fieldName)) //nolint:revive // from buffer.go: "err is always nil"
+			m.WriteString(serializeMetricFieldSeparate(name, fieldName))
 
 		case Carbon2FormatMetricIncludesField:
-			m.WriteString(serializeMetricIncludeField(name, fieldName)) //nolint:revive // from buffer.go: "err is always nil"
+			m.WriteString(serializeMetricIncludeField(name, fieldName))
 		}
 
 		for _, tag := range metric.TagList() {
-			m.WriteString(strings.ReplaceAll(tag.Key, " ", "_")) //nolint:revive // from buffer.go: "err is always nil"
-			m.WriteString("=")                                   //nolint:revive // from buffer.go: "err is always nil"
+			m.WriteString(strings.ReplaceAll(tag.Key, " ", "_"))
+			m.WriteString("=")
 			value := tag.Value
 			if len(value) == 0 {
 				value = "null"
 			}
-			m.WriteString(strings.ReplaceAll(value, " ", "_")) //nolint:revive // from buffer.go: "err is always nil"
-			m.WriteString(" ")                                 //nolint:revive // from buffer.go: "err is always nil"
+			m.WriteString(strings.ReplaceAll(value, " ", "_"))
+			m.WriteString(" ")
 		}
-		m.WriteString(" ")                                         //nolint:revive // from buffer.go: "err is always nil"
-		m.WriteString(formatValue(fieldValue))                     //nolint:revive // from buffer.go: "err is always nil"
-		m.WriteString(" ")                                         //nolint:revive // from buffer.go: "err is always nil"
-		m.WriteString(strconv.FormatInt(metric.Time().Unix(), 10)) //nolint:revive // from buffer.go: "err is always nil"
-		m.WriteString("\n")                                        //nolint:revive // from buffer.go: "err is always nil"
+		m.WriteString(" ")
+		m.WriteString(formatValue(fieldValue))
+		m.WriteString(" ")
+		m.WriteString(strconv.FormatInt(metric.Time().Unix(), 10))
+		m.WriteString("\n")
 	}
 	return m.Bytes()
 }

--- a/plugins/serializers/prometheus/collection.go
+++ b/plugins/serializers/prometheus/collection.go
@@ -87,10 +87,10 @@ type MetricKey uint64
 func MakeMetricKey(labels []LabelPair) MetricKey {
 	h := fnv.New64a()
 	for _, label := range labels {
-		h.Write([]byte(label.Name))  //nolint:revive // from hash.go: "It never returns an error"
-		h.Write([]byte("\x00"))      //nolint:revive // from hash.go: "It never returns an error"
-		h.Write([]byte(label.Value)) //nolint:revive // from hash.go: "It never returns an error"
-		h.Write([]byte("\x00"))      //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte(label.Name))
+		h.Write([]byte("\x00"))
+		h.Write([]byte(label.Value))
+		h.Write([]byte("\x00"))
 	}
 	return MetricKey(h.Sum64())
 }

--- a/plugins/serializers/prometheus/convert.go
+++ b/plugins/serializers/prometheus/convert.go
@@ -90,13 +90,13 @@ func sanitize(name string, table Table) (string, bool) {
 		switch {
 		case i == 0:
 			if unicode.In(r, table.First) {
-				b.WriteRune(r) //nolint:revive // from builder.go: "It returns the length of r and a nil error."
+				b.WriteRune(r)
 			}
 		default:
 			if unicode.In(r, table.Rest) {
-				b.WriteRune(r) //nolint:revive // from builder.go: "It returns the length of r and a nil error."
+				b.WriteRune(r)
 			} else {
-				b.WriteString("_") //nolint:revive // from builder.go: "It returns the length of s and a nil error."
+				b.WriteString("_")
 			}
 		}
 	}

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -239,7 +239,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		return nil, fmt.Errorf("unable to marshal protobuf: %w", err)
 	}
 	encoded := snappy.Encode(nil, data)
-	buf.Write(encoded) //nolint:revive // from buffer.go: "err is always nil"
+	buf.Write(encoded)
 	return buf.Bytes(), nil
 }
 
@@ -318,10 +318,10 @@ func (s *Serializer) createLabels(metric telegraf.Metric) []prompb.Label {
 func MakeMetricKey(labels []prompb.Label) MetricKey {
 	h := fnv.New64a()
 	for _, label := range labels {
-		h.Write([]byte(label.Name))  //nolint:revive // from hash.go: "It never returns an error"
-		h.Write([]byte("\x00"))      //nolint:revive // from hash.go: "It never returns an error"
-		h.Write([]byte(label.Value)) //nolint:revive // from hash.go: "It never returns an error"
-		h.Write([]byte("\x00"))      //nolint:revive // from hash.go: "It never returns an error"
+		h.Write([]byte(label.Name))
+		h.Write([]byte("\x00"))
+		h.Write([]byte(label.Value))
+		h.Write([]byte("\x00"))
 	}
 	return MetricKey(h.Sum64())
 }

--- a/selfstat/selfstat.go
+++ b/selfstat/selfstat.go
@@ -175,7 +175,7 @@ func (r *Registry) set(key uint64, s Stat) {
 
 func key(measurement string, tags map[string]string) uint64 {
 	h := fnv.New64a()
-	h.Write([]byte(measurement)) //nolint:revive // all Write() methods for hash in fnv.go returns nil err
+	h.Write([]byte(measurement))
 
 	tmp := make([]string, 0, len(tags))
 	for k, v := range tags {
@@ -184,7 +184,7 @@ func key(measurement string, tags map[string]string) uint64 {
 	sort.Strings(tmp)
 
 	for _, s := range tmp {
-		h.Write([]byte(s)) //nolint:revive // all Write() methods for hash in fnv.go returns nil err
+		h.Write([]byte(s))
 	}
 
 	return h.Sum64()


### PR DESCRIPTION
It doesn't make sense to support two linters for checking if returned error is handled.

`errcheck` is able to find more problems, and have default exclusion list (which can be extended in `.golangci.yml`) 
https://github.com/kisielk/errcheck/blob/master/errcheck/excludes.go#L11
```go
		// bytes
		"(*bytes.Buffer).Write",
		"(*bytes.Buffer).WriteByte",
		"(*bytes.Buffer).WriteRune",
		"(*bytes.Buffer).WriteString",

		// fmt
		"fmt.Errorf",
		"fmt.Print",
		"fmt.Printf",
		"fmt.Println",
		"fmt.Fprint(*bytes.Buffer)",
		"fmt.Fprintf(*bytes.Buffer)",
		"fmt.Fprintln(*bytes.Buffer)",
		"fmt.Fprint(*strings.Builder)",
		"fmt.Fprintf(*strings.Builder)",
		"fmt.Fprintln(*strings.Builder)",
		"fmt.Fprint(os.Stderr)",
		"fmt.Fprintf(os.Stderr)",
		"fmt.Fprintln(os.Stderr)",

		// io
		"(*io.PipeReader).CloseWithError",
		"(*io.PipeWriter).CloseWithError",

		// math/rand
		"math/rand.Read",
		"(*math/rand.Rand).Read",

		// strings
		"(*strings.Builder).Write",
		"(*strings.Builder).WriteByte",
		"(*strings.Builder).WriteRune",
		"(*strings.Builder).WriteString",

		// hash
		"(hash.Hash).Write",
```

`revive` allows to exclude only functions. `errcheck` supports also methods, so doesn't need a lot of repeating `//nolint`'s in code.