### PR TITLE
feat(outputs.timestream): Support customer defined partition key

### DIFF
--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -292,8 +292,9 @@ and store each field in a separate table row. In that case:
 
 You can organize data more efficiently obtaining significant query performance
 gains by specifying composite partition key when creating a new table.
-[Using customer-defined partition keys](
-https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys-using.html)
+[Using customer-defined partition keys](https://docs.aws.amazon.com/
+timestream/latest/developerguide/
+customer-defined-partition-keys-using.html)
 
 To start, you need to specify this configuration with your desired input:
 

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -76,7 +76,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Specifies if the plugin should create the table, if the table does not exist.
   create_table_if_not_exists = true
 
-  ## Specifies if table should be created with composite partition key
+  ## Specifies if the table should be created with composite partition key
   ## that determines how your data will be stored and distributed.
   ## create_table_composite_partition_key is an array of array with type string
   ## Dimension type partition key requires 3 elements:
@@ -92,7 +92,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##
   ## NOTES:
   ## You can't add or remove a partition key after the table has been created.
-  ## We currently only support using one partition key.
+  ## Timestream currently only support using one partition key.
   ##
   #  create_table_composite_partition_key = [["Dimension", "composite_partition_key_dimension_name", "true"]]
 
@@ -292,7 +292,7 @@ and store each field in a separate table row. In that case:
 
 You can organize data more efficiently obtaining significant query performance
 gains by specifying composite partition key when creating a new table.
-[Developer Guide](https://docs.aws.amazon.com/timestream/latest/developerguide)
+[Document](https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys)
 
 To start, you need to specify this configuration with your desired input:
 
@@ -300,23 +300,24 @@ To start, you need to specify this configuration with your desired input:
 [["Dimension", "composite_partition_key_dimension_name", "true"]]`
 
 - `create_table_composite_partition_key` is an array of array that can contain either a partition key configuration
-with type dimension or type measure
+with type dimension or type measure.
   
   1. Dimension type partition key requires 3 elements:
-      1. `"Dimension"` to indicate its type
-      2. Your composite_partition_key_dimension_name. We recommend using a dimension name that has high cardinality
-     for better query performance.
+      1. `"Dimension"` to indicate its type. Dimensions represent the metadata attributes 
+     of a time-series data point in a record.
+      2. Your composite_partition_key_dimension_name. Timestream recommend using a dimension name that has
+     high cardinality for better query performance.
       3. Enforcement level can be `"true"` or `"false"`. If set to true dimension key must be specified
           during ingestion of new records or else they will be rejected. If set to false then records
           without specifying the dimension key can still be ingested.
 
      Example: `["Dimension", "composite_partition_key_dimension_name", "true"]`
   2. Measure type partition key requires 1 element:
-      1. "Measure_name" to indicate its type
+      1. "Measure_name" to indicate its type. Measure name is the name of the measure being collected in a record.
   
       Example: `["Measure_name"]`
 
-- We currently support using one partition key.
+- Timestream currently support using one partition key.
 - You can't add or remove a partition key after the table has been created.
 
 ### References

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -299,11 +299,11 @@ To start, you need to specify this configuration with your desired input:
 `create_table_composite_partition_key =
 [["Dimension", "composite_partition_key_dimension_name", "true"]]`
 
-- `create_table_composite_partition_key` is an array of array that can contain either a partition key configuration
+- `create_table_composite_partition_key` is an array of arrays that can contain either a partition key configuration
 with type dimension or type measure.
   
   1. Dimension type partition key requires 3 elements:
-      1. `"Dimension"` to indicate its type. Dimensions represent the metadata attributes 
+      1. `"Dimension"` to indicate its type. Dimensions represent the metadata attributes
      of a time-series data point in a record.
       2. Your composite_partition_key_dimension_name. Timestream recommend using a dimension name that has
      high cardinality for better query performance.

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -75,7 +75,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Specifies if the plugin should create the table, if the table does not exist.
   create_table_if_not_exists = true
-  
+
   ## Specifies if table should be created with composite partition key
   ## that determines how your data will be stored and distributed.
   ## create_table_composite_partition_key is an array of array with type string

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -78,7 +78,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Specifies if the table should be created with composite partition key
   ## that determines how your data will be stored and distributed.
-  ## create_table_composite_partition_key is an array of array with type string
+  ## create_table_composite_partition_key is an array of arrays with type string
   ## Dimension type partition key requires 3 elements:
   ##    1. "Dimension" to indicate its type
   ##    2. Your composite_partition_key_dimension_name

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -75,6 +75,26 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Specifies if the plugin should create the table, if the table does not exist.
   create_table_if_not_exists = true
+  
+  ## Specifies if table should be created with composite partition key
+  ## that determines how your data will be stored and distributed.
+  ## create_table_composite_partition_key is an array of array with type string
+  ## Dimension type partition key requires 3 elements:
+  ##    1. "Dimension" to indicate its type
+  ##    2. Your composite_partition_key_dimension_name
+  ##    3. Enforcement level can be "true" or "false". If set to true dimension key must be specified
+  ##        during ingestion of new records or else they will be rejected. If set to false then records
+  ##        without specifying the dimension key can still be ingested.
+  ##    example: ["Dimension", "composite_partition_key_dimension_name", "true"]
+  ## Measure type partition key requires 1 element:
+  ##    1. "Measure_name" to indicate its type
+  ##    example: ["Measure_name"]
+  ##
+  ## NOTES:
+  ## You can't add or remove a partition key after the table has been created.
+  ## We currently only support using one partition key.
+  ##
+  #  create_table_composite_partition_key = [["Dimension", "composite_partition_key_dimension_name", "true"]]
 
   ## Specifies the Timestream table magnetic store retention period in days.
   ## Check Timestream documentation for more details.
@@ -267,6 +287,37 @@ and store each field in a separate table row. In that case:
    actual value of that property.
    `<measure_name_for_multi_measure_records>` represents the actual value of
    that property.
+
+### Create Table With Composite Partition Key To Improve Query Performance
+
+You can organize data more efficiently obtaining significant query performance gains by specifying
+composite partition key when creating a new table.
+[Using customer-defined partition keys](
+https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys-using.html)
+
+To start, you need to specify this configuration with your desired input:
+
+`create_table_composite_partition_key = [["Dimension", "composite_partition_key_dimension_name", "true"]]`
+
+- `create_table_composite_partition_key` is an array of array that can contain either a partition key configuration 
+with type dimension or type measure
+  
+  1. Dimension type partition key requires 3 elements:
+      1. `"Dimension"` to indicate its type
+      2. Your composite_partition_key_dimension_name. We recommend using a dimension name that has high cardinality 
+     for better query performance.
+      3. Enforcement level can be `"true"` or `"false"`. If set to true dimension key must be specified
+          during ingestion of new records or else they will be rejected. If set to false then records
+          without specifying the dimension key can still be ingested.
+
+     Example: `["Dimension", "composite_partition_key_dimension_name", "true"]`
+  2. Measure type partition key requires 1 element:
+      1. "Measure_name" to indicate its type
+  
+      Example: `["Measure_name"]`
+
+- We currently support using one partition key.
+- You can't add or remove a partition key after the table has been created.
 
 ### References
 

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -292,7 +292,7 @@ and store each field in a separate table row. In that case:
 
 You can organize data more efficiently obtaining significant query performance
 gains by specifying composite partition key when creating a new table.
-https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys
+[Developer Guide](https://docs.aws.amazon.com/timestream/latest/developerguide/what-is-timestream.html)
 
 To start, you need to specify this configuration with your desired input:
 

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -292,7 +292,7 @@ and store each field in a separate table row. In that case:
 
 You can organize data more efficiently obtaining significant query performance
 gains by specifying composite partition key when creating a new table.
-[Document](https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys)
+https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys
 
 To start, you need to specify this configuration with your desired input:
 

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -91,7 +91,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##    example: ["Measure_name"]
   ##
   ## NOTES:
-  ## You can't add or remove a partition key after the table has been created.
+  ## Users cannot add or remove a partition key after the table has been created.
   ## Timestream currently only support using one partition key.
   ##
   #  create_table_composite_partition_key = [["Dimension", "composite_partition_key_dimension_name", "true"]]

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -290,21 +290,22 @@ and store each field in a separate table row. In that case:
 
 ### Create Table With Composite Partition Key To Improve Query Performance
 
-You can organize data more efficiently obtaining significant query performance gains by specifying
-composite partition key when creating a new table.
+You can organize data more efficiently obtaining significant query performance
+gains by specifying composite partition key when creating a new table.
 [Using customer-defined partition keys](
 https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys-using.html)
 
 To start, you need to specify this configuration with your desired input:
 
-`create_table_composite_partition_key = [["Dimension", "composite_partition_key_dimension_name", "true"]]`
+`create_table_composite_partition_key =
+[["Dimension", "composite_partition_key_dimension_name", "true"]]`
 
-- `create_table_composite_partition_key` is an array of array that can contain either a partition key configuration 
+- `create_table_composite_partition_key` is an array of array that can contain either a partition key configuration
 with type dimension or type measure
   
   1. Dimension type partition key requires 3 elements:
       1. `"Dimension"` to indicate its type
-      2. Your composite_partition_key_dimension_name. We recommend using a dimension name that has high cardinality 
+      2. Your composite_partition_key_dimension_name. We recommend using a dimension name that has high cardinality
      for better query performance.
       3. Enforcement level can be `"true"` or `"false"`. If set to true dimension key must be specified
           during ingestion of new records or else they will be rejected. If set to false then records

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -292,7 +292,7 @@ and store each field in a separate table row. In that case:
 
 You can organize data more efficiently obtaining significant query performance
 gains by specifying composite partition key when creating a new table.
-<https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys-using.html>
+[Developer Guide](https://docs.aws.amazon.com/timestream/latest/developerguide)
 
 To start, you need to specify this configuration with your desired input:
 

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -292,7 +292,7 @@ and store each field in a separate table row. In that case:
 
 You can organize data more efficiently obtaining significant query performance
 gains by specifying composite partition key when creating a new table.
-[Developer Guide](https://docs.aws.amazon.com/timestream/latest/developerguide/what-is-timestream.html)
+[Developer Guide](https://docs.aws.amazon.com/timestream/latest/developerguide)
 
 To start, you need to specify this configuration with your desired input:
 

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -292,9 +292,7 @@ and store each field in a separate table row. In that case:
 
 You can organize data more efficiently obtaining significant query performance
 gains by specifying composite partition key when creating a new table.
-[Using customer-defined partition keys](https://docs.aws.amazon.com/
-timestream/latest/developerguide/
-customer-defined-partition-keys-using.html)
+<https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys-using.html>
 
 To start, you need to specify this configuration with your desired input:
 

--- a/plugins/outputs/timestream/sample.conf
+++ b/plugins/outputs/timestream/sample.conf
@@ -47,7 +47,7 @@
   ## Specifies if the plugin should create the table, if the table does not exist.
   create_table_if_not_exists = true
 
-  ## Specifies if table should be created with composite partition key
+  ## Specifies if the table should be created with composite partition key
   ## that determines how your data will be stored and distributed.
   ## create_table_composite_partition_key is an array of array with type string
   ## Dimension type partition key requires 3 elements:
@@ -62,8 +62,8 @@
   ##    example: ["Measure_name"]
   ##
   ## NOTES:
-  ## You can't add or remove a partition key after the table has been created.
-  ## We currently only support using one partition key.
+  ## Users cannot add or remove a partition key after the table has been created.
+  ## Timestream currently only support using one partition key.
   ##
   #  create_table_composite_partition_key = [["Dimension", "composite_partition_key_dimension_name", "true"]]
 

--- a/plugins/outputs/timestream/sample.conf
+++ b/plugins/outputs/timestream/sample.conf
@@ -47,6 +47,26 @@
   ## Specifies if the plugin should create the table, if the table does not exist.
   create_table_if_not_exists = true
 
+  ## Specifies if table should be created with composite partition key
+  ## that determines how your data will be stored and distributed.
+  ## create_table_composite_partition_key is an array of array with type string
+  ## Dimension type partition key requires 3 elements:
+  ##    1. "Dimension" to indicate its type
+  ##    2. Your composite_partition_key_dimension_name
+  ##    3. Enforcement level can be "true" or "false". If set to true dimension key must be specified
+  ##        during ingestion of new records or else they will be rejected. If set to false then records
+  ##        without specifying the dimension key can still be ingested.
+  ##    example: ["Dimension", "composite_partition_key_dimension_name", "true"]
+  ## Measure type partition key requires 1 element:
+  ##    1. "Measure_name" to indicate its type
+  ##    example: ["Measure_name"]
+  ##
+  ## NOTES:
+  ## You can't add or remove a partition key after the table has been created.
+  ## We currently only support using one partition key.
+  ##
+  #  create_table_composite_partition_key = [["Dimension", "composite_partition_key_dimension_name", "true"]]
+
   ## Specifies the Timestream table magnetic store retention period in days.
   ## Check Timestream documentation for more details.
   ## NOTE: This property is valid when create_table_if_not_exists = true.

--- a/plugins/outputs/timestream/sample.conf
+++ b/plugins/outputs/timestream/sample.conf
@@ -49,7 +49,7 @@
 
   ## Specifies if the table should be created with composite partition key
   ## that determines how your data will be stored and distributed.
-  ## create_table_composite_partition_key is an array of array with type string
+  ## create_table_composite_partition_key is an array of arrays with type string
   ## Dimension type partition key requires 3 elements:
   ##    1. "Dimension" to indicate its type
   ##    2. Your composite_partition_key_dimension_name

--- a/plugins/outputs/timestream/timestream.go
+++ b/plugins/outputs/timestream/timestream.go
@@ -38,6 +38,7 @@ type (
 		MeasureNameForMultiMeasureRecords string `toml:"measure_name_for_multi_measure_records"`
 
 		CreateTableIfNotExists                        bool              `toml:"create_table_if_not_exists"`
+		CreateTableCompositePartitionKey              [][]string        `toml:"create_table_composite_partition_key"`
 		CreateTableMagneticStoreRetentionPeriodInDays int64             `toml:"create_table_magnetic_store_retention_period_in_days"`
 		CreateTableMemoryStoreRetentionPeriodInHours  int64             `toml:"create_table_memory_store_retention_period_in_hours"`
 		CreateTableTags                               map[string]string `toml:"create_table_tags"`
@@ -348,12 +349,20 @@ func (t *Timestream) createTableAndRetry(writeRecordsInput *timestreamwrite.Writ
 
 // createTable creates a Timestream table according to the configuration.
 func (t *Timestream) createTable(tableName *string) error {
+	compositePartitionKeyList, inputErr := t.getCompositePartitionKeyList()
+	if inputErr != nil {
+		return inputErr
+	}
+
 	createTableInput := &timestreamwrite.CreateTableInput{
 		DatabaseName: aws.String(t.DatabaseName),
 		TableName:    aws.String(*tableName),
 		RetentionProperties: &types.RetentionProperties{
 			MagneticStoreRetentionPeriodInDays: t.CreateTableMagneticStoreRetentionPeriodInDays,
 			MemoryStoreRetentionPeriodInHours:  t.CreateTableMemoryStoreRetentionPeriodInHours,
+		},
+		Schema: &types.Schema{
+			CompositePartitionKey: compositePartitionKeyList,
 		},
 	}
 	tags := make([]types.Tag, 0, len(t.CreateTableTags))
@@ -375,6 +384,50 @@ func (t *Timestream) createTable(tableName *string) error {
 		return err
 	}
 	return nil
+}
+
+// Parse user input CreateTableCompositePartitionKey into Timestream partition key list
+// Dimension type partition key requires 3 string elements:
+//  1. "Dimension" to indicate its type
+//  2. User specified composite_partition_key_dimension_name
+//  3. Enforcement level can be "true" or "false"
+//
+// Measure type partition key requires 1 string element:
+//  1. "Measure_name" to indicate its type
+func (t *Timestream) getCompositePartitionKeyList() ([]types.PartitionKey, error) {
+	compositePartitionKeyList := make([]types.PartitionKey, 0, len(t.CreateTableCompositePartitionKey))
+	if len(t.CreateTableCompositePartitionKey) > 0 {
+		for _, PartitionKey := range t.CreateTableCompositePartitionKey {
+			if len(PartitionKey) == 3 && PartitionKey[0] == "Dimension" {
+				var enforcementInRecord types.PartitionKeyEnforcementLevel
+				partitionKeyDimensionName := PartitionKey[1]
+				isEnforced := PartitionKey[2]
+				if isEnforced == "true" {
+					enforcementInRecord = types.PartitionKeyEnforcementLevelRequired
+				} else {
+					enforcementInRecord = types.PartitionKeyEnforcementLevelOptional
+				}
+				compositePartitionKeyList = append(compositePartitionKeyList, types.PartitionKey{
+					Name:                aws.String(partitionKeyDimensionName),
+					EnforcementInRecord: enforcementInRecord,
+					Type:                types.PartitionKeyTypeDimension,
+				})
+			} else if len(PartitionKey) == 1 && PartitionKey[0] == "Measure_name" {
+				compositePartitionKeyList = append(compositePartitionKeyList, types.PartitionKey{
+					Type: types.PartitionKeyTypeMeasure,
+				})
+			} else {
+				return nil, fmt.Errorf("error parsing input for composite partition key %+q", PartitionKey)
+			}
+		}
+	}
+	if len(compositePartitionKeyList) == 0 {
+		t.Log.Info("no valid composite partition key provided, creating table with measure type partition key")
+		compositePartitionKeyList = append(compositePartitionKeyList, types.PartitionKey{
+			Type: types.PartitionKeyTypeMeasure,
+		})
+	}
+	return compositePartitionKeyList, nil
 }
 
 // TransformMetrics transforms a collection of Telegraf Metrics into write requests to Timestream.

--- a/plugins/outputs/timestream/timestream.go
+++ b/plugins/outputs/timestream/timestream.go
@@ -396,29 +396,27 @@ func (t *Timestream) createTable(tableName *string) error {
 //  1. "Measure_name" to indicate its type
 func (t *Timestream) getCompositePartitionKeyList() ([]types.PartitionKey, error) {
 	compositePartitionKeyList := make([]types.PartitionKey, 0, len(t.CreateTableCompositePartitionKey))
-	if len(t.CreateTableCompositePartitionKey) > 0 {
-		for _, PartitionKey := range t.CreateTableCompositePartitionKey {
-			if len(PartitionKey) == 3 && PartitionKey[0] == "Dimension" {
-				var enforcementInRecord types.PartitionKeyEnforcementLevel
-				partitionKeyDimensionName := PartitionKey[1]
-				isEnforced := PartitionKey[2]
-				if isEnforced == "true" {
-					enforcementInRecord = types.PartitionKeyEnforcementLevelRequired
-				} else {
-					enforcementInRecord = types.PartitionKeyEnforcementLevelOptional
-				}
-				compositePartitionKeyList = append(compositePartitionKeyList, types.PartitionKey{
-					Name:                aws.String(partitionKeyDimensionName),
-					EnforcementInRecord: enforcementInRecord,
-					Type:                types.PartitionKeyTypeDimension,
-				})
-			} else if len(PartitionKey) == 1 && PartitionKey[0] == "Measure_name" {
-				compositePartitionKeyList = append(compositePartitionKeyList, types.PartitionKey{
-					Type: types.PartitionKeyTypeMeasure,
-				})
+	for _, PartitionKey := range t.CreateTableCompositePartitionKey {
+		if len(PartitionKey) == 3 && PartitionKey[0] == "Dimension" {
+			var enforcementInRecord types.PartitionKeyEnforcementLevel
+			partitionKeyDimensionName := PartitionKey[1]
+			isEnforced := PartitionKey[2]
+			if isEnforced == "true" {
+				enforcementInRecord = types.PartitionKeyEnforcementLevelRequired
 			} else {
-				return nil, fmt.Errorf("error parsing input for composite partition key %+q", PartitionKey)
+				enforcementInRecord = types.PartitionKeyEnforcementLevelOptional
 			}
+			compositePartitionKeyList = append(compositePartitionKeyList, types.PartitionKey{
+				Name:                aws.String(partitionKeyDimensionName),
+				EnforcementInRecord: enforcementInRecord,
+				Type:                types.PartitionKeyTypeDimension,
+			})
+		} else if len(PartitionKey) == 1 && PartitionKey[0] == "Measure_name" {
+			compositePartitionKeyList = append(compositePartitionKeyList, types.PartitionKey{
+				Type: types.PartitionKeyTypeMeasure,
+			})
+		} else {
+			return nil, fmt.Errorf("error parsing input for composite partition key %+q", PartitionKey)
 		}
 	}
 	if len(compositePartitionKeyList) == 0 {

--- a/plugins/outputs/timestream/timestream_test.go
+++ b/plugins/outputs/timestream/timestream_test.go
@@ -221,6 +221,64 @@ func TestConnectValidatesConfigParameters(t *testing.T) {
 	require.Contains(t, describeTableInvoked.Connect().Error(), "hello from DescribeDatabase")
 }
 
+func TestGetCompositePartitionKey(t *testing.T) {
+	compositePartitionKeyWithMeasure := [][]string{{"Measure_name"}}
+	compositePartitionKeyWithMeasurePlugin := Timestream{
+		DatabaseName:                     tsDbName,
+		MappingMode:                      MappingModeMultiTable,
+		Log:                              testutil.Logger{},
+		CreateTableCompositePartitionKey: compositePartitionKeyWithMeasure,
+	}
+	_, measureNoErr := compositePartitionKeyWithMeasurePlugin.getCompositePartitionKeyList()
+	require.NoError(t, measureNoErr)
+
+	compositePartitionKeyWithDimension := [][]string{{"Dimension", "pkDim1", "true"}}
+	compositePartitionKeyWithDimensionPlugin := Timestream{
+		DatabaseName:                     tsDbName,
+		MappingMode:                      MappingModeMultiTable,
+		Log:                              testutil.Logger{},
+		CreateTableCompositePartitionKey: compositePartitionKeyWithDimension,
+	}
+	_, dimensionNoErr := compositePartitionKeyWithDimensionPlugin.getCompositePartitionKeyList()
+	require.NoError(t, dimensionNoErr)
+
+	noCompositePartitionKey := [][]string{}
+	createTableWithNoCompositePartitionKeyPlugin := Timestream{
+		DatabaseName:                     tsDbName,
+		MappingMode:                      MappingModeMultiTable,
+		Log:                              testutil.Logger{},
+		CreateTableCompositePartitionKey: noCompositePartitionKey,
+	}
+	noPartitionKeyOutput, noPartitionKeyNoErr := createTableWithNoCompositePartitionKeyPlugin.getCompositePartitionKeyList()
+	compositePartitionKeyListWithMeasure := make([]types.PartitionKey, 0, 1)
+	compositePartitionKeyListWithMeasure = append(compositePartitionKeyListWithMeasure, types.PartitionKey{
+		Type: types.PartitionKeyTypeMeasure,
+	})
+	require.NoError(t, noPartitionKeyNoErr)
+	require.Equal(t, compositePartitionKeyListWithMeasure, noPartitionKeyOutput,
+		"If no partition key is specified we create table with measure partition key instead")
+
+	invalidTypeCompositePartitionKey := [][]string{{"invalid_type"}}
+	invalidTypeCompositePartitionKeyPlugin := Timestream{
+		DatabaseName:                     tsDbName,
+		MappingMode:                      MappingModeMultiTable,
+		Log:                              testutil.Logger{},
+		CreateTableCompositePartitionKey: invalidTypeCompositePartitionKey,
+	}
+	_, inValidTypeErr := invalidTypeCompositePartitionKeyPlugin.getCompositePartitionKeyList()
+	require.Contains(t, inValidTypeErr.Error(), "error parsing input for composite partition key")
+
+	missingFieldCompositePartitionKey := [][]string{{"Dimension", "pkDim1"}}
+	compositePartitionKeyMissingFieldPlugin := Timestream{
+		DatabaseName:                     tsDbName,
+		MappingMode:                      MappingModeMultiTable,
+		Log:                              testutil.Logger{},
+		CreateTableCompositePartitionKey: missingFieldCompositePartitionKey,
+	}
+	_, missingFieldErr := compositePartitionKeyMissingFieldPlugin.getCompositePartitionKeyList()
+	require.Contains(t, missingFieldErr.Error(), "error parsing input for composite partition key")
+}
+
 func TestWriteMultiMeasuresSingleTableMode(t *testing.T) {
 	const recordCount = 100
 	mockClient := &mockTimestreamClient{0}


### PR DESCRIPTION
# Required for all PRs

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Adds support for [Timestream customer defined partition key feature](https://docs.aws.amazon.com/timestream/latest/developerguide/customer-defined-partition-keys-using.html).

This feature allowed creating Timestream table with partition keys using the input `create_table_composite_partition_key` that is not set by default and can be enabled.


<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
