### PR TITLE
fix(inputs.prometheus): fix missing metrics when multiple plugin instances specified

### DIFF
--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -125,8 +125,8 @@ func shouldScrapePod(pod *corev1.Pod, p *Prometheus) bool {
 	return isCandidate && shouldScrape
 }
 
-// Share informer across all instances of this plugin
-var informerfactory informers.SharedInformerFactory
+// Share informer per namespace across all instances of this plugin
+var informerfactory map[string]informers.SharedInformerFactory
 
 // An edge case exists if a pod goes offline at the same time a new pod is created
 // (without the scrape annotations). K8s may re-assign the old pod ip to the non-scrape
@@ -142,16 +142,23 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 	}
 
 	if informerfactory == nil {
+		informerfactory = make(map[string]informers.SharedInformerFactory)
+	}
+
+	var f informers.SharedInformerFactory
+	var ok bool
+	if f, ok = informerfactory[p.PodNamespace]; !ok {
 		var informerOptions []informers.SharedInformerOption
 		if p.PodNamespace != "" {
 			informerOptions = append(informerOptions, informers.WithNamespace(p.PodNamespace))
 		}
-		informerfactory = informers.NewSharedInformerFactoryWithOptions(clientset, resyncinterval, informerOptions...)
+		f = informers.NewSharedInformerFactoryWithOptions(clientset, resyncinterval, informerOptions...)
+		informerfactory[p.PodNamespace] = f
 	}
 
-	p.nsStore = informerfactory.Core().V1().Namespaces().Informer().GetStore()
+	p.nsStore = f.Core().V1().Namespaces().Informer().GetStore()
 
-	podinformer := informerfactory.Core().V1().Pods()
+	podinformer := f.Core().V1().Pods()
 	_, err := podinformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(newObj interface{}) {
 			newPod, ok := newObj.(*corev1.Pod)
@@ -195,8 +202,8 @@ func (p *Prometheus) watchPod(ctx context.Context, clientset *kubernetes.Clients
 		},
 	})
 
-	informerfactory.Start(ctx.Done())
-	informerfactory.WaitForCacheSync(wait.NeverStop)
+	f.Start(ctx.Done())
+	f.WaitForCacheSync(wait.NeverStop)
 	return err
 }
 


### PR DESCRIPTION
# Required for all PRs

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13405


Plugins share SharedInformerFactory so that they reuse single connection to K8S API servers. If a plugin limits scope to just one namespace it can't share InformerFactory with another plugin which specifies different namespace.

To handle it correctly create a map of Namespace -> InformerFactory so that plugins can hook up to the right one.

