### PR TITLE
test: Use -e to print newlines on yum tests

### DIFF
--- a/tools/package_lxd_test/container.go
+++ b/tools/package_lxd_test/container.go
@@ -195,7 +195,7 @@ func (c *Container) configureYum() error {
 	err := c.client.Exec(
 		c.Name,
 		"bash", "-c", "--",
-		fmt.Sprintf("echo %q > /etc/yum.repos.d/influxdata.repo", influxDataRPMRepo),
+		fmt.Sprintf("echo -e %q > /etc/yum.repos.d/influxdata.repo", influxDataRPMRepo),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
In #13435, the tests which use `dnf` as a package manager were updated to ensure newlines were printed. This updates the tests which use `yum`, which is the one test I was not able to run locally. 

Looking at the test output it is the same issue, when doing an `yum update`:

```s
File contains no section headers.
file: file:///etc/yum.repos.d/influxdata.repo, line: 1
'[influxdata]\\nname = InfluxData Repository - Stable\\nbaseurl = https://repos.influxdata.com/stable/x86_64/main\\nenabled = 1\\ngpgcheck = 1\\ngpgkey = https://repos.influxdata.com/influxdata-archive_compat.key\\n\n'
```

The echo did not format the entry correctly.