### PR TITLE
feat(inputs.kafka_consumer): Refresh regexp topics periodically

### DIFF
--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -50,6 +50,12 @@ to use them.
   ## Example: topic_regexps = [ "*test", "metric[0-9A-z]*" ]
   # topic_regexps = [ ]
 
+  ## Topic regexp refresh interval.  If enabled, and if regular expressions
+  ## are enabled, available topics will be rescanned at this interval to
+  ## determine whether new ones are present.
+  ## Exmaple: topic_refresh_interval = "5m"
+  # topic_refresh_interval = ""
+
   ## When set this tag will be added to all metrics with the topic as the value.
   # topic_tag = ""
 

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -168,7 +168,6 @@ func (k *KafkaConsumer) Init() error {
 		}
 		k.topicClient = client
 	}
-
 	return nil
 }
 
@@ -311,6 +310,7 @@ func (k *KafkaConsumer) handleTicker(acc telegraf.Accumulator) {
 }
 
 func (k *KafkaConsumer) consumeTopics(ctx context.Context, acc telegraf.Accumulator) {
+	k.Log.Debug("consumeTopics")
 	k.wg.Add(1)
 	defer k.wg.Done()
 	go func() {
@@ -386,6 +386,9 @@ func (k *KafkaConsumer) restartConsumer(acc telegraf.Accumulator) error {
 func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 	var err error
 
+	k.Log.Debugf("TopicRegexps: %v", k.TopicRegexps)
+	k.Log.Debugf("TopicRefreshInterval: %v", k.TopicRefreshInterval)
+	
 	// If TopicRegexps is set, add matches to Topics
 	if len(k.TopicRegexps) > 0 {
 		if _, err = k.changedTopics(); err != nil {

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -312,7 +312,6 @@ func (k *KafkaConsumer) handleTicker(acc telegraf.Accumulator) {
 }
 
 func (k *KafkaConsumer) consumeTopics(ctx context.Context, acc telegraf.Accumulator) {
-	k.Log.Debug("consumeTopics")
 	k.wg.Add(1)
 	defer k.wg.Done()
 	go func() {
@@ -321,8 +320,8 @@ func (k *KafkaConsumer) consumeTopics(ctx context.Context, acc telegraf.Accumula
 			// We need to copy allWantedTopics; the Consume() is
 			// long-running and we can easily deadlock if our
 			// topic-update-checker fires.
-			topics := make([]string, len(k.allWantedTopics))
 			k.topicLock.Lock()
+			topics := make([]string, len(k.allWantedTopics))
 			copy(topics, k.allWantedTopics)
 			k.topicLock.Unlock()
 			err := k.consumer.Consume(ctx, topics, handler)

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -388,7 +388,7 @@ func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 
 	k.Log.Debugf("TopicRegexps: %v", k.TopicRegexps)
 	k.Log.Debugf("TopicRefreshInterval: %v", k.TopicRefreshInterval)
-	
+
 	// If TopicRegexps is set, add matches to Topics
 	if len(k.TopicRegexps) > 0 {
 		if _, err = k.changedTopics(); err != nil {

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -285,12 +285,15 @@ func (k *KafkaConsumer) refreshTopics(acc telegraf.Accumulator) error {
 			oldConsumer := k.consumer
 			k.consumer = newConsumer
 			k.cancel = cancel
-			k.Log.Debug("closing old consumer group")
-			err = oldConsumer.Close()
-			if err != nil {
-				acc.AddError(err)
-				return err
-			}
+			// Do this in the background
+			go func() {
+				k.Log.Debug("closing old consumer group")
+				err = oldConsumer.Close()
+				if err != nil {
+					acc.AddError(err)
+					return
+				}
+			}()
 			k.Log.Info("starting new consumer group")
 			// Lock would end here.
 			k.consumeTopics(ctx, acc)

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -262,6 +262,8 @@ func (k *KafkaConsumer) refreshTopics(acc telegraf.Accumulator) error {
 			k.cancel = cancel
 			k.consumeTopics(ctx, acc)
 		}
+	} else {
+		k.Log.Debugf("topic list unchanged on refresh")
 	}
 	return nil
 }
@@ -353,13 +355,15 @@ func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 			k.wg.Add(1)
 			go func() {
 				defer k.wg.Done()
+				dstr := time.Duration(k.TopicRefreshInterval).String()
+				k.Log.Infof("starting refresh ticker: scanning topics every %s", dstr)
 				for {
 					select {
 					case <-done:
 						k.Log.Info("refresh ticker shutting down")
 						return
 					case <-k.ticker.C:
-						k.Log.Infof("received topic refresh request (every %v)", k.TopicRefreshInterval)
+						k.Log.Debugf("received topic refresh request (every %s)", dstr)
 						k.refreshTopics(acc)
 					}
 				}

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -214,7 +214,7 @@ func (k *KafkaConsumer) changedTopics() (bool, error) {
 		return false, err
 	}
 	sort.Strings(allDiscoveredTopics)
-	k.Log.Debugf("discovered %d topics", len(allDiscoveredTopics))
+	k.Log.Debugf("discovered %d topics in total", len(allDiscoveredTopics))
 
 	extantTopicSet := make(map[string]bool, len(allDiscoveredTopics))
 	for _, t := range allDiscoveredTopics {
@@ -249,6 +249,7 @@ func (k *KafkaConsumer) changedTopics() (bool, error) {
 	}
 	sort.Strings(topicList)
 	fingerprint := strings.Join(topicList, ";")
+	k.Log.Debugf("Regular expression list %q matched %d topics", k.TopicRegexps, len(topicList))
 	if fingerprint != k.fingerprint {
 		k.Log.Infof("updating topics: replacing %q with %q", k.allWantedTopics, topicList)
 		k.topicLock.Lock()

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -204,6 +204,11 @@ func (k *KafkaConsumer) refreshTopics(acc telegraf.Accumulator) error {
 		return nil
 	}
 
+	// Refresh metadata for all topics.
+	err := k.topicClient.RefreshMetadata()
+	if err != nil {
+		return err
+	}
 	allDiscoveredTopics, err := k.topicClient.Topics()
 	if err != nil {
 		return err

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -678,7 +678,7 @@ func TestDynamicTopicRefresh(t *testing.T) {
 				Topics:                 tt.topics,
 				TopicRegexps:           tt.topicRegexps,
 				TopicRefreshInterval:   tt.topicRefreshInterval,
-				MaxUndeliveredMessages: 1000,  // Default
+				MaxUndeliveredMessages: 1000, // Default
 				ConnectionStrategy:     tt.connectionStrategy,
 			}
 			parser := &influx.Parser{}

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -678,7 +678,7 @@ func TestDynamicTopicRefresh(t *testing.T) {
 				Topics:                 tt.topics,
 				TopicRegexps:           tt.topicRegexps,
 				TopicRefreshInterval:   tt.topicRefreshInterval,
-				MaxUndeliveredMessages: 1,
+				MaxUndeliveredMessages: 1000,  // Default
 				ConnectionStrategy:     tt.connectionStrategy,
 			}
 			parser := &influx.Parser{}

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -476,10 +476,10 @@ func TestKafkaRoundTripIntegration(t *testing.T) {
 	}
 
 	var tests = []struct {
-		name                 string
-		connectionStrategy   string
-		topics               []string
-		topicRegexps         []string
+		name               string
+		connectionStrategy string
+		topics             []string
+		topicRegexps       []string
 	}{
 		{"connection strategy startup", "startup", []string{"Test"}, nil},
 		{"connection strategy defer", "defer", []string{"Test"}, nil},

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -484,9 +484,12 @@ func TestKafkaRoundTripIntegration(t *testing.T) {
 	}{
 		{"connection strategy startup", "startup", []string{"Test"}, nil, config.Duration(0)},
 		{"connection strategy defer", "defer", []string{"Test"}, nil, config.Duration(0)},
-		{"topic regexp", "startup", nil, []string{"T*"}, config.Duration(5 * time.Second)},
+		{"topic regexp", "startup", nil, []string{"T*"}, config.Duration(0)},
+		{"topic regexp with refresh", "startup", nil, []string{"T*"}, config.Duration(5 * time.Second)},
 	}
 
+	// FIXME: I don't see how to inject a new topic into the broker
+	// with the docker container, needed for testing refresh end-to-end.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Logf("rt: starting network")

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -591,6 +591,9 @@ func TestKafkaRoundTripIntegration(t *testing.T) {
 }
 
 func TestDynamicTopicRefresh(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 	var tests = []struct {
 		name                 string
 		connectionStrategy   string

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -712,27 +712,48 @@ func TestDynamicTopicRefresh(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
-			// FIXME it should not be necessary to delay.  If we
-			// push a metric through and THEN a consumer comes
-			// online, that should be OK.  But maybe it isn't?
+			// FIXME: more often than not, we do not see
+			// the injected metrics.  Having tested on a
+			// live installation, where I receive all the
+			// messages at up to 100Hz reliably, I'm
+			// pretty sure it's a fault in the test
+			// harness rather than the implementation, but
+			// I do not understand what is going on.  I
+			// wonder if this is the same thing as in line
+			// 316 (search for 'flappy').  Help would be
+			// greatly appreciated.
+
+			// Whether or not we consume a backlog is
+			// dependent on the "offset" configuration
+			// setting.  The default is "oldest", so we
+			// shouldn't need a delay.  But since the test
+			// case isn't working consistently, I put one
+			// in.  It doesn't seem to matter, but it will
+			// make iterating on this a little easier if
+			// someone decides to tackle this later on.
+			// Delay or not, or length of delay, does not
+			// seem to make a difference in testing.  Nor does
+			// varying offset between "oldest" and "newest".
 			delay := 4 * time.Second // For easy experimentation
 			// Wait for new consumer group to come online
 			if delay > 0 {
 				t.Logf("rt: waiting %v ns for consumer group", delay)
 				time.Sleep(delay)
+				t.Logf("rt: consumer group delay complete")
 			}
 			// Shove some metrics through
-			// The writing seems to work...
+			// The writing claims to always work...
 			expected := testutil.MockMetrics()
 			t.Logf("rt: writing %v to %s", expected, output.Topic)
 			require.NoError(t, output.Write(expected))
 
 			// Check that they were received
 			t.Logf("rt: expecting")
-			// FIXME And this usually hangs and we never read.
+			// This usually hangs and we never read.
 			// Sometimes, though, we do read the expected data.
 			// Why?
 			acc.Wait(len(expected))
+			t.Logf("rt: received %d", len(expected))
 			q := acc.GetTelegrafMetrics()
 			t.Logf("rt: received metrics %v", q)
 			testutil.RequireMetricsEqual(t, expected, q)

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -704,7 +704,11 @@ func TestDynamicTopicRefresh(t *testing.T) {
 				return				
 			}
 			t.Logf("rt: creating new Kafkfa topic")
-			err = admin.CreateTopic("TestDynamic", new(sarama.TopicDetail), false)
+			detail := sarama.TopicDetail{
+				NumPartitions:1,
+				ReplicationFactor: 1,
+			}
+			err = admin.CreateTopic("TestDynamic", &detail, false)
 			if err != nil {
 				require.Error(t, err)
 				return				

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -10,6 +10,12 @@
   ## Example: topic_regexps = [ "*test", "metric[0-9A-z]*" ]
   # topic_regexps = [ ]
 
+  ## Topic regexp refresh interval.  If enabled, and if regular expressions
+  ## are enabled, available topics will be rescanned at this interval to
+  ## determine whether new ones are present.
+  ## Exmaple: topic_refresh_interval = "5m"
+  # topic_refresh_interval = ""
+
   ## When set this tag will be added to all metrics with the topic as the value.
   # topic_tag = ""
 


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

~With a caveat: I do not see how, in the current test framework, to dynamically add/remove topics from the test broker.  So all we're really testing in the new test is that the configuration is valid and if the topics never change, then the consumer works.~

~I've tested this at my installation, where I can use Kafdrop to mess around with the topic list, and verified that when the periodic timer goes off, the right thing happens...but being told how to get this test suite to change the available topics would be good.~

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #13409 

New feature: if kafka_consumers regular expressions are given for topic matching, periodically rescan topics to see whether there are topics that should be added or removed.

In installations like Rubin Observatory's, topics are created and destroyed with some frequency, and we would rather not have to restart telegraf to pick up the changes.

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Added periodic refresh to check for updated topics and if found, create and swap in a new consumer group to consume those topics.