### PR TITLE
test: clearer error msg from AssertContainsTaggedFields

### DIFF
--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -354,13 +354,14 @@ func (a *Accumulator) AssertContainsTaggedFields(
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
-		if !reflect.DeepEqual(tags, p.Tags) {
+		if p.Measurement != measurement || !reflect.DeepEqual(tags, p.Tags) {
 			continue
 		}
 
-		if p.Measurement == measurement && reflect.DeepEqual(fields, p.Fields) {
-			return
+		if !reflect.DeepEqual(fields, p.Fields) {
+			assert.Fail(t, fmt.Sprintf("Measurement %q with tags %v has fields %v instead of %v", measurement, tags, p.Fields, fields))
 		}
+		return
 	}
 	// We've failed. spit out some debug logging
 	for _, p := range a.Metrics {


### PR DESCRIPTION
- [n/a] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

As a first time contributor (working on #12836), I found the default error msg from `AssertContainsTaggedFields` to be confusing. After hacking up a test to fail (`s/128/127/`), here is what the current error looks like:
```
    accumulator.go:368: measurement disk tags map[device:sda fstype:ext4 mode:ro path:/] fields map[free:23 inodes_free:234 inodes_total:1234 inodes_used:1000 total:128 used:100 used_percent:81.30081300813008]
    accumulator.go:368: measurement disk tags map[device:sdb fstype:ext4 mode:rw path:/home] fields map[free:46 inodes_free:468 inodes_total:2468 inodes_used:2000 total:256 used:200 used_percent:81.30081300813008]
    accumulator.go:368: measurement disk tags map[device:sda fstype:ext4 mode:ro path:/var/rootbind] fields map[free:23 inodes_free:234 inodes_total:1234 inodes_used:1000 total:128 used:100 used_percent:81.30081300813008]
    accumulator.go:372:
                Error Trace:    /home/lyeager/code/telegraf/testutil/accumulator.go:372
                                                        /home/lyeager/code/telegraf/plugins/inputs/disk/disk_test.go:147
                Error:          unknown measurement "disk" with tags map[device:sda fstype:ext4 mode:ro path:/var/rootbind]
                Test:           TestDiskUsage
```
I'd argue that the message is incorrect. The measurement with those tags isn't "unknown" - it just doesn't match the expected value. Plus, for some tests, the current debug logging contains an enormous amount of irrelevant lines.

After this change, it looks like this instead:
```
    accumulator.go:362:
                Error Trace:    /home/lyeager/code/telegraf/testutil/accumulator.go:362
                                                        /home/lyeager/code/telegraf/plugins/inputs/disk/disk_test.go:147
                Error:          Measurement "disk" with tags map[device:sda fstype:ext4 mode:ro path:/var/rootbind] has fields map[free:23 inodes_free:234 inodes_total:1234 inodes_used:1000 total:128 used:100 used_percent:81.30081300813008] instead of map[free:23 inodes_free:234 inodes_total:1234 inodes_used:1000 total:127 used:100 used_percent:81.30081300813008]
                Test:           TestDiskUsage
```