### PR TITLE
fix(parsers.xpath): Improve handling of complex-type nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -485,3 +485,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/antchfx/jsonquery => github.com/srebhan/jsonquery v0.0.0-20230724130435-97fc5c5b79bf

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/aliyun/alibaba-cloud-sdk-go v1.62.389
 	github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9
-	github.com/antchfx/jsonquery v1.3.2
+	github.com/antchfx/jsonquery v1.3.3
 	github.com/antchfx/xmlquery v1.3.17
 	github.com/antchfx/xpath v1.2.4
 	github.com/apache/arrow/go/v13 v13.0.0-20230630125530-5a06b2ec2a8e
@@ -485,5 +485,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/antchfx/jsonquery => github.com/srebhan/jsonquery v0.0.0-20230724130435-97fc5c5b79bf

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/antchfx/jsonquery v1.3.3 h1:zjZpbnZhYng3uOAbIfdNq81A9mMEeuDJeYIpeKpZ4es=
+github.com/antchfx/jsonquery v1.3.3/go.mod h1:1JG4DqRlRCHgVYDPY1ioYFAGSXGfWHzNgrbiGQHsWck=
 github.com/antchfx/xmlquery v1.3.17 h1:d0qWjPp/D+vtRw7ivCwT5ApH/3CkQU8JOeo3245PpTk=
 github.com/antchfx/xmlquery v1.3.17/go.mod h1:Afkq4JIeXut75taLSuI31ISJ/zeq+3jG7TunF7noreA=
 github.com/antchfx/xpath v1.1.7/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
@@ -1390,8 +1392,6 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/srebhan/cborquery v0.0.0-20230626165538-38be85b82316 h1:HVv8JjpX24FuI59aET1uInn0ItuEiyj8CZMuR9Uw+lE=
 github.com/srebhan/cborquery v0.0.0-20230626165538-38be85b82316/go.mod h1:9vX3Dhehey14KFYwWo4K/4JOJRve6jvQf6R9Y8PymLI=
-github.com/srebhan/jsonquery v0.0.0-20230724130435-97fc5c5b79bf h1:0XE4sYreKTR5kpDmEBdbYV4+AVn+sNRdB/LiL9JBUHI=
-github.com/srebhan/jsonquery v0.0.0-20230724130435-97fc5c5b79bf/go.mod h1:1JG4DqRlRCHgVYDPY1ioYFAGSXGfWHzNgrbiGQHsWck=
 github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,6 @@ github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
-github.com/antchfx/jsonquery v1.3.2 h1:/BgHv1le9CCkqDe7t1x5BRlCg6DQmXTsztnMQFG5Hoc=
-github.com/antchfx/jsonquery v1.3.2/go.mod h1:VsW9O/sNgHoUVvhoMEjR+opjIOjKOViNFTpAlxcI4Ws=
 github.com/antchfx/xmlquery v1.3.17 h1:d0qWjPp/D+vtRw7ivCwT5ApH/3CkQU8JOeo3245PpTk=
 github.com/antchfx/xmlquery v1.3.17/go.mod h1:Afkq4JIeXut75taLSuI31ISJ/zeq+3jG7TunF7noreA=
 github.com/antchfx/xpath v1.1.7/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
@@ -1392,6 +1390,8 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/srebhan/cborquery v0.0.0-20230626165538-38be85b82316 h1:HVv8JjpX24FuI59aET1uInn0ItuEiyj8CZMuR9Uw+lE=
 github.com/srebhan/cborquery v0.0.0-20230626165538-38be85b82316/go.mod h1:9vX3Dhehey14KFYwWo4K/4JOJRve6jvQf6R9Y8PymLI=
+github.com/srebhan/jsonquery v0.0.0-20230724130435-97fc5c5b79bf h1:0XE4sYreKTR5kpDmEBdbYV4+AVn+sNRdB/LiL9JBUHI=
+github.com/srebhan/jsonquery v0.0.0-20230724130435-97fc5c5b79bf/go.mod h1:1JG4DqRlRCHgVYDPY1ioYFAGSXGfWHzNgrbiGQHsWck=
 github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -2,7 +2,6 @@ package xpath
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -519,23 +518,6 @@ func (p *Parser) executeQuery(doc, selected dataNode, query string) (r interface
 				return nn.GetValue(), nil
 			case *protobufquery.NodeNavigator:
 				return nn.GetValue(), nil
-			}
-		}
-		// Fallback to get the string value representation
-		if nn, ok := current.(*jsonquery.NodeNavigator); ok {
-			// For complex types such as arrays or maps, we cannot simply
-			// stringify the value as the upstream library does, but need to
-			// convert it to JSON again.
-			raw := nn.GetValue()
-			switch raw.(type) {
-			case string, bool:
-				// Fallthrough to the normal return
-			default:
-				v, err := json.Marshal(raw)
-				if err != nil {
-					return nil, err
-				}
-				return string(v), nil
 			}
 		}
 

--- a/plugins/parsers/xpath/testcases/json_array_expand/telegraf.conf
+++ b/plugins/parsers/xpath/testcases/json_array_expand/telegraf.conf
@@ -7,6 +7,6 @@
   [[inputs.file.xpath]]
     field_name_expansion = true
     metric_name = "'foo'"
-    field_selection = "descendant::*"
+    field_selection = "descendant::*[not(*)]"
     timestamp = "//timestamp"
     timestamp_format = "unix_ns"

--- a/plugins/parsers/xpath/testcases/json_native_nonnested/expected.out
+++ b/plugins/parsers/xpath/testcases/json_native_nonnested/expected.out
@@ -1,0 +1,1 @@
+foo a="a string",b=3.1415,c=true,d="map[d1:1 d2:foo d3:true d4:<nil>]",e="[master 42 true]",timestamp=1690193829 1690193829000000000

--- a/plugins/parsers/xpath/testcases/json_native_nonnested/telegraf.conf
+++ b/plugins/parsers/xpath/testcases/json_native_nonnested/telegraf.conf
@@ -1,0 +1,11 @@
+[[inputs.file]]
+  files = ["./testcases/json_string_representation/test.json"]
+  data_format = "xpath_json"
+
+  xpath_native_types = true
+
+  [[inputs.file.xpath]]
+    metric_name = "'foo'"
+    field_selection = "*"
+    timestamp = "timestamp"
+    timestamp_format = "unix"

--- a/plugins/parsers/xpath/testcases/json_native_nonnested/test.json
+++ b/plugins/parsers/xpath/testcases/json_native_nonnested/test.json
@@ -1,0 +1,13 @@
+{
+   "a": "a string",
+   "b": 3.1415,
+   "c": true,
+   "d": {
+     "d1": 1,
+     "d2": "foo",
+     "d3": true,
+     "d4": null
+   },
+   "e": ["master", 42, true],
+   "timestamp": 1690193829
+ }

--- a/plugins/parsers/xpath/testcases/json_string_representation/expected.out
+++ b/plugins/parsers/xpath/testcases/json_string_representation/expected.out
@@ -1,0 +1,1 @@
+foo a="a string",b="3.1415",c="true",d="{\"d1\":1,\"d2\":\"foo\",\"d3\":true,\"d4\":null}",e="[\"master\",42,true]",timestamp="1690193829" 1690193829000000000

--- a/plugins/parsers/xpath/testcases/json_string_representation/telegraf.conf
+++ b/plugins/parsers/xpath/testcases/json_string_representation/telegraf.conf
@@ -1,0 +1,9 @@
+[[inputs.file]]
+  files = ["./testcases/json_string_representation/test.json"]
+  data_format = "xpath_json"
+
+  [[inputs.file.xpath]]
+    metric_name = "'foo'"
+    field_selection = "*"
+    timestamp = "timestamp"
+    timestamp_format = "unix"

--- a/plugins/parsers/xpath/testcases/json_string_representation/test.json
+++ b/plugins/parsers/xpath/testcases/json_string_representation/test.json
@@ -1,0 +1,13 @@
+{
+   "a": "a string",
+   "b": 3.1415,
+   "c": true,
+   "d": {
+     "d1": 1,
+     "d2": "foo",
+     "d3": true,
+     "d4": null
+   },
+   "e": ["master", 42, true],
+   "timestamp": 1690193829
+ }

--- a/plugins/parsers/xpath/testcases/name_expansion/telegraf.conf
+++ b/plugins/parsers/xpath/testcases/name_expansion/telegraf.conf
@@ -6,5 +6,5 @@
   [[inputs.file.xpath]]
     metric_name = "'devices'"
     metric_selection = "/devices/*"
-    field_selection = "descendant::*"
+    field_selection = "descendant::*[not(*)]"
     field_name_expansion = true


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13655 

This PR improves the handling of map and array types, delivering those types _at all_ for native-type queries. Furthermore, we work-around issue #https://github.com/antchfx/jsonquery/issues/15 for maps and arrays in JSON to return a valid string representation of those nodes.