### PR TITLE
fix: Handle compression level correctly for different algorithms

### DIFF
--- a/internal/content_coding_test.go
+++ b/internal/content_coding_test.go
@@ -120,6 +120,93 @@ func TestStreamGzipDecode(t *testing.T) {
 	require.Equal(t, []byte("howdy"), b[:n])
 }
 
+func TestCompressionLevel(t *testing.T) {
+	tests := []struct {
+		algorithm   string
+		compression string
+		errormsg    string
+	}{
+		{
+			algorithm:   "gzip",
+			compression: "default",
+		},
+		{
+			algorithm:   "gzip",
+			compression: "none",
+		},
+		{
+			algorithm:   "gzip",
+			compression: "best compression",
+		},
+		{
+			algorithm:   "gzip",
+			compression: "best speed",
+		},
+		{
+			algorithm:   "gzip",
+			compression: "invalid",
+			errormsg:    "invalid compression level",
+		},
+		{
+			algorithm:   "zlib",
+			compression: "default",
+		},
+		{
+			algorithm:   "zlib",
+			compression: "none",
+		},
+		{
+			algorithm:   "zlib",
+			compression: "best compression",
+		},
+		{
+			algorithm:   "zlib",
+			compression: "best speed",
+		},
+		{
+			algorithm:   "zlib",
+			compression: "invalid",
+			errormsg:    "invalid compression level",
+		},
+		{
+			algorithm:   "identity",
+			compression: "default",
+		},
+		{
+			algorithm:   "identity",
+			compression: "none",
+		},
+		{
+			algorithm:   "identity",
+			compression: "best compression",
+		},
+		{
+			algorithm:   "identity",
+			compression: "best speed",
+		},
+		{
+			algorithm:   "identity",
+			compression: "invalid",
+			errormsg:    "invalid compression level",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.algorithm+" "+tt.compression, func(t *testing.T) {
+			level, err := ToCompressionLevel(tt.compression)
+			if tt.errormsg != "" {
+				require.ErrorContains(t, err, tt.errormsg)
+				return
+			}
+			require.NoError(t, err)
+
+			enc, err := NewContentEncoder(tt.algorithm, WithCompressionLevel(level))
+			require.NoError(t, err)
+			require.NotNil(t, enc)
+		})
+	}
+}
+
 func BenchmarkGzipEncode(b *testing.B) {
 	data := []byte(strings.Repeat("-howdy stranger-", 64))
 	dataLen := int64(len(data)) + 1

--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -37,7 +37,7 @@ func TestAutoEncoding(t *testing.T) {
 	require.NoError(t, err)
 	acc.AssertContainsFields(t, "measurementName", map[string]interface{}{"fieldKey": "gzip"})
 
-	encIdentity := internal.NewIdentityEncoder()
+	encIdentity, err := internal.NewIdentityEncoder()
 	require.NoError(t, err)
 	payload, err = encIdentity.Encode([]byte(`measurementName2 fieldKey="identity" 1556813561098000000`))
 	require.NoError(t, err)


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

replaces #13424

This PR maps the given, standardized compression level to the individual values for each compression algorithm. Furthermore, we add a function to map a string configuration value to the defined levels.