### PR TITLE
feat(inputs.pgbouncer): Added show_commands to select the collected pgbouncer metrics

### DIFF
--- a/plugins/inputs/pgbouncer/README.md
+++ b/plugins/inputs/pgbouncer/README.md
@@ -32,9 +32,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   address = "host=localhost user=pgbouncer sslmode=disable"
 
   ## Specify which "show" commands to gather metrics for.
-  ## Valid options: "stats", "pools", "lists", "databases"
-  ## If the parameter is not specified, the "stats" and "pools" metrics will be collected
-  # show_commands = ["stats", "pools", "lists", "databases"]
+  ## Choose from: "stats", "pools", "lists", "databases"
+  # show_commands = ["stats", "pools"]
 ```
 
 ### `address`

--- a/plugins/inputs/pgbouncer/README.md
+++ b/plugins/inputs/pgbouncer/README.md
@@ -30,6 +30,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## All connection parameters are optional.
   ##
   address = "host=localhost user=pgbouncer sslmode=disable"
+
+  ## Specify which "show" commands to gather metrics for.
+  ## Valid options: "stats", "pools", "lists", "databases"
+  ## If the parameter is not specified, the "stats" and "pools" metrics will be collected
+  # show_commands = ["stats", "pools", "lists", "databases"]
 ```
 
 ### `address`
@@ -89,9 +94,45 @@ the server and doesn't restrict the databases we are trying to grab metrics for.
     - sv_tested
     - sv_used
 
+- pgbouncer_lists
+  - tags:
+    - db
+    - server
+    - user
+  - fields:
+    - databases
+    - users
+    - pools
+    - free_clients
+    - used_clients
+    - login_clients
+    - free_servers
+    - used_servers
+    - dns_names
+    - dns_zones
+    - dns_queries
+
+- pgbouncer_databases
+  - tags:
+    - db
+    - pg_dbname
+    - server
+    - user
+  - fields:
+    - current_connections
+    - pool_size
+    - min_pool_size
+    - reserve_pool
+    - max_connections
+    - paused
+    - disabled
+
 ## Example Output
 
 ```text
 pgbouncer,db=pgbouncer,server=host\=debian-buster-postgres\ user\=dbn\ port\=6432\ dbname\=pgbouncer\  avg_query_count=0i,avg_query_time=0i,avg_wait_time=0i,avg_xact_count=0i,avg_xact_time=0i,total_query_count=26i,total_query_time=0i,total_received=0i,total_sent=0i,total_wait_time=0i,total_xact_count=26i,total_xact_time=0i 1581569936000000000
 pgbouncer_pools,db=pgbouncer,pool_mode=statement,server=host\=debian-buster-postgres\ user\=dbn\ port\=6432\ dbname\=pgbouncer\ ,user=pgbouncer cl_active=1i,cl_waiting=0i,maxwait=0i,maxwait_us=0i,sv_active=0i,sv_idle=0i,sv_login=0i,sv_tested=0i,sv_used=0i 1581569936000000000
+pgbouncer_lists,db=pgbouncer,server=host\=debian-buster-postgres\ user\=dbn\ port\=6432\ dbname\=pgbouncer\ ,user=pgbouncer databases=1i,dns_names=0i,dns_queries=0i,dns_zones=0i,free_clients=47i,free_servers=0i,login_clients=0i,pools=1i,used_clients=3i,used_servers=0i,users=4i 1581569936000000000
+pgbouncer_databases,db=pgbouncer,pg_dbname=pgbouncer,server=host\=debian-buster-postgres\ user\=dbn\ port\=6432\ dbname\=pgbouncer\ name=pgbouncer disabled=0i,pool_size=2i,current_connections=0i,min_pool_size=0i,reserve_pool=0i,max_connections=0i,paused=0i 1581569936000000000
+pgbouncer_databases,db=postgres,pg_dbname=postgres,server=host\=debian-buster-postgres\ user\=dbn\ port\=6432\ dbname\=pgbouncer\ name=postgres current_connections=0i,disabled=0i,pool_size=20i,min_pool_size=0i,reserve_pool=0i,paused=0i,max_connections=0i 1581569936000000000
 ```

--- a/plugins/inputs/pgbouncer/pgbouncer.go
+++ b/plugins/inputs/pgbouncer/pgbouncer.go
@@ -105,7 +105,7 @@ func (p *PgBouncer) accRow(row scanner, columns []string) (map[string]string, ma
 	} else {
 		_, err := dbname.WriteString("postgres")
 		if err != nil {
-			return nil, nil, fmt.Errorf("writing database name failed: %w", err)
+			return nil, nil, fmt.Errorf("writing 'postgres' failed: %w", err)
 		}
 	}
 

--- a/plugins/inputs/pgbouncer/pgbouncer.go
+++ b/plugins/inputs/pgbouncer/pgbouncer.go
@@ -71,13 +71,11 @@ type scanner interface {
 	Scan(dest ...interface{}) error
 }
 
-func (p *PgBouncer) accRow(row scanner, columns []string) (map[string]string,
-	map[string]*interface{}, error) {
+func (p *PgBouncer) accRow(row scanner, columns []string) (map[string]string, map[string]*interface{}, error) {
 	var dbname bytes.Buffer
 
 	// this is where we'll store the column name with its *interface{}
 	columnMap := make(map[string]*interface{})
-
 	for _, column := range columns {
 		columnMap[column] = new(interface{})
 	}
@@ -90,17 +88,18 @@ func (p *PgBouncer) accRow(row scanner, columns []string) (map[string]string,
 
 	// deconstruct array of variables and send to Scan
 	err := row.Scan(columnVars...)
-
 	if err != nil {
 		return nil, nil, err
 	}
 	if columnMap["database"] != nil {
 		// extract the database name from the column map
-		if _, err := dbname.WriteString((*columnMap["database"]).(string)); err != nil {
+		_, err := dbname.WriteString((*columnMap["database"]).(string))
+		if err != nil {
 			return nil, nil, err
 		}
 	} else {
-		if _, err := dbname.WriteString("postgres"); err != nil {
+		_, err := dbname.WriteString("postgres")
+		if err != nil {
 			return nil, nil, err
 		}
 	}
@@ -117,14 +116,7 @@ func (p *PgBouncer) accRow(row scanner, columns []string) (map[string]string,
 
 func (p *PgBouncer) showStats(acc telegraf.Accumulator) error {
 	// STATS
-	var (
-		err     error
-		query   string
-		columns []string
-	)
-	query = `SHOW STATS`
-
-	rows, err := p.DB.Query(query)
+	rows, err := p.DB.Query(`SHOW STATS`)
 	if err != nil {
 		return err
 	}
@@ -132,7 +124,7 @@ func (p *PgBouncer) showStats(acc telegraf.Accumulator) error {
 	defer rows.Close()
 
 	// grab the column information from the result
-	columns, err = rows.Columns()
+	columns, err := rows.Columns()
 	if err != nil {
 		return err
 	}
@@ -173,14 +165,7 @@ func (p *PgBouncer) showStats(acc telegraf.Accumulator) error {
 
 func (p *PgBouncer) showPools(acc telegraf.Accumulator) error {
 	// POOLS
-	var (
-		err     error
-		query   string
-		columns []string
-	)
-	query = `SHOW POOLS`
-
-	poolRows, err := p.DB.Query(query)
+	poolRows, err := p.DB.Query(`SHOW POOLS`)
 	if err != nil {
 		return err
 	}
@@ -188,7 +173,7 @@ func (p *PgBouncer) showPools(acc telegraf.Accumulator) error {
 	defer poolRows.Close()
 
 	// grab the column information from the result
-	columns, err = poolRows.Columns()
+	columns, err := poolRows.Columns()
 	if err != nil {
 		return err
 	}
@@ -226,14 +211,7 @@ func (p *PgBouncer) showPools(acc telegraf.Accumulator) error {
 
 func (p *PgBouncer) showLists(acc telegraf.Accumulator) error {
 	// LISTS
-	var (
-		err     error
-		query   string
-		columns []string
-	)
-	query = `SHOW LISTS`
-
-	rows, err := p.DB.Query(query)
+	rows, err := p.DB.Query(`SHOW LISTS`)
 	if err != nil {
 		return err
 	}
@@ -241,7 +219,7 @@ func (p *PgBouncer) showLists(acc telegraf.Accumulator) error {
 	defer rows.Close()
 
 	// grab the column information from the result
-	columns, err = rows.Columns()
+	columns, err := rows.Columns()
 	if err != nil {
 		return err
 	}
@@ -266,20 +244,14 @@ func (p *PgBouncer) showLists(acc telegraf.Accumulator) error {
 
 func (p *PgBouncer) showDatabase(acc telegraf.Accumulator) error {
 	// DATABASES
-	var (
-		err     error
-		query   string
-		columns []string
-	)
-	query = `SHOW DATABASES`
-	rows, err := p.DB.Query(query)
+	rows, err := p.DB.Query(`SHOW DATABASES`)
 	if err != nil {
 		return err
 	}
 	defer rows.Close()
 
 	// grab the column information from the result
-	columns, err = rows.Columns()
+	columns, err := rows.Columns()
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/pgbouncer/pgbouncer_test.go
+++ b/plugins/inputs/pgbouncer/pgbouncer_test.go
@@ -34,7 +34,7 @@ func TestPgBouncerGeneratesMetricsIntegration(t *testing.T) {
 	defer backend.Terminate()
 
 	container := testutil.Container{
-		Image:        "z9pascal/pgbouncer-container:1.17.0-latest",
+		Image:        "z9pascal/pgbouncer-container:1.18.0-latest",
 		ExposedPorts: []string{pgBouncerServicePort},
 		Env: map[string]string{
 			"PG_ENV_POSTGRESQL_USER": "pgbouncer",
@@ -93,8 +93,6 @@ func TestPgBouncerGeneratesMetricsIntegration(t *testing.T) {
 		"maxwait",
 	}
 
-	int32Metrics := []string{}
-
 	metricsCounted := 0
 
 	for _, metric := range intMetricsPgBouncer {
@@ -107,11 +105,125 @@ func TestPgBouncerGeneratesMetricsIntegration(t *testing.T) {
 		metricsCounted++
 	}
 
-	for _, metric := range int32Metrics {
-		require.True(t, acc.HasInt32Field("pgbouncer", metric))
+	require.True(t, metricsCounted > 0)
+	require.Equal(t, len(intMetricsPgBouncer)+len(intMetricsPgBouncerPools), metricsCounted)
+}
+
+func TestPgBouncerGeneratesMetricsIntegrationShowCommands(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	postgresServicePort := "5432"
+	pgBouncerServicePort := "6432"
+
+	backend := testutil.Container{
+		Image:        "postgres:alpine",
+		ExposedPorts: []string{postgresServicePort},
+		Env: map[string]string{
+			"POSTGRES_HOST_AUTH_METHOD": "trust",
+		},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+	}
+	err := backend.Start()
+	require.NoError(t, err, "failed to start container")
+	defer backend.Terminate()
+
+	container := testutil.Container{
+		Image:        "z9pascal/pgbouncer-container:1.18.0-latest",
+		ExposedPorts: []string{pgBouncerServicePort},
+		Env: map[string]string{
+			"PG_ENV_POSTGRESQL_USER": "pgbouncer",
+			"PG_ENV_POSTGRESQL_PASS": "pgbouncer",
+		},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(nat.Port(pgBouncerServicePort)),
+			wait.ForLog("LOG process up"),
+		),
+	}
+	err = container.Start()
+	require.NoError(t, err, "failed to start container")
+	defer container.Terminate()
+
+	addr := fmt.Sprintf(
+		"host=%s user=pgbouncer password=pgbouncer dbname=pgbouncer port=%s sslmode=disable",
+		container.Address,
+		container.Ports[pgBouncerServicePort],
+	)
+
+	p := &PgBouncer{
+		Service: postgresql.Service{
+			Address:     config.NewSecret([]byte(addr)),
+			IsPgBouncer: true,
+		},
+		ShowCommands: []string{"pools", "lists", "databases"},
+	}
+
+	var acc testutil.Accumulator
+	require.NoError(t, p.Start(&acc))
+	require.NoError(t, p.Gather(&acc))
+
+	// Return value of pgBouncer
+	// [pgbouncer_pools map[db:pgbouncer pool_mode:statement server:host=localhost user=pgbouncer dbname=pgbouncer port=6432  user:pgbouncer]
+	// map[cl_active:1 cl_waiting:0 maxwait:0 maxwait_us:0 sv_active:0 sv_idle:0 sv_login:0 sv_tested:0 sv_used:0] 1620163750041444466
+	// [pgbouncer_lists map[server:host=localhost]
+	// map[databases:1 dns_names:0 dns_queries:0 dns_zones:0 free_clients:49 free_servers:0 login_clients:0 pools:1 used_clients:1 used_servers:0 users:2]
+	// [pgbouncer_databases map[db:pgbouncer pg_dbname:pgbouncer server:host=localhost]
+	// map[current_connections:0 disabled:0 max_connections:0 min_pool_size:0 paused:0 pool_size:2 reserve_pool:0]
+
+	intMetricsPgBouncerPools := []string{
+		"cl_active",
+		"cl_waiting",
+		"sv_active",
+		"sv_idle",
+		"sv_used",
+		"sv_tested",
+		"sv_login",
+		"maxwait",
+	}
+
+	intMetricsPgBouncerLists := []string{
+		"databases",
+		"users",
+		"pools",
+		"free_clients",
+		"used_clients",
+		"login_clients",
+		"free_servers",
+		"used_servers",
+		"dns_names",
+		"dns_zones",
+		"dns_queries",
+	}
+
+	intMetricsPgBouncerDatabases := []string{
+		"pool_size",
+		"min_pool_size",
+		"reserve_pool",
+		"max_connections",
+		"current_connections",
+		"paused",
+		"disabled",
+	}
+
+	metricsCounted := 0
+
+	for _, metric := range intMetricsPgBouncerPools {
+		require.True(t, acc.HasInt64Field("pgbouncer_pools", metric))
+		metricsCounted++
+	}
+
+	for _, metric := range intMetricsPgBouncerLists {
+		require.True(t, acc.HasInt64Field("pgbouncer_lists", metric))
+		metricsCounted++
+	}
+
+	for _, metric := range intMetricsPgBouncerDatabases {
+		fmt.Println(acc)
+		require.True(t, acc.HasInt64Field("pgbouncer_databases", metric))
 		metricsCounted++
 	}
 
 	require.True(t, metricsCounted > 0)
-	require.Equal(t, len(intMetricsPgBouncer)+len(intMetricsPgBouncerPools)+len(int32Metrics), metricsCounted)
+	require.Equal(t, len(intMetricsPgBouncerPools)+len(intMetricsPgBouncerLists)+len(intMetricsPgBouncerDatabases), metricsCounted)
 }

--- a/plugins/inputs/pgbouncer/pgbouncer_test.go
+++ b/plugins/inputs/pgbouncer/pgbouncer_test.go
@@ -219,7 +219,6 @@ func TestPgBouncerGeneratesMetricsIntegrationShowCommands(t *testing.T) {
 	}
 
 	for _, metric := range intMetricsPgBouncerDatabases {
-		fmt.Println(acc)
 		require.True(t, acc.HasInt64Field("pgbouncer_databases", metric))
 		metricsCounted++
 	}

--- a/plugins/inputs/pgbouncer/pgbouncer_test.go
+++ b/plugins/inputs/pgbouncer/pgbouncer_test.go
@@ -66,13 +66,6 @@ func TestPgBouncerGeneratesMetricsIntegration(t *testing.T) {
 	require.NoError(t, p.Start(&acc))
 	require.NoError(t, p.Gather(&acc))
 
-	// Return value of pgBouncer
-	// [pgbouncer map[db:pgbouncer server:host=localhost user=pgbouncer dbname=pgbouncer port=6432 ]
-	// map[avg_query_count:0 avg_query_time:0 avg_wait_time:0 avg_xact_count:0 avg_xact_time:0 total_query_count:3 total_query_time:0 total_received:0
-	// total_sent:0 total_wait_time:0 total_xact_count:3 total_xact_time:0] 1620163750039747891 pgbouncer_pools map[db:pgbouncer pool_mode:statement
-	// server:host=localhost user=pgbouncer dbname=pgbouncer port=6432  user:pgbouncer] map[cl_active:1 cl_waiting:0 maxwait:0 maxwait_us:0
-	// sv_active:0 sv_idle:0 sv_login:0 sv_tested:0 sv_used:0] 1620163750041444466]
-
 	intMetricsPgBouncer := []string{
 		"total_received",
 		"total_sent",
@@ -162,14 +155,6 @@ func TestPgBouncerGeneratesMetricsIntegrationShowCommands(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, p.Start(&acc))
 	require.NoError(t, p.Gather(&acc))
-
-	// Return value of pgBouncer
-	// [pgbouncer_pools map[db:pgbouncer pool_mode:statement server:host=localhost user=pgbouncer dbname=pgbouncer port=6432  user:pgbouncer]
-	// map[cl_active:1 cl_waiting:0 maxwait:0 maxwait_us:0 sv_active:0 sv_idle:0 sv_login:0 sv_tested:0 sv_used:0] 1620163750041444466
-	// [pgbouncer_lists map[server:host=localhost]
-	// map[databases:1 dns_names:0 dns_queries:0 dns_zones:0 free_clients:49 free_servers:0 login_clients:0 pools:1 used_clients:1 used_servers:0 users:2]
-	// [pgbouncer_databases map[db:pgbouncer pg_dbname:pgbouncer server:host=localhost]
-	// map[current_connections:0 disabled:0 max_connections:0 min_pool_size:0 paused:0 pool_size:2 reserve_pool:0]
 
 	intMetricsPgBouncerPools := []string{
 		"cl_active",

--- a/plugins/inputs/pgbouncer/sample.conf
+++ b/plugins/inputs/pgbouncer/sample.conf
@@ -11,6 +11,5 @@
   address = "host=localhost user=pgbouncer sslmode=disable"
 
   ## Specify which "show" commands to gather metrics for.
-  ## Valid options: "stats", "pools", "lists", "databases"
-  ## If the parameter is not specified, the "stats" and "pools" metrics will be collected
-  # show_commands = ["stats", "pools", "lists", "databases"]
+  ## Choose from: "stats", "pools", "lists", "databases"
+  # show_commands = ["stats", "pools"]

--- a/plugins/inputs/pgbouncer/sample.conf
+++ b/plugins/inputs/pgbouncer/sample.conf
@@ -9,3 +9,8 @@
   ## All connection parameters are optional.
   ##
   address = "host=localhost user=pgbouncer sslmode=disable"
+
+  ## Specify which "show" commands to gather metrics for.
+  ## Valid options: "stats", "pools", "lists", "databases"
+  ## If the parameter is not specified, the "stats" and "pools" metrics will be collected
+  # show_commands = ["stats", "pools", "lists", "databases"]


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

In PR #11706 it was proposed to add the show_commands parameter to select the metrics to be collected.

Added the ability to choose which metrics to collect
Added the ability to collect metrics using show lists and show databases
