### PR TITLE
fix(parsers.grok): Fix nil metric for multiline inputs

### DIFF
--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -387,7 +387,9 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		if err != nil {
 			return nil, err
 		}
-		metrics = append(metrics, m)
+		if m != nil {
+			metrics = append(metrics, m)
+		}
 		return metrics, nil
 	}
 

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -1167,3 +1167,19 @@ func TestTrimRegression(t *testing.T) {
 	)
 	require.Equal(t, expected, actual)
 }
+
+func TestMultilineNilMetric(t *testing.T) {
+	buf, err := os.ReadFile("./testdata/test_multiline.log")
+	require.NoError(t, err)
+
+	p := &Parser{
+		Measurement: "multiline",
+		Patterns:    []string{`%{TIMESTAMP_ISO8601:timestamp:ts-rfc3339} Info%{MULTILINEDATA:text}`},
+		Multiline:   true,
+		Log:         testutil.Logger{},
+	}
+	require.NoError(t, p.Compile())
+	actual, err := p.Parse(buf)
+	require.NoError(t, err)
+	require.Empty(t, actual)
+}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

When parsing multiline inputs that do not match the given pattern the parser currently returns a `nil` metric in the `metrics` array. In turn this can lead to a panic when the parent plugin loops through the returned metrics and tries to process them  (e.g. `inputs.tail`).

This PR checks if the metric is `nil` and does not add it to the returned metrics array. Thus the array is empty and upstream plugins will not panic.