### PR TITLE
feat(inputs.fail2ban): Allow specification of socket

### DIFF
--- a/plugins/inputs/fail2ban/README.md
+++ b/plugins/inputs/fail2ban/README.md
@@ -24,7 +24,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Read metrics from fail2ban.
 [[inputs.fail2ban]]
   ## Use sudo to run fail2ban-client
-  use_sudo = false
+  # use_sudo = false
+
+  ## Use the given socket instead of the default one
+  # socket = "/var/run/fail2ban/fail2ban.sock"
 ```
 
 ## Using sudo

--- a/plugins/inputs/fail2ban/fail2ban.go
+++ b/plugins/inputs/fail2ban/fail2ban.go
@@ -21,8 +21,9 @@ var (
 )
 
 type Fail2ban struct {
+	UseSudo bool   `toml:"use_sudo"`
+	Socket  string `toml:"socket"`
 	path    string
-	UseSudo bool
 }
 
 var metricsTargets = []struct {
@@ -69,14 +70,17 @@ func (f *Fail2ban) Gather(acc telegraf.Accumulator) error {
 	}
 
 	name := f.path
-	var arg []string
+	var args []string
 
 	if f.UseSudo {
 		name = "sudo"
-		arg = append(arg, f.path)
+		args = append(args, f.path)
 	}
 
-	args := append(arg, "status")
+	if f.Socket != "" {
+		args = append(args, "--socket", f.Socket)
+	}
+	args = append(args, "status")
 
 	cmd := execCommand(name, args...)
 	out, err := cmd.Output()
@@ -97,9 +101,12 @@ func (f *Fail2ban) Gather(acc telegraf.Accumulator) error {
 	}
 
 	for _, jail := range jails {
+		// Skip over empty jails
+		if jail == "" {
+			continue
+		}
 		fields := make(map[string]interface{})
-		args := append(arg, "status", jail)
-		cmd := execCommand(name, args...)
+		cmd := execCommand(name, append(args, jail)...)
 		out, err := cmd.Output()
 		if err != nil {
 			return fmt.Errorf("failed to run command %q: %w - %s", strings.Join(cmd.Args, " "), err, string(out))

--- a/plugins/inputs/fail2ban/sample.conf
+++ b/plugins/inputs/fail2ban/sample.conf
@@ -1,4 +1,7 @@
 # Read metrics from fail2ban.
 [[inputs.fail2ban]]
   ## Use sudo to run fail2ban-client
-  use_sudo = false
+  # use_sudo = false
+
+  ## Use the given socket instead of the default one
+  # socket = "/var/run/fail2ban/fail2ban.sock"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR allows to specify the `socket` for `fail2ban-client` to read from via config setting. This is relevant if you host multiple fail2ban servers (each with a different socket). Another use-case is when running fail2ban in a Docker container and export the socket to a custom location via
```shell
# docker run --name fail2ban -v /my/custom/location/fail2ban:/var/run/fail2ban:rw ... 
```