### PR TITLE
feat(processors.parser): Allow also non-string fields

### DIFF
--- a/plugins/processors/parser/parser_test.go
+++ b/plugins/processors/parser/parser_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/parsers"
+	"github.com/influxdata/telegraf/plugins/parsers/binary"
 	"github.com/influxdata/telegraf/plugins/parsers/grok"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/plugins/parsers/json"
@@ -624,6 +625,84 @@ func TestApply(t *testing.T) {
 					map[string]string{},
 					map[string]interface{}{
 						"value": float64(42.1),
+					},
+					time.Unix(1593287020, 0)),
+			},
+		},
+		{
+			name:        "non-string field with binary parser",
+			parseFields: []string{"value"},
+			merge:       "override",
+			parser: &binary.Parser{
+				Configs: []binary.Config{
+					{
+						MetricName: "parser",
+						Entries: []binary.Entry{
+							{
+								Name: "alarm_0",
+								Type: "bool",
+								Bits: 1,
+							},
+							{
+								Name: "alarm_1",
+								Type: "bool",
+								Bits: 1,
+							},
+							{
+								Name: "alarm_2",
+								Type: "bool",
+								Bits: 1,
+							},
+							{
+								Name: "alarm_3",
+								Type: "bool",
+								Bits: 1,
+							},
+							{
+								Name: "alarm_4",
+								Type: "bool",
+								Bits: 1,
+							},
+							{
+								Name: "alarm_5",
+								Type: "bool",
+								Bits: 1,
+							},
+							{
+								Name: "alarm_6",
+								Type: "bool",
+								Bits: 1,
+							},
+							{
+								Name: "alarm_7",
+								Type: "bool",
+								Bits: 1,
+							},
+						},
+					},
+				},
+			},
+			input: metric.New(
+				"myname",
+				map[string]string{},
+				map[string]interface{}{
+					"value": uint8(13),
+				},
+				time.Unix(1593287020, 0)),
+			expected: []telegraf.Metric{
+				metric.New(
+					"myname",
+					map[string]string{},
+					map[string]interface{}{
+						"value":   uint8(13),
+						"alarm_0": false,
+						"alarm_1": false,
+						"alarm_2": false,
+						"alarm_3": false,
+						"alarm_4": true,
+						"alarm_5": true,
+						"alarm_6": false,
+						"alarm_7": true,
 					},
 					time.Unix(1593287020, 0)),
 			},


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13546

This PR allows to parse non-string fields in the parser processor to e.g. decode binary data. In the example from #13546 the input data looks like

```
mes,t1=y operating_state=13u,value=42.0 1688556620000000000
```

and the `operating_state` should be decoded into its bit-values. With the present PR this can easily be done using

```toml
[[processors.parser]]
  parse_fields = ["operating_state"]
  drop_original = false
  merge = "override"
  data_format = "binary"

  [[processors.parser.binary]]
    entries = [
      { name = "alarm_0", type = "bool", bits=1 },
      { name = "alarm_1", type = "bool", bits=1 },
      { name = "alarm_2", type = "bool", bits=1 },
      { name = "alarm_3", type = "bool", bits=1 },
      { name = "alarm_4", type = "bool", bits=1 },
      { name = "alarm_5", type = "bool", bits=1 },
      { name = "alarm_6", type = "bool", bits=1 },
      { name = "alarm_7", type = "bool", bits=1 },
    ]
```

resulting in the following output

```
mes,t1=y alarm_0=false,alarm_1=false,alarm_2=false,alarm_3=false,alarm_4=true,alarm_5=true,alarm_6=false,alarm_7=true,operating_state=13i,value=42 1688556620000000000
```