### PR TITLE
chore: create default statefile and folder during package install

### DIFF
--- a/scripts/deb/post-install.sh
+++ b/scripts/deb/post-install.sh
@@ -51,6 +51,16 @@ test -d $LOG_DIR || mkdir -p $LOG_DIR
 chown -R -L telegraf:telegraf $LOG_DIR
 chmod 755 $LOG_DIR
 
+STATE_DIR=/var/lib/telegraf
+test -d $STATE_DIR || mkdir -p $STATE_DIR
+chown -R -L root:telegraf $STATE_DIR
+chmod 770 $STATE_DIR
+
+STATE_FILE=$STATE_DIR/statefile
+test -f $STATE_FILE || touch $STATE_FILE
+chown -R -L root:telegraf $STATE_FILE
+chmod 770 $STATE_FILE
+
 if [ -d /run/systemd/system ]; then
     install_systemd /lib/systemd/system/telegraf.service
     # if and only if the service was already running then restart

--- a/scripts/deb/post-install.sh
+++ b/scripts/deb/post-install.sh
@@ -53,7 +53,8 @@ chmod 755 $LOG_DIR
 
 STATE_DIR=/var/lib/telegraf
 test -d "$STATE_DIR" || {
-    mkdir -m 0770 -p "$STATE_DIR"
+    mkdir -p "$STATE_DIR"
+    chmod 770 "$STATE_DIR"
     chown root:telegraf "$STATE_DIR"
 }
 

--- a/scripts/deb/post-install.sh
+++ b/scripts/deb/post-install.sh
@@ -52,14 +52,17 @@ chown -R -L telegraf:telegraf $LOG_DIR
 chmod 755 $LOG_DIR
 
 STATE_DIR=/var/lib/telegraf
-test -d $STATE_DIR || mkdir -p $STATE_DIR
-chown -R -L root:telegraf $STATE_DIR
-chmod 770 $STATE_DIR
+test -d "$STATE_DIR" || {
+    mkdir -m 0770 -p "$STATE_DIR"
+    chown root:telegraf "$STATE_DIR"
+}
 
-STATE_FILE=$STATE_DIR/statefile
-test -f $STATE_FILE || touch $STATE_FILE
-chown -R -L root:telegraf $STATE_FILE
-chmod 770 $STATE_FILE
+STATE_FILE="$STATE_DIR/statefile"
+test -f "$STATE_FILE" || {
+    touch -h "$STATE_FILE"
+    chown root:telegraf "$STATE_FILE"
+    chmod 660 "$STATE_FILE"
+}
 
 if [ -d /run/systemd/system ]; then
     install_systemd /lib/systemd/system/telegraf.service

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -32,7 +32,8 @@ chmod 755 $LOG_DIR
 
 STATE_DIR=/var/lib/telegraf
 test -d "$STATE_DIR" || {
-    mkdir -m 0770 -p "$STATE_DIR"
+    mkdir -p "$STATE_DIR"
+    chmod 770 "$STATE_DIR"
     chown root:telegraf "$STATE_DIR"
 }
 

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -30,6 +30,16 @@ test -d $LOG_DIR || mkdir -p $LOG_DIR
 chown -R -L telegraf:telegraf $LOG_DIR
 chmod 755 $LOG_DIR
 
+STATE_DIR=/var/lib/telegraf
+test -d $STATE_DIR || mkdir -p $STATE_DIR
+chown -R -L root:telegraf $STATE_DIR
+chmod 770 $STATE_DIR
+
+STATE_FILE=$STATE_DIR/statefile
+test -f $STATE_FILE || touch $STATE_FILE
+chown -R -L root:telegraf $STATE_FILE
+chmod 770 $STATE_FILE
+
 # Set up systemd service - check if the systemd directory exists per:
 # https://www.freedesktop.org/software/systemd/man/sd_booted.html
 if [[ -d /run/systemd/system ]]; then

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -31,14 +31,17 @@ chown -R -L telegraf:telegraf $LOG_DIR
 chmod 755 $LOG_DIR
 
 STATE_DIR=/var/lib/telegraf
-test -d $STATE_DIR || mkdir -p $STATE_DIR
-chown -R -L root:telegraf $STATE_DIR
-chmod 770 $STATE_DIR
+test -d "$STATE_DIR" || {
+    mkdir -m 0770 -p "$STATE_DIR"
+    chown root:telegraf "$STATE_DIR"
+}
 
-STATE_FILE=$STATE_DIR/statefile
-test -f $STATE_FILE || touch $STATE_FILE
-chown -R -L root:telegraf $STATE_FILE
-chmod 770 $STATE_FILE
+STATE_FILE="$STATE_DIR/statefile"
+test -f "$STATE_FILE" || {
+    touch -h "$STATE_FILE"
+    chown root:telegraf "$STATE_FILE"
+    chmod 660 "$STATE_FILE"
+}
 
 # Set up systemd service - check if the systemd directory exists per:
 # https://www.freedesktop.org/software/systemd/man/sd_booted.html


### PR DESCRIPTION
This creates the stated default statefile directory and the file itself during package install. This does not enable the state file feature itself, but makes it available to a user post-install.

fixes: #13290