### PR TITLE
feat(processors.template): Allow `tag` to be a template

### DIFF
--- a/plugins/processors/template/README.md
+++ b/plugins/processors/template/README.md
@@ -24,12 +24,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Uses a Go template to create a new tag
 [[processors.template]]
-  ## Tag to set with the output of the template.
+  ## Go template used to create the tag name of the output. In order to
+  ## ease TOML escaping requirements, you should use single quotes around
+  ## the# template string.
   tag = "topic"
 
-  ## Go template used to create the tag value.  In order to ease TOML
-  ## escaping requirements, you may wish to use single quotes around the
-  ## template string.
+  ## Go template used to create the tag value of the output. In order to
+  ## ease TOML escaping requirements, you should use single quotes around
+  ## the# template string.
   template = '{{ .Tag "hostname" }}.{{ .Tag "level" }}'
 ```
 
@@ -46,6 +48,19 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```diff
 - cpu,level=debug,hostname=localhost time_idle=42
 + cpu,level=debug,hostname=localhost,topic=localhost.debug time_idle=42
+```
+
+### Use a field value as tag name
+
+```toml
+[[processors.template]]
+  tag = '{{ .Field "type" }}'
+  template = '{{ .Name }}'
+```
+
+```diff
+- cpu,level=debug,hostname=localhost time_idle=42,type=sensor
++ cpu,level=debug,hostname=localhost,sensor=abc123xyz time_idle=42,type=sensor
 ```
 
 ### Add measurement name as a tag

--- a/plugins/processors/template/README.md
+++ b/plugins/processors/template/README.md
@@ -26,7 +26,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 [[processors.template]]
   ## Go template used to create the tag name of the output. In order to
   ## ease TOML escaping requirements, you should use single quotes around
-  ## the# template string.
+  ## the template string.
   tag = "topic"
 
   ## Go template used to create the tag value of the output. In order to

--- a/plugins/processors/template/README.md
+++ b/plugins/processors/template/README.md
@@ -60,7 +60,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```diff
 - cpu,level=debug,hostname=localhost time_idle=42,type=sensor
-+ cpu,level=debug,hostname=localhost,sensor=abc123xyz time_idle=42,type=sensor
++ cpu,level=debug,hostname=localhost,sensor=cpu time_idle=42,type=sensor
 ```
 
 ### Add measurement name as a tag

--- a/plugins/processors/template/README.md
+++ b/plugins/processors/template/README.md
@@ -31,7 +31,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Go template used to create the tag value of the output. In order to
   ## ease TOML escaping requirements, you should use single quotes around
-  ## the# template string.
+  ## the template string.
   template = '{{ .Tag "hostname" }}.{{ .Tag "level" }}'
 ```
 

--- a/plugins/processors/template/sample.conf
+++ b/plugins/processors/template/sample.conf
@@ -7,5 +7,5 @@
 
   ## Go template used to create the tag value of the output. In order to
   ## ease TOML escaping requirements, you should use single quotes around
-  ## the# template string.
+  ## the template string.
   template = '{{ .Tag "hostname" }}.{{ .Tag "level" }}'

--- a/plugins/processors/template/sample.conf
+++ b/plugins/processors/template/sample.conf
@@ -2,7 +2,7 @@
 [[processors.template]]
   ## Go template used to create the tag name of the output. In order to
   ## ease TOML escaping requirements, you should use single quotes around
-  ## the# template string.
+  ## the template string.
   tag = "topic"
 
   ## Go template used to create the tag value of the output. In order to

--- a/plugins/processors/template/sample.conf
+++ b/plugins/processors/template/sample.conf
@@ -1,9 +1,11 @@
 # Uses a Go template to create a new tag
 [[processors.template]]
-  ## Tag to set with the output of the template.
+  ## Go template used to create the tag name of the output. In order to
+  ## ease TOML escaping requirements, you should use single quotes around
+  ## the# template string.
   tag = "topic"
 
-  ## Go template used to create the tag value.  In order to ease TOML
-  ## escaping requirements, you may wish to use single quotes around the
-  ## template string.
+  ## Go template used to create the tag value of the output. In order to
+  ## ease TOML escaping requirements, you should use single quotes around
+  ## the# template string.
   template = '{{ .Tag "hostname" }}.{{ .Tag "level" }}'

--- a/plugins/processors/template/template.go
+++ b/plugins/processors/template/template.go
@@ -14,10 +14,10 @@ import (
 var sampleConfig string
 
 type TemplateProcessor struct {
-	Tag      string          `toml:"tag"`
-	Template string          `toml:"template"`
-	Log      telegraf.Logger `toml:"-"`
-	tmpl     *template.Template
+	Tag       string          `toml:"tag"`
+	Template  string          `toml:"template"`
+	Log       telegraf.Logger `toml:"-"`
+	tmplValue *template.Template
 }
 
 func (*TemplateProcessor) SampleConfig() string {
@@ -31,7 +31,7 @@ func (r *TemplateProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
 		newM := TemplateMetric{metric}
 
 		// supply TemplateMetric and Template from configuration to Template.Execute
-		err := r.tmpl.Execute(&b, &newM)
+		err := r.tmplValue.Execute(&b, &newM)
 		if err != nil {
 			r.Log.Errorf("failed to execute template: %v", err)
 			continue
@@ -43,10 +43,10 @@ func (r *TemplateProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
 }
 
 func (r *TemplateProcessor) Init() error {
-	// create template
-	t, err := template.New("configured_template").Parse(r.Template)
+	var err error
 
-	r.tmpl = t
+	// create template
+	r.tmplValue, err = template.New("configured_template").Parse(r.Template)
 	return err
 }
 

--- a/plugins/processors/template/template.go
+++ b/plugins/processors/template/template.go
@@ -3,6 +3,7 @@ package template
 
 import (
 	_ "embed"
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -14,9 +15,11 @@ import (
 var sampleConfig string
 
 type TemplateProcessor struct {
-	Tag       string          `toml:"tag"`
-	Template  string          `toml:"template"`
-	Log       telegraf.Logger `toml:"-"`
+	Tag      string          `toml:"tag"`
+	Template string          `toml:"template"`
+	Log      telegraf.Logger `toml:"-"`
+
+	tmplTag   *template.Template
 	tmplValue *template.Template
 }
 
@@ -27,17 +30,23 @@ func (*TemplateProcessor) SampleConfig() string {
 func (r *TemplateProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	// for each metric in "in" array
 	for _, metric := range in {
-		var b strings.Builder
 		newM := TemplateMetric{metric}
 
-		// supply TemplateMetric and Template from configuration to Template.Execute
-		err := r.tmplValue.Execute(&b, &newM)
-		if err != nil {
-			r.Log.Errorf("failed to execute template: %v", err)
+		var b strings.Builder
+		if err := r.tmplTag.Execute(&b, &newM); err != nil {
+			r.Log.Errorf("failed to execute tag name template: %v", err)
 			continue
 		}
+		tag := b.String()
 
-		metric.AddTag(r.Tag, b.String())
+		b.Reset()
+		if err := r.tmplValue.Execute(&b, &newM); err != nil {
+			r.Log.Errorf("failed to execute value template: %v", err)
+			continue
+		}
+		value := b.String()
+
+		metric.AddTag(tag, value)
 	}
 	return in
 }
@@ -45,9 +54,16 @@ func (r *TemplateProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
 func (r *TemplateProcessor) Init() error {
 	var err error
 
-	// create template
-	r.tmplValue, err = template.New("configured_template").Parse(r.Template)
-	return err
+	r.tmplTag, err = template.New("tag template").Parse(r.Tag)
+	if err != nil {
+		return fmt.Errorf("creating tag name template failed: %w", err)
+	}
+
+	r.tmplValue, err = template.New("value template").Parse(r.Template)
+	if err != nil {
+		return fmt.Errorf("creating value template failed: %w", err)
+	}
+	return nil
 }
 
 func init() {

--- a/plugins/processors/template/template_test.go
+++ b/plugins/processors/template/template_test.go
@@ -46,6 +46,43 @@ func TestName(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expected, actual)
 }
 
+func TestNameTemplate(t *testing.T) {
+	plugin := TemplateProcessor{
+		Tag:      `{{ .Tag "foo" }}`,
+		Template: `{{ .Name }}`,
+	}
+
+	err := plugin.Init()
+	require.NoError(t, err)
+
+	input := []telegraf.Metric{
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{"foo": "measurement"},
+			map[string]interface{}{
+				"time_idle": 42,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	actual := plugin.Apply(input...)
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{
+				"foo":         "measurement",
+				"measurement": "cpu",
+			},
+			map[string]interface{}{
+				"time_idle": 42,
+			},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, actual)
+}
+
 func TestTagTemplateConcatenate(t *testing.T) {
 	now := time.Now()
 


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR allows the `tag` option to also be a Go template to make it more flexible.