### PR TITLE
docs: added info to secretstores: not all plugin options support secrets.

### DIFF
--- a/plugins/secretstores/docker/README.md
+++ b/plugins/secretstores/docker/README.md
@@ -72,9 +72,12 @@ Referencing the secret within a plugin occurs by:
   password = "@{docker_secretstore:secret_for_plugin}"
 ```
 
-See the plugin documentation to find out if the respective plugin option supports secrets.
+To see which plugins and options support secrets, see their respective
+documentation (e.g. `plugins/outputs/influxdb/README.md`). If the plugin's
+README has the `Secret-store support` section, it will detail what options
+support secret store usage.
 
-## Additonal Information
+## Additional Information
 
 [Docker Secrets in Swarm][2]
 

--- a/plugins/secretstores/docker/README.md
+++ b/plugins/secretstores/docker/README.md
@@ -71,6 +71,7 @@ Referencing the secret within a plugin occurs by:
 [[inputs.<some_plugin>]]
   password = "@{docker_secretstore:secret_for_plugin}"
 ```
+See the plugin documentation to find out if the respective plugin option supports secrets.
 
 ## Additonal Information
 

--- a/plugins/secretstores/docker/README.md
+++ b/plugins/secretstores/docker/README.md
@@ -71,6 +71,7 @@ Referencing the secret within a plugin occurs by:
 [[inputs.<some_plugin>]]
   password = "@{docker_secretstore:secret_for_plugin}"
 ```
+
 See the plugin documentation to find out if the respective plugin option supports secrets.
 
 ## Additonal Information

--- a/plugins/secretstores/http/README.md
+++ b/plugins/secretstores/http/README.md
@@ -12,6 +12,7 @@ telegraf secrets help
 to get more information on how to do this.
 
 ## How to use the secrets
+
 Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options of plugins which support this.
 To see which plugins and options support this, see their respective documentation. (Ex: outputs.influxdb)
 

--- a/plugins/secretstores/http/README.md
+++ b/plugins/secretstores/http/README.md
@@ -11,6 +11,10 @@ telegraf secrets help
 
 to get more information on how to do this.
 
+## How to use the secrets
+Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options of plugins which support this.
+To see which plugins and options support this, see their respective documentation. (Ex: outputs.influxdb)
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/secretstores/http/README.md
+++ b/plugins/secretstores/http/README.md
@@ -13,8 +13,9 @@ to get more information on how to do this.
 
 ## How to use the secrets
 
-Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options of plugins which support this.
-To see which plugins and options support this, see their respective documentation. (Ex: outputs.influxdb)
+Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options
+of plugins which support this. To see which plugins and options support this,
+see their respective documentation (e.g. `plugins/outputs/influxdb/README.md`).
 
 ## Configuration
 

--- a/plugins/secretstores/http/README.md
+++ b/plugins/secretstores/http/README.md
@@ -14,8 +14,11 @@ to get more information on how to do this.
 ## How to use the secrets
 
 Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options
-of plugins which support this. To see which plugins and options support this,
-see their respective documentation (e.g. `plugins/outputs/influxdb/README.md`).
+of plugins which support this. To see which plugins and options support
+secrets, see their respective documentation
+(e.g. `plugins/outputs/influxdb/README.md`). If the plugin's README has the
+`Secret-store support` section, it will detail what options support secret
+store usage.
 
 ## Configuration
 

--- a/plugins/secretstores/jose/README.md
+++ b/plugins/secretstores/jose/README.md
@@ -12,6 +12,7 @@ telegraf secrets help
 to get more information on how to do this.
 
 ## How to use the secrets
+
 Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options of plugins which support this.
 To see which plugins and options support this, see their respective documentation. (Ex: outputs.influxdb)
 

--- a/plugins/secretstores/jose/README.md
+++ b/plugins/secretstores/jose/README.md
@@ -11,6 +11,10 @@ telegraf secrets help
 
 to get more information on how to do this.
 
+## How to use the secrets
+Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options of plugins which support this.
+To see which plugins and options support this, see their respective documentation. (Ex: outputs.influxdb)
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/secretstores/jose/README.md
+++ b/plugins/secretstores/jose/README.md
@@ -13,8 +13,12 @@ to get more information on how to do this.
 
 ## How to use the secrets
 
-Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options of plugins which support this.
-To see which plugins and options support this, see their respective documentation. (Ex: outputs.influxdb)
+Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options
+of plugins which support this. To see which plugins and options support
+secrets, see their respective documentation
+(e.g. `plugins/outputs/influxdb/README.md`). If the plugin's README has the
+`Secret-store support` section, it will detail what options support secret
+store usage.
 
 ## Configuration
 

--- a/plugins/secretstores/os/README.md
+++ b/plugins/secretstores/os/README.md
@@ -14,6 +14,7 @@ telegraf secrets help
 to get more information on how to do this with Telegraf.
 
 ## How to use the secrets
+
 Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options of plugins which support this.
 To see which plugins and options support this, see their respective documentation. (Ex: outputs.influxdb)
 

--- a/plugins/secretstores/os/README.md
+++ b/plugins/secretstores/os/README.md
@@ -15,8 +15,12 @@ to get more information on how to do this with Telegraf.
 
 ## How to use the secrets
 
-Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options of plugins which support this.
-To see which plugins and options support this, see their respective documentation. (Ex: outputs.influxdb)
+Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options
+of plugins which support this. To see which plugins and options support
+secrets, see their respective documentation
+(e.g. `plugins/outputs/influxdb/README.md`). If the plugin's README has the
+`Secret-store support` section, it will detail what options support secret
+store usage.
 
 ## Configuration
 

--- a/plugins/secretstores/os/README.md
+++ b/plugins/secretstores/os/README.md
@@ -13,6 +13,10 @@ telegraf secrets help
 
 to get more information on how to do this with Telegraf.
 
+## How to use the secrets
+Secrets can be referenced with `@{<store-id>:<secret_key>}` in certain options of plugins which support this.
+To see which plugins and options support this, see their respective documentation. (Ex: outputs.influxdb)
+
 ## Configuration
 
 The configuration differs slightly depending on the Operating System. We first


### PR DESCRIPTION
# Required for all PRs

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.  / does not apply. Only changed docs.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13328

Added a section (in the docker secretstore README.md only one line) in the secretstore README.mds to document how secrets are referenced and mentioning that this doesn't work everywhere but only in certain plugins and options.
