### PR TITLE
feat(serializers): Add CloudEvents serializer

### DIFF
--- a/docs/DATA_FORMATS_OUTPUT.md
+++ b/docs/DATA_FORMATS_OUTPUT.md
@@ -6,6 +6,7 @@ plugins.
 
 1. [InfluxDB Line Protocol](/plugins/serializers/influx)
 1. [Carbon2](/plugins/serializers/carbon2)
+1. [CloudEvents](/plugins/serializers/cloudevents)
 1. [CSV](/plugins/serializers/csv)
 1. [Graphite](/plugins/serializers/graphite)
 1. [JSON](/plugins/serializers/json)

--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -87,6 +87,7 @@ following works:
 - github.com/cenkalti/backoff [MIT License](https://github.com/cenkalti/backoff/blob/master/LICENSE)
 - github.com/cespare/xxhash [MIT License](https://github.com/cespare/xxhash/blob/master/LICENSE.txt)
 - github.com/cisco-ie/nx-telemetry-proto [Apache License 2.0](https://github.com/cisco-ie/nx-telemetry-proto/blob/master/LICENSE)
+- github.com/cloudevents/sdk-go [Apache License 2.0](https://github.com/cloudevents/sdk-go/blob/main/LICENSE)
 - github.com/containerd/containerd [Apache License 2.0](https://github.com/containerd/containerd/blob/master/LICENSE)
 - github.com/coocood/freecache [MIT License](https://github.com/coocood/freecache/blob/master/LICENSE)
 - github.com/coreos/go-semver [Apache License 2.0](https://github.com/coreos/go-semver/blob/main/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -150,6 +150,7 @@ require (
 	github.com/riemann/riemann-go-client v0.5.1-0.20211206220514-f58f10cdce16
 	github.com/robbiet480/go.nut v0.0.0-20220219091450-bd8f121e1fa1
 	github.com/safchain/ethtool v0.3.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/sensu/sensu-go/api/core/v2 v2.16.0
 	github.com/shirou/gopsutil/v3 v3.23.3
 	github.com/showwin/speedtest-go v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -261,6 +261,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cloudevents/sdk-go/v2 v2.14.0
 	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 // indirect
 	github.com/containerd/containerd v1.6.18 // indirect
 	github.com/couchbase/gomemcached v0.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/cisco-ie/nx-telemetry-proto v0.0.0-20230117155933-f64c045c77df h1:GmrltUp5Qf5XhT+LmqMDizsgm/6VHTSxPWRdrq21yRo=
 github.com/cisco-ie/nx-telemetry-proto v0.0.0-20230117155933-f64c045c77df/go.mod h1:rJDd05J5hqWVU9MjJ+5jw1CuLn/jRhvU0xtFEzzqjwM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudevents/sdk-go/v2 v2.14.0 h1:Nrob4FwVgi5L4tV9lhjzZcjYqFVyJzsA56CwPaPfv6s=
+github.com/cloudevents/sdk-go/v2 v2.14.0/go.mod h1:xDmKfzNjM8gBvjaF8ijFjM1VYOVUEeUfapHMUX1T5To=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 h1:F1EaeKL/ta07PY/k9Os/UFtwERei2/XzGemhpGnBKNg=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -1522,6 +1524,12 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.23.5 h1:xbrU7tAYviSpqeR3X4nEFWUdB/uDZ6DE+HxmRU7Xtyw=
 github.com/urfave/cli/v2 v2.23.5/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
+github.com/uudashr/gocognit v1.0.1/go.mod h1:j44Ayx2KW4+oB6SWMv8KsmHzZrOInQav7D3cQMJ5JUM=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
+github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD5KW4lOuSdPKzY=
+github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vapourismo/knx-go v0.0.0-20220829185957-fb5458a5389d h1:BJMc7MNW/p80cCkC46JimNuowOWCnSSW5IHjtUrXzNk=
 github.com/vapourismo/knx-go v0.0.0-20220829185957-fb5458a5389d/go.mod h1:43Jz/tjx4Ehy/CmohTtTIM33hIwYm/6ccdpddnK8KVY=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=

--- a/go.sum
+++ b/go.sum
@@ -1401,6 +1401,10 @@ github.com/safchain/ethtool v0.3.0 h1:gimQJpsI6sc1yIqP/y8GYgiXn/NjgvpM0RNoWLVVmP
 github.com/safchain/ethtool v0.3.0/go.mod h1:SA9BwrgyAqNo7M+uaL6IYbxpm5wk3L7Mm6ocLW+CJUs=
 github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e h1:CGjiMQ0wMH4wtNWrlj6kiTbkPt2F3rbYnhGX6TWLfco=
 github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/sanity-io/litter v1.2.0/go.mod h1:JF6pZUFgu2Q0sBZ+HSV35P8TVPI1TTzEwyu9FXAw2W4=
+github.com/sanposhiho/wastedassign v0.1.3/go.mod h1:LGpq5Hsv74QaqM47WtIsRSF/ik9kqk07kchgv66tLVE=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVPt6lD4/bhmzfiKo=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/go.sum
+++ b/go.sum
@@ -1401,8 +1401,6 @@ github.com/safchain/ethtool v0.3.0 h1:gimQJpsI6sc1yIqP/y8GYgiXn/NjgvpM0RNoWLVVmP
 github.com/safchain/ethtool v0.3.0/go.mod h1:SA9BwrgyAqNo7M+uaL6IYbxpm5wk3L7Mm6ocLW+CJUs=
 github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e h1:CGjiMQ0wMH4wtNWrlj6kiTbkPt2F3rbYnhGX6TWLfco=
 github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/sanity-io/litter v1.2.0/go.mod h1:JF6pZUFgu2Q0sBZ+HSV35P8TVPI1TTzEwyu9FXAw2W4=
-github.com/sanposhiho/wastedassign v0.1.3/go.mod h1:LGpq5Hsv74QaqM47WtIsRSF/ik9kqk07kchgv66tLVE=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVPt6lD4/bhmzfiKo=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
@@ -1528,12 +1526,7 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.23.5 h1:xbrU7tAYviSpqeR3X4nEFWUdB/uDZ6DE+HxmRU7Xtyw=
 github.com/urfave/cli/v2 v2.23.5/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
-github.com/uudashr/gocognit v1.0.1/go.mod h1:j44Ayx2KW4+oB6SWMv8KsmHzZrOInQav7D3cQMJ5JUM=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
-github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
-github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
-github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD5KW4lOuSdPKzY=
-github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vapourismo/knx-go v0.0.0-20220829185957-fb5458a5389d h1:BJMc7MNW/p80cCkC46JimNuowOWCnSSW5IHjtUrXzNk=
 github.com/vapourismo/knx-go v0.0.0-20220829185957-fb5458a5389d/go.mod h1:43Jz/tjx4Ehy/CmohTtTIM33hIwYm/6ccdpddnK8KVY=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=

--- a/plugins/serializers/all/cloudevents.go
+++ b/plugins/serializers/all/cloudevents.go
@@ -1,0 +1,7 @@
+//go:build !custom || serializers || serializers.cloudevents
+
+package all
+
+import (
+	_ "github.com/influxdata/telegraf/plugins/serializers/cloudevents" // register plugin
+)

--- a/plugins/serializers/cloudevents/README.md
+++ b/plugins/serializers/cloudevents/README.md
@@ -1,45 +1,64 @@
 # CloudEvents Serializer
 
-The `influx` data format outputs metrics into [InfluxDB Line Protocol][line
-protocol].  This is the recommended format unless another format is required
-for interoperability.
+The `cloudevents` data format outputs metrics as [CloudEvents][CloudEvents] in
+[JSON format][JSON Spec]. Currently, versions v1.0 and v0.3 of the specification
+are supported with the former being the default.
+
+[CloudEvents]: https://cloudevents.io
+[JSON Spec]: https://github.com/cloudevents/spec/blob/v1.0/json-format.md
 
 ## Configuration
 
 ```toml
 [[outputs.file]]
-  ## Files to write to, "stdout" is a specially handled file.
+  ## Files to write to, "stdout" is a specially handled file
   files = ["stdout", "/tmp/metrics.out"]
 
-  ## Data format to output.
+  ## Data format to output
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
-  data_format = "influx"
+  data_format = "cloudevents"
 
-  ## Maximum line length in bytes.  Useful only for debugging.
-  influx_max_line_bytes = 0
+  ## Specification version to use for events
+  ## Currently versions "0.3" and "1.0" are supported.
+  # cloudevents_version = "1.0"
 
-  ## When true, fields will be output in ascending lexical order.  Enabling
-  ## this option will result in decreased performance and is only recommended
-  ## when you need predictable ordering while debugging.
-  influx_sort_fields = false
+  ## Event source specifier
+  ## This allows to overwrite the source header-field with the given value.
+	# cloudevents_source = "telegraf"
 
-  ## When true, Telegraf will output unsigned integers as unsigned values,
-  ## i.e.: `42u`.  You will need a version of InfluxDB supporting unsigned
-  ## integer values.  Enabling this option will result in field type errors if
-  ## existing data has been written.
-  influx_uint_support = false
+  ## Tag to use as event source specifier
+  ## This allows to overwrite the source header-field with the value of the
+  ## specified tag. If both 'cloudevents_source' and 'cloudevents_source_tag'
+  ## are set, the this setting will take precedence. In case the specified tag
+  ## value does not exist for a metric, the serializer will fallback to
+  ## 'cloudevents_source'.
+	# cloudevents_source_tag = ""
+
+  ## Event-type specifier to overwrite the default value
+  ## By default, events (and event batches) containing a single metric will
+  ## set the event-type to 'com.influxdata.telegraf.metric' while events
+  ## containing a batch of metrics will set the event-type to
+  ## 'com.influxdata.telegraf.metric' (plural).
+	# cloudevents_event_type = ""
+
+  ## Set time header of the event
+  ## Supported values are:
+  ##   none     -- do not set event time
+  ##   earliest -- use timestamp of the earliest metric
+  ##   latest   -- use timestamp of the latest metric
+  ##   creation -- use timestamp of event creation
+  ## For events containing only a single metric, earliest and latest are
+  ## equivalent.
+	# cloudevents_event_time = "latest"
+
+  ## Batch format of the output when running in batch mode
+  ## If set to 'events' the resulting output will contain a list of events,
+  ## each with a single metric according to the JSON Batch Format of the
+  ## specification. Use 'application/cloudevents-batch+json' for this format.
+  ##
+  ## When set to 'metrics', a single event will be generated containing a list
+  ## of metrics as payload. Use 'application/cloudevents+json' for this format.
+	# cloudevents_batch_format = "events"
 ```
-
-## Metrics
-
-Conversion is direct taking into account some limitations of the Line Protocol
-format:
-
-- Float fields that are `NaN` or `Inf` are skipped.
-- Trailing backslash `\` characters are removed from tag keys and values.
-- Tags with a key or value that is the empty string are skipped.
-- When not using `influx_uint_support`, unsigned integers are capped at the max int64.
-
-[line protocol]: https://docs.influxdata.com/influxdb/latest/write_protocols/line_protocol_tutorial/

--- a/plugins/serializers/cloudevents/README.md
+++ b/plugins/serializers/cloudevents/README.md
@@ -1,0 +1,45 @@
+# CloudEvents Serializer
+
+The `influx` data format outputs metrics into [InfluxDB Line Protocol][line
+protocol].  This is the recommended format unless another format is required
+for interoperability.
+
+## Configuration
+
+```toml
+[[outputs.file]]
+  ## Files to write to, "stdout" is a specially handled file.
+  files = ["stdout", "/tmp/metrics.out"]
+
+  ## Data format to output.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "influx"
+
+  ## Maximum line length in bytes.  Useful only for debugging.
+  influx_max_line_bytes = 0
+
+  ## When true, fields will be output in ascending lexical order.  Enabling
+  ## this option will result in decreased performance and is only recommended
+  ## when you need predictable ordering while debugging.
+  influx_sort_fields = false
+
+  ## When true, Telegraf will output unsigned integers as unsigned values,
+  ## i.e.: `42u`.  You will need a version of InfluxDB supporting unsigned
+  ## integer values.  Enabling this option will result in field type errors if
+  ## existing data has been written.
+  influx_uint_support = false
+```
+
+## Metrics
+
+Conversion is direct taking into account some limitations of the Line Protocol
+format:
+
+- Float fields that are `NaN` or `Inf` are skipped.
+- Trailing backslash `\` characters are removed from tag keys and values.
+- Tags with a key or value that is the empty string are skipped.
+- When not using `influx_uint_support`, unsigned integers are capped at the max int64.
+
+[line protocol]: https://docs.influxdata.com/influxdb/latest/write_protocols/line_protocol_tutorial/

--- a/plugins/serializers/cloudevents/README.md
+++ b/plugins/serializers/cloudevents/README.md
@@ -26,7 +26,7 @@ are supported with the former being the default.
 
   ## Event source specifier
   ## This allows to overwrite the source header-field with the given value.
-	# cloudevents_source = "telegraf"
+  # cloudevents_source = "telegraf"
 
   ## Tag to use as event source specifier
   ## This allows to overwrite the source header-field with the value of the
@@ -34,14 +34,14 @@ are supported with the former being the default.
   ## are set, the this setting will take precedence. In case the specified tag
   ## value does not exist for a metric, the serializer will fallback to
   ## 'cloudevents_source'.
-	# cloudevents_source_tag = ""
+  # cloudevents_source_tag = ""
 
   ## Event-type specifier to overwrite the default value
   ## By default, events (and event batches) containing a single metric will
   ## set the event-type to 'com.influxdata.telegraf.metric' while events
   ## containing a batch of metrics will set the event-type to
   ## 'com.influxdata.telegraf.metric' (plural).
-	# cloudevents_event_type = ""
+  # cloudevents_event_type = ""
 
   ## Set time header of the event
   ## Supported values are:
@@ -51,7 +51,7 @@ are supported with the former being the default.
   ##   creation -- use timestamp of event creation
   ## For events containing only a single metric, earliest and latest are
   ## equivalent.
-	# cloudevents_event_time = "latest"
+  # cloudevents_event_time = "latest"
 
   ## Batch format of the output when running in batch mode
   ## If set to 'events' the resulting output will contain a list of events,
@@ -60,5 +60,5 @@ are supported with the former being the default.
   ##
   ## When set to 'metrics', a single event will be generated containing a list
   ## of metrics as payload. Use 'application/cloudevents+json' for this format.
-	# cloudevents_batch_format = "events"
+  # cloudevents_batch_format = "events"
 ```

--- a/plugins/serializers/cloudevents/cloudevents.go
+++ b/plugins/serializers/cloudevents/cloudevents.go
@@ -67,11 +67,11 @@ func (s *Serializer) Init() error {
 
 func (s *Serializer) Serialize(m telegraf.Metric) ([]byte, error) {
 	// Create the event that forms the envelop around the metric
-	event, err := s.createEvent(m)
+	evt, err := s.createEvent(m)
 	if err != nil {
 		return nil, err
 	}
-	return event.MarshalJSON()
+	return evt.MarshalJSON()
 }
 
 func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
@@ -119,7 +119,9 @@ func (s *Serializer) batchMetrics(metrics []telegraf.Metric) ([]byte, error) {
 	evt.SetSource(s.Source)
 	evt.SetID(id.String())
 	evt.SetType(eventType)
-	evt.SetData(cloudevents.ApplicationJSON, data)
+	if err := evt.SetData(cloudevents.ApplicationJSON, data); err != nil {
+		return nil, fmt.Errorf("setting data failed: %w", err)
+	}
 	switch s.EventTime {
 	case "creation":
 		evt.SetTime(time.Now())
@@ -175,7 +177,9 @@ func (s *Serializer) createEvent(m telegraf.Metric) (*cloudevents.Event, error) 
 	evt.SetSource(source)
 	evt.SetID(id.String())
 	evt.SetType(eventType)
-	evt.SetData(cloudevents.ApplicationJSON, data)
+	if err := evt.SetData(cloudevents.ApplicationJSON, data); err != nil {
+		return nil, fmt.Errorf("setting data failed: %w", err)
+	}
 	switch s.EventTime {
 	case "creation":
 		evt.SetTime(time.Now())

--- a/plugins/serializers/cloudevents/cloudevents.go
+++ b/plugins/serializers/cloudevents/cloudevents.go
@@ -1,0 +1,195 @@
+package cloudevents
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/gofrs/uuid/v5"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/serializers"
+)
+
+const (
+	EventTypeSingle = "com.influxdata.telegraf.metric"
+	EventTypeBatch  = "com.influxdata.telegraf.metrics"
+)
+
+type Serializer struct {
+	Version     string          `toml:"cloudevents_version"`
+	Source      string          `toml:"cloudevents_source"`
+	SourceTag   string          `toml:"cloudevents_source_tag"`
+	EventType   string          `toml:"cloudevents_event_type"`
+	EventTime   string          `toml:"cloudevents_event_time"`
+	BatchFormat string          `toml:"cloudevents_batch_format"`
+	Log         telegraf.Logger `toml:"-"`
+
+	idgen uuid.Generator
+}
+
+func (s *Serializer) Init() error {
+	switch s.Version {
+	case "":
+		s.Version = event.CloudEventsVersionV1
+	case event.CloudEventsVersionV03, event.CloudEventsVersionV1:
+	default:
+		return errors.New("invalid 'cloudevents_version'")
+	}
+
+	switch s.EventTime {
+	case "":
+		s.EventTime = "latest"
+	case "none", "earliest", "latest", "creation":
+	default:
+		return errors.New("invalid 'cloudevents_event_time'")
+	}
+
+	switch s.BatchFormat {
+	case "":
+		s.BatchFormat = "events"
+	case "metrics", "events":
+	default:
+		return errors.New("invalid 'cloudevents_batch_format'")
+	}
+
+	if s.Source == "" {
+		s.Source = "telegraf"
+	}
+
+	s.idgen = uuid.NewGen()
+
+	return nil
+}
+
+func (s *Serializer) Serialize(m telegraf.Metric) ([]byte, error) {
+	// Create the event that forms the envelop around the metric
+	event, err := s.createEvent(m)
+	if err != nil {
+		return nil, err
+	}
+	return event.MarshalJSON()
+}
+
+func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
+	switch s.BatchFormat {
+	case "metrics":
+		return s.batchMetrics(metrics)
+	case "events":
+		return s.batchEvents(metrics)
+	}
+	return nil, fmt.Errorf("unexpected batch-format %q", s.BatchFormat)
+}
+
+func (s *Serializer) batchMetrics(metrics []telegraf.Metric) ([]byte, error) {
+	// Determine the necessary information
+	eventType := EventTypeBatch
+	if s.EventType != "" {
+		eventType = s.EventType
+	}
+	id, err := s.idgen.NewV1()
+	if err != nil {
+		return nil, fmt.Errorf("generating ID failed: %w", err)
+	}
+
+	// Serialize the metrics
+	var earliest, latest time.Time
+	data := make([]map[string]interface{}, 0, len(metrics))
+	for _, m := range metrics {
+		ts := m.Time()
+		data = append(data, map[string]interface{}{
+			"name":      m.Name(),
+			"tags":      m.Tags(),
+			"fields":    m.Fields(),
+			"timestamp": ts.UnixNano(),
+		})
+		if ts.Before(earliest) {
+			earliest = ts
+		}
+		if ts.After(latest) {
+			latest = ts
+		}
+	}
+
+	// Create the event that forms the envelop around the metric
+	evt := cloudevents.NewEvent(s.Version)
+	evt.SetSource(s.Source)
+	evt.SetID(id.String())
+	evt.SetType(eventType)
+	evt.SetData(cloudevents.ApplicationJSON, data)
+	switch s.EventTime {
+	case "creation":
+		evt.SetTime(time.Now())
+	case "earliest":
+		evt.SetTime(earliest)
+	case "latest":
+		evt.SetTime(latest)
+	}
+
+	return json.Marshal(evt)
+}
+
+func (s *Serializer) batchEvents(metrics []telegraf.Metric) ([]byte, error) {
+	events := make([]*cloudevents.Event, 0, len(metrics))
+	for _, m := range metrics {
+		e, err := s.createEvent(m)
+		if err != nil {
+			s.Log.Errorf("creating event for %v failed: %w", m, err)
+			continue
+		}
+		events = append(events, e)
+	}
+	return json.Marshal(events)
+}
+
+func (s *Serializer) createEvent(m telegraf.Metric) (*cloudevents.Event, error) {
+	// Determine the necessary information
+	source := s.Source
+	if s.SourceTag != "" {
+		if v, ok := m.GetTag(s.SourceTag); ok {
+			source = v
+		}
+	}
+	eventType := EventTypeSingle
+	if s.EventType != "" {
+		eventType = s.EventType
+	}
+	id, err := s.idgen.NewV1()
+	if err != nil {
+		return nil, fmt.Errorf("generating ID failed: %w", err)
+	}
+
+	// Serialize the metric
+	data := map[string]interface{}{
+		"name":      m.Name(),
+		"tags":      m.Tags(),
+		"fields":    m.Fields(),
+		"timestamp": m.Time().UnixNano(),
+	}
+
+	// Create the event that forms the envelop around the metric
+	evt := cloudevents.NewEvent(s.Version)
+	evt.SetSource(source)
+	evt.SetID(id.String())
+	evt.SetType(eventType)
+	evt.SetData(cloudevents.ApplicationJSON, data)
+	switch s.EventTime {
+	case "creation":
+		evt.SetTime(time.Now())
+	case "earliest", "latest":
+		evt.SetTime(m.Time())
+	}
+
+	return &evt, nil
+}
+
+func init() {
+	serializers.Add("cloudevents",
+		func() serializers.Serializer {
+			return &Serializer{}
+		},
+	)
+}

--- a/plugins/serializers/cloudevents/cloudevents_test.go
+++ b/plugins/serializers/cloudevents/cloudevents_test.go
@@ -105,7 +105,7 @@ func unmarshalEvents(messages [][]byte) ([]cloudevents.Event, error) {
 		// Check for batch settings
 		var es []cloudevents.Event
 		if err := json.Unmarshal(msg, &es); err != nil {
-			if _, ok := err.(*json.UnmarshalTypeError); !ok {
+			if errors.Is(err, &json.UnmarshalTypeError{}) {
 				return nil, fmt.Errorf("message %d: %w", i, err)
 			}
 			var e cloudevents.Event
@@ -189,10 +189,10 @@ func (*dummygen) NewV1() (uuid.UUID, error) {
 	if err != nil {
 		return uuid.UUID([16]byte{}), err
 	}
-	return uuid.UUID([]byte(id)), nil
+	return uuid.UUID(id), nil
 }
 
-func (*dummygen) NewV3(ns uuid.UUID, name string) uuid.UUID {
+func (*dummygen) NewV3(_ uuid.UUID, _ string) uuid.UUID {
 	return uuid.UUID([16]byte{})
 }
 
@@ -200,7 +200,7 @@ func (*dummygen) NewV4() (uuid.UUID, error) {
 	return uuid.UUID([16]byte{}), errors.New("wrong type")
 }
 
-func (*dummygen) NewV5(ns uuid.UUID, name string) uuid.UUID {
+func (*dummygen) NewV5(_ uuid.UUID, _ string) uuid.UUID {
 	return uuid.UUID([16]byte{})
 }
 

--- a/plugins/serializers/cloudevents/cloudevents_test.go
+++ b/plugins/serializers/cloudevents/cloudevents_test.go
@@ -1,0 +1,239 @@
+package cloudevents
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/models"
+	"github.com/influxdata/telegraf/plugins/outputs"
+	"github.com/influxdata/telegraf/plugins/parsers/influx"
+	"github.com/influxdata/telegraf/testutil"
+)
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	// Make sure tests contains data
+	require.NotEmpty(t, folders)
+
+	// Set up for file inputs
+	outputs.Add("dummy", func() telegraf.Output {
+		return &OutputDummy{}
+	})
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		fname := f.Name()
+		t.Run(fname, func(t *testing.T) {
+			testdataPath := filepath.Join("testcases", fname)
+			configFilename := filepath.Join(testdataPath, "telegraf.conf")
+			inputFilename := filepath.Join(testdataPath, "input.influx")
+			expectedFilename := filepath.Join(testdataPath, "expected.json")
+
+			// Get parser to parse input and expected output
+			parser := &influx.Parser{}
+			require.NoError(t, parser.Init())
+
+			input, err := testutil.ParseMetricsFromFile(inputFilename, parser)
+			require.NoError(t, err)
+
+			var expected []map[string]interface{}
+			ebuf, err := os.ReadFile(expectedFilename)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(ebuf, &expected))
+
+			// Configure the plugin
+			cfg := config.NewConfig()
+			require.NoError(t, cfg.LoadConfig(configFilename))
+			require.Len(t, cfg.Outputs, 1, "wrong number of outputs")
+			plugin, ok := cfg.Outputs[0].Output.(*OutputDummy)
+			require.True(t, ok)
+			serializer, ok := plugin.serializer.(*models.RunningSerializer).Serializer.(*Serializer)
+			require.True(t, ok)
+			serializer.idgen = &dummygen{}
+
+			// Write input and compare with expected metrics
+			require.NoError(t, plugin.Write(input))
+			require.NoError(t, checkEvents(plugin.output))
+
+			var joined string
+			switch len(plugin.output) {
+			case 0:
+				require.Emptyf(t, expected, "empty output but %d expected", len(expected))
+			case 1:
+				joined = string(plugin.output[0])
+				if !strings.HasPrefix(joined, "[") {
+					joined = "[" + joined + "]"
+				}
+			default:
+				joined = "[" + string(bytes.Join(plugin.output, []byte(","))) + "]"
+			}
+			var actual []map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(joined), &actual))
+			require.Len(t, actual, len(expected))
+			require.ElementsMatch(t, expected, actual)
+		})
+	}
+}
+
+/* Internal testing functions */
+func unmarshalEvents(messages [][]byte) ([]cloudevents.Event, error) {
+	var events []cloudevents.Event
+
+	for i, msg := range messages {
+		// Check for batch settings
+		var es []cloudevents.Event
+		if err := json.Unmarshal(msg, &es); err != nil {
+			if _, ok := err.(*json.UnmarshalTypeError); !ok {
+				return nil, fmt.Errorf("message %d: %w", i, err)
+			}
+			var e cloudevents.Event
+			if err := json.Unmarshal(msg, &e); err != nil {
+				return nil, fmt.Errorf("message %d: %w", i, err)
+			}
+			events = append(events, e)
+		} else {
+			events = append(events, es...)
+		}
+	}
+
+	return events, nil
+}
+
+func checkEvents(messages [][]byte) error {
+	events, err := unmarshalEvents(messages)
+	if err != nil {
+		return err
+	}
+
+	for i, e := range events {
+		if err := e.Validate(); err != nil {
+			return fmt.Errorf("event %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+/* Dummy output to allow full config parsing loop */
+type OutputDummy struct {
+	Batch      bool `toml:"batch"`
+	serializer telegraf.Serializer
+	output     [][]byte
+}
+
+func (*OutputDummy) SampleConfig() string {
+	return "dummy"
+}
+
+func (o *OutputDummy) Connect() error {
+	o.output = make([][]byte, 0)
+	return nil
+}
+
+func (*OutputDummy) Close() error {
+	return nil
+}
+
+func (o *OutputDummy) Write(metrics []telegraf.Metric) error {
+	if o.Batch {
+		buf, err := o.serializer.SerializeBatch(metrics)
+		if err != nil {
+			return err
+		}
+		o.output = append(o.output, buf)
+	} else {
+		for _, m := range metrics {
+			buf, err := o.serializer.Serialize(m)
+			if err != nil {
+				return err
+			}
+			o.output = append(o.output, buf)
+		}
+	}
+
+	return nil
+}
+
+func (o *OutputDummy) SetSerializer(s telegraf.Serializer) {
+	o.serializer = s
+}
+
+/* Dummy UUID generator to get predictable UUIDs for testing */
+const testid = "845f6acae52a11ed9976d8bbc1a4a0c6"
+
+type dummygen struct{}
+
+func (*dummygen) NewV1() (uuid.UUID, error) {
+	id, err := hex.DecodeString(testid)
+	if err != nil {
+		return uuid.UUID([16]byte{}), err
+	}
+	return uuid.UUID([]byte(id)), nil
+}
+
+func (*dummygen) NewV3(ns uuid.UUID, name string) uuid.UUID {
+	return uuid.UUID([16]byte{})
+}
+
+func (*dummygen) NewV4() (uuid.UUID, error) {
+	return uuid.UUID([16]byte{}), errors.New("wrong type")
+}
+
+func (*dummygen) NewV5(ns uuid.UUID, name string) uuid.UUID {
+	return uuid.UUID([16]byte{})
+}
+
+func (*dummygen) NewV6() (uuid.UUID, error) {
+	return uuid.UUID([16]byte{}), errors.New("wrong type")
+}
+
+func (*dummygen) NewV7() (uuid.UUID, error) {
+	return uuid.UUID([16]byte{}), errors.New("wrong type")
+}
+
+/* Benchmarks */
+func BenchmarkSerializer(b *testing.B) {
+	m := metric.New(
+		"test",
+		map[string]string{
+			"source": "somehost.company.com",
+			"host":   "localhost",
+			"status": "healthy",
+		},
+		map[string]interface{}{
+			"temperature":     23.5,
+			"operating_hours": 4242,
+			"connections":     123,
+			"standby":         true,
+			"SN":              "DC5423DE4CE/2",
+		},
+		time.Now(),
+	)
+
+	serializer := &Serializer{}
+	for n := 0; n < b.N; n++ {
+		_, err := serializer.Serialize(m)
+		require.NoError(b, err)
+	}
+}

--- a/plugins/serializers/cloudevents/testcases/batch-events/expected.json
+++ b/plugins/serializers/cloudevents/testcases/batch-events/expected.json
@@ -1,0 +1,478 @@
+[
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu0",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000000
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000001Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu1",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000001
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000002Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu2",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000002
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000003Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu3",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000003
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000004Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu4",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000004
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000005Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu5",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000005
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000006Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu6",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000006
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000007Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu7",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000007
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000008Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu8",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000008
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000009Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu9",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000009
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.00000001Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu10",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000010
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000011Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu11",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000011
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000012Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu12",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000012
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000013Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu13",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000013
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000014Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu14",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000014
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000015Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu15",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000015
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000999Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 99.62546816517232,
+                "usage_iowait": 0,
+                "usage_irq": 0.12484394506911513,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0.12484394506840547,
+                "usage_user": 0.12484394507124409
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu-total",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000999
+        }
+    }
+]

--- a/plugins/serializers/cloudevents/testcases/batch-events/input.influx
+++ b/plugins/serializers/cloudevents/testcases/batch-events/input.influx
@@ -1,0 +1,17 @@
+cpu,cpu=cpu0,host=Hugin usage_softirq=0,usage_steal=0,usage_guest=0,usage_user=0,usage_idle=100,usage_nice=0,usage_iowait=0,usage_system=0,usage_irq=0,usage_guest_nice=0 1682613051000000000
+cpu,cpu=cpu1,host=Hugin usage_user=0,usage_idle=100,usage_softirq=0,usage_steal=0,usage_guest_nice=0,usage_system=0,usage_nice=0,usage_iowait=0,usage_irq=0,usage_guest=0 1682613051000000001
+cpu,cpu=cpu2,host=Hugin usage_system=0,usage_idle=100,usage_softirq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0,usage_user=0,usage_nice=0,usage_iowait=0,usage_irq=0 1682613051000000002
+cpu,cpu=cpu3,host=Hugin usage_idle=100,usage_nice=0,usage_iowait=0,usage_irq=0,usage_user=0,usage_system=0,usage_softirq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0 1682613051000000003
+cpu,cpu=cpu4,host=Hugin usage_user=0,usage_steal=0,usage_system=0,usage_idle=100,usage_nice=0,usage_iowait=0,usage_irq=0,usage_softirq=0,usage_guest=0,usage_guest_nice=0 1682613051000000004
+cpu,cpu=cpu5,host=Hugin usage_user=0,usage_nice=0,usage_irq=0,usage_softirq=0,usage_guest_nice=0,usage_system=0,usage_idle=100,usage_iowait=0,usage_steal=0,usage_guest=0 1682613051000000005
+cpu,cpu=cpu6,host=Hugin usage_user=0,usage_system=0,usage_iowait=0,usage_softirq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0,usage_idle=100,usage_nice=0,usage_irq=0 1682613051000000006
+cpu,cpu=cpu7,host=Hugin usage_system=0,usage_iowait=0,usage_softirq=0,usage_user=0,usage_nice=0,usage_irq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0,usage_idle=100 1682613051000000007
+cpu,cpu=cpu8,host=Hugin usage_guest_nice=0,usage_user=0,usage_iowait=0,usage_irq=0,usage_softirq=0,usage_guest=0,usage_system=0,usage_idle=100,usage_nice=0,usage_steal=0 1682613051000000008
+cpu,cpu=cpu9,host=Hugin usage_user=0,usage_idle=100,usage_iowait=0,usage_irq=0,usage_guest_nice=0,usage_system=0,usage_nice=0,usage_softirq=0,usage_steal=0,usage_guest=0 1682613051000000009
+cpu,cpu=cpu10,host=Hugin usage_softirq=0,usage_steal=0,usage_guest=0,usage_nice=0,usage_system=0,usage_idle=100,usage_iowait=0,usage_irq=0,usage_guest_nice=0,usage_user=0 1682613051000000010
+cpu,cpu=cpu11,host=Hugin usage_guest=0,usage_guest_nice=0,usage_user=0,usage_idle=100,usage_nice=0,usage_iowait=0,usage_softirq=0,usage_steal=0,usage_system=0,usage_irq=0 1682613051000000011
+cpu,cpu=cpu12,host=Hugin usage_softirq=0,usage_steal=0,usage_guest_nice=0,usage_user=0,usage_system=0,usage_nice=0,usage_irq=0,usage_idle=100,usage_iowait=0,usage_guest=0 1682613051000000012
+cpu,cpu=cpu13,host=Hugin usage_iowait=0,usage_guest=0,usage_guest_nice=0,usage_steal=0,usage_user=0,usage_system=0,usage_idle=100,usage_nice=0,usage_irq=0,usage_softirq=0 1682613051000000013
+cpu,cpu=cpu14,host=Hugin usage_system=0,usage_idle=100,usage_softirq=0,usage_steal=0,usage_guest=0,usage_user=0,usage_nice=0,usage_iowait=0,usage_irq=0,usage_guest_nice=0 1682613051000000014
+cpu,cpu=cpu15,host=Hugin usage_user=0,usage_idle=100,usage_steal=0,usage_irq=0,usage_softirq=0,usage_guest=0,usage_guest_nice=0,usage_system=0,usage_nice=0,usage_iowait=0 1682613051000000015
+cpu,cpu=cpu-total,host=Hugin usage_idle=99.62546816517232,usage_irq=0.12484394506911513,usage_softirq=0,usage_guest_nice=0,usage_steal=0,usage_guest=0,usage_user=0.12484394507124409,usage_system=0.12484394506840547,usage_nice=0,usage_iowait=0 1682613051000000999

--- a/plugins/serializers/cloudevents/testcases/batch-events/telegraf.conf
+++ b/plugins/serializers/cloudevents/testcases/batch-events/telegraf.conf
@@ -1,0 +1,3 @@
+[[outputs.dummy]]
+  batch = true
+  data_format = "cloudevents"

--- a/plugins/serializers/cloudevents/testcases/batch-metrics/expected.json
+++ b/plugins/serializers/cloudevents/testcases/batch-metrics/expected.json
@@ -1,0 +1,112 @@
+[
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metrics",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51Z.000000999",
+        "data": [
+            {
+                "fields": {
+                    "usage_guest": 0,
+                    "usage_guest_nice": 0,
+                    "usage_idle": 100,
+                    "usage_iowait": 0,
+                    "usage_irq": 0,
+                    "usage_nice": 0,
+                    "usage_softirq": 0,
+                    "usage_steal": 0,
+                    "usage_system": 0,
+                    "usage_user": 0
+                },
+                "name": "cpu",
+                "tags": {
+                    "cpu": "cpu0",
+                    "host": "Hugin"
+                },
+                "timestamp": 1682613051000000000
+            },
+            {
+                "fields": {
+                    "usage_guest": 0,
+                    "usage_guest_nice": 0,
+                    "usage_idle": 100,
+                    "usage_iowait": 0,
+                    "usage_irq": 0,
+                    "usage_nice": 0,
+                    "usage_softirq": 0,
+                    "usage_steal": 0,
+                    "usage_system": 0,
+                    "usage_user": 0
+                },
+                "name": "cpu",
+                "tags": {
+                    "cpu": "cpu1",
+                    "host": "Hugin"
+                },
+                "timestamp": 1682613051000000001
+            },
+            {
+                "fields": {
+                    "usage_guest": 0,
+                    "usage_guest_nice": 0,
+                    "usage_idle": 100,
+                    "usage_iowait": 0,
+                    "usage_irq": 0,
+                    "usage_nice": 0,
+                    "usage_softirq": 0,
+                    "usage_steal": 0,
+                    "usage_system": 0,
+                    "usage_user": 0
+                },
+                "name": "cpu",
+                "tags": {
+                    "cpu": "cpu2",
+                    "host": "Hugin"
+                },
+                "timestamp": 1682613051000000002
+            },
+            {
+                "fields": {
+                    "usage_guest": 0,
+                    "usage_guest_nice": 0,
+                    "usage_idle": 100,
+                    "usage_iowait": 0,
+                    "usage_irq": 0,
+                    "usage_nice": 0,
+                    "usage_softirq": 0,
+                    "usage_steal": 0,
+                    "usage_system": 0,
+                    "usage_user": 0
+                },
+                "name": "cpu",
+                "tags": {
+                    "cpu": "cpu3",
+                    "host": "Hugin"
+                },
+                "timestamp": 1682613051000000003
+            },
+            {
+                "fields": {
+                    "usage_guest": 0,
+                    "usage_guest_nice": 0,
+                    "usage_idle": 99.62546816517232,
+                    "usage_iowait": 0,
+                    "usage_irq": 0.12484394506911513,
+                    "usage_nice": 0,
+                    "usage_softirq": 0,
+                    "usage_steal": 0,
+                    "usage_system": 0.12484394506840547,
+                    "usage_user": 0.12484394507124409
+                },
+                "name": "cpu",
+                "tags": {
+                    "cpu": "cpu-total",
+                    "host": "Hugin"
+                },
+                "timestamp": 1682613051000000999
+            }
+        ]
+    }
+]

--- a/plugins/serializers/cloudevents/testcases/batch-metrics/expected.json
+++ b/plugins/serializers/cloudevents/testcases/batch-metrics/expected.json
@@ -5,7 +5,7 @@
         "source": "telegraf",
         "type": "com.influxdata.telegraf.metrics",
         "datacontenttype": "application/json",
-        "time": "2023-04-27T16:30:51Z.000000999",
+        "time": "2023-04-27T16:30:51.000000999Z",
         "data": [
             {
                 "fields": {

--- a/plugins/serializers/cloudevents/testcases/batch-metrics/input.influx
+++ b/plugins/serializers/cloudevents/testcases/batch-metrics/input.influx
@@ -1,0 +1,5 @@
+cpu,cpu=cpu0,host=Hugin usage_softirq=0,usage_steal=0,usage_guest=0,usage_user=0,usage_idle=100,usage_nice=0,usage_iowait=0,usage_system=0,usage_irq=0,usage_guest_nice=0 1682613051000000000
+cpu,cpu=cpu1,host=Hugin usage_user=0,usage_idle=100,usage_softirq=0,usage_steal=0,usage_guest_nice=0,usage_system=0,usage_nice=0,usage_iowait=0,usage_irq=0,usage_guest=0 1682613051000000001
+cpu,cpu=cpu2,host=Hugin usage_system=0,usage_idle=100,usage_softirq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0,usage_user=0,usage_nice=0,usage_iowait=0,usage_irq=0 1682613051000000002
+cpu,cpu=cpu3,host=Hugin usage_idle=100,usage_nice=0,usage_iowait=0,usage_irq=0,usage_user=0,usage_system=0,usage_softirq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0 1682613051000000003
+cpu,cpu=cpu-total,host=Hugin usage_idle=99.62546816517232,usage_irq=0.12484394506911513,usage_softirq=0,usage_guest_nice=0,usage_steal=0,usage_guest=0,usage_user=0.12484394507124409,usage_system=0.12484394506840547,usage_nice=0,usage_iowait=0 1682613051000000999

--- a/plugins/serializers/cloudevents/testcases/batch-metrics/telegraf.conf
+++ b/plugins/serializers/cloudevents/testcases/batch-metrics/telegraf.conf
@@ -1,0 +1,5 @@
+[[outputs.dummy]]
+  batch = true
+  data_format = "cloudevents"
+
+  cloudevents_batch_format = "metrics"

--- a/plugins/serializers/cloudevents/testcases/cloudevents-v0.3-schema.json
+++ b/plugins/serializers/cloudevents/testcases/cloudevents-v0.3-schema.json
@@ -1,0 +1,79 @@
+{
+  "$ref": "#/definitions/event",
+  "definitions": {
+    "specversion": {
+      "type": "string",
+      "minLength": 1
+    },
+    "datacontenttype": {
+      "type": "string"
+    },
+    "data": {
+      "type": ["object", "string"]
+    },
+    "event": {
+      "properties": {
+        "specversion": {
+          "$ref": "#/definitions/specversion"
+        },
+        "datacontenttype": {
+          "$ref": "#/definitions/datacontenttype"
+        },
+        "data": {
+          "$ref": "#/definitions/data"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "time": {
+          "$ref": "#/definitions/time"
+        },
+        "schemaurl": {
+          "$ref": "#/definitions/schemaurl"
+        },
+        "subject": {
+          "$ref": "#/definitions/subject"
+        },
+        "type": {
+          "$ref": "#/definitions/type"
+        },
+        "extensions": {
+          "$ref": "#/definitions/extensions"
+        },
+        "source": {
+          "$ref": "#/definitions/source"
+        }
+      },
+      "required": ["specversion", "id", "type", "source"],
+      "type": "object"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "time": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "schemaurl": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "subject": {
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "extensions": {
+      "type": "object"
+    },
+    "source": {
+      "format": "uri-reference",
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/plugins/serializers/cloudevents/testcases/cloudevents-v1.0-schema.json
+++ b/plugins/serializers/cloudevents/testcases/cloudevents-v1.0-schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "CloudEvents Specification JSON Schema",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Identifies the event.",
+      "$ref": "#/definitions/iddef",
+      "examples": [
+        "A234-1234-1234"
+      ]
+    },
+    "source": {
+      "description": "Identifies the context in which an event happened.",
+      "$ref": "#/definitions/sourcedef",
+      "examples" : [
+        "https://github.com/cloudevents",
+        "mailto:cncf-wg-serverless@lists.cncf.io",
+        "urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66",
+        "cloudevents/spec/pull/123",
+        "/sensors/tn-1234567/alerts",
+        "1-555-123-4567"
+      ]
+    },
+    "specversion": {
+      "description": "The version of the CloudEvents specification which the event uses.",
+      "$ref": "#/definitions/specversiondef",
+      "examples": [
+        "1.0"
+      ]
+    },
+    "type": {
+      "description": "Describes the type of event related to the originating occurrence.",
+      "$ref": "#/definitions/typedef",
+      "examples" : [
+        "com.github.pull_request.opened",
+        "com.example.object.deleted.v2"
+      ]
+    },
+    "datacontenttype": {
+      "description": "Content type of the data value. Must adhere to RFC 2046 format.",
+      "$ref": "#/definitions/datacontenttypedef",
+      "examples": [
+        "text/xml",
+        "application/json",
+        "image/png",
+        "multipart/form-data"
+      ]
+    },
+    "dataschema": {
+      "description": "Identifies the schema that data adheres to.",
+      "$ref": "#/definitions/dataschemadef"
+    },
+    "subject": {
+      "description": "Describes the subject of the event in the context of the event producer (identified by source).",
+      "$ref": "#/definitions/subjectdef",
+      "examples": [
+        "mynewfile.jpg"
+      ]
+    },
+    "time": {
+      "description": "Timestamp of when the occurrence happened. Must adhere to RFC 3339.",
+      "$ref": "#/definitions/timedef",
+      "examples": [
+        "2018-04-05T17:31:00Z"
+      ]
+    },
+    "data": {
+      "description": "The event payload.",
+      "$ref": "#/definitions/datadef",
+      "examples": [
+        "<much wow=\"xml\"/>"
+      ]
+    },
+    "data_base64": {
+      "description": "Base64 encoded event payload. Must adhere to RFC4648.",
+      "$ref": "#/definitions/data_base64def",
+      "examples": [
+        "Zm9vYg=="
+      ]
+    }
+  },
+  "required": ["id", "source", "specversion", "type"],
+  "definitions": {
+    "iddef": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sourcedef": {
+      "type": "string",
+      "format": "uri-reference",
+      "minLength": 1
+    },
+    "specversiondef": {
+      "type": "string",
+      "minLength": 1
+    },
+    "typedef": {
+      "type": "string",
+      "minLength": 1
+    },
+    "datacontenttypedef": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "dataschemadef": {
+      "type": ["string", "null"],
+      "format": "uri",
+      "minLength": 1
+    },
+    "subjectdef": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "timedef": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "minLength": 1
+    },
+    "datadef": {
+      "type": ["object", "string", "number", "array", "boolean", "null"]
+    },
+    "data_base64def": {
+      "type": ["string", "null"],
+      "contentEncoding": "base64"
+    }
+  }
+}

--- a/plugins/serializers/cloudevents/testcases/single-multiple/expected.json
+++ b/plugins/serializers/cloudevents/testcases/single-multiple/expected.json
@@ -1,0 +1,478 @@
+[
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu0",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000000
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000001Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu1",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000001
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000002Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu2",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000002
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000003Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu3",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000003
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000004Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu4",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000004
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000005Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu5",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000005
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000006Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu6",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000006
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000007Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu7",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000007
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000008Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu8",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000008
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000009Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu9",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000009
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.00000001Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu10",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000010
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000011Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu11",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000011
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000012Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu12",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000012
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000013Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu13",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000013
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000014Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu14",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000014
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000015Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu15",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000015
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000999Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 99.62546816517232,
+                "usage_iowait": 0,
+                "usage_irq": 0.12484394506911513,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0.12484394506840547,
+                "usage_user": 0.12484394507124409
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu-total",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000999
+        }
+    }
+]

--- a/plugins/serializers/cloudevents/testcases/single-multiple/input.influx
+++ b/plugins/serializers/cloudevents/testcases/single-multiple/input.influx
@@ -1,0 +1,17 @@
+cpu,cpu=cpu0,host=Hugin usage_softirq=0,usage_steal=0,usage_guest=0,usage_user=0,usage_idle=100,usage_nice=0,usage_iowait=0,usage_system=0,usage_irq=0,usage_guest_nice=0 1682613051000000000
+cpu,cpu=cpu1,host=Hugin usage_user=0,usage_idle=100,usage_softirq=0,usage_steal=0,usage_guest_nice=0,usage_system=0,usage_nice=0,usage_iowait=0,usage_irq=0,usage_guest=0 1682613051000000001
+cpu,cpu=cpu2,host=Hugin usage_system=0,usage_idle=100,usage_softirq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0,usage_user=0,usage_nice=0,usage_iowait=0,usage_irq=0 1682613051000000002
+cpu,cpu=cpu3,host=Hugin usage_idle=100,usage_nice=0,usage_iowait=0,usage_irq=0,usage_user=0,usage_system=0,usage_softirq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0 1682613051000000003
+cpu,cpu=cpu4,host=Hugin usage_user=0,usage_steal=0,usage_system=0,usage_idle=100,usage_nice=0,usage_iowait=0,usage_irq=0,usage_softirq=0,usage_guest=0,usage_guest_nice=0 1682613051000000004
+cpu,cpu=cpu5,host=Hugin usage_user=0,usage_nice=0,usage_irq=0,usage_softirq=0,usage_guest_nice=0,usage_system=0,usage_idle=100,usage_iowait=0,usage_steal=0,usage_guest=0 1682613051000000005
+cpu,cpu=cpu6,host=Hugin usage_user=0,usage_system=0,usage_iowait=0,usage_softirq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0,usage_idle=100,usage_nice=0,usage_irq=0 1682613051000000006
+cpu,cpu=cpu7,host=Hugin usage_system=0,usage_iowait=0,usage_softirq=0,usage_user=0,usage_nice=0,usage_irq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0,usage_idle=100 1682613051000000007
+cpu,cpu=cpu8,host=Hugin usage_guest_nice=0,usage_user=0,usage_iowait=0,usage_irq=0,usage_softirq=0,usage_guest=0,usage_system=0,usage_idle=100,usage_nice=0,usage_steal=0 1682613051000000008
+cpu,cpu=cpu9,host=Hugin usage_user=0,usage_idle=100,usage_iowait=0,usage_irq=0,usage_guest_nice=0,usage_system=0,usage_nice=0,usage_softirq=0,usage_steal=0,usage_guest=0 1682613051000000009
+cpu,cpu=cpu10,host=Hugin usage_softirq=0,usage_steal=0,usage_guest=0,usage_nice=0,usage_system=0,usage_idle=100,usage_iowait=0,usage_irq=0,usage_guest_nice=0,usage_user=0 1682613051000000010
+cpu,cpu=cpu11,host=Hugin usage_guest=0,usage_guest_nice=0,usage_user=0,usage_idle=100,usage_nice=0,usage_iowait=0,usage_softirq=0,usage_steal=0,usage_system=0,usage_irq=0 1682613051000000011
+cpu,cpu=cpu12,host=Hugin usage_softirq=0,usage_steal=0,usage_guest_nice=0,usage_user=0,usage_system=0,usage_nice=0,usage_irq=0,usage_idle=100,usage_iowait=0,usage_guest=0 1682613051000000012
+cpu,cpu=cpu13,host=Hugin usage_iowait=0,usage_guest=0,usage_guest_nice=0,usage_steal=0,usage_user=0,usage_system=0,usage_idle=100,usage_nice=0,usage_irq=0,usage_softirq=0 1682613051000000013
+cpu,cpu=cpu14,host=Hugin usage_system=0,usage_idle=100,usage_softirq=0,usage_steal=0,usage_guest=0,usage_user=0,usage_nice=0,usage_iowait=0,usage_irq=0,usage_guest_nice=0 1682613051000000014
+cpu,cpu=cpu15,host=Hugin usage_user=0,usage_idle=100,usage_steal=0,usage_irq=0,usage_softirq=0,usage_guest=0,usage_guest_nice=0,usage_system=0,usage_nice=0,usage_iowait=0 1682613051000000015
+cpu,cpu=cpu-total,host=Hugin usage_idle=99.62546816517232,usage_irq=0.12484394506911513,usage_softirq=0,usage_guest_nice=0,usage_steal=0,usage_guest=0,usage_user=0.12484394507124409,usage_system=0.12484394506840547,usage_nice=0,usage_iowait=0 1682613051000000999

--- a/plugins/serializers/cloudevents/testcases/single-multiple/telegraf.conf
+++ b/plugins/serializers/cloudevents/testcases/single-multiple/telegraf.conf
@@ -1,0 +1,2 @@
+[[outputs.dummy]]
+  data_format = "cloudevents"

--- a/plugins/serializers/cloudevents/testcases/single-source-overwrite/expected.json
+++ b/plugins/serializers/cloudevents/testcases/single-source-overwrite/expected.json
@@ -1,0 +1,30 @@
+[
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "myownsource",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 99.62546816517232,
+                "usage_iowait": 0,
+                "usage_irq": 0.12484394506911513,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0.12484394506840547,
+                "usage_user": 0.12484394507124409
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu-total",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000000
+        },
+        "time": "2023-04-27T16:30:51Z"
+    }
+]

--- a/plugins/serializers/cloudevents/testcases/single-source-overwrite/input.influx
+++ b/plugins/serializers/cloudevents/testcases/single-source-overwrite/input.influx
@@ -1,0 +1,1 @@
+cpu,cpu=cpu-total,host=Hugin usage_idle=99.62546816517232,usage_irq=0.12484394506911513,usage_softirq=0,usage_guest_nice=0,usage_steal=0,usage_guest=0,usage_user=0.12484394507124409,usage_system=0.12484394506840547,usage_nice=0,usage_iowait=0 1682613051000000000

--- a/plugins/serializers/cloudevents/testcases/single-source-overwrite/telegraf.conf
+++ b/plugins/serializers/cloudevents/testcases/single-source-overwrite/telegraf.conf
@@ -1,0 +1,3 @@
+[[outputs.dummy]]
+  data_format = "cloudevents"
+  cloudevents_source = "myownsource"

--- a/plugins/serializers/cloudevents/testcases/single-sourcetag-overwrite/expected.json
+++ b/plugins/serializers/cloudevents/testcases/single-sourcetag-overwrite/expected.json
@@ -1,0 +1,142 @@
+[
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "cpu0",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu0",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000000
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "cpu1",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000001Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu1",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000001
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "cpu2",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000002Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu2",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000002
+        }
+    },
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "cpu3",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000003Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 100,
+                "usage_iowait": 0,
+                "usage_irq": 0,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0,
+                "usage_user": 0
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu3",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000003
+        }
+    },
+   {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "cpu-total",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "time": "2023-04-27T16:30:51.000000999Z",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 99.62546816517232,
+                "usage_iowait": 0,
+                "usage_irq": 0.12484394506911513,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0.12484394506840547,
+                "usage_user": 0.12484394507124409
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu-total",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000999
+        }
+    }
+]

--- a/plugins/serializers/cloudevents/testcases/single-sourcetag-overwrite/input.influx
+++ b/plugins/serializers/cloudevents/testcases/single-sourcetag-overwrite/input.influx
@@ -1,0 +1,5 @@
+cpu,cpu=cpu0,host=Hugin usage_softirq=0,usage_steal=0,usage_guest=0,usage_user=0,usage_idle=100,usage_nice=0,usage_iowait=0,usage_system=0,usage_irq=0,usage_guest_nice=0 1682613051000000000
+cpu,cpu=cpu1,host=Hugin usage_user=0,usage_idle=100,usage_softirq=0,usage_steal=0,usage_guest_nice=0,usage_system=0,usage_nice=0,usage_iowait=0,usage_irq=0,usage_guest=0 1682613051000000001
+cpu,cpu=cpu2,host=Hugin usage_system=0,usage_idle=100,usage_softirq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0,usage_user=0,usage_nice=0,usage_iowait=0,usage_irq=0 1682613051000000002
+cpu,cpu=cpu3,host=Hugin usage_idle=100,usage_nice=0,usage_iowait=0,usage_irq=0,usage_user=0,usage_system=0,usage_softirq=0,usage_steal=0,usage_guest=0,usage_guest_nice=0 1682613051000000003
+cpu,cpu=cpu-total,host=Hugin usage_idle=99.62546816517232,usage_irq=0.12484394506911513,usage_softirq=0,usage_guest_nice=0,usage_steal=0,usage_guest=0,usage_user=0.12484394507124409,usage_system=0.12484394506840547,usage_nice=0,usage_iowait=0 1682613051000000999

--- a/plugins/serializers/cloudevents/testcases/single-sourcetag-overwrite/telegraf.conf
+++ b/plugins/serializers/cloudevents/testcases/single-sourcetag-overwrite/telegraf.conf
@@ -1,0 +1,3 @@
+[[outputs.dummy]]
+  data_format = "cloudevents"
+  cloudevents_source_tag = "cpu"

--- a/plugins/serializers/cloudevents/testcases/single/expected.json
+++ b/plugins/serializers/cloudevents/testcases/single/expected.json
@@ -1,0 +1,30 @@
+[
+    {
+        "specversion": "1.0",
+        "id": "845f6aca-e52a-11ed-9976-d8bbc1a4a0c6",
+        "source": "telegraf",
+        "type": "com.influxdata.telegraf.metric",
+        "datacontenttype": "application/json",
+        "data": {
+            "fields": {
+                "usage_guest": 0,
+                "usage_guest_nice": 0,
+                "usage_idle": 99.62546816517232,
+                "usage_iowait": 0,
+                "usage_irq": 0.12484394506911513,
+                "usage_nice": 0,
+                "usage_softirq": 0,
+                "usage_steal": 0,
+                "usage_system": 0.12484394506840547,
+                "usage_user": 0.12484394507124409
+            },
+            "name": "cpu",
+            "tags": {
+                "cpu": "cpu-total",
+                "host": "Hugin"
+            },
+            "timestamp": 1682613051000000000
+        },
+        "time": "2023-04-27T16:30:51Z"
+    }
+]

--- a/plugins/serializers/cloudevents/testcases/single/input.influx
+++ b/plugins/serializers/cloudevents/testcases/single/input.influx
@@ -1,0 +1,1 @@
+cpu,cpu=cpu-total,host=Hugin usage_idle=99.62546816517232,usage_irq=0.12484394506911513,usage_softirq=0,usage_guest_nice=0,usage_steal=0,usage_guest=0,usage_user=0.12484394507124409,usage_system=0.12484394506840547,usage_nice=0,usage_iowait=0 1682613051000000000

--- a/plugins/serializers/cloudevents/testcases/single/telegraf.conf
+++ b/plugins/serializers/cloudevents/testcases/single/telegraf.conf
@@ -1,0 +1,2 @@
+[[outputs.dummy]]
+  data_format = "cloudevents"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10170

This PR adds a serializer to convert Telegraf metrics into the [CloudEvents](https://cloudevents.io/) JSON format.