### PR TITLE
chore: Bump golangci-lint from v1.51.2 to v1.52.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli


### PR DESCRIPTION
follow-up: https://github.com/influxdata/telegraf/pull/13110