### PR TITLE
fix(outputs.opentelemetry): group metrics by age and timestamp

### DIFF
--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -126,7 +126,7 @@ func (o *OpenTelemetry) Close() error {
 func (o *OpenTelemetry) Write(metrics []telegraf.Metric) error {
 	metricBatch := make(map[int64][]telegraf.Metric)
 	timestamps := []int64{}
-	for _, metric := range sorted(metrics) {
+	for _, metric := range metrics {
 		timestamp := metric.Time().UnixNano()
 		if existingSlice, ok := metricBatch[timestamp]; ok {
 			metricBatch[timestamp] = append(existingSlice, metric)
@@ -197,20 +197,6 @@ func (o *OpenTelemetry) sendBatch(metrics []telegraf.Metric) error {
 	defer cancel()
 	_, err := o.metricsServiceClient.Export(ctx, md, o.callOptions...)
 	return err
-}
-
-// Sorted returns a copy of the metrics in time ascending order.  A copy is
-// made to avoid modifying the input metric slice since doing so is not
-// allowed.
-func sorted(metrics []telegraf.Metric) []telegraf.Metric {
-	batch := make([]telegraf.Metric, 0, len(metrics))
-	for i := len(metrics) - 1; i >= 0; i-- {
-		batch = append(batch, metrics[i])
-	}
-	sort.Slice(batch, func(i, j int) bool {
-		return batch[i].Time().Before(batch[j].Time())
-	})
-	return batch
 }
 
 const (

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -139,8 +139,7 @@ func (o *OpenTelemetry) Write(metrics []telegraf.Metric) error {
 	// sort the timestamps we collected
 	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
 
-	o.Log.Debugf("received %d metrics\n", len(metrics))
-	o.Log.Debugf("split into %d groups by timestamp\n", len(metricBatch))
+	o.Log.Debugf("received %d metrics and split into %d groups by timestamp", len(metrics), len(metricBatch))
 	for _, timestamp := range timestamps {
 		if err := o.sendBatch(metricBatch[timestamp]); err != nil {
 			return err

--- a/plugins/outputs/opentelemetry/opentelemetry_test.go
+++ b/plugins/outputs/opentelemetry/opentelemetry_test.go
@@ -50,6 +50,7 @@ func TestOpenTelemetry(t *testing.T) {
 		metricsConverter:     metricsConverter,
 		grpcClientConn:       m.GrpcClient(),
 		metricsServiceClient: pmetricotlp.NewGRPCClient(m.GrpcClient()),
+		Log:                  testutil.Logger{},
 	}
 
 	input := testutil.MustMetric(


### PR DESCRIPTION
This will group open telemetry metrics from oldest to newest and group them by timestamp. This ensures they are kept in order in the event that old and new metrics become grouped up after buffering metrics.

fixes: #13233