### PR TITLE
fix(outputs.wavefront): flush metric buffer before reaching overflow

### DIFF
--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -135,10 +135,10 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 						if isRetryable(err) {
 							return fmt.Errorf("wavefront sending error: %w", err)
 						}
-						w.Log.Errorf("non-retryable error during Wavefront.Write: %v", err)
-						w.Log.Debugf("non-retryable metric data: %+v", point)
 					}
 				}
+				w.Log.Errorf("non-retryable error during Wavefront.Write: %v", err)
+				w.Log.Debugf("non-retryable metric data: %+v", point)
 			}
 		}
 	}

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -122,7 +122,7 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 		for _, point := range w.buildMetrics(m) {
 			err := w.sender.SendMetric(point.Metric, point.Value, point.Timestamp, point.Source, point.Tags)
 			if err != nil {
-				if strings.Contains(err.Error(), "buffer full, dropping line") {
+				if isRetryable(err) {
 					// The internal buffer in the Wavefront SDK is full. To prevent data loss,
 					// we flush the buffer (which is a blocking operation) and try again.
 					w.Log.Debug("SDK buffer overrun, forcibly flushing the buffer")

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -131,13 +131,13 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 					}
 					// Try again.
 					err = w.sender.SendMetric(point.Metric, point.Value, point.Timestamp, point.Source, point.Tags)
-				}
-				if err != nil {
-					if isRetryable(err) {
-						return fmt.Errorf("wavefront sending error: %w", err)
-					}
-					w.Log.Errorf("non-retryable error during Wavefront.Write: %v", err)
-					w.Log.Debugf("non-retryable metric data: %+v", point)
+				        if err != nil {
+					        if isRetryable(err) {
+						        return fmt.Errorf("wavefront sending error: %w", err)
+					        }
+					        w.Log.Errorf("non-retryable error during Wavefront.Write: %v", err)
+					        w.Log.Debugf("non-retryable metric data: %+v", point)
+				        }
 				}
 			}
 		}

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -131,13 +131,13 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 					}
 					// Try again.
 					err = w.sender.SendMetric(point.Metric, point.Value, point.Timestamp, point.Source, point.Tags)
-				        if err != nil {
-					        if isRetryable(err) {
-						        return fmt.Errorf("wavefront sending error: %w", err)
-					        }
-					        w.Log.Errorf("non-retryable error during Wavefront.Write: %v", err)
-					        w.Log.Debugf("non-retryable metric data: %+v", point)
-				        }
+					if err != nil {
+						if isRetryable(err) {
+							return fmt.Errorf("wavefront sending error: %w", err)
+						}
+						w.Log.Errorf("non-retryable error during Wavefront.Write: %v", err)
+						w.Log.Debugf("non-retryable metric data: %+v", point)
+					}
 				}
 			}
 		}

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -137,7 +137,7 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 						return fmt.Errorf("wavefront sending error: %w", err)
 					}
 					w.Log.Errorf("non-retryable error during Wavefront.Write: %v", err)
-					w.Log.Debugf("Non-retryable metric data: Name: %v, Value: %v, Timestamp: %v, Source: %v, PointTags: %v ", point.Metric, point.Value, point.Timestamp, point.Source, point.Tags)
+					w.Log.Debugf("non-retryable metric data: %+v", point)
 				}
 			}
 		}

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -126,9 +126,8 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 					// The internal buffer in the Wavefront SDK is full. To prevent data loss,
 					// we flush the buffer (which is a blocking operation) and try again.
 					w.Log.Debug("SDK buffer overrun, forcibly flushing the buffer")
-					err = w.sender.Flush()
-					if err != nil {
-						return err
+					if err = w.sender.Flush(); err != nil {
+						return fmt.Errorf("wavefront flushing error: %w", err)
 					}
 					// Try again.
 					err = w.sender.SendMetric(point.Metric, point.Value, point.Timestamp, point.Source, point.Tags)

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -125,7 +125,7 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 				if strings.Contains(err.Error(), "buffer full, dropping line") {
 					// The internal buffer in the Wavefront SDK is full. To prevent data loss,
 					// we flush the buffer (which is a blocking operation) and try again.
-					w.Log.Debug("SDK buffer overrun. Forcibly flushing the buffer")
+					w.Log.Debug("SDK buffer overrun, forcibly flushing the buffer")
 					err = w.sender.Flush()
 					if err != nil {
 						return err

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -135,7 +135,7 @@ func (w *Wavefront) Write(metrics []telegraf.Metric) error {
 				}
 				if err != nil {
 					if isRetryable(err) {
-						return fmt.Errorf("wavefront sending error: %v", err)
+						return fmt.Errorf("wavefront sending error: %w", err)
 					}
 					w.Log.Errorf("non-retryable error during Wavefront.Write: %v", err)
 					w.Log.Debugf("Non-retryable metric data: Name: %v, Value: %v, Timestamp: %v, Source: %v, PointTags: %v ", point.Metric, point.Value, point.Timestamp, point.Source, point.Tags)


### PR DESCRIPTION
# Required for all PRs

- [ ] Updated associated README.md. (not needed as this is a quick bufix)
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #10009

Fixes bug introduced in telegraf 1.25.0 where after brief period of ~10mins depending on metric load, telegraf begins erroring with `Error writing to outputs.wavefront: wavefront sending error: buffer full, dropping line`. This patch flushes the buffer when it becomes full and continues outputting as expected. 
