### PR TITLE
fix(inputs.socket_listener): Fix race in tests

### DIFF
--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -136,9 +136,8 @@ func TestSocketListener(t *testing.T) {
 			}
 
 			// Setup plugin according to test specification
-			logger := &testutil.CaptureLogger{}
 			plugin := &SocketListener{
-				Log:             logger,
+				Log:             &testutil.Logger{},
 				ServiceAddress:  proto + "://" + serverAddr,
 				ContentEncoding: tt.encoding,
 				ReadBufferSize:  tt.buffersize,
@@ -190,27 +189,61 @@ func TestSocketListener(t *testing.T) {
 			}, time.Second, 100*time.Millisecond, "did not receive metrics (%d)", acc.NMetrics())
 			actual := acc.GetTelegrafMetrics()
 			testutil.RequireMetricsEqual(t, expected, actual, testutil.SortMetrics())
-
-			if sl, ok := plugin.listener.(*streamListener); ok {
-				require.NotEmpty(t, sl.connections)
-			}
-
-			plugin.Stop()
-
-			// Make sure we clear out old messages
-			logger.Clear()
-			if _, ok := plugin.listener.(*streamListener); ok {
-				// Verify that plugin.Stop() closed the client's connection
-				_ = client.SetReadDeadline(time.Now().Add(time.Second))
-				buf := []byte{1}
-				_, err = client.Read(buf)
-				require.Equal(t, err, io.EOF)
-			}
-
-			require.Empty(t, logger.Errors())
-			require.Empty(t, logger.Warnings())
 		})
 	}
+}
+
+func TestSocketListenerStream(t *testing.T) {
+	logger := &testutil.CaptureLogger{}
+
+	plugin := &SocketListener{
+		Log:            logger,
+		ServiceAddress: "tcp://127.0.0.1:0",
+		ReadBufferSize: 1024,
+	}
+	parser := &influx.Parser{}
+	require.NoError(t, parser.Init())
+	plugin.SetParser(parser)
+
+	// Start the plugin
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	addr := plugin.listener.addr()
+
+	// Create a noop client
+	client, err := createClient(plugin.ServiceAddress, addr, nil)
+	require.NoError(t, err)
+
+	_, err = client.Write([]byte("test value=42i\n"))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		acc.Lock()
+		defer acc.Unlock()
+		return acc.NMetrics() >= 1
+	}, time.Second, 100*time.Millisecond, "did not receive metric")
+
+	// This has to be a stream-listener...
+	listener, ok := plugin.listener.(*streamListener)
+	require.True(t, ok)
+	listener.Lock()
+	conns := len(listener.connections)
+	listener.Unlock()
+	require.NotZero(t, conns)
+
+	plugin.Stop()
+
+	// Verify that plugin.Stop() closed the client's connection
+	_ = client.SetReadDeadline(time.Now().Add(time.Second))
+	buf := []byte{1}
+	_, err = client.Read(buf)
+	require.Equal(t, err, io.EOF)
+
+	require.Empty(t, logger.Errors())
+	require.Empty(t, logger.Warnings())
 }
 
 func TestCases(t *testing.T) {


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR tries to fix a race in the unit-test observed on CI.

```text
=== Failed
=== FAIL: plugins/inputs/socket_listener TestSocketListener/TCP_with_TLS (0.28s)
2023/05/19 19:23:12 I! [] Listening on tcp://127.0.0.1:49719
==================
WARNING: DATA RACE
Read at 0x00c0005a6960 by goroutine 51:
  reflect.maplen()
      C:/Program Files/Go/src/runtime/map.go:1394 +0x0
  reflect.Value.lenNonSlice()
      C:/Program Files/Go/src/reflect/value.go:1704 +0x26d
  reflect.Value.Len()
      C:/Program Files/Go/src/reflect/value.go:1693 +0x290
  github.com/stretchr/testify/assert.isEmpty()
      C:/Users/circleci.PACKER-64370BA5/go/pkg/mod/github.com/stretchr/testify@v1.8.2/assert/assertions.go:567 +0x281
  github.com/stretchr/testify/assert.NotEmpty()
      C:/Users/circleci.PACKER-64370BA5/go/pkg/mod/github.com/stretchr/testify@v1.8.2/assert/assertions.go:607 +0x5c
  github.com/stretchr/testify/require.NotEmpty()
      C:/Users/circleci.PACKER-64370BA5/go/pkg/mod/github.com/stretchr/testify@v1.8.2/require/require.go:1349 +0xa4
  github.com/influxdata/telegraf/plugins/inputs/socket_listener.TestSocketListener.func1()
      C:/Users/circleci.PACKER-64370BA5/project/plugins/inputs/socket_listener/socket_listener_test.go:195 +0x15fe
  testing.tRunner()
      C:/Program Files/Go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      C:/Program Files/Go/src/testing/testing.go:1629 +0x47

Previous write at 0x00c0005a6960 by goroutine 54:
  runtime.mapdelete()
      C:/Program Files/Go/src/runtime/map.go:695 +0x0
  github.com/influxdata/telegraf/plugins/inputs/socket_listener.(*streamListener).closeConnection()
      C:/Users/circleci.PACKER-64370BA5/project/plugins/inputs/socket_listener/stream_listener.go:141 +0x2b4
  github.com/influxdata/telegraf/plugins/inputs/socket_listener.(*streamListener).listen.func1()
      C:/Users/circleci.PACKER-64370BA5/project/plugins/inputs/socket_listener/stream_listener.go:200 +0x204
  github.com/influxdata/telegraf/plugins/inputs/socket_listener.(*streamListener).listen.func3()
      C:/Users/circleci.PACKER-64370BA5/project/plugins/inputs/socket_listener/stream_listener.go:202 +0x58

Goroutine 51 (running) created at:
  testing.(*T).Run()
      C:/Program Files/Go/src/testing/testing.go:1629 +0x805
  github.com/influxdata/telegraf/plugins/inputs/socket_listener.TestSocketListener()
      C:/Users/circleci.PACKER-64370BA5/project/plugins/inputs/socket_listener/socket_listener_test.go:116 +0x944
  testing.tRunner()
      C:/Program Files/Go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      C:/Program Files/Go/src/testing/testing.go:1629 +0x47

Goroutine 54 (finished) created at:
  github.com/influxdata/telegraf/plugins/inputs/socket_listener.(*streamListener).listen()
      C:/Users/circleci.PACKER-64370BA5/project/plugins/inputs/socket_listener/stream_listener.go:192 +0x4e9
  github.com/influxdata/telegraf/plugins/inputs/socket_listener.(*SocketListener).Start.func1()
      C:/Users/circleci.PACKER-64370BA5/project/plugins/inputs/socket_listener/socket_listener.go:241 +0xd8
==================
    testing.go:1446: race detected during execution of test

=== FAIL: plugins/inputs/socket_listener TestSocketListener (0.75s)
    testing.go:1446: race detected during execution of test
```