### PR TITLE
feat(outputs.timestream): Support customer defined partition key

### DIFF
--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -75,6 +75,26 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Specifies if the plugin should create the table, if the table does not exist.
   create_table_if_not_exists = true
+  
+  ## Specifies if table should be created with composite partition key
+  ## that determines how your data will be stored and distributed.
+  ## create_table_composite_partition_key is an array of array with type string
+  ## Dimension type partition key requires 3 elements:
+  ##    1. "Dimension" to indicate its type
+  ##    2. Your composite_partition_key_dimension_name
+  ##    3. Enforcement level can be "true" or "false". If set to true dimension key must be specified
+  ##        during ingestion of new records or else they will be rejected. If set to false then records
+  ##        without specifying the dimension key can still be ingested.
+  ##    example: ["Dimension", "composite_partition_key_dimension_name", "true"]
+  ## Measure type partition key requires 1 element:
+  ##    1. "Measure_name" to indicate its type
+  ##    example: ["Measure_name"]
+  ##
+  ## NOTES:
+  ## You can't add or remove a partition key after the table has been created.
+  ## We currently only support using one partition key.
+  ##
+  #  create_table_composite_partition_key = [["Dimension", "composite_partition_key_dimension_name", "true"]]
 
   ## Specifies the Timestream table magnetic store retention period in days.
   ## Check Timestream documentation for more details.
@@ -267,6 +287,32 @@ and store each field in a separate table row. In that case:
    actual value of that property.
    `<measure_name_for_multi_measure_records>` represents the actual value of
    that property.
+
+### Create Table With Composite Partition Key To Improve Query Performance
+You can organize data more efficiently obtaining significant query performance gains by specifying 
+composite partition key when creating a new table. [Using customer-defined partition keys](https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys-using.html
+)
+
+To start, you need to specify this configuration with your desired input: 
+
+`create_table_composite_partition_key = [["Dimension", "composite_partition_key_dimension_name", "true"]]`
+- `create_table_composite_partition_key` is an array of array that can contain either a partition key configuration with type dimension or type measure
+  
+  1. Dimension type partition key requires 3 elements:
+      1. `"Dimension"` to indicate its type
+      2. Your composite_partition_key_dimension_name. We recommend using a dimension name that has high cardinality for better query performance.
+      3. Enforcement level can be `"true"` or `"false"`. If set to true dimension key must be specified
+          during ingestion of new records or else they will be rejected. If set to false then records
+          without specifying the dimension key can still be ingested.
+      
+     Example: `["Dimension", "composite_partition_key_dimension_name", "true"]`
+  2. Measure type partition key requires 1 element:
+      1. "Measure_name" to indicate its type
+  
+      Example: `["Measure_name"]`
+   
+- We currently support using one partition key.
+- You can't add or remove a partition key after the table has been created.
 
 ### References
 

--- a/plugins/outputs/timestream/sample.conf
+++ b/plugins/outputs/timestream/sample.conf
@@ -47,6 +47,26 @@
   ## Specifies if the plugin should create the table, if the table does not exist.
   create_table_if_not_exists = true
 
+  ## Specifies if table should be created with composite partition key
+  ## that determines how your data will be stored and distributed.
+  ## create_table_composite_partition_key is an array of array with type string
+  ## Dimension type partition key requires 3 elements:
+  ##    1. "Dimension" to indicate its type
+  ##    2. Your composite_partition_key_dimension_name
+  ##    3. Enforcement level can be "true" or "false". If set to true dimension key must be specified
+  ##        during ingestion of new records or else they will be rejected. If set to false then records
+  ##        without specifying the dimension key can still be ingested.
+  ##    example: ["Dimension", "composite_partition_key_dimension_name", "true"]
+  ## Measure type partition key requires 1 element:
+  ##    1. "Measure_name" to indicate its type
+  ##    example: ["Measure_name"]
+  ##
+  ## NOTES:
+  ## You can't add or remove a partition key after the table has been created.
+  ## We currently only support using one partition key.
+  ##
+  #  create_table_composite_partition_key = [["Dimension", "composite_partition_key_dimension_name", "true"]]
+
   ## Specifies the Timestream table magnetic store retention period in days.
   ## Check Timestream documentation for more details.
   ## NOTE: This property is valid when create_table_if_not_exists = true.


### PR DESCRIPTION
# Required for all PRs

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Adds support for [Timestream customer defined partition key feature](https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys-using.html).

This feature allowed creating Timestream table with partition keys using the input `create_table_composite_partition_key` that is not set by default and can be enabled.


<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
