### PR TITLE
fix(inputs.vpshere): compare versions as a string

### DIFF
--- a/plugins/inputs/vsphere/vsan.go
+++ b/plugins/inputs/vsphere/vsan.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -41,7 +40,7 @@ var (
 // collectVsan is the entry point for vsan metrics collection
 func (e *Endpoint) collectVsan(ctx context.Context, acc telegraf.Accumulator) error {
 	//resourceType := "vsan"
-	lower := versionLowerThan(e.apiVersion, "5.5")
+	lower := versionLowerThan(e.apiVersion, 5, 5)
 	if lower {
 		return fmt.Errorf("a minimum API version of 5.5 is required for vSAN. Found: %s. Skipping vCenter: %s", e.apiVersion, e.URL.Host)
 	}
@@ -362,7 +361,7 @@ func (e *Endpoint) queryHealthSummary(ctx context.Context, vsanClient *soap.Clie
 // queryResyncSummary adds resync information to accumulator
 func (e *Endpoint) queryResyncSummary(ctx context.Context, vsanClient *soap.Client, clusterObj *object.ClusterComputeResource,
 	clusterRef *objectRef, acc telegraf.Accumulator) error {
-	if lower := versionLowerThan(e.apiVersion, "6.7"); lower {
+	if lower := versionLowerThan(e.apiVersion, 6, 7); lower {
 		e.Parent.Log.Infof("I! [inputs.vsphere][vSAN] Minimum API Version 6.7 required for resync summary. Found: %s. Skipping VCenter: %s",
 			e.apiVersion, e.URL.Host)
 		return nil
@@ -495,10 +494,30 @@ func populateCMMDSTags(tags map[string]string, entityName string, uuid string, c
 }
 
 // versionLowerThan returns true is the current version < a base version
-func versionLowerThan(current string, base string) bool {
-	v1 := semver.New(current)
-	v2 := semver.New(base)
-	return v1.LessThan(*v2)
+func versionLowerThan(current string, major int, minor int) bool {
+	version := strings.Split(current, ".")
+	currentMajor, err := strconv.Atoi(version[0])
+	if err != nil {
+		return false
+	}
+
+	if currentMajor > major {
+		return false
+	}
+	if currentMajor == major {
+		if len(version) < 2 {
+			return true
+		}
+		currentMinor, err := strconv.Atoi(version[1])
+		if err != nil {
+			return true
+		}
+		if currentMinor >= minor {
+			return false
+		}
+	}
+
+	return true
 }
 
 type CmmdsEntity struct {

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -569,3 +569,53 @@ func mustContainAll(t *testing.T, tagMap map[string]string, mustHave []string) {
 		require.Contains(t, tagMap, tag)
 	}
 }
+
+func TestVersionLowerThan(t *testing.T) {
+	tests := []struct {
+		current string
+		major   int
+		minor   int
+		result  bool
+	}{
+		{
+			current: "7",
+			major:   6,
+			minor:   3,
+			result:  false,
+		},
+		{
+			current: "5",
+			major:   6,
+			minor:   3,
+			result:  true,
+		},
+		{
+			current: "6.0",
+			major:   6,
+			minor:   3,
+			result:  true,
+		},
+		{
+			current: "6.3",
+			major:   6,
+			minor:   3,
+			result:  false,
+		},
+		{
+			current: "6.2",
+			major:   6,
+			minor:   3,
+			result:  true,
+		},
+		{
+			current: "7.0.3.0",
+			major:   6,
+			minor:   7,
+			result:  false,
+		},
+	}
+	for _, tc := range tests {
+		result := versionLowerThan(tc.current, tc.major, tc.minor)
+		require.Equal(t, tc.result, result, fmt.Sprintf("%s < %d.%d", tc.current, tc.major, tc.minor))
+	}
+}


### PR DESCRIPTION
Not all versions from Vsphere follow semantic versioning, so do this by hand.

fixes: #13519