### PR TITLE
chore(serializers.nowmetric): Migrate to new-style framework

### DIFF
--- a/plugins/serializers/all/nowmetric.go
+++ b/plugins/serializers/all/nowmetric.go
@@ -1,0 +1,7 @@
+//go:build !custom || serializers || serializers.nowmetric
+
+package all
+
+import (
+	_ "github.com/influxdata/telegraf/plugins/serializers/nowmetric" // register plugin
+)

--- a/plugins/serializers/nowmetric/nowmetric.go
+++ b/plugins/serializers/nowmetric/nowmetric.go
@@ -10,9 +10,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
-type Serializer struct {
-	TimestampUnits time.Duration
-}
+type Serializer struct{}
 
 /*
 Example for the JSON generated and pushed to the MID

--- a/plugins/serializers/nowmetric/nowmetric.go
+++ b/plugins/serializers/nowmetric/nowmetric.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
-type serializer struct {
+type Serializer struct {
 	TimestampUnits time.Duration
 }
 
@@ -38,12 +39,7 @@ type OIMetric struct {
 
 type OIMetrics []OIMetric
 
-func NewSerializer() (*serializer, error) {
-	s := &serializer{}
-	return s, nil
-}
-
-func (s *serializer) Serialize(metric telegraf.Metric) (out []byte, err error) {
+func (s *Serializer) Serialize(metric telegraf.Metric) (out []byte, err error) {
 	serialized, err := s.createObject(metric)
 	if err != nil {
 		return []byte{}, err
@@ -51,7 +47,7 @@ func (s *serializer) Serialize(metric telegraf.Metric) (out []byte, err error) {
 	return serialized, nil
 }
 
-func (s *serializer) SerializeBatch(metrics []telegraf.Metric) (out []byte, err error) {
+func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) (out []byte, err error) {
 	objects := make([]byte, 0)
 	for _, metric := range metrics {
 		m, err := s.createObject(metric)
@@ -65,7 +61,7 @@ func (s *serializer) SerializeBatch(metrics []telegraf.Metric) (out []byte, err 
 	return replaced, nil
 }
 
-func (s *serializer) createObject(metric telegraf.Metric) ([]byte, error) {
+func (s *Serializer) createObject(metric telegraf.Metric) ([]byte, error) {
 	/*  ServiceNow Operational Intelligence supports an array of JSON objects.
 	** Following elements accepted in the request body:
 		 ** metric_type: 	The name of the metric
@@ -131,4 +127,17 @@ func (s *serializer) createObject(metric telegraf.Metric) ([]byte, error) {
 func verifyValue(v interface{}) bool {
 	_, ok := v.(string)
 	return !ok
+}
+
+func init() {
+	serializers.Add("nowmetric",
+		func() serializers.Serializer {
+			return &Serializer{}
+		},
+	)
+}
+
+// InitFromConfig is a compatibility function to construct the parser the old way
+func (s *Serializer) InitFromConfig(_ *serializers.Config) error {
+	return nil
 }

--- a/plugins/serializers/nowmetric/nowmetric_test.go
+++ b/plugins/serializers/nowmetric/nowmetric_test.go
@@ -22,7 +22,7 @@ func TestSerializeMetricFloat(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s, _ := NewSerializer()
+	s := &Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestSerialize_TimestampUnits(t *testing.T) {
 				},
 				time.Unix(1525478795, 123456789),
 			)
-			s, _ := NewSerializer()
+			s := &Serializer{}
 			actual, err := s.Serialize(m)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, string(actual))
@@ -90,7 +90,7 @@ func TestSerializeMetricInt(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s, _ := NewSerializer()
+	s := &Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestSerializeMetricString(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s, _ := NewSerializer()
+	s := &Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestSerializeMultiFields(t *testing.T) {
 		return m.FieldList()[i].Key < m.FieldList()[j].Key
 	})
 
-	s, _ := NewSerializer()
+	s := &Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -164,7 +164,7 @@ func TestSerializeMetricWithEscapes(t *testing.T) {
 	}
 	m := metric.New("My CPU", tags, fields, now)
 
-	s, _ := NewSerializer()
+	s := &Serializer{}
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
 
@@ -187,7 +187,7 @@ func TestSerializeBatch(t *testing.T) {
 		time.Unix(0, 0),
 	)
 	metrics := []telegraf.Metric{m, m}
-	s, _ := NewSerializer()
+	s := &Serializer{}
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
 	require.Equal(

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/plugins/serializers/nowmetric"
 	"github.com/influxdata/telegraf/plugins/serializers/prometheus"
 	"github.com/influxdata/telegraf/plugins/serializers/prometheusremotewrite"
 	"github.com/influxdata/telegraf/plugins/serializers/splunkmetric"
@@ -163,8 +162,6 @@ func NewSerializer(config *Config) (Serializer, error) {
 	switch config.DataFormat {
 	case "splunkmetric":
 		serializer, err = NewSplunkmetricSerializer(config.HecRouting, config.SplunkmetricMultiMetric, config.SplunkmetricOmitEventTag), nil
-	case "nowmetric":
-		serializer, err = NewNowSerializer()
 	case "wavefront":
 		serializer, err = NewWavefrontSerializer(
 			config.Prefix,
@@ -242,8 +239,4 @@ func NewWavefrontSerializer(prefix string, useStrict bool, sourceOverride []stri
 
 func NewSplunkmetricSerializer(splunkmetricHecRouting bool, splunkmetricMultimetric bool, splunkmetricOmitEventTag bool) Serializer {
 	return splunkmetric.NewSerializer(splunkmetricHecRouting, splunkmetricMultimetric, splunkmetricOmitEventTag)
-}
-
-func NewNowSerializer() (Serializer, error) {
-	return nowmetric.NewSerializer()
 }


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR migrates the nowmetric serializer to the new-style framework.