### PR TITLE
fix(inputs.sysstat): document and expose intervals

### DIFF
--- a/plugins/inputs/sysstat/README.md
+++ b/plugins/inputs/sysstat/README.md
@@ -32,6 +32,18 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Path to the sadf command, if it is not in PATH
   # sadf_path = "/usr/bin/sadf"
 
+  ## Parse interval
+  ## This sets the amount of time to reserve for parsing the result of sadf
+  ## with sadc. Increase this if you find that parsing is taking too long after
+  ## collection and collection intervals are skipped.
+  # parse_interval = "1s"
+
+  ## sadc interval
+  ## When set this determines the amount of time to use to collect data. It is
+  ## best to leave this alone and change the plugin-level interval setting if
+  ## more time is required.
+  # sadc_interval = "0s"
+
   ## Activities is a list of activities, that are passed as argument to the
   ## sadc collector utility (e.g: DISK, SNMP etc...)
   ## The more activities that are added, the more data is collected.

--- a/plugins/inputs/sysstat/sample.conf
+++ b/plugins/inputs/sysstat/sample.conf
@@ -12,6 +12,18 @@
   ## Path to the sadf command, if it is not in PATH
   # sadf_path = "/usr/bin/sadf"
 
+  ## Parse interval
+  ## This sets the amount of time to reserve for parsing the result of sadf
+  ## with sadc. Increase this if you find that parsing is taking too long after
+  ## collection and collection intervals are skipped.
+  # parse_interval = "1s"
+
+  ## sadc interval
+  ## When set this determines the amount of time to use to collect data. It is
+  ## best to leave this alone and change the plugin-level interval setting if
+  ## more time is required.
+  # sadc_interval = "0s"
+
   ## Activities is a list of activities, that are passed as argument to the
   ## sadc collector utility (e.g: DISK, SNMP etc...)
   ## The more activities that are added, the more data is collected.


### PR DESCRIPTION
This allows the user to tune the parse interval to something larger than 1 second in the even that the system is overloaded or has a lot of data to parse.

Additionally, it adds the sadc_interval to the sample.conf but warns to avoid modifying this.

fixes: #13125