### PR TITLE
fix(parsers.grok): use UTC as the default timezone

### DIFF
--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -585,7 +585,7 @@ func (p *Parser) Init() error {
 	}
 
 	if p.Timezone == "" {
-		p.Timezone = "Canada/Eastern"
+		p.Timezone = "UTC"
 	}
 
 	return p.Compile()


### PR DESCRIPTION
fixes: #13523
