### PR TITLE
fix(inputs.mqtt_consumer): Correctly handle semaphores on messages

### DIFF
--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -261,18 +261,11 @@ func (m *MQTTConsumer) onMessage(_ mqtt.Client, msg mqtt.Message) {
 	m.messagesRecv.Incr(1)
 
 	metrics, err := m.parser.Parse(msg.Payload())
-	if err != nil {
+	if err != nil || len(metrics) == 0 {
 		if m.PersistentSession {
 			msg.Ack()
 		}
 		m.acc.AddError(err)
-		<-m.sem
-		return
-	}
-	if len(metrics) == 0 {
-		if m.PersistentSession {
-			msg.Ack()
-		}
 		<-m.sem
 		return
 	}


### PR DESCRIPTION
The recent changes to the mqtt_consumer to ack messages would not
release semaphores when an error occured during parsing. This resulted
in Telegraf to seemingly to receving metrics once it reached the limit
of the max undelievered messages.

The change ensures that whenever we error or do not have any metrics
during the initial message handling we also decrement the semaphores.

Additionally, this ensures that we only ack messages when persistence is
enabled.

fixes: #13476
