### PR TITLE
fix(outputs.stackdriver): allow for custom metric type prefix

### DIFF
--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -38,6 +38,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## The namespace for the metric descriptor
   namespace = "telegraf"
 
+  ## Metric Type Prefix
+  ## The DNS name used with the metric type as a prefix.
+  # metric_type_prefix = "custom.googleapis.com"
+
   ## Custom resource type
   # resource_type = "generic_node"
 

--- a/plugins/outputs/stackdriver/sample.conf
+++ b/plugins/outputs/stackdriver/sample.conf
@@ -6,6 +6,10 @@
   ## The namespace for the metric descriptor
   namespace = "telegraf"
 
+  ## Metric Type Prefix
+  ## The DNS name used with the metric type as a prefix.
+  # metric_type_prefix = "custom.googleapis.com"
+
   ## Custom resource type
   # resource_type = "generic_node"
 

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -27,11 +27,12 @@ var sampleConfig string
 
 // Stackdriver is the Google Stackdriver config info.
 type Stackdriver struct {
-	Project        string            `toml:"project"`
-	Namespace      string            `toml:"namespace"`
-	ResourceType   string            `toml:"resource_type"`
-	ResourceLabels map[string]string `toml:"resource_labels"`
-	Log            telegraf.Logger   `toml:"-"`
+	Project          string            `toml:"project"`
+	Namespace        string            `toml:"namespace"`
+	ResourceType     string            `toml:"resource_type"`
+	ResourceLabels   map[string]string `toml:"resource_labels"`
+	MetricTypePrefix string            `toml:"metric_type_prefix"`
+	Log              telegraf.Logger   `toml:"-"`
 
 	client       *monitoring.MetricClient
 	counterCache *counterCache
@@ -55,6 +56,14 @@ const (
 	errStringPointsTooOld      = "data points cannot be written more than 24h in the past"
 	errStringPointsTooFrequent = "one or more points were written more frequently than the maximum sampling period configured for the metric"
 )
+
+func (s *Stackdriver) Init() error {
+	if s.MetricTypePrefix == "" {
+		s.MetricTypePrefix = "custom.googleapis.com"
+	}
+
+	return nil
+}
 
 func (*Stackdriver) SampleConfig() string {
 	return sampleConfig
@@ -172,7 +181,7 @@ func (s *Stackdriver) Write(metrics []telegraf.Metric) error {
 			// Prepare time series.
 			timeSeries := &monitoringpb.TimeSeries{
 				Metric: &metricpb.Metric{
-					Type:   path.Join("custom.googleapis.com", s.Namespace, m.Name(), f.Key),
+					Type:   path.Join(s.MetricTypePrefix, s.Namespace, m.Name(), f.Key),
 					Labels: s.getStackdriverLabels(m.TagList()),
 				},
 				MetricKind: metricKind,


### PR DESCRIPTION
fixes: #13132