### PR TITLE
feat(agent): Add option to avoid filtering of global tags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -263,6 +263,10 @@ type AgentConfig struct {
 	// Flag to always keep tags explicitly defined in the plugin itself and
 	// ensure those tags always pass filtering.
 	AlwaysIncludeLocalTags bool `toml:"always_include_local_tags"`
+
+	// Flag to always keep tags explicitly defined in the global tags section
+	// and ensure those tags always pass filtering.
+	AlwaysIncludeGlobalTags bool `toml:"always_include_global_tags"`
 }
 
 // InputNames returns a list of strings of the configured inputs.
@@ -1459,8 +1463,9 @@ func (c *Config) buildFilter(tbl *ast.Table) (models.Filter, error) {
 // models.InputConfig to be inserted into models.RunningInput
 func (c *Config) buildInput(name string, tbl *ast.Table) (*models.InputConfig, error) {
 	cp := &models.InputConfig{
-		Name:                   name,
-		AlwaysIncludeLocalTags: c.Agent.AlwaysIncludeLocalTags,
+		Name:                    name,
+		AlwaysIncludeLocalTags:  c.Agent.AlwaysIncludeLocalTags,
+		AlwaysIncludeGlobalTags: c.Agent.AlwaysIncludeGlobalTags,
 	}
 	c.getFieldDuration(tbl, "interval", &cp.Interval)
 	c.getFieldDuration(tbl, "precision", &cp.Precision)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -326,6 +326,11 @@ The agent table configures Telegraf and the defaults used across all plugins.
   via `taginclude` or `tagexclude`. This removes the need to specify local tags
   twice.
 
+- **always_include_global_tags**:
+  Ensure tags explicitly defined in the `global_tags` section will *always* pass
+  tag-filtering   via `taginclude` or `tagexclude`. This removes the need to
+  specify those tags twice.
+
 ## Plugins
 
 Telegraf plugins are divided into 4 types: [inputs][], [outputs][],


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13492 

This PR adds a flag `always_include_global_tags` that allows to always keep global tags despite filtering similar to the `always_include_local_tags` option.