### PR TITLE
chore(inputs.net): Deprecate 'ignore_protocol_stats' value 'false'

### DIFF
--- a/plugins/inputs/net/README.md
+++ b/plugins/inputs/net/README.md
@@ -27,8 +27,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## On linux systems telegraf also collects protocol stats.
   ## Setting ignore_protocol_stats to true will skip reporting of protocol metrics.
   ##
+  ## DEPRECATION NOTICE: A value of 'false' is deprecated and discouraged!
+  ##                     Please set this to `true` and use the 'inputs.nstat'
+  ##                     plugin instead.
   # ignore_protocol_stats = false
-  ##
 ```
 
 ## Metrics

--- a/plugins/inputs/net/net.go
+++ b/plugins/inputs/net/net.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/filter"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/inputs/system"
 )
@@ -27,6 +28,20 @@ type NetIOStats struct {
 
 func (*NetIOStats) SampleConfig() string {
 	return sampleConfig
+}
+
+func (n *NetIOStats) Init() error {
+	if !n.IgnoreProtocolStats {
+		models.PrintOptionValueDeprecationNotice(telegraf.Warn, "inputs.net", "ignore_protocol_stats", "false",
+			telegraf.DeprecationInfo{
+				Since:     "1.27.3",
+				RemovalIn: "1.36.0",
+				Notice:    "use the 'inputs.nstat' plugin instead",
+			},
+		)
+	}
+
+	return nil
 }
 
 func (n *NetIOStats) Gather(acc telegraf.Accumulator) error {

--- a/plugins/inputs/net/sample.conf
+++ b/plugins/inputs/net/sample.conf
@@ -10,5 +10,7 @@
   ## On linux systems telegraf also collects protocol stats.
   ## Setting ignore_protocol_stats to true will skip reporting of protocol metrics.
   ##
+  ## DEPRECATION NOTICE: A value of 'false' is deprecated and discouraged!
+  ##                     Please set this to `true` and use the 'inputs.nstat'
+  ##                     plugin instead.
   # ignore_protocol_stats = false
-  ##


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13248 

This deprecates output protocol statistics in the `inputs.net` plugin and suggests using `inputs.nstat` instead.