### PR TITLE
fix(inputs.modbus): Check number of register for datatype

### DIFF
--- a/plugins/inputs/modbus/configuration_register.go
+++ b/plugins/inputs/modbus/configuration_register.go
@@ -235,7 +235,7 @@ func (c *ConfigurationOriginal) validateFieldDefinitions(fieldDefs []fieldDefini
 			case "UINT64", "INT64", "FLOAT64-IEEE":
 				requiredAddresses = 4
 			}
-			if len(item.Address) != requiredAddresses {
+			if requiredAddresses > 0 && len(item.Address) != requiredAddresses {
 				return fmt.Errorf(
 					"invalid address '%v' length '%v'in %q - %q, expecting %d entries for datatype",
 					item.Address, len(item.Address), registerType, item.Name, requiredAddresses,

--- a/plugins/inputs/modbus/configuration_register.go
+++ b/plugins/inputs/modbus/configuration_register.go
@@ -224,12 +224,30 @@ func (c *ConfigurationOriginal) validateFieldDefinitions(fieldDefs []fieldDefini
 				return fmt.Errorf("invalid byte order %q and address '%v'  in %q - %q", item.ByteOrder, item.Address, registerType, item.Name)
 			}
 
+			// Check for the request size corresponding to the data-type
+			var requiredAddresses int
+			switch item.DataType {
+			case "INT8L", "INT8H", "UINT8L", "UINT8H", "UINT16", "INT16", "FLOAT16-IEEE":
+				requiredAddresses = 1
+			case "UINT32", "INT32", "FLOAT32-IEEE":
+				requiredAddresses = 2
+
+			case "UINT64", "INT64", "FLOAT64-IEEE":
+				requiredAddresses = 4
+			}
+			if len(item.Address) != requiredAddresses {
+				return fmt.Errorf(
+					"invalid address '%v' length '%v'in %q - %q, expecting %d entries for datatype",
+					item.Address, len(item.Address), registerType, item.Name, requiredAddresses,
+				)
+			}
+
 			// search duplicated
 			if len(item.Address) > len(removeDuplicates(item.Address)) {
 				return fmt.Errorf("duplicate address '%v'  in %q - %q", item.Address, registerType, item.Name)
 			}
 		} else if len(item.Address) != 1 {
-			return fmt.Errorf("invalid address'%v' length'%v' in %q - %q", item.Address, len(item.Address), registerType, item.Name)
+			return fmt.Errorf("invalid address '%v' length '%v'in %q - %q", item.Address, len(item.Address), registerType, item.Name)
 		}
 	}
 	return nil

--- a/plugins/inputs/modbus/testcases/field_request_too_short_issue_13482/init.err
+++ b/plugins/inputs/modbus/testcases/field_request_too_short_issue_13482/init.err
@@ -1,0 +1,1 @@
+invalid address

--- a/plugins/inputs/modbus/testcases/field_request_too_short_issue_13482/telegraf.conf
+++ b/plugins/inputs/modbus/testcases/field_request_too_short_issue_13482/telegraf.conf
@@ -1,0 +1,9 @@
+[[inputs.modbus]]
+  name = "Device"
+  slave_id = 1
+  timeout = "1s"
+  controller = "tcp://localhost:502"
+
+  holding_registers = [
+    { name = "data", byte_order = "DCBA",   data_type = "UINT64", scale=0.01, address = [0, 1]}
+  ]


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13482 

Check if the number of registers matches the field's datatype to prevent a panic.