### PR TITLE
fix(agent): pass quiet flag earlier

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -211,6 +211,7 @@ func (t *Telegraf) watchLocalConfig(signals chan os.Signal, fConfig string) {
 func (t *Telegraf) loadConfiguration() (*config.Config, error) {
 	// If no other options are specified, load the config file and run.
 	c := config.NewConfig()
+	c.Agent.Quiet = t.quiet
 	c.OutputFilters = t.outputFilters
 	c.InputFilters = t.inputFilters
 	c.SecretStoreFilters = t.secretstoreFilters

--- a/config/config.go
+++ b/config/config.go
@@ -443,6 +443,10 @@ func (c *Config) LoadConfig(path string) error {
 	}
 
 	for _, path := range paths {
+		if !c.Agent.Quiet {
+			log.Printf("I! Loading config: %s", path)
+		}
+
 		data, err := LoadConfigFile(path)
 		if err != nil {
 			return fmt.Errorf("error loading config file %s: %w", path, err)
@@ -700,7 +704,6 @@ func escapeEnv(value string) string {
 
 func LoadConfigFile(config string) ([]byte, error) {
 	if fetchURLRe.MatchString(config) {
-		log.Printf("I! Loading config url: %s", config)
 		u, err := url.Parse(config)
 		if err != nil {
 			return nil, err
@@ -715,7 +718,6 @@ func LoadConfigFile(config string) ([]byte, error) {
 	}
 
 	// If it isn't a https scheme, try it as a file
-	log.Printf("I! Loading config file: %s", config)
 	buffer, err := os.ReadFile(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Additional messages were added to help users know what file was getting loaded or not. The quiet flag was not yet set up or parsed which meant these messages were printed no matter what. This will at least check if the quiet flag was passed and suppress output.

fixes: #13011