### PR TITLE
feat(outputs.loki): add option for metric name label

### DIFF
--- a/plugins/outputs/loki/README.md
+++ b/plugins/outputs/loki/README.md
@@ -52,4 +52,10 @@ to use them.
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
+
+  ## Metric Name Label
+  ## Label to use for the metric name to when sending metrics. If set to an
+  ## empty string, this will not add the label. This is NOT suggested as there
+  ## is no way to differentiate between multiple metrics.
+  # metric_name_label = "__name"
 ```

--- a/plugins/outputs/loki/loki.go
+++ b/plugins/outputs/loki/loki.go
@@ -32,17 +32,18 @@ const (
 )
 
 type Loki struct {
-	Domain       string            `toml:"domain"`
-	Endpoint     string            `toml:"endpoint"`
-	Timeout      config.Duration   `toml:"timeout"`
-	Username     config.Secret     `toml:"username"`
-	Password     config.Secret     `toml:"password"`
-	Headers      map[string]string `toml:"http_headers"`
-	ClientID     string            `toml:"client_id"`
-	ClientSecret string            `toml:"client_secret"`
-	TokenURL     string            `toml:"token_url"`
-	Scopes       []string          `toml:"scopes"`
-	GZipRequest  bool              `toml:"gzip_request"`
+	Domain          string            `toml:"domain"`
+	Endpoint        string            `toml:"endpoint"`
+	Timeout         config.Duration   `toml:"timeout"`
+	Username        config.Secret     `toml:"username"`
+	Password        config.Secret     `toml:"password"`
+	Headers         map[string]string `toml:"http_headers"`
+	ClientID        string            `toml:"client_id"`
+	ClientSecret    string            `toml:"client_secret"`
+	TokenURL        string            `toml:"token_url"`
+	Scopes          []string          `toml:"scopes"`
+	GZipRequest     bool              `toml:"gzip_request"`
+	MetricNameLabel string            `toml:"metric_name_label"`
 
 	url    string
 	client *http.Client
@@ -119,7 +120,9 @@ func (l *Loki) Write(metrics []telegraf.Metric) error {
 	})
 
 	for _, m := range metrics {
-		m.AddTag("__name", m.Name())
+		if l.MetricNameLabel != "" {
+			m.AddTag(l.MetricNameLabel, m.Name())
+		}
 
 		tags := m.TagList()
 		var line string
@@ -197,6 +200,8 @@ func (l *Loki) writeMetrics(s Streams) error {
 
 func init() {
 	outputs.Add("loki", func() telegraf.Output {
-		return &Loki{}
+		return &Loki{
+			MetricNameLabel: "__name",
+		}
 	})
 }

--- a/plugins/outputs/loki/sample.conf
+++ b/plugins/outputs/loki/sample.conf
@@ -23,3 +23,9 @@
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
+
+  ## Metric Name Label
+  ## Label to use for the metric name to when sending metrics. If set to an
+  ## empty string, this will not add the label. This is NOT suggested as there
+  ## is no way to differentiate between multiple metrics.
+  # metric_name_label = "__name"


### PR DESCRIPTION
This allows the user to specify the label name used to store the metric name. This label was added in #10001, but a user may not want this value in which case they could set it to an empty string or use some other customer value.

fixes: #13146
