### PR TITLE
feat(outputs.exec): Add ability to exec command once per metric

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -311,7 +311,6 @@ following works:
 - github.com/sirupsen/logrus [MIT License](https://github.com/sirupsen/logrus/blob/master/LICENSE)
 - github.com/sleepinggenius2/gosmi [MIT License](https://github.com/sleepinggenius2/gosmi/blob/master/LICENSE)
 - github.com/snowflakedb/gosnowflake [Apache License 2.0](https://github.com/snowflakedb/gosnowflake/blob/master/LICENSE)
-- github.com/spf13/cast [MIT License](https://github.com/spf13/cast/blob/master/LICENSE)
 - github.com/spf13/pflag [BSD 3-Clause "New" or "Revised" License](https://github.com/spf13/pflag/blob/master/LICENSE)
 - github.com/srebhan/cborquery [MIT License](https://github.com/srebhan/cborquery/blob/main/LICENSE)
 - github.com/stoewer/go-strcase [MIT License](https://github.com/stoewer/go-strcase/blob/master/LICENSE)

--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -311,6 +311,7 @@ following works:
 - github.com/sirupsen/logrus [MIT License](https://github.com/sirupsen/logrus/blob/master/LICENSE)
 - github.com/sleepinggenius2/gosmi [MIT License](https://github.com/sleepinggenius2/gosmi/blob/master/LICENSE)
 - github.com/snowflakedb/gosnowflake [Apache License 2.0](https://github.com/snowflakedb/gosnowflake/blob/master/LICENSE)
+- github.com/spf13/cast [MIT License](https://github.com/spf13/cast/blob/master/LICENSE)
 - github.com/spf13/pflag [BSD 3-Clause "New" or "Revised" License](https://github.com/spf13/pflag/blob/master/LICENSE)
 - github.com/srebhan/cborquery [MIT License](https://github.com/srebhan/cborquery/blob/main/LICENSE)
 - github.com/stoewer/go-strcase [MIT License](https://github.com/stoewer/go-strcase/blob/master/LICENSE)

--- a/plugins/outputs/exec/README.md
+++ b/plugins/outputs/exec/README.md
@@ -37,6 +37,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Timeout for command to complete.
   # timeout = "5s"
+  
+  ## Whether the command gets executed once per metric, or once per metric batch
+  # batch_exec = true
 
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/outputs/exec/README.md
+++ b/plugins/outputs/exec/README.md
@@ -37,7 +37,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Timeout for command to complete.
   # timeout = "5s"
-  
+
   ## Whether the command gets executed once per metric, or once per metric batch
   ## The serializer will also run in batch mode when this is true.
   # use_batch_format = true

--- a/plugins/outputs/exec/README.md
+++ b/plugins/outputs/exec/README.md
@@ -39,7 +39,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # timeout = "5s"
   
   ## Whether the command gets executed once per metric, or once per metric batch
-  # batch_exec = true
+  ## The serializer will also run in batch mode when this is true.
+  # use_batch_format = true
 
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/outputs/exec/exec.go
+++ b/plugins/outputs/exec/exec.go
@@ -77,7 +77,7 @@ func (e *Exec) Write(metrics []telegraf.Metric) error {
 
 		return e.runner.Run(time.Duration(e.Timeout), e.Command, e.Environment, &buffer)
 	}
-	var errs []error
+	errs := make([]error, 0, len(metrics))
 	for _, metric := range metrics {
 		serializedMetric, err := e.serializer.Serialize(metric)
 		if err != nil {

--- a/plugins/outputs/exec/exec.go
+++ b/plugins/outputs/exec/exec.go
@@ -26,11 +26,11 @@ const maxStderrBytes = 512
 
 // Exec defines the exec output plugin.
 type Exec struct {
-	Command     []string        `toml:"command"`
-	Environment []string        `toml:"environment"`
-	Timeout     config.Duration `toml:"timeout"`
-	BatchExec   bool            `toml:"batch_exec"`
-	Log         telegraf.Logger `toml:"-"`
+	Command        []string        `toml:"command"`
+	Environment    []string        `toml:"environment"`
+	Timeout        config.Duration `toml:"timeout"`
+	UseBatchFormat bool            `toml:"use_batch_format"`
+	Log            telegraf.Logger `toml:"-"`
 
 	runner     Runner
 	serializer serializers.Serializer
@@ -64,7 +64,7 @@ func (e *Exec) Close() error {
 // Write writes the metrics to the configured command.
 func (e *Exec) Write(metrics []telegraf.Metric) error {
 	var buffer bytes.Buffer
-	if e.BatchExec {
+	if e.UseBatchFormat {
 		serializedMetrics, err := e.serializer.SerializeBatch(metrics)
 		if err != nil {
 			return err
@@ -165,8 +165,8 @@ func (c *CommandRunner) truncate(buf bytes.Buffer) string {
 func init() {
 	outputs.Add("exec", func() telegraf.Output {
 		return &Exec{
-			Timeout:   config.Duration(time.Second * 5),
-			BatchExec: true,
+			Timeout:        config.Duration(time.Second * 5),
+			UseBatchFormat: true,
 		}
 	})
 }

--- a/plugins/outputs/exec/exec_test.go
+++ b/plugins/outputs/exec/exec_test.go
@@ -32,7 +32,7 @@ func TestExternalOutputBatch(t *testing.T) {
 	e := &Exec{
 		Command:        []string{exe, "-testoutput"},
 		Environment:    []string{"PLUGINS_OUTPUTS_EXEC_MODE=application", "METRIC_NAME=cpu"},
-		Timeout:        1000000000,
+		Timeout:        3000000000,
 		UseBatchFormat: true,
 		serializer:     serializer,
 		Log:            testutil.Logger{},
@@ -64,7 +64,7 @@ func TestExternalOutputNoBatch(t *testing.T) {
 	e := &Exec{
 		Command:        []string{exe, "-testoutput"},
 		Environment:    []string{"PLUGINS_OUTPUTS_EXEC_MODE=application", "METRIC_NAME=cpu"},
-		Timeout:        1000000000,
+		Timeout:        3000000000,
 		UseBatchFormat: false,
 		serializer:     serializer,
 		Log:            testutil.Logger{},
@@ -224,4 +224,5 @@ func runOutputConsumerProgram() {
 		}
 	}
 	fmt.Fprintf(os.Stdout, "%d\n", numMetrics)
+	os.Exit(0)
 }

--- a/plugins/outputs/exec/exec_test.go
+++ b/plugins/outputs/exec/exec_test.go
@@ -224,5 +224,4 @@ func runOutputConsumerProgram() {
 		}
 	}
 	fmt.Fprintf(os.Stdout, "%d\n", numMetrics)
-	os.Exit(0)
 }

--- a/plugins/outputs/exec/exec_test.go
+++ b/plugins/outputs/exec/exec_test.go
@@ -32,7 +32,7 @@ func TestExternalOutputBatch(t *testing.T) {
 	e := &Exec{
 		Command:        []string{exe, "-testoutput"},
 		Environment:    []string{"PLUGINS_OUTPUTS_EXEC_MODE=application", "METRIC_NAME=cpu"},
-		Timeout:        300000000,
+		Timeout:        1000000000,
 		UseBatchFormat: true,
 		serializer:     serializer,
 		Log:            testutil.Logger{},
@@ -64,7 +64,7 @@ func TestExternalOutputNoBatch(t *testing.T) {
 	e := &Exec{
 		Command:        []string{exe, "-testoutput"},
 		Environment:    []string{"PLUGINS_OUTPUTS_EXEC_MODE=application", "METRIC_NAME=cpu"},
-		Timeout:        300000000,
+		Timeout:        1000000000,
 		UseBatchFormat: false,
 		serializer:     serializer,
 		Log:            testutil.Logger{},

--- a/plugins/outputs/exec/exec_test.go
+++ b/plugins/outputs/exec/exec_test.go
@@ -2,6 +2,11 @@ package exec
 
 import (
 	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/influxdata/telegraf/metric"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -10,9 +15,76 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	influxParser "github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/influxdata/telegraf/testutil"
 )
+
+var now = time.Date(2020, 6, 30, 16, 16, 0, 0, time.UTC)
+
+func TestExternalOutputBatch(t *testing.T) {
+	serializer := &influx.Serializer{}
+	require.NoError(t, serializer.Init())
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	e := &Exec{
+		Command:        []string{exe, "-testoutput"},
+		Environment:    []string{"PLUGINS_OUTPUTS_EXEC_MODE=application", "METRIC_NAME=cpu"},
+		Timeout:        300000000,
+		UseBatchFormat: true,
+		serializer:     serializer,
+		Log:            testutil.Logger{},
+	}
+
+	require.NoError(t, e.Init())
+
+	m := metric.New(
+		"cpu",
+		map[string]string{"name": "cpu1"},
+		map[string]interface{}{"idle": 50, "sys": 30},
+		now,
+	)
+
+	require.NoError(t, e.Connect())
+	require.NoError(t, e.Write([]telegraf.Metric{m, m}))
+	// Make sure it executed the command once, with 2 metrics
+	require.Equal(t, e.outBuffer.String(), "2\n")
+	require.NoError(t, e.Close())
+}
+
+func TestExternalOutputNoBatch(t *testing.T) {
+	serializer := &influx.Serializer{}
+	require.NoError(t, serializer.Init())
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	e := &Exec{
+		Command:        []string{exe, "-testoutput"},
+		Environment:    []string{"PLUGINS_OUTPUTS_EXEC_MODE=application", "METRIC_NAME=cpu"},
+		Timeout:        300000000,
+		UseBatchFormat: false,
+		serializer:     serializer,
+		Log:            testutil.Logger{},
+	}
+
+	require.NoError(t, e.Init())
+
+	m := metric.New(
+		"cpu",
+		map[string]string{"name": "cpu1"},
+		map[string]interface{}{"idle": 50, "sys": 30},
+		now,
+	)
+
+	require.NoError(t, e.Connect())
+	require.NoError(t, e.Write([]telegraf.Metric{m, m}))
+	// Make sure it executed the command twice, both with a single metric
+	require.Equal(t, e.outBuffer.String(), "1\n1\n")
+	require.NoError(t, e.Close())
+}
 
 func TestExec(t *testing.T) {
 	t.Skip("Skipping test due to OS/executable dependencies and race condition when ran as part of a test-all")
@@ -100,4 +172,56 @@ func TestExecDocs(t *testing.T) {
 
 	e = &Exec{runner: &CommandRunner{}}
 	require.NoError(t, e.Close())
+}
+
+var testoutput = flag.Bool("testoutput", false,
+	"if true, act like line input program instead of test")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	runMode := os.Getenv("PLUGINS_OUTPUTS_EXEC_MODE")
+	if *testoutput && runMode == "application" {
+		runOutputConsumerProgram()
+		os.Exit(0)
+	}
+	code := m.Run()
+	os.Exit(code)
+}
+
+func runOutputConsumerProgram() {
+	metricName := os.Getenv("METRIC_NAME")
+	parser := influxParser.NewStreamParser(os.Stdin)
+	numMetrics := 0
+
+	for {
+		m, err := parser.Next()
+		if err != nil {
+			if errors.Is(err, influxParser.EOF) {
+				break // stream ended
+			}
+			var parseErr *influxParser.ParseError
+			if errors.As(err, &parseErr) {
+				fmt.Fprintf(os.Stderr, "parse ERR %v\n", parseErr)
+				//nolint:revive // error code is important for this "test"
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "ERR %v\n", err)
+			//nolint:revive // error code is important for this "test"
+			os.Exit(1)
+		}
+		numMetrics++
+
+		expected := testutil.MustMetric(metricName,
+			map[string]string{"name": "cpu1"},
+			map[string]interface{}{"idle": 50, "sys": 30},
+			now,
+		)
+
+		if !testutil.MetricEqual(expected, m) {
+			fmt.Fprintf(os.Stderr, "metric doesn't match expected\n")
+			//nolint:revive // error code is important for this "test"
+			os.Exit(1)
+		}
+	}
+	fmt.Fprintf(os.Stdout, "%d\n", numMetrics)
 }

--- a/plugins/outputs/exec/sample.conf
+++ b/plugins/outputs/exec/sample.conf
@@ -12,6 +12,9 @@
   ## Timeout for command to complete.
   # timeout = "5s"
 
+  ## Whether the command gets executed once per metric, or once per metric batch
+  # batch_exec = true
+
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/exec/sample.conf
+++ b/plugins/outputs/exec/sample.conf
@@ -13,7 +13,8 @@
   # timeout = "5s"
 
   ## Whether the command gets executed once per metric, or once per metric batch
-  # batch_exec = true
+  ## The serializer will also run in batch mode when this is true.
+  # use_batch_format = true
 
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

refs #13654

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

This adds a mode to the exec plugin which will run the command once per metric, rather than once per batch. 

Open questions:
- Is the option name `batch_exec` good?
- I wasn't too sure how errors should be handled in this mode. Right now it:
  - Aborts if there is an error serializing a metric.
  - Continues running the command for all metrics even if one has an error, then returns all the errors Joined at the end.
- Not sure how to do unit tests for this either. If someone has some ideas I'd love to hear them.
