### PR TITLE
docs(inputs.postgresql_extensible): document 'measurement' query config option

### DIFF
--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -59,6 +59,9 @@ to use them.
   # The script option can be used to specify the .sql file path.
   # If script and sqlquery options specified at same time, sqlquery will be used
   #
+  # the measurement field defines measurement name for metrics produced
+  # by the query. Default is "postgresql".
+  #
   # the tagvalue field is used to define custom tags (separated by comas).
   # the query is expected to return columns which match the names of the
   # defined tags. The values in these columns must be of a string-type,
@@ -70,12 +73,14 @@ to use them.
   #
   # Structure :
   # [[inputs.postgresql_extensible.query]]
+  #   measurement string
   #   sqlquery string
   #   version string
   #   withdbname boolean
   #   tagvalue string (coma separated)
   #   timestamp string
   [[inputs.postgresql_extensible.query]]
+    measurement="pg_stat_database"
     sqlquery="SELECT * FROM pg_stat_database where datname"
     version=901
     withdbname=false

--- a/plugins/inputs/postgresql_extensible/sample.conf
+++ b/plugins/inputs/postgresql_extensible/sample.conf
@@ -26,6 +26,9 @@
   # The script option can be used to specify the .sql file path.
   # If script and sqlquery options specified at same time, sqlquery will be used
   #
+  # the measurement field defines measurement name for metrics produced
+  # by the query. Default is "postgresql".
+  #
   # the tagvalue field is used to define custom tags (separated by comas).
   # the query is expected to return columns which match the names of the
   # defined tags. The values in these columns must be of a string-type,
@@ -37,12 +40,14 @@
   #
   # Structure :
   # [[inputs.postgresql_extensible.query]]
+  #   measurement string
   #   sqlquery string
   #   version string
   #   withdbname boolean
   #   tagvalue string (coma separated)
   #   timestamp string
   [[inputs.postgresql_extensible.query]]
+    measurement="pg_stat_database"
     sqlquery="SELECT * FROM pg_stat_database where datname"
     version=901
     withdbname=false


### PR DESCRIPTION
# Required for all PRs

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)


No code change, just documenting missing config option


