### PR TITLE
chore: Fix linter findings for Windows (part2)

### DIFF
--- a/logger/event_logger.go
+++ b/logger/event_logger.go
@@ -22,9 +22,11 @@ type eventLogger struct {
 	logger *eventlog.Log
 }
 
-func (t *eventLogger) Write(b []byte) (n int, err error) {
+func (t *eventLogger) Write(b []byte) (int, error) {
+	var err error
+
 	loc := prefixRegex.FindIndex(b)
-	n = len(b)
+	n := len(b)
 	if loc == nil {
 		err = t.logger.Info(1, string(b))
 	} else if n > 2 { //skip empty log messages
@@ -39,7 +41,7 @@ func (t *eventLogger) Write(b []byte) (n int, err error) {
 		}
 	}
 
-	return
+	return n, err
 }
 
 type eventLoggerCreator struct {

--- a/logger/event_logger_test.go
+++ b/logger/event_logger_test.go
@@ -5,6 +5,7 @@ package logger
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
 	"log"
 	"os/exec"
 	"testing"
@@ -30,7 +31,12 @@ type Event struct {
 func getEventLog(t *testing.T, since time.Time) []Event {
 	timeStr := since.UTC().Format(time.RFC3339)
 	timeStr = timeStr[:19]
-	cmd := exec.Command("wevtutil", "qe", "Application", "/rd:true", "/q:Event[System[TimeCreated[@SystemTime >= '"+timeStr+"'] and Provider[@Name='telegraf']]]")
+	args := []string{
+		"qe",
+		"Application",
+		"/rd:true",
+		fmt.Sprintf("/q:Event[System[TimeCreated[@SystemTime >= %q] and Provider[@Name='telegraf']]]", timeStr)}
+	cmd := exec.Command("wevtutil", args...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()

--- a/plugins/inputs/win_eventlog/util.go
+++ b/plugins/inputs/win_eventlog/util.go
@@ -45,7 +45,7 @@ func DecodeUTF16(b []byte) ([]byte, error) {
 // GetFromSnapProcess finds information about process by the given pid
 // Returns process parent pid, threads info handle and process name
 func GetFromSnapProcess(pid uint32) (uint32, uint32, string, error) {
-	snap, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, uint32(pid))
+	snap, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, pid)
 	if err != nil {
 		return 0, 0, "", err
 	}
@@ -56,9 +56,9 @@ func GetFromSnapProcess(pid uint32) (uint32, uint32, string, error) {
 		return 0, 0, "", err
 	}
 	for {
-		if pe32.ProcessID == uint32(pid) {
+		if pe32.ProcessID == pid {
 			szexe := windows.UTF16ToString(pe32.ExeFile[:])
-			return uint32(pe32.ParentProcessID), uint32(pe32.Threads), szexe, nil
+			return pe32.ParentProcessID, pe32.Threads, szexe, nil
 		}
 		if err = windows.Process32Next(snap, &pe32); err != nil {
 			break
@@ -139,7 +139,7 @@ func walkXML(nodes []xmlnode, parents []string, separator string, f func(xmlnode
 // by adding _<num> if there are several of them
 func UniqueFieldNames(fields []EventField, fieldsUsage map[string]int, separator string) []EventField {
 	var fieldsCounter = map[string]int{}
-	var fieldsUnique []EventField
+	fieldsUnique := make([]EventField, 0, len(fields))
 	for _, field := range fields {
 		fieldName := field.Name
 		if fieldsUsage[field.Name] > 1 {

--- a/plugins/inputs/win_perf_counters/pdh.go
+++ b/plugins/inputs/win_perf_counters/pdh.go
@@ -308,7 +308,7 @@ func init() {
 //	\\LogicalDisk(C:)\% Free Space
 //
 // To view all (internationalized...) counters on a system, there are three non-programmatic ways: perfmon utility,
-// the typeperf command, and the the registry editor. perfmon.exe is perhaps the easiest way, because it's basically a
+// the typeperf command, and the registry editor. perfmon.exe is perhaps the easiest way, because it's basically a
 // full implementation of the pdh.dll API, except with a GUI and all that. The registry setting also provides an
 // interface to the available counters, and can be found at the following key:
 //
@@ -376,7 +376,7 @@ func PdhCloseQuery(hQuery PDH_HQUERY) uint32 {
 	return uint32(ret)
 }
 
-// Collects the current raw data value for all counters in the specified query and updates the status
+// PdhCollectQueryData collects the current raw data value for all counters in the specified query and updates the status
 // code of each counter. With some counters, this function needs to be repeatedly called before the value
 // of the counter can be extracted with PdhGetFormattedCounterValue(). For example, the following code
 // requires at least two calls:
@@ -510,13 +510,13 @@ func PdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *PDH_HQUERY)
 	return uint32(ret)
 }
 
-// PdhExpandWildCardPath examines the specified computer or log file and returns those counter paths that match the given counter path which contains wildcard characters.
-// The general counter path format is as follows:
+// PdhExpandWildCardPath examines the specified computer or log file and returns those counter paths that match the given counter path
+// which contains wildcard characters. The general counter path format is as follows:
 //
 // \\computer\object(parent/instance#index)\counter
 //
-// The parent, instance, index, and counter components of the counter path may contain either a valid name or a wildcard character. The computer, parent, instance,
-// and index components are not necessary for all counters.
+// The parent, instance, index, and counter components of the counter path may contain either a valid name or a wildcard character.
+// The computer, parent, instance, and index components are not necessary for all counters.
 //
 // The following is a list of the possible formats:
 //
@@ -532,11 +532,13 @@ func PdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *PDH_HQUERY)
 // \object\counter
 // Use an asterisk (*) as the wildcard character, for example, \object(*)\counter.
 //
-// If a wildcard character is specified in the parent name, all instances of the specified object that match the specified instance and counter fields will be returned.
+// If a wildcard character is specified in the parent name, all instances of the specified object
+// that match the specified instance and counter fields will be returned.
 // For example, \object(*/instance)\counter.
 //
 // If a wildcard character is specified in the instance name, all instances of the specified object and parent object will be returned if all instance names
-// corresponding to the specified index match the wildcard character. For example, \object(parent/*)\counter. If the object does not contain an instance, an error occurs.
+// corresponding to the specified index match the wildcard character. For example, \object(parent/*)\counter.
+// If the object does not contain an instance, an error occurs.
 //
 // If a wildcard character is specified in the counter name, all counters of the specified object are returned.
 //
@@ -572,18 +574,23 @@ func PdhFormatError(msgId uint32) string {
 	return fmt.Sprintf("(pdhErr=%d) %s", msgId, err.Error())
 }
 
-// Retrieves information about a counter, such as data size, counter type, path, and user-supplied data values
+// PdhGetCounterInfo retrieves information about a counter, such as data size, counter type, path, and user-supplied data values
 // hCounter [in]
 // Handle of the counter from which you want to retrieve information. The PdhAddCounter function returns this handle.
 //
 // bRetrieveExplainText [in]
-// Determines whether explain text is retrieved. If you set this parameter to TRUE, the explain text for the counter is retrieved. If you set this parameter to FALSE, the field in the returned buffer is NULL.
+// Determines whether explain text is retrieved. If you set this parameter to TRUE, the explain text for the counter is retrieved.
+// If you set this parameter to FALSE, the field in the returned buffer is NULL.
 //
 // pdwBufferSize [in, out]
-// Size of the lpBuffer buffer, in bytes. If zero on input, the function returns PDH_MORE_DATA and sets this parameter to the required buffer size. If the buffer is larger than the required size, the function sets this parameter to the actual size of the buffer that was used. If the specified size on input is greater than zero but less than the required size, you should not rely on the returned size to reallocate the buffer.
+// Size of the lpBuffer buffer, in bytes. If zero on input, the function returns PDH_MORE_DATA and sets this parameter to the required buffer size.
+// If the buffer is larger than the required size, the function sets this parameter to the actual size of the buffer that was used.
+// If the specified size on input is greater than zero but less than the required size, you should not rely on the returned size to reallocate the buffer.
 //
 // lpBuffer [out]
-// Caller-allocated buffer that receives a PDH_COUNTER_INFO structure. The structure is variable-length, because the string data is appended to the end of the fixed-format portion of the structure. This is done so that all data is returned in a single buffer allocated by the caller. Set to NULL if pdwBufferSize is zero.
+// Caller-allocated buffer that receives a PDH_COUNTER_INFO structure.
+// The structure is variable-length, because the string data is appended to the end of the fixed-format portion of the structure.
+// This is done so that all data is returned in a single buffer allocated by the caller. Set to NULL if pdwBufferSize is zero.
 func PdhGetCounterInfo(hCounter PDH_HCOUNTER, bRetrieveExplainText int, pdwBufferSize *uint32, lpBuffer *byte) uint32 {
 	ret, _, _ := pdh_GetCounterInfoW.Call(
 		uintptr(hCounter),
@@ -594,7 +601,7 @@ func PdhGetCounterInfo(hCounter PDH_HCOUNTER, bRetrieveExplainText int, pdwBuffe
 	return uint32(ret)
 }
 
-// Returns the current raw value of the counter.
+// PdhGetRawCounterValue returns the current raw value of the counter.
 // If the specified counter instance does not exist, this function will return ERROR_SUCCESS
 // and the CStatus member of the PDH_RAW_COUNTER structure will contain PDH_CSTATUS_NO_INSTANCE.
 //
@@ -616,7 +623,7 @@ func PdhGetRawCounterValue(hCounter PDH_HCOUNTER, lpdwType *uint32, pValue *PDH_
 	return uint32(ret)
 }
 
-// Returns an array of raw values from the specified counter. Use this function when you want to retrieve the raw counter values
+// PdhGetRawCounterArray returns an array of raw values from the specified counter. Use this function when you want to retrieve the raw counter values
 // of a counter that contains a wildcard character for the instance name.
 // hCounter
 // Handle of the counter for whose current raw instance values you want to retrieve. The PdhAddCounter function returns this handle.

--- a/plugins/inputs/win_perf_counters/pdh_amd64.go
+++ b/plugins/inputs/win_perf_counters/pdh_amd64.go
@@ -32,37 +32,38 @@
 
 package win_perf_counters
 
-// Union specialization for double values
+// PDH_FMT_COUNTERVALUE_DOUBLE is an union specialization for double values
 type PDH_FMT_COUNTERVALUE_DOUBLE struct {
 	CStatus     uint32
 	DoubleValue float64
 }
 
-// Union specialization for 64 bit integer values
+// PDH_FMT_COUNTERVALUE_LARGE is a union specialization for 64-bit integer values
 type PDH_FMT_COUNTERVALUE_LARGE struct {
 	CStatus    uint32
 	LargeValue int64
 }
 
-// Union specialization for long values
+// PDH_FMT_COUNTERVALUE_LONG is a union specialization for long values
 type PDH_FMT_COUNTERVALUE_LONG struct {
 	CStatus   uint32
 	LongValue int32
 	padding   [4]byte
 }
 
+// PDH_FMT_COUNTERVALUE_ITEM_DOUBLE is a union specialization for double values, used by PdhGetFormattedCounterArrayDouble
 type PDH_FMT_COUNTERVALUE_ITEM_DOUBLE struct {
 	SzName   *uint16
 	FmtValue PDH_FMT_COUNTERVALUE_DOUBLE
 }
 
-// Union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
+// PDH_FMT_COUNTERVALUE_ITEM_LARGE is n union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
 type PDH_FMT_COUNTERVALUE_ITEM_LARGE struct {
 	SzName   *uint16 // pointer to a string
 	FmtValue PDH_FMT_COUNTERVALUE_LARGE
 }
 
-// Union specialization for long values, used by PdhGetFormattedCounterArrayLong()
+// PDH_FMT_COUNTERVALUE_ITEM_LONG is n union specialization for long values, used by PdhGetFormattedCounterArrayLong()
 type PDH_FMT_COUNTERVALUE_ITEM_LONG struct {
 	SzName   *uint16 // pointer to a string
 	FmtValue PDH_FMT_COUNTERVALUE_LONG
@@ -72,7 +73,8 @@ type PDH_FMT_COUNTERVALUE_ITEM_LONG struct {
 type PDH_COUNTER_INFO struct {
 	//Size of the structure, including the appended strings, in bytes.
 	DwLength uint32
-	//Counter type. For a list of counter types, see the Counter Types section of the <a "href=http://go.microsoft.com/fwlink/p/?linkid=84422">Windows Server 2003 Deployment Kit</a>.
+	//Counter type. For a list of counter types,
+	//see the Counter Types section of the <a "href=http://go.microsoft.com/fwlink/p/?linkid=84422">Windows Server 2003 Deployment Kit</a>.
 	//The counter type constants are defined in Winperf.h.
 	DwType uint32
 	//Counter version information. Not used.
@@ -100,8 +102,8 @@ type PDH_COUNTER_INFO struct {
 	//Null-terminated string that contains the name of the object instance specified in the counter path. Is NULL, if the path does not specify an instance.
 	//The string follows this structure in memory.
 	SzInstanceName *uint16 // pointer to a string
-	//Null-terminated string that contains the name of the parent instance specified in the counter path. Is NULL, if the path does not specify a parent instance.
-	//The string follows this structure in memory.
+	//Null-terminated string that contains the name of the parent instance specified in the counter path.
+	//Is NULL, if the path does not specify a parent instance. The string follows this structure in memory.
 	SzParentInstance *uint16 // pointer to a string
 	//Instance index specified in the counter path. Is 0, if the path does not specify an instance index.
 	DwInstanceIndex uint32 // pointer to a string
@@ -113,10 +115,11 @@ type PDH_COUNTER_INFO struct {
 	DataBuffer [1]uint32 // pointer to an extra space
 }
 
-// The PDH_RAW_COUNTER structure returns the data as it was collected from the counter provider. No translation, formatting, or other interpretation is performed on the data
+// The PDH_RAW_COUNTER structure returns the data as it was collected from the counter provider.
+// No translation, formatting, or other interpretation is performed on the data
 type PDH_RAW_COUNTER struct {
-	// Counter status that indicates if the counter value is valid. Check this member before using the data in a calculation or displaying its value. For a list of possible values,
-	// see https://docs.microsoft.com/windows/desktop/PerfCtrs/checking-pdh-interface-return-values
+	// Counter status that indicates if the counter value is valid. Check this member before using the data in a calculation or displaying its value.
+	// For a list of possible values, see https://docs.microsoft.com/windows/desktop/PerfCtrs/checking-pdh-interface-return-values
 	CStatus uint32
 	// Local time for when the data was collected
 	TimeStamp FILETIME

--- a/plugins/inputs/win_perf_counters/performance_query.go
+++ b/plugins/inputs/win_perf_counters/performance_query.go
@@ -10,13 +10,15 @@ import (
 	"unsafe"
 )
 
-// PerformanceQuery is abstraction for PDH_FMT_COUNTERVALUE_ITEM_DOUBLE
+// CounterValue is abstraction for PDH_FMT_COUNTERVALUE_ITEM_DOUBLE
 type CounterValue struct {
 	InstanceName string
 	Value        interface{}
 }
 
 // PerformanceQuery provides wrappers around Windows performance counters API for easy usage in GO
+//
+//nolint:interfacebloat // conditionally allow to contain more methods
 type PerformanceQuery interface {
 	Open() error
 	Close() error

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -165,7 +165,17 @@ func (m *WinPerfCounters) hostname() string {
 	return m.cachedHostname
 }
 
-func newCounter(counterHandle PDH_HCOUNTER, counterPath string, computer string, objectName string, instance string, counterName string, measurement string, includeTotal bool, useRawValue bool) *counter {
+func newCounter(
+	counterHandle PDH_HCOUNTER,
+	counterPath string,
+	computer string,
+	objectName string,
+	instance string,
+	counterName string,
+	measurement string,
+	includeTotal bool,
+	useRawValue bool,
+) *counter {
 	measurementName := sanitizedChars.Replace(measurement)
 	if measurementName == "" {
 		measurementName = "win_perf_counters"
@@ -364,7 +374,8 @@ func (m *WinPerfCounters) ParseConfig() error {
 
 					counterPath = formatPath(computer, objectname, instance, counter)
 
-					err := m.AddItem(counterPath, computer, objectname, instance, counter, PerfObject.Measurement, PerfObject.IncludeTotal, PerfObject.UseRawValues)
+					err := m.AddItem(counterPath, computer, objectname, instance, counter,
+						PerfObject.Measurement, PerfObject.IncludeTotal, PerfObject.UseRawValues)
 					if err != nil {
 						if PerfObject.FailOnMissing || PerfObject.WarnOnMissing {
 							m.Log.Errorf("invalid counterPath %q: %s", counterPath, err.Error())

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -535,10 +535,9 @@ func TestWinPerfcountersConfigError2Integration(t *testing.T) {
 		Log:          testutil.Logger{},
 	}
 
-	err := m.ParseConfig()
+	require.Error(t, m.ParseConfig())
 	var acc testutil.Accumulator
-	err = m.Gather(&acc)
-	require.Error(t, err)
+	require.Error(t, m.Gather(&acc))
 }
 
 func TestWinPerfcountersConfigError3Integration(t *testing.T) {

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -232,14 +232,22 @@ type FakePerformanceQueryCreator struct {
 func (m FakePerformanceQueryCreator) NewPerformanceQuery(computer string) PerformanceQuery {
 	var ret PerformanceQuery
 	var ok bool
-	ret = nil
 	if ret, ok = m.fakeQueries[computer]; !ok {
 		panic(fmt.Errorf("query for %s not found", computer))
 	}
 	return ret
 }
 
-func createPerfObject(computer string, measurement string, object string, instances []string, counters []string, failOnMissing bool, includeTotal bool, useRawValues bool) []perfobject {
+func createPerfObject(
+	computer string,
+	measurement string,
+	object string,
+	instances []string,
+	counters []string,
+	failOnMissing bool,
+	includeTotal bool,
+	useRawValues bool,
+) []perfobject {
 	PerfObject := perfobject{
 		ObjectName:    object,
 		Instances:     instances,
@@ -250,11 +258,11 @@ func createPerfObject(computer string, measurement string, object string, instan
 		IncludeTotal:  includeTotal,
 		UseRawValues:  useRawValues,
 	}
+
 	if computer != "" {
 		PerfObject.Sources = []string{computer}
 	}
-	perfObjects := []perfobject{PerfObject}
-	return perfObjects
+	return []perfobject{PerfObject}
 }
 
 func createCounterMap(counterPaths []string, values []float64, status []uint32) map[string]testCounter {
@@ -1348,11 +1356,7 @@ func TestGatherError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping long taking test in short mode")
 	}
-	var err error
-	expectedError := "error during collecting data on host 'localhost': error while getting value for counter \\O(I)\\C: The information passed is not valid.\r\n"
-	if testing.Short() {
-		t.Skip("Skipping long taking test in short mode")
-	}
+
 	measurement := "test"
 	perfObjects := createPerfObject("", measurement, "O", []string{"I"}, []string{"C"}, false, false, false)
 	cp1 := "\\O(I)\\C"
@@ -1371,26 +1375,24 @@ func TestGatherError(t *testing.T) {
 			},
 		},
 	}
+
+	expectedError := "error during collecting data on host 'localhost': error while getting value for counter \\O(I)\\C: " +
+		"The information passed is not valid.\r\n"
 	var acc1 testutil.Accumulator
-	err = m.Gather(&acc1)
-	require.NoError(t, err)
+	require.NoError(t, m.Gather(&acc1))
 	require.Len(t, acc1.Errors, 1)
 	require.Equal(t, expectedError, acc1.Errors[0].Error())
 
 	m.UseWildcardsExpansion = true
-	err = m.cleanQueries()
-	require.NoError(t, err)
+	require.NoError(t, m.cleanQueries())
+
 	m.lastRefreshed = time.Time{}
-
 	var acc2 testutil.Accumulator
-
-	err = m.Gather(&acc2)
-	require.NoError(t, err)
+	require.NoError(t, m.Gather(&acc2))
 	require.Len(t, acc2.Errors, 1)
 	require.Equal(t, expectedError, acc2.Errors[0].Error())
 
-	err = m.cleanQueries()
-	require.NoError(t, err)
+	require.NoError(t, m.cleanQueries())
 }
 
 func TestGatherInvalidDataIgnore(t *testing.T) {
@@ -1728,7 +1730,10 @@ func TestGatherTotalNoExpansion(t *testing.T) {
 		Object:                perfObjects,
 		queryCreator: &FakePerformanceQueryCreator{
 			fakeQueries: map[string]*FakePerformanceQuery{"localhost": {
-				counters: createCounterMap(append([]string{"\\O(*)\\C1", "\\O(*)\\C2"}, cps1...), []float64{0, 0, 1.1, 1.2, 1.3, 1.4}, []uint32{0, 0, 0, 0, 0, 0}),
+				counters: createCounterMap(
+					append([]string{"\\O(*)\\C1", "\\O(*)\\C2"}, cps1...),
+					[]float64{0, 0, 1.1, 1.2, 1.3, 1.4},
+					[]uint32{0, 0, 0, 0, 0, 0}),
 				expandPaths: map[string][]string{
 					"\\O(*)\\C1": {cps1[0], cps1[2]},
 					"\\O(*)\\C2": {cps1[1], cps1[3]},
@@ -1923,7 +1928,10 @@ func TestGatherRaw(t *testing.T) {
 		Object:                perfObjects,
 		queryCreator: &FakePerformanceQueryCreator{
 			fakeQueries: map[string]*FakePerformanceQuery{"localhost": {
-				counters: createCounterMap(append([]string{"\\O(*)\\C1", "\\O(*)\\C2"}, cps1...), []float64{0, 0, 1.1, 2.2, 3.3, 4.4}, []uint32{0, 0, 0, 0, 0, 0}),
+				counters: createCounterMap(
+					append([]string{"\\O(*)\\C1", "\\O(*)\\C2"}, cps1...),
+					[]float64{0, 0, 1.1, 2.2, 3.3, 4.4},
+					[]uint32{0, 0, 0, 0, 0, 0}),
 				expandPaths: map[string][]string{
 					"\\O(*)\\C1": {cps1[0], cps1[2]},
 					"\\O(*)\\C2": {cps1[1], cps1[3]},

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -53,7 +53,7 @@ func (m *FakeSvcMgr) OpenService(name string) (WinService, error) {
 			}
 		}
 	}
-	return nil, fmt.Errorf("Cannot find service %s", name)
+	return nil, fmt.Errorf("cannot find service %q", name)
 }
 
 func (m *FakeSvcMgr) ListServices() ([]string, error) {
@@ -116,15 +116,15 @@ func (m *FakeWinSvc) Query() (svc.Status, error) {
 }
 
 var testErrors = []testData{
-	{nil, errors.New("Fake mgr connect error"), nil, nil},
-	{nil, nil, errors.New("Fake mgr list services error"), nil},
+	{nil, errors.New("fake mgr connect error"), nil, nil},
+	{nil, nil, errors.New("fake mgr list services error"), nil},
 	{[]string{"Fake service 1", "Fake service 2", "Fake service 3"}, nil, nil, []serviceTestInfo{
-		{errors.New("Fake srv open error"), nil, nil, "Fake service 1", "", 0, 0},
-		{nil, errors.New("Fake srv query error"), nil, "Fake service 2", "", 0, 0},
-		{nil, nil, errors.New("Fake srv config error"), "Fake service 3", "", 0, 0},
+		{errors.New("fake srv open error"), nil, nil, "Fake service 1", "", 0, 0},
+		{nil, errors.New("fake srv query error"), nil, "Fake service 2", "", 0, 0},
+		{nil, nil, errors.New("fake srv config error"), "Fake service 3", "", 0, 0},
 	}},
 	{[]string{"Fake service 1"}, nil, nil, []serviceTestInfo{
-		{errors.New("Fake srv open error"), nil, nil, "Fake service 1", "", 0, 0},
+		{errors.New("fake srv open error"), nil, nil, "Fake service 1", "", 0, 0},
 	}},
 }
 
@@ -206,8 +206,8 @@ func TestGatherContainsTag(t *testing.T) {
 	for _, s := range testSimpleData[0].services {
 		fields := make(map[string]interface{})
 		tags := make(map[string]string)
-		fields["state"] = int(s.state)
-		fields["startup_mode"] = int(s.startUpMode)
+		fields["state"] = s.state
+		fields["startup_mode"] = s.startUpMode
 		tags["service_name"] = s.serviceName
 		tags["display_name"] = s.displayName
 		acc1.AssertContainsTaggedFields(t, "win_services", fields, tags)
@@ -227,8 +227,8 @@ func TestExcludingNamesTag(t *testing.T) {
 	for _, s := range testSimpleData[0].services {
 		fields := make(map[string]interface{})
 		tags := make(map[string]string)
-		fields["state"] = int(s.state)
-		fields["startup_mode"] = int(s.startUpMode)
+		fields["state"] = s.state
+		fields["startup_mode"] = s.startUpMode
 		tags["service_name"] = s.serviceName
 		tags["display_name"] = s.displayName
 		acc1.AssertDoesNotContainsTaggedFields(t, "win_services", fields, tags)


### PR DESCRIPTION
It is only part of the bigger job: https://github.com/influxdata/telegraf/issues/13036
After all findings in whole project are handled for `Windows`, linter CI job for Windows can be enabled.

Fixes for following linters have been made:
- `gosec`
- `ineffassign`
- `interfacebloat`
- `lll`
- `nakedret`
- `nilerr`
- `prealloc`
- `staticcheck`
- `unconvert`

Following findings were addressed:
```
logger\event_logger.go:42:2                                                   nakedret        naked return in func `Write` with 18 lines of code
logger\event_logger_test.go:33                                                lll             line is 162 characters
plugins\inputs\win_eventlog\util.go:47:82                                     unconvert       unnecessary conversion
plugins\inputs\win_eventlog\util.go:58:30                                     unconvert       unnecessary conversion
plugins\inputs\win_eventlog\util.go:60:17                                     unconvert       unnecessary conversion
plugins\inputs\win_eventlog\util.go:60:47                                     unconvert       unnecessary conversion
plugins\inputs\win_eventlog\util.go:139:2                                     prealloc        Consider pre-allocating `fieldsUnique`
plugins\inputs\win_eventlog\win_eventlog.go:137:27                            gosec           G601: Implicit memory aliasing in for loop.
plugins\inputs\win_eventlog\win_eventlog.go:407:28                            unconvert       unnecessary conversion
plugins\inputs\win_eventlog\win_eventlog.go:412:3                             nilerr          error is not nil (line 407) but it returns nil
plugins\inputs\win_eventlog\win_eventlog.go:430:3                             nilerr          error is not nil (line 428) but it returns nil
plugins\inputs\win_eventlog\zsyscall_windows.go:92:15                         staticcheck     SA1019: syscall.Syscall9 has been deprecated since Go 1.18: Use SyscallN instead.
plugins\inputs\win_eventlog\zsyscall_windows.go:96:10                         unconvert       unnecessary conversion
plugins\inputs\win_eventlog\zsyscall_windows.go:100:10                        unconvert       unnecessary conversion
plugins\inputs\win_eventlog\zsyscall_windows.go:113:2                         nakedret        naked return in func `_EvtSubscribe` with 32 lines of code
plugins\inputs\win_eventlog\zsyscall_windows.go:125:15                        staticcheck     SA1019: syscall.Syscall9 has been deprecated since Go 1.18: Use SyscallN instead.
plugins\inputs\win_eventlog\zsyscall_windows.go:145:2                         nakedret        naked return in func `_EvtRender` with 30 lines of code
plugins\inputs\win_eventlog\zsyscall_windows.go:149:15                        staticcheck     SA1019: syscall.Syscall has been deprecated since Go 1.18: Use SyscallN instead.
plugins\inputs\win_eventlog\zsyscall_windows.go:157:2                         nakedret        naked return in func `_EvtClose` with 10 lines of code
plugins\inputs\win_eventlog\zsyscall_windows.go:161:15                        staticcheck     SA1019: syscall.Syscall6 has been deprecated since Go 1.18: Use SyscallN instead.
plugins\inputs\win_eventlog\zsyscall_windows.go:178:2                         nakedret        naked return in func `_EvtNext` with 19 lines of code
plugins\inputs\win_eventlog\zsyscall_windows.go:192:15                        staticcheck     SA1019: syscall.Syscall9 has been deprecated since Go 1.18: Use SyscallN instead.
plugins\inputs\win_eventlog\zsyscall_windows.go:199:10                        unconvert       unnecessary conversion
plugins\inputs\win_eventlog\zsyscall_windows.go:212:2                         nakedret        naked return in func `_EvtFormatMessage` with 32 lines of code
plugins\inputs\win_eventlog\zsyscall_windows.go:216:15                        staticcheck     SA1019: syscall.Syscall6 has been deprecated since Go 1.18: Use SyscallN instead.
plugins\inputs\win_eventlog\zsyscall_windows.go:234:2                         nakedret        naked return in func `_EvtOpenPublisherMetadata` with 20 lines of code
plugins\inputs\win_eventlog\zsyscall_windows.go:239:15                        staticcheck     SA1019: syscall.Syscall has been deprecated since Go 1.18: Use SyscallN instead.
plugins\inputs\win_eventlog\zsyscall_windows.go:251:15                        staticcheck     SA1019: syscall.Syscall has been deprecated since Go 1.18: Use SyscallN instead.
plugins\inputs\win_perf_counters\pdh.go:513                                   lll             line is 170 characters
plugins\inputs\win_perf_counters\pdh.go:518                                   lll             line is 163 characters
plugins\inputs\win_perf_counters\pdh.go:535                                   lll             line is 168 characters
plugins\inputs\win_perf_counters\pdh.go:539                                   lll             line is 170 characters
plugins\inputs\win_perf_counters\pdh.go:580                                   lll             line is 208 characters
plugins\inputs\win_perf_counters\pdh.go:583                                   lll             line is 428 characters
plugins\inputs\win_perf_counters\pdh.go:586                                   lll             line is 321 characters
plugins\inputs\win_perf_counters\pdh_amd64.go:75                              lll             line is 182 characters
plugins\inputs\win_perf_counters\pdh_amd64.go:103                             lll             line is 162 characters
plugins\inputs\win_perf_counters\pdh_amd64.go:116                             lll             line is 173 characters
plugins\inputs\win_perf_counters\pdh_amd64.go:118                             lll             line is 180 characters
plugins\inputs\win_perf_counters\performance_query.go:20:23                   interfacebloat  the interface has more than 10 methods: 13
plugins\inputs\win_perf_counters\win_perf_counters.go:168                     lll             line is 204 characters
plugins\inputs\win_perf_counters\win_perf_counters.go:367                     lll             line is 164 characters
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:541:2  ineffassign     ineffectual assignment to err
plugins\inputs\win_perf_counters\win_perf_counters_integration_test.go:541:2  staticcheck     SA4006: this value of `err` is never used
plugins\inputs\win_perf_counters\win_perf_counters_test.go:235:2              ineffassign     ineffectual assignment to ret
plugins\inputs\win_perf_counters\win_perf_counters_test.go:242                lll             line is 185 characters
plugins\inputs\win_perf_counters\win_perf_counters_test.go:1352               lll             line is 162 characters
plugins\inputs\win_perf_counters\win_perf_counters_test.go:1731               lll             line is 163 characters
plugins\inputs\win_perf_counters\win_perf_counters_test.go:1926               lll             line is 163 characters
plugins\inputs\win_services\win_services_test.go:214:24                       unconvert       unnecessary conversion
plugins\inputs\win_services\win_services_test.go:215:31                       unconvert       unnecessary conversion
plugins\inputs\win_services\win_services_test.go:237:24                       unconvert       unnecessary conversion
plugins\inputs\win_services\win_services_test.go:238:31                       unconvert       unnecessary conversion
```

