### PR TITLE
feat(inputs.http): Rework token options

### DIFF
--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -17,8 +17,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ## Secret-store support
 
-This plugin supports secrets from secret-stores for the `username` and
-`password` option.
+This plugin supports secrets from secret-stores for the `username`, `password`
+and `token` option.
 See the [secret-store documentation][SECRETSTORE] for more details on how
 to use them.
 
@@ -47,9 +47,10 @@ to use them.
   ## compress body or "identity" to apply no encoding.
   # content_encoding = "identity"
 
-  ## Optional file with Bearer token
-  ## file content is added as an Authorization header
-  # bearer_token = "/path/to/file"
+  ## Optional Bearer token settings to use for the API calls.
+  ## Use either the token itself or the token file if you need a token.
+  # token = "eyJhbGc...Qssw5c"
+  # token_file = "/path/to/file"
 
   ## Optional HTTP Basic Auth Credentials
   # username = "username"

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -23,15 +23,20 @@ import (
 var sampleConfig string
 
 type HTTP struct {
-	URLs               []string          `toml:"urls"`
-	Method             string            `toml:"method"`
-	Body               string            `toml:"body"`
-	ContentEncoding    string            `toml:"content_encoding"`
-	Username           config.Secret     `toml:"username"`
-	Password           config.Secret     `toml:"password"`
-	BearerToken        string            `toml:"bearer_token" deprecated:"1.28.0;use 'token_file' instead"`
-	Token              config.Secret     `toml:"token"`
-	TokenFile          string            `toml:"token_file"`
+	URLs            []string `toml:"urls"`
+	Method          string   `toml:"method"`
+	Body            string   `toml:"body"`
+	ContentEncoding string   `toml:"content_encoding"`
+
+	// Basic authentication
+	Username config.Secret `toml:"username"`
+	Password config.Secret `toml:"password"`
+
+	// Bearer authentication
+	BearerToken string        `toml:"bearer_token" deprecated:"1.28.0;use 'token_file' instead"`
+	Token       config.Secret `toml:"token"`
+	TokenFile   string        `toml:"token_file"`
+
 	Headers            map[string]string `toml:"headers"`
 	SuccessStatusCodes []int             `toml:"success_status_codes"`
 	Log                telegraf.Logger   `toml:"-"`

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -23,23 +23,18 @@ import (
 var sampleConfig string
 
 type HTTP struct {
-	URLs            []string `toml:"urls"`
-	Method          string   `toml:"method"`
-	Body            string   `toml:"body"`
-	ContentEncoding string   `toml:"content_encoding"`
-
-	Headers map[string]string `toml:"headers"`
-
-	// HTTP Basic Auth Credentials
-	Username config.Secret `toml:"username"`
-	Password config.Secret `toml:"password"`
-
-	// Absolute path to file with Bearer token
-	BearerToken string `toml:"bearer_token"`
-
-	SuccessStatusCodes []int `toml:"success_status_codes"`
-
-	Log telegraf.Logger `toml:"-"`
+	URLs               []string          `toml:"urls"`
+	Method             string            `toml:"method"`
+	Body               string            `toml:"body"`
+	ContentEncoding    string            `toml:"content_encoding"`
+	Username           config.Secret     `toml:"username"`
+	Password           config.Secret     `toml:"password"`
+	BearerToken        string            `toml:"bearer_token" deprecated:"1.28.0;use 'token_file' instead"`
+	Token              config.Secret     `toml:"token"`
+	TokenFile          string            `toml:"token_file"`
+	Headers            map[string]string `toml:"headers"`
+	SuccessStatusCodes []int             `toml:"success_status_codes"`
+	Log                telegraf.Logger   `toml:"-"`
 
 	httpconfig.HTTPClientConfig
 
@@ -52,12 +47,24 @@ func (*HTTP) SampleConfig() string {
 }
 
 func (h *HTTP) Init() error {
+	// For backward compatibility
+	if h.TokenFile != "" && h.BearerToken != "" && h.TokenFile != h.BearerToken {
+		return fmt.Errorf("conflicting settings for 'bearer_token' and 'token_file'")
+	} else if h.TokenFile == "" && h.BearerToken != "" {
+		h.TokenFile = h.BearerToken
+	}
+
+	// We cannot use multiple sources for tokens
+	if h.TokenFile != "" && !h.Token.Empty() {
+		return fmt.Errorf("either use 'token_file' or 'token' not both")
+	}
+
+	// Create the client
 	ctx := context.Background()
 	client, err := h.HTTPClientConfig.CreateClient(ctx, h.Log)
 	if err != nil {
 		return err
 	}
-
 	h.client = client
 
 	// Set default as [200]
@@ -110,7 +117,14 @@ func (h *HTTP) gatherURL(
 		return err
 	}
 
-	if h.BearerToken != "" {
+	if !h.Token.Empty() {
+		token, err := h.Token.Get()
+		if err != nil {
+			return err
+		}
+		bearer := "Bearer " + strings.TrimSpace(string(token))
+		request.Header.Set("Authorization", bearer)
+	} else if h.TokenFile != "" {
 		token, err := os.ReadFile(h.BearerToken)
 		if err != nil {
 			return err

--- a/plugins/inputs/http/sample.conf
+++ b/plugins/inputs/http/sample.conf
@@ -18,9 +18,10 @@
   ## compress body or "identity" to apply no encoding.
   # content_encoding = "identity"
 
-  ## Optional file with Bearer token
-  ## file content is added as an Authorization header
-  # bearer_token = "/path/to/file"
+  ## Optional Bearer token settings to use for the API calls.
+  ## Use either the token itself or the token file if you need a token.
+  # token = "eyJhbGc...Qssw5c"
+  # token_file = "/path/to/file"
 
   ## Optional HTTP Basic Auth Credentials
   # username = "username"

--- a/plugins/inputs/http/sample.conf.in
+++ b/plugins/inputs/http/sample.conf.in
@@ -18,9 +18,10 @@
   ## compress body or "identity" to apply no encoding.
   # content_encoding = "identity"
 
-  ## Optional file with Bearer token
-  ## file content is added as an Authorization header
-  # bearer_token = "/path/to/file"
+  ## Optional Bearer token settings to use for the API calls.
+  ## Use either the token itself or the token file if you need a token.
+  # token = "eyJhbGc...Qssw5c"
+  # token_file = "/path/to/file"
 
   ## Optional HTTP Basic Auth Credentials
   # username = "username"


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

relates to #9455

This PR adds a new `token` option that allows to directly specify a token _or_ to reference a secret store entry. Together with PR #13621 (and potentially other secret-stores) this offers a powerful way to dynamically update the tokens in an arbitrary manner. Furthermore, this PR renames the `bearer_token` option to `token_file` for clarity and deprecates the former.