### PR TITLE
fix(inputs.temp): ignore warnings, return errors

### DIFF
--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -218,7 +218,7 @@ func (s *SystemPS) Temperature() ([]host.TemperatureStat, error) {
 	temp, err := host.SensorsTemperatures()
 	if err != nil {
 		var hostWarnings *host.Warnings
-		if errors.As(err, &hostWarnings) {
+		if !errors.As(err, &hostWarnings) {
 			return temp, err
 		}
 	}


### PR DESCRIPTION
Currently, we are ignoring errors and only returning an "error" for warnings. This is the opposite of what we want. Instead, we are supposed to check for warnings and ignore these, but error on anything else.

fixes: #13308