### PR TITLE
fix(inputs.cloud_pubsub): Properly lock for decompression

### DIFF
--- a/plugins/inputs/cloud_pubsub/cloud_pubsub.go
+++ b/plugins/inputs/cloud_pubsub/cloud_pubsub.go
@@ -217,12 +217,11 @@ func (ps *PubSub) decompressData(data []byte) ([]byte, error) {
 	}
 
 	ps.decoderMutex.Lock()
+	defer ps.decoderMutex.Unlock()
 	data, err := ps.decoder.Decode(data)
 	if err != nil {
-		ps.decoderMutex.Unlock()
 		return nil, err
 	}
-	ps.decoderMutex.Unlock()
 
 	decompressedData := make([]byte, len(data))
 	copy(decompressedData, data)


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13513

During #13094 the decompression code was reworked and with it the locking of the decompressor changed slightly. As a consequence the mutex is unlocked just *before* copying the decompressed data out of the internal buffer leaving a small window where the next decompression could overwrite the internal buffer content partially or as a whole.

The present PR holds the lock until after copying thus avoiding the previous race condition.