### PR TITLE
fix(inputs.gnmi): Add option to explicitly trim field-names

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -55,6 +55,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Enable to get the canonical path as field-name
   # canonical_field_names = false
 
+  ## Remove leading slashes and dots in field-name
+  # trim_field_names = false
+
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -57,6 +57,7 @@ type GNMI struct {
 	MaxMsgSize          config.Size       `toml:"max_msg_size"`
 	Trace               bool              `toml:"dump_responses"`
 	CanonicalFieldNames bool              `toml:"canonical_field_names"`
+	TrimFieldNames      bool              `toml:"trim_field_names"`
 	EnableTLS           bool              `toml:"enable_tls" deprecated:"1.27.0;use 'tls_enable' instead"`
 	Log                 telegraf.Logger   `toml:"-"`
 	internaltls.ClientConfig
@@ -222,6 +223,7 @@ func (c *GNMI) Start(acc telegraf.Accumulator) error {
 				tagStore:            newTagStore(c.TagSubscriptions),
 				trace:               c.Trace,
 				canonicalFieldNames: c.CanonicalFieldNames,
+				trimSlash:           c.TrimFieldNames,
 				log:                 c.Log,
 			}
 			for ctx.Err() == nil {

--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -37,6 +37,7 @@ type handler struct {
 	tagStore            *tagStore
 	trace               bool
 	canonicalFieldNames bool
+	trimSlash           bool
 	log                 telegraf.Logger
 }
 
@@ -254,7 +255,9 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 					key = path.Base(key)
 				}
 			}
-			key = strings.TrimLeft(key, "/.")
+			if h.trimSlash {
+				key = strings.TrimLeft(key, "/.")
+			}
 			if key == "" {
 				h.log.Errorf("invalid empty path: %q", k)
 				continue

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -19,6 +19,9 @@
   ## Enable to get the canonical path as field-name
   # canonical_field_names = false
 
+  ## Remove leading slashes and dots in field-name
+  # trim_field_names = false
+
   ## enable client-side TLS and define CA to authenticate the device
   # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/gnmi/testcases/canonical_field_names/expected.out
+++ b/plugins/inputs/gnmi/testcases/canonical_field_names/expected.out
@@ -1,1 +1,1 @@
-interfaces,name=eth42,path=openconfig-interfaces:/interfaces/interface,source=127.0.0.1 interfaces/interface/descr="eth42",interfaces/interface/config/id=42425u,interfaces/interface/state/in_pkts=5678u,interfaces/interface/state/out_pkts=5125u 1673608605875353770
+interfaces,name=eth42,path=openconfig-interfaces:/interfaces/interface,source=127.0.0.1 /interfaces/interface/descr="eth42",/interfaces/interface/config/id=42425u,/interfaces/interface/state/in_pkts=5678u,/interfaces/interface/state/out_pkts=5125u 1673608605875353770

--- a/plugins/inputs/gnmi/testcases/canonical_field_names_trim/expected.out
+++ b/plugins/inputs/gnmi/testcases/canonical_field_names_trim/expected.out
@@ -1,0 +1,1 @@
+interfaces,name=eth42,path=openconfig-interfaces:/interfaces/interface,source=127.0.0.1 interfaces/interface/descr="eth42",interfaces/interface/config/id=42425u,interfaces/interface/state/in_pkts=5678u,interfaces/interface/state/out_pkts=5125u 1673608605875353770

--- a/plugins/inputs/gnmi/testcases/canonical_field_names_trim/responses.json
+++ b/plugins/inputs/gnmi/testcases/canonical_field_names_trim/responses.json
@@ -1,0 +1,79 @@
+[
+    {
+        "update": {
+            "timestamp": "1673608605875353770",
+            "prefix": {
+                "origin": "openconfig-interfaces",
+                "elem": [
+                    {
+                        "name": "interfaces"
+                    },
+                    {
+                        "name": "interface",
+                        "key":{"name":"eth42"}
+                    }
+                ],
+                "target": "subscription"
+            },
+            "update": [
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "descr"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "stringVal": "eth42"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "config"
+                            },
+                            {
+                                "name": "id"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "42425"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "state"
+                            },
+                            {
+                                "name": "in-pkts"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "5678"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "state"
+                            },
+                            {
+                                "name": "out-pkts"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "5125"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/plugins/inputs/gnmi/testcases/canonical_field_names_trim/telegraf.conf
+++ b/plugins/inputs/gnmi/testcases/canonical_field_names_trim/telegraf.conf
@@ -1,0 +1,24 @@
+[[inputs.gnmi]]
+  addresses     = ["dummy"]
+  name_override = "gnmi"
+  redial        = "10s"
+  canonical_field_names = true
+  trim_field_names = true
+  [[inputs.gnmi.subscription]]
+    name              = "interfaces"
+    origin            = "openconfig-interfaces"
+    path              = "/interfaces/interface/descr"
+    subscription_mode = "sample"
+    sample_interval   = "10s"
+  [[inputs.gnmi.subscription]]
+    name              = "interfaces"
+    origin            = "openconfig-interfaces"
+    path              = "/interfaces/interface/config/id"
+    subscription_mode = "sample"
+    sample_interval   = "10s"
+  [[inputs.gnmi.subscription]]
+    name              = "interfaces"
+    origin            = "openconfig-interfaces"
+    path              = "/interfaces/interface/state"
+    subscription_mode = "sample"
+    sample_interval   = "10s"

--- a/plugins/inputs/gnmi/testcases/issue_13512/expected.out
+++ b/plugins/inputs/gnmi/testcases/issue_13512/expected.out
@@ -1,0 +1,1 @@
+interfaces,name=eth42,path=openconfig-interfaces:/interfaces/interface,source=127.0.0.1 descr="eth42",id=42425u,in_pkts=5678u,out_pkts=5125u 1673608605875353770

--- a/plugins/inputs/gnmi/testcases/issue_13512/responses.json
+++ b/plugins/inputs/gnmi/testcases/issue_13512/responses.json
@@ -1,0 +1,79 @@
+[
+    {
+        "update": {
+            "timestamp": "1673608605875353770",
+            "prefix": {
+                "origin": "openconfig-interfaces",
+                "elem": [
+                    {
+                        "name": "interfaces"
+                    },
+                    {
+                        "name": "interface",
+                        "key":{"name":"eth42"}
+                    }
+                ],
+                "target": "subscription"
+            },
+            "update": [
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "descr"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "stringVal": "eth42"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "config"
+                            },
+                            {
+                                "name": "id"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "42425"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "state"
+                            },
+                            {
+                                "name": "in-pkts"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "5678"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "state"
+                            },
+                            {
+                                "name": "out-pkts"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "5125"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/plugins/inputs/gnmi/testcases/issue_13512/telegraf.conf
+++ b/plugins/inputs/gnmi/testcases/issue_13512/telegraf.conf
@@ -1,0 +1,22 @@
+[[inputs.gnmi]]
+  addresses     = ["dummy"]
+  name_override = "gnmi"
+  redial        = "10s"
+  [[inputs.gnmi.subscription]]
+    name              = "interfaces"
+    origin            = "openconfig-interfaces"
+    path              = "/interfaces/interface/descr"
+    subscription_mode = "sample"
+    sample_interval   = "10s"
+  [[inputs.gnmi.subscription]]
+    name              = "interfaces"
+    origin            = "openconfig-interfaces"
+    path              = "/interfaces/interface/config/id"
+    subscription_mode = "sample"
+    sample_interval   = "10s"
+  [[inputs.gnmi.subscription]]
+    name              = "interfaces"
+    origin            = "openconfig-interfaces"
+    path              = "/interfaces/interface/state"
+    subscription_mode = "sample"
+    sample_interval   = "10s"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13512 

This PR adds an option to explicitly trim leading dots and slashes from field-names defaulting the new option to false (i.e. keep the leading dots and slashes). This is required to fix a regression where the field-names contain a leading slash for Telegraf versions before v1.27.0 in case a subpath matched the subscription. In this case the field-name still contained a leading slash.