### PR TITLE
test(outputs.instrumental): Allow setting custom port

### DIFF
--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -28,6 +28,7 @@ var (
 
 type Instrumental struct {
 	Host       string          `toml:"host"`
+	Port       string          `toml:"port"`
 	APIToken   config.Secret   `toml:"api_token"`
 	Prefix     string          `toml:"prefix"`
 	DataFormat string          `toml:"data_format"`
@@ -44,6 +45,7 @@ type Instrumental struct {
 
 const (
 	DefaultHost     = "collector.instrumentalapp.com"
+	DefaultPort     = "8000"
 	HelloMessage    = "hello version go/telegraf/1.1\n"
 	AuthFormat      = "authenticate %s\n"
 	HandshakeFormat = HelloMessage + AuthFormat
@@ -70,7 +72,7 @@ func (i *Instrumental) Init() error {
 }
 
 func (i *Instrumental) Connect() error {
-	connection, err := net.DialTimeout("tcp", i.Host+":8000", time.Duration(i.Timeout))
+	connection, err := net.DialTimeout("tcp", i.Host+":"+i.Port, time.Duration(i.Timeout))
 
 	if err != nil {
 		i.conn = nil
@@ -203,6 +205,7 @@ func init() {
 	outputs.Add("instrumental", func() telegraf.Output {
 		return &Instrumental{
 			Host:     DefaultHost,
+			Port:     DefaultPort,
 			Template: graphite.DefaultTemplate,
 		}
 	})

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -28,7 +28,7 @@ var (
 
 type Instrumental struct {
 	Host       string          `toml:"host"`
-	Port       string          `toml:"port"`
+	Port       int             `toml:"port"`
 	APIToken   config.Secret   `toml:"api_token"`
 	Prefix     string          `toml:"prefix"`
 	DataFormat string          `toml:"data_format"`
@@ -45,7 +45,7 @@ type Instrumental struct {
 
 const (
 	DefaultHost     = "collector.instrumentalapp.com"
-	DefaultPort     = "8000"
+	DefaultPort     = 8000
 	HelloMessage    = "hello version go/telegraf/1.1\n"
 	AuthFormat      = "authenticate %s\n"
 	HandshakeFormat = HelloMessage + AuthFormat
@@ -72,7 +72,8 @@ func (i *Instrumental) Init() error {
 }
 
 func (i *Instrumental) Connect() error {
-	connection, err := net.DialTimeout("tcp", i.Host+":"+i.Port, time.Duration(i.Timeout))
+	addr := fmt.Sprintf("%s:%d", i.Host, i.Port)
+	connection, err := net.DialTimeout("tcp", addr, time.Duration(i.Timeout))
 
 	if err != nil {
 		i.conn = nil

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -18,11 +18,11 @@ import (
 func TestWrite(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
-	TCPServer(t, &wg)
+	port := TCPServer(t, &wg)
 
 	i := Instrumental{
 		Host:     "127.0.0.1",
-		Port:     "8887",
+		Port:     port,
 		APIToken: config.NewSecret([]byte("abc123token")),
 		Prefix:   "my.prefix",
 	}
@@ -81,7 +81,7 @@ func TestWrite(t *testing.T) {
 	wg.Wait()
 }
 
-func TCPServer(t *testing.T, wg *sync.WaitGroup) {
+func TCPServer(t *testing.T, wg *sync.WaitGroup) int {
 	tcpServer, err := net.Listen("tcp", "127.0.0.1:8887")
 	require.NoError(t, err)
 
@@ -133,4 +133,6 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 		err = conn.Close()
 		require.NoError(t, err)
 	}()
+
+	return tcpServer.Addr().(*net.TCPAddr).Port
 }

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -82,7 +82,7 @@ func TestWrite(t *testing.T) {
 }
 
 func TCPServer(t *testing.T, wg *sync.WaitGroup) int {
-	tcpServer, err := net.Listen("tcp", "127.0.0.1:8887")
+	tcpServer, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	go func() {

--- a/plugins/outputs/instrumental/instrumental_test.go
+++ b/plugins/outputs/instrumental/instrumental_test.go
@@ -22,6 +22,7 @@ func TestWrite(t *testing.T) {
 
 	i := Instrumental{
 		Host:     "127.0.0.1",
+		Port:     "8887",
 		APIToken: config.NewSecret([]byte("abc123token")),
 		Prefix:   "my.prefix",
 	}
@@ -81,7 +82,7 @@ func TestWrite(t *testing.T) {
 }
 
 func TCPServer(t *testing.T, wg *sync.WaitGroup) {
-	tcpServer, err := net.Listen("tcp", "127.0.0.1:8000")
+	tcpServer, err := net.Listen("tcp", "127.0.0.1:8887")
 	require.NoError(t, err)
 
 	go func() {


### PR DESCRIPTION
Primarily for testing to avoid using the already busy and often used port 8000.
