### PR TITLE
chore: Enable G303 and G305 rules for gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,8 @@ linters-settings:
       - G203
       - G301
       - G302
+      - G303
+      - G305
       - G306
       - G401
       - G403


### PR DESCRIPTION
resolves https://github.com/influxdata/telegraf/issues/12942
resolves https://github.com/influxdata/telegraf/issues/12944