### PR TITLE
feat(inputs.postgresql_extensible): introduce MaxVersion

### DIFF
--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -68,27 +68,32 @@ to use them.
   # default, all rows inserted with current time. By setting a timestamp column,
   # the row will be inserted with that column's value.
   #
-  # The minversion field specifies minimal database version this query will run on.
-  # Datbase version is represented as single integer, for example:
+  # The minversion field specifies minimal database version this query
+  # will run on.
+  #
+  # The maxversion field when set specifies maximal database version
+  # this query will NOT run on.
+  #
+  # Database version in `minversion` and `maxversion` is represented as
+  # a single integer without last component, for example:
   # 9.6.2 -> 906
   # 15.2 -> 1500
   #
   # Structure :
   # [[inputs.postgresql_extensible.query]]
   #   sqlquery string
-  #   minversion string
+  #   minversion int
+  #   maxversion int
   #   withdbname boolean
   #   tagvalue string (coma separated)
   #   timestamp string
   [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT * FROM pg_stat_database where datname"
     minversion=901
-    withdbname=false
     tagvalue=""
   [[inputs.postgresql_extensible.query]]
     script="your_sql-filepath.sql"
     minversion=901
-    withdbname=false
     tagvalue=""
 ```
 

--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -68,10 +68,10 @@ to use them.
   # default, all rows inserted with current time. By setting a timestamp column,
   # the row will be inserted with that column's value.
   #
-  # The minversion field specifies minimal database version this query
+  # The min_version field specifies minimal database version this query
   # will run on.
   #
-  # The maxversion field when set specifies maximal database version
+  # The max_version field when set specifies maximal database version
   # this query will NOT run on.
   #
   # Database version in `minversion` and `maxversion` is represented as
@@ -82,18 +82,19 @@ to use them.
   # Structure :
   # [[inputs.postgresql_extensible.query]]
   #   sqlquery string
-  #   minversion int
-  #   maxversion int
+  #   min_version int
+  #   max_version int
   #   withdbname boolean
   #   tagvalue string (coma separated)
   #   timestamp string
   [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT * FROM pg_stat_database where datname"
-    minversion=901
+    min_version=901
     tagvalue=""
   [[inputs.postgresql_extensible.query]]
     script="your_sql-filepath.sql"
-    minversion=901
+    min_version=901
+    max_version=1300
     tagvalue=""
 ```
 

--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -68,21 +68,26 @@ to use them.
   # default, all rows inserted with current time. By setting a timestamp column,
   # the row will be inserted with that column's value.
   #
+  # The minversion field specifies minimal database version this query will run on.
+  # Datbase version is represented as single integer, for example:
+  # 9.6.2 -> 906
+  # 15.2 -> 1500
+  #
   # Structure :
   # [[inputs.postgresql_extensible.query]]
   #   sqlquery string
-  #   version string
+  #   minversion string
   #   withdbname boolean
   #   tagvalue string (coma separated)
   #   timestamp string
   [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT * FROM pg_stat_database where datname"
-    version=901
+    minversion=901
     withdbname=false
     tagvalue=""
   [[inputs.postgresql_extensible.query]]
     script="your_sql-filepath.sql"
-    version=901
+    minversion=901
     withdbname=false
     tagvalue=""
 ```

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -37,9 +37,9 @@ type Postgresql struct {
 type query []struct {
 	Sqlquery    string
 	Script      string
-	Version     int `deprecated:"1.28.0;use minVersion to specify minimal DB version this query supports"`
-	MinVersion  int
-	MaxVersion  int
+	Version     int  `deprecated:"1.28.0;use minVersion to specify minimal DB version this query supports"`
+	MinVersion  int  `toml:"min_version"`
+	MaxVersion  int  `toml:"max_version"`
 	Withdbname  bool `deprecated:"1.22.4;use the sqlquery option to specify database to use"`
 	Tagvalue    string
 	Measurement string

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -37,7 +37,8 @@ type Postgresql struct {
 type query []struct {
 	Sqlquery    string
 	Script      string
-	Version     int
+	Version     int `deprecated:"1.28.0;use minVersion to specify minimal DB version this query supports"`
+	MinVersion  int
 	Withdbname  bool `deprecated:"1.22.4;use the sqlquery option to specify database to use"`
 	Tagvalue    string
 	Measurement string
@@ -58,6 +59,9 @@ func (p *Postgresql) Init() error {
 			if err != nil {
 				return err
 			}
+		}
+		if p.Query[i].MinVersion == 0 {
+			p.Query[i].MinVersion = p.Query[i].Version
 		}
 	}
 	p.Service.IsPgBouncer = !p.PreparedStatements
@@ -120,7 +124,7 @@ func (p *Postgresql) Gather(acc telegraf.Accumulator) error {
 		}
 		sqlQuery += queryAddon
 
-		if p.Query[i].Version <= dbVersion {
+		if p.Query[i].MinVersion <= dbVersion {
 			p.gatherMetricsFromQuery(acc, sqlQuery, p.Query[i].Tagvalue, p.Query[i].Timestamp, measName)
 		}
 	}

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -39,6 +39,7 @@ type query []struct {
 	Script      string
 	Version     int `deprecated:"1.28.0;use minVersion to specify minimal DB version this query supports"`
 	MinVersion  int
+	MaxVersion  int
 	Withdbname  bool `deprecated:"1.22.4;use the sqlquery option to specify database to use"`
 	Tagvalue    string
 	Measurement string
@@ -124,7 +125,9 @@ func (p *Postgresql) Gather(acc telegraf.Accumulator) error {
 		}
 		sqlQuery += queryAddon
 
-		if p.Query[i].MinVersion <= dbVersion {
+		maxVer := p.Query[i].MaxVersion
+
+		if p.Query[i].MinVersion <= dbVersion && (maxVer == 0 || maxVer > dbVersion) {
 			p.gatherMetricsFromQuery(acc, sqlQuery, p.Query[i].Tagvalue, p.Query[i].Timestamp, measName)
 		}
 	}

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
@@ -63,7 +63,7 @@ func TestPostgresqlGeneratesMetricsIntegration(t *testing.T) {
 
 	acc := queryRunner(t, query{{
 		Sqlquery:   "select * from pg_stat_database",
-		Version:    901,
+		MinVersion: 901,
 		Withdbname: false,
 		Tagvalue:   "",
 	}})
@@ -163,7 +163,7 @@ func TestPostgresqlQueryOutputTestsIntegration(t *testing.T) {
 	for q, assertions := range examples {
 		acc := queryRunner(t, query{{
 			Sqlquery:   q,
-			Version:    901,
+			MinVersion: 901,
 			Withdbname: false,
 			Tagvalue:   "",
 			Timestamp:  "ts",
@@ -180,7 +180,7 @@ func TestPostgresqlFieldOutputIntegration(t *testing.T) {
 
 	acc := queryRunner(t, query{{
 		Sqlquery:   "select * from pg_stat_database",
-		Version:    901,
+		MinVersion: 901,
 		Withdbname: false,
 		Tagvalue:   "",
 	}})
@@ -238,7 +238,7 @@ func TestPostgresqlFieldOutputIntegration(t *testing.T) {
 func TestPostgresqlSqlScript(t *testing.T) {
 	q := query{{
 		Script:     "testdata/test.sql",
-		Version:    901,
+		MinVersion: 901,
 		Withdbname: false,
 		Tagvalue:   "",
 	}}

--- a/plugins/inputs/postgresql_extensible/sample.conf
+++ b/plugins/inputs/postgresql_extensible/sample.conf
@@ -35,10 +35,10 @@
   # default, all rows inserted with current time. By setting a timestamp column,
   # the row will be inserted with that column's value.
   #
-  # The minversion field specifies minimal database version this query
+  # The min_version field specifies minimal database version this query
   # will run on.
   #
-  # The maxversion field when set specifies maximal database version
+  # The max_version field when set specifies maximal database version
   # this query will NOT run on.
   #
   # Database version in `minversion` and `maxversion` is represented as
@@ -49,16 +49,17 @@
   # Structure :
   # [[inputs.postgresql_extensible.query]]
   #   sqlquery string
-  #   minversion int
-  #   maxversion int
+  #   min_version int
+  #   max_version int
   #   withdbname boolean
   #   tagvalue string (coma separated)
   #   timestamp string
   [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT * FROM pg_stat_database where datname"
-    minversion=901
+    min_version=901
     tagvalue=""
   [[inputs.postgresql_extensible.query]]
     script="your_sql-filepath.sql"
-    minversion=901
+    min_version=901
+    max_version=1300
     tagvalue=""

--- a/plugins/inputs/postgresql_extensible/sample.conf
+++ b/plugins/inputs/postgresql_extensible/sample.conf
@@ -35,8 +35,14 @@
   # default, all rows inserted with current time. By setting a timestamp column,
   # the row will be inserted with that column's value.
   #
-  # The minversion field specifies minimal database version this query will run on.
-  # Datbase version is represented as single integer, for example:
+  # The minversion field specifies minimal database version this query
+  # will run on.
+  #
+  # The maxversion field when set specifies maximal database version
+  # this query will NOT run on.
+  #
+  # Database version in `minversion` and `maxversion` is represented as
+  # a single integer without last component, for example:
   # 9.6.2 -> 906
   # 15.2 -> 1500
   #
@@ -44,6 +50,7 @@
   # [[inputs.postgresql_extensible.query]]
   #   sqlquery string
   #   minversion int
+  #   maxversion int
   #   withdbname boolean
   #   tagvalue string (coma separated)
   #   timestamp string

--- a/plugins/inputs/postgresql_extensible/sample.conf
+++ b/plugins/inputs/postgresql_extensible/sample.conf
@@ -35,20 +35,23 @@
   # default, all rows inserted with current time. By setting a timestamp column,
   # the row will be inserted with that column's value.
   #
+  # The minversion field specifies minimal database version this query will run on.
+  # Datbase version is represented as single integer, for example:
+  # 9.6.2 -> 906
+  # 15.2 -> 1500
+  #
   # Structure :
   # [[inputs.postgresql_extensible.query]]
   #   sqlquery string
-  #   version string
+  #   minversion int
   #   withdbname boolean
   #   tagvalue string (coma separated)
   #   timestamp string
   [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT * FROM pg_stat_database where datname"
-    version=901
-    withdbname=false
+    minversion=901
     tagvalue=""
   [[inputs.postgresql_extensible.query]]
     script="your_sql-filepath.sql"
-    version=901
-    withdbname=false
+    minversion=901
     tagvalue=""


### PR DESCRIPTION
# Required for all PRs
<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13568

Rename `version` to `minversion` and introduce `maxversion` to limit DB version query should run on.
