### PR TITLE
fix(agent): Respect processor order in file

### DIFF
--- a/agent/testcases/processor-order-appearance/expected.out
+++ b/agent/testcases/processor-order-appearance/expected.out
@@ -1,0 +1,2 @@
+new_metric_from_starlark,foo=bar baz=42i,timestamp="2023-07-13T12:53:54.197709713Z" 1689252834197709713
+old_metric_from_mock,mood=good value=23i,timestamp="2023-07-13T13:10:34Z" 1689253834000000000

--- a/agent/testcases/processor-order-appearance/input.influx
+++ b/agent/testcases/processor-order-appearance/input.influx
@@ -1,0 +1,1 @@
+old_metric_from_mock,mood=good value=23i 1689253834000000000

--- a/agent/testcases/processor-order-appearance/telegraf.conf
+++ b/agent/testcases/processor-order-appearance/telegraf.conf
@@ -1,0 +1,26 @@
+# Test for using the appearance order in the file for processor order
+[[inputs.file]]
+  files = ["testcases/processor-order-appearance/input.influx"]
+  data_format = "influx"
+
+[[processors.starlark]]
+  source = '''
+def apply(metric):
+  metrics = []
+
+  m = Metric("new_metric_from_starlark")
+  m.tags["foo"] = "bar"
+  m.fields["baz"] = 42
+  m.time = 1689252834197709713
+  metrics.append(m)
+  metrics.append(metric)
+
+  return metrics
+'''
+
+[[processors.date]]
+  field_key = "timestamp"
+  date_format = "2006-01-02T15:04:05.999999999Z"
+  timezone = "UTC"
+
+

--- a/agent/testcases/processor-order-explicit/expected.out
+++ b/agent/testcases/processor-order-explicit/expected.out
@@ -1,0 +1,2 @@
+new_metric_from_starlark,foo=bar baz=42i,timestamp="2023-07-13T12:53:54.197709713Z" 1689252834197709713
+old_metric_from_mock,mood=good value=23i,timestamp="2023-07-13T13:10:34Z" 1689253834000000000

--- a/agent/testcases/processor-order-explicit/input.influx
+++ b/agent/testcases/processor-order-explicit/input.influx
@@ -1,0 +1,1 @@
+old_metric_from_mock,mood=good value=23i 1689253834000000000

--- a/agent/testcases/processor-order-explicit/telegraf.conf
+++ b/agent/testcases/processor-order-explicit/telegraf.conf
@@ -1,0 +1,27 @@
+# Test for specifying an explicit processor order
+[[inputs.file]]
+  files = ["testcases/processor-order-explicit/input.influx"]
+  data_format = "influx"
+
+
+[[processors.date]]
+  field_key = "timestamp"
+  date_format = "2006-01-02T15:04:05.999999999Z"
+  timezone = "UTC"
+  order = 2
+
+[[processors.starlark]]
+  source = '''
+def apply(metric):
+  metrics = []
+
+  m = Metric("new_metric_from_starlark")
+  m.tags["foo"] = "bar"
+  m.fields["baz"] = 42
+  m.time = 1689252834197709713
+  metrics.append(m)
+  metrics.append(metric)
+
+  return metrics
+'''
+  order = 1

--- a/agent/testcases/processor-order-mixed/expected.out
+++ b/agent/testcases/processor-order-mixed/expected.out
@@ -1,0 +1,2 @@
+new_metric_from_starlark,foo=bar baz=42i,timestamp="2023-07-13T12:53:54.197709713Z" 1689252834197709713
+old_metric_from_mock,mood=good value=23i,timestamp="2023-07-13T13:10:34Z" 1689253834000000000

--- a/agent/testcases/processor-order-mixed/input.influx
+++ b/agent/testcases/processor-order-mixed/input.influx
@@ -1,0 +1,1 @@
+old_metric_from_mock,mood=good value=23i 1689253834000000000

--- a/agent/testcases/processor-order-mixed/telegraf.conf
+++ b/agent/testcases/processor-order-mixed/telegraf.conf
@@ -1,0 +1,25 @@
+# Test for using the appearance order in the file for processor order
+[[inputs.file]]
+  files = ["testcases/processor-order-appearance/input.influx"]
+  data_format = "influx"
+
+[[processors.starlark]]
+  source = '''
+def apply(metric):
+  metrics = []
+
+  m = Metric("new_metric_from_starlark")
+  m.tags["foo"] = "bar"
+  m.fields["baz"] = 42
+  m.time = 1689252834197709713
+  metrics.append(m)
+  metrics.append(metric)
+
+  return metrics
+'''
+
+[[processors.date]]
+  field_key = "timestamp"
+  date_format = "2006-01-02T15:04:05.999999999Z"
+  timezone = "UTC"
+  order = 1

--- a/agent/testcases/processor-order-no-starlark/expected.out
+++ b/agent/testcases/processor-order-no-starlark/expected.out
@@ -1,0 +1,2 @@
+new_metric_from_starlark,foo=bar baz=42i 1689252834197709713
+old_metric_from_mock,mood=good value=23i,timestamp="2023-07-13T13:10:34Z" 1689253834000000000

--- a/agent/testcases/processor-order-no-starlark/input.influx
+++ b/agent/testcases/processor-order-no-starlark/input.influx
@@ -1,0 +1,1 @@
+old_metric_from_mock,mood=good value=23i 1689253834000000000

--- a/agent/testcases/processor-order-no-starlark/telegraf.conf
+++ b/agent/testcases/processor-order-no-starlark/telegraf.conf
@@ -24,6 +24,3 @@ def apply(metric):
 
   return metrics
 '''
-
-
-

--- a/agent/testcases/processor-order-no-starlark/telegraf.conf
+++ b/agent/testcases/processor-order-no-starlark/telegraf.conf
@@ -1,0 +1,29 @@
+# Test for using the appearance order in the file for processor order.
+# This will not add the "timestamp" field as the starlark processor runs _after_
+# the date processor.
+[[inputs.file]]
+  files = ["testcases/processor-order-no-starlark/input.influx"]
+  data_format = "influx"
+
+[[processors.date]]
+  field_key = "timestamp"
+  date_format = "2006-01-02T15:04:05.999999999Z"
+  timezone = "UTC"
+
+[[processors.starlark]]
+  source = '''
+def apply(metric):
+  metrics = []
+
+  m = Metric("new_metric_from_starlark")
+  m.tags["foo"] = "bar"
+  m.fields["baz"] = 42
+  m.time = 1689252834197709713
+  metrics.append(m)
+  metrics.append(metric)
+
+  return metrics
+'''
+
+
+


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12849

Processor and aggregators are sensitive to order changes in Telegraf as their order defines the actual processing done and the metrics that are taken into account. When loading the configuration files, the order of those plugins is preserved taking the `order` option into account. However, the agent itself sorts the processors _again_ before actually setting up the processing pipeline. While this on itself does not cause an issue, there is a subtle twist as the "order" is reversed using the sorting. This is necessary because the agent constructs the pipeline from _output to input_ and thus needs to start with the "last" processor.
However, the sorting _only_ affects the processors with an _explicit_ `order` setting, leaving all other processors in the initial order. As a consequence, those processors will then process in *reverse order* wrt the appearance in the config file...

This PR removes the superfluous sorting in the agent and takes the config-order as-is. It then adds the processors from output-to-input, i.e. it _truly_ iterates the processors in reverse order, thus keeping the processing order equivalent to the appearance in the file while respecting explicit order statements.