### PR TITLE
chore: Clean up secret store usage

### DIFF
--- a/cmd/telegraf/cmd_secretstore.go
+++ b/cmd/telegraf/cmd_secretstore.go
@@ -236,7 +236,7 @@ you will be prompted to enter the value of the secret.
 						key := args.Get(1)
 						value := args.Get(2)
 						if value == "" {
-							fmt.Printf("enter secret: ")
+							fmt.Printf("Enter secret value: ")
 							b, err := term.ReadPassword(int(os.Stdin.Fd()))
 							if err != nil {
 								return err

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -103,6 +103,7 @@ func (t *Telegraf) ListSecretStores() ([]string, error) {
 }
 
 func (t *Telegraf) GetSecretStore(id string) (telegraf.SecretStore, error) {
+	t.quiet = true
 	c, err := t.loadConfiguration()
 	if err != nil {
 		return nil, err

--- a/plugins/secretstores/README.md
+++ b/plugins/secretstores/README.md
@@ -2,6 +2,9 @@
 
 This folder contains the plugins for the secret-store functionality:
 
+* docker: Docker Secrets within containers
+* http: Query secrets from an HTTP endpoint
 * jose: Javascript Object Signing and Encryption
 * os: Native tooling provided on Linux, MacOS, or Windows.
-* docker: Docker Secrets within containers
+
+See each plugin's README for additional details.

--- a/plugins/secretstores/http/README.md
+++ b/plugins/secretstores/http/README.md
@@ -16,6 +16,11 @@ to get more information on how to do this.
 ```toml @sample.conf
 # Read secrets from a HTTP endpoint
 [[secretstores.http]]
+  ## Unique identifier for the secret-store.
+  ## This id can later be used in plugins to reference the secrets
+  ## in this secret-store via @{<id>:<secret_key>} (mandatory)
+  id = "secretstore"
+
   ## URLs from which to read the secrets
   url = "http://localhost/secrets"
 

--- a/plugins/secretstores/http/sample.conf
+++ b/plugins/secretstores/http/sample.conf
@@ -1,5 +1,10 @@
 # Read secrets from a HTTP endpoint
 [[secretstores.http]]
+  ## Unique identifier for the secret-store.
+  ## This id can later be used in plugins to reference the secrets
+  ## in this secret-store via @{<id>:<secret_key>} (mandatory)
+  id = "secretstore"
+
   ## URLs from which to read the secrets
   url = "http://localhost/secrets"
 


### PR DESCRIPTION
This makes the following updates:

* Update generic secret store README with additional details
* Ensure `id` is in each sample config & README
* Hide loading files log message
* Enhance the enter secret message to make clearer