### PR TITLE
chore(serializers.prometheus): Migrate to new-style framework

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1478,11 +1478,6 @@ func (c *Config) buildSerializerOld(tbl *ast.Table) (telegraf.Serializer, error)
 	c.getFieldString(tbl, "template", &sc.Template)
 	c.getFieldStringSlice(tbl, "templates", &sc.Templates)
 
-	c.getFieldBool(tbl, "prometheus_export_timestamp", &sc.PrometheusExportTimestamp)
-	c.getFieldBool(tbl, "prometheus_sort_metrics", &sc.PrometheusSortMetrics)
-	c.getFieldBool(tbl, "prometheus_string_as_label", &sc.PrometheusStringAsLabel)
-	c.getFieldBool(tbl, "prometheus_compact_encoding", &sc.PrometheusCompactEncoding)
-
 	if c.hasErrs() {
 		return nil, c.firstErr()
 	}
@@ -1548,9 +1543,7 @@ func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 	case "data_type", "influx_parser_type":
 
 	// Serializer options to ignore
-	case "prefix", "template", "templates",
-		"prometheus_export_timestamp", "prometheus_sort_metrics", "prometheus_string_as_label",
-		"prometheus_compact_encoding":
+	case "prefix", "template", "templates":
 	default:
 		c.unusedFieldsMutex.Lock()
 		c.UnusedFields[key] = true

--- a/plugins/outputs/prometheus_client/v2/collector.go
+++ b/plugins/outputs/prometheus_client/v2/collector.go
@@ -44,18 +44,14 @@ type Collector struct {
 }
 
 func NewCollector(expire time.Duration, stringsAsLabel bool, exportTimestamp bool) *Collector {
-	config := serializer.FormatConfig{}
-	if stringsAsLabel {
-		config.StringHandling = serializer.StringAsLabel
-	}
-
-	if exportTimestamp {
-		config.TimestampExport = serializer.ExportTimestamp
+	cfg := serializer.FormatConfig{
+		StringAsLabel:   stringsAsLabel,
+		ExportTimestamp: exportTimestamp,
 	}
 
 	return &Collector{
 		expireDuration: expire,
-		coll:           serializer.NewCollection(config),
+		coll:           serializer.NewCollection(cfg),
 	}
 }
 

--- a/plugins/serializers/all/prometheus.go
+++ b/plugins/serializers/all/prometheus.go
@@ -1,0 +1,7 @@
+//go:build !custom || serializers || serializers.prometheus
+
+package all
+
+import (
+	_ "github.com/influxdata/telegraf/plugins/serializers/prometheus" // register plugin
+)

--- a/plugins/serializers/prometheus/collection_test.go
+++ b/plugins/serializers/prometheus/collection_test.go
@@ -830,7 +830,7 @@ func TestExportTimestamps(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewCollection(FormatConfig{TimestampExport: ExportTimestamp})
+			c := NewCollection(FormatConfig{ExportTimestamp: true})
 			for _, item := range tt.input {
 				c.Add(item.metric, item.addtime)
 			}

--- a/plugins/serializers/prometheus/prometheus_test.go
+++ b/plugins/serializers/prometheus/prometheus_test.go
@@ -141,7 +141,7 @@ http_request_duration_seconds_count 0
 		{
 			name: "simple with timestamp",
 			config: FormatConfig{
-				TimestampExport: ExportTimestamp,
+				ExportTimestamp: true,
 			},
 			metric: testutil.MustMetric(
 				"cpu",
@@ -182,12 +182,14 @@ cpu_time_idle{host="example.org"} 42
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewSerializer(FormatConfig{
-				MetricSortOrder: SortMetrics,
-				TimestampExport: tt.config.TimestampExport,
-				StringHandling:  tt.config.StringHandling,
-				CompactEncoding: tt.config.CompactEncoding,
-			})
+			s := &Serializer{
+				FormatConfig{
+					SortMetrics:     true,
+					ExportTimestamp: tt.config.ExportTimestamp,
+					StringAsLabel:   tt.config.StringAsLabel,
+					CompactEncoding: tt.config.CompactEncoding,
+				},
+			}
 
 			actual, err := s.Serialize(tt.metric)
 			require.NoError(t, err)
@@ -536,7 +538,7 @@ cpu_time_idle 42
 		{
 			name: "string as label",
 			config: FormatConfig{
-				StringHandling: StringAsLabel,
+				StringAsLabel: true,
 			},
 			metrics: []telegraf.Metric{
 				testutil.MustMetric(
@@ -558,7 +560,7 @@ cpu_time_idle{cpu="cpu0"} 42
 		{
 			name: "string as label duplicate tag",
 			config: FormatConfig{
-				StringHandling: StringAsLabel,
+				StringAsLabel: true,
 			},
 			metrics: []telegraf.Metric{
 				testutil.MustMetric(
@@ -582,7 +584,7 @@ cpu_time_idle{cpu="cpu0"} 42
 		{
 			name: "replace characters when using string as label",
 			config: FormatConfig{
-				StringHandling: StringAsLabel,
+				StringAsLabel: true,
 			},
 			metrics: []telegraf.Metric{
 				testutil.MustMetric(
@@ -698,11 +700,13 @@ rpc_duration_seconds_count 2693
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewSerializer(FormatConfig{
-				MetricSortOrder: SortMetrics,
-				TimestampExport: tt.config.TimestampExport,
-				StringHandling:  tt.config.StringHandling,
-			})
+			s := &Serializer{
+				FormatConfig{
+					SortMetrics:     true,
+					ExportTimestamp: tt.config.ExportTimestamp,
+					StringAsLabel:   tt.config.StringAsLabel,
+				},
+			}
 			actual, err := s.SerializeBatch(tt.metrics)
 			require.NoError(t, err)
 


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR migrates the prometheus serializer to the new-style framework.