### PR TITLE
chore(serializers.carbon2): Migrate to new-style framework

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1452,8 +1452,6 @@ func (c *Config) buildSerializerOld(tbl *ast.Table) (telegraf.Serializer, error)
 	c.getFieldString(tbl, "prefix", &sc.Prefix)
 	c.getFieldString(tbl, "template", &sc.Template)
 	c.getFieldStringSlice(tbl, "templates", &sc.Templates)
-	c.getFieldString(tbl, "carbon2_format", &sc.Carbon2Format)
-	c.getFieldString(tbl, "carbon2_sanitize_replace_char", &sc.Carbon2SanitizeReplaceChar)
 	c.getFieldBool(tbl, "csv_column_prefix", &sc.CSVPrefix)
 	c.getFieldBool(tbl, "csv_header", &sc.CSVHeader)
 	c.getFieldString(tbl, "csv_separator", &sc.CSVSeparator)
@@ -1552,7 +1550,6 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 
 	// Serializer options to ignore
 	case "prefix", "template", "templates",
-		"carbon2_format", "carbon2_sanitize_replace_char",
 		"csv_column_prefix", "csv_header", "csv_separator", "csv_timestamp_format",
 		"graphite_strict_sanitize_regex",
 		"graphite_tag_sanitize_mode", "graphite_tag_support", "graphite_separator",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -610,8 +610,10 @@ func TestConfig_SerializerInterfaceNewFormat(t *testing.T) {
 
 		var serializer telegraf.Serializer
 		if creator, found := serializers.Serializers[format]; found {
+			t.Logf("new-style %q", format)
 			serializer = creator()
 		} else {
+			t.Logf("old-style %q", format)
 			var err error
 			serializer, err = serializers.NewSerializer(formatCfg)
 			require.NoErrorf(t, err, "No serializer for format %q", format)
@@ -699,8 +701,10 @@ func TestConfig_SerializerInterfaceOldFormat(t *testing.T) {
 
 		var serializer serializers.Serializer
 		if creator, found := serializers.Serializers[format]; found {
+			t.Logf("new-style %q", format)
 			serializer = creator()
 		} else {
+			t.Logf("old-style %q", format)
 			var err error
 			serializer, err = serializers.NewSerializer(formatCfg)
 			require.NoErrorf(t, err, "No serializer for format %q", format)

--- a/plugins/outputs/sumologic/sumologic.go
+++ b/plugins/outputs/sumologic/sumologic.go
@@ -71,22 +71,13 @@ func (s *SumoLogic) SetSerializer(serializer serializers.Serializer) {
 		s.headers = make(map[string]string)
 	}
 
-	switch sr := serializer.(type) {
+	switch serializer.(type) {
 	case *carbon2.Serializer:
 		s.headers[contentTypeHeader] = carbon2ContentType
-
-		// In case Carbon2 is used and the metrics format was unset, default to
-		// include field in metric name.
-		if sr.IsMetricsFormatUnset() {
-			sr.SetMetricsFormat(carbon2.Carbon2FormatMetricIncludesField)
-		}
-
 	case *graphite.GraphiteSerializer:
 		s.headers[contentTypeHeader] = graphiteContentType
-
 	case *prometheus.Serializer:
 		s.headers[contentTypeHeader] = prometheusContentType
-
 	default:
 		s.err = fmt.Errorf("unsupported serializer %T", serializer)
 	}

--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -95,7 +95,7 @@ func TestMethod(t *testing.T) {
 			})
 
 			serializer := &carbon2.Serializer{
-				Format: string(carbon2.Carbon2FormatFieldSeparate),
+				Format: "field_separate",
 			}
 			require.NoError(t, serializer.Init())
 
@@ -174,7 +174,7 @@ func TestStatusCode(t *testing.T) {
 			})
 
 			serializer := &carbon2.Serializer{
-				Format: string(carbon2.Carbon2FormatFieldSeparate),
+				Format: "field_separate",
 			}
 			require.NoError(t, serializer.Init())
 
@@ -202,7 +202,7 @@ func TestContentType(t *testing.T) {
 					contentTypeHeader: carbon2ContentType,
 				}
 				serializer := &carbon2.Serializer{
-					Format: string(carbon2.Carbon2FormatFieldSeparate),
+					Format: "field_separate",
 				}
 				require.NoError(t, serializer.Init())
 				s.SetSerializer(serializer)
@@ -218,7 +218,7 @@ func TestContentType(t *testing.T) {
 					contentTypeHeader: carbon2ContentType,
 				}
 				serializer := &carbon2.Serializer{
-					Format: string(carbon2.Carbon2FormatMetricIncludesField),
+					Format: "metric_includes_field",
 				}
 				require.NoError(t, serializer.Init())
 				s.SetSerializer(serializer)
@@ -325,7 +325,7 @@ func TestContentEncodingGzip(t *testing.T) {
 			})
 
 			serializer := &carbon2.Serializer{
-				Format: string(carbon2.Carbon2FormatFieldSeparate),
+				Format: "field_separate",
 			}
 			require.NoError(t, serializer.Init())
 
@@ -360,7 +360,7 @@ func TestDefaultUserAgent(t *testing.T) {
 		}
 
 		serializer := &carbon2.Serializer{
-			Format: string(carbon2.Carbon2FormatFieldSeparate),
+			Format: "field_separate",
 		}
 		require.NoError(t, serializer.Init())
 
@@ -611,7 +611,7 @@ func TestMaxRequestBodySize(t *testing.T) {
 			})
 
 			serializer := &carbon2.Serializer{
-				Format: string(carbon2.Carbon2FormatFieldSeparate),
+				Format: "field_separate",
 			}
 			require.NoError(t, serializer.Init())
 
@@ -646,7 +646,7 @@ func TestTryingToSendEmptyMetricsDoesntFail(t *testing.T) {
 	plugin.URL = u.String()
 
 	serializer := &carbon2.Serializer{
-		Format: string(carbon2.Carbon2FormatFieldSeparate),
+		Format: "field_separate",
 	}
 	require.NoError(t, serializer.Init())
 	plugin.SetSerializer(serializer)

--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -94,8 +94,10 @@ func TestMethod(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			serializer := &carbon2.Serializer{
+				Format: string(carbon2.Carbon2FormatFieldSeparate),
+			}
+			require.NoError(t, serializer.Init())
 
 			plugin := tt.plugin()
 			plugin.SetSerializer(serializer)
@@ -171,8 +173,10 @@ func TestStatusCode(t *testing.T) {
 				w.WriteHeader(tt.statusCode)
 			})
 
-			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			serializer := &carbon2.Serializer{
+				Format: string(carbon2.Carbon2FormatFieldSeparate),
+			}
+			require.NoError(t, serializer.Init())
 
 			tt.plugin.SetSerializer(serializer)
 			err = tt.plugin.Connect()
@@ -197,9 +201,11 @@ func TestContentType(t *testing.T) {
 				s.headers = map[string]string{
 					contentTypeHeader: carbon2ContentType,
 				}
-				sr, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
-				require.NoError(t, err)
-				s.SetSerializer(sr)
+				serializer := &carbon2.Serializer{
+					Format: string(carbon2.Carbon2FormatFieldSeparate),
+				}
+				require.NoError(t, serializer.Init())
+				s.SetSerializer(serializer)
 				return s
 			},
 			expectedBody: []byte("metric=cpu field=value  42 0\n"),
@@ -211,9 +217,11 @@ func TestContentType(t *testing.T) {
 				s.headers = map[string]string{
 					contentTypeHeader: carbon2ContentType,
 				}
-				sr, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatMetricIncludesField), carbon2.DefaultSanitizeReplaceChar)
-				require.NoError(t, err)
-				s.SetSerializer(sr)
+				serializer := &carbon2.Serializer{
+					Format: string(carbon2.Carbon2FormatMetricIncludesField),
+				}
+				require.NoError(t, serializer.Init())
+				s.SetSerializer(serializer)
 				return s
 			},
 			expectedBody: []byte("metric=cpu_value  42 0\n"),
@@ -316,8 +324,10 @@ func TestContentEncodingGzip(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			serializer := &carbon2.Serializer{
+				Format: string(carbon2.Carbon2FormatFieldSeparate),
+			}
+			require.NoError(t, serializer.Init())
 
 			plugin := tt.plugin()
 
@@ -349,8 +359,10 @@ func TestDefaultUserAgent(t *testing.T) {
 			MaxRequstBodySize: Default().MaxRequstBodySize,
 		}
 
-		serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
-		require.NoError(t, err)
+		serializer := &carbon2.Serializer{
+			Format: string(carbon2.Carbon2FormatFieldSeparate),
+		}
+		require.NoError(t, serializer.Init())
 
 		plugin.SetSerializer(serializer)
 		err = plugin.Connect()
@@ -598,8 +610,10 @@ func TestMaxRequestBodySize(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			serializer := &carbon2.Serializer{
+				Format: string(carbon2.Carbon2FormatFieldSeparate),
+			}
+			require.NoError(t, serializer.Init())
 
 			plugin := tt.plugin()
 			plugin.SetSerializer(serializer)
@@ -631,8 +645,10 @@ func TestTryingToSendEmptyMetricsDoesntFail(t *testing.T) {
 	plugin := Default()
 	plugin.URL = u.String()
 
-	serializer, err := carbon2.NewSerializer(string(carbon2.Carbon2FormatFieldSeparate), carbon2.DefaultSanitizeReplaceChar)
-	require.NoError(t, err)
+	serializer := &carbon2.Serializer{
+		Format: string(carbon2.Carbon2FormatFieldSeparate),
+	}
+	require.NoError(t, serializer.Init())
 	plugin.SetSerializer(serializer)
 
 	err = plugin.Connect()

--- a/plugins/serializers/all/carbon2.go
+++ b/plugins/serializers/all/carbon2.go
@@ -1,0 +1,7 @@
+//go:build !custom || serializers || serializers.carbon2
+
+package all
+
+import (
+	_ "github.com/influxdata/telegraf/plugins/serializers/carbon2" // register plugin
+)

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -22,15 +22,15 @@ func TestSerializeMetricFloat(t *testing.T) {
 	m := metric.New("cpu", tags, fields, now)
 
 	testcases := []struct {
-		format   format
+		format   string
 		expected string
 	}{
 		{
-			format:   Carbon2FormatFieldSeparate,
+			format:   "field_separate",
 			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=cpu0  91.5 %d\n", now.Unix()),
 		},
 		{
-			format:   Carbon2FormatMetricIncludesField,
+			format:   "metric_includes_field",
 			expected: fmt.Sprintf("metric=cpu_usage_idle cpu=cpu0  91.5 %d\n", now.Unix()),
 		},
 	}
@@ -61,15 +61,15 @@ func TestSerializeMetricWithEmptyStringTag(t *testing.T) {
 	m := metric.New("cpu", tags, fields, now)
 
 	testcases := []struct {
-		format   format
+		format   string
 		expected string
 	}{
 		{
-			format:   Carbon2FormatFieldSeparate,
+			format:   "field_separate",
 			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=null  91.5 %d\n", now.Unix()),
 		},
 		{
-			format:   Carbon2FormatMetricIncludesField,
+			format:   "metric_includes_field",
 			expected: fmt.Sprintf("metric=cpu_usage_idle cpu=null  91.5 %d\n", now.Unix()),
 		},
 	}
@@ -100,15 +100,15 @@ func TestSerializeWithSpaces(t *testing.T) {
 	m := metric.New("cpu metric", tags, fields, now)
 
 	testcases := []struct {
-		format   format
+		format   string
 		expected string
 	}{
 		{
-			format:   Carbon2FormatFieldSeparate,
+			format:   "field_separate",
 			expected: fmt.Sprintf("metric=cpu_metric field=usage_idle_1 cpu_0=cpu_0  91.5 %d\n", now.Unix()),
 		},
 		{
-			format:   Carbon2FormatMetricIncludesField,
+			format:   "metric_includes_field",
 			expected: fmt.Sprintf("metric=cpu_metric_usage_idle_1 cpu_0=cpu_0  91.5 %d\n", now.Unix()),
 		},
 	}
@@ -139,15 +139,15 @@ func TestSerializeMetricInt(t *testing.T) {
 	m := metric.New("cpu", tags, fields, now)
 
 	testcases := []struct {
-		format   format
+		format   string
 		expected string
 	}{
 		{
-			format:   Carbon2FormatFieldSeparate,
+			format:   "field_separate",
 			expected: fmt.Sprintf("metric=cpu field=usage_idle cpu=cpu0  90 %d\n", now.Unix()),
 		},
 		{
-			format:   Carbon2FormatMetricIncludesField,
+			format:   "metric_includes_field",
 			expected: fmt.Sprintf("metric=cpu_usage_idle cpu=cpu0  90 %d\n", now.Unix()),
 		},
 	}
@@ -178,15 +178,15 @@ func TestSerializeMetricString(t *testing.T) {
 	m := metric.New("cpu", tags, fields, now)
 
 	testcases := []struct {
-		format   format
+		format   string
 		expected string
 	}{
 		{
-			format:   Carbon2FormatFieldSeparate,
+			format:   "field_separate",
 			expected: "",
 		},
 		{
-			format:   Carbon2FormatMetricIncludesField,
+			format:   "metric_includes_field",
 			expected: "",
 		},
 	}
@@ -224,27 +224,27 @@ func TestSerializeMetricBool(t *testing.T) {
 
 	testcases := []struct {
 		metric   telegraf.Metric
-		format   format
+		format   string
 		expected string
 	}{
 		{
 			metric:   requireMetric(now, false),
-			format:   Carbon2FormatFieldSeparate,
+			format:   "field_separate",
 			expected: fmt.Sprintf("metric=cpu field=java_lang_GarbageCollector_Valid tag_name=tag_value  0 %d\n", now.Unix()),
 		},
 		{
 			metric:   requireMetric(now, false),
-			format:   Carbon2FormatMetricIncludesField,
+			format:   "metric_includes_field",
 			expected: fmt.Sprintf("metric=cpu_java_lang_GarbageCollector_Valid tag_name=tag_value  0 %d\n", now.Unix()),
 		},
 		{
 			metric:   requireMetric(now, true),
-			format:   Carbon2FormatFieldSeparate,
+			format:   "field_separate",
 			expected: fmt.Sprintf("metric=cpu field=java_lang_GarbageCollector_Valid tag_name=tag_value  1 %d\n", now.Unix()),
 		},
 		{
 			metric:   requireMetric(now, true),
-			format:   Carbon2FormatMetricIncludesField,
+			format:   "metric_includes_field",
 			expected: fmt.Sprintf("metric=cpu_java_lang_GarbageCollector_Valid tag_name=tag_value  1 %d\n", now.Unix()),
 		},
 	}
@@ -277,17 +277,17 @@ func TestSerializeBatch(t *testing.T) {
 	metrics := []telegraf.Metric{m, m}
 
 	testcases := []struct {
-		format   format
+		format   string
 		expected string
 	}{
 		{
-			format: Carbon2FormatFieldSeparate,
+			format: "field_separate",
 			expected: `metric=cpu field=value  42 0
 metric=cpu field=value  42 0
 `,
 		},
 		{
-			format: Carbon2FormatMetricIncludesField,
+			format: "metric_includes_field",
 			expected: `metric=cpu_value  42 0
 metric=cpu_value  42 0
 `,
@@ -314,7 +314,7 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 
 	testcases := []struct {
 		metricFunc  func() telegraf.Metric
-		format      format
+		format      string
 		expected    string
 		replaceChar string
 		expectedErr bool
@@ -326,7 +326,7 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1", nil, fields, now)
 			},
-			format:   Carbon2FormatFieldSeparate,
+			format:   "field_separate",
 			expected: fmt.Sprintf("metric=cpu:1 field=usage_idle  91.5 %d\n", now.Unix()),
 		},
 		{
@@ -336,7 +336,7 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1", nil, fields, now)
 			},
-			format:      Carbon2FormatFieldSeparate,
+			format:      "field_separate",
 			expected:    fmt.Sprintf("metric=cpu_1 field=usage_idle  91.5 %d\n", now.Unix()),
 			replaceChar: "_",
 		},
@@ -347,7 +347,7 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom", nil, fields, now)
 			},
-			format:   Carbon2FormatFieldSeparate,
+			format:   "field_separate",
 			expected: fmt.Sprintf("metric=cpu:1:tmp:custom field=usage_idle  91.5 %d\n", now.Unix()),
 		},
 		{
@@ -357,7 +357,7 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
 			},
-			format:   Carbon2FormatFieldSeparate,
+			format:   "field_separate",
 			expected: fmt.Sprintf("metric=cpu:1:tmp:custom:namespace field=usage_idle  91.5 %d\n", now.Unix()),
 		},
 		{
@@ -367,7 +367,7 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
 			},
-			format:   Carbon2FormatMetricIncludesField,
+			format:   "metric_includes_field",
 			expected: fmt.Sprintf("metric=cpu:1:tmp:custom:namespace_usage_idle  91.5 %d\n", now.Unix()),
 		},
 		{
@@ -377,7 +377,7 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
 			},
-			format:      Carbon2FormatMetricIncludesField,
+			format:      "metric_includes_field",
 			expected:    fmt.Sprintf("metric=cpu_1_tmp_custom_namespace_usage_idle  91.5 %d\n", now.Unix()),
 			replaceChar: "_",
 		},
@@ -388,7 +388,7 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
 			},
-			format:      Carbon2FormatMetricIncludesField,
+			format:      "metric_includes_field",
 			expectedErr: true,
 			replaceChar: "___",
 		},

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -37,8 +37,10 @@ func TestSerializeMetricFloat(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			s := &Serializer{
+				Format: string(tc.format),
+			}
+			require.NoError(t, s.Init())
 
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
@@ -74,8 +76,10 @@ func TestSerializeMetricWithEmptyStringTag(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			s := &Serializer{
+				Format: string(tc.format),
+			}
+			require.NoError(t, s.Init())
 
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
@@ -111,8 +115,10 @@ func TestSerializeWithSpaces(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			s := &Serializer{
+				Format: string(tc.format),
+			}
+			require.NoError(t, s.Init())
 
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
@@ -148,8 +154,10 @@ func TestSerializeMetricInt(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			s := &Serializer{
+				Format: string(tc.format),
+			}
+			require.NoError(t, s.Init())
 
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
@@ -185,8 +193,10 @@ func TestSerializeMetricString(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			s := &Serializer{
+				Format: string(tc.format),
+			}
+			require.NoError(t, s.Init())
 
 			buf, err := s.Serialize(m)
 			require.NoError(t, err)
@@ -241,8 +251,10 @@ func TestSerializeMetricBool(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			s := &Serializer{
+				Format: string(tc.format),
+			}
+			require.NoError(t, s.Init())
 
 			buf, err := s.Serialize(tc.metric)
 			require.NoError(t, err)
@@ -284,8 +296,10 @@ metric=cpu_value  42 0
 
 	for _, tc := range testcases {
 		t.Run(string(tc.format), func(t *testing.T) {
-			s, err := NewSerializer(string(tc.format), DefaultSanitizeReplaceChar)
-			require.NoError(t, err)
+			s := &Serializer{
+				Format: string(tc.format),
+			}
+			require.NoError(t, s.Init())
 
 			buf, err := s.SerializeBatch(metrics)
 			require.NoError(t, err)
@@ -312,9 +326,8 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1", nil, fields, now)
 			},
-			format:      Carbon2FormatFieldSeparate,
-			expected:    fmt.Sprintf("metric=cpu:1 field=usage_idle  91.5 %d\n", now.Unix()),
-			replaceChar: DefaultSanitizeReplaceChar,
+			format:   Carbon2FormatFieldSeparate,
+			expected: fmt.Sprintf("metric=cpu:1 field=usage_idle  91.5 %d\n", now.Unix()),
 		},
 		{
 			metricFunc: func() telegraf.Metric {
@@ -334,9 +347,8 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom", nil, fields, now)
 			},
-			format:      Carbon2FormatFieldSeparate,
-			expected:    fmt.Sprintf("metric=cpu:1:tmp:custom field=usage_idle  91.5 %d\n", now.Unix()),
-			replaceChar: DefaultSanitizeReplaceChar,
+			format:   Carbon2FormatFieldSeparate,
+			expected: fmt.Sprintf("metric=cpu:1:tmp:custom field=usage_idle  91.5 %d\n", now.Unix()),
 		},
 		{
 			metricFunc: func() telegraf.Metric {
@@ -345,9 +357,8 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
 			},
-			format:      Carbon2FormatFieldSeparate,
-			expected:    fmt.Sprintf("metric=cpu:1:tmp:custom:namespace field=usage_idle  91.5 %d\n", now.Unix()),
-			replaceChar: DefaultSanitizeReplaceChar,
+			format:   Carbon2FormatFieldSeparate,
+			expected: fmt.Sprintf("metric=cpu:1:tmp:custom:namespace field=usage_idle  91.5 %d\n", now.Unix()),
 		},
 		{
 			metricFunc: func() telegraf.Metric {
@@ -356,9 +367,8 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 				}
 				return metric.New("cpu=1=tmp$custom%namespace", nil, fields, now)
 			},
-			format:      Carbon2FormatMetricIncludesField,
-			expected:    fmt.Sprintf("metric=cpu:1:tmp:custom:namespace_usage_idle  91.5 %d\n", now.Unix()),
-			replaceChar: DefaultSanitizeReplaceChar,
+			format:   Carbon2FormatMetricIncludesField,
+			expected: fmt.Sprintf("metric=cpu:1:tmp:custom:namespace_usage_idle  91.5 %d\n", now.Unix()),
 		},
 		{
 			metricFunc: func() telegraf.Metric {
@@ -388,12 +398,15 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 		t.Run(string(tc.format), func(t *testing.T) {
 			m := tc.metricFunc()
 
-			s, err := NewSerializer(string(tc.format), tc.replaceChar)
+			s := &Serializer{
+				Format:              string(tc.format),
+				SanitizeReplaceChar: tc.replaceChar,
+			}
+			err := s.Init()
 			if tc.expectedErr {
 				require.Error(t, err)
 				return
 			}
-
 			require.NoError(t, err)
 
 			buf, err := s.Serialize(m)

--- a/plugins/serializers/carbon2/carbon2_test.go
+++ b/plugins/serializers/carbon2/carbon2_test.go
@@ -36,9 +36,9 @@ func TestSerializeMetricFloat(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(string(tc.format), func(t *testing.T) {
+		t.Run(tc.format, func(t *testing.T) {
 			s := &Serializer{
-				Format: string(tc.format),
+				Format: tc.format,
 			}
 			require.NoError(t, s.Init())
 
@@ -75,9 +75,9 @@ func TestSerializeMetricWithEmptyStringTag(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(string(tc.format), func(t *testing.T) {
+		t.Run(tc.format, func(t *testing.T) {
 			s := &Serializer{
-				Format: string(tc.format),
+				Format: tc.format,
 			}
 			require.NoError(t, s.Init())
 
@@ -114,9 +114,9 @@ func TestSerializeWithSpaces(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(string(tc.format), func(t *testing.T) {
+		t.Run(tc.format, func(t *testing.T) {
 			s := &Serializer{
-				Format: string(tc.format),
+				Format: tc.format,
 			}
 			require.NoError(t, s.Init())
 
@@ -153,9 +153,9 @@ func TestSerializeMetricInt(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(string(tc.format), func(t *testing.T) {
+		t.Run(tc.format, func(t *testing.T) {
 			s := &Serializer{
-				Format: string(tc.format),
+				Format: tc.format,
 			}
 			require.NoError(t, s.Init())
 
@@ -192,9 +192,9 @@ func TestSerializeMetricString(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(string(tc.format), func(t *testing.T) {
+		t.Run(tc.format, func(t *testing.T) {
 			s := &Serializer{
-				Format: string(tc.format),
+				Format: tc.format,
 			}
 			require.NoError(t, s.Init())
 
@@ -250,9 +250,9 @@ func TestSerializeMetricBool(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(string(tc.format), func(t *testing.T) {
+		t.Run(tc.format, func(t *testing.T) {
 			s := &Serializer{
-				Format: string(tc.format),
+				Format: tc.format,
 			}
 			require.NoError(t, s.Init())
 
@@ -295,9 +295,9 @@ metric=cpu_value  42 0
 	}
 
 	for _, tc := range testcases {
-		t.Run(string(tc.format), func(t *testing.T) {
+		t.Run(tc.format, func(t *testing.T) {
 			s := &Serializer{
-				Format: string(tc.format),
+				Format: tc.format,
 			}
 			require.NoError(t, s.Init())
 
@@ -395,11 +395,11 @@ func TestSerializeMetricIsProperlySanitized(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(string(tc.format), func(t *testing.T) {
+		t.Run(tc.format, func(t *testing.T) {
 			m := tc.metricFunc()
 
 			s := &Serializer{
-				Format:              string(tc.format),
+				Format:              tc.format,
 				SanitizeReplaceChar: tc.replaceChar,
 			}
 			err := s.Init()

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/plugins/serializers/carbon2"
 	"github.com/influxdata/telegraf/plugins/serializers/csv"
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 	"github.com/influxdata/telegraf/plugins/serializers/json"
@@ -185,8 +184,6 @@ func NewSerializer(config *Config) (Serializer, error) {
 		serializer, err = NewSplunkmetricSerializer(config.HecRouting, config.SplunkmetricMultiMetric, config.SplunkmetricOmitEventTag), nil
 	case "nowmetric":
 		serializer, err = NewNowSerializer()
-	case "carbon2":
-		serializer, err = NewCarbon2Serializer(config.Carbon2Format, config.Carbon2SanitizeReplaceChar)
 	case "wavefront":
 		serializer, err = NewWavefrontSerializer(
 			config.Prefix,
@@ -276,10 +273,6 @@ func NewJSONSerializer(config *Config) (Serializer, error) {
 		NestedFieldsInclude: config.JSONNestedFieldInclude,
 		NestedFieldsExclude: config.JSONNestedFieldExclude,
 	})
-}
-
-func NewCarbon2Serializer(carbon2format string, carbon2SanitizeReplaceChar string) (Serializer, error) {
-	return carbon2.NewSerializer(carbon2format, carbon2SanitizeReplaceChar)
 }
 
 func NewSplunkmetricSerializer(splunkmetricHecRouting bool, splunkmetricMultimetric bool, splunkmetricOmitEventTag bool) Serializer {


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR migrates the carbon2 serializer to the new-style framework.