### PR TITLE
docs: Fix markdownlinter issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Check out our [guidelines](/docs/EXTERNAL_PLUGINS.md#external-plugin-guidelines)
 ## Security Vulnerability Reporting
 
 InfluxData takes security and our users' trust very seriously. If you believe you have found a security issue in any of our
-open source projects, please responsibly disclose it by contacting security@influxdata.com. More details about
+open source projects, please responsibly disclose it by contacting `security@influxdata.com`. More details about
 security vulnerability reporting,
 including our GPG key, [can be found here](https://www.influxdata.com/how-to-report-security-vulnerabilities/).
 

--- a/plugins/inputs/bind/README.md
+++ b/plugins/inputs/bind/README.md
@@ -41,7 +41,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 - **urls** []string: List of BIND statistics channel URLs to collect from.
   Do not include a trailing slash in the URL.
-  Default is "http://localhost:8053/xml/v3".
+  Default is `http://localhost:8053/xml/v3`.
 - **gather_memory_contexts** bool: Report per-context memory statistics.
 - **gather_views** bool: Report per-view query statistics.
 - **timeout** Timeout for http requests made by bind (example: "4s").

--- a/plugins/outputs/clarify/README.md
+++ b/plugins/outputs/clarify/README.md
@@ -19,14 +19,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 [[outputs.clarify]]
   ## Credentials File (Oauth 2.0 from Clarify integration)
   credentials_file = "/path/to/clarify/credentials.json"
-  
+
   ## Clarify username password (Basic Auth from Clarify integration)
   username = "i-am-bob"
   password = "secret-password"
-  
+
   ## Timeout for Clarify operations
   # timeout = "20s"
-  
+
   ## Optional tags to be included when generating the unique ID for a signal in Clarify
   # id_tags = []
   # clarify_id_tag = 'clarify_input_id'
@@ -83,5 +83,4 @@ temperature,host=demo.clarifylocal,sensor=TC0P value=49 1682670910000000000
 ```
 
 [clarify]: https://clarify.io
-[clarifydoc]: https://docs.clarify.io
 [credentials]: https://docs.clarify.io/users/admin/integrations/credentials


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR fixes the following linter issues found with markdownlint version 0.34.0:

```text
docs/developers/README.md:57:68 MD034/no-bare-urls Bare URL used [Context: "security@influxdata.com"]
plugins/inputs/bind/README.md:44:15 MD034/no-bare-urls Bare URL used [Context: "http://localhost:8053/xml/v3"]
plugins/outputs/clarify/README.md:86:1 MD053/link-image-reference-definitions Link and image reference definitions should be needed [Unused link or image reference definition: "clarifydoc"] [Context: "[clarifydoc]: https://docs.cla..."]
```