### PR TITLE
feat(inputs.gnmi): Allow canonical field names

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -52,6 +52,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 
+  ## Enable to get the canonical path as field-name
+  # canonical_field_names = false
+
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -16,6 +16,9 @@
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 
+  ## Enable to get the canonical path as field-name
+  # canonical_field_names = false
+
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/gnmi/testcases/canonical_field_names/expected.out
+++ b/plugins/inputs/gnmi/testcases/canonical_field_names/expected.out
@@ -1,0 +1,1 @@
+interfaces,name=eth42,path=openconfig-interfaces:/interfaces/interface,source=127.0.0.1 /interfaces/interface/descr="eth42",/interfaces/interface/config/id=42425u,/interfaces/interface/state/in_pkts=5678u,/interfaces/interface/state/out_pkts=5125u 1673608605875353770

--- a/plugins/inputs/gnmi/testcases/canonical_field_names/responses.json
+++ b/plugins/inputs/gnmi/testcases/canonical_field_names/responses.json
@@ -1,0 +1,79 @@
+[
+    {
+        "update": {
+            "timestamp": "1673608605875353770",
+            "prefix": {
+                "origin": "openconfig-interfaces",
+                "elem": [
+                    {
+                        "name": "interfaces"
+                    },
+                    {
+                        "name": "interface",
+                        "key":{"name":"eth42"}
+                    }
+                ],
+                "target": "subscription"
+            },
+            "update": [
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "descr"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "stringVal": "eth42"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "config"
+                            },
+                            {
+                                "name": "id"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "42425"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "state"
+                            },
+                            {
+                                "name": "in-pkts"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "5678"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "state"
+                            },
+                            {
+                                "name": "out-pkts"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "5125"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/plugins/inputs/gnmi/testcases/canonical_field_names/telegraf.conf
+++ b/plugins/inputs/gnmi/testcases/canonical_field_names/telegraf.conf
@@ -1,0 +1,29 @@
+[[inputs.gnmi]]
+  addresses     = ["dummy"]
+  name_override = "gnmi"
+  redial        = "10s"
+  canonical_field_names = true
+  [[inputs.gnmi.subscription]]
+    name              = "interfaces"
+    origin            = "openconfig-interfaces"
+    path              = "/interfaces/interface/descr"
+    subscription_mode = "sample"
+    sample_interval   = "10s"
+  [[inputs.gnmi.subscription]]
+    name              = "interfaces"
+    origin            = "openconfig-interfaces"
+    path              = "/interfaces/interface/config/id"
+    subscription_mode = "sample"
+    sample_interval   = "10s"
+  [[inputs.gnmi.subscription]]
+    name              = "interfaces"
+    origin            = "openconfig-interfaces"
+    path              = "/interfaces/interface/state/in-pkts"
+    subscription_mode = "sample"
+    sample_interval   = "10s"
+  [[inputs.gnmi.subscription]]
+    name              = "interfaces"
+    origin            = "openconfig-interfaces"
+    path              = "/interfaces/interface/state/out-pkts"
+    subscription_mode = "sample"
+    sample_interval   = "10s"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12352

This PR adds an option to get the canonical path as field name instead of the name being a path relative to the subscription. This allows for a consistent field-name output when changing the configuration to subscribe more specific paths.