### PR TITLE
fix(processors.lookup): Fix tracking metrics

### DIFF
--- a/metric/tracking.go
+++ b/metric/tracking.go
@@ -150,6 +150,11 @@ func (m *trackingMetric) decr() {
 	}
 }
 
+// Unwrap allows to access the underlying metric directly e.g. for go-templates
+func (m *trackingMetric) Unwrap() telegraf.Metric {
+	return m.Metric
+}
+
 type deliveryInfo struct {
 	id       telegraf.TrackingID
 	accepted int

--- a/plugins/processors/lookup/lookup_test.go
+++ b/plugins/processors/lookup/lookup_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/plugins/processors"
 	"github.com/influxdata/telegraf/testutil"
@@ -83,6 +84,69 @@ func TestCases(t *testing.T) {
 
 			type unwrappable interface{ Unwrap() telegraf.Processor }
 			proc := cfg.Processors[0].Processor.(unwrappable)
+			plugin := proc.Unwrap().(*Processor)
+			require.NoError(t, plugin.Init())
+
+			// Process expected metrics and compare with resulting metrics
+			actual := plugin.Apply(input...)
+			testutil.RequireMetricsEqual(t, expected, actual)
+		})
+	}
+}
+
+func TestCasesTracking(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	// Make sure tests contains data
+	require.NotEmpty(t, folders)
+
+	// Set up for file inputs
+	processors.Add("lookup", func() telegraf.Processor {
+		return &Processor{Log: testutil.Logger{}}
+	})
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		fname := f.Name()
+		testdataPath := filepath.Join("testcases", fname)
+		configFilename := filepath.Join(testdataPath, "telegraf.conf")
+		inputFilename := filepath.Join(testdataPath, "input.influx")
+		expectedFilename := filepath.Join(testdataPath, "expected.out")
+
+		t.Run(fname, func(t *testing.T) {
+			// Get parser to parse input and expected output
+			parser := &influx.Parser{}
+			require.NoError(t, parser.Init())
+
+			inputRaw, err := testutil.ParseMetricsFromFile(inputFilename, parser)
+			require.NoError(t, err)
+			input := make([]telegraf.Metric, 0, len(inputRaw))
+			notify := func(_ telegraf.DeliveryInfo) {}
+			for _, m := range inputRaw {
+				tm, _ := metric.WithTracking(m, notify)
+				input = append(input, tm)
+			}
+
+			var expected []telegraf.Metric
+			if _, err := os.Stat(expectedFilename); err == nil {
+				var err error
+				expected, err = testutil.ParseMetricsFromFile(expectedFilename, parser)
+				require.NoError(t, err)
+			}
+
+			// Configure the plugin
+			cfg := config.NewConfig()
+			require.NoError(t, cfg.LoadConfig(configFilename))
+			require.Len(t, cfg.Processors, 1, "wrong number of processors")
+
+			type unwrappableProcessor interface{ Unwrap() telegraf.Processor }
+			proc := cfg.Processors[0].Processor.(unwrappableProcessor)
 			plugin := proc.Unwrap().(*Processor)
 			require.NoError(t, plugin.Init())
 

--- a/plugins/processors/lookup/testcases/non_existing_tag/expected.out
+++ b/plugins/processors/lookup/testcases/non_existing_tag/expected.out
@@ -1,0 +1,3 @@
+test,lutkey=peters_friend,location=home value=42i 1678124473000000123
+other,status=alert value=-1i 1678124473000000575
+test,lutkey=marys_son,location=party value=666i 1678124473000000944

--- a/plugins/processors/lookup/testcases/non_existing_tag/input.influx
+++ b/plugins/processors/lookup/testcases/non_existing_tag/input.influx
@@ -1,0 +1,3 @@
+test,lutkey=peters_friend value=42i 1678124473000000123
+other,status=alert value=-1i 1678124473000000575
+test,lutkey=marys_son value=666i 1678124473000000944

--- a/plugins/processors/lookup/testcases/non_existing_tag/lut.json
+++ b/plugins/processors/lookup/testcases/non_existing_tag/lut.json
@@ -1,0 +1,8 @@
+{
+    "peters_friend": {
+        "location": "home"
+    },
+    "marys_son": {
+        "location": "party"
+    }
+}

--- a/plugins/processors/lookup/testcases/non_existing_tag/telegraf.conf
+++ b/plugins/processors/lookup/testcases/non_existing_tag/telegraf.conf
@@ -1,0 +1,3 @@
+[[processors.lookup]]
+    files = ["testcases/non_existing_tag/lut.json"]
+    key = '{{.Tag "lutkey"}}'


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13077 

When using the lookup processor with **tracking** metrics the template cannot access the template-specific functions of the embedded metric. Therefore, the lookup processor will fail as described in #13077.

This PR adds the possibility to "unwrap" the tracked metric and directly access the inner raw metric. We then use the new possibility to fix the lookup processor.