### PR TITLE
fix(processors.starlark): do not reject tracking metrics twice

### DIFF
--- a/plugins/processors/starlark/starlark.go
+++ b/plugins/processors/starlark/starlark.go
@@ -57,7 +57,6 @@ func (s *Starlark) Add(metric telegraf.Metric, acc telegraf.Accumulator) error {
 	rv, err := s.Call("apply")
 	if err != nil {
 		s.LogError(err)
-		metric.Reject()
 		return err
 	}
 


### PR DESCRIPTION
If an error occurs in the starlark processor tracking metrics are rejected, decrementing their count. However, immediately after the agent when running processors, if an error occurs in the processor it will also attempt to drop the metric. This double reject + drop results in a negative reference count, panicing telegraf.

This did not affect metrics which do not use tracking metrics. It requires a metric that uses a tracking metric to expose as well as an error in starlark.

fixes: #13148