### PR TITLE
fix: replace altool with notarytool

### DIFF
--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -7,6 +7,71 @@ function cleanup () {
   rm -rf Telegraf.app
 }
 
+function archive_notarize()
+{
+  target="${1}"
+
+  # submit archive for notarization, extract uuid
+  uuid="$(
+    # This extracts the value from `notarytool's` output. Unfortunately,
+    # the 'id' is written to multiple times in the output. This requires
+    # `awk` to `exit` after the first instance. However, doing so closes
+    # `stdout` for `notarytool` which results with error code 141. This
+    # takes the *complete* output from `notarytool` then
+    # parses it with `awk`.
+    awk '{ if ( $1 == "id:" ) { $1 = ""; print $0; exit 0; } }' \
+      <<< "$(
+        # shellcheck disable=SC2154
+        xcrun notarytool submit \
+          --apple-id "${AppleUsername}" \
+          --password "${ApplePassword}" \
+          --team-id 'M7DN9H35QT' \
+          "${target}"
+      )"
+  )"
+  shopt -s extglob
+  uuid="${uuid%%+([[:space:]])}"  # strips leading whitespace
+  uuid="${uuid##+([[:space:]])}"  # strips trailing whitespace
+
+  if [[ -z "${uuid}" ]]; then
+    exit 1
+  fi
+
+  # loop until notarization is complete
+  while true ; do
+    sleep 10
+
+    response="$(
+      # This extracts the value from `notarytool's` output. Unfortunately,
+      # the 'id' is written to multiple times in the output. This requires
+      # `awk` to `exit` after the first instance. However, doing so closes
+      # `stdout` for `notarytool` which results with error code 141. This
+      # takes the *complete* output from `notarytool` then
+      # parses it with `awk`.
+      awk '{ if ( $1 == "status:" ) { $1 = ""; print $0; exit 0; } }' \
+        <<< "$(
+          # shellcheck disable=SC2154
+          xcrun notarytool info \
+            --apple-id "${AppleUsername}" \
+            --password "${ApplePassword}" \
+            --team-id 'M7DN9H35QT' \
+            "${uuid}"
+        )"
+    )"
+    shopt -s extglob
+    response="${response%%+([[:space:]])}"  # strips leading whitespace
+    response="${response##+([[:space:]])}"  # strips trailing whitespace
+
+    if [[ "${response}" != 'In Progress' ]] ; then
+      break
+    fi
+  done
+
+  if [[ "${response}" != 'Accepted' ]]; then
+    exit 1
+  fi
+}
+
 # Acquire the necessary certificates.
 # MacCertificate, MacCertificatePassword, AppleSigningAuthorityCertificate are environment variables, to follow convention they should have been all caps.
 # shellcheck disable=SC2154
@@ -68,32 +133,7 @@ do
   hdiutil create -size 500m -volname Telegraf -srcfolder Telegraf.app "$baseName".dmg
   codesign -s "$DeveloperID" --timestamp --options=runtime "$baseName".dmg
 
-  # Send the DMG to be notarized.
-  # AppleUsername and ApplePassword are environment variables, to follow convention they should have been all caps.
-  # shellcheck disable=SC2154
-  uuid=$(xcrun altool --notarize-app --primary-bundle-id "com.influxdata.telegraf" --username "$AppleUsername" --password "$ApplePassword" --file "$baseName".dmg | awk '/RequestUUID/ { print $NF; }')
-  echo "UUID: $uuid"
-  if [[ $uuid == "" ]]; then
-    echo "Could not upload for notarization."
-    exit 1
-  fi
-
-  printf "\n"
-
-  # Wait until the status returns something other than 'in progress'.
-  request_status="in progress"
-  while [[ "$request_status" == "in progress" ]]; do
-    sleep 10
-    request_response=$(xcrun altool --notarization-info "$uuid" --username "$AppleUsername" --password "$ApplePassword" 2>&1)
-    request_status=$(echo "$request_response" | awk -F ': ' '/Status:/ { print $2; }' )
-  done
-
-  if [[ $request_status != "success" ]]; then
-    echo "Failed to notarize."
-    echo "$request_response"
-    cleanup
-    exit 1
-  fi
+  archive_notarize "${baseName}.dmg"
 
   # Attach the notarization to the DMG.
   xcrun stapler staple "$baseName".dmg


### PR DESCRIPTION
Apple has deprecated `altool` and intends for `notarytool` to replace it. This replaces the `altool` in the mac signing script. The output for `notarytool`  uses a different syntax than `altool`. So, the code that validates that the notarization occurred had to be changed as well.