### PR TITLE
chore: update golanglint-ci

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,5 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.53.2
           args: --timeout 15m0s --verbose --out-${NO_FUTURE}format tab

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,7 @@ linters-settings:
           - pkg: log
             desc: 'Use injected telegraf.Logger instead'
         files:
+          - "$all"
           - "!**/agent/**"
           - "!**/cmd/**"
           - "!**/config/**"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 linters:
   disable-all: true
   enable:
-    # - telegraflinter
     - asasalint
     - asciicheck
     - bidichk
@@ -39,44 +38,26 @@ linters:
 
 linters-settings:
   depguard:
-    # Kind of list is passed in.
-    # Allowed values: allowlist|denylist
-    # Default: denylist
-    list-type: denylist
-    # Check the list against standard lib.
-    # Default: false
-    include-go-root: true
-    # A list of packages for the list type specified.
-    # Can accept both string prefixes and string glob patterns.
-    # Default: []
-    packages:
-      - log
-    # A list of packages for the list type specified.
-    # Specify an error message to output when a denied package is used.
-    # Default: []
-    packages-with-error-message:
-      - log: 'Use injected telegraf.Logger instead'
-    # Specify rules by which the linter ignores certain files for consideration.
-    # Can accept both string prefixes and string glob patterns.
-    # The ! character in front of the rule is a special character
-    # which signals that the linter should negate the rule.
-    # This allows for more precise control, but it is only available for glob patterns.
-    # Default: []
-    ignore-file-rules:
-      - "**/agent/**"
-      - "**/cmd/**"
-      - "**/config/**"
-      - "**/filter/**"
-      - "**/internal/**"
-      - "**/logger/**"
-      - "**/metric/**"
-      - "**/models/**"
-      - "**/plugins/serializers/**"
-      - "**/scripts/**"
-      - "**/selfstat/**"
-      - "**/testutil/**"
-      - "**/tools/**"
-      - "**/*_test.go"
+    rules:
+      main:
+        deny:
+          - pkg: log
+            desc: 'Use injected telegraf.Logger instead'
+        files:
+          - "!**/agent/**"
+          - "!**/cmd/**"
+          - "!**/config/**"
+          - "!**/filter/**"
+          - "!**/internal/**"
+          - "!**/logger/**"
+          - "!**/metric/**"
+          - "!**/models/**"
+          - "!**/plugins/serializers/**"
+          - "!**/scripts/**"
+          - "!**/selfstat/**"
+          - "!**/testutil/**"
+          - "!**/tools/**"
+          - "!**/*_test.go"
   errcheck:
     # List of functions to exclude from checking, where each entry is a single function to exclude.
     # See https://github.com/kisielk/errcheck#excluding-functions for details.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,12 +39,15 @@ linters:
 linters-settings:
   depguard:
     rules:
+      # Name of a rule.
       main:
+        # Packages that are not allowed where the value is a suggestion.
         deny:
           - pkg: log
             desc: 'Use injected telegraf.Logger instead'
+        # List of file globs that will match this list of settings to compare against.
+        # Default: $all
         files:
-          - "$all"
           - "!**/agent/**"
           - "!**/cmd/**"
           - "!**/config/**"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-community@influxdata.com.
+`community@influxdata.com`.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.2
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,5 +2,10 @@
 
 ## Reporting a Vulnerability
 
-InfluxData takes security and our users' trust very seriously. If you believe you have found a security issue in any of our open source projects,
-please responsibly disclose it by contacting security@influxdata.com. More details about security vulnerability reporting, including our GPG key, can be found [here](https://www.influxdata.com/how-to-report-security-vulnerabilities/).
+InfluxData takes security and our users' trust very seriously. If you believe
+you have found a security issue in any of our open source projects, please
+responsibly disclose it by contacting `security@influxdata.com`. More details
+about security vulnerability reporting, including our GPG key, can be found
+on the [InfluxData How to Report Vulnerabilities page][InfluxData Security].
+
+[InfluxData Security]: https://www.influxdata.com/how-to-report-security-vulnerabilities/


### PR DESCRIPTION
Fixes issues with latest version of golanglint-ci and the changed depguard settings in the config.

Updates a few markdown linter bare URLs.