### PR TITLE
chore(serializers.graphite): Migrate to new-style framework

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1456,11 +1456,6 @@ func (c *Config) buildSerializerOld(tbl *ast.Table) (telegraf.Serializer, error)
 	c.getFieldBool(tbl, "influx_sort_fields", &sc.InfluxSortFields)
 	c.getFieldBool(tbl, "influx_uint_support", &sc.InfluxUintSupport)
 
-	c.getFieldString(tbl, "graphite_strict_sanitize_regex", &sc.GraphiteStrictRegex)
-	c.getFieldBool(tbl, "graphite_tag_support", &sc.GraphiteTagSupport)
-	c.getFieldString(tbl, "graphite_tag_sanitize_mode", &sc.GraphiteTagSanitizeMode)
-	c.getFieldString(tbl, "graphite_separator", &sc.GraphiteSeparator)
-
 	c.getFieldDuration(tbl, "json_timestamp_units", &sc.TimestampUnits)
 	c.getFieldString(tbl, "json_timestamp_format", &sc.TimestampFormat)
 	c.getFieldString(tbl, "json_transformation", &sc.Transformation)
@@ -1546,8 +1541,6 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 
 	// Serializer options to ignore
 	case "prefix", "template", "templates",
-		"graphite_strict_sanitize_regex",
-		"graphite_tag_sanitize_mode", "graphite_tag_support", "graphite_separator",
 		"influx_max_line_bytes", "influx_sort_fields", "influx_uint_support",
 		"json_timestamp_format", "json_timestamp_units", "json_transformation",
 		"json_nested_fields_include", "json_nested_fields_exclude",

--- a/plugins/outputs/graphite/graphite_test.go
+++ b/plugins/outputs/graphite/graphite_test.go
@@ -22,6 +22,8 @@ func TestGraphiteError(t *testing.T) {
 		Prefix:  "my.prefix",
 		Log:     testutil.Logger{},
 	}
+	require.NoError(t, g.Init())
+
 	// Init metrics
 	m1 := metric.New(
 		"mymeasurement",
@@ -56,6 +58,7 @@ func TestGraphiteReconnect(t *testing.T) {
 		Log:                 testutil.Logger{},
 		GraphiteStrictRegex: `[^a-zA-Z0-9-:._=|\p{L}]`,
 	}
+	require.NoError(t, g.Init())
 
 	t.Log("Writing metric, without any server up, expected to fail")
 	require.NoError(t, g.Connect())
@@ -98,6 +101,7 @@ func TestGraphiteOK(t *testing.T) {
 		Servers: []string{"localhost:12003"},
 		Log:     testutil.Logger{},
 	}
+	require.NoError(t, g.Init())
 
 	// Init metrics
 	m1 := metric.New(
@@ -179,6 +183,7 @@ func TestGraphiteStrictRegex(t *testing.T) {
 		Log:                 testutil.Logger{},
 		GraphiteStrictRegex: `[^a-zA-Z0-9-:._=|\p{L}]`,
 	}
+	require.NoError(t, g.Init())
 	require.NoError(t, g.Connect())
 	require.NoError(t, g.Write([]telegraf.Metric{m}))
 
@@ -200,6 +205,7 @@ func TestGraphiteOkWithSeparatorDot(t *testing.T) {
 		Servers:           []string{"localhost:12003"},
 		Log:               testutil.Logger{},
 	}
+	require.NoError(t, g.Init())
 
 	// Init metrics
 	m1 := metric.New(
@@ -263,6 +269,7 @@ func TestGraphiteOkWithSeparatorUnderscore(t *testing.T) {
 		Servers:           []string{"localhost:12003"},
 		Log:               testutil.Logger{},
 	}
+	require.NoError(t, g.Init())
 
 	// Init metrics
 	m1 := metric.New(
@@ -330,6 +337,7 @@ func TestGraphiteOKWithMultipleTemplates(t *testing.T) {
 		Servers: []string{"localhost:12003"},
 		Log:     testutil.Logger{},
 	}
+	require.NoError(t, g.Init())
 
 	// Init metrics
 	m1 := metric.New(
@@ -393,6 +401,7 @@ func TestGraphiteOkWithTags(t *testing.T) {
 		Servers:            []string{"localhost:12003"},
 		Log:                testutil.Logger{},
 	}
+	require.NoError(t, g.Init())
 
 	// Init metrics
 	m1 := metric.New(
@@ -457,6 +466,7 @@ func TestGraphiteOkWithTagsAndSeparatorDot(t *testing.T) {
 		Servers:            []string{"localhost:12003"},
 		Log:                testutil.Logger{},
 	}
+	require.NoError(t, g.Init())
 
 	// Init metrics
 	m1 := metric.New(
@@ -521,6 +531,7 @@ func TestGraphiteOkWithTagsAndSeparatorUnderscore(t *testing.T) {
 		Servers:            []string{"localhost:12003"},
 		Log:                testutil.Logger{},
 	}
+	require.NoError(t, g.Init())
 
 	// Init metrics
 	m1 := metric.New(

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -25,6 +25,7 @@ func TestWrite(t *testing.T) {
 		APIToken: config.NewSecret([]byte("abc123token")),
 		Prefix:   "my.prefix",
 	}
+	require.NoError(t, i.Init())
 
 	// Default to gauge
 	m1 := metric.New(

--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -233,7 +233,9 @@ func TestContentType(t *testing.T) {
 				s.headers = map[string]string{
 					contentTypeHeader: graphiteContentType,
 				}
-				s.SetSerializer(&graphite.GraphiteSerializer{})
+				serializer := &graphite.GraphiteSerializer{}
+				require.NoError(t, serializer.Init())
+				s.SetSerializer(serializer)
 				return s
 			},
 		},

--- a/plugins/serializers/all/graphite.go
+++ b/plugins/serializers/all/graphite.go
@@ -1,0 +1,7 @@
+//go:build !custom || serializers || serializers.graphite
+
+package all
+
+import (
+	_ "github.com/influxdata/telegraf/plugins/serializers/graphite" // register plugin
+)

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/filter"
+	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
 const DefaultTemplate = "host.tags.measurement.field"
@@ -38,20 +39,51 @@ type GraphiteTemplate struct {
 }
 
 type GraphiteSerializer struct {
-	Prefix             string              `json:"prefix"`
-	Template           string              `json:"template"`
-	StrictAllowedChars *regexp.Regexp      `json:"graphite_strict_sanitize_regex"`
-	TagSupport         bool                `json:"graphite_tag_support"`
-	TagSanitizeMode    string              `json:"graphite_tag_sanitize_mode"`
-	Separator          string              `json:"graphite_separator"`
-	Templates          []*GraphiteTemplate `json:"templates"`
+	Prefix          string   `toml:"prefix"`
+	Template        string   `toml:"template"`
+	StrictRegex     string   `toml:"graphite_strict_sanitize_regex"`
+	TagSupport      bool     `toml:"graphite_tag_support"`
+	TagSanitizeMode string   `toml:"graphite_tag_sanitize_mode"`
+	Separator       string   `toml:"graphite_separator"`
+	Templates       []string `toml:"templates"`
+
+	tmplts             []*GraphiteTemplate
+	strictAllowedChars *regexp.Regexp
+}
+
+func (s *GraphiteSerializer) Init() error {
+	graphiteTemplates, defaultTemplate, err := InitGraphiteTemplates(s.Templates)
+	if err != nil {
+		return err
+	}
+	s.tmplts = graphiteTemplates
+
+	if defaultTemplate != "" {
+		s.Template = defaultTemplate
+	}
+
+	if s.TagSanitizeMode == "" {
+		s.TagSanitizeMode = "strict"
+	}
+
+	if s.Separator == "" {
+		s.Separator = "."
+	}
+
+	if s.StrictRegex == "" {
+		s.strictAllowedChars = regexp.MustCompile(`[^a-zA-Z0-9-:._=\p{L}]`)
+	} else {
+		var err error
+		s.strictAllowedChars, err = regexp.Compile(s.StrictRegex)
+		if err != nil {
+			return fmt.Errorf("invalid regex provided %q: %w", s.StrictRegex, err)
+		}
+	}
+
+	return nil
 }
 
 func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
-	if s.StrictAllowedChars == nil {
-		s.StrictAllowedChars = regexp.MustCompile(`[^a-zA-Z0-9-:._=\p{L}]`)
-	}
-
 	out := []byte{}
 
 	// Convert UnixNano to Unix timestamps
@@ -76,7 +108,7 @@ func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 		}
 	default:
 		template := s.Template
-		for _, graphiteTemplate := range s.Templates {
+		for _, graphiteTemplate := range s.tmplts {
 			if graphiteTemplate.Filter.Match(metric.Name()) {
 				template = graphiteTemplate.Value
 				break
@@ -326,7 +358,7 @@ func (s *GraphiteSerializer) strictSanitize(value string) string {
 	// Apply rule to drop some chars to preserve backwards compatibility
 	value = dropChars.Replace(value)
 	// Replace any remaining illegal chars
-	return s.StrictAllowedChars.ReplaceAllLiteralString(value, "_")
+	return s.strictAllowedChars.ReplaceAllLiteralString(value, "_")
 }
 
 func compatibleSanitize(name string, value string) string {
@@ -334,4 +366,24 @@ func compatibleSanitize(name string, value string) string {
 	value = compatibleAllowedCharsValue.ReplaceAllLiteralString(value, "_")
 	value = compatibleLeadingTildeDrop.FindStringSubmatch(value)[1]
 	return name + "=" + value
+}
+
+func init() {
+	serializers.Add("graphite",
+		func() serializers.Serializer {
+			return &GraphiteSerializer{}
+		},
+	)
+}
+
+// InitFromConfig is a compatibility function to construct the parser the old way
+func (s *GraphiteSerializer) InitFromConfig(cfg *serializers.Config) error {
+	s.Prefix = cfg.Prefix
+	s.Templates = cfg.Templates
+	s.StrictRegex = cfg.GraphiteStrictRegex
+	s.TagSupport = cfg.GraphiteTagSupport
+	s.TagSanitizeMode = cfg.GraphiteTagSanitizeMode
+	s.Separator = cfg.GraphiteSeparator
+
+	return nil
 }

--- a/plugins/serializers/graphite/graphite_test.go
+++ b/plugins/serializers/graphite/graphite_test.go
@@ -250,7 +250,8 @@ func TestSerializeMetricHostWithTagSupport(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -278,7 +279,8 @@ func TestSerializeValueField(t *testing.T) {
 	s := GraphiteSerializer{}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -305,7 +307,8 @@ func TestSerializeValueFieldWithTagSupport(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -332,7 +335,8 @@ func TestSerializeValueField2(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -358,7 +362,8 @@ func TestSerializeValueString(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 	require.Equal(t, "", mS[0])
 }
@@ -381,7 +386,8 @@ func TestSerializeValueStringWithTagSupport(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 	require.Equal(t, "", mS[0])
 }
@@ -404,7 +410,8 @@ func TestSerializeValueBoolean(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -435,7 +442,8 @@ func TestSerializeValueBooleanWithTagSupport(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -482,7 +490,8 @@ func TestSerializeFieldWithSpaces(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -509,7 +518,8 @@ func TestSerializeFieldWithSpacesWithTagSupport(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -536,7 +546,8 @@ func TestSerializeTagWithSpaces(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -563,7 +574,8 @@ func TestSerializeTagWithSpacesWithTagSupport(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -591,7 +603,8 @@ func TestSerializeTagWithSpacesWithTagSupportCompatibleSanitize(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -618,7 +631,8 @@ func TestSerializeValueField3(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -645,7 +659,8 @@ func TestSerializeValueField5(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -670,7 +685,8 @@ func TestSerializeMetricPrefix(t *testing.T) {
 	s := GraphiteSerializer{Prefix: "prefix"}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -702,7 +718,8 @@ func TestSerializeMetricPrefixWithTagSupport(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -732,7 +749,8 @@ func TestSerializeCustomRegex(t *testing.T) {
 	}
 	require.NoError(t, s.Init())
 
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{
@@ -936,7 +954,8 @@ func TestClean(t *testing.T) {
 			require.NoError(t, s.Init())
 
 			m := metric.New(tt.metricName, tt.tags, tt.fields, now)
-			actual, _ := s.Serialize(m)
+			actual, err := s.Serialize(m)
+			require.NoError(t, err)
 			require.Equal(t, tt.expected, string(actual))
 		})
 	}

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -2,11 +2,9 @@ package serializers
 
 import (
 	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/plugins/serializers/graphite"
 	"github.com/influxdata/telegraf/plugins/serializers/json"
 	"github.com/influxdata/telegraf/plugins/serializers/msgpack"
 	"github.com/influxdata/telegraf/plugins/serializers/nowmetric"
@@ -165,16 +163,6 @@ func NewSerializer(config *Config) (Serializer, error) {
 	var err error
 	var serializer Serializer
 	switch config.DataFormat {
-	case "graphite":
-		serializer, err = NewGraphiteSerializer(
-			config.Prefix,
-			config.Template,
-			config.GraphiteStrictRegex,
-			config.GraphiteTagSupport,
-			config.GraphiteTagSanitizeMode,
-			config.GraphiteSeparator,
-			config.Templates,
-		)
 	case "json":
 		serializer, err = NewJSONSerializer(config)
 	case "splunkmetric":
@@ -274,52 +262,6 @@ func NewSplunkmetricSerializer(splunkmetricHecRouting bool, splunkmetricMultimet
 
 func NewNowSerializer() (Serializer, error) {
 	return nowmetric.NewSerializer()
-}
-
-//nolint:revive //argument-limit conditionally more arguments allowed
-func NewGraphiteSerializer(
-	prefix,
-	template string,
-	strictRegex string,
-	tagSupport bool,
-	tagSanitizeMode string,
-	separator string,
-	templates []string,
-) (Serializer, error) {
-	graphiteTemplates, defaultTemplate, err := graphite.InitGraphiteTemplates(templates)
-	if err != nil {
-		return nil, err
-	}
-
-	if defaultTemplate != "" {
-		template = defaultTemplate
-	}
-
-	if tagSanitizeMode == "" {
-		tagSanitizeMode = "strict"
-	}
-
-	if separator == "" {
-		separator = "."
-	}
-
-	strictAllowedChars := regexp.MustCompile(`[^a-zA-Z0-9-:._=\p{L}]`)
-	if strictRegex != "" {
-		strictAllowedChars, err = regexp.Compile(strictRegex)
-		if err != nil {
-			return nil, fmt.Errorf("invalid regex provided %q: %w", strictRegex, err)
-		}
-	}
-
-	return &graphite.GraphiteSerializer{
-		Prefix:             prefix,
-		Template:           template,
-		StrictAllowedChars: strictAllowedChars,
-		TagSupport:         tagSupport,
-		TagSanitizeMode:    tagSanitizeMode,
-		Separator:          separator,
-		Templates:          graphiteTemplates,
-	}, nil
 }
 
 func NewMsgpackSerializer() Serializer {


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR migrates the graphite serializer to the new-style framework.