### PR TITLE
docs(inputs.cisco_telemetry_mdt): specify max msg upper limit

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/README.md
+++ b/plugins/inputs/cisco_telemetry_mdt/README.md
@@ -44,7 +44,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
  ## Address and port to host telemetry listener
  service_address = ":57000"
 
- ## Grpc Maximum Message Size, default is 4MB, increase the size.
+ ## Grpc Maximum Message Size, default is 4MB, increase the size. This is
+ ## stored as a uint32, and limited to 4294967295.
  max_msg_size = 4000000
 
  ## Enable TLS; grpc transport only.

--- a/plugins/inputs/cisco_telemetry_mdt/sample.conf
+++ b/plugins/inputs/cisco_telemetry_mdt/sample.conf
@@ -7,7 +7,8 @@
  ## Address and port to host telemetry listener
  service_address = ":57000"
 
- ## Grpc Maximum Message Size, default is 4MB, increase the size.
+ ## Grpc Maximum Message Size, default is 4MB, increase the size. This is
+ ## stored as a uint32, and limited to 4294967295.
  max_msg_size = 4000000
 
  ## Enable TLS; grpc transport only.


### PR DESCRIPTION
fixes: #13270