### PR TITLE
fix(inputs.intel_pmu): fix handling of the json perfmon format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/influxdata/tail v1.0.1-0.20210707231403-b283181d1fa7
 	github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65
 	github.com/influxdata/wlog v0.0.0-20160411224016-7c63b0a71ef8
-	github.com/intel/iaevents v1.0.0
+	github.com/intel/iaevents v1.1.0
 	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgio v1.0.0
 	github.com/jackc/pgtype v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -1287,8 +1287,8 @@ github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65/go.mod h1:zApaNFpP
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
 github.com/influxdata/wlog v0.0.0-20160411224016-7c63b0a71ef8 h1:W2IgzRCb0L9VzMujq/QuTaZUKcH8096jWwP519mHN6Q=
 github.com/influxdata/wlog v0.0.0-20160411224016-7c63b0a71ef8/go.mod h1:/2NMgWB1DHM1ti/gqhOlg+LJeBVk6FqR5aVGYY0hlwI=
-github.com/intel/iaevents v1.0.0 h1:J8lETV13FMImV0VbOrKhkA790z7+cAHQ/28gbiefu7E=
-github.com/intel/iaevents v1.0.0/go.mod h1:nFsAQmrbF6MoZUomrSl4jgmHhe0SrLxTGtyqvqU2X9Y=
+github.com/intel/iaevents v1.1.0 h1:FzxMBfXk/apG2EUXUCfaq3gUQ+q+TgZ1HNMjjUILUGE=
+github.com/intel/iaevents v1.1.0/go.mod h1:CyUUzXw0lHRCsmyyF7Pwco9Y7NiTNQUUlcJ7RJAazKs=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -2793,7 +2793,6 @@ golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210314195730-07df6a141424/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/plugins/inputs/intel_pmu/README.md
+++ b/plugins/inputs/intel_pmu/README.md
@@ -113,7 +113,7 @@ easier.
 Intel PMU plugin, is only intended for use on **linux 64-bit** systems.
 
 Event definition JSON files for specific architectures can be found at
-[01.org](https://download.01.org/perfmon/).  A script to download the event
+[github](https://github.com/intel/perfmon).  A script to download the event
 definitions that are appropriate for your system (event_download.py) is
 available at [pmu-tools](https://github.com/andikleen/pmu-tools).  Please keep
 these files in a safe place on your system.
@@ -244,3 +244,10 @@ pmu_metric,cpu=0,event=L1D_PEND_MISS.PENDING_CYCLES,host=xyz raw=18767833i,scale
 ```
 
 [man]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+
+## Changelog
+
+| Version | Description |
+| --- | --- |
+| v1.0.0 | Initial version |
+| v1.1.0 | Added support for [new perfmon event format](https://github.com/intel/perfmon/issues/22). Old event format is still accepted (warn message will be printed in the log) |

--- a/plugins/inputs/intel_pmu/intel_pmu.go
+++ b/plugins/inputs/intel_pmu/intel_pmu.go
@@ -5,6 +5,7 @@ package intel_pmu
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -131,7 +132,7 @@ func (i *IntelPMU) Init() error {
 		return fmt.Errorf("error during event definitions paths validation: %w", err)
 	}
 
-	reader, err := newReader(i.EventListPaths)
+	reader, err := newReader(i.Log, i.EventListPaths)
 	if err != nil {
 		return err
 	}
@@ -270,11 +271,16 @@ func (i *IntelPMU) Stop() {
 	}
 }
 
-func newReader(files []string) (*ia.JSONFilesReader, error) {
+func newReader(log telegraf.Logger, files []string) (*ia.JSONFilesReader, error) {
 	reader := ia.NewFilesReader()
 	for _, file := range files {
 		err := reader.AddFiles(file)
 		if err != nil {
+			var deprecatedFormatError *ia.DeprecatedFormatError
+			if errors.As(err, &deprecatedFormatError) {
+				log.Warnf("%v. Consider using perfmon event file in updated format", deprecatedFormatError)
+				continue
+			}
 			return nil, fmt.Errorf("failed to add files to reader: %w", err)
 		}
 	}

--- a/plugins/inputs/intel_pmu/intel_pmu.go
+++ b/plugins/inputs/intel_pmu/intel_pmu.go
@@ -278,7 +278,7 @@ func newReader(log telegraf.Logger, files []string) (*ia.JSONFilesReader, error)
 		if err != nil {
 			var deprecatedFormatError *ia.DeprecatedFormatError
 			if errors.As(err, &deprecatedFormatError) {
-				log.Warnf("%v. Consider using perfmon event file in updated format", deprecatedFormatError)
+				log.Warnf("%v. See the perfmon repo for updated event files", deprecatedFormatError)
 				continue
 			}
 			return nil, fmt.Errorf("failed to add files to reader: %w", err)


### PR DESCRIPTION
Intel PMU plugin stopped working after introducing new version of json perfmon format.

This PR fixes this bug. More info can be found inside on [issue](https://github.com/intel/perfmon/issues/22). 
Old event format is still accepted.

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)