### PR TITLE
chore: fix touch command

### DIFF
--- a/scripts/deb/post-install.sh
+++ b/scripts/deb/post-install.sh
@@ -60,7 +60,7 @@ test -d "$STATE_DIR" || {
 
 STATE_FILE="$STATE_DIR/statefile"
 test -f "$STATE_FILE" || {
-    touch -h "$STATE_FILE"
+    touch "$STATE_FILE"
     chown root:telegraf "$STATE_FILE"
     chmod 660 "$STATE_FILE"
 }

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -39,7 +39,7 @@ test -d "$STATE_DIR" || {
 
 STATE_FILE="$STATE_DIR/statefile"
 test -f "$STATE_FILE" || {
-    touch -h "$STATE_FILE"
+    touch "$STATE_FILE"
     chown root:telegraf "$STATE_FILE"
     chmod 660 "$STATE_FILE"
 }


### PR DESCRIPTION
The -h option is used to update a timestamp, but the file does not exist, so we do not want this option. Touch will not create the file when using this option either.

