### PR TITLE
chore: Enable G401, G403, G501, G502, G503 and G505 rules for gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,6 +100,12 @@ linters-settings:
       - G201
       - G202
       - G203
+      - G401
+      - G403
+      - G501
+      - G502
+      - G503
+      - G505
   lll:
     # Max line length, lines longer will be reported.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option.

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -2,7 +2,7 @@
 package filestat
 
 import (
-	"crypto/md5"
+	"crypto/md5" //nolint:gosec // G501: Blocklisted import crypto/md5: weak cryptographic primitive - md5 hash is what is desired in this case
 	_ "embed"
 	"fmt"
 	"io"
@@ -116,7 +116,7 @@ func (f *FileStat) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-// Read given file and calculate an md5 hash.
+// Read given file and calculate a md5 hash.
 func getMd5(file string) (string, error) {
 	of, err := os.Open(file)
 	if err != nil {
@@ -124,6 +124,7 @@ func getMd5(file string) (string, error) {
 	}
 	defer of.Close()
 
+	//nolint:gosec // G401: Use of weak cryptographic primitive - md5 hash is what is desired in this case
 	hash := md5.New()
 	_, err = io.Copy(hash, of)
 	if err != nil {

--- a/plugins/inputs/webhooks/artifactory/artifactory_webhook.go
+++ b/plugins/inputs/webhooks/artifactory/artifactory_webhook.go
@@ -2,7 +2,7 @@ package artifactory
 
 import (
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha1" //nolint:gosec // G505: Blocklisted import crypto/sha1: weak cryptographic primitive - sha1 hash is what is desired in this case
 	"encoding/hex"
 	"encoding/json"
 	"fmt"

--- a/plugins/inputs/webhooks/github/github_webhooks.go
+++ b/plugins/inputs/webhooks/github/github_webhooks.go
@@ -2,7 +2,7 @@ package github
 
 import (
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha1" //nolint:gosec // G505: Blocklisted import crypto/sha1: weak cryptographic primitive - sha1 hash is what is desired in this case
 	"encoding/hex"
 	"encoding/json"
 	"io"


### PR DESCRIPTION
resolves https://github.com/influxdata/telegraf/issues/12946
resolves https://github.com/influxdata/telegraf/issues/12948
resolves https://github.com/influxdata/telegraf/issues/12950
resolves https://github.com/influxdata/telegraf/issues/12951
resolves https://github.com/influxdata/telegraf/issues/12952
resolves https://github.com/influxdata/telegraf/issues/12954