### PR TITLE
fix(inputs.mqtt_consumer): client logs via option

### DIFF
--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -101,8 +101,9 @@ to use them.
   # insecure_skip_verify = false
 
   ## Client trace messages
-  ## When set to true, the MQTT client's messages are printed to stdout. These
-  ## messages are very noisey, but essential for debugging issues.
+  ## When set to true, and debug mode enabled in the agent settings, the MQTT
+  ## client's messages are included in telegraf logs. These messages are very
+  ## noisey, but essential for debugging issues.
   # client_trace = false
 
   ## Data format to consume.

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -100,6 +100,11 @@ to use them.
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
+  ## Client trace messages
+  ## When set to true, the MQTT client's messages are printed to stdout. These
+  ## messages are very noisey, but essential for debugging issues.
+  # client_trace = false
+
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/inputs/mqtt_consumer/logger.go
+++ b/plugins/inputs/mqtt_consumer/logger.go
@@ -1,0 +1,17 @@
+package mqtt_consumer
+
+import (
+	"github.com/influxdata/telegraf"
+)
+
+type mqttLogger struct {
+	telegraf.Logger
+}
+
+func (l mqttLogger) Printf(fmt string, args ...interface{}) {
+	l.Logger.Debugf(fmt, args...)
+}
+
+func (l mqttLogger) Println(args ...interface{}) {
+	l.Logger.Debug(args...)
+}

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -70,6 +70,7 @@ type MQTTConsumer struct {
 	Password               config.Secret        `toml:"password"`
 	QoS                    int                  `toml:"qos"`
 	ConnectionTimeout      config.Duration      `toml:"connection_timeout"`
+	ClientTrace            bool                 `toml:"client_trace"`
 	MaxUndeliveredMessages int                  `toml:"max_undelivered_messages"`
 	parser                 telegraf.Parser
 
@@ -104,6 +105,14 @@ func (m *MQTTConsumer) SetParser(parser telegraf.Parser) {
 	m.parser = parser
 }
 func (m *MQTTConsumer) Init() error {
+	if m.ClientTrace {
+		log := &mqttLogger{m.Log}
+		mqtt.ERROR = log
+		mqtt.CRITICAL = log
+		mqtt.WARN = log
+		mqtt.DEBUG = log
+	}
+
 	m.state = Disconnected
 	if m.PersistentSession && m.ClientID == "" {
 		return errors.New("persistent_session requires client_id")

--- a/plugins/inputs/mqtt_consumer/sample.conf
+++ b/plugins/inputs/mqtt_consumer/sample.conf
@@ -64,8 +64,9 @@
   # insecure_skip_verify = false
 
   ## Client trace messages
-  ## When set to true, the MQTT client's messages are printed to stdout. These
-  ## messages are very noisey, but essential for debugging issues.
+  ## When set to true, and debug mode enabled in the agent settings, the MQTT
+  ## client's messages are included in telegraf logs. These messages are very
+  ## noisey, but essential for debugging issues.
   # client_trace = false
 
   ## Data format to consume.

--- a/plugins/inputs/mqtt_consumer/sample.conf
+++ b/plugins/inputs/mqtt_consumer/sample.conf
@@ -63,6 +63,11 @@
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
+  ## Client trace messages
+  ## When set to true, the MQTT client's messages are printed to stdout. These
+  ## messages are very noisey, but essential for debugging issues.
+  # client_trace = false
+
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:


### PR DESCRIPTION
This enables the ability to get logs from the client via an option. These messages are essential to debugging connection issues or understanding what the client is doing.

The option produces an enormous amount of data so it is disabled by default.
