### PR TITLE
fix(serializers.splunkmetric): Fix TOML option name for multi-metric

### DIFF
--- a/plugins/serializers/splunkmetric/README.md
+++ b/plugins/serializers/splunkmetric/README.md
@@ -66,42 +66,43 @@ to manage the HEC authorization, here's a sample config for an HTTP output:
 
 ```toml
 [[outputs.http]]
-   ## URL is the address to send metrics to
-   url = "https://localhost:8088/services/collector"
+  ## URL is the address to send metrics to
+  url = "https://localhost:8088/services/collector"
 
-   ## Timeout for HTTP message
-   # timeout = "5s"
+  ## Timeout for HTTP message
+  # timeout = "5s"
 
-   ## HTTP method, one of: "POST" or "PUT"
-   # method = "POST"
+  ## HTTP method, one of: "POST" or "PUT"
+  # method = "POST"
 
-   ## HTTP Basic Auth credentials
-   # username = "username"
-   # password = "pa$$word"
+  ## HTTP Basic Auth credentials
+  # username = "username"
+  # password = "pa$$word"
 
-   ## Optional TLS Config
-   # tls_ca = "/etc/telegraf/ca.pem"
-   # tls_cert = "/etc/telegraf/cert.pem"
-   # tls_key = "/etc/telegraf/key.pem"
-   ## Use TLS but skip chain & host verification
-   # insecure_skip_verify = false
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
 
-   ## Data format to output.
-   ## Each data format has it's own unique set of configuration options, read
-   ## more about them here:
-   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
-   data_format = "splunkmetric"
-    ## Provides time, index, source overrides for the HEC
-   splunkmetric_hec_routing = true
-   # splunkmetric_multimetric = true
-   # splunkmetric_omit_event_tag = false
+  ## Data format to output.
+  ## Each data format has it's own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "splunkmetric"
 
-   ## Additional HTTP headers
-    [outputs.http.headers]
-   # Should be set manually to "application/json" for json data_format
-      Content-Type = "application/json"
-      Authorization = "Splunk xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-      X-Splunk-Request-Channel = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  ## Provides time, index, source overrides for the HEC
+  splunkmetric_hec_routing = true
+  # splunkmetric_multimetric = true
+  # splunkmetric_omit_event_tag = false
+
+  ## Additional HTTP headers
+  [outputs.http.headers]
+    # Should be set manually to "application/json" for json data_format
+    Content-Type = "application/json"
+    Authorization = "Splunk xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    X-Splunk-Request-Channel = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 ```
 
 ## Overrides

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -10,7 +10,7 @@ import (
 
 type Serializer struct {
 	HecRouting   bool `toml:"splunkmetric_hec_routing"`
-	MultiMetric  bool `toml:"splunkmetric_multi_metric"`
+	MultiMetric  bool `toml:"splunkmetric_multimetric"`
 	OmitEventTag bool `toml:"splunkmetric_omit_event_tag"`
 }
 


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13510

In the course of migrating serializers to the new-style framework TOML annotations where created based in the `Config` structure in `registry.go`. However, there are subtle differences between those and the actual option parsing that was done in `config.go`. This is one instance of such a difference.

The present PR reverts the TOML option back to `splunkmetric_multimetric` as used before v1.27.0.