### PR TITLE
feat(outputs.wavefront): Add TLS and HTTP Timeout configuration fields

### DIFF
--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -75,6 +75,24 @@ to use them.
   ## of metrics will block for a longer time, but this will be handled gracefully by the internal buffering in
   ## Telegraf.
   #immediate_flush = true
+
+  ## Optional TLS Config
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
+  ## Trusted root certificates for server
+  # tls_ca = "/path/to/cafile"
+  ## Used for TLS client certificate authentication
+  # tls_cert = "/path/to/certfile"
+  ## Used for TLS client certificate authentication
+  # tls_key = "/path/to/keyfile"
+  ## Send the specified TLS server name via SNI
+  # tls_server_name = "kubernetes.example.com"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## HTTP Timeout
+  #timeout="10s"
 ```
 
 ### Convert Path & Metric Separator

--- a/plugins/outputs/wavefront/sample.conf
+++ b/plugins/outputs/wavefront/sample.conf
@@ -50,3 +50,21 @@
   ## of metrics will block for a longer time, but this will be handled gracefully by the internal buffering in
   ## Telegraf.
   #immediate_flush = true
+
+  ## Optional TLS Config
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
+  ## Trusted root certificates for server
+  # tls_ca = "/path/to/cafile"
+  ## Used for TLS client certificate authentication
+  # tls_cert = "/path/to/certfile"
+  ## Used for TLS client certificate authentication
+  # tls_key = "/path/to/keyfile"
+  ## Send the specified TLS server name via SNI
+  # tls_server_name = "kubernetes.example.com"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## HTTP Timeout
+  #timeout="10s"

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -383,6 +383,8 @@ func TestSenderURLFromURLAndToken(t *testing.T) {
 func TestDefaults(t *testing.T) {
 	defaultWavefront := outputs.Outputs["wavefront"]().(*Wavefront)
 	require.Equal(t, 10000, defaultWavefront.HTTPMaximumBatchSize)
+	require.Equal(t, config.Duration(10*time.Second), defaultWavefront.Timeout)
+	require.Equal(t, "", defaultWavefront.TLSCA)
 }
 
 // Benchmarks to test performance of string replacement via Regex and Sanitize


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR adds configuration fields for the Wavefront output allowing users to provide TLS configuration and to set an HTTP Timeout. The underlying Wavefront SDK recently added its own hooks for configuring these settings.