### PR TITLE
fix(inputs.gnmi): Handle canonical field-name correctly for non-explicit subscriptions

### DIFF
--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -244,7 +244,6 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 				if parts := strings.SplitN(key, ":", 2); len(parts) == 2 {
 					key = parts[1]
 				}
-				h.log.Debugf("using canonical key %q -> %q", k, key)
 			} else {
 				if len(aliasPath) < len(key) && len(aliasPath) != 0 {
 					// This may not be an exact prefix, due to naming style

--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -244,7 +244,7 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 				if parts := strings.SplitN(key, ":", 2); len(parts) == 2 {
 					key = parts[1]
 				}
-				key = strings.TrimLeft(key, "/.")
+				h.log.Debugf("using canonical key %q -> %q", k, key)
 			} else {
 				if len(aliasPath) < len(key) && len(aliasPath) != 0 {
 					// This may not be an exact prefix, due to naming style
@@ -253,15 +253,12 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 				} else if len(aliasPath) >= len(key) {
 					// Otherwise use the last path element as the field key.
 					key = path.Base(key)
-
-					// If there are no elements skip the item; this would be an
-					// invalid message.
-					key = strings.TrimLeft(key, "/.")
-					if key == "" {
-						h.log.Errorf("invalid empty path: %q", k)
-						continue
-					}
 				}
+			}
+			key = strings.TrimLeft(key, "/.")
+			if key == "" {
+				h.log.Errorf("invalid empty path: %q", k)
+				continue
 			}
 			grouper.Add(name, tags, timestamp, key, v)
 		}

--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -239,17 +239,17 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 		// Group metrics
 		for k, v := range fields {
 			key := k
-			if len(aliasPath) < len(key) && len(aliasPath) != 0 {
-				// This may not be an exact prefix, due to naming style
-				// conversion on the key.
-				key = key[len(aliasPath)+1:]
-			} else if len(aliasPath) >= len(key) {
-				if h.canonicalFieldNames {
-					// Strip the origin is any for the field names
-					if parts := strings.SplitN(key, ":", 2); len(parts) == 2 {
-						key = parts[1]
-					}
-				} else {
+			if h.canonicalFieldNames {
+				// Strip the origin is any for the field names
+				if parts := strings.SplitN(key, ":", 2); len(parts) == 2 {
+					key = parts[1]
+				}
+			} else {
+				if len(aliasPath) < len(key) && len(aliasPath) != 0 {
+					// This may not be an exact prefix, due to naming style
+					// conversion on the key.
+					key = key[len(aliasPath)+1:]
+				} else if len(aliasPath) >= len(key) {
 					// Otherwise use the last path element as the field key.
 					key = path.Base(key)
 

--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -242,8 +242,9 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 			if h.canonicalFieldNames {
 				// Strip the origin is any for the field names
 				if parts := strings.SplitN(key, ":", 2); len(parts) == 2 {
-					key = strings.TrimLeft(parts[1], "/.")
+					key = parts[1]
 				}
+				key = strings.TrimLeft(key, "/.")
 			} else {
 				if len(aliasPath) < len(key) && len(aliasPath) != 0 {
 					// This may not be an exact prefix, due to naming style

--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -242,7 +242,7 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 			if h.canonicalFieldNames {
 				// Strip the origin is any for the field names
 				if parts := strings.SplitN(key, ":", 2); len(parts) == 2 {
-					key = parts[1]
+					key = strings.TrimLeft(parts[1], "/.")
 				}
 			} else {
 				if len(aliasPath) < len(key) && len(aliasPath) != 0 {

--- a/plugins/inputs/gnmi/testcases/canonical_field_names/expected.out
+++ b/plugins/inputs/gnmi/testcases/canonical_field_names/expected.out
@@ -1,1 +1,1 @@
-interfaces,name=eth42,path=openconfig-interfaces:/interfaces/interface,source=127.0.0.1 /interfaces/interface/descr="eth42",/interfaces/interface/config/id=42425u,/interfaces/interface/state/in_pkts=5678u,/interfaces/interface/state/out_pkts=5125u 1673608605875353770
+interfaces,name=eth42,path=openconfig-interfaces:/interfaces/interface,source=127.0.0.1 interfaces/interface/descr="eth42",interfaces/interface/config/id=42425u,interfaces/interface/state/in_pkts=5678u,interfaces/interface/state/out_pkts=5125u 1673608605875353770

--- a/plugins/inputs/gnmi/testcases/canonical_field_names/telegraf.conf
+++ b/plugins/inputs/gnmi/testcases/canonical_field_names/telegraf.conf
@@ -18,12 +18,6 @@
   [[inputs.gnmi.subscription]]
     name              = "interfaces"
     origin            = "openconfig-interfaces"
-    path              = "/interfaces/interface/state/in-pkts"
-    subscription_mode = "sample"
-    sample_interval   = "10s"
-  [[inputs.gnmi.subscription]]
-    name              = "interfaces"
-    origin            = "openconfig-interfaces"
-    path              = "/interfaces/interface/state/out-pkts"
+    path              = "/interfaces/interface/state"
     subscription_mode = "sample"
     sample_interval   = "10s"


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12352

Fix canonical field names for cases where we do not have a subscription that exactly matches the path. Also adapted the unit-test to cover that code-path.