### PR TITLE
feat(inputs.filecount): Add oldestFileTimestamp and newestFileTimestamp

### DIFF
--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -46,6 +46,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## duration. If mtime is negative, only count files that have been
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
+
+  ## Collect older and newer file timestamp. Defaults to true.
+  FileTimestamp = true
 ```
 
 ## Metrics

--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -46,9 +46,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## duration. If mtime is negative, only count files that have been
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
-
-  ## Collect older and newer file timestamp. Defaults to true.
-  FileTimestamp = true
 ```
 
 ## Metrics

--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -56,10 +56,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   - fields:
     - count (integer)
     - size_bytes (integer)
+    - oldest_file_timestamp (int, unix time nanoseconds)
+    - newest_file_timestamp (int, unix time nanoseconds)
 
 ## Example Output
 
 ```text
-filecount,directory=/var/cache/apt count=7i,size_bytes=7438336i 1530034445000000000
-filecount,directory=/tmp count=17i,size_bytes=28934786i 1530034445000000000
+filecount,directory=/var/cache/apt count=7i,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
+filecount,directory=/tmp count=17i,size_bytes=28934786i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
 ```

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -146,10 +146,10 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			parent := filepath.Dir(path)
 			childCount[parent]++
 			childSize[parent] += file.Size()
-			if oldestFileTimestamp[parent] > file.ModTime().UnixNano() {
+			if oldestFileTimestamp[parent] == nil || oldestFileTimestamp[parent] > file.ModTime().UnixNano() {
 				oldestFileTimestamp[parent] = file.ModTime().UnixNano()
 			}
-			if newestFileTimestamp[parent] < file.ModTime().UnixNano() {
+			if newestFileTimestamp[parent] == nil || newestFileTimestamp[parent] < file.ModTime().UnixNano() {
 				newestFileTimestamp[parent] = file.ModTime().UnixNano()
 			}
 		}
@@ -176,10 +176,10 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 		if fc.Recursive {
 			childCount[parent] += childCount[path]
 			childSize[parent] += childSize[path]
-			if oldestFileTimestamp[parent] > oldestFileTimestamp[path] {
+			if oldestFileTimestamp[parent] == nil || oldestFileTimestamp[parent] > oldestFileTimestamp[path] {
 				oldestFileTimestamp[parent] = oldestFileTimestamp[path]
 			}
-			if newestFileTimestamp[parent] < newestFileTimestamp[path] {
+			if newestFileTimestamp[parent] == nil || newestFileTimestamp[parent] < newestFileTimestamp[path] {
 				newestFileTimestamp[parent] = newestFileTimestamp[path]
 			}
 		}

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -25,6 +25,7 @@ type FileCount struct {
 	Directories    []string
 	Name           string
 	Recursive      bool
+	FileTimestamp  bool
 	RegularOnly    bool
 	FollowSymlinks bool
 	Size           config.Size
@@ -290,6 +291,7 @@ func NewFileCount() *FileCount {
 		Directories:    []string{},
 		Name:           "*",
 		Recursive:      true,
+		FileTimestamp:  true,
 		RegularOnly:    true,
 		FollowSymlinks: false,
 		Size:           config.Size(0),

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -146,10 +146,10 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			parent := filepath.Dir(path)
 			childCount[parent]++
 			childSize[parent] += file.Size()
-			if oldestFileTimestamp[parent] == nil || oldestFileTimestamp[parent] > file.ModTime().UnixNano() {
+			if oldestFileTimestamp[parent] == 0 || oldestFileTimestamp[parent] > file.ModTime().UnixNano() {
 				oldestFileTimestamp[parent] = file.ModTime().UnixNano()
 			}
-			if newestFileTimestamp[parent] == nil || newestFileTimestamp[parent] < file.ModTime().UnixNano() {
+			if newestFileTimestamp[parent] == 0 || newestFileTimestamp[parent] < file.ModTime().UnixNano() {
 				newestFileTimestamp[parent] = file.ModTime().UnixNano()
 			}
 		}
@@ -176,10 +176,10 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 		if fc.Recursive {
 			childCount[parent] += childCount[path]
 			childSize[parent] += childSize[path]
-			if oldestFileTimestamp[parent] == nil || oldestFileTimestamp[parent] > oldestFileTimestamp[path] {
+			if oldestFileTimestamp[parent] == 0 || oldestFileTimestamp[parent] > oldestFileTimestamp[path] {
 				oldestFileTimestamp[parent] = oldestFileTimestamp[path]
 			}
-			if newestFileTimestamp[parent] == nil || newestFileTimestamp[parent] < newestFileTimestamp[path] {
+			if newestFileTimestamp[parent] == 0 || newestFileTimestamp[parent] < newestFileTimestamp[path] {
 				newestFileTimestamp[parent] = newestFileTimestamp[path]
 			}
 		}

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -25,7 +25,6 @@ type FileCount struct {
 	Directories    []string
 	Name           string
 	Recursive      bool
-	FileTimestamp  bool
 	RegularOnly    bool
 	FollowSymlinks bool
 	Size           config.Size
@@ -147,13 +146,11 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			parent := filepath.Dir(path)
 			childCount[parent]++
 			childSize[parent] += file.Size()
-			if fc.FileTimestamp {
-				if oldestFileTimestamp[parent] > file.ModTime().UnixNano() {
-					oldestFileTimestamp[parent] = file.ModTime().UnixNano()
-				}
-				if newestFileTimestamp[parent] < file.ModTime().UnixNano() {
-					newestFileTimestamp[parent] = file.ModTime().UnixNano()
-				}
+			if oldestFileTimestamp[parent] > file.ModTime().UnixNano() {
+				oldestFileTimestamp[parent] = file.ModTime().UnixNano()
+			}
+			if newestFileTimestamp[parent] < file.ModTime().UnixNano() {
+				newestFileTimestamp[parent] = file.ModTime().UnixNano()
 			}
 		}
 		if file.IsDir() && !fc.Recursive && !glob.HasSuperMeta {
@@ -168,10 +165,8 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 				"count":      childCount[path],
 				"size_bytes": childSize[path],
 			}
-			if fc.FileTimestamp {
-				gauge["oldest_file_timestamp"] = oldestFileTimestamp[path]
-				gauge["newest_file_timestamp"] = newestFileTimestamp[path]
-			}
+			gauge["oldest_file_timestamp"] = oldestFileTimestamp[path]
+			gauge["newest_file_timestamp"] = newestFileTimestamp[path]
 			acc.AddGauge("filecount", gauge,
 				map[string]string{
 					"directory": path,
@@ -291,7 +286,6 @@ func NewFileCount() *FileCount {
 		Directories:    []string{},
 		Name:           "*",
 		Recursive:      true,
-		FileTimestamp:  true,
 		RegularOnly:    true,
 		FollowSymlinks: false,
 		Size:           config.Size(0),

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -122,6 +122,8 @@ func (fc *FileCount) initFileFilters() {
 func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpath.GlobPath) {
 	childCount := make(map[string]int64)
 	childSize := make(map[string]int64)
+	oldestFileTimestamp := make(map[string]int64)
+	newestFileTimestamp := make(map[string]int64)
 
 	walkFn := func(path string, de *godirwalk.Dirent) error {
 		rel, err := filepath.Rel(basedir, path)
@@ -144,6 +146,14 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			parent := filepath.Dir(path)
 			childCount[parent]++
 			childSize[parent] += file.Size()
+			if fc.FileTimestamp {
+				if oldestFileTimestamp[parent] > fileInfo.ModTime().UnixNano() {
+					oldestFileTimestamp[parent] = fileInfo.ModTime().UnixNano()
+				}
+				if newestFileTimestamp[parent] < fileInfo.ModTime().UnixNano() {
+					newestFileTimestamp[parent] = fileInfo.ModTime().UnixNano()
+				}
+			}
 		}
 		if file.IsDir() && !fc.Recursive && !glob.HasSuperMeta {
 			return filepath.SkipDir
@@ -157,6 +167,10 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 				"count":      childCount[path],
 				"size_bytes": childSize[path],
 			}
+			if fc.FileTimestamp {
+				tmpFields["oldest_file_timestamp"] = oldestFileTimestamp[path]
+				tmpFields["newest_file_timestamp"] = newestFileTimestamp[path]
+			}
 			acc.AddGauge("filecount", gauge,
 				map[string]string{
 					"directory": path,
@@ -166,9 +180,17 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 		if fc.Recursive {
 			childCount[parent] += childCount[path]
 			childSize[parent] += childSize[path]
+			if oldestFileTimestamp[parent] > oldestFileTimestamp[path] {
+				oldestFileTimestamp[parent] = oldestFileTimestamp[path]
+			}
+			if newestFileTimestamp[parent] < newestFileTimestamp[path] {
+				newestFileTimestamp[parent] = newestFileTimestamp[path]
+			}
 		}
 		delete(childCount, path)
 		delete(childSize, path)
+		delete(oldestFileTimestamp, path)
+		delete(newestFileTimestamp, path)
 		return nil
 	}
 

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -148,11 +148,11 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			childCount[parent]++
 			childSize[parent] += file.Size()
 			if fc.FileTimestamp {
-				if oldestFileTimestamp[parent] > fileInfo.ModTime().UnixNano() {
-					oldestFileTimestamp[parent] = fileInfo.ModTime().UnixNano()
+				if oldestFileTimestamp[parent] > file.ModTime().UnixNano() {
+					oldestFileTimestamp[parent] = file.ModTime().UnixNano()
 				}
-				if newestFileTimestamp[parent] < fileInfo.ModTime().UnixNano() {
-					newestFileTimestamp[parent] = fileInfo.ModTime().UnixNano()
+				if newestFileTimestamp[parent] < file.ModTime().UnixNano() {
+					newestFileTimestamp[parent] = file.ModTime().UnixNano()
 				}
 			}
 		}
@@ -169,8 +169,8 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 				"size_bytes": childSize[path],
 			}
 			if fc.FileTimestamp {
-				tmpFields["oldest_file_timestamp"] = oldestFileTimestamp[path]
-				tmpFields["newest_file_timestamp"] = newestFileTimestamp[path]
+				gauge["oldest_file_timestamp"] = oldestFileTimestamp[path]
+				gauge["newest_file_timestamp"] = newestFileTimestamp[path]
 			}
 			acc.AddGauge("filecount", gauge,
 				map[string]string{

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -38,6 +38,8 @@ func TestNoFiltersOnChildDir(t *testing.T) {
 	require.NoError(t, acc.GatherError(fc.Gather))
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(len(matches))))
 	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(600)))
+	require.True(t, acc.HasInt64Field("filecount", "oldest_file_timestamp"))
+	require.True(t, acc.HasInt64Field("filecount", "newest_file_timestamp"))
 }
 
 func TestNoRecursiveButSuperMeta(t *testing.T) {
@@ -52,6 +54,8 @@ func TestNoRecursiveButSuperMeta(t *testing.T) {
 
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(len(matches))))
 	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(200)))
+	require.True(t, acc.HasInt64Field("filecount", "oldest_file_timestamp"))
+	require.True(t, acc.HasInt64Field("filecount", "newest_file_timestamp"))
 }
 
 func TestNameFilter(t *testing.T) {

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -161,8 +161,8 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 				"directory": getTestdataDir(),
 			},
 			map[string]interface{}{
-				"count":      9,
-				"size_bytes": 5096,
+				"count":                 9,
+				"size_bytes":            5096,
 				"newest_file_timestamp": 1450117505000000000,
 				"oldest_file_timestamp": 0,
 			},

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -164,7 +164,7 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 				"count":                 9,
 				"size_bytes":            5096,
 				"newest_file_timestamp": time.Unix(1450117505, 0).UnixNano(),
-				"oldest_file_timestamp": 0,
+				"oldest_file_timestamp": time.Unix(1292351105, 0).UnixNano(),
 			},
 			time.Unix(0, 0),
 			telegraf.Gauge,

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -163,6 +163,8 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 			map[string]interface{}{
 				"count":      9,
 				"size_bytes": 5096,
+				"newest_file_timestamp": 1450117505000000000,
+				"oldest_file_timestamp": 0,
 			},
 			time.Unix(0, 0),
 			telegraf.Gauge,

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -163,7 +163,7 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 			map[string]interface{}{
 				"count":                 9,
 				"size_bytes":            5096,
-				"newest_file_timestamp": 1450117505000000000,
+				"newest_file_timestamp": time.Unix(1450117505, 0).UnixNano(),
 				"oldest_file_timestamp": 0,
 			},
 			time.Unix(0, 0),

--- a/plugins/inputs/filecount/sample.conf
+++ b/plugins/inputs/filecount/sample.conf
@@ -30,6 +30,3 @@
   ## duration. If mtime is negative, only count files that have been
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
-
-  ## Collect older and newer file timestamp. Defaults to true.
-  FileTimestamp = true

--- a/plugins/inputs/filecount/sample.conf
+++ b/plugins/inputs/filecount/sample.conf
@@ -30,3 +30,6 @@
   ## duration. If mtime is negative, only count files that have been
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
+
+  ## Collect older and newer file timestamp. Defaults to true.
+  FileTimestamp = true


### PR DESCRIPTION
Add fields like :
oldest_file_timestamp
newest_file_timestamp

Use case:

With this two fields, we can generate alarming if nothing append in the directeory.
For exemple if we wait for daily file reception.

resolves https://github.com/influxdata/telegraf/issues/11087