### PR TITLE
feat(processor.Scaler): Adding scaler processor plugin

### DIFF
--- a/plugins/processors/all/scaler.go
+++ b/plugins/processors/all/scaler.go
@@ -1,0 +1,5 @@
+//go:build !custom || processors || processors.scaler
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/processors/scaler" // register plugin

--- a/plugins/processors/scaler/README.md
+++ b/plugins/processors/scaler/README.md
@@ -1,0 +1,53 @@
+# Scaler Processor Plugin
+
+The scaler processor filters for a set of fields and scales the respective values from an input range in to a given output range according to this formula:
+
+$$\textnormal{result}=(\textnormal{value}-\textnormal{input\_minimum})\cdot \frac{(\textnormal{\textnormal{output\_maximum}}-\textnormal{output\_minimum})}{(\textnormal{input\_maximum}-\textnormal{input\_minimum})} + \textnormal{output\_minimum}$$
+
+Nither the input, not the output values, are required to be in the respective ranges.
+However, it is required, that input_minimum and input_maximum do not have the same value.
+
+## Global configuration options <!-- @/docs/includes/plugin_config.md -->
+
+In addition to the plugin-specific configuration settings, plugins support
+additional global and plugin configuration settings. These settings are used to
+modify metrics, tags, and field or create aliases and configure ordering, etc.
+See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
+
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
+
+## Configuration
+
+```toml @sample.conf
+# Scale values with a predefined range to a different output range.
+[[processors.scaler]]
+
+    # It is possible to define multiple different scalings that can be applied do different sets of fields
+    # Each scaling expects five arguments:
+    #   - input_minimum: Minimum expected input value
+    #   - input_maximum: Maximum expected input value
+    #   - output_minimum: Minimum desired output value
+    #   - output_maximum: Maximum desired output value
+    #   - fields: a list of field names (or filters) to apply this scaling to
+    
+    # Convert Fahrenheit to Celsius
+    [processors.scaler.scaling]
+        input_minimum = 32
+        input_maximum = 212
+        output_minimum = 0
+        output_maximum = 100
+        fields = ["temperature1", "temperature2"]
+        
+
+    # Defined a second scaling. 
+    [processors.scaler.scaling]
+        input_minimum = -2800
+        input_maximum = 100
+        output_minimum = -20
+        output_maximum = 40
+        fields = ["humidity1", "humidity2"]
+```
+
+## Tags
+
+No tags are applied by this processor.

--- a/plugins/processors/scaler/sample.conf
+++ b/plugins/processors/scaler/sample.conf
@@ -1,24 +1,27 @@
-# Scale values with a predifined range to a different output range
+# Scale values with a predefined range to a different output range.
 [[processors.scaler]]
 
     # It is possible to define multiple different scalings that can be applied do different sets of fields
-    # Each scaling exects five arguments:
+    # Each scaling expects five arguments:
     #   - input_minimum: Minimum expected input value
     #   - input_maximum: Maximum expected input value
     #   - output_minimum: Minimum desired output value
     #   - output_maximum: Maximum desired output value
     #   - fields: a list of field names (or filters) to apply this scaling to
+    
+    # Convert Fahrenheit to Celsius
     [processors.scaler.scaling]
-        input_minimum = 4
-        input_maximum = 20
+        input_minimum = 32
+        input_maximum = 212
         output_minimum = 0
         output_maximum = 100
-        fields = ["humidity1", "humidity2"]
+        fields = ["temperature1", "temperature2"]
+        
 
-
+    # Defined a second scaling. 
     [processors.scaler.scaling]
         input_minimum = -2800
         input_maximum = 100
         output_minimum = -20
         output_maximum = 40
-        fields = ["temperature1", "temperature2"]
+        fields = ["humidity1", "humidity2"]

--- a/plugins/processors/scaler/sample.conf
+++ b/plugins/processors/scaler/sample.conf
@@ -1,0 +1,24 @@
+# Scale values with a predifined range to a different output range
+[[processors.scaler]]
+
+    # It is possible to define multiple different scalings that can be applied do different sets of fields
+    # Each scaling exects five arguments:
+    #   - input_minimum: Minimum expected input value
+    #   - input_maximum: Maximum expected input value
+    #   - output_minimum: Minimum desired output value
+    #   - output_maximum: Maximum desired output value
+    #   - fields: a list of field names (or filters) to apply this scaling to
+    [processors.scaler.scaling]
+        input_minimum = 4
+        input_maximum = 20
+        output_minimum = 0
+        output_maximum = 100
+        fields = ["humidity1", "humidity2"]
+
+
+    [processors.scaler.scaling]
+        input_minimum = -2800
+        input_maximum = 100
+        output_minimum = -20
+        output_maximum = 40
+        fields = ["temperature1", "temperature2"]

--- a/plugins/processors/scaler/scaler.go
+++ b/plugins/processors/scaler/scaler.go
@@ -1,0 +1,104 @@
+//go:generate ../../../tools/readme_config_includer/generator
+package scaler
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/filter"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+func (*Scaler) SampleConfig() string {
+	return sampleConfig
+}
+
+type Scaling struct {
+	InMin  float64  `toml:"input_minimum"`
+	InMax  float64  `toml:"input_maximum"`
+	OutMin float64  `toml:"output_minimum"`
+	OutMax float64  `toml:"output_maximum"`
+	Fields []string `toml:"fields"`
+}
+
+type Scaler struct {
+	Scalings   []Scaling       `toml:"scaling"`
+	Log        telegraf.Logger `toml:"-"`
+	scalingMap map[filter.Filter]Scaling
+}
+
+func (s *Scaler) Init() error {
+
+	s.scalingMap = make(map[filter.Filter]Scaling)
+
+	for _, element := range s.Scalings {
+		filter, err := filter.Compile(element.Fields)
+		if err != nil {
+			return nil
+		}
+		s.scalingMap[filter] = element
+	}
+	return nil
+}
+
+func Scale(value float64, in_min float64, in_max float64, out_min float64, out_max float64) float64 {
+	return (value-in_min)*(out_max-out_min)/(in_max-in_min) + out_min
+}
+
+func toFloat(v interface{}) (float64, bool) {
+	switch value := v.(type) {
+	case int64:
+		return float64(value), true
+	case uint64:
+		return float64(value), true
+	case float64:
+		return value, true
+	}
+	return 0.0, false
+}
+
+func (s *Scaler) ScaleValues(metric telegraf.Metric) {
+	if s.Scalings == nil || s.scalingMap == nil || len(s.scalingMap) == 0 {
+		return
+	}
+
+	fields := metric.Fields()
+
+	for key := range fields {
+		for filter, scaling := range s.scalingMap {
+			if filter != nil && filter.Match(key) {
+
+				// This call will always succeed as we are only using the fields from this specific metric
+				value, _ := metric.GetField(key)
+
+				v, ok := toFloat(value)
+
+				if !ok {
+					metric.RemoveField(key)
+					s.Log.Errorf("error converting to float [%T]: %v", value, value)
+					continue
+				}
+
+				metric.RemoveField(key)
+				res := Scale(v, scaling.InMin, scaling.InMax, scaling.OutMin, scaling.OutMax)
+				metric.AddField(key, res)
+			}
+		}
+	}
+}
+
+func (p *Scaler) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	for _, metric := range in {
+		p.ScaleValues(metric)
+	}
+	return in
+}
+
+func init() {
+	processors.Add("scaler", func() telegraf.Processor {
+		return &Scaler{}
+	})
+}

--- a/plugins/processors/scaler/scaler.go
+++ b/plugins/processors/scaler/scaler.go
@@ -27,27 +27,37 @@ type Scaling struct {
 type Scaler struct {
 	Scalings   []Scaling       `toml:"scaling"`
 	Log        telegraf.Logger `toml:"-"`
-	scalingMap map[filter.Filter]Scaling
+	scalingMap map[filter.Filter]*Scaling
 }
 
 func (s *Scaler) Init() error {
+	s.scalingMap = make(map[filter.Filter]*Scaling)
 
-	s.scalingMap = make(map[filter.Filter]Scaling)
-
-	for _, element := range s.Scalings {
+	// convert filter list to filter map for better performance
+	for i, element := range s.Scalings {
 		filter, err := filter.Compile(element.Fields)
+
 		if err != nil {
+			s.Log.Errorf("Could not compile filter: %v\n", err)
 			return nil
 		}
-		s.scalingMap[filter] = element
+
+		if element.InMax != element.InMin {
+			s.scalingMap[filter] = &s.Scalings[i]
+		} else {
+			s.Log.Error("Found scaling with equal input_minimum and input_maximum. Skipping it.")
+		}
 	}
+
 	return nil
 }
 
+// scale a float according to the input and output range
 func Scale(value float64, in_min float64, in_max float64, out_min float64, out_max float64) float64 {
 	return (value-in_min)*(out_max-out_min)/(in_max-in_min) + out_min
 }
 
+// convert a numeric value to float
 func toFloat(v interface{}) (float64, bool) {
 	switch value := v.(type) {
 	case int64:
@@ -60,8 +70,10 @@ func toFloat(v interface{}) (float64, bool) {
 	return 0.0, false
 }
 
+// handle the scaling process
 func (s *Scaler) ScaleValues(metric telegraf.Metric) {
 	if s.Scalings == nil || s.scalingMap == nil || len(s.scalingMap) == 0 {
+		s.Log.Errorf("No valid scalings defined. Skipping scaling")
 		return
 	}
 
@@ -78,10 +90,11 @@ func (s *Scaler) ScaleValues(metric telegraf.Metric) {
 
 				if !ok {
 					metric.RemoveField(key)
-					s.Log.Errorf("error converting to float [%T]: %v", value, value)
+					s.Log.Errorf("error converting to float [%T]: %v\n", value, value)
 					continue
 				}
 
+				// replace filed with the new value (the name remains the same)
 				metric.RemoveField(key)
 				res := Scale(v, scaling.InMin, scaling.InMax, scaling.OutMin, scaling.OutMax)
 				metric.AddField(key, res)

--- a/plugins/processors/scaler/scaler_test.go
+++ b/plugins/processors/scaler/scaler_test.go
@@ -1,0 +1,166 @@
+package scaler
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/stretchr/testify/require"
+)
+
+func newMetric(name string, tags map[string]string, fields map[string]interface{}) telegraf.Metric {
+	if tags == nil {
+		tags = map[string]string{}
+	}
+	if fields == nil {
+		fields = map[string]interface{}{}
+	}
+	m := metric.New(name, tags, fields, time.Now())
+	return m
+}
+
+func TestScaler(t *testing.T) {
+	s := Scaler{
+		Scalings: []Scaling{
+			{
+				InMin:  -1,
+				InMax:  1,
+				OutMin: 0,
+				OutMax: 100,
+				Fields: []string{"test1", "test2"},
+			},
+			{
+				InMin:  -5,
+				InMax:  0,
+				OutMin: 1,
+				OutMax: 9,
+				Fields: []string{"test3", "test4"},
+			},
+		},
+	}
+
+	s.Init()
+
+	m1 := newMetric("Name1", nil, map[string]interface{}{"test1": int64(0), "test2": uint64(1)})
+	m2 := newMetric("Name2", nil, map[string]interface{}{"test1": float64(0.5), "test2": float32(-0.5)})
+	m3 := newMetric("Name3", nil, map[string]interface{}{"test3": int64(-3), "test4": uint64(0)})
+	m4 := newMetric("Name4", nil, map[string]interface{}{"test3": int64(-5), "test4": float32(-0.5)})
+
+	results := s.Apply(m1, m2, m3, m4)
+
+
+	val, ok := results[0].GetField("test1")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(50), val, 1e-10)
+
+	val, ok = results[0].GetField("test2")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(100), val, 1e-10)
+
+	val, ok = results[1].GetField("test1")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(75), val, 1e-10)
+
+	val, ok = results[1].GetField("test2")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(25), val, 1e-10)
+
+
+
+
+	val, ok = results[2].GetField("test3")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(4.2), val, 1e-10)
+
+	val, ok = results[2].GetField("test4")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(9), val, 1e-10)
+
+	val, ok = results[3].GetField("test3")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(1), val, 1e-10)
+
+	val, ok = results[3].GetField("test4")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(8.2), val, 1e-10)
+}
+
+func TestOutOfInputRange(t *testing.T) {
+	s := Scaler{
+		Scalings: []Scaling{
+			{
+				InMin:  -1,
+				InMax:  1,
+				OutMin: 0,
+				OutMax: 100,
+				Fields: []string{"test1", "test2"},
+			},
+		},
+	}
+
+	s.Init()
+
+	m1 := newMetric("Name1", nil, map[string]interface{}{"test1": int64(-2), "test2": uint64(2)})
+
+	results := s.Apply(m1)
+
+	val, ok := results[0].GetField("test1")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(-50), val, 1e-10)
+
+	val, ok = results[0].GetField("test2")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(150), val, 1e-10)
+
+}
+
+func TestNoFiltersDefined(t *testing.T) {
+	s := Scaler{
+		Scalings: []Scaling{
+			{
+				InMin:  -1,
+				InMax:  1,
+				OutMin: 0,
+				OutMax: 100,
+				Fields: []string{},
+			},
+		},
+	}
+
+	s.Init()
+
+	m1 := newMetric("Name1", nil, map[string]interface{}{"test1": int64(-2), "test2": uint64(2)})
+
+	results := s.Apply(m1)
+
+	val, ok := results[0].GetField("test1")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(-2), val, 1e-10)
+
+	val, ok = results[0].GetField("test2")
+	require.True(t, ok)
+	require.InEpsilon(t, float64(2), val, 1e-10)
+}
+
+
+func TestNoScalerDefined(t *testing.T) {
+	s := Scaler{}
+
+	s.Init()
+
+	m1 := newMetric("Name1", nil, map[string]interface{}{"test1": int64(-2), "test2": uint64(2)})
+
+	results := s.Apply(m1)
+
+	val, ok := results[0].GetField("test1")
+	require.True(t, ok)
+	fmt.Printf("val %v\n", val)
+	require.InEpsilon(t, float64(-2), val, 1e-10)
+
+	val, ok = results[0].GetField("test2")
+	require.True(t, ok)
+	fmt.Printf("val %v\n", val)
+	require.InEpsilon(t, float64(2), val, 1e-10)
+}

--- a/plugins/processors/scaler/scaler_test.go
+++ b/plugins/processors/scaler/scaler_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,7 +42,8 @@ func TestScaler(t *testing.T) {
 		},
 	}
 
-	s.Init()
+	err := s.Init()
+	require.NoError(t, err)
 
 	m1 := newMetric("Name1", nil, map[string]interface{}{"test1": int64(0), "test2": uint64(1)})
 	m2 := newMetric("Name2", nil, map[string]interface{}{"test1": float64(0.5), "test2": float32(-0.5)})
@@ -100,7 +102,8 @@ func TestOutOfInputRange(t *testing.T) {
 		},
 	}
 
-	s.Init()
+	err := s.Init()
+	require.NoError(t, err)
 
 	m1 := newMetric("Name1", nil, map[string]interface{}{"test1": int64(-2), "test2": uint64(2)})
 
@@ -129,7 +132,8 @@ func TestNoFiltersDefined(t *testing.T) {
 		},
 	}
 
-	s.Init()
+	err := s.Init()
+	require.NoError(t, err)
 
 	m1 := newMetric("Name1", nil, map[string]interface{}{"test1": int64(-2), "test2": uint64(2)})
 
@@ -146,9 +150,10 @@ func TestNoFiltersDefined(t *testing.T) {
 
 
 func TestNoScalerDefined(t *testing.T) {
-	s := Scaler{}
+	s := Scaler{Log: testutil.Logger{},}
 
-	s.Init()
+	err := s.Init()
+	require.NoError(t, err)
 
 	m1 := newMetric("Name1", nil, map[string]interface{}{"test1": int64(-2), "test2": uint64(2)})
 
@@ -163,4 +168,6 @@ func TestNoScalerDefined(t *testing.T) {
 	require.True(t, ok)
 	fmt.Printf("val %v\n", val)
 	require.InEpsilon(t, float64(2), val, 1e-10)
+
+	
 }

--- a/plugins/processors/scaler/scaler_test.go
+++ b/plugins/processors/scaler/scaler_test.go
@@ -52,7 +52,6 @@ func TestScaler(t *testing.T) {
 
 	results := s.Apply(m1, m2, m3, m4)
 
-
 	val, ok := results[0].GetField("test1")
 	require.True(t, ok)
 	require.InEpsilon(t, float64(50), val, 1e-10)
@@ -68,9 +67,6 @@ func TestScaler(t *testing.T) {
 	val, ok = results[1].GetField("test2")
 	require.True(t, ok)
 	require.InEpsilon(t, float64(25), val, 1e-10)
-
-
-
 
 	val, ok = results[2].GetField("test3")
 	require.True(t, ok)
@@ -148,9 +144,8 @@ func TestNoFiltersDefined(t *testing.T) {
 	require.InEpsilon(t, float64(2), val, 1e-10)
 }
 
-
 func TestNoScalerDefined(t *testing.T) {
-	s := Scaler{Log: testutil.Logger{},}
+	s := Scaler{Log: testutil.Logger{}}
 
 	err := s.Init()
 	require.NoError(t, err)
@@ -169,5 +164,4 @@ func TestNoScalerDefined(t *testing.T) {
 	fmt.Printf("val %v\n", val)
 	require.InEpsilon(t, float64(2), val, 1e-10)
 
-	
 }


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format]

Adding a Scaler processor plugin.
It makes it possible to scale values from a specified input range into a different output range.