### PR TITLE
feat(parsers.avro): Add support for JSON format

### DIFF
--- a/plugins/parsers/avro/README.md
+++ b/plugins/parsers/avro/README.md
@@ -27,6 +27,10 @@ The message is supposed to be encoded as follows:
   ## Avro data format settings
   data_format = "avro"
 
+  ## Avro message format
+  ## Supported values are "binary" (default) and "json"
+  # avro_format = "binary"
+
   ## Url of the schema registry; exactly one of schema registry and
   ## schema must be set
   avro_schema_registry = "http://localhost:8081"
@@ -82,6 +86,11 @@ The message is supposed to be encoded as follows:
   # tags = { "application": "hermes", "region": "central" }
 
 ```
+
+### `avro_format`
+
+This optional setting specifies the format of the Avro messages. Currently, the
+parser supports the `binary` and `json` formats with `binary` being the default.
 
 ### `avro_timestamp` and `avro_timestamp_format`
 

--- a/plugins/parsers/avro/testdata/json-format/expected.out
+++ b/plugins/parsers/avro/testdata/json-format/expected.out
@@ -1,0 +1,1 @@
+Switch,switch_wwn=10:00:50:EB:1A:0B:84:3A statistics_collection_time=1682509200092i,up_time=1166984904i,cpu_utilization=14.0,memory_utilization=20.0 1682509200092000

--- a/plugins/parsers/avro/testdata/json-format/message.json
+++ b/plugins/parsers/avro/testdata/json-format/message.json
@@ -1,0 +1,7 @@
+{
+    "switch_wwn": "10:00:50:EB:1A:0B:84:3A",
+    "statistics_collection_time": 1682509200092,
+    "up_time": 1166984904,
+    "cpu_utilization": 14.0,
+    "memory_utilization": 20.0
+}

--- a/plugins/parsers/avro/testdata/json-format/telegraf.conf
+++ b/plugins/parsers/avro/testdata/json-format/telegraf.conf
@@ -1,0 +1,25 @@
+[[ inputs.file ]]
+  files = ["./testdata/json-format/message.json"]
+  data_format = "avro"
+
+  avro_format = "json"
+  avro_measurement = "Switch"
+  avro_tags = ["switch_wwn"]
+  avro_fields = ["up_time", "cpu_utilization", "memory_utilization"]
+  avro_timestamp = "statistics_collection_time"
+  avro_timestamp_format = "unix_ms"
+  avro_schema = '''
+        {
+                "namespace": "com.brocade.streaming",
+                "name": "fibrechannel_switch_statistics",
+                "type": "record",
+                "version": "1",
+                "fields": [
+                        {"name": "switch_wwn", "type": "string", "doc": "WWN of the Physical Switch."},
+                        {"name": "statistics_collection_time", "type": "long", "doc": "Epoch time when statistics is collected."},
+                        {"name": "up_time", "type": "long", "doc": "Switch Up Time (in hundredths of a second)"},
+                        {"name": "cpu_utilization", "type": "float", "default": 0, "doc": "CPU Utilization in %"},
+                        {"name": "memory_utilization", "type": "float", "default": 0, "doc": "Memory Utilization in %"}
+                ]
+        }
+  '''


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13155 

This PR adds support for Avro's JSON message format using a new `avro_format` option.