### PR TITLE
chore: update lxd images for testing

### DIFF
--- a/tools/package_lxd_test/main.go
+++ b/tools/package_lxd_test/main.go
@@ -20,10 +20,8 @@ var imagesRPM = []string{
 }
 
 var imagesDEB = []string{
-	"debian/buster",
 	"debian/bullseye",
 	"debian/bookworm",
-	"ubuntu/bionic",
 	"ubuntu/focal",
 	"ubuntu/jammy",
 }


### PR DESCRIPTION
Ubuntu Bionic is about to hit EOL at the end of the month. Debian Buster is about to become old, old stable.