### PR TITLE
Revert "chore: Update to go1.20.6 (#13618)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     resource_class: large
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.20.6'
+      - image: 'quay.io/influxdb/telegraf-ci:1.20.5'
     environment:
       GOFLAGS: -p=4
   mac:

--- a/Makefile
+++ b/Makefile
@@ -249,8 +249,8 @@ plugins/parsers/influx/machine.go: plugins/parsers/influx/machine.go.rl
 
 .PHONY: ci
 ci:
-	docker build -t quay.io/influxdb/telegraf-ci:1.20.6 - < scripts/ci.docker
-	docker push quay.io/influxdb/telegraf-ci:1.20.6
+	docker build -t quay.io/influxdb/telegraf-ci:1.20.5 - < scripts/ci.docker
+	docker push quay.io/influxdb/telegraf-ci:1.20.5
 
 .PHONY: install
 install: $(buildbin)

--- a/scripts/ci.docker
+++ b/scripts/ci.docker
@@ -1,4 +1,4 @@
-FROM golang:1.20.6
+FROM golang:1.20.5
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/installgo_linux.sh
+++ b/scripts/installgo_linux.sh
@@ -2,10 +2,10 @@
 
 set -eux
 
-GO_VERSION="1.20.6"
+GO_VERSION="1.20.5"
 GO_ARCH="linux-amd64"
 # from https://golang.org/dl
-GO_VERSION_SHA="b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1eb"
+GO_VERSION_SHA="d7ec48cde0d3d2be2c69203bc3e0a44de8660b9c09a6e85c4732a3f7dc442612"
 
 # Download Go and verify Go tarball
 setup_go () {

--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -3,9 +3,9 @@
 set -eux
 
 ARCH=$(uname -m)
-GO_VERSION="1.20.6"
-GO_VERSION_SHA_arm64="1163be1998835a13f00dfc869a8e3cdebf86984ad41ff2fff43e35ac2a0d8344" # from https://golang.org/dl
-GO_VERSION_SHA_amd64="98a09c085b4c385abae7d35b9155195d5e584d14988347ac7f18e4cbe3b5ef3d" # from https://golang.org/dl
+GO_VERSION="1.20.5"
+GO_VERSION_SHA_arm64="94ad76b7e1593bb59df7fd35a738194643d6eed26a4181c94e3ee91381e40459" # from https://golang.org/dl
+GO_VERSION_SHA_amd64="79715ca5b8becd120703ac9af5d1da749e095d2b9bf830c4f3af4b15b2cb049d" # from https://golang.org/dl
 
 if [ "$ARCH" = 'arm64' ]; then
     GO_ARCH="darwin-arm64"

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION="1.20.6"
+GO_VERSION="1.20.5"
 
 setup_go () {
     choco upgrade golang --allow-downgrade --version=${GO_VERSION}


### PR DESCRIPTION
This reverts commit de8a9c514c398640fdc1b9c265000c38655c82aa.

go1.20.6 introduces a change that breaks our integration tests. This is tracked at https://github.com/testcontainers/testcontainers-go/issues/1306 which links to https://github.com/moby/moby/pull/45942