### PR TITLE
test: do not use /tmp/telegraf

### DIFF
--- a/plugins/inputs/bcache/bcache_test.go
+++ b/plugins/inputs/bcache/bcache_test.go
@@ -23,15 +23,17 @@ const (
 	cacheReadaheads     = "2"
 )
 
-var (
-	testBcachePath           = os.TempDir() + "/telegraf/sys/fs/bcache"
-	testBcacheUUIDPath       = testBcachePath + "/663955a3-765a-4737-a9fd-8250a7a78411"
-	testBcacheDevPath        = os.TempDir() + "/telegraf/sys/devices/virtual/block/bcache0"
-	testBcacheBackingDevPath = os.TempDir() + "/telegraf/sys/devices/virtual/block/md10"
-)
-
 func TestBcacheGeneratesMetrics(t *testing.T) {
-	err := os.MkdirAll(testBcacheUUIDPath, 0750)
+	tmpDir, err := os.MkdirTemp("", "telegraf-bcache")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	testBcachePath := tmpDir + "/telegraf-bcache/sys/fs/bcache"
+	testBcacheUUIDPath := testBcachePath + "/663955a3-765a-4737-a9fd-8250a7a78411"
+	testBcacheDevPath := tmpDir + "/telegraf/sys/devices/virtual/block/bcache0"
+	testBcacheBackingDevPath := tmpDir + "/telegraf/sys/devices/virtual/block/md10"
+
+	err = os.MkdirAll(testBcacheUUIDPath, 0750)
 	require.NoError(t, err)
 
 	err = os.MkdirAll(testBcacheDevPath, 0750)
@@ -108,7 +110,4 @@ func TestBcacheGeneratesMetrics(t *testing.T) {
 	err = b.Gather(&acc)
 	require.NoError(t, err)
 	acc.AssertContainsTaggedFields(t, "bcache", fields, tags)
-
-	err = os.RemoveAll(os.TempDir() + "/telegraf")
-	require.NoError(t, err)
 }

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -132,11 +132,15 @@ const mdtJobStatsContents = `job_stats:
 `
 
 func TestLustre2GeneratesMetrics(t *testing.T) {
-	tempdir := os.TempDir() + "/telegraf/proc/fs/lustre/"
+	tmpDir, err := os.MkdirTemp("", "telegraf-lustre")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	tempdir := tmpDir + "/telegraf/proc/fs/lustre/"
 	ostName := "OST0001"
 
 	mdtdir := tempdir + "/mdt/"
-	err := os.MkdirAll(mdtdir+"/"+ostName, 0750)
+	err = os.MkdirAll(mdtdir+"/"+ostName, 0750)
 	require.NoError(t, err)
 
 	osddir := tempdir + "/osd-ldiskfs/"
@@ -198,17 +202,18 @@ func TestLustre2GeneratesMetrics(t *testing.T) {
 	}
 
 	acc.AssertContainsTaggedFields(t, "lustre2", fields, tags)
-
-	err = os.RemoveAll(os.TempDir() + "/telegraf")
-	require.NoError(t, err)
 }
 
 func TestLustre2GeneratesClientMetrics(t *testing.T) {
-	tempdir := os.TempDir() + "/telegraf/proc/fs/lustre/"
+	tmpDir, err := os.MkdirTemp("", "telegraf-lustre-client")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	tempdir := tmpDir + "/telegraf/proc/fs/lustre/"
 	ostName := "OST0001"
 	clientName := "10.2.4.27@o2ib1"
 	mdtdir := tempdir + "/mdt/"
-	err := os.MkdirAll(mdtdir+"/"+ostName+"/exports/"+clientName, 0750)
+	err = os.MkdirAll(mdtdir+"/"+ostName+"/exports/"+clientName, 0750)
 	require.NoError(t, err)
 
 	obddir := tempdir + "/obdfilter/"
@@ -261,18 +266,19 @@ func TestLustre2GeneratesClientMetrics(t *testing.T) {
 	}
 
 	acc.AssertContainsTaggedFields(t, "lustre2", fields, tags)
-
-	err = os.RemoveAll(os.TempDir() + "/telegraf")
-	require.NoError(t, err)
 }
 
 func TestLustre2GeneratesJobstatsMetrics(t *testing.T) {
-	tempdir := os.TempDir() + "/telegraf/proc/fs/lustre/"
+	tmpDir, err := os.MkdirTemp("", "telegraf-lustre-jobstats")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	tempdir := tmpDir + "/telegraf/proc/fs/lustre/"
 	ostName := "OST0001"
 	jobNames := []string{"cluster-testjob1", "testjob2"}
 
 	mdtdir := tempdir + "/mdt/"
-	err := os.MkdirAll(mdtdir+"/"+ostName, 0750)
+	err = os.MkdirAll(mdtdir+"/"+ostName, 0750)
 	require.NoError(t, err)
 
 	obddir := tempdir + "/obdfilter/"
@@ -389,11 +395,6 @@ func TestLustre2GeneratesJobstatsMetrics(t *testing.T) {
 	for index := 0; index < len(fields); index++ {
 		acc.AssertContainsTaggedFields(t, "lustre2", fields[index], tags[index])
 	}
-
-	// run this over both tags
-
-	err = os.RemoveAll(os.TempDir() + "/telegraf")
-	require.NoError(t, err)
 }
 
 func TestLustre2CanParseConfiguration(t *testing.T) {

--- a/plugins/inputs/zfs/zfs_linux_test.go
+++ b/plugins/inputs/zfs/zfs_linux_test.go
@@ -193,10 +193,13 @@ scatter_page_alloc_retry        4    99311
 scatter_sg_table_retry          4    99221
 `
 
-var testKstatPath = os.TempDir() + "/telegraf/proc/spl/kstat/zfs"
-
 func TestZfsPoolMetrics(t *testing.T) {
-	err := os.MkdirAll(testKstatPath, 0750)
+	tmpDir, err := os.MkdirTemp("", "telegraf-zfs-pool")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	testKstatPath := tmpDir + "/telegraf/proc/spl/kstat/zfs"
+	err = os.MkdirAll(testKstatPath, 0750)
 	require.NoError(t, err)
 
 	err = os.MkdirAll(testKstatPath+"/HOME", 0750)
@@ -242,13 +245,18 @@ func TestZfsPoolMetrics(t *testing.T) {
 
 	poolMetrics = getPoolMetricsNewFormat()
 	acc.AssertContainsTaggedFields(t, "zfs_pool", poolMetrics, tags)
-
-	err = os.RemoveAll(os.TempDir() + "/telegraf")
-	require.NoError(t, err)
 }
 
 func TestZfsGeneratesMetrics(t *testing.T) {
-	err := os.MkdirAll(testKstatPath, 0750)
+	tmpDir, err := os.MkdirTemp("", "telegraf-zfs-generates")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	testKstatPath := tmpDir + "/telegraf/proc/spl/kstat/zfs"
+	err = os.MkdirAll(testKstatPath, 0750)
+	require.NoError(t, err)
+
+	err = os.MkdirAll(testKstatPath, 0750)
 	require.NoError(t, err)
 
 	err = os.MkdirAll(testKstatPath+"/HOME", 0750)
@@ -319,9 +327,6 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	acc3.AssertContainsTaggedFields(t, "zfs", intMetrics, tags)
-
-	err = os.RemoveAll(os.TempDir() + "/telegraf")
-	require.NoError(t, err)
 }
 
 func TestGetTags(t *testing.T) {


### PR DESCRIPTION
Rather than using a hard-coded `/tmp/telegraf` path as a place for tmp files during testing, this updates the bcache, lustre2 and zfs input's tests to uses MkdirTemp function to create a unique path. This was discovered after checking out telegraf to `/tmp` and then running tests. Each of those tests will remove the directory I have checked out to.