### PR TITLE
fix(outputs.graphite): Rework connection handling

### DIFF
--- a/plugins/outputs/graphite/README.md
+++ b/plugins/outputs/graphite/README.md
@@ -62,7 +62,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   #]
 
   ## timeout in seconds for the write connection to graphite
-  timeout = 2
+  # timeout = "2s"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 	"github.com/influxdata/telegraf/plugins/serializers/graphite"
@@ -20,6 +21,14 @@ import (
 
 //go:embed sample.conf
 var sampleConfig string
+
+var ErrNotConnected = errors.New("could not write to any server in cluster")
+
+type connection struct {
+	name      string
+	conn      net.Conn
+	connected bool
+}
 
 type Graphite struct {
 	GraphiteTagSupport      bool   `toml:"graphite_tag_support"`
@@ -31,14 +40,12 @@ type Graphite struct {
 	Prefix    string          `toml:"prefix"`
 	Template  string          `toml:"template"`
 	Templates []string        `toml:"templates"`
-	Timeout   int             `toml:"timeout"`
+	Timeout   config.Duration `toml:"timeout"`
 	Log       telegraf.Logger `toml:"-"`
-
-	conns []net.Conn
 	tlsint.ClientConfig
-	failedServers []string
 
-	serializer *graphite.GraphiteSerializer
+	connections []connection
+	serializer  *graphite.GraphiteSerializer
 }
 
 func (*Graphite) SampleConfig() string {
@@ -60,75 +67,67 @@ func (g *Graphite) Init() error {
 	}
 	g.serializer = s
 
-	return nil
-}
-
-func (g *Graphite) Connect() error {
 	// Set default values
-	if g.Timeout <= 0 {
-		g.Timeout = 2
-	}
 	if len(g.Servers) == 0 {
 		g.Servers = append(g.Servers, "localhost:2003")
 	}
 
+	// Fill in the connections from the server
+	g.connections = make([]connection, 0, len(g.Servers))
+	for _, server := range g.Servers {
+		g.connections = append(g.connections, connection{
+			name:      server,
+			connected: false,
+		})
+	}
+
+	return nil
+}
+
+func (g *Graphite) Connect() error {
 	// Set tls config
 	tlsConfig, err := g.ClientConfig.TLSConfig()
 	if err != nil {
 		return err
 	}
 
-	// Only retry the failed servers
-	servers := g.Servers
-	if len(g.failedServers) > 0 {
-		servers = g.failedServers
-		// Remove failed server from exisiting connections
-		var workingConns []net.Conn
-		for _, conn := range g.conns {
-			var found bool
-			for _, server := range servers {
-				if conn.RemoteAddr().String() == server {
-					found = true
-					break
-				}
-			}
-			if !found {
-				workingConns = append(workingConns, conn)
-			}
-		}
-		g.conns = workingConns
-	}
-
-	// Get Connections
-	var conns []net.Conn
+	// Find all non-connected servers and try to reconnect
+	var newConnection bool
+	var connectedServers int
 	var failedServers []string
-	for _, server := range servers {
+	for i, server := range g.connections {
+		if server.connected {
+			connectedServers++
+			continue
+		}
+		newConnection = true
+
 		// Dialer with timeout
 		d := net.Dialer{Timeout: time.Duration(g.Timeout) * time.Second}
 
 		// Get secure connection if tls config is set
 		var conn net.Conn
 		if tlsConfig != nil {
-			conn, err = tls.DialWithDialer(&d, "tcp", server, tlsConfig)
+			conn, err = tls.DialWithDialer(&d, "tcp", server.name, tlsConfig)
 		} else {
-			conn, err = d.Dial("tcp", server)
+			conn, err = d.Dial("tcp", server.name)
 		}
 
 		if err == nil {
-			conns = append(conns, conn)
+			g.connections[i].conn = conn
+			g.connections[i].connected = true
+			connectedServers++
 		} else {
 			g.Log.Debugf("Failed to establish connection: %v", err)
-			failedServers = append(failedServers, server)
+			failedServers = append(failedServers, server.name)
 		}
 	}
 
-	g.Log.Debugf("Successful connections: %d", len(conns))
+	if newConnection {
+		g.Log.Debugf("Successful connections: %d of %d", connectedServers, len(g.connections))
+	}
 	if len(failedServers) > 0 {
 		g.Log.Debugf("Failed servers: %d", len(failedServers))
-		g.conns = append(g.conns, conns...)
-		g.failedServers = failedServers
-	} else {
-		g.conns = conns
 	}
 
 	return nil
@@ -136,8 +135,9 @@ func (g *Graphite) Connect() error {
 
 func (g *Graphite) Close() error {
 	// Closing all connections
-	for _, conn := range g.conns {
-		_ = conn.Close()
+	for _, c := range g.connections {
+		_ = c.conn.Close()
+		c.connected = false
 	}
 	return nil
 }
@@ -196,61 +196,84 @@ func (g *Graphite) Write(metrics []telegraf.Metric) error {
 		batch = append(batch, buf...)
 	}
 
-	err := g.send(batch)
-
-	// If a send failed for a server, try to reconnect to that server
-	if len(g.failedServers) > 0 {
-		g.Log.Debugf("Reconnecting and retrying for the following servers: %s", strings.Join(g.failedServers, ","))
-		err = g.Connect()
-		if err != nil {
-			return fmt.Errorf("failed to reconnect: %w", err)
-		}
-		err = g.send(batch)
+	// Try to connect to all servers not yet connected if any
+	if err := g.Connect(); err != nil {
+		return fmt.Errorf("failed to reconnect: %w", err)
 	}
 
-	return err
+	// Return on success of if we encounter a non-retryable error
+	if err := g.send(batch); err == nil || !errors.Is(err, ErrNotConnected) {
+		return err
+	}
+
+	// Try to reconnect and resend
+	failedServers := make([]string, 0, len(g.connections))
+	for _, c := range g.connections {
+		if !c.connected {
+			failedServers = append(failedServers, c.name)
+		}
+	}
+	if len(failedServers) > 0 {
+		g.Log.Debugf("Reconnecting and retrying for the following servers: %s", strings.Join(failedServers, ","))
+		if err := g.Connect(); err != nil {
+			return fmt.Errorf("failed to reconnect: %w", err)
+		}
+	}
+
+	return g.send(batch)
 }
 
 func (g *Graphite) send(batch []byte) error {
-	// This will get set to nil if a successful write occurs
-	globalErr := errors.New("could not write to any Graphite server in cluster")
+	// Try sending the data to a server. Try them in random order
+	p := rand.Perm(len(g.connections))
+	for i, n := range p {
+		server := g.connections[n]
 
-	// Send data to a random server
-	p := rand.Perm(len(g.conns))
-	for _, n := range p {
+		// Skip unconnected servers
+		if !server.connected {
+			continue
+		}
+
 		if g.Timeout > 0 {
-			err := g.conns[n].SetWriteDeadline(time.Now().Add(time.Duration(g.Timeout) * time.Second))
-			if err != nil {
-				g.Log.Errorf("failed to set write deadline for %s: %v", g.conns[n].RemoteAddr().String(), err)
-				// Mark server as failed so a new connection will be made
-				g.failedServers = append(g.failedServers, g.conns[n].RemoteAddr().String())
+			deadline := time.Now().Add(time.Duration(g.Timeout))
+			if err := server.conn.SetWriteDeadline(deadline); err != nil {
+				g.Log.Warnf("failed to set write deadline for %q: %v", server.name, err)
+				g.connections[n].connected = false
+				continue
 			}
 		}
-		err := g.checkEOF(g.conns[n])
-		if err != nil {
+
+		// Check the connection state
+		if err := g.checkEOF(server.conn); err != nil {
 			// Mark server as failed so a new connection will be made
-			g.failedServers = append(g.failedServers, g.conns[n].RemoteAddr().String())
-			break
+			g.connections[n].connected = false
+			continue
 		}
-		_, e := g.conns[n].Write(batch)
-		if e == nil {
-			globalErr = nil
-			break
+		if _, err := server.conn.Write(batch); err != nil {
+			g.Log.Errorf("Writing to %q failed: %v", server.name, err)
+			if i < len(p)-1 {
+				g.Log.Info("Trying next server...")
+			}
+			// Mark server as failed so a new connection will be made
+			if server.conn != nil {
+				if err := server.conn.Close(); err != nil {
+					g.Log.Debugf("Failed to close connection to %q: %v", server.name, err)
+				}
+			}
+			g.connections[n].connected = false
+			continue
+		} else {
+			// Sent the data successfully
+			return nil
 		}
-		// Error
-		g.Log.Debugf("Graphite Error: " + e.Error())
-		// Close explicitly and let's try the next one
-		err = g.conns[n].Close()
-		g.Log.Debugf("Failed to close the connection: %v", err)
-		// Mark server as failed so a new connection will be made
-		g.failedServers = append(g.failedServers, g.conns[n].RemoteAddr().String())
 	}
 
-	return globalErr
+	// If we end here, none of the writes were successful
+	return ErrNotConnected
 }
 
 func init() {
 	outputs.Add("graphite", func() telegraf.Output {
-		return &Graphite{}
+		return &Graphite{Timeout: config.Duration(2 * time.Second)}
 	})
 }

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -103,7 +103,7 @@ func (g *Graphite) Connect() error {
 		newConnection = true
 
 		// Dialer with timeout
-		d := net.Dialer{Timeout: time.Duration(g.Timeout) * time.Second}
+		d := net.Dialer{Timeout: time.Duration(g.Timeout)}
 
 		// Get secure connection if tls config is set
 		var conn net.Conn

--- a/plugins/outputs/graphite/graphite_test.go
+++ b/plugins/outputs/graphite/graphite_test.go
@@ -32,14 +32,12 @@ func TestGraphiteError(t *testing.T) {
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 	// Prepare point list
-	var metrics []telegraf.Metric
-	metrics = append(metrics, m1)
-	// Error
-	err1 := g.Connect()
-	require.NoError(t, err1)
-	err2 := g.Write(metrics)
-	require.Error(t, err2)
-	require.Equal(t, "could not write to any Graphite server in cluster", err2.Error())
+	metrics := []telegraf.Metric{m1}
+
+	require.NoError(t, g.Connect())
+	err := g.Write(metrics)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNotConnected)
 }
 
 func TestGraphiteReconnect(t *testing.T) {

--- a/plugins/outputs/graphite/graphite_test.go
+++ b/plugins/outputs/graphite/graphite_test.go
@@ -658,6 +658,7 @@ func TestIntegration(t *testing.T) {
 }
 
 func query(url string, data interface{}) error {
+	//nolint:gosec // Parameters are fixed in the above call
 	resp, err := http.Get(url)
 	if err != nil {
 		fmt.Println("response:", resp)
@@ -668,6 +669,7 @@ func query(url string, data interface{}) error {
 		fmt.Println("raw:", string(raw))
 		return err
 	}
+	resp.Body.Close()
 
 	return json.Unmarshal(raw, &data)
 }

--- a/plugins/outputs/graphite/sample.conf
+++ b/plugins/outputs/graphite/sample.conf
@@ -40,7 +40,7 @@
   #]
 
   ## timeout in seconds for the write connection to graphite
-  timeout = 2
+  # timeout = "2s"
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13483  
resolves #13491

The graphite connection handling was complex and error prone as the connection information was split among three three struct members (`Servers`, `conns` and `failedServers`). This PR centralizes the information into a struct shared by all functions. This way, we can always know which servers are available, mark them unavailable and reconnect correctly.