### PR TITLE
chore: Enable G107 rule for gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,6 +83,7 @@ linters-settings:
     includes:
       - G102
       - G106
+      - G107
       - G108
       - G109
       - G111

--- a/tools/license_checker/package.go
+++ b/tools/license_checker/package.go
@@ -31,7 +31,7 @@ func (pkg *packageInfo) Classify() (float64, error) {
 	}
 	debugf("%q downloading from %q", pkg.name, source)
 
-	response, err := http.Get(source)
+	response, err := http.Get(source.String())
 	if err != nil {
 		return 0.0, fmt.Errorf("download from %q failed: %w", source, err)
 	}
@@ -62,10 +62,10 @@ func (pkg *packageInfo) Classify() (float64, error) {
 	return coverage.Percent, nil
 }
 
-func normalizeURL(raw string) (string, error) {
+func normalizeURL(raw string) (*url.URL, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	switch u.Hostname() {
@@ -93,5 +93,5 @@ func normalizeURL(raw string) (string, error) {
 		u.RawQuery = strings.Join(parts, ";")
 	}
 
-	return u.String(), nil
+	return u, nil
 }


### PR DESCRIPTION
resolves https://github.com/influxdata/telegraf/issues/12894