### PR TITLE
docs(common.kafka): remove experimental notes

### DIFF
--- a/plugins/common/kafka/sasl.go
+++ b/plugins/common/kafka/sasl.go
@@ -22,7 +22,7 @@ type SASLAuth struct {
 	SASLGSSAPIKeyTabPath         string `toml:"sasl_gssapi_key_tab_path"`
 	SASLGSSAPIRealm              string `toml:"sasl_gssapi_realm"`
 
-	// OAUTHBEARER config. experimental. undoubtedly this is not good enough.
+	// OAUTHBEARER config
 	SASLAccessToken config.Secret `toml:"sasl_access_token"`
 }
 

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -79,7 +79,7 @@ to use them.
   ## (defaults to PLAIN)
   # sasl_mechanism = ""
 
-  ## used if sasl_mechanism is GSSAPI (experimental)
+  ## used if sasl_mechanism is GSSAPI
   # sasl_gssapi_service_name = ""
   # ## One of: KRB5_USER_AUTH and KRB5_KEYTAB_AUTH
   # sasl_gssapi_auth_type = "KRB5_USER_AUTH"
@@ -88,7 +88,7 @@ to use them.
   # sasl_gssapi_key_tab_path = ""
   # sasl_gssapi_disable_pafxfast = false
 
-  ## used if sasl_mechanism is OAUTHBEARER (experimental)
+  ## used if sasl_mechanism is OAUTHBEARER
   # sasl_access_token = ""
 
   ## SASL protocol version.  When connecting to Azure EventHub set to 0.

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -39,7 +39,7 @@
   ## (defaults to PLAIN)
   # sasl_mechanism = ""
 
-  ## used if sasl_mechanism is GSSAPI (experimental)
+  ## used if sasl_mechanism is GSSAPI
   # sasl_gssapi_service_name = ""
   # ## One of: KRB5_USER_AUTH and KRB5_KEYTAB_AUTH
   # sasl_gssapi_auth_type = "KRB5_USER_AUTH"
@@ -48,7 +48,7 @@
   # sasl_gssapi_key_tab_path = ""
   # sasl_gssapi_disable_pafxfast = false
 
-  ## used if sasl_mechanism is OAUTHBEARER (experimental)
+  ## used if sasl_mechanism is OAUTHBEARER
   # sasl_access_token = ""
 
   ## SASL protocol version.  When connecting to Azure EventHub set to 0.

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -161,7 +161,7 @@ to use them.
   ## (defaults to PLAIN)
   # sasl_mechanism = ""
 
-  ## used if sasl_mechanism is GSSAPI (experimental)
+  ## used if sasl_mechanism is GSSAPI
   # sasl_gssapi_service_name = ""
   # ## One of: KRB5_USER_AUTH and KRB5_KEYTAB_AUTH
   # sasl_gssapi_auth_type = "KRB5_USER_AUTH"
@@ -170,7 +170,7 @@ to use them.
   # sasl_gssapi_key_tab_path = ""
   # sasl_gssapi_disable_pafxfast = false
 
-  ## used if sasl_mechanism is OAUTHBEARER (experimental)
+  ## used if sasl_mechanism is OAUTHBEARER
   # sasl_access_token = ""
 
   ## SASL protocol version.  When connecting to Azure EventHub set to 0.

--- a/plugins/outputs/kafka/sample.conf
+++ b/plugins/outputs/kafka/sample.conf
@@ -135,7 +135,7 @@
   ## (defaults to PLAIN)
   # sasl_mechanism = ""
 
-  ## used if sasl_mechanism is GSSAPI (experimental)
+  ## used if sasl_mechanism is GSSAPI
   # sasl_gssapi_service_name = ""
   # ## One of: KRB5_USER_AUTH and KRB5_KEYTAB_AUTH
   # sasl_gssapi_auth_type = "KRB5_USER_AUTH"
@@ -144,7 +144,7 @@
   # sasl_gssapi_key_tab_path = ""
   # sasl_gssapi_disable_pafxfast = false
 
-  ## used if sasl_mechanism is OAUTHBEARER (experimental)
+  ## used if sasl_mechanism is OAUTHBEARER
   # sasl_access_token = ""
 
   ## SASL protocol version.  When connecting to Azure EventHub set to 0.


### PR DESCRIPTION
A common question from users is why this is experimental or what is left. To my knowledge, nothing about it is experimental and at this time any issues found are real issues, either in telegraf or in the upstream sarama library.