### PR TITLE
fix(processors.lookup): Do not strip tracking info

### DIFF
--- a/plugins/processors/lookup/lookup.go
+++ b/plugins/processors/lookup/lookup.go
@@ -67,27 +67,21 @@ func (p *Processor) Init() error {
 func (p *Processor) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	out := make([]telegraf.Metric, 0, len(in))
 	for _, raw := range in {
-		var m telegraf.Metric
+		m := raw
 		if wm, ok := raw.(unwrappableMetric); ok {
 			m = wm.Unwrap()
-		} else {
-			m = raw
 		}
 
 		var buf bytes.Buffer
 		if err := p.tmpl.Execute(&buf, m); err != nil {
 			p.Log.Errorf("generating key failed: %v", err)
 			p.Log.Debugf("metric was %v", m)
-			out = append(out, m)
-			continue
-		}
-
-		if tags, found := p.mappings[buf.String()]; found {
+		} else if tags, found := p.mappings[buf.String()]; found {
 			for _, tag := range tags {
 				m.AddTag(tag.Key, tag.Value)
 			}
 		}
-		out = append(out, m)
+		out = append(out, raw)
 	}
 	return out
 }


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #

Currently, the tracking info of tracking-metrics is stripped by the lookup processors resulting in input plugins never receiving a notification from the output side as the output cannot know about tracking. This PR keeps the tracking info and extends the test-cases to verify that the tracking works.

The issue is described in a [community forum thread](https://community.influxdata.com/t/inputs-mqtt-consumer-stops-when-using-processors-lookup-after-some-time/29854/5),