### PR TITLE
fix(CI): Replace last 'cat' instance in tests

### DIFF
--- a/plugins/processors/execd/testcases/defaults/telegraf.conf
+++ b/plugins/processors/execd/testcases/defaults/telegraf.conf
@@ -1,2 +1,2 @@
 [[processors.execd]]
-  command = ["cat"]
+  command = ["go", "run", "testcases/pass-through.go"]


### PR DESCRIPTION
This replaces the last `cat` instance in the `processors.execd` unit-tests that leads to flaky tests especially for MacOS...