### PR TITLE
feat(common.http): Add support for connecting over unix-socket

### DIFF
--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -34,6 +34,9 @@ to use them.
     "http://localhost/metrics"
   ]
 
+  ## Connect over unix-socket
+  # unix_socket_path = ""
+
   ## HTTP method
   # method = "GET"
 

--- a/plugins/inputs/http/sample.conf
+++ b/plugins/inputs/http/sample.conf
@@ -5,6 +5,9 @@
     "http://localhost/metrics"
   ]
 
+  ## Connect over unix-socket
+  # unix_socket_path = ""
+
   ## HTTP method
   # method = "GET"
 

--- a/plugins/inputs/http/sample.conf.in
+++ b/plugins/inputs/http/sample.conf.in
@@ -5,6 +5,9 @@
     "http://localhost/metrics"
   ]
 
+  ## Connect over unix-socket
+  # unix_socket_path = ""
+
   ## HTTP method
   # method = "GET"
 


### PR DESCRIPTION
The `inputs.http` and `outputs.http` now supports connecting over unix-socket. The unix-socket path can be specified via `unix_socket_path` configuration parameter. When this is set to a non-emtpy value, we connect over a unix-socket.

Note: Even when connecting over unix-socket, the value for the `urls` must still begin with "http://". The hostname is not really important in such case and so it can be set to anything. However, "localhost" is recommended to avoid any confusion.

Example:
```
[[inputs.http]
    urls = ["http://localhost/data/endpoint"]
    unix_socket_path = "/tmp/foo/server.sock"
```


# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #11038

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
