### PR TITLE
fix(config): Setup logger for secret-stores

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -953,6 +953,9 @@ func (c *Config) addSecretStore(name string, table *ast.Table) error {
 		return err
 	}
 
+	logger := models.NewLogger("secretstores", name, "")
+	models.SetLoggerOnPlugin(store, logger)
+
 	if err := store.Init(); err != nil {
 		return fmt.Errorf("error initializing secret-store %q: %w", storeid, err)
 	}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Currently, the logger of secret-stores is not set, leading to situations where any logging will result in a panic. This PR sets-up the loggers correctly (if instantiated) and thus fixing those potential issues.