### PR TITLE
feat(parsers.value): Add support for automatic fallback for numeric types

### DIFF
--- a/plugins/outputs/mqtt/mqtt_test.go
+++ b/plugins/outputs/mqtt/mqtt_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/common/mqtt"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
-	"github.com/influxdata/telegraf/plugins/parsers/value"
 	influxSerializer "github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -597,13 +596,6 @@ func TestIntegrationMQTTLayoutHomieV4(t *testing.T) {
 	}
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()
-
-	// Setup the parser / serializer pair
-	parser := &value.Parser{
-		MetricName: "test",
-		DataType:   "auto",
-	}
-	require.NoError(t, parser.Init())
 
 	// Setup the plugin
 	url := fmt.Sprintf("tcp://%s:%s", container.Address, container.Ports[servicePort])

--- a/plugins/parsers/value/README.md
+++ b/plugins/parsers/value/README.md
@@ -25,14 +25,35 @@ as the parsed metric.
   data_type = "integer" # required
 ```
 
+### Metric name
+
+It is recommended to set `name_override` to a measurement name that makes sense
+for your metric, otherwise it will just be set to the name of the plugin.
+
+### Datatype
+
 You **must** tell Telegraf what type of metric to collect by using the
 `data_type` configuration option. Available options are:
 
-1. integer
-2. float or long
-3. string
-4. boolean
+- `integer`: converts the received data to an integer value. This setting will
+             produce an error on non-integer data.
+- `float`:   converts the received data to a floating-point value. This setting
+             will treat integers as floating-point values and produces an error
+             on data that cannot be converted (e.g. strings).
+- `string`:  outputs the data as a string.
+- `boolean`: converts the received data to a floating-point value. This setting
+             will produce an error on any data except for `true` and `false`
+             strings.
+- `auto_integer`: converts the received data to an integer value if possible and
+                  will return the data as string otherwise. This is helpful for
+                  mixed-type data.
+- `auto_float`: converts the received data to a floating-point value if possible
+                and will return the data as string otherwise. This is helpful
+                for mixed-type data. Integer data will be treated as
+                floating-point values.
 
-**Note:** It is also recommended that you set `name_override` to a measurement
-name that makes sense for your metric, otherwise it will just be set to the
-name of the plugin.
+**NOTE**: The `auto` conversions might convert data to their prioritized type
+by accident, for example if a string data-source provides `"55"` it will be
+converted to integer/float. This might break outputs that require the same
+datatype within a field or column. It is thus recommended to use *strict* typing
+whenever possible.

--- a/plugins/parsers/value/README.md
+++ b/plugins/parsers/value/README.md
@@ -41,9 +41,8 @@ You **must** tell Telegraf what type of metric to collect by using the
              will treat integers as floating-point values and produces an error
              on data that cannot be converted (e.g. strings).
 - `string`:  outputs the data as a string.
-- `boolean`: converts the received data to a floating-point value. This setting
-             will produce an error on any data except for `true` and `false`
-             strings.
+- `boolean`: converts the received data to a boolean value. This setting will
+             produce an error on any data except for `true` and `false` strings.
 - `auto_integer`: converts the received data to an integer value if possible and
                   will return the data as string otherwise. This is helpful for
                   mixed-type data.

--- a/plugins/parsers/value/parser.go
+++ b/plugins/parsers/value/parser.go
@@ -19,6 +19,29 @@ type Parser struct {
 	DefaultTags map[string]string `toml:"-"`
 }
 
+func (v *Parser) Init() error {
+	switch v.DataType {
+	case "", "int", "integer":
+		v.DataType = "int"
+	case "float", "long":
+		v.DataType = "float"
+	case "str", "string":
+		v.DataType = "string"
+	case "bool", "boolean":
+		v.DataType = "bool"
+	case "auto_integer", "auto_float":
+		// Do nothing both are valid
+	default:
+		return fmt.Errorf("unknown datatype %q", v.DataType)
+	}
+
+	if v.FieldName == "" {
+		v.FieldName = "value"
+	}
+
+	return nil
+}
+
 func (v *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	vStr := string(bytes.TrimSpace(bytes.Trim(buf, "\x00")))
 
@@ -35,14 +58,26 @@ func (v *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	var value interface{}
 	var err error
 	switch v.DataType {
-	case "", "int", "integer":
+	case "int":
 		value, err = strconv.Atoi(vStr)
-	case "float", "long":
+	case "float":
 		value, err = strconv.ParseFloat(vStr, 64)
-	case "str", "string":
+	case "string":
 		value = vStr
-	case "bool", "boolean":
+	case "bool":
 		value, err = strconv.ParseBool(vStr)
+	case "auto_integer":
+		value, err = strconv.Atoi(vStr)
+		if err != nil {
+			value = vStr
+			err = nil
+		}
+	case "auto_float":
+		value, err = strconv.ParseFloat(vStr, 64)
+		if err != nil {
+			value = vStr
+			err = nil
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -71,14 +106,6 @@ func (v *Parser) ParseLine(line string) (telegraf.Metric, error) {
 
 func (v *Parser) SetDefaultTags(tags map[string]string) {
 	v.DefaultTags = tags
-}
-
-func (v *Parser) Init() error {
-	if v.FieldName == "" {
-		v.FieldName = "value"
-	}
-
-	return nil
 }
 
 func init() {

--- a/plugins/parsers/value/parser_test.go
+++ b/plugins/parsers/value/parser_test.go
@@ -46,6 +46,42 @@ func TestParseValidValues(t *testing.T) {
 			input:    []byte(`55 45 223 12 999`),
 			expected: int64(999),
 		},
+		{
+			name:     "auto integer",
+			dtype:    "auto_integer",
+			input:    []byte("55"),
+			expected: int64(55),
+		},
+		{
+			name:     "auto integer with string",
+			dtype:    "auto_integer",
+			input:    []byte("foobar"),
+			expected: "foobar",
+		},
+		{
+			name:     "auto integer with float",
+			dtype:    "auto_integer",
+			input:    []byte("55.0"),
+			expected: "55.0",
+		},
+		{
+			name:     "auto float",
+			dtype:    "auto_float",
+			input:    []byte("64.2"),
+			expected: float64(64.2),
+		},
+		{
+			name:     "auto float with string",
+			dtype:    "auto_float",
+			input:    []byte("foobar"),
+			expected: "foobar",
+		},
+		{
+			name:     "auto float with integer",
+			dtype:    "auto_float",
+			input:    []byte("64"),
+			expected: float64(64),
+		},
 	}
 
 	for _, tt := range tests {
@@ -253,4 +289,12 @@ func TestParseValuesWithNullCharacter(t *testing.T) {
 		"value": int64(55),
 	}, metrics[0].Fields())
 	require.Equal(t, map[string]string{}, metrics[0].Tags())
+}
+
+func TestInvalidDatatype(t *testing.T) {
+	parser := Parser{
+		MetricName: "value_test",
+		DataType:   "foo",
+	}
+	require.ErrorContains(t, parser.Init(), "unknown datatype")
 }


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

This PR adds `auto_integer` and `auto_float` options to the value parser. Those two options allow to fallback to string if the parsing into the numeric types fails. This is helpful when the data-source produces multiple streams with mixed numeric and string data such as subscriptions to multiple MQTT topics.