### PR TITLE
chore(serializers.splunkmetric): Migrate to new-style framework

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1477,13 +1477,6 @@ func (c *Config) buildSerializerOld(tbl *ast.Table) (telegraf.Serializer, error)
 	c.getFieldString(tbl, "prefix", &sc.Prefix)
 	c.getFieldString(tbl, "template", &sc.Template)
 	c.getFieldStringSlice(tbl, "templates", &sc.Templates)
-	c.getFieldInt(tbl, "influx_max_line_bytes", &sc.InfluxMaxLineBytes)
-	c.getFieldBool(tbl, "influx_sort_fields", &sc.InfluxSortFields)
-	c.getFieldBool(tbl, "influx_uint_support", &sc.InfluxUintSupport)
-
-	c.getFieldBool(tbl, "splunkmetric_hec_routing", &sc.HecRouting)
-	c.getFieldBool(tbl, "splunkmetric_multimetric", &sc.SplunkmetricMultiMetric)
-	c.getFieldBool(tbl, "splunkmetric_omit_event_tag", &sc.SplunkmetricOmitEventTag)
 
 	c.getFieldStringSlice(tbl, "wavefront_source_override", &sc.WavefrontSourceOverride)
 	c.getFieldBool(tbl, "wavefront_use_strict", &sc.WavefrontUseStrict)
@@ -1562,7 +1555,6 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 	case "prefix", "template", "templates",
 		"prometheus_export_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label",
 		"prometheus_compact_encoding",
-		"splunkmetric_hec_routing", "splunkmetric_multimetric", "splunkmetric_omit_event_tag",
 		"wavefront_disable_prefix_conversion", "wavefront_source_override", "wavefront_use_strict":
 	default:
 		c.unusedFieldsMutex.Lock()

--- a/plugins/serializers/all/splunkmetric.go
+++ b/plugins/serializers/all/splunkmetric.go
@@ -1,0 +1,7 @@
+//go:build !custom || serializers || serializers.splunkmetric
+
+package all
+
+import (
+	_ "github.com/influxdata/telegraf/plugins/serializers/splunkmetric" // register plugin
+)

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -8,7 +8,6 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers/nowmetric"
 	"github.com/influxdata/telegraf/plugins/serializers/prometheus"
 	"github.com/influxdata/telegraf/plugins/serializers/prometheusremotewrite"
-	"github.com/influxdata/telegraf/plugins/serializers/splunkmetric"
 	"github.com/influxdata/telegraf/plugins/serializers/wavefront"
 )
 
@@ -161,8 +160,6 @@ func NewSerializer(config *Config) (Serializer, error) {
 	var err error
 	var serializer Serializer
 	switch config.DataFormat {
-	case "splunkmetric":
-		serializer, err = NewSplunkmetricSerializer(config.HecRouting, config.SplunkmetricMultiMetric, config.SplunkmetricOmitEventTag), nil
 	case "nowmetric":
 		serializer, err = NewNowSerializer()
 	case "wavefront":
@@ -238,10 +235,6 @@ func NewPrometheusSerializer(config *Config) Serializer {
 
 func NewWavefrontSerializer(prefix string, useStrict bool, sourceOverride []string, disablePrefixConversions bool) Serializer {
 	return wavefront.NewSerializer(prefix, useStrict, sourceOverride, disablePrefixConversions)
-}
-
-func NewSplunkmetricSerializer(splunkmetricHecRouting bool, splunkmetricMultimetric bool, splunkmetricOmitEventTag bool) Serializer {
-	return splunkmetric.NewSerializer(splunkmetricHecRouting, splunkmetricMultimetric, splunkmetricOmitEventTag)
 }
 
 func NewNowSerializer() (Serializer, error) {

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Serializer struct {
-	HecRouting   bool `toml:"hec_routing"`
+	HecRouting   bool `toml:"splunkmetric_hec_routing"`
 	MultiMetric  bool `toml:"splunkmetric_multi_metric"`
 	OmitEventTag bool `toml:"splunkmetric_omit_event_tag"`
 }

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -5,12 +5,13 @@ import (
 	"log"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
-type serializer struct {
-	HecRouting              bool
-	SplunkmetricMultiMetric bool
-	OmitEventTag            bool
+type Serializer struct {
+	HecRouting   bool `toml:"hec_routing"`
+	MultiMetric  bool `toml:"splunkmetric_multi_metric"`
+	OmitEventTag bool `toml:"splunkmetric_omit_event_tag"`
 }
 
 type CommonTags struct {
@@ -30,22 +31,11 @@ type HECTimeSeries struct {
 	Fields map[string]interface{} `json:"fields"`
 }
 
-// NewSerializer Setup our new serializer
-func NewSerializer(splunkmetricHecRouting bool, splunkmetricMultimetric bool, splunkmetricOmitEventTag bool) *serializer {
-	/*	Define output params */
-	s := &serializer{
-		HecRouting:              splunkmetricHecRouting,
-		SplunkmetricMultiMetric: splunkmetricMultimetric,
-		OmitEventTag:            splunkmetricOmitEventTag,
-	}
-	return s
-}
-
-func (s *serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
+func (s *Serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 	return s.createObject(metric), nil
 }
 
-func (s *serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
+func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	var serialized []byte
 
 	for _, metric := range metrics {
@@ -58,7 +48,7 @@ func (s *serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	return serialized, nil
 }
 
-func (s *serializer) createMulti(metric telegraf.Metric, dataGroup HECTimeSeries, commonTags CommonTags) (metricGroup []byte, err error) {
+func (s *Serializer) createMulti(metric telegraf.Metric, dataGroup HECTimeSeries, commonTags CommonTags) (metricGroup []byte, err error) {
 	/* When splunkmetric_multimetric is true, then we can write out multiple name=value pairs as part of the same
 	** event payload. This only works when the time, host, and dimensions are the same for every name=value pair
 	** in the timeseries data.
@@ -108,7 +98,7 @@ func (s *serializer) createMulti(metric telegraf.Metric, dataGroup HECTimeSeries
 	return metricGroup, nil
 }
 
-func (s *serializer) createSingle(metric telegraf.Metric, dataGroup HECTimeSeries, commonTags CommonTags) (metricGroup []byte, err error) {
+func (s *Serializer) createSingle(metric telegraf.Metric, dataGroup HECTimeSeries, commonTags CommonTags) (metricGroup []byte, err error) {
 	/* The default mode is to generate one JSON entity per metric (required for pre-8.0 Splunks)
 	**
 	** The format for single metric is 'nameOfMetric = valueOfMetric'
@@ -158,7 +148,7 @@ func (s *serializer) createSingle(metric telegraf.Metric, dataGroup HECTimeSerie
 	return metricGroup, nil
 }
 
-func (s *serializer) createObject(metric telegraf.Metric) (metricGroup []byte) {
+func (s *Serializer) createObject(metric telegraf.Metric) (metricGroup []byte) {
 	/*  Splunk supports one metric json object, and does _not_ support an array of JSON objects.
 	     ** Splunk has the following required names for the metric store:
 		 ** metric_name: The name of the metric
@@ -187,7 +177,7 @@ func (s *serializer) createObject(metric telegraf.Metric) (metricGroup []byte) {
 		}
 	}
 	commonTags.Time = float64(metric.Time().UnixNano()) / float64(1000000000)
-	switch s.SplunkmetricMultiMetric {
+	switch s.MultiMetric {
 	case true:
 		metricGroup, _ = s.createMulti(metric, dataGroup, commonTags)
 	default:
@@ -218,4 +208,21 @@ func verifyValue(v interface{}) (value interface{}, valid bool) {
 		value = v
 	}
 	return value, valid
+}
+
+func init() {
+	serializers.Add("splunkmetric",
+		func() serializers.Serializer {
+			return &Serializer{}
+		},
+	)
+}
+
+// InitFromConfig is a compatibility function to construct the parser the old way
+func (s *Serializer) InitFromConfig(cfg *serializers.Config) error {
+	s.HecRouting = cfg.HecRouting
+	s.MultiMetric = cfg.SplunkmetricMultiMetric
+	s.OmitEventTag = cfg.SplunkmetricOmitEventTag
+
+	return nil
 }

--- a/plugins/serializers/splunkmetric/splunkmetric_test.go
+++ b/plugins/serializers/splunkmetric/splunkmetric_test.go
@@ -21,7 +21,7 @@ func TestSerializeMetricFloat(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := NewSerializer(false, false, false)
+	s := &Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -40,7 +40,7 @@ func TestSerializeMetricFloatHec(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := NewSerializer(true, false, false)
+	s := &Serializer{HecRouting: true}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestSerializeMetricInt(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := NewSerializer(false, false, false)
+	s := &Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestSerializeMetricIntHec(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := NewSerializer(true, false, false)
+	s := &Serializer{HecRouting: true}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestSerializeMetricBool(t *testing.T) {
 	}
 	m := metric.New("docker", tags, fields, now)
 
-	s := NewSerializer(false, false, false)
+	s := &Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestSerializeMetricBoolHec(t *testing.T) {
 	}
 	m := metric.New("docker", tags, fields, now)
 
-	s := NewSerializer(true, false, false)
+	s := &Serializer{HecRouting: true}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestSerializeMetricString(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := NewSerializer(false, false, false)
+	s := &Serializer{}
 	var buf []byte
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -165,7 +165,7 @@ func TestSerializeBatch(t *testing.T) {
 	)
 
 	metrics := []telegraf.Metric{m, n}
-	s := NewSerializer(false, false, false)
+	s := &Serializer{}
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
 
@@ -185,7 +185,7 @@ func TestSerializeMulti(t *testing.T) {
 	)
 
 	metrics := []telegraf.Metric{m}
-	s := NewSerializer(false, true, false)
+	s := &Serializer{MultiMetric: true}
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
 
@@ -211,7 +211,7 @@ func TestSerializeBatchHec(t *testing.T) {
 		time.Unix(0, 0),
 	)
 	metrics := []telegraf.Metric{m, n}
-	s := NewSerializer(true, false, false)
+	s := &Serializer{HecRouting: true}
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
 
@@ -232,7 +232,10 @@ func TestSerializeMultiHec(t *testing.T) {
 	)
 
 	metrics := []telegraf.Metric{m}
-	s := NewSerializer(true, true, false)
+	s := &Serializer{
+		HecRouting:  true,
+		MultiMetric: true,
+	}
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
 
@@ -252,7 +255,11 @@ func TestSerializeOmitEvent(t *testing.T) {
 	)
 
 	metrics := []telegraf.Metric{m}
-	s := NewSerializer(true, true, true)
+	s := &Serializer{
+		HecRouting:   true,
+		MultiMetric:  true,
+		OmitEventTag: true,
+	}
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
 


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR migrates the splunkmetric serializer to the new-style framework.