### PR TITLE
chore: produce single digest file with sha256sum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,10 +540,9 @@ jobs:
             case "${target}"
             in
               *.deb|*.dmg|*.rpm|*.tar.gz|*.zip)
-                # Combine the metadata from the *.DIGESTS and *.asc files into one
-                # listing. Since the gpg signature contains multiple lines which
-                # must be preserved, it is base64 encoded.
-                printf '%s %s %s\n' "${target}" "$(awk '{ print $1 }' "${target}.DIGESTS")" "$(base64 -w 0 <"${target}.asc")" >>"telegraf-${CIRCLE_TAG}-digests"
+                # Print sha256 hash and target for artifacts all in one file
+                # for use later during the release.
+                cat "${target}.DIGESTS" >> "telegraf-${CIRCLE_TAG}.DIGESTS"
               ;;
             esac
           done


### PR DESCRIPTION
This will update the name of the digests file that is produced to ensure it is uploaded to S3. Additionally, it removes the unneeded signatures and switches the order so that the hash is listed first, then the filename as is more common. As this is already produced in the individual digests we are essentially only combining them all into one.