### PR TITLE
feat(agent): Add option to avoid filtering of explicit plugin tags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1436,6 +1436,7 @@ func (c *Config) buildInput(name string, tbl *ast.Table) (*models.InputConfig, e
 	c.getFieldString(tbl, "name_prefix", &cp.MeasurementPrefix)
 	c.getFieldString(tbl, "name_suffix", &cp.MeasurementSuffix)
 	c.getFieldString(tbl, "name_override", &cp.NameOverride)
+	c.getFieldBool(tbl, "always_include_local_tags", &cp.AlwaysIncludeLocalTags)
 	c.getFieldString(tbl, "alias", &cp.Alias)
 
 	cp.Tags = make(map[string]string)
@@ -1528,7 +1529,7 @@ func (c *Config) buildOutput(name string, tbl *ast.Table) (*models.OutputConfig,
 func (c *Config) missingTomlField(_ reflect.Type, key string) error {
 	switch key {
 	// General options to ignore
-	case "alias",
+	case "alias", "always_include_local_tags",
 		"collection_jitter", "collection_offset",
 		"data_format", "delay", "drop", "drop_original",
 		"fielddrop", "fieldpass", "flush_interval", "flush_jitter",

--- a/config/config.go
+++ b/config/config.go
@@ -252,6 +252,10 @@ type AgentConfig struct {
 	// stateful plugins on termination of Telegraf. If the file exists on start,
 	// the state in the file will be restored for the plugins.
 	Statefile string `toml:"statefile"`
+
+	// Flag to always keep tags explicitly defined in the plugin itself and
+	// ensure those tags always pass filtering.
+	AlwaysIncludeLocalTags bool `toml:"always_include_local_tags"`
 }
 
 // InputNames returns a list of strings of the configured inputs.
@@ -1428,7 +1432,10 @@ func (c *Config) buildFilter(tbl *ast.Table) (models.Filter, error) {
 // builds the filter and returns a
 // models.InputConfig to be inserted into models.RunningInput
 func (c *Config) buildInput(name string, tbl *ast.Table) (*models.InputConfig, error) {
-	cp := &models.InputConfig{Name: name}
+	cp := &models.InputConfig{
+		Name:                   name,
+		AlwaysIncludeLocalTags: c.Agent.AlwaysIncludeLocalTags,
+	}
 	c.getFieldDuration(tbl, "interval", &cp.Interval)
 	c.getFieldDuration(tbl, "precision", &cp.Precision)
 	c.getFieldDuration(tbl, "collection_jitter", &cp.CollectionJitter)
@@ -1436,7 +1443,6 @@ func (c *Config) buildInput(name string, tbl *ast.Table) (*models.InputConfig, e
 	c.getFieldString(tbl, "name_prefix", &cp.MeasurementPrefix)
 	c.getFieldString(tbl, "name_suffix", &cp.MeasurementSuffix)
 	c.getFieldString(tbl, "name_override", &cp.NameOverride)
-	c.getFieldBool(tbl, "always_include_local_tags", &cp.AlwaysIncludeLocalTags)
 	c.getFieldString(tbl, "alias", &cp.Alias)
 
 	cp.Tags = make(map[string]string)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -407,7 +407,7 @@ Use the name_override parameter to emit measurements with the name `foobar`:
 Emit measurements with two additional tags: `tag1=foo` and `tag2=bar`
 
 > **NOTE**: With TOML, order matters.  Parameters belong to the last defined
-> table header, place `[inputs.cpu.tags]` table at the _end_ of the plugin
+> table header, place `[inputs.cpu.tags]` table at the *end* of the plugin
 > definition.
 
 ```toml
@@ -643,7 +643,7 @@ for time-based filtering. An introduction to the CEL language can be found
 are provided in the [language definition][CEL lang] as well as in the
 [extension documentation][CEL ext].
 
-> NOTE: As CEL is an _interpreted_ languguage, this type of filtering is much
+> NOTE: As CEL is an *interpreted* languguage, this type of filtering is much
 > slower compared to `namepass`/`namedrop` and friends. So consider to use the
 > more restricted filter options where possible in case of high-throughput
 > scenarios.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -321,6 +321,11 @@ The agent table configures Telegraf and the defaults used across all plugins.
   stateful plugins on termination of Telegraf. If the file exists on start,
   the state in the file will be restored for the plugins.
 
+- **always_include_local_tags**:
+  Ensure tags explicitly defined in a plugin will *always* pass tag-filtering
+  via `taginclude` or `tagexclude`. This removes the need to specify local tags
+  twice.
+
 ## Plugins
 
 Telegraf plugins are divided into 4 types: [inputs][], [outputs][],
@@ -675,11 +680,6 @@ tag.
 The inverse of `taginclude`. Tags with a tag key matching one of the patterns
 will be discarded from the metric.  Any tag can be filtered including global
 tags and the agent `host` tag.
-
-- **always_include_local_tags**:
-If `true` always include the tags specified in the plugin when tag-filtering
-via `taginclude` or `tagexclude`. This removes the need to specify local tags
-twice. The option is only effective if tag-filtering is performed.
 
 ### Filtering Examples
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -676,6 +676,11 @@ The inverse of `taginclude`. Tags with a tag key matching one of the patterns
 will be discarded from the metric.  Any tag can be filtered including global
 tags and the agent `host` tag.
 
+- **always_include_local_tags**:
+If `true` always include the tags specified in the plugin when tag-filtering
+via `taginclude` or `tagexclude`. This removes the need to specify local tags
+twice. The option is only effective if tag-filtering is performed.
+
 ### Filtering Examples
 
 #### Using tagpass and tagdrop


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12361

Currently _all_ tags of a plugin are filtered using `taginclude` and `tagexclude`. This also includes tags explicitly declared in the plugin. As a result when defining
```toml
[[inputs.myplugin]]
  taginclude = [ "namespace", "url" ]
  
  [inputs.myplugin.tags]
    app = "myapp"
```
the explicitly defined `app` tag will be filtered out. This PR adds a new `always_include_local_tags` agent option to override this behavior. When set to `true` _all_ locally defined tags are preserved and pass filtering.