### PR TITLE
chore: Fix linter findings for Windows (part1)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -241,7 +241,7 @@ issues:
     # revive:var-naming
     - don't use an underscore in package name
     # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
-    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close.*|.*Flush|.*Disconnect|.*Clear|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
     # EXC0013 revive: Annoying issue about not having a comment. The rare codebase has such comments
     - package comment should be of the form "(.+)...
     # EXC0015 revive: Annoying issue about not having a comment. The rare codebase has such comments

--- a/plugins/inputs/execd/execd_windows.go
+++ b/plugins/inputs/execd/execd_windows.go
@@ -19,10 +19,12 @@ func (e *Execd) Gather(acc telegraf.Accumulator) error {
 	switch e.Signal {
 	case "STDIN":
 		if osStdin, ok := e.process.Stdin.(*os.File); ok {
-			osStdin.SetWriteDeadline(time.Now().Add(1 * time.Second))
+			if err := osStdin.SetWriteDeadline(time.Now().Add(1 * time.Second)); err != nil {
+				return fmt.Errorf("error writing dealine: %w", err)
+			}
 		}
 		if _, err := io.WriteString(e.process.Stdin, "\n"); err != nil {
-			return fmt.Errorf("Error writing to stdin: %s", err)
+			return fmt.Errorf("error writing to stdin: %w", err)
 		}
 	case "none":
 	default:

--- a/plugins/inputs/execd/shim/goshim_windows.go
+++ b/plugins/inputs/execd/shim/goshim_windows.go
@@ -13,6 +13,7 @@ func listenForCollectMetricsSignals(ctx context.Context, collectMetricsPrompt ch
 	signal.Notify(collectMetricsPrompt, syscall.SIGHUP)
 
 	go func() {
+		//nolint:gosimple // for-select used on purpose
 		select {
 		case <-ctx.Done():
 			// context done. stop to signals to avoid pushing messages to a closed channel

--- a/plugins/inputs/ping/ping_windows.go
+++ b/plugins/inputs/ping/ping_windows.go
@@ -12,11 +12,11 @@ import (
 	"github.com/influxdata/telegraf"
 )
 
-func (p *Ping) pingToURL(u string, acc telegraf.Accumulator) {
-	tags := map[string]string{"url": u}
+func (p *Ping) pingToURL(host string, acc telegraf.Accumulator) {
+	tags := map[string]string{"url": host}
 	fields := map[string]interface{}{"result_code": 0}
 
-	args := p.args(u)
+	args := p.args(host)
 	totalTimeout := 60.0
 	if len(p.Arguments) == 0 {
 		totalTimeout = p.timeout() * float64(p.Count)
@@ -34,9 +34,9 @@ func (p *Ping) pingToURL(u string, acc telegraf.Accumulator) {
 	if err != nil {
 		// fatal error
 		if pendingError != nil {
-			acc.AddError(fmt.Errorf("%s: %s", pendingError, u))
+			acc.AddError(fmt.Errorf("%w: %q", pendingError, host))
 		} else {
-			acc.AddError(fmt.Errorf("%s: %s", err, u))
+			acc.AddError(fmt.Errorf("%w: %q", err, host))
 		}
 
 		fields["result_code"] = 2

--- a/plugins/inputs/ping/ping_windows_test.go
+++ b/plugins/inputs/ping/ping_windows_test.go
@@ -73,7 +73,8 @@ func TestPingGather(t *testing.T) {
 		pingHost: mockHostPinger,
 	}
 
-	acc.GatherError(p.Gather)
+	err := acc.GatherError(p.Gather)
+	require.NoError(t, err)
 	tags := map[string]string{"url": "www.google.com"}
 	fields := map[string]interface{}{
 		"packets_transmitted": 4,
@@ -118,7 +119,9 @@ func TestBadPingGather(t *testing.T) {
 		pingHost: mockErrorHostPinger,
 	}
 
-	acc.GatherError(p.Gather)
+	err := acc.GatherError(p.Gather)
+	require.NoError(t, err)
+
 	tags := map[string]string{"url": "www.amazon.com"}
 	fields := map[string]interface{}{
 		"packets_transmitted": 4,
@@ -176,7 +179,9 @@ func TestLossyPingGather(t *testing.T) {
 		pingHost: mockLossyHostPinger,
 	}
 
-	acc.GatherError(p.Gather)
+	err := acc.GatherError(p.Gather)
+	require.NoError(t, err)
+
 	tags := map[string]string{"url": "www.google.com"}
 	fields := map[string]interface{}{
 		"packets_transmitted": 9,
@@ -237,7 +242,9 @@ func TestFatalPingGather(t *testing.T) {
 		pingHost: mockFatalHostPinger,
 	}
 
-	acc.GatherError(p.Gather)
+	err := acc.GatherError(p.Gather)
+	require.NoError(t, err)
+
 	require.True(t, acc.HasFloatField("ping", "errors"),
 		"Fatal ping should have packet measurements")
 	require.False(t, acc.HasInt64Field("ping", "packets_transmitted"),
@@ -283,7 +290,8 @@ func TestUnreachablePingGather(t *testing.T) {
 		pingHost: mockUnreachableHostPinger,
 	}
 
-	acc.GatherError(p.Gather)
+	err := acc.GatherError(p.Gather)
+	require.NoError(t, err)
 
 	tags := map[string]string{"url": "www.google.com"}
 	fields := map[string]interface{}{
@@ -331,7 +339,8 @@ func TestTTLExpiredPingGather(t *testing.T) {
 		pingHost: mockTTLExpiredPinger,
 	}
 
-	acc.GatherError(p.Gather)
+	err := acc.GatherError(p.Gather)
+	require.NoError(t, err)
 
 	tags := map[string]string{"url": "www.google.com"}
 	fields := map[string]interface{}{
@@ -365,5 +374,6 @@ func TestPingBinary(t *testing.T) {
 			return "", nil
 		},
 	}
-	acc.GatherError(p.Gather)
+	err := acc.GatherError(p.Gather)
+	require.NoError(t, err)
 }

--- a/plugins/inputs/procstat/win_service_windows.go
+++ b/plugins/inputs/procstat/win_service_windows.go
@@ -3,6 +3,7 @@
 package procstat
 
 import (
+	"errors"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -34,7 +35,8 @@ func queryPidWithWinServiceName(winServiceName string) (uint32, error) {
 	var bytesNeeded uint32
 	var buf []byte
 
-	if err := windows.QueryServiceStatusEx(srv.Handle, windows.SC_STATUS_PROCESS_INFO, nil, 0, &bytesNeeded); err != windows.ERROR_INSUFFICIENT_BUFFER {
+	err = windows.QueryServiceStatusEx(srv.Handle, windows.SC_STATUS_PROCESS_INFO, nil, 0, &bytesNeeded)
+	if !errors.Is(err, windows.ERROR_INSUFFICIENT_BUFFER) {
 		return 0, err
 	}
 

--- a/plugins/inputs/win_eventlog/util.go
+++ b/plugins/inputs/win_eventlog/util.go
@@ -8,6 +8,7 @@ package win_eventlog
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -97,12 +98,10 @@ func UnrollXMLFields(data []byte, fieldsUsage map[string]int, separator string) 
 	for {
 		var node xmlnode
 		err := dec.Decode(&node)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) || err != nil {
 			break
 		}
-		if err != nil {
-			break
-		}
+
 		var parents []string
 		walkXML([]xmlnode{node}, parents, separator, func(node xmlnode, parents []string, separator string) bool {
 			innerText := strings.TrimSpace(node.Text)

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -120,7 +121,7 @@ func (w *WinEventLog) Gather(acc telegraf.Accumulator) error {
 	for {
 		events, err := w.fetchEvents(w.subscription)
 		if err != nil {
-			if err == ERROR_NO_MORE_ITEMS {
+			if errors.Is(err, ERROR_NO_MORE_ITEMS) {
 				break
 			}
 			w.Log.Errorf("Error getting events: %v", err)
@@ -333,7 +334,7 @@ func (w *WinEventLog) fetchEventHandles(subsHandle EvtHandle) ([]EvtHandle, erro
 
 	err := _EvtNext(subsHandle, eventsNumber, &eventHandles[0], 0, 0, &evtReturned)
 	if err != nil {
-		if err == ERROR_INVALID_OPERATION && evtReturned == 0 {
+		if errors.Is(err, ERROR_INVALID_OPERATION) && evtReturned == 0 {
 			return nil, ERROR_NO_MORE_ITEMS
 		}
 		return nil, err
@@ -428,7 +429,7 @@ func (w *WinEventLog) renderLocalMessage(event Event, eventHandle EvtHandle) (Ev
 	if err != nil {
 		return event, nil
 	}
-	defer _EvtClose(publisherHandle)
+	defer _EvtClose(publisherHandle) //nolint:errcheck // Ignore error returned during Close
 
 	// Populating text values
 	keywords, err := formatEventString(EvtFormatMessageKeyword, eventHandle, publisherHandle)
@@ -493,7 +494,7 @@ func formatEventString(
 	var bufferUsed uint32
 	err := _EvtFormatMessage(publisherHandle, eventHandle, 0, 0, 0, messageFlag,
 		0, nil, &bufferUsed)
-	if err != nil && err != ERROR_INSUFFICIENT_BUFFER {
+	if err != nil && !errors.Is(err, ERROR_INSUFFICIENT_BUFFER) {
 		return "", err
 	}
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -382,7 +382,8 @@ func (m *WinPerfCounters) ParseConfig() error {
 }
 
 func (m *WinPerfCounters) checkError(err error) error {
-	if pdhErr, ok := err.(*PdhError); ok {
+	var pdhErr *PdhError
+	if errors.As(err, &pdhErr) {
 		for _, ignoredErrors := range m.IgnoredErrors {
 			if PDHErrors[pdhErr.ErrorCode] == ignoredErrors {
 				return nil
@@ -466,7 +467,7 @@ func (m *WinPerfCounters) gatherComputerCounters(hostCounterInfo *hostCountersIn
 			if err != nil {
 				//ignore invalid data  as some counters from process instances returns this sometimes
 				if !isKnownCounterDataError(err) {
-					return fmt.Errorf("error while getting value for counter %s: %v", metric.counterPath, err)
+					return fmt.Errorf("error while getting value for counter %q: %w", metric.counterPath, err)
 				}
 				m.Log.Warnf("error while getting value for counter %q, instance: %s, will skip metric: %v", metric.counterPath, metric.instance, err)
 				continue
@@ -482,7 +483,7 @@ func (m *WinPerfCounters) gatherComputerCounters(hostCounterInfo *hostCountersIn
 			if err != nil {
 				//ignore invalid data  as some counters from process instances returns this sometimes
 				if !isKnownCounterDataError(err) {
-					return fmt.Errorf("error while getting value for counter %s: %v", metric.counterPath, err)
+					return fmt.Errorf("error while getting value for counter %q: %w", metric.counterPath, err)
 				}
 				m.Log.Warnf("error while getting value for counter %q, instance: %s, will skip metric: %v", metric.counterPath, metric.instance, err)
 				continue
@@ -555,7 +556,8 @@ func addCounterMeasurement(metric *counter, instanceName string, value interface
 }
 
 func isKnownCounterDataError(err error) bool {
-	if pdhErr, ok := err.(*PdhError); ok && (pdhErr.ErrorCode == PDH_INVALID_DATA ||
+	var pdhErr *PdhError
+	if errors.As(err, &pdhErr) && (pdhErr.ErrorCode == PDH_INVALID_DATA ||
 		pdhErr.ErrorCode == PDH_CALC_NEGATIVE_DENOMINATOR ||
 		pdhErr.ErrorCode == PDH_CALC_NEGATIVE_VALUE ||
 		pdhErr.ErrorCode == PDH_CSTATUS_INVALID_DATA ||

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -3,13 +3,15 @@
 package win_perf_counters
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestWinPerformanceQueryImplIntegration(t *testing.T) {
@@ -107,7 +109,8 @@ func TestWinPerformanceQueryImplIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	farr, err := query.GetFormattedCounterArrayDouble(hCounter)
-	if phderr, ok := err.(*PdhError); ok && phderr.ErrorCode != PDH_INVALID_DATA && phderr.ErrorCode != PDH_CALC_NEGATIVE_VALUE {
+	var phdErr *PdhError
+	if errors.As(err, &phdErr) && phdErr.ErrorCode != PDH_INVALID_DATA && phdErr.ErrorCode != PDH_CALC_NEGATIVE_VALUE {
 		time.Sleep(time.Second)
 		farr, err = query.GetFormattedCounterArrayDouble(hCounter)
 	}

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -31,7 +31,7 @@ type FakePerformanceQuery struct {
 var MetricTime = time.Date(2018, 5, 28, 12, 0, 0, 0, time.UTC)
 
 func (m *testCounter) ToCounterValue(raw bool) *CounterValue {
-	_, _, inst, _, _ := extractCounterInfoFromCounterPath(m.path)
+	_, _, inst, _, _ := extractCounterInfoFromCounterPath(m.path) //nolint:dogsled // only instance is needed for this helper function in tests
 	if inst == "" {
 		inst = "--"
 	}
@@ -71,7 +71,7 @@ func (m *FakePerformanceQuery) AddCounterToQuery(counterPath string) (PDH_HCOUNT
 	if c, ok := m.counters[counterPath]; ok {
 		return c.handle, nil
 	} else {
-		return 0, errors.New(fmt.Sprintf("AddCounterToQuery: invalid counter path: %s", counterPath))
+		return 0, fmt.Errorf("AddCounterToQuery: invalid counter path: %q", counterPath)
 	}
 }
 
@@ -82,7 +82,7 @@ func (m *FakePerformanceQuery) AddEnglishCounterToQuery(counterPath string) (PDH
 	if c, ok := m.counters[counterPath]; ok {
 		return c.handle, nil
 	} else {
-		return 0, fmt.Errorf("AddEnglishCounterToQuery: invalid counter path: %s", counterPath)
+		return 0, fmt.Errorf("AddEnglishCounterToQuery: invalid counter path: %q", counterPath)
 	}
 }
 

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -5,6 +5,7 @@ package win_services
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 
@@ -19,19 +20,20 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type ServiceErr struct {
+type ServiceError struct {
 	Message string
 	Service string
 	Err     error
 }
 
-func (e *ServiceErr) Error() string {
+func (e *ServiceError) Error() string {
 	return fmt.Sprintf("%s: %q: %v", e.Message, e.Service, e.Err)
 }
 
 func IsPermission(err error) bool {
-	if err, ok := err.(*ServiceErr); ok {
-		return os.IsPermission(err.Err)
+	var serviceErr *ServiceError
+	if errors.As(err, &serviceErr) {
+		return os.IsPermission(serviceErr.Err)
 	}
 	return false
 }
@@ -119,7 +121,7 @@ func (m *WinServices) Init() error {
 func (m *WinServices) Gather(acc telegraf.Accumulator) error {
 	scmgr, err := m.mgrProvider.Connect()
 	if err != nil {
-		return fmt.Errorf("Could not open service manager: %s", err)
+		return fmt.Errorf("could not open service manager: %w", err)
 	}
 	defer scmgr.Disconnect()
 
@@ -161,7 +163,7 @@ func (m *WinServices) Gather(acc telegraf.Accumulator) error {
 func (m *WinServices) listServices(scmgr WinServiceManager) ([]string, error) {
 	names, err := scmgr.ListServices()
 	if err != nil {
-		return nil, fmt.Errorf("Could not list services: %s", err)
+		return nil, fmt.Errorf("could not list services: %w", err)
 	}
 
 	var services []string
@@ -178,7 +180,7 @@ func (m *WinServices) listServices(scmgr WinServiceManager) ([]string, error) {
 func collectServiceInfo(scmgr WinServiceManager, serviceName string) (*ServiceInfo, error) {
 	srv, err := scmgr.OpenService(serviceName)
 	if err != nil {
-		return nil, &ServiceErr{
+		return nil, &ServiceError{
 			Message: "could not open service",
 			Service: serviceName,
 			Err:     err,
@@ -188,7 +190,7 @@ func collectServiceInfo(scmgr WinServiceManager, serviceName string) (*ServiceIn
 
 	srvStatus, err := srv.Query()
 	if err != nil {
-		return nil, &ServiceErr{
+		return nil, &ServiceError{
 			Message: "could not query service",
 			Service: serviceName,
 			Err:     err,
@@ -197,7 +199,7 @@ func collectServiceInfo(scmgr WinServiceManager, serviceName string) (*ServiceIn
 
 	srvCfg, err := srv.Config()
 	if err != nil {
-		return nil, &ServiceErr{
+		return nil, &ServiceError{
 			Message: "could not get config of service",
 			Service: serviceName,
 			Err:     err,

--- a/plugins/inputs/win_services/win_services_integration_test.go
+++ b/plugins/inputs/win_services/win_services_integration_test.go
@@ -20,12 +20,17 @@ func TestListIntegration(t *testing.T) {
 	provider := &MgProvider{}
 	scmgr, err := provider.Connect()
 	require.NoError(t, err)
-	defer scmgr.Disconnect()
+	defer func() {
+		err := scmgr.Disconnect()
+		require.NoError(t, err)
+	}()
 
 	winServices := &WinServices{
 		ServiceNames: KnownServices,
 	}
-	winServices.Init()
+	err = winServices.Init()
+	require.NoError(t, err)
+
 	services, err := winServices.listServices(scmgr)
 	require.NoError(t, err)
 	require.Len(t, services, 2, "Different number of services")
@@ -40,12 +45,16 @@ func TestEmptyListIntegration(t *testing.T) {
 	provider := &MgProvider{}
 	scmgr, err := provider.Connect()
 	require.NoError(t, err)
-	defer scmgr.Disconnect()
+	defer func() {
+		err := scmgr.Disconnect()
+		require.NoError(t, err)
+	}()
 
 	winServices := &WinServices{
 		ServiceNames: []string{},
 	}
-	winServices.Init()
+	err = winServices.Init()
+	require.NoError(t, err)
 	services, err := winServices.listServices(scmgr)
 	require.NoError(t, err)
 	require.Condition(t, func() bool { return len(services) > 20 }, "Too few service")
@@ -60,7 +69,8 @@ func TestGatherErrorsIntegration(t *testing.T) {
 		ServiceNames: InvalidServices,
 		mgrProvider:  &MgProvider{},
 	}
-	ws.Init()
+	err := ws.Init()
+	require.NoError(t, err)
 	require.Len(t, ws.ServiceNames, 3, "Different number of services")
 	var acc testutil.Accumulator
 	require.NoError(t, ws.Gather(&acc))

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -155,9 +155,10 @@ func TestMgrErrors(t *testing.T) {
 		ServiceNames: []string{"Fake service 1"},
 		mgrProvider:  &FakeMgProvider{testErrors[3]},
 	}
-	winServices.Init()
-	var acc3 testutil.Accumulator
+	err = winServices.Init()
+	require.NoError(t, err)
 
+	var acc3 testutil.Accumulator
 	buf := &bytes.Buffer{}
 	log.SetOutput(buf)
 	require.NoError(t, winServices.Gather(&acc3))
@@ -170,9 +171,10 @@ func TestServiceErrors(t *testing.T) {
 		Log:         testutil.Logger{},
 		mgrProvider: &FakeMgProvider{testErrors[2]},
 	}
-	winServices.Init()
-	var acc1 testutil.Accumulator
+	err := winServices.Init()
+	require.NoError(t, err)
 
+	var acc1 testutil.Accumulator
 	buf := &bytes.Buffer{}
 	log.SetOutput(buf)
 	require.NoError(t, winServices.Gather(&acc1))
@@ -198,7 +200,10 @@ func TestGatherContainsTag(t *testing.T) {
 		ServiceNames: []string{"Service*"},
 		mgrProvider:  &FakeMgProvider{testSimpleData[0]},
 	}
-	winServices.Init()
+
+	err := winServices.Init()
+	require.NoError(t, err)
+
 	var acc1 testutil.Accumulator
 	require.NoError(t, winServices.Gather(&acc1))
 	require.Len(t, acc1.Errors, 0, "There should be no errors after gather")
@@ -220,7 +225,9 @@ func TestExcludingNamesTag(t *testing.T) {
 		ServiceNamesExcluded: []string{"Service*"},
 		mgrProvider:          &FakeMgProvider{testSimpleData[0]},
 	}
-	winServices.Init()
+	err := winServices.Init()
+	require.NoError(t, err)
+
 	var acc1 testutil.Accumulator
 	require.NoError(t, winServices.Gather(&acc1))
 

--- a/plugins/inputs/win_wmi/win_wmi.go
+++ b/plugins/inputs/win_wmi/win_wmi.go
@@ -5,6 +5,7 @@ package win_wmi
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -110,8 +111,8 @@ func (q *Query) doQuery(acc telegraf.Accumulator) error {
 
 	// init COM
 	if err := ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED); err != nil {
-		oleCode := err.(*ole.OleError).Code()
-		if oleCode != ole.S_OK && oleCode != sFalse {
+		var oleCode *ole.OleError
+		if errors.As(err, &oleCode) && oleCode.Code() != ole.S_OK && oleCode.Code() != sFalse {
 			return err
 		}
 	}

--- a/plugins/inputs/win_wmi/win_wmi_test.go
+++ b/plugins/inputs/win_wmi/win_wmi_test.go
@@ -68,7 +68,9 @@ func TestWmi_Gather(t *testing.T) {
 	var logger = new(testutil.Logger)
 	var acc = new(testutil.Accumulator)
 	plugin := Wmi{Queries: []Query{testQuery}, Log: logger}
-	plugin.Init()
+	err := plugin.Init()
+	require.NoError(t, err)
+
 	require.NoError(t, plugin.Gather(acc))
 	// no errors in accumulator
 	require.Empty(t, acc.Errors)


### PR DESCRIPTION
It is only part of the bigger job: https://github.com/influxdata/telegraf/issues/13036
After all findings in whole project are handled for `Windows`, linter CI job for Windows can be enabled.

Fixes for following linters have been made:
- `dogsled`
- `errcheck`
- `errname`
- `errorlint`
- `gosimple`

Following findings were addressed:
```
plugins/inputs/execd/execd_windows.go:22:28                                    errcheck   Error return value of `osStdin.SetWriteDeadline` is not checked
plugins/inputs/execd/execd_windows.go:25:52                                    errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/execd/shim/goshim_windows.go:16:3                               gosimple   S1000: should use a simple channel send/receive instead of `select` with a single case
plugins/inputs/ping/ping_windows.go:37:38                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/ping/ping_windows.go:39:38                                      errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/ping/ping_windows_test.go:121:17                                errcheck   Error return value of `acc.GatherError` is not checked
plugins/inputs/ping/ping_windows_test.go:179:17                                errcheck   Error return value of `acc.GatherError` is not checked
plugins/inputs/ping/ping_windows_test.go:240:17                                errcheck   Error return value of `acc.GatherError` is not checked
plugins/inputs/ping/ping_windows_test.go:286:17                                errcheck   Error return value of `acc.GatherError` is not checked
plugins/inputs/ping/ping_windows_test.go:334:17                                errcheck   Error return value of `acc.GatherError` is not checked
plugins/inputs/ping/ping_windows_test.go:368:17                                errcheck   Error return value of `acc.GatherError` is not checked
plugins/inputs/ping/ping_windows_test.go:76:17                                 errcheck   Error return value of `acc.GatherError` is not checked
plugins/inputs/procstat/win_service_windows.go:17:20                           errcheck   Error return value of `m.Disconnect` is not checked
plugins/inputs/procstat/win_service_windows.go:37:108                          errorlint  comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/inputs/win_eventlog/util.go:100:6                                      errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/inputs/win_eventlog/util.go:52:27                                      errcheck   Error return value of `windows.CloseHandle` is not checked
plugins/inputs/win_eventlog/win_eventlog.go:123:7                              errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/inputs/win_eventlog/win_eventlog.go:302:27                             errcheck   Error return value of `windows.CloseHandle` is not checked
plugins/inputs/win_eventlog/win_eventlog.go:336:6                              errorlint  comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/inputs/win_eventlog/win_eventlog.go:431:17                             errcheck   Error return value is not checked
plugins/inputs/win_eventlog/win_eventlog.go:496:19                             errorlint  comparing with != will fail on wrapped errors. Use errors.Is to check for a specific error
plugins/inputs/win_perf_counters/win_perf_counters.go:385:19                   errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/inputs/win_perf_counters/win_perf_counters.go:469:92                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/win_perf_counters/win_perf_counters.go:485:92                   errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/win_perf_counters/win_perf_counters.go:558:19                   errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go:110:19  errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/inputs/win_perf_counters/win_perf_counters_test.go:34:2                dogsled    declaration has 4 blank identifiers
plugins/inputs/win_perf_counters/win_perf_counters_test.go:74:13               gosimple   S1028: should use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...))
plugins/inputs/win_services/win_services.go:122:59                             errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/win_services/win_services.go:124:24                             errcheck   Error return value of `scmgr.Disconnect` is not checked
plugins/inputs/win_services/win_services.go:164:57                             errorlint  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
plugins/inputs/win_services/win_services.go:22:6                               errname    the type name `ServiceErr` should conform to the `XxxError` format
plugins/inputs/win_services/win_services.go:33:16                              errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/inputs/win_services/win_services_integration_test.go:23:24             errcheck   Error return value of `scmgr.Disconnect` is not checked
plugins/inputs/win_services/win_services_integration_test.go:28:18             errcheck   Error return value of `winServices.Init` is not checked
plugins/inputs/win_services/win_services_integration_test.go:43:24             errcheck   Error return value of `scmgr.Disconnect` is not checked
plugins/inputs/win_services/win_services_integration_test.go:48:18             errcheck   Error return value of `winServices.Init` is not checked
plugins/inputs/win_services/win_services_integration_test.go:63:9              errcheck   Error return value of `ws.Init` is not checked
plugins/inputs/win_services/win_services_test.go:158:18                        errcheck   Error return value of `winServices.Init` is not checked
plugins/inputs/win_services/win_services_test.go:173:18                        errcheck   Error return value of `winServices.Init` is not checked
plugins/inputs/win_services/win_services_test.go:201:18                        errcheck   Error return value of `winServices.Init` is not checked
plugins/inputs/win_services/win_services_test.go:223:18                        errcheck   Error return value of `winServices.Init` is not checked
plugins/inputs/win_wmi/win_wmi.go:113:14                                       errorlint  type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
plugins/inputs/win_wmi/win_wmi.go:141:24                                       errcheck   Error return value of `serviceRaw.Clear` is not checked
plugins/inputs/win_wmi/win_wmi.go:149:23                                       errcheck   Error return value of `resultRaw.Clear` is not checked
plugins/inputs/win_wmi/win_wmi.go:171:20                                       errcheck   Error return value of `prop.Clear` is not checked
plugins/inputs/win_wmi/win_wmi.go:50:15                                        errcheck   Error return value of `v.Clear` is not checked
plugins/inputs/win_wmi/win_wmi_test.go:71:13                                   errcheck   Error return value of `plugin.Init` is not checked
```

