### PR TITLE
chore: Enable deferInLoop, exitAfterDefer and unnecessaryDefer checkers for gocritic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,11 +98,13 @@ linters-settings:
       - builtinShadowDecl
       - caseOrder
       - codegenComment
+      - deferInLoop
       - dupBranchBody
       - dupCase
       - dupSubExpr
       - emptyDecl
       - evalOrder
+      - exitAfterDefer
       - externalErrorReassign
       - nilValReturn
       - regexpPattern
@@ -110,6 +112,7 @@ linters-settings:
       - sortSlice
       - sqlQuery
       - uncheckedInlineErr
+      - unnecessaryDefer
       - weakCond
   gosec:
     # To select a subset of rules to run.

--- a/agent/agent_posix.go
+++ b/agent/agent_posix.go
@@ -15,5 +15,5 @@ func watchForFlushSignal(flushRequested chan os.Signal) {
 }
 
 func stopListeningForFlushSignal(flushRequested chan os.Signal) {
-	defer signal.Stop(flushRequested)
+	signal.Stop(flushRequested)
 }

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/awnumar/memguard"
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/secretstores"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSecretConstantManually(t *testing.T) {
@@ -96,7 +97,7 @@ func TestUninitializedEnclave(t *testing.T) {
 	retrieved, err := s.Get()
 	require.NoError(t, err)
 	require.Empty(t, retrieved)
-	defer ReleaseSecret(retrieved)
+	ReleaseSecret(retrieved)
 }
 
 func TestEnclaveOpenError(t *testing.T) {

--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -134,7 +134,7 @@ func TestHaproxyGeneratesMetricsUsingSocket(t *testing.T) {
 		}
 
 		sockets[i] = sock
-		defer sock.Close() //nolint:revive // done on purpose, closing will be executed properly
+		defer sock.Close() //nolint:revive,gocritic // done on purpose, closing will be executed properly
 
 		s := statServer{}
 		go s.serverSocket(sock)

--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry_test.go
@@ -253,6 +253,11 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Failed to listen: %v", err)
 	}
 
+	exitCode := 0
+	defer func() {
+		os.Exit(exitCode)
+	}()
+
 	cfg.Servers = []string{lis.Addr().String()}
 
 	var opts []grpc.ServerOption
@@ -262,5 +267,6 @@ func TestMain(m *testing.M) {
 		grpcServer.Serve(lis) //nolint:errcheck // ignore the returned error as the tests will fail anyway
 	}()
 	defer grpcServer.Stop()
-	os.Exit(m.Run())
+
+	exitCode = m.Run()
 }

--- a/plugins/inputs/zipkin/cmd/stress_test_write/stress_test_write.go
+++ b/plugins/inputs/zipkin/cmd/stress_test_write/stress_test_write.go
@@ -61,12 +61,12 @@ func main() {
 
 	endpoint, err := zipkin.NewEndpoint("Trivial", "127.0.0.1:0")
 	if err != nil {
-		log.Fatalf("Error: %v\n", err)
+		log.Panicf("Error: %v\n", err)
 	}
 
 	nativeTracer, err := zipkin.NewTracer(reporter, zipkin.WithLocalEndpoint(endpoint))
 	if err != nil {
-		log.Fatalf("Error: %v\n", err)
+		log.Panicf("Error: %v\n", err)
 	}
 
 	tracer := zipkinot.Wrap(nativeTracer)

--- a/plugins/outputs/groundwork/groundwork_test.go
+++ b/plugins/outputs/groundwork/groundwork_test.go
@@ -68,7 +68,7 @@ func TestWriteWithDefaults(t *testing.T) {
 	err := i.Write([]telegraf.Metric{intMetric})
 	require.NoError(t, err)
 
-	defer server.Close()
+	server.Close()
 }
 
 func TestWriteWithFields(t *testing.T) {
@@ -120,7 +120,7 @@ func TestWriteWithFields(t *testing.T) {
 	err := i.Write([]telegraf.Metric{floatMetric})
 	require.NoError(t, err)
 
-	defer server.Close()
+	server.Close()
 }
 
 func TestWriteWithTags(t *testing.T) {
@@ -189,5 +189,5 @@ func TestWriteWithTags(t *testing.T) {
 	err := i.Write([]telegraf.Metric{floatMetric})
 	require.NoError(t, err)
 
-	defer server.Close()
+	server.Close()
 }

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -248,7 +248,7 @@ func (p *SQL) Write(metrics []telegraf.Metric) error {
 			if err != nil {
 				return fmt.Errorf("prepare failed: %w", err)
 			}
-			defer stmt.Close() //nolint:revive // We cannot do anything about a failing close.
+			defer stmt.Close() //nolint:revive,gocritic // done on purpose, closing will be executed properly
 
 			_, err = stmt.Exec(values...)
 			if err != nil {

--- a/tools/readme_config_includer/generator.go
+++ b/tools/readme_config_includer/generator.go
@@ -257,6 +257,6 @@ func main() {
 	}
 	defer file.Close()
 	if _, err := output.WriteTo(file); err != nil {
-		log.Fatalf("Writing output file failed: %v", err)
+		log.Panicf("Writing output file failed: %v", err)
 	}
 }


### PR DESCRIPTION
resolves https://github.com/influxdata/telegraf/issues/13182 (deferInLoop)
resolves https://github.com/influxdata/telegraf/issues/13191 (exitAfterDefer)
resolves https://github.com/influxdata/telegraf/issues/13210 (unnecessaryDefer)