### PR TITLE
chore(serializers.msgpack): Migrate to new-style framework

### DIFF
--- a/plugins/serializers/all/msgpack.go
+++ b/plugins/serializers/all/msgpack.go
@@ -1,0 +1,7 @@
+//go:build !custom || serializers || serializers.msgpack
+
+package all
+
+import (
+	_ "github.com/influxdata/telegraf/plugins/serializers/msgpack" // register plugin
+)

--- a/plugins/serializers/msgpack/msgpack.go
+++ b/plugins/serializers/msgpack/msgpack.go
@@ -47,6 +47,6 @@ func init() {
 }
 
 // InitFromConfig is a compatibility function to construct the parser the old way
-func (s *Serializer) InitFromConfig(cfg *serializers.Config) error {
+func (s *Serializer) InitFromConfig(_ *serializers.Config) error {
 	return nil
 }

--- a/plugins/serializers/msgpack/msgpack.go
+++ b/plugins/serializers/msgpack/msgpack.go
@@ -2,15 +2,11 @@ package msgpack
 
 import (
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
 // Serializer encodes metrics in MessagePack format
 type Serializer struct{}
-
-// NewSerializer creates a msgpack.Serializer
-func NewSerializer() *Serializer {
-	return &Serializer{}
-}
 
 func marshalMetric(buf []byte, metric telegraf.Metric) ([]byte, error) {
 	return (&Metric{
@@ -40,4 +36,17 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		}
 	}
 	return buf, nil
+}
+
+func init() {
+	serializers.Add("msgpack",
+		func() serializers.Serializer {
+			return &Serializer{}
+		},
+	)
+}
+
+// InitFromConfig is a compatibility function to construct the parser the old way
+func (s *Serializer) InitFromConfig(cfg *serializers.Config) error {
+	return nil
 }

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/serializers/json"
-	"github.com/influxdata/telegraf/plugins/serializers/msgpack"
 	"github.com/influxdata/telegraf/plugins/serializers/nowmetric"
 	"github.com/influxdata/telegraf/plugins/serializers/prometheus"
 	"github.com/influxdata/telegraf/plugins/serializers/prometheusremotewrite"
@@ -180,8 +179,6 @@ func NewSerializer(config *Config) (Serializer, error) {
 		serializer, err = NewPrometheusSerializer(config), nil
 	case "prometheusremotewrite":
 		serializer, err = NewPrometheusRemoteWriteSerializer(config), nil
-	case "msgpack":
-		serializer, err = NewMsgpackSerializer(), nil
 	default:
 		creator, found := Serializers[config.DataFormat]
 		if !found {
@@ -262,8 +259,4 @@ func NewSplunkmetricSerializer(splunkmetricHecRouting bool, splunkmetricMultimet
 
 func NewNowSerializer() (Serializer, error) {
 	return nowmetric.NewSerializer()
-}
-
-func NewMsgpackSerializer() Serializer {
-	return msgpack.NewSerializer()
 }


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR migrates the message-pack serializer to the new-style framework.