### PR TITLE
fix(tools.custom_builder): Ignore non-plugin sections during configuration

### DIFF
--- a/tools/custom_builder/config.go
+++ b/tools/custom_builder/config.go
@@ -175,6 +175,19 @@ func (s *selection) extractPluginsFromConfig(buf []byte) error {
 	}
 
 	for category, subtbl := range table.Fields {
+		// Check if we should handle the category, i.e. it contains plugins
+		// to configure.
+		var valid bool
+		for _, c := range categories {
+			if c == category {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			continue
+		}
+
 		categoryTbl, ok := subtbl.(*ast.Table)
 		if !ok {
 			continue


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13592 

Ignore non-plugin sections when loading the configuration.