### PR TITLE
fix(inputs.postgresql): Default database definition

### DIFF
--- a/plugins/inputs/pgbouncer/pgbouncer.go
+++ b/plugins/inputs/pgbouncer/pgbouncer.go
@@ -103,9 +103,9 @@ func (p *PgBouncer) accRow(row scanner, columns []string) (map[string]string, ma
 			return nil, nil, fmt.Errorf("writing database name failed: %w", err)
 		}
 	} else {
-		_, err := dbname.WriteString("postgres")
+		_, err := dbname.WriteString("pgbouncer")
 		if err != nil {
-			return nil, nil, fmt.Errorf("writing 'postgres' failed: %w", err)
+			return nil, nil, fmt.Errorf("writing 'pgbouncer' failed: %w", err)
 		}
 	}
 

--- a/plugins/inputs/postgresql/postgresql.go
+++ b/plugins/inputs/postgresql/postgresql.go
@@ -120,8 +120,13 @@ func (p *Postgresql) accRow(row scanner, acc telegraf.Accumulator, columns []str
 		columnVars = append(columnVars, columnMap[columns[i]])
 	}
 
+	tagAddress, err := p.SanitizedAddress()
+	if err != nil {
+		return err
+	}
+
 	// deconstruct array of variables and send to Scan
-	err := row.Scan(columnVars...)
+	err = row.Scan(columnVars...)
 
 	if err != nil {
 		return err
@@ -139,15 +144,13 @@ func (p *Postgresql) accRow(row scanner, acc telegraf.Accumulator, columns []str
 			}
 		}
 	} else {
-		if _, err := dbname.WriteString("postgres"); err != nil {
+		database, err := p.GetConnectDatabase(tagAddress)
+		if err != nil {
 			return err
 		}
-	}
-
-	var tagAddress string
-	tagAddress, err = p.SanitizedAddress()
-	if err != nil {
-		return err
+		if _, err := dbname.WriteString(database); err != nil {
+			return err
+		}
 	}
 
 	tags := map[string]string{"server": tagAddress, "db": dbname.String()}

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -174,3 +174,18 @@ func (p *Service) SanitizedAddress() (sanitizedAddress string, err error) {
 
 	return kvMatcher.ReplaceAllString(canonicalizedAddress, ""), nil
 }
+
+// GetConnectDatabase utility function for getting the database to which the connection was made
+func (p *Service) GetConnectDatabase(connectionString string) (string, error) {
+	databaseRegexp, err := regexp.Compile(`dbname=(\w+)`)
+	if err != nil {
+		return "", fmt.Errorf("compiling a regular expression failed: %w", err)
+	}
+
+	listMatch := databaseRegexp.FindStringSubmatch(connectionString)
+	if len(listMatch) > 1 {
+		return listMatch[1], nil
+	} else {
+		return "postgres", nil
+	}
+}

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -177,14 +177,13 @@ func (p *Service) SanitizedAddress() (sanitizedAddress string, err error) {
 
 // GetConnectDatabase utility function for getting the database to which the connection was made
 func (p *Service) GetConnectDatabase(connectionString string) (string, error) {
-	databaseRegexp, err := regexp.Compile(`dbname=(\w+)`)
+	connConfig, err := pgx.ParseConfig(connectionString)
 	if err != nil {
-		return "", fmt.Errorf("compiling a regular expression failed: %w", err)
+		return "", fmt.Errorf("connection string parsing failed: %w", err)
 	}
 
-	listMatch := databaseRegexp.FindStringSubmatch(connectionString)
-	if len(listMatch) > 1 {
-		return listMatch[1], nil
+	if len(connConfig.Database) != 0 {
+		return connConfig.Database, nil
 	}
 
 	return "postgres", nil

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -185,7 +185,7 @@ func (p *Service) GetConnectDatabase(connectionString string) (string, error) {
 	listMatch := databaseRegexp.FindStringSubmatch(connectionString)
 	if len(listMatch) > 1 {
 		return listMatch[1], nil
-	} else {
-		return "postgres", nil
 	}
+
+	return "postgres", nil
 }

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -186,6 +186,10 @@ func (p *Postgresql) accRow(measName string, row scanner, acc telegraf.Accumulat
 		columnVars = append(columnVars, columnMap[columns[i]])
 	}
 
+	if tagAddress, err = p.SanitizedAddress(); err != nil {
+		return err
+	}
+
 	// deconstruct array of variables and send to Scan
 	if err = row.Scan(columnVars...); err != nil {
 		return err
@@ -199,18 +203,22 @@ func (p *Postgresql) accRow(measName string, row scanner, acc telegraf.Accumulat
 				return err
 			}
 		default:
-			if _, err := dbname.WriteString("postgres"); err != nil {
+			database, err := p.GetConnectDatabase(tagAddress)
+			if err != nil {
+				return err
+			}
+			if _, err := dbname.WriteString(database); err != nil {
 				return err
 			}
 		}
 	} else {
-		if _, err := dbname.WriteString("postgres"); err != nil {
+		database, err := p.GetConnectDatabase(tagAddress)
+		if err != nil {
 			return err
 		}
-	}
-
-	if tagAddress, err = p.SanitizedAddress(); err != nil {
-		return err
+		if _, err := dbname.WriteString(database); err != nil {
+			return err
+		}
 	}
 
 	// Process the additional tags


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #9735 

- Fixing the default DB in the absence of the "datname" field. Now the default DB definition is taken from the connection string.
- Fixing the default database for pgbouncer. System database pgbouncer -> pgbouncer (https://www.pgbouncer.org/usage.html)
