### PR TITLE
chore: Enable the easiest checkers for gocritic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - errorlint
     - exportloopref
     - gocheckcompilerdirectives
+    - gocritic
     - goprintffuncname
     - gosec
     - gosimple
@@ -83,6 +84,33 @@ linters-settings:
       - "(*hash/maphash.Hash).Write"
       - "(*hash/maphash.Hash).WriteByte"
       - "(*hash/maphash.Hash).WriteString"
+  gocritic:
+    # Which checks should be enabled; can't be combined with 'disabled-checks'.
+    # See https://go-critic.github.io/overview#checks-overview.
+    # To check which checks are enabled run `GL_DEBUG=gocritic golangci-lint run`.
+    # By default, list of stable checks is used.
+    enabled-checks:
+      - argOrder
+      - badCall
+      - badCond
+      - badLock
+      - badSorting
+      - builtinShadowDecl
+      - caseOrder
+      - codegenComment
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - emptyDecl
+      - evalOrder
+      - externalErrorReassign
+      - nilValReturn
+      - regexpPattern
+      - sloppyTypeAssert
+      - sortSlice
+      - sqlQuery
+      - uncheckedInlineErr
+      - weakCond
   gosec:
     # To select a subset of rules to run.
     # Available rules: https://github.com/securego/gosec#available-rules


### PR DESCRIPTION
resolves https://github.com/influxdata/telegraf/issues/13172 (argOrder)
resolves https://github.com/influxdata/telegraf/issues/13173 (badCall)
resolves https://github.com/influxdata/telegraf/issues/13174 (badCond)
resolves https://github.com/influxdata/telegraf/issues/13175 (badLock)
resolves https://github.com/influxdata/telegraf/issues/13177 (badSorting)
resolves https://github.com/influxdata/telegraf/issues/13178 (builtinShadowDecl)
resolves https://github.com/influxdata/telegraf/issues/13179 (caseOrder)
resolves https://github.com/influxdata/telegraf/issues/13180 (codegenComment)
resolves https://github.com/influxdata/telegraf/issues/13185 (dupBranchBody)
resolves https://github.com/influxdata/telegraf/issues/13186 (dupCase)
resolves https://github.com/influxdata/telegraf/issues/13187 (dupSubExpr)
resolves https://github.com/influxdata/telegraf/issues/13189 (emptyDecl)
resolves https://github.com/influxdata/telegraf/issues/13190 (evalOrder)
resolves https://github.com/influxdata/telegraf/issues/13192 (externalErrorReassign)
resolves https://github.com/influxdata/telegraf/issues/13197 (nilValReturn)
resolves https://github.com/influxdata/telegraf/issues/13199 (regexpPattern)
resolves https://github.com/influxdata/telegraf/issues/13203 (sloppyTypeAssert)
resolves https://github.com/influxdata/telegraf/issues/13204 (sortSlice)
resolves https://github.com/influxdata/telegraf/issues/13206 (sqlQuery)
resolves https://github.com/influxdata/telegraf/issues/13209 (uncheckedInlineErr)
resolves https://github.com/influxdata/telegraf/issues/13211 (weakCond)